### PR TITLE
[ntuple] replace RFieldBase::DestroyValue by deleter

### DIFF
--- a/tree/ntuple/v7/doc/architecture.md
+++ b/tree/ntuple/v7/doc/architecture.md
@@ -15,7 +15,7 @@ However, the object should not rely on its transient state to remain unchanged d
 it may be destructed and constructed again when it is read as part of a collection (see below).
 
 An object that is being read from disk may have been constructed by `RField::GenerateValue()`.
-In this case, RNTuple owns the object and it will be destructed by `RField::DestroyValue()`.
+In this case, RNTuple owns the object. The deleter returned by `RField::GetDeleter()` releases the resources.
 
 When reading collections of type `T` (`std::vector<T>`, `ROOT::RVec<T>`, ...), RNTuple uses `RField::GenerateValue()` to construct elements of the inner type `T`.
 As the size of a collection changes from event to event, this has the following effect on its elements

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -116,7 +116,7 @@ public:
    /// No constructor needs to be called, i.e. any bit pattern in the allocated memory represents a valid type
    /// A trivially constructible field has a no-op GenerateValue() implementation
    static constexpr int kTraitTriviallyConstructible = 0x01;
-   /// The type is cleaned up just by freeing its memory. I.e. the deleter performs a no-op.
+   /// The type is cleaned up just by freeing its memory. I.e. the destructor performs a no-op.
    static constexpr int kTraitTriviallyDestructible = 0x02;
    /// A field of a fundamental type that can be directly mapped via `RField<T>::Map()`, i.e. maps as-is to a single
    /// column

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -86,12 +86,37 @@ class RFieldBase {
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
    using ReadCallback_t = std::function<void(void *)>;
 
+protected:
+   /// A functor to release the memory acquired by GenerateValue (memory and constructor).
+   /// This implementation works for types with a trivial destructor. More complex fields implement a derived deleter.
+   /// The deleter is operational without the field object and thus can be used to destruct/release a value after
+   /// the field has been destructed.
+   class RDeleter {
+   public:
+      virtual void operator()(void *objPtr, bool dtorOnly)
+      {
+         if (!dtorOnly)
+            operator delete(objPtr);
+      }
+   };
+
+   /// A deleter for templated RFieldBase descendents where the value type is known.
+   template <typename T>
+   class RTypedDeleter : public RDeleter {
+   public:
+      void operator()(void *objPtr, bool dtorOnly) final
+      {
+         std::destroy_at(static_cast<T *>(objPtr));
+         RDeleter::operator()(objPtr, dtorOnly);
+      }
+   };
+
 public:
    static constexpr std::uint32_t kInvalidTypeVersion = -1U;
    /// No constructor needs to be called, i.e. any bit pattern in the allocated memory represents a valid type
    /// A trivially constructible field has a no-op GenerateValue() implementation
    static constexpr int kTraitTriviallyConstructible = 0x01;
-   /// The type is cleaned up just by freeing its memory. I.e. DestroyValue() is a no-op.
+   /// The type is cleaned up just by freeing its memory. I.e. the deleter performs a no-op.
    static constexpr int kTraitTriviallyDestructible = 0x02;
    /// A field of a fundamental type that can be directly mapped via `RField<T>::Map()`, i.e. maps as-is to a single
    /// column
@@ -143,27 +168,35 @@ public:
 
    private:
       RFieldBase *fField = nullptr; ///< The field that created the RValue
+      std::unique_ptr<RFieldBase::RDeleter> fDeleter;
       /// Created by RFieldBase::GenerateValue() or a non-owning pointer from SplitValue() or BindValue()
       void *fObjPtr = nullptr;
       bool fIsOwning = false; ///< If true, fObjPtr is destroyed in the destructor
 
-      RValue(RFieldBase *field, void *objPtr, bool isOwning) : fField(field), fObjPtr(objPtr), fIsOwning(isOwning) {}
+      RValue(RFieldBase *field, void *objPtr, bool isOwning)
+         : fField(field), fDeleter(fField->GetDeleter()), fObjPtr(objPtr), fIsOwning(isOwning)
+      {
+      }
 
       void DestroyIfOwning()
       {
          if (fIsOwning)
-            fField->DestroyValue(fObjPtr);
+            fDeleter->operator()(fObjPtr, false /* dtorOnly */);
       }
 
    public:
       RValue(const RValue &) = delete;
       RValue &operator=(const RValue &) = delete;
-      RValue(RValue &&other) : fField(other.fField), fObjPtr(other.fObjPtr) { std::swap(fIsOwning, other.fIsOwning); }
+      RValue(RValue &&other) : fField(other.fField), fDeleter(fField->GetDeleter()), fObjPtr(other.fObjPtr)
+      {
+         std::swap(fIsOwning, other.fIsOwning);
+      }
       RValue &operator=(RValue &&other)
       {
          DestroyIfOwning();
          fIsOwning = false;
          std::swap(fField, other.fField);
+         std::swap(fDeleter, other.fDeleter);
          std::swap(fObjPtr, other.fObjPtr);
          std::swap(fIsOwning, other.fIsOwning);
          return *this;
@@ -211,6 +244,7 @@ public:
       friend class RFieldBase;
 
       RFieldBase *fField = nullptr;       ///< The field that created the array of values
+      std::unique_ptr<RFieldBase::RDeleter> fDeleter; /// Cached deleter of fField
       void *fValues = nullptr;            ///< Pointer to the start of the array
       std::size_t fValueSize = 0;         ///< Cached copy of fField->GetValueSize()
       std::size_t fCapacity = 0;          ///< The size of the array memory block in number of values
@@ -242,7 +276,10 @@ public:
          return reinterpret_cast<unsigned char *>(fValues) + idx * fValueSize;
       }
 
-      explicit RBulk(RFieldBase *field) : fField(field), fValueSize(field->GetValueSize()) {}
+      explicit RBulk(RFieldBase *field)
+         : fField(field), fDeleter(field->GetDeleter()), fValueSize(field->GetValueSize())
+      {
+      }
 
    public:
       ~RBulk();
@@ -386,15 +423,10 @@ protected:
 
    /// Constructs value in a given location of size at least GetValueSize(). Called by the base class' GenerateValue().
    virtual void GenerateValue(void *where) const = 0;
-   /// Releases the resources acquired during GenerateValue (memory and constructor)
-   /// This implementation works for types with a trivial destructor and should be overwritten otherwise.
-   virtual void DestroyValue(void *objPtr, bool dtorOnly = false) const;
-   /// Allow derived classes to call GenerateValue(void *) and DestroyValue on other (sub) fields.
+   virtual std::unique_ptr<RDeleter> GetDeleter() const { return std::make_unique<RDeleter>(); }
+   /// Allow derived classes to call GenerateValue(void *) and GetDeleter on other (sub) fields.
    static void CallGenerateValueOn(const RFieldBase &other, void *where) { other.GenerateValue(where); }
-   static void CallDestroyValueOn(const RFieldBase &other, void *objPtr, bool dtorOnly = false)
-   {
-      other.DestroyValue(objPtr, dtorOnly);
-   }
+   static std::unique_ptr<RDeleter> GetDeleterOf(const RFieldBase &other) { return other.GetDeleter(); }
 
    /// Operations on values of complex types, e.g. ones that involve multiple columns or for which no direct
    /// column type exists.
@@ -693,6 +725,15 @@ private:
    /// Prefix used in the subfield names generated for base classes
    static constexpr const char *kPrefixInherited{":"};
 
+   class RClassDeleter : public RDeleter {
+   private:
+      TClass *fClass;
+
+   public:
+      explicit RClassDeleter(TClass *cl) : fClass(cl) {}
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    TClass* fClass;
    /// Additional information kept for each entry in `fSubFields`
    std::vector<RSubFieldInfo> fSubFieldsInfo;
@@ -711,7 +752,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RClassDeleter>(fClass); }
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -843,9 +884,28 @@ protected:
 
       RIterator begin() { return RIterator(*this, fBegin); }
       RIterator end() { return fStride ? RIterator(*this, fEnd) : RIterator(*this); }
+   }; // class RCollectionIterableOnce
+
+   class RProxiedCollectionDeleter : public RDeleter {
+   private:
+      std::shared_ptr<TVirtualCollectionProxy> fProxy;
+      std::unique_ptr<RDeleter> fItemDeleter;
+      std::size_t fItemSize = 0;
+      RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;
+
+   public:
+      explicit RProxiedCollectionDeleter(std::shared_ptr<TVirtualCollectionProxy> proxy) : fProxy(proxy) {}
+      RProxiedCollectionDeleter(std::shared_ptr<TVirtualCollectionProxy> proxy, std::unique_ptr<RDeleter> itemDeleter,
+                                size_t itemSize)
+         : fProxy(proxy), fItemDeleter(std::move(itemDeleter)), fItemSize(itemSize)
+      {
+         fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
    };
 
-   std::unique_ptr<TVirtualCollectionProxy> fProxy;
+   /// The collection proxy is needed by the deleters and thus defined as a shared pointer
+   std::shared_ptr<TVirtualCollectionProxy> fProxy;
    Int_t fProperties;
    Int_t fCollectionType;
    /// Two sets of functions to operate on iterators, to be used depending on the access type.  The direction preserves
@@ -869,7 +929,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const override;
 
    std::size_t AppendImpl(const void *from) override;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
@@ -900,6 +960,20 @@ public:
 /// The field for an untyped record. The subfields are stored consequitively in a memory block, i.e.
 /// the memory layout is identical to one that a C++ struct would have
 class RRecordField : public Detail::RFieldBase {
+private:
+   class RRecordDeleter : public RDeleter {
+   private:
+      std::vector<std::unique_ptr<RDeleter>> fItemDeleters;
+      std::vector<std::size_t> fOffsets;
+
+   public:
+      RRecordDeleter(std::vector<std::unique_ptr<RDeleter>> &itemDeleters, const std::vector<std::size_t> &offsets)
+         : fItemDeleters(std::move(itemDeleters)), fOffsets(offsets)
+      {
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
 protected:
    std::size_t fMaxAlignment = 1;
    std::size_t fSize = 0;
@@ -913,7 +987,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const override;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -955,8 +1029,23 @@ public:
 /// The generic field for a (nested) std::vector<Type> except for std::vector<bool>
 class RVectorField : public Detail::RFieldBase {
 private:
+   class RVectorDeleter : public RDeleter {
+   private:
+      std::size_t fItemSize = 0;
+      std::unique_ptr<RDeleter> fItemDeleter;
+
+   public:
+      RVectorDeleter() = default;
+      RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
+         : fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
+      {
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    std::size_t fItemSize;
    ClusterSize_t fNWritten;
+   std::unique_ptr<RDeleter> fItemDeleter;
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -965,8 +1054,8 @@ protected:
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
    void GenerateValue(void *where) const override { new (where) std::vector<char>(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -994,6 +1083,25 @@ public:
 
 /// The type-erased field for a RVec<Type>
 class RRVecField : public Detail::RFieldBase {
+public:
+   /// the RRVecDeleter is also used by RArrayAsRVecField and therefore declared public
+   class RRVecDeleter : public RDeleter {
+   private:
+      std::size_t fItemAlignment;
+      std::size_t fItemSize = 0;
+      std::unique_ptr<RDeleter> fItemDeleter;
+
+   public:
+      explicit RRVecDeleter(std::size_t itemAlignment) : fItemAlignment(itemAlignment) {}
+      RRVecDeleter(std::size_t itemAlignment, std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
+         : fItemAlignment(itemAlignment), fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
+      {
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
+   std::unique_ptr<RDeleter> fItemDeleter;
+
 protected:
    std::size_t fItemSize;
    ClusterSize_t fNWritten;
@@ -1005,7 +1113,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const override;
 
    std::size_t AppendImpl(const void *from) override;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
@@ -1039,6 +1147,20 @@ public:
 /// The generic field for fixed size arrays, which do not need an offset column
 class RArrayField : public Detail::RFieldBase {
 private:
+   class RArrayDeleter : public RDeleter {
+   private:
+      std::size_t fItemSize = 0;
+      std::size_t fArrayLength = 0;
+      std::unique_ptr<RDeleter> fItemDeleter;
+
+   public:
+      RArrayDeleter(std::size_t itemSize, std::size_t arrayLength, std::unique_ptr<RDeleter> itemDeleter)
+         : fItemSize(itemSize), fArrayLength(arrayLength), fItemDeleter(std::move(itemDeleter))
+      {
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    std::size_t fItemSize;
    std::size_t fArrayLength;
 
@@ -1049,7 +1171,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -1078,9 +1200,10 @@ arbitrarily-nested std::array on-disk fields as RVecs for usage in RDataFrame.
 */
 class RArrayAsRVecField final : public Detail::RFieldBase {
 private:
-   std::size_t fItemSize;    /// The size of a child field's item
-   std::size_t fArrayLength; /// The length of the arrays in this field
-   std::size_t fValueSize;   /// The size of a value of this field, i.e. an RVec
+   std::unique_ptr<RDeleter> fItemDeleter; /// Sub field deleter or nullptr for simple fields
+   std::size_t fItemSize;                  /// The size of a child field's item
+   std::size_t fArrayLength;               /// The length of the arrays in this field
+   std::size_t fValueSize;                 /// The size of a value of this field, i.e. an RVec
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -1089,7 +1212,8 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void GenerateValue(void *where) const final;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   /// Returns an RRVecField::RRVecDeleter
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
@@ -1158,6 +1282,19 @@ public:
 /// The generic field for std::variant types
 class RVariantField : public Detail::RFieldBase {
 private:
+   class RVariantDeleter : public RDeleter {
+   private:
+      std::size_t fTagOffset;
+      std::vector<std::unique_ptr<RDeleter>> fItemDeleters;
+
+   public:
+      RVariantDeleter(std::size_t tagOffset, std::vector<std::unique_ptr<RDeleter>> &itemDeleters)
+         : fTagOffset(tagOffset), fItemDeleters(std::move(itemDeleters))
+      {
+      }
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    size_t fMaxItemSize = 0;
    size_t fMaxAlignment = 1;
    /// In the std::variant memory layout, at which byte number is the index stored
@@ -1166,8 +1303,8 @@ private:
 
    static std::string GetTypeList(const std::vector<Detail::RFieldBase *> &itemFields);
    /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column
-   std::uint32_t GetTag(const void *variantPtr) const;
-   void SetTag(void *variantPtr, std::uint32_t tag) const;
+   static std::uint32_t GetTag(const void *variantPtr, std::size_t tagOffset);
+   static void SetTag(void *variantPtr, std::size_t tagOffset, std::uint32_t tag);
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -1177,7 +1314,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -1275,11 +1412,22 @@ public:
 };
 
 class RUniquePtrField : public RNullableField {
+   class RUniquePtrDeleter : public RDeleter {
+   private:
+      std::unique_ptr<RDeleter> fItemDeleter;
+
+   public:
+      explicit RUniquePtrDeleter(std::unique_ptr<RDeleter> itemDeleter) : fItemDeleter(std::move(itemDeleter)) {}
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
+   std::unique_ptr<RDeleter> fItemDeleter;
+
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
 
    void GenerateValue(void *where) const final { new (where) std::unique_ptr<char>(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -1304,10 +1452,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void GenerateValue(void *where) const final { CallGenerateValueOn(*fSubFields[0], where); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      CallDestroyValueOn(*fSubFields[0], objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return GetDeleterOf(*fSubFields[0]); }
 
    std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
@@ -1480,6 +1625,15 @@ public:
 /// The generic field for `std::pair<T1, T2>` types
 class RPairField : public RRecordField {
 private:
+   class RPairDeleter : public RDeleter {
+   private:
+      TClass *fClass;
+
+   public:
+      explicit RPairDeleter(TClass *cl) : fClass(cl) {}
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    TClass *fClass = nullptr;
    static std::string GetTypeList(const std::array<std::unique_ptr<Detail::RFieldBase>, 2> &itemFields);
 
@@ -1487,7 +1641,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const override { return std::make_unique<RPairDeleter>(fClass); }
 
    RPairField(std::string_view fieldName, std::array<std::unique_ptr<Detail::RFieldBase>, 2> &&itemFields,
               const std::array<std::size_t, 2> &offsets);
@@ -1504,6 +1658,15 @@ public:
 /// The generic field for `std::tuple<Ts...>` types
 class RTupleField : public RRecordField {
 private:
+   class RTupleDeleter : public RDeleter {
+   private:
+      TClass *fClass;
+
+   public:
+      explicit RTupleDeleter(TClass *cl) : fClass(cl) {}
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
    TClass *fClass = nullptr;
    static std::string GetTypeList(const std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields);
 
@@ -1511,7 +1674,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
 
    void GenerateValue(void *where) const override;
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const override { return std::make_unique<RTupleDeleter>(fClass); }
 
    RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &&itemFields,
                const std::vector<std::size_t> &offsets);
@@ -2236,7 +2399,7 @@ private:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const final { new (where) std::string(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::string>>(); }
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final;
@@ -2295,11 +2458,7 @@ class RField<std::set<ItemT>> : public RSetField {
 
 protected:
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName() { return "std::set<" + RField<ItemT>::TypeName() + ">"; }
@@ -2320,11 +2479,7 @@ class RField<std::unordered_set<ItemT>> : public RSetField {
 
 protected:
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName() { return "std::unordered_set<" + RField<ItemT>::TypeName() + ">"; }
@@ -2345,11 +2500,7 @@ class RField<std::map<KeyT, ValueT>> : public RMapField {
 
 protected:
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName()
@@ -2376,11 +2527,7 @@ class RField<std::unordered_map<KeyT, ValueT>> : public RMapField {
 
 protected:
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName()
@@ -2475,7 +2622,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const final { new (where) std::vector<bool>(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::vector<bool>>>(); }
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -2514,11 +2661,7 @@ protected:
    }
 
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
    std::size_t AppendImpl(const void *from) final
    {
@@ -2592,11 +2735,7 @@ protected:
    }
 
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName() {
@@ -2671,11 +2810,7 @@ protected:
    }
 
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const final
-   {
-      std::destroy_at(static_cast<ContainerT *>(objPtr));
-      Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-   }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName() { return "std::tuple<" + BuildItemTypes<ItemTs...>() + ">"; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -93,6 +93,7 @@ protected:
    /// the field has been destructed.
    class RDeleter {
    public:
+      virtual ~RDeleter() = default;
       virtual void operator()(void *objPtr, bool dtorOnly)
       {
          if (!dtorOnly)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -752,3 +752,22 @@ TEST(RNTuple, FillBytesWritten)
    optsSmall.SetHasSmallClusters(true);
    checkFillReturnValue(optsSmall);
 }
+
+TEST(RNTuple, RFieldDeleter)
+{
+   auto f1 = RFieldBase::Create("f1", "CustomStruct").Unwrap();
+   auto f2 = RFieldBase::Create("f2", "std::vector<std::vector<std::variant<std::string, float>>>").Unwrap();
+   auto f3 = RFieldBase::Create("f3", "std::variant<std::unique_ptr<CustomStruct>, ComplexStruct>>").Unwrap();
+   auto v1 = f1->GenerateValue();
+   auto v2 = f2->GenerateValue();
+   auto v3 = f3->GenerateValue();
+
+   // Destruct fields to check if the deleters work without the fields
+   f1 = nullptr;
+   f2 = nullptr;
+   f3 = nullptr;
+
+   // The deleters are called in the destructors of the values
+
+   // TODO(jblomer): this becomes more explicit when the RValues contain shared pointers
+}


### PR DESCRIPTION
Introduces the RFieldBase::RDeleter functor that can destroy a value created by an RField. The deleter interface is virtual and RField descendents implement their own version of it. The deleter works without the corresponding field and therefore is the basis to hand out shared pointers to objects in the RValues returned by the field.

Also switches to new and delete for allocation instead of malloc/free.