### PR TITLE
[CI] Correct typo in code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 
 # Coarse-grained ownership
 * @dpiparo
-/bindings/ @ dpiparo @vepadulano
-/core/ @ dpiparo @pcanal
+/bindings/ @dpiparo @vepadulano
+/core/ @dpiparo @pcanal
 /documentation/ @couet
 /fonts/ @bellenot
 /geom/ @agheata


### PR DESCRIPTION
# This Pull request:
Fixes a typo in the code owners file
