### PR TITLE
[mysql] alternative for deprecated or removed methods in v8 (#14378)

### DIFF
--- a/sql/mysql/src/TMySQLServer.cxx
+++ b/sql/mysql/src/TMySQLServer.cxx
@@ -639,7 +639,13 @@ Int_t TMySQLServer::Reload()
 {
    CheckConnect("Reload", -1);
 
-   Int_t res = mysql_reload(fMySQL);
+   Int_t res;
+   
+   #if MYSQL_VERSION_ID >= 80000
+   res = mysql_query(fMySQL, "FLUSH PRIVILEGES");
+   #else
+   res = mysql_reload(fMySQL);
+   #endif
 
    CheckErrNo("Reload", kFALSE, res);
 
@@ -656,7 +662,9 @@ Int_t TMySQLServer::Shutdown()
 
    Int_t res;
 
-#if MYSQL_VERSION_ID >= 50001 || \
+#if MYSQL_VERSION_ID >= 80000
+   res = mysql_query(fMySQL, "SHUTDOWN");
+#elif MYSQL_VERSION_ID >= 50001 || \
     (MYSQL_VERSION_ID < 50000 && MYSQL_VERSION_ID >= 40103)
    res = mysql_shutdown(fMySQL, SHUTDOWN_DEFAULT);
 #else


### PR DESCRIPTION
* [sql] alternative for deprecated or removed methods

Fixes https://github.com/root-project/root/issues/14376

See https://dev.mysql.com/doc/relnotes/mysql/8.3/en/news-8-3-0.html#mysqld-8-3-0-deprecation-removal

* fix syntax

Backport of #14378 