### PR TITLE
core: Allow build on MacOS with Cocoa disable.

### DIFF
--- a/core/base/inc/LinkDef.h
+++ b/core/base/inc/LinkDef.h
@@ -7,7 +7,9 @@
 #if defined(SYSTEM_TYPE_winnt)
 #include "../../winnt/inc/LinkDef.h"
 #elif defined(SYSTEM_TYPE_macosx)
+#if defined(R__HAS_COCOA)
 #include "../../macosx/inc/LinkDef.h"
+#endif
 #include "../../unix/inc/LinkDef.h"
 #elif defined(SYSTEM_TYPE_unix)
 #include "../../unix/inc/LinkDef.h"


### PR DESCRIPTION
Without this patch we get:

ld: Undefined symbols:
  TMacOSXSystem::TMacOSXSystem(), referenced from:
      ROOT::new_TMacOSXSystem(void*) in G__Core.cxx.o
      ROOT::new_TMacOSXSystem(void*) in G__Core.cxx.o
      ROOT::newArray_TMacOSXSystem(long, void*) in G__Core.cxx.o
      ROOT::newArray_TMacOSXSystem(long, void*) in G__Core.cxx.o
  TMacOSXSystem::~TMacOSXSystem(), referenced from:
      ROOT::newArray_TMacOSXSystem(long, void*) in G__Core.cxx.o
      ROOT::newArray_TMacOSXSystem(long, void*) in G__Core.cxx.o
      ROOT::deleteArray_TMacOSXSystem(void*) in G__Core.cxx.o
  typeinfo for TMacOSXSystem, referenced from:
      ROOT::GenerateInitInstanceLocal(TMacOSXSystem const*) in G__Core.cxx.o
clang: error: linker command failed with exit code 1
