### PR TITLE
Revert "Build core/macosx only when cocoa=ON"

### DIFF
--- a/core/macosx/CMakeLists.txt
+++ b/core/macosx/CMakeLists.txt
@@ -12,15 +12,15 @@ if(NOT APPLE)
   return()
 endif()
 
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TMacOSXSystem.h)
-
-target_include_directories(Core PRIVATE inc)
-
 target_link_libraries(Core PRIVATE
   "-F/System/Library/PrivateFrameworks -framework CoreSymbolication"
 )
 
 if(cocoa)
+  set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TMacOSXSystem.h)
+
+  target_include_directories(Core PRIVATE inc)
+
   target_link_libraries(Core PRIVATE "-framework Cocoa")
 
   ROOT_OBJECT_LIBRARY(Macosx

--- a/core/macosx/CMakeLists.txt
+++ b/core/macosx/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/macosx package
 ############################################################################
 
-if(NOT (APPLE AND cocoa))
+if(NOT APPLE)
   return()
 endif()
 
@@ -20,16 +20,19 @@ target_link_libraries(Core PRIVATE
   "-F/System/Library/PrivateFrameworks -framework CoreSymbolication"
 )
 
-target_link_libraries(Core PRIVATE "-framework Cocoa")
+if(cocoa)
+  target_link_libraries(Core PRIVATE "-framework Cocoa")
 
-ROOT_OBJECT_LIBRARY(Macosx
-  src/CocoaUtils.mm
-  src/TMacOSXSystem.mm
-)
+  ROOT_OBJECT_LIBRARY(Macosx
+    src/CocoaUtils.mm
+    src/TMacOSXSystem.mm
+  )
 
-target_compile_options(Macosx PRIVATE -ObjC++)
-target_include_directories(Macosx PRIVATE ../unix/inc)
+  target_compile_options(Macosx PRIVATE -ObjC++)
+  target_include_directories(Macosx PRIVATE ../unix/inc)
 
-target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
+  target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
+
+endif()
 
 ROOT_INSTALL_HEADERS()


### PR DESCRIPTION
The part
```
"-F/System/Library/PrivateFrameworks -framework CoreSymbolication"
```

is necessary whether Cocoa in enabled or not.
