### PR TITLE
[skip-ci] the condition should be >99

### DIFF
--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -830,7 +830,7 @@ void TLegend::PaintPrimitives()
          if (eobj && eobj->InheritsFrom(TAttLine::Class())
                   && eobj->InheritsFrom(TGraph::Class())) {
             Int_t w = dynamic_cast<TAttLine*>(eobj)->GetLineWidth();
-            if (TMath::Abs(w)>999) {
+            if (TMath::Abs(w)>99) {
                if (w<0) wu = 0;
                else     wl = 0;
             }


### PR DESCRIPTION

As said here:
https://github.com/root-project/root/pull/14382#pullrequestreview-1830470315

This drawing mode is activated when the absolute value of the graph line width (set by [SetLineWidth()](https://root.cern.ch/doc/master/TGWin32VirtualXProxy_8cxx.html#a18a240c3a19b7b71d058ce1da94747e9)) is greater than 99
the condition be changed to >99 instead of >999?