### PR TITLE
[ntuple] Refactor RNTupleWriter into RNTupleFillContext

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -43,7 +43,7 @@ class REntry {
    friend class RCollectionNTupleWriter;
    friend class RNTupleModel;
    friend class RNTupleReader;
-   friend class RNTupleWriter;
+   friend class RNTupleFillContext;
 
    /// The entry must be linked to a specific model (or one if its clones), identified by a model ID
    std::uint64_t fModelId = 0;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -430,7 +430,7 @@ public:
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 
-   const RNTupleModel *GetModel() const { return fModel.get(); }
+   const RNTupleModel &GetModel() const { return *fModel; }
 
    /// Get a `RNTupleModel::RUpdater` that provides limited support for incremental updates to the underlying
    /// model, e.g. addition of new fields.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -362,6 +362,8 @@ private:
    /// Needs to be destructed before fSink
    std::unique_ptr<RNTupleModel> fModel;
 
+   Detail::RNTupleMetrics fMetrics;
+
    NTupleSize_t fLastCommitted = 0;
    NTupleSize_t fNEntries = 0;
    /// Keeps track of the number of bytes written into the current cluster
@@ -407,6 +409,9 @@ public:
    NTupleSize_t GetLastCommitted() const { return fLastCommitted; }
    /// Return the number of entries filled so far.
    NTupleSize_t GetNEntries() const { return fNEntries; }
+
+   void EnableMetrics() { fMetrics.Enable(); }
+   const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -349,7 +349,7 @@ public:
 An output ntuple can be filled with entries. The caller has to make sure that the data that gets filled into an ntuple
 is not modified for the time of the Fill() call. The fill call serializes the C++ object into the column format and
 writes data into the corresponding column page buffers.  Writing of the buffers to storage is deferred and can be
-triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception is thrown.
+triggered by CommitCluster() or by destructing the writer.  On I/O errors, an exception is thrown.
 */
 // clang-format on
 class RNTupleWriter {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -266,7 +266,7 @@ const ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleReader::
 
 ROOT::Experimental::RNTupleFillContext::RNTupleFillContext(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
                                                            std::unique_ptr<ROOT::Experimental::Detail::RPageSink> sink)
-   : fSink(std::move(sink)), fModel(std::move(model))
+   : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleFillContext")
 {
    if (!fModel) {
       throw RException(R__FAIL("null model"));
@@ -276,6 +276,7 @@ ROOT::Experimental::RNTupleFillContext::RNTupleFillContext(std::unique_ptr<ROOT:
    }
    fModel->Freeze();
    fSink->Create(*fModel.get());
+   fMetrics.ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();
    fMaxUnzippedClusterSize = writeOpts.GetMaxUnzippedClusterSize();
@@ -332,6 +333,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimen
       fFillContext.fSink->SetTaskScheduler(fZipTasks.get());
    }
 #endif
+   // Observe directly the sink's metrics to avoid an additional prefix from the fill context.
    fMetrics.ObserveMetrics(fFillContext.fSink->GetMetrics());
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -129,7 +129,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::Clone(const RNTupleModel *ne
 }
 
 ROOT::Experimental::RNTupleModel::RUpdater::RUpdater(RNTupleWriter &writer)
-   : fWriter(writer), fOpenChangeset(*fWriter.fModel)
+   : fWriter(writer), fOpenChangeset(fWriter.GetUpdatableModel())
 {
 }
 
@@ -146,7 +146,7 @@ void ROOT::Experimental::RNTupleModel::RUpdater::CommitUpdate()
    Detail::RNTupleModelChangeset toCommit{fOpenChangeset.fModel};
    std::swap(fOpenChangeset.fAddedFields, toCommit.fAddedFields);
    std::swap(fOpenChangeset.fAddedProjectedFields, toCommit.fAddedProjectedFields);
-   fWriter.fSink->UpdateSchema(toCommit, fWriter.fNEntries);
+   fWriter.GetSink().UpdateSchema(toCommit, fWriter.GetNEntries());
 }
 
 void ROOT::Experimental::RNTupleModel::RUpdater::AddField(std::unique_ptr<Detail::RFieldBase> field)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -630,24 +630,24 @@ TEST(RNTuple, BareEntry)
    FileRaii fileGuard("test_ntuple_bare_entry.root");
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(m), "ntpl", fileGuard.GetPath());
-      const auto model = ntuple->GetModel();
+      const auto &model = ntuple->GetModel();
       try {
-         model->GetDefaultEntry();
+         model.GetDefaultEntry();
          FAIL() << "accessing default entry of bare model should throw";
       } catch (const RException &err) {
          EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
       }
       try {
-         model->Get<float>("pt");
+         model.Get<float>("pt");
          FAIL() << "accessing default entry of bare model should throw";
       } catch (const RException &err) {
          EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
       }
 
-      auto e1 = model->CreateEntry();
+      auto e1 = model.CreateEntry();
       ASSERT_NE(nullptr, e1->Get<float>("pt"));
       *(e1->Get<float>("pt")) = 1.0;
-      auto e2 = model->CreateBareEntry();
+      auto e2 = model.CreateBareEntry();
       EXPECT_EQ(nullptr, e2->Get<float>("pt"));
       float pt = 2.0;
       e2->CaptureValueUnsafe("pt", &pt);

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -87,7 +87,7 @@ TEST(RNTuple, ModelExtensionInvalidUse)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto entry = ntuple->GetModel()->CreateEntry();
+      auto entry = ntuple->GetModel().CreateEntry();
 
       auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
@@ -96,14 +96,14 @@ TEST(RNTuple, ModelExtensionInvalidUse)
       // Cannot fill if the model is not frozen
       EXPECT_THROW(ntuple->Fill(), ROOT::Experimental::RException);
       // Trying to create an entry should throw if model is not frozen
-      EXPECT_THROW((void)ntuple->GetModel()->CreateEntry(), ROOT::Experimental::RException);
+      EXPECT_THROW((void)ntuple->GetModel().CreateEntry(), ROOT::Experimental::RException);
       modelUpdater->CommitUpdate();
 
       // Using an entry that does not match the model should throw
       EXPECT_THROW(ntuple->Fill(*entry), ROOT::Experimental::RException);
 
       ntuple->Fill();
-      auto entry2 = ntuple->GetModel()->CreateEntry();
+      auto entry2 = ntuple->GetModel().CreateEntry();
       ntuple->Fill(*entry2);
 
       ntuple->Fill();

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -167,8 +167,8 @@ TEST(RNTuple, ArrayField)
       model->AddField(RFieldBase::Create("array2", "unsigned char[4]").Unwrap());
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto array1_field = ntuple->GetModel()->GetDefaultEntry()->Get<float[2]>("array1");
-      auto array2_field = ntuple->GetModel()->GetDefaultEntry()->Get<unsigned char[4]>("array2");
+      auto array1_field = ntuple->GetModel().GetDefaultEntry()->Get<float[2]>("array1");
+      auto array2_field = ntuple->GetModel().GetDefaultEntry()->Get<unsigned char[4]>("array2");
       for (int i = 0; i < 2; i++) {
          new (struct_field.get()) StructWithArrays({{'n', 't', 'p', 'l'}, {1.0, 42.0}, {{2*i}, {2*i + 1}}});
          new (array1_field) float[2]{0.0f, static_cast<float>(i)};
@@ -208,8 +208,8 @@ TEST(RNTuple, NDimArrayField)
       model->AddField(RFieldBase::Create("dim3", "int[1][2][3]").Unwrap());
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto dim2_field = ntuple->GetModel()->GetDefaultEntry()->Get<int[2][3]>("dim2");
-      auto dim3_field = ntuple->GetModel()->GetDefaultEntry()->Get<int[1][2][3]>("dim3");
+      auto dim2_field = ntuple->GetModel().GetDefaultEntry()->Get<int[2][3]>("dim2");
+      auto dim3_field = ntuple->GetModel().GetDefaultEntry()->Get<int[1][2][3]>("dim3");
       (*dim2_field)[0][0] = 0;
       (*dim2_field)[0][1] = 1;
       (*dim2_field)[0][2] = 2;
@@ -270,7 +270,7 @@ TEST(RNTuple, StdPair)
       model->AddField(std::move(myPair2));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "pair_ntuple", fileGuard.GetPath());
-      auto pair_field2 = ntuple->GetModel()->GetDefaultEntry()->Get<std::pair<double, std::string>>("myPair2");
+      auto pair_field2 = ntuple->GetModel().GetDefaultEntry()->Get<std::pair<double, std::string>>("myPair2");
       for (int i = 0; i < 2; i++) {
          *pair_field = {static_cast<double>(i), std::to_string(i)};
          *pair_field2 = {static_cast<double>(i + 1), std::to_string(i + 1)};
@@ -320,9 +320,9 @@ TEST(RNTuple, StdTuple)
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "tuple_ntuple", fileGuard.GetPath());
       auto tuple_field2 =
-         ntuple->GetModel()->GetDefaultEntry()->Get<std::tuple<char, float, std::string, char>>("myTuple2");
+         ntuple->GetModel().GetDefaultEntry()->Get<std::tuple<char, float, std::string, char>>("myTuple2");
       auto tuple_field3 =
-         ntuple->GetModel()->GetDefaultEntry()->Get<std::tuple<int32_t, std::tuple<std::string, char>>>("myTuple3");
+         ntuple->GetModel().GetDefaultEntry()->Get<std::tuple<int32_t, std::tuple<std::string, char>>>("myTuple3");
       for (int i = 0; i < 2; i++) {
          *tuple_field = {'A' + i, static_cast<float>(i), std::to_string(i), '0' + i};
          *tuple_field2 = {'B' + i, static_cast<float>(i), std::to_string(i), '1' + i};
@@ -384,8 +384,8 @@ TEST(RNTuple, StdSet)
       model->AddField(std::move(mySet4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "set_ntuple", fileGuard.GetPath());
-      auto set_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::string>>("mySet3");
-      auto set_field4 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::set<char>>>("mySet4");
+      auto set_field3 = ntuple->GetModel().GetDefaultEntry()->Get<std::set<std::string>>("mySet3");
+      auto set_field4 = ntuple->GetModel().GetDefaultEntry()->Get<std::set<std::set<char>>>("mySet4");
       for (int i = 0; i < 2; i++) {
          *set_field = {static_cast<float>(i), 3.14, 0.42};
          *set_field2 = {
@@ -450,8 +450,8 @@ TEST(RNTuple, StdUnorderedSet)
       model->AddField(std::move(mySet4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "set_ntuple", fileGuard.GetPath());
-      auto set_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::unordered_set<std::string>>("mySet3");
-      auto set_field4 = ntuple->GetModel()->GetDefaultEntry()->Get<std::unordered_set<std::vector<bool>>>("mySet4");
+      auto set_field3 = ntuple->GetModel().GetDefaultEntry()->Get<std::unordered_set<std::string>>("mySet3");
+      auto set_field4 = ntuple->GetModel().GetDefaultEntry()->Get<std::unordered_set<std::vector<bool>>>("mySet4");
       for (int i = 0; i < 2; i++) {
          *set_field = {static_cast<float>(i), 3.14, 0.42};
          *set_field2 = {CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"},
@@ -527,9 +527,9 @@ TEST(RNTuple, StdMap)
       model->AddField(std::move(myMap4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "map_ntuple", fileGuard.GetPath());
-      auto map_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::map<char, std::string>>("myMap3");
+      auto map_field3 = ntuple->GetModel().GetDefaultEntry()->Get<std::map<char, std::string>>("myMap3");
       auto map_field4 =
-         ntuple->GetModel()->GetDefaultEntry()->Get<std::map<float, std::map<char, std::int32_t>>>("myMap4");
+         ntuple->GetModel().GetDefaultEntry()->Get<std::map<float, std::map<char, std::int32_t>>>("myMap4");
       for (int i = 0; i < 2; i++) {
          *map_field = {{"foo", static_cast<float>(i + 0.1)},
                        {"bar", static_cast<float>(i * 0.2)},
@@ -617,9 +617,9 @@ TEST(RNTuple, StdUnorderedMap)
       model->AddField(std::move(myMap4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "map_ntuple", fileGuard.GetPath());
-      auto map_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::unordered_map<char, std::string>>("myMap3");
+      auto map_field3 = ntuple->GetModel().GetDefaultEntry()->Get<std::unordered_map<char, std::string>>("myMap3");
       auto map_field4 =
-         ntuple->GetModel()->GetDefaultEntry()->Get<std::unordered_map<float, std::vector<bool>>>("myMap4");
+         ntuple->GetModel().GetDefaultEntry()->Get<std::unordered_map<float, std::vector<bool>>>("myMap4");
       for (int i = 0; i < 2; i++) {
          *map_field = {{"foo", static_cast<float>(i + 0.1)},
                        {"bar", static_cast<float>(i * 0.2)},
@@ -955,7 +955,7 @@ TEST(RNTuple, StdAtomic)
       model->AddField(RFieldBase::Create("f2", "std::atomic<float>").Unwrap());
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
-      auto f2 = writer->GetModel()->GetDefaultEntry()->Get<std::atomic<float>>("f2");
+      auto f2 = writer->GetModel().GetDefaultEntry()->Get<std::atomic<float>>("f2");
       for (int i = 0; i < 2; i++) {
          *f1 = i % 2 == 0;
          *f2 = static_cast<float>(i);
@@ -1058,30 +1058,30 @@ TYPED_TEST(UniquePtr, Basics)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
 
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDefault>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsDense());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldSparse>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PIOConstructor")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PPString")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsSparse());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDense>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PIOConstructor")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PPString")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsDense());
       }
 
-      auto pBool = writer->GetModel()->Get<std::unique_ptr<bool>>("PBool");
-      auto pCustomStruct = writer->GetModel()->Get<std::unique_ptr<CustomStruct>>("PCustomStruct");
-      auto pIOConstructor = writer->GetModel()->Get<std::unique_ptr<IOConstructor>>("PIOConstructor");
-      auto ppString = writer->GetModel()->Get<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
-      auto pArray = writer->GetModel()->Get<std::unique_ptr<std::array<char, 2>>>("PArray");
+      auto pBool = writer->GetModel().Get<std::unique_ptr<bool>>("PBool");
+      auto pCustomStruct = writer->GetModel().Get<std::unique_ptr<CustomStruct>>("PCustomStruct");
+      auto pIOConstructor = writer->GetModel().Get<std::unique_ptr<IOConstructor>>("PIOConstructor");
+      auto ppString = writer->GetModel().Get<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
+      auto pArray = writer->GetModel().Get<std::unique_ptr<std::array<char, 2>>>("PArray");
 
       *pBool = std::make_unique<bool>(true);
       EXPECT_EQ(nullptr, pCustomStruct->get());
@@ -1202,8 +1202,8 @@ TEST(RNTuple, Casting)
    modelA->AddField(std::move(fldF));
    {
       auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
-      *writer->GetModel()->GetDefaultEntry()->Get<std::int32_t>("i1") = 42;
-      *writer->GetModel()->GetDefaultEntry()->Get<std::int32_t>("i2") = 137;
+      *writer->GetModel().GetDefaultEntry()->Get<std::int32_t>("i1") = 42;
+      *writer->GetModel().GetDefaultEntry()->Get<std::int32_t>("i2") = 137;
       writer->Fill();
    }
 
@@ -1258,8 +1258,8 @@ TEST(RNTuple, HalfPrecisionFloat)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto f1 = writer->GetModel()->GetDefaultEntry()->Get<float>("f1");
-      auto fVec = writer->GetModel()->GetDefaultEntry()->Get<std::vector<float>>("fVec");
+      auto f1 = writer->GetModel().GetDefaultEntry()->Get<float>("f1");
+      auto fVec = writer->GetModel().GetDefaultEntry()->Get<std::vector<float>>("fVec");
       *f1 = 0.1f;
       *fVec = {0.1f, 0.2f};
       writer->Fill();
@@ -1305,8 +1305,8 @@ TEST(RNTuple, Double32)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto d1 = writer->GetModel()->GetDefaultEntry()->Get<double>("d1");
-      auto d2 = writer->GetModel()->GetDefaultEntry()->Get<double>("d2");
+      auto d1 = writer->GetModel().GetDefaultEntry()->Get<double>("d1");
+      auto d2 = writer->GetModel().GetDefaultEntry()->Get<double>("d2");
       *d1 = 0.0;
       *d2 = 0.0;
       writer->Fill();
@@ -1654,9 +1654,9 @@ TEST(RNTuple, TVirtualCollectionProxy)
       auto fieldNested = model->MakeField<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>>("nested");
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
-      auto fieldC = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<char>>("C");
-      auto fieldF = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<float>>("F");
-      auto fieldS = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<CustomStruct>>("S");
+      auto fieldC = ntuple->GetModel().GetDefaultEntry()->Get<StructUsingCollectionProxy<char>>("C");
+      auto fieldF = ntuple->GetModel().GetDefaultEntry()->Get<StructUsingCollectionProxy<float>>("F");
+      auto fieldS = ntuple->GetModel().GetDefaultEntry()->Get<StructUsingCollectionProxy<CustomStruct>>("S");
       for (unsigned i = 0; i < 1000; ++i) {
          if ((i % 100) == 0) {
             fieldC->v.clear();

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -78,7 +78,7 @@ void Convert() {
    // The new ntuple takes ownership of the model
    auto ntuple = RNTupleWriter::Recreate(std::move(model), "DecayTree", kNTupleFileName);
 
-   auto entry = ntuple->GetModel()->CreateEntry();
+   auto entry = ntuple->GetModel().CreateEntry();
    for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
       auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can


### PR DESCRIPTION
A context is responsible for preparing a cluster, and will be the unit of parallelisation for concurrent writing. Also has a commit to return `const` reference from `RNTupleWriter::GetModel()`.