### PR TITLE
[ntuple] Pass RClusterIndex by value

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -101,7 +101,7 @@ public:
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
-   void ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex, void *to) final
+   void ReadInClusterImpl(ROOT::Experimental::RClusterIndex clusterIndex, void *to) final
    {
       RClusterIndex collectionStart;
       ClusterSize_t size;
@@ -127,7 +127,7 @@ private:
    void GenerateColumnsImpl() final { assert(false && "RArraySizeField fields must only be used for reading"); }
    void GenerateColumnsImpl(const ROOT::Experimental::RNTupleDescriptor &) final {}
    void ReadGlobalImpl(NTupleSize_t /*globalIndex*/, void *to) final { *static_cast<std::size_t *>(to) = fArrayLength; }
-   void ReadInClusterImpl(const RClusterIndex & /*clusterIndex*/, void *to) final
+   void ReadInClusterImpl(RClusterIndex /*clusterIndex*/, void *to) final
    {
       *static_cast<std::size_t *>(to) = fArrayLength;
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -174,7 +174,7 @@ public:
       std::memcpy(to, from, elemSize);
    }
 
-   void Read(const RClusterIndex &clusterIndex, void *to)
+   void Read(RClusterIndex clusterIndex, void *to)
    {
       if (!fReadPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
@@ -204,7 +204,7 @@ public:
       }
    }
 
-   void ReadV(const RClusterIndex &clusterIndex, const ClusterSize_t::ValueType count, void *to)
+   void ReadV(RClusterIndex clusterIndex, const ClusterSize_t::ValueType count, void *to)
    {
       if (!fReadPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
@@ -230,7 +230,8 @@ public:
    }
 
    template <typename CppT>
-   CppT *Map(const RClusterIndex &clusterIndex) {
+   CppT *Map(RClusterIndex clusterIndex)
+   {
       NTupleSize_t nItems;
       return MapV<CppT>(clusterIndex, nItems);
    }
@@ -248,7 +249,8 @@ public:
    }
 
    template <typename CppT>
-   CppT *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   CppT *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       if (!fReadPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
       }
@@ -259,7 +261,8 @@ public:
          (clusterIndex.GetIndex() - fReadPage.GetClusterRangeFirst()) * RColumnElement<CppT>::kSize);
    }
 
-   NTupleSize_t GetGlobalIndex(const RClusterIndex &clusterIndex) {
+   NTupleSize_t GetGlobalIndex(RClusterIndex clusterIndex)
+   {
       if (!fReadPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
       }
@@ -298,8 +301,7 @@ public:
       *collectionStart = RClusterIndex(fReadPage.GetClusterInfo().GetId(), idxStart);
    }
 
-   void GetCollectionInfo(const RClusterIndex &clusterIndex,
-                          RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
    {
       auto index = clusterIndex.GetIndex();
       auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t>(clusterIndex - 1);
@@ -317,7 +319,7 @@ public:
 
    void Flush();
    void MapPage(const NTupleSize_t index);
-   void MapPage(const RClusterIndex &clusterIndex);
+   void MapPage(RClusterIndex clusterIndex);
    NTupleSize_t GetNElements() const { return fNElements; }
    RColumnElementBase *GetElement() const { return fElement.get(); }
    const RColumnModel &GetModel() const { return fModel; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -184,7 +184,7 @@ public:
 
       std::size_t Append() { return fField->Append(fObjPtr); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr); }
-      void Read(const RClusterIndex &clusterIndex) { fField->Read(clusterIndex, fObjPtr); }
+      void Read(RClusterIndex clusterIndex) { fField->Read(clusterIndex, fObjPtr); }
       void Bind(void *objPtr)
       {
          DestroyIfOwning();
@@ -226,10 +226,10 @@ public:
       void ReleaseValues();
       /// Sets a new range for the bulk. If there is enough capacity, the fValues array will be reused.
       /// Otherwise a new array is allocated. After reset, fMaskAvail is false for all values.
-      void Reset(const RClusterIndex &firstIndex, std::size_t size);
+      void Reset(RClusterIndex firstIndex, std::size_t size);
       void CountValidValues();
 
-      bool ContainsRange(const RClusterIndex &firstIndex, std::size_t size) const
+      bool ContainsRange(RClusterIndex firstIndex, std::size_t size) const
       {
          if (firstIndex.GetClusterId() != fFirstIndex.GetClusterId())
             return false;
@@ -255,7 +255,7 @@ public:
       /// relative to a certain cluster. The return value points to the array of read objects.
       /// The 'maskReq' parameter is a bool array of at least 'size' elements. Only objects for which the mask is
       /// true are guaranteed to be read in the returned value array.
-      void *ReadBulk(const RClusterIndex &firstIndex, const bool *maskReq, std::size_t size)
+      void *ReadBulk(RClusterIndex firstIndex, const bool *maskReq, std::size_t size)
       {
          if (!ContainsRange(firstIndex, size))
             Reset(firstIndex, size);
@@ -400,7 +400,7 @@ protected:
    /// column type exists.
    virtual std::size_t AppendImpl(const void *from);
    virtual void ReadGlobalImpl(NTupleSize_t globalIndex, void *to);
-   virtual void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
+   virtual void ReadInClusterImpl(RClusterIndex clusterIndex, void *to)
    {
       ReadGlobalImpl(fPrincipalColumn->GetGlobalIndex(clusterIndex), to);
    }
@@ -432,7 +432,7 @@ protected:
          InvokeReadCallbacks(to);
    }
 
-   void Read(const RClusterIndex &clusterIndex, void *to)
+   void Read(RClusterIndex clusterIndex, void *to)
    {
       if (fIsSimple)
          return (void)fPrincipalColumn->Read(clusterIndex, to);
@@ -467,10 +467,7 @@ protected:
 
    /// Allow derived classes to call Append and Read on other (sub) fields.
    static std::size_t CallAppendOn(RFieldBase &other, const void *from) { return other.Append(from); }
-   static void CallReadOn(RFieldBase &other, const RClusterIndex &clusterIndex, void *to)
-   {
-      other.Read(clusterIndex, to);
-   }
+   static void CallReadOn(RFieldBase &other, RClusterIndex clusterIndex, void *to) { other.Read(clusterIndex, to); }
    static void CallReadOn(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
 
    /// Fields may need direct access to the principal column of their sub fields, e.g. in RRVecField::ReadBulk
@@ -715,7 +712,7 @@ protected:
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
    void OnConnectPageSource() final;
 
 public:
@@ -747,10 +744,7 @@ protected:
 
    std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final
-   {
-      CallReadOn(*fSubFields[0], clusterIndex, to);
-   }
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final { CallReadOn(*fSubFields[0], clusterIndex, to); }
 
 public:
    REnumField(std::string_view fieldName, std::string_view enumName);
@@ -891,7 +885,7 @@ public:
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
@@ -917,7 +911,7 @@ protected:
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
 
    RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &&itemFields,
                 const std::vector<std::size_t> &offsets, std::string_view typeName = "");
@@ -987,7 +981,8 @@ public:
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const {
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
 };
@@ -1030,7 +1025,7 @@ public:
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
@@ -1053,7 +1048,7 @@ protected:
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
 
 public:
    RArrayField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField, std::size_t arrayLength);
@@ -1092,7 +1087,7 @@ protected:
    void DestroyValue(void *objPtr, bool dtorOnly = false) const final;
 
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
 
 public:
    /**
@@ -1311,10 +1306,7 @@ protected:
 
    std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final
-   {
-      CallReadOn(*fSubFields[0], clusterIndex, to);
-   }
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final { CallReadOn(*fSubFields[0], clusterIndex, to); }
 
 public:
    RAtomicField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<Detail::RFieldBase> itemField);
@@ -1583,13 +1575,12 @@ public:
    ClusterSize_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<ClusterSize_t>(globalIndex);
    }
-   ClusterSize_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<ClusterSize_t>(clusterIndex);
-   }
+   ClusterSize_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<ClusterSize_t>(clusterIndex); }
    ClusterSize_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<ClusterSize_t>(globalIndex, nItems);
    }
-   ClusterSize_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   ClusterSize_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<ClusterSize_t>(clusterIndex, nItems);
    }
 
@@ -1601,7 +1592,8 @@ public:
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) {
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size)
+   {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -1637,7 +1629,7 @@ public:
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
-   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final
    {
       RClusterIndex collectionStart;
       ClusterSize_t size;
@@ -1698,13 +1690,12 @@ public:
    bool *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<bool>(globalIndex);
    }
-   bool *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<bool>(clusterIndex);
-   }
+   bool *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<bool>(clusterIndex); }
    bool *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<bool>(globalIndex, nItems);
    }
-   bool *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   bool *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<bool>(clusterIndex, nItems);
    }
 
@@ -1740,13 +1731,12 @@ public:
    float *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<float>(globalIndex);
    }
-   float *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<float>(clusterIndex);
-   }
+   float *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<float>(clusterIndex); }
    float *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<float>(globalIndex, nItems);
    }
-   float *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   float *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<float>(clusterIndex, nItems);
    }
 
@@ -1784,13 +1774,12 @@ public:
    double *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<double>(globalIndex);
    }
-   double *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<double>(clusterIndex);
-   }
+   double *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<double>(clusterIndex); }
    double *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<double>(globalIndex, nItems);
    }
-   double *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   double *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<double>(clusterIndex, nItems);
    }
 
@@ -1828,12 +1817,12 @@ public:
    ~RField() override = default;
 
    std::byte *Map(NTupleSize_t globalIndex) { return fPrincipalColumn->Map<std::byte>(globalIndex); }
-   std::byte *Map(const RClusterIndex &clusterIndex) { return fPrincipalColumn->Map<std::byte>(clusterIndex); }
+   std::byte *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::byte>(clusterIndex); }
    std::byte *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems)
    {
       return fPrincipalColumn->MapV<std::byte>(globalIndex, nItems);
    }
-   std::byte *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems)
+   std::byte *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
    {
       return fPrincipalColumn->MapV<std::byte>(clusterIndex, nItems);
    }
@@ -1870,13 +1859,12 @@ public:
    char *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<char>(globalIndex);
    }
-   char *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<char>(clusterIndex);
-   }
+   char *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<char>(clusterIndex); }
    char *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<char>(globalIndex, nItems);
    }
-   char *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   char *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<char>(clusterIndex, nItems);
    }
 
@@ -1912,13 +1900,12 @@ public:
    std::int8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int8_t>(globalIndex);
    }
-   std::int8_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int8_t>(clusterIndex);
-   }
+   std::int8_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::int8_t>(clusterIndex); }
    std::int8_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::int8_t>(globalIndex, nItems);
    }
-   std::int8_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::int8_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::int8_t>(clusterIndex, nItems);
    }
 
@@ -1954,13 +1941,12 @@ public:
    std::uint8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint8_t>(globalIndex);
    }
-   std::uint8_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint8_t>(clusterIndex);
-   }
+   std::uint8_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::uint8_t>(clusterIndex); }
    std::uint8_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::uint8_t>(globalIndex, nItems);
    }
-   std::uint8_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::uint8_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::uint8_t>(clusterIndex, nItems);
    }
 
@@ -1996,13 +1982,12 @@ public:
    std::int16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int16_t>(globalIndex);
    }
-   std::int16_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int16_t>(clusterIndex);
-   }
+   std::int16_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::int16_t>(clusterIndex); }
    std::int16_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::int16_t>(globalIndex, nItems);
    }
-   std::int16_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::int16_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::int16_t>(clusterIndex, nItems);
    }
 
@@ -2038,13 +2023,12 @@ public:
    std::uint16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint16_t>(globalIndex);
    }
-   std::uint16_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint16_t>(clusterIndex);
-   }
+   std::uint16_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::uint16_t>(clusterIndex); }
    std::uint16_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::uint16_t>(globalIndex, nItems);
    }
-   std::uint16_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::uint16_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::uint16_t>(clusterIndex, nItems);
    }
 
@@ -2080,13 +2064,12 @@ public:
    std::int32_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int32_t>(globalIndex);
    }
-   std::int32_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int32_t>(clusterIndex);
-   }
+   std::int32_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::int32_t>(clusterIndex); }
    std::int32_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::int32_t>(globalIndex, nItems);
    }
-   std::int32_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::int32_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::int32_t>(clusterIndex, nItems);
    }
 
@@ -2128,7 +2111,8 @@ public:
    std::uint32_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::uint32_t>(globalIndex, nItems);
    }
-   std::uint32_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::uint32_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::uint32_t>(clusterIndex, nItems);
    }
 
@@ -2164,13 +2148,12 @@ public:
    std::uint64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint64_t>(globalIndex);
    }
-   std::uint64_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint64_t>(clusterIndex);
-   }
+   std::uint64_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::uint64_t>(clusterIndex); }
    std::uint64_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::uint64_t>(globalIndex, nItems);
    }
-   std::uint64_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::uint64_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::uint64_t>(clusterIndex, nItems);
    }
 
@@ -2206,13 +2189,12 @@ public:
    std::int64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int64_t>(globalIndex);
    }
-   std::int64_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int64_t>(clusterIndex);
-   }
+   std::int64_t *Map(RClusterIndex clusterIndex) { return fPrincipalColumn->Map<std::int64_t>(clusterIndex); }
    std::int64_t *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems) {
       return fPrincipalColumn->MapV<std::int64_t>(globalIndex, nItems);
    }
-   std::int64_t *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems) {
+   std::int64_t *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
       return fPrincipalColumn->MapV<std::int64_t>(clusterIndex, nItems);
    }
 
@@ -2498,7 +2480,7 @@ public:
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -121,10 +121,8 @@ public:
    RClusterIndex  operator-(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex - off); }
    RClusterIndex  operator++(int) /* postfix */        { auto r = *this; fIndex++; return r; }
    RClusterIndex& operator++()    /* prefix */         { ++fIndex; return *this; }
-   bool operator==(const RClusterIndex &other) const {
-      return fClusterId == other.fClusterId && fIndex == other.fIndex;
-   }
-   bool operator!=(const RClusterIndex &other) const { return !(*this == other); }
+   bool operator==(RClusterIndex other) const { return fClusterId == other.fClusterId && fIndex == other.fIndex; }
+   bool operator!=(RClusterIndex other) const { return !(*this == other); }
 
    DescriptorId_t GetClusterId() const { return fClusterId; }
    ClusterSize_t::ValueType GetIndex() const { return fIndex; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -96,7 +96,7 @@ public:
       using reference = RClusterIndex&;
 
       RIterator() = default;
-      explicit RIterator(const RClusterIndex &index) : fIndex(index) {}
+      explicit RIterator(RClusterIndex index) : fIndex(index) {}
       ~RIterator() = default;
 
       iterator  operator++(int) /* postfix */        { auto r = *this; fIndex++; return r; }
@@ -186,7 +186,7 @@ public:
       }
    }
 
-   const T &operator()(const RClusterIndex &clusterIndex)
+   const T &operator()(RClusterIndex clusterIndex)
    {
       if constexpr (Internal::isMappable<FieldT>)
          return *fField.Map(clusterIndex);
@@ -204,8 +204,8 @@ public:
    }
 
    // TODO(bgruber): turn enable_if into requires clause with C++20
-   template <typename C = T, std::enable_if_t<Internal::isMappable<FieldT>, C*> = nullptr>
-   const C *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems)
+   template <typename C = T, std::enable_if_t<Internal::isMappable<FieldT>, C *> = nullptr>
+   const C *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
    {
       return fField.MapV(clusterIndex, nItems);
    }
@@ -246,7 +246,8 @@ public:
       return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndex(),
                                  collectionStart.GetIndex() + size);
    }
-   RNTupleClusterRange GetCollectionRange(const RClusterIndex &clusterIndex) {
+   RNTupleClusterRange GetCollectionRange(RClusterIndex clusterIndex)
+   {
       ClusterSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(clusterIndex, &collectionStart, &size);
@@ -280,7 +281,8 @@ public:
       fField.GetCollectionInfo(globalIndex, &collectionStart, &size);
       return size;
    }
-   ClusterSize_t operator()(const RClusterIndex &clusterIndex) {
+   ClusterSize_t operator()(RClusterIndex clusterIndex)
+   {
       ClusterSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(clusterIndex, &collectionStart, &size);

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -97,13 +97,14 @@ public:
       return (globalIndex >= fRangeFirst) && (globalIndex < fRangeFirst + NTupleSize_t(fNElements));
    }
 
-   bool Contains(const RClusterIndex &clusterIndex) const {
+   bool Contains(RClusterIndex clusterIndex) const
+   {
       if (fClusterInfo.GetId() != clusterIndex.GetClusterId())
          return false;
       auto clusterRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetIndexOffset());
       return (clusterIndex.GetIndex() >= clusterRangeFirst) &&
              (clusterIndex.GetIndex() < clusterRangeFirst + fNElements);
-    }
+   }
 
    void* GetBuffer() const { return fBuffer; }
    /// Called during writing: returns a pointer after the last element and increases the element counter

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -70,7 +70,7 @@ public:
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
    Detail::RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);
-   Detail::RPage GetPage(ColumnId_t columnId, const RClusterIndex &clusterIndex);
+   Detail::RPage GetPage(ColumnId_t columnId, RClusterIndex clusterIndex);
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in
    /// during registration.

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -96,11 +96,10 @@ public:
    void DropColumn(ColumnHandle_t columnHandle) final;
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
-   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void
-   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
+   void LoadSealedPage(DescriptorId_t physicalColumnId, RClusterIndex clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -524,7 +524,7 @@ public:
    /// Allocates and fills a page that contains the index-th element
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;
    /// Another version of PopulatePage that allows to specify cluster-relative indexes
-   virtual RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) = 0;
+   virtual RPage PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex) = 0;
 
    /// Read the packed and compressed bytes of a page into the memory buffer provided by selaedPage. The sealed page
    /// can be used subsequently in a call to RPageSink::CommitSealedPage.
@@ -532,7 +532,7 @@ public:
    /// no data will be copied but the returned size information can be used by the caller to allocate a large enough
    /// buffer and call LoadSealedPage again.
    virtual void
-   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) = 0;
+   LoadSealedPage(DescriptorId_t physicalColumnId, RClusterIndex clusterIndex, RSealedPage &sealedPage) = 0;
 
    /// Populates all the pages of the given cluster ids and columns; it is possible that some columns do not
    /// contain any pages.  The page source may load more columns than the minimal necessary set from `columns`.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -195,11 +195,10 @@ public:
    ~RPageSourceDaos() override;
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
-   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void
-   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
+   void LoadSealedPage(DescriptorId_t physicalColumnId, RClusterIndex clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -164,11 +164,10 @@ public:
    ~RPageSourceFile() override;
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
-   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void
-   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
+   void LoadSealedPage(DescriptorId_t physicalColumnId, RClusterIndex clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 };

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -99,7 +99,7 @@ void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
    R__ASSERT(fReadPage.Contains(index));
 }
 
-void ROOT::Experimental::Detail::RColumn::MapPage(const RClusterIndex &clusterIndex)
+void ROOT::Experimental::Detail::RColumn::MapPage(RClusterIndex clusterIndex)
 {
    fPageSource->ReleasePage(fReadPage);
    // Set fReadPage to an empty page before populating it to prevent double destruction of the previously page in case

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -366,7 +366,7 @@ void ROOT::Experimental::Detail::RFieldBase::RBulk::ReleaseValues()
    free(fValues);
 }
 
-void ROOT::Experimental::Detail::RFieldBase::RBulk::Reset(const RClusterIndex &firstIndex, std::size_t size)
+void ROOT::Experimental::Detail::RFieldBase::RBulk::Reset(RClusterIndex firstIndex, std::size_t size)
 {
    if (fCapacity < size) {
       ReleaseValues();
@@ -1516,7 +1516,7 @@ void ROOT::Experimental::RClassField::ReadGlobalImpl(NTupleSize_t globalIndex, v
    }
 }
 
-void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
+void ROOT::Experimental::RClassField::ReadInClusterImpl(RClusterIndex clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); i++) {
       CallReadOn(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
@@ -1912,7 +1912,7 @@ void ROOT::Experimental::RRecordField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 }
 
-void ROOT::Experimental::RRecordField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
+void ROOT::Experimental::RRecordField::ReadInClusterImpl(RClusterIndex clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
       CallReadOn(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
@@ -2455,7 +2455,7 @@ void ROOT::Experimental::RArrayField::ReadGlobalImpl(NTupleSize_t globalIndex, v
    }
 }
 
-void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
+void ROOT::Experimental::RArrayField::ReadInClusterImpl(RClusterIndex clusterIndex, void *to)
 {
    auto arrayPtr = static_cast<unsigned char *>(to);
    for (unsigned i = 0; i < fArrayLength; ++i) {
@@ -2607,8 +2607,7 @@ void ROOT::Experimental::RArrayAsRVecField::ReadGlobalImpl(ROOT::Experimental::N
    }
 }
 
-void ROOT::Experimental::RArrayAsRVecField::ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex,
-                                                              void *to)
+void ROOT::Experimental::RArrayAsRVecField::ReadInClusterImpl(ROOT::Experimental::RClusterIndex clusterIndex, void *to)
 {
    auto [beginPtr, _, __] = GetRVecDataMembers(to);
    auto rvecBeginPtr = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -77,7 +77,7 @@ ROOT::Experimental::Internal::RPagePool::GetPage(ColumnId_t columnId, NTupleSize
 }
 
 ROOT::Experimental::Detail::RPage
-ROOT::Experimental::Internal::RPagePool::GetPage(ColumnId_t columnId, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Internal::RPagePool::GetPage(ColumnId_t columnId, RClusterIndex clusterIndex)
 {
    std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -166,10 +166,8 @@ ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
    return page;
 }
 
-
 ROOT::Experimental::Detail::RPage
-ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
-   ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex)
 {
    auto virtualColumnId = columnHandle.fPhysicalId;
    auto originColumnId = fIdBiMap.GetOriginId(virtualColumnId);
@@ -185,8 +183,7 @@ ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
 }
 
 void ROOT::Experimental::Detail::RPageSourceFriends::LoadSealedPage(DescriptorId_t physicalColumnId,
-                                                                    const RClusterIndex &clusterIndex,
-                                                                    RSealedPage &sealedPage)
+                                                                    RClusterIndex clusterIndex, RSealedPage &sealedPage)
 {
    auto originColumnId = fIdBiMap.GetOriginId(physicalColumnId);
    RClusterIndex originClusterIndex(

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -564,8 +564,7 @@ std::string ROOT::Experimental::Detail::RPageSourceDaos::GetObjectClass() const
 }
 
 void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(DescriptorId_t physicalColumnId,
-                                                                 const RClusterIndex &clusterIndex,
-                                                                 RSealedPage &sealedPage)
+                                                                 RClusterIndex clusterIndex, RSealedPage &sealedPage)
 {
    const auto clusterId = clusterIndex.GetClusterId();
 
@@ -694,8 +693,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnH
 }
 
 ROOT::Experimental::Detail::RPage
-ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnHandle,
-                                                          const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex)
 {
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -319,8 +319,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
 }
 
 void ROOT::Experimental::Detail::RPageSourceFile::LoadSealedPage(DescriptorId_t physicalColumnId,
-                                                                 const RClusterIndex &clusterIndex,
-                                                                 RSealedPage &sealedPage)
+                                                                 RClusterIndex clusterIndex, RSealedPage &sealedPage)
 {
    const auto clusterId = clusterIndex.GetClusterId();
 
@@ -435,9 +434,8 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
    return PopulatePageFromCluster(columnHandle, clusterInfo, idxInCluster);
 }
 
-
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::PopulatePage(
-   ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSourceFile::PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex)
 {
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -77,11 +77,9 @@ public:
    }
    std::unique_ptr<RPageSource> Clone() const final { return nullptr; }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::NTupleSize_t) final { return RPage(); }
-   RPage PopulatePage(ColumnHandle_t, const ROOT::Experimental::RClusterIndex &) final { return RPage(); }
+   RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPage(); }
    void ReleasePage(RPage &) final {}
-   void LoadSealedPage(
-      ROOT::Experimental::DescriptorId_t, const ROOT::Experimental::RClusterIndex &, RSealedPage &) final
-   { }
+   void LoadSealedPage(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::RClusterIndex, RSealedPage &) final {}
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final
    {
       std::vector<std::unique_ptr<RCluster>> result;

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -88,12 +88,9 @@ public:
    {
       return RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId);
    }
-   RPage PopulatePage(ColumnHandle_t, const ROOT::Experimental::RClusterIndex &) final { return RPage(); }
+   RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPage(); }
    void ReleasePage(RPage &) final {}
-   void
-   LoadSealedPage(ROOT::Experimental::DescriptorId_t, const ROOT::Experimental::RClusterIndex &, RSealedPage &) final
-   {
-   }
+   void LoadSealedPage(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::RClusterIndex, RSealedPage &) final {}
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey>) final { return {}; }
 };
 } // anonymous namespace


### PR DESCRIPTION
This follows the C++ Core Guidelines item F.16, 'For "in" parameters, pass cheaply-copied types by value and others by reference to const.' `RClusterIndex` consists of two 64-bit values which for most recent platforms with 64-bit pointers is cheap to copy and better to pass in two registers instead of passing a pointer to stack memory. This in turn helps some recursive calls in RNTuple, for example `RColumn::ReadV` (at the moment of writing).

In numbers, this scores a single-digit performance improvement in the usual ATLAS analysis benchmark, -5% analysis runtime on my system. The other usual benchmarks show no changes beyond fluctuations.

This changes was prepared by running
```
 $ git grep -l "RClusterIndex &" | xargs sed -i "s/const \(ROOT::Experimental::\)\?RClusterIndex &/\\1RClusterIndex /g"
```
then reverting the change in `RNTupleUtil.hxx` for the copy-constructor and copy-assignment operator, and finally running clang-format.