### PR TITLE
[ntuple] remove REntry::GetRawPtr()

### DIFF
--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -83,7 +83,7 @@ void Convert() {
       auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
-      void *fieldDataPtr = entry->GetRawPtr(l->GetName());
+      void *fieldDataPtr = entry->Get<void>(l->GetName());
       tree->SetBranchAddress(b->GetName(), fieldDataPtr);
    }
 


### PR DESCRIPTION
Can be replaced by `REntry::Get<void>` where needed.