### PR TITLE
[ntuple] use shared pointer in RFieldBase::RValue

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -26,6 +26,7 @@
 #include <TError.h>
 
 #include <cassert>
+#include <memory>
 #include <string>
 #include <vector>
 #include <typeinfo>
@@ -158,7 +159,7 @@ class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    RFieldBase *fProtoField;                    ///< The prototype field from which fField is cloned
    std::unique_ptr<RFieldBase> fField;         ///< The field backing the RDF column
    std::unique_ptr<RFieldBase::RValue> fValue; ///< The memory location used to read from fField
-   void *fValuePtr = nullptr;                  ///< Used to reuse the object created by fValue when reconnecting sources
+   std::shared_ptr<void> fValuePtr;            ///< Used to reuse the object created by fValue when reconnecting sources
    Long64_t fLastEntry = -1;                   ///< Last entry number that was read
    /// For chains, the logical entry and the physical entry in any particular file can be different.
    /// The entry offset stores the logical entry number (sum of all previous physical entries) when a file of the corresponding
@@ -195,8 +196,8 @@ public:
 
       if (fValuePtr) {
          // When the reader reconnects to a new file, the fValuePtr is already set
-         fValue = std::make_unique<RFieldBase::RValue>(fField->BindValue(fValuePtr));
-         fValue->TakeOwnership();
+         fValue = std::make_unique<RFieldBase::RValue>(fField->BindValue(fValuePtr.get()));
+         fValue->Bind(fValuePtr);
          fValuePtr = nullptr;
       } else {
          // For the first file, create a new object for this field (reader)
@@ -207,7 +208,7 @@ public:
    void Disconnect(bool keepValue)
    {
       if (fValue && keepValue) {
-         fValuePtr = fValue->Release<void>();
+         fValuePtr = fValue->GetPtr();
       }
       fValue = nullptr;
       fField = nullptr;

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -95,7 +95,11 @@ public:
    REntry &operator=(REntry &&other) = default;
    ~REntry() = default;
 
-   void CaptureValueUnsafe(std::string_view fieldName, void *where);
+   void BindValue(std::string_view fieldName, std::shared_ptr<void> objPtr);
+   void BindRawPtr(std::string_view fieldName, void *rawPtr)
+   {
+      BindValue(fieldName, std::shared_ptr<void>(rawPtr, [](void *) {}));
+   }
 
    template <typename T>
    T *Get(std::string_view fieldName) const

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -190,7 +190,7 @@ public:
 
       std::size_t Append() { return fField->Append(fObjPtr.get()); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }
-      void Read(const RClusterIndex &clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
+      void Read(RClusterIndex clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
       void Bind(std::shared_ptr<void> objPtr) { fObjPtr = objPtr; }
 
       std::shared_ptr<void> GetPtr() const { return fObjPtr; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -197,13 +197,11 @@ public:
       }
 
    public:
-      RValue(const RValue &) = delete;
-      RValue &operator=(const RValue &) = delete;
+      RValue(const RValue &) = default;
+      RValue &operator=(const RValue &) = default;
       RValue(RValue &&other) = default;
       RValue &operator=(RValue &&other) = default;
       ~RValue() = default;
-
-      RValue GetNonOwningCopy() const { return RValue(fField, fObjPtr.get(), false); }
 
       std::size_t Append() { return fField->Append(fObjPtr.get()); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -185,14 +185,11 @@ public:
       RFieldBase *fField = nullptr; ///< The field that created the RValue
       /// Created by RFieldBase::GenerateValue(), SplitValue() or BindValue()
       std::shared_ptr<void> fObjPtr;
-      bool fIsOwning = false; ///< If true, fObjPtr is destroyed in the destructor
 
       RValue(RFieldBase *field, void *objPtr, bool isOwning)
-         : fField(field),
-           fObjPtr(std::shared_ptr<void>(objPtr, RSharedPtrDeleter(fField->GetDeleter()))),
-           fIsOwning(isOwning)
+         : fField(field), fObjPtr(std::shared_ptr<void>(objPtr, RSharedPtrDeleter(fField->GetDeleter())))
       {
-         if (!fIsOwning)
+         if (!isOwning)
             std::get_deleter<RSharedPtrDeleter>(fObjPtr)->fDontDelete = true;
       }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -205,20 +205,12 @@ public:
 
       RValue GetNonOwningCopy() const { return RValue(fField, fObjPtr.get(), false); }
 
-      template <typename T>
-      void *Release()
-      {
-         std::get_deleter<RSharedPtrDeleter>(fObjPtr)->fDontDelete = true;
-         void *result = fObjPtr.get();
-         fObjPtr = nullptr;
-         return static_cast<T *>(result);
-      }
-      void TakeOwnership() { std::get_deleter<RSharedPtrDeleter>(fObjPtr)->fDontDelete = false; }
-
       std::size_t Append() { return fField->Append(fObjPtr.get()); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }
       void Read(const RClusterIndex &clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
       void Bind(std::shared_ptr<void> objPtr) { fObjPtr = objPtr; }
+
+      std::shared_ptr<void> GetPtr() const { return fObjPtr; }
 
       template <typename T>
       T *Get() const

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -218,10 +218,7 @@ public:
       std::size_t Append() { return fField->Append(fObjPtr.get()); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }
       void Read(const RClusterIndex &clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
-      void Bind(void *objPtr)
-      {
-         fObjPtr = std::shared_ptr<void>(objPtr, [](void *) {});
-      }
+      void Bind(std::shared_ptr<void> objPtr) { fObjPtr = objPtr; }
 
       template <typename T>
       T *Get() const

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -191,9 +191,9 @@ private:
    void PrintCollection(const Detail::RFieldBase &field);
 
 public:
-   RPrintValueVisitor(Detail::RFieldBase::RValue &&value, std::ostream &output, unsigned int level = 0,
+   RPrintValueVisitor(Detail::RFieldBase::RValue value, std::ostream &output, unsigned int level = 0,
                       RPrintOptions options = RPrintOptions())
-      : fValue(std::move(value)), fOutput{output}, fLevel(level), fPrintOptions(options)
+      : fValue(value), fOutput{output}, fLevel(level), fPrintOptions(options)
    {
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -322,7 +322,7 @@ public:
       std::unique_ptr<RNTupleModel> collectionModel);
 
    std::unique_ptr<REntry> CreateEntry() const;
-   /// In a bare entry, all values point to nullptr. The resulting entry shall use CaptureValueUnsafe() in order
+   /// In a bare entry, all values point to nullptr. The resulting entry shall use BindValue() in order
    /// set memory addresses to be serialized / deserialized
    std::unique_ptr<REntry> CreateBareEntry() const;
    REntry *GetDefaultEntry() const;

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -17,7 +17,6 @@
 #include <ROOT/RError.hxx>
 
 #include <algorithm>
-#include <memory>
 
 void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
 {

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -17,6 +17,7 @@
 #include <ROOT/RError.hxx>
 
 #include <algorithm>
+#include <memory>
 
 void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
 {
@@ -28,7 +29,7 @@ void ROOT::Experimental::REntry::CaptureValueUnsafe(std::string_view fieldName, 
    for (std::size_t i = 0; i < fValues.size(); ++i) {
       if (fValues[i].GetField().GetName() != fieldName)
          continue;
-      fValues[i].Bind(where);
+      fValues[i].Bind(std::shared_ptr<void>(where, [](void *) {}));
       return;
    }
    throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -23,14 +23,3 @@ void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
 {
    fValues.emplace_back(std::move(value));
 }
-
-void ROOT::Experimental::REntry::BindValue(std::string_view fieldName, std::shared_ptr<void> objName)
-{
-   for (std::size_t i = 0; i < fValues.size(); ++i) {
-      if (fValues[i].GetField().GetName() != fieldName)
-         continue;
-      fValues[i].Bind(objName);
-      return;
-   }
-   throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
-}

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -24,12 +24,12 @@ void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
    fValues.emplace_back(std::move(value));
 }
 
-void ROOT::Experimental::REntry::CaptureValueUnsafe(std::string_view fieldName, void *where)
+void ROOT::Experimental::REntry::BindValue(std::string_view fieldName, std::shared_ptr<void> objName)
 {
    for (std::size_t i = 0; i < fValues.size(); ++i) {
       if (fValues[i].GetField().GetName() != fieldName)
          continue;
-      fValues[i].Bind(std::shared_ptr<void>(where, [](void *) {}));
+      fValues[i].Bind(objName);
       return;
    }
    throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -675,7 +675,7 @@ ROOT::Experimental::Detail::RFieldBase::RValue ROOT::Experimental::Detail::RFiel
    void *where = operator new(GetValueSize());
    R__ASSERT(where != nullptr);
    GenerateValue(where);
-   return RValue(this, where, true /* isOwning */);
+   return RValue(this, std::shared_ptr<void>(where, RSharedPtrDeleter(GetDeleter())));
 }
 
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -135,7 +135,7 @@ void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const Detail::RFiel
       RPrintOptions options;
       options.fPrintSingleLine = true;
       options.fPrintName = false;
-      RPrintValueVisitor elemVisitor(iValue->GetNonOwningCopy(), fOutput, 0 /* level */, options);
+      RPrintValueVisitor elemVisitor(*iValue, fOutput, 0 /* level */, options);
       iValue->GetField().AcceptVisitor(elemVisitor);
 
       if (++iValue == elems.end())
@@ -319,7 +319,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &
 
       RPrintOptions options;
       options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
-      RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), fOutput, fLevel + 1, options);
+      RPrintValueVisitor visitor(*iValue, fOutput, fLevel + 1, options);
       iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == elems.end()) {
@@ -349,7 +349,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField
 
       RPrintOptions options;
       options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
-      RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), fOutput, fLevel + 1, options);
+      RPrintValueVisitor visitor(*iValue, fOutput, fLevel + 1, options);
       iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == elems.end()) {
@@ -377,7 +377,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableF
       RPrintOptions options;
       options.fPrintSingleLine = true;
       options.fPrintName = false;
-      RPrintValueVisitor visitor(elems[0].GetNonOwningCopy(), fOutput, fLevel, options);
+      RPrintValueVisitor visitor(elems[0], fOutput, fLevel, options);
       elems[0].GetField().AcceptVisitor(visitor);
    }
 }
@@ -386,11 +386,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &fi
 {
    PrintIndent();
    PrintName(field);
-   auto intValue = field.SplitValue(fValue)[0].GetNonOwningCopy();
+   auto intValue = field.SplitValue(fValue)[0];
    RPrintOptions options;
    options.fPrintSingleLine = true;
    options.fPrintName = false;
-   RPrintValueVisitor visitor(intValue.GetNonOwningCopy(), fOutput, fLevel, options);
+   RPrintValueVisitor visitor(intValue, fOutput, fLevel, options);
    intValue.GetField().AcceptVisitor(visitor);
 }
 
@@ -398,11 +398,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField
 {
    PrintIndent();
    PrintName(field);
-   auto itemValue = field.SplitValue(fValue)[0].GetNonOwningCopy();
+   auto itemValue = field.SplitValue(fValue)[0];
    RPrintOptions options;
    options.fPrintSingleLine = true;
    options.fPrintName = false;
-   RPrintValueVisitor visitor(itemValue.GetNonOwningCopy(), fOutput, fLevel, options);
+   RPrintValueVisitor visitor(itemValue, fOutput, fLevel, options);
    itemValue.GetField().AcceptVisitor(visitor);
 }
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -241,7 +241,7 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, std::ostream &o
    output << "{";
    for (auto iValue = entry->begin(); iValue != entry->end();) {
       output << std::endl;
-      RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), output, 1 /* level */);
+      RPrintValueVisitor visitor(*iValue, output, 1 /* level */);
       iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == entry->end()) {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -650,7 +650,7 @@ TEST(RNTuple, BareEntry)
       auto e2 = model.CreateBareEntry();
       EXPECT_EQ(nullptr, e2->Get<float>("pt"));
       float pt = 2.0;
-      e2->CaptureValueUnsafe("pt", &pt);
+      e2->BindRawPtr("pt", &pt);
 
       ntuple->Fill(*e1);
       ntuple->Fill(*e2);

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -459,9 +459,9 @@ TEST(RNTupleShow, RVecTypeErased)
       ROOT::RVec<CustomStruct> customStructVec{CustomStruct(), {1.f, {2.f, 3.f}, {{4.f}, {5.f}}, "foo", std::byte{0}}};
 
       m->Freeze();
-      m->GetDefaultEntry()->CaptureValueUnsafe("intVec", &intVec);
-      m->GetDefaultEntry()->CaptureValueUnsafe("floatVecVec", &floatVecVec);
-      m->GetDefaultEntry()->CaptureValueUnsafe("customStructVec", &customStructVec);
+      m->GetDefaultEntry()->BindRawPtr("intVec", &intVec);
+      m->GetDefaultEntry()->BindRawPtr("floatVecVec", &floatVecVec);
+      m->GetDefaultEntry()->BindRawPtr("customStructVec", &customStructVec);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(m), ntupleName, rootFileName);
 

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -219,7 +219,7 @@ TEST(RNTuple, RVecTypeErased)
       auto field = RFieldBase::Create("v", "ROOT::VecOps::RVec<int>").Unwrap();
       m->AddField(std::move(field));
       m->Freeze();
-      m->GetDefaultEntry()->CaptureValueUnsafe("v", (void *)&rvec);
+      m->GetDefaultEntry()->BindRawPtr("v", &rvec);
 
       auto w = RNTupleWriter::Recreate(std::move(m), "r", fileGuard.GetPath());
       w->Fill();

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -326,7 +326,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       for (auto idx : c.fImportFieldIndexes) {
          const auto name = fImportFields[idx].fField->GetName();
          const auto buffer = fImportFields[idx].fFieldBuffer;
-         c.fCollectionEntry->CaptureValueUnsafe(name, buffer);
+         c.fCollectionEntry->BindRawPtr(name, buffer);
       }
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
       c.fCollectionWriter = fModel->MakeCollection(c.fFieldName, std::move(c.fCollectionModel));
@@ -354,10 +354,10 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    for (const auto &f : fImportFields) {
       if (f.fIsInUntypedCollection)
          continue;
-      fEntry->CaptureValueUnsafe(f.fField->GetName(), f.fFieldBuffer);
+      fEntry->BindRawPtr(f.fField->GetName(), f.fFieldBuffer);
    }
    for (const auto &[_, c] : fLeafCountCollections) {
-      fEntry->CaptureValueUnsafe(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
+      fEntry->BindRawPtr(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
    }
 
    if (!fIsQuiet)

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -357,7 +357,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       fEntry->BindRawPtr(f.fField->GetName(), f.fFieldBuffer);
    }
    for (const auto &[_, c] : fLeafCountCollections) {
-      fEntry->BindRawPtr(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
+      fEntry->BindRawPtr<void>(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
    }
 
    if (!fIsQuiet)


### PR DESCRIPTION
- Instead of a raw pointer, a deleter, and some custom memory management methods, RValue now stores a shared void pointer to the object to be written to / read from disk. Follow-up PRs are coming to change the `RField::BindValue` API to a shared pointer interface and to change RValue to not return raw pointers.
- Splits the `REntry::CaptureValueUnsafe` API into a shared-pointer based safe `BindValue` and a `BindRawPtr` unsafe version. This could be a separate PR but it ended up here...

It probably makes sense to review the final change set and not go through the transitional commits.
