### PR TITLE
[tmva] [sofie] Add support for tensors with dynamic shape

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_gnn.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_gnn.py
@@ -257,6 +257,8 @@ class RModel_GNN:
         blas_routines.push_back("Axpy")
         blas_routines.push_back("Gemv")
         gnn_model.AddBlasRoutines(blas_routines)
+        gnn_model.AddNeededStdLib("algorithm")
+        gnn_model.AddNeededStdLib("cmath")
         return gnn_model
 
 
@@ -323,6 +325,8 @@ class RModel_GraphIndependent:
         blas_routines = gbl_namespace.std.vector['std::string']()
         blas_routines.push_back("Gemm")
         graph_independent_model.AddBlasRoutines(blas_routines)
+        graph_independent_model.AddNeededStdLib("algorithm")
+        graph_independent_model.AddNeededStdLib("cmath")
         return graph_independent_model
 
 

--- a/tmva/sofie/CMakeLists.txt
+++ b/tmva/sofie/CMakeLists.txt
@@ -47,6 +47,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofie
    TMVA/ROperator_Elu.hxx
    TMVA/ROperator_Comparision.hxx
    TMVA/ROperator_EyeLike.hxx
+   TMVA/ROperator_Range.hxx
    TMVA/SOFIE_common.hxx
    TMVA/SOFIEHelpers.hxx
 

--- a/tmva/sofie/inc/TMVA/OperatorList.hxx
+++ b/tmva/sofie/inc/TMVA/OperatorList.hxx
@@ -32,3 +32,5 @@
 #include "TMVA/ROperator_Elu.hxx"
 #include "TMVA/ROperator_Comparision.hxx"
 #include "TMVA/ROperator_EyeLike.hxx"
+#include "TMVA/ROperator_Range.hxx"
+

--- a/tmva/sofie/inc/TMVA/RFunction.hxx
+++ b/tmva/sofie/inc/TMVA/RFunction.hxx
@@ -47,7 +47,8 @@ public:
     virtual void Initialize() {};
     virtual void AddLayerNormalization(int, float, size_t, const std::string&,
                                        const std::string&, const std::string&, const std::string&) {};
-    void AddInputTensors(const std::vector<std::vector<std::size_t>>& fInputShape);
+    void AddInputTensors(const std::vector<std::vector<std::size_t>>& inputShapes);
+    void AddInputTensors(const std::vector<std::vector<Dim>>& inputShapes);
     std::shared_ptr<RModel> GetFunctionBlock() {
         return function_block;
     }

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -17,6 +17,7 @@ private:
     std::unordered_map<std::string, TensorInfo> fReadyInputTensorInfos;
     std::unordered_map<std::string, InitializedTensor> fInitializedTensors;
     std::unordered_map<std::string, TensorInfo> fIntermediateTensorInfos;
+    std::unordered_map<std::string, DynamicTensorInfo> fDynamicTensorInfos;
     std::vector<std::string> fOutputTensorNames;
     std::vector<std::string> fInputTensorNames;  //input tensor names using ONNX order
 
@@ -40,6 +41,7 @@ public:
     RModel(std::string function_name):RModel_Base(function_name) {}
 
     const std::vector<size_t>& GetTensorShape(std::string name);
+    const std::vector<Dim>& GetDynamicTensorShape(std::string name);
     const ETensorType& GetTensorType(std::string name);
 
     bool CheckIfTensorAlreadyExist(std::string tensor_name);
@@ -65,7 +67,10 @@ public:
 
     // Check if a tensor is initialized
     bool IsInitializedTensor(const std::string& name) const;
+    bool IsDynamicTensor(const std::string& name) const;
+
     void AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape);
+    void AddDynamicTensor(std::string tensor_name, ETensorType type, std::vector<Dim> shape);
 
     void AddInputTensorName(std::string name);
     void AddOutputTensorNameList(std::vector<std::string> outputtensornames);

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -18,7 +18,7 @@ private:
     std::unordered_map<std::string, InitializedTensor> fInitializedTensors;
     std::unordered_map<std::string, TensorInfo> fIntermediateTensorInfos;
     std::unordered_map<std::string, DynamicTensorInfo> fDynamicTensorInfos;
-    std::unordered_map<std::string, int> fShapeParams; // parameters defining the dynamic shape (e.g. batch size)
+    std::unordered_map<std::string, std::string> fShapeParams; // parameters defining the dynamic shape (e.g. batch size), store also its default value
     std::vector<std::string> fOutputTensorNames;
     std::vector<std::string> fInputTensorNames;  //input tensor names using ONNX order
 

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -122,6 +122,7 @@ public:
 
     void PrintRequiredInputTensors();
     void PrintInitializedTensors();
+    void PrintDynamicTensors();
     void HeadInitializedTensors(std::string name, int n_print = 50);
 
     bool UseSession() const {

--- a/tmva/sofie/inc/TMVA/RModel_GNN.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GNN.hxx
@@ -15,7 +15,7 @@ class RFunction_Update;
 class RFunction_Aggregate;
 
 struct GNN_Init {
-    // updation blocks
+    // update blocks
     std::unique_ptr<RFunction_Update> edges_update_block;
     std::unique_ptr<RFunction_Update> nodes_update_block;
     std::unique_ptr<RFunction_Update> globals_update_block;
@@ -25,7 +25,7 @@ struct GNN_Init {
     std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
     std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
 
-    int num_nodes;
+    std::size_t num_nodes;
     std::vector<std::pair<int,int>> edges;
 
     std::size_t num_node_features;
@@ -92,7 +92,7 @@ class RModel_GNN: public RModel_GNNBase {
 
 private:
 
-    // updation function for edges, nodes & global attributes
+    // update function for edges, nodes & global attributes
     std::unique_ptr<RFunction_Update> edges_update_block;
     std::unique_ptr<RFunction_Update> nodes_update_block;
     std::unique_ptr<RFunction_Update> globals_update_block;
@@ -102,8 +102,8 @@ private:
     std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
     std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
 
-    int num_nodes;   // maximum number of nodes
-    int num_edges;   // maximum number of edges
+    std::size_t num_nodes;   // maximum number of nodes
+    std::size_t num_edges;   // maximum number of edges
 
     std::size_t num_node_features;
     std::size_t num_edge_features;

--- a/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
@@ -14,12 +14,12 @@ namespace SOFIE {
 class RFunction_Update;
 
 struct GraphIndependent_Init {
-    // updation blocks
+    // update blocks
     std::unique_ptr<RFunction_Update> edges_update_block;
     std::unique_ptr<RFunction_Update> nodes_update_block;
     std::unique_ptr<RFunction_Update> globals_update_block;
 
-    int num_nodes;
+    std::size_t num_nodes;
     std::vector<std::pair<int,int>> edges;
 
     int num_node_features;
@@ -65,8 +65,8 @@ private:
     std::unique_ptr<RFunction_Update> nodes_update_block;
     std::unique_ptr<RFunction_Update> globals_update_block;
 
-    int num_nodes;
-    int num_edges;
+    std::size_t num_nodes;
+    std::size_t num_edges;
 
     std::size_t num_node_features;
     std::size_t num_edge_features;

--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -24,7 +24,7 @@ public:
    virtual std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) = 0;
    virtual std::vector<ETensorType> TypeInference(std::vector<ETensorType>) = 0;
    virtual void Initialize(RModel&) = 0;
-   virtual std::string Generate(std::string OpName) = 0;  //expect unique opname for each operator within the same RModel
+   virtual std::string Generate(std::string OpName) = 0;  //expect unique opName for each operator within the same RModel
    // generate initialization code
    virtual std::string GenerateInitCode() { return "";}
    // generate session data members specific to operator

--- a/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
@@ -161,11 +161,11 @@ public:
       }
       const std::string& nameX1 = fNBroadcastedX1.empty()? fNX1 : fNBroadcastedX1;
       const std::string& nameX2 = fNBroadcastedX2.empty()? fNX2 : fNBroadcastedX2;
-     
+
       out << SP << "for (size_t id = 0; id < " << length << " ; id++){\n";
-      out << SP << SP << "tensor_" << fNY << "[id] = " << ComparisionTrait<T,Op>::Op( "tensor_" + nameX1 + "[id]" , "tensor_" + nameX2 + "[id]") <<  " ;\n";
+      out << SP << SP << "fTensor_" << fNY << "[id] = " << ComparisionTrait<T,Op>::Op( "tensor_" + nameX1 + "[id]" , "tensor_" + nameX2 + "[id]") <<  " ;\n";
       out << SP << "}\n";
-   
+
       return out.str();
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -46,24 +46,20 @@ namespace SOFIE{
       ROperator_Gemm(){}
       ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameY):
          fAttrAlpha(alpha), fAttrBeta(beta), fAttrTransA(transA), fAttrTransB(transB), fNA(UTILITY::Clean_name(nameA)),
-         fNB(UTILITY::Clean_name(nameB)), fNY(UTILITY::Clean_name(nameY)) {
-
-         if (std::is_same<T, float>::value) {
-            fType = "float";
-         }else{
-            throw std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a gemm operator");
-         }
+         fNB(UTILITY::Clean_name(nameB)), fNY(UTILITY::Clean_name(nameY))
+      {
+         fType = "float";
+         static_assert(std::is_same_v<T, float>,
+                  "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
       }
 
       ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameC, std::string nameY):
          fAttrAlpha(alpha), fAttrBeta(beta), fAttrTransA(transA), fAttrTransB(transB), fNA(UTILITY::Clean_name(nameA)),
-         fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY)) {
-
-         if (std::is_same<T, float>::value) {
-            fType = "float";
-         }else{
-            throw std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a gemm operator");
-         }
+         fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY))
+      {
+         fType = "float";
+         static_assert(std::is_same_v<T, float>,
+                  "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
       }
 
       std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -71,35 +71,6 @@ namespace SOFIE{
          return {out};
       }
 
-#if 0
-      std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input){
-         if (input.size() > 3) throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only need 2 or 3 input tensor");
-         for (auto& i: input){
-            if (i.size() > 2){
-               throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only accept input tensor with 2 dimensions");
-            }
-         }
-         std::vector<std::vector<size_t>> ret;
-         if (input.size() == 3){
-            ret.push_back(input[2]);   //shape of C is shape of Y
-            return ret;
-         }
-         std::vector<size_t> s_a(input[0]);
-         std::vector<size_t> s_b(input[1]);
-         if (fAttrTransA){
-            std::reverse(s_a.begin(), s_a.end());
-         }
-         if (fAttrTransB){
-            std::reverse(s_b.begin(), s_b.end());
-         }
-         std::vector<size_t> s_y(2);
-         s_y[0] = s_a[0];
-         s_y[1] = s_b[1];
-         ret.push_back(s_y);
-         return ret;
-      }
-   #endif
-
       template <typename U>
       std::vector<std::vector<U>> DoShapeInference(const std::vector<std::vector<U>> & input){
          if (input.size() > 3) throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only need 2 or 3 input tensor");

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -23,6 +23,8 @@ namespace SOFIE{
    {
 
    private:
+      bool fIsDynamic = false;
+
       float fAttrAlpha = 1.0;
       float fAttrBeta = 1.0;
       int_t fAttrTransA = 0;
@@ -33,12 +35,11 @@ namespace SOFIE{
       std::string fNC = "";
       std::string fNC2; // bias tensor name after broadcasting
       std::string fNY;
-      std::vector<size_t> fShapeA;
-      std::vector<size_t> fShapeB;
-      std::vector<size_t> fShapeC;
-      std::vector<size_t> fShapeY;
-
       std::string fType;
+      std::vector<Dim> fShapeA;
+      std::vector<Dim> fShapeB;
+      std::vector<size_t> fShapeC;
+      std::vector<Dim> fShapeY;
 
    public:
 
@@ -70,6 +71,7 @@ namespace SOFIE{
          return {out};
       }
 
+#if 0
       std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input){
          if (input.size() > 3) throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only need 2 or 3 input tensor");
          for (auto& i: input){
@@ -96,6 +98,42 @@ namespace SOFIE{
          ret.push_back(s_y);
          return ret;
       }
+   #endif
+
+      template <typename U>
+      std::vector<std::vector<U>> DoShapeInference(const std::vector<std::vector<U>> & input){
+         if (input.size() > 3) throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only need 2 or 3 input tensor");
+         for (auto& i: input){
+            if (i.size() > 2){
+               throw std::runtime_error("TMVA SOFIE Gemm Op Shape Inference only accept input tensor with 2 dimensions");
+            }
+         }
+         std::vector<std::vector<U>> ret;
+         if (input.size() == 3){
+            ret.push_back(input[2]);   //shape of C is shape of Y
+            return ret;
+         }
+         std::vector<U> s_a(input[0]);
+         std::vector<U> s_b(input[1]);
+         if (fAttrTransA){
+            std::reverse(s_a.begin(), s_a.end());
+         }
+         if (fAttrTransB){
+            std::reverse(s_b.begin(), s_b.end());
+         }
+         std::vector<U> s_y(2);
+         s_y[0] = s_a[0];
+         s_y[1] = s_b[1];
+         ret.push_back(s_y);
+         return ret;
+      }
+
+      std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input){
+         return DoShapeInference<size_t>(input);
+      }
+      std::vector<std::vector<Dim>> DynamicShapeInference(const std::vector<std::vector<Dim>> & input){
+         return DoShapeInference<Dim>(input);
+      }
 
 
 
@@ -110,23 +148,52 @@ namespace SOFIE{
                throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNC + " is not found in model");
             }
          }
-         fShapeA = model.GetTensorShape(fNA);
-         if (fShapeA.size() != 2){
-            if (fShapeA.size() == 1)
-               fShapeA = {1,fShapeA[0]};
-            else
-               throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNA +
-                                     " is not of 2 dimensions: A " +  ConvertShapeToString(fShapeA));
+         if (model.IsDynamicTensor(fNA) || model.IsInputTensor(fNA) ) {
+            fShapeA = model.GetDynamicTensorShape(fNA);
+            fIsDynamic = true;
          }
-         fShapeB = model.GetTensorShape(fNB);
-         if (fShapeB.size() != 2){
-            throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNB + " is not of 2 dimensions: B " +  ConvertShapeToString(fShapeB));
+         else {
+            auto shapeA_int = model.GetTensorShape(fNA);
+            // don't think this is needed?
+            if (shapeA_int.size() == 1)
+               shapeA_int = {1,shapeA_int[0]};
+            fShapeA = ConvertShapeToDim(shapeA_int);
          }
-         fShapeY = ShapeInference({fShapeA, fShapeB})[0];
+
+         if (model.IsDynamicTensor(fNB) || model.IsInputTensor(fNB)) {
+            fShapeB = model.GetDynamicTensorShape(fNB);
+            fIsDynamic = true;
+         }
+         else {
+            auto shapeB_int = model.GetTensorShape(fNB);
+            fShapeB = ConvertShapeToDim(shapeB_int);
+         }
+         if (fShapeA.size() != 2)
+            throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNA +
+                                       " is not of 2 dimensions: A " +  ConvertDynamicShapeToString(fShapeA));
+         if (fShapeB.size() != 2)
+               throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNB +
+                                       " is not of 2 dimensions: B " +  ConvertDynamicShapeToString(fShapeB));
+
+         fShapeY = DynamicShapeInference({fShapeA, fShapeB})[0];
+         std::vector<size_t> shapeY;
+         if (!fIsDynamic) {
+            shapeY = ConvertShapeToInt(fShapeY);
+            if (shapeY.empty()) {
+               throw std::runtime_error("TMVA SOFIE Gemm Op " + fNY + " has invalid shape" + ConvertDynamicShapeToString(fShapeY));
+            }
+         }
+
+         // bias is normally not dynamic (not support it for time being)
          if (fNC != ""){
+            // normally bias is fixed and not dynamic
+            if (model.IsDynamicTensor(fNC)) {
+               throw std::runtime_error("TMVA SOFIE Gemm Op Input Tensor" + fNC + " is dynamic and is not supported");
+            }
             fShapeC = model.GetTensorShape(fNC);
             fNC2 = fNC;
             bool broadcast_needed = !UTILITY::AreSameShape(fShapeC, fShapeY);
+
             // For Gemm broadcasting is not needed if fShapeY[0] == 1 i.e. C and Y have same length
             //if (fShapeY[0] == 1 && ConvertShapeToLength(fShapeC) != ConvertShapeToLength(fShapeY)) {
             //   broadcast_needed = false;
@@ -138,29 +205,38 @@ namespace SOFIE{
 
             if (broadcast_needed) {
                if (!model.UseSession()) {
+                  // without session dynamic tensors not supported in Gemm
+                  if (fIsDynamic) {
+                      throw std::runtime_error("TMVA SOFIE Gemm Op:  dynamic tensors not supported without a session");
+                  }
                   auto original_data = model.GetInitializedTensorData(fNC);
-                  auto targetShape = UTILITY::UnidirectionalBroadcastShape(fShapeC, fShapeY);
+                  auto targetShape = UTILITY::UnidirectionalBroadcastShape(fShapeC, shapeY);
                   if (fType == "float") {
                      std::shared_ptr<void> new_data_ptr(UTILITY::UnidirectionalBroadcast<float>(
                         static_cast<float *>(original_data.get()), fShapeC, targetShape),
                         std::default_delete<float[]>());
 
-                     model.UpdateInitializedTensor(fNC, model.GetTensorType(fNC), fShapeY, new_data_ptr);
-                     fShapeC = fShapeY;
+                     model.UpdateInitializedTensor(fNC, model.GetTensorType(fNC), shapeY, new_data_ptr);
+                     fShapeC = shapeY;
                   }
                } else {
                   // In case of session add broadcasting code in Session constructor and in GenerateInitCode
                   // we need to add a new intermediate tensor for broadcasted bias tensor
                   fNC2 = fNC + "bcast";
-                  model.AddIntermediateTensor(fNC2, model.GetTensorType(fNC), fShapeY);
+                  if (!fIsDynamic) {
+                     model.AddIntermediateTensor(fNC2, model.GetTensorType(fNC), shapeY);
+                  }
+                  else
+                     model.AddDynamicTensor(fNC2,model.GetTensorType(fNC), fShapeY);
                }
             }
          }
 
+         if (!fIsDynamic)
+            model.AddIntermediateTensor(fNY, model.GetTensorType(fNA), shapeY);
+         else
+            model.AddDynamicTensor(fNY, model.GetTensorType(fNA), fShapeY);
 
-
-
-         model.AddIntermediateTensor(fNY, model.GetTensorType(fNA), fShapeY);
          model.AddNeededStdLib("algorithm");
 
       }
@@ -170,12 +246,16 @@ namespace SOFIE{
          std::stringstream out;
          // generate initialization code for broadcasting of bias tensor
          if (fShapeC.size() != fShapeY.size() && fNC != fNC2) {
-            auto targetShape = UTILITY::UnidirectionalBroadcastShape(fShapeC, fShapeY);
+            // we broadcast here always C in Y output, so target shape is the one of Y
+            // no need to call UTILITY::UnidirectionalBroadcastShape.
+            // here in case of parametric shape we need to assume that the parameters will be defined in the initialization code.
+            auto targetShape = fShapeY;
             // include a separate scope to avoid defining unique operator temp variables
+            out << "//--- broadcast bias tensor " << fNC << "for Gemm op\n";
             out << SP << "{\n";
             out << "      float * data = TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast<float>(tensor_"
-               << fNC << "," << ConvertShapeToString(fShapeC) << ", " << ConvertShapeToString(targetShape) << ");\n";
-            size_t length = TMVA::Experimental::SOFIE::ConvertShapeToLength(fShapeY); // output size
+               << fNC << "," << ConvertShapeToString(fShapeC) << ", " << ConvertDynamicShapeToString(fShapeY) << ");\n";
+            auto length = TMVA::Experimental::SOFIE::ConvertDynamicShapeToLength(fShapeY); // output size
             out << SP << SP << "std::copy(data, data + " << length << ", tensor_" << fNC2 << ");\n";
             out << SP << SP << "delete [] data;\n";
             out << SP << "}\n";
@@ -193,9 +273,12 @@ namespace SOFIE{
          out << "\n//--------- Gemm\n";
          out << SP << "char " << OpName << "_transA = " << (fAttrTransA ? "\'t\'" : "\'n\'") << ";\n";
          out << SP << "char " << OpName << "_transB = " << (fAttrTransB ? "\'t\'" : "\'n\'") << ";\n";
-         int m = (fAttrTransA ? fShapeA[1] : fShapeA[0]);
-         int n = (fAttrTransB ? fShapeB[0] : fShapeB[1]);
-         int k = (fAttrTransA ? fShapeA[0] : fShapeA[1]);
+
+         auto m = (fAttrTransA ? fShapeA[1].GetVal() : fShapeA[0].GetVal());
+         auto n = (fAttrTransB ? fShapeB[0].GetVal() : fShapeB[1].GetVal());
+         auto k = (fAttrTransA ? fShapeA[0].GetVal() : fShapeA[1].GetVal());
+         auto length = ConvertDynamicShapeToLength(fShapeY);
+
          out << SP << "int " << OpName << "_m = " << m << ";\n";
          out << SP << "int " << OpName << "_n = " << n << ";\n";
          out << SP << "int " << OpName << "_k = " << k << ";\n";
@@ -203,11 +286,19 @@ namespace SOFIE{
          out << SP << "float " << OpName << "_beta = " << std::setprecision(std::numeric_limits<float>::max_digits10) << fAttrBeta << ";\n";
          out << SP << "int " << OpName << "_lda = " << (fAttrTransA ? m : k) << ";\n";
          out << SP << "int " << OpName << "_ldb = " << (fAttrTransB ? k : n) << ";\n";
-         if (fNC != ""){
-            size_t length = ConvertShapeToLength(fShapeY);
-            if (fNC2 == fNC)
-               // case broadcasting was not needed or done outside of session
-               assert(length == ConvertShapeToLength(fShapeC));
+         // case bias is present
+         if (!fNC.empty()){
+            if (fNC2 == fNC) {
+               // add a check in case broadcasting was not needed or done outside of session
+               if (!fIsDynamic) {
+                  if (std::stoi(ConvertDynamicShapeToLength(fShapeY)) != static_cast<int>(ConvertShapeToLength(fShapeC)))
+                     throw std::runtime_error("TMVA SOFIE Gemm Op " + OpName + " Bias tensor has not correct size "
+                            + ConvertShapeToString(fShapeC) + " output length " + length);
+               } else {
+                  // add a dynamic check
+                  out << SP << "assert(" << length << " != " <<  ConvertShapeToLength(fShapeC) << ");\n";
+               }
+            }
             out << SP << "std::copy(" << "tensor_" << fNC2 << ", " << "tensor_" << fNC2 << " + " << length << ", " << "tensor_" << fNY << ");\n";
          } else {
             //in this case fAttrBeta needs to be equal to zero otherwise second time we run we will use

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -29,22 +29,23 @@ private:
    std::string fNNormalizedX;
    std::string fNBroadcastedB;
 
-   std::vector<size_t> fShapeX;
-   std::vector<size_t> fShapeScale;
-   std::vector<size_t> fShapeB;
-   std::vector<size_t> fShapeY;
-   std::vector<size_t> fShapeMean;
-   std::vector<size_t> fShapeInvStdDev;
+   std::vector<Dim> fShapeX;
+   std::vector<Dim> fShapeScale;
+   std::vector<size_t> fShapeB;  // shape of input Bias (B) is assumed to be fully defined
+   std::vector<Dim> fShapeY;
+   std::vector<Dim> fShapeMean;
+   std::vector<Dim> fShapeInvStdDev;
 
    size_t fAxis; // axis in [0, size)
    size_t fSize; // Size of the input
    // size_t fAxisDim;
-   size_t fLength; // Length of the input X
 
-   std::vector<size_t> fNormalizedShape;
-   std::vector<size_t> fAxesShape;
-   size_t fNormalizedLength;
-   size_t fAxesLength;
+   std::vector<Dim> fNormalizedShape;
+   std::vector<Dim> fAxesShape;
+   // lengths in string format
+   std::string fLength; // Length of the input
+   std::string fNormalizedLength;
+   std::string fAxesLength;
 
    std::string fType;
 
@@ -69,7 +70,8 @@ public:
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA::SOFIE - Tensor " + fNX + " not found.");
       }
-      fShapeX = model.GetTensorShape(fNX);
+      bool isDynamic = model.IsDynamicTensor(fNX);
+      fShapeX = model.GetDynamicTensorShape(fNX);
       fShapeY = fShapeX;
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShapeY);
       // Type of the output
@@ -79,27 +81,33 @@ public:
       // Axis in [0, size)
       fAxis = (fAttrAxis < 0) ? fSize + fAttrAxis : fAttrAxis;
       // Shape of fShapeX[0, ..., fAxis)
-      fAxesShape = std::vector<size_t>(fShapeX.begin(), fShapeX.begin() + fAxis);
+      fAxesShape = std::vector<Dim>(fShapeX.begin(), fShapeX.begin() + fAxis);
       // Length of the axes
-      fAxesLength = ConvertShapeToLength(fAxesShape);
+      fAxesLength = ConvertDynamicShapeToLength(fAxesShape);
       // Shape of fShapeX[fAxis, ..., fSize)
-      fNormalizedShape = std::vector<size_t>(fShapeX.begin() + fAxis, fShapeX.end());
+      fNormalizedShape = std::vector<Dim>(fShapeX.begin() + fAxis, fShapeX.end());
       // Length of the normalized axis
-      fNormalizedLength = ConvertShapeToLength(fNormalizedShape);
+      fNormalizedLength = ConvertDynamicShapeToLength(fNormalizedShape);
       // length of the input
-      fLength = ConvertShapeToLength(fShapeX);
+      fLength = ConvertDynamicShapeToLength(fShapeX);
       // Type of mean and std
       ETensorType type = (fAttrStashType == 1) ? ETensorType::FLOAT : model.GetTensorType(fNX);
       // Mean
       if (fNMean.empty()) {
          fNMean = "Mean" + fNX;
          // cannot use initializer list with one element since it is ambiguous
-         model.AddIntermediateTensor(fNMean, type, std::vector<size_t>(1,fAxesLength));
+         if (isDynamic)
+            model.AddIntermediateTensor(fNMean, type, std::vector<Dim>(1,Dim{true,0,"layernorm_length"}));
+         else
+            model.AddIntermediateTensor(fNMean, type, std::vector<size_t>(1,std::stoi(fAxesLength)));
       }
       // Inverse Standard Deviation
       if (fNInvStdDev.empty()) {
          fNInvStdDev = "InvStdDev" + fNX;
-         model.AddIntermediateTensor(fNInvStdDev, type, std::vector<size_t>(1,fAxesLength));
+         if (isDynamic)
+            model.AddIntermediateTensor(fNMean, type, std::vector<Dim>(1,Dim{true,0,"layernorm_length"}));
+         else
+            model.AddIntermediateTensor(fNInvStdDev, type, std::vector<size_t>(1,std::stoi(fAxesLength)));
       }
       // Cast X to float
       if (fAttrStashType == 1 && model.GetTensorType(fNX) != ETensorType::FLOAT) {
@@ -112,7 +120,7 @@ public:
       if (!fNB.empty()) {
          fShapeB = model.GetTensorShape(fNB);
          size_t lengthB = ConvertShapeToLength(fShapeB);
-         if (lengthB < fLength) {
+         if (isDynamic || lengthB < static_cast<size_t>(std::stoi(fLength))) {
             fNBroadcastedB = "Broadcasted" + fNB;
             model.AddIntermediateTensor(fNBroadcastedB, ConvertStringToType(fType), fShapeX);
          }
@@ -123,10 +131,10 @@ public:
    {
       std::stringstream out;
       if (!fNBroadcastedB.empty()) {
-         out << SP << "// Broadcasting the bias of LayerNormlization op\n";
+         out << SP << "// Broadcasting the bias of LayerNormalization op\n";
          out << SP << "{\n";
          out << SP << SP << "float* data = TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast<float>(tensor_";
-         out << fNB << ", " << ConvertShapeToString(fShapeB) << ", " << ConvertShapeToString(fShapeX) << ");\n";
+         out << fNB << ", " << ConvertShapeToString(fShapeB) << ", " << ConvertDynamicShapeToString(fShapeX) << ");\n";
          out << SP << "std::copy(data, data + " << fLength << ", tensor_" << fNBroadcastedB << ");\n";
          out << SP << "delete[] data;\n";
          out << SP << "}\n";
@@ -139,7 +147,7 @@ public:
       OpName = "op_" + OpName;
       if (fShapeX.empty()) {
          throw std::runtime_error("TMVA::SOFIE LayerNormalization operator " + OpName +
-                                  " called to generate without beging initialized first.");
+                                  " called to generate without being initialized first.");
       }
       if (fShapeX.size() > 5) {
          throw std::runtime_error("TMVA::SOFIE LayerNormalization operator not "
@@ -148,12 +156,12 @@ public:
 
       std::stringstream out;
 
-      out << SP << "// Operator " << OpName << "\n";
+      out << "//---- Layer Normalization  operator " << OpName << "\n";
 
       // Loop over all the normalized axes i.e. [axis, ..., size)
       out << SP << "std::vector<size_t> " << OpName << "_InputShape ({";
       for (size_t i = 0; i < fSize; i++) {
-         out << fShapeX[i];
+         out << fShapeX[i].GetVal();
          if (i + 1 < fSize) {
             out << ",";
          }
@@ -162,21 +170,21 @@ public:
       std::string inputShape = OpName + "_InputShape";
 
       auto strides = UTILITY::ComputeStrideFromShape(fShapeX);
-      std::string InputIndex = "axis_0 * " + std::to_string(strides[0]);
+      std::string InputIndex = "axis_0 * " + strides[0].GetVal();
       for (size_t i = 1; i < fSize; i++) {
-         InputIndex += " + axis_" + std::to_string(i) + " * " + std::to_string(strides[i]);
+         InputIndex += " + axis_" + std::to_string(i) + " * " + strides[i].GetVal();
       }
 
       auto axesStrides = UTILITY::ComputeStrideFromShape(fAxesShape);
-      std::string axesIndex = "axis_" + std::to_string(0) + " * " + std::to_string(axesStrides[0]);
+      std::string axesIndex = "axis_" + std::to_string(0) + " * " + axesStrides[0].GetVal();
       for (size_t i = 1; i < fAxis; i++) {
-         axesIndex += " + axis_" + std::to_string(i) + " * " + std::to_string(axesStrides[i]);
+         axesIndex += " + axis_" + std::to_string(i) + " * " + axesStrides[i].GetVal();
       }
 
       auto normalizedStrides = UTILITY::ComputeStrideFromShape(fNormalizedShape);
-      std::string normalizedIndex = "axis_" + std::to_string(fAxis) + " * " + std::to_string(normalizedStrides[0]);
+      std::string normalizedIndex = "axis_" + std::to_string(fAxis) + " * " + normalizedStrides[0].GetVal();
       for (size_t i = fAxis + 1; i < fSize; i++) {
-         normalizedIndex += " + axis_" + std::to_string(i) + " * " + std::to_string(normalizedStrides[i - fAxis]);
+         normalizedIndex += " + axis_" + std::to_string(i) + " * " + normalizedStrides[i - fAxis].GetVal();
       }
 
       if (!fNCastedX.empty()) {

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -93,12 +93,13 @@ public:
       // Mean
       if (fNMean.empty()) {
          fNMean = "Mean" + fNX;
-         model.AddIntermediateTensor(fNMean, type, {fAxesLength});
+         // cannot use initializer list with one element since it is ambiguous
+         model.AddIntermediateTensor(fNMean, type, std::vector<size_t>(1,fAxesLength));
       }
       // Inverse Standard Deviation
       if (fNInvStdDev.empty()) {
          fNInvStdDev = "InvStdDev" + fNX;
-         model.AddIntermediateTensor(fNInvStdDev, type, {fAxesLength});
+         model.AddIntermediateTensor(fNInvStdDev, type, std::vector<size_t>(1,fAxesLength));
       }
       // Cast X to float
       if (fAttrStashType == 1 && model.GetTensorType(fNX) != ETensorType::FLOAT) {

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -97,7 +97,8 @@ public:
          fNMean = "Mean" + fNX;
          // cannot use initializer list with one element since it is ambiguous
          if (isDynamic)
-            model.AddIntermediateTensor(fNMean, type, std::vector<Dim>(1,Dim{true,0,"layernorm_length"}));
+            // add size_t(-1) to indicate that shape is an expression
+            model.AddIntermediateTensor(fNMean, type, std::vector<Dim>(1,Dim{fAxesLength,std::size_t(-1)}));
          else
             model.AddIntermediateTensor(fNMean, type, std::vector<size_t>(1,std::stoi(fAxesLength)));
       }
@@ -105,7 +106,7 @@ public:
       if (fNInvStdDev.empty()) {
          fNInvStdDev = "InvStdDev" + fNX;
          if (isDynamic)
-            model.AddIntermediateTensor(fNMean, type, std::vector<Dim>(1,Dim{true,0,"layernorm_length"}));
+            model.AddIntermediateTensor(fNInvStdDev, type, std::vector<Dim>(1,Dim{fAxesLength,std::size_t(-1)}));
          else
             model.AddIntermediateTensor(fNInvStdDev, type, std::vector<size_t>(1,std::stoi(fAxesLength)));
       }
@@ -125,6 +126,7 @@ public:
             model.AddIntermediateTensor(fNBroadcastedB, ConvertStringToType(fType), fShapeX);
          }
       }
+      model.AddNeededStdLib("cmath");
    }
 
    std::string GenerateInitCode() override

--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -63,7 +63,7 @@ public:
             std::runtime_error("TMVA SOFIE Range Op Input Tensor " + fNDelta + "is not found in model");
       }
       ETensorType type = ConvertStringToType(fType);
-      fShape = {Dim{true, 0, "range_size"}};
+      fShape = {Dim{"range_size"}};
       model.AddDynamicTensor(fNOutput, type, fShape);
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -30,13 +30,12 @@ public:
       fNStart(start), fNLimit(limit), fNDelta(delta),
       fNOutput(UTILITY::Clean_name(nameOutput)) {
       if (std::is_same<T, float>::value) {
-         fType = "float";
+          fType = "float";
       } else if (std::is_same<T, int64_t>::value) {
-         fType = "int64_t";
-      } else {
-         throw
-            std::runtime_error("TMVA::SOFIE - Unsupported type by Range operator");
+          fType = "int64_t";
       }
+      static_assert( (std::is_same_v<T, float> || std::is_same_v<T, int64_t>),
+                  "TMVA::SOFIE - Unsupported type by Range operator");
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {

--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -76,9 +76,13 @@ public:
       out << "\n//------ Range\n";
       std::string sizeName = fShape[0].param;
       out << SP << "size_t " << sizeName << " = static_cast<size_t>(std::max(std::ceil((static_cast<float>(*tensor_" << fNLimit << ") - static_cast<float>(*tensor_" << fNStart << ")) / static_cast<float>(*tensor_" << fNDelta << ")), 0.0f));\n";
-      out << SP << "tensor_" << fNOutput << ".resize(" << sizeName << ");\n";
+      out << SP << "if (" << sizeName << " > " << "fTensor_" << fNOutput << ".size() ){\n";
+      out << SP << SP << "fTensor_" << fNOutput << ".resize(" << sizeName << ");\n";
+      // need to re-initialized pointer to tensor data
+      out << SP << SP << "tensor_" << fNOutput << " = fTensor_" << fNOutput << ".data();\n";
+      out << SP << "}\n";
       out << SP << "for (size_t i = 0; i < " << sizeName << "; i++) {\n";
-      out << SP << SP << "tensor_" << fNOutput << "[i] = *tensor_" << fNStart << " + i * (*tensor_" << fNDelta << ");\n";
+      out << SP << SP << "fTensor_" << fNOutput << "[i] = *tensor_" << fNStart << " + i * (*tensor_" << fNDelta << ");\n";
       out << SP << "}\n";
       return out.str();
    }

--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -1,0 +1,91 @@
+#ifndef TMVA_SOFIE_ROPERATOR_RANGE
+#define TMVA_SOFIE_ROPERATOR_RANGE
+
+#include "TMVA/SOFIE_common.hxx"
+#include "TMVA/ROperator.hxx"
+#include "TMVA/RModel.hxx"
+
+#include <sstream>
+
+namespace TMVA{
+namespace Experimental{
+namespace SOFIE{
+
+template <typename T>
+class ROperator_Range final : public ROperator
+{
+private:
+
+   std::string fNStart;
+   std::string fNLimit;
+   std::string fNDelta;
+   std::string fNOutput;
+   std::vector<Dim> fShape;
+   std::string fType;
+
+public:
+   ROperator_Range(){}
+
+   ROperator_Range(std::string start, std::string limit, std::string delta, std::string nameOutput):
+      fNStart(start), fNLimit(limit), fNDelta(delta),
+      fNOutput(UTILITY::Clean_name(nameOutput)) {
+      if (std::is_same<T, float>::value) {
+         fType = "float";
+      } else if (std::is_same<T, int64_t>::value) {
+         fType = "int64_t";
+      } else {
+         throw
+            std::runtime_error("TMVA::SOFIE - Unsupported type by Range operator");
+      }
+   }
+
+   std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {
+      return input;
+   }
+
+   std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input) override {
+      auto ret = input; //suggest copy to compiler
+      return ret;
+   }
+
+   void Initialize(RModel& model) override {
+       //input must be a graph input, or already initialized intermediate tensor
+      if (!model.CheckIfTensorAlreadyExist(fNStart)) {
+         throw
+            std::runtime_error("TMVA SOFIE Range Op Input Tensor " + fNStart + "is not found in model");
+      }
+      if (!model.CheckIfTensorAlreadyExist(fNLimit)) {
+         throw
+            std::runtime_error("TMVA SOFIE Range Op Input Tensor " + fNLimit + "is not found in model");
+      }
+      if (!model.CheckIfTensorAlreadyExist(fNDelta)) {
+         throw
+            std::runtime_error("TMVA SOFIE Range Op Input Tensor " + fNDelta + "is not found in model");
+      }
+      ETensorType type = ConvertStringToType(fType);
+      fShape = {Dim{true, 0, "range_size"}};
+      model.AddDynamicTensor(fNOutput, type, fShape);
+   }
+
+   std::string Generate(std::string OpName) override {
+      OpName = "op_" + OpName;
+      if (fShape.empty()) {
+         throw std::runtime_error("TMVA SOFIE Range operator called to Generate without being initialized first");
+      }
+      std::stringstream out;
+      out << "\n//------ Range\n";
+      std::string sizeName = fShape[0].param;
+      out << SP << "size_t " << sizeName << " = static_cast<size_t>(std::max(std::ceil((static_cast<float>(*tensor_" << fNLimit << ") - static_cast<float>(*tensor_" << fNStart << ")) / static_cast<float>(*tensor_" << fNDelta << ")), 0.0f));\n";
+      out << SP << "tensor_" << fNOutput << ".resize(" << sizeName << ");\n";
+      out << SP << "for (size_t i = 0; i < " << sizeName << "; i++) {\n";
+      out << SP << SP << "tensor_" << fNOutput << "[i] = *tensor_" << fNStart << " + i * (*tensor_" << fNDelta << ");\n";
+      out << SP << "}\n";
+      return out.str();
+   }
+};
+
+}//SOFIE
+}//Experimental
+}//TMVA
+
+#endif //TMVA_SOFIE_ROPERATOR_RANGE

--- a/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
@@ -19,7 +19,7 @@ private:
 
    std::string fNX;
    std::string fNY;
-   std::vector<size_t> fShape;
+   std::vector<Dim> fShape;
 
 public:
    ROperator_Relu(){}
@@ -39,7 +39,9 @@ public:
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Relu Op Input Tensor " + fNX + " is not found in model");
       }
-      fShape = model.GetTensorShape(fNX);
+
+      fShape = model.GetDynamicTensorShape(fNX);
+
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShape);
    }
 
@@ -50,10 +52,7 @@ public:
          throw std::runtime_error("TMVA SOFIE Operator Relu called to Generate without being initialized first");
       }
       std::stringstream out;
-      int length = 1;
-      for(auto& i: fShape){
-         length *= i;
-      }
+      auto length = ConvertDynamicShapeToLength(fShape);
       out << "\n//------ RELU\n";
       out << SP << "for (int id = 0; id < " << length << " ; id++){\n";
       out << SP << SP << "tensor_" << fNY << "[id] = ((tensor_" << fNX << "[id] > 0 )? tensor_" << fNX << "[id] : 0);\n";

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -32,15 +32,13 @@ ETensorType ConvertStringToType(std::string type);
 
 struct Dim{
    bool isParam = false;
-   size_t dim;
+   size_t dim = 0;
    std::string param;
 
    std::string GetVal() const {
       return (isParam) ? param : std::to_string(dim);
    }
 };
-
-std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);
 
 
 struct InputTensorInfo{
@@ -57,6 +55,10 @@ struct DynamicTensorInfo{
    ETensorType type;
    std::vector<Dim> shape;
 };
+
+std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);
+
+std::vector<size_t> ConvertShapeToInt(std::vector<Dim> shape);
 
 std::size_t ConvertShapeToLength(std::vector<size_t> shape);
 
@@ -150,6 +152,8 @@ namespace UTILITY{
 // Check if two shapes are equal
 bool AreSameShape(const std::vector<size_t>&, const std::vector<size_t>&);
 bool AreSameShape(const std::vector<size_t>&, const std::vector<Dim>&);
+bool AreSameShape(const std::vector<Dim>&, const std::vector<Dim>&);
+
 
 // Multidirectional broadcast a list of tensors to the same shape
 std::vector<size_t> MultidirectionalBroadcastShape(std::vector<std::vector<size_t>>);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -34,6 +34,10 @@ struct Dim{
    bool isParam = false;
    size_t dim;
    std::string param;
+
+   std::string GetVal() const {
+      return (isParam) ? param : std::to_string(dim);
+   }
 };
 
 std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);
@@ -57,6 +61,8 @@ struct DynamicTensorInfo{
 std::size_t ConvertShapeToLength(std::vector<size_t> shape);
 
 std::string ConvertShapeToString(std::vector<size_t> shape);
+
+std::string ConvertDynamicShapeToString(std::vector<Dim> shape);
 
 std::string ConvertDynamicShapeToLength(std::vector<Dim> shape);
 
@@ -143,6 +149,7 @@ ETensorType GetTemplatedType(T /*obj*/ ){
 namespace UTILITY{
 // Check if two shapes are equal
 bool AreSameShape(const std::vector<size_t>&, const std::vector<size_t>&);
+bool AreSameShape(const std::vector<size_t>&, const std::vector<Dim>&);
 
 // Multidirectional broadcast a list of tensors to the same shape
 std::vector<size_t> MultidirectionalBroadcastShape(std::vector<std::vector<size_t>>);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -49,9 +49,16 @@ struct TensorInfo{
    std::vector<size_t> shape;
 };
 
+struct DynamicTensorInfo{
+   ETensorType type;
+   std::vector<Dim> shape;
+};
+
 std::size_t ConvertShapeToLength(std::vector<size_t> shape);
 
 std::string ConvertShapeToString(std::vector<size_t> shape);
+
+std::string ConvertDynamicShapeToLength(std::vector<Dim> shape);
 
 struct InitializedTensor{
    ETensorType fType;

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -63,8 +63,10 @@ std::vector<size_t> ConvertShapeToInt(std::vector<Dim> shape);
 std::size_t ConvertShapeToLength(std::vector<size_t> shape);
 
 std::string ConvertShapeToString(std::vector<size_t> shape);
-
 std::string ConvertDynamicShapeToString(std::vector<Dim> shape);
+// std::string ConvertShapeToString(std::vector<Dim> shape) {
+//    return ConvertDynamicShapeToString(shape);
+// }
 
 std::string ConvertDynamicShapeToLength(std::vector<Dim> shape);
 
@@ -273,6 +275,7 @@ T* UnidirectionalBroadcast(const T* data, const std::vector<size_t>& shape, cons
 
 /// compute stride of a tensor given its shape (assume layout is row-major)
 std::vector<size_t> ComputeStrideFromShape(const std::vector<size_t> & shape);
+std::vector<Dim> ComputeStrideFromShape(const std::vector<Dim> & shape);
 
 /// function to check if a >> 0 and a < MAX using a single comparison
 //// use trick casting to unsigned values so it becomes a single comparison

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -35,6 +35,15 @@ struct Dim{
    size_t dim = 0;
    std::string param;
 
+    // default constructor (for I/O)
+   Dim() {}
+
+   // constructor for a parametric dimension with the option to pass a default dim value
+   Dim(const std::string & p, size_t d = 0) : isParam(true), dim(d), param(p) {}
+
+   // constructor for a non-parametric dimension
+   Dim(size_t d) : dim(d) {}
+
    std::string GetVal() const {
       return (isParam) ? param : std::to_string(dim);
    }

--- a/tmva/sofie/src/RFunction.cxx
+++ b/tmva/sofie/src/RFunction.cxx
@@ -46,9 +46,16 @@ RFunction_Update::RFunction_Update(FunctionTarget target, GraphType gType): fTar
     }
 }
 
-void RFunction_Update::AddInputTensors(const std::vector<std::vector<std::size_t>>& fInputShape) {
-    for(long unsigned int i=0; i<fInputShape.size(); ++i) {
-        function_block->AddInputTensorInfo(fInputTensors[i],ETensorType::FLOAT, fInputShape[i]);
+// add inpuit tensors, order of provided shapes must be the same as in fInputTensors
+void RFunction_Update::AddInputTensors(const std::vector<std::vector<std::size_t>>& inputShapes) {
+    for(long unsigned int i=0; i<inputShapes.size(); ++i) {
+        function_block->AddInputTensorInfo(fInputTensors[i],ETensorType::FLOAT, inputShapes[i]);
+        function_block->AddInputTensorName(fInputTensors[i]);
+    }
+}
+void RFunction_Update::AddInputTensors(const std::vector<std::vector<Dim>>& inputShapes) {
+    for(long unsigned int i=0; i<inputShapes.size(); ++i) {
+        function_block->AddInputTensorInfo(fInputTensors[i],ETensorType::FLOAT, inputShapes[i]);
         function_block->AddInputTensorName(fInputTensors[i]);
     }
 }
@@ -56,6 +63,8 @@ void RFunction_Update::AddInputTensors(const std::vector<std::vector<std::size_t
 std::string RFunction_Update::GenerateModel(const std::string& filename, long read_pos, long block_size) {
     function_block->SetFilename(filename);
     // use batch size as block size in RModel::generate
+    function_block->PrintRequiredInputTensors();
+    function_block->PrintDynamicTensors();
     function_block->Generate(Options::kGNNComponent,block_size,read_pos);
     std::string modelGenerationString;
     modelGenerationString = "\n//--------- GNN_Update_Function---"+fFuncName+"\n"+function_block->ReturnGenerated();

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cctype>
 #include <memory>
+#include <string>
 
 #include "TFile.h"
 
@@ -73,6 +74,15 @@ const std::vector<size_t>& RModel::GetTensorShape(std::string name) {
     throw std::runtime_error("TMVA SOFIE tensor [" + name + "] for which the shape is requested is not found");
 }
 
+const std::vector<Dim> &RModel::GetDynamicTensorShape(std::string name) {
+   auto f = fDynamicTensorInfos.find(name);
+   if (f != fDynamicTensorInfos.end()) {
+      return f->second.shape;
+   }
+
+   throw std::runtime_error("TMVA SOFIE tensor [" + name + "] for which the shape is requested is not found");
+}
+
 const ETensorType& RModel::GetTensorType(std::string name) {
     auto f = fReadyInputTensorInfos.find(name);
     if (f != fReadyInputTensorInfos.end()) {
@@ -90,6 +100,10 @@ const ETensorType& RModel::GetTensorType(std::string name) {
     if (f4 != fIntermediateTensorInfos.end()) {
         return f4->second.type;
     }
+    auto f5 = fDynamicTensorInfos.find(name);
+    if (f5 != fDynamicTensorInfos.end()){
+      return f5->second.type;
+    }
 
     throw std::runtime_error("TMVA SOFIE tensor [" + name + "] for which the type is requested is not found");
 }
@@ -98,6 +112,7 @@ bool RModel::CheckIfTensorAlreadyExist(std::string tensor_name) {
     if (fReadyInputTensorInfos.find(tensor_name) != fReadyInputTensorInfos.end())  return true;
     if (fInitializedTensors.find(tensor_name) != fInitializedTensors.end()) return true;
     if (fIntermediateTensorInfos.find(tensor_name) != fIntermediateTensorInfos.end()) return true;
+    if (fDynamicTensorInfos.find(tensor_name) != fDynamicTensorInfos.end()) return true;
     return false;
 }
 
@@ -153,6 +168,11 @@ bool RModel::IsInitializedTensor(const std::string& tensorName) const {
     return fInitializedTensors.find(name) != fInitializedTensors.end();
 }
 
+bool RModel::IsDynamicTensor(const std::string& tensorName) const {
+   std::string name = UTILITY::Clean_name(tensorName);
+   return fDynamicTensorInfos.find(name) != fDynamicTensorInfos.end();
+}
+
 void RModel::AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape) {
     tensor_name = UTILITY::Clean_name(tensor_name);
     if (CheckIfTensorAlreadyExist(tensor_name)) {
@@ -160,6 +180,15 @@ void RModel::AddIntermediateTensor(std::string tensor_name, ETensorType type, st
     }
     TensorInfo new_tensor {type, shape};
     fIntermediateTensorInfos[tensor_name] = new_tensor;
+}
+
+void RModel::AddDynamicTensor(std::string tensor_name, ETensorType type, std::vector<Dim> shape){
+   tensor_name = UTILITY::Clean_name(tensor_name);
+   if (CheckIfTensorAlreadyExist(tensor_name)){
+      throw std::runtime_error("TMVA-SOFIE: intermediate tensor with name " + tensor_name + " already exists \n");
+   }
+   DynamicTensorInfo new_tensor {type, shape};
+   fDynamicTensorInfos[tensor_name] = new_tensor;
 }
 
 void RModel::AddOutputTensorNameList(std::vector<std::string> outputtensornames) {
@@ -227,8 +256,8 @@ void RModel::Initialize(int batchSize) {
         if (!modelHasWeights) fUseWeightFile = false;
     }
 
-    for (auto& i : fOperators) {
-        i->Initialize(*this);
+    for (auto& op : fOperators) {
+      op->Initialize(*this);
     }
 }
 
@@ -275,9 +304,19 @@ void RModel::GenerateIntermediateTensorInfo() {
             fGC += "int64_t * tensor_" + i.first + " = fTensor_" + i.first  + ".data();\n";
         }
         if (i.second.type == ETensorType::BOOL){
-            fGC += "bool tensor_" + i.first  + " [" + std::to_string(length) + "] = {false};\n";         
+            fGC += "bool tensor_" + i.first  + " [" + std::to_string(length) + "] = {false};\n";
         }
-    }
+   }
+   // add also intermediate tensors
+   for (auto&i: fDynamicTensorInfos) {
+      if (i.second.type == ETensorType::FLOAT) {
+         fGC += "std::vector<float> tensor_" + i.first  + ";\n";
+      } else if (i.second.type == ETensorType::DOUBLE) {
+         fGC += "std::vector<double> tensor_" + i.first  + ";\n";
+      } else if (i.second.type == ETensorType::INT64) {
+         fGC += "std::vector<int64_t> tensor_" + i.first  + ";\n";
+      }
+   }
 }
 
 void RModel::GenerateOutput() {
@@ -296,11 +335,16 @@ void RModel::GenerateOutput() {
         std::vector<ETensorType> outputTensorsTypes(outputSize);
         for (size_t i = 0; i < outputSize; i++) {
             auto f = fIntermediateTensorInfos.find(fOutputTensorNames[i]);
-            if (f == fIntermediateTensorInfos.end()) {
-                throw std::runtime_error("TMVA-SOFIE: output tensor " + fOutputTensorNames[i]
-                                         + " not found when trying to get its info");
-            } else {
+            if (f != fIntermediateTensorInfos.end()) {
                 outputTensorsTypes[i] = f->second.type;
+            } else {
+               auto f2 = fDynamicTensorInfos.find(fOutputTensorNames[i]);
+               if (f2 != fDynamicTensorInfos.end()) {
+                  outputTensorsTypes[i] = f2->second.type;
+               } else {
+                  throw std::runtime_error("TMVA-SOFIE: output tensor " + fOutputTensorNames[i]
+                     + " not found when trying to get its info");
+               }
             }
         }
         // assume all output types are the same
@@ -353,10 +397,14 @@ void RModel::GenerateOutput() {
     }
 
     if (outputSize == 1) {
-        size_t outputLength = ConvertShapeToLength(GetTensorShape(fOutputTensorNames[0]));
-
-        fGC += SP + "std::vector<" + outputType + "> ret (tensor_" + fOutputTensorNames[0] + ", tensor_" + fOutputTensorNames[0] + " + " +
+         std::string tensorName = fOutputTensorNames[0];
+         if (IsDynamicTensor(tensorName)) {
+            fGC += SP + "std::vector<" + outputType + "> ret (tensor_" + tensorName + ");\n";
+         } else {
+            size_t outputLength = ConvertShapeToLength(GetTensorShape(fOutputTensorNames[0]));
+            fGC += SP + "std::vector<" + outputType + "> ret (tensor_" + fOutputTensorNames[0] + ", tensor_" + fOutputTensorNames[0] + " + " +
                std::to_string(outputLength) + ");\n";
+         }
     } else {
         for (size_t i = 0; i < outputSize; i++) {
             if (!fOutputTensorNames[i].empty()) {

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -373,7 +373,21 @@ std::vector<size_t> UTILITY::ComputeStrideFromShape(const std::vector<size_t> & 
    const auto size = shape.size();
    std::vector<size_t> strides(size,1);
    for (std::size_t i = 1; i < size; i++) {
-      strides[size - 1 - i] = strides[size - 1 - i + 1] * shape[size - 1 - i + 1];
+      strides[size - 1 - i] = strides[size - i ] * shape[size - i];
+   }
+   return strides;
+}
+
+std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> & shape) {
+   // assume row major layout
+   const auto size = shape.size();
+   std::vector<Dim> strides(size);
+   strides[size-1] = Dim{false,1,""};
+   for (std::size_t i = 1; i < size; i++) {
+      if (!shape[size-i].isParam && !strides[size-i].isParam)
+         strides[size - 1 - i] = Dim{false, strides[size-i].dim * shape[size-i].dim,""};
+      else
+         strides[size - 1 - i] = Dim{true, 0, std::string(strides[size-i].GetVal() + "*" + shape[size-i].GetVal())};
    }
    return strides;
 }

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -382,12 +382,12 @@ std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> & shape)
    // assume row major layout
    const auto size = shape.size();
    std::vector<Dim> strides(size);
-   strides[size-1] = Dim{false,1,""};
+   strides[size-1] = Dim{1};
    for (std::size_t i = 1; i < size; i++) {
       if (!shape[size-i].isParam && !strides[size-i].isParam)
-         strides[size - 1 - i] = Dim{false, strides[size-i].dim * shape[size-i].dim,""};
+         strides[size - 1 - i] = Dim{strides[size-i].dim * shape[size-i].dim};
       else
-         strides[size - 1 - i] = Dim{true, 0, std::string(strides[size-i].GetVal() + "*" + shape[size-i].GetVal())};
+         strides[size - 1 - i] = Dim{std::string(strides[size-i].GetVal() + "*" + shape[size-i].GetVal())};
    }
    return strides;
 }

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -61,7 +61,7 @@ ETensorType ConvertStringToType(std::string type){
    if(type == "float32" || type == "float" || type == "Float"){
      return ETensorType::FLOAT;
    }
-   else if(type == "int64"){
+   else if(type == "int64" || type == "int64_t"){
      return ETensorType::INT64;
    }
    else if (type == "double" || type == "float64"){
@@ -84,6 +84,24 @@ std::string ConvertShapeToString(std::vector<size_t> shape) {
    }
    out << " }";
    return out.str();
+}
+
+std::string ConvertDynamicShapeToLength(std::vector<Dim> shape) {
+   std::string length;
+   if (shape[0].isParam) {
+      length += shape[0].param;
+   } else {
+      length += std::to_string(shape[0].dim);
+   }
+   for (size_t i = 1; i < shape.size(); i++) {
+      length += " * ";
+      if (shape[i].isParam) {
+         length += shape[i].param;
+      } else {
+         length += std::to_string(shape[i].dim);
+      }
+   }
+   return length;
 }
 
 namespace{

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -86,6 +86,17 @@ std::string ConvertShapeToString(std::vector<size_t> shape) {
    return out.str();
 }
 
+std::string ConvertDynamicShapeToString(std::vector<Dim> shape) {
+   std::stringstream out;
+   out << "{ ";
+   for (size_t i = 0; i < shape.size(); i++) {
+      out << shape[i].GetVal();
+      if (i < shape.size()-1) out << " , ";
+   }
+   out << " }";
+   return out.str();
+}
+
 std::string ConvertDynamicShapeToLength(std::vector<Dim> shape) {
    std::string length;
    if (shape[0].isParam) {
@@ -127,6 +138,18 @@ bool UTILITY::AreSameShape(const std::vector<size_t>& shapeA, const std::vector<
    }
    for (size_t dim = 0; dim < shapeA.size(); dim++) {
       if (shapeA[dim] != shapeB[dim]) {
+         return false;
+      }
+   }
+   return true;
+}
+bool UTILITY::AreSameShape(const std::vector<size_t>& shapeA, const std::vector<Dim>& shapeB) {
+   if (shapeA.size() != shapeB.size()) {
+      return false;
+   }
+   for (size_t dim = 0; dim < shapeA.size(); dim++) {
+      if (shapeB[dim].isParam) return false;
+      if (shapeA[dim] != shapeB[dim].dim) {
          return false;
       }
    }

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -277,6 +277,11 @@
 
 #include "EyeLike_FromONNX.hxx"
 #include "input_models/references/EyeLike.ref.hxx"
+#include "RangeFloat_FromONNX.hxx"
+#include "input_models/references/RangeFloat.ref.hxx"
+
+#include "RangeInt_FromONNX.hxx"
+#include "input_models/references/RangeInt.ref.hxx"
 
 #include "gtest/gtest.h"
 
@@ -1178,12 +1183,12 @@ TEST(ONNX, Shape){
    std::vector<float> input({
       1, 2
    });
-   
+
    TMVA_SOFIE_Shape::Session s("Shape_FromONNX.dat");
    auto output = s.infer(input.data());
    // Checking output size
    EXPECT_EQ(output.size(), sizeof(Shape_ExpectedOutput::outputs) / sizeof(float));
-   
+
    int *correct = Shape_ExpectedOutput::outputs;
 
    // Checking every output value, one by one
@@ -2593,14 +2598,14 @@ TEST(ONNX, Slice) {
    std::vector<float> input = Slice::input;
    TMVA_SOFIE_Slice::Session s("Slice.dat");
    std::vector<float> output(s.infer(input.data()));
-   
+
    EXPECT_EQ(output.size(), sizeof(Slice::output) / sizeof(float));
    float *correct = Slice::output;
 
    for (size_t i=0; i<output.size(); i++) {
       EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
    }
-   
+
 }
 
 TEST(ONNX, Slice_Default_Axis) {
@@ -2609,14 +2614,14 @@ TEST(ONNX, Slice_Default_Axis) {
    std::vector<float> input = Slice_Default_Axis::input;
    TMVA_SOFIE_Slice_Default_Axis::Session s("Slice_Default_Axis.dat");
    std::vector<float> output(s.infer(input.data()));
-   
+
    EXPECT_EQ(output.size(), sizeof(Slice_Default_Axis::output) / sizeof(float));
    float *correct = Slice_Default_Axis::output;
 
    for (size_t i=0; i<output.size(); i++) {
       EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
    }
-   
+
 }
 
 TEST(ONNX, Slice_Default_Steps) {
@@ -2625,14 +2630,14 @@ TEST(ONNX, Slice_Default_Steps) {
    std::vector<float> input = Slice_Default_Steps::input;
    TMVA_SOFIE_Slice_Default_Steps::Session s("Slice_Default_Steps.dat");
    std::vector<float> output(s.infer(input.data()));
-   
+
    EXPECT_EQ(output.size(), sizeof(Slice_Default_Steps::output) / sizeof(float));
    float *correct = Slice_Default_Steps::output;
 
    for (size_t i=0; i<output.size(); i++) {
       EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
    }
-   
+
 }
 
 TEST(ONNX, Slice_Neg) {
@@ -2641,12 +2646,52 @@ TEST(ONNX, Slice_Neg) {
    std::vector<float> input = Slice_Neg::input;
    TMVA_SOFIE_Slice_Neg::Session s("Slice_Neg.dat");
    std::vector<float> output(s.infer(input.data()));
-   
+
    EXPECT_EQ(output.size(), sizeof(Slice_Neg::output) / sizeof(float));
    float *correct = Slice_Neg::output;
 
    for (size_t i=0; i<output.size(); i++) {
       EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
    }
-   
+
 }
+TEST(ONNX, RangeFloat) {
+   constexpr float TOLERANCE = DEFAULT_TOLERANCE;
+
+   // inputs
+   float start = 1.;
+   float limit = 10.;
+   float delta = 2.;
+   TMVA_SOFIE_RangeFloat::Session s("RangeFloat_FromONNX.dat");
+   std::vector<float> output(s.infer(&start, &limit, &delta));
+
+   // Checking the output size
+   EXPECT_EQ(output.size(), sizeof(RangeFloat_ExpectedOutput::outputs) / sizeof(float));
+
+   float* correct = RangeFloat_ExpectedOutput::outputs;
+
+   // Checking every output value, one by one
+   for (size_t i = 0; i < output.size(); i++) {
+      EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
+   }
+}
+
+TEST(ONNX, RangeInt) {
+   // inputs
+   int64_t start = 1;
+   int64_t limit = 10;
+   int64_t delta = 2;
+   TMVA_SOFIE_RangeInt::Session s("RangeInt_FromONNX.dat");
+   std::vector<int64_t> output(s.infer(&start, &limit, &delta));
+
+   // Checking the output size
+   EXPECT_EQ(output.size(), sizeof(RangeInt_ExpectedOutput::outputs) / sizeof(int64_t));
+
+   int64_t* correct = RangeInt_ExpectedOutput::outputs;
+
+   // Checking every output value, one by one
+   for (size_t i = 0; i < output.size(); i++) {
+      EXPECT_EQ(output[i], correct[i]);
+   }
+}
+

--- a/tmva/sofie/test/TestCustomModelsFromROOT.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromROOT.cxx
@@ -84,6 +84,12 @@
 #include "GRUSeqLength_FromROOT.hxx"
 #include "input_models/references/GRUSeqLength.ref.hxx"
 
+#include "RangeFloat_FromROOT.hxx"
+#include "input_models/references/RangeFloat.ref.hxx"
+
+#include "RangeInt_FromROOT.hxx"
+#include "input_models/references/RangeInt.ref.hxx"
+
 #include "gtest/gtest.h"
 
 constexpr float DEFAULT_TOLERANCE = 1e-3f;
@@ -875,5 +881,43 @@ TEST(ROOT, GRUSeqLength)
    // Checking every output value, one by one
    for (size_t i = 0; i < output_yh.size(); ++i) {
       EXPECT_LE(std::abs(output_yh[i] - correct_yh[i]), TOLERANCE);
+   }
+}
+
+TEST(ROOT, RangeFloat) {
+   constexpr float TOLERANCE = DEFAULT_TOLERANCE;
+
+   // inputs
+   float start = 1.;
+   float limit = 10.;
+   float delta = 2.;
+   std::vector<float> output = TMVA_SOFIE_RangeFloat::infer(&start, &limit, &delta);
+
+   // Checking the output size
+   EXPECT_EQ(output.size(), sizeof(RangeFloat_ExpectedOutput::outputs) / sizeof(float));
+
+   float* correct = RangeFloat_ExpectedOutput::outputs;
+
+   // Checking every output value, one by one
+   for (size_t i = 0; i < output.size(); i++) {
+      EXPECT_LE(std::abs(output[i] - correct[i]), TOLERANCE);
+   }
+}
+
+TEST(ROOT, RangeInt) {
+   // inputs
+   int64_t start = 1;
+   int64_t limit = 10;
+   int64_t delta = 2;
+   std::vector<int64_t> output = TMVA_SOFIE_RangeInt::infer(&start, &limit, &delta);
+
+   // Checking the output size
+   EXPECT_EQ(output.size(), sizeof(RangeInt_ExpectedOutput::outputs) / sizeof(int64_t));
+
+   int64_t* correct = RangeInt_ExpectedOutput::outputs;
+
+   // Checking every output value, one by one
+   for (size_t i = 0; i < output.size(); i++) {
+      EXPECT_EQ(output[i], correct[i]);
    }
 }

--- a/tmva/sofie/test/input_models/RangeFloat.onnx
+++ b/tmva/sofie/test/input_models/RangeFloat.onnx
@@ -1,0 +1,20 @@
+	:ƒ
+
+start
+limit
+deltaY"RangeRangeZ
+start
+
+
+Z
+limit
+
+
+Z
+delta
+
+
+b
+Y
+
+output_sizeB

--- a/tmva/sofie/test/input_models/RangeInt.onnx
+++ b/tmva/sofie/test/input_models/RangeInt.onnx
@@ -1,0 +1,20 @@
+	:ƒ
+
+start
+limit
+deltaY"RangeRangeZ
+start
+
+
+Z
+limit
+
+
+Z
+delta
+
+
+b
+Y
+
+output_sizeB

--- a/tmva/sofie/test/input_models/references/RangeFloat.ref.hxx
+++ b/tmva/sofie/test/input_models/references/RangeFloat.ref.hxx
@@ -1,0 +1,3 @@
+namespace RangeFloat_ExpectedOutput{
+   float outputs[] = {1., 3., 5., 7., 9.};
+} // namespace RangeFloat_ExpectedOutput

--- a/tmva/sofie/test/input_models/references/RangeInt.ref.hxx
+++ b/tmva/sofie/test/input_models/references/RangeInt.ref.hxx
@@ -1,0 +1,3 @@
+namespace RangeInt_ExpectedOutput{
+   int64_t outputs[] = {1, 3, 5, 7, 9};
+} // namespace RangeInt_ExpectedOutput

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -49,6 +49,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser
     src/ParseTanh.cxx
     src/ParseTranspose.cxx
     src/ParseErf.cxx
+    src/ParseRange.cxx
     src/ParseLayerNormalization.cxx
     src/ParseExpand.cxx
     src/ParseGather.cxx

--- a/tmva/sofie_parsers/src/ParseConcat.cxx
+++ b/tmva/sofie_parsers/src/ParseConcat.cxx
@@ -34,7 +34,7 @@ ParserFuncSignature ParseConcat = [](RModelParser_ONNX &parser, const onnx::Node
       std::string attribute_name = nodeproto.attribute(i).name();
       if (attribute_name == "axis")
          attr_axis = nodeproto.attribute(i).i();
-      else if (attribute_name == "new_axis")
+      else if (attribute_name == "new_axis") // this is for ConcatFromSequence (that is equivalent to np.stack)
          attr_new_axis = nodeproto.attribute(i).i();
    }
    switch (input_type) {

--- a/tmva/sofie_parsers/src/ParseRange.cxx
+++ b/tmva/sofie_parsers/src/ParseRange.cxx
@@ -1,0 +1,52 @@
+#include "TMVA/RModelParser_ONNX.hxx"
+#include "TMVA/ROperator_Range.hxx"
+#include "onnx_proto3.pb.h"
+
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+ParserFuncSignature ParseRange = [](RModelParser_ONNX &parser, const onnx::NodeProto &nodeproto) {
+   ETensorType input_type;
+
+   auto start = nodeproto.input(0);
+   if (parser.IsRegisteredTensorType(start)) {
+      input_type = parser.GetTensorType(start);
+   } else {
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser Tanh op has input tensor" + start +
+                               " but its type is not yet registered");
+   }
+
+   auto limit = nodeproto.input(1);
+   if (!parser.IsRegisteredTensorType(limit)) {
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser Tanh op has input tensor" + limit +
+                               " but its type is not yet registered");
+   }
+
+   auto delta = nodeproto.input(2);
+   if (!parser.IsRegisteredTensorType(delta)) {
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser Tanh op has input tensor" + delta +
+                               " but its type is not yet registered");
+   }
+
+   std::unique_ptr<ROperator> op;
+   std::string output_name = nodeproto.output(0);
+
+   switch (input_type) {
+   case ETensorType::FLOAT: op.reset(new ROperator_Range<float>(start, limit, delta, output_name)); break;
+   case ETensorType::INT64: op.reset(new ROperator_Range<int64_t>(start, limit, delta, output_name)); break;
+   default:
+      throw std::runtime_error("TMVA::SOFIE - Unsupported - Operator Range does not yet support input type " +
+                               std::to_string(static_cast<int>(input_type)));
+   }
+
+   if (!parser.IsRegisteredTensorType(output_name)) {
+      parser.RegisterTensorType(output_name, input_type);
+   }
+
+   return op;
+};
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -71,6 +71,7 @@ extern ParserFuncSignature ParseGather;
 extern ParserFuncSignature ParseErf;
 extern ParserFuncSignature ParseElu;
 extern ParserFuncSignature ParseEyeLike;
+extern ParserFuncSignature ParseRange;
 // Decalaration of fused operators
 extern ParserFuseFuncSignature ParseFuseConvAdd;
 extern ParserFuseFuncSignature ParseFuseConvTransposeAdd;
@@ -148,6 +149,7 @@ RModelParser_ONNX::RModelParser_ONNX() noexcept : fOperatorsMapImpl(std::make_un
    RegisterOperator("Erf", ParseErf);
    RegisterOperator("Elu", ParseElu);
    RegisterOperator("EyeLike", ParseEyeLike);
+   RegisterOperator("Range", ParseRange);
 }
 
 // Destructor of the parser


### PR DESCRIPTION
# This Pull request:

This PR is continuing #13457 by Ahmat and it is based on https://github.com/root-project/root/pull/12941 and [Dynamic-Op](https://github.com/root-project/root/compare/master...Neel-Shah-29:root-1:Dynamic-Op) both by Neel Shah

# Changes of Fixes

- Introduce intermediate tensors with parametric shapes (Dynamic tensors)
- Implement the [Range operator](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Range)
- Add tests for the Range operator
- Add full support for Input tensors with parametric shapes (using the Dim structure) and propagate the shapes using Dim also in the intermediate ones.
- Start changing operators to support inputs/output tensors with Dim shapes. 
    - support now Gemm, Relu, Concat, LayerNormalization
- Add support for input Dim shapes in GNN classes to support fully variable number of nodes and edges