### PR TITLE
[PyROOT] More use of public CPyCppyy API instead of internals

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -90,7 +90,6 @@ target_include_directories(${libname}
       ${CMAKE_BINARY_DIR}/ginclude
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 
 set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tclass.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tclass.py
@@ -16,6 +16,7 @@ def pythonize_tclass():
     klass = cppyy.gbl.TClass
 
     # DynamicCast
+    klass._TClass__DynamicCast = klass.DynamicCast
     AddTClassDynamicCastPyz(klass)
 
 # Instant pythonization (executed at `import ROOT` time), no need of a

--- a/bindings/pyroot/pythonizations/src/CPPInstancePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/CPPInstancePyz.cxx
@@ -10,15 +10,15 @@
  *************************************************************************/
 
 // Bindings
-#include "CPyCppyy.h"
+#include "CPyCppyy/API.h"
+
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/CustomPyTypes.h"
+
 #include "PyROOTPythonize.h"
-#include "CPPInstance.h"
-#include "ProxyWrappers.h"
-#include "Converters.h"
-#include "Utility.h"
 #include "PyzCppHelpers.hxx"
 #include "TBufferFile.h"
-#include "CustomPyTypes.h"
 
 using namespace CPyCppyy;
 
@@ -39,7 +39,7 @@ extern PyObject *gRootModule;
 PyObject *PyROOT::CPPInstanceExpand(PyObject * /*self*/, PyObject *args)
 {
    PyObject *pybuf = 0, *pyname = 0;
-   if (!PyArg_ParseTuple(args, const_cast<char *>("O!O!:__expand__"), &PyBytes_Type, &pybuf, &PyBytes_Type, &pyname))
+   if (!PyArg_ParseTuple(args, "O!O!:__expand__", &PyBytes_Type, &pybuf, &PyBytes_Type, &pyname))
       return 0;
    const char *clname = PyBytes_AS_STRING(pyname);
    // TBuffer and its derived classes can't write themselves, but can be created
@@ -55,12 +55,7 @@ PyObject *PyROOT::CPPInstanceExpand(PyObject * /*self*/, PyObject *args)
       TBufferFile buf(TBuffer::kRead, PyBytes_GET_SIZE(pybuf), PyBytes_AS_STRING(pybuf), kFALSE);
       newObj = buf.ReadObjectAny(0);
    }
-   PyObject *result = BindCppObject(newObj, Cppyy::GetScope(clname));
-   if (result) {
-      // this object is to be owned by the Python interpreter, assuming that the call
-      // originated from there
-      ((CPPInstance *)result)->PythonOwns();
-   }
+   PyObject *result = CPyCppyy::Instance_FromVoidPtr(newObj, clname, /*python_owns=*/ true);
    return result;
 }
 
@@ -68,22 +63,23 @@ PyObject *PyROOT::CPPInstanceExpand(PyObject * /*self*/, PyObject *args)
 /// Turn the object proxy instance into a character stream and return for
 /// pickle, together with the callable object that can restore the stream
 /// into the object proxy instance.
-PyObject *op_reduce(CPPInstance *self, PyObject * /*args*/)
+PyObject *op_reduce(PyObject *self, PyObject * /*args*/)
 {
    // keep a borrowed reference around to the callable function for expanding;
    // because it is borrowed, it means that there can be no pickling during the
    // shutdown of the libPyROOT module
    static PyObject *s_expand =
-      PyDict_GetItemString(PyModule_GetDict(PyROOT::gRootModule), const_cast<char *>("_CPPInstance__expand__"));
+      PyDict_GetItemString(PyModule_GetDict(PyROOT::gRootModule), "_CPPInstance__expand__");
 
    // TBuffer and its derived classes can't write themselves, but can be created
    // directly from the buffer, so handle them in a special case
    static Cppyy::TCppType_t s_bfClass = Cppyy::GetScope("TBufferFile");
    TBufferFile *buff = 0;
-   if (s_bfClass == self->ObjectIsA()) {
-      buff = (TBufferFile *)self->GetObject();
+   Cppyy::TCppType_t selfClass = ((CPPInstance*)self)->ObjectIsA();
+   if (selfClass == s_bfClass) {
+      buff = (TBufferFile *)CPyCppyy::Instance_AsVoidPtr(self);
    } else {
-      auto className = Cppyy::GetScopedFinalName(self->ObjectIsA());
+      auto className = GetScopedFinalNameFromPyObject(self);
       if (className.find("__cppyy_internal::Dispatcher") == 0) {
          PyErr_Format(PyExc_IOError, "generic streaming of Python objects whose class derives from a C++ class is not supported. "
                                      "Please refer to the Python pickle documentation for instructions on how to define "
@@ -95,10 +91,10 @@ PyObject *op_reduce(CPPInstance *self, PyObject * /*args*/)
       static TBufferFile s_buff(TBuffer::kWrite);
       s_buff.Reset();
       // to delete
-      if (s_buff.WriteObjectAny(self->GetObject(),
+      if (s_buff.WriteObjectAny(CPyCppyy::Instance_AsVoidPtr(self),
                                 TClass::GetClass(className.c_str())) != 1) {
          PyErr_Format(PyExc_IOError, "could not stream object of type %s",
-                      Cppyy::GetScopedFinalName(self->ObjectIsA()).c_str());
+                      GetScopedFinalNameFromPyObject(self).c_str());
          return 0;
       }
       buff = &s_buff;
@@ -108,7 +104,7 @@ PyObject *op_reduce(CPPInstance *self, PyObject * /*args*/)
    // on reading back in (see CPPInstanceExpand defined above)
    PyObject *res2 = PyTuple_New(2);
    PyTuple_SET_ITEM(res2, 0, PyBytes_FromStringAndSize(buff->Buffer(), buff->Length()));
-   PyTuple_SET_ITEM(res2, 1, PyBytes_FromString(Cppyy::GetScopedFinalName(self->ObjectIsA()).c_str()));
+   PyTuple_SET_ITEM(res2, 1, PyBytes_FromString(GetScopedFinalNameFromPyObject(self).c_str()));
 
    PyObject *result = PyTuple_New(2);
    Py_INCREF(s_expand);
@@ -145,7 +141,7 @@ PyObject *PyROOT::AddCPPInstancePickling(PyObject * /*self*/, PyObject *args)
    // attribute assignment using PyObject_SetAttr
    // for more info refer to:
    // https://bitbucket.org/wlav/cppyy/issues/110/user-defined-classes-in-c-dont-seem-to-be
-   PyObject_GenericSetAttr(pyclass, CPyCppyy_PyText_FromString(attr), method);
+   PyObject_GenericSetAttr(pyclass, PyUnicode_FromString(attr), method);
    Py_DECREF(method);
    Py_DECREF(func);
 

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -15,10 +15,9 @@
 #include "RPyROOTApplication.h"
 
 // Cppyy
-#include "CPyCppyy.h"
-#include "CallContext.h"
-#include "ProxyWrappers.h"
-#include "Utility.h"
+#include "CPyCppyy/API.h"
+#include "../../cppyy/CPyCppyy/src/CallContext.h"
+#include "../../cppyy/CPyCppyy/src/ProxyWrappers.h"
 
 // ROOT
 #include "TROOT.h"

--- a/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
@@ -14,8 +14,7 @@
 #include "TMemoryRegulator.h"
 
 // Cppyy
-#include "CPyCppyy.h"
-#include "ProxyWrappers.h"
+#include "CPyCppyy/API.h"
 
 // ROOT
 #include "TROOT.h"
@@ -32,11 +31,11 @@ using namespace PyROOT;
 
 namespace {
 
-static void AddToGlobalScope(const char *label, const char * /* hdr */, TObject *obj, Cppyy::TCppType_t klass)
+static void AddToGlobalScope(const char *label, TObject *obj, const char * classname)
 {
    // Bind the given object with the given class in the global scope with the
    // given label for its reference.
-   PyModule_AddObject(gRootModule, const_cast<char *>(label), CPyCppyy::BindCppObjectNoCast(obj, klass));
+   PyModule_AddObject(gRootModule, label, CPyCppyy::Instance_FromVoidPtr(obj, classname));
 }
 
 } // unnamed namespace
@@ -58,9 +57,9 @@ void PyROOT::Init()
    gROOT->GetListOfCleanups()->Add(&GetMemoryRegulator());
 
    // Bind ROOT globals that will be needed in ROOT.py
-   AddToGlobalScope("gROOT", "TROOT.h", gROOT, Cppyy::GetScope(gROOT->IsA()->GetName()));
-   AddToGlobalScope("gSystem", "TSystem.h", gSystem, Cppyy::GetScope(gSystem->IsA()->GetName()));
-   AddToGlobalScope("gInterpreter", "TInterpreter.h", gInterpreter, Cppyy::GetScope(gInterpreter->IsA()->GetName()));
+   AddToGlobalScope("gROOT", gROOT, gROOT->IsA()->GetName());
+   AddToGlobalScope("gSystem", gSystem, gSystem->IsA()->GetName());
+   AddToGlobalScope("gInterpreter", gInterpreter, gInterpreter->IsA()->GetName());
 }
 
 PyObject *PyROOT::ClearProxiedObjects(PyObject * /* self */, PyObject * /* args */)

--- a/bindings/pyroot/pythonizations/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot/pythonizations/src/PyzCppHelpers.hxx
@@ -11,8 +11,8 @@
 #ifndef PYROOT_PYZCPPHELPERS
 #define PYROOT_PYZCPPHELPERS
 
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
+#include "CPyCppyy/API.h"
+
 #include "TClass.h"
 #include "ROOT/RConfig.hxx"
 
@@ -21,7 +21,8 @@
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth);
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1);
 PyObject *BoolNot(PyObject *value);
-TClass *GetTClass(const CPyCppyy::CPPInstance *pyobj);
+TClass *GetTClass(const PyObject *pyobj);
+std::string GetScopedFinalNameFromPyObject(const PyObject *pyobj);
 std::string GetCppTypeFromNumpyType(const std::string& dtype);
 PyObject *GetArrayInterface(PyObject *obj);
 unsigned long long GetDataPointerFromArrayInterface(PyObject *obj);

--- a/bindings/pyroot/pythonizations/src/RDataFramePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/RDataFramePyz.cxx
@@ -9,13 +9,15 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
-#include "ProxyWrappers.h"
+#include "CPyCppyy/API.h"
+
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/ProxyWrappers.h"
+
 #include "PyROOTPythonize.h"
 #include "ROOT/RConfig.hxx"
 #include "TInterpreter.h"
-#include "CPyCppyy/API.h"
 
 #include <utility> // std::pair
 #include <sstream> // std::stringstream

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -11,7 +11,6 @@
 
 // Bindings
 #include "Python.h"
-#include "CPyCppyy.h"
 #include "RPyROOTApplication.h"
 
 // ROOT
@@ -50,14 +49,14 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
          argv = new char *[argc];
       } else {
          // Retrieve sys.argv list from Python
-         PyObject *argl = PySys_GetObject(const_cast<char *>("argv"));
+         PyObject *argl = PySys_GetObject("argv");
 
          if (argl && 0 < PyList_Size(argl))
             argc = (int)PyList_GET_SIZE(argl);
 
          argv = new char *[argc];
          for (int i = 1; i < argc; ++i) {
-            char *argi = const_cast<char *>(CPyCppyy_PyText_AsString(PyList_GET_ITEM(argl, i)));
+            char *argi = const_cast<char *>(PyUnicode_AsUTF8(PyList_GET_ITEM(argl, i)));
             if (strcmp(argi, "-") == 0 || strcmp(argi, "--") == 0) {
                // Stop collecting options, the remaining are for the Python script
                argc = i; // includes program name

--- a/bindings/pyroot/pythonizations/src/RTensorPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/RTensorPyz.cxx
@@ -9,9 +9,10 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
-#include "ProxyWrappers.h"
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/ProxyWrappers.h"
+
 #include "PyROOTPythonize.h"
 #include "TInterpreter.h"
 #include "PyzCppHelpers.hxx"

--- a/bindings/pyroot/pythonizations/src/RVecPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/RVecPyz.cxx
@@ -9,9 +9,10 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
-#include "ProxyWrappers.h"
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/ProxyWrappers.h"
+
 #include "PyROOTPythonize.h"
 #include "TInterpreter.h"
 #include "PyzCppHelpers.hxx"

--- a/bindings/pyroot/pythonizations/src/TMemoryRegulator.cxx
+++ b/bindings/pyroot/pythonizations/src/TMemoryRegulator.cxx
@@ -11,9 +11,8 @@
 
 #include "TMemoryRegulator.h"
 
-#include "ProxyWrappers.h"
-#include "CPPInstance.h"
-#include "CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/ProxyWrappers.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
 
 using namespace CPyCppyy;
 

--- a/bindings/pyroot/pythonizations/src/TMemoryRegulator.h
+++ b/bindings/pyroot/pythonizations/src/TMemoryRegulator.h
@@ -34,8 +34,8 @@
 // Bindings
 // CPyCppyy.h must be go first, since it includes Python.h, which must be
 // included before any standard header
-#include "CPyCppyy.h"
-#include "MemoryRegulator.h"
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/MemoryRegulator.h"
 
 // ROOT
 #include "TObject.h"

--- a/bindings/pyroot/pythonizations/src/TObjectPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TObjectPyz.cxx
@@ -10,9 +10,12 @@
  *************************************************************************/
 
 // Bindings
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
-#include "Utility.h"
+#include "CPyCppyy/API.h"
+
+#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
+#include "../../cppyy/CPyCppyy/src/CPPInstance.h"
+#include "../../cppyy/CPyCppyy/src/Utility.h"
+
 #include "PyROOTPythonize.h"
 #include "PyzCppHelpers.hxx"
 
@@ -24,7 +27,7 @@ using namespace CPyCppyy;
 // Implement Python's __eq__ with TObject::IsEqual
 PyObject *TObjectIsEqual(PyObject *self, PyObject *obj)
 {
-   if (!CPPInstance_Check(obj) || !((CPPInstance *)obj)->fObject)
+   if (!CPyCppyy::Instance_Check(obj) || !((CPPInstance *)obj)->fObject)
       return CPPInstance_Type.tp_richcompare(self, obj, Py_EQ);
 
    return CallPyObjMethod(self, "IsEqual", obj);
@@ -33,7 +36,7 @@ PyObject *TObjectIsEqual(PyObject *self, PyObject *obj)
 // Implement Python's __ne__ with TObject::IsEqual
 PyObject *TObjectIsNotEqual(PyObject *self, PyObject *obj)
 {
-   if (!CPPInstance_Check(obj) || !((CPPInstance *)obj)->fObject)
+   if (!CPyCppyy::Instance_Check(obj) || !((CPPInstance *)obj)->fObject)
       return CPPInstance_Type.tp_richcompare(self, obj, Py_NE);
 
    return BoolNot(CallPyObjMethod(self, "IsEqual", obj));

--- a/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
+++ b/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
@@ -9,10 +9,10 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-// Bindings
-#include "CPyCppyy.h"
 #include "TPyDispatcher.h"
-#include "ProxyWrappers.h"
+
+// Bindings
+#include "CPyCppyy/API.h"
 
 // ROOT
 #include "TClass.h"
@@ -113,7 +113,7 @@ PyObject *TPyDispatcher::DispatchVA(const char *format, ...)
 
 PyObject *TPyDispatcher::DispatchVA1(const char *clname, void *obj, const char *format, ...)
 {
-   PyObject *pyobj = CPyCppyy::BindCppObject(obj, Cppyy::GetScope(clname), kFALSE /* isRef */);
+   PyObject *pyobj = CPyCppyy::Instance_FromVoidPtr(obj, clname);
    if (!pyobj) {
       PyErr_Print();
       return 0;
@@ -171,9 +171,9 @@ PyObject *TPyDispatcher::DispatchVA1(const char *clname, void *obj, const char *
 PyObject *TPyDispatcher::Dispatch(TPad *selpad, TObject *selected, Int_t event)
 {
    PyObject *args = PyTuple_New(3);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(selpad, Cppyy::GetScope("TPad")));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(selected, Cppyy::GetScope("TObject")));
-   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(event));
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(selpad, "TPad"));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
+   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(event));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);
@@ -191,10 +191,10 @@ PyObject *TPyDispatcher::Dispatch(TPad *selpad, TObject *selected, Int_t event)
 PyObject *TPyDispatcher::Dispatch(Int_t event, Int_t x, Int_t y, TObject *selected)
 {
    PyObject *args = PyTuple_New(4);
-   PyTuple_SET_ITEM(args, 0, PyInt_FromLong(event));
-   PyTuple_SET_ITEM(args, 1, PyInt_FromLong(x));
-   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(y));
-   PyTuple_SET_ITEM(args, 3, CPyCppyy::BindCppObject(selected, Cppyy::GetScope("TObject")));
+   PyTuple_SET_ITEM(args, 0, PyLong_FromLong(event));
+   PyTuple_SET_ITEM(args, 1, PyLong_FromLong(x));
+   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(y));
+   PyTuple_SET_ITEM(args, 3, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);
@@ -212,9 +212,9 @@ PyObject *TPyDispatcher::Dispatch(Int_t event, Int_t x, Int_t y, TObject *select
 PyObject *TPyDispatcher::Dispatch(TVirtualPad *pad, TObject *obj, Int_t event)
 {
    PyObject *args = PyTuple_New(3);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(pad, Cppyy::GetScope("TVirtualPad")));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(obj, Cppyy::GetScope("TObject")));
-   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(event));
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(pad, "TVirtualPad"));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(obj, "TObject"));
+   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(event));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);
@@ -232,8 +232,8 @@ PyObject *TPyDispatcher::Dispatch(TVirtualPad *pad, TObject *obj, Int_t event)
 PyObject *TPyDispatcher::Dispatch(TGListTreeItem *item, TDNDData *data)
 {
    PyObject *args = PyTuple_New(2);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(item, Cppyy::GetScope("TGListTreeItem")));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(data, Cppyy::GetScope("TDNDData")));
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(item, "TGListTreeItem"));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(data, "TDNDData"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);
@@ -252,7 +252,7 @@ PyObject *TPyDispatcher::Dispatch(const char *name, const TList *attr)
 {
    PyObject *args = PyTuple_New(2);
    PyTuple_SET_ITEM(args, 0, PyBytes_FromString(name));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject((void *)attr, Cppyy::GetScope("TList")));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr((void *)attr, "TList"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);
@@ -270,8 +270,8 @@ PyObject *TPyDispatcher::Dispatch(const char *name, const TList *attr)
 PyObject *TPyDispatcher::Dispatch(TSlave *slave, TProofProgressInfo *pi)
 {
    PyObject *args = PyTuple_New(2);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(slave, Cppyy::GetScope("TSlave")));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(pi, Cppyy::GetScope("TProofProgressInfo")));
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(slave, "TSlave"));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(pi, "TProofProgressInfo"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
    Py_XDECREF(args);


### PR DESCRIPTION
We have to avoid using the CPyCppyy internals in the ROOT pythonization
libray. Otherwise, the ROOT pythonizations will break when updating to the
new CPyCppyy, where the internals have changed a lot.

This commit makes sure the internals are not used where it can easily
avoided by using the public CPyCppyy API, or using the C Python API
directly instead of some private compatibility  macros defined in
CPyCppyy (that were necessary in the past to support both Python 2 and
3).

Furthermore, the private sources of `CPyCppyy` are now not publically
exposed anymore at the CMake level. This means that we are now forced to
include them via relative paths in the ROOT repository. This makes is
much easier to spot remaining usage of the internal headers (it is quite
hard to tell otherwise that `Utility.h` is a private header from
CPyCppyy). Better exposing this should help in the discussion about how
the get rid of the remaining usage of private headers.