### PR TITLE
[matrix] fix TMatrixT(a,TMatrixT::kInvMult,b) constructor

### DIFF
--- a/math/matrix/src/TMatrixT.cxx
+++ b/math/matrix/src/TMatrixT.cxx
@@ -158,7 +158,8 @@ TMatrixT<Element>::TMatrixT(EMatrixCreatorsOp1 op, const TMatrixT<Element> &prot
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of matrix applying a specific operation to two prototypes.
 /// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
-/// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
+/// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b);
+/// Whenever kInvMult is invoked and b is not squared, additional memory is allocated for a^(-1)
 
 template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a, EMatrixCreatorsOp2 op, const TMatrixT<Element> &b)
@@ -274,6 +275,7 @@ TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a, EMatrixCreatorsOp2 op, c
 /// Constructor of matrix applying a specific operation to two prototypes.
 /// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
 /// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
+/// Whenever kInvMult is invoked and b is not squared, additional memory is allocated for a^(-1)
 
 template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a, EMatrixCreatorsOp2 op, const TMatrixT<Element> &b)

--- a/math/matrix/src/TMatrixT.cxx
+++ b/math/matrix/src/TMatrixT.cxx
@@ -36,19 +36,19 @@ templateClassImp(TMatrixT);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for (nrows x ncols) matrix
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(Int_t nrows,Int_t ncols)
+template <class Element>
+TMatrixT<Element>::TMatrixT(Int_t nrows, Int_t ncols)
 {
-   Allocate(nrows,ncols,0,0,1);
+   Allocate(nrows, ncols, 0, 0, 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for ([row_lwb..row_upb] x [col_lwb..col_upb]) matrix
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb)
+template <class Element>
+TMatrixT<Element>::TMatrixT(Int_t row_lwb, Int_t row_upb, Int_t col_lwb, Int_t col_upb)
 {
-   Allocate(row_upb-row_lwb+1,col_upb-col_lwb+1,row_lwb,col_lwb,1);
+   Allocate(row_upb - row_lwb + 1, col_upb - col_lwb + 1, row_lwb, col_lwb, 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,54 +59,54 @@ TMatrixT<Element>::TMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_
 ///
 /// array elements are copied
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(Int_t no_rows,Int_t no_cols,const Element *elements,Option_t *option)
+template <class Element>
+TMatrixT<Element>::TMatrixT(Int_t no_rows, Int_t no_cols, const Element *elements, Option_t *option)
 {
-   Allocate(no_rows,no_cols);
-   TMatrixTBase<Element>::SetMatrixArray(elements,option);
+   Allocate(no_rows, no_cols);
+   TMatrixTBase<Element>::SetMatrixArray(elements, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// array elements are copied
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                            const Element *elements,Option_t *option)
+template <class Element>
+TMatrixT<Element>::TMatrixT(Int_t row_lwb, Int_t row_upb, Int_t col_lwb, Int_t col_upb, const Element *elements,
+                            Option_t *option)
 {
-   Allocate(row_upb-row_lwb+1,col_upb-col_lwb+1,row_lwb,col_lwb);
-   TMatrixTBase<Element>::SetMatrixArray(elements,option);
+   Allocate(row_upb - row_lwb + 1, col_upb - col_lwb + 1, row_lwb, col_lwb);
+   TMatrixTBase<Element>::SetMatrixArray(elements, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-template<class Element>
+template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &another) : TMatrixTBase<Element>(another)
 {
    R__ASSERT(another.IsValid());
-   Allocate(another.GetNrows(),another.GetNcols(),another.GetRowLwb(),another.GetColLwb());
+   Allocate(another.GetNrows(), another.GetNcols(), another.GetRowLwb(), another.GetColLwb());
    *this = another;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor of a symmetric matrix
 
-template<class Element>
+template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &another)
 {
    R__ASSERT(another.IsValid());
-   Allocate(another.GetNrows(),another.GetNcols(),another.GetRowLwb(),another.GetColLwb());
+   Allocate(another.GetNrows(), another.GetNcols(), another.GetRowLwb(), another.GetColLwb());
    *this = another;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor of a sparse matrix
 
-template<class Element>
+template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixTSparse<Element> &another)
 {
    R__ASSERT(another.IsValid());
-   Allocate(another.GetNrows(),another.GetNcols(),another.GetRowLwb(),another.GetColLwb());
+   Allocate(another.GetNrows(), another.GetNcols(), another.GetRowLwb(), another.GetColLwb());
    *this = another;
 }
 
@@ -115,49 +115,43 @@ TMatrixT<Element>::TMatrixT(const TMatrixTSparse<Element> &another)
 /// Example: TMatrixT<Element> a(10,12); ...; TMatrixT<Element> b(TMatrixT::kTransposed, a);
 /// Supported operations are: kZero, kUnit, kTransposed, kInverted and kAtA.
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(EMatrixCreatorsOp1 op,const TMatrixT<Element> &prototype)
+template <class Element>
+TMatrixT<Element>::TMatrixT(EMatrixCreatorsOp1 op, const TMatrixT<Element> &prototype)
 {
    R__ASSERT(prototype.IsValid());
 
-   switch(op) {
-      case kZero:
-         Allocate(prototype.GetNrows(),prototype.GetNcols(),
-                  prototype.GetRowLwb(),prototype.GetColLwb(),1);
-         break;
+   switch (op) {
+   case kZero:
+      Allocate(prototype.GetNrows(), prototype.GetNcols(), prototype.GetRowLwb(), prototype.GetColLwb(), 1);
+      break;
 
-      case kUnit:
-         Allocate(prototype.GetNrows(),prototype.GetNcols(),
-                  prototype.GetRowLwb(),prototype.GetColLwb(),1);
-         this->UnitMatrix();
-         break;
+   case kUnit:
+      Allocate(prototype.GetNrows(), prototype.GetNcols(), prototype.GetRowLwb(), prototype.GetColLwb(), 1);
+      this->UnitMatrix();
+      break;
 
-      case kTransposed:
-         Allocate(prototype.GetNcols(), prototype.GetNrows(),
-                  prototype.GetColLwb(),prototype.GetRowLwb());
-         Transpose(prototype);
-         break;
+   case kTransposed:
+      Allocate(prototype.GetNcols(), prototype.GetNrows(), prototype.GetColLwb(), prototype.GetRowLwb());
+      Transpose(prototype);
+      break;
 
-      case kInverted:
-      {
-         Allocate(prototype.GetNrows(),prototype.GetNcols(),
-                  prototype.GetRowLwb(),prototype.GetColLwb(),1);
-         *this = prototype;
-         // Since the user can not control the tolerance of this newly created matrix
-         // we put it to the smallest possible number
-         const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
-         this->Invert();
-         this->SetTol(oldTol);
-         break;
-      }
+   case kInverted: {
+      Allocate(prototype.GetNrows(), prototype.GetNcols(), prototype.GetRowLwb(), prototype.GetColLwb(), 1);
+      *this = prototype;
+      // Since the user can not control the tolerance of this newly created matrix
+      // we put it to the smallest possible number
+      const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
+      this->Invert();
+      this->SetTol(oldTol);
+      break;
+   }
 
-      case kAtA:
-         Allocate(prototype.GetNcols(),prototype.GetNcols(),prototype.GetColLwb(),prototype.GetColLwb(),1);
-         TMult(prototype,prototype);
-         break;
+   case kAtA:
+      Allocate(prototype.GetNcols(), prototype.GetNcols(), prototype.GetColLwb(), prototype.GetColLwb(), 1);
+      TMult(prototype, prototype);
+      break;
 
-      default:
-         Error("TMatrixT(EMatrixCreatorOp1)", "operation %d not yet implemented", op);
+   default: Error("TMatrixT(EMatrixCreatorOp1)", "operation %d not yet implemented", op);
    }
 }
 
@@ -166,121 +160,60 @@ TMatrixT<Element>::TMatrixT(EMatrixCreatorsOp1 op,const TMatrixT<Element> &proto
 /// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
 /// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a,EMatrixCreatorsOp2 op,const TMatrixT<Element> &b)
+template <class Element>
+TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a, EMatrixCreatorsOp2 op, const TMatrixT<Element> &b)
 {
    R__ASSERT(a.IsValid());
    R__ASSERT(b.IsValid());
 
-   switch(op) {
-      case kMult:
-         Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         Mult(a,b);
-         break;
+   switch (op) {
+   case kMult:
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      Mult(a, b);
+      break;
 
-      case kTransposeMult:
-         Allocate(a.GetNcols(),b.GetNcols(),a.GetColLwb(),b.GetColLwb(),1);
-         TMult(a,b);
-         break;
+   case kTransposeMult:
+      Allocate(a.GetNcols(), b.GetNcols(), a.GetColLwb(), b.GetColLwb(), 1);
+      TMult(a, b);
+      break;
 
-      case kMultTranspose:
-         Allocate(a.GetNrows(),b.GetNrows(),a.GetRowLwb(),b.GetRowLwb(),1);
-         MultT(a,b);
-         break;
+   case kMultTranspose:
+      Allocate(a.GetNrows(), b.GetNrows(), a.GetRowLwb(), b.GetRowLwb(), 1);
+      MultT(a, b);
+      break;
 
-      case kInvMult:
-      {  Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         // if size(a) == size(b), perform in place computation
-         if (a.GetNrows() == b.GetNcols()){
-            *this = a;
-            const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
-            this->Invert();
-            this->SetTol(oldTol);
-            *this *= b;
-         }
-         else{
-            TMatrixT<Element> ainv = a;
-            const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
-            ainv.Invert();
-            ainv.SetTol(oldTol);
-            Mult(ainv,b);
-         }
-         break;
-      }
-
-      case kPlus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Plus(a,b);
-         break;
-      }
-
-      case kMinus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Minus(a,b);
-         break;
-      }
-
-      default:
-         Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor of matrix applying a specific operation to two prototypes.
-/// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
-/// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
-
-template<class Element>
-TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a,EMatrixCreatorsOp2 op,const TMatrixTSym<Element> &b)
-{
-   R__ASSERT(a.IsValid());
-   R__ASSERT(b.IsValid());
-
-   switch(op) {
-      case kMult:
-         Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         Mult(a,b);
-         break;
-
-      case kTransposeMult:
-         Allocate(a.GetNcols(),b.GetNcols(),a.GetColLwb(),b.GetColLwb(),1);
-         TMult(a,b);
-         break;
-
-      case kMultTranspose:
-         Allocate(a.GetNrows(),b.GetNrows(),a.GetRowLwb(),b.GetRowLwb(),1);
-         MultT(a,b);
-         break;
-
-      case kInvMult:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
+   case kInvMult: {
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      // if size(a) == size(b), perform in place computation
+      if (a.GetNrows() == b.GetNcols()) {
          *this = a;
          const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
          this->Invert();
          this->SetTol(oldTol);
          *this *= b;
-         break;
+      } else {
+         TMatrixT<Element> ainv = a;
+         const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
+         ainv.Invert();
+         ainv.SetTol(oldTol);
+         Mult(ainv, b);
       }
+      break;
+   }
 
-      case kPlus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Plus(a,b);
-         break;
-      }
+   case kPlus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Plus(a, b);
+      break;
+   }
 
-      case kMinus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Minus(a,b);
-         break;
-      }
+   case kMinus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Minus(a, b);
+      break;
+   }
 
-      default:
-         Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
+   default: Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
    }
 }
 
@@ -289,64 +222,51 @@ TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a,EMatrixCreatorsOp2 op,con
 /// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
 /// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a,EMatrixCreatorsOp2 op,const TMatrixT<Element> &b)
+template <class Element>
+TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a, EMatrixCreatorsOp2 op, const TMatrixTSym<Element> &b)
 {
    R__ASSERT(a.IsValid());
    R__ASSERT(b.IsValid());
 
-   switch(op) {
-      case kMult:
-         Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         Mult(a,b);
-         break;
+   switch (op) {
+   case kMult:
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      Mult(a, b);
+      break;
 
-      case kTransposeMult:
-         Allocate(a.GetNcols(),b.GetNcols(),a.GetColLwb(),b.GetColLwb(),1);
-         TMult(a,b);
-         break;
+   case kTransposeMult:
+      Allocate(a.GetNcols(), b.GetNcols(), a.GetColLwb(), b.GetColLwb(), 1);
+      TMult(a, b);
+      break;
 
-      case kMultTranspose:
-         Allocate(a.GetNrows(),b.GetNrows(),a.GetRowLwb(),b.GetRowLwb(),1);
-         MultT(a,b);
-         break;
+   case kMultTranspose:
+      Allocate(a.GetNrows(), b.GetNrows(), a.GetRowLwb(), b.GetRowLwb(), 1);
+      MultT(a, b);
+      break;
 
-      case kInvMult:
-      {  Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         // if size(a) == size(b), perform in place computation
-         if (a.GetNrows() == b.GetNcols()){
-            *this = a;
-            const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
-            this->Invert();
-            this->SetTol(oldTol);
-            *this *= b;
-         }
-         else{
-            TMatrixTSym<Element> ainv = a;
-            const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
-            ainv.Invert();
-            ainv.SetTol(oldTol);
-            Mult(ainv,b);
-         }
-         break;
-      }
+   case kInvMult: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      *this = a;
+      const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
+      this->Invert();
+      this->SetTol(oldTol);
+      *this *= b;
+      break;
+   }
 
-      case kPlus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Plus(a,b);
-         break;
-      }
+   case kPlus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Plus(a, b);
+      break;
+   }
 
-      case kMinus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Minus(a,b);
-         break;
-      }
+   case kMinus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Minus(a, b);
+      break;
+   }
 
-      default:
-         Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
+   default: Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
    }
 }
 
@@ -355,79 +275,137 @@ TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a,EMatrixCreatorsOp2 op,
 /// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
 /// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
 
-template<class Element>
-TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a,EMatrixCreatorsOp2 op,const TMatrixTSym<Element> &b)
+template <class Element>
+TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a, EMatrixCreatorsOp2 op, const TMatrixT<Element> &b)
 {
    R__ASSERT(a.IsValid());
    R__ASSERT(b.IsValid());
 
-   switch(op) {
-      case kMult:
-         Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
-         Mult(a,b);
-         break;
+   switch (op) {
+   case kMult:
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      Mult(a, b);
+      break;
 
-      case kTransposeMult:
-         Allocate(a.GetNcols(),b.GetNcols(),a.GetColLwb(),b.GetColLwb(),1);
-         TMult(a,b);
-         break;
+   case kTransposeMult:
+      Allocate(a.GetNcols(), b.GetNcols(), a.GetColLwb(), b.GetColLwb(), 1);
+      TMult(a, b);
+      break;
 
-      case kMultTranspose:
-         Allocate(a.GetNrows(),b.GetNrows(),a.GetRowLwb(),b.GetRowLwb(),1);
-         MultT(a,b);
-         break;
+   case kMultTranspose:
+      Allocate(a.GetNrows(), b.GetNrows(), a.GetRowLwb(), b.GetRowLwb(), 1);
+      MultT(a, b);
+      break;
 
-      case kInvMult:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
+   case kInvMult: {
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      // if size(a) == size(b), perform in place computation
+      if (a.GetNrows() == b.GetNcols()) {
          *this = a;
          const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
          this->Invert();
          this->SetTol(oldTol);
          *this *= b;
-         break;
+      } else {
+         TMatrixTSym<Element> ainv = a;
+         const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
+         ainv.Invert();
+         ainv.SetTol(oldTol);
+         Mult(ainv, b);
       }
+      break;
+   }
 
-      case kPlus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Plus(*dynamic_cast<const TMatrixT<Element> *>(&a),b);
-         break;
-      }
+   case kPlus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Plus(a, b);
+      break;
+   }
 
-      case kMinus:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         Minus(*dynamic_cast<const TMatrixT<Element> *>(&a),b);
-         break;
-      }
+   case kMinus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Minus(a, b);
+      break;
+   }
 
-      default:
-         Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
+   default: Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor of matrix applying a specific operation to two prototypes.
+/// Example: TMatrixT<Element> a(10,12), b(12,5); ...; TMatrixT<Element> c(a, TMatrixT::kMult, b);
+/// Supported operations are: kMult (a*b), kTransposeMult (a'*b), kInvMult (a^(-1)*b)
+
+template <class Element>
+TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a, EMatrixCreatorsOp2 op, const TMatrixTSym<Element> &b)
+{
+   R__ASSERT(a.IsValid());
+   R__ASSERT(b.IsValid());
+
+   switch (op) {
+   case kMult:
+      Allocate(a.GetNrows(), b.GetNcols(), a.GetRowLwb(), b.GetColLwb(), 1);
+      Mult(a, b);
+      break;
+
+   case kTransposeMult:
+      Allocate(a.GetNcols(), b.GetNcols(), a.GetColLwb(), b.GetColLwb(), 1);
+      TMult(a, b);
+      break;
+
+   case kMultTranspose:
+      Allocate(a.GetNrows(), b.GetNrows(), a.GetRowLwb(), b.GetRowLwb(), 1);
+      MultT(a, b);
+      break;
+
+   case kInvMult: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      *this = a;
+      const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
+      this->Invert();
+      this->SetTol(oldTol);
+      *this *= b;
+      break;
+   }
+
+   case kPlus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Plus(*dynamic_cast<const TMatrixT<Element> *>(&a), b);
+      break;
+   }
+
+   case kMinus: {
+      Allocate(a.GetNrows(), a.GetNcols(), a.GetRowLwb(), a.GetColLwb(), 1);
+      Minus(*dynamic_cast<const TMatrixT<Element> *>(&a), b);
+      break;
+   }
+
+   default: Error("TMatrixT(EMatrixCreatorOp2)", "operation %d not yet implemented", op);
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor using the TMatrixTLazy class
 
-template<class Element>
+template <class Element>
 TMatrixT<Element>::TMatrixT(const TMatrixTLazy<Element> &lazy_constructor)
 {
-   Allocate(lazy_constructor.GetRowUpb()-lazy_constructor.GetRowLwb()+1,
-            lazy_constructor.GetColUpb()-lazy_constructor.GetColLwb()+1,
-            lazy_constructor.GetRowLwb(),lazy_constructor.GetColLwb(),1);
+   Allocate(lazy_constructor.GetRowUpb() - lazy_constructor.GetRowLwb() + 1,
+            lazy_constructor.GetColUpb() - lazy_constructor.GetColLwb() + 1, lazy_constructor.GetRowLwb(),
+            lazy_constructor.GetColLwb(), 1);
    lazy_constructor.FillIn(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete data pointer m, if it was assigned on the heap
 
-template<class Element>
-void TMatrixT<Element>::Delete_m(Int_t size,Element *&m)
+template <class Element>
+void TMatrixT<Element>::Delete_m(Int_t size, Element *&m)
 {
    if (m) {
       if (size > this->kSizeMax)
-         delete [] m;
+         delete[] m;
       m = nullptr;
    }
 }
@@ -436,12 +414,13 @@ void TMatrixT<Element>::Delete_m(Int_t size,Element *&m)
 /// Return data pointer . if requested size <= kSizeMax, assign pointer
 /// to the stack space
 
-template<class Element>
-Element* TMatrixT<Element>::New_m(Int_t size)
+template <class Element>
+Element *TMatrixT<Element>::New_m(Int_t size)
 {
-   if (size == 0) return nullptr;
+   if (size == 0)
+      return nullptr;
    else {
-      if ( size <= this->kSizeMax )
+      if (size <= this->kSizeMax)
          return fDataStack;
       else {
          Element *heap = new Element[size];
@@ -454,25 +433,23 @@ Element* TMatrixT<Element>::New_m(Int_t size)
 /// Copy copySize doubles from *oldp to *newp . However take care of the
 /// situation where both pointers are assigned to the same stack space
 
-template<class Element>
-Int_t TMatrixT<Element>::Memcpy_m(Element *newp,const Element *oldp,Int_t copySize,
-                                  Int_t newSize,Int_t oldSize)
+template <class Element>
+Int_t TMatrixT<Element>::Memcpy_m(Element *newp, const Element *oldp, Int_t copySize, Int_t newSize, Int_t oldSize)
 {
    if (copySize == 0 || oldp == newp)
       return 0;
    else {
-      if ( newSize <= this->kSizeMax && oldSize <= this->kSizeMax ) {
+      if (newSize <= this->kSizeMax && oldSize <= this->kSizeMax) {
          // both pointers are inside fDataStack, be careful with copy direction !
          if (newp > oldp) {
-            for (Int_t i = copySize-1; i >= 0; i--)
+            for (Int_t i = copySize - 1; i >= 0; i--)
                newp[i] = oldp[i];
          } else {
             for (Int_t i = 0; i < copySize; i++)
                newp[i] = oldp[i];
          }
-      }
-      else
-         memcpy(newp,oldp,copySize*sizeof(Element));
+      } else
+         memcpy(newp, oldp, copySize * sizeof(Element));
    }
    return 0;
 }
@@ -481,37 +458,35 @@ Int_t TMatrixT<Element>::Memcpy_m(Element *newp,const Element *oldp,Int_t copySi
 /// Allocate new matrix. Arguments are number of rows, columns, row
 /// lowerbound (0 default) and column lowerbound (0 default).
 
-template<class Element>
-void TMatrixT<Element>::Allocate(Int_t no_rows,Int_t no_cols,Int_t row_lwb,Int_t col_lwb,
-                                 Int_t init,Int_t /*nr_nonzeros*/)
+template <class Element>
+void TMatrixT<Element>::Allocate(Int_t no_rows, Int_t no_cols, Int_t row_lwb, Int_t col_lwb, Int_t init,
+                                 Int_t /*nr_nonzeros*/)
 {
    this->fIsOwner = kTRUE;
-   this->fTol     = std::numeric_limits<Element>::epsilon();
-   fElements      = nullptr;
-   this->fNrows   = 0;
-   this->fNcols   = 0;
-   this->fRowLwb  = 0;
-   this->fColLwb  = 0;
-   this->fNelems  = 0;
+   this->fTol = std::numeric_limits<Element>::epsilon();
+   fElements = nullptr;
+   this->fNrows = 0;
+   this->fNcols = 0;
+   this->fRowLwb = 0;
+   this->fColLwb = 0;
+   this->fNelems = 0;
 
-   if (no_rows < 0 || no_cols < 0)
-   {
-      Error("Allocate","no_rows=%d no_cols=%d",no_rows,no_cols);
+   if (no_rows < 0 || no_cols < 0) {
+      Error("Allocate", "no_rows=%d no_cols=%d", no_rows, no_cols);
       this->Invalidate();
       return;
    }
 
    this->MakeValid();
-   this->fNrows   = no_rows;
-   this->fNcols   = no_cols;
-   this->fRowLwb  = row_lwb;
-   this->fColLwb  = col_lwb;
-   this->fNelems  = this->fNrows*this->fNcols;
+   this->fNrows = no_rows;
+   this->fNcols = no_cols;
+   this->fRowLwb = row_lwb;
+   this->fColLwb = col_lwb;
+   this->fNelems = this->fNrows * this->fNcols;
 
    // Check if fNelems does not have an overflow.
-   if( ((Long64_t)this->fNrows)*this->fNcols != this->fNelems )
-   {
-      Error("Allocate","too large: no_rows=%d no_cols=%d",no_rows,no_cols);
+   if (((Long64_t)this->fNrows) * this->fNcols != this->fNelems) {
+      Error("Allocate", "too large: no_rows=%d no_cols=%d", no_rows, no_cols);
       this->Invalidate();
       return;
    }
@@ -519,106 +494,106 @@ void TMatrixT<Element>::Allocate(Int_t no_rows,Int_t no_cols,Int_t row_lwb,Int_t
    if (this->fNelems > 0) {
       fElements = New_m(this->fNelems);
       if (init)
-         memset(fElements,0,this->fNelems*sizeof(Element));
+         memset(fElements, 0, this->fNelems * sizeof(Element));
    } else
-     fElements = nullptr;
+      fElements = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix summation. Create a matrix C such that C = A + B.
 
-template<class Element>
-void TMatrixT<Element>::Plus(const TMatrixT<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Plus(const TMatrixT<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
-      if (!AreCompatible(a,b)) {
-         Error("Plus","matrices not compatible");
+      if (!AreCompatible(a, b)) {
+         Error("Plus", "matrices not compatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Plus","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Plus", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Plus","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Plus", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
 
-   const Element *       ap      = a.GetMatrixArray();
-   const Element *       bp      = b.GetMatrixArray();
-         Element *       cp      = this->GetMatrixArray();
-   const Element * const cp_last = cp+this->fNelems;
+   const Element *ap = a.GetMatrixArray();
+   const Element *bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
+   const Element *const cp_last = cp + this->fNelems;
 
    while (cp < cp_last) {
-       *cp = *ap++ + *bp++;
-       cp++;
+      *cp = *ap++ + *bp++;
+      cp++;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix summation. Create a matrix C such that C = A + B.
 
-template<class Element>
-void TMatrixT<Element>::Plus(const TMatrixT<Element> &a,const TMatrixTSym<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Plus(const TMatrixT<Element> &a, const TMatrixTSym<Element> &b)
 {
    if (gMatrixCheck) {
-      if (!AreCompatible(a,b)) {
-         Error("Plus","matrices not compatible");
+      if (!AreCompatible(a, b)) {
+         Error("Plus", "matrices not compatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Plus","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Plus", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Plus","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Plus", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
 
-   const Element *       ap      = a.GetMatrixArray();
-   const Element *       bp      = b.GetMatrixArray();
-         Element *       cp      = this->GetMatrixArray();
-   const Element * const cp_last = cp+this->fNelems;
+   const Element *ap = a.GetMatrixArray();
+   const Element *bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
+   const Element *const cp_last = cp + this->fNelems;
 
    while (cp < cp_last) {
-       *cp = *ap++ + *bp++;
-       cp++;
+      *cp = *ap++ + *bp++;
+      cp++;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix summation. Create a matrix C such that C = A - B.
 
-template<class Element>
-void TMatrixT<Element>::Minus(const TMatrixT<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Minus(const TMatrixT<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
-      if (!AreCompatible(a,b)) {
-         Error("Minus","matrices not compatible");
+      if (!AreCompatible(a, b)) {
+         Error("Minus", "matrices not compatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Minus","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Minus", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Minus","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Minus", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
 
-   const Element *       ap      = a.GetMatrixArray();
-   const Element *       bp      = b.GetMatrixArray();
-         Element *       cp      = this->GetMatrixArray();
-   const Element * const cp_last = cp+this->fNelems;
+   const Element *ap = a.GetMatrixArray();
+   const Element *bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
+   const Element *const cp_last = cp + this->fNelems;
 
    while (cp < cp_last) {
       *cp = *ap++ - *bp++;
@@ -629,56 +604,56 @@ void TMatrixT<Element>::Minus(const TMatrixT<Element> &a,const TMatrixT<Element>
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix summation. Create a matrix C such that C = A - B.
 
-template<class Element>
-void TMatrixT<Element>::Minus(const TMatrixT<Element> &a,const TMatrixTSym<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Minus(const TMatrixT<Element> &a, const TMatrixTSym<Element> &b)
 {
    if (gMatrixCheck) {
-      if (!AreCompatible(a,b)) {
-         Error("Minus","matrices not compatible");
+      if (!AreCompatible(a, b)) {
+         Error("Minus", "matrices not compatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Minus","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Minus", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Minus","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Minus", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
 
-   const Element *       ap      = a.GetMatrixArray();
-   const Element *       bp      = b.GetMatrixArray();
-         Element *       cp      = this->GetMatrixArray();
-   const Element * const cp_last = cp+this->fNelems;
+   const Element *ap = a.GetMatrixArray();
+   const Element *bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
+   const Element *const cp_last = cp + this->fNelems;
 
    while (cp < cp_last) {
-       *cp = *ap++ - *bp++;
-       cp++;
+      *cp = *ap++ - *bp++;
+      cp++;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix multiplication. Create a matrix C such that C = A * B.
 
-template<class Element>
-void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Mult(const TMatrixT<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
       if (a.GetNcols() != b.GetNrows() || a.GetColLwb() != b.GetRowLwb()) {
-         Error("Mult","A rows and B columns incompatible");
+         Error("Mult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -686,25 +661,25 @@ void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixT<Element> 
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dgemm (CblasRowMajor,CblasNoTrans,CblasNoTrans,fNrows,fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, fNrows, fNcols, a.GetNcols(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_sgemm (CblasRowMajor,CblasNoTrans,CblasNoTrans,fNrows,fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, fNrows, fNcols, a.GetNcols(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else
-      Error("Mult","type %s not implemented in BLAS library",typeid(Element));
+      Error("Mult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultB(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultB(ap, na, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
@@ -712,24 +687,24 @@ void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixT<Element> 
 /// Matrix multiplication, with A symmetric and B general.
 /// Create a matrix C such that C = A * B.
 
-template<class Element>
-void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNcols() != b.GetNrows() || a.GetColLwb() != b.GetRowLwb()) {
-         Error("Mult","A rows and B columns incompatible");
+         Error("Mult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -737,25 +712,25 @@ void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixT<Elemen
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dsymm (CblasRowMajor,CblasLeft,CblasUpper,fNrows,fNcols,1.0,
-                   ap,a.GetNcols(),bp,b.GetNcols(),0.0,cp,fNcols);
+      cblas_dsymm(CblasRowMajor, CblasLeft, CblasUpper, fNrows, fNcols, 1.0, ap, a.GetNcols(), bp, b.GetNcols(), 0.0,
+                  cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_ssymm (CblasRowMajor,CblasLeft,CblasUpper,fNrows,fNcols,1.0,
-                   ap,a.GetNcols(),bp,b.GetNcols(),0.0,cp,fNcols);
+      cblas_ssymm(CblasRowMajor, CblasLeft, CblasUpper, fNrows, fNcols, 1.0, ap, a.GetNcols(), bp, b.GetNcols(), 0.0,
+                  cp, fNcols);
    else
-      Error("Mult","type %s not implemented in BLAS library",typeid(Element));
+      Error("Mult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultB(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultB(ap, na, ncolsa, bp, nb, ncolsb, cp);
 
 #endif
 }
@@ -764,24 +739,24 @@ void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixT<Elemen
 /// Matrix multiplication, with A general and B symmetric.
 /// Create a matrix C such that C = A * B.
 
-template<class Element>
-void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixTSym<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Mult(const TMatrixT<Element> &a, const TMatrixTSym<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNcols() != b.GetNrows() || a.GetColLwb() != b.GetRowLwb()) {
-         Error("Mult","A rows and B columns incompatible");
+         Error("Mult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -789,25 +764,25 @@ void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixTSym<Elemen
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dsymm (CblasRowMajor,CblasRight,CblasUpper,fNrows,fNcols,1.0,
-                   bp,b.GetNcols(),ap,a.GetNcols(),0.0,cp,fNcols);
+      cblas_dsymm(CblasRowMajor, CblasRight, CblasUpper, fNrows, fNcols, 1.0, bp, b.GetNcols(), ap, a.GetNcols(), 0.0,
+                  cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_ssymm (CblasRowMajor,CblasRight,CblasUpper,fNrows,fNcols,1.0,
-                   bp,b.GetNcols(),ap,a.GetNcols(),0.0,cp,fNcols);
+      cblas_ssymm(CblasRowMajor, CblasRight, CblasUpper, fNrows, fNcols, 1.0, bp, b.GetNcols(), ap, a.GetNcols(), 0.0,
+                  cp, fNcols);
    else
-      Error("Mult","type %s not implemented in BLAS library",typeid(Element));
+      Error("Mult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultB(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultB(ap, na, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
@@ -816,24 +791,24 @@ void TMatrixT<Element>::Mult(const TMatrixT<Element> &a,const TMatrixTSym<Elemen
 /// (Actually copied for the moment routine for B general)
 /// Create a matrix C such that C = A * B.
 
-template<class Element>
-void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b)
+template <class Element>
+void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a, const TMatrixTSym<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNcols() != b.GetNrows() || a.GetColLwb() != b.GetRowLwb()) {
-         Error("Mult","A rows and B columns incompatible");
+         Error("Mult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("Mult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("Mult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -841,25 +816,25 @@ void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixTSym<Ele
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dsymm (CblasRowMajor,CblasLeft,CblasUpper,fNrows,fNcols,1.0,
-                   ap,a.GetNcols(),bp,b.GetNcols(),0.0,cp,fNcols);
+      cblas_dsymm(CblasRowMajor, CblasLeft, CblasUpper, fNrows, fNcols, 1.0, ap, a.GetNcols(), bp, b.GetNcols(), 0.0,
+                  cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_ssymm (CblasRowMajor,CblasLeft,CblasUpper,fNrows,fNcols,1.0,
-                   ap,a.GetNcols(),bp,b.GetNcols(),0.0,cp,fNcols);
+      cblas_ssymm(CblasRowMajor, CblasLeft, CblasUpper, fNrows, fNcols, 1.0, ap, a.GetNcols(), bp, b.GetNcols(), 0.0,
+                  cp, fNcols);
    else
-      Error("Mult","type %s not implemented in BLAS library",typeid(Element));
+      Error("Mult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultB(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultB(ap, na, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
@@ -867,24 +842,24 @@ void TMatrixT<Element>::Mult(const TMatrixTSym<Element> &a,const TMatrixTSym<Ele
 /// Create a matrix C such that C = A' * B. In other words,
 /// c[i,j] = SUM{ a[k,i] * b[k,j] }.
 
-template<class Element>
-void TMatrixT<Element>::TMult(const TMatrixT<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::TMult(const TMatrixT<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNrows() != b.GetNrows() || a.GetRowLwb() != b.GetRowLwb()) {
-         Error("TMult","A rows and B columns incompatible");
+         Error("TMult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("TMult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("TMult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("TMult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("TMult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -892,24 +867,24 @@ void TMatrixT<Element>::TMult(const TMatrixT<Element> &a,const TMatrixT<Element>
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dgemm (CblasRowMajor,CblasTrans,CblasNoTrans,this->fNrows,this->fNcols,a.GetNrows(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,this->fNcols);
+      cblas_dgemm(CblasRowMajor, CblasTrans, CblasNoTrans, this->fNrows, this->fNcols, a.GetNrows(), 1.0, ap,
+                  a.GetNcols(), bp, b.GetNcols(), 1.0, cp, this->fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_sgemm (CblasRowMajor,CblasTrans,CblasNoTrans,fNrows,fNcols,a.GetNrows(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, fNrows, fNcols, a.GetNrows(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else
-      Error("TMult","type %s not implemented in BLAS library",typeid(Element));
+      Error("TMult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t nb     = b.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AtMultB(ap,ncolsa,bp,nb,ncolsb,cp);
+   AtMultB(ap, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
@@ -917,24 +892,24 @@ void TMatrixT<Element>::TMult(const TMatrixT<Element> &a,const TMatrixT<Element>
 /// Create a matrix C such that C = A' * B. In other words,
 /// c[i,j] = SUM{ a[k,i] * b[k,j] }.
 
-template<class Element>
-void TMatrixT<Element>::TMult(const TMatrixT<Element> &a,const TMatrixTSym<Element> &b)
+template <class Element>
+void TMatrixT<Element>::TMult(const TMatrixT<Element> &a, const TMatrixTSym<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNrows() != b.GetNrows() || a.GetRowLwb() != b.GetRowLwb()) {
-         Error("TMult","A rows and B columns incompatible");
+         Error("TMult", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("TMult","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("TMult", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("TMult","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("TMult", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -942,49 +917,49 @@ void TMatrixT<Element>::TMult(const TMatrixT<Element> &a,const TMatrixTSym<Eleme
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dgemm (CblasRowMajor,CblasTrans,CblasNoTrans,fNrows,fNcols,a.GetNrows(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_dgemm(CblasRowMajor, CblasTrans, CblasNoTrans, fNrows, fNcols, a.GetNrows(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_sgemm (CblasRowMajor,CblasTrans,CblasNoTrans,fNrows,fNcols,a.GetNrows(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, fNrows, fNcols, a.GetNrows(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else
-      Error("TMult","type %s not implemented in BLAS library",typeid(Element));
+      Error("TMult", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t nb     = b.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AtMultB(ap,ncolsa,bp,nb,ncolsb,cp);
+   AtMultB(ap, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// General matrix multiplication. Create a matrix C such that C = A * B^T.
 
-template<class Element>
-void TMatrixT<Element>::MultT(const TMatrixT<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::MultT(const TMatrixT<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
 
       if (a.GetNcols() != b.GetNcols() || a.GetColLwb() != b.GetColLwb()) {
-         Error("MultT","A rows and B columns incompatible");
+         Error("MultT", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("MultT","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("MultT", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("MultT","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("MultT", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -992,25 +967,25 @@ void TMatrixT<Element>::MultT(const TMatrixT<Element> &a,const TMatrixT<Element>
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dgemm (CblasRowMajor,CblasNoTrans,CblasTrans,fNrows,fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans, fNrows, fNcols, a.GetNcols(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_sgemm (CblasRowMajor,CblasNoTrans,CblasTrans,fNrows,fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, fNrows, fNcols, a.GetNcols(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else
-      Error("MultT","type %s not implemented in BLAS library",typeid(Element));
+      Error("MultT", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultBt(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultBt(ap, na, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
@@ -1018,24 +993,24 @@ void TMatrixT<Element>::MultT(const TMatrixT<Element> &a,const TMatrixT<Element>
 /// Matrix multiplication, with A symmetric and B general.
 /// Create a matrix C such that C = A * B^T.
 
-template<class Element>
-void TMatrixT<Element>::MultT(const TMatrixTSym<Element> &a,const TMatrixT<Element> &b)
+template <class Element>
+void TMatrixT<Element>::MultT(const TMatrixTSym<Element> &a, const TMatrixT<Element> &b)
 {
    if (gMatrixCheck) {
       R__ASSERT(a.IsValid());
       R__ASSERT(b.IsValid());
       if (a.GetNcols() != b.GetNcols() || a.GetColLwb() != b.GetColLwb()) {
-         Error("MultT","A rows and B columns incompatible");
+         Error("MultT", "A rows and B columns incompatible");
          return;
       }
 
       if (this->GetMatrixArray() == a.GetMatrixArray()) {
-         Error("MultT","this->GetMatrixArray() == a.GetMatrixArray()");
+         Error("MultT", "this->GetMatrixArray() == a.GetMatrixArray()");
          return;
       }
 
       if (this->GetMatrixArray() == b.GetMatrixArray()) {
-         Error("MultT","this->GetMatrixArray() == b.GetMatrixArray()");
+         Error("MultT", "this->GetMatrixArray() == b.GetMatrixArray()");
          return;
       }
    }
@@ -1043,56 +1018,53 @@ void TMatrixT<Element>::MultT(const TMatrixTSym<Element> &a,const TMatrixT<Eleme
 #ifdef CBLAS
    const Element *ap = a.GetMatrixArray();
    const Element *bp = b.GetMatrixArray();
-         Element *cp = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    if (typeid(Element) == typeid(Double_t))
-      cblas_dgemm (CblasRowMajor,CblasNoTrans,CblasTrans,this->fNrows,this->fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,this->fNcols);
+      cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans, this->fNrows, this->fNcols, a.GetNcols(), 1.0, ap,
+                  a.GetNcols(), bp, b.GetNcols(), 1.0, cp, this->fNcols);
    else if (typeid(Element) != typeid(Float_t))
-      cblas_sgemm (CblasRowMajor,CblasNoTrans,CblasTrans,fNrows,fNcols,a.GetNcols(),
-                   1.0,ap,a.GetNcols(),bp,b.GetNcols(),1.0,cp,fNcols);
+      cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, fNrows, fNcols, a.GetNcols(), 1.0, ap, a.GetNcols(), bp,
+                  b.GetNcols(), 1.0, cp, fNcols);
    else
-      Error("MultT","type %s not implemented in BLAS library",typeid(Element));
+      Error("MultT", "type %s not implemented in BLAS library", typeid(Element));
 #else
-   const Int_t na     = a.GetNoElements();
-   const Int_t nb     = b.GetNoElements();
+   const Int_t na = a.GetNoElements();
+   const Int_t nb = b.GetNoElements();
    const Int_t ncolsa = a.GetNcols();
    const Int_t ncolsb = b.GetNcols();
-   const Element * const ap = a.GetMatrixArray();
-   const Element * const bp = b.GetMatrixArray();
-         Element *       cp = this->GetMatrixArray();
+   const Element *const ap = a.GetMatrixArray();
+   const Element *const bp = b.GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
 
-   AMultBt(ap,na,ncolsa,bp,nb,ncolsb,cp);
+   AMultBt(ap, na, ncolsa, bp, nb, ncolsb, cp);
 #endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use the array data to fill the matrix ([row_lwb..row_upb] x [col_lwb..col_upb])
 
-template<class Element>
-TMatrixT<Element> &TMatrixT<Element>::Use(Int_t row_lwb,Int_t row_upb,
-                                          Int_t col_lwb,Int_t col_upb,Element *data)
+template <class Element>
+TMatrixT<Element> &TMatrixT<Element>::Use(Int_t row_lwb, Int_t row_upb, Int_t col_lwb, Int_t col_upb, Element *data)
 {
    if (gMatrixCheck) {
-      if (row_upb < row_lwb)
-      {
-         Error("Use","row_upb=%d < row_lwb=%d",row_upb,row_lwb);
+      if (row_upb < row_lwb) {
+         Error("Use", "row_upb=%d < row_lwb=%d", row_upb, row_lwb);
          return *this;
       }
-      if (col_upb < col_lwb)
-      {
-         Error("Use","col_upb=%d < col_lwb=%d",col_upb,col_lwb);
+      if (col_upb < col_lwb) {
+         Error("Use", "col_upb=%d < col_lwb=%d", col_upb, col_lwb);
          return *this;
       }
    }
 
    Clear();
-   this->fNrows    = row_upb-row_lwb+1;
-   this->fNcols    = col_upb-col_lwb+1;
-   this->fRowLwb   = row_lwb;
-   this->fColLwb   = col_lwb;
-   this->fNelems   = this->fNrows*this->fNcols;
-         fElements = data;
-   this->fIsOwner  = kFALSE;
+   this->fNrows = row_upb - row_lwb + 1;
+   this->fNcols = col_upb - col_lwb + 1;
+   this->fRowLwb = row_lwb;
+   this->fColLwb = col_lwb;
+   this->fNelems = this->fNrows * this->fNcols;
+   fElements = data;
+   this->fIsOwner = kFALSE;
 
    return *this;
 }
@@ -1104,30 +1076,30 @@ TMatrixT<Element> &TMatrixT<Element>::Use(Int_t row_lwb,Int_t row_upb,
 /// option == "S" : return [0..row_upb-row_lwb][0..col_upb-col_lwb] (default)
 /// else          : return [row_lwb..row_upb][col_lwb..col_upb]
 
-template<class Element>
-TMatrixTBase<Element> &TMatrixT<Element>::GetSub(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                                                 TMatrixTBase<Element> &target,Option_t *option) const
+template <class Element>
+TMatrixTBase<Element> &TMatrixT<Element>::GetSub(Int_t row_lwb, Int_t row_upb, Int_t col_lwb, Int_t col_upb,
+                                                 TMatrixTBase<Element> &target, Option_t *option) const
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
-      if (row_lwb < this->fRowLwb || row_lwb > this->fRowLwb+this->fNrows-1) {
-         Error("GetSub","row_lwb out of bounds");
+      if (row_lwb < this->fRowLwb || row_lwb > this->fRowLwb + this->fNrows - 1) {
+         Error("GetSub", "row_lwb out of bounds");
          return target;
       }
-      if (col_lwb < this->fColLwb || col_lwb > this->fColLwb+this->fNcols-1) {
-         Error("GetSub","col_lwb out of bounds");
+      if (col_lwb < this->fColLwb || col_lwb > this->fColLwb + this->fNcols - 1) {
+         Error("GetSub", "col_lwb out of bounds");
          return target;
       }
-      if (row_upb < this->fRowLwb || row_upb > this->fRowLwb+this->fNrows-1) {
-         Error("GetSub","row_upb out of bounds");
+      if (row_upb < this->fRowLwb || row_upb > this->fRowLwb + this->fNrows - 1) {
+         Error("GetSub", "row_upb out of bounds");
          return target;
       }
-      if (col_upb < this->fColLwb || col_upb > this->fColLwb+this->fNcols-1) {
-         Error("GetSub","col_upb out of bounds");
+      if (col_upb < this->fColLwb || col_upb > this->fColLwb + this->fNcols - 1) {
+         Error("GetSub", "col_upb out of bounds");
          return target;
       }
       if (row_upb < row_lwb || col_upb < col_lwb) {
-         Error("GetSub","row_upb < row_lwb || col_upb < col_lwb");
+         Error("GetSub", "row_upb < row_lwb || col_upb < col_lwb");
          return target;
       }
    }
@@ -1136,24 +1108,24 @@ TMatrixTBase<Element> &TMatrixT<Element>::GetSub(Int_t row_lwb,Int_t row_upb,Int
    opt.ToUpper();
    const Int_t shift = (opt.Contains("S")) ? 1 : 0;
 
-   const Int_t row_lwb_sub = (shift) ? 0               : row_lwb;
-   const Int_t row_upb_sub = (shift) ? row_upb-row_lwb : row_upb;
-   const Int_t col_lwb_sub = (shift) ? 0               : col_lwb;
-   const Int_t col_upb_sub = (shift) ? col_upb-col_lwb : col_upb;
+   const Int_t row_lwb_sub = (shift) ? 0 : row_lwb;
+   const Int_t row_upb_sub = (shift) ? row_upb - row_lwb : row_upb;
+   const Int_t col_lwb_sub = (shift) ? 0 : col_lwb;
+   const Int_t col_upb_sub = (shift) ? col_upb - col_lwb : col_upb;
 
-   target.ResizeTo(row_lwb_sub,row_upb_sub,col_lwb_sub,col_upb_sub);
-   const Int_t nrows_sub = row_upb_sub-row_lwb_sub+1;
-   const Int_t ncols_sub = col_upb_sub-col_lwb_sub+1;
+   target.ResizeTo(row_lwb_sub, row_upb_sub, col_lwb_sub, col_upb_sub);
+   const Int_t nrows_sub = row_upb_sub - row_lwb_sub + 1;
+   const Int_t ncols_sub = col_upb_sub - col_lwb_sub + 1;
 
    if (target.GetRowIndexArray() && target.GetColIndexArray()) {
       for (Int_t irow = 0; irow < nrows_sub; irow++) {
          for (Int_t icol = 0; icol < ncols_sub; icol++) {
-            target(irow+row_lwb_sub,icol+col_lwb_sub) = (*this)(row_lwb+irow,col_lwb+icol);
+            target(irow + row_lwb_sub, icol + col_lwb_sub) = (*this)(row_lwb + irow, col_lwb + icol);
          }
       }
    } else {
-      const Element *ap = this->GetMatrixArray()+(row_lwb-this->fRowLwb)*this->fNcols+(col_lwb-this->fColLwb);
-            Element *bp = target.GetMatrixArray();
+      const Element *ap = this->GetMatrixArray() + (row_lwb - this->fRowLwb) * this->fNcols + (col_lwb - this->fColLwb);
+      Element *bp = target.GetMatrixArray();
 
       for (Int_t irow = 0; irow < nrows_sub; irow++) {
          const Element *ap_sub = ap;
@@ -1171,24 +1143,24 @@ TMatrixTBase<Element> &TMatrixT<Element>::GetSub(Int_t row_lwb,Int_t row_upb,Int
 /// Insert matrix source starting at [row_lwb][col_lwb], thereby overwriting the part
 /// [row_lwb..row_lwb+nrows_source][col_lwb..col_lwb+ncols_source];
 
-template<class Element>
-TMatrixTBase<Element> &TMatrixT<Element>::SetSub(Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source)
+template <class Element>
+TMatrixTBase<Element> &TMatrixT<Element>::SetSub(Int_t row_lwb, Int_t col_lwb, const TMatrixTBase<Element> &source)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(source.IsValid());
 
-      if (row_lwb < this->fRowLwb || row_lwb > this->fRowLwb+this->fNrows-1) {
-         Error("SetSub","row_lwb outof bounds");
+      if (row_lwb < this->fRowLwb || row_lwb > this->fRowLwb + this->fNrows - 1) {
+         Error("SetSub", "row_lwb outof bounds");
          return *this;
       }
-      if (col_lwb < this->fColLwb || col_lwb > this->fColLwb+this->fNcols-1) {
-         Error("SetSub","col_lwb outof bounds");
+      if (col_lwb < this->fColLwb || col_lwb > this->fColLwb + this->fNcols - 1) {
+         Error("SetSub", "col_lwb outof bounds");
          return *this;
       }
-      if (row_lwb+source.GetNrows() > this->fRowLwb+this->fNrows ||
-            col_lwb+source.GetNcols() > this->fColLwb+this->fNcols) {
-         Error("SetSub","source matrix too large");
+      if (row_lwb + source.GetNrows() > this->fRowLwb + this->fNrows ||
+          col_lwb + source.GetNcols() > this->fColLwb + this->fNcols) {
+         Error("SetSub", "source matrix too large");
          return *this;
       }
    }
@@ -1201,12 +1173,12 @@ TMatrixTBase<Element> &TMatrixT<Element>::SetSub(Int_t row_lwb,Int_t col_lwb,con
       const Int_t collwb_s = source.GetColLwb();
       for (Int_t irow = 0; irow < nRows_source; irow++) {
          for (Int_t icol = 0; icol < nCols_source; icol++) {
-            (*this)(row_lwb+irow,col_lwb+icol) = source(rowlwb_s+irow,collwb_s+icol);
+            (*this)(row_lwb + irow, col_lwb + icol) = source(rowlwb_s + irow, collwb_s + icol);
          }
       }
    } else {
       const Element *bp = source.GetMatrixArray();
-            Element *ap = this->GetMatrixArray()+(row_lwb-this->fRowLwb)*this->fNcols+(col_lwb-this->fColLwb);
+      Element *ap = this->GetMatrixArray() + (row_lwb - this->fRowLwb) * this->fNcols + (col_lwb - this->fColLwb);
 
       for (Int_t irow = 0; irow < nRows_source; irow++) {
          Element *ap_sub = ap;
@@ -1225,12 +1197,12 @@ TMatrixTBase<Element> &TMatrixT<Element>::SetSub(Int_t row_lwb,Int_t col_lwb,con
 /// New dynamic elements are created, the overlapping part of the old ones are
 /// copied to the new structures, then the old elements are deleted.
 
-template<class Element>
-TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t nrows,Int_t ncols,Int_t /*nr_nonzeros*/)
+template <class Element>
+TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t nrows, Int_t ncols, Int_t /*nr_nonzeros*/)
 {
    R__ASSERT(this->IsValid());
    if (!this->fIsOwner) {
-      Error("ResizeTo(Int_t,Int_t)","Not owner of data array,cannot resize");
+      Error("ResizeTo(Int_t,Int_t)", "Not owner of data array,cannot resize");
       return *this;
    }
 
@@ -1238,48 +1210,47 @@ TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t nrows,Int_t ncols,Int_t
       if (this->fNrows == nrows && this->fNcols == ncols)
          return *this;
       else if (nrows == 0 || ncols == 0) {
-         this->fNrows = nrows; this->fNcols = ncols;
+         this->fNrows = nrows;
+         this->fNcols = ncols;
          Clear();
          return *this;
       }
 
-      Element    *elements_old = GetMatrixArray();
-      const Int_t nelems_old   = this->fNelems;
-      const Int_t nrows_old    = this->fNrows;
-      const Int_t ncols_old    = this->fNcols;
+      Element *elements_old = GetMatrixArray();
+      const Int_t nelems_old = this->fNelems;
+      const Int_t nrows_old = this->fNrows;
+      const Int_t ncols_old = this->fNcols;
 
-      Allocate(nrows,ncols);
+      Allocate(nrows, ncols);
       R__ASSERT(this->IsValid());
 
       Element *elements_new = GetMatrixArray();
       // new memory should be initialized but be careful not to wipe out the stack
       // storage. Initialize all when old or new storage was on the heap
       if (this->fNelems > this->kSizeMax || nelems_old > this->kSizeMax)
-         memset(elements_new,0,this->fNelems*sizeof(Element));
+         memset(elements_new, 0, this->fNelems * sizeof(Element));
       else if (this->fNelems > nelems_old)
-         memset(elements_new+nelems_old,0,(this->fNelems-nelems_old)*sizeof(Element));
+         memset(elements_new + nelems_old, 0, (this->fNelems - nelems_old) * sizeof(Element));
 
       // Copy overlap
-      const Int_t ncols_copy = TMath::Min(this->fNcols,ncols_old);
-      const Int_t nrows_copy = TMath::Min(this->fNrows,nrows_old);
+      const Int_t ncols_copy = TMath::Min(this->fNcols, ncols_old);
+      const Int_t nrows_copy = TMath::Min(this->fNrows, nrows_old);
 
       const Int_t nelems_new = this->fNelems;
       if (ncols_old < this->fNcols) {
-         for (Int_t i = nrows_copy-1; i >= 0; i--) {
-            Memcpy_m(elements_new+i*this->fNcols,elements_old+i*ncols_old,ncols_copy,
-                     nelems_new,nelems_old);
+         for (Int_t i = nrows_copy - 1; i >= 0; i--) {
+            Memcpy_m(elements_new + i * this->fNcols, elements_old + i * ncols_old, ncols_copy, nelems_new, nelems_old);
             if (this->fNelems <= this->kSizeMax && nelems_old <= this->kSizeMax)
-               memset(elements_new+i*this->fNcols+ncols_copy,0,(this->fNcols-ncols_copy)*sizeof(Element));
+               memset(elements_new + i * this->fNcols + ncols_copy, 0, (this->fNcols - ncols_copy) * sizeof(Element));
          }
       } else {
          for (Int_t i = 0; i < nrows_copy; i++)
-            Memcpy_m(elements_new+i*this->fNcols,elements_old+i*ncols_old,ncols_copy,
-                     nelems_new,nelems_old);
+            Memcpy_m(elements_new + i * this->fNcols, elements_old + i * ncols_old, ncols_copy, nelems_new, nelems_old);
       }
 
-      Delete_m(nelems_old,elements_old);
+      Delete_m(nelems_old, elements_old);
    } else {
-      Allocate(nrows,ncols,0,0,1);
+      Allocate(nrows, ncols, 0, 0, 1);
    }
 
    return *this;
@@ -1290,84 +1261,86 @@ TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t nrows,Int_t ncols,Int_t
 /// New dynamic elements are created, the overlapping part of the old ones are
 /// copied to the new structures, then the old elements are deleted.
 
-template<class Element>
-TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                                                   Int_t /*nr_nonzeros*/)
+template <class Element>
+TMatrixTBase<Element> &
+TMatrixT<Element>::ResizeTo(Int_t row_lwb, Int_t row_upb, Int_t col_lwb, Int_t col_upb, Int_t /*nr_nonzeros*/)
 {
    R__ASSERT(this->IsValid());
    if (!this->fIsOwner) {
-      Error("ResizeTo(Int_t,Int_t,Int_t,Int_t)","Not owner of data array,cannot resize");
+      Error("ResizeTo(Int_t,Int_t,Int_t,Int_t)", "Not owner of data array,cannot resize");
       return *this;
    }
 
-   const Int_t new_nrows = row_upb-row_lwb+1;
-   const Int_t new_ncols = col_upb-col_lwb+1;
+   const Int_t new_nrows = row_upb - row_lwb + 1;
+   const Int_t new_ncols = col_upb - col_lwb + 1;
 
    if (this->fNelems > 0) {
 
-      if (this->fNrows  == new_nrows  && this->fNcols  == new_ncols &&
-           this->fRowLwb == row_lwb    && this->fColLwb == col_lwb)
-          return *this;
+      if (this->fNrows == new_nrows && this->fNcols == new_ncols && this->fRowLwb == row_lwb &&
+          this->fColLwb == col_lwb)
+         return *this;
       else if (new_nrows == 0 || new_ncols == 0) {
-         this->fNrows = new_nrows; this->fNcols = new_ncols;
-         this->fRowLwb = row_lwb; this->fColLwb = col_lwb;
+         this->fNrows = new_nrows;
+         this->fNcols = new_ncols;
+         this->fRowLwb = row_lwb;
+         this->fColLwb = col_lwb;
          Clear();
          return *this;
       }
 
-      Element    *elements_old = GetMatrixArray();
-      const Int_t nelems_old   = this->fNelems;
-      const Int_t nrows_old    = this->fNrows;
-      const Int_t ncols_old    = this->fNcols;
-      const Int_t rowLwb_old   = this->fRowLwb;
-      const Int_t colLwb_old   = this->fColLwb;
+      Element *elements_old = GetMatrixArray();
+      const Int_t nelems_old = this->fNelems;
+      const Int_t nrows_old = this->fNrows;
+      const Int_t ncols_old = this->fNcols;
+      const Int_t rowLwb_old = this->fRowLwb;
+      const Int_t colLwb_old = this->fColLwb;
 
-      Allocate(new_nrows,new_ncols,row_lwb,col_lwb);
+      Allocate(new_nrows, new_ncols, row_lwb, col_lwb);
       R__ASSERT(this->IsValid());
 
       Element *elements_new = GetMatrixArray();
       // new memory should be initialized but be careful not to wipe out the stack
       // storage. Initialize all when old or new storage was on the heap
       if (this->fNelems > this->kSizeMax || nelems_old > this->kSizeMax)
-         memset(elements_new,0,this->fNelems*sizeof(Element));
+         memset(elements_new, 0, this->fNelems * sizeof(Element));
       else if (this->fNelems > nelems_old)
-         memset(elements_new+nelems_old,0,(this->fNelems-nelems_old)*sizeof(Element));
+         memset(elements_new + nelems_old, 0, (this->fNelems - nelems_old) * sizeof(Element));
 
       // Copy overlap
-      const Int_t rowLwb_copy = TMath::Max(this->fRowLwb,rowLwb_old);
-      const Int_t colLwb_copy = TMath::Max(this->fColLwb,colLwb_old);
-      const Int_t rowUpb_copy = TMath::Min(this->fRowLwb+this->fNrows-1,rowLwb_old+nrows_old-1);
-      const Int_t colUpb_copy = TMath::Min(this->fColLwb+this->fNcols-1,colLwb_old+ncols_old-1);
+      const Int_t rowLwb_copy = TMath::Max(this->fRowLwb, rowLwb_old);
+      const Int_t colLwb_copy = TMath::Max(this->fColLwb, colLwb_old);
+      const Int_t rowUpb_copy = TMath::Min(this->fRowLwb + this->fNrows - 1, rowLwb_old + nrows_old - 1);
+      const Int_t colUpb_copy = TMath::Min(this->fColLwb + this->fNcols - 1, colLwb_old + ncols_old - 1);
 
-      const Int_t nrows_copy = rowUpb_copy-rowLwb_copy+1;
-      const Int_t ncols_copy = colUpb_copy-colLwb_copy+1;
+      const Int_t nrows_copy = rowUpb_copy - rowLwb_copy + 1;
+      const Int_t ncols_copy = colUpb_copy - colLwb_copy + 1;
 
       if (nrows_copy > 0 && ncols_copy > 0) {
-         const Int_t colOldOff = colLwb_copy-colLwb_old;
-         const Int_t colNewOff = colLwb_copy-this->fColLwb;
+         const Int_t colOldOff = colLwb_copy - colLwb_old;
+         const Int_t colNewOff = colLwb_copy - this->fColLwb;
          if (ncols_old < this->fNcols) {
-            for (Int_t i = nrows_copy-1; i >= 0; i--) {
-               const Int_t iRowOld = rowLwb_copy+i-rowLwb_old;
-               const Int_t iRowNew = rowLwb_copy+i-this->fRowLwb;
-               Memcpy_m(elements_new+iRowNew*this->fNcols+colNewOff,
-                        elements_old+iRowOld*ncols_old+colOldOff,ncols_copy,this->fNelems,nelems_old);
+            for (Int_t i = nrows_copy - 1; i >= 0; i--) {
+               const Int_t iRowOld = rowLwb_copy + i - rowLwb_old;
+               const Int_t iRowNew = rowLwb_copy + i - this->fRowLwb;
+               Memcpy_m(elements_new + iRowNew * this->fNcols + colNewOff,
+                        elements_old + iRowOld * ncols_old + colOldOff, ncols_copy, this->fNelems, nelems_old);
                if (this->fNelems <= this->kSizeMax && nelems_old <= this->kSizeMax)
-                  memset(elements_new+iRowNew*this->fNcols+colNewOff+ncols_copy,0,
-                         (this->fNcols-ncols_copy)*sizeof(Element));
+                  memset(elements_new + iRowNew * this->fNcols + colNewOff + ncols_copy, 0,
+                         (this->fNcols - ncols_copy) * sizeof(Element));
             }
          } else {
             for (Int_t i = 0; i < nrows_copy; i++) {
-               const Int_t iRowOld = rowLwb_copy+i-rowLwb_old;
-               const Int_t iRowNew = rowLwb_copy+i-this->fRowLwb;
-               Memcpy_m(elements_new+iRowNew*this->fNcols+colNewOff,
-                        elements_old+iRowOld*ncols_old+colOldOff,ncols_copy,this->fNelems,nelems_old);
+               const Int_t iRowOld = rowLwb_copy + i - rowLwb_old;
+               const Int_t iRowNew = rowLwb_copy + i - this->fRowLwb;
+               Memcpy_m(elements_new + iRowNew * this->fNcols + colNewOff,
+                        elements_old + iRowOld * ncols_old + colOldOff, ncols_copy, this->fNelems, nelems_old);
             }
          }
       }
 
-      Delete_m(nelems_old,elements_old);
+      Delete_m(nelems_old, elements_old);
    } else {
-      Allocate(new_nrows,new_ncols,row_lwb,col_lwb,1);
+      Allocate(new_nrows, new_ncols, row_lwb, col_lwb, 1);
    }
 
    return *this;
@@ -1376,25 +1349,25 @@ TMatrixTBase<Element> &TMatrixT<Element>::ResizeTo(Int_t row_lwb,Int_t row_upb,I
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the matrix determinant
 
-template<class Element>
+template <class Element>
 Double_t TMatrixT<Element>::Determinant() const
 {
    const TMatrixT<Element> &tmp = *this;
-   TDecompLU lu(tmp,this->fTol);
-   Double_t d1,d2;
-   lu.Det(d1,d2);
-   return d1*TMath::Power(2.0,d2);
+   TDecompLU lu(tmp, this->fTol);
+   Double_t d1, d2;
+   lu.Det(d1, d2);
+   return d1 * TMath::Power(2.0, d2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the matrix determinant as d1,d2 where det = d1*TMath::Power(2.0,d2)
 
-template<class Element>
-void TMatrixT<Element>::Determinant(Double_t &d1,Double_t &d2) const
+template <class Element>
+void TMatrixT<Element>::Determinant(Double_t &d1, Double_t &d2) const
 {
    const TMatrixT<Element> &tmp = *this;
-   TDecompLU lu(tmp,Double_t(this->fTol));
-   lu.Det(d1,d2);
+   TDecompLU lu(tmp, Double_t(this->fTol));
+   lu.Det(d1, d2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1411,11 +1384,11 @@ TMatrixT<Double_t> &TMatrixT<Double_t>::Invert(Double_t *det)
 ////////////////////////////////////////////////////////////////////////////////
 /// Invert the matrix and calculate its determinant
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::Invert(Double_t *det)
 {
    TMatrixD tmp(*this);
-   if (TDecompLU::InvertLU(tmp, Double_t(this->fTol),det))
+   if (TDecompLU::InvertLU(tmp, Double_t(this->fTol), det))
       std::copy(tmp.GetMatrixArray(), tmp.GetMatrixArray() + this->GetNoElements(), this->GetMatrixArray());
 
    return *this;
@@ -1425,66 +1398,58 @@ TMatrixT<Element> &TMatrixT<Element>::Invert(Double_t *det)
 /// Invert the matrix and calculate its determinant, however upto (6x6)
 /// a fast Cramer inversion is used .
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::InvertFast(Double_t *det)
 {
    R__ASSERT(this->IsValid());
 
    const Char_t nRows = Char_t(this->GetNrows());
    switch (nRows) {
-      case 1:
-      {
-         if (this->GetNrows() != this->GetNcols() || this->GetRowLwb() != this->GetColLwb()) {
-             Error("Invert()","matrix should be square");
+   case 1: {
+      if (this->GetNrows() != this->GetNcols() || this->GetRowLwb() != this->GetColLwb()) {
+         Error("Invert()", "matrix should be square");
+      } else {
+         Element *pM = this->GetMatrixArray();
+         if (*pM == 0.) {
+            Error("InvertFast", "matrix is singular");
+            *det = 0;
          } else {
-            Element *pM = this->GetMatrixArray();
-            if (*pM == 0.) {
-               Error("InvertFast","matrix is singular");
-               *det = 0;
-            }
-            else {
-               *det = *pM;
-               *pM = 1.0/(*pM);
-            }
+            *det = *pM;
+            *pM = 1.0 / (*pM);
          }
-         return *this;
       }
-      case 2:
-      {
-         TMatrixTCramerInv::Inv2x2<Element>(*this,det);
-         return *this;
-      }
-      case 3:
-      {
-         TMatrixTCramerInv::Inv3x3<Element>(*this,det);
-         return *this;
-      }
-      case 4:
-      {
-         TMatrixTCramerInv::Inv4x4<Element>(*this,det);
-         return *this;
-      }
-      case 5:
-      {
-         TMatrixTCramerInv::Inv5x5<Element>(*this,det);
-         return *this;
-      }
-      case 6:
-      {
-         TMatrixTCramerInv::Inv6x6<Element>(*this,det);
-         return *this;
-      }
-      default:
-      {
-         return Invert(det);
-      }
+      return *this;
+   }
+   case 2: {
+      TMatrixTCramerInv::Inv2x2<Element>(*this, det);
+      return *this;
+   }
+   case 3: {
+      TMatrixTCramerInv::Inv3x3<Element>(*this, det);
+      return *this;
+   }
+   case 4: {
+      TMatrixTCramerInv::Inv4x4<Element>(*this, det);
+      return *this;
+   }
+   case 5: {
+      TMatrixTCramerInv::Inv5x5<Element>(*this, det);
+      return *this;
+   }
+   case 6: {
+      TMatrixTCramerInv::Inv6x6<Element>(*this, det);
+      return *this;
+   }
+   default: {
+      return Invert(det);
+   }
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Transpose matrix source.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::Transpose(const TMatrixT<Element> &source)
 {
    R__ASSERT(this->IsValid());
@@ -1494,44 +1459,45 @@ TMatrixT<Element> &TMatrixT<Element>::Transpose(const TMatrixT<Element> &source)
       Element *ap = this->GetMatrixArray();
       if (this->fNrows == this->fNcols && this->fRowLwb == this->fColLwb) {
          for (Int_t i = 0; i < this->fNrows; i++) {
-            const Int_t off_i = i*this->fNrows;
-            for (Int_t j = i+1; j < this->fNcols; j++) {
-               const Int_t off_j = j*this->fNcols;
-               const Element tmp = ap[off_i+j];
-               ap[off_i+j] = ap[off_j+i];
-               ap[off_j+i] = tmp;
+            const Int_t off_i = i * this->fNrows;
+            for (Int_t j = i + 1; j < this->fNcols; j++) {
+               const Int_t off_j = j * this->fNcols;
+               const Element tmp = ap[off_i + j];
+               ap[off_i + j] = ap[off_j + i];
+               ap[off_j + i] = tmp;
             }
          }
       } else {
          Element *oldElems = new Element[source.GetNoElements()];
-         memcpy(oldElems,source.GetMatrixArray(),source.GetNoElements()*sizeof(Element));
-         const Int_t nrows_old  = this->fNrows;
-         const Int_t ncols_old  = this->fNcols;
+         memcpy(oldElems, source.GetMatrixArray(), source.GetNoElements() * sizeof(Element));
+         const Int_t nrows_old = this->fNrows;
+         const Int_t ncols_old = this->fNcols;
          const Int_t rowlwb_old = this->fRowLwb;
          const Int_t collwb_old = this->fColLwb;
 
-         this->fNrows  = ncols_old;  this->fNcols  = nrows_old;
-         this->fRowLwb = collwb_old; this->fColLwb = rowlwb_old;
-         for (Int_t irow = this->fRowLwb; irow < this->fRowLwb+this->fNrows; irow++) {
-            for (Int_t icol = this->fColLwb; icol < this->fColLwb+this->fNcols; icol++) {
-               const Int_t off = (icol-collwb_old)*ncols_old;
-               (*this)(irow,icol) = oldElems[off+irow-rowlwb_old];
+         this->fNrows = ncols_old;
+         this->fNcols = nrows_old;
+         this->fRowLwb = collwb_old;
+         this->fColLwb = rowlwb_old;
+         for (Int_t irow = this->fRowLwb; irow < this->fRowLwb + this->fNrows; irow++) {
+            for (Int_t icol = this->fColLwb; icol < this->fColLwb + this->fNcols; icol++) {
+               const Int_t off = (icol - collwb_old) * ncols_old;
+               (*this)(irow, icol) = oldElems[off + irow - rowlwb_old];
             }
          }
-         delete [] oldElems;
+         delete[] oldElems;
       }
    } else {
-      if (this->fNrows  != source.GetNcols()  || this->fNcols  != source.GetNrows() ||
-          this->fRowLwb != source.GetColLwb() || this->fColLwb != source.GetRowLwb())
-      {
-         Error("Transpose","matrix has wrong shape");
+      if (this->fNrows != source.GetNcols() || this->fNcols != source.GetNrows() ||
+          this->fRowLwb != source.GetColLwb() || this->fColLwb != source.GetRowLwb()) {
+         Error("Transpose", "matrix has wrong shape");
          return *this;
       }
 
       const Element *sp1 = source.GetMatrixArray();
       const Element *scp = sp1; // Row source pointer
-            Element *tp  = this->GetMatrixArray();
-      const Element * const tp_last = this->GetMatrixArray()+this->fNelems;
+      Element *tp = this->GetMatrixArray();
+      const Element *const tp_last = this->GetMatrixArray() + this->fNelems;
 
       // (This: target) matrix is traversed row-wise way,
       // whilst the source matrix is scanned column-wise
@@ -1539,12 +1505,12 @@ TMatrixT<Element> &TMatrixT<Element>::Transpose(const TMatrixT<Element> &source)
          const Element *sp2 = scp++;
 
          // Move tp to the next elem in the row and sp to the next elem in the curr col
-         while (sp2 < sp1+this->fNelems) {
+         while (sp2 < sp1 + this->fNelems) {
             *tp++ = *sp2;
             sp2 += this->fNrows;
          }
       }
-      R__ASSERT(tp == tp_last && scp == sp1+this->fNrows);
+      R__ASSERT(tp == tp_last && scp == sp1 + this->fNrows);
    }
 
    return *this;
@@ -1554,25 +1520,25 @@ TMatrixT<Element> &TMatrixT<Element>::Transpose(const TMatrixT<Element> &source)
 /// Perform a rank 1 operation on matrix A:
 ///     A += alpha * v * v^T
 
-template<class Element>
-TMatrixT<Element> &TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v,Element alpha)
+template <class Element>
+TMatrixT<Element> &TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v, Element alpha)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(v.IsValid());
-      if (v.GetNoElements() < TMath::Max(this->fNrows,this->fNcols)) {
-         Error("Rank1Update","vector too short");
+      if (v.GetNoElements() < TMath::Max(this->fNrows, this->fNcols)) {
+         Error("Rank1Update", "vector too short");
          return *this;
       }
    }
 
-   const Element * const pv = v.GetMatrixArray();
-         Element *mp = this->GetMatrixArray();
+   const Element *const pv = v.GetMatrixArray();
+   Element *mp = this->GetMatrixArray();
 
    for (Int_t i = 0; i < this->fNrows; i++) {
-      const Element tmp = alpha*pv[i];
+      const Element tmp = alpha * pv[i];
       for (Int_t j = 0; j < this->fNcols; j++)
-         *mp++ += tmp*pv[j];
+         *mp++ += tmp * pv[j];
    }
 
    return *this;
@@ -1582,32 +1548,33 @@ TMatrixT<Element> &TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v,Ele
 /// Perform a rank 1 operation on matrix A:
 ///     A += alpha * v1 * v2^T
 
-template<class Element>
-TMatrixT<Element> &TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v1,const TVectorT<Element> &v2,Element alpha)
+template <class Element>
+TMatrixT<Element> &
+TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v1, const TVectorT<Element> &v2, Element alpha)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(v1.IsValid());
       R__ASSERT(v2.IsValid());
       if (v1.GetNoElements() < this->fNrows) {
-         Error("Rank1Update","vector v1 too short");
+         Error("Rank1Update", "vector v1 too short");
          return *this;
       }
 
       if (v2.GetNoElements() < this->fNcols) {
-         Error("Rank1Update","vector v2 too short");
+         Error("Rank1Update", "vector v2 too short");
          return *this;
       }
    }
 
-   const Element * const pv1 = v1.GetMatrixArray();
-   const Element * const pv2 = v2.GetMatrixArray();
-         Element *mp = this->GetMatrixArray();
+   const Element *const pv1 = v1.GetMatrixArray();
+   const Element *const pv2 = v2.GetMatrixArray();
+   Element *mp = this->GetMatrixArray();
 
    for (Int_t i = 0; i < this->fNrows; i++) {
-      const Element tmp = alpha*pv1[i];
+      const Element tmp = alpha * pv1[i];
       for (Int_t j = 0; j < this->fNcols; j++)
-         *mp++ += tmp*pv2[j];
+         *mp++ += tmp * pv2[j];
    }
 
    return *this;
@@ -1616,19 +1583,19 @@ TMatrixT<Element> &TMatrixT<Element>::Rank1Update(const TVectorT<Element> &v1,co
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate scalar v * (*this) * v^T
 
-template<class Element>
+template <class Element>
 Element TMatrixT<Element>::Similarity(const TVectorT<Element> &v) const
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(v.IsValid());
       if (this->fNcols != this->fNrows || this->fColLwb != this->fRowLwb) {
-         Error("Similarity(const TVectorT &)","matrix is not square");
+         Error("Similarity(const TVectorT &)", "matrix is not square");
          return -1.;
       }
 
       if (this->fNcols != v.GetNrows() || this->fColLwb != v.GetLwb()) {
-         Error("Similarity(const TVectorT &)","vector and matrix incompatible");
+         Error("Similarity(const TVectorT &)", "vector and matrix incompatible");
          return -1.;
       }
    }
@@ -1637,16 +1604,16 @@ Element TMatrixT<Element>::Similarity(const TVectorT<Element> &v) const
    const Element *vp = v.GetMatrixArray();     // vector ptr
 
    Element sum1 = 0;
-   const Element * const vp_first = vp;
-   const Element * const vp_last  = vp+v.GetNrows();
+   const Element *const vp_first = vp;
+   const Element *const vp_last = vp + v.GetNrows();
    while (vp < vp_last) {
       Element sum2 = 0;
-      for (const Element *sp = vp_first; sp < vp_last; )
+      for (const Element *sp = vp_first; sp < vp_last;)
          sum2 += *mp++ * *sp++;
       sum1 += sum2 * *vp++;
    }
 
-   R__ASSERT(mp == this->GetMatrixArray()+this->GetNoElements());
+   R__ASSERT(mp == this->GetMatrixArray() + this->GetNoElements());
 
    return sum1;
 }
@@ -1657,14 +1624,14 @@ Element TMatrixT<Element>::Similarity(const TVectorT<Element> &v) const
 /// "D"   :  b(i,j) = a(i,j)/v(i)   i = 0,fNrows-1 (default)
 /// else  :  b(i,j) = a(i,j)*v(i)
 
-template<class Element>
-TMatrixT<Element> &TMatrixT<Element>::NormByColumn(const TVectorT<Element> &v,Option_t *option)
+template <class Element>
+TMatrixT<Element> &TMatrixT<Element>::NormByColumn(const TVectorT<Element> &v, Option_t *option)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(v.IsValid());
       if (v.GetNoElements() < this->fNrows) {
-         Error("NormByColumn","vector shorter than matrix column");
+         Error("NormByColumn", "vector shorter than matrix column");
          return *this;
       }
    }
@@ -1674,23 +1641,22 @@ TMatrixT<Element> &TMatrixT<Element>::NormByColumn(const TVectorT<Element> &v,Op
    const Int_t divide = (opt.Contains("D")) ? 1 : 0;
 
    const Element *pv = v.GetMatrixArray();
-         Element *mp = this->GetMatrixArray();
-   const Element * const mp_last = mp+this->fNelems;
+   Element *mp = this->GetMatrixArray();
+   const Element *const mp_last = mp + this->fNelems;
 
    if (divide) {
-      for ( ; mp < mp_last; pv++) {
-         for (Int_t j = 0; j < this->fNcols; j++)
-         {
+      for (; mp < mp_last; pv++) {
+         for (Int_t j = 0; j < this->fNcols; j++) {
             if (*pv != 0.0)
                *mp++ /= *pv;
             else {
-               Error("NormbyColumn","vector element %ld is zero",Long_t(pv-v.GetMatrixArray()));
+               Error("NormbyColumn", "vector element %ld is zero", Long_t(pv - v.GetMatrixArray()));
                mp++;
             }
          }
       }
    } else {
-      for ( ; mp < mp_last; pv++)
+      for (; mp < mp_last; pv++)
          for (Int_t j = 0; j < this->fNcols; j++)
             *mp++ *= *pv;
    }
@@ -1704,14 +1670,14 @@ TMatrixT<Element> &TMatrixT<Element>::NormByColumn(const TVectorT<Element> &v,Op
 /// "D"   :  b(i,j) = a(i,j)/v(j)   i = 0,fNcols-1 (default)
 /// else  :  b(i,j) = a(i,j)*v(j)
 
-template<class Element>
-TMatrixT<Element> &TMatrixT<Element>::NormByRow(const TVectorT<Element> &v,Option_t *option)
+template <class Element>
+TMatrixT<Element> &TMatrixT<Element>::NormByRow(const TVectorT<Element> &v, Option_t *option)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(v.IsValid());
       if (v.GetNoElements() < this->fNcols) {
-         Error("NormByRow","vector shorter than matrix column");
+         Error("NormByRow", "vector shorter than matrix column");
          return *this;
       }
    }
@@ -1721,25 +1687,25 @@ TMatrixT<Element> &TMatrixT<Element>::NormByRow(const TVectorT<Element> &v,Optio
    const Int_t divide = (opt.Contains("D")) ? 1 : 0;
 
    const Element *pv0 = v.GetMatrixArray();
-   const Element *pv  = pv0;
-         Element *mp  = this->GetMatrixArray();
-   const Element * const mp_last = mp+this->fNelems;
+   const Element *pv = pv0;
+   Element *mp = this->GetMatrixArray();
+   const Element *const mp_last = mp + this->fNelems;
 
    if (divide) {
-      for ( ; mp < mp_last; pv = pv0 )
+      for (; mp < mp_last; pv = pv0)
          for (Int_t j = 0; j < this->fNcols; j++) {
             if (*pv != 0.0)
                *mp++ /= *pv++;
             else {
-               Error("NormbyRow","vector element %ld is zero",Long_t(pv-pv0));
+               Error("NormbyRow", "vector element %ld is zero", Long_t(pv - pv0));
                mp++;
             }
          }
-    } else {
-       for ( ; mp < mp_last; pv = pv0 )
-          for (Int_t j = 0; j < this->fNcols; j++)
-             *mp++ *= *pv++;
-    }
+   } else {
+      for (; mp < mp_last; pv = pv0)
+         for (Int_t j = 0; j < this->fNcols; j++)
+            *mp++ *= *pv++;
+   }
 
    return *this;
 }
@@ -1747,17 +1713,17 @@ TMatrixT<Element> &TMatrixT<Element>::NormByRow(const TVectorT<Element> &v,Optio
 ////////////////////////////////////////////////////////////////////////////////
 /// Assignment operator
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator=(const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator=(const TMatrixT &)", "matrices not compatible");
       return *this;
    }
 
    if (this->GetMatrixArray() != source.GetMatrixArray()) {
       TObject::operator=(source);
-      memcpy(fElements,source.GetMatrixArray(),this->fNelems*sizeof(Element));
+      memcpy(fElements, source.GetMatrixArray(), this->fNelems * sizeof(Element));
       this->fTol = source.GetTol();
    }
    return *this;
@@ -1766,17 +1732,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixT<Element> &source)
 ////////////////////////////////////////////////////////////////////////////////
 /// Assignment operator
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator=(const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator=(const TMatrixTSym &)", "matrices not compatible");
       return *this;
    }
 
    if (this->GetMatrixArray() != source.GetMatrixArray()) {
       TObject::operator=(source);
-      memcpy(fElements,source.GetMatrixArray(),this->fNelems*sizeof(Element));
+      memcpy(fElements, source.GetMatrixArray(), this->fNelems * sizeof(Element));
       this->fTol = source.GetTol();
    }
    return *this;
@@ -1785,32 +1751,31 @@ TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTSym<Element> &sour
 ////////////////////////////////////////////////////////////////////////////////
 /// Assignment operator
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTSparse<Element> &source)
 {
-   if ((gMatrixCheck &&
-        this->GetNrows()  != source.GetNrows())  || this->GetNcols()  != source.GetNcols() ||
-        this->GetRowLwb() != source.GetRowLwb() || this->GetColLwb() != source.GetColLwb()) {
-      Error("operator=(const TMatrixTSparse &","matrices not compatible");
+   if ((gMatrixCheck && this->GetNrows() != source.GetNrows()) || this->GetNcols() != source.GetNcols() ||
+       this->GetRowLwb() != source.GetRowLwb() || this->GetColLwb() != source.GetColLwb()) {
+      Error("operator=(const TMatrixTSparse &", "matrices not compatible");
       return *this;
    }
 
    if (this->GetMatrixArray() != source.GetMatrixArray()) {
       TObject::operator=(source);
-      memset(fElements,0,this->fNelems*sizeof(Element));
+      memset(fElements, 0, this->fNelems * sizeof(Element));
 
-      const Element * const sp = source.GetMatrixArray();
-            Element *       tp = this->GetMatrixArray();
+      const Element *const sp = source.GetMatrixArray();
+      Element *tp = this->GetMatrixArray();
 
-      const Int_t * const pRowIndex = source.GetRowIndexArray();
-      const Int_t * const pColIndex = source.GetColIndexArray();
+      const Int_t *const pRowIndex = source.GetRowIndexArray();
+      const Int_t *const pColIndex = source.GetColIndexArray();
 
-      for (Int_t irow = 0; irow < this->fNrows; irow++ ) {
-         const Int_t off = irow*this->fNcols;
+      for (Int_t irow = 0; irow < this->fNrows; irow++) {
+         const Int_t off = irow * this->fNcols;
          const Int_t sIndex = pRowIndex[irow];
-         const Int_t eIndex = pRowIndex[irow+1];
+         const Int_t eIndex = pRowIndex[irow + 1];
          for (Int_t index = sIndex; index < eIndex; index++)
-            tp[off+pColIndex[index]] = sp[index];
+            tp[off + pColIndex[index]] = sp[index];
       }
       this->fTol = source.GetTol();
    }
@@ -1820,17 +1785,15 @@ TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTSparse<Element> &s
 ////////////////////////////////////////////////////////////////////////////////
 /// Assignment operator
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTLazy<Element> &lazy_constructor)
 {
    R__ASSERT(this->IsValid());
 
-   if (lazy_constructor.GetRowUpb() != this->GetRowUpb() ||
-       lazy_constructor.GetColUpb() != this->GetColUpb() ||
-       lazy_constructor.GetRowLwb() != this->GetRowLwb() ||
-       lazy_constructor.GetColLwb() != this->GetColLwb()) {
+   if (lazy_constructor.GetRowUpb() != this->GetRowUpb() || lazy_constructor.GetColUpb() != this->GetColUpb() ||
+       lazy_constructor.GetRowLwb() != this->GetRowLwb() || lazy_constructor.GetColLwb() != this->GetColLwb()) {
       Error("operator=(const TMatrixTLazy&)", "matrix is incompatible with "
-            "the assigned Lazy matrix");
+                                              "the assigned Lazy matrix");
       return *this;
    }
 
@@ -1841,13 +1804,13 @@ TMatrixT<Element> &TMatrixT<Element>::operator=(const TMatrixTLazy<Element> &laz
 ////////////////////////////////////////////////////////////////////////////////
 /// Assign val to every element of the matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator=(Element val)
 {
    R__ASSERT(this->IsValid());
 
    Element *ep = this->GetMatrixArray();
-   const Element * const ep_last = ep+this->fNelems;
+   const Element *const ep_last = ep + this->fNelems;
    while (ep < ep_last)
       *ep++ = val;
 
@@ -1857,13 +1820,13 @@ TMatrixT<Element> &TMatrixT<Element>::operator=(Element val)
 ////////////////////////////////////////////////////////////////////////////////
 /// Add val to every element of the matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator+=(Element val)
 {
    R__ASSERT(this->IsValid());
 
    Element *ep = this->GetMatrixArray();
-   const Element * const ep_last = ep+this->fNelems;
+   const Element *const ep_last = ep + this->fNelems;
    while (ep < ep_last)
       *ep++ += val;
 
@@ -1873,13 +1836,13 @@ TMatrixT<Element> &TMatrixT<Element>::operator+=(Element val)
 ////////////////////////////////////////////////////////////////////////////////
 /// Subtract val from every element of the matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator-=(Element val)
 {
    R__ASSERT(this->IsValid());
 
    Element *ep = this->GetMatrixArray();
-   const Element * const ep_last = ep+this->fNelems;
+   const Element *const ep_last = ep + this->fNelems;
    while (ep < ep_last)
       *ep++ -= val;
 
@@ -1889,13 +1852,13 @@ TMatrixT<Element> &TMatrixT<Element>::operator-=(Element val)
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiply every element of the matrix with val.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(Element val)
 {
    R__ASSERT(this->IsValid());
 
    Element *ep = this->GetMatrixArray();
-   const Element * const ep_last = ep+this->fNelems;
+   const Element *const ep_last = ep + this->fNelems;
    while (ep < ep_last)
       *ep++ *= val;
 
@@ -1905,17 +1868,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(Element val)
 ////////////////////////////////////////////////////////////////////////////////
 /// Add the source matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator+=(const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator+=(const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator+=(const TMatrixT &)", "matrices not compatible");
       return *this;
    }
 
    const Element *sp = source.GetMatrixArray();
    Element *tp = this->GetMatrixArray();
-   const Element * const tp_last = tp+this->fNelems;
+   const Element *const tp_last = tp + this->fNelems;
    while (tp < tp_last)
       *tp++ += *sp++;
 
@@ -1925,17 +1888,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator+=(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// Add the source matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator+=(const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator+=(const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator+=(const TMatrixTSym &)", "matrices not compatible");
       return *this;
    }
 
    const Element *sp = source.GetMatrixArray();
    Element *tp = this->GetMatrixArray();
-   const Element * const tp_last = tp+this->fNelems;
+   const Element *const tp_last = tp + this->fNelems;
    while (tp < tp_last)
       *tp++ += *sp++;
 
@@ -1945,17 +1908,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator+=(const TMatrixTSym<Element> &sou
 ////////////////////////////////////////////////////////////////////////////////
 /// Subtract the source matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator-=(const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator=-(const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator=-(const TMatrixT &)", "matrices not compatible");
       return *this;
    }
 
    const Element *sp = source.GetMatrixArray();
    Element *tp = this->GetMatrixArray();
-   const Element * const tp_last = tp+this->fNelems;
+   const Element *const tp_last = tp + this->fNelems;
    while (tp < tp_last)
       *tp++ -= *sp++;
 
@@ -1965,17 +1928,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator-=(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// Subtract the source matrix.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator-=(const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(*this,source)) {
-      Error("operator=-(const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(*this, source)) {
+      Error("operator=-(const TMatrixTSym &)", "matrices not compatible");
       return *this;
    }
 
    const Element *sp = source.GetMatrixArray();
    Element *tp = this->GetMatrixArray();
-   const Element * const tp_last = tp+this->fNelems;
+   const Element *const tp_last = tp + this->fNelems;
    while (tp < tp_last)
       *tp++ -= *sp++;
 
@@ -1987,7 +1950,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator-=(const TMatrixTSym<Element> &sou
 /// done inplace, though only the row of the target matrix needs to be saved.
 /// "Inplace" multiplication is only allowed when the 'source' matrix is square.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixT<Element> &source)
 {
    if (gMatrixCheck) {
@@ -1995,7 +1958,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixT<Element> &source
       R__ASSERT(source.IsValid());
       if (this->fNcols != source.GetNrows() || this->fColLwb != source.GetRowLwb() ||
           this->fNcols != source.GetNcols() || this->fColLwb != source.GetColLwb()) {
-         Error("operator*=(const TMatrixT &)","source matrix has wrong shape");
+         Error("operator*=(const TMatrixT &)", "source matrix has wrong shape");
          return *this;
       }
    }
@@ -2007,8 +1970,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixT<Element> &source
       tmp.ResizeTo(source);
       tmp = source;
       sp = tmp.GetMatrixArray();
-   }
-   else
+   } else
       sp = source.GetMatrixArray();
 
    // One row of the old_target matrix
@@ -2020,28 +1982,28 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixT<Element> &source
       trp = new Element[this->fNcols];
    }
 
-         Element *cp   = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    const Element *trp0 = cp; // Pointer to  target[i,0];
-   const Element * const trp0_last = trp0+this->fNelems;
+   const Element *const trp0_last = trp0 + this->fNelems;
    while (trp0 < trp0_last) {
-      memcpy(trp,trp0,this->fNcols*sizeof(Element));        // copy the i-th row of target, Start at target[i,0]
-      for (const Element *scp = sp; scp < sp+this->fNcols; ) {  // Pointer to the j-th column of source,
-                                                           // Start scp = source[0,0]
+      memcpy(trp, trp0, this->fNcols * sizeof(Element));        // copy the i-th row of target, Start at target[i,0]
+      for (const Element *scp = sp; scp < sp + this->fNcols;) { // Pointer to the j-th column of source,
+                                                                // Start scp = source[0,0]
          Element cij = 0;
          for (Int_t j = 0; j < this->fNcols; j++) {
-            cij += trp[j] * *scp;                        // the j-th col of source
+            cij += trp[j] * *scp; // the j-th col of source
             scp += this->fNcols;
          }
          *cp++ = cij;
-         scp -= source.GetNoElements()-1;               // Set bcp to the (j+1)-th col
+         scp -= source.GetNoElements() - 1; // Set bcp to the (j+1)-th col
       }
-      trp0 += this->fNcols;                            // Set trp0 to the (i+1)-th row
+      trp0 += this->fNcols; // Set trp0 to the (i+1)-th row
       R__ASSERT(trp0 == cp);
    }
 
    R__ASSERT(cp == trp0_last && trp0 == trp0_last);
    if (isAllocated)
-      delete [] trp;
+      delete[] trp;
 
    return *this;
 }
@@ -2050,14 +2012,14 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixT<Element> &source
 /// Compute target = target * source inplace. Strictly speaking, it can't be
 /// done inplace, though only the row of the target matrix needs to be saved.
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTSym<Element> &source)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(source.IsValid());
       if (this->fNcols != source.GetNrows() || this->fColLwb != source.GetRowLwb()) {
-         Error("operator*=(const TMatrixTSym &)","source matrix has wrong shape");
+         Error("operator*=(const TMatrixTSym &)", "source matrix has wrong shape");
          return *this;
       }
    }
@@ -2069,8 +2031,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTSym<Element> &sou
       tmp.ResizeTo(source);
       tmp = source;
       sp = tmp.GetMatrixArray();
-   }
-   else
+   } else
       sp = source.GetMatrixArray();
 
    // One row of the old_target matrix
@@ -2082,28 +2043,28 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTSym<Element> &sou
       trp = new Element[this->fNcols];
    }
 
-         Element *cp   = this->GetMatrixArray();
+   Element *cp = this->GetMatrixArray();
    const Element *trp0 = cp; // Pointer to  target[i,0];
-   const Element * const trp0_last = trp0+this->fNelems;
+   const Element *const trp0_last = trp0 + this->fNelems;
    while (trp0 < trp0_last) {
-      memcpy(trp,trp0,this->fNcols*sizeof(Element));        // copy the i-th row of target, Start at target[i,0]
-      for (const Element *scp = sp; scp < sp+this->fNcols; ) {  // Pointer to the j-th column of source,
-                                                           // Start scp = source[0,0]
+      memcpy(trp, trp0, this->fNcols * sizeof(Element));        // copy the i-th row of target, Start at target[i,0]
+      for (const Element *scp = sp; scp < sp + this->fNcols;) { // Pointer to the j-th column of source,
+                                                                // Start scp = source[0,0]
          Element cij = 0;
          for (Int_t j = 0; j < this->fNcols; j++) {
-            cij += trp[j] * *scp;                        // the j-th col of source
+            cij += trp[j] * *scp; // the j-th col of source
             scp += this->fNcols;
          }
          *cp++ = cij;
-         scp -= source.GetNoElements()-1;               // Set bcp to the (j+1)-th col
+         scp -= source.GetNoElements() - 1; // Set bcp to the (j+1)-th col
       }
-      trp0 += this->fNcols;                            // Set trp0 to the (i+1)-th row
+      trp0 += this->fNcols; // Set trp0 to the (i+1)-th row
       R__ASSERT(trp0 == cp);
    }
 
    R__ASSERT(cp == trp0_last && trp0 == trp0_last);
    if (isAllocated)
-      delete [] trp;
+      delete[] trp;
 
    return *this;
 }
@@ -2112,20 +2073,20 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTSym<Element> &sou
 /// Multiply a matrix row by the diagonal of another matrix
 /// matrix(i,j) *= diag(j), j=0,fNcols-1
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTDiag_const<Element> &diag)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(diag.GetMatrix()->IsValid());
       if (this->fNcols != diag.GetNdiags()) {
-         Error("operator*=(const TMatrixTDiag_const &)","wrong diagonal length");
+         Error("operator*=(const TMatrixTDiag_const &)", "wrong diagonal length");
          return *this;
       }
    }
 
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
    const Int_t inc = diag.GetInc();
    while (mp < mp_last) {
       const Element *dp = diag.GetPtr();
@@ -2142,20 +2103,20 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTDiag_const<Elemen
 /// Divide a matrix row by the diagonal of another matrix
 /// matrix(i,j) /= diag(j)
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTDiag_const<Element> &diag)
 {
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(diag.GetMatrix()->IsValid());
       if (this->fNcols != diag.GetNdiags()) {
-         Error("operator/=(const TMatrixTDiag_const &)","wrong diagonal length");
+         Error("operator/=(const TMatrixTDiag_const &)", "wrong diagonal length");
          return *this;
       }
    }
 
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
    const Int_t inc = diag.GetInc();
    while (mp < mp_last) {
       const Element *dp = diag.GetPtr();
@@ -2163,7 +2124,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTDiag_const<Elemen
          if (*dp != 0.0)
             *mp++ /= *dp;
          else {
-            Error("operator/=","%d-diagonal element is zero",j);
+            Error("operator/=", "%d-diagonal element is zero", j);
             mp++;
          }
          dp += inc;
@@ -2177,7 +2138,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTDiag_const<Elemen
 /// Multiply a matrix by the column of another matrix
 /// matrix(i,j) *= another(i,k) for fixed k
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTColumn_const<Element> &col)
 {
    const TMatrixTBase<Element> *mt = col.GetMatrix();
@@ -2186,15 +2147,15 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTColumn_const<Elem
       R__ASSERT(this->IsValid());
       R__ASSERT(mt->IsValid());
       if (this->fNrows != mt->GetNrows()) {
-         Error("operator*=(const TMatrixTColumn_const &)","wrong column length");
+         Error("operator*=(const TMatrixTColumn_const &)", "wrong column length");
          return *this;
       }
    }
 
-   const Element * const endp = col.GetPtr()+mt->GetNoElements();
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
-   const Element *cp = col.GetPtr();      //  ptr
+   const Element *const endp = col.GetPtr() + mt->GetNoElements();
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
+   const Element *cp = col.GetPtr(); //  ptr
    const Int_t inc = col.GetInc();
    while (mp < mp_last) {
       R__ASSERT(cp < endp);
@@ -2210,7 +2171,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTColumn_const<Elem
 /// Divide a matrix by the column of another matrix
 /// matrix(i,j) /= another(i,k) for fixed k
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTColumn_const<Element> &col)
 {
    const TMatrixTBase<Element> *mt = col.GetMatrix();
@@ -2219,15 +2180,15 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTColumn_const<Elem
       R__ASSERT(this->IsValid());
       R__ASSERT(mt->IsValid());
       if (this->fNrows != mt->GetNrows()) {
-         Error("operator/=(const TMatrixTColumn_const &)","wrong column matrix");
+         Error("operator/=(const TMatrixTColumn_const &)", "wrong column matrix");
          return *this;
       }
    }
 
-   const Element * const endp = col.GetPtr()+mt->GetNoElements();
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
-   const Element *cp = col.GetPtr();      //  ptr
+   const Element *const endp = col.GetPtr() + mt->GetNoElements();
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
+   const Element *cp = col.GetPtr(); //  ptr
    const Int_t inc = col.GetInc();
    while (mp < mp_last) {
       R__ASSERT(cp < endp);
@@ -2235,8 +2196,8 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTColumn_const<Elem
          for (Int_t j = 0; j < this->fNcols; j++)
             *mp++ /= *cp;
       } else {
-         const Int_t icol = (cp-mt->GetMatrixArray())/inc;
-         Error("operator/=","%d-row of matrix column is zero",icol);
+         const Int_t icol = (cp - mt->GetMatrixArray()) / inc;
+         Error("operator/=", "%d-row of matrix column is zero", icol);
          mp += this->fNcols;
       }
       cp += inc;
@@ -2249,7 +2210,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTColumn_const<Elem
 /// Multiply a matrix by the row of another matrix
 /// matrix(i,j) *= another(k,j) for fixed k
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTRow_const<Element> &row)
 {
    const TMatrixTBase<Element> *mt = row.GetMatrix();
@@ -2258,17 +2219,17 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTRow_const<Element
       R__ASSERT(this->IsValid());
       R__ASSERT(mt->IsValid());
       if (this->fNcols != mt->GetNcols()) {
-         Error("operator*=(const TMatrixTRow_const &)","wrong row length");
+         Error("operator*=(const TMatrixTRow_const &)", "wrong row length");
          return *this;
       }
    }
 
-   const Element * const endp = row.GetPtr()+mt->GetNoElements();
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
+   const Element *const endp = row.GetPtr() + mt->GetNoElements();
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
    const Int_t inc = row.GetInc();
    while (mp < mp_last) {
-      const Element *rp = row.GetPtr();    // Row ptr
+      const Element *rp = row.GetPtr(); // Row ptr
       for (Int_t j = 0; j < this->fNcols; j++) {
          R__ASSERT(rp < endp);
          *mp++ *= *rp;
@@ -2283,7 +2244,7 @@ TMatrixT<Element> &TMatrixT<Element>::operator*=(const TMatrixTRow_const<Element
 /// Divide a matrix by the row of another matrix
 /// matrix(i,j) /= another(k,j) for fixed k
 
-template<class Element>
+template <class Element>
 TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTRow_const<Element> &row)
 {
    const TMatrixTBase<Element> *mt = row.GetMatrix();
@@ -2291,22 +2252,22 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTRow_const<Element
    R__ASSERT(mt->IsValid());
 
    if (this->fNcols != mt->GetNcols()) {
-      Error("operator/=(const TMatrixTRow_const &)","wrong row length");
+      Error("operator/=(const TMatrixTRow_const &)", "wrong row length");
       return *this;
    }
 
-   const Element * const endp = row.GetPtr()+mt->GetNoElements();
-   Element *mp = this->GetMatrixArray();  // Matrix ptr
-   const Element * const mp_last = mp+this->fNelems;
+   const Element *const endp = row.GetPtr() + mt->GetNoElements();
+   Element *mp = this->GetMatrixArray(); // Matrix ptr
+   const Element *const mp_last = mp + this->fNelems;
    const Int_t inc = row.GetInc();
    while (mp < mp_last) {
-      const Element *rp = row.GetPtr();    // Row ptr
+      const Element *rp = row.GetPtr(); // Row ptr
       for (Int_t j = 0; j < this->fNcols; j++) {
          R__ASSERT(rp < endp);
          if (*rp != 0.0) {
-           *mp++ /= *rp;
+            *mp++ /= *rp;
          } else {
-            Error("operator/=","%d-col of matrix row is zero",j);
+            Error("operator/=", "%d-col of matrix row is zero", j);
             mp++;
          }
          rp += inc;
@@ -2322,11 +2283,11 @@ TMatrixT<Element> &TMatrixT<Element>::operator/=(const TMatrixTRow_const<Element
 /// If the matrix is asymmetric, only the real part of the eigen-values is
 /// returned . For full functionality use TMatrixDEigen .
 
-template<class Element>
+template <class Element>
 const TMatrixT<Element> TMatrixT<Element>::EigenVectors(TVectorT<Element> &eigenValues) const
 {
    if (!this->IsSymmetric())
-      Warning("EigenVectors(TVectorT &)","Only real part of eigen-values will be returned");
+      Warning("EigenVectors(TVectorT &)", "Only real part of eigen-values will be returned");
    TMatrixDEigen eigen(*this);
    eigenValues.ResizeTo(this->fNrows);
    eigenValues = eigen.GetEigenValuesRe();
@@ -2336,8 +2297,8 @@ const TMatrixT<Element> TMatrixT<Element>::EigenVectors(TVectorT<Element> &eigen
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1+source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target(source1);
    target += source2;
@@ -2347,8 +2308,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1+source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target(source1);
    target += source2;
@@ -2358,17 +2319,17 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1+source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return operator+(source2,source1);
+   return operator+(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source+val
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source,Element val)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source, Element val)
 {
    TMatrixT<Element> target(source);
    target += val;
@@ -2378,17 +2339,17 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator+(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = val+source
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator+(Element val,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator+(Element val, const TMatrixT<Element> &source)
 {
-   return operator+(source,val);
+   return operator+(source, val);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1-source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target(source1);
    target -= source2;
@@ -2398,8 +2359,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1-source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target(source1);
    target -= source2;
@@ -2409,17 +2370,17 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1-source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return Element(-1.0)*(operator-(source2,source1));
+   return Element(-1.0) * (operator-(source2, source1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source-val
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source,Element val)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source, Element val)
 {
    TMatrixT<Element> target(source);
    target -= val;
@@ -2429,17 +2390,17 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator-(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = val-source
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator-(Element val,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator-(Element val, const TMatrixT<Element> &source)
 {
-   return Element(-1.0)*operator-(source,val);
+   return Element(-1.0) * operator-(source, val);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = val*source
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(Element val,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator*(Element val, const TMatrixT<Element> &source)
 {
    TMatrixT<Element> target(source);
    target *= val;
@@ -2449,62 +2410,63 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator*(Element val,const TMatrixT<Elem
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = val*source
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source,Element val)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source, Element val)
 {
-   return operator*(val,source);
+   return operator*(val, source);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1*source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
-   TMatrixT<Element> target(source1,TMatrixT<Element>::kMult,source2);
+   TMatrixT<Element> target(source1, TMatrixT<Element>::kMult, source2);
    return target;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1*source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
-   TMatrixT<Element> target(source1,TMatrixT<Element>::kMult,source2);
+   TMatrixT<Element> target(source1, TMatrixT<Element>::kMult, source2);
    return target;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1*source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   TMatrixT<Element> target(source1,TMatrixT<Element>::kMult,source2);
+   TMatrixT<Element> target(source1, TMatrixT<Element>::kMult, source2);
    return target;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// operation this = source1*source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator*(const TMatrixTSym<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element>
+TMatrixTAutoloadOps::operator*(const TMatrixTSym<Element> &source1, const TMatrixTSym<Element> &source2)
 {
-   TMatrixT<Element> target(source1,TMatrixT<Element>::kMult,source2);
+   TMatrixT<Element> target(source1, TMatrixT<Element>::kMult, source2);
    return target;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical AND
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator&&(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator&&(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2512,8 +2474,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last)
       *tp++ = (*sp1++ != 0.0 && *sp2++ != 0.0);
 
@@ -2523,13 +2485,13 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical AND
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator&&(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator&&(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
       return target;
    }
 
@@ -2537,8 +2499,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last)
       *tp++ = (*sp1++ != 0.0 && *sp2++ != 0.0);
 
@@ -2548,22 +2510,22 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical AND
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator&&(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return operator&&(source2,source1);
+   return operator&&(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical OR
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator||(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator||(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2571,8 +2533,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last)
       *tp++ = (*sp1++ != 0.0 || *sp2++ != 0.0);
 
@@ -2582,13 +2544,13 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical OR
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator||(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator||(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
       return target;
    }
 
@@ -2596,8 +2558,8 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last)
       *tp++ = (*sp1++ != 0.0 || *sp2++ != 0.0);
 
@@ -2607,22 +2569,22 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// Logical OR
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator||(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return operator||(source2,source1);
+   return operator||(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 > source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator|(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator|(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2630,36 +2592,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last) {
-      *tp++ = (*sp1) > (*sp2); sp1++; sp2++;
-   }
-
-   return target;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// logical operation source1 > source2
-
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
-{
-   TMatrixT<Element> target;
-
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator>(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
-      return target;
-   }
-
-   target.ResizeTo(source1);
-
-   const Element *sp1 = source1.GetMatrixArray();
-   const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
-   while (tp < tp_last) {
-      *tp++ = (*sp1) > (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) > (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2668,22 +2606,50 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 > source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
-   return operator<=(source2,source1);
+   TMatrixT<Element> target;
+
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator>(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
+      return target;
+   }
+
+   target.ResizeTo(source1);
+
+   const Element *sp1 = source1.GetMatrixArray();
+   const Element *sp2 = source2.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
+   while (tp < tp_last) {
+      *tp++ = (*sp1) > (*sp2);
+      sp1++;
+      sp2++;
+   }
+
+   return target;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// logical operation source1 > source2
+
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
+{
+   return operator<=(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 >= source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator>=(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator>=(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2691,10 +2657,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last) {
-      *tp++ = (*sp1) >= (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) >= (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2703,13 +2671,13 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 >= source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator>=(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator>=(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
       return target;
    }
 
@@ -2717,10 +2685,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last) {
-      *tp++ = (*sp1) >= (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) >= (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2729,22 +2699,22 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 >= source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator>=(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return operator<(source2,source1);
+   return operator<(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 <= source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator<=(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator<=(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2752,36 +2722,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last) {
-      *tp++ = (*sp1) <= (*sp2); sp1++; sp2++;
-   }
-
-   return target;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// logical operation source1 <= source2
-
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
-{
-   TMatrixT<Element> target;
-
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator<=(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
-      return target;
-   }
-
-   target.ResizeTo(source1);
-
-   const Element *sp1 = source1.GetMatrixArray();
-   const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
-   while (tp < tp_last) {
-      *tp++ = (*sp1) <= (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) <= (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2790,46 +2736,13 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 <= source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
-{
-   return operator>(source2,source1);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// logical operation source1 < source2
-
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator<(const TMatrixT&,const TMatrixT&)","matrices not compatible");
-      return target;
-   }
-
-   const Element *sp1 = source1.GetMatrixArray();
-   const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
-   while (tp < tp_last) {
-      *tp++ = (*sp1) < (*sp2); sp1++; sp2++;
-   }
-
-   return target;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// logical operation source1 < source2
-
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
-{
-  TMatrixT<Element> target;
-
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator<(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator<=(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
       return target;
    }
 
@@ -2837,10 +2750,47 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp < tp_last) {
-      *tp++ = (*sp1) < (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) <= (*sp2);
+      sp1++;
+      sp2++;
+   }
+
+   return target;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// logical operation source1 <= source2
+
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<=(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
+{
+   return operator>(source2, source1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// logical operation source1 < source2
+
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
+{
+   TMatrixT<Element> target;
+
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator<(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
+      return target;
+   }
+
+   const Element *sp1 = source1.GetMatrixArray();
+   const Element *sp2 = source2.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
+   while (tp < tp_last) {
+      *tp++ = (*sp1) < (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2849,22 +2799,50 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 < source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
-   return operator>=(source2,source1);
+   TMatrixT<Element> target;
+
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator<(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
+      return target;
+   }
+
+   target.ResizeTo(source1);
+
+   const Element *sp1 = source1.GetMatrixArray();
+   const Element *sp2 = source2.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
+   while (tp < tp_last) {
+      *tp++ = (*sp1) < (*sp2);
+      sp1++;
+      sp2++;
+   }
+
+   return target;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// logical operation source1 < source2
+
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator<(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
+{
+   return operator>=(source2, source1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 != source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &source1, const TMatrixT<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator!=(const TMatrixT&,const TMatrixT&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator!=(const TMatrixT&,const TMatrixT&)", "matrices not compatible");
       return target;
    }
 
@@ -2872,10 +2850,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp != tp_last) {
-      *tp++ = (*sp1) != (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) != (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2884,13 +2864,13 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 != source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &source1,const TMatrixTSym<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &source1, const TMatrixTSym<Element> &source2)
 {
    TMatrixT<Element> target;
 
-   if (gMatrixCheck && !AreCompatible(source1,source2)) {
-      Error("operator!=(const TMatrixT&,const TMatrixTSym&)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(source1, source2)) {
+      Error("operator!=(const TMatrixT&,const TMatrixTSym&)", "matrices not compatible");
       return target;
    }
 
@@ -2898,10 +2878,12 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &sourc
 
    const Element *sp1 = source1.GetMatrixArray();
    const Element *sp2 = source2.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element * const tp_last = tp+target.GetNoElements();
+   Element *tp = target.GetMatrixArray();
+   const Element *const tp_last = tp + target.GetNoElements();
    while (tp != tp_last) {
-      *tp++ = (*sp1) != (*sp2); sp1++; sp2++;
+      *tp++ = (*sp1) != (*sp2);
+      sp1++;
+      sp2++;
    }
 
    return target;
@@ -2910,10 +2892,10 @@ TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixT<Element> &sourc
 ////////////////////////////////////////////////////////////////////////////////
 /// logical operation source1 != source2
 
-template<class Element>
-TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixTSym<Element> &source1,const TMatrixT<Element> &source2)
+template <class Element>
+TMatrixT<Element> TMatrixTAutoloadOps::operator!=(const TMatrixTSym<Element> &source1, const TMatrixT<Element> &source2)
 {
-   return operator!=(source2,source1);
+   return operator!=(source2, source1);
 }
 
 /*
@@ -2948,26 +2930,26 @@ TMatrixT<Element> operator!=(Element val,const TMatrixT<Element> &source1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Modify addition: target += scalar * source.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::Add(TMatrixT<Element> &target,Element scalar,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> &TMatrixTAutoloadOps::Add(TMatrixT<Element> &target, Element scalar, const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("Add(TMatrixT &,Element,const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("Add(TMatrixT &,Element,const TMatrixT &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
    if (scalar == 0) {
-       while ( tp < ftp )
-          *tp++  = scalar * (*sp++);
+      while (tp < ftp)
+         *tp++ = scalar * (*sp++);
    } else if (scalar == 1.) {
-       while ( tp < ftp )
-          *tp++ = (*sp++);
+      while (tp < ftp)
+         *tp++ = (*sp++);
    } else {
-       while ( tp < ftp )
-          *tp++ += scalar * (*sp++);
+      while (tp < ftp)
+         *tp++ += scalar * (*sp++);
    }
 
    return target;
@@ -2976,18 +2958,19 @@ TMatrixT<Element> &TMatrixTAutoloadOps::Add(TMatrixT<Element> &target,Element sc
 ////////////////////////////////////////////////////////////////////////////////
 /// Modify addition: target += scalar * source.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::Add(TMatrixT<Element> &target,Element scalar,const TMatrixTSym<Element> &source)
+template <class Element>
+TMatrixT<Element> &
+TMatrixTAutoloadOps::Add(TMatrixT<Element> &target, Element scalar, const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("Add(TMatrixT &,Element,const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("Add(TMatrixT &,Element,const TMatrixTSym &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
-   while ( tp < ftp )
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
+   while (tp < ftp)
       *tp++ += scalar * (*sp++);
 
    return target;
@@ -2996,18 +2979,18 @@ TMatrixT<Element> &TMatrixTAutoloadOps::Add(TMatrixT<Element> &target,Element sc
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiply target by the source, element-by-element.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target, const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("ElementMult(TMatrixT &,const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("ElementMult(TMatrixT &,const TMatrixT &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
-   while ( tp < ftp )
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
+   while (tp < ftp)
       *tp++ *= *sp++;
 
    return target;
@@ -3016,18 +2999,18 @@ TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target,co
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiply target by the source, element-by-element.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target,const TMatrixTSym<Element> &source)
+template <class Element>
+TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target, const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("ElementMult(TMatrixT &,const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("ElementMult(TMatrixT &,const TMatrixTSym &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
-   while ( tp < ftp )
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
+   while (tp < ftp)
       *tp++ *= *sp++;
 
    return target;
@@ -3036,24 +3019,24 @@ TMatrixT<Element> &TMatrixTAutoloadOps::ElementMult(TMatrixT<Element> &target,co
 ////////////////////////////////////////////////////////////////////////////////
 /// Divide target by the source, element-by-element.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target,const TMatrixT<Element> &source)
+template <class Element>
+TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target, const TMatrixT<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("ElementDiv(TMatrixT &,const TMatrixT &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("ElementDiv(TMatrixT &,const TMatrixT &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
-   while ( tp < ftp ) {
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
+   while (tp < ftp) {
       if (*sp != 0.0)
          *tp++ /= *sp++;
       else {
-         const Int_t irow = (sp-source.GetMatrixArray())/source.GetNcols();
-         const Int_t icol = (sp-source.GetMatrixArray())%source.GetNcols();
-         Error("ElementDiv","source (%d,%d) is zero",irow,icol);
+         const Int_t irow = (sp - source.GetMatrixArray()) / source.GetNcols();
+         const Int_t icol = (sp - source.GetMatrixArray()) % source.GetNcols();
+         Error("ElementDiv", "source (%d,%d) is zero", irow, icol);
          tp++;
       }
    }
@@ -3064,24 +3047,24 @@ TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target,con
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiply target by the source, element-by-element.
 
-template<class Element>
-TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target,const TMatrixTSym<Element> &source)
+template <class Element>
+TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target, const TMatrixTSym<Element> &source)
 {
-   if (gMatrixCheck && !AreCompatible(target,source)) {
-      ::Error("ElementDiv(TMatrixT &,const TMatrixTSym &)","matrices not compatible");
+   if (gMatrixCheck && !AreCompatible(target, source)) {
+      ::Error("ElementDiv(TMatrixT &,const TMatrixTSym &)", "matrices not compatible");
       return target;
    }
 
-   const Element *sp  = source.GetMatrixArray();
-         Element *tp  = target.GetMatrixArray();
-   const Element *ftp = tp+target.GetNoElements();
-   while ( tp < ftp ) {
+   const Element *sp = source.GetMatrixArray();
+   Element *tp = target.GetMatrixArray();
+   const Element *ftp = tp + target.GetNoElements();
+   while (tp < ftp) {
       if (*sp != 0.0)
          *tp++ /= *sp++;
       else {
-         const Int_t irow = (sp-source.GetMatrixArray())/source.GetNcols();
-         const Int_t icol = (sp-source.GetMatrixArray())%source.GetNcols();
-         Error("ElementDiv","source (%d,%d) is zero",irow,icol);
+         const Int_t irow = (sp - source.GetMatrixArray()) / source.GetNcols();
+         const Int_t icol = (sp - source.GetMatrixArray()) % source.GetNcols();
+         Error("ElementDiv", "source (%d,%d) is zero", irow, icol);
          *tp++ = 0.0;
       }
    }
@@ -3092,77 +3075,77 @@ TMatrixT<Element> &TMatrixTAutoloadOps::ElementDiv(TMatrixT<Element> &target,con
 ////////////////////////////////////////////////////////////////////////////////
 /// Elementary routine to calculate matrix multiplication A*B
 
-template<class Element>
-void TMatrixTAutoloadOps::AMultB(const Element * const ap,Int_t na,Int_t ncolsa,
-            const Element * const bp,Int_t nb,Int_t ncolsb,Element *cp)
+template <class Element>
+void TMatrixTAutoloadOps::AMultB(const Element *const ap, Int_t na, Int_t ncolsa, const Element *const bp, Int_t nb,
+                                 Int_t ncolsb, Element *cp)
 {
-   const Element *arp0 = ap;                     // Pointer to  A[i,0];
-   while (arp0 < ap+na) {
-      for (const Element *bcp = bp; bcp < bp+ncolsb; ) { // Pointer to the j-th column of B, Start bcp = B[0,0]
+   const Element *arp0 = ap; // Pointer to  A[i,0];
+   while (arp0 < ap + na) {
+      for (const Element *bcp = bp; bcp < bp + ncolsb;) { // Pointer to the j-th column of B, Start bcp = B[0,0]
          const Element *arp = arp0;                       // Pointer to the i-th row of A, reset to A[i,0]
          Element cij = 0;
-         while (bcp < bp+nb) {                     // Scan the i-th row of A and
-            cij += *arp++ * *bcp;                   // the j-th col of B
+         while (bcp < bp + nb) {  // Scan the i-th row of A and
+            cij += *arp++ * *bcp; // the j-th col of B
             bcp += ncolsb;
          }
          *cp++ = cij;
-         bcp -= nb-1;                              // Set bcp to the (j+1)-th col
+         bcp -= nb - 1; // Set bcp to the (j+1)-th col
       }
-      arp0 += ncolsa;                             // Set ap to the (i+1)-th row
+      arp0 += ncolsa; // Set ap to the (i+1)-th row
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Elementary routine to calculate matrix multiplication A^T*B
 
-template<class Element>
-void TMatrixTAutoloadOps::AtMultB(const Element * const ap,Int_t ncolsa,
-             const Element * const bp,Int_t nb,Int_t ncolsb,Element *cp)
+template <class Element>
+void TMatrixTAutoloadOps::AtMultB(const Element *const ap, Int_t ncolsa, const Element *const bp, Int_t nb,
+                                  Int_t ncolsb, Element *cp)
 {
-   const Element *acp0 = ap;           // Pointer to  A[i,0];
-   while (acp0 < ap+ncolsa) {
-      for (const Element *bcp = bp; bcp < bp+ncolsb; ) { // Pointer to the j-th column of B, Start bcp = B[0,0]
+   const Element *acp0 = ap; // Pointer to  A[i,0];
+   while (acp0 < ap + ncolsa) {
+      for (const Element *bcp = bp; bcp < bp + ncolsb;) { // Pointer to the j-th column of B, Start bcp = B[0,0]
          const Element *acp = acp0;                       // Pointer to the i-th column of A, reset to A[0,i]
          Element cij = 0;
-         while (bcp < bp+nb) {           // Scan the i-th column of A and
-            cij += *acp * *bcp;           // the j-th col of B
+         while (bcp < bp + nb) { // Scan the i-th column of A and
+            cij += *acp * *bcp;  // the j-th col of B
             acp += ncolsa;
             bcp += ncolsb;
          }
          *cp++ = cij;
-         bcp -= nb-1;                    // Set bcp to the (j+1)-th col
+         bcp -= nb - 1; // Set bcp to the (j+1)-th col
       }
-      acp0++;                           // Set acp0 to the (i+1)-th col
+      acp0++; // Set acp0 to the (i+1)-th col
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Elementary routine to calculate matrix multiplication A*B^T
 
-template<class Element>
-void TMatrixTAutoloadOps::AMultBt(const Element * const ap,Int_t na,Int_t ncolsa,
-             const Element * const bp,Int_t nb,Int_t ncolsb,Element *cp)
+template <class Element>
+void TMatrixTAutoloadOps::AMultBt(const Element *const ap, Int_t na, Int_t ncolsa, const Element *const bp, Int_t nb,
+                                  Int_t ncolsb, Element *cp)
 {
-   const Element *arp0 = ap;                    // Pointer to  A[i,0];
-   while (arp0 < ap+na) {
-      const Element *brp0 = bp;                  // Pointer to  B[j,0];
-      while (brp0 < bp+nb) {
-         const Element *arp = arp0;               // Pointer to the i-th row of A, reset to A[i,0]
-         const Element *brp = brp0;               // Pointer to the j-th row of B, reset to B[j,0]
+   const Element *arp0 = ap; // Pointer to  A[i,0];
+   while (arp0 < ap + na) {
+      const Element *brp0 = bp; // Pointer to  B[j,0];
+      while (brp0 < bp + nb) {
+         const Element *arp = arp0; // Pointer to the i-th row of A, reset to A[i,0]
+         const Element *brp = brp0; // Pointer to the j-th row of B, reset to B[j,0]
          Element cij = 0;
-         while (brp < brp0+ncolsb)                 // Scan the i-th row of A and
-            cij += *arp++ * *brp++;                 // the j-th row of B
+         while (brp < brp0 + ncolsb) // Scan the i-th row of A and
+            cij += *arp++ * *brp++;  // the j-th row of B
          *cp++ = cij;
-         brp0 += ncolsb;                           // Set brp0 to the (j+1)-th row
+         brp0 += ncolsb; // Set brp0 to the (j+1)-th row
       }
-      arp0 += ncolsa;                             // Set arp0 to the (i+1)-th row
+      arp0 += ncolsa; // Set arp0 to the (i+1)-th row
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Stream an object of class TMatrixT.
 
-template<class Element>
+template <class Element>
 void TMatrixT<Element>::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
@@ -3170,8 +3153,8 @@ void TMatrixT<Element>::Streamer(TBuffer &R__b)
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
       if (R__v > 2) {
          Clear();
-         R__b.ReadClassBuffer(TMatrixT<Element>::Class(),this,R__v,R__s,R__c);
-      } else if (R__v == 2) { //process old version 2
+         R__b.ReadClassBuffer(TMatrixT<Element>::Class(), this, R__v, R__s, R__c);
+      } else if (R__v == 2) { // process old version 2
          Clear();
          TObject::Streamer(R__b);
          this->MakeValid();
@@ -3185,11 +3168,11 @@ void TMatrixT<Element>::Streamer(TBuffer &R__b)
          if (isArray) {
             if (this->fNelems > 0) {
                fElements = new Element[this->fNelems];
-               R__b.ReadFastArray(fElements,this->fNelems);
+               R__b.ReadFastArray(fElements, this->fNelems);
             } else
                fElements = nullptr;
          }
-         R__b.CheckByteCount(R__s,R__c,TMatrixT<Element>::IsA());
+         R__b.CheckByteCount(R__s, R__c, TMatrixT<Element>::IsA());
       } else { //====process old versions before automatic schema evolution
          TObject::Streamer(R__b);
          this->MakeValid();
@@ -3198,144 +3181,143 @@ void TMatrixT<Element>::Streamer(TBuffer &R__b)
          R__b >> this->fRowLwb;
          R__b >> this->fColLwb;
          this->fNelems = R__b.ReadArray(fElements);
-         R__b.CheckByteCount(R__s,R__c,TMatrixT<Element>::IsA());
+         R__b.CheckByteCount(R__s, R__c, TMatrixT<Element>::IsA());
       }
       // in version <=2 , the matrix was stored column-wise
       if (R__v <= 2 && fElements) {
          for (Int_t i = 0; i < this->fNrows; i++) {
-            const Int_t off_i = i*this->fNcols;
+            const Int_t off_i = i * this->fNcols;
             for (Int_t j = i; j < this->fNcols; j++) {
-               const Int_t off_j = j*this->fNrows;
-               const Element tmp = fElements[off_i+j];
-               fElements[off_i+j] = fElements[off_j+i];
-               fElements[off_j+i] = tmp;
+               const Int_t off_j = j * this->fNrows;
+               const Element tmp = fElements[off_i + j];
+               fElements[off_i + j] = fElements[off_j + i];
+               fElements[off_j + i] = tmp;
             }
          }
       }
       if (this->fNelems > 0 && this->fNelems <= this->kSizeMax) {
          if (fElements) {
-            memcpy(fDataStack,fElements,this->fNelems*sizeof(Element));
-            delete [] fElements;
+            memcpy(fDataStack, fElements, this->fNelems * sizeof(Element));
+            delete[] fElements;
          }
          fElements = fDataStack;
       } else if (this->fNelems < 0)
          this->Invalidate();
-      } else {
-         R__b.WriteClassBuffer(TMatrixT<Element>::Class(),this);
+   } else {
+      R__b.WriteClassBuffer(TMatrixT<Element>::Class(), this);
    }
 }
-
 
 template class TMatrixT<Float_t>;
 
 #include "TMatrixFfwd.h"
 #include "TMatrixFSymfwd.h"
 
-template TMatrixF  TMatrixTAutoloadOps::operator+  <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator+  <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator+  <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator+  <Float_t>(const TMatrixF    &source ,      Float_t      val    );
-template TMatrixF  TMatrixTAutoloadOps::operator+  <Float_t>(      Float_t      val    ,const TMatrixF    &source );
-template TMatrixF  TMatrixTAutoloadOps::operator-  <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator-  <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator-  <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator-  <Float_t>(const TMatrixF    &source ,      Float_t      val    );
-template TMatrixF  TMatrixTAutoloadOps::operator-  <Float_t>(      Float_t      val    ,const TMatrixF    &source );
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(      Float_t      val    ,const TMatrixF    &source );
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(const TMatrixF    &source ,      Float_t      val    );
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator*  <Float_t>(const TMatrixFSym &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator&& <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator&& <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator&& <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator|| <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator|| <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator|| <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>  <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>  <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>  <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>= <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>= <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator>= <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<= <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<= <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<= <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<  <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<  <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator<  <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator!= <Float_t>(const TMatrixF    &source1,const TMatrixF    &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator!= <Float_t>(const TMatrixF    &source1,const TMatrixFSym &source2);
-template TMatrixF  TMatrixTAutoloadOps::operator!= <Float_t>(const TMatrixFSym &source1,const TMatrixF    &source2);
+template TMatrixF TMatrixTAutoloadOps::operator+<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator+<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator+<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator+<Float_t>(const TMatrixF &source, Float_t val);
+template TMatrixF TMatrixTAutoloadOps::operator+<Float_t>(Float_t val, const TMatrixF &source);
+template TMatrixF TMatrixTAutoloadOps::operator-<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator-<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator-<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator-<Float_t>(const TMatrixF &source, Float_t val);
+template TMatrixF TMatrixTAutoloadOps::operator-<Float_t>(Float_t val, const TMatrixF &source);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(Float_t val, const TMatrixF &source);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(const TMatrixF &source, Float_t val);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator*<Float_t>(const TMatrixFSym &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator&&<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator&&<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator&&<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator||<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator||<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator||<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator><Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator><Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator><Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator>=<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator>=<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator>=<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator<=<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator<=<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator<=<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator< <Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator< <Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator< <Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator!=<Float_t>(const TMatrixF &source1, const TMatrixF &source2);
+template TMatrixF TMatrixTAutoloadOps::operator!=<Float_t>(const TMatrixF &source1, const TMatrixFSym &source2);
+template TMatrixF TMatrixTAutoloadOps::operator!=<Float_t>(const TMatrixFSym &source1, const TMatrixF &source2);
 
-template TMatrixF &TMatrixTAutoloadOps::Add        <Float_t>(TMatrixF &target,      Float_t      scalar,const TMatrixF    &source);
-template TMatrixF &TMatrixTAutoloadOps::Add        <Float_t>(TMatrixF &target,      Float_t      scalar,const TMatrixFSym &source);
-template TMatrixF &TMatrixTAutoloadOps::ElementMult<Float_t>(TMatrixF &target,const TMatrixF    &source);
-template TMatrixF &TMatrixTAutoloadOps::ElementMult<Float_t>(TMatrixF &target,const TMatrixFSym &source);
-template TMatrixF &TMatrixTAutoloadOps::ElementDiv <Float_t>(TMatrixF &target,const TMatrixF    &source);
-template TMatrixF &TMatrixTAutoloadOps::ElementDiv <Float_t>(TMatrixF &target,const TMatrixFSym &source);
+template TMatrixF &TMatrixTAutoloadOps::Add<Float_t>(TMatrixF &target, Float_t scalar, const TMatrixF &source);
+template TMatrixF &TMatrixTAutoloadOps::Add<Float_t>(TMatrixF &target, Float_t scalar, const TMatrixFSym &source);
+template TMatrixF &TMatrixTAutoloadOps::ElementMult<Float_t>(TMatrixF &target, const TMatrixF &source);
+template TMatrixF &TMatrixTAutoloadOps::ElementMult<Float_t>(TMatrixF &target, const TMatrixFSym &source);
+template TMatrixF &TMatrixTAutoloadOps::ElementDiv<Float_t>(TMatrixF &target, const TMatrixF &source);
+template TMatrixF &TMatrixTAutoloadOps::ElementDiv<Float_t>(TMatrixF &target, const TMatrixFSym &source);
 
-template void TMatrixTAutoloadOps::AMultB <Float_t>(const Float_t * const ap,Int_t na,Int_t ncolsa,
-                               const Float_t * const bp,Int_t nb,Int_t ncolsb,Float_t *cp);
-template void TMatrixTAutoloadOps::AtMultB<Float_t>(const Float_t * const ap,Int_t ncolsa,
-                               const Float_t * const bp,Int_t nb,Int_t ncolsb,Float_t *cp);
-template void TMatrixTAutoloadOps::AMultBt<Float_t>(const Float_t * const ap,Int_t na,Int_t ncolsa,
-                               const Float_t * const bp,Int_t nb,Int_t ncolsb,Float_t *cp);
+template void TMatrixTAutoloadOps::AMultB<Float_t>(const Float_t *const ap, Int_t na, Int_t ncolsa,
+                                                   const Float_t *const bp, Int_t nb, Int_t ncolsb, Float_t *cp);
+template void TMatrixTAutoloadOps::AtMultB<Float_t>(const Float_t *const ap, Int_t ncolsa, const Float_t *const bp,
+                                                    Int_t nb, Int_t ncolsb, Float_t *cp);
+template void TMatrixTAutoloadOps::AMultBt<Float_t>(const Float_t *const ap, Int_t na, Int_t ncolsa,
+                                                    const Float_t *const bp, Int_t nb, Int_t ncolsb, Float_t *cp);
 
 #include "TMatrixDfwd.h"
 #include "TMatrixDSymfwd.h"
 
 template class TMatrixT<Double_t>;
 
-template TMatrixD  TMatrixTAutoloadOps::operator+  <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator+  <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator+  <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator+  <Double_t>(const TMatrixD    &source ,      Double_t     val    );
-template TMatrixD  TMatrixTAutoloadOps::operator+  <Double_t>(      Double_t     val    ,const TMatrixD    &source );
-template TMatrixD  TMatrixTAutoloadOps::operator-  <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator-  <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator-  <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator-  <Double_t>(const TMatrixD    &source ,      Double_t     val    );
-template TMatrixD  TMatrixTAutoloadOps::operator-  <Double_t>(      Double_t     val    ,const TMatrixD    &source );
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(      Double_t     val    ,const TMatrixD    &source );
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(const TMatrixD    &source ,      Double_t     val    );
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator*  <Double_t>(const TMatrixDSym &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator&& <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator&& <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator&& <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator|| <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator|| <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator|| <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>  <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>  <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>  <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>= <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>= <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator>= <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<= <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<= <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<= <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<  <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<  <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator<  <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator!= <Double_t>(const TMatrixD    &source1,const TMatrixD    &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator!= <Double_t>(const TMatrixD    &source1,const TMatrixDSym &source2);
-template TMatrixD  TMatrixTAutoloadOps::operator!= <Double_t>(const TMatrixDSym &source1,const TMatrixD    &source2);
+template TMatrixD TMatrixTAutoloadOps::operator+<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator+<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator+<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator+<Double_t>(const TMatrixD &source, Double_t val);
+template TMatrixD TMatrixTAutoloadOps::operator+<Double_t>(Double_t val, const TMatrixD &source);
+template TMatrixD TMatrixTAutoloadOps::operator-<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator-<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator-<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator-<Double_t>(const TMatrixD &source, Double_t val);
+template TMatrixD TMatrixTAutoloadOps::operator-<Double_t>(Double_t val, const TMatrixD &source);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(Double_t val, const TMatrixD &source);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(const TMatrixD &source, Double_t val);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator*<Double_t>(const TMatrixDSym &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator&&<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator&&<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator&&<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator||<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator||<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator||<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator><Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator><Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator><Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator>=<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator>=<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator>=<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator<=<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator<=<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator<=<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator< <Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator< <Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator< <Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator!=<Double_t>(const TMatrixD &source1, const TMatrixD &source2);
+template TMatrixD TMatrixTAutoloadOps::operator!=<Double_t>(const TMatrixD &source1, const TMatrixDSym &source2);
+template TMatrixD TMatrixTAutoloadOps::operator!=<Double_t>(const TMatrixDSym &source1, const TMatrixD &source2);
 
-template TMatrixD &TMatrixTAutoloadOps::Add        <Double_t>(TMatrixD &target,      Double_t     scalar,const TMatrixD    &source);
-template TMatrixD &TMatrixTAutoloadOps::Add        <Double_t>(TMatrixD &target,      Double_t     scalar,const TMatrixDSym &source);
-template TMatrixD &TMatrixTAutoloadOps::ElementMult<Double_t>(TMatrixD &target,const TMatrixD    &source);
-template TMatrixD &TMatrixTAutoloadOps::ElementMult<Double_t>(TMatrixD &target,const TMatrixDSym &source);
-template TMatrixD &TMatrixTAutoloadOps::ElementDiv <Double_t>(TMatrixD &target,const TMatrixD    &source);
-template TMatrixD &TMatrixTAutoloadOps::ElementDiv <Double_t>(TMatrixD &target,const TMatrixDSym &source);
+template TMatrixD &TMatrixTAutoloadOps::Add<Double_t>(TMatrixD &target, Double_t scalar, const TMatrixD &source);
+template TMatrixD &TMatrixTAutoloadOps::Add<Double_t>(TMatrixD &target, Double_t scalar, const TMatrixDSym &source);
+template TMatrixD &TMatrixTAutoloadOps::ElementMult<Double_t>(TMatrixD &target, const TMatrixD &source);
+template TMatrixD &TMatrixTAutoloadOps::ElementMult<Double_t>(TMatrixD &target, const TMatrixDSym &source);
+template TMatrixD &TMatrixTAutoloadOps::ElementDiv<Double_t>(TMatrixD &target, const TMatrixD &source);
+template TMatrixD &TMatrixTAutoloadOps::ElementDiv<Double_t>(TMatrixD &target, const TMatrixDSym &source);
 
-template void TMatrixTAutoloadOps::AMultB <Double_t>(const Double_t * const ap,Int_t na,Int_t ncolsa,
-                                const Double_t * const bp,Int_t nb,Int_t ncolsb,Double_t *cp);
-template void TMatrixTAutoloadOps::AtMultB<Double_t>(const Double_t * const ap,Int_t ncolsa,
-                                const Double_t * const bp,Int_t nb,Int_t ncolsb,Double_t *cp);
-template void TMatrixTAutoloadOps::AMultBt<Double_t>(const Double_t * const ap,Int_t na,Int_t ncolsa,
-                                const Double_t * const bp,Int_t nb,Int_t ncolsb,Double_t *cp);
+template void TMatrixTAutoloadOps::AMultB<Double_t>(const Double_t *const ap, Int_t na, Int_t ncolsa,
+                                                    const Double_t *const bp, Int_t nb, Int_t ncolsb, Double_t *cp);
+template void TMatrixTAutoloadOps::AtMultB<Double_t>(const Double_t *const ap, Int_t ncolsa, const Double_t *const bp,
+                                                     Int_t nb, Int_t ncolsb, Double_t *cp);
+template void TMatrixTAutoloadOps::AMultBt<Double_t>(const Double_t *const ap, Int_t na, Int_t ncolsa,
+                                                     const Double_t *const bp, Int_t nb, Int_t ncolsb, Double_t *cp);

--- a/math/matrix/src/TMatrixT.cxx
+++ b/math/matrix/src/TMatrixT.cxx
@@ -189,13 +189,22 @@ TMatrixT<Element>::TMatrixT(const TMatrixT<Element> &a,EMatrixCreatorsOp2 op,con
          break;
 
       case kInvMult:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         *this = a;
-         const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
-         this->Invert();
-         this->SetTol(oldTol);
-         *this *= b;
+      {  Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
+         // if size(a) == size(b), perform in place computation
+         if (a.GetNrows() == b.GetNcols()){
+            *this = a;
+            const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
+            this->Invert();
+            this->SetTol(oldTol);
+            *this *= b;
+         }
+         else{
+            TMatrixT<Element> ainv = a;
+            const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
+            ainv.Invert();
+            ainv.SetTol(oldTol);
+            Mult(ainv,b);
+         }
          break;
       }
 
@@ -303,13 +312,22 @@ TMatrixT<Element>::TMatrixT(const TMatrixTSym<Element> &a,EMatrixCreatorsOp2 op,
          break;
 
       case kInvMult:
-      {
-         Allocate(a.GetNrows(),a.GetNcols(),a.GetRowLwb(),a.GetColLwb(),1);
-         *this = a;
-         const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
-         this->Invert();
-         this->SetTol(oldTol);
-         *this *= b;
+      {  Allocate(a.GetNrows(),b.GetNcols(),a.GetRowLwb(),b.GetColLwb(),1);
+         // if size(a) == size(b), perform in place computation
+         if (a.GetNrows() == b.GetNcols()){
+            *this = a;
+            const Element oldTol = this->SetTol(std::numeric_limits<Element>::min());
+            this->Invert();
+            this->SetTol(oldTol);
+            *this *= b;
+         }
+         else{
+            TMatrixTSym<Element> ainv = a;
+            const Element oldTol = ainv.SetTol(std::numeric_limits<Element>::min());
+            ainv.Invert();
+            ainv.SetTol(oldTol);
+            Mult(ainv,b);
+         }
          break;
       }
 

--- a/math/matrix/test/CMakeLists.txt
+++ b/math/matrix/test/CMakeLists.txt
@@ -6,3 +6,4 @@
 
 ROOT_ADD_GTEST(testMatrixTSparse testMatrixTSparse.cxx LIBRARIES Matrix)
 ROOT_ADD_GTEST(testMatrixTDecomp testMatrixTDecomp.cxx LIBRARIES Matrix)
+ROOT_ADD_GTEST(testMatrixT testMatrixT.cxx LIBRARIES Matrix)

--- a/math/matrix/test/CMakeLists.txt
+++ b/math/matrix/test/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.
-# All rights reserved.
+#Copyright(C) 1995 - 2023, Rene Brun and Fons Rademakers.
+#All rights reserved.
 #
-# For the licensing terms see $ROOTSYS/LICENSE.
-# For the list of contributors see $ROOTSYS/README/CREDITS.
+#For the licensing terms see $ROOTSYS / LICENSE.
+#For the list of contributors see $ROOTSYS / README / CREDITS.
 
 ROOT_ADD_GTEST(testMatrixTSparse testMatrixTSparse.cxx LIBRARIES Matrix)
 ROOT_ADD_GTEST(testMatrixTDecomp testMatrixTDecomp.cxx LIBRARIES Matrix)

--- a/math/matrix/test/testMatrixT.cxx
+++ b/math/matrix/test/testMatrixT.cxx
@@ -1,0 +1,168 @@
+// Authors: Monica Dessole   Jan 2024
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <TMatrixD.h>
+#include <TMatrixDSym.h>
+#include <TMatrixF.h>
+#include <TMatrixFSym.h>
+//#include <Math.h>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+typedef TMatrixF MTX;
+typedef float Scalar;
+double tol = std::numeric_limits<double>::epsilon() * 100;
+float tol_f = std::numeric_limits<float>::epsilon() * 100;
+
+// Helper functions for element-wise comparison of TMatrix.
+
+#define CHECK_TMATRIX_FLOAT(a, b, m, n)                                                     \
+   {                                                                                        \
+      for (size_t i = 0; i < m; i++) {                                                      \
+         for (size_t j = 0; j < n; j++) {                                                   \
+            EXPECT_NEAR(a(i, j), b(i, j), tol_f) << "  at entry (" << i << "," << j << ")"; \
+         }                                                                                  \
+      }                                                                                     \
+   }
+
+#define CHECK_TMATRIX_DOUBLE(a, b, m, n)                                                  \
+   {                                                                                      \
+      for (size_t i = 0; i < m; i++) {                                                    \
+         for (size_t j = 0; j < n; j++) {                                                 \
+            EXPECT_NEAR(a(i, j), b(i, j), tol) << "  at entry (" << i << "," << j << ")"; \
+         }                                                                                \
+      }                                                                                   \
+   }
+
+void CompareTMatrix(TMatrixD result, TMatrixD expected)
+{
+   CHECK_TMATRIX_DOUBLE(result, expected, result.GetNrows(), result.GetNcols())
+}
+
+void CompareTMatrix(TMatrixF result,
+                    TMatrixF expected){CHECK_TMATRIX_FLOAT(result, expected, result.GetNrows(), result.GetNcols())}
+
+Int_t n = 5;
+Scalar values[5] = {-0.26984126984127, -0.1375661375661377, -0.0052910052910052, 0.1269841269841271,
+                    0.2592592592592592};
+
+// template <typename MTX>
+class testMatrix : public testing::Test {
+protected:
+   void SetUp() override
+   {
+      m1.ResizeTo(n, n);
+      m2.ResizeTo(n, n * 2);
+      eye.ResizeTo(n, n);
+      eye.UnitMatrix();
+
+      for (int i = 0; i < n; i++)
+         for (int j = 0; j < n; j++)
+            m1(i, j) = n * i + j;
+
+      for (int i = 0; i < n; i++)
+         for (int j = 0; j < 2 * n; j++)
+            m2(i, j) = 1;
+   }
+
+   MTX m1;
+   MTX m2;
+   MTX eye;
+};
+
+TEST_F(testMatrix, kPlus)
+{
+   MTX b(n, n);
+
+   for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+         b(i, j) = n * i + j + 1 * (i == j);
+
+   MTX c(m1, MTX::kPlus, eye);
+
+   EXPECT_EQ(c, b);
+}
+
+TEST_F(testMatrix, kMinus)
+{
+   MTX b(n, n);
+
+   for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+         b(i, j) = n * i + j - 1 * (i == j);
+
+   MTX c(m1, MTX::kMinus, eye);
+
+   EXPECT_EQ(c, b);
+}
+
+TEST_F(testMatrix, kMult)
+{
+
+   MTX b(n, 2 * n);
+   // b = m1;
+   Scalar sum;
+
+   for (int i = 0; i < n; i++) {
+      sum = 0.0;
+      for (int j = 0; j < n; j++)
+         sum += n * i + j;
+      for (int j = 0; j < 2 * n; j++)
+         b(i, j) = sum;
+   }
+
+   MTX c(m1, MTX::kMult, m2);
+
+   EXPECT_EQ(c, b);
+}
+
+TEST_F(testMatrix, kInvMult)
+{
+
+   MTX b(n, 2 * n);
+   MTX tol(n, 2 * n);
+   // b = m1;
+   Scalar sum;
+   Scalar eps = std::numeric_limits<Scalar>::min();
+
+   for (int i = 0; i < n; i++) {
+      sum = values[i];
+      for (int j = 0; j < 2 * n; j++) {
+         b(i, j) = sum;
+         tol(i, j) = eps;
+         if (i == j)
+            m1(i, j) += 1;
+      }
+   }
+
+   MTX c(m1, MTX::kInvMult, m2);
+
+   CompareTMatrix(c, b);
+}
+
+TEST_F(testMatrix, Invert)
+{
+   MTX b(n, n);
+   // b = m1;
+
+   for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+         b(i, j) = n * i + j + 1 * (i == j);
+
+   b.Invert();
+
+   m1 += eye;
+
+   MTX c(m1, MTX::kMult, b);
+
+   CompareTMatrix(c, eye);
+}

--- a/math/matrix/test/testMatrixT.cxx
+++ b/math/matrix/test/testMatrixT.cxx
@@ -23,8 +23,8 @@ float tol_f = std::numeric_limits<float>::epsilon() * 100;
 // Helper functions for element-wise comparison of TMatrix.
 #define CHECK_TMATRIX_FLOAT(a, b, m, n)                                                     \
    {                                                                                        \
-      for (Int_t i = 0; i < m; i++) {                                                      \
-         for (Int_t j = 0; j < n; j++) {                                                   \
+      for (Int_t i = 0; i < m; i++) {                                                       \
+         for (Int_t j = 0; j < n; j++) {                                                    \
             EXPECT_NEAR(a(i, j), b(i, j), tol_f) << "  at entry (" << i << "," << j << ")"; \
          }                                                                                  \
       }                                                                                     \
@@ -32,8 +32,8 @@ float tol_f = std::numeric_limits<float>::epsilon() * 100;
 
 #define CHECK_TMATRIX_DOUBLE(a, b, m, n)                                                  \
    {                                                                                      \
-      for (Int_t i = 0; i < m; i++) {                                                    \
-         for (Int_t j = 0; j < n; j++) {                                                 \
+      for (Int_t i = 0; i < m; i++) {                                                     \
+         for (Int_t j = 0; j < n; j++) {                                                  \
             EXPECT_NEAR(a(i, j), b(i, j), tol) << "  at entry (" << i << "," << j << ")"; \
          }                                                                                \
       }                                                                                   \

--- a/math/matrix/test/testMatrixT.cxx
+++ b/math/matrix/test/testMatrixT.cxx
@@ -23,8 +23,8 @@ float tol_f = std::numeric_limits<float>::epsilon() * 100;
 // Helper functions for element-wise comparison of TMatrix.
 #define CHECK_TMATRIX_FLOAT(a, b, m, n)                                                     \
    {                                                                                        \
-      for (size_t i = 0; i < m; i++) {                                                      \
-         for (size_t j = 0; j < n; j++) {                                                   \
+      for (Int_t i = 0; i < m; i++) {                                                      \
+         for (Int_t j = 0; j < n; j++) {                                                   \
             EXPECT_NEAR(a(i, j), b(i, j), tol_f) << "  at entry (" << i << "," << j << ")"; \
          }                                                                                  \
       }                                                                                     \
@@ -32,8 +32,8 @@ float tol_f = std::numeric_limits<float>::epsilon() * 100;
 
 #define CHECK_TMATRIX_DOUBLE(a, b, m, n)                                                  \
    {                                                                                      \
-      for (size_t i = 0; i < m; i++) {                                                    \
-         for (size_t j = 0; j < n; j++) {                                                 \
+      for (Int_t i = 0; i < m; i++) {                                                    \
+         for (Int_t j = 0; j < n; j++) {                                                 \
             EXPECT_NEAR(a(i, j), b(i, j), tol) << "  at entry (" << i << "," << j << ")"; \
          }                                                                                \
       }                                                                                   \


### PR DESCRIPTION
# This Pull request:

Fixes TMatrixT constructor behavior when it calculates a^(-1) b, which is now possible even when the number of columns of b does not equal the size of a.

## Changes or fixes:

Fixes [ROOT-10231](https://its.cern.ch/jira/browse/ROOT-10231).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
