### PR TITLE
Fixing a typo in the documentation of TGraph::SetHighlight in TGraph.cxx

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2278,7 +2278,7 @@ void TGraph::SetEditable(Bool_t editable)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set highlight (enable/disble) mode for the graph
+/// Set highlight (enable/disable) mode for the graph
 /// by default highlight mode is disable
 
 void TGraph::SetHighlight(Bool_t set)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes: 
fixes a typo in the documentation of `TGraph::SetHighlight` in `TGraph.cxx`


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)


