### PR TITLE
Implement some missing "IsInside"

### DIFF
--- a/graf2d/graf/inc/TCrown.h
+++ b/graf2d/graf/inc/TCrown.h
@@ -25,11 +25,12 @@ public:
    TCrown(const TCrown &crown);
    ~TCrown() override;
 
-   void   Copy(TObject &crown) const override;
+   void    Copy(TObject &crown) const override;
    Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
    virtual TCrown *DrawCrown(Double_t x1, Double_t y1, Double_t radin, Double_t radout,
                              Double_t  phimin=0, Double_t  phimax=360, Option_t *option="");
    void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   virtual Int_t IsInside(Double_t x, Double_t y) const override;
    void    Paint(Option_t *option="") override;
    void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
 

--- a/graf2d/graf/inc/TCrown.h
+++ b/graf2d/graf/inc/TCrown.h
@@ -30,7 +30,7 @@ public:
    virtual TCrown *DrawCrown(Double_t x1, Double_t y1, Double_t radin, Double_t radout,
                              Double_t  phimin=0, Double_t  phimax=360, Option_t *option="");
    void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
-   virtual Int_t IsInside(Double_t x, Double_t y) const override;
+   Int_t IsInside(Double_t x, Double_t y) const override;
    void    Paint(Option_t *option="") override;
    void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
 

--- a/graf2d/graf/inc/TCrown.h
+++ b/graf2d/graf/inc/TCrown.h
@@ -30,7 +30,7 @@ public:
    virtual TCrown *DrawCrown(Double_t x1, Double_t y1, Double_t radin, Double_t radout,
                              Double_t  phimin=0, Double_t  phimax=360, Option_t *option="");
    void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
-   Int_t IsInside(Double_t x, Double_t y) const override;
+   Int_t   IsInside(Double_t x, Double_t y) const;
    void    Paint(Option_t *option="") override;
    void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
 

--- a/graf2d/graf/inc/TDiamond.h
+++ b/graf2d/graf/inc/TDiamond.h
@@ -23,6 +23,7 @@ public:
    ~TDiamond() override;
    Int_t DistancetoPrimitive(Int_t px, Int_t py) override;
    void  Draw(Option_t *option="") override;
+   virtual Int_t IsInside(Double_t x, Double_t y) const override;
    void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    void  Paint(Option_t *option="") override;
    void  SavePrimitive(std::ostream &out, Option_t *option = "") override;

--- a/graf2d/graf/inc/TDiamond.h
+++ b/graf2d/graf/inc/TDiamond.h
@@ -23,7 +23,7 @@ public:
    ~TDiamond() override;
    Int_t DistancetoPrimitive(Int_t px, Int_t py) override;
    void  Draw(Option_t *option="") override;
-   virtual Int_t IsInside(Double_t x, Double_t y) const override;
+   Int_t IsInside(Double_t x, Double_t y) const override;
    void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    void  Paint(Option_t *option="") override;
    void  SavePrimitive(std::ostream &out, Option_t *option = "") override;

--- a/graf2d/graf/inc/TEllipse.h
+++ b/graf2d/graf/inc/TEllipse.h
@@ -45,7 +45,7 @@ public:
    void                 Draw(Option_t *option="") override;
    virtual TEllipse    *DrawEllipse(Double_t x1, Double_t y1, Double_t r1,Double_t r2,Double_t phimin, Double_t phimax,Double_t theta,Option_t *option="");
    void                 ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
-   Int_t        IsInside(Double_t x, Double_t y) const;
+   Int_t                IsInside(Double_t x, Double_t y) const;
    Double_t             GetX1() const {return fX1;}
    Double_t             GetY1() const {return fY1;}
    Double_t             GetR1() const {return fR1;}

--- a/graf2d/graf/inc/TEllipse.h
+++ b/graf2d/graf/inc/TEllipse.h
@@ -45,7 +45,7 @@ public:
    void                 Draw(Option_t *option="") override;
    virtual TEllipse    *DrawEllipse(Double_t x1, Double_t y1, Double_t r1,Double_t r2,Double_t phimin, Double_t phimax,Double_t theta,Option_t *option="");
    void                 ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
-   virtual Int_t        IsInside(Double_t x, Double_t y) const;
+   Int_t        IsInside(Double_t x, Double_t y) const;
    Double_t             GetX1() const {return fX1;}
    Double_t             GetY1() const {return fY1;}
    Double_t             GetR1() const {return fR1;}

--- a/graf2d/graf/inc/TEllipse.h
+++ b/graf2d/graf/inc/TEllipse.h
@@ -45,6 +45,7 @@ public:
    void                 Draw(Option_t *option="") override;
    virtual TEllipse    *DrawEllipse(Double_t x1, Double_t y1, Double_t r1,Double_t r2,Double_t phimin, Double_t phimax,Double_t theta,Option_t *option="");
    void                 ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   virtual Int_t        IsInside(Double_t x, Double_t y) const;
    Double_t             GetX1() const {return fX1;}
    Double_t             GetY1() const {return fY1;}
    Double_t             GetR1() const {return fR1;}

--- a/graf2d/graf/src/TCrown.cxx
+++ b/graf2d/graf/src/TCrown.cxx
@@ -174,6 +174,45 @@ void TCrown::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return 1 if the point (x,y) is inside the polygon defined by
+/// the crown 0 otherwise.
+
+Int_t TCrown::IsInside(Double_t x, Double_t y) const
+{
+
+   const Double_t kPI = TMath::Pi();
+   const Int_t np = 40;
+   static Double_t xc[2*np+3], yc[2*np+3];
+
+   Double_t angle,dx,dy;
+   Double_t dphi = (fPhimax-fPhimin)*kPI/(180*np);
+   Double_t ct   = TMath::Cos(kPI*fTheta/180);
+   Double_t st   = TMath::Sin(kPI*fTheta/180);
+   Int_t i;
+
+   //compute outer points
+   for (i=0;i<=np;i++) {
+      angle = fPhimin*kPI/180 + Double_t(i)*dphi;
+      dx    = fR2*TMath::Cos(angle);
+      dy    = fR2*TMath::Sin(angle);
+      xc[i]  = fX1 + dx*ct - dy*st;
+      yc[i]  = fY1 + dx*st + dy*ct;
+   }
+   //compute inner points
+   for (i=0;i<=np;i++) {
+      angle = fPhimin*kPI/180 + Double_t(i)*dphi;
+      dx    = fR1*TMath::Cos(angle);
+      dy    = fR1*TMath::Sin(angle);
+      xc[2*np-i+1]  = fX1 + dx*ct - dy*st;
+      yc[2*np-i+1]  = fY1 + dx*st + dy*ct;
+   }
+   xc[2*np+2]  = xc[0];
+   yc[2*np+2]  = yc[0];
+
+   return (Int_t)TMath::IsInside(x, y, 2*np+3, xc, yc);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Paint this crown with its current attributes.
 
 void TCrown::Paint(Option_t *)

--- a/graf2d/graf/src/TDiamond.cxx
+++ b/graf2d/graf/src/TDiamond.cxx
@@ -375,6 +375,27 @@ void TDiamond::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return 1 if the point (x,y) is inside the polygon defined by
+/// the diamond 0 otherwise.
+
+Int_t TDiamond::IsInside(Double_t x, Double_t y) const
+{
+
+   Double_t xd[4], yd[4];
+
+   xd[0] = fX1;
+   yd[0] = (fY2+fY1)/2.;
+   xd[1] = (fX2+fX1)/2.;
+   yd[1] = fY1;
+   xd[2] = fX2;
+   yd[2] = yd[0];
+   xd[3] = xd[1];
+   yd[3] = fY2;
+
+   return (Int_t)TMath::IsInside(x, y, 4, xd, yd);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Paint this diamond with its current attributes.
 
 void TDiamond::Paint(Option_t *)

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -21,7 +21,7 @@
 #include "TVirtualX.h"
 
 
-const Double_t kPI = 3.14159265358979323846;
+const Double_t kPI = TMath::Pi();
 
 ClassImp(TEllipse);
 
@@ -506,6 +506,38 @@ void TEllipse::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       }
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return 1 if the point (x,y) is inside the polygon defined by
+/// the ellipse 0 otherwise.
+
+Int_t TEllipse::IsInside(Double_t x, Double_t y) const
+{
+
+   const Int_t n = 200;
+   Double_t xe[n+3], ye[n+3];
+
+   Double_t phi1 = TMath::Min(fPhimin,fPhimax);
+   Double_t phi2 = TMath::Max(fPhimin,fPhimax);
+   Double_t angle,dx,dy;
+   Double_t dphi = (phi2-phi1)*kPI/(180*n);
+   Double_t ct   = TMath::Cos(kPI*fTheta/180);
+   Double_t st   = TMath::Sin(kPI*fTheta/180);
+   for (Int_t i=0; i<=n; i++) {
+      angle = phi1*kPI/180 + Double_t(i)*dphi;
+      dx    = fR1*TMath::Cos(angle);
+      dy    = fR2*TMath::Sin(angle);
+      xe[i] = fX1 + dx*ct - dy*st;
+      ye[i] = fY1 + dx*st + dy*ct;
+   }
+   xe[n+1] = fX1;
+   ye[n+1] = fY1;
+   xe[n+2] = xe[0];
+   ye[n+2] = ye[0];
+
+   return (Int_t)TMath::IsInside(x, y, n+3, xe, ye);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// List this ellipse with its attributes.

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -21,7 +21,7 @@
 #include "TVirtualX.h"
 
 
-const Double_t kPI = TMath::Pi();
+constexpr Double_t kPI = TMath::Pi();
 
 ClassImp(TEllipse);
 

--- a/tutorials/graphics/inside.C
+++ b/tutorials/graphics/inside.C
@@ -8,51 +8,40 @@
 ///
 /// \author Olivier Couet
 
-TGraph   *gr;
-TEllipse *el;
-TBox     *bx;
-TPave    *pv;
-TDiamond *di;
-TCrown   *cr;
-
-void InPoint(double x, double y) {
-   auto p = new TMarker(x,y,7);
-   p->Draw();
-
-   if (el->IsInside(x,y) ||
-       bx->IsInside(x,y) ||
-       pv->IsInside(x,y) ||
-       di->IsInside(x,y) ||
-       cr->IsInside(x,y) ||
-       gr->IsInside(x,y)) {
-      p->SetMarkerColor(kGreen);
-   } else {
-      p->SetMarkerColor(kRed);
-   }
-}
-
 void inside(){
-   el = new TEllipse(0.75, 0.25, .2,.15,45,315,62);
+   auto el = new TEllipse(0.75, 0.25, .2,.15,45,315,62);
    el->Draw();
 
-   gr = new TGraph();
+   auto gr = new TGraph();
    double gr_x1[5] = { 0.1, 0.3388252, 0.03796561, 0.4176218, 0.1 };
    double gr_y1[5] = { 0.5, 0.9644737, 0.7776316, 0.6960526, 0.5 };
    gr = new TGraph(5,gr_x1,gr_y1);
    gr->Draw("L");
 
-   bx = new TBox(.7,.8,.9,.95);
+   auto bx = new TBox(.7,.8,.9,.95);
    bx->Draw();
 
-   pv = new TPave(.05,.1,.3,.2);
+   auto pv = new TPave(.05,.1,.3,.2);
    pv->Draw();
 
-   di = new TDiamond(.05,.25,.3,.4);
+   auto di = new TDiamond(.05,.25,.3,.4);
    di->Draw();
 
-    cr = new TCrown(.5,.5,.1,.15);
-    cr->SetFillColor(19);
+   auto cr = new TCrown(.5,.5,.1,.15);
+   cr->SetFillColor(19);
    cr->Draw();
 
-   for (int i=0; i<20000; i++) InPoint(gRandom->Rndm(),gRandom->Rndm());
+   for (int i=0; i<10000; i++) {
+      double x = gRandom->Rndm();
+      double y = gRandom->Rndm();
+      auto p   = new TMarker(x,y,7);
+      p->Draw();
+      if (el->IsInside(x,y) || bx->IsInside(x,y) ||
+          pv->IsInside(x,y) || di->IsInside(x,y) ||
+          cr->IsInside(x,y) || gr->IsInside(x,y)) {
+         p->SetMarkerColor(kGreen);
+      } else {
+         p->SetMarkerColor(kRed);
+      }
+   }
 }

--- a/tutorials/graphics/inside.C
+++ b/tutorials/graphics/inside.C
@@ -1,0 +1,58 @@
+/// \file
+/// \ingroup tutorial_graphics
+/// \notebook -js
+/// Test the IsInside methods of various graphics primitives.
+///
+/// \macro_image
+/// \macro_code
+///
+/// \author Olivier Couet
+
+TGraph   *gr;
+TEllipse *el;
+TBox     *bx;
+TPave    *pv;
+TDiamond *di;
+TCrown   *cr;
+
+void InPoint(double x, double y) {
+   auto p = new TMarker(x,y,7);
+   p->Draw();
+
+   if (el->IsInside(x,y) ||
+       bx->IsInside(x,y) ||
+       pv->IsInside(x,y) ||
+       di->IsInside(x,y) ||
+       cr->IsInside(x,y) ||
+       gr->IsInside(x,y)) {
+      p->SetMarkerColor(kGreen);
+   } else {
+      p->SetMarkerColor(kRed);
+   }
+}
+
+void inside(){
+   el = new TEllipse(0.75, 0.25, .2,.15,45,315,62);
+   el->Draw();
+
+   gr = new TGraph();
+   double gr_x1[5] = { 0.1, 0.3388252, 0.03796561, 0.4176218, 0.1 };
+   double gr_y1[5] = { 0.5, 0.9644737, 0.7776316, 0.6960526, 0.5 };
+   gr = new TGraph(5,gr_x1,gr_y1);
+   gr->Draw("L");
+
+   bx = new TBox(.7,.8,.9,.95);
+   bx->Draw();
+
+   pv = new TPave(.05,.1,.3,.2);
+   pv->Draw();
+
+   di = new TDiamond(.05,.25,.3,.4);
+   di->Draw();
+
+    cr = new TCrown(.5,.5,.1,.15);
+    cr->SetFillColor(19);
+   cr->Draw();
+
+   for (int i=0; i<20000; i++) InPoint(gRandom->Rndm(),gRandom->Rndm());
+}


### PR DESCRIPTION
As said in [this issue](https://github.com/root-project/root/issues/14453) TEllipse was missing the IsInside method.
Some other classes were missing it too (TCrown) or some were wrong (TDiamond). This PR implements the missing ones and fixes the wrong ones.

Also, a new graphics example `inside.C` has been added.

