### PR TITLE
Improve thread-safety in tutorials

### DIFF
--- a/tutorials/v7/concurrentfill.cxx
+++ b/tutorials/v7/concurrentfill.cxx
@@ -25,9 +25,12 @@
 
 using namespace ROOT;
 
-double wasteCPUTime(std::mt19937 &gen)
+double wasteCPUTime()
 {
-   // Simulate number crunching through gen and ridiculous num bits
+   // Simulate number crunching through gen and ridiculous num bits in a
+   // thread-safe way
+   thread_local std::random_device rd{};
+   thread_local std::mt19937 gen{rd()};
    return std::generate_canonical<double, 100>(gen) + std::generate_canonical<double, 100>(gen) +
           std::generate_canonical<double, 100>(gen) + std::generate_canonical<double, 100>(gen) +
           std::generate_canonical<double, 100>(gen);
@@ -40,10 +43,9 @@ using Filler_t = Experimental::RHistConcurrentFiller<Experimental::RH2D, 1024>;
 /// several times.
 void theTask(Filler_t filler)
 {
-   std::mt19937 gen;
-
-   for (int i = 0; i < 3000000; ++i)
-      filler.Fill({wasteCPUTime(gen), wasteCPUTime(gen)});
+   const int nFills{3000000};
+   for (int i = 0; i < nFills; ++i)
+      filler.Fill({wasteCPUTime(), wasteCPUTime()});
 }
 
 /// This example fills a histogram concurrently, from several threads.

--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -158,7 +158,7 @@ void Read()
    auto nEvents = ntuple->GetNEntries();
    auto viewId = ntuple->GetView<std::uint32_t>("id");
    TH2F hFillSequence("","Entry Id vs Thread Id;Entry Sequence Number;Filling Thread",
-                      100, 0, nEvents, 100, 0, kNWriterThreads);
+                      100, 0, nEvents, 100, 0, kNWriterThreads+1);
    for (auto i : ntuple->GetEntryRange())
       hFillSequence.Fill(i, viewId(i));
    hFillSequence.DrawCopy();


### PR DESCRIPTION
This might help with some unclear Windows errors seen sporadically in the CI e.g. https://github.com/root-project/root/actions/runs/7674413699/job/20918943965?pr=14463