### PR TITLE
[ntuple] make RFieldBase::ConnectPageSource() recursive

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -191,8 +191,6 @@ public:
       }
 
       fField->ConnectPageSource(source);
-      for (auto &f : *fField)
-         f.ConnectPageSource(source);
 
       if (fValuePtr) {
          // When the reader reconnects to a new file, the fValuePtr is already set

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -635,6 +635,10 @@ public:
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.
    /// \param firstEntry The global index of the first entry with on-disk data for the connected field
    void ConnectPageSink(RPageSink &pageSink, NTupleSize_t firstEntry = 0);
+   /// Connects the field and its sub field tree to the given page source. Once connected, data can be read.
+   /// Only unconnected fields may be connected, i.e. the method is not idempotent. The field ID has to be set prior to
+   /// calling this function. For sub fields, a field ID may or may not be set. If the field ID is unset, it will be
+   /// determined using the page source descriptor, based on the parent field ID and the sub field name.
    void ConnectPageSource(RPageSource &pageSource);
 
    /// Indicates an evolution of the mapping scheme from C++ type to columns

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -160,12 +160,6 @@ public:
       fField.ConnectPageSource(*pageSource);
       if ((fField.GetTraits() & Detail::RFieldBase::kTraitMappable) && fField.HasReadCallbacks())
          throw RException(R__FAIL("view disallowed on field with mappable type and read callback"));
-      for (auto &f : fField) {
-         auto subFieldId =
-            pageSource->GetSharedDescriptorGuard()->FindFieldId(f.GetFieldName(), f.GetParent()->GetOnDiskId());
-         f.SetOnDiskId(subFieldId);
-         f.ConnectPageSource(*pageSource);
-      }
    }
 
    RNTupleView(const RNTupleView& other) = delete;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -875,6 +875,13 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &page
    if (!fDescription.empty())
       throw RException(R__FAIL("setting description only valid when connecting to a page sink"));
 
+   for (auto &f : fSubFields) {
+      if (f->GetOnDiskId() == kInvalidDescriptorId) {
+         f->SetOnDiskId(pageSource.GetSharedDescriptorGuard()->FindFieldId(f->GetFieldName(), GetOnDiskId()));
+      }
+      f->ConnectPageSource(pageSource);
+   }
+
    {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -125,7 +125,6 @@ TEST(RNTuple, InsideCollection)
    ASSERT_NE(idA, ROOT::Experimental::kInvalidDescriptorId);
    auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec.a", "float").Unwrap());
    fieldInner->SetOnDiskId(idA);
-   fieldInner->ConnectPageSource(*source);
 
    auto field = std::make_unique<ROOT::Experimental::RVectorField>("klassVec", std::move(fieldInner));
    field->SetOnDiskId(idKlassVec);


### PR DESCRIPTION
Connect the sub fields prior to connecting the field itself. All uses of ConnectPageSource() are also connecting the sub fields anyway. That makes sense because a connected field without connected sub fields is in a broken state.

@Nowakus This probably affects you