### PR TITLE
[PyROOT] Remove unneeded custom `__setattr__` function of ROOT facade

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -127,7 +127,6 @@ class ROOTFacade(types.ModuleType):
         # - Set batch mode in gROOT
         # - Set options in PyConfig
         self.__class__.__getattr__ = self._getattr
-        self.__class__.__setattr__ = self._setattr
 
     def AddressOf(self, obj):
         # Return an indexable buffer of length 1, whose only element
@@ -202,7 +201,6 @@ class ROOTFacade(types.ModuleType):
 
         # Redirect lookups to cppyy's global namespace
         self.__class__.__getattr__ = self._fallback_getattr
-        self.__class__.__setattr__ = lambda self, name, val: setattr(gbl_namespace, name, val)
 
         # Run rootlogon if exists
         self._run_rootlogon()
@@ -215,11 +213,6 @@ class ROOTFacade(types.ModuleType):
         self._finalSetup()
 
         return getattr(self, name)
-
-    def _setattr(self, name, val):
-        self._finalSetup()
-
-        return setattr(self, name, val)
 
     def _execute_rootlogon_module(self, file_path):
         """Execute the 'rootlogon.py' module found at the given 'file_path'"""


### PR DESCRIPTION
In the old PyROOT, it might have made sense to re-implement `__setattr__` for ROOT in a way that it sets an attribute of the `gbl_namespace` (`cppyy.gbl` in new PyROOT), because back at that time setting an attribute to the global namespace also meant forwarding the definition to the interpreter and the variable was then also available in C++.

However, this is not supported anymore by the new PyROOT, so the custom `__setattr__` appears unneeded and this commits suggests to remove it.

See also the discussion here:
https://its.cern.ch/jira/browse/ROOT-10451