### PR TITLE
[rdf] Test updating column register data instead of copying

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -104,7 +104,7 @@ class RColumnRegister {
    /// Variations that affect multiple columns are inserted in the map multiple times, once per column,
    /// and conversely each column (i.e. each key) can have several associated variations.
    std::shared_ptr<VariationsMap_t> fVariations;
-   std::shared_ptr<const ColumnNames_t> fColumnNames; ///< Names of Defines and Aliases registered so far.
+   std::shared_ptr<ColumnNames_t> fColumnNames; ///< Names of Defines and Aliases registered so far.
 
    void AddName(std::string_view name);
 

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -137,13 +137,13 @@ bool RColumnRegister::IsDefineOrAlias(std::string_view name) const
 /// Internally it recreates the map with the new column, and swaps it with the old one.
 void RColumnRegister::AddDefine(std::shared_ptr<RDFDetail::RDefineBase> define)
 {
-   auto newDefines = std::make_shared<DefinesMap_t>(*fDefines);
+   // auto newDefines = std::make_shared<DefinesMap_t>(*fDefines);
    const std::string &colName = define->GetName();
 
    // this will assign over a pre-existing element in case this AddDefine is due to a Redefine
-   (*newDefines)[colName] = std::make_shared<RDefinesWithReaders>(define, fLoopManager->GetNSlots());
+   (*fDefines)[colName] = std::make_shared<RDefinesWithReaders>(define, fLoopManager->GetNSlots());
 
-   fDefines = std::move(newDefines);
+   // fDefines = std::move(newDefines);
    AddName(colName);
 }
 
@@ -246,9 +246,7 @@ void RColumnRegister::AddName(std::string_view name)
    if (std::find(names.begin(), names.end(), name) != names.end())
       return; // must be a Redefine of an existing column. Nothing to do.
 
-   auto newColsNames = std::make_shared<ColumnNames_t>(names);
-   newColsNames->emplace_back(std::string(name));
-   fColumnNames = newColsNames;
+   fColumnNames->emplace_back(std::string(name));
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`RColumnRegister` has a copy-on-write policy, introduced by https://github.com/root-project/root/pull/10899 and further explained at https://github.com/root-project/root/pull/11297 .

For very large computation graphs (e.g. O(10K) `Define` calls) this means that we are allocating/deallocating `std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<RDefinesWithReaders>>>` of thousands of nodes, with an increasing size at each Define call.

While keeping the map with *all* the defined columns is necessary in order to avoid losing information about the computation graph itself, I wonder if we can move away from the copy-on-write policy without too many problems, given the situation presented by the large computation graphs.