### PR TITLE
[ntuple] disambiguate RPageSink::Create()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -142,7 +142,7 @@ public:
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 
-   void Create(RNTupleModel &model) final;
+   void CreateDataset(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -142,7 +142,7 @@ public:
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 
-   void CreateDataset(RNTupleModel &model) final;
+   void Init(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -284,7 +284,7 @@ protected:
    };
    std::unique_ptr<RCounters> fCounters;
 
-   virtual void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) = 0;
+   virtual void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) = 0;
 
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -221,8 +221,8 @@ public:
    void DropColumn(ColumnHandle_t /*columnHandle*/) final {}
 
    /// Physically creates the storage container to hold the ntuple (e.g., a keys a TFile or an S3 bucket)
-   /// CreateDataset() associates column handles to the columns referenced by the model
-   virtual void CreateDataset(RNTupleModel &model) = 0;
+   /// Init() associates column handles to the columns referenced by the model
+   virtual void Init(RNTupleModel &model) = 0;
    /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
    /// added after the initial call to `RPageSink::Create(RNTupleModel &)`.
    /// `firstEntry` specifies the global index for the first stored element in the added columns.
@@ -284,7 +284,7 @@ protected:
    };
    std::unique_ptr<RCounters> fCounters;
 
-   virtual void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) = 0;
+   virtual void InitImpl(unsigned char *serializedHeader, std::uint32_t length) = 0;
 
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator
@@ -322,8 +322,8 @@ public:
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 
-   /// Updates the descriptor and calls CreateDatasetImpl() that handles the backend-specific details (file, DAOS, etc.)
-   void CreateDataset(RNTupleModel &model) final;
+   /// Updates the descriptor and calls InitImpl() that handles the backend-specific details (file, DAOS, etc.)
+   void Init(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -224,7 +224,7 @@ public:
    /// Init() associates column handles to the columns referenced by the model
    virtual void Init(RNTupleModel &model) = 0;
    /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
-   /// added after the initial call to `RPageSink::Create(RNTupleModel &)`.
+   /// added after the initial call to `RPageSink::Init(RNTupleModel &)`.
    /// `firstEntry` specifies the global index for the first stored element in the added columns.
    virtual void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) = 0;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -221,9 +221,8 @@ public:
    void DropColumn(ColumnHandle_t /*columnHandle*/) final {}
 
    /// Physically creates the storage container to hold the ntuple (e.g., a keys a TFile or an S3 bucket)
-   /// To do so, Create() calls CreateImpl() after updating the descriptor.
-   /// Create() associates column handles to the columns referenced by the model
-   virtual void Create(RNTupleModel &model) = 0;
+   /// CreateDataset() associates column handles to the columns referenced by the model
+   virtual void CreateDataset(RNTupleModel &model) = 0;
    /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
    /// added after the initial call to `RPageSink::Create(RNTupleModel &)`.
    /// `firstEntry` specifies the global index for the first stored element in the added columns.
@@ -285,7 +284,7 @@ protected:
    };
    std::unique_ptr<RCounters> fCounters;
 
-   virtual void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) = 0;
+   virtual void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) = 0;
 
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator
@@ -323,7 +322,8 @@ public:
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 
-   void Create(RNTupleModel &model) final;
+   /// Updates the descriptor and calls CreateDatasetImpl() that handles the backend-specific details (file, DAOS, etc.)
+   void CreateDataset(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -126,7 +126,7 @@ private:
    uint32_t fCageSizeLimit{};
 
 protected:
-   void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
+   void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -126,7 +126,7 @@ private:
    uint32_t fCageSizeLimit{};
 
 protected:
-   void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) final;
+   void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -126,7 +126,7 @@ private:
    uint32_t fCageSizeLimit{};
 
 protected:
-   void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
+   void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -71,7 +71,7 @@ private:
                                                 std::size_t bytesPacked);
 
 protected:
-   void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
+   void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -71,7 +71,7 @@ private:
                                                 std::size_t bytesPacked);
 
 protected:
-   void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
+   void CreateDatasetImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -71,7 +71,7 @@ private:
                                                 std::size_t bytesPacked);
 
 protected:
-   void CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length) final;
+   void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -277,7 +277,7 @@ ROOT::Experimental::RNTupleFillContext::RNTupleFillContext(std::unique_ptr<ROOT:
       throw RException(R__FAIL("null sink"));
    }
    fModel->Freeze();
-   fSink->CreateDataset(*fModel.get());
+   fSink->Init(*fModel.get());
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -277,7 +277,7 @@ ROOT::Experimental::RNTupleFillContext::RNTupleFillContext(std::unique_ptr<ROOT:
       throw RException(R__FAIL("null sink"));
    }
    fModel->Freeze();
-   fSink->Create(*fModel.get());
+   fSink->CreateDataset(*fModel.get());
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -124,7 +124,7 @@ void ROOT::Experimental::RNTupleMerger::Merge(std::span<Detail::RPageSource *> s
       // Create sink from the input model of the very first input file
       if (isFirstSource) {
          auto model = descriptor->CreateModel();
-         destination.Create(*model.get());
+         destination.CreateDataset(*model.get());
          isFirstSource = false;
       }
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -124,7 +124,7 @@ void ROOT::Experimental::RNTupleMerger::Merge(std::span<Detail::RPageSource *> s
       // Create sink from the input model of the very first input file
       if (isFirstSource) {
          auto model = descriptor->CreateModel();
-         destination.CreateDataset(*model.get());
+         destination.Init(*model.get());
          isFirstSource = false;
       }
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -79,12 +79,12 @@ void ROOT::Experimental::Detail::RPageSinkBuf::ConnectFields(const std::vector<R
    fBufferedColumns.resize(fNColumns);
 }
 
-void ROOT::Experimental::Detail::RPageSinkBuf::Create(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPageSinkBuf::CreateDataset(RNTupleModel &model)
 {
    ConnectFields(model.GetFieldZero().GetSubFields(), 0U);
 
    fInnerModel = model.Clone();
-   fInnerSink->Create(*fInnerModel);
+   fInnerSink->CreateDataset(*fInnerModel);
 }
 
 void ROOT::Experimental::Detail::RPageSinkBuf::UpdateSchema(const RNTupleModelChangeset &changeset,

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -79,12 +79,12 @@ void ROOT::Experimental::Detail::RPageSinkBuf::ConnectFields(const std::vector<R
    fBufferedColumns.resize(fNColumns);
 }
 
-void ROOT::Experimental::Detail::RPageSinkBuf::CreateDataset(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPageSinkBuf::Init(RNTupleModel &model)
 {
    ConnectFields(model.GetFieldZero().GetSubFields(), 0U);
 
    fInnerModel = model.Clone();
-   fInnerSink->CreateDataset(*fInnerModel);
+   fInnerSink->Init(*fInnerModel);
 }
 
 void ROOT::Experimental::Detail::RPageSinkBuf::UpdateSchema(const RNTupleModelChangeset &changeset,

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -465,7 +465,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::UpdateSchema(const RNTuple
       fSerializationContext.MapSchema(descriptor, /*forHeaderExtension=*/true);
 }
 
-void ROOT::Experimental::Detail::RPagePersistentSink::CreateDataset(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPagePersistentSink::Init(RNTupleModel &model)
 {
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
@@ -486,7 +486,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::CreateDataset(RNTupleModel
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(nullptr, descriptor);
    auto buffer = std::make_unique<unsigned char[]>(fSerializationContext.GetHeaderSize());
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(buffer.get(), descriptor);
-   CreateDatasetImpl(buffer.get(), fSerializationContext.GetHeaderSize());
+   InitImpl(buffer.get(), fSerializationContext.GetHeaderSize());
 
    fDescriptorBuilder.BeginHeaderExtension();
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -465,7 +465,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::UpdateSchema(const RNTuple
       fSerializationContext.MapSchema(descriptor, /*forHeaderExtension=*/true);
 }
 
-void ROOT::Experimental::Detail::RPagePersistentSink::Create(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPagePersistentSink::CreateDataset(RNTupleModel &model)
 {
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
@@ -486,7 +486,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::Create(RNTupleModel &model
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(nullptr, descriptor);
    auto buffer = std::make_unique<unsigned char[]>(fSerializationContext.GetHeaderSize());
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(buffer.get(), descriptor);
-   CreateImpl(model, buffer.get(), fSerializationContext.GetHeaderSize());
+   CreateDatasetImpl(model, buffer.get(), fSerializationContext.GetHeaderSize());
 
    fDescriptorBuilder.BeginHeaderExtension();
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -486,7 +486,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::CreateDataset(RNTupleModel
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(nullptr, descriptor);
    auto buffer = std::make_unique<unsigned char[]>(fSerializationContext.GetHeaderSize());
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeader(buffer.get(), descriptor);
-   CreateDatasetImpl(model, buffer.get(), fSerializationContext.GetHeaderSize());
+   CreateDatasetImpl(buffer.get(), fSerializationContext.GetHeaderSize());
 
    fDescriptorBuilder.BeginHeaderExtension();
 }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -297,8 +297,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntuple
 
 ROOT::Experimental::Detail::RPageSinkDaos::~RPageSinkDaos() = default;
 
-void ROOT::Experimental::Detail::RPageSinkDaos::CreateDatasetImpl(const RNTupleModel & /* model */,
-                                                                  unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkDaos::CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length)
 {
    auto opts = dynamic_cast<RNTupleWriteOptionsDaos *>(fOptions.get());
    fNTupleAnchor.fObjClass = opts ? opts->GetObjectClass() : RNTupleWriteOptionsDaos().GetObjectClass();

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -297,7 +297,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntuple
 
 ROOT::Experimental::Detail::RPageSinkDaos::~RPageSinkDaos() = default;
 
-void ROOT::Experimental::Detail::RPageSinkDaos::CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkDaos::InitImpl(unsigned char *serializedHeader, std::uint32_t length)
 {
    auto opts = dynamic_cast<RNTupleWriteOptionsDaos *>(fOptions.get());
    fNTupleAnchor.fObjClass = opts ? opts->GetObjectClass() : RNTupleWriteOptionsDaos().GetObjectClass();

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -297,8 +297,8 @@ ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntuple
 
 ROOT::Experimental::Detail::RPageSinkDaos::~RPageSinkDaos() = default;
 
-void ROOT::Experimental::Detail::RPageSinkDaos::CreateImpl(const RNTupleModel & /* model */,
-                                                           unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkDaos::CreateDatasetImpl(const RNTupleModel & /* model */,
+                                                                  unsigned char *serializedHeader, std::uint32_t length)
 {
    auto opts = dynamic_cast<RNTupleWriteOptionsDaos *>(fOptions.get());
    fNTupleAnchor.fObjClass = opts ? opts->GetObjectClass() : RNTupleWriteOptionsDaos().GetObjectClass();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -89,8 +89,8 @@ ROOT::Experimental::Detail::RPageSinkFile::~RPageSinkFile()
 {
 }
 
-void ROOT::Experimental::Detail::RPageSinkFile::CreateImpl(const RNTupleModel & /* model */,
-                                                           unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkFile::CreateDatasetImpl(const RNTupleModel & /* model */,
+                                                                  unsigned char *serializedHeader, std::uint32_t length)
 {
    auto zipBuffer = std::make_unique<unsigned char[]>(length);
    auto szZipHeader = fCompressor->Zip(serializedHeader, length, GetWriteOptions().GetCompression(),

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -89,7 +89,7 @@ ROOT::Experimental::Detail::RPageSinkFile::~RPageSinkFile()
 {
 }
 
-void ROOT::Experimental::Detail::RPageSinkFile::CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkFile::InitImpl(unsigned char *serializedHeader, std::uint32_t length)
 {
    auto zipBuffer = std::make_unique<unsigned char[]>(length);
    auto szZipHeader = fCompressor->Zip(serializedHeader, length, GetWriteOptions().GetCompression(),

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -89,8 +89,7 @@ ROOT::Experimental::Detail::RPageSinkFile::~RPageSinkFile()
 {
 }
 
-void ROOT::Experimental::Detail::RPageSinkFile::CreateDatasetImpl(const RNTupleModel & /* model */,
-                                                                  unsigned char *serializedHeader, std::uint32_t length)
+void ROOT::Experimental::Detail::RPageSinkFile::CreateDatasetImpl(unsigned char *serializedHeader, std::uint32_t length)
 {
    auto zipBuffer = std::make_unique<unsigned char[]>(length);
    auto szZipHeader = fCompressor->Zip(serializedHeader, length, GetWriteOptions().GetCompression(),

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -12,7 +12,7 @@ TEST(RNTuple, ReconstructModel)
    model->Freeze();
    {
       RPageSinkFile sink("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions());
-      sink.CreateDataset(*model.get());
+      sink.Init(*model.get());
       sink.CommitClusterGroup();
       sink.CommitDataset();
       model = nullptr;

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -12,7 +12,7 @@ TEST(RNTuple, ReconstructModel)
    model->Freeze();
    {
       RPageSinkFile sink("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions());
-      sink.Create(*model.get());
+      sink.CreateDataset(*model.get());
       sink.CommitClusterGroup();
       sink.CommitDataset();
       model = nullptr;

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -41,7 +41,7 @@ protected:
       return {};
    }
 
-   void CreateDataset(RNTupleModel &) final {}
+   void Init(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Detail::RNTupleModelChangeset &, NTupleSize_t) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -41,7 +41,7 @@ protected:
       return {};
    }
 
-   void Create(RNTupleModel &) final {}
+   void CreateDataset(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Detail::RNTupleModelChangeset &, NTupleSize_t) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -19,7 +19,7 @@ protected:
       return {};
    }
 
-   void Create(RNTupleModel &) final {}
+   void CreateDataset(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Detail::RNTupleModelChangeset &, NTupleSize_t) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -19,7 +19,7 @@ protected:
       return {};
    }
 
-   void CreateDataset(RNTupleModel &) final {}
+   void Init(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Detail::RNTupleModelChangeset &, NTupleSize_t) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final


### PR DESCRIPTION
Rename the Create() overload the initialized the on-disk dataset to `Init()`. The other overload creates the `RPageSink` object.

Additionally remove unused parameter from `InitImpl()`.
