### PR TITLE
Implement the title for the palette of a TH3

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -8405,6 +8405,11 @@ void THistPainter::PaintLegoAxis(TGaxis *axis, Double_t ang)
          }
       }
       axis->SetOption(chopaz);
+      TString ztit = fZaxis->GetTitle();
+      if (ztit.Index(";")>0) {
+         ztit.Remove(ztit.Index(";"),ztit.Length());
+         axis->SetTitle(ztit.Data());
+      }
       axis->PaintAxis(z1[0], z1[1], z2[0], z2[1], bmin, bmax, ndivz, chopaz);
    }
 

--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -477,9 +477,23 @@ void TPaletteAxis::Paint(Option_t *)
    ndivz = TMath::Abs(ndivz);
    Int_t theColor, color;
    // import Attributes already here since we might need them for CJUST
-   if (fH && fH->GetDimension() == 2) fAxis.ImportAxisAttributes(fH->GetZaxis());
-   // for 3D histograms there is no palette's title
-   if (fH && fH->GetDimension() >  2) fAxis.SetTitle("");
+   if (fH && fH->GetDimension() == 2) {
+      fAxis.ImportAxisAttributes(fH->GetZaxis());
+      TString ztit = fAxis.GetTitle();
+      if (ztit.Index(";")>0) {
+         ztit.Remove(ztit.Index(";"),ztit.Length());
+         fAxis.SetTitle(ztit.Data());
+      }
+   }
+   // the 3D histogram's title is stored in Zaxis
+   if (fH && fH->GetDimension() >  2) {
+      TString ztit = fH->GetZaxis()->GetTitle();
+      fAxis.SetTitle("");
+      if (ztit.Index(";")>0) {
+         ztit.Remove(0,ztit.Index(";")+1);
+         fAxis.SetTitle(ztit.Data());
+      }
+   }
    // case option "CJUST": put labels directly at color boundaries
    TLatex *label = nullptr;
    TLine *line = nullptr;


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/root-project/root/issues/14499).
It is now possible to set a TH3 palette title with:
```
   h3->SetTitle("h3-Title;XXXXX;YYYYY;ZZZZZ;TTTTTT");
```
