### PR TITLE
[ntuple] Remove API to recreate TFile from RPageSinkFile

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -161,10 +161,6 @@ public:
    /// Uses a C stream for writing
    static RNTupleFileWriter *Recreate(std::string_view ntupleName, std::string_view path, int defaultCompression,
                                       ENTupleContainerFormat containerFormat);
-   /// Create or truncate the local or remote file given by path with the new empty RNTuple identified by ntupleName.
-   /// Creates a new TFile object for writing and hands over ownership of the object to the user.
-   static RNTupleFileWriter *Recreate(std::string_view ntupleName, std::string_view path,
-                                      std::unique_ptr<TFile> &file);
    /// Add a new RNTuple identified by ntupleName to the existing TFile.
    static RNTupleFileWriter *Append(std::string_view ntupleName, TFile &file);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -82,8 +82,6 @@ protected:
 
 public:
    RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options);
-   RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options,
-                 std::unique_ptr<TFile> &file);
    RPageSinkFile(std::string_view ntupleName, TFile &file, const RNTupleWriteOptions &options);
    RPageSinkFile(const RPageSinkFile&) = delete;
    RPageSinkFile& operator=(const RPageSinkFile&) = delete;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1318,18 +1318,6 @@ ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::R
 }
 
 
-ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(
-   std::string_view ntupleName, std::string_view path, std::unique_ptr<TFile> &file)
-{
-   file = std::unique_ptr<TFile>(TFile::Open(std::string(path.data(), path.size()).c_str(), "RECREATE"));
-   R__ASSERT(file && !file->IsZombie());
-
-   auto writer = new RNTupleFileWriter(ntupleName);
-   writer->fFileProper.fFile = file.get();
-   return writer;
-}
-
-
 ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::RNTupleFileWriter::Append(
    std::string_view ntupleName, TFile &file)
 {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -76,15 +76,6 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
 }
 
 
-ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, std::string_view path,
-   const RNTupleWriteOptions &options, std::unique_ptr<TFile> &file)
-   : RPageSinkFile(ntupleName, options)
-{
-   fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(
-      Internal::RNTupleFileWriter::Recreate(ntupleName, path, file));
-}
-
-
 ROOT::Experimental::Detail::RPageSinkFile::~RPageSinkFile()
 {
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -88,8 +88,8 @@ TEST(MiniFile, Proper)
 {
    FileRaii fileGuard("test_ntuple_minifile_proper.root");
 
-   std::unique_ptr<TFile> file;
-   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), file));
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("MyNTuple", *file));
 
    char header = 'h';
    char footer = 'f';
@@ -223,8 +223,8 @@ TEST(MiniFile, ProperKeys)
 {
    FileRaii fileGuard("test_ntuple_minifile_proper_keys.root");
 
-   std::unique_ptr<TFile> file;
-   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), file));
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("MyNTuple", *file));
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
@@ -352,9 +352,9 @@ TEST(MiniFile, Multi)
 {
    FileRaii fileGuard("test_ntuple_minifile_multi.root");
 
-   std::unique_ptr<TFile> file;
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
    auto writer1 =
-      std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Recreate("FirstNTuple", fileGuard.GetPath(), file));
+      std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("FirstNTuple", *file));
    auto writer2 = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("SecondNTuple", *file));
 
    char header1 = 'h';


### PR DESCRIPTION
This should be done by the caller to properly handle errors and ensure lifetime longer than the `RPageSinkFile`.