### PR TITLE
[ntuple] Replace virtual GetBitsOnStorage() with member

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -82,7 +82,6 @@ public:
    ColumnId_t GetColumnId() const { return fColumnId; }
    /// The space taken by column elements in the buffer
    std::uint32_t GetNBytes() const { return fElementSize * fNElements; }
-   std::uint32_t GetElementSize() const { return fElementSize; }
    std::uint32_t GetNElements() const { return fNElements; }
    std::uint32_t GetMaxElements() const { return fMaxElements; }
    NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -79,7 +79,7 @@ void ROOT::Experimental::Detail::RColumn::Flush()
       // Small tail page: merge with previously used page; we know that there is enough space in the shadow page
       auto &thisPage = fWritePage[fWritePageIdx];
       void *dst = fWritePage[otherIdx].GrowUnchecked(thisPage.GetNElements());
-      memcpy(dst, thisPage.GetBuffer(), thisPage.GetElementSize() * thisPage.GetNElements());
+      memcpy(dst, thisPage.GetBuffer(), thisPage.GetNBytes());
       thisPage.Reset(0);
       std::swap(fWritePageIdx, otherIdx);
    }


### PR DESCRIPTION
It was called from `GetPackedSize()` which was on the hot path in `RFieldBase::Append()` for mappable fields and various `AppendImpl()`, for example `RVectorField::AppendImpl()`. This change yields more than 10% lower overhead for writing 5 floats, either as separate fields or in a `std::vector`.

---

(the last two commits are optional, found while looking some more into `RPage::GrowUnchecked`, but nothing successful came out)