### PR TITLE
[math] Fix for Kurtosis Skewness NaNs

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7548,6 +7548,9 @@ Double_t TH1::GetSkewness(Int_t axis) const
 
       Double_t mean = GetMean(axis);
       Double_t stddev = GetStdDev(axis);
+      if (stddev == 0) {
+	Fatal("GetSkewness", "illegal value of stdev (division by zero)");
+      }
       Double_t stddev3 = stddev*stddev*stddev;
 
       Int_t firstBinX = fXaxis.GetFirst();
@@ -7573,8 +7576,8 @@ Double_t TH1::GetSkewness(Int_t axis) const
       }
 
       Double_t x = 0;
-      Double_t sum=0;
-      Double_t np=0;
+      Double_t sum = 0;
+      Double_t np = 0;
       for (Int_t  binx = firstBinX; binx <= lastBinX; binx++) {
          for (Int_t biny = firstBinY; biny <= lastBinY; biny++) {
             for (Int_t binz = firstBinZ; binz <= lastBinZ; binz++) {
@@ -7620,6 +7623,9 @@ Double_t TH1::GetKurtosis(Int_t axis) const
 
       Double_t mean = GetMean(axis);
       Double_t stddev = GetStdDev(axis);
+      if (stddev == 0) {
+	Fatal("GetKurtosis", "illegal value of stdev (division by zero)");
+      }
       Double_t stddev4 = stddev*stddev*stddev*stddev;
 
       Int_t firstBinX = fXaxis.GetFirst();


### PR DESCRIPTION
# This Pull request:

Dear All. This PR fixes #13878 by adding if statement which checks if stdev is zero and gives a fatal error (Fatal). Without it there would be division by zero. I chose the fatal error instead of "Error" and returning some value (e.g. zero) because in my opinion the program should exit in situations where the result would not make sense. For example skewness of a histogram consisting only of identical values would be undefined.

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13878