### PR TITLE
[ntuple] Add initial version of RNTupleParallelWriter

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -31,6 +31,7 @@ HEADERS
   ROOT/RNTupleMetrics.hxx
   ROOT/RNTupleModel.hxx
   ROOT/RNTupleOptions.hxx
+  ROOT/RNTupleParallelWriter.hxx
   ROOT/RNTupleSerialize.hxx
   ROOT/RNTupleUtil.hxx
   ROOT/RNTupleView.hxx
@@ -58,6 +59,7 @@ SOURCES
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx
   v7/src/RNTupleOptions.cxx
+  v7/src/RNTupleParallelWriter.cxx
   v7/src/RNTupleSerialize.cxx
   v7/src/RNTupleUtil.cxx
   v7/src/RPage.cxx

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -349,11 +349,13 @@ is not modified for the time of the Fill() call. The fill call serializes the C+
 writes data into the corresponding column page buffers.  Writing of the buffers to storage is deferred and can be
 triggered by CommitCluster() or by destructing the context.  On I/O errors, an exception is thrown.
 
-Instances of this class are not meant to be used in isolation. For sequential writing, please refer to RNTupleWriter.
+Instances of this class are not meant to be used in isolation and can be created from an RNTupleParallelWriter. For
+sequential writing, please refer to RNTupleWriter.
 */
 // clang-format on
 class RNTupleFillContext {
-   friend RNTupleWriter;
+   friend class RNTupleWriter;
+   friend class RNTupleParallelWriter;
 
 private:
    std::unique_ptr<Detail::RPageSink> fSink;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
@@ -1,0 +1,101 @@
+/// \file ROOT/RNTupleParallelWriter.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
+/// \date 2024-02-01
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleParallelWriter
+#define ROOT7_RNTupleParallelWriter
+
+#include <ROOT/RNTupleMetrics.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <vector>
+
+class TFile;
+
+namespace ROOT {
+namespace Experimental {
+
+namespace Detail {
+class RPageSink;
+} // namespace Detail
+
+class RNTupleFillContext;
+class RNTupleModel;
+
+/**
+\class ROOT::Experimental::RNTupleParallelWriter
+\ingroup NTuple
+\brief A writer to fill an RNTuple from multiple contexts
+
+Compared to the sequential RNTupleWriter, a parallel writer enables the creation of multiple RNTupleFillContext (see
+RNTupleParallelWriter::CreateFillContext).  Each fill context prepares independent clusters that are appended to the
+common ntuple with internal synchronization.  Before destruction, all fill contexts must have flushed their data and
+been destroyed (or data could be lost!).
+
+Note that the sequence of independently prepared clusters is indeterminate and therefore entries are only partially
+ordered:  Entries from one context are totally ordered as they were filled.  However, there is no orderering with other
+contexts and the entries may be appended to the ntuple either before or after other entries written in parallel into
+other contexts.  In addition, two consecutive entries in one fill context can end up separated in the final ntuple, if
+they happen to fall onto a cluster boundary and other contexts append more entries before the next cluster is full.
+
+At the moment, the parallel writer does not (yet) support incremental updates of the underlying model. Please refer to
+RNTupleWriter::CreateModelUpdater if required for your use case.
+*/
+class RNTupleParallelWriter {
+private:
+   /// A global mutex to protect the internal data structures of this object.
+   std::mutex fMutex;
+   /// A mutex to synchronize the final page sink.
+   std::mutex fSinkMutex;
+   /// The final RPageSink that represents the synchronization point.
+   std::unique_ptr<Detail::RPageSink> fSink;
+   /// The original RNTupleModel connected to fSink; needs to be destructed before it.
+   std::unique_ptr<RNTupleModel> fModel;
+   Detail::RNTupleMetrics fMetrics;
+   /// List of all created helpers. They must be destroyed before this RNTupleParallelWriter is destructed.
+   std::vector<std::weak_ptr<RNTupleFillContext>> fFillContexts;
+
+   RNTupleParallelWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSink> sink);
+   RNTupleParallelWriter(const RNTupleParallelWriter &) = delete;
+   RNTupleParallelWriter &operator=(const RNTupleParallelWriter &) = delete;
+
+public:
+   /// Recreate a new file and return a writer to write an ntuple.
+   static std::unique_ptr<RNTupleParallelWriter> Recreate(std::unique_ptr<RNTupleModel> model,
+                                                          std::string_view ntupleName, std::string_view storage,
+                                                          const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   /// Append an ntuple to the existing file, which must not be accessed while data is filled into any created context.
+   static std::unique_ptr<RNTupleParallelWriter> Append(std::unique_ptr<RNTupleModel> model,
+                                                        std::string_view ntupleName, TFile &file,
+                                                        const RNTupleWriteOptions &options = RNTupleWriteOptions());
+
+   ~RNTupleParallelWriter();
+
+   /// Create a new RNTupleFillContext that can be used to fill entries and prepare clusters in parallel. This method is
+   /// thread-safe and may be called from multiple threads in parallel.
+   ///
+   /// Note that all fill contexts must be destroyed before the RNTupleParallelWriter is destructed.
+   std::shared_ptr<RNTupleFillContext> CreateFillContext();
+
+   void EnableMetrics() { fMetrics.Enable(); }
+   const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -118,6 +118,8 @@ private:
    /// I/O performance counters that get registered in fMetrics
    struct RCounters {
       RNTuplePlainCounter &fParallelZip;
+      RNTuplePlainCounter &fTimeWallCriticalSection;
+      RNTupleTickCounter<RNTuplePlainCounter> &fTimeCpuCriticalSection;
    };
    std::unique_ptr<RCounters> fCounters;
    /// The inner sink, responsible for actually performing I/O.

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -1,0 +1,175 @@
+/// \file RNTupleParallelWriter.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
+/// \date 2024-02-01
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleParallelWriter.hxx>
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RPageSinkBuf.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+
+namespace {
+
+using ROOT::Experimental::DescriptorId_t;
+using ROOT::Experimental::NTupleSize_t;
+using ROOT::Experimental::RException;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::Detail::RColumn;
+using ROOT::Experimental::Detail::RNTupleModelChangeset;
+using ROOT::Experimental::Detail::RPage;
+using ROOT::Experimental::Detail::RPageSink;
+
+/// An internal RPageSink that enables multiple RNTupleFillContext to write into a single common RPageSink.
+///
+/// The setup with two contexts looks as follows:
+///
+///      +------ owned by RNTupleFillContext ------+
+///      |                                         |
+/// RPageSinkBuf --- forwards to ---> RPageSynchronizingSink ---+
+///                  (and owns)                                 |
+///                                    (via raw fInnerSink ptr) +-- RPageSink (usually a persistent sink)
+///                                                             |
+/// RPageSinkBuf --- forwards to ---> RPageSynchronizingSink ---+
+///      |           (and owns)                    |
+///      |                                         |
+///      +------ owned by RNTupleFillContext ------+
+///
+/// The mutex used by the synchronizing sinks is owned by the RNTupleParallelWriter that also owns the original model,
+/// the "final" sink (usually a persistent sink) and keeps weak_ptr's of the contexts (to make sure they are destroyed
+/// before the writer is destructed).
+class RPageSynchronizingSink : public RPageSink {
+private:
+   /// The wrapped inner sink, not owned by this class.
+   RPageSink *fInnerSink;
+   std::mutex *fMutex;
+
+public:
+   explicit RPageSynchronizingSink(RPageSink &inner, std::mutex &mutex)
+      : RPageSink(inner.GetNTupleName(), inner.GetWriteOptions()), fInnerSink(&inner), fMutex(&mutex)
+   {
+      // Do not observe the sink's metrics: It will contain some counters for all threads, which is misleading for the
+      // users.
+      // fMetrics.ObserveMetrics(fSink->GetMetrics());
+   }
+   RPageSynchronizingSink(const RPageSynchronizingSink &) = delete;
+   RPageSynchronizingSink &operator=(const RPageSynchronizingSink &) = delete;
+
+   ColumnHandle_t AddColumn(DescriptorId_t, const RColumn &) final { return {}; }
+   void Init(RNTupleModel &) final {}
+   void UpdateSchema(const RNTupleModelChangeset &, NTupleSize_t) final
+   {
+      throw RException(R__FAIL("UpdateSchema not supported via RPageSynchronizingSink"));
+   }
+
+   void CommitPage(ColumnHandle_t, const RPage &) final
+   {
+      throw RException(R__FAIL("should never commit single pages via RPageSynchronizingSink"));
+   }
+   void CommitSealedPage(DescriptorId_t, const RSealedPage &) final
+   {
+      throw RException(R__FAIL("should never commit sealed pages via RPageSynchronizingSink"));
+   }
+   void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final
+   {
+      fInnerSink->CommitSealedPageV(ranges);
+   }
+   std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final { return fInnerSink->CommitCluster(nNewEntries); }
+   void CommitClusterGroup() final
+   {
+      throw RException(R__FAIL("should never commit cluster group via RPageSynchronizingSink"));
+   }
+   void CommitDataset() final { throw RException(R__FAIL("should never commit dataset via RPageSynchronizingSink")); }
+
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final
+   {
+      return fInnerSink->ReservePage(columnHandle, nElements);
+   }
+   void ReleasePage(RPage &page) final { fInnerSink->ReleasePage(page); }
+
+   RSinkGuard GetSinkGuard() final { return RSinkGuard(fMutex); }
+};
+
+} // namespace
+
+ROOT::Experimental::RNTupleParallelWriter::RNTupleParallelWriter(std::unique_ptr<RNTupleModel> model,
+                                                                 std::unique_ptr<Detail::RPageSink> sink)
+   : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleParallelWriter")
+{
+   fModel->Freeze();
+   fSink->Init(*fModel.get());
+   fMetrics.ObserveMetrics(fSink->GetMetrics());
+}
+
+ROOT::Experimental::RNTupleParallelWriter::~RNTupleParallelWriter()
+{
+   for (const auto &context : fFillContexts) {
+      if (!context.expired()) {
+         R__LOG_ERROR(NTupleLog()) << "RNTupleFillContext has not been destructed";
+         return;
+      }
+   }
+
+   // Now commit all clusters as a cluster group and then the dataset.
+   try {
+      fSink->CommitClusterGroup();
+      fSink->CommitDataset();
+   } catch (const RException &err) {
+      R__LOG_ERROR(NTupleLog()) << "failure committing ntuple: " << err.GetError().GetReport();
+   }
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleParallelWriter>
+ROOT::Experimental::RNTupleParallelWriter::Recreate(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
+                                                    std::string_view storage, const RNTupleWriteOptions &options)
+{
+   if (!options.GetUseBufferedWrite()) {
+      throw RException(R__FAIL("parallel writing requires buffering"));
+   }
+
+   auto sink = std::make_unique<Detail::RPageSinkFile>(ntupleName, storage, options);
+   // Cannot use std::make_unique because the constructor of RNTupleParallelWriter is private.
+   return std::unique_ptr<RNTupleParallelWriter>(new RNTupleParallelWriter(std::move(model), std::move(sink)));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleParallelWriter>
+ROOT::Experimental::RNTupleParallelWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
+                                                  TFile &file, const RNTupleWriteOptions &options)
+{
+   if (!options.GetUseBufferedWrite()) {
+      throw RException(R__FAIL("parallel writing requires buffering"));
+   }
+
+   auto sink = std::make_unique<Detail::RPageSinkFile>(ntupleName, file, options);
+   // Cannot use std::make_unique because the constructor of RNTupleParallelWriter is private.
+   return std::unique_ptr<RNTupleParallelWriter>(new RNTupleParallelWriter(std::move(model), std::move(sink)));
+}
+
+std::shared_ptr<ROOT::Experimental::RNTupleFillContext> ROOT::Experimental::RNTupleParallelWriter::CreateFillContext()
+{
+   std::lock_guard g(fMutex);
+
+   auto model = fModel->Clone();
+
+   // TODO: Think about honoring RNTupleWriteOptions::SetUseBufferedWrite(false); this requires synchronization on every
+   // call to CommitPage() *and* preparing multiple cluster descriptors in parallel!
+   auto sink = std::make_unique<Detail::RPageSinkBuf>(std::make_unique<RPageSynchronizingSink>(*fSink, fSinkMutex));
+
+   // Cannot use std::make_shared because the constructor of RNTupleFillContext is private. Also it would mean that the
+   // (direct) memory of all contexts stays around until the vector of weak_ptr's is cleared.
+   std::shared_ptr<RNTupleFillContext> context(new RNTupleFillContext(std::move(model), std::move(sink)));
+   fFillContexts.push_back(context);
+   return context;
+}

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -60,6 +60,8 @@ ROOT_ADD_GTEST(ntuple_show ntuple_show.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_storage ntuple_storage.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_extended ntuple_extended.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
 
+ROOT_ADD_GTEST(ntuple_parallel_writer ntuple_parallel_writer.cxx LIBRARIES ROOTNTuple)
+
 ROOT_ADD_GTEST(ntuple_limits ntuple_limits.cxx LIBRARIES ROOTNTuple)
 
 if(daos OR daos_mock)

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -1,0 +1,106 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTupleParallelWriter, Basics)
+{
+   FileRaii fileGuard("test_ntuple_parallel_basics.root");
+
+   auto test = [&](std::unique_ptr<RNTupleParallelWriter> writer) {
+      // Create two RNTupleFillContext to prepare clusters in parallel.
+      auto c1 = writer->CreateFillContext();
+      auto e1 = c1->CreateEntry();
+      auto pt1 = e1->GetPtr<float>("pt");
+
+      auto c2 = writer->CreateFillContext();
+      auto e2 = c2->CreateEntry();
+      auto pt2 = e2->GetPtr<float>("pt");
+
+      // Fill one entry per context and commit a cluster each.
+      *pt1 = 1.0;
+      c1->Fill(*e1);
+      c1->CommitCluster();
+
+      *pt2 = 2.0;
+      c2->Fill(*e2);
+      c2->CommitCluster();
+
+      // The two contexts should act independently.
+      EXPECT_EQ(c1->GetNEntries(), 1);
+      EXPECT_EQ(c2->GetNEntries(), 1);
+      EXPECT_EQ(c1->GetLastCommitted(), 1);
+      EXPECT_EQ(c2->GetLastCommitted(), 1);
+
+      // Fill another entry per context without explicitly committing a cluster.
+      *pt1 = 3.0;
+      c1->Fill(*e1);
+
+      *pt2 = 4.0;
+      c2->Fill(*e2);
+
+      EXPECT_EQ(c1->GetNEntries(), 2);
+      EXPECT_EQ(c2->GetNEntries(), 2);
+
+      // Release the contexts (in reverse order) and the writer.
+      c2.reset();
+      c1.reset();
+      writer.reset();
+
+      auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
+      const auto &model = reader->GetModel();
+
+      EXPECT_EQ(reader->GetNEntries(), 4);
+      auto pt = model.GetDefaultEntry().GetPtr<float>("pt");
+
+      reader->LoadEntry(0);
+      EXPECT_EQ(*pt, 1.0);
+      reader->LoadEntry(1);
+      EXPECT_EQ(*pt, 2.0);
+
+      // This entry ordering is enforced by the context destruction.
+      reader->LoadEntry(2);
+      EXPECT_EQ(*pt, 4.0);
+      reader->LoadEntry(3);
+      EXPECT_EQ(*pt, 3.0);
+   };
+
+   {
+      auto model = RNTupleModel::CreateBare();
+      model->MakeField<float>("pt");
+
+      auto writer = RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+      test(std::move(writer));
+   }
+
+   {
+      auto model = RNTupleModel::CreateBare();
+      model->MakeField<float>("pt");
+
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleParallelWriter::Append(std::move(model), "f", *file);
+      test(std::move(writer));
+   }
+}
+
+TEST(RNTupleParallelWriter, Options)
+{
+   FileRaii fileGuard("test_ntuple_parallel_options.root");
+
+   RNTupleWriteOptions options;
+   options.SetUseBufferedWrite(false);
+
+   try {
+      auto model = RNTupleModel::CreateBare();
+      RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
+      FAIL() << "should require buffered writing";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("parallel writing requires buffering"));
+   }
+
+   try {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto model = RNTupleModel::CreateBare();
+      RNTupleParallelWriter::Append(std::move(model), "f", *file, options);
+      FAIL() << "should require buffered writing";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("parallel writing requires buffering"));
+   }
+}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -12,6 +12,7 @@
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleParallelWriter.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageAllocator.hxx>
@@ -80,6 +81,7 @@ using RNTupleDecompressor = ROOT::Experimental::Internal::RNTupleDecompressor;
 using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
 using RNTupleDescriptorBuilder = ROOT::Experimental::Internal::RNTupleDescriptorBuilder;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
+using RNTupleParallelWriter = ROOT::Experimental::RNTupleParallelWriter;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;

--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_ntuple
 /// \notebook
-/// Example of multi-threaded writes using multuple REntry objects
+/// Example of multi-threaded writes using multiple REntry objects
 ///
 /// \macro_image
 /// \macro_code
@@ -37,10 +37,10 @@ R__LOAD_LIBRARY(ROOTNTuple)
 #include <utility>
 
 // Import classes from experimental namespace for the time being
-using REntry = ROOT::Experimental::REntry;
-using RNTupleModel = ROOT::Experimental::RNTupleModel;
-using RNTupleReader = ROOT::Experimental::RNTupleReader;
-using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::REntry;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriter;
 
 // Where to store the ntuple of this example
 constexpr char const *kNTupleFileName = "ntpl007_mtFill.root";
@@ -52,7 +52,7 @@ constexpr int kNWriterThreads = 4;
 constexpr int kNEventsPerThread = 25000;
 
 // Thread function to generate and write events
-void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *ntuple) {
+void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *writer) {
    // Protect the ntuple->Fill() call
    static std::mutex gLock;
 
@@ -63,6 +63,7 @@ void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *ntuple) {
    prng->SetSeed();
 
    auto id = entry->GetPtr<std::uint32_t>("id");
+   *id = threadId;
    auto vpx = entry->GetPtr<std::vector<float>>("vpx");
    auto vpy = entry->GetPtr<std::vector<float>>("vpy");
    auto vpz = entry->GetPtr<std::vector<float>>("vpz");
@@ -71,7 +72,6 @@ void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *ntuple) {
       vpx->clear();
       vpy->clear();
       vpz->clear();
-      *id = threadId;
 
       int npx = static_cast<int>(prng->Rndm(1) * 15);
       // Set the field data for the current event
@@ -86,7 +86,7 @@ void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *ntuple) {
       }
 
       std::lock_guard<std::mutex> guard(gLock);
-      ntuple->Fill(*entry);
+      writer->Fill(*entry);
    }
 }
 
@@ -101,18 +101,18 @@ void Write()
    model->MakeField<std::vector<float>>("vpz");
 
    // We hand-over the data model to a newly created ntuple of name "NTuple", stored in kNTupleFileName
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "NTuple", kNTupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "NTuple", kNTupleFileName);
 
    std::vector<std::unique_ptr<REntry>> entries;
    std::vector<std::thread> threads;
    for (int i = 0; i < kNWriterThreads; ++i)
-      entries.emplace_back(ntuple->CreateEntry());
+      entries.emplace_back(writer->CreateEntry());
    for (int i = 0; i < kNWriterThreads; ++i)
-      threads.emplace_back(FillData, std::move(entries[i]), ntuple.get());
+      threads.emplace_back(FillData, std::move(entries[i]), writer.get());
    for (int i = 0; i < kNWriterThreads; ++i)
       threads[i].join();
 
-   // The ntuple unique pointer goes out of scope here.  On destruction, the ntuple flushes unwritten data to disk
+   // The writer unique pointer goes out of scope here.  On destruction, the writer flushes unwritten data to disk
    // and closes the attached ROOT file.
 }
 
@@ -120,9 +120,8 @@ void Write()
 // For all of the events, histogram only one of the written vectors
 void Read()
 {
-   auto ntuple = RNTupleReader::Open("NTuple", kNTupleFileName);
-   // TODO(jblomer): the "inner name" of the vector should become "vpx._0"
-   auto viewVpx = ntuple->GetView<float>("vpx._0");
+   auto reader = RNTupleReader::Open("NTuple", kNTupleFileName);
+   auto viewVpx = reader->GetView<float>("vpx._0");
 
    gStyle->SetOptStat(0);
 
@@ -139,11 +138,11 @@ void Read()
    h.DrawCopy();
 
    c1->cd(2);
-   auto nEvents = ntuple->GetNEntries();
-   auto viewId = ntuple->GetView<std::uint32_t>("id");
-   TH2F hFillSequence("","Entry Id vs Thread Id;Entry Sequence Number;Filling Thread",
-                      100, 0, nEvents, 100, 0, kNWriterThreads);
-   for (auto i : ntuple->GetEntryRange())
+   auto nEvents = reader->GetNEntries();
+   auto viewId = reader->GetView<std::uint32_t>("id");
+   TH2F hFillSequence("", "Entry Id vs Thread Id;Entry Sequence Number;Filling Thread", 100, 0, nEvents, 100, 0,
+                      kNWriterThreads + 1);
+   for (auto i : reader->GetEntryRange())
       hFillSequence.Fill(i, viewId(i));
    hFillSequence.DrawCopy();
 }

--- a/tutorials/v7/ntuple/ntpl009_parallelWriter.C
+++ b/tutorials/v7/ntuple/ntpl009_parallelWriter.C
@@ -1,0 +1,156 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Example of multi-threaded writes using RNTupleParallelWriter.  Adapted from the ntpl007_mtFill tutorial.
+///
+/// \macro_image
+/// \macro_code
+///
+/// \date Feburary 2024
+/// \author The ROOT Team
+
+// NOTE: The RNTuple classes are experimental at this point.
+// Functionality, interface, and data format is still subject to changes.
+// Do not use for real data!
+
+// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
+// triggering autoloading from the use of templated types would require an exhaustive enumeration
+// of "all" template instances in the LinkDef file.
+R__LOAD_LIBRARY(ROOTNTuple)
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleParallelWriter.hxx>
+
+#include <TCanvas.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TRandom.h>
+#include <TRandom3.h>
+#include <TStyle.h>
+#include <TSystem.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <utility>
+
+// Import classes from experimental namespace for the time being
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleParallelWriter;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriteOptions;
+
+// Where to store the ntuple of this example
+constexpr char const *kNTupleFileName = "ntpl009_parallelWriter.root";
+
+// Number of parallel threads to fill the ntuple
+constexpr int kNWriterThreads = 4;
+
+// Number of events to generate is kNEventsPerThread * kNWriterThreads
+constexpr int kNEventsPerThread = 25000;
+
+// Thread function to generate and write events
+void FillData(RNTupleParallelWriter *writer)
+{
+   static std::atomic<std::uint32_t> gThreadId;
+   const auto threadId = ++gThreadId;
+
+   auto prng = std::make_unique<TRandom3>();
+   prng->SetSeed();
+
+   auto fillContext = writer->CreateFillContext();
+   auto entry = fillContext->CreateEntry();
+
+   auto id = entry->GetPtr<std::uint32_t>("id");
+   *id = threadId;
+   auto vpx = entry->GetPtr<std::vector<float>>("vpx");
+   auto vpy = entry->GetPtr<std::vector<float>>("vpy");
+   auto vpz = entry->GetPtr<std::vector<float>>("vpz");
+
+   for (int i = 0; i < kNEventsPerThread; i++) {
+      vpx->clear();
+      vpy->clear();
+      vpz->clear();
+
+      int npx = static_cast<int>(prng->Rndm(1) * 15);
+      // Set the field data for the current event
+      for (int j = 0; j < npx; ++j) {
+         float px, py, pz;
+         prng->Rannor(px, py);
+         pz = px * px + py * py;
+
+         vpx->emplace_back(px);
+         vpy->emplace_back(py);
+         vpz->emplace_back(pz);
+      }
+
+      fillContext->Fill(*entry);
+   }
+}
+
+// Generate kNEvents with multiple threads in kNTupleFileName
+void Write()
+{
+   // Create the data model
+   auto model = RNTupleModel::CreateBare();
+   model->MakeField<std::uint32_t>("id");
+   model->MakeField<std::vector<float>>("vpx");
+   model->MakeField<std::vector<float>>("vpy");
+   model->MakeField<std::vector<float>>("vpz");
+
+   // Create RNTupleWriteOptions to make the writing commit multiple clusters (so that "Entry Id vs Thread Id" shows the
+   // interleaved clusters).
+   RNTupleWriteOptions options;
+   options.SetApproxZippedClusterSize(1024 * 1024);
+
+   // We hand-over the data model to a newly created ntuple of name "NTuple", stored in kNTupleFileName
+   auto writer = RNTupleParallelWriter::Recreate(std::move(model), "NTuple", kNTupleFileName, options);
+
+   std::vector<std::thread> threads;
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads.emplace_back(FillData, writer.get());
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads[i].join();
+
+   // The writer unique pointer goes out of scope here.  On destruction, the writer flushes unwritten data to disk
+   // and closes the attached ROOT file.
+}
+
+// For all of the events, histogram only one of the written vectors
+void Read()
+{
+   auto reader = RNTupleReader::Open("NTuple", kNTupleFileName);
+   auto viewVpx = reader->GetView<float>("vpx._0");
+
+   gStyle->SetOptStat(0);
+
+   TCanvas *c1 = new TCanvas("c2", "Multi-Threaded Filling Example", 200, 10, 1500, 500);
+   c1->Divide(2, 1);
+
+   c1->cd(1);
+   TH1F h("h", "This is the px distribution", 100, -4, 4);
+   h.SetFillColor(48);
+   // Iterate through all values of vpx in all events
+   for (auto i : viewVpx.GetFieldRange())
+      h.Fill(viewVpx(i));
+   // Prevent the histogram from disappearing
+   h.DrawCopy();
+
+   c1->cd(2);
+   auto nEvents = reader->GetNEntries();
+   auto viewId = reader->GetView<std::uint32_t>("id");
+   TH2F hFillSequence("", "Entry Id vs Thread Id;Entry Sequence Number;Filling Thread", 100, 0, nEvents, 100, 0,
+                      kNWriterThreads + 1);
+   for (auto i : reader->GetEntryRange())
+      hFillSequence.Fill(i, viewId(i));
+   hFillSequence.DrawCopy();
+}
+
+void ntpl009_parallelWriter()
+{
+   Write();
+   Read();
+}


### PR DESCRIPTION
A parallel writer enables the creation of multiple `RNTupleFillContext`, where each context prepares independent clusters that are appended to the common ntuple with internal synchronization. At the moment, this synchronization makes sure that only one thread is writing to the file at any moment. Fully parallel writing into reserved offsets can be a future extension, pending further investigation and evaluation.