### PR TITLE
[ntuple] avoid page source/sink in public reader/writer interface

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -181,9 +181,8 @@ public:
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
    static std::unique_ptr<RNTupleReader>
-   Open(RNTuple *ntuple, const RNTupleReadOptions &options =
-                            RNTupleReadOptions()); /// The caller imposes a model, which must be compatible with the
-                                                   /// model found in the data on storage.
+   Open(RNTuple *ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
+   /// The caller imposes a model, which must be compatible with the model found in the data on storage.
    static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -122,10 +122,9 @@ TEST(RNTuple, WriteRead)
    auto rdNnlo = modelRead->GetDefaultEntry().GetPtr<std::vector<std::vector<float>>>("nnlo");
    auto rdKlass = modelRead->GetDefaultEntry().GetPtr<CustomStruct>("klass");
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(1U, ntuple.GetNEntries());
-   ntuple.LoadEntry(0);
+   auto reader = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
 
    EXPECT_TRUE(*rdSignal);
    EXPECT_EQ(42.0, *rdPt);
@@ -229,11 +228,10 @@ TEST(RNTuple, Clusters)
    auto rdNnlo = modelRead->GetDefaultEntry().GetPtr<std::vector<std::vector<float>>>("nnlo");
    auto rdFourVec = modelRead->GetDefaultEntry().GetPtr<std::array<float, 4>>("fourVec");
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(3U, ntuple.GetNEntries());
+   auto reader = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(3U, reader->GetNEntries());
 
-   ntuple.LoadEntry(0);
+   reader->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
    EXPECT_STREQ("xyz", rdTag->c_str());
    EXPECT_EQ(3U, rdNnlo->size());
@@ -250,13 +248,13 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(2.0, (*rdFourVec)[2]);
    EXPECT_EQ(3.0, (*rdFourVec)[3]);
 
-   ntuple.LoadEntry(1);
+   reader->LoadEntry(1);
    EXPECT_EQ(24.0, *rdPt);
    EXPECT_STREQ("", rdTag->c_str());
    EXPECT_TRUE(rdNnlo->empty());
    EXPECT_EQ(42.0, (*rdFourVec)[2]);
 
-   ntuple.LoadEntry(2);
+   reader->LoadEntry(2);
    EXPECT_EQ(12.0, *rdPt);
    EXPECT_STREQ("12345", rdTag->c_str());
    EXPECT_EQ(1U, rdNnlo->size());
@@ -505,32 +503,6 @@ TEST(RNTuple, NullSafety)
       FAIL() << "null models should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
-   }
-
-   try {
-      auto ntuple = RNTupleReader::Open(nullptr, "myNTuple", fileGuard.GetPath());
-      FAIL() << "null models should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
-   }
-   try {
-      RNTupleReader ntuple(nullptr,
-         std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-      FAIL() << "null models should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
-   }
-   try {
-      RNTupleReader ntuple(RNTupleModel::Create(), nullptr);
-      FAIL() << "null sources should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null source"));
-   }
-   try {
-      RNTupleReader ntuple(nullptr);
-      FAIL() << "null sources should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null source"));
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -109,9 +109,8 @@ TEST(RNTuple, WriteRead)
    auto modelRead = modelWrite->Clone();
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto rdSignal = modelRead->GetDefaultEntry().GetPtr<bool>("signal");
@@ -207,20 +206,19 @@ TEST(RNTuple, Clusters)
    auto modelRead = modelWrite->Clone();
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
-      ntuple.CommitCluster();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster();
       *wrPt = 24.0;
       wrNnlo->clear();
       *wrTag = "";
       wrFourVec->at(2) = 42.0;
-      ntuple.Fill();
+      writer->Fill();
       *wrPt = 12.0;
       wrNnlo->push_back(std::vector<float>{42.0});
       *wrTag = "12345";
       wrFourVec->at(1) = 24.0;
-      ntuple.Fill();
+      writer->Fill();
    }
 
    auto rdPt = modelRead->GetDefaultEntry().GetPtr<float>("pt");
@@ -474,35 +472,6 @@ TEST(RNTuple, NullSafety)
       FAIL() << "null fields should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("null field"));
-   }
-
-   // RNTupleReader and RNTupleWriter
-   FileRaii fileGuard("test_ntuple_null_safety.root");
-   try {
-      RNTupleWriter ntuple(nullptr,
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      FAIL() << "null models should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
-   }
-   try {
-      RNTupleWriter ntuple(std::move(model), nullptr);
-      FAIL() << "null sinks should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null sink"));
-   }
-   try {
-      auto ntuple = RNTupleWriter::Recreate(nullptr, "myNtuple", fileGuard.GetPath());
-      FAIL() << "null models should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
-   }
-   try {
-      auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
-      auto ntuple = RNTupleWriter::Append(nullptr, "myNtuple", *file);
-      FAIL() << "null models should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -332,14 +332,12 @@ TEST(PageStorageFile, LoadClusters)
    auto wrTag = modelWrite->MakeField<std::int32_t>("tag", 0);
 
    {
-      ROOT::Experimental::RNTupleWriter ntuple(
-         std::move(modelWrite), std::make_unique<ROOT::Experimental::Detail::RPageSinkFile>(
-            "myNTuple", fileGuard.GetPath(), ROOT::Experimental::RNTupleWriteOptions()));
-      ntuple.Fill();
-      ntuple.CommitCluster();
+      auto writer = ROOT::Experimental::RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster();
       *wrPt = 24.0;
       *wrTag = 1;
-      ntuple.Fill();
+      writer->Fill();
    }
 
    ROOT::Experimental::Detail::RPageSourceFile source(

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -262,8 +262,7 @@ TEST(RNTupleDescriptor, QualifiedFieldName)
    model->MakeField<std::vector<float>>("jets");
    FileRaii fileGuard("test_field_qualified.root");
    {
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
@@ -287,9 +286,8 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
 
    FileRaii fileGuard("test_field_iterator.root");
    {
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
@@ -345,9 +343,8 @@ TEST(RFieldDescriptorIterable, SortByLambda)
 
    FileRaii fileGuard("test_field_iterator.root");
    {
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
@@ -401,9 +398,8 @@ TEST(RColumnDescriptorIterable, IterateOverColumns)
 
    FileRaii fileGuard("test_column_iterator.root");
    {
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
@@ -450,12 +446,11 @@ TEST(RClusterDescriptor, GetBytesOnStorage)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), options));
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       fldJets->push_back(1.0);
       fldJets->push_back(2.0);
       *fldTag = "abc";
-      ntuple.Fill();
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
@@ -474,11 +469,10 @@ TEST(RNTupleDescriptor, Clone)
 
    FileRaii fileGuard("test_ntuple_descriptor_clone.root");
    {
-      RNTupleWriter ntuple(std::move(model),
-                           std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
-      ntuple.CommitCluster(true /* commitClusterGroup */);
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster(true /* commitClusterGroup */);
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -29,12 +29,12 @@ TEST(RPageStorage, ReadSealedPages)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
-      RNTupleWriter ntuple(std::move(model), std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), options));
-      ntuple.Fill();
-      ntuple.CommitCluster();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
+      writer->Fill();
+      writer->CommitCluster();
       for (unsigned i = 0; i < 100000; ++i) {
          *wrPt = i;
-         ntuple.Fill();
+         writer->Fill();
       }
    }
 

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -327,10 +327,10 @@ TEST(Packing, OnDiskEncoding)
                                  0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00};
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
 
-   auto reader = RNTupleReader(std::move(source));
-   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel().GetField("str").GetColumnRepresentative()[0]);
-   EXPECT_EQ(2u, reader.GetNEntries());
-   auto viewStr = reader.GetView<std::string>("str");
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(EColumnType::kIndex64, reader->GetModel().GetField("str").GetColumnRepresentative()[0]);
+   EXPECT_EQ(2u, reader->GetNEntries());
+   auto viewStr = reader->GetView<std::string>("str");
    EXPECT_EQ(std::string("abc"), viewStr(0));
    EXPECT_EQ(std::string("de"), viewStr(1));
 }

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -21,18 +21,18 @@ TEST(RNTuple, View)
       ntuple.Fill();
    }
 
-   RNTupleReader ntuple(std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   auto viewPt = ntuple.GetView<float>("pt");
+   auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   auto viewPt = reader->GetView<float>("pt");
    int n = 0;
-   for (auto i : ntuple.GetEntryRange()) {
+   for (auto i : reader->GetEntryRange()) {
       EXPECT_EQ(42.0, viewPt(i));
       n++;
    }
    EXPECT_EQ(2, n);
 
-   auto viewJets = ntuple.GetView<std::vector<std::int32_t>>("jets");
+   auto viewJets = reader->GetView<std::vector<std::int32_t>>("jets");
    n = 0;
-   for (auto i : ntuple.GetEntryRange()) {
+   for (auto i : reader->GetEntryRange()) {
       if (i == 0) {
          EXPECT_EQ(3U, viewJets(i).size());
          EXPECT_EQ(1, viewJets(i)[0]);
@@ -45,7 +45,7 @@ TEST(RNTuple, View)
    }
    EXPECT_EQ(2, n);
 
-   auto viewJetElements = ntuple.GetView<std::int32_t>("jets._0");
+   auto viewJetElements = reader->GetView<std::int32_t>("jets._0");
    n = 0;
    for (auto i : viewJetElements.GetFieldRange()) {
       n++;

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -13,12 +13,11 @@ TEST(RNTuple, View)
    fieldJets->push_back(3);
 
    {
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
-      ntuple.CommitCluster();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster();
       fieldJets->clear();
-      ntuple.Fill();
+      writer->Fill();
    }
 
    auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/rfield_variant.cxx
+++ b/tree/ntuple/v7/test/rfield_variant.cxx
@@ -12,14 +12,13 @@ TEST(RNTuple, Variant)
    auto modelRead = std::unique_ptr<RNTupleModel>(modelWrite->Clone());
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
-      ntuple.CommitCluster();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster();
       *wrVariant = 4;
-      ntuple.Fill();
+      writer->Fill();
       *wrVariant = 8.0;
-      ntuple.Fill();
+      writer->Fill();
    }
    auto rdVariant = modelRead->GetDefaultEntry().GetPtr<std::variant<double, int>>("variant").get();
 

--- a/tree/ntuple/v7/test/rfield_variant.cxx
+++ b/tree/ntuple/v7/test/rfield_variant.cxx
@@ -23,14 +23,13 @@ TEST(RNTuple, Variant)
    }
    auto rdVariant = modelRead->GetDefaultEntry().GetPtr<std::variant<double, int>>("variant").get();
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(3U, ntuple.GetNEntries());
+   auto reader = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(3U, reader->GetNEntries());
 
-   ntuple.LoadEntry(0);
+   reader->LoadEntry(0);
    EXPECT_EQ(2.0, *std::get_if<double>(rdVariant));
-   ntuple.LoadEntry(1);
+   reader->LoadEntry(1);
    EXPECT_EQ(4, *std::get_if<int>(rdVariant));
-   ntuple.LoadEntry(2);
+   reader->LoadEntry(2);
    EXPECT_EQ(8.0, *std::get_if<double>(rdVariant));
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -33,10 +33,10 @@ void TestClassVector(const char *fname)
       ntuple.Fill();
    }
 
-   RNTupleReader ntuple(std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(3U, ntuple.GetNEntries());
+   auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(3U, reader->GetNEntries());
 
-   auto viewKlassVec = ntuple.GetViewCollection("klassVec");
+   auto viewKlassVec = reader->GetViewCollection("klassVec");
    auto viewKlass = viewKlassVec.GetView<CustomStruct>("_0");
    auto viewKlassA = viewKlassVec.GetView<float>("_0.a");
    auto viewKlassV1 = viewKlassVec.GetView<std::vector<float>>("_0.v1");
@@ -176,32 +176,30 @@ TEST(RNTuple, RVec)
    auto modelReadAsRVec = RNTupleModel::Create();
    auto rdJetsAsRVec = modelReadAsRVec->MakeField<ROOT::VecOps::RVec<float>>("jets");
 
-   RNTupleReader ntupleRVec(std::move(modelReadAsRVec),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(2U, ntupleRVec.GetNEntries());
+   auto ntupleRVec = RNTupleReader::Open(std::move(modelReadAsRVec), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(2U, ntupleRVec->GetNEntries());
 
-   ntupleRVec.LoadEntry(0);
+   ntupleRVec->LoadEntry(0);
    EXPECT_EQ(2U, rdJetsAsRVec->size());
    EXPECT_EQ(42.0, (*rdJetsAsRVec)[0]);
    EXPECT_EQ(7.0, (*rdJetsAsRVec)[1]);
 
-   ntupleRVec.LoadEntry(1);
+   ntupleRVec->LoadEntry(1);
    EXPECT_EQ(1U, rdJetsAsRVec->size());
    EXPECT_EQ(1.0, (*rdJetsAsRVec)[0]);
 
    auto modelReadAsStdVector = RNTupleModel::Create();
    auto rdJetsAsStdVector = modelReadAsStdVector->MakeField<std::vector<float>>("jets");
 
-   RNTupleReader ntupleStdVector(std::move(modelReadAsStdVector), std::make_unique<RPageSourceFile>(
-      "myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(2U, ntupleRVec.GetNEntries());
+   auto ntupleStdVector = RNTupleReader::Open(std::move(modelReadAsStdVector), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(2U, ntupleStdVector->GetNEntries());
 
-   ntupleStdVector.LoadEntry(0);
+   ntupleStdVector->LoadEntry(0);
    EXPECT_EQ(2U, rdJetsAsStdVector->size());
    EXPECT_EQ(42.0, (*rdJetsAsStdVector)[0]);
    EXPECT_EQ(7.0, (*rdJetsAsStdVector)[1]);
 
-   ntupleStdVector.LoadEntry(1);
+   ntupleStdVector->LoadEntry(1);
    EXPECT_EQ(1U, rdJetsAsStdVector->size());
    EXPECT_EQ(1.0, (*rdJetsAsStdVector)[0]);
 }
@@ -301,10 +299,9 @@ TEST(RNTuple, BoolVector)
 
    auto rdBoolStdVec = modelRead->GetDefaultEntry().GetPtr<std::vector<bool>>("boolStdVec");
    auto rdBoolRVec = modelRead->GetDefaultEntry().GetPtr<ROOT::RVec<bool>>("boolRVec");
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(1U, ntuple.GetNEntries());
-   ntuple.LoadEntry(0);
+   auto reader = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
 
    EXPECT_EQ(4U, rdBoolStdVec->size());
    EXPECT_TRUE((*rdBoolStdVec)[0]);

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -18,19 +18,18 @@ void TestClassVector(const char *fname)
    wrKlassVec->emplace_back(klass);
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-                           std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
 
       // enlarge
       wrKlassVec->emplace_back(CustomStruct{1.f, {1.f, 2.f, 3.f}, {{42.f}}, "foo", std::byte{0}});
       wrKlassVec->emplace_back(CustomStruct{2.f, {4.f, 5.f, 6.f}, {{1.f}, {2.f, 3.f}}, "bar", std::byte{0}});
-      ntuple.Fill();
+      writer->Fill();
 
       // shrink
       wrKlassVec->clear();
       wrKlassVec->emplace_back(CustomStruct{3.f, {7.f, 8.f, 9.f}, {{4.f, 5.f}, {}}, "baz", std::byte{0}});
-      ntuple.Fill();
+      writer->Fill();
    }
 
    auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
@@ -108,9 +107,8 @@ TEST(RNTuple, InsideCollection)
    wrKlassVec->emplace_back(klass);
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto source = std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
@@ -165,12 +163,11 @@ TEST(RNTuple, RVec)
    wrJets->push_back(7.0);
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
       wrJets->clear();
       wrJets->push_back(1.0);
-      ntuple.Fill();
+      writer->Fill();
    }
 
    auto modelReadAsRVec = RNTupleModel::Create();
@@ -292,9 +289,8 @@ TEST(RNTuple, BoolVector)
    auto modelRead = modelWrite->Clone();
 
    {
-      RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      writer->Fill();
    }
 
    auto rdBoolStdVec = modelRead->GetDefaultEntry().GetPtr<std::vector<bool>>("boolStdVec");

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -377,7 +377,7 @@ void ROOT::Experimental::RNTupleImporter::Import()
    sink->GetMetrics().Enable();
    auto ctrZippedBytes = sink->GetMetrics().GetCounter("RPageSinkFile.szWritePayload");
 
-   auto ntplWriter = std::make_unique<RNTupleWriter>(std::move(fModel), std::move(sink));
+   auto ntplWriter = Internal::CreateRNTupleWriter(std::move(fModel), std::move(sink));
    // The guard needs to be destructed before the writer goes out of scope
    RImportGuard importGuard(*this);
 


### PR DESCRIPTION
**Edit**: also removes the `nullptr` checks for user-provided unique pointers. It seems like non-neglible amount of code (if done consistently, which it is currently not) for little benefit. Such cases will crash immediately with a null pointer de-reference. We can still add such checks consistently at a later point.