### PR TITLE
[core] Add `TString::size_type` member

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -278,6 +278,7 @@ public:
    enum EStripType   { kLeading = 0x1, kTrailing = 0x2, kBoth = 0x3 };
    enum ECaseCompare { kExact, kIgnoreCase };
    static constexpr Ssiz_t kNPOS = ::kNPOS;
+   using size_type = Ssiz_t;
 
    TString();                           // Null string
    explicit TString(Ssiz_t ic);         // Suggested capacity


### PR DESCRIPTION
The `size_type` member is required by the helper macros in the new CPyCppyy that can be used to declare string converters.

See also https://github.com/root-project/root/pull/14507