### PR TITLE
[ntuple] remove page source from pulic view interface

### DIFF
--- a/gui/browsable/src/RFieldHolder.hxx
+++ b/gui/browsable/src/RFieldHolder.hxx
@@ -25,23 +25,24 @@ class RPageSource;
 }
 
 class RFieldHolder : public ROOT::Browsable::RHolder {
-   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fNtplSource;
+   std::shared_ptr<ROOT::Experimental::RNTupleReader> fNtplReader;
    std::string fParentName;
 
    ROOT::Experimental::DescriptorId_t fFieldId;
 
 public:
-   RFieldHolder(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> ntplSource,
-                const std::string &parent_name,
+   RFieldHolder(std::shared_ptr<ROOT::Experimental::RNTupleReader> ntplReader, const std::string &parent_name,
                 ROOT::Experimental::DescriptorId_t id)
-                : fNtplSource(ntplSource), fParentName(parent_name), fFieldId(id) {}
+      : fNtplReader(ntplReader), fParentName(parent_name), fFieldId(id)
+   {
+   }
 
    const TClass *GetClass() const override { return TClass::GetClass<ROOT::Experimental::RNTuple>(); }
 
    /** Returns direct (temporary) object pointer */
    const void *GetObject() const override { return nullptr; }
 
-   auto GetNtplSource() const { return fNtplSource; }
+   auto GetNtplReader() const { return fNtplReader; }
    auto GetParentName() const { return fParentName; }
    auto GetId() const { return fFieldId; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -297,6 +297,12 @@ public:
          throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
                                   fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
+      return GetView<T>(fieldId);
+   }
+
+   template <typename T>
+   RNTupleView<T> GetView(DescriptorId_t fieldId)
+   {
       return RNTupleView<T>(fieldId, fSource.get());
    }
 
@@ -309,6 +315,11 @@ public:
          throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
                                   fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
+      return GetViewCollection(fieldId);
+   }
+
+   RNTupleViewCollection GetViewCollection(DescriptorId_t fieldId)
+   {
       return RNTupleViewCollection(fieldId, fSource.get());
    }
 

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -199,6 +199,26 @@ TEST(RNTuple, Composable)
    EXPECT_EQ(8, nEv);
 }
 
+TEST(RNTuple, VoidView)
+{
+   FileRaii fileGuard("test_ntuple_voidview.root");
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float>("pt", 42.0);
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+   auto viewPt = reader->GetView<void>("pt");
+   viewPt(0);
+   EXPECT_FLOAT_EQ(42.0, viewPt.GetValue().GetRef<float>());
+   EXPECT_STREQ("pt", viewPt.GetField().GetFieldName().c_str());
+}
+
 TEST(RNTuple, MissingViewNames)
 {
    FileRaii fileGuard("test_ntuple_missing_view_names.root");


### PR DESCRIPTION
Changes the RNTuple support in RBrowser from page source to the reader interface along the way. It turns out that the views are not only an interface for zero-copy reading but they also provide a quite useful way to read individual fields from a reader.