### PR TITLE
[ntuple] add token-based addressing to REntry

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -115,7 +115,8 @@ public:
    void BindValue(RFieldToken token, std::shared_ptr<T> objPtr)
    {
       if (fModelId != token.fModelId) {
-         throw RException(R__FAIL("invalid token for this entry"));
+         throw RException(R__FAIL("invalid token for this entry, "
+                                  "make sure to use a token from the same model as this entry."));
       }
       auto &v = fValues[token.fIndex];
       if constexpr (!std::is_void_v<T>) {

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -22,6 +22,8 @@
 
 #include <TError.h>
 
+#include <algorithm>
+#include <iterator>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -104,11 +106,13 @@ public:
    /// The ordinal of the top-level field fieldName; can be used in other methods to address the corresponding value
    RFieldToken GetToken(std::string_view fieldName) const
    {
-      for (std::size_t i = 0; i < fValues.size(); ++i) {
-         if (fValues[i].GetField().GetFieldName() == fieldName)
-            return RFieldToken(i, fModelId);
+      auto it = std::find_if(fValues.begin(), fValues.end(),
+         [&fieldName] (const RFieldBase::RValue &value) { return value.GetField().GetFieldName() == fieldName; });
+
+      if ( it == fValues.end() ) {
+         throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
       }
-      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
+      return RFieldToken(std::distance(fValues.begin(), it), fModelId);
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -145,6 +145,7 @@ public:
    private:
       RNTupleWriter &fWriter;
       Detail::RNTupleModelChangeset fOpenChangeset;
+      std::uint64_t fNewModelId = 0; ///< The model ID after committing
 
    public:
       explicit RUpdater(RNTupleWriter &writer);
@@ -186,9 +187,11 @@ private:
    std::string fDescription;
    /// The set of projected top-level fields
    std::unique_ptr<RProjectedFields> fProjectedFields;
-   /// Upon freezing, every model has a unique ID to distingusish it from other models.  Cloning preserves the ID.
-   /// Entries are linked to models via the ID.
+   /// Every model has a unique ID to distinguish it from other models. Entries are linked to models via the ID.
+   /// Cloned models get a new model ID.
    std::uint64_t fModelId = 0;
+   /// Changed by Freeze() / Unfreeze() and by the RUpdater.
+   bool fIsFrozen = false;
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.
@@ -289,7 +292,7 @@ public:
 
    void Freeze();
    void Unfreeze();
-   bool IsFrozen() const { return fModelId != 0; }
+   bool IsFrozen() const { return fIsFrozen; }
    std::uint64_t GetModelId() const { return fModelId; }
 
    /// Ingests a model for a sub collection and attaches it to the current model

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -701,20 +701,19 @@ TEST(REntry, Basics)
       EXPECT_STREQ("pt", v.GetField().GetFieldName().c_str());
    }
 
-   EXPECT_EQ(0u, e->GetIndex("pt"));
-   EXPECT_THROW(e->GetIndex(""), ROOT::Experimental::RException);
-   EXPECT_THROW(e->GetIndex("eta"), ROOT::Experimental::RException);
+   EXPECT_THROW(e->GetToken(""), ROOT::Experimental::RException);
+   EXPECT_THROW(e->GetToken("eta"), ROOT::Experimental::RException);
 
    std::shared_ptr<float> ptrPt;
-   e->BindValue(0, ptrPt);
-   EXPECT_EQ(ptrPt.get(), e->GetPtr<float>(0).get());
+   e->BindValue("pt", ptrPt);
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<float>("pt").get());
 
-   EXPECT_THROW(e->GetPtr<void>(1), ROOT::Experimental::RException);
-   EXPECT_THROW(e->BindValue(1, ptrPt), ROOT::Experimental::RException);
+   auto model2 = model->Clone();
+   EXPECT_THROW(e->GetPtr<void>(model2->GetDefaultEntry().GetToken("pt")), ROOT::Experimental::RException);
    std::shared_ptr<double> ptrDouble;
-   EXPECT_THROW(e->BindValue(0, ptrDouble), ROOT::Experimental::RException);
+   EXPECT_THROW(e->BindValue("pt", ptrDouble), ROOT::Experimental::RException);
 
    float pt;
-   e->BindRawPtr(0, &pt);
-   EXPECT_EQ(&pt, e->GetPtr<void>(0).get());
+   e->BindRawPtr("pt", &pt);
+   EXPECT_EQ(&pt, e->GetPtr<void>("pt").get());
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -480,7 +480,7 @@ TEST(RNTuple, ModelId)
    auto m1 = RNTupleModel::Create();
    auto m2 = RNTupleModel::Create();
    EXPECT_FALSE(m1->IsFrozen());
-   EXPECT_EQ(m1->GetModelId(), m2->GetModelId());
+   EXPECT_NE(m1->GetModelId(), m2->GetModelId());
 
    m1->Freeze();
    EXPECT_TRUE(m1->IsFrozen());
@@ -498,18 +498,14 @@ TEST(RNTuple, ModelId)
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to modify frozen model"));
    }
 
-   EXPECT_NE(m1->GetModelId(), m2->GetModelId());
    // Freeze() should be idempotent call
    auto id = m1->GetModelId();
    m1->Freeze();
    EXPECT_TRUE(m1->IsFrozen());
    EXPECT_EQ(id, m1->GetModelId());
 
-   m2->Freeze();
-   EXPECT_NE(m1->GetModelId(), m2->GetModelId());
-
    auto m2c = m2->Clone();
-   EXPECT_EQ(m2->GetModelId(), m2c->GetModelId());
+   EXPECT_NE(m2->GetModelId(), m2c->GetModelId());
 }
 
 TEST(RNTuple, Entry)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -692,3 +692,33 @@ TEST(RNTuple, RValue)
 
    // The deleters are called in the destructors of the values
 }
+
+TEST(REntry, Basics)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   model->Freeze();
+
+   auto e = model->CreateEntry();
+   EXPECT_EQ(e->GetModelId(), model->GetModelId());
+   for (const auto &v : *e) {
+      EXPECT_STREQ("pt", v.GetField().GetFieldName().c_str());
+   }
+
+   EXPECT_EQ(0u, e->GetIndex("pt"));
+   EXPECT_THROW(e->GetIndex(""), ROOT::Experimental::RException);
+   EXPECT_THROW(e->GetIndex("eta"), ROOT::Experimental::RException);
+
+   std::shared_ptr<float> ptrPt;
+   e->BindValue(0, ptrPt);
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<float>(0).get());
+
+   EXPECT_THROW(e->GetPtr<void>(1), ROOT::Experimental::RException);
+   EXPECT_THROW(e->BindValue(1, ptrPt), ROOT::Experimental::RException);
+   std::shared_ptr<double> ptrDouble;
+   EXPECT_THROW(e->BindValue(0, ptrDouble), ROOT::Experimental::RException);
+
+   float pt;
+   e->BindRawPtr(0, &pt);
+   EXPECT_EQ(&pt, e->GetPtr<void>(0).get());
+}


### PR DESCRIPTION
Allows to search for field names only once and not every time the top-level fields get a new binding.

@Dr15Jones This should improve the writing