### PR TITLE
[cmake] ROOTConfig: if not builtin Vdt find it

### DIFF
--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -136,6 +136,8 @@ if(ROOT_vdt_FOUND AND NOT TARGET VDT::VDT)
       find_dependency(Vdt)
     endfunction()
     find_builtin_vdt()
+  else()
+    find_dependency(Vdt)
   endif()
 endif()
 


### PR DESCRIPTION
# This Pull request:

Fixes ROOTConfig when Vdt was built externally

## Changes or fixes:

https://github.com/root-project/root/issues/14113#issuecomment-1925245792

## Checklist:

- [x] tested changes locally

This PR fixes #14113

