### PR TITLE
[PyROOT] Drop support for `from ROOT import *`

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -44,6 +44,7 @@ The following people have contributed to this new version:
 - Some redundant **RooDataSet** constructors are deprecated and will be removed in ROOT 6.34.
   Please use the RooDataSet constructors that take RooFit command arguments instead
 - ROOT does not longer support Python 2. The minimum required Python version to build ROOT is 3.8.
+- Support for wildcard imports like `from ROOT import *` is dropped from PyROOT
 
 ## Core Libraries
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -82,9 +82,8 @@ class ROOTFacade(types.ModuleType):
         types.ModuleType.__init__(self, module.__name__)
 
         self.module = module
-        # Importing all will be customised later
-        self.module.__all__ = []
 
+        self.__all__ = module.__all__
         self.__name__ = module.__name__
         self.__file__ = module.__file__
         self.__cached__ = module.__cached__


### PR DESCRIPTION
Wild card imports like `from ROOT import *` stopped working with Python 3.11 given some changes in the CPython API.

For that reason, upstream `cppyy` also dropped support for lazy lookups, which was the feature that enabled wildcard imports: https://github.com/wlav/CPyCppyy/commit/64fd89050a66bf8cb119f236cadd365efa07b005#diff-6160c0eb004dabeedaeb58d804a7ecd3e563d9379e9e7af39623fd38d0bc6a37R352

This commit suggests to document `from ROOT import *` officially as unsupported and remove the corresponding code path in the ROOT facade.

Closes #7669.