### PR TITLE
Very long text string generated a wrong SVG file

### DIFF
--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1978,6 +1978,7 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       }
    }
 
+   PrintStr("@");
    PrintFast(7,"</text>");
 
    if (fTextAngle != 0.) {


### PR DESCRIPTION
Fix [this issue](https://github.com/root-project/root/issues/9514).

The change inserts a new line in the SVG file before the <\text> tag. This avoids the syntax error the user sees when inserting a very long text.

