### PR TITLE
[ntuple] remove page source/sink from public RField interface

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -193,7 +193,7 @@ public:
          }
       }
 
-      fField->ConnectPageSource(source);
+      ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fField, source);
 
       if (fValuePtr) {
          // When the reader reconnects to a new file, the fValuePtr is already set

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -65,6 +65,7 @@ namespace Internal {
 struct RFieldCallbackInjector;
 void CallCommitClusterOnField(RFieldBase &);
 void CallConnectPageSinkOnField(RFieldBase &, Detail::RPageSink &, NTupleSize_t firstEntry = 0);
+void CallConnectPageSourceOnField(RFieldBase &, Detail::RPageSource &);
 } // namespace Internal
 
 namespace Detail {
@@ -89,6 +90,7 @@ class RFieldBase {
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
    friend void Internal::CallCommitClusterOnField(RFieldBase &);
    friend void Internal::CallConnectPageSinkOnField(RFieldBase &, Detail::RPageSink &, NTupleSize_t);
+   friend void Internal::CallConnectPageSourceOnField(RFieldBase &, Detail::RPageSource &);
    using ReadCallback_t = std::function<void(void *)>;
 
 protected:
@@ -345,6 +347,11 @@ private:
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.
    /// \param firstEntry The global index of the first entry with on-disk data for the connected field
    void ConnectPageSink(Detail::RPageSink &pageSink, NTupleSize_t firstEntry = 0);
+   /// Connects the field and its sub field tree to the given page source. Once connected, data can be read.
+   /// Only unconnected fields may be connected, i.e. the method is not idempotent. The field ID has to be set prior to
+   /// calling this function. For sub fields, a field ID may or may not be set. If the field ID is unset, it will be
+   /// determined using the page source descriptor, based on the parent field ID and the sub field name.
+   void ConnectPageSource(Detail::RPageSource &pageSource);
 
 protected:
    /// Input parameter to ReadBulk() and ReadBulkImpl(). See RBulk class for more information
@@ -639,12 +646,6 @@ public:
    void SetColumnRepresentative(const ColumnRepresentation_t &representative);
    /// Whether or not an explicit column representative was set
    bool HasDefaultColumnRepresentative() const { return fColumnRepresentative == nullptr; }
-
-   /// Connects the field and its sub field tree to the given page source. Once connected, data can be read.
-   /// Only unconnected fields may be connected, i.e. the method is not idempotent. The field ID has to be set prior to
-   /// calling this function. For sub fields, a field ID may or may not be set. If the field ID is unset, it will be
-   /// determined using the page source descriptor, based on the parent field ID and the sub field name.
-   void ConnectPageSource(Detail::RPageSource &pageSource);
 
    /// Indicates an evolution of the mapping scheme from C++ type to columns
    virtual std::uint32_t GetFieldVersion() const { return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -63,6 +63,7 @@ class REntry;
 
 namespace Internal {
 struct RFieldCallbackInjector;
+// TODO(jblomer): find a better way to not have these three methods in the RFieldBase public API
 void CallCommitClusterOnField(RFieldBase &);
 void CallConnectPageSinkOnField(RFieldBase &, Detail::RPageSink &, NTupleSize_t firstEntry = 0);
 void CallConnectPageSourceOnField(RFieldBase &, Detail::RPageSource &);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -53,6 +53,7 @@ class TEnum;
 namespace ROOT {
 
 class TSchemaRule;
+class RFieldBase;
 
 namespace Experimental {
 
@@ -62,6 +63,7 @@ class REntry;
 
 namespace Internal {
 struct RFieldCallbackInjector;
+void CallCommitClusterOnField(RFieldBase &);
 } // namespace Internal
 
 namespace Detail {
@@ -84,6 +86,7 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 class RFieldBase {
    friend class ROOT::Experimental::RCollectionField; // to move the fields from the collection model
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
+   friend void Internal::CallCommitClusterOnField(RFieldBase &);
    using ReadCallback_t = std::function<void(void *)>;
 
 protected:
@@ -333,6 +336,9 @@ private:
    /// The column element index also depends on the number of repetitions of each field in the hierarchy, e.g., given a
    /// field with type `std::array<std::array<float, 4>, 2>`, this function returns 8 for the inner-most field.
    NTupleSize_t EntryToColumnElementIndex(NTupleSize_t globalIndex) const;
+
+   /// Flushes data from active columns to disk and calls CommitClusterImpl
+   void CommitCluster();
 
 protected:
    /// Input parameter to ReadBulk() and ReadBulkImpl(). See RBulk class for more information
@@ -599,9 +605,6 @@ public:
    int GetTraits() const { return fTraits; }
    bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }
 
-   /// Flushes data from active columns to disk and calls CommitClusterImpl
-   void CommitCluster();
-
    std::string GetFieldName() const { return fName; }
    /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
    std::string GetQualifiedFieldName() const;
@@ -660,7 +663,7 @@ public:
    RConstSchemaIterator cend() const { return RConstSchemaIterator(this, -1); }
 
    virtual void AcceptVisitor(Detail::RFieldVisitor &visitor) const;
-};
+}; // class RFieldBase
 
 /// The container field for an ntuple model, which itself has no physical representation.
 /// Therefore, the zero field must not be connected to a page source or sink.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -155,7 +155,7 @@ private:
         fValue(fField.CreateValue())
    {
       fField.SetOnDiskId(fieldId);
-      fField.ConnectPageSource(*pageSource);
+      Internal::CallConnectPageSourceOnField(fField, *pageSource);
       if ((fField.GetTraits() & RFieldBase::kTraitMappable) && fField.HasReadCallbacks())
          throw RException(R__FAIL("view disallowed on field with mappable type and read callback"));
    }
@@ -233,7 +233,7 @@ private:
       : fField(CreateField(fieldId, pageSource->GetSharedDescriptorGuard().GetRef())), fValue(fField->CreateValue())
    {
       fField->SetOnDiskId(fieldId);
-      fField->ConnectPageSource(*pageSource);
+      Internal::CallConnectPageSourceOnField(*fField, *pageSource);
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -51,7 +51,7 @@ public:
 
    void ConnectFields(const std::vector<RFieldBase *> &fields, NTupleSize_t firstEntry)
    {
-      auto connectField = [&](RFieldBase &f) { f.ConnectPageSink(*this, firstEntry); };
+      auto connectField = [&](RFieldBase &f) { CallConnectPageSinkOnField(f, *this, firstEntry); };
       for (auto *f : fields) {
          connectField(*f);
          for (auto &descendant : *f) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -300,6 +300,11 @@ void DestroyRVecWithChecks(std::size_t alignOfT, void **beginPtr, char *begin, s
 
 } // anonymous namespace
 
+void ROOT::Experimental::Internal::CallCommitClusterOnField(RFieldBase &field)
+{
+   field.CommitCluster();
+}
+
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations()

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -304,6 +304,11 @@ void ROOT::Experimental::Internal::CallCommitClusterOnField(RFieldBase &field)
 {
    field.CommitCluster();
 }
+void ROOT::Experimental::Internal::CallConnectPageSinkOnField(RFieldBase &field, Detail::RPageSink &sink,
+                                                              NTupleSize_t firstEntry)
+{
+   field.ConnectPageSink(sink, firstEntry);
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -309,6 +309,10 @@ void ROOT::Experimental::Internal::CallConnectPageSinkOnField(RFieldBase &field,
 {
    field.ConnectPageSink(sink, firstEntry);
 }
+void ROOT::Experimental::Internal::CallConnectPageSourceOnField(RFieldBase &field, Detail::RPageSource &source)
+{
+   field.ConnectPageSource(source);
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -304,7 +304,7 @@ void ROOT::Experimental::RNTupleFillContext::CommitCluster()
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
    for (auto &field : fModel->GetFieldZero()) {
-      field.CommitCluster();
+      Internal::CallCommitClusterOnField(field);
    }
    auto nEntriesInCluster = fNEntries - fLastCommitted;
    fNBytesCommitted += fSink->CommitCluster(nEntriesInCluster);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -79,7 +79,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
       if (field->GetOnDiskId() == kInvalidDescriptorId) {
          field->SetOnDiskId(fSource->GetSharedDescriptorGuard()->FindFieldId(field->GetFieldName(), fieldZeroId));
       }
-      field->ConnectPageSource(*fSource);
+      Internal::CallConnectPageSourceOnField(*field, *fSource);
    }
 }
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -70,7 +70,7 @@ void ROOT::Experimental::Detail::RPageSinkBuf::ConnectFields(const std::vector<R
       // Field Zero would have id 0.
       ++fNFields;
       f.SetOnDiskId(fNFields);
-      f.ConnectPageSink(*this, firstEntry); // issues in turn one or several calls to `AddColumn()`
+      Internal::CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
    };
    for (auto *f : fields) {
       connectField(*f);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -412,7 +412,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::UpdateSchema(const RNTuple
          Internal::RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
       f.SetOnDiskId(fieldId);
-      f.ConnectPageSink(*this, firstEntry); // issues in turn one or several calls to `AddColumn()`
+      Internal::CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
    };
    auto addProjectedField = [&](RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -126,14 +126,14 @@ TEST(RNTuple, InsideCollection)
 
    auto field = std::make_unique<ROOT::Experimental::RVectorField>("klassVec", std::move(fieldInner));
    field->SetOnDiskId(idKlassVec);
-   field->ConnectPageSource(*source);
+   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*field, *source);
 
    auto fieldCardinality64 = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint64_t>").Unwrap();
    fieldCardinality64->SetOnDiskId(idKlassVec);
-   fieldCardinality64->ConnectPageSource(*source);
+   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fieldCardinality64, *source);
    auto fieldCardinality32 = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint32_t>").Unwrap();
    fieldCardinality32->SetOnDiskId(idKlassVec);
-   fieldCardinality32->ConnectPageSource(*source);
+   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fieldCardinality32, *source);
 
    auto value = field->CreateValue();
    value.Read(0);


### PR DESCRIPTION
Includes moving CommitCluster out of the public RFieldBase interface.