### PR TITLE
[meta][cppyy] Export `isAggregate` property to TDictionary

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/capi.h
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/capi.h
@@ -104,6 +104,8 @@ extern "C" {
     int cppyy_is_abstract(cppyy_type_t type);
     RPY_EXPORTED
     int cppyy_is_enum(const char* type_name);
+    RPY_EXPORTED
+    int cppyy_is_aggregate(cppyy_type_t type);
 
     RPY_EXPORTED
     const char** cppyy_get_all_cpp_names(cppyy_scope_t scope, size_t* count);

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -993,6 +993,15 @@ bool Cppyy::IsEnum(const std::string& type_name)
     return gInterpreter->ClassInfo_IsEnum(tn_short.c_str());
 }
 
+bool Cppyy::IsAggregate(TCppType_t klass)
+{
+// Test if this type is an aggregate type
+    TClassRef& cr = type_from_handle(klass);
+    if (cr.GetClass())
+        return cr->ClassProperty() & kClassIsAggregate;
+    return false;
+}
+
 // helpers for stripping scope names
 static
 std::string outer_with_template(const std::string& name)
@@ -2483,6 +2492,10 @@ int cppyy_is_abstract(cppyy_type_t type) {
 
 int cppyy_is_enum(const char* type_name) {
     return (int)Cppyy::IsEnum(type_name);
+}
+
+int cppyy_is_aggregate(cppyy_type_t type) {
+    return (int)Cppyy::IsAggregate(type);
 }
 
 const char** cppyy_get_all_cpp_names(cppyy_scope_t scope, size_t* count) {

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/cpp_cppyy.h
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/cpp_cppyy.h
@@ -114,6 +114,8 @@ namespace Cppyy {
     bool IsAbstract(TCppType_t type);
     RPY_EXPORTED
     bool IsEnum(const std::string& type_name);
+    RPY_EXPORTED
+    bool IsAggregate(TCppType_t type);
 
     RPY_EXPORTED
     void GetAllCppNames(TCppScope_t scope, std::set<std::string>& cppnames);

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -143,7 +143,8 @@ enum EClassProperty {
    kClassHasImplicitDtor = 0x00000200,
    kClassHasDtor         = 0x00000300,
    kClassHasVirtual      = 0x00001000,
-   kClassIsAbstract      = 0x00002000
+   kClassIsAbstract      = 0x00002000,
+   kClassIsAggregate     = 0x00004000
 };
 
 enum ERefTypeValues {

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -194,6 +194,10 @@ long TClingClassInfo::ClassProperty() const
    if (CRD->isPolymorphic()) {
       property |= kClassHasVirtual;
    }
+   if (CRD->isAggregate() || CRD->isPOD()) {
+      // according to the C++ standard, being a POD implies being an aggregate
+      property |= kClassIsAggregate;
+   }
    return property;
 }
 


### PR DESCRIPTION
This the upstream version of a patch to ROOT meta that exposes the `isAggregate()` class property from Cling.

The current `master` branch of CPyCppyy relies on this property.

Originally implemented in this commit by @wlav:
https://github.com/wlav/cppyy-backend/commit/fe1c0f114800ab45b8136fa74ade3a71c137e86f

This PR is part of the larger effort to sync `CPyCppyy`:
https://github.com/root-project/root/pull/14507