### PR TITLE
[ntuple] Refactor sink creation

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -465,6 +465,11 @@ private:
    // Helper function that is called from CommitCluster() when necessary
    void CommitClusterGroup();
 
+   /// Create a writer, potentially wrapping the sink in a RPageSinkBuf.
+   static std::unique_ptr<RNTupleWriter> Create(std::unique_ptr<RNTupleModel> model,
+                                                std::unique_ptr<Detail::RPageSink> sink,
+                                                const RNTupleWriteOptions &options);
+
 public:
    /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Recreate(std::unique_ptr<RNTupleModel> model,

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -212,9 +212,6 @@ public:
    RPageSink& operator=(RPageSink&&) = default;
    ~RPageSink() override;
 
-   /// Guess the concrete derived page source from the file name (location)
-   static std::unique_ptr<RPageSink> Create(std::string_view ntupleName, std::string_view location,
-                                            const RNTupleWriteOptions &options = RNTupleWriteOptions());
    EPageStorageType GetType() final { return EPageStorageType::kSink; }
    /// Returns the sink's write options.
    const RNTupleWriteOptions &GetWriteOptions() const { return *fOptions; }
@@ -349,6 +346,10 @@ public:
    RPagePersistentSink(RPagePersistentSink &&) = default;
    RPagePersistentSink &operator=(RPagePersistentSink &&) = default;
    ~RPagePersistentSink() override;
+
+   /// Guess the concrete derived page source from the location
+   static std::unique_ptr<RPageSink> Create(std::string_view ntupleName, std::string_view location,
+                                            const RNTupleWriteOptions &options = RNTupleWriteOptions());
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -139,7 +139,7 @@ ROOT::Experimental::RNTupleParallelWriter::Recreate(std::unique_ptr<RNTupleModel
       throw RException(R__FAIL("parallel writing requires buffering"));
    }
 
-   auto sink = std::make_unique<Detail::RPageSinkFile>(ntupleName, storage, options);
+   auto sink = Detail::RPagePersistentSink::Create(ntupleName, storage, options);
    // Cannot use std::make_unique because the constructor of RNTupleParallelWriter is private.
    return std::unique_ptr<RNTupleParallelWriter>(new RNTupleParallelWriter(std::move(model), std::move(sink)));
 }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -116,9 +116,7 @@ TEST(RNTupleMerger, MergeSymmetric)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       RNTupleMerger merger;
@@ -207,9 +205,7 @@ TEST(RNTupleMerger, MergeAsymmetric1)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       // We expect this to fail since the fields between the sources do NOT match
@@ -258,9 +254,7 @@ TEST(RNTupleMerger, MergeAsymmetric2)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       // We expect this to fail since the fields between the sources do NOT match
@@ -309,9 +303,7 @@ TEST(RNTupleMerger, MergeAsymmetric3)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       // We expect this to fail since the fields between the sources do NOT match
@@ -369,9 +361,7 @@ TEST(RNTupleMerger, MergeVector)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       RNTupleMerger merger;
@@ -463,9 +453,7 @@ TEST(RNTupleMerger, MergeInconsistentTypes)
       }
 
       // Create the output
-      RNTupleWriteOptions writeOpts;
-      writeOpts.SetUseBufferedWrite(false);
-      auto destination = RPageSink::Create("ntuple", fileGuard3.GetPath(), writeOpts);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
 
       // Now Merge the inputs
       // We expect this to fail since the fields between the sources do NOT match


### PR DESCRIPTION
`RPagePersistentSink::Create` guesses the concrete derived sink without wrapping it in a `RPageSinkBuf`, which is now entirely left in the responsibility of the `RNTupleWriter`.

(as suggested in https://github.com/root-project/root/pull/14519#discussion_r1477061194)