### PR TITLE
[graf2d][TTF] Improve SetTextSize error: show code and values

### DIFF
--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -570,8 +570,10 @@ void TTF::SetTextSize(Float_t textsize)
    }
 
    Int_t tsize = (Int_t)(textsize*kScale+0.5) << 6;
-   if (FT_Set_Char_Size(fgFace[fgCurFontIdx], tsize, tsize, 72, 72))
-      Error("TTF::SetTextSize", "error in FT_Set_Char_Size");
+   FT_Error err = FT_Set_Char_Size(fgFace[fgCurFontIdx], tsize, tsize, 72, 72);
+   if (err)
+      Error("TTF::SetTextSize", "error in FT_Set_Char_Size: 0x%x (input size %f, calc. size 0x%x)", err, textsize,
+            tsize);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Improvements in the error message displayed when the call to `FT_Set_Char_Size` fails in `TTF::SetTextSize`:
- The error code returned by the call to TTF FT_Set_Char_Size function was lost in the if condition, now it is displayed.
- Adding the display of passed parameters to the error message helps distinguish TTF related errors from context related ones.

## Checklist:

- [x] tested changes locally (execution v6.22 and v6.26, compilation v6.22, v6.26 and master
- [ ] updated the docs (not necessary I suspect)

This PR fixes the easy part of #14592
