### PR TITLE
[skip-ci] Introduce condition to skip CI for pull requests

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -8,6 +8,12 @@ on: pull_request
 
 jobs:
   clang-format:
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+
     runs-on: ubuntu-latest
     env:
       TRAVIS_BRANCH: ${{ github.base_ref }} 

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -81,7 +81,11 @@ concurrency:
 
 jobs:
   build-macos:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
 
     permissions:
       contents: read
@@ -208,7 +212,11 @@ jobs:
 
 
   build-windows:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
 
     permissions:
       contents: read
@@ -316,7 +324,11 @@ jobs:
 
 
   build-linux:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
 
     permissions:
       contents: read
@@ -482,7 +494,12 @@ jobs:
           if-no-files-found: error
 
   event_file:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+
     name: "Upload Event Payload"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -13,7 +13,7 @@ jobs:
   comment-test-results:
     name: Publish Test Results
 
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'skipped'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
If the tag `[skip-ci]` is present in the PR title, the CI builds for that PR will not be executed.
