### PR TITLE
[http] implement `file.root` handler

### DIFF
--- a/net/http/inc/TRootSniffer.h
+++ b/net/http/inc/TRootSniffer.h
@@ -167,6 +167,8 @@ protected:
 
    virtual Bool_t ProduceBinary(const std::string &path, const std::string &options, std::string &res);
 
+   virtual Bool_t ProduceRootFile(const std::string &path, const std::string &options, std::string &res);
+
    virtual Bool_t ProduceImage(Int_t kind, const std::string &path, const std::string &options, std::string &res);
 
    virtual Bool_t ProduceExe(const std::string &path, const std::string &options, Int_t reskind, std::string &res);

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -1448,6 +1448,16 @@ Bool_t TRootSniffer::ProduceBinary(const std::string & /*path*/, const std::stri
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Produce ROOT file for specified item
+///
+/// Implemented only in TRootSnifferFull class
+
+Bool_t TRootSniffer::ProduceRootFile(const std::string & /*path*/, const std::string & /*query*/, std::string & /*res*/)
+{
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Method to produce image from specified object
 ///
 /// Parameters:
@@ -1496,6 +1506,7 @@ Bool_t TRootSniffer::CallProduceImage(const std::string &/*kind*/, const std::st
 /// * "root.gif"  - gif image
 /// * "root.xml"  - xml representation
 /// * "root.json" - json representation
+/// * "file.root" - ROOT file with stored object
 /// * "exe.json"  - method execution with json reply
 /// * "exe.bin"   - method execution with binary reply
 /// * "exe.txt"   - method execution with debug output
@@ -1528,6 +1539,9 @@ Bool_t TRootSniffer::Produce(const std::string &path, const std::string &file, c
 
    if (file == "root.json")
       return ProduceJson(path, options, res);
+
+   if (file == "file.root")
+      return ProduceRootFile(path, options, res);
 
    // used for debugging
    if (file == "exe.txt")

--- a/net/httpsniff/inc/TRootSnifferFull.h
+++ b/net/httpsniff/inc/TRootSnifferFull.h
@@ -36,6 +36,8 @@ protected:
 
    Bool_t ProduceBinary(const std::string &path, const std::string &options, std::string &res) override;
 
+   Bool_t ProduceRootFile(const std::string &path, const std::string &options, std::string &res) override;
+
    Bool_t ProduceImage(Int_t kind, const std::string &path, const std::string &options, std::string &res) override;
 
    Bool_t ProduceXml(const std::string &path, const std::string &options, std::string &res) override;


### PR DESCRIPTION
For any registered to http server object
now one can sumbit request like:

http://localhost:8080/hpx/file.root

THttpServer will create file in memory and store
specified object there.
Either object name will be used or "object" when
name cannot be obtained.

This PR implement new feature from #14594 