### PR TITLE
Change if condition for github actions

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -81,7 +81,7 @@ concurrency:
 
 jobs:
   build-macos:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' && github.event_name == 'pull_request'
 
     permissions:
       contents: read
@@ -208,7 +208,7 @@ jobs:
 
 
   build-windows:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' && github.event_name == 'pull_request'
 
     permissions:
       contents: read
@@ -316,7 +316,7 @@ jobs:
 
 
   build-linux:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' && github.event_name == 'pull_request'
 
     permissions:
       contents: read
@@ -482,7 +482,7 @@ jobs:
           if-no-files-found: error
 
   event_file:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' && github.event_name == 'pull_request'
     name: "Upload Event Payload"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -45,7 +45,7 @@ env:
 jobs:
 
   build-linux:
-    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' && github.event_name == 'pull_request'
 
     permissions:
       contents: read


### PR DESCRIPTION
Using `||` means that *any* event type would trigger the CI, as long as it was done against the main ROOT repository.

I open this PR to understand why that condition was there in that way, I am sure there is a reason but it's undocumented

