### PR TITLE
Add CONST properties to optical surfaces (as they are supported by Geant4)

### DIFF
--- a/geom/geom/inc/TGeoMaterial.h
+++ b/geom/geom/inc/TGeoMaterial.h
@@ -80,7 +80,10 @@ public:
    Int_t GetNproperties() const { return fProperties.GetSize(); }
    Int_t GetNconstProperties() const { return fConstProperties.GetSize(); }
    const char *GetPropertyRef(const char *property) const;
-   const char *GetPropertyRef(Int_t i) const { return (fProperties.At(i) ? fProperties.At(i)->GetTitle() : nullptr); }
+   const char *GetPropertyRef(Int_t i) const
+   {
+      return (fProperties.At(i) ? fProperties.At(i)->GetTitle() : nullptr);
+   }
    Double_t GetConstProperty(const char *property, Bool_t *error = nullptr) const;
    Double_t GetConstProperty(Int_t i, Bool_t *error = nullptr) const;
    const char *GetConstPropertyRef(const char *property) const;

--- a/geom/geom/inc/TGeoOpticalSurface.h
+++ b/geom/geom/inc/TGeoOpticalSurface.h
@@ -102,7 +102,8 @@ private:
    Double_t fSigmaAlpha = 0.0; // The sigma of micro-facet polar angle
    Double_t fPolish = 0.0;     // Polish parameter in glisur model
 
-   TList fProperties; // List of surface properties
+   TList fProperties;          // List of surface properties
+   TList fConstProperties;     // user-defined constant properties
 
    // No copy
    TGeoOpticalSurface(const TGeoOpticalSurface &) = delete;
@@ -119,11 +120,25 @@ public:
 
    // Accessors
    bool AddProperty(const char *property, const char *ref);
+   bool AddConstProperty(const char *property, const char *ref);
    const char *GetPropertyRef(const char *property);
+   const char *GetPropertyRef(Int_t i) const
+   {
+      return (fProperties.At(i) ? fProperties.At(i)->GetTitle() : nullptr);
+   }
+   const char *GetConstPropertyRef(const char *property) const;
+   const char *GetConstPropertyRef(Int_t i) const
+   {
+      return (fConstProperties.At(i) ? fConstProperties.At(i)->GetTitle() : nullptr);
+   }
    TList const &GetProperties() const { return fProperties; }
+   TList const &GetConstProperties() const { return fConstProperties; }
    Int_t GetNproperties() const { return fProperties.GetSize(); }
+   Int_t GetNconstProperties() const { return fConstProperties.GetSize(); }
    TGDMLMatrix *GetProperty(const char *name) const;
    TGDMLMatrix *GetProperty(Int_t i) const;
+   Double_t GetConstProperty(const char *property, Bool_t *error = nullptr) const;
+   Double_t GetConstProperty(Int_t i, Bool_t *error = nullptr) const;
    ESurfaceType GetType() const { return fType; }
    ESurfaceModel GetModel() const { return fModel; }
    ESurfaceFinish GetFinish() const { return fFinish; }

--- a/geom/geom/inc/TGeoOpticalSurface.h
+++ b/geom/geom/inc/TGeoOpticalSurface.h
@@ -162,7 +162,7 @@ public:
    static ESurfaceFinish StringToFinish(const char *finish);
    static const char *FinishToString(ESurfaceFinish finish);
 
-   ClassDefOverride(TGeoOpticalSurface, 1) // Class representing an optical surface
+   ClassDefOverride(TGeoOpticalSurface, 2) // Class representing an optical surface
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoOpticalSurface.cxx
+++ b/geom/geom/src/TGeoOpticalSurface.cxx
@@ -269,6 +269,40 @@ TGDMLMatrix *TGeoOpticalSurface::GetProperty(Int_t i) const
 }
 
 //_____________________________________________________________________________
+const char *TGeoOpticalSurface::GetConstPropertyRef(const char *property) const
+{
+   // Find reference for a given constant property
+   TNamed *prop = (TNamed *)fConstProperties.FindObject(property);
+   return (prop) ? prop->GetTitle() : nullptr;
+}
+
+//_____________________________________________________________________________
+Double_t TGeoOpticalSurface::GetConstProperty(const char *property, Bool_t *err) const
+{
+   // Find reference for a given constant property
+   TNamed *prop = (TNamed *)fConstProperties.FindObject(property);
+   if (!prop) {
+      if (err)
+         *err = kTRUE;
+      return 0.;
+   }
+   return gGeoManager->GetProperty(prop->GetTitle(), err);
+}
+
+//_____________________________________________________________________________
+Double_t TGeoOpticalSurface::GetConstProperty(Int_t i, Bool_t *err) const
+{
+   // Find reference for a given constant property
+   TNamed *prop = (TNamed *)fConstProperties.At(i);
+   if (!prop) {
+      if (err)
+         *err = kTRUE;
+      return 0.;
+   }
+   return gGeoManager->GetProperty(prop->GetTitle(), err);
+}
+
+//_____________________________________________________________________________
 bool TGeoOpticalSurface::AddProperty(const char *property, const char *ref)
 {
    fProperties.SetOwner();
@@ -277,6 +311,18 @@ bool TGeoOpticalSurface::AddProperty(const char *property, const char *ref)
       return false;
    }
    fProperties.Add(new TNamed(property, ref));
+   return true;
+}
+
+//_____________________________________________________________________________
+bool TGeoOpticalSurface::AddConstProperty(const char *property, const char *ref)
+{
+   fConstProperties.SetOwner();
+   if (GetConstPropertyRef(property)) {
+      Error("AddConstProperty", "Constant property %s already added to material %s", property, GetName());
+      return false;
+   }
+   fConstProperties.Add(new TNamed(property, ref));
    return true;
 }
 
@@ -292,6 +338,16 @@ void TGeoOpticalSurface::Print(Option_t *) const
       TNamed *property;
       while ((property = (TNamed *)next()))
          printf("   property: %s ref: %s\n", property->GetName(), property->GetTitle());
+   }
+   if (fConstProperties.GetSize()) {
+      TIter next(&fConstProperties);
+      TNamed *property;
+      Bool_t err;
+      while ((property = (TNamed *)next()))   {
+         Double_t value = this->GetConstProperty(property->GetName(), &err);
+         printf("   constant: %s ref: %s value: %g\n",
+                property->GetName(), property->GetTitle(), value);
+      }
    }
 }
 


### PR DESCRIPTION
# This Pull request:
Adds the support to CONST properties (double scalars) to TGeoOpticalSurface instances.
This MR enables the TGeoOpticalSurface to have the same functionality as the G4OpticalSurface from Geant4.
Since the class TGeoOpticalSurface is only enhanced by additional member data/functions,  the backwards 
compatibility is ensured.

## Changes or fixes:


## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

