### PR TITLE
[matrix] Enable Transpose for rectangular matrices

### DIFF
--- a/math/matrix/inc/TMatrixTSparse.h
+++ b/math/matrix/inc/TMatrixTSparse.h
@@ -106,7 +106,8 @@ public:
    TMatrixTBase<Element>   &SetMatrixArray  (const Element *data,Option_t * /*option*/="") override
                                                     { memcpy(fElements,data,this->fNelems*sizeof(Element)); return *this; }
    virtual TMatrixTBase<Element>   &SetMatrixArray  (Int_t nr_nonzeros,Int_t *irow,Int_t *icol,Element *data);
-   virtual TMatrixTBase<Element>   &SetMatrixArray  (Int_t nr_nonzeros, Int_t nrows, Int_t ncols, Int_t *irow,Int_t *icol,Element *data);
+   virtual TMatrixTBase<Element> &
+   SetMatrixArray(Int_t nr_nonzeros, Int_t nrows, Int_t ncols, Int_t *irow, Int_t *icol, Element *data);
    TMatrixTBase<Element>   &InsertRow       (Int_t row,Int_t col,const Element *v,Int_t n=-1) override;
    void                     ExtractRow      (Int_t row,Int_t col,      Element *v,Int_t n=-1) const override;
 

--- a/math/matrix/inc/TMatrixTSparse.h
+++ b/math/matrix/inc/TMatrixTSparse.h
@@ -106,6 +106,7 @@ public:
    TMatrixTBase<Element>   &SetMatrixArray  (const Element *data,Option_t * /*option*/="") override
                                                     { memcpy(fElements,data,this->fNelems*sizeof(Element)); return *this; }
    virtual TMatrixTBase<Element>   &SetMatrixArray  (Int_t nr_nonzeros,Int_t *irow,Int_t *icol,Element *data);
+   virtual TMatrixTBase<Element>   &SetMatrixArray  (Int_t nr_nonzeros, Int_t nrows, Int_t ncols, Int_t *irow,Int_t *icol,Element *data);
    TMatrixTBase<Element>   &InsertRow       (Int_t row,Int_t col,const Element *v,Int_t n=-1) override;
    void                     ExtractRow      (Int_t row,Int_t col,      Element *v,Int_t n=-1) const override;
 

--- a/math/matrix/src/TMatrixTSparse.cxx
+++ b/math/matrix/src/TMatrixTSparse.cxx
@@ -1262,22 +1262,26 @@ TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t *r
    return *this;
 }
 
-template<class Element>
-TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t nrows,Int_t ncols,Int_t *row,Int_t *col,Element *data)
+template <class Element>
+TMatrixTBase<Element> &
+TMatrixTSparse<Element>::SetMatrixArray(Int_t nr, Int_t nrows, Int_t ncols, Int_t *row, Int_t *col, Element *data)
 {
    R__ASSERT(this->IsValid());
    if (nr <= 0) {
-      Error("SetMatrixArray(Int_t,Int_t*,Int_t*,Element*","nr <= 0");
+      Error("SetMatrixArray(Int_t,Int_t*,Int_t*,Element*", "nr <= 0");
       return *this;
    }
 
    if (nrows != this->fNrows) {
-      if (fRowIndex) { delete [] fRowIndex; fRowIndex = nullptr; }
+      if (fRowIndex) {
+         delete[] fRowIndex;
+         fRowIndex = nullptr;
+      }
       this->fNrows = nrows;
       if (this->fNrows > 0) {
-         fRowIndex = new Int_t[nrows+1];
-         this->fNrowIndex = nrows+1;
-      }  else {
+         fRowIndex = new Int_t[nrows + 1];
+         this->fNrowIndex = nrows + 1;
+      } else {
          fRowIndex = nullptr;
          this->fNrowIndex = 0;
       }
@@ -1293,49 +1297,56 @@ TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t nr
       this->fColLwb = tmp;
    }
 
-   const Int_t irowmin = TMath::LocMin(nr,row);
-   const Int_t irowmax = TMath::LocMax(nr,row);
-   const Int_t icolmin = TMath::LocMin(nr,col);
-   const Int_t icolmax = TMath::LocMax(nr,col);
+   const Int_t irowmin = TMath::LocMin(nr, row);
+   const Int_t irowmax = TMath::LocMax(nr, row);
+   const Int_t icolmin = TMath::LocMin(nr, col);
+   const Int_t icolmax = TMath::LocMax(nr, col);
 
-   R__ASSERT(row[irowmin] >= this->fRowLwb && row[irowmax] <= this->fRowLwb+this->fNrows-1);
-   R__ASSERT(col[icolmin] >= this->fColLwb && col[icolmax] <= this->fColLwb+this->fNcols-1);
+   R__ASSERT(row[irowmin] >= this->fRowLwb && row[irowmax] <= this->fRowLwb + this->fNrows - 1);
+   R__ASSERT(col[icolmin] >= this->fColLwb && col[icolmax] <= this->fColLwb + this->fNcols - 1);
 
-   if (row[irowmin] <  this->fRowLwb|| row[irowmax] > this->fRowLwb+this->fNrows-1) {
-      Error("SetMatrixArray","Inconsistency between row index and its range");
+   if (row[irowmin] < this->fRowLwb || row[irowmax] > this->fRowLwb + this->fNrows - 1) {
+      Error("SetMatrixArray", "Inconsistency between row index and its range");
       if (row[irowmin] < this->fRowLwb) {
-         Info("SetMatrixArray","row index lower bound adjusted to %d",row[irowmin]);
+         Info("SetMatrixArray", "row index lower bound adjusted to %d", row[irowmin]);
          this->fRowLwb = row[irowmin];
       }
-      if (row[irowmax] > this->fRowLwb+this->fNrows-1) {
-         Info("SetMatrixArray","row index upper bound adjusted to %d",row[irowmax]);
-         this->fNrows = row[irowmax]-this->fRowLwb+1;
+      if (row[irowmax] > this->fRowLwb + this->fNrows - 1) {
+         Info("SetMatrixArray", "row index upper bound adjusted to %d", row[irowmax]);
+         this->fNrows = row[irowmax] - this->fRowLwb + 1;
       }
    }
-   if (col[icolmin] < this->fColLwb || col[icolmax] > this->fColLwb+this->fNcols-1) {
-      Error("SetMatrixArray","Inconsistency between column index and its range");
+   if (col[icolmin] < this->fColLwb || col[icolmax] > this->fColLwb + this->fNcols - 1) {
+      Error("SetMatrixArray", "Inconsistency between column index and its range");
       if (col[icolmin] < this->fColLwb) {
-         Info("SetMatrixArray","column index lower bound adjusted to %d",col[icolmin]);
+         Info("SetMatrixArray", "column index lower bound adjusted to %d", col[icolmin]);
          this->fColLwb = col[icolmin];
       }
-      if (col[icolmax] > this->fColLwb+this->fNcols-1) {
-         Info("SetMatrixArray","column index upper bound adjusted to %d",col[icolmax]);
-         this->fNcols = col[icolmax]-this->fColLwb+1;
+      if (col[icolmax] > this->fColLwb + this->fNcols - 1) {
+         Info("SetMatrixArray", "column index upper bound adjusted to %d", col[icolmax]);
+         this->fNcols = col[icolmax] - this->fColLwb + 1;
       }
    }
 
-   TMatrixTBase<Element>::DoubleLexSort(nr,row,col,data);
+   TMatrixTBase<Element>::DoubleLexSort(nr, row, col, data);
 
    Int_t nr_nonzeros = 0;
-   const Element *ep        = data;
-   const Element * const fp = data+nr;
+   const Element *ep = data;
+   const Element *const fp = data + nr;
 
    while (ep < fp)
-      if (*ep++ != 0.0) nr_nonzeros++;
+      if (*ep++ != 0.0)
+         nr_nonzeros++;
 
    if (nr_nonzeros != this->fNelems) {
-      if (fColIndex) { delete [] fColIndex; fColIndex = nullptr; }
-      if (fElements) { delete [] fElements; fElements = nullptr; }
+      if (fColIndex) {
+         delete[] fColIndex;
+         fColIndex = nullptr;
+      }
+      if (fElements) {
+         delete[] fElements;
+         fElements = nullptr;
+      }
       this->fNelems = nr_nonzeros;
       if (this->fNelems > 0) {
          fColIndex = new Int_t[nr_nonzeros];
@@ -1346,23 +1357,22 @@ TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t nr
       }
    }
 
-
    if (this->fNelems <= 0)
       return *this;
 
    fRowIndex[0] = 0;
    Int_t ielem = 0;
    nr_nonzeros = 0;
-   for (Int_t irow = 1; irow < this->fNrows+1; irow++) {
+   for (Int_t irow = 1; irow < this->fNrows + 1; irow++) {
       if (ielem < nr && row[ielem] - this->fRowLwb < irow) {
          while (ielem < nr) {
             if (data[ielem] != 0.0) {
-               fColIndex[nr_nonzeros] = col[ielem]-this->fColLwb;
+               fColIndex[nr_nonzeros] = col[ielem] - this->fColLwb;
                fElements[nr_nonzeros] = data[ielem];
                nr_nonzeros++;
             }
             ielem++;
-            if (ielem >= nr || row[ielem] != row[ielem-1])
+            if (ielem >= nr || row[ielem] != row[ielem - 1])
                break;
          }
       }
@@ -2136,7 +2146,7 @@ TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse
    R__ASSERT(nr_nonzeros >= ielem);
 
    TMatrixTBase<Element>::DoubleLexSort(nr_nonzeros,rownr,colnr,pData_t);
-   SetMatrixArray(nr_nonzeros,source.GetNcols(),source.GetNrows(),rownr,colnr,pData_t);
+   SetMatrixArray(nr_nonzeros, source.GetNcols(), source.GetNrows(), rownr, colnr, pData_t);
 
    R__ASSERT(this->fNelems == fRowIndex[this->fNrowIndex-1]);
 

--- a/math/matrix/src/TMatrixTSparse.cxx
+++ b/math/matrix/src/TMatrixTSparse.cxx
@@ -2145,8 +2145,11 @@ TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse
 
    R__ASSERT(nr_nonzeros >= ielem);
 
-   TMatrixTBase<Element>::DoubleLexSort(nr_nonzeros,rownr,colnr,pData_t);
-   SetMatrixArray(nr_nonzeros, source.GetNcols(), source.GetNrows(), rownr, colnr, pData_t);
+   if (source.GetNcols() != source.GetNrows()) {
+      SetMatrixArray(nr_nonzeros, source.GetNcols(), source.GetNrows(), rownr, colnr, pData_t);
+   } else {
+      SetMatrixArray(nr_nonzeros, rownr, colnr, pData_t);
+   }
 
    R__ASSERT(this->fNelems == fRowIndex[this->fNrowIndex-1]);
 

--- a/math/matrix/src/TMatrixTSparse.cxx
+++ b/math/matrix/src/TMatrixTSparse.cxx
@@ -1255,6 +1255,116 @@ TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t *r
    return *this;
 }
 
+template<class Element>
+TMatrixTBase<Element> &TMatrixTSparse<Element>::SetMatrixArray(Int_t nr,Int_t nrows,Int_t ncols,Int_t *row,Int_t *col,Element *data)
+{
+   R__ASSERT(this->IsValid());
+   if (nr <= 0) {
+      Error("SetMatrixArray(Int_t,Int_t*,Int_t*,Element*","nr <= 0");
+      return *this;
+   }
+
+   if (nrows != this->fNrows) {
+      if (fRowIndex) { delete [] fRowIndex; fRowIndex = nullptr; }
+      this->fNrows = nrows;
+      if (this->fNrows > 0) {
+         fRowIndex = new Int_t[nrows+1];
+         this->fNrowIndex = nrows+1;
+      }  else {
+         fRowIndex = nullptr;
+         this->fNrowIndex = 0;
+      }
+   }
+
+   if (ncols != this->fNcols) {
+      this->fNcols = ncols;
+   }
+
+   if (this->fRowLwb != this->fColLwb) {
+      auto tmp = this->fRowLwb;
+      this->fRowLwb = this->fColLwb;
+      this->fColLwb = tmp;
+   }
+
+   const Int_t irowmin = TMath::LocMin(nr,row);
+   const Int_t irowmax = TMath::LocMax(nr,row);
+   const Int_t icolmin = TMath::LocMin(nr,col);
+   const Int_t icolmax = TMath::LocMax(nr,col);
+
+   R__ASSERT(row[irowmin] >= this->fRowLwb && row[irowmax] <= this->fRowLwb+this->fNrows-1);
+   R__ASSERT(col[icolmin] >= this->fColLwb && col[icolmax] <= this->fColLwb+this->fNcols-1);
+
+   if (row[irowmin] <  this->fRowLwb|| row[irowmax] > this->fRowLwb+this->fNrows-1) {
+      Error("SetMatrixArray","Inconsistency between row index and its range");
+      if (row[irowmin] < this->fRowLwb) {
+         Info("SetMatrixArray","row index lower bound adjusted to %d",row[irowmin]);
+         this->fRowLwb = row[irowmin];
+      }
+      if (row[irowmax] > this->fRowLwb+this->fNrows-1) {
+         Info("SetMatrixArray","row index upper bound adjusted to %d",row[irowmax]);
+         this->fNrows = row[irowmax]-this->fRowLwb+1;
+      }
+   }
+   if (col[icolmin] < this->fColLwb || col[icolmax] > this->fColLwb+this->fNcols-1) {
+      Error("SetMatrixArray","Inconsistency between column index and its range");
+      if (col[icolmin] < this->fColLwb) {
+         Info("SetMatrixArray","column index lower bound adjusted to %d",col[icolmin]);
+         this->fColLwb = col[icolmin];
+      }
+      if (col[icolmax] > this->fColLwb+this->fNcols-1) {
+         Info("SetMatrixArray","column index upper bound adjusted to %d",col[icolmax]);
+         this->fNcols = col[icolmax]-this->fColLwb+1;
+      }
+   }
+
+   TMatrixTBase<Element>::DoubleLexSort(nr,row,col,data);
+
+   Int_t nr_nonzeros = 0;
+   const Element *ep        = data;
+   const Element * const fp = data+nr;
+
+   while (ep < fp)
+      if (*ep++ != 0.0) nr_nonzeros++;
+
+   if (nr_nonzeros != this->fNelems) {
+      if (fColIndex) { delete [] fColIndex; fColIndex = nullptr; }
+      if (fElements) { delete [] fElements; fElements = nullptr; }
+      this->fNelems = nr_nonzeros;
+      if (this->fNelems > 0) {
+         fColIndex = new Int_t[nr_nonzeros];
+         fElements = new Element[nr_nonzeros];
+      } else {
+         fColIndex = nullptr;
+         fElements = nullptr;
+      }
+   }
+
+
+   if (this->fNelems <= 0)
+      return *this;
+
+   fRowIndex[0] = 0;
+   Int_t ielem = 0;
+   nr_nonzeros = 0;
+   for (Int_t irow = 1; irow < this->fNrows+1; irow++) {
+      if (ielem < nr && row[ielem] - this->fRowLwb < irow) {
+         while (ielem < nr) {
+            if (data[ielem] != 0.0) {
+               fColIndex[nr_nonzeros] = col[ielem]-this->fColLwb;
+               fElements[nr_nonzeros] = data[ielem];
+               nr_nonzeros++;
+            }
+            ielem++;
+            if (ielem >= nr || row[ielem] != row[ielem-1])
+               break;
+         }
+      }
+      fRowIndex[irow] = nr_nonzeros;
+   }
+
+   return *this;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Increase/decrease the number of non-zero elements to nelems_new
 
@@ -1990,11 +2100,11 @@ TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse
       R__ASSERT(this->IsValid());
       R__ASSERT(source.IsValid());
 
-      if (this->fNrows  != source.GetNcols()  || this->fNcols  != source.GetNrows() ||
-          this->fRowLwb != source.GetColLwb() || this->fColLwb != source.GetRowLwb()) {
-         Error("Transpose","matrix has wrong shape");
-         return *this;
-      }
+      // if (this->fNrows  != source.GetNcols()  || this->fNcols  != source.GetNrows() ||
+      //     this->fRowLwb != source.GetColLwb() || this->fColLwb != source.GetRowLwb()) {
+      //    Error("Transpose","matrix has wrong shape");
+      //    return *this;
+      // }
 
       if (source.NonZeros() <= 0)
          return *this;
@@ -2025,7 +2135,7 @@ TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse
    R__ASSERT(nr_nonzeros >= ielem);
 
    TMatrixTBase<Element>::DoubleLexSort(nr_nonzeros,rownr,colnr,pData_t);
-   SetMatrixArray(nr_nonzeros,rownr,colnr,pData_t);
+   SetMatrixArray(nr_nonzeros,source.GetNcols(),source.GetNrows(),rownr,colnr,pData_t);
 
    R__ASSERT(this->fNelems == fRowIndex[this->fNrowIndex-1]);
 

--- a/math/matrix/src/TMatrixTSparse.cxx
+++ b/math/matrix/src/TMatrixTSparse.cxx
@@ -65,7 +65,14 @@
     nr entries . Only the entries with non-zero data[i] value are
     inserted. Be aware that the input data array will be modified
     inside the routine for doing the necessary sorting of indices !
- 4. TMatrixTSparse a(n,m); for(....) { a(i,j) = ....
+ 4. SetMatrixArray(Int_t nr,Int_t nrows,Int_t ncols,Int_t *irow,
+    Int_t *icol,Element *data) where it is expected that the irow,
+    icol and data array contain nr entries . It allows to reshape
+    the matrix according to nrows and ncols. Only the entries with
+    non-zero data[i] value are inserted. Be aware that the input
+    data array will be modified inside the routine for doing the
+    necessary sorting of indices !
+ 5. TMatrixTSparse a(n,m); for(....) { a(i,j) = ....
     This is a very flexible method but expensive :
     - if no entry for slot (i,j) is found in the sparse index table
       it will be entered, which involves some memory management !
@@ -2091,7 +2098,7 @@ TMatrixTBase<Element> &TMatrixTSparse<Element>::SetSub(Int_t row_lwb,Int_t col_l
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Transpose a matrix.
+/// Transpose a matrix. Set the matrix to ncols x nrows if nrows != ncols.
 
 template<class Element>
 TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse<Element> &source)
@@ -2099,12 +2106,6 @@ TMatrixTSparse<Element> &TMatrixTSparse<Element>::Transpose(const TMatrixTSparse
    if (gMatrixCheck) {
       R__ASSERT(this->IsValid());
       R__ASSERT(source.IsValid());
-
-      // if (this->fNrows  != source.GetNcols()  || this->fNcols  != source.GetNrows() ||
-      //     this->fRowLwb != source.GetColLwb() || this->fColLwb != source.GetRowLwb()) {
-      //    Error("Transpose","matrix has wrong shape");
-      //    return *this;
-      // }
 
       if (source.NonZeros() <= 0)
          return *this;

--- a/math/matrix/test/testMatrixTSparse.cxx
+++ b/math/matrix/test/testMatrixTSparse.cxx
@@ -46,3 +46,18 @@ TEST(testSparse, LwbInit)
 
   EXPECT_EQ(m1, m2);
 }
+
+TEST(testSparse, Transpose)
+{
+   Int_t nr = 4;
+   Int_t row[] = {0, 0, 1, 2};
+   Int_t col[] = {1, 0, 1, 0};
+   Double_t data[] = {1, 2, 3, 4};
+
+   TMatrixDSparse m1(0, 2, 0, 1, nr, row, col, data);
+   TMatrixDSparse m2(0, 1, 0, 2, nr, col, row, data);
+
+   m1.T();
+
+   EXPECT_EQ(m1, m2);
+}


### PR DESCRIPTION
# This Pull request:

Enables Transpose to work with rectangular matrices. SetMatrixArray has been modified to reshape the matrix, if needed. A Google Test has been added to test this functionality.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes [ROOT-9261](https://its.cern.ch/jira/browse/ROOT-9261)

