### PR TITLE
Fixed tutorial. Added explicit dependency of shared library on ROOT dictionary

### DIFF
--- a/tutorials/tree/dictionary/CMakeLists.txt
+++ b/tutorials/tree/dictionary/CMakeLists.txt
@@ -37,6 +37,7 @@ ROOT_GENERATE_DICTIONARY(G__data2Tree data2Tree.hxx LINKDEF data2TreeLinkDef.hxx
 #   * the class implementation
 add_library(data2TreeLib SHARED data2Tree.cxx G__data2Tree.cxx)
 target_link_libraries(data2TreeLib ${ROOT_LIBRARIES}  ) 
+add_dependencies(data2TreeLib G__data2Tree  )
 
 #--- This is needed on Windows in order to export the symbols and create the data2TreeLib.lib file
 if(MSVC)


### PR DESCRIPTION
# This Pull request: 
tutorial/tree/dictionary C++ stand-alone application can not be compiled when the cmake project is generated for xcode. The solution is to explicitly tell cmake that the shared library depends on the ROOT dictionary

## Changes or fixes: 
New line in the CMakeLists specifying the dependency 

## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (not needed)

This PR fixes https://github.com/root-project/root/issues/14595

