### PR TITLE
[cling] Explicitly disable `RelLookupTableConvertedPass`

### DIFF
--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -378,12 +378,18 @@ void BackendPasses::CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
           P.equals("ModuleInlinerPass") || P.equals("InlinerPass") ||
           P.equals("InlineAdvisorAnalysis") ||
           P.equals("PartiallyInlineLibCallsPass") ||
+          P.equals("RelLookupTableConverterPass") ||
           P.equals("InlineCostAnnotationPrinterPass") ||
           P.equals("InlineSizeEstimatorAnalysisPrinterPass") ||
           P.equals("InlineSizeEstimatorAnalysis"))
         return false;
 
       return true;
+    });
+  } else {
+    // Register a callback for disabling RelLookupTableConverterPass.
+    PIC.registerShouldRunOptionalPassCallback([](StringRef P, Any) {
+      return !P.equals("RelLookupTableConverterPass");
     });
   }
 


### PR DESCRIPTION
Before the passmanager update, the function `populateModulePassManager` was called instead of `buildPerModuleDefaultPipeline` to set the default passes. But the former did not have `RelLookupTableConverterPass` turned on by default.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14598

