### PR TITLE
[core/zip+lzma] Properly account for header size [v6.28]

### DIFF
--- a/core/lzma/src/ZipLZMA.c
+++ b/core/lzma/src/ZipLZMA.c
@@ -68,7 +68,7 @@ void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
    stream.avail_in  = (size_t)(*srcsize);
 
    stream.next_out  = (uint8_t *)(&tgt[kHeaderSize]);
-   stream.avail_out = (size_t)(*tgtsize);
+   stream.avail_out = (size_t)(*tgtsize) - kHeaderSize;
 
    returnStatus = lzma_code(&stream, LZMA_FINISH);
    if (returnStatus != LZMA_STREAM_END) {
@@ -117,7 +117,7 @@ void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char 
    }
 
    stream.next_in   = (const uint8_t *)(&src[kHeaderSize]);
-   stream.avail_in  = (size_t)(*srcsize);
+   stream.avail_in  = (size_t)(*srcsize) - kHeaderSize;
    stream.next_out  = (uint8_t *)tgt;
    stream.avail_out = (size_t)(*tgtsize);
 

--- a/core/zip/CMakeLists.txt
+++ b/core/zip/CMakeLists.txt
@@ -28,3 +28,5 @@ target_include_directories(Zip PRIVATE
 )
 
 ROOT_INSTALL_HEADERS()
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -197,7 +197,7 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
     stream.avail_in  = (uInt)(*srcsize);
 
     stream.next_out  = (Bytef*)(&tgt[HDRSIZE]);
-    stream.avail_out = (uInt)(*tgtsize);
+    stream.avail_out = (uInt)(*tgtsize) - HDRSIZE;
 
     stream.zalloc    = (alloc_func)0;
     stream.zfree     = (free_func)0;

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -78,14 +78,18 @@ unsigned long R__crc32(unsigned long crc, const unsigned char* buf, unsigned int
 /*                      3 = old */
 void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm)
 {
+  *irep = 0;
 
+  // Performance optimization: avoid compressing tiny source buffers.
   if (*srcsize < 1 + HDRSIZE + 1) {
-     *irep = 0;
+     return;
+  }
+  // Correctness check: we need at least enough bytes to prepend the header!
+  if (*tgtsize <= HDRSIZE) {
      return;
   }
 
   if (cxlevel <= 0) {
-    *irep = 0;
     return;
   }
 

--- a/core/zip/test/CMakeLists.txt
+++ b/core/zip/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+ROOT_ADD_GTEST(ZipTest ZipTest.cxx LIBRARIES Core)

--- a/core/zip/test/ZipTest.cxx
+++ b/core/zip/test/ZipTest.cxx
@@ -1,0 +1,70 @@
+#include <Compression.h>
+#include <RZip.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+static void testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm)
+{
+   static constexpr size_t BufferSize = 256;
+   static constexpr size_t MaxBytes = 128;
+   static_assert(MaxBytes <= BufferSize, "MaxBytes must be smaller than BufferSize");
+   static constexpr size_t StartOffset = (BufferSize - MaxBytes) / 2;
+   // For extra "safety", allocate the buffers on the heap to avoid corrupting the stack should anything go wrong.
+   std::unique_ptr<char[]> source(new char[BufferSize]);
+   std::unique_ptr<char[]> target(new char[BufferSize]);
+
+   // Fill the buffers with monotonically increasing numbers. This is easy to compress, but that's fine because we scan
+   // through all possible sizes.
+   for (size_t i = 0; i < BufferSize; i++) {
+      source[i] = static_cast<char>(i);
+      target[i] = static_cast<char>(i);
+   }
+
+   // Now test all possible combinations of target and source sizes. The outer loop is for the target sizes because that
+   // allows us to check that nothing got overwritten.
+   for (size_t targetSize = 1; targetSize <= MaxBytes; targetSize++) {
+      for (size_t sourceSize = 1; sourceSize <= MaxBytes; sourceSize++) {
+         for (int cxlevel = 1; cxlevel <= 9; cxlevel++) {
+            int srcsize = static_cast<int>(sourceSize);
+            int tgtsize = static_cast<int>(targetSize);
+            int irep = -1;
+            R__zipMultipleAlgorithm(cxlevel, &srcsize, source.get(), &tgtsize, target.get() + StartOffset, &irep,
+                                    compressionAlgorithm);
+
+            for (size_t i = 0; i < StartOffset; i++) {
+               EXPECT_EQ(target[i], static_cast<char>(i));
+            }
+            for (size_t i = StartOffset + targetSize + 1; i < BufferSize; i++) {
+               EXPECT_EQ(target[i], static_cast<char>(i));
+            }
+         }
+      }
+   }
+}
+
+TEST(RZip, ZipBufferSizesOld)
+{
+   testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::kOldCompressionAlgo);
+}
+
+TEST(RZip, ZipBufferSizesZLIB)
+{
+   testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
+}
+
+TEST(RZip, ZipBufferSizesLZMA)
+{
+   testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
+}
+
+TEST(RZip, ZipBufferSizesLZ4)
+{
+   testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
+}
+
+TEST(RZip, ZipBufferSizesZSTD)
+{
+   testZipBufferSizes(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
+}


### PR DESCRIPTION
The compression algorithms only see the buffers without the header, so the sizes have to be adjusted accordingly.

Fixes https://github.com/root-project/root/issues/14508, backport of https://github.com/root-project/root/pull/14523