### PR TITLE
Enable RNTupleModel usage in PyROOT

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -211,10 +211,11 @@ public:
    ~RNTupleModel() = default;
 
    std::unique_ptr<RNTupleModel> Clone() const;
-   static std::unique_ptr<RNTupleModel> Create(std::unique_ptr<RFieldZero> fieldZero = std::make_unique<RFieldZero>());
+   static std::unique_ptr<RNTupleModel> Create();
+   static std::unique_ptr<RNTupleModel> Create(std::unique_ptr<RFieldZero> fieldZero);
    /// A bare model has no default entry
-   static std::unique_ptr<RNTupleModel>
-   CreateBare(std::unique_ptr<RFieldZero> fieldZero = std::make_unique<RFieldZero>());
+   static std::unique_ptr<RNTupleModel> CreateBare();
+   static std::unique_ptr<RNTupleModel> CreateBare(std::unique_ptr<RFieldZero> fieldZero);
 
    /// Creates a new field given a `name` or `{name, description}` pair and a
    /// corresponding value that is managed by a shared pointer.

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -193,12 +193,22 @@ void ROOT::Experimental::RNTupleModel::EnsureNotBare() const
 ROOT::Experimental::RNTupleModel::RNTupleModel(std::unique_ptr<RFieldZero> fieldZero) : fFieldZero(std::move(fieldZero))
 {}
 
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::CreateBare()
+{
+   return CreateBare(std::make_unique<RFieldZero>());
+}
+
 std::unique_ptr<ROOT::Experimental::RNTupleModel>
 ROOT::Experimental::RNTupleModel::CreateBare(std::unique_ptr<RFieldZero> fieldZero)
 {
    auto model = std::unique_ptr<RNTupleModel>(new RNTupleModel(std::move(fieldZero)));
    model->fProjectedFields = std::make_unique<RProjectedFields>(model.get());
    return model;
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::Create()
+{
+   return Create(std::make_unique<RFieldZero>());
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel>

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -78,3 +78,9 @@ if(daos OR daos_mock)
             APPEND PROPERTY COMPILE_DEFINITIONS R__DAOS_TEST_MOCK=1)
   endif()
 endif()
+
+
+# RNTuple Python interface tests
+if(pyroot)
+  ROOT_ADD_PYUNITTEST(ntuple_py_model ntuple_model.py)
+endif()

--- a/tree/ntuple/v7/test/ntuple_model.py
+++ b/tree/ntuple/v7/test/ntuple_model.py
@@ -1,0 +1,26 @@
+import unittest
+
+import ROOT
+
+RNTupleModel = ROOT.Experimental.RNTupleModel
+RFieldZero = ROOT.Experimental.RFieldZero
+
+
+class NTupleModel(unittest.TestCase):
+    """Various tests for the RNTupleModel class"""
+
+    def test_create_model(self):
+        """A model can be created."""
+
+        model = RNTupleModel.Create()
+        self.assertTrue(model)
+
+    def test_create_bare_model(self):
+        """A bare model can be created."""
+
+        model = RNTupleModel.CreateBare()
+        self.assertTrue(model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By creating an overload with no arguments instead of having one with a default argument. The overload taking a `std::unique_ptr` cannot work with current PyROOT. See #14425
