### PR TITLE
[ntuple] Fix writing of RCollectionFields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1571,6 +1571,9 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    void CreateValue(void *) const final {}
 
+   std::size_t AppendImpl(const void *from) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
+
    void CommitClusterImpl() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -41,6 +41,7 @@ class TFile;
 namespace ROOT {
 namespace Experimental {
 
+class RCollectionField;
 class REntry;
 class RNTuple;
 class RNTupleModel;
@@ -550,7 +551,10 @@ public:
 */
 // clang-format on
 class RCollectionNTupleWriter {
+   friend class RCollectionField;
+
 private:
+   std::size_t fBytesWritten = 0;
    ClusterSize_t fOffset;
    std::unique_ptr<REntry> fDefaultEntry;
 public:
@@ -559,10 +563,13 @@ public:
    RCollectionNTupleWriter& operator=(const RCollectionNTupleWriter&) = delete;
    ~RCollectionNTupleWriter() = default;
 
-   void Fill() { Fill(*fDefaultEntry); }
-   void Fill(REntry &entry) {
-      entry.Append();
+   std::size_t Fill() { return Fill(*fDefaultEntry); }
+   std::size_t Fill(REntry &entry)
+   {
+      const std::size_t bytesWritten = entry.Append();
+      fBytesWritten += bytesWritten;
       fOffset++;
+      return bytesWritten;
    }
 
    ClusterSize_t *GetOffsetPtr() { return &fOffset; }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -559,9 +559,9 @@ public:
    RCollectionNTupleWriter& operator=(const RCollectionNTupleWriter&) = delete;
    ~RCollectionNTupleWriter() = default;
 
-   void Fill() { Fill(fDefaultEntry.get()); }
-   void Fill(REntry *entry) {
-      entry->Append();
+   void Fill() { Fill(*fDefaultEntry); }
+   void Fill(REntry &entry) {
+      entry.Append();
       fOffset++;
    }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -672,6 +672,47 @@ TEST(RNTuple, FillBytesWritten)
    checkFillReturnValue(optsSmall);
 }
 
+TEST(RNTuple, FillBytesWrittenCollections)
+{
+   FileRaii fileGuard("test_ntuple_fillbytes_collections.root");
+
+   auto eventModel = RNTupleModel::Create();
+   auto fldPt = eventModel->MakeField<float>("pt", 0.0);
+
+   auto hitModel = RNTupleModel::Create();
+   auto fldHitX = hitModel->MakeField<float>("x", 0.0);
+   auto fldHitY = hitModel->MakeField<float>("y", 0.0);
+
+   auto trackModel = RNTupleModel::Create();
+   auto fldTrackEnergy = trackModel->MakeField<float>("energy", 0.0);
+
+   auto fldHits = trackModel->MakeCollection("hits", std::move(hitModel));
+   auto fldTracks = eventModel->MakeCollection("tracks", std::move(trackModel));
+
+   {
+      RNTupleWriteOptions options;
+      options.SetApproxZippedClusterSize(1024 * 1024);
+      auto writer = RNTupleWriter::Recreate(std::move(eventModel), "myNTuple", fileGuard.GetPath(), options);
+
+      for (unsigned i = 0; i < 30000; ++i) {
+         for (unsigned t = 0; t < 3; ++t) {
+            for (unsigned h = 0; h < 2; ++h) {
+               *fldHitX = 4.0;
+               *fldHitY = 8.0;
+               EXPECT_EQ(4 + 4, fldHits->Fill());
+            }
+            *fldTrackEnergy = i * t;
+            EXPECT_EQ(2 * (4 + 4) + 8 + 4, fldTracks->Fill());
+         }
+         *fldPt = float(i);
+         EXPECT_EQ(3 * (2 * (4 + 4) + 8 + 4) + 8 + 4, writer->Fill());
+      }
+   }
+
+   auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(reader->GetDescriptor().GetNClusters(), 2);
+}
+
 TEST(RNTuple, RValue)
 {
    auto f1 = RFieldBase::Create("f1", "CustomStruct").Unwrap();

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -409,7 +409,7 @@ void ROOT::Experimental::RNTupleImporter::Import()
                if (!result)
                   throw RException(R__FORWARD_ERROR(result));
             }
-            c.fCollectionWriter->Fill(c.fCollectionEntry.get());
+            c.fCollectionWriter->Fill(*c.fCollectionEntry);
          }
          for (auto &t : c.fTransformations)
             t->ResetEntry();


### PR DESCRIPTION
Their `AppendImpl` must return all bytes written by its sub fields.