### PR TITLE
[cling] Add deprecation warning for declarations without `auto`

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -33,6 +33,7 @@
 #include "clang/Sema/Scope.h"
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/GlobalModuleIndex.h"
+#include "clang/Basic/DiagnosticSema.h"
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 
@@ -1004,6 +1005,11 @@ bool TClingCallbacks::tryInjectImplicitAutoKeyword(LookupResult &R, Scope *S) {
    Result->addAttr(AnnotateAttr::CreateImplicit(C, "__Auto"));
 
    R.addDecl(Result);
+
+   // Raise a warning when trying to use implicit auto injection feature.
+   SemaRef.Diag(Loc, diag::warn_deprecated_message)
+      << "declaration without the 'auto' keyword" << DC << Loc << FixItHint::CreateInsertion(Loc, "auto ");
+
    // Say that we can handle the situation. Clang should try to recover
    return true;
 }

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -1007,6 +1007,7 @@ bool TClingCallbacks::tryInjectImplicitAutoKeyword(LookupResult &R, Scope *S) {
    R.addDecl(Result);
 
    // Raise a warning when trying to use implicit auto injection feature.
+   SemaRef.getDiagnostics().setSeverity(diag::warn_deprecated_message, diag::Severity::Warning, SourceLocation());
    SemaRef.Diag(Loc, diag::warn_deprecated_message)
       << "declaration without the 'auto' keyword" << DC << Loc << FixItHint::CreateInsertion(Loc, "auto ");
 

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -239,6 +239,19 @@ TEST_F(TClingTests, GetSharedLibDeps)
 }
 #endif
 
+// Check that a warning message is generated when using auto-injection.
+TEST_F(TClingTests, WarningAutoInjection)
+{
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kWarning, "cling", "declaration without the 'auto' keyword is deprecated",
+                      /*matchFullMessage=*/false);
+
+   gInterpreter->ProcessLine("/* no auto */ t = new int;");
+
+   auto t = gInterpreter->GetDataMember(nullptr, "t");
+   EXPECT_TRUE(t != nullptr);
+}
+
 // Check the interface which interacts with the cling::LookupHelper.
 TEST_F(TClingTests, ClingLookupHelper) {
   // Exception spec evaluation.


### PR DESCRIPTION
Declarations without the auto keyword are not part of standard C++. Even though it is a nice feature to have, it requires a patch on top of clang and is one of the hurdles preventing us from using the upstream clang.

Implicit auto injection is currently only supported at the prompt (and only in the top-most function-level scope). So it should ideally not break other features.

There are a few GitHub and JIRA issues related to this feature that can also be closed if we completely remove it.

For the warning messages, I'm reusing one of the existing clang warning message (to not introduce more patches on top of the clang with custom error messages).

EDIT:
Glancing through JIRA issues, these are the issues that can be closed (list might not be exhaustive):

https://its.cern.ch/jira/browse/ROOT-10309
https://its.cern.ch/jira/browse/ROOT-10593
https://its.cern.ch/jira/browse/ROOT-10284
https://its.cern.ch/jira/browse/ROOT-8828
https://its.cern.ch/jira/browse/ROOT-8538
https://its.cern.ch/jira/browse/ROOT-7970


# This Pull request:
Requires https://github.com/root-project/roottest/pull/1056 to be merged for tests to pass

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

