### PR TITLE
[ci] Disable LLVM assertions on mac X86 builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -101,7 +101,6 @@ jobs:
         include:
           - platform: mac12
             arch: X64
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - platform: mac13   
             arch: ARM64
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]


### PR DESCRIPTION
On apple M2 chips, LLVM assertion slow down the execution of the test suite (>2k tests) by some 20%. This PR aims to check whether this is the case on the Core i7 mac, too.
