### PR TITLE
[clad] Bump clad version to v1.3.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -74,7 +74,7 @@ list(APPEND _clad_cmake_logging_settings LOG_OUTPUT_ON_FAILURE ON)
 ExternalProject_Add(
   clad
   GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG v1.2
+  GIT_TAG v1.3
   UPDATE_COMMAND ""
   PATCH_COMMAND ${_clad_patch_command}
   CMAKE_ARGS -G ${CMAKE_GENERATOR}

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -774,6 +774,7 @@ INSTANTIATE_TEST_SUITE_P(HistFactory, HFFixtureFit,
                                           testing::Values(ROOFIT_EVAL_BACKENDS)),
                          getNameFromInfo);
 
+#ifndef R__WIN32 // See https://github.com/vgvassilev/clad/issues/752
 #ifdef TEST_CODEGEN_AD
 // TODO: merge with the previous HFFixtureFix test suite once the codegen AD
 // supports all of HistFactory
@@ -783,4 +784,5 @@ INSTANTIATE_TEST_SUITE_P(HistFactoryCodeGen, HFFixtureFit,
                                           testing::Values(false), // no non-uniform bins
                                           testing::Values(RooFit::EvalBackend::Codegen())),
                          getNameFromInfo);
-#endif
+#endif // TEST_CODEGEN_AD
+#endif // R__WIN32

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -774,7 +774,7 @@ INSTANTIATE_TEST_SUITE_P(HistFactory, HFFixtureFit,
                                           testing::Values(ROOFIT_EVAL_BACKENDS)),
                          getNameFromInfo);
 
-#ifndef R__WIN32 // See https://github.com/vgvassilev/clad/issues/752
+#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS) // See https://github.com/vgvassilev/clad/issues/752
 #ifdef TEST_CODEGEN_AD
 // TODO: merge with the previous HFFixtureFix test suite once the codegen AD
 // supports all of HistFactory

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -46,10 +46,9 @@ if(NOT MSVC OR win_broken_tests)
   # unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
   # According to the internet, this has to do with gtest, so it's not a RooFit problem
   ROOT_ADD_GTEST(testRooRealIntegral testRooRealIntegral.cxx LIBRARIES RooFitCore)
-  if(clad)
-    # Test disabled on windows due to an issue with cling symbols.
-    ROOT_ADD_GTEST(testRooFuncWrapper testRooFuncWrapper.cxx LIBRARIES RooFitCore RooFit HistFactory)
-  endif()
+endif()
+if(clad)
+  ROOT_ADD_GTEST(testRooFuncWrapper testRooFuncWrapper.cxx LIBRARIES RooFitCore RooFit HistFactory)
 endif()
 ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFitCore)

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -578,9 +578,14 @@ FactoryTestParams param13{"RooFormulaVar",
                          1e-4,
                          /*randomizeParameters=*/false};
 
-INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest,
-                         testing::Values(param1, param2, param3, param4, param5, param6, param7, param8, param8p1,
-                                         param9, param10, param11, param12, param13),
+auto testValues = testing::Values(param1, param2,
+#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
+                                         param3,
+#endif
+                              param4, param5, param6, param7, param8, param8p1,
+                              param9, param10, param11, param12, param13);
+
+INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest, testValues,
                          [](testing::TestParamInfo<FactoryTest::ParamType> const &paramInfo) {
                             return paramInfo.param._name;
                          });


### PR DESCRIPTION
This new release includes performance and stability improvements.

See more at: https://github.com/vgvassilev/clad/releases/tag/v1.3