### PR TITLE
[ntuple] Create proper RVec alias fields from importer

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -756,6 +756,9 @@ They are stored as two fields:
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
+For RVecs, ROOT will always store the fully qualified type name `ROOT::VecOps::RVec<T>`.
+Implementations should also be able to parse the shorter alias `ROOT::Vec<T>`.
+
 #### std::array<T, N> and array type of the form T[N]
 
 Fixed-sized arrays are stored as two fields:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -82,10 +82,12 @@ const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
    {"unsigned int", "std::uint32_t"},
    {"uint32_t",     "std::uint32_t"},
 
+   // FIXME: Long_t and ULong_t are 32-bit on 64-bit Windows.
    {"Long_t",        "std::int64_t"},
    {"Long64_t",      "std::int64_t"},
    {"int64_t",       "std::int64_t"},
    {"long",          "std::int64_t"},
+   {"ULong_t",       "std::uint64_t"},
    {"ULong64_t",     "std::uint64_t"},
    {"unsigned long", "std::uint64_t"},
    {"uint64_t",      "std::uint64_t"}

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -162,7 +162,8 @@ std::string GetCanonicalTypeName(const std::string &typeName)
 /// Applies type name normalization rules that lead to the final name used to create a RField, e.g. transforms
 /// `unsigned int` to `std::uint32_t` or `const vector<T>` to `std::vector<T>`.  Specifically, `const` / `volatile`
 /// qualifiers are removed, integral types such as `unsigned int` or `long` are translated to fixed-length integer types
-/// (e.g. `std::uint32_t`), and `std::` is added to fully qualify known types in the `std` namespace.
+/// (e.g. `std::uint32_t`), and `std::` is added to fully qualify known types in the `std` namespace.  The same happens
+/// to `ROOT::RVec` which is normalized to `ROOT::VecOps::RVec`.
 std::string GetNormalizedTypeName(const std::string &typeName)
 {
    std::string normalizedType{TClassEdit::CleanType(typeName.c_str(), /*mode=*/2)};
@@ -196,6 +197,9 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType == "byte")
       normalizedType = "std::byte";
+
+   if (normalizedType.substr(0, 11) == "ROOT::RVec<")
+      normalizedType = "ROOT::VecOps::RVec<" + normalizedType.substr(11);
 
    return normalizedType;
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -59,6 +59,7 @@ const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
    {"Double_t", "double"},
    {"string",   "std::string"},
 
+   {"byte",          "std::byte"},
    {"Char_t",        "char"},
    {"int8_t",        "std::int8_t"},
    {"signed char",   "char"},
@@ -195,8 +196,6 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
-   if (normalizedType == "byte")
-      normalizedType = "std::byte";
 
    if (normalizedType.substr(0, 11) == "ROOT::RVec<")
       normalizedType = "ROOT::VecOps::RVec<" + normalizedType.substr(11);

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -339,7 +339,8 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       for (auto idx : c.fImportFieldIndexes) {
          const auto name = fImportFields[idx].fField->GetFieldName();
          auto projectedField =
-            RFieldBase::Create(name, "ROOT::RVec<" + fImportFields[idx].fField->GetTypeName() + ">").Unwrap();
+            RFieldBase::Create(name, "ROOT::VecOps::RVec<" + fImportFields[idx].fField->GetTypeName() + ">").Unwrap();
+         R__ASSERT(dynamic_cast<RRVecField *>(projectedField.get()));
          fModel->AddProjectedField(std::move(projectedField), [&name, &c](const std::string &fieldName) {
             if (fieldName == name)
                return c.fFieldName;

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -378,6 +378,9 @@ TEST(RNTupleImporter, LeafCountArray)
    importer->Import();
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   // Ensure that it's possible to get a ptr to the projected RVec fields.
+   reader->GetModel().GetDefaultEntry().GetPtr<ROOT::RVec<float>>("jet_pt");
+
    EXPECT_EQ(3U, reader->GetNEntries());
    auto viewBegin = reader->GetView<std::int32_t>("begin");
    auto viewMiddle = reader->GetView<std::int32_t>("middle");


### PR DESCRIPTION
Otherwise we get an `RProxiedCollectionField` with identical column representations, but getting the pointer to `RVec` from an `REntry` fails because of the mismatch between `ROOT::VecOps::RVec` and `ROOT::RVec`. Also normalize the latter to the fully qualified name to allow reading previously written ntuples and those by other implementations.