### PR TITLE
[PyROOT] Replace `TDirectory.__getattr__` with `__getitem__`

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -266,6 +266,18 @@ struct.char_buffer            :  <cppyy.LowLevelView object at 0x74c7a2682fb0>
 struct.char_buffer.as_string():  foo
 ```
 
+### Deprecate the attribute pythonization of `TDirectory` in favor of item-getting syntax
+
+The new recommended way to get objects from a `TFile` or any `TDirectory` in general is now via `__getitem__`:
+
+```python
+tree = my_file["my_tree"] # instead of my_file.my_tree
+```
+
+This is more consistent with other Python collections (like dictionaries), makes sure that member functions can't be confused with branch names, and easily allows you to use string variables as keys.
+
+The old pythonization with the `__getattr__` syntax still works, but emits a deprecation warning and will be removed from ROOT 6.34.
+
 ## Language Bindings
 
 

--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -276,6 +276,25 @@ tree = my_file["my_tree"] # instead of my_file.my_tree
 
 This is more consistent with other Python collections (like dictionaries), makes sure that member functions can't be confused with branch names, and easily allows you to use string variables as keys.
 
+With the new dictionary-like syntax, you can also get objects with names that don't qualify as a Python variable. Here is a short demo:
+```python
+import ROOT
+
+with ROOT.TFile.Open("my_file.root", "RECREATE") as my_file:
+
+    # Populate the TFile with simple objects.
+    my_file.WriteObject(ROOT.std.string("hello world"), "my_string")
+    my_file.WriteObject(ROOT.vector["int"]([1, 2, 3]), "my vector")
+
+    print(my_file["my_string"])  # new syntax
+    print(my_file.my_string)  # old deprecated syntax
+
+    # With the dictionary syntax, you can also use names that don't qualify as
+    # a Python variable:
+    print(my_file["my vector"])
+    # print(my_file.my vector) # the old syntax would not work here!
+```
+
 The old pythonization with the `__getattr__` syntax still works, but emits a deprecation warning and will be removed from ROOT 6.34.
 
 ## Language Bindings

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -17,26 +17,26 @@ r"""
 \endhtmlonly
 ## PyROOT
 
-From Python, it is possible to inspect the content of a TDirectory object
-as if the subdirectories and objects it contains were its attributes.
+It is possible to retrieve the content of a TDirectory object
+just like getting items from a Python dictionary.
 Moreover, once a subdirectory or object is accessed for the first time,
 it is cached for later use.
 For example, assuming `d` is a TDirectory instance:
 \code{.py}
 # Access a subdirectory
-d.subdir
+d["subdir"]
 
 # We can go further down in the hierarchy of directories
-d.subdir.subsubdir
+d["subdir"]["subsubdir"]
 
 # Access an object (e.g. a histogram) in the directory
-d.obj
+d["obj"]
 
 # ... or in a subdirectory
-d.subdir.obj
+d["subdir"]["obj"]
 
-# Wrong attribute: raises AttributeError
-d.wrongAttr
+# Wrong key: raises KeyError
+d["wrongAttr"]
 \endcode
 
 Furthermore, TDirectory implements a `WriteObject` Python method which relies

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -18,9 +18,9 @@ r'''
 \endhtmlonly
 ## PyROOT
 
-In the same way as for TDirectory, it is possible to inspect the content of a
-TFile object from Python as if the directories and objects it contains were its
-attributes. For more information, please refer to the TDirectory documentation.
+In the same way as for TDirectory, it is possible to get the content of a
+TFile object with the familiar item-getting syntax.
+For more information, please refer to the TDirectory documentation.
 
 In addition, TFile instances can be inspected via the `Get` method, a feature
 that is inherited from TDirectoryFile (please see the documentation of

--- a/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
+++ b/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
@@ -6,7 +6,7 @@ from libcppyy import SetOwnership
 
 class TDirectoryReadWrite(unittest.TestCase):
     """
-    Test for the attr syntax of TDirectory.
+    Test for the getitem syntax of TDirectory.
     """
 
     nbins = 8
@@ -39,18 +39,18 @@ class TDirectoryReadWrite(unittest.TestCase):
         self.assertEqual(self.xmax, xaxis.GetXmax())
 
     # Tests
-    def test_readHisto_attrsyntax(self):
-        self.checkHisto(self.dir0.h)
-        self.checkHisto(self.dir0.dir1.h1)
-        self.checkHisto(self.dir0.dir1.dir2.h2)
+    def test_readHisto_itemsyntax(self):
+        self.checkHisto(self.dir0["h"])
+        self.checkHisto(self.dir0["dir1"]["h1"])
+        self.checkHisto(self.dir0["dir1"]["dir2"]["h2"])
 
-    def test_caching_getattr(self):
+    def test_caching_getitem(self):
         # check that object is not cached initially
         self.assertFalse("h" in self.dir0.__dict__)
-        self.dir0.h
-        # check that the value in __dict__ is actually the object
+        self.dir0["h"]
+        # check that the cached value in is actually the object
         # inside the directory
-        self.assertEqual(self.dir0.__dict__['h'], self.dir0.h)
+        self.assertEqual(self.dir0._cached_items["h"], self.dir0["h"])
 
 
 if __name__ == '__main__':

--- a/tutorials/dataframe/df007_snapshot.py
+++ b/tutorials/dataframe/df007_snapshot.py
@@ -58,7 +58,7 @@ d2.Snapshot(treeName, outFileName, \
     ["b1", "b1_square", "b2_vector"])
 # Open the new file and list the columns of the tree
 f1 = ROOT.TFile(outFileName)
-t = f1.myTree
+t = f1[treeName]
 print("These are the columns b1, b1_square and b2_vector:")
 for branch in t.GetListOfBranches():
     print("Branch: %s" %branch.GetName())
@@ -72,7 +72,7 @@ d2.Snapshot(treeName, outFileNameAllColumns)
 
 # Open the new file and list the columns of the tree
 f2 = ROOT.TFile(outFileNameAllColumns)
-t = f2.myTree
+t = f2[treeName]
 print("These are all the columns available to this dataframe:")
 for branch in t.GetListOfBranches():
     print("Branch: %s" %branch.GetName())

--- a/tutorials/dataframe/df017_vecOpsHEP.py
+++ b/tutorials/dataframe/df017_vecOpsHEP.py
@@ -25,7 +25,7 @@ def WithPyROOT(filename):
     from math import sqrt
     f = ROOT.TFile(filename)
     h = ROOT.TH1F("pt", "With PyROOT", 16, 0, 4)
-    for event in f.myDataset:
+    for event in f[treename]:
         for E, px, py in zip(event.E, event.px, event.py):
             if (E > 100):
                h.Fill(sqrt(px*px + py*py))

--- a/tutorials/pyroot/pyroot005_tfile_context_manager.py
+++ b/tutorials/pyroot/pyroot005_tfile_context_manager.py
@@ -57,7 +57,7 @@ print(" Accessing 'histo_2' gives: '{}'.\n".format(histo_2))
 with TFile.Open("pyroot005_file_1.root", "read") as f:
     # Retrieve histogram using the name given to f.WriteObject in the previous
     # with statement
-    histo_2_fromfile = f.my_histogram
+    histo_2_fromfile = f["my_histogram"]
     print("Retrieved '{}' histogram from file '{}'.\n".format(histo_2_fromfile.GetName(), f.GetName()))
 
 # Cleanup the file created for this tutorial


### PR DESCRIPTION
The new recommended way to get objects from a `TFile` or any
`TDirectory` in general is now via `__getitem__`:

```python
tree = my_file["my_tree"] # instead of my_file.my_tree
```

This is more consistent with other Python collections (like
dictionaries), makes sure that member functions can't be confused with
branch names, and easily allows you to use string variables as keys.

The old pythonization with the `__getattr__` syntax still works, but
emits a deprecation warning and will be removed from ROOT 6.34.