### PR TITLE
[PyROOT] Remove JupyROOT welcome message

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -170,9 +170,6 @@ def _getLibExtension(thePlatform):
     }
     return pExtMap.get(thePlatform, '.so')
 
-def welcomeMsg():
-    print("Welcome to JupyROOT %s" %ROOT.gROOT.GetVersion())
-
 @contextmanager
 def _setIgnoreLevel(level):
     originalLevel = ROOT.gErrorIgnoreLevel
@@ -693,5 +690,3 @@ def iPythonize():
     declareProcessLineWrapper()
     #enableCppHighlighting()
     enhanceROOTModule()
-    welcomeMsg()
-


### PR DESCRIPTION
Printing a welcome message when importing a module is uncommon in Python and quite old fashioned.

If one wants to see the ROOT version, one can always print `ROOT.__version__` like for many other modules.