### PR TITLE
fix: call to implicitly-deleted copy constructor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -125,7 +125,7 @@ protected:
    struct RSharedPtrDeleter {
       std::unique_ptr<RFieldBase::RDeleter> fDeleter;
       void operator()(void *objPtr) { fDeleter->operator()(objPtr, false /* dtorOnly*/); }
-      RSharedPtrDeleter(const RSharedPtrDeleter& deleter) : fDeleter( new RFieldBase::RDeleter(*deleter.fDeleter)) {}
+      RSharedPtrDeleter(const RSharedPtrDeleter& deleter) : fDeleter(new RFieldBase::RDeleter(*deleter.fDeleter)) {}
       explicit RSharedPtrDeleter(std::unique_ptr<RFieldBase::RDeleter> deleter) : fDeleter(std::move(deleter)) {}
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -125,6 +125,7 @@ protected:
    struct RSharedPtrDeleter {
       std::unique_ptr<RFieldBase::RDeleter> fDeleter;
       void operator()(void *objPtr) { fDeleter->operator()(objPtr, false /* dtorOnly*/); }
+      RSharedPtrDeleter(const RSharedPtrDeleter& deleter) : fDeleter( new RFieldBase::RDeleter(*deleter.fDeleter)) {}
       explicit RSharedPtrDeleter(std::unique_ptr<RFieldBase::RDeleter> deleter) : fDeleter(std::move(deleter)) {}
    };
 


### PR DESCRIPTION
# This Pull request:

fixes an error: call to implicitly-deleted copy constructor of 'ROOT::Experimental::RFieldBase::RSharedPtrDeleter'
## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/memory:3023:39: error: call to implicitly-deleted copy constructor of 'ROOT::Experimental::RFieldBase::RSharedPtrDeleter'
        __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
                                      ^~~
/Users/yana/Projects/ROOT/Fixathon_13_02_2024/root/tree/ntuple/v7/src/RField.cxx:689:24: note: in instantiation of function template specialization 'std::shared_ptr<void>::shared_ptr<void, ROOT::Experimental::RFieldBase::RSharedPtrDeleter>' requested here
   return RValue(this, std::shared_ptr<void>(where, RSharedPtrDeleter(GetDeleter())));
                       ^
/Users/yana/Projects/ROOT/Fixathon_13_02_2024/root/tree/ntuple/v7/inc/ROOT/RField.hxx:126:45: note: copy constructor of 'RSharedPtrDeleter' is implicitly deleted because field 'fDeleter' has a deleted copy constructor
      std::unique_ptr<RFieldBase::RDeleter> fDeleter;
                                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/memory:1584:3: note: copy constructor is implicitly deleted because 'unique_ptr<ROOT::Experimental::RFieldBase::RDeleter>' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/memory:2569:39: note: passing argument to parameter '__d' here
    __shared_ptr_pointer(_Tp __p, _Dp __d, _Alloc __a)
                                      ^
```

```
% clang -v
Homebrew clang version 16.0.1
Target: x86_64-apple-darwin20.6.0
Thread model: posix
```