### PR TITLE
[cling] Fix disabling optimizations with CLING_DEBUG

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1342,18 +1342,21 @@ namespace {
     if(COpts.CUDAHost)
       argvCompile.push_back("--cuda-host-only");
 
+    // argv[0] already inserted, get the rest
+    argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
+
 #ifdef __linux__
     // Keep frame pointer to make JIT stack unwinding reliable for profiling
     if (profilingEnabled)
       argvCompile.push_back("-fno-omit-frame-pointer");
 #endif
 
-    // Disable optimizations and keep frame pointer when debugging
-    if (debuggingEnabled)
-      argvCompile.push_back("-O0 -fno-omit-frame-pointer");
-
-    // argv[0] already inserted, get the rest
-    argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
+    // Disable optimizations and keep frame pointer when debugging, overriding
+    // other optimization options that might be in argv
+    if (debuggingEnabled) {
+      argvCompile.push_back("-O0");
+      argvCompile.push_back("-fno-omit-frame-pointer");
+    }
 
     // Add host specific includes, -resource-dir if necessary, and -isysroot
     std::string ClingBin = GetExecutablePath(argv[0]);


### PR DESCRIPTION
As noted in #14593, the build fails during a `rootcling` execution when setting `CLING_DEBUG=1` in the environment with
```
error: invalid integral value '0 -fno-omit-frame-pointer' in '-O0 -fno-omit-frame-pointer'
```

Upon investigation, it only works in the ROOT prompt because TCling turns on basic `-O1` unless in `rootcling`. This overrides the (misformed) `"-O0 -fno-omit-frame-pointer"`. Split the argument in two entries and move it after inserting the user-provided arguments to properly apply also on the prompt by now taking precedence over `-O1`.

Closes #14593