### PR TITLE
[PyROOT] Add tests for stl containers pythonic behaviour

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -28,7 +28,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS nu
 
 # STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)
-ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_set stl_set.py)
+if(NOT MSVC OR win_broken_tests)
+  ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_set stl_set.py)
+endif()
 
 # TObject and subclasses pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_contains tobject_contains.py)

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -26,8 +26,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)
 
-# STL vector pythonizations
+# STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_set stl_set.py)
 
 # TObject and subclasses pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_contains tobject_contains.py)

--- a/bindings/pyroot/pythonizations/test/stl_set.py
+++ b/bindings/pyroot/pythonizations/test/stl_set.py
@@ -24,6 +24,7 @@ class STL_set(unittest.TestCase):
         """
         Instantiate std::set with different types.
         """
+
         for entry_type in ['int', 'float', 'double', 'char', 'const char*', 'std::string']:
             ROOT.std.set[entry_type]()
 
@@ -32,6 +33,7 @@ class STL_set(unittest.TestCase):
         Test that the boolean conversion of a std::set works as expected.
         https://github.com/root-project/root/issues/14573
         """
+
         for entry_type in ['int', 'float', 'double']:
             s = ROOT.std.set[entry_type]()
             self.assertTrue(s.empty())
@@ -40,6 +42,38 @@ class STL_set(unittest.TestCase):
             s.insert(1)
             self.assertFalse(s.empty())
             self.assertTrue(bool(s))
+
+    def test_stl_set_tree(self):
+        """
+        Test that a TTree with a std::set branch behaves as expected.
+        """
+
+        tree = ROOT.TTree("tree", "Tree with std::vector")
+
+        entries_to_fill = [
+            set(),
+            {1},
+            {1, 2},
+        ]
+
+        # Create variables to store std::vector elements
+        entry_root = ROOT.std.set(int)()
+
+        # Create branches in the TTree
+        tree.Branch("set", entry_root)
+
+        for entry in entries_to_fill:
+            entry_root.clear()
+            for element in entry:
+                entry_root.insert(element)
+            tree.Fill()
+
+        for i in range(tree.GetEntries()):
+            tree.GetEntry(i)
+            entry_python = entries_to_fill[i]
+            self.assertEqual(entry_python, set(entry_root))
+            self.assertEqual(bool(entry_python), bool(entry_root))
+            self.assertEqual(len(entry_python), len(entry_root))
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/stl_set.py
+++ b/bindings/pyroot/pythonizations/test/stl_set.py
@@ -1,0 +1,46 @@
+import unittest
+import ROOT
+
+
+class STL_set(unittest.TestCase):
+    """
+    Tests for the pythonizations of std::set.
+    """
+
+    def test_set_char_data(self):
+        """
+        Test that a std::set of char behaves as a Python set.
+        """
+
+        elems = ['a', 'b', 'b', 'c']
+        s = ROOT.std.set['char'](elems)
+        self.assertEqual(set(s), set(elems))
+        self.assertTrue(s)
+
+        for entry in s:
+            self.assertTrue(entry in set(elems))
+
+    def test_set_types(self):
+        """
+        Instantiate std::set with different types.
+        """
+        for entry_type in ['int', 'float', 'double', 'char', 'const char*', 'std::string']:
+            ROOT.std.set[entry_type]()
+
+    def test_stl_set_boolean(self):
+        """
+        Test that the boolean conversion of a std::set works as expected.
+        https://github.com/root-project/root/issues/14573
+        """
+        for entry_type in ['int', 'float', 'double']:
+            s = ROOT.std.set[entry_type]()
+            self.assertTrue(s.empty())
+            self.assertFalse(bool(s))
+
+            s.insert(1)
+            self.assertFalse(s.empty())
+            self.assertTrue(bool(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -1,5 +1,7 @@
 import unittest
 import ROOT
+import random
+import numpy as np
 
 
 class STL_vector(unittest.TestCase):
@@ -8,13 +10,13 @@ class STL_vector(unittest.TestCase):
     """
 
     def test_vec_char_data(self):
-        '''
+        """
         Test that calling std::vector<char>::data() returns a Python string
         that contains the characters of the vector and no exception is raised.
         Check also that the iteration over the vector runs normally (#9632).
-        '''
+        """
 
-        elems = ['a','b','c']
+        elems = ['a', 'b', 'c']
         v = ROOT.std.vector['char'](elems)
         self.assertEqual(v.data(), ''.join(elems))
 
@@ -22,11 +24,64 @@ class STL_vector(unittest.TestCase):
             self.assertEqual(elem, elems.pop(0))
 
     def test_vec_const_char_p(self):
-        '''
+        """
         Test that creating a std::vector<const char*> does not raise any
         exception (#11581).
-        '''
+        """
         ROOT.std.vector['const char*']()
+
+    def test_vector_boolean(self):
+        """
+        Test that the boolean conversion of a std::vector works as expected.
+        https://github.com/root-project/root/issues/14573
+        """
+        for entry_type in ['int', 'float', 'double']:
+            vector = ROOT.std.vector[entry_type]()
+            self.assertTrue(vector.empty())
+            self.assertTrue(bool(vector))
+
+            vector.push_back(1)
+            self.assertFalse(vector.empty())
+            self.assertFalse(bool(vector))
+
+    def test_tree_with_containers(self):
+        """
+        Test that the boolean conversion of a std::vector works as expected inside a TTree.
+        Also checks that the contents are correctly filled and read back.
+        https://github.com/root-project/root/issues/14573
+        """
+
+        # Create a TTree
+        tree = ROOT.TTree("tree", "Tree with std::vector")
+
+        # list of random arrays with lengths between 0 and 5 (0 is always included)
+        entries_to_fill = [
+            np.array([random.uniform(10, 20) for _ in range(n % 5)]) for n in range(100)
+        ]
+
+        # Create variables to store std::vector elements
+        entry_root = ROOT.std.vector(float)()
+
+        # Create branches in the TTree
+        tree.Branch("vector", entry_root)
+
+        # Fill the TTree with 100 entries
+        for entry in entries_to_fill:
+            entry_root.clear()
+
+            for element in entry:
+                entry_root.push_back(element)
+
+            tree.Fill()
+
+        for i in range(tree.GetEntries()):
+            tree.GetEntry(i)
+            entry_numpy = entries_to_fill[i]
+            entry_python_list = list(entry_root)
+
+            assert len(entry_numpy) == len(entry_root)
+            assert bool(entry_python_list) == bool(entry_root)  # numpy arrays cannot be converted to bool
+            np.testing.assert_allclose(entry_numpy, np.array(entry_root), rtol=1e-5)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -44,20 +44,6 @@ class STL_vector(unittest.TestCase):
             self.assertFalse(vector.empty())
             self.assertTrue(bool(vector))
 
-    def test_stl_set_boolean(self):
-        """
-        Test that the boolean conversion of a std::vector works as expected.
-        https://github.com/root-project/root/issues/14573
-        """
-        for entry_type in ['int', 'float', 'double']:
-            vector = ROOT.stl.vector[entry_type]()
-            self.assertTrue(vector.empty())
-            self.assertFalse(bool(vector))
-
-            vector.insert(1)
-            self.assertFalse(vector.empty())
-            self.assertTrue(bool(vector))
-
     def test_tree_with_containers(self):
         """
         Test that the boolean conversion of a std::vector works as expected inside a TTree.

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -30,7 +30,7 @@ class STL_vector(unittest.TestCase):
         """
         ROOT.std.vector['const char*']()
 
-    def test_vector_boolean(self):
+    def test_stl_vector_boolean(self):
         """
         Test that the boolean conversion of a std::vector works as expected.
         https://github.com/root-project/root/issues/14573
@@ -38,11 +38,25 @@ class STL_vector(unittest.TestCase):
         for entry_type in ['int', 'float', 'double']:
             vector = ROOT.std.vector[entry_type]()
             self.assertTrue(vector.empty())
-            self.assertTrue(bool(vector))
+            self.assertFalse(bool(vector))
 
             vector.push_back(1)
             self.assertFalse(vector.empty())
+            self.assertTrue(bool(vector))
+
+    def test_stl_set_boolean(self):
+        """
+        Test that the boolean conversion of a std::vector works as expected.
+        https://github.com/root-project/root/issues/14573
+        """
+        for entry_type in ['int', 'float', 'double']:
+            vector = ROOT.set.vector[entry_type]()
+            self.assertTrue(vector.empty())
             self.assertFalse(bool(vector))
+
+            vector.insert(1)
+            self.assertFalse(vector.empty())
+            self.assertTrue(bool(vector))
 
     def test_tree_with_containers(self):
         """
@@ -79,8 +93,8 @@ class STL_vector(unittest.TestCase):
             entry_numpy = entries_to_fill[i]
             entry_python_list = list(entry_root)
 
-            assert len(entry_numpy) == len(entry_root)
-            assert bool(entry_python_list) == bool(entry_root)  # numpy arrays cannot be converted to bool
+            self.assertEqual(len(entry_numpy), len(entry_root))
+            self.assertEqual(bool(entry_python_list), bool(entry_root))  # numpy arrays cannot be converted to bool
             np.testing.assert_allclose(entry_numpy, np.array(entry_root), rtol=1e-5)
 
 

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -50,7 +50,7 @@ class STL_vector(unittest.TestCase):
         https://github.com/root-project/root/issues/14573
         """
         for entry_type in ['int', 'float', 'double']:
-            vector = ROOT.set.vector[entry_type]()
+            vector = ROOT.stl.vector[entry_type]()
             self.assertTrue(vector.empty())
             self.assertFalse(bool(vector))
 


### PR DESCRIPTION
# This Pull request:

Closes https://github.com/root-project/root/issues/14573.

## Changes or fixes:

The pythonization of stl containers should behave in a pythonic way: empty containers should evaluate to false in an `if` statement, etc.

While working on the issue I realized this is already the case, so this PR just adds some python tests that should cover this.

I also added a new test file that checks the `std::set` also behaves as expected.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

