### PR TITLE
[DF] Update functions to use ROOT::Internal::GetDemangledTypeName

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -569,7 +569,7 @@ public:
       RDFInternal::CheckForRedefinition("DefinePerSample", name, fColRegister, fLoopManager->GetBranchNames(),
                                         fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
 
-      auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType_t));
+      auto retTypeName = ROOT::Internal::GetDemangledTypeName(typeid(RetType_t));
       if (retTypeName.empty()) {
          // The type is not known to the interpreter.
          // We must not error out here, but if/when this column is used in jitted code
@@ -2952,9 +2952,9 @@ private:
       CheckAndFillDSColumns(validColumnNames, ColTypes_t());
 
       // Declare return type to the interpreter, for future use by jitted actions
-      auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
+      auto retTypeName = ROOT::Internal::GetDemangledTypeName(typeid(RetType));
       if (retTypeName.empty()) {
-         // The type is not known to the interpreter.
+         // The type is not known to the interpreter
          // We must not error out here, but if/when this column is used in jitted code
          const auto demangledType = RDFInternal::DemangleTypeIdName(typeid(RetType));
          retTypeName = "CLING_UNKNOWN_TYPE_" + demangledType;
@@ -3063,7 +3063,7 @@ private:
       const auto validColumnNames = GetValidatedColumnNames(nColumns, inputColumns);
       CheckAndFillDSColumns(validColumnNames, ColTypes_t{});
 
-      auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
+      auto retTypeName = ROOT::Internal::GetDemangledTypeName(typeid(RetType));
       if (retTypeName.empty()) {
          // The type is not known to the interpreter, but we don't want to error out
          // here, rather if/when this column is used in jitted code, so we inject a broken but telling type name.

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -102,8 +102,8 @@ protected:
             const auto *expectedTypeID = define ? &define->GetTypeId() : &RDFInternal::TypeName2TypeID(colTypes[i]);
             if (innerTypeID != *expectedTypeID)
                throw std::runtime_error("Varied values for column \"" + colNames[i] + "\" have a different type (" +
-                                        RDFInternal::TypeID2TypeName(innerTypeID) + ") than the nominal value (" +
-                                        colTypes[i] + ").");
+                                        ROOT::Internal::GetDemangledTypeName(innerTypeID) +
+                                        ") than the nominal value (" + colTypes[i] + ").");
          }
       } else { // we are varying a single column, RetType is RVec<T>
          const auto &retTypeID = typeid(typename RetType::value_type);
@@ -113,7 +113,7 @@ protected:
             define ? &define->GetTypeId() : &RDFInternal::TypeName2TypeID(GetColumnType(colName));
          if (retTypeID != *expectedTypeID)
             throw std::runtime_error("Varied values for column \"" + colName + "\" have a different type (" +
-                                     RDFInternal::TypeID2TypeName(retTypeID) + ") than the nominal value (" +
+                                     ROOT::Internal::GetDemangledTypeName(retTypeID) + ") than the nominal value (" +
                                      GetColumnType(colName) + ").");
       }
 

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -57,7 +57,7 @@ class RLazyDS final : public ROOT::RDF::RDataSource {
    {
       auto colNameStr = std::string(colName);
       // This could be optimised and done statically
-      const auto idName = ROOT::Internal::RDF::TypeID2TypeName(id);
+      const auto idName = ROOT::Internal::GetDemangledTypeName(id);
       auto it = fColTypesMap.find(colNameStr);
       if (fColTypesMap.end() == it) {
          std::string err = "The specified column name, \"" + colNameStr + "\" is not known to the data source.";
@@ -120,7 +120,7 @@ public:
    RLazyDS(std::pair<std::string, RResultPtr<std::vector<ColumnTypes>>>... colsNameVals)
       : fColumns(std::tuple<RResultPtr<std::vector<ColumnTypes>>...>(colsNameVals.second...)),
         fColNames({colsNameVals.first...}),
-        fColTypesMap({{colsNameVals.first, ROOT::Internal::RDF::TypeID2TypeName(typeid(ColumnTypes))}...}),
+        fColTypesMap({{colsNameVals.first, ROOT::Internal::GetDemangledTypeName(typeid(ColumnTypes))}...}),
         fPointerHoldersModels({new ROOT::Internal::TDS::TTypedPointerHolder<ColumnTypes>(new ColumnTypes())...})
    {
    }

--- a/tree/dataframe/inc/ROOT/RResultHandle.hxx
+++ b/tree/dataframe/inc/ROOT/RResultHandle.hxx
@@ -59,8 +59,8 @@ class RResultHandle {
    {
       if (*fType != type) {
          std::stringstream ss;
-         ss << "Got the type " << ROOT::Internal::RDF::TypeID2TypeName(type)
-            << " but the RResultHandle refers to a result of type " << ROOT::Internal::RDF::TypeID2TypeName(*fType)
+         ss << "Got the type " << ROOT::Internal::GetDemangledTypeName(type)
+            << " but the RResultHandle refers to a result of type " << ROOT::Internal::GetDemangledTypeName(*fType)
             << ".";
          throw std::runtime_error(ss.str());
       }

--- a/tree/dataframe/inc/ROOT/RVecDS.hxx
+++ b/tree/dataframe/inc/ROOT/RVecDS.hxx
@@ -62,7 +62,7 @@ class RVecDS final : public ROOT::RDF::RDataSource {
    {
       auto colNameStr = std::string(colName);
       // This could be optimised and done statically
-      const auto idName = ROOT::Internal::RDF::TypeID2TypeName(id);
+      const auto idName = ROOT::Internal::GetDemangledTypeName(id);
       auto it = fColTypesMap.find(colNameStr);
       if (fColTypesMap.end() == it) {
          std::string err = "The specified column name, \"" + colNameStr + "\" is not known to the data source.";
@@ -125,7 +125,7 @@ public:
    RVecDS(std::function<void()> deleteRVecs, std::pair<std::string, ROOT::RVec<ColumnTypes>> const &...colsNameVals)
       : fColumns(colsNameVals.second...),
         fColNames{colsNameVals.first...},
-        fColTypesMap({{colsNameVals.first, ROOT::Internal::RDF::TypeID2TypeName(typeid(ColumnTypes))}...}),
+        fColTypesMap({{colsNameVals.first, ROOT::Internal::GetDemangledTypeName(typeid(ColumnTypes))}...}),
         fPointerHoldersModels({new ROOT::Internal::TDS::TTypedPointerHolder<ColumnTypes>(new ColumnTypes())...}),
         fDeleteRVecs(deleteRVecs)
    {

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -845,7 +845,7 @@ std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail:
    const std::string actionTypeNameBase = actionTypeName.substr(actionTypeName.rfind(':') + 1);
 
    // retrieve type of result of the action as a string
-   const auto helperArgTypeName = TypeID2TypeName(helperArgType);
+   const auto helperArgTypeName = ROOT::Internal::GetDemangledTypeName(helperArgType);
    if (helperArgTypeName.empty()) {
       ThrowJitBuildActionHelperTypeError(actionTypeNameBase, helperArgType);
    }

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -400,8 +400,8 @@ void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info 
    };
 
    if (!explicitlySupported && diffTypes && !inheritedType()) {
-      const auto tName = TypeID2TypeName(requestedType);
-      const auto colTypeName = TypeID2TypeName(colType);
+      const auto tName = ROOT::Internal::GetDemangledTypeName(requestedType);
+      const auto colTypeName = ROOT::Internal::GetDemangledTypeName(colType);
       std::string errMsg = "RDataFrame: type mismatch: column \"" + colName + "\" is being used as ";
       if (tName.empty()) {
          errMsg += requestedType.name();


### PR DESCRIPTION
@vepadulano 

This PR departs from using RDFInternal::TypeID2TypeName and obtains the Demangled name

Fixes https://github.com/root-project/root/issues/14577

### Checklist:

- [x] tested changes locally

gtest-root-dataframe-test-norootextension fails but seems like it does not have anything to do with this change.


