### PR TITLE
[skip-ci] Correct documentation for `TGLViewer::SetPerspectiveCamera`

### DIFF
--- a/graf3d/gl/src/TGLViewer.cxx
+++ b/graf3d/gl/src/TGLViewer.cxx
@@ -1952,7 +1952,7 @@ void TGLViewer::SetOrthoCamera(ECameraType camera,
 ///  - 'center' - world position from which dolly/hRotate/vRotate are measured
 ///                camera rotates round this, always facing in (in center of viewport)
 ///  - 'hRotate' - horizontal rotation from initial configuration in radians
-///  - 'hRotate' - vertical rotation from initial configuration in radians
+///  - 'vRotate' - vertical rotation from initial configuration in radians
 
 void TGLViewer::SetPerspectiveCamera(ECameraType camera,
                                      Double_t fov, Double_t dolly,

--- a/graf3d/gl/src/TGLViewer.cxx
+++ b/graf3d/gl/src/TGLViewer.cxx
@@ -1951,8 +1951,8 @@ void TGLViewer::SetOrthoCamera(ECameraType camera,
 ///  - 'dolly' - distance from 'center'
 ///  - 'center' - world position from which dolly/hRotate/vRotate are measured
 ///                camera rotates round this, always facing in (in center of viewport)
-///  - 'hRotate' - horizontal rotation from initial configuration in degrees
-///  - 'hRotate' - vertical rotation from initial configuration in degrees
+///  - 'hRotate' - horizontal rotation from initial configuration in radians
+///  - 'hRotate' - vertical rotation from initial configuration in radians
 
 void TGLViewer::SetPerspectiveCamera(ECameraType camera,
                                      Double_t fov, Double_t dolly,


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Only changes to documentation. Previously `hRotate` and `vRotate` were documented to be degrees while they should be radians. Also `hRotate` appeared twice instead of `vRotate`.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

Closes https://github.com/root-project/root/issues/14576