### PR TITLE
[ci-config] Add dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Add `dependabot.yml` file which will configure the dependabot to periodically create PRs whenever GitHub actions can be updated.

Currently configured to submit the PR weekly with a maximum of 5 concurrent open PRs.

GitHub actions cannot (or should not) be configured to run on the latest version, you can only specify which major version to run. Many times whenever there is a new version released it never gets updated on the developer's end. This PR fixes this with the added benefit of a dedicated PR for each action which should test if there are any breaking changes. The PR also contains a link to the action changelog.

