### PR TITLE
[ntuple] Remove `R__LOAD_LIBRARY` from tutorials

### DIFF
--- a/tutorials/v7/ntuple/ntpl001_staff.C
+++ b/tutorials/v7/ntuple/ntpl001_staff.C
@@ -15,11 +15,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 

--- a/tutorials/v7/ntuple/ntpl002_vector.C
+++ b/tutorials/v7/ntuple/ntpl002_vector.C
@@ -13,11 +13,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -18,11 +18,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>

--- a/tutorials/v7/ntuple/ntpl004_dimuon.C
+++ b/tutorials/v7/ntuple/ntpl004_dimuon.C
@@ -17,11 +17,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleDS.hxx>

--- a/tutorials/v7/ntuple/ntpl005_introspection.C
+++ b/tutorials/v7/ntuple/ntpl005_introspection.C
@@ -14,11 +14,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleOptions.hxx>

--- a/tutorials/v7/ntuple/ntpl006_friends.C
+++ b/tutorials/v7/ntuple/ntpl006_friends.C
@@ -13,11 +13,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 

--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -13,11 +13,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -13,11 +13,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTupleUtil)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleDS.hxx>
 #include <ROOT/RNTupleImporter.hxx>

--- a/tutorials/v7/ntuple/ntpl009_parallelWriter.C
+++ b/tutorials/v7/ntuple/ntpl009_parallelWriter.C
@@ -13,11 +13,6 @@
 // Functionality, interface, and data format is still subject to changes.
 // Do not use for real data!
 
-// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
-// triggering autoloading from the use of templated types would require an exhaustive enumeration
-// of "all" template instances in the LinkDef file.
-R__LOAD_LIBRARY(ROOTNTuple)
-
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleParallelWriter.hxx>


### PR DESCRIPTION
C++ runtime modules are now used by default, and it actually seems to not pose any issues for builds that don't have it enabled.
