### PR TITLE
Improving TRandom::GetSeed() documentation

### DIFF
--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -46,13 +46,18 @@ public:
    TRandom1(UInt_t seed, Int_t lux = 3);
    TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux);
    ~TRandom1() override;
-   // Returns current luxury value.
-   virtual Int_t GetLuxury() const;
-   // Returns the current seed (first element of the seed table)
-   UInt_t GetSeed() const override;
-   // Returns the pointer to the current seeds array.
-   const UInt_t *GetTheSeeds() const;
-   // Returns the current array of seeds.
+   /////////////////////////////////////////////////////////////////////////////
+   /// Returns current luxury value.
+   virtual Int_t GetLuxury() const {return fLuxury;}
+   /////////////////////////////////////////////////////////////////////////////
+   /// Returns the current seed (first element of the seed table)
+   /// \warning This is not the initial seed!
+   UInt_t GetSeed() const override { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
+   /////////////////////////////////////////////////////////////////////////////
+   /// Returns the pointer to the current seeds array.
+   const UInt_t *GetTheSeeds() const {return fTheSeeds;}
+   /////////////////////////////////////////////////////////////////////////////
+   /// Returns an array of seed values stored in the table, given the index.
    static void GetTableSeeds(UInt_t *seeds, Int_t index);
    using TRandom::Rndm;
    Double_t Rndm() override;

--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -58,9 +58,9 @@ public:
    Double_t Rndm() override;
    void RndmArray(Int_t size, Float_t *vect) override;
    void RndmArray(Int_t size, Double_t *vect) override;
-   virtual void SetSeed2(UInt_t seed, Int_t lux=3);
+   virtual void SetSeed2(UInt_t seed, Int_t lux = 3);
    // Sets the state of the algorithm according to seed.
-   virtual void SetSeeds(const UInt_t * seeds, Int_t lux=3);
+   virtual void SetSeeds(const UInt_t *seeds, Int_t lux = 3);
    // Sets the state of the algorithm according to the zero terminated
    // array of seeds. Only the first seed is used.
    void SetSeed(ULong_t seed) override;

--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -47,17 +47,17 @@ public:
    TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux );
    ~TRandom1() override;
    // Returns current luxury value.
-   virtual Int_t GetLuxury() const {return fLuxury;}
+   virtual Int_t GetLuxury() const { return fLuxury; }
    // Returns the current seed (first element of the table) \warning This is not the initial seed!
-   UInt_t GetSeed() const override { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
+   UInt_t GetSeed() const override { return UInt_t(fFloatSeedTable[0] / fMantissaBit24); }
    // Returns the pointer to the current seeds array.
-   const UInt_t *GetTheSeeds() const {return fTheSeeds;}
+   const UInt_t *GetTheSeeds() const { return fTheSeeds; }
    // Returns the current array of seeds.
-   static void GetTableSeeds(UInt_t* seeds, Int_t index);
+   static void GetTableSeeds(UInt_t *seeds, Int_t index);
    using TRandom::Rndm;
-   Double_t Rndm( ) override;
-    void     RndmArray(Int_t size, Float_t *vect) override;
-    void     RndmArray(Int_t size, Double_t *vect) override;
+   Double_t Rndm() override;
+   void RndmArray(Int_t size, Float_t *vect) override;
+   void RndmArray(Int_t size, Double_t *vect) override;
    virtual  void     SetSeed2(UInt_t seed, Int_t lux=3);
                      // Sets the state of the algorithm according to seed.
    virtual  void     SetSeeds(const UInt_t * seeds, Int_t lux=3);

--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -43,27 +43,27 @@ protected:
 
 public:
    TRandom1();
-   TRandom1(UInt_t seed, Int_t lux = 3 );
-   TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux );
+   TRandom1(UInt_t seed, Int_t lux = 3);
+   TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux);
    ~TRandom1() override;
    // Returns current luxury value.
-   virtual Int_t GetLuxury() const { return fLuxury; }
-   // Returns the current seed (first element of the table) \warning This is not the initial seed!
-   UInt_t GetSeed() const override { return UInt_t(fFloatSeedTable[0] / fMantissaBit24); }
+   virtual Int_t GetLuxury() const;
+   // Returns the current seed (first element of the seed table)
+   UInt_t GetSeed() const override;
    // Returns the pointer to the current seeds array.
-   const UInt_t *GetTheSeeds() const { return fTheSeeds; }
+   const UInt_t *GetTheSeeds() const;
    // Returns the current array of seeds.
    static void GetTableSeeds(UInt_t *seeds, Int_t index);
    using TRandom::Rndm;
    Double_t Rndm() override;
    void RndmArray(Int_t size, Float_t *vect) override;
    void RndmArray(Int_t size, Double_t *vect) override;
-   virtual  void     SetSeed2(UInt_t seed, Int_t lux=3);
-                     // Sets the state of the algorithm according to seed.
-   virtual  void     SetSeeds(const UInt_t * seeds, Int_t lux=3);
-                     // Sets the state of the algorithm according to the zero terminated
-                     // array of seeds. Only the first seed is used.
-    void     SetSeed(ULong_t seed) override;
+   virtual void SetSeed2(UInt_t seed, Int_t lux=3);
+   // Sets the state of the algorithm according to seed.
+   virtual void SetSeeds(const UInt_t * seeds, Int_t lux=3);
+   // Sets the state of the algorithm according to the zero terminated
+   // array of seeds. Only the first seed is used.
+   void SetSeed(ULong_t seed) override;
 
    ClassDefOverride(TRandom1,2)  //Ranlux Random number generators with periodicity > 10**14
 };

--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -46,16 +46,16 @@ public:
    TRandom1(UInt_t seed, Int_t lux = 3 );
    TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux );
    ~TRandom1() override;
-   virtual  Int_t    GetLuxury() const {return fLuxury;}
-                    // Get the current seed (first element of the table)
-    UInt_t   GetSeed() const override { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
-                    // Gets the current seed.
-   const UInt_t     *GetTheSeeds() const {return fTheSeeds;}
-                     // Gets the current array of seeds.
-   static   void     GetTableSeeds(UInt_t* seeds, Int_t index);
-                     // Gets back seed values stored in the table, given the index.
+   // Returns current luxury value.
+   virtual Int_t GetLuxury() const {return fLuxury;}
+   // Returns the current seed (first element of the table) \warning This is not the initial seed!
+   UInt_t GetSeed() const override { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
+   // Returns the pointer to the current seeds array.
+   const UInt_t *GetTheSeeds() const {return fTheSeeds;}
+   // Returns the current array of seeds.
+   static void GetTableSeeds(UInt_t* seeds, Int_t index);
    using TRandom::Rndm;
-    Double_t Rndm( ) override;
+   Double_t Rndm( ) override;
     void     RndmArray(Int_t size, Float_t *vect) override;
     void     RndmArray(Int_t size, Double_t *vect) override;
    virtual  void     SetSeed2(UInt_t seed, Int_t lux=3);

--- a/math/mathcore/inc/TRandom2.h
+++ b/math/mathcore/inc/TRandom2.h
@@ -38,6 +38,7 @@ public:
     void     RndmArray(Int_t n, Float_t *array) override;
     void     RndmArray(Int_t n, Double_t *array) override;
     void     SetSeed(ULong_t seed=0) override;
+    UInt_t   GetSeed() const override;
 
    ClassDefOverride(TRandom2,1)  //Random number generator with periodicity of 10**26
 };

--- a/math/mathcore/inc/TRandom2.h
+++ b/math/mathcore/inc/TRandom2.h
@@ -38,9 +38,9 @@ public:
     void     RndmArray(Int_t n, Float_t *array) override;
     void     RndmArray(Int_t n, Double_t *array) override;
     void     SetSeed(ULong_t seed=0) override;
-    UInt_t   GetSeed() const override;
+    UInt_t GetSeed() const override;
 
-   ClassDefOverride(TRandom2,1)  //Random number generator with periodicity of 10**26
+    ClassDefOverride(TRandom2, 1) // Random number generator with periodicity of 10**26
 };
 
 R__EXTERN TRandom *gRandom;

--- a/math/mathcore/src/TRandom.cxx
+++ b/math/mathcore/src/TRandom.cxx
@@ -22,7 +22,7 @@ href="https://www.gnu.org/software/gsl/manual/html_node/Unix-random-number-gener
 that it should not be used because its period is only 2**31, i.e. approximately 2 billion events, that can be generated
 in just few seconds.
 
-To generate random numbers, one should use the derived class, which  are :
+To generate random numbers, one should use one of the derived classes, which are:
 - TRandom3: it is based on the "Mersenne Twister generator",
 it is fast and a very long period of about \f$10^{6000}\f$. However it fails some of the most stringent tests of the
 <a href="http://simul.iro.umontreal.ca/testu01/tu01.html">TestU01 suite</a>.
@@ -85,7 +85,7 @@ for the random numbers obtained using a macbookpro 2.6 GHz Intel Core i7 CPU:
 -   ::TRandom1          80   ns/call
 -   ::TRandomRanlux48  250  ns/call
 
-The following methods are provided to generate random numbers disctributed according to some basic distributions:
+The following methods are provided to generate random numbers distributed according to some basic distributions:
 
 - Exp(Double_t tau)
 - Integer(UInt_t imax)
@@ -618,7 +618,7 @@ void TRandom::SetSeed(ULong_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get the random generator seed.
+/// Get the random generator seed. \warning Might not be the initial seed!
 /// Note that this function returns the given seed only when using
 /// as random generator engine TRandom itself, which is an LCG generator
 /// and it has as seed (state) only one 32 bit word.

--- a/math/mathcore/src/TRandom.cxx
+++ b/math/mathcore/src/TRandom.cxx
@@ -618,7 +618,10 @@ void TRandom::SetSeed(ULong_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get the random generator seed. \warning Might not be the initial seed!
+/// \brief Get the random generator seed.
+///
+/// \warning Might not be the initial seed!
+///
 /// Note that this function returns the given seed only when using
 /// as random generator engine TRandom itself, which is an LCG generator
 /// and it has as seed (state) only one 32 bit word.

--- a/math/mathcore/src/TRandom1.cxx
+++ b/math/mathcore/src/TRandom1.cxx
@@ -603,7 +603,7 @@ void TRandom1::SetSeed(ULong_t seed)
 ///
 Int_t TRandom1::GetLuxury() const
 {
-  return fLuxury;
+   return fLuxury;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -612,12 +612,12 @@ Int_t TRandom1::GetLuxury() const
 /// \warning This is not the initial seed!
 UInt_t TRandom1::GetSeed() const
 {
-  return static_cast<UInt_t>(fFloatSeedTable[0] / fMantissaBit24);
+   return static_cast<UInt_t>(fFloatSeedTable[0] / fMantissaBit24);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Returns the pointer to the current seeds array.
-const UInt_t * TRandom1::GetTheSeeds() const
+const UInt_t *TRandom1::GetTheSeeds() const
 {
-  return fTheSeeds;
+   return fTheSeeds;
 }

--- a/math/mathcore/src/TRandom1.cxx
+++ b/math/mathcore/src/TRandom1.cxx
@@ -251,17 +251,17 @@ const UInt_t fgSeedTable[215][2] = {
 ClassImp(TRandom1);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Luxury level is set in the same way as the original FORTRAN routine.
-///  level 0  (p=24): equivalent to the original RCARRY of Marsaglia
-///           and Zaman, very long period, but fails many tests.
-///  level 1  (p=48): considerable improvement in quality over level 0,
-///           now passes the gap test, but still fails spectral test.
-///  level 2  (p=97): passes all known tests, but theoretically still
-///           defective.
-///  level 3  (p=223): DEFAULT VALUE.  Any theoretically possible
-///           correlations have very small chance of being observed.
-///  level 4  (p=389): highest possible luxury, all 24 bits chaotic.
-
+/// \brief Luxury level is set in the same way as the original FORTRAN routine.
+///
+///  - level 0 (p=24): equivalent to the original RCARRY of Marsaglia
+///                    and Zaman, very long period, but fails many tests.
+///  - level 1 (p=48): considerable improvement in quality over level 0,
+///                    now passes the gap test, but still fails spectral test.
+///  - level 2 (p=97): passes all known tests, but theoretically still
+///                    defective.
+///  - level 3 (p=223): DEFAULT VALUE. Any theoretically possible
+///                     correlations have very small chance of being observed.
+///  - level 4 (p=389): highest possible luxury, all 24 bits chaotic.
 TRandom1::TRandom1(UInt_t seed, Int_t lux)
         : fIntModulus(0x1000000),
           fMantissaBit24( TMath::Power(0.5,24.) ),
@@ -282,8 +282,7 @@ TRandom1::TRandom1(UInt_t seed, Int_t lux)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///default constructor
-
+/// \brief Default constructor.
 TRandom1::TRandom1()
         : fIntModulus(0x1000000),
           fMantissaBit24( TMath::Power(0.5,24.) ),
@@ -309,8 +308,7 @@ TRandom1::TRandom1()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///constructor
-
+/// \brief Constructor.
 TRandom1::TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux)
         : fIntModulus(0x1000000),
           fMantissaBit24( TMath::Power(0.5,24.) ),
@@ -336,15 +334,13 @@ TRandom1::TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///destructor
-
+/// \brief Destructor.
 TRandom1::~TRandom1()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///static function returning the table of seeds
-
+/// \brief Static function returning the seeds table.
 void TRandom1::GetTableSeeds(UInt_t* seeds, Int_t index)
 {
    if ((index >= 0) && (index < 215)) {
@@ -355,8 +351,7 @@ void TRandom1::GetTableSeeds(UInt_t* seeds, Int_t index)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///return a random number in ]0,1]
-
+/// \brief Returns a random number in ]0,1]
 Double_t TRandom1::Rndm( )
 {
    float next_random;
@@ -404,20 +399,18 @@ Double_t TRandom1::Rndm( )
          if(fJlag < 0) fJlag = 23;
       }
    }
-   return (double) next_random;
+   return static_cast<Double_t>(next_random);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///return an array of random numbers in ]0,1]
-
+/// \brief Returns an array of random numbers in ]0,1]
 void TRandom1::RndmArray(const Int_t size, Float_t *vect)
 {
    for (Int_t i=0;i<size;i++) vect[i] = Rndm();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///return an array of random numbers in ]0,1[
-
+/// \brief Returns an array of random numbers in ]0,1[
 void TRandom1::RndmArray(const Int_t size, Double_t *vect)
 {
    float next_random;
@@ -472,7 +465,8 @@ void TRandom1::RndmArray(const Int_t size, Double_t *vect)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set the state of the generator providing an array of seeds
+/// \brief Set the state of the generator providing an array of seeds.
+///
 /// The array of seeds can be of size 24 or less. In case of an array of n seeds with n < 24
 /// the n+1 element must be equal to zero.
 /// The other elements are the initialized using a Multiplicative
@@ -551,15 +545,16 @@ void TRandom1::SetSeeds(const UInt_t *seeds, int lux)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set the state of the generator providing a single seed value and a
+/// \brief Set the state of the generator providing a single seed value and a
 /// luxury level.
-///  The initialisation of the other state values is carried out using a Multiplicative
+///
+/// The initialisation of the other state values is carried out using a Multiplicative
 /// Congruential generator using formula constants of L'Ecuyer
 /// as described in "A review of pseudorandom number generators"
 /// (Fred James) published in Computer Physics Communications 60 (1990)
 /// pages 329-344
 ///
-/// Note: When the provided seed = 0, a random and unique seed is generated
+/// \note When provided with seed = 0, a random and unique seed is generated.
 ///
 ///  \param[in] seed   seed value (note special case if seed=0)
 ///  \param[in] lux    Luxury level
@@ -586,11 +581,13 @@ void TRandom1::SetSeed2(UInt_t seed, int lux)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set the state of the generator providing a single seed value and using
-/// the luxury level defined when constructing the class
-///  The initialisation of the other state values is carried out using a Multiplicative
+/// \brief Set the state of the generator providing a single seed value and using
+/// the luxury level defined when constructing the class.
+///
+/// The initialisation of the other state values is carried out using a Multiplicative
 /// Congruential generator.
-/// Note: When seed = 0, a random and unique seed is generated
+///
+/// Note: When seed = 0, a random and unique seed is generated.
 ///
 /// \param[in] seed   seed value (note special case if seed=0)
 ///
@@ -599,4 +596,28 @@ void TRandom1::SetSeed(ULong_t seed)
 {
    // Set RanLux seed using the luxury level provided in the constructor
    SetSeed2(seed,fLuxury);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Returns current luxury value.
+///
+Int_t TRandom1::GetLuxury() const
+{
+  return fLuxury;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Returns the current seed (first element of the seed table).
+///
+/// \warning This is not the initial seed!
+UInt_t TRandom1::GetSeed() const
+{
+  return static_cast<UInt_t>(fFloatSeedTable[0] / fMantissaBit24);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Returns the pointer to the current seeds array.
+const UInt_t * TRandom1::GetTheSeeds() const
+{
+  return fTheSeeds;
 }

--- a/math/mathcore/src/TRandom1.cxx
+++ b/math/mathcore/src/TRandom1.cxx
@@ -597,27 +597,3 @@ void TRandom1::SetSeed(ULong_t seed)
    // Set RanLux seed using the luxury level provided in the constructor
    SetSeed2(seed,fLuxury);
 }
-
-////////////////////////////////////////////////////////////////////////////////
-/// \brief Returns current luxury value.
-///
-Int_t TRandom1::GetLuxury() const
-{
-   return fLuxury;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// \brief Returns the current seed (first element of the seed table).
-///
-/// \warning This is not the initial seed!
-UInt_t TRandom1::GetSeed() const
-{
-   return static_cast<UInt_t>(fFloatSeedTable[0] / fMantissaBit24);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// \brief Returns the pointer to the current seeds array.
-const UInt_t *TRandom1::GetTheSeeds() const
-{
-   return fTheSeeds;
-}

--- a/math/mathcore/src/TRandom1.cxx
+++ b/math/mathcore/src/TRandom1.cxx
@@ -587,7 +587,7 @@ void TRandom1::SetSeed2(UInt_t seed, int lux)
 /// The initialisation of the other state values is carried out using a Multiplicative
 /// Congruential generator.
 ///
-/// Note: When seed = 0, a random and unique seed is generated.
+/// \note When seed = 0, a random and unique seed is generated.
 ///
 /// \param[in] seed   seed value (note special case if seed=0)
 ///

--- a/math/mathcore/src/TRandom2.cxx
+++ b/math/mathcore/src/TRandom2.cxx
@@ -15,7 +15,7 @@ For more information see:
 P. L'Ecuyer, Mathematics of Computation, 65, 213 (1996)
 P. L'Ecuyer, Mathematics of Computation, 68, 225 (1999)
 
-The publication are available online at
+The publications are available online at
  [http://www.iro.umontreal.ca/~lecuyer/myftp/papers/tausme.ps]
  [http://www.iro.umontreal.ca/~lecuyer/myftp/papers/tausme2.ps]
 
@@ -24,7 +24,6 @@ The publication are available online at
 */
 
 #include "TRandom2.h"
-#include "TRandom3.h"
 #include "TUUID.h"
 
 
@@ -111,7 +110,7 @@ void TRandom2::RndmArray(Int_t n, Double_t *array)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the generator seed.
 /// If the seed given is zero, generate automatically seed values which
-/// are different every time by using TRandom3  and TUUID
+/// are different every time by using TUUID.
 /// If a seed is given generate the other two needed for the generator state using
 /// a linear congruential generator
 /// The only condition, stated at the end of the 1999 L'Ecuyer paper is that the seeds
@@ -143,12 +142,6 @@ void TRandom2::SetSeed(ULong_t seed)
       UInt_t seed3 = UInt_t(uuid[15])*16777216 + UInt_t(uuid[14])*65536 + UInt_t(uuid[13])*256 + UInt_t(uuid[12]);
       fSeed2 += seed3;
 
-
-      //    TRandom r3(0);
-      // fSeed   = static_cast<UInt_t> (4294967296.*r3.Rndm());
-      // fSeed1  = static_cast<UInt_t> (4294967296.*r3.Rndm());
-      // fSeed2  = static_cast<UInt_t> (4294967296.*r3.Rndm());
-
       if (fSeed < 2)   fSeed  += 2UL;
       if (fSeed1 < 8)  fSeed1 += 8UL;
       if (fSeed2 < 16) fSeed2 += 16UL;
@@ -159,4 +152,18 @@ void TRandom2::SetSeed(ULong_t seed)
       Rndm();
 
    return;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Returns one of the seeds of the generator. \warning This is not the
+/// initial seed!
+///
+/// Explanation: The internal state of the generator is described by three
+/// `UInt_t` numbers, called seed numbers, but they are not initial seeds.
+/// This function exposes one of them and can't provide full description of the
+/// generator state.
+///
+UInt_t TRandom2::GetSeed() const
+{
+  return fSeed;
 }

--- a/math/mathcore/src/TRandom2.cxx
+++ b/math/mathcore/src/TRandom2.cxx
@@ -155,13 +155,13 @@ void TRandom2::SetSeed(ULong_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \brief Returns one of the seeds of the generator. \warning This is not the
-/// initial seed!
+/// \brief Returns one of the seeds of the generator.
 ///
-/// Explanation: The internal state of the generator is described by three
-/// `UInt_t` numbers, called seed numbers, but they are not initial seeds.
-/// This function exposes one of them and can't provide full description of the
-/// generator state.
+/// \warning This is not the initial seed!
+///
+/// The internal state of the generator is described by three `UInt_t` numbers,
+/// called seed numbers, but they are not initial seeds. This function exposes
+/// one of them and can't provide full description of the generator state.
 ///
 UInt_t TRandom2::GetSeed() const
 {

--- a/math/mathcore/src/TRandom2.cxx
+++ b/math/mathcore/src/TRandom2.cxx
@@ -165,5 +165,5 @@ void TRandom2::SetSeed(ULong_t seed)
 ///
 UInt_t TRandom2::GetSeed() const
 {
-  return fSeed;
+   return fSeed;
 }


### PR DESCRIPTION
# This Pull request: Improves documentation of TRandom::GetSeed() methods in derived classes.

## Changes or fixes:
Documentation involving inconsistencies in `TRandom::GetSeed()` methods. In the derived classes the seed variable is used to store internal state of the generator not to keep track of the initial state with which it was invoked.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #14580

