### PR TITLE
[skip-ci] Update .clang-format to comply with schema

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,16 @@
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
+AlignConsecutiveAssignments:
+  Enabled: false
 # This would be nice to have but seems to also (mis)align function parameters
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: true
+AlignConsecutiveDeclarations:
+  Enabled: false
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
@@ -17,12 +19,12 @@ AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: No
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass:      false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   true
   AfterNamespace:  false
@@ -32,7 +34,7 @@ BraceWrapping:
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
-BreakBeforeBinaryOperators: false
+BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
@@ -64,8 +66,8 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 10
 PointerAlignment: Right
-ReflowComments:  true
-SortIncludes: false
+ReflowComments: true
+SortIncludes: Never
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 # You want this : enable it if you have https://reviews.llvm.org/D32525
@@ -78,7 +80,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++11
 TabWidth:        3
 UseTab:          Never
 

--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@ AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: No
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

I noticed that the current `.clang-format` file does not fully comply with the schema (https://clang.llvm.org/docs/ClangFormatStyleOptions.html). I updated the configuration file so it's compliant (I made the choices based on what I thought the original authors wanted to achieve with the selected options). I am not sure if the lack of compliance with the schema is because of updates to `clang-format` or not.

The changes in this PR should only affect style, but these updates may make `clang-format` behave differently than before (because previous options may have being ignored).

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

