### PR TITLE
[tree] Add regression test for `GetEntry` after `Refresh`

### DIFF
--- a/tree/tree/test/TTreeRegressions.cxx
+++ b/tree/tree/test/TTreeRegressions.cxx
@@ -115,3 +115,21 @@ TEST(TTreeRegressions, GetLeafAndFriends)
    EXPECT_EQ(t.GetLeaf("asdklj", "x"), nullptr);
    EXPECT_EQ(t.GetLeaf("asdklj", "vec"), nullptr);
 }
+
+// ROOT-4839
+TEST(TTreeRegressions, RefreshAndGetEntry)
+{
+   TMemFile f("RefreshAndGetEntry.root", "recreate");
+   {
+      TTree t("t", "t");
+      int x = 42;
+      t.Branch("x", &x);
+      t.Fill();
+      t.Write();
+   }
+
+   auto t = f.Get<TTree>("t");
+   EXPECT_EQ(t->GetEntry(0), 4);
+   t->Refresh();
+   EXPECT_EQ(t->GetEntry(0), 4);
+}


### PR DESCRIPTION
As reported by https://its.cern.ch/jira/browse/ROOT-4839. See also #14560.
