### PR TITLE
[TUnix] RAM stats (gSystem->GetMemInfo) to htop/procps style

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -178,11 +178,17 @@ struct MemInfo_t {
    Int_t     fMemTotal;    // total RAM in MB
    Int_t     fMemUsed;     // used RAM in MB
    Int_t     fMemFree;     // free RAM in MB
+   Int_t     fMemAvailable; // available RAM in MB
+   Int_t     fMemCached; // cached RAM in MB
+   Int_t     fMemBuffer; // buffer RAM in MB
+   Int_t     fMemShared; // shared RAM in MB
    Int_t     fSwapTotal;   // total swap in MB
    Int_t     fSwapUsed;    // used swap in MB
    Int_t     fSwapFree;    // free swap in MB
-   MemInfo_t() : fMemTotal(0), fMemUsed(0), fMemFree(0),
-                 fSwapTotal(0), fSwapUsed(0), fSwapFree(0) { }
+   Int_t     fSwapCached; // cached swap in MB
+   Int_t     fSReclaimable; // slab that might be reclaimed
+   MemInfo_t() : fMemTotal(0), fMemUsed(0), fMemFree(0), fMemAvailable(0), fMemCached(0), fMemBuffer(0), fMemShared(0),
+                 fSwapTotal(0), fSwapUsed(0), fSwapFree(0), fSwapCached(0), fSReclaimable(0){ }
    virtual ~MemInfo_t() { }
    ClassDef(MemInfo_t, 1); // Memory utilization information.
 };


### PR DESCRIPTION
@vepadulano @dpiparo 

This PR fixes

- https://github.com/root-project/root/issues/7196

This issue is very case-dependent.
When trying to calculate memory usage, normally the actual free memory on the system is `free + buffer + cached `

If shared memory usage is high (e.g mmaping a big cache) the calculation is slightly different:
`(free + buffer/cache) - shared`

The author of **htop** mentions on [this](https://stackoverflow.com/questions/55090900/how-can-i-calculate-memory-utilisation-of-a-linux-server-using-sar-report) question that htop uses this convention(in 2016):

- Total used memory = MemTotal - MemFree
- Non cache/buffer memory = Total used memory - (Buffers + Cached memory)

Now htop (managed by htop-dev) uses this (on https://github.com/htop-dev/htop/blob/main/linux/LinuxMachine.c#L210):

```
const memory_t usedDiff = freeMem + cachedMem + sreclaimableMem + buffersMem;
host->usedMem = (totalMem >= usedDiff) ? totalMem - usedDiff : totalMem - freeMem;
```

This issue intends to merge the total used memory to include cached instead of just free which isn't strictly a correct solution.

This PR implements the current approach utilised by **htop** which includes the following fields to calculate `MemUsed`, `MemAvailable` and  `SwapUsed`:

```
Int_t     fMemAvailable; // available RAM in MB
Int_t     fMemCached; // cached RAM in MB
Int_t     fMemBuffer; // buffer RAM in MB
Int_t     fMemShared; // shared RAM in MB
Int_t     fSwapCached; // cached swap in MB
Int_t     fSReclaimable // slab that might be reclaimed
```

Results:

```
➜  ROOT free -h
              total        used        free      shared  buff/cache   available
Mem:           23Gi       3.4Gi       7.4Gi       214Mi        12Gi        19Gi
Swap:         7.6Gi       2.1Gi       5.5Gi
```

```
➜  ROOT root -l
root [0] MemInfo_t memInfo; gSystem->GetMemInfo(&memInfo);
root [1] cout << memInfo.fMemTotal << " " << memInfo.fMemUsed << " " << memInfo.fMemFree << endl;
23877 2786 7562
root [2] 
```
Checklist:

- [x] tested changes locally
