### PR TITLE
[core][aclic] Improve CleanCompiledMacros()

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -4340,14 +4340,29 @@ TString TSystem::SplitAclicMode(const char *filename, TString &aclicMode,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Remove the shared libs produced by the CompileMacro() function.
+/// Remove the shared libs produced by the CompileMacro() function, together
+/// with their rootmaps, linkdefs, and pcms (and some more on Windows).
 
 void TSystem::CleanCompiledMacros()
 {
    TIter next(fCompiled);
    TNamed *lib;
+   const char *extensions[] = {".lib", ".exp", ".d", ".def", ".rootmap",
+                               "_ACLiC_linkdef.h", "_ACLiC_dict_rdict.pcm"};
    while ((lib = (TNamed*)next())) {
-      if (lib->TestBit(kMustCleanup)) Unlink(lib->GetTitle());
+      if (lib->TestBit(kMustCleanup)) {
+         TString libname = lib->GetTitle();
+         std::cout << "TSystem::CleanCompiledMacros() : " << libname << std::endl;
+         if (gInterpreter->IsLibraryLoaded(libname))
+            Unload(libname);
+         Unlink(libname);
+         TString target, soExt = "." + fSoExt;
+         libname.ReplaceAll(soExt, "");
+         for (const char *ext : extensions) {
+            target = libname + ext;
+            Unlink(target);
+         }
+      }
    }
 }
 

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -57,6 +57,7 @@ allows a simple partial implementation for new OS'es.
 
 #ifdef WIN32
 #include <io.h>
+#include "Windows4Root.h"
 #endif
 
 const char *gRootDir = nullptr;
@@ -4352,9 +4353,11 @@ void TSystem::CleanCompiledMacros()
    while ((lib = (TNamed*)next())) {
       if (lib->TestBit(kMustCleanup)) {
          TString libname = lib->GetTitle();
-         std::cout << "TSystem::CleanCompiledMacros() : " << libname << std::endl;
+#ifdef WIN32
+         // On Windows, we need to unload the dll before deleting it
          if (gInterpreter->IsLibraryLoaded(libname))
-            Unload(libname);
+            ::FreeLibrary(::GetModuleHandle(libname));
+#endif
          Unlink(libname);
          TString target, soExt = "." + fSoExt;
          libname.ReplaceAll(soExt, "");

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2812,6 +2812,12 @@ static void R__WriteDependencyFile(const TString & build_loc, const TString &dep
 ///
 /// (the ... have to be replaced by the actual values and are here only to
 /// shorten this comment).
+///
+/// Note that the default behavior is to remove libraries when closing ROOT,
+/// ie TSystem::CleanCompiledMacros() is called in the TROOT destructor.
+/// The default behavior of .L script.C+ is the opposite one, leaving things
+/// after closing, without removing. In other words, .L always passes the 'k'
+/// option behind the scenes.
 
 int TSystem::CompileMacro(const char *filename, Option_t *opt,
                           const char *library_specified,
@@ -4348,8 +4354,7 @@ void TSystem::CleanCompiledMacros()
 {
    TIter next(fCompiled);
    TNamed *lib;
-   const char *extensions[] = {".lib", ".exp", ".d", ".def", ".rootmap",
-                               "_ACLiC_linkdef.h", "_ACLiC_dict_rdict.pcm"};
+   const char *extensions[] = {".lib", ".exp", ".d", ".def", ".rootmap", "_ACLiC_linkdef.h", "_ACLiC_dict_rdict.pcm"};
    while ((lib = (TNamed*)next())) {
       if (lib->TestBit(kMustCleanup)) {
          TString libname = lib->GetTitle();


### PR DESCRIPTION
Unload the library before deleting it (might be needed on Windows)
Delete also the associated files generated with CompileMacro()
Fixes https://github.com/root-project/root/issues/10395
