### PR TITLE
Removed skipping of 0 (zero) in TRandom3.Rndm()

### DIFF
--- a/math/mathcore/src/TRandom3.cxx
+++ b/math/mathcore/src/TRandom3.cxx
@@ -71,8 +71,10 @@ namespace {
 ClassImp(TRandom3);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-/// If seed is 0, the seed array is automatically computed via a TUUID object.
+/// \brief Default constructor.
+///
+/// If seed is 0, the seed array is automatically computed via a TRandom2
+/// object, which internally uses TUUID.
 /// In this case the seed is guaranteed to be unique in space and time.
 
 TRandom3::TRandom3(UInt_t seed)
@@ -83,7 +85,7 @@ TRandom3::TRandom3(UInt_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Default destructor.
+/// \brief Default destructor.
 
 TRandom3::~TRandom3()
 {
@@ -136,7 +138,8 @@ Double_t TRandom3::Rndm()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  \brief Return an array of n random numbers uniformly distributed in [0, 1[
+///  \brief Return an array of n random numbers uniformly distributed in [0, 1[.
+///
 ///  \warning Can produce 0 (zero).
 
 void TRandom3::RndmArray(Int_t n, Float_t *array)
@@ -145,7 +148,8 @@ void TRandom3::RndmArray(Int_t n, Float_t *array)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  \brief Return an array of n random numbers uniformly distributed in [0, 1[
+///  \brief Return an array of n random numbers uniformly distributed in [0, 1[.
+///
 ///  \warning Can produce 0 (zero).
 
 void TRandom3::RndmArray(Int_t n, Double_t *array)
@@ -219,8 +223,8 @@ void TRandom3::SetSeed(ULong_t seed)
 
    } else {
 
-      // use TRandom2 (which is based on TUUId to generate the seed
-      // TRandom2 works fairly well  and has been tested against example
+      // use TRandom2 (which is based on TUUID to generate the seed.
+      // TRandom2 works fairly well and has been tested against example
       // layout in https://savannah.cern.ch/bugs/?99516
       TRandom2 r(0);
       for (Int_t i = 0; i< 624; i++) {
@@ -234,7 +238,7 @@ void TRandom3::SetSeed(ULong_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Stream an object of class TRandom3.
+/// \brief Streamer for an object of class TRandom3.
 
 void TRandom3::Streamer(TBuffer &R__b)
 {

--- a/math/mathcore/src/TRandom3.cxx
+++ b/math/mathcore/src/TRandom3.cxx
@@ -185,10 +185,8 @@ void TRandom3::RndmArray(Int_t n, Double_t *array)
       y ^= ((y << 15) & kTemperingMaskC );
       y ^=  (y >> 18);
 
-      if (y) {
-         array[k] = (static_cast<Double_t>(y) + 1) * 2.3283064365386963e-10; // * Power(2,-32)
-         k++;
-      }
+      array[k] = (static_cast<Double_t>(y) + 1) * 2.3283064365386963e-10; // * Power(2,-32)
+      k++;
    }
 }
 

--- a/math/mathcore/src/TRandom3.cxx
+++ b/math/mathcore/src/TRandom3.cxx
@@ -94,9 +94,7 @@ TRandom3::~TRandom3()
 ////////////////////////////////////////////////////////////////////////////////
 ///  \brief Machine independent random number generator.
 ///
-///  \warning Can produce 0 (zero).
-///
-///  Produces uniformly-distributed floating points in [0, 1[.
+///  Produces uniformly-distributed floating points in ]0, 1].
 ///  Method: Mersenne Twister
 Double_t TRandom3::Rndm()
 {
@@ -133,31 +131,25 @@ Double_t TRandom3::Rndm()
    y ^= ((y << 15) & kTemperingMaskC );
    y ^=  (y >> 18);
 
-   // 2.3283064365386963e-10 == 1. / (max<UInt_t> + 1) -> then returned value cannot be = 1.0
-   return static_cast<Double_t>(y * 2.3283064365386963e-10);
+   // 2.3283064365386963e-10 == 1. / (max<UInt_t> + 1)
+   return (static_cast<Double_t>(y) + 1) * 2.3283064365386963e-10;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  \brief Return an array of n random numbers uniformly distributed in [0, 1[.
-///
-///  \warning Can produce 0 (zero).
+///  \brief Return an array of n random numbers uniformly distributed in ]0, 1].
 
 void TRandom3::RndmArray(Int_t n, Float_t *array)
 {
-  for(Int_t i=0; i<n; i++) array[i]=(Float_t)Rndm();
+  for(Int_t i=0; i<n; i++) {
+    array[i] = static_cast<Float_t>(Rndm());
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  \brief Return an array of n random numbers uniformly distributed in [0, 1[.
-///
-///  \warning Can produce 0 (zero).
+///  \brief Return an array of n random numbers uniformly distributed in ]0, 1].
 
 void TRandom3::RndmArray(Int_t n, Double_t *array)
 {
-   Int_t k = 0;
-
-   UInt_t y;
-
    const Int_t  kM = 397;
    const Int_t  kN = 624;
    const UInt_t kTemperingMaskB =  0x9d2c5680;
@@ -166,6 +158,8 @@ void TRandom3::RndmArray(Int_t n, Double_t *array)
    const UInt_t kLowerMask =       0x7fffffff;
    const UInt_t kMatrixA =         0x9908b0df;
 
+   Int_t k = 0;
+   UInt_t y;
    while (k < n) {
       if (fCount624 >= kN) {
          Int_t i;
@@ -192,7 +186,7 @@ void TRandom3::RndmArray(Int_t n, Double_t *array)
       y ^=  (y >> 18);
 
       if (y) {
-         array[k] = Double_t( y * 2.3283064365386963e-10); // * Power(2,-32)
+         array[k] = (static_cast<Double_t>(y) + 1) * 2.3283064365386963e-10; // * Power(2,-32)
          k++;
       }
    }
@@ -228,7 +222,7 @@ void TRandom3::SetSeed(ULong_t seed)
       // layout in https://savannah.cern.ch/bugs/?99516
       TRandom2 r(0);
       for (Int_t i = 0; i< 624; i++) {
-         fMt[i]   = static_cast<UInt_t> (4294967296.*r.Rndm());
+         fMt[i] = static_cast<UInt_t>(4294967296.*r.Rndm());
       }
       // warm up the generator calling it 10 times
       for (Int_t i = 0; i < 10; ++i) Rndm();

--- a/math/mathcore/src/TRandom3.cxx
+++ b/math/mathcore/src/TRandom3.cxx
@@ -7,7 +7,7 @@
 
 Random number generator class based on
   M. Matsumoto and T. Nishimura,
-  Mersenne Twister: A 623-diminsionally equidistributed
+  Mersenne Twister: A 623-dimensionally equidistributed
   uniform pseudorandom number generator
   ACM Transactions on Modeling and Computer Simulation,
   Vol. 8, No. 1, January 1998, pp 3--30.
@@ -15,19 +15,18 @@ Random number generator class based on
 For more information see the Mersenne Twister homepage
   [http://www.math.keio.ac.jp/~matumoto/emt.html]
 
-Advantage:
+Advantages:
+- large period 2**19937 - 1
+- relatively fast (slightly slower than TRandom2 but much faster than TRandom1)
 
--  large period 2**19937 -1
--  relatively fast (slightly slower than TRandom2 but much faster than TRandom1)
-
-Drawback:
--  a relative large internal state of 624 integers 
-- generate only 32 random bits 
+Drawbacks:
+- a relative large internal state of 624 integers
+- generate only 32 random bits
 - not passing all the random generator tests. It fails some tests in TestU01
- (see [http://simul.iro.umontreal.ca/testu01/tu01.html])
+    (see [http://simul.iro.umontreal.ca/testu01/tu01.html])
 
-An altenativly excellent generator passing all tests of TestU01, having 61 random bits and 
-fast as Mersenne and Twister is MIXMAX (TRandomMixMax). 
+An alternatively excellent generator passing all tests of TestU01, having 61 random bits and
+being as fast as Mersenne and Twister is MIXMAX (TRandomMixMax).
 
 @ingroup Random
 
@@ -58,7 +57,6 @@ fast as Mersenne and Twister is MIXMAX (TRandomMixMax).
 #include "TRandom3.h"
 #include "TBuffer.h"
 #include "TRandom2.h"
-#include "TUUID.h"
 
 TRandom *gRandom = new TRandom3();
 #ifdef R__COMPLETE_MEM_TERMINATION
@@ -74,7 +72,7 @@ ClassImp(TRandom3);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
-/// If seed is 0, the seed is automatically computed via a TUUID object.
+/// If seed is 0, the seed array is automatically computed via a TUUID object.
 /// In this case the seed is guaranteed to be unique in space and time.
 
 TRandom3::TRandom3(UInt_t seed)
@@ -85,21 +83,21 @@ TRandom3::TRandom3(UInt_t seed)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Default destructor
+/// Default destructor.
 
 TRandom3::~TRandom3()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  Machine independent random number generator.
-///  Produces uniformly-distributed floating points in (0,1)
+///  \brief Machine independent random number generator.
+///
+///  \warning Can produce 0 (zero).
+///
+///  Produces uniformly-distributed floating points in [0, 1[.
 ///  Method: Mersenne Twister
-
 Double_t TRandom3::Rndm()
 {
-   UInt_t y;
-
    const Int_t  kM = 397;
    const Int_t  kN = 624;
    const UInt_t kTemperingMaskB =  0x9d2c5680;
@@ -108,6 +106,7 @@ Double_t TRandom3::Rndm()
    const UInt_t kLowerMask =       0x7fffffff;
    const UInt_t kMatrixA =         0x9908b0df;
 
+   UInt_t y;
    if (fCount624 >= kN) {
       Int_t i;
 
@@ -132,13 +131,13 @@ Double_t TRandom3::Rndm()
    y ^= ((y << 15) & kTemperingMaskC );
    y ^=  (y >> 18);
 
-   // 2.3283064365386963e-10 == 1./(max<UINt_t>+1)  -> then returned value cannot be = 1.0
-   if (y) return ( (Double_t) y * 2.3283064365386963e-10); // * Power(2,-32)
-   return Rndm();
+   // 2.3283064365386963e-10 == 1. / (max<UInt_t> + 1) -> then returned value cannot be = 1.0
+   return static_cast<Double_t>(y * 2.3283064365386963e-10);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return an array of n random numbers uniformly distributed in ]0,1]
+///  \brief Return an array of n random numbers uniformly distributed in [0, 1[
+///  \warning Can produce 0 (zero).
 
 void TRandom3::RndmArray(Int_t n, Float_t *array)
 {
@@ -146,7 +145,8 @@ void TRandom3::RndmArray(Int_t n, Float_t *array)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return an array of n random numbers uniformly distributed in ]0,1]
+///  \brief Return an array of n random numbers uniformly distributed in [0, 1[
+///  \warning Can produce 0 (zero).
 
 void TRandom3::RndmArray(Int_t n, Double_t *array)
 {
@@ -195,13 +195,15 @@ void TRandom3::RndmArray(Int_t n, Double_t *array)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  Set the random generator sequence
-/// if seed is 0 (default value) a TUUID is generated and used to fill
-/// the first 8 integers of the seed array.
+/// \brief Set the random generator sequence.
+///
+/// If seed is 0 (default value) a TRandom2 (internally uses TUUID) is used to
+/// generate all 624 unsigned integers of the seed array.
 /// In this case the seed is guaranteed to be unique in space and time.
-/// Use upgraded seeding procedure to fix a known problem when seeding with values
-/// with many zero in the bit pattern (like 2**28).
-/// see http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html
+///
+/// Upgraded seeding procedure is used to fix a known problem when seeding with
+/// values with many zero in the bit pattern (like 2**28), see
+/// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html
 
 void TRandom3::SetSeed(ULong_t seed)
 {

--- a/math/mathcore/src/TRandom3.cxx
+++ b/math/mathcore/src/TRandom3.cxx
@@ -140,9 +140,9 @@ Double_t TRandom3::Rndm()
 
 void TRandom3::RndmArray(Int_t n, Float_t *array)
 {
-  for(Int_t i=0; i<n; i++) {
-    array[i] = static_cast<Float_t>(Rndm());
-  }
+   for (Int_t i = 0; i < n; i++) {
+      array[i] = static_cast<Float_t>(Rndm());
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -222,7 +222,7 @@ void TRandom3::SetSeed(ULong_t seed)
       // layout in https://savannah.cern.ch/bugs/?99516
       TRandom2 r(0);
       for (Int_t i = 0; i< 624; i++) {
-         fMt[i] = static_cast<UInt_t>(4294967296.*r.Rndm());
+         fMt[i] = static_cast<UInt_t>(4294967296. * r.Rndm());
       }
       // warm up the generator calling it 10 times
       for (Int_t i = 0; i < 10; ++i) Rndm();

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -96,6 +96,8 @@ ROOT_ADD_GTEST(testRootFinder testRootFinder.cxx  LIBRARIES ${Libraries})
 ROOT_ADD_GTEST(testKahan testKahan.cxx LIBRARIES Core MathCore)
 ROOT_ADD_GTEST(testDelaunay2D testDelaunay2D.cxx LIBRARIES Core MathCore)
 
+ROOT_ADD_GTEST(testTRandom3vsStdMt19937 testTRandom3vsStdMt19937.cxx LIBRARIES Core MathCore)
+
 if(clad)
   ROOT_ADD_GTEST(CladDerivatorTests CladDerivatorTests.cxx LIBRARIES Core MathCore)
 endif()

--- a/math/mathcore/test/testTRandom3vsStdMt19937.cxx
+++ b/math/mathcore/test/testTRandom3vsStdMt19937.cxx
@@ -19,7 +19,7 @@ TEST(TRandom3Test, TRandom3vsStdMt19937)
    // Test inspired by code of Giovanni Cerretani in this issue:
    // https://its.cern.ch/jira/browse/ROOT-9733
    // https://github.com/root-project/root/issues/14581
-   for (size_t generation = 0; generation < 3; ++generation) {
+   for (size_t generation = 0; generation < 2; ++generation) {
       unsigned int iteration = 0;
       while (++iteration) {
          double rnd_std = (gen_std() + 1) * 2.3283064365386963e-10;

--- a/math/mathcore/test/testTRandom3vsStdMt19937.cxx
+++ b/math/mathcore/test/testTRandom3vsStdMt19937.cxx
@@ -19,10 +19,10 @@ TEST(TRandom3Test, TRandom3vsStdMt19937)
    // Test inspired by code of Giovanni Cerretani in this issue:
    // https://its.cern.ch/jira/browse/ROOT-9733
    // https://github.com/root-project/root/issues/14581
-   for (size_t generation = 0; generation < 5; ++generation) {
+   for (size_t generation = 0; generation < 3; ++generation) {
       unsigned int iteration = 0;
       while (++iteration) {
-         double rnd_std = gen_std() * 2.3283064365386963e-10;
+         double rnd_std = (gen_std() + 1) * 2.3283064365386963e-10;
          double rnd_root = gen_root.Rndm();
 
          ASSERT_EQ(rnd_std, rnd_root);

--- a/math/mathcore/test/testTRandom3vsStdMt19937.cxx
+++ b/math/mathcore/test/testTRandom3vsStdMt19937.cxx
@@ -1,0 +1,31 @@
+// std
+#include <random>
+
+// ROOT
+#include "TRandom3.h"
+
+#include "gtest/gtest.h"
+
+TEST(TRandom3Test, TRandom3vsStdMt19937)
+{
+  unsigned int seed = 28u;
+
+  std::mt19937 gen_std(seed);
+  TRandom3 gen_root(seed);
+
+  // Test TRandom3 generator against other implementation of Mersenne Twister
+  // 32-bit algoritm.
+  //
+  // Test inspired by code of Giovanni Cerretani in this issue:
+  // https://its.cern.ch/jira/browse/ROOT-9733
+  // https://github.com/root-project/root/issues/14581
+  for (size_t generation = 0; generation < 5; ++generation) {
+    unsigned int iteration = 0;
+    while (++iteration) {
+      double rnd_std = gen_std() * 2.3283064365386963e-10;
+      double rnd_root = gen_root.Rndm();
+
+      ASSERT_EQ(rnd_std, rnd_root);
+    }
+  }
+}

--- a/math/mathcore/test/testTRandom3vsStdMt19937.cxx
+++ b/math/mathcore/test/testTRandom3vsStdMt19937.cxx
@@ -8,24 +8,24 @@
 
 TEST(TRandom3Test, TRandom3vsStdMt19937)
 {
-  unsigned int seed = 28u;
+   unsigned int seed = 28u;
 
-  std::mt19937 gen_std(seed);
-  TRandom3 gen_root(seed);
+   std::mt19937 gen_std(seed);
+   TRandom3 gen_root(seed);
 
-  // Test TRandom3 generator against other implementation of Mersenne Twister
-  // 32-bit algoritm.
-  //
-  // Test inspired by code of Giovanni Cerretani in this issue:
-  // https://its.cern.ch/jira/browse/ROOT-9733
-  // https://github.com/root-project/root/issues/14581
-  for (size_t generation = 0; generation < 5; ++generation) {
-    unsigned int iteration = 0;
-    while (++iteration) {
-      double rnd_std = gen_std() * 2.3283064365386963e-10;
-      double rnd_root = gen_root.Rndm();
+   // Test TRandom3 generator against other implementation of Mersenne Twister
+   // 32-bit algoritm.
+   //
+   // Test inspired by code of Giovanni Cerretani in this issue:
+   // https://its.cern.ch/jira/browse/ROOT-9733
+   // https://github.com/root-project/root/issues/14581
+   for (size_t generation = 0; generation < 5; ++generation) {
+      unsigned int iteration = 0;
+      while (++iteration) {
+         double rnd_std = gen_std() * 2.3283064365386963e-10;
+         double rnd_root = gen_root.Rndm();
 
-      ASSERT_EQ(rnd_std, rnd_root);
-    }
-  }
+         ASSERT_EQ(rnd_std, rnd_root);
+      }
+   }
 }


### PR DESCRIPTION
# This Pull request: Removes skipping of 0 (zero) in TRandom3.Rndm()

## Changes or fixes:
* Removes skipping of 0 (zero) in TRandom3.Rndm()
* Updates documentation, adds warnings


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #14581

