### PR TITLE
[ntuple] add RFieldBase::CreateObject()

### DIFF
--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -766,11 +766,13 @@ TEST(RFieldBase, CreateObject)
 
    void *rawPtr = RField<int>("name").CreateObject<void>().release();
    EXPECT_EQ(0, *static_cast<int *>(rawPtr));
+   delete static_cast<int *>(rawPtr);
 
    {
       ROOT::TestSupport::CheckDiagsRAII diagRAII;
       diagRAII.requiredDiag(kWarning, "[ROOT.NTuple]", "possibly leaking", false /* matchFullMessage */);
       auto p = RField<int>("name").CreateObject<void>();
+      delete static_cast<int *>(p.get()); // avoid release
    }
 
    EXPECT_THROW(RField<int>("name").CreateObject<float>(), RException);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -758,3 +758,23 @@ TEST(REntry, Basics)
    e->BindRawPtr("pt", &pt);
    EXPECT_EQ(&pt, e->GetPtr<void>("pt").get());
 }
+
+TEST(RFieldBase, CreateObject)
+{
+   auto ptrInt = RField<int>("name").CreateObject<int>();
+   EXPECT_EQ(0, *ptrInt);
+
+   void *rawPtr = RField<int>("name").CreateObject<void>().release();
+   EXPECT_EQ(0, *static_cast<int *>(rawPtr));
+
+   {
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.requiredDiag(kWarning, "[ROOT.NTuple]", "possibly leaking", false /* matchFullMessage */);
+      auto p = RField<int>("name").CreateObject<void>();
+   }
+
+   EXPECT_THROW(RField<int>("name").CreateObject<float>(), RException);
+
+   auto ptrClass = RField<LowPrecisionFloats>("name").CreateObject<LowPrecisionFloats>();
+   EXPECT_DOUBLE_EQ(1.0, ptrClass->b);
+}


### PR DESCRIPTION
A templated factory method for the field's type. Returns a unique_ptr<T>. If called with void, returns a unique pointer with a deleter that complains when called. The `unique_ptr<void>` is supposed to be explicitly released (ownership transfer).

@Nowakus FYI