### PR TITLE
[ntuple] add REntry::EmplaceNewValue()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -115,6 +115,18 @@ public:
       return RFieldToken(std::distance(fValues.begin(), it), fModelId);
    }
 
+   void EmplaceNewValue(RFieldToken token)
+   {
+      if (fModelId != token.fModelId) {
+         throw RException(R__FAIL("invalid token for this entry, "
+                                  "make sure to use a token from the same model as this entry."));
+      }
+      auto &v = fValues[token.fIndex];
+      v.EmplaceNew();
+   }
+
+   void EmplaceNewValue(std::string_view fieldName) { EmplaceNewValue(GetToken(fieldName)); }
+
    template <typename T>
    void BindValue(RFieldToken token, std::shared_ptr<T> objPtr)
    {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -757,4 +757,7 @@ TEST(REntry, Basics)
    float pt;
    e->BindRawPtr("pt", &pt);
    EXPECT_EQ(&pt, e->GetPtr<void>("pt").get());
+
+   e->EmplaceNewValue("pt");
+   EXPECT_NE(&pt, e->GetPtr<void>("pt").get());
 }


### PR DESCRIPTION
Makes it easy to have an entry whose values are partially managed by RNTuple and partially be the application.

