### PR TITLE
[PyROOT] Relax overly pedantic `getattr` pythonization tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
+++ b/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
@@ -45,13 +45,9 @@ class TDirectoryReadWrite(unittest.TestCase):
         self.checkHisto(self.dir0.dir1.dir2.h2)
 
     def test_caching_getattr(self):
-        # check that __dict__ of self.dir_caching is initially empty
-        self.assertFalse(self.dir0.__dict__)
+        # check that object is not cached initially
+        self.assertFalse("h" in self.dir0.__dict__)
         self.dir0.h
-        # check that after call __dict__ is not empty anymore
-        self.assertTrue(self.dir0.__dict__)
-        # check that __dict__ has only one entry
-        self.assertEqual(len(self.dir0.__dict__), 1)
         # check that the value in __dict__ is actually the object
         # inside the directory
         self.assertEqual(self.dir0.__dict__['h'], self.dir0.h)

--- a/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
+++ b/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
@@ -50,13 +50,9 @@ class TDirectoryFileReadWrite(unittest.TestCase):
         self.checkHisto(self.dir0.Get("dir1/dir2/h2"))
 
     def test_caching_getattr(self):
-        # check that __dict__ of self.dir_caching is initially empty
-        self.assertFalse(self.dir0.__dict__)
+        # check that object is not cached initially
+        self.assertFalse("h" in self.dir0.__dict__)
         self.dir0.h
-        # check that after call is not empty anymore
-        self.assertTrue(self.dir0.__dict__)
-        # check that __dict__ has only one entry
-        self.assertEqual(len(self.dir0.__dict__), 1)
         # check that the value in __dict__ is actually the object
         # inside the directory
         self.assertEqual(self.dir0.__dict__['h'], self.dir0.h)

--- a/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -57,13 +57,9 @@ class TFileOpenReadWrite(unittest.TestCase):
 
     def test_caching_getattr(self):
         f = ROOT.TFile.Open(self.filename)
-        # check that __dict__ of self.dir_caching is initially empty
-        self.assertFalse(f.__dict__)
+        # check that object is not cached initially
+        self.assertFalse("h" in f.__dict__)
         f.h
-        # check that after call is not empty anymore
-        self.assertTrue(f.__dict__)
-        # check that __dict__ has only one entry
-        self.assertEqual(len(f.__dict__), 1)
         # check that the value in __dict__ is actually the object
         # inside the directory
         self.assertEqual(f.__dict__['h'], f.h)


### PR DESCRIPTION
The `getattr` pythonization for TDirectory is caching the retrieved objects as attributes of the TDirectory. To check that the objects are not cached initially, there is a check that the TDirectory instance has no attributes at all. This is too strict, as we care only that the supposedly cached attribute is not there.

This commit suggests to explicity check for at attribute with the name of the object.

The reason for changing this now is because the old check would not work anymore with the new CPyCppyy. With the new version, additional lifeline attributes are set by cppyy to manage the lifetimes of objects.

This is a spinoff of the CPyCppyy syncronization PR, which was created to factorize the review process.