### PR TITLE
[TMVA] TSpline2: fix memory issues

### DIFF
--- a/tmva/tmva/inc/TMVA/TSpline1.h
+++ b/tmva/tmva/inc/TMVA/TSpline1.h
@@ -53,9 +53,8 @@ namespace TMVA {
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
    private:
-      int N;
-      std::vector<Double_t> X;
-      std::vector<Double_t> Y;
+      std::vector<Double_t> fX;
+      std::vector<Double_t> fY;
 
       ClassDef(TSpline1,0); //Linear interpolation class
    };

--- a/tmva/tmva/inc/TMVA/TSpline1.h
+++ b/tmva/tmva/inc/TMVA/TSpline1.h
@@ -43,8 +43,7 @@ namespace TMVA {
    class TSpline1 : public TSpline {
 
    public:
-
-      TSpline1( const TString& title, TGraph* theGraph );
+      TSpline1(const TString &title, const TGraph *theGraph);
       virtual ~TSpline1( void );
 
       virtual  Double_t Eval( Double_t x ) const;
@@ -53,11 +52,10 @@ namespace TMVA {
       virtual void BuildCoeff( void );
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
-      const TGraph* GetGraph() const { return fGraph; }
-
    private:
-
-      TGraph *fGraph;  ///< graph that is splined
+      int N;
+      std::vector<Double_t> X;
+      std::vector<Double_t> Y;
 
       ClassDef(TSpline1,0); //Linear interpolation class
    };

--- a/tmva/tmva/inc/TMVA/TSpline2.h
+++ b/tmva/tmva/inc/TMVA/TSpline2.h
@@ -54,9 +54,8 @@ namespace TMVA {
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
    private:
-      int N;
-      std::vector<Double_t> X;
-      std::vector<Double_t> Y;
+      std::vector<Double_t> fX;
+      std::vector<Double_t> fY;
 
       Double_t Quadrax( Float_t dm, Float_t dm1,
                         Float_t dm2, Float_t dm3,

--- a/tmva/tmva/inc/TMVA/TSpline2.h
+++ b/tmva/tmva/inc/TMVA/TSpline2.h
@@ -44,7 +44,7 @@ namespace TMVA {
 
    public:
   
-      TSpline2( const TString& title, TGraph* theGraph );
+      TSpline2( const TString& title, const TGraph *theGraph );
       virtual ~TSpline2( void );
 
       virtual  Double_t Eval( Double_t x ) const;
@@ -54,8 +54,10 @@ namespace TMVA {
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
    private:
+      int N;
+      std::vector<Double_t> X;
+      std::vector<Double_t> Y;
 
-      TGraph *fGraph;   // graph that is splined
       Double_t Quadrax( Float_t dm, Float_t dm1,
                         Float_t dm2, Float_t dm3,
                         Float_t cos1, Float_t cos2, 

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -339,11 +339,11 @@ void TMVA::PDF::BuildSplinePDF()
       break;
 
    case kSpline1:
-      fSpline = new TMVA::TSpline1( "spline1", new TGraph(*fGraph) );
+      fSpline = new TMVA::TSpline1( "spline1", fGraph ); //TSpline1 only copies graph points
       break;
 
    case kSpline2:
-      fSpline = new TMVA::TSpline2( "spline2", new TGraph(*fGraph) );
+      fSpline = new TMVA::TSpline2( "spline2", fGraph ); //TSpline2 only copies graph points
       break;
 
    case kSpline3:
@@ -356,7 +356,7 @@ void TMVA::PDF::BuildSplinePDF()
 
    default:
       Log() << kWARNING << "No valid interpolation method given! Use Spline2" << Endl;
-      fSpline = new TMVA::TSpline2( "spline2", new TGraph(*fGraph) );
+      fSpline = new TMVA::TSpline2( "spline2", fGraph );
       Log() << kFATAL << " Well.. .thinking about it, I better quit so you notice you are forced to fix the mistake " << Endl;
       std::exit(1);
    }

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -339,19 +339,19 @@ void TMVA::PDF::BuildSplinePDF()
       break;
 
    case kSpline1:
-      fSpline = new TMVA::TSpline1( "spline1", fGraph ); //TSpline1 only copies graph points
+      fSpline = new TMVA::TSpline1( "spline1", fGraph );
       break;
 
    case kSpline2:
-      fSpline = new TMVA::TSpline2( "spline2", fGraph ); //TSpline2 only copies graph points
+      fSpline = new TMVA::TSpline2( "spline2", fGraph );
       break;
 
    case kSpline3:
-      fSpline = new TSpline3( "spline3", new TGraph(*fGraph) );
+      fSpline = new TSpline3( "spline3", fGraph );
       break;
 
    case kSpline5:
-      fSpline = new TSpline5( "spline5", new TGraph(*fGraph) );
+      fSpline = new TSpline5( "spline5", fGraph );
       break;
 
    default:

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -38,11 +38,13 @@ Linear interpolation of TGraph
 ClassImp(TMVA::TSpline1);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// constructor from TGraph
+/// constructor from TGraph pointer (not owned by TSpline1)
 /// TSpline is a TNamed object
 
-TMVA::TSpline1::TSpline1( const TString& title, TGraph* theGraph )
-: fGraph( theGraph )
+TMVA::TSpline1::TSpline1( const TString& title, const TGraph *theGraph )
+   : N(theGraph->GetN()),
+     X(theGraph->GetX(), theGraph->GetX() + N),
+     Y(theGraph->GetY(), theGraph->GetY() + N)
 {
    SetNameTitle( title, title );
 }
@@ -50,35 +52,28 @@ TMVA::TSpline1::TSpline1( const TString& title, TGraph* theGraph )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::TSpline1::~TSpline1( void )
-{
-   if (fGraph) delete fGraph; // ROOT's spline classes also own the TGraph
-}
+TMVA::TSpline1::~TSpline1( void ) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// returns linearly interpolated TGraph entry around x
 
 Double_t TMVA::TSpline1::Eval( Double_t x ) const
 {
-   Int_t ibin = TMath::BinarySearch( fGraph->GetN(),
-                                     fGraph->GetX(),
-                                     x );
-   Int_t nbin = fGraph->GetN();
-
+   Int_t ibin = std::distance(X.begin(), TMath::BinarySearch(X.begin(), X.end(), x));
    // sanity checks
-   if (ibin < 0    ) ibin = 0;
-   if (ibin >= nbin) ibin = nbin - 1;
+   if (ibin < 0 ) ibin = 0;
+   if (ibin >= N) ibin = N - 1;
 
    Int_t nextbin = ibin;
-   if ((x > fGraph->GetX()[ibin] && ibin != nbin-1) || ibin == 0)
+   if ((x > X[ibin] && ibin != N-1) || ibin == 0)
       nextbin++;
    else
       nextbin--;
 
    // linear interpolation
-   Double_t dx = fGraph->GetX()[ibin] - fGraph->GetX()[nextbin];
-   Double_t dy = fGraph->GetY()[ibin] - fGraph->GetY()[nextbin];
-   return fGraph->GetY()[ibin] + (x - fGraph->GetX()[ibin]) * dy/dx;
+   Double_t dx = X[ibin] - X[nextbin];
+   Double_t dy = Y[ibin] - Y[nextbin];
+   return Y[ibin] + (x - X[ibin]) * dy/dx;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -58,8 +58,8 @@ TMVA::TSpline1::~TSpline1( void ) {}
 
 Double_t TMVA::TSpline1::Eval( Double_t x ) const
 {
-   auto N = fX.size();
-   auto ibin = std::distance(fX.begin(), TMath::BinarySearch(fX.begin(), fX.end(), x));
+   Int_t N = fX.size();
+   Int_t ibin = std::distance(fX.begin(), TMath::BinarySearch(fX.begin(), fX.end(), x));
    // sanity checks
    if (ibin < 0 ) ibin = 0;
    if (ibin >= N) ibin = N - 1;

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -42,9 +42,8 @@ ClassImp(TMVA::TSpline1);
 /// TSpline is a TNamed object
 
 TMVA::TSpline1::TSpline1( const TString& title, const TGraph *theGraph )
-   : N(theGraph->GetN()),
-     X(theGraph->GetX(), theGraph->GetX() + N),
-     Y(theGraph->GetY(), theGraph->GetY() + N)
+: fX(theGraph->GetX(), theGraph->GetX() + theGraph->GetN()),
+  fY(theGraph->GetY(), theGraph->GetY() + theGraph->GetN())
 {
    SetNameTitle( title, title );
 }
@@ -59,21 +58,22 @@ TMVA::TSpline1::~TSpline1( void ) {}
 
 Double_t TMVA::TSpline1::Eval( Double_t x ) const
 {
-   Int_t ibin = std::distance(X.begin(), TMath::BinarySearch(X.begin(), X.end(), x));
+   auto N = fX.size();
+   auto ibin = std::distance(fX.begin(), TMath::BinarySearch(fX.begin(), fX.end(), x));
    // sanity checks
    if (ibin < 0 ) ibin = 0;
    if (ibin >= N) ibin = N - 1;
 
    Int_t nextbin = ibin;
-   if ((x > X[ibin] && ibin != N-1) || ibin == 0)
+   if ((x > fX[ibin] && ibin != N-1) || ibin == 0)
       nextbin++;
    else
       nextbin--;
 
    // linear interpolation
-   Double_t dx = X[ibin] - X[nextbin];
-   Double_t dy = Y[ibin] - Y[nextbin];
-   return Y[ibin] + (x - X[ibin]) * dy/dx;
+   Double_t dx = fX[ibin] - fX[nextbin];
+   Double_t dy = fY[ibin] - fY[nextbin];
+   return fY[ibin] + (x - fX[ibin]) * dy/dx;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -42,8 +42,8 @@ ClassImp(TMVA::TSpline2);
 /// constructor from TGraph pointer (not owned by TSpline2)
 /// TSpline is a TNamed object
 
-TMVA::TSpline2::TSpline2( const TString& title, TGraph* theGraph )
-: fGraph( theGraph ) // not owned by TSpline2
+TMVA::TSpline2::TSpline2(const TString &title, const TGraph *theGraph)
+   : N(theGraph->GetN()), X(theGraph->GetX(), theGraph->GetX() + N), Y(theGraph->GetY(), theGraph->GetY() + N)
 {
    SetNameTitle( title, title );
 }
@@ -60,55 +60,53 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
 {
    Double_t retval=0;
 
-   Int_t ibin = TMath::BinarySearch( fGraph->GetN(),
-                                     fGraph->GetX(),
-                                     x );
+   Int_t ibin = std::distance(X.begin(), TMath::BinarySearch( X.begin(), X.end(), x ));
 
    // sanity checks
-   if (ibin < 0               ) ibin = 0;
-   if (ibin >= fGraph->GetN()) ibin =  fGraph->GetN() - 1;
+   if (ibin < 0 ) ibin = 0;
+   if (ibin >= N) ibin = N - 1;
 
    Float_t dx = 0; // should be zero
-   if (fGraph->GetN() < 3) { // if the graph does not have enough points
+   if (N < 3) { // if the graph does not have enough points
       Warning("Eval", "Graph has less than 3 points, returning value of the closest");
-      retval = fGraph->GetY()[ibin];
+      retval = Y[ibin];
    } else if (ibin == 0) {
 
       retval = Quadrax(x,
-                       fGraph->GetX()[ibin] + dx,
-                       fGraph->GetX()[ibin + 1] + dx,
-                       fGraph->GetX()[ibin + 2] + dx,
-                       fGraph->GetY()[ibin],
-                       fGraph->GetY()[ibin + 1],
-                       fGraph->GetY()[ibin + 2]);
+                       X[ibin] + dx,
+                       X[ibin + 1] + dx,
+                       X[ibin + 2] + dx,
+                       Y[ibin],
+                       Y[ibin + 1],
+                       Y[ibin + 2]);
 
-   } else if (ibin >= (fGraph->GetN() - 2)) {
-      ibin = fGraph->GetN() - 1; // always fixed to last bin
+   } else if (ibin >= (N - 2)) {
+      ibin = N - 1; // always fixed to last bin
 
       retval = Quadrax(x,
-                       fGraph->GetX()[ibin - 2] + dx,
-                       fGraph->GetX()[ibin - 1] + dx,
-                       fGraph->GetX()[ibin] + dx,
-                       fGraph->GetY()[ibin - 2],
-                       fGraph->GetY()[ibin - 1],
-                       fGraph->GetY()[ibin]);
+                       X[ibin - 2] + dx,
+                       X[ibin - 1] + dx,
+                       X[ibin] + dx,
+                       Y[ibin - 2],
+                       Y[ibin - 1],
+                       Y[ibin]);
    } else {
 
       retval = ( Quadrax( x,
-                          fGraph->GetX()[ibin-1] + dx,
-                          fGraph->GetX()[ibin]   + dx,
-                          fGraph->GetX()[ibin+1] + dx,
-                          fGraph->GetY()[ibin-1],
-                          fGraph->GetY()[ibin],
-                          fGraph->GetY()[ibin+1])
+                          X[ibin-1] + dx,
+                          X[ibin]   + dx,
+                          X[ibin+1] + dx,
+                          Y[ibin-1],
+                          Y[ibin],
+                          Y[ibin+1])
                  +
                  Quadrax( x,
-                          fGraph->GetX()[ibin] + dx,
-                          fGraph->GetX()[ibin+1]  + dx,
-                          fGraph->GetX()[ibin+2]  + dx,
-                          fGraph->GetY()[ibin],
-                          fGraph->GetY()[ibin+1],
-                          fGraph->GetY()[ibin+2]) )*0.5;
+                          X[ibin] + dx,
+                          X[ibin+1]  + dx,
+                          X[ibin+2]  + dx,
+                          Y[ibin],
+                          Y[ibin+1],
+                          Y[ibin+2]) )*0.5;
    }
 
    return retval;

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -51,10 +51,7 @@ TMVA::TSpline2::TSpline2( const TString& title, TGraph* theGraph )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::TSpline2::~TSpline2( void )
-{
-   if (fGraph) delete fGraph; // ROOT's spline classes also own the TGraph
-}
+TMVA::TSpline2::~TSpline2(void) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// returns quadratically interpolated TGraph entry around x
@@ -72,30 +69,30 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
    if (ibin >= fGraph->GetN()) ibin =  fGraph->GetN() - 1;
 
    Float_t dx = 0; // should be zero
+   if (fGraph->GetN() < 3) { // if the graph does not have enough points
+      Warning("Eval", "Graph has less than 3 points, returning value of the closest");
+      retval = fGraph->GetY()[ibin];
+   } else if (ibin == 0) {
 
-   if (ibin == 0 ) {
+      retval = Quadrax(x,
+                       fGraph->GetX()[ibin] + dx,
+                       fGraph->GetX()[ibin + 1] + dx,
+                       fGraph->GetX()[ibin + 2] + dx,
+                       fGraph->GetY()[ibin],
+                       fGraph->GetY()[ibin + 1],
+                       fGraph->GetY()[ibin + 2]);
 
-      retval = Quadrax(  x,
-                         fGraph->GetX()[ibin]   + dx,
-                         fGraph->GetX()[ibin+1] + dx,
-                         fGraph->GetX()[ibin+2] + dx,
-                         fGraph->GetY()[ibin],
-                         fGraph->GetY()[ibin+1],
-                         fGraph->GetY()[ibin+2]);
-
-   }
-   else if (ibin >= (fGraph->GetN()-2)) {
+   } else if (ibin >= (fGraph->GetN() - 2)) {
       ibin = fGraph->GetN() - 1; // always fixed to last bin
 
-      retval = Quadrax( x,
-                        fGraph->GetX()[ibin-2] + dx,
-                        fGraph->GetX()[ibin-1] + dx,
-                        fGraph->GetX()[ibin]   + dx,
-                        fGraph->GetY()[ibin-2],
-                        fGraph->GetY()[ibin-1],
-                        fGraph->GetY()[ibin]);
-   }
-   else {
+      retval = Quadrax(x,
+                       fGraph->GetX()[ibin - 2] + dx,
+                       fGraph->GetX()[ibin - 1] + dx,
+                       fGraph->GetX()[ibin] + dx,
+                       fGraph->GetY()[ibin - 2],
+                       fGraph->GetY()[ibin - 1],
+                       fGraph->GetY()[ibin]);
+   } else {
 
       retval = ( Quadrax( x,
                           fGraph->GetX()[ibin-1] + dx,
@@ -105,7 +102,8 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
                           fGraph->GetY()[ibin],
                           fGraph->GetY()[ibin+1])
                  +
-                 Quadrax( x, fGraph->GetX()[ibin] + dx,
+                 Quadrax( x,
+                          fGraph->GetX()[ibin] + dx,
                           fGraph->GetX()[ibin+1]  + dx,
                           fGraph->GetX()[ibin+2]  + dx,
                           fGraph->GetY()[ibin],

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -43,7 +43,8 @@ ClassImp(TMVA::TSpline2);
 /// TSpline is a TNamed object
 
 TMVA::TSpline2::TSpline2(const TString &title, const TGraph *theGraph)
-   : N(theGraph->GetN()), X(theGraph->GetX(), theGraph->GetX() + N), Y(theGraph->GetY(), theGraph->GetY() + N)
+: fX(theGraph->GetX(), theGraph->GetX() + theGraph->GetN()),
+  fY(theGraph->GetY(), theGraph->GetY() + theGraph->GetN())
 {
    SetNameTitle( title, title );
 }
@@ -59,8 +60,8 @@ TMVA::TSpline2::~TSpline2(void) {}
 Double_t TMVA::TSpline2::Eval( const Double_t x ) const
 {
    Double_t retval=0;
-
-   Int_t ibin = std::distance(X.begin(), TMath::BinarySearch( X.begin(), X.end(), x ));
+   auto N = fX.size();
+   auto ibin = std::distance(fX.begin(), TMath::BinarySearch( fX.begin(), fX.end(), x ));
 
    // sanity checks
    if (ibin < 0 ) ibin = 0;
@@ -69,44 +70,44 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
    Float_t dx = 0; // should be zero
    if (N < 3) { // if the graph does not have enough points
       Warning("Eval", "Graph has less than 3 points, returning value of the closest");
-      retval = Y[ibin];
+      retval = fY[ibin];
    } else if (ibin == 0) {
 
       retval = Quadrax(x,
-                       X[ibin] + dx,
-                       X[ibin + 1] + dx,
-                       X[ibin + 2] + dx,
-                       Y[ibin],
-                       Y[ibin + 1],
-                       Y[ibin + 2]);
+                       fX[ibin] + dx,
+                       fX[ibin + 1] + dx,
+                       fX[ibin + 2] + dx,
+                       fY[ibin],
+                       fY[ibin + 1],
+                       fY[ibin + 2]);
 
    } else if (ibin >= (N - 2)) {
       ibin = N - 1; // always fixed to last bin
 
       retval = Quadrax(x,
-                       X[ibin - 2] + dx,
-                       X[ibin - 1] + dx,
-                       X[ibin] + dx,
-                       Y[ibin - 2],
-                       Y[ibin - 1],
-                       Y[ibin]);
+                       fX[ibin - 2] + dx,
+                       fX[ibin - 1] + dx,
+                       fX[ibin] + dx,
+                       fY[ibin - 2],
+                       fY[ibin - 1],
+                       fY[ibin]);
    } else {
 
       retval = ( Quadrax( x,
-                          X[ibin-1] + dx,
-                          X[ibin]   + dx,
-                          X[ibin+1] + dx,
-                          Y[ibin-1],
-                          Y[ibin],
-                          Y[ibin+1])
+                          fX[ibin-1] + dx,
+                          fX[ibin]   + dx,
+                          fX[ibin+1] + dx,
+                          fY[ibin-1],
+                          fY[ibin],
+                          fY[ibin+1])
                  +
                  Quadrax( x,
-                          X[ibin] + dx,
-                          X[ibin+1]  + dx,
-                          X[ibin+2]  + dx,
-                          Y[ibin],
-                          Y[ibin+1],
-                          Y[ibin+2]) )*0.5;
+                          fX[ibin] + dx,
+                          fX[ibin+1]  + dx,
+                          fX[ibin+2]  + dx,
+                          fY[ibin],
+                          fY[ibin+1],
+                          fY[ibin+2]) )*0.5;
    }
 
    return retval;

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -60,8 +60,8 @@ TMVA::TSpline2::~TSpline2(void) {}
 Double_t TMVA::TSpline2::Eval( const Double_t x ) const
 {
    Double_t retval=0;
-   auto N = fX.size();
-   auto ibin = std::distance(fX.begin(), TMath::BinarySearch( fX.begin(), fX.end(), x ));
+   Int_t N = fX.size();
+   Int_t ibin = std::distance(fX.begin(), TMath::BinarySearch( fX.begin(), fX.end(), x ));
 
    // sanity checks
    if (ibin < 0 ) ibin = 0;

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -39,7 +39,7 @@ Quadratic interpolation of TGraph
 ClassImp(TMVA::TSpline2);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// constructor from TGraph
+/// constructor from TGraph pointer (not owned by TSpline2)
 /// TSpline is a TNamed object
 
 TMVA::TSpline2::TSpline2( const TString& title, TGraph* theGraph )


### PR DESCRIPTION
* Avoids deleting non-owned pointer in destructor
* In a case where the graph does not have enough points for interpolation graph values are returned directly and a warning is emitted; this avoids heap overflow when trying to address graph points outside of the point array range

This PR resolves #8021  

