### PR TITLE
[DF,io,eve7,math,rcanvas] Remove `R__LOAD_LIBRARY` call from tutorials

### DIFF
--- a/tutorials/dataframe/df034_SaveGraph.C
+++ b/tutorials/dataframe/df034_SaveGraph.C
@@ -18,8 +18,6 @@
 // only the branch of the computation graph that the node belongs to.
 // If a filename is passed as second argument, the graph is saved to that file, otherwise it is returned as a string.
 
-R__LOAD_LIBRARY(ROOTDataFrame) // only required for ROOT installations without runtime_cxxmodules
-
 void df034_SaveGraph()
 {
    ROOT::RDataFrame rd1(1);

--- a/tutorials/eve7/geom_cms.C
+++ b/tutorials/eve7/geom_cms.C
@@ -14,9 +14,6 @@
 #include <ROOT/REveElement.hxx>
 #include <ROOT/REveManager.hxx>
 
-R__LOAD_LIBRARY(libGeom);
-R__LOAD_LIBRARY(libROOTEve);
-
 namespace REX = ROOT::Experimental;
 
 void makeEveGeoShape(TGeoNode* n, REX::REveTrans& trans, REX::REveElement* holder)

--- a/tutorials/io/testTMPIFile.C
+++ b/tutorials/io/testTMPIFile.C
@@ -15,14 +15,10 @@
 
 #include "TMPIFile.h"
 
-R__LOAD_LIBRARY(RMPI)  // Work around autoloading issue when ROOT modules are enabled 
-
 #ifdef TMPI_SECOND_RUN
 
 #include <chrono>
 #include <sstream>
-
-R__LOAD_LIBRARY(JetEvent_cxx)
 
 /* ---------------------------------------------------------------------------
 
@@ -217,11 +213,11 @@ void testTMPIFile()
    }
    // Wait until it's done
    MPI_Barrier(MPI_COMM_WORLD);
-   
+
    gROOT->ProcessLine("#define TMPI_SECOND_RUN yes");
    gROOT->ProcessLine("#include \"" __FILE__ "\"");
    gROOT->ProcessLine("testTMPIFile(true)");
-   
+
    // TMPIFile will do MPI_Finalize() when closing the file
    Int_t finalized = 0;
    MPI_Finalized(&finalized);

--- a/tutorials/math/Bessel.C
+++ b/tutorials/math/Bessel.C
@@ -33,8 +33,6 @@
 
 void Bessel()
 {
-   R__LOAD_LIBRARY(libMathMore);
-
    TCanvas *DistCanvas = new TCanvas("DistCanvas", "Bessel functions example", 10, 10, 800, 600);
    DistCanvas->SetFillColor(17);
    DistCanvas->Divide(2, 2);

--- a/tutorials/math/FeldmanCousins.C
+++ b/tutorials/math/FeldmanCousins.C
@@ -14,9 +14,6 @@
 
 void FeldmanCousins()
 {
-   if (!gROOT->GetClass("TFeldmanCousins"))
-      R__LOAD_LIBRARY(libPhysics);
-
    TFeldmanCousins f;
 
    // calculate either the upper or lower limit for 10 observed
@@ -36,4 +33,3 @@ void FeldmanCousins()
    cout << "\tLower Limit = " <<  ll << endl;
    cout << "at the 90% CL"<< endl;
 }
-

--- a/tutorials/math/Legendre.C
+++ b/tutorials/math/Legendre.C
@@ -26,8 +26,6 @@
 
 void Legendre()
 {
-   R__LOAD_LIBRARY(libMathMore);
-
    TCanvas *Canvas = new TCanvas("DistCanvas", "Legendre polynomials example", 10, 10, 750, 600);
    Canvas->SetGrid();
    TLegend *leg = new TLegend(0.5, 0.7, 0.4, 0.89);
@@ -53,4 +51,3 @@ void Legendre()
 
    Canvas->cd();
 }
-

--- a/tutorials/math/LegendreAssoc.C
+++ b/tutorials/math/LegendreAssoc.C
@@ -34,8 +34,6 @@
 
 void LegendreAssoc()
 {
-   R__LOAD_LIBRARY(libMathMore);
-
    std::cout <<"Drawing associate Legendre Polynomials.." << std::endl;
    TCanvas *Canvas = new TCanvas("DistCanvas", "Associate Legendre polynomials", 10, 10, 800, 500);
    Canvas->Divide(2,1);
@@ -108,4 +106,3 @@ void LegendreAssoc()
       std::cout <<"Integral [-1,1] for Associated Legendre Polynomial of Degree " << nu << "\t = \t" << integral[nu] <<  std::endl;
    }
 }
-

--- a/tutorials/rcanvas/raxis.cxx
+++ b/tutorials/rcanvas/raxis.cxx
@@ -17,11 +17,6 @@
 
 #include "TDatime.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTGpadv7)
-
-
 void raxis()
 {
    using namespace ROOT::Experimental;

--- a/tutorials/rcanvas/rcanvas_mt.cxx
+++ b/tutorials/rcanvas/rcanvas_mt.cxx
@@ -33,10 +33,6 @@
 #include <thread>
 #include <iostream>
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void draw_canvas(const std::string &title, RColor col)

--- a/tutorials/rcanvas/rh1.cxx
+++ b/tutorials/rcanvas/rh1.cxx
@@ -26,10 +26,6 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh1()

--- a/tutorials/rcanvas/rh1_large.cxx
+++ b/tutorials/rcanvas/rh1_large.cxx
@@ -27,11 +27,6 @@
 #include "TMath.h"
 #include "TString.h"
 
-
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh1_large()

--- a/tutorials/rcanvas/rh1_twoscales.cxx
+++ b/tutorials/rcanvas/rh1_twoscales.cxx
@@ -26,10 +26,6 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh1_twoscales()

--- a/tutorials/rcanvas/rh2.cxx
+++ b/tutorials/rcanvas/rh2.cxx
@@ -25,10 +25,6 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh2()

--- a/tutorials/rcanvas/rh2_colz.cxx
+++ b/tutorials/rcanvas/rh2_colz.cxx
@@ -27,10 +27,6 @@
 #include "ROOT/RFrame.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh2_colz()

--- a/tutorials/rcanvas/rh2_large.cxx
+++ b/tutorials/rcanvas/rh2_large.cxx
@@ -26,10 +26,6 @@
 #include "ROOT/RFrame.hxx"
 #include "TString.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh2_large()

--- a/tutorials/rcanvas/rh3.cxx
+++ b/tutorials/rcanvas/rh3.cxx
@@ -26,10 +26,6 @@
 #include "ROOT/RFrameTitle.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh3()

--- a/tutorials/rcanvas/rh3_large.cxx
+++ b/tutorials/rcanvas/rh3_large.cxx
@@ -26,10 +26,6 @@
 #include "ROOT/RFrame.hxx"
 #include "TString.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 using namespace ROOT::Experimental;
 
 void rh3_large()

--- a/tutorials/rcanvas/rlegend.cxx
+++ b/tutorials/rcanvas/rlegend.cxx
@@ -25,11 +25,6 @@
 #include "ROOT/RLegend.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-R__LOAD_LIBRARY(libROOTGraphicsPrimitives)
-
 using namespace ROOT::Experimental;
 
 void rlegend()

--- a/tutorials/rcanvas/subpads.cxx
+++ b/tutorials/rcanvas/subpads.cxx
@@ -25,10 +25,6 @@
 #include "ROOT/RStyle.hxx"
 #include "TRandom.h"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 void subpads()
 {
   using namespace ROOT::Experimental;


### PR DESCRIPTION
This PR is a follow-up from #14570 and fixes #14715. It turns out that this is not required anymore, even for builds/platforms without runtime modules enabled.

