### PR TITLE
[DF] fix SaveGraph display and Describe printout for unnamed TChain

### DIFF
--- a/tree/dataframe/src/RInterfaceBase.cxx
+++ b/tree/dataframe/src/RInterfaceBase.cxx
@@ -50,7 +50,7 @@ std::string ROOT::RDF::RInterfaceBase::DescribeDataset() const
       std::stringstream ss;
       ss << "Dataframe from " << treeType;
       if (*treeName != 0) {
-         ss << treeName;
+         ss << " " << treeName;
       }
       if (isInMemory) {
          ss << " (in-memory)";

--- a/tree/dataframe/src/RInterfaceBase.cxx
+++ b/tree/dataframe/src/RInterfaceBase.cxx
@@ -48,7 +48,10 @@ std::string ROOT::RDF::RInterfaceBase::DescribeDataset() const
       const auto friendInfo = ROOT::Internal::TreeUtils::GetFriendInfo(*tree);
       const auto hasFriends = friendInfo.fFriendNames.empty() ? false : true;
       std::stringstream ss;
-      ss << "Dataframe from " << treeType << " " << treeName;
+      ss << "Dataframe from " << treeType;
+      if (*treeName != 0) {
+         ss << treeName;
+      }
       if (isInMemory) {
          ss << " (in-memory)";
       } else {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1030,6 +1030,8 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetG
       name = fDataSource->GetLabel();
    } else if (fTree) {
       name = fTree->GetName();
+      if (name.empty())
+         name = fTree->ClassName();
    } else {
       name = "Empty source\\nEntries: " + std::to_string(GetNEmptyEntries());
    }

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -486,7 +486,7 @@ TEST_P(RDatasetSpecTest, SaveGraph)
    static const std::string expectedGraph(
       "digraph {\n"
       "\t1 [label=\"Sum\", style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
-      "\t0 [label=\"\", style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
+      "\t0 [label=\"TChain\", style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
       "\t2 [label=\"Sum\", style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
       "\t0 -> 1;\n"
       "\t0 -> 2;\n"
@@ -512,7 +512,7 @@ TEST(RDatasetSpecTest, Describe)
    auto res0 = df.Sum<double>("x");
    auto res1 = df.Sum<double>("w");
 
-   static const std::string expectedDescribe("Dataframe from TChain  in files\n"
+   static const std::string expectedDescribe("Dataframe from TChain in files\n"
                                              "  specTestDescribe1.root\n"
                                              "  specTestDescribe2.root\n"
                                              "with friend\n"
@@ -588,7 +588,7 @@ TEST(RDatasetSpecTest, FromSpec_ordering_samplesAndFriends)
 
    auto rdf_1 = FromSpec("spec_ordering_samples_withFriends.json");
 
-   static const std::string expectedDescribe("Dataframe from TChain  in files\n"
+   static const std::string expectedDescribe("Dataframe from TChain in files\n"
                                              "  FromSpecTestFile2.root\n"
                                              "  FromSpecTestFile1.root\n"
                                              "with friends\n"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
In `ROOT::RDF::SaveGraph`, write "TChain" in the output `.dot` if the `TChain` is unnamed, instead of a blank. In `ROOT::RDF::RInterfaceBase::Describe`, if the `TChain` is unnamed, do not write a blank.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes [#10928](https://github.com/root-project/root/issues/10928).

