### PR TITLE
[ntuple] Allow inline model definition in RNTupleWriter::Recreate

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -473,10 +473,9 @@ public:
                                                   std::string_view ntupleName,
                                                   std::string_view storage,
                                                   const RNTupleWriteOptions &options = RNTupleWriteOptions());
-   static std::unique_ptr<RNTupleWriter> Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields,
-                                                  std::string_view ntupleName,
-                                                  std::string_view storage,
-                                                  const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   static std::unique_ptr<RNTupleWriter>
+   Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields, std::string_view ntupleName,
+            std::string_view storage, const RNTupleWriteOptions &options = RNTupleWriteOptions());
    /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
                                                 TFile &file,

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -473,6 +473,10 @@ public:
                                                   std::string_view ntupleName,
                                                   std::string_view storage,
                                                   const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   static std::unique_ptr<RNTupleWriter> Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields,
+                                                  std::string_view ntupleName,
+                                                  std::string_view storage,
+                                                  const RNTupleWriteOptions &options = RNTupleWriteOptions());
    /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
                                                 TFile &file,

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -366,6 +366,21 @@ ROOT::Experimental::RNTupleWriter::Recreate(std::unique_ptr<RNTupleModel> model,
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleWriter>
+ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields, std::string_view ntupleName,
+                                            std::string_view storage, const RNTupleWriteOptions &options)
+{
+   auto sink = Detail::RPagePersistentSink::Create(ntupleName, storage, options);
+   auto model = RNTupleModel::Create();
+   for ( const auto& fieldDesc : fields ) {
+      std::string typeName(fieldDesc.first);
+      std::string fieldName(fieldDesc.second);
+      auto field = RFieldBase::Create(fieldName, typeName);
+      model->AddField(field.Unwrap());
+   }
+   return Create(std::move(model), std::move(sink), options);
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleWriter>
 ROOT::Experimental::RNTupleWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, TFile &file,
                                           const RNTupleWriteOptions &options)
 {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -366,12 +366,13 @@ ROOT::Experimental::RNTupleWriter::Recreate(std::unique_ptr<RNTupleModel> model,
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleWriter>
-ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields, std::string_view ntupleName,
-                                            std::string_view storage, const RNTupleWriteOptions &options)
+ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std::string_view, std::string_view>> fields,
+                                            std::string_view ntupleName, std::string_view storage,
+                                            const RNTupleWriteOptions &options)
 {
    auto sink = Detail::RPagePersistentSink::Create(ntupleName, storage, options);
    auto model = RNTupleModel::Create();
-   for ( const auto& fieldDesc : fields ) {
+   for (const auto &fieldDesc : fields) {
       std::string typeName(fieldDesc.first);
       std::string fieldName(fieldDesc.second);
       auto field = RFieldBase::Create(fieldName, typeName);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -370,7 +370,7 @@ ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std:
                                             std::string_view ntupleName, std::string_view storage,
                                             const RNTupleWriteOptions &options)
 {
-   auto sink = Detail::RPagePersistentSink::Create(ntupleName, storage, options);
+   auto sink = Internal::RPagePersistentSink::Create(ntupleName, storage, options);
    auto model = RNTupleModel::Create();
    for (const auto &fieldDesc : fields) {
       std::string typeName(fieldDesc.first);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -147,6 +147,47 @@ TEST(RNTuple, WriteRead)
    EXPECT_STREQ("abc", rdKlass->s.c_str());
 }
 
+TEST(RNTuple, WriteReadInlinedModel)
+{
+   FileRaii fileGuard("test_ntuple_writeread_inlinedmodel.root");
+
+   {
+      auto writer = RNTupleWriter::Recreate({
+         {"std::uint32_t", "id"},
+         {"std::vector<float>", "vpx"},
+         {"std::vector<float>", "vpy"},
+         {"std::vector<float>", "vpz"},
+      }, "NTuple", fileGuard.GetPath());
+
+      auto entry = writer->CreateEntry();
+      *entry->GetPtr<std::uint32_t>("id") = 1;
+      *entry->GetPtr<std::vector<float>>("vpx") = {1.0, 1.1, 1.2};
+      *entry->GetPtr<std::vector<float>>("vpy") = {2.0, 2.1, 2.2};
+      *entry->GetPtr<std::vector<float>>("vpz") = {3.0, 3.1, 3.2};
+
+      writer->Fill(*entry);
+   }
+
+   auto reader = RNTupleReader::Open("NTuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
+   auto readid = reader->GetModel().GetDefaultEntry().GetPtr<std::uint32_t>("id");
+   EXPECT_EQ(1, *readid);
+   auto readvpx = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<float>>("vpx");
+   EXPECT_FLOAT_EQ(1.0, (*readvpx)[0]);
+   EXPECT_FLOAT_EQ(1.1, (*readvpx)[1]);
+   EXPECT_FLOAT_EQ(1.2, (*readvpx)[2]);
+   auto readvpy = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<float>>("vpy");
+   EXPECT_FLOAT_EQ(2.0, (*readvpy)[0]);
+   EXPECT_FLOAT_EQ(2.1, (*readvpy)[1]);
+   EXPECT_FLOAT_EQ(2.2, (*readvpy)[2]);
+   auto readvpz = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<float>>("vpz");
+   EXPECT_FLOAT_EQ(3.0, (*readvpz)[0]);
+   EXPECT_FLOAT_EQ(3.1, (*readvpz)[1]);
+   EXPECT_FLOAT_EQ(3.2, (*readvpz)[2]);
+
+}
+
 TEST(RNTuple, FileAnchor)
 {
    FileRaii fileGuard("test_ntuple_file_anchor.root");

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -152,12 +152,14 @@ TEST(RNTuple, WriteReadInlinedModel)
    FileRaii fileGuard("test_ntuple_writeread_inlinedmodel.root");
 
    {
-      auto writer = RNTupleWriter::Recreate({
-         {"std::uint32_t", "id"},
-         {"std::vector<float>", "vpx"},
-         {"std::vector<float>", "vpy"},
-         {"std::vector<float>", "vpz"},
-      }, "NTuple", fileGuard.GetPath());
+      auto writer = RNTupleWriter::Recreate(
+         {
+            {"std::uint32_t", "id"},
+            {"std::vector<float>", "vpx"},
+            {"std::vector<float>", "vpy"},
+            {"std::vector<float>", "vpz"},
+         },
+         "NTuple", fileGuard.GetPath());
 
       auto entry = writer->CreateEntry();
       *entry->GetPtr<std::uint32_t>("id") = 1;
@@ -185,7 +187,6 @@ TEST(RNTuple, WriteReadInlinedModel)
    EXPECT_FLOAT_EQ(3.0, (*readvpz)[0]);
    EXPECT_FLOAT_EQ(3.1, (*readvpz)[1]);
    EXPECT_FLOAT_EQ(3.2, (*readvpz)[2]);
-
 }
 
 TEST(RNTuple, FileAnchor)


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/8711

It was suggested in the issue to enable something like:

```cpp
auto ntuple = RNTupleWriter::Recreate({
   RField<std::uint32_t>("id"),
   RField<std::vector<float>>("vpx"),
   RField<std::vector<float>>("vpy"),
   RField<std::vector<float>>("vpz")
}, "NTuple", kNTupleFileName);
```

However, `std::initializer_list` needs homogeneous types, so after discussion with @jblomer , I tried an approach with the list of the pairs of strings, i.e.:

```cpp
auto writer = RNTupleWriter::Recreate({
   {"std::uint32_t", "id"},
   {"std::vector<float>", "vpx"},
   {"std::vector<float>", "vpy"},
   {"std::vector<float>", "vpz"},
}, "NTuple", fileGuard.GetPath());
```
 
