### PR TITLE
[ntuple] reduce memory allocations in BindRawPtr

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -183,6 +183,10 @@ public:
       friend class RFieldBase;
 
    private:
+      /// Empty shared pointer, used as the basis for an aliasing shared pointer constructor in BindRawPtr.
+      /// Note that as a result of BindRawPtr, fObjPtr will be non-empty but have use count zero.
+      static std::shared_ptr<void> fgRawPtrCtrlBlock;
+
       RFieldBase *fField = nullptr; ///< The field that created the RValue
       std::shared_ptr<void> fObjPtr; ///< Set by Bind() or by RFieldBase::CreateValue(), SplitValue() or BindValue()
 
@@ -199,6 +203,7 @@ public:
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }
       void Read(RClusterIndex clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
       void Bind(std::shared_ptr<void> objPtr) { fObjPtr = objPtr; }
+      void BindRawPtr(void *rawPtr) { fObjPtr = std::shared_ptr<void>(fgRawPtrCtrlBlock, rawPtr); }
       /// Replace the current object pointer by a pointer to a new object constructed by the field
       void EmplaceNew() { fObjPtr = fField->CreateValue().GetPtr<void>(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -183,10 +183,6 @@ public:
       friend class RFieldBase;
 
    private:
-      /// Empty shared pointer, used as the basis for an aliasing shared pointer constructor in BindRawPtr.
-      /// Note that as a result of BindRawPtr, fObjPtr will be non-empty but have use count zero.
-      static std::shared_ptr<void> fgRawPtrCtrlBlock;
-
       RFieldBase *fField = nullptr; ///< The field that created the RValue
       std::shared_ptr<void> fObjPtr; ///< Set by Bind() or by RFieldBase::CreateValue(), SplitValue() or BindValue()
 
@@ -203,7 +199,7 @@ public:
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr.get()); }
       void Read(RClusterIndex clusterIndex) { fField->Read(clusterIndex, fObjPtr.get()); }
       void Bind(std::shared_ptr<void> objPtr) { fObjPtr = objPtr; }
-      void BindRawPtr(void *rawPtr) { fObjPtr = std::shared_ptr<void>(fgRawPtrCtrlBlock, rawPtr); }
+      void BindRawPtr(void *rawPtr);
       /// Replace the current object pointer by a pointer to a new object constructed by the field
       void EmplaceNew() { fObjPtr = fField->CreateValue().GetPtr<void>(); }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -338,7 +338,13 @@ ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
 
 //------------------------------------------------------------------------------
 
-std::shared_ptr<void> ROOT::Experimental::RFieldBase::RValue::fgRawPtrCtrlBlock;
+void ROOT::Experimental::RFieldBase::RValue::BindRawPtr(void *rawPtr)
+{
+   /// Empty shared pointer, used as the basis for the aliasing shared pointer constructor around rawPtr.
+   /// Note that as a result of BindRawPtr, fObjPtr will be non-empty but have use count zero.
+   static std::shared_ptr<void> fgRawPtrCtrlBlock;
+   fObjPtr = std::shared_ptr<void>(fgRawPtrCtrlBlock, rawPtr);
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -338,6 +338,10 @@ ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
 
 //------------------------------------------------------------------------------
 
+std::shared_ptr<void> ROOT::Experimental::RFieldBase::RValue::fgRawPtrCtrlBlock;
+
+//------------------------------------------------------------------------------
+
 ROOT::Experimental::RFieldBase::RBulk::RBulk(RBulk &&other)
    : fField(other.fField),
      fValueSize(other.fValueSize),


### PR DESCRIPTION
Adds a dummy shared pointer to RValue: the dummy shared pointer holds the control block with a noop deleter if BindRawPtr is used. The object shared pointer, in this case, shares the control block with the dummy shared pointer (aliasing constructor). In this way, we avoid a memory allocation for the control block every time BindRawPtr is called.

Also some minor improvements to the internals of REntry.

@Dr15Jones FYI