### PR TITLE
[ntuple] Use `R__ASSERT` in `RArrayAsRVecField::GenerateColumnsImpl`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1211,7 +1211,7 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void GenerateColumnsImpl() final { assert(false && "RArrayAsRVec fields must only be used for reading"); }
+   void GenerateColumnsImpl() final { R__ASSERT(false && "RArrayAsRVec fields must only be used for reading"); }
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void CreateValue(void *where) const final;


### PR DESCRIPTION
With some more minimal cmake configurations `assert` is not declared in `RField.hxx` and needs an `#include <cassert>`. `R__ASSERT` is declared however. Additionally, this makes it more consistent with other assertions in `RField`.


