### PR TITLE
[ntuple] Allow MakeField with a std::string

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -84,6 +84,7 @@ public:
    /// A wrapper over a field name and an optional description; used in `AddField()` and `RUpdater::AddField()`
    struct NameWithDescription_t {
       NameWithDescription_t(const char *name) : fName(name) {}
+      NameWithDescription_t(const std::string &name) : fName(name) {}
       NameWithDescription_t(std::string_view name) : fName(name) {}
       NameWithDescription_t(std::string_view name, std::string_view descr) : fName(name), fDescription(descr) {}
 

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -25,7 +25,7 @@ TEST(RNTuple, DISABLED_Limits_ManyFields)
 
       for (int i = 0; i < NumFields; i++) {
          std::string name = "f" + std::to_string(i);
-         model->MakeField<int>(name.c_str(), i);
+         model->MakeField<int>(name, i);
       }
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());


### PR DESCRIPTION
`NameWithDescription_t` takes a `std::string_view`, but the compiler only attempts one implicit conversion so `std::string` -> `std::string_view` and then to `NameWithDescription_t` doesn't work. Enabling this overload is particularly helpful for programmatically generated field names, as demonstrated by the `Limits_ManyFields` test.