### PR TITLE
[hist] Using TKDE::Fill works with empty tkde

### DIFF
--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -518,7 +518,15 @@ void TKDE::InitFromNewData() {
    if (fUseMirroring) {
       SetMirroredEvents();
    }
+   else {
+      // to set fBinCount and fSumOfCounts
+      SetBinCountData();
+   }
    // in case of I/O reset the kernel
+   if (!fKernelFunction) SetKernelFunction(nullptr);
+
+   SetKernel();
+   
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1015,8 +1023,7 @@ Double_t TKDE::TKernel::operator()(Double_t x) const {
    Bool_t useCount = (fKDE->fBinCount.size() == n);
    // also in case of unbinned unweighted data fSumOfCounts is sum of events in range
    // events outside range should be used to normalize the TKDE ??
-   Double_t nSum = fKDE->fSumOfCounts; //(useBins) ? fKDE->fSumOfCounts : fKDE->fNEvents;
-   //if (!useCount) nSum = fKDE->fNEvents;
+   Double_t nSum = (useCount) ? fKDE->fSumOfCounts : fKDE->fNEvents;
    // in case of non-adaptive fWeights is a vector of size 1
    Bool_t hasAdaptiveWeights = (fWeights.size() == n);
    Double_t invWeight = (!hasAdaptiveWeights) ? 1. / fWeights[0] : 0;


### PR DESCRIPTION
This PR fixes
- https://github.com/root-project/root/issues/7808

This is happening because in when the parentheses operator overload `TKDE::operator()(Double_t x)` calls ReInit `(const_cast<TKDE*>(this))->ReInit()`  it returns before setting the fKernel in the case of new data.

One approach is to call SetKernel here:

```cpp
if (fNewData)  {
      InitFromNewData();
      SetKernel();
      return;
   }
```
or call it at the end of InitFromNewData().

When that happens, the fKernel is no longer null but this error is reproducible with both iterative options -
With Adaptive we get **NaN** and Fixed we get **inf**

This is because the weight calculation is using the nSum that is 0 when binning is not used
Inversing that gives the infinity in the Iteration:Fixed case

This fix:
- adds the call to SetBinCountData() in InitFromNewData()
- recreates the kernel fun pointer (previously fKernel ends up a `nullptr`)
- calculating nSum as fNEvents if not binning in TKDE::TKernel::operator().

Results:

```cpp
    auto kde = new TKDE(0, nullptr, 0, 5, "KernelType:Gaussian;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", 1);
    for (unsigned int i = 0; i < 100; i++) { kde->Fill(gRandom->Gaus(2,1)); }
    std::cout<<kde->GetValue(2)<<"\n"; 
```

Gives 
0.487581

