### PR TITLE
[ci] Simplify clang-format options for compatibility with older versions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,9 @@
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments:
-  Enabled: false
+AlignConsecutiveAssignments: None
 # This would be nice to have but seems to also (mis)align function parameters
-AlignConsecutiveDeclarations:
-  Enabled: false
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

I authored PR https://github.com/root-project/root/pull/14690 which updated some .clang-format options which were not compliant with the (atleast) latest schema. Some of these options appear not to work with older version of `clang-format` so I simplify them in this PR. the behaviour should remain the same.

## Checklist:

- [x] tested changes locally
