### PR TITLE
[core] Do not skip libCore when finding out to what library the class belongs

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -157,7 +157,7 @@ public:
    virtual Int_t    GenerateDictionary(const char *classes, const char *includes = nullptr, const char *options = nullptr) = 0;
    virtual char    *GetPrompt() = 0;
    virtual const char *GetSharedLibs() = 0;
-   virtual const char *GetClassSharedLibs(const char *cls) = 0;
+   virtual const char *GetClassSharedLibs(const char *cls, bool skipCore = true) = 0;
    virtual const char *GetSharedLibDeps(const char *lib, bool tryDyld = false) = 0;
    virtual const char *GetIncludePath() = 0;
    virtual const char *GetSTLIncludePath() const { return ""; }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7019,9 +7019,6 @@ static std::string GetClassSharedLibsForModule(const char *cls, cling::LookupHel
          // link declaration.
          if (!M->LinkLibraries.size())
             continue;
-         // We have preloaded the Core module thus libCore.so
-         if (M->Name == "Core")
-            continue;
          assert(M->LinkLibraries.size() == 1);
          if (!result.empty())
             result += ' ';

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -216,7 +216,7 @@ public: // Public Interface
    Int_t   GenerateDictionary(const char* classes, const char* includes = "", const char* options = nullptr) final;
    char*   GetPrompt() final { return fPrompt; }
    const char* GetSharedLibs() final;
-   const char* GetClassSharedLibs(const char* cls) final;
+   const char* GetClassSharedLibs(const char* cls, bool skipCore = true) final;
    const char* GetSharedLibDeps(const char* lib, bool tryDyld = false) final;
    const char* GetIncludePath() final;
    virtual const char* GetSTLIncludePath() const final;

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -132,7 +132,7 @@ TEST_F(TClingTests, GetClassSharedLibs)
 {
    // Shortens the invocation.
    auto GetLibs = [](const char *cls) -> std::string {
-      if (const char *val = gInterpreter->GetClassSharedLibs(cls))
+      if (const char *val = gInterpreter->GetClassSharedLibs(cls,false))
          return val;
       return "";
    };
@@ -169,45 +169,6 @@ TEST_F(TClingTests, GetClassSharedLibs)
    // GetLibs("ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >")
    //    != GetLibs("ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>>")
    // note the missing space.
-
-   lib = GetLibs("TArray");
-   EXPECT_EQ("Core", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TInterpreter");
-   EXPECT_EQ("Core", MakeLibNamePlatformIndependent(lib));
-   
-   lib = GetLibs("TRandom");
-   EXPECT_EQ("MathCore", MakeLibNamePlatformIndependent(lib));
-   
-   lib = GetLibs("TTree");
-   EXPECT_EQ("Tree", MakeLibNamePlatformIndependent(lib));
-   
-   lib = GetLibs("TTreeViewer");
-   EXPECT_EQ("TreeViewer", MakeLibNamePlatformIndependent(lib));
-   
-   lib = GetLibs("TGraph");
-   EXPECT_EQ("Hist", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TGWindow");
-   EXPECT_EQ("Gui", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TPad");
-   EXPECT_EQ("Gpad", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TArrow");
-   EXPECT_EQ("Graf", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TImage");
-   EXPECT_EQ("Graf", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TASImage");
-   EXPECT_EQ("ASImage", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TSpectrum");
-   EXPECT_EQ("Spectrum", MakeLibNamePlatformIndependent(lib));
-
-   lib = GetLibs("TFile");
-   EXPECT_EQ("RIO", MakeLibNamePlatformIndependent(lib));
 }
 
 static std::string MakeDepLibsPlatformIndependent(const std::string &libs) {

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -169,6 +169,45 @@ TEST_F(TClingTests, GetClassSharedLibs)
    // GetLibs("ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >")
    //    != GetLibs("ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>>")
    // note the missing space.
+
+   lib = GetLibs("TArray");
+   EXPECT_EQ("Core", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TInterpreter");
+   EXPECT_EQ("Core", MakeLibNamePlatformIndependent(lib));
+   
+   lib = GetLibs("TRandom");
+   EXPECT_EQ("MathCore", MakeLibNamePlatformIndependent(lib));
+   
+   lib = GetLibs("TTree");
+   EXPECT_EQ("Tree", MakeLibNamePlatformIndependent(lib));
+   
+   lib = GetLibs("TTreeViewer");
+   EXPECT_EQ("TreeViewer", MakeLibNamePlatformIndependent(lib));
+   
+   lib = GetLibs("TGraph");
+   EXPECT_EQ("Hist", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TGWindow");
+   EXPECT_EQ("Gui", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TPad");
+   EXPECT_EQ("Gpad", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TArrow");
+   EXPECT_EQ("Graf", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TImage");
+   EXPECT_EQ("Graf", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TASImage");
+   EXPECT_EQ("ASImage", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TSpectrum");
+   EXPECT_EQ("Spectrum", MakeLibNamePlatformIndependent(lib));
+
+   lib = GetLibs("TFile");
+   EXPECT_EQ("RIO", MakeLibNamePlatformIndependent(lib));
 }
 
 static std::string MakeDepLibsPlatformIndependent(const std::string &libs) {

--- a/documentation/doxygen/libs.C
+++ b/documentation/doxygen/libs.C
@@ -12,7 +12,7 @@ void libs(TString classname)
    int i = classname.Index("_3");
    if (i>0) classname.Remove(i,classname.Length()-i);
 
-   libname = gInterpreter->GetClassSharedLibs(classname.Data());
+   libname = gInterpreter->GetClassSharedLibs(classname.Data(),false);
    if (!libname)
       return;
 


### PR DESCRIPTION


# This Pull request:

## Changes or fixes:

Bug introduced in commit from 2019 Jun 2nd, where gInterpreter->GetClassSharedLibs() returns nullptr for any class inside the ROOT core base classes.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

Fixes https://github.com/root-project/root/issues/11667


