### PR TITLE
[ntuple] Fix field construction for friends

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -62,18 +62,27 @@ ROOT::Experimental::RFieldDescriptor::Clone() const
 std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplDesc) const
 {
-   if (GetTypeName().empty() && GetStructure() == ENTupleStructure::kCollection) {
-      // For untyped collections, we have no class available to collect all the sub fields.
-      // Therefore, we create an untyped record field as an artifical binder for the collection items.
+   if (GetTypeName().empty()) {
+      // For untyped records or collections, we have no class available to collect all the sub fields.
+      // Therefore, we create an untyped record field as an artificial binder for the record itself, and in the case of
+      // collections, its items.
       std::vector<std::unique_ptr<RFieldBase>> memberFields;
       for (auto id : fLinkIds) {
          const auto &memberDesc = ntplDesc.GetFieldDescriptor(id);
          memberFields.emplace_back(memberDesc.CreateField(ntplDesc));
       }
-      auto recordField = std::make_unique<RRecordField>("_0", memberFields);
-      auto collectionField = std::make_unique<RVectorField>(GetFieldName(), std::move(recordField));
-      collectionField->SetOnDiskId(fFieldId);
-      return collectionField;
+      if (GetStructure() == ENTupleStructure::kRecord) {
+         auto recordField = std::make_unique<RRecordField>(GetFieldName(), memberFields);
+         recordField->SetOnDiskId(fFieldId);
+         return recordField;
+      } else if (GetStructure() == ENTupleStructure::kCollection) {
+         auto recordField = std::make_unique<RRecordField>("_0", memberFields);
+         auto collectionField = std::make_unique<RVectorField>(GetFieldName(), std::move(recordField));
+         collectionField->SetOnDiskId(fFieldId);
+         return collectionField;
+      } else {
+         throw RException(R__FAIL("unknown field type for field \"" + GetFieldName() + "\""));
+      }
    }
 
    auto field = RFieldBase::Create(GetFieldName(), GetTypeAlias().empty() ? GetTypeName() : GetTypeAlias()).Unwrap();

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -605,3 +605,42 @@ TEST(RNTupleShow, Enum)
    // clang-format on
    EXPECT_EQ(os1.str(), expected);
 }
+
+TEST(RNTupleShow, Friends)
+{
+   FileRaii fileGuard1("test_ntuple_show_friends1.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto foo = model->MakeField<float>("foo");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl1", fileGuard1.GetPath());
+      *foo = 3.14;
+      writer->Fill();
+   }
+
+   FileRaii fileGuard2("test_ntuple_show_friends2.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto bar = model->MakeField<float>("bar");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl2", fileGuard2.GetPath());
+      *bar = 2.72;
+      writer->Fill();
+   }
+
+   std::vector<RNTupleReader::ROpenSpec> friends = {{"ntpl1", fileGuard1.GetPath()}, {"ntpl2", fileGuard2.GetPath()}};
+   auto ntuple = RNTupleReader::OpenFriends(friends);
+   std::ostringstream os;
+   ntuple->Show(0, os);
+   // clang-format off
+   std::string expected{std::string("")
+      + "{\n"
+      + "  \"ntpl1\": {\n"
+      + "    \"foo\": 3.14\n"
+      + "  },\n"
+      + "  \"ntpl2\": {\n"
+      + "    \"bar\": 2.72\n"
+      + "  }\n"
+      + "}\n"
+   };
+   // clang-format on
+   EXPECT_EQ(os.str(), expected);
+}


### PR DESCRIPTION
This PR for now fixes #14748, but IMO down the line we might need a more tailored representation for friends (at least in how they are presented to the user).

Friends are (virtually) represented as untyped records. To properly create them as fields (neede e.g. for `Show` and `PrintInfo`), we artificially bind them to an untyped `RRecordField`.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)



