### PR TITLE
[rcanvas] Comment out SaveAs() in last tutorial

### DIFF
--- a/tutorials/rcanvas/rline.cxx
+++ b/tutorials/rcanvas/rline.cxx
@@ -44,8 +44,8 @@ void rline()
 
    canvas->SetSize(900, 700);
 
-   if (canvas->SaveAs("line.png"))
-      printf("Store RCanvas in line.png\n");
+   // if (canvas->SaveAs("line.png"))
+   //    printf("Store RCanvas in line.png\n");
 
    canvas->Show();
 }


### PR DESCRIPTION
This is currently the only tutorial calling `RCanvas::SaveAs()` and it fails very often (more than 90% of the time) on fedora38 and fedora39 since the last update of chromium.