### PR TITLE
[RF] Determine asymptotically correct uncertainties for extended unbinned maximum likelihood fits

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -26,6 +26,7 @@ The following people have contributed to this new version:
  Jonas Hahnfeld, CERN/EP-SFT,\
  Akeem Hart, Queen Mary University of London/DUNE and MINERvA,\
  Dennis Klein, GSI,\
+ Christoph Langenbruch, Heidelberg University/LHCb,\
  Sergey Linev, GSI,\
  Pere Mato, CERN/EP-SFT,\
  Lorenzo Moneta, CERN/EP-SFT,\
@@ -37,7 +38,7 @@ The following people have contributed to this new version:
  Jonas Rembser, CERN/EP-SFT,\
  Matevz Tadel, UCSD/CMS,\
  Vassil Vassilev, Princeton/CMS,\
- Wouter Verkerke, NIKHEF/Atlas,
+ Wouter Verkerke, NIKHEF/ATLAS,
 
 ## Deprecation and Removal
 - The RooFit legacy iterators are deprecated and will be removed in ROOT 6.34 (see section "RooFit libraries")
@@ -93,6 +94,13 @@ In case you observe any slowdowns with the new likelihood evaluation, please
 open a GitHub issue about this, as such a performance regression is considered
 a bug.
 
+### Asymptotically correct uncertainties for extended unbinned likelihood fits
+
+Added correct treatment of extended term in asymptotically correct method for uncertainty determination in the presence of weights.
+This improvement will allow for extended unbinned maximum likelihood fits to use the asymptotically correct method when using the `RooFit::AsymptoticError()` command argument in [RooAbsPdf::fitTo()](https://root.cern.ch/doc/master/classRooAbsPdf.html#ab0721374836c343a710f5ff92a326ff5).
+See also this [writeup on extended weighted fits](https://root.cern/files/extended_weighted_fits.pdf) that is also linked from the reference guide.
+The [pull request](https://github.com/root-project/root/pull/14751) that introduced this feature might also be a good reference.
+
 ### Compile your code with memory safe interfaces
 
 If you define the `ROOFIT_MEMORY_SAFE_INTERFACES` preprocessor macro, the
@@ -103,7 +111,7 @@ return an owning pointer (e.g., a pointer to an object that you need to
 manually `delete`) are then returning a `std::unique_pt` for automatic memory
 management.
 
-For example this code would not compile anymore, because there is the rist that
+For example this code would not compile anymore, because there is the risk that
 the caller forgets to `delete params`:
 ```c++
 RooArgSet * params = pdf.getParameters(nullptr);

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -205,7 +205,7 @@ void PiecewiseInterpolation::translate(RooFit::Detail::CodeSquashContext &ctx) c
    // models, where is is always used the same way: all RooAbsReals in _lowSet,
    // _histSet, and also nominal are 1D RooHistFuncs with with same structure.
    //
-   // Therefore, we can make a big optimization: we get the bin index ony once
+   // Therefore, we can make a big optimization: we get the bin index only once
    // here in the generated code for PiecewiseInterpolation. Then, we also
    // rearrange the histogram data in such a way that we can always pass the
    // same arrays to the free function that implements the interpolation, just

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -415,7 +415,7 @@ int FitUsingTFit(T *hist, TF1 *func)
       iret |= hist->Fit(func, "BFV0");
    else
       iret |= hist->Fit(func, "V0");
-   // get precice value of minimum
+   // get precise value of minimum
    int pr = std::cout.precision(18);
    std::cout << "Chi2 value = " << func->GetChisquare() << std::endl;
    std::cout.precision(pr);

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -35,6 +35,7 @@
 #include <RooMinimizer.h>
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
+#include <RooFormulaVar.h>
 
 #include <Math/CholeskyDecomp.h>
 
@@ -66,6 +67,21 @@ constexpr int extendedFitDefault = 2;
 /// \param[in] data The dataset that was used for the fit.
 int calcAsymptoticCorrectedCovariance(RooAbsReal &pdf, RooMinimizer &minimizer, RooAbsData const &data)
 {
+   RooFormulaVar logpdf("logpdf", "log(pdf)", "log(@0)", pdf);
+   RooArgSet obs;
+   logpdf.getObservables(data.get(), obs);
+
+   // Warning if the dataset is binned. TODO: in some cases,
+   // people also use RooDataSet to encode binned data,
+   // e.g. for simultaneous fits. It would be useful to detect
+   // this in this future as well.
+   if (dynamic_cast<RooDataHist const *>(&data)) {
+      oocoutW(&pdf, InputArguments)
+         << "RooAbsPdf::fitTo(" << pdf.GetName()
+         << ") WARNING: Asymptotic error correction is requested for a binned data set. "
+            "This method is not designed to handle binned data. A standard chi2 fit will likely be more suitable.";
+   };
+
    // Calculated corrected errors for weighted likelihood fits
    std::unique_ptr<RooFitResult> rw(minimizer.save());
    // Weighted inverse Hessian matrix
@@ -83,17 +99,42 @@ int calcAsymptoticCorrectedCovariance(RooAbsReal &pdf, RooMinimizer &minimizer, 
          num(k, l) = 0.0;
       }
    }
-   RooArgSet obs;
-   pdf.getObservables(data.get(), obs);
+
    // Create derivative objects
    std::vector<std::unique_ptr<RooDerivative>> derivatives;
    const RooArgList &floated = rw->floatParsFinal();
-   std::unique_ptr<RooArgSet> floatingparams{
-      static_cast<RooArgSet *>(pdf.getParameters(data)->selectByAttrib("Constant", false))};
+   RooArgSet allparams;
+   logpdf.getParameters(data.get(), allparams);
+   std::unique_ptr<RooArgSet> floatingparams{static_cast<RooArgSet *>(allparams.selectByAttrib("Constant", false))};
+
+   const double eps = 1.0e-4;
+
+   // Calculate derivatives of logpdf
    for (const auto paramresult : floated) {
       auto paraminternal = static_cast<RooRealVar *>(floatingparams->find(*paramresult));
       assert(floatingparams->find(*paramresult)->IsA() == RooRealVar::Class());
-      derivatives.emplace_back(pdf.derivative(*paraminternal, obs, 1));
+      double error = static_cast<RooRealVar *>(paramresult)->getError();
+      derivatives.emplace_back(logpdf.derivative(*paraminternal, obs, 1, eps * error));
+   }
+
+   // Calculate derivatives for number of expected events, needed for extended ML fit
+   RooAbsPdf *extended_pdf = dynamic_cast<RooAbsPdf *>(&pdf);
+   std::vector<double> diffs_expected(floated.size(), 0.0);
+   if (extended_pdf && extended_pdf->expectedEvents(obs) != 0.0) {
+      for (std::size_t k = 0; k < floated.size(); k++) {
+         const auto paramresult = static_cast<RooRealVar *>(floated.at(k));
+         auto paraminternal = static_cast<RooRealVar *>(floatingparams->find(*paramresult));
+
+         *paraminternal = paramresult->getVal();
+         double error = paramresult->getError();
+         paraminternal->setVal(paramresult->getVal() + eps * error);
+         double expected_plus = log(extended_pdf->expectedEvents(obs));
+         paraminternal->setVal(paramresult->getVal() - eps * error);
+         double expected_minus = log(extended_pdf->expectedEvents(obs));
+         *paraminternal = paramresult->getVal();
+         double diff = (expected_plus - expected_minus) / (2.0 * eps * error);
+         diffs_expected[k] = diff;
+      }
    }
 
    // Loop over data
@@ -111,11 +152,11 @@ int calcAsymptoticCorrectedCovariance(RooAbsReal &pdf, RooMinimizer &minimizer, 
          *paraminternal = paramresult->getVal();
          diffs[k] = diff;
       }
+
       // Fill numerator matrix
-      double prob = pdf.getVal(&obs);
       for (std::size_t k = 0; k < floated.size(); k++) {
          for (std::size_t l = 0; l < floated.size(); l++) {
-            num(k, l) += data.weightSquared() * diffs[k] * diffs[l] / (prob * prob);
+            num(k, l) += data.weightSquared() * (diffs[k] + diffs_expected[k]) * (diffs[l] + diffs_expected[l]);
          }
       }
    }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1024,6 +1024,8 @@ std::unique_ptr<RooAbsReal> RooAbsPdf::createNLLImpl(RooAbsData &data, const Roo
  *             matrix calculated with the squared weights.
  * <tr><td> `AsymptoticError()`               <td> Use the asymptotically correct approach to estimate errors in the presence of weights.
  *                                                 This is slower but more accurate than `SumW2Error`. See also https://arxiv.org/abs/1911.01303).
+                                                   This option even correctly implements the case of extended likelihood fits
+                                                   (see this [writeup on extended weighted fits](https://root.cern/files/extended_weighted_fits.pdf) that complements the paper linked before).
  * <tr><td> `PrefitDataFraction(double fraction)`
  *                                            <td>  Runs a prefit on a small dataset of size fraction*(actual data size). This can speed up fits
  *                                                  by finding good starting values for the parameters for the actual fit.

--- a/roofit/roofitcore/src/RooDerivative.cxx
+++ b/roofit/roofitcore/src/RooDerivative.cxx
@@ -59,27 +59,18 @@ RooDerivative::RooDerivative(const char* name, const char* title, RooAbsReal& fu
   _x("x","x",this,x)
 {
   if (_order<0 || _order>3 ) {
-    throw std::string(Form("RooDerivative::ctor(%s) ERROR, derivation order must be 1,2 or 3",name)) ;
+    throw std::runtime_error(Form("RooDerivative::ctor(%s) ERROR, derivation order must be 1,2 or 3",name)) ;
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooDerivative::RooDerivative(const char* name, const char* title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, Int_t orderIn, double epsIn) :
-  RooAbsReal(name, title),
-  _order(orderIn),
-  _eps(epsIn),
-  _nset("nset","nset",this,false,false),
-  _func("function","function",this,func),
-  _x("x","x",this,x)
+RooDerivative::RooDerivative(const char *name, const char *title, RooAbsReal &func, RooRealVar &x,
+                             const RooArgSet &nset, Int_t orderIn, double epsIn)
+   : RooDerivative(name, title, func, x, orderIn, epsIn)
 {
-  if (_order<0 || _order>3) {
-    throw std::string(Form("RooDerivative::ctor(%s) ERROR, derivation order must be 1,2 or 3",name)) ;
-  }
-  _nset.add(nset) ;
+   _nset.add(nset);
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -103,7 +94,7 @@ double RooDerivative::evaluate() const
   if (!_ftor) {
     _ftor = std::unique_ptr<RooFunctor>{_func.arg().functor(_x.arg(),RooArgSet(),_nset)};
     ROOT::Math::WrappedFunction<RooFunctor&> wf(*_ftor);
-    _rd = std::make_unique<ROOT::Math::RichardsonDerivator>(wf,_eps*(_x.max()-_x.min()),true);
+    _rd = std::make_unique<ROOT::Math::RichardsonDerivator>(wf,_eps,true);
   }
 
   switch (_order) {

--- a/tutorials/roofit/rf514_RooCustomizer.C
+++ b/tutorials/roofit/rf514_RooCustomizer.C
@@ -56,14 +56,14 @@ void rf514_RooCustomizer() {
   // ---------------------------------------------------------------------------
 
   // We need two sets for bookkeeping of PDF nodes:
-  RooArgSet newLeafs;           // This set collects leafs that are created in the process.
-  RooArgSet allCustomiserNodes; // This set lists leafs that have been used in a replacement operation.
+  RooArgSet newLeaves;           // This set collects leaves that are created in the process.
+  RooArgSet allCustomiserNodes; // This set lists leaves that have been used in a replacement operation.
 
 
   // 1. Each sample should have its own mean for the gaussian
   // The customiser will make copies of `meanG` for each category.
-  // These will all appear in the set `newLeafs`, which will own the new nodes.
-  RooCustomizer cust(model, sample, newLeafs, &allCustomiserNodes);
+  // These will all appear in the set `newLeaves`, which will own the new nodes.
+  RooCustomizer cust(model, sample, newLeaves, &allCustomiserNodes);
   cust.splitArg(meanG, sample);
 
 
@@ -96,8 +96,8 @@ void rf514_RooCustomizer() {
   std::cout << "\nPDF 3 with a free yield:" << std::endl;
   pdf3->Print("T");
 
-  std::cout << "\nThe following leafs have been created automatically while customising:" << std::endl;
-  newLeafs.Print("V");
+  std::cout << "\nThe following leaves have been created automatically while customising:" << std::endl;
+  newLeaves.Print("V");
 
 
   // If we needed to set reasonable values for the means of the gaussians, this could be done as follows:
@@ -106,7 +106,7 @@ void rf514_RooCustomizer() {
   auto& meanG2 = static_cast<RooRealVar&>(allCustomiserNodes["meanG_Sample2"]);
   meanG2.setVal(300);
 
-  std::cout << "\nThe following leafs have been used while customising"
+  std::cout << "\nThe following leaves have been used while customising"
     << "\n\t(partial overlap with the set of automatically created leaves."
     << "\n\ta new customiser for a different PDF could reuse them if necessary.):" << std::endl;
   allCustomiserNodes.Print("V");

--- a/tutorials/roofit/rf514_RooCustomizer.py
+++ b/tutorials/roofit/rf514_RooCustomizer.py
@@ -38,14 +38,14 @@ sample = ROOT.RooCategory("sample", "sample", {"Sample1": 1, "Sample2": 2, "Samp
 # ---------------------------------------------------------------------------
 
 # We need two sets for bookkeeping of PDF nodes:
-newLeafs = ROOT.RooArgSet()
+newLeaves = ROOT.RooArgSet()
 allCustomiserNodes = ROOT.RooArgSet()
 
 
 # 1. Each sample should have its own mean for the gaussian
 # The customiser will make copies of `meanG` for each category.
-# These will all appear in the set `newLeafs`, which will own the new nodes.
-cust = ROOT.RooCustomizer(model, sample, newLeafs, allCustomiserNodes)
+# These will all appear in the set `newLeaves`, which will own the new nodes.
+cust = ROOT.RooCustomizer(model, sample, newLeaves, allCustomiserNodes)
 cust.splitArg(meanG, sample)
 
 
@@ -78,8 +78,8 @@ pdf2.Print("T")
 print("\nPDF 3 with a free yield:\n")
 pdf3.Print("T")
 
-print("\nThe following leafs have been created automatically while customising:\n")
-newLeafs.Print("V")
+print("\nThe following leaves have been created automatically while customising:\n")
+newLeaves.Print("V")
 
 #  If we needed to set reasonable values for the means of the gaussians, this could be done as follows:
 meanG1 = allCustomiserNodes["meanG_Sample1"]
@@ -88,6 +88,6 @@ meanG2 = allCustomiserNodes["meanG_Sample2"]
 meanG2.setVal(300)
 
 print(
-    "\nThe following leafs have been used while customising\n\t(partial overlap with the set of automatically created leaves.\n\ta new customiser for a different PDF could reuse them if necessary.):"
+    "\nThe following leaves have been used while customising\n\t(partial overlap with the set of automatically created leaves.\n\ta new customiser for a different PDF could reuse them if necessary.):"
 )
 allCustomiserNodes.Print("V")

--- a/tutorials/roofit/rf611_weightedfits.C
+++ b/tutorials/roofit/rf611_weightedfits.C
@@ -7,10 +7,11 @@
 ///
 /// Based on example from https://arxiv.org/abs/1911.01303
 ///
-/// This example compares different approaches to determining parameter uncertainties in weighted unbinned maximum likelihood fits.
-/// Performing a weighted unbinned maximum likelihood fits can be useful to account for acceptance effects and to statistically subtract background events using the sPlot formalism.
-/// It is however well known that the inverse Hessian matrix does not yield parameter uncertainties with correct coverage in the presence of event weights.
-/// Three approaches to the determination of parameter uncertainties are compared in this example:
+/// This example compares different approaches to determining parameter uncertainties in weighted unbinned maximum
+/// likelihood fits. Performing a weighted unbinned maximum likelihood fits can be useful to account for acceptance
+/// effects and to statistically subtract background events using the sPlot formalism. It is however well known that the
+/// inverse Hessian matrix does not yield parameter uncertainties with correct coverage in the presence of event
+/// weights. Three approaches to the determination of parameter uncertainties are compared in this example:
 ///
 /// 1. Using the inverse weighted Hessian matrix [`SumW2Error(false)`]
 ///
@@ -20,13 +21,15 @@
 ///    \f]
 ///    where H is the weighted Hessian matrix and C is the Hessian matrix with squared weights
 ///
-/// 3. The asymptotically correct approach (for details please see https://arxiv.org/abs/1911.01303) [`Asymptotic(true)`]
+/// 3. The asymptotically correct approach (for details please see https://arxiv.org/abs/1911.01303)
+/// [`Asymptotic(true)`]
 ///    \f[
 ///      V_{ij} = H_{ik}^{-1} D_{kl} H_{lj}^{-1}
 ///    \f]
 ///    where H is the weighted Hessian matrix and D is given by
 ///    \f[
-///      D_{kl} = \sum_{e=1}^{N} w_e^2 \frac{\partial \log(P)}{\partial \lambda_k}\frac{\partial \log(P)}{\partial \lambda_l}
+///      D_{kl} = \sum_{e=1}^{N} w_e^2 \frac{\partial \log(P)}{\partial \lambda_k}\frac{\partial \log(P)}{\partial
+///      \lambda_l}
 ///    \f]
 ///    with the event weight \f$w_e\f$.
 ///
@@ -42,10 +45,11 @@
 /// - `acceptancemodel==2`: eff = \f$ 1.0 - 0.7 \cdot \cos(\theta) \cdot \cos(\theta) \f$
 /// The data is generated to be flat before the acceptance effect.
 ///
-/// The performance of the different approaches to determine parameter uncertainties is compared using the pull distributions from a large number of pseudoexperiments.
-/// The pull is defined as \f$ (\lambda_i - \lambda_{gen})/\sigma(\lambda_i) \f$, where \f$ \lambda_i \f$ is the fitted parameter and \f$ \sigma(\lambda_i) \f$ its
-/// uncertainty for pseudoexperiment number i.
-/// If the fit is unbiased and the parameter uncertainties are estimated correctly, the pull distribution should be a Gaussian centered around zero with a width of one.
+/// The performance of the different approaches to determine parameter uncertainties is compared using the pull
+/// distributions from a large number of pseudoexperiments. The pull is defined as \f$ (\lambda_i -
+/// \lambda_{gen})/\sigma(\lambda_i) \f$, where \f$ \lambda_i \f$ is the fitted parameter and \f$ \sigma(\lambda_i) \f$
+/// its uncertainty for pseudoexperiment number i. If the fit is unbiased and the parameter uncertainties are estimated
+/// correctly, the pull distribution should be a Gaussian centered around zero with a width of one.
 ///
 /// \macro_image
 /// \macro_code
@@ -67,164 +71,180 @@
 
 using namespace RooFit;
 
+void rf611_weightedfits(int acceptancemodel = 2)
+{
+   // I n i t i a l i s a t i o n   a n d   S e t u p
+   //------------------------------------------------
 
-int rf611_weightedfits(int acceptancemodel=2) {
-  // I n i t i a l i s a t i o n   a n d   S e t u p
-  //------------------------------------------------
+   // plotting options
+   gStyle->SetPaintTextFormat(".1f");
+   gStyle->SetEndErrorSize(6.0);
+   gStyle->SetTitleSize(0.05, "XY");
+   gStyle->SetLabelSize(0.05, "XY");
+   gStyle->SetTitleOffset(0.9, "XY");
+   gStyle->SetTextSize(0.05);
+   gStyle->SetPadLeftMargin(0.125);
+   gStyle->SetPadBottomMargin(0.125);
+   gStyle->SetPadTopMargin(0.075);
+   gStyle->SetPadRightMargin(0.075);
+   gStyle->SetMarkerStyle(20);
+   gStyle->SetMarkerSize(1.0);
+   gStyle->SetHistLineWidth(2.0);
+   gStyle->SetHistLineColor(1);
 
-  //plotting options
-  gStyle->SetPaintTextFormat(".1f");
-  gStyle->SetEndErrorSize(6.0);
-  gStyle->SetTitleSize(0.05, "XY");
-  gStyle->SetLabelSize(0.05, "XY");
-  gStyle->SetTitleOffset(0.9, "XY");
-  gStyle->SetTextSize(0.05);
-  gStyle->SetPadLeftMargin(0.125);
-  gStyle->SetPadBottomMargin(0.125);
-  gStyle->SetPadTopMargin(0.075);
-  gStyle->SetPadRightMargin(0.075);
-  gStyle->SetMarkerStyle(20);
-  gStyle->SetMarkerSize(1.0);
-  gStyle->SetHistLineWidth(2.0);
-  gStyle->SetHistLineColor(1);
+   // initialise TRandom3
+   TRandom3 *rnd = new TRandom3();
+   rnd->SetSeed(191101303);
 
-  //initialise TRandom3
-  TRandom3* rnd = new TRandom3();
-  rnd->SetSeed(191101303);
+   // accepted events and events weighted to account for the acceptance
+   TH1 *haccepted = new TH1D("haccepted", "Generated events;cos(#theta);#events", 40, -1.0, 1.0);
+   TH1 *hweighted = new TH1D("hweighted", "Generated events;cos(#theta);#events", 40, -1.0, 1.0);
+   // histograms holding pull distributions
+   std::array<TH1 *, 3> hc0pull;
+   std::array<TH1 *, 3> hc1pull;
+   std::array<TH1 *, 3> hntotpull;
+   std::array<std::string, 3> methodLabels{"Inverse weighted Hessian matrix [SumW2Error(false)]",
+                                           "Hessian matrix with squared weights [SumW2Error(true)]",
+                                           "Asymptotically correct approach [Asymptotic(true)]"};
+   auto makePullXLabel = [](std::string const &pLabel) {
+      return "Pull (" + pLabel + "^{fit}-" + pLabel + "^{gen})/#sigma(" + pLabel + ")";
+   };
+   for (std::size_t i = 0; i < 3; ++i) {
+      std::string const &iLabel = std::to_string(i);
+      // using the inverse Hessian matrix
+      std::string hc0XLabel = methodLabels[i] + ";" + makePullXLabel("c_{0}") + ";";
+      std::string hc1XLabel = methodLabels[i] + ";" + makePullXLabel("c_{1}") + ";";
+      std::string hntotXLabel = methodLabels[i] + ";" + makePullXLabel("N_{tot}") + ";";
+      hc0pull[i] = new TH1D(("hc0pull" + iLabel).c_str(), hc0XLabel.c_str(), 20, -5.0, 5.0);
+      // using the correction with the Hessian matrix with squared weights
+      hc1pull[i] = new TH1D(("hc1pull" + iLabel).c_str(), hc1XLabel.c_str(), 20, -5.0, 5.0);
+      // asymptotically correct approach
+      hntotpull[i] = new TH1D(("hntotpull" + iLabel).c_str(), hntotXLabel.c_str(), 20, -5.0, 5.0);
+   }
 
-  //accepted events and events weighted to account for the acceptance
-  TH1D* haccepted = new TH1D("haccepted", "Generated events;cos(#theta);#events", 40, -1.0, 1.0);
-  TH1D* hweighted = new TH1D("hweighted", "Generated events;cos(#theta);#events", 40, -1.0, 1.0);
-  //histograms holding pull distributions
-  //using the inverse Hessian matrix
-  TH1D* hc0pull1 = new TH1D("hc0pull1", "Inverse weighted Hessian matrix [SumW2Error(false)];Pull (c_{0}^{fit}-c_{0}^{gen})/#sigma(c_{0});", 20, -5.0, 5.0);
-  TH1D* hc1pull1 = new TH1D("hc1pull1", "Inverse weighted Hessian matrix [SumW2Error(false)];Pull (c_{1}^{fit}-c_{1}^{gen})/#sigma(c_{1});", 20, -5.0, 5.0);
-  //using the correction with the Hessian matrix with squared weights
-  TH1D* hc0pull2 = new TH1D("hc0pull2", "Hessian matrix with squared weights [SumW2Error(true)];Pull (c_{0}^{fit}-c_{0}^{gen})/#sigma(c_{0});", 20, -5.0, 5.0);
-  TH1D* hc1pull2 = new TH1D("hc1pull2", "Hessian matrix with squared weights [SumW2Error(true)];Pull (c_{1}^{fit}-c_{1}^{gen})/#sigma(c_{1});", 20, -5.0, 5.0);
-  //asymptotically correct approach
-  TH1D* hc0pull3 = new TH1D("hc0pull3", "Asymptotically correct approach [Asymptotic(true)];Pull (c_{0}^{fit}-c_{0}^{gen})/#sigma(c_{0});", 20, -5.0, 5.0);
-  TH1D* hc1pull3 = new TH1D("hc1pull3", "Asymptotically correct approach [Asymptotic(true)];Pull (c_{1}^{fit}-c_{1}^{gen})/#sigma(c_{1});", 20, -5.0, 5.0);
+   // number of pseudoexperiments (toys) and number of events per pseudoexperiment
+   constexpr std::size_t ntoys = 500;
+   constexpr std::size_t nstats = 500;
+   // parameters used in the generation
+   constexpr double c0gen = 0.0;
+   constexpr double c1gen = 0.0;
 
-  //number of pseudoexperiments (toys) and number of events per pseudoexperiment
-  constexpr unsigned int ntoys = 500;
-  constexpr unsigned int nstats = 5000;
-  //parameters used in the generation
-  constexpr double c0gen = 0.0;
-  constexpr double c1gen = 0.0;
+   // Silence fitting and minimisation messages
+   auto &msgSv = RooMsgService::instance();
+   msgSv.getStream(1).removeTopic(RooFit::Minimization);
+   msgSv.getStream(1).removeTopic(RooFit::Fitting);
 
-  // Silence fitting and minimisation messages
-  auto& msgSv = RooMsgService::instance();
-  msgSv.getStream(1).removeTopic(RooFit::Minimization);
-  msgSv.getStream(1).removeTopic(RooFit::Fitting);
+   std::cout << "Running " << ntoys * 3 << " toy fits ..." << std::endl;
 
-  std::cout << "Running " << ntoys*3 << " toy fits ..." << std::endl;
+   // M a i n   l o o p :   r u n   p s e u d o e x p e r i m e n t s
+   //----------------------------------------------------------------
+   for (std::size_t i = 0; i < ntoys; i++) {
+      // S e t u p   p a r a m e t e r s   a n d   P D F
+      //-----------------------------------------------
+      // angle theta and the weight to account for the acceptance effect
+      RooRealVar costheta("costheta", "costheta", -1.0, 1.0);
+      RooRealVar weight("weight", "weight", 0.0, 1000.0);
 
-  // M a i n   l o o p :   r u n   p s e u d o e x p e r i m e n t s
-  //----------------------------------------------------------------
-  for (unsigned int i=0; i<ntoys; i++) {
-    //S e t u p   p a r a m e t e r s   a n d   P D F
-    //-----------------------------------------------
-    //angle theta and the weight to account for the acceptance effect
-    RooRealVar costheta("costheta","costheta", -1.0, 1.0);
-    RooRealVar weight("weight","weight", 0.0, 1000.0);
+      // initialise parameters to fit
+      RooRealVar c0("c0", "0th-order coefficient", c0gen, -1.0, 1.0);
+      RooRealVar c1("c1", "1st-order coefficient", c1gen, -1.0, 1.0);
+      c0.setError(0.01);
+      c1.setError(0.01);
+      // create simple second-order polynomial as probability density function
+      RooPolynomial pol("pol", "pol", costheta, {c0, c1}, 1);
 
-    //initialise parameters to fit
-    RooRealVar c0("c0","0th-order coefficient", c0gen, -1.0, 1.0);
-    RooRealVar c1("c1","1st-order coefficient", c1gen, -1.0, 1.0);
-    c0.setError(0.01);
-    c1.setError(0.01);
-    //create simple second-order polynomial as probability density function
-    RooPolynomial pol("pol", "pol", costheta, RooArgList(c0, c1), 1);
+      double ngen = nstats;
+      if (acceptancemodel == 1)
+         ngen *= 2.0 / (23.0 / 15.0);
+      else
+         ngen *= 2.0 / (16.0 / 15.0);
+      RooRealVar ntot("ntot", "ntot", ngen, 0.0, 2.0 * ngen);
+      RooExtendPdf extended("extended", "extended pdf", pol, ntot);
+      int npoisson = rnd->Poisson(nstats);
 
-    //G e n e r a t e   d a t a   s e t   f o r   p s e u d o e x p e r i m e n t   i
-    //-------------------------------------------------------------------------------
-    RooDataSet data("data","data",RooArgSet(costheta, weight), WeightVar("weight"));
-    //generate nstats events
-    for (unsigned int j=0; j<nstats; j++) {
-      bool finished = false;
-      //use simple accept/reject for generation
-      while (!finished) {
-        costheta = 2.0*rnd->Rndm()-1.0;
-        //efficiency for the specific value of cos(theta)
-        double eff = 1.0;
-        if (acceptancemodel == 1)
-          eff = 1.0 - 0.7 * costheta.getVal()*costheta.getVal();
-        else
-          eff = 0.3 + 0.7 * costheta.getVal()*costheta.getVal();
-        //use 1/eff as weight to account for acceptance
-        weight = 1.0/eff;
-        //accept/reject
-        if (10.0*rnd->Rndm() < eff*pol.getVal())
-          finished = true;
+      // G e n e r a t e   d a t a   s e t   f o r   p s e u d o e x p e r i m e n t   i
+      //-------------------------------------------------------------------------------
+      RooDataSet data("data", "data", {costheta, weight}, WeightVar("weight"));
+      // generate nstats events
+      for (std::size_t j = 0; j < npoisson; j++) {
+         bool finished = false;
+         // use simple accept/reject for generation
+         while (!finished) {
+            costheta = 2.0 * rnd->Rndm() - 1.0;
+            // efficiency for the specific value of cos(theta)
+            double eff = 1.0;
+            if (acceptancemodel == 1)
+               eff = 1.0 - 0.7 * costheta.getVal() * costheta.getVal();
+            else
+               eff = 0.3 + 0.7 * costheta.getVal() * costheta.getVal();
+            // use 1/eff as weight to account for acceptance
+            weight = 1.0 / eff;
+            // accept/reject
+            if (10.0 * rnd->Rndm() < eff * pol.getVal())
+               finished = true;
+         }
+         haccepted->Fill(costheta.getVal());
+         hweighted->Fill(costheta.getVal(), weight.getVal());
+         data.add({costheta, weight}, weight.getVal());
       }
-      haccepted->Fill(costheta.getVal());
-      hweighted->Fill(costheta.getVal(), weight.getVal());
-      data.add(RooArgSet(costheta, weight), weight.getVal());
-    }
 
-    //F i t   t o y   u s i n g   t h e   t h r e e   d i f f e r e n t   a p p r o a c h e s   t o   u n c e r t a i n t y   d e t e r m i n a t i o n
-    //-------------------------------------------------------------------------------------------------------------------------------------------------
-    //this uses the inverse weighted Hessian matrix
-    std::unique_ptr<RooFitResult> result{pol.fitTo(data, Save(true), SumW2Error(false), PrintLevel(-1), EvalBackend("cpu"))};
-    hc0pull1->Fill((c0.getVal()-c0gen)/c0.getError());
-    hc1pull1->Fill((c1.getVal()-c1gen)/c1.getError());
+      auto fillPulls = [&](std::size_t i) {
+         hc0pull[i]->Fill((c0.getVal() - c0gen) / c0.getError());
+         hc1pull[i]->Fill((c1.getVal() - c1gen) / c1.getError());
+         hntotpull[i]->Fill((ntot.getVal() - ngen) / ntot.getError());
+      };
 
-    //this uses the correction with the Hesse matrix with squared weights
-    result = std::unique_ptr<RooFitResult>{pol.fitTo(data, Save(true), SumW2Error(true), PrintLevel(-1), EvalBackend("cpu"))};
-    hc0pull2->Fill((c0.getVal()-c0gen)/c0.getError());
-    hc1pull2->Fill((c1.getVal()-c1gen)/c1.getError());
+      // F i t   t o y   u s i n g   t h e   t h r e e   d i f f e r e n t   a p p r o a c h e s   t o   u n c e r t a i
+      // n t y   d e t e r m i n a t i o n
+      //-------------------------------------------------------------------------------------------------------------------------------------------------
+      // this uses the inverse weighted Hessian matrix
+      extended.fitTo(data, SumW2Error(false), PrintLevel(-1));
+      fillPulls(0);
 
-    //this uses the asymptotically correct approach
-    result = std::unique_ptr<RooFitResult>{pol.fitTo(data, Save(true), AsymptoticError(true), PrintLevel(-1), EvalBackend("cpu"))};
-    hc0pull3->Fill((c0.getVal()-c0gen)/c0.getError());
-    hc1pull3->Fill((c1.getVal()-c1gen)/c1.getError());
-  }
+      // this uses the correction with the Hesse matrix with squared weights
+      extended.fitTo(data, SumW2Error(true), PrintLevel(-1));
+      fillPulls(1);
 
-  std::cout << "... done." << std::endl;
+      // this uses the asymptotically correct approach
+      extended.fitTo(data, AsymptoticError(true), PrintLevel(-1));
+      fillPulls(2);
+   }
 
-  // P l o t   o u t p u t   d i s t r i b u t i o n s
-  //--------------------------------------------------
+   std::cout << "... done." << std::endl;
 
-  //plot accepted (weighted) events
-  gStyle->SetOptStat(0);
-  gStyle->SetOptFit(0);
-  TCanvas* cevents = new TCanvas("cevents", "cevents", 800, 600);
-  cevents->cd(1);
-  hweighted->SetMinimum(0.0);
-  hweighted->SetLineColor(2);
-  hweighted->Draw("hist");
-  haccepted->Draw("same hist");
-  TLegend* leg = new TLegend(0.6, 0.8, 0.9, 0.9);
-  leg->AddEntry(haccepted, "Accepted");
-  leg->AddEntry(hweighted, "Weighted");
-  leg->Draw();
-  cevents->Update();
+   // P l o t   o u t p u t   d i s t r i b u t i o n s
+   //--------------------------------------------------
 
-  //plot pull distributions
-  TCanvas* cpull = new TCanvas("cpull", "cpull", 1200, 800);
-  cpull->Divide(3,2);
-  cpull->cd(1);
-  gStyle->SetOptStat(1100);
-  gStyle->SetOptFit(11);
-  hc0pull1->Fit("gaus");
-  hc0pull1->Draw("ep");
-  cpull->cd(2);
-  hc0pull2->Fit("gaus");
-  hc0pull2->Draw("ep");
-  cpull->cd(3);
-  hc0pull3->Fit("gaus");
-  hc0pull3->Draw("ep");
-  cpull->cd(4);
-  hc1pull1->Fit("gaus");
-  hc1pull1->Draw("ep");
-  cpull->cd(5);
-  hc1pull2->Fit("gaus");
-  hc1pull2->Draw("ep");
-  cpull->cd(6);
-  hc1pull3->Fit("gaus");
-  hc1pull3->Draw("ep");
-  cpull->Update();
+   // plot accepted (weighted) events
+   gStyle->SetOptStat(0);
+   gStyle->SetOptFit(0);
+   TCanvas *cevents = new TCanvas("cevents", "cevents", 800, 600);
+   cevents->cd(1);
+   hweighted->SetMinimum(0.0);
+   hweighted->SetLineColor(2);
+   hweighted->Draw("hist");
+   haccepted->Draw("same hist");
+   TLegend *leg = new TLegend(0.6, 0.8, 0.9, 0.9);
+   leg->AddEntry(haccepted, "Accepted");
+   leg->AddEntry(hweighted, "Weighted");
+   leg->Draw();
+   cevents->Update();
 
-  return 0;
+   // plot pull distributions
+   TCanvas *cpull = new TCanvas("cpull", "cpull", 1200, 800);
+   cpull->Divide(3, 3);
+
+   std::vector<TH1 *> pullHistos{hc0pull[0], hc0pull[1],   hc0pull[2],   hc1pull[0],  hc1pull[1],
+                                 hc1pull[2], hntotpull[0], hntotpull[1], hntotpull[2]};
+
+   gStyle->SetOptStat(1100);
+   gStyle->SetOptFit(11);
+
+   for (std::size_t i = 0; i < pullHistos.size(); ++i) {
+      cpull->cd(i + 1);
+      pullHistos[i]->Fit("gaus");
+      pullHistos[i]->Draw("ep");
+   }
+
+   cpull->Update();
 }


### PR DESCRIPTION
# This Pull request:
Added correct treatment of extended term in asymptotically correct method for uncertainty determination in the presence of weights. This improvement will allow for extended unbinned maximum likelihood fits to use the asymptotically correct method. 

## Changes or fixes:
-Added extended term to asymptotically correct method to allow for weighted extended maximum likelihood fits
-Usage of logarithmic PDFs for derivatives may have some numerical benefits
-Fixed RooDerivative to not use the parameter range in the step size calculation in case the parameter supplied has no range. This now allows to use the method (and RooDerivative in general) for parameters that do not specify a range. 
-Added warning in case of binned fits. In this case a chi2 fit using the std. treatment of weights should be preferrable.


## Checklist:

- [x] tested changes locally

This PR fixes # 
resolves https://its.cern.ch/jira/browse/ROOT-10827
resolves https://its.cern.ch/jira/browse/ROOT-10866
related #11660 
note https://github.com/root-project/root/issues/11112 can not be fixed since the resulting minuit covariance matrix is not positive definite (set PrintLevel(0) to see this). Calculations with the inverse Hessians are thus not reliable. High stats fit show the expected behaviour.