### PR TITLE
[RF] Explicitly use legacy backend for references in `testRooRealL`

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -135,6 +135,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussian1DTwice)
    EXPECT_EQ(nll0, nll1.Sum());
 }
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
 {
    using namespace RooFit;
@@ -152,6 +153,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
    EXPECT_EQ(nll0, nll1.Sum());
    //   printf("%a =?= %a\n", nll0, nll1.Sum());
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
 {
@@ -415,6 +417,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
    EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // A variation to test some additional parameters (ConstrainedParameters and offsetting)
@@ -425,7 +428,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
    // RooAbsTestStatistic.
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
                                                     RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true), RooFit::EvalBackend("legacy"))};
+                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
 
    // --------
 
@@ -458,6 +461,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
    EXPECT_EQ(nll0, nll2);
    EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_F(LikelihoodJobTest, BatchedUnbinnedGaussianND)
 {
@@ -481,6 +485,7 @@ TEST_F(LikelihoodJobTest, BatchedUnbinnedGaussianND)
 class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTest,
                                      public testing::WithParamInterface<std::tuple<std::size_t, std::size_t>> {};
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
 {
    // Based on ConstrainedAndOffset, this test tests different parallelization strategies
@@ -491,7 +496,7 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    // RooAbsTestStatistic.
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
                                                     RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true), RooFit::EvalBackend("legacy"))};
+                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
 
    // --------
 
@@ -528,6 +533,7 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    EXPECT_EQ(nll0, nll2);
    EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 INSTANTIATE_TEST_SUITE_P(SplitStrategies, LikelihoodJobSplitStrategies,
                          testing::Combine(

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -115,6 +115,7 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussian1D)
    EXPECT_EQ(nll0, nll1.Sum());
 }
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
 {
    unsigned int N = 4;
@@ -130,6 +131,7 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
 
    EXPECT_EQ(nll0, nll1.Sum());
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 {
@@ -395,6 +397,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
    EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // A variation to test some additional parameters (ConstrainedParameters and offsetting)
@@ -405,7 +408,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    // RooAbsTestStatistic.
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
                                                     RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))),
-                                                    RooFit::Offset(true), RooFit::EvalBackend("legacy"))};
+                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
 
    // --------
 
@@ -437,6 +440,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    EXPECT_EQ(nll0, nll2);
    EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
 {

--- a/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
@@ -196,7 +196,6 @@ TEST_P(RooRealL, getValRooConstraintSumAddition)
    count_NLL_components(nll.get());
 }
 #endif // !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
-#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_P(RooRealL, setVal)
 {
@@ -209,7 +208,12 @@ TEST_P(RooRealL, setVal)
    auto x = w.var("x");
    RooAbsPdf *pdf = w.pdf("g");
    std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
-   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data)};
+
+   // The reference likelihood is using the legacy evaluation backend, because
+   // the multiprocess test statistics classes were designed to give values
+   // that are bit-by-bit identical with the old test statistics based on
+   // RooAbsTestStatistic.
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::EvalBackend::Legacy())};
 
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
                                             std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
@@ -239,11 +243,13 @@ TEST_P(RooRealL, setVal)
       std::cout << "failed test had seed = " << std::get<0>(GetParam()) << std::endl;
    }
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 INSTANTIATE_TEST_SUITE_P(NworkersModeSeed, RooRealL, ::testing::Values(2, 3)); // random seed
 
 class RealLVsMPFE : public ::testing::TestWithParam<std::tuple<std::size_t>> {};
 
+#ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_P(RealLVsMPFE, getVal)
 {
    // Compare our MP NLL to actual RooRealMPFE results using the same strategies.
@@ -261,7 +267,11 @@ TEST_P(RealLVsMPFE, getVal)
    RooAbsPdf *pdf = w.pdf("g");
    std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
 
-   std::unique_ptr<RooAbsReal> nll_mpfe{pdf->createNLL(*data)};
+   // The reference likelihood is using the legacy evaluation backend, because
+   // the multiprocess test statistics classes were designed to give values
+   // that are bit-by-bit identical with the old test statistics based on
+   // RooAbsTestStatistic.
+   std::unique_ptr<RooAbsReal> nll_mpfe{pdf->createNLL(*data, RooFit::EvalBackend::Legacy())};
 
    auto mpfe_result = nll_mpfe->getVal();
 
@@ -275,6 +285,7 @@ TEST_P(RealLVsMPFE, getVal)
       std::cout << "failed test had seed = " << std::get<0>(GetParam()) << std::endl;
    }
 }
+#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 TEST_P(RealLVsMPFE, minimize)
 {


### PR DESCRIPTION
The new multiprocessing test statistics were designed to be bit-by-bit compatible with the old test statistics, not the new CPU evaluation backend. Therefore, the old NLL evaluation backend has to be used for the offsetting tests (the new CPU backend is not bit-by-bit compatible with the legacy backend).

This is a followup to commit 65b15d333c, which didn't apply this change to all relevant tests. Doing `EXPECT_EQ` on floats is quite fragile...