### PR TITLE
[RF] Set workspace on imported roofit objects

### DIFF
--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -689,6 +689,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
             << node->GetName() << endl ;
       }
       _allOwnedNodes.addOwned(std::unique_ptr<RooAbsArg>{node});
+      node->setWorkspace(*this);
       if (_openTrans) {
         _sandboxNodes.add(*node) ;
       } else {


### PR DESCRIPTION
Imported RooAbsArgs should have their workspace set to the workspace they are being imported to.

Can we please sweep this into 6.30 patches too please.