### PR TITLE
[core] use one instead of two lookups within TClass::Init()

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -209,14 +209,14 @@ public:
    virtual void     UpdateListOfGlobals() = 0;
    virtual void     UpdateListOfGlobalFunctions() = 0;
    virtual void     UpdateListOfTypes() = 0;
-   virtual void     SetClassInfo(TClass *cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE) = 0;
+   virtual void     SetClassInfo(TClass *cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE, TDictionary::DeclId_t decl = nullptr, Bool_t preChecked = kFALSE) = 0;
 
    enum ECheckClassInfo {
       kUnknown = 0, // backward compatible with false
       kKnown = 1,
       kWithClassDefInline = 2
    };
-   virtual ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE) = 0;
+   virtual ECheckClassInfo CheckClassInfo(const char *name, TDictionary::DeclId_t &decl, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE, Bool_t instantiateTemplate = kFALSE) = 0;
 
    virtual Bool_t   CheckClassTemplate(const char *name) = 0;
    virtual Longptr_t Calc(const char *line, EErrorCode* error = nullptr) = 0;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1586,8 +1586,9 @@ void TClass::Init(const char *name, Version_t cversion,
          if (proto)
             proto->FillTClass(this);
       }
-      if (!fHasRootPcmInfo && gInterpreter->CheckClassInfo(fName, /* autoload = */ kTRUE)) {
-         gInterpreter->SetClassInfo(this, kFALSE, silent);   // sets fClassInfo pointer
+      TDictionary::DeclId_t decl {};
+      if (!fHasRootPcmInfo && gInterpreter->CheckClassInfo(fName, decl, /* autoload = */ kTRUE, /* instantiateTemplate */ kTRUE)) {
+         gInterpreter->SetClassInfo(this, kFALSE, silent, decl, kTRUE);   // sets fClassInfo pointer
          if (fClassInfo) {
             // This should be moved out of GetCheckSum itself however the last time
             // we tried this cause problem, in particular in the end-of-process operation.
@@ -3305,7 +3306,8 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
       printf("TClass::GetClass: Header Parsing - The representation of %s was not found in the type system. A lookup in the interpreter is about to be tried: this can cause parsing. This can be avoided selecting %s in the linkdef/selection file.\n",normalizedName.c_str(), normalizedName.c_str());
    }
    if (normalizedName.length()) {
-      auto cci = gInterpreter->CheckClassInfo(normalizedName.c_str(), kTRUE /* autoload */,
+      TDictionary::DeclId_t decl {};
+      auto cci = gInterpreter->CheckClassInfo(normalizedName.c_str(), decl, kTRUE /* autoload */,
                                               kTRUE /*Only class, structs and ns*/);
 
       // We could have an interpreted class with an inline ClassDef, in this case we do not

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -271,9 +271,9 @@ public: // Public Interface
    void    UpdateListOfGlobals() final;
    void    UpdateListOfGlobalFunctions() final;
    void    UpdateListOfTypes() final;
-   void    SetClassInfo(TClass* cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE) final;
+   void    SetClassInfo(TClass* cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE, TDictionary::DeclId_t decl = nullptr, Bool_t preChecked = kFALSE) final;
 
-   ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE) final;
+   ECheckClassInfo CheckClassInfo(const char *name, TDictionary::DeclId_t &decl, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE, Bool_t instantiateTemplate = kFALSE) final;
 
    Bool_t  CheckClassTemplate(const char *name) final;
    Longptr_t Calc(const char* line, EErrorCode* error = nullptr) final;

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -78,7 +78,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    SetDecl(TU);
 }
 
-TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, bool intantiateTemplate /* = true */)
+TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, bool instantiateTemplate /* = true */)
    : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false),
      fOffsetCache(0)
 {
@@ -87,14 +87,14 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, b
    const Decl *decl = lh.findScope(name,
                                    gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                    : cling::LookupHelper::NoDiagnostics,
-                                   &type, intantiateTemplate);
+                                   &type, instantiateTemplate);
    if (!decl) {
       std::string buf = TClassEdit::InsertStd(name);
       if (buf != name) {
          decl = lh.findScope(buf,
                              gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                              : cling::LookupHelper::NoDiagnostics,
-                             &type, intantiateTemplate);
+                             &type, instantiateTemplate);
       }
    }
    if (!decl && type) {

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -94,7 +94,7 @@ public:
       fDeclFileName(rhs.fDeclFileName), fOffsetCache(rhs.fOffsetCache)
    {}
    explicit TClingClassInfo(cling::Interpreter *, Bool_t all = kTRUE);
-   explicit TClingClassInfo(cling::Interpreter *, const char *classname, bool intantiateTemplate = kTRUE);
+   explicit TClingClassInfo(cling::Interpreter *, const char *classname, bool instantiateTemplate = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *interp, const clang::Type &tag);
    explicit TClingClassInfo(cling::Interpreter *interp, const clang::Decl *D);
    TClingClassInfo &operator=(const TClingClassInfo &rhs)

--- a/core/textinput/src/Getline_color.cxx
+++ b/core/textinput/src/Getline_color.cxx
@@ -232,9 +232,10 @@ void ROOT::TextInputColorizer::ProcessTextChange(EditorRange& Modification,
          }
          std::string word = text.substr(i, wordLen);
          char color = kColorNone;
+         TDictionary::DeclId_t decl;
          if (gClassTable->GetDict(word.c_str())
              || gInterpreter->GetClassSharedLibs(word.c_str())
-             || gInterpreter->CheckClassInfo(word.c_str(), false /*autoload*/)
+             || gInterpreter->CheckClassInfo(word.c_str(), decl, false /*autoload*/)
              || ((THashTable*)gROOT->GetListOfTypes())
                 ->THashTable::FindObject(word.c_str())) {
             color = kColorType;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/7123

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)