### PR TITLE
[ntuple] remove ENTupleContainerFormat

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -162,10 +162,16 @@ private:
    void WriteBareFileSkeleton(int defaultCompression);
 
 public:
+   /// For testing purposes, RNTuple data can be written into a bare file container instead of a ROOT file
+   enum class EContainerFormat {
+      kTFile, // ROOT TFile
+      kBare,  // A thin envelope supporting a single RNTuple only
+   };
+
    /// Create or truncate the local file given by path with the new empty RNTuple identified by ntupleName.
    /// Uses a C stream for writing
    static RNTupleFileWriter *Recreate(std::string_view ntupleName, std::string_view path, int defaultCompression,
-                                      ENTupleContainerFormat containerFormat);
+                                      EContainerFormat containerFormat);
    /// Add a new RNTuple identified by ntupleName to the existing TFile.
    static RNTupleFileWriter *Append(std::string_view ntupleName, TFile &file);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -26,19 +26,6 @@ namespace Experimental {
 
 // clang-format off
 /**
-\class ROOT::Experimental::ENTupleContainerFormat
-\ingroup NTuple
-\brief Describes the options for wrapping RNTuple data in files
-*/
-// clang-format on
-enum class ENTupleContainerFormat {
-   kTFile, // ROOT TFile
-   kBare, // A thin envelope supporting a single RNTuple only
-};
-
-
-// clang-format off
-/**
 \class ROOT::Experimental::RNTupleWriteOptions
 \ingroup NTuple
 \brief Common user-tunable settings for storing ntuples
@@ -49,7 +36,6 @@ All page sink classes need to support the common options.
 class RNTupleWriteOptions {
 protected:
    int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
-   ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
    /// Approximation of the target compressed cluster size
    std::size_t fApproxZippedClusterSize = 50 * 1000 * 1000;
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
@@ -79,9 +65,6 @@ public:
    void SetCompression(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel) {
       fCompression = CompressionSettings(algorithm, compressionLevel);
    }
-
-   ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
-   void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
 
    std::size_t GetApproxZippedClusterSize() const { return fApproxZippedClusterSize; }
    void SetApproxZippedClusterSize(std::size_t val);

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1289,9 +1289,9 @@ ROOT::Experimental::Internal::RNTupleFileWriter::~RNTupleFileWriter()
 {
 }
 
-
-ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(
-   std::string_view ntupleName, std::string_view path, int defaultCompression, ENTupleContainerFormat containerFormat)
+ROOT::Experimental::Internal::RNTupleFileWriter *
+ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupleName, std::string_view path,
+                                                          int defaultCompression, EContainerFormat containerFormat)
 {
    std::string fileName(path);
    size_t idxDirSep = fileName.find_last_of("\\/");
@@ -1310,10 +1310,8 @@ ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::R
    writer->fFileName = fileName;
 
    switch (containerFormat) {
-   case ENTupleContainerFormat::kTFile:
-      writer->WriteTFileSkeleton(defaultCompression);
-      break;
-   case ENTupleContainerFormat::kBare:
+   case EContainerFormat::kTFile: writer->WriteTFileSkeleton(defaultCompression); break;
+   case EContainerFormat::kBare:
       writer->fIsBare = true;
       writer->WriteBareFileSkeleton(defaultCompression);
       break;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -63,8 +63,8 @@ ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntup
                                                            const RNTupleWriteOptions &options)
    : RPageSinkFile(ntupleName, options)
 {
-   fWriter = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate(ntupleName, path, options.GetCompression(), options.GetContainerFormat()));
+   fWriter = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Recreate(
+      ntupleName, path, options.GetCompression(), RNTupleFileWriter::EContainerFormat::kTFile));
 }
 
 ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, TFile &file,

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -32,7 +32,8 @@ TEST(RNTupleCompat, FeatureFlag)
       RFieldDescriptorBuilder::FromField(ROOT::Experimental::RFieldZero()).FieldId(0).MakeDescriptor().Unwrap());
    ASSERT_TRUE(static_cast<bool>(descBuilder.EnsureValidDescriptor()));
 
-   auto writer = RNTupleFileWriter::Recreate("ntpl", fileGuard.GetPath(), 0, ENTupleContainerFormat::kTFile);
+   auto writer =
+      RNTupleFileWriter::Recreate("ntpl", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile);
    RNTupleSerializer serializer;
 
    auto ctx = serializer.SerializeHeader(nullptr, descBuilder.GetDescriptor());

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -26,7 +26,7 @@ TEST(MiniFile, Raw)
    FileRaii fileGuard("test_ntuple_minifile_raw.ntuple");
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, ENTupleContainerFormat::kBare));
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kBare));
    char header = 'h';
    char footer = 'f';
    char blob = 'b';
@@ -56,7 +56,7 @@ TEST(MiniFile, Stream)
    FileRaii fileGuard("test_ntuple_minifile_stream.root");
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, ENTupleContainerFormat::kTFile));
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
    char header = 'h';
    char footer = 'f';
    char blob = 'b';
@@ -121,7 +121,7 @@ TEST(MiniFile, SimpleKeys)
    FileRaii fileGuard("test_ntuple_minifile_simple_keys.root");
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, ENTupleContainerFormat::kTFile));
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
@@ -402,12 +402,13 @@ TEST(MiniFile, Multi)
 TEST(MiniFile, Failures)
 {
    // TODO(jblomer): failures should be exceptions
-   EXPECT_DEATH(RNTupleFileWriter::Recreate("MyNTuple", "/can/not/open", 0, ENTupleContainerFormat::kTFile), ".*");
+   EXPECT_DEATH(
+      RNTupleFileWriter::Recreate("MyNTuple", "/can/not/open", 0, RNTupleFileWriter::EContainerFormat::kTFile), ".*");
 
    FileRaii fileGuard("test_ntuple_minifile_failures.root");
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, ENTupleContainerFormat::kTFile));
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
    char header = 'h';
    char footer = 'f';
    char blob = 'b';

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -51,15 +51,13 @@ public:
 
 TEST(RNTuple, Basics)
 {
-   FileRaii fileGuard("test_ntuple_barefile.ntuple");
+   FileRaii fileGuard("test_ntuple_basics.ntuple");
 
    {
       auto model = RNTupleModel::Create();
       auto wrPt = model->MakeField<float>("pt", 42.0);
 
-      RNTupleWriteOptions options;
-      options.SetContainerFormat(ENTupleContainerFormat::kBare);
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       EXPECT_EQ(ntuple->GetNEntries(), 0);
       ntuple->Fill();
       EXPECT_EQ(ntuple->GetNEntries(), 1);
@@ -94,7 +92,7 @@ TEST(RNTuple, Basics)
 
 TEST(RNTuple, Extended)
 {
-   FileRaii fileGuard("test_ntuple_barefile_ext.ntuple");
+   FileRaii fileGuard("test_ntuple_ext.ntuple");
 
    TRandom3 rnd(42);
    double chksumWrite = 0.0;
@@ -102,9 +100,7 @@ TEST(RNTuple, Extended)
       auto model = RNTupleModel::Create();
       auto wrVector = model->MakeField<std::vector<double>>("vector");
 
-      RNTupleWriteOptions options;
-      options.SetContainerFormat(ENTupleContainerFormat::kBare);
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       constexpr unsigned int nEvents = 32000;
       for (unsigned int i = 0; i < nEvents; ++i) {
          auto nVec = 1 + floor(rnd.Rndm() * 1000.);

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -55,7 +55,6 @@
 using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 using DescriptorId_t = ROOT::Experimental::DescriptorId_t;
 using EColumnType = ROOT::Experimental::EColumnType;
-using ENTupleContainerFormat = ROOT::Experimental::ENTupleContainerFormat;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;


### PR DESCRIPTION
The bare file container is only used for testing and therefore should not be part of the public interface.
