### PR TITLE
[math][fit] Change FitFCN/SetFCN to pass a flag for the type of fit

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -466,6 +466,7 @@ public:
    {
       return (fType == EFType::kTemplVec) || (fType == EFType::kFormula && fFormula && fFormula->IsVectorized());
    }
+   /// Return the Chisquare after fitting. See ROOT::Fit::FitResult::Chi2()
    Double_t     GetChisquare() const
    {
       return fChisquare;

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -146,8 +146,10 @@ public:
    const BinData * FittedBinData() const;
 
 
-   /// Chi2 fit value
-   /// in case of likelihood must be computed ?
+   /// Return the Chi2 value after fitting
+   /// In case of unbinned fits (or not defined one, see the documentation of Fitter::FitFCN) return -1
+   /// In case of binned likelihood fits (Poisson Likelihood) return the 2 * negative log-likelihood ratio
+   /// using the definition of Baker-Cousins
    double Chi2() const { return fChi2; }
 
    /// Number of degree of freedom

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -263,7 +263,7 @@ public:
       For the options see documentation for following methods FitFCN(IMultiGenFunction & fcn,..)
     */
    template <class Function>
-   bool FitFCN(unsigned int npar, Function  & fcn, const double * params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN(unsigned int npar, Function  & fcn, const double * params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
       Set a generic FCN function as a C++ callable object implementing
@@ -272,13 +272,14 @@ public:
       For the options see documentation for following methods FitFCN(IMultiGenFunction & fcn,..)
     */
    template <class Function>
-   bool SetFCN(unsigned int npar, Function  & fcn, const double * params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(unsigned int npar, Function  & fcn, const double * params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
       Fit using the given FCN function represented by a multi-dimensional function interface
       (ROOT::Math::IMultiGenFunction).
       Give optionally the initial parameter values, data size to have the fit Ndf correctly
-      set in the FitResult and flag specifying if it is a chi2 fit.
+      set in the FitResult and flag specifying the type of fit. The fitType can be:
+      0 undefined, 1 least square fit, 2 unbinned likelihood fit, 3 binned likelihood fit
       Note that if the parameters values are not given (params=0) the
       current parameter settings are used. The parameter settings can be created before
       by using the FitConfig::SetParamsSetting. If they have not been created they are created
@@ -286,7 +287,7 @@ public:
       Note that passing a params != 0 will set the parameter settings to the new value AND also the
       step sizes to some pre-defined value (stepsize = 0.3 * abs(parameter_value) )
     */
-   bool FitFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
        Fit using a FitMethodFunction interface. Same as method above, but now extra information
@@ -299,7 +300,7 @@ public:
       (ROOT::Math::IMultiGenFunction) and optionally the initial parameters
       See also note above for the initial parameters for FitFCN
     */
-   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
       Set the FCN function represented by a multi-dimensional function interface
@@ -309,7 +310,7 @@ public:
       used to compute confidence interval of the fit
    */
    bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFunction & func, const double *params = nullptr,
-               unsigned int dataSize = 0, bool chi2fit = false);
+               unsigned int dataSize = 0, int fitType = 0);
 
    /**
        Set the objective function (FCN)  using a FitMethodFunction interface.
@@ -336,14 +337,14 @@ public:
       For the options same consideration as in the previous method
     */
    typedef  void (* MinuitFCN_t )(int &npar, double *gin, double &f, double *u, int flag);
-   bool FitFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
       set objective function using user provided FCN with Minuit-like interface
       If npar = 0 it is assumed that the parameters are specified in the parameter settings created before
       For the options same consideration as in the previous method
     */
-   bool SetFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, int fitType = 0);
 
    /**
       Perform a fit with the previously set FCN function. Require SetFCN before
@@ -495,7 +496,7 @@ protected:
    bool DoLinearFit();
    /// Set Objective function
    bool DoSetFCN(bool useExtFCN, const ROOT::Math::IMultiGenFunction &fcn, const double *params, unsigned int dataSize,
-                 bool chi2fit);
+                 int fitType);
 
    // initialize the minimizer
    bool DoInitMinimizer();
@@ -646,16 +647,16 @@ void Fitter::SetFunction(const IGradModelFunction_v &func, bool useGradient)
 #include "Math/WrappedFunction.h"
 
 template<class Function>
-bool ROOT::Fit::Fitter::FitFCN(unsigned int npar, Function & f, const double * par, unsigned int datasize,bool chi2fit) {
+bool ROOT::Fit::Fitter::FitFCN(unsigned int npar, Function & f, const double * par, unsigned int datasize,int fitType) {
    ROOT::Math::WrappedMultiFunction<Function &> wf(f,npar);
-   if (!DoSetFCN(false, wf, par, datasize, chi2fit))
+   if (!DoSetFCN(false, wf, par, datasize, fitType))
       return false;
    return FitFCN();
 }
 template<class Function>
-bool ROOT::Fit::Fitter::SetFCN(unsigned int npar, Function & f, const double * par, unsigned int datasize,bool chi2fit) {
+bool ROOT::Fit::Fitter::SetFCN(unsigned int npar, Function & f, const double * par, unsigned int datasize,int fitType) {
    ROOT::Math::WrappedMultiFunction<Function &> wf(f,npar);
-   return DoSetFCN(false, wf, par, datasize, chi2fit);
+   return DoSetFCN(false, wf, par, datasize, fitType);
 }
 
 

--- a/math/mathcore/inc/Math/FitMethodFunction.h
+++ b/math/mathcore/inc/Math/FitMethodFunction.h
@@ -43,7 +43,7 @@ public:
    typedef  typename FunctionType::BaseFunc BaseFunction;
 
    /// enumeration specifying the possible fit method types
-   enum Type_t { kUndefined , kLeastSquare, kLogLikelihood, kPoissonLikelihood };
+   enum Type_t { kUndefined  = 0, kLeastSquare, kLogLikelihood, kPoissonLikelihood };
 
 
    BasicFitMethodFunction(int dim, int npoint) :


### PR DESCRIPTION
In the FitFCN/SetFCN functions use a flag for the fit type instead of passing a boolean for the chi2 fit.
The flag is by default 0 (undefined type), but can be 1 (for chi2 fit), so compatible as passing a boolean as before, 2 for unbinned likelihood and 3 for binned likelihood (FCN is defined to be the Baker-Cousins log-likelihood ratio)

By passing the correct flag the function FitResult::Chi2() returns the corresponding Chi2() and the Baker-Cousins chi2 equivalent  in case a binned likelihood fits.



This PR fixes #11143

