### PR TITLE
[core] Introduce suffix in `TSystem::TempFileName()` method

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -422,7 +422,7 @@ public:
    Bool_t                  cd(const char *path) { return ChangeDirectory(path); }
    const char             *pwd() { return WorkingDirectory(); }
    virtual const char     *TempDirectory() const;
-   virtual FILE           *TempFileName(TString &base, const char *dir = nullptr);
+   virtual FILE           *TempFileName(TString &base, const char *dir = nullptr, const char *suffix = nullptr);
 
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1477,12 +1477,14 @@ const char *TSystem::TempDirectory() const
 /// Create a secure temporary file by appending a unique
 /// 6 letter string to base. The file will be created in
 /// a standard (system) directory or in the directory
-/// provided in dir. The full filename is returned in base
+/// provided in dir. Optionally one can provide suffix
+/// append to the final name - like extension ".txt" or ".html".
+/// The full filename is returned in base
 /// and a filepointer is returned for safely writing to the file
 /// (this avoids certain security problems). Returns 0 in case
 /// of error.
 
-FILE *TSystem::TempFileName(TString &, const char *)
+FILE *TSystem::TempFileName(TString &, const char *, const char *)
 {
    AbstractMethod("TempFileName");
    return nullptr;

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -26,5 +26,7 @@ ROOT_ADD_GTEST(CoreBaseTests
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)
 
+ROOT_ADD_GTEST(CoreSystemTests TSystemTests.cxx LIBRARIES Core)
+
 configure_file(Foo.C Foo.C COPYONLY)
 ROOT_ADD_GTEST(IncludePathTest IncludePathTest.cxx LIBRARIES Core)

--- a/core/base/test/TSystemTests.cxx
+++ b/core/base/test/TSystemTests.cxx
@@ -1,0 +1,57 @@
+#include "gtest/gtest.h"
+
+#include "TSystem.h"
+#include "TString.h"
+
+#include <string>
+#include <cstdio>
+#include <fstream>
+#include <streambuf>
+
+TEST(TSystem, TempFile)
+{
+   TString fname = "root_test_";
+   auto ftmp = gSystem->TempFileName(fname);
+
+   EXPECT_TRUE(fname.Length() > 10);
+   EXPECT_TRUE(ftmp != nullptr);
+
+   std::string content = "test_temp_file_content";
+   auto res_write = fwrite(content.data(), 1, content.length(), ftmp);
+   EXPECT_EQ(res_write, content.length());
+
+   auto res_close = fclose(ftmp);
+   EXPECT_EQ(res_close, 0);
+
+   std::ifstream fread(fname.Data());
+   std::string str((std::istreambuf_iterator<char>(fread)), std::istreambuf_iterator<char>());
+   EXPECT_STREQ(content.c_str(), str.c_str());
+
+   gSystem->Unlink(fname);
+}
+
+TEST(TSystem, TempFileSuffix)
+{
+   TString fname = "root_suffix_test_";
+   const char *suffix = ".txt";
+   auto ftmp = gSystem->TempFileName(fname, nullptr, suffix);
+
+   EXPECT_TRUE(fname.Length() > 16);
+   EXPECT_TRUE(ftmp != nullptr);
+
+   // check that suffix really at the end of the file name
+   EXPECT_STREQ(fname(fname.Length() - strlen(suffix), strlen(suffix)).Data(), suffix);
+
+   std::string content = "test_temp_file_content_suffix";
+   auto res_write = fwrite(content.data(), 1, content.length(), ftmp);
+   EXPECT_EQ(res_write, content.length());
+
+   auto res_close = fclose(ftmp);
+   EXPECT_EQ(res_close, 0);
+
+   std::ifstream fread(fname.Data());
+   std::string str((std::istreambuf_iterator<char>(fread)), std::istreambuf_iterator<char>());
+   EXPECT_STREQ(content.c_str(), str.c_str());
+
+   gSystem->Unlink(fname);
+}

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -132,7 +132,7 @@ public:
    const char       *HomeDirectory(const char *userName = nullptr) override;
    std::string       GetHomeDirectory(const char *userName = nullptr) const override;
    const char       *TempDirectory() const override;
-   FILE             *TempFileName(TString &base, const char *dir = nullptr) override;
+   FILE             *TempFileName(TString &base, const char *dir = nullptr, const char *suffix = nullptr) override;
 
    //---- Paths & Files ----------------------------------------
    const char       *PrependPathName(const char *dir, TString& name) override;

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -1493,12 +1493,13 @@ FILE *TUnixSystem::TempFileName(TString &base, const char *dir, const char *suff
    char *b = ConcatFileName(dir ? dir : TempDirectory(), base);
    base = b;
    base += "XXXXXX";
-   if (suffix && *suffix)
+   const bool hasSuffix = suffix && *suffix;
+   if (hasSuffix)
       base.Append(suffix);
    delete [] b;
 
    char *arg = StrDup(base);
-   int fd = suffix && *suffix ? mkstemps(arg, strlen(suffix)) : mkstemp(arg);
+   int fd = hasSuffix ? mkstemps(arg, strlen(suffix)) : mkstemp(arg);
    base = arg;
    delete [] arg;
 

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -1481,20 +1481,24 @@ const char *TUnixSystem::TempDirectory() const
 /// Create a secure temporary file by appending a unique
 /// 6 letter string to base. The file will be created in
 /// a standard (system) directory or in the directory
-/// provided in dir. The full filename is returned in base
+/// provided in dir. Optionally one can provide suffix
+/// append to the final name - like extension ".txt" or ".html".
+/// The full filename is returned in base
 /// and a filepointer is returned for safely writing to the file
 /// (this avoids certain security problems). Returns 0 in case
 /// of error.
 
-FILE *TUnixSystem::TempFileName(TString &base, const char *dir)
+FILE *TUnixSystem::TempFileName(TString &base, const char *dir, const char *suffix)
 {
    char *b = ConcatFileName(dir ? dir : TempDirectory(), base);
    base = b;
    base += "XXXXXX";
+   if (suffix && *suffix)
+      base.Append(suffix);
    delete [] b;
 
    char *arg = StrDup(base);
-   int fd = mkstemp(arg);
+   int fd = suffix && *suffix ? mkstemps(arg, strlen(suffix)) : mkstemp(arg);
    base = arg;
    delete [] arg;
 

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -152,7 +152,7 @@ public:
    FILE             *OpenPipe(const char *shellcmd, const char *mode) override;
    int               ClosePipe(FILE *pipe) override;
    int               GetPid() override;
-   
+
    [[ noreturn ]] void Exit (int code, Bool_t mode = kTRUE) override;
    [[ noreturn ]] void Abort (int code = 0) override;
 
@@ -175,7 +175,7 @@ public:
    const char       *HomeDirectory(const char *userName=0) override;
    std::string       GetHomeDirectory(const char *userName = nullptr) const override;
    const char       *TempDirectory() const override;
-   FILE             *TempFileName(TString &base, const char *dir = nullptr) override;
+   FILE             *TempFileName(TString &base, const char *dir = nullptr, const char *suffix = nullptr) override;
 
    //---- Users & Groups ---------------------------------------
    Int_t             GetUid(const char *user = nullptr) override;


### PR DESCRIPTION
Allows to specify extension of temporary-created file.

Used in webgui to create temporary html files to start web widgets