### PR TITLE
REve: Re-enable remote connections

### DIFF
--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -18,6 +18,8 @@
 #include <ROOT/REveSceneInfo.hxx>
 #include <ROOT/REveClient.hxx>
 #include <ROOT/RWebWindow.hxx>
+#include <ROOT/RWebWindowsManager.hxx>
+
 #include <ROOT/RLogger.hxx>
 #include <ROOT/REveSystem.hxx>
 
@@ -155,6 +157,10 @@ REveManager::REveManager()
    TColor::SetColorThreshold(0.1);
 
    fWebWindow = ROOT::RWebWindow::Create();
+
+   ROOT::RWebWindowsManager::SetLoopbackMode(false);
+   ROOT::RWebWindowsManager::SetUseSessionKey(false);
+   fWebWindow->SetRequireAuthKey(false); 
    fWebWindow->UseServerThreads();
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/index.html");
 


### PR DESCRIPTION

The loopback option has been removed in January release.
The change in  #14136 allows to disable loopback in REveManager.