### PR TITLE
[windows] Prevent JIT error with VS 2022 v17.9.0

### DIFF
--- a/tutorials/multicore/mt201_parallelHistoFill.C
+++ b/tutorials/multicore/mt201_parallelHistoFill.C
@@ -52,7 +52,9 @@ Int_t mt201_parallelHistoFill()
    // of interrupting it.
    auto monitor = [&]() {
       for (auto i : ROOT::TSeqI(5)) {
+#if !defined(_MSC_VER) || (_MSC_VER < 1939)
          std::this_thread::sleep_for(std::chrono::duration<double, std::nano>(500));
+#endif
          auto h = ts_h.SnapshotMerge();
          std::cout << "Entries for the snapshot " << h->GetEntries() << std::endl;
       }


### PR DESCRIPTION
Prevent the following error when running the test with VS 2022 v17.9.0:
```
779: Processing C:/root-dev/git/master/tutorials/multicore/mt201_parallelHistoFill.C...
779: [runStaticInitializersOnce]: Failed to materialize symbols: { (main, { ?_Swap@?$_Ptr_base@VTH1F@@@std@@IEAAXAEAV12@@Z,
[...]
779: [runStaticInitializersOnce]: Failed to materialize symbols: { (main, { __orc_init_func.cling-module-9 }) }
779: cling JIT session error: Failed to materialize symbols: { (main, { ?mt201_parallelHistoFill@@YAHXZ }) }
779: CMake Error at C:/root-dev/build/x64/debug/RootTestDriver.cmake:232 (message):
779:   error code: 1
```
