### PR TITLE
[cmake] properly use nlohmann in ctest

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -45,6 +45,12 @@ if(NOT (MSVC OR (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64)) OR win_broken_
 endif()
 
 ROOT_ADD_GTEST(dataframe_datasetspec dataframe_datasetspec.cxx LIBRARIES ROOTDataFrame)
+if(builtin_nlohmannjson)
+  target_include_directories(dataframe_datasetspec PRIVATE ${CMAKE_SOURCE_DIR}/builtins)
+else()
+  target_link_libraries(dataframe_datasetspec nlohmann_json::nlohmann_json)
+endif()
+
 ROOT_ADD_GTEST(dataframe_display dataframe_display.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_ranges dataframe_ranges.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_leaves dataframe_leaves.cxx LIBRARIES ROOTDataFrame)


### PR DESCRIPTION
If external nlohmann/json.hpp used in ROOT,
it also has to be used in the tests

Should fix #14769 