### PR TITLE
[NFC][cling] Use StringRef::{starts,ends}_with

### DIFF
--- a/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
+++ b/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
@@ -51,7 +51,7 @@ namespace cling {
       = sema.getDiagnostics().getCustomDiagID(DiagnosticsEngine::Level::Note,
                                                 "Type : %0 , Full Path: %1")*/;
 
-    if (header.startswith(llvm::StringRef(annoTag, lenAnnoTag)))
+    if (header.starts_with(llvm::StringRef(annoTag, lenAnnoTag)))
       sema.Diags.Report(l, id) << name << header.drop_front(lenAnnoTag);
 
   }
@@ -89,7 +89,7 @@ namespace cling {
         if (!attr->isInherited()) {
           llvm::StringRef annotation = attr->getAnnotation();
           assert(!annotation.empty() && "Empty annotation!");
-          if (annotation.startswith(llvm::StringRef(annoTag, lenAnnoTag))) {
+          if (annotation.starts_with(llvm::StringRef(annoTag, lenAnnoTag))) {
             // autoload annotation.
             return true;
           }
@@ -223,7 +223,7 @@ namespace cling {
       {
         if (!attr->isInherited()) {
           auto annot = attr->getAnnotation();
-          if (annot.startswith(llvm::StringRef(annoTag, lenAnnoTag))) {
+          if (annot.starts_with(llvm::StringRef(annoTag, lenAnnoTag))) {
             if (annotations.first.empty()) {
               annotations.first = annot.drop_front(lenAnnoTag);
             } else {

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -53,7 +53,7 @@ namespace {
       if (!GV.hasName())
         return false;
 
-      if (GV.getName().startswith(".str"))
+      if (GV.getName().starts_with(".str"))
         return false;
 
       llvm::GlobalValue::LinkageTypes LT = GV.getLinkage();
@@ -137,7 +137,7 @@ namespace {
       if (GV.getLinkage() != llvm::GlobalValue::ExternalLinkage)
         return false;
 
-      if (GV.getName().startswith("_ZT")) {
+      if (GV.getName().starts_with("_ZT")) {
         // Currently, if Cling sees the "key function" of a virtual class, it
         // emits typeinfo and vtable variables in every transaction llvm::Module
         // that reference them. Turn them into weak linkage to avoid duplicate

--- a/interpreter/cling/lib/Interpreter/ClangInternalState.cpp
+++ b/interpreter/cling/lib/Interpreter/ClangInternalState.cpp
@@ -144,13 +144,13 @@ namespace cling {
     for (auto i = clang::Builtin::NotBuiltin+1;
          i != clang::Builtin::FirstTSBuiltin; ++i) {
       llvm::StringRef Name(BuiltinCtx.getName(i));
-      if (Name.startswith("__builtin"))
+      if (Name.starts_with("__builtin"))
         builtinNames.emplace_back(Name);
     }
 
     for (auto&& BuiltinInfo: m_ASTContext.getTargetInfo().getTargetBuiltins()) {
       llvm::StringRef Name(BuiltinInfo.Name);
-      if (!Name.startswith("__builtin"))
+      if (!Name.starts_with("__builtin"))
         builtinNames.emplace_back(Name);
 #ifndef NDEBUG
       else // Make sure it's already in the list

--- a/interpreter/cling/lib/Interpreter/ClingCodeCompleteConsumer.cpp
+++ b/interpreter/cling/lib/Interpreter/ClingCodeCompleteConsumer.cpp
@@ -61,17 +61,19 @@ namespace cling {
                                                   CodeCompletionResult Result) {
     switch (Result.Kind) {
       case CodeCompletionResult::RK_Declaration: {
-        return !(Result.Declaration->getIdentifier() &&
-            Result.Declaration->getIdentifier()->getName().startswith(Filter));
+        return !(
+            Result.Declaration->getIdentifier() &&
+            Result.Declaration->getIdentifier()->getName().starts_with(Filter));
       }
       case CodeCompletionResult::RK_Keyword: {
-        return !((StringRef(Result.Keyword)).startswith(Filter));
+        return !((StringRef(Result.Keyword)).starts_with(Filter));
       }
       case CodeCompletionResult::RK_Macro: {
-        return !(Result.Macro->getName().startswith(Filter));
+        return !(Result.Macro->getName().starts_with(Filter));
       }
       case CodeCompletionResult::RK_Pattern: {
-        return !(StringRef((Result.Pattern->getAsString())).startswith(Filter));
+        return !(
+            StringRef((Result.Pattern->getAsString())).starts_with(Filter));
       }
       default: llvm_unreachable("Unknown code completion result Kind.");
     }

--- a/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
@@ -226,7 +226,7 @@ namespace {
     /// Find values that are marked as llvm.used.
     void FindUsedValues(const llvm::Module& m) {
       for (const llvm::GlobalVariable& GV : m.globals()) {
-        if (!GV.getName().startswith("llvm.used"))
+        if (!GV.getName().starts_with("llvm.used"))
           continue;
 
         const llvm::ConstantArray* Inits
@@ -934,8 +934,9 @@ namespace cling {
         // clang cannot mangle everything in the ms-abi.
 #ifndef NDEBUG
         utils::DiagnosticsStore Errors(m_Sema->getDiagnostics(), false, false);
-        assert(Errors.empty() || (Errors.size() == 1 &&
-               Errors[0].getMessage().startswith("cannot mangle this")));
+        assert(Errors.empty() ||
+               (Errors.size() == 1 &&
+                Errors[0].getMessage().starts_with("cannot mangle this")));
 #else
         utils::DiagnosticsOverride IgnoreMangleErrors(m_Sema->getDiagnostics());
 #endif

--- a/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
+++ b/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
@@ -73,7 +73,7 @@ namespace cling {
 
   bool DefinitionShadower::isClingShadowNamespace(const DeclContext *DC) {
     auto NS = dyn_cast<NamespaceDecl>(DC);
-    return NS && NS->getName().startswith("__cling_N5");
+    return NS && NS->getName().starts_with("__cling_N5");
   }
 
   void DefinitionShadower::hideDecl(clang::NamedDecl *D) const {

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -69,7 +69,7 @@ namespace cling {
   /// Example: substFront("@rpath/abc", "@rpath/", "/tmp") -> "/tmp/abc"
   static std::string substFront(llvm::StringRef original, llvm::StringRef pattern,
                                 llvm::StringRef replacement) {
-    if (!original.startswith_insensitive(pattern))
+    if (!original.starts_with_insensitive(pattern))
       return original.str();
     llvm::SmallString<512> result(replacement);
     result.append(original.drop_front(pattern.size()));
@@ -307,7 +307,7 @@ namespace cling {
     // Subst all known linker variables ($origin, @rpath, etc.)
 #ifdef __APPLE__
     // On MacOS @rpath is preplaced by all paths in RPATH one by one.
-    if (libStem.startswith_insensitive("@rpath")) {
+    if (libStem.starts_with_insensitive("@rpath")) {
       for (auto& P : RPath) {
         std::string result = substFront(libStem, "@rpath", P);
         if (isSharedLibrary(result))
@@ -328,7 +328,7 @@ namespace cling {
       foundName = lookupLibMaybeAddExt(libStem, RPath, RunPath, libLoader);
       if (foundName.empty()) {
         llvm::StringRef libStemName = llvm::sys::path::filename(libStem);
-        if (!libStemName.startswith("lib")) {
+        if (!libStemName.starts_with("lib")) {
           // try with "lib" prefix:
           foundName = lookupLibMaybeAddExt(
              libStem.str().insert(libStem.size()-libStemName.size(), "lib"),

--- a/interpreter/cling/lib/Interpreter/ExternalInterpreterSource.cpp
+++ b/interpreter/cling/lib/Interpreter/ExternalInterpreterSource.cpp
@@ -268,7 +268,7 @@ namespace cling {
         DeclarationName childDeclName = parentDecl->getDeclName();
         if (auto II = childDeclName.getAsIdentifierInfo()) {
           StringRef name = II->getName();
-          if (!name.empty() && name.startswith(filter))
+          if (!name.empty() && name.starts_with(filter))
             ImportDecl(parentDecl, childDeclName, childDeclName,
                        childDeclContext);
         }

--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -191,7 +191,7 @@ namespace cling {
        // start in this case as the '<header>' still has the correct value.
        // FIXME: Once the C++ modules replaced the forward decls, remove this.
        if (D->getASTContext().getLangOpts().Modules &&
-           llvm::StringRef(includeText).startswith("include ")) {
+           llvm::StringRef(includeText).starts_with("include ")) {
          includeText += strlen("include ");
        }
 

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -193,7 +193,7 @@ namespace cling {
 
     // Disable suggestions for ROOT
     bool showSuggestions =
-        !llvm::StringRef(ClingStringify(CLING_VERSION)).startswith("ROOT");
+        !llvm::StringRef(ClingStringify(CLING_VERSION)).starts_with("ROOT");
 
     std::unique_ptr<InterpreterCallbacks> AutoLoadCB(
         new AutoloadCallback(&Interp, showSuggestions));
@@ -1125,7 +1125,7 @@ namespace cling {
   }
 
   bool Interpreter::isUniqueName(llvm::StringRef name) {
-    return name.startswith(utils::Synthesize::UniquePrefix);
+    return name.starts_with(utils::Synthesize::UniquePrefix);
   }
 
   clang::SourceLocation Interpreter::getSourceLocation(bool skipWrapper) const {

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -320,11 +320,11 @@ namespace cling {
   {
     bool issigned = false;
     bool isunsigned = false;
-    if (typeName.startswith("signed ")) {
+    if (typeName.starts_with("signed ")) {
       issigned = true;
       typeName = StringRef(typeName.data()+7, typeName.size()-7);
     }
-    if (!issigned && typeName.startswith("unsigned ")) {
+    if (!issigned && typeName.starts_with("unsigned ")) {
       isunsigned = true;
       typeName = StringRef(typeName.data()+9, typeName.size()-9);
     }
@@ -386,7 +386,7 @@ namespace cling {
     llvm::StringRef quickTypeName = typeName.trim();
     bool innerConst = false;
     bool outerConst = false;
-    if (quickTypeName.startswith("const ")) {
+    if (quickTypeName.starts_with("const ")) {
       // Use this syntax to avoid the redudant tests in substr.
       quickTypeName = StringRef(quickTypeName.data()+6,
                                 quickTypeName.size()-6);
@@ -395,7 +395,7 @@ namespace cling {
 
     enum PointerType { kPointerType, kLRefType, kRRefType, };
 
-    if (quickTypeName.endswith("const")) {
+    if (quickTypeName.ends_with("const")) {
       if (quickTypeName.size() < 6) return true;
       auto c = quickTypeName[quickTypeName.size()-6];
       if (c==' ' || c=='&' || c=='*') {

--- a/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
+++ b/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
@@ -234,7 +234,7 @@ class PointerCheckInjector : public RecursiveASTVisitor<PointerCheckInjector> {
         return true;
       else if (Ann->getAnnotation() == "__cling__ptrcheck(on)")
         return false;
-      else if (Ann->getAnnotation().startswith("__cling__ptrcheck(")) {
+      else if (Ann->getAnnotation().starts_with("__cling__ptrcheck(")) {
         DiagnosticsEngine& Diags = S->getDiagnostics();
         Diags.Report(Ann->getLocation(),
                     Diags.getCustomDiagID(

--- a/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
+++ b/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
@@ -84,9 +84,9 @@ namespace cling {
         Lex.LexAnyString(Tok);
         if (Tok.isNot(tok::eof)) {
           const llvm::StringRef PPtk = Tok.getIdent();
-          if (PPtk.startswith("if")) {
+          if (PPtk.starts_with("if")) {
             m_ParenStack.push_back(tok::hash);
-          } else if (PPtk.startswith("endif") &&
+          } else if (PPtk.starts_with("endif") &&
                      (PPtk.size() == 5 || PPtk[5] == '/' || isspace(PPtk[5]))) {
             if (m_ParenStack.empty() || m_ParenStack.back() != tok::hash)
               Res = kMismatch;

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -373,7 +373,7 @@ namespace cling {
     const Token& currTok = getCurTok();
     if (currTok.is(tok::ident)) {
       llvm::StringRef ident = currTok.getIdent();
-      if (ident.startswith("O")) {
+      if (ident.starts_with("O")) {
         if (ident.size() > 1) {
           int level = 0;
           if (!ident.substr(1).getAsInteger(10, level) && level >= 0) {

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -70,7 +70,7 @@ namespace utils {
     if (!ND->getDeclName().isIdentifier())
       return false;
 
-    return ND->getName().startswith(Synthesize::UniquePrefix);
+    return ND->getName().starts_with(Synthesize::UniquePrefix);
   }
 
   void Analyze::maybeMangleDeclName(const GlobalDecl& GD,

--- a/interpreter/cling/lib/Utils/Paths.cpp
+++ b/interpreter/cling/lib/Utils/Paths.cpp
@@ -277,7 +277,7 @@ bool SplitPaths(llvm::StringRef PathStr,
   }
 
   // Trim trailing sep in case of A:B:C:D:
-  if (!PathStr.empty() && PathStr.endswith(Delim))
+  if (!PathStr.empty() && PathStr.ends_with(Delim))
     PathStr = PathStr.substr(0, PathStr.size()-Delim.size());
 
   if (!PathStr.empty()) {

--- a/interpreter/cling/lib/Utils/PlatformWin.cpp
+++ b/interpreter/cling/lib/Utils/PlatformWin.cpp
@@ -227,7 +227,7 @@ static bool getWindows10SDKVersion(std::string& SDKPath,
     // There could be subfolders like "wdf" in the "Include" directory, so only
     // test names that start with "10." or match input.
     const bool Match = Candidate == UcrtCompiledVers;
-    if (Match || (Candidate.startswith("10.") && Candidate > SDKVersion)) {
+    if (Match || (Candidate.starts_with("10.") && Candidate > SDKVersion)) {
       SDKPath = DirIt->path();
       Candidate.str().swap(SDKVersion);
       if (Match)

--- a/interpreter/cling/lib/Utils/SourceNormalization.cpp
+++ b/interpreter/cling/lib/Utils/SourceNormalization.cpp
@@ -393,7 +393,7 @@ cling::utils::isUnnamedMacro(llvm::StringRef source,
       if (AfterHash) {
         if (Tok.is(tok::raw_identifier)) {
           StringRef keyword(Tok.getRawIdentifier());
-          if (keyword.startswith("if")) {
+          if (keyword.starts_with("if")) {
             // This could well be
             //   #if FOO
             //   {


### PR DESCRIPTION
Follows the changes introduced in https://reviews.llvm.org/D136030 to be more compatible with std::string and std::string_view.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

