### PR TITLE
[ntuple] split off RNTupleCollectionWriter header

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -25,6 +25,7 @@ HEADERS
   ROOT/RFieldVisitor.hxx
   ROOT/RMiniFile.hxx
   ROOT/RNTupleAnchor.hxx
+  ROOT/RNTupleCollectionWriter.hxx
   ROOT/RNTupleDescriptor.hxx
   ROOT/RNTupleImtTaskScheduler.hxx
   ROOT/RNTupleMerger.hxx

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -43,7 +43,7 @@ that are associated to values are managed.
 */
 // clang-format on
 class REntry {
-   friend class RCollectionNTupleWriter;
+   friend class RNTupleCollectionWriter;
    friend class RNTupleModel;
    friend class RNTupleReader;
    friend class RNTupleFillContext;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -58,7 +58,7 @@ class RFieldBase;
 namespace Experimental {
 
 class RCollectionField;
-class RCollectionNTupleWriter;
+class RNTupleCollectionWriter;
 class REntry;
 
 namespace Internal {
@@ -1582,7 +1582,7 @@ public:
 class RCollectionField final : public ROOT::Experimental::RFieldBase {
 private:
    /// Save the link to the collection ntuple in order to reset the offset counter when committing the cluster
-   std::shared_ptr<RCollectionNTupleWriter> fCollectionWriter;
+   std::shared_ptr<RNTupleCollectionWriter> fCollectionWriter;
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -1598,7 +1598,7 @@ protected:
 
 public:
    static std::string TypeName() { return ""; }
-   RCollectionField(std::string_view name, std::shared_ptr<RCollectionNTupleWriter> collectionWriter,
+   RCollectionField(std::string_view name, std::shared_ptr<RNTupleCollectionWriter> collectionWriter,
                     std::unique_ptr<RFieldZero> collectionParent);
    RCollectionField(RCollectionField&& other) = default;
    RCollectionField& operator =(RCollectionField&& other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
@@ -1,0 +1,72 @@
+/// \file ROOT/RNTupleCollectionWriter.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2024-02-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleCollectionWriter
+#define ROOT7_RNTupleCollectionWriter
+
+#include <ROOT/REntry.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleCollectionWriter
+\ingroup NTuple
+\brief A virtual ntuple used for writing untyped collections that can be used to some extent like an RNTupleWriter
+*
+* This class is between a field and a ntuple.  It carries the offset column for the collection and the default entry
+* taken from the collection model.  It does not, however, own an ntuple model because the collection model has been
+* merged into the larger ntuple model.
+*/
+// clang-format on
+class RNTupleCollectionWriter {
+   friend class RCollectionField;
+
+private:
+   std::size_t fBytesWritten = 0;
+   ClusterSize_t fOffset;
+   std::unique_ptr<REntry> fDefaultEntry;
+
+public:
+   explicit RNTupleCollectionWriter(std::unique_ptr<REntry> defaultEntry)
+      : fOffset(0), fDefaultEntry(std::move(defaultEntry))
+   {
+   }
+   RNTupleCollectionWriter(const RNTupleCollectionWriter &) = delete;
+   RNTupleCollectionWriter &operator=(const RNTupleCollectionWriter &) = delete;
+   ~RNTupleCollectionWriter() = default;
+
+   std::size_t Fill() { return Fill(*fDefaultEntry); }
+   std::size_t Fill(REntry &entry)
+   {
+      const std::size_t bytesWritten = entry.Append();
+      fBytesWritten += bytesWritten;
+      fOffset++;
+      return bytesWritten;
+   }
+
+   ClusterSize_t *GetOffsetPtr() { return &fOffset; }
+}; // class RNTupleCollectionWriter
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleCollectionWriter

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -33,7 +33,7 @@
 namespace ROOT {
 namespace Experimental {
 
-class RCollectionNTupleWriter;
+class RNTupleCollectionWriter;
 class RNTupleModel;
 class RNTupleWriter;
 
@@ -301,9 +301,8 @@ public:
    /// Ingests a model for a sub collection and attaches it to the current model
    ///
    /// Throws an exception if collectionModel is null.
-   std::shared_ptr<RCollectionNTupleWriter> MakeCollection(
-      std::string_view fieldName,
-      std::unique_ptr<RNTupleModel> collectionModel);
+   std::shared_ptr<RNTupleCollectionWriter>
+   MakeCollection(std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel);
 
    std::unique_ptr<REntry> CreateEntry() const;
    /// In a bare entry, all values point to nullptr. The resulting entry shall use BindValue() in order

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -228,43 +228,6 @@ public:
    }
 }; // class RNTupleWriter
 
-// clang-format off
-/**
-\class ROOT::Experimental::RCollectionNTupleWriter
-\ingroup NTuple
-\brief A virtual ntuple used for writing untyped collections that can be used to some extent like an RNTupleWriter
-*
-* This class is between a field and a ntuple.  It carries the offset column for the collection and the default entry
-* taken from the collection model.  It does not, however, own an ntuple model because the collection model has been
-* merged into the larger ntuple model.
-*/
-// clang-format on
-class RCollectionNTupleWriter {
-   friend class RCollectionField;
-
-private:
-   std::size_t fBytesWritten = 0;
-   ClusterSize_t fOffset;
-   std::unique_ptr<REntry> fDefaultEntry;
-
-public:
-   explicit RCollectionNTupleWriter(std::unique_ptr<REntry> defaultEntry);
-   RCollectionNTupleWriter(const RCollectionNTupleWriter &) = delete;
-   RCollectionNTupleWriter &operator=(const RCollectionNTupleWriter &) = delete;
-   ~RCollectionNTupleWriter() = default;
-
-   std::size_t Fill() { return Fill(*fDefaultEntry); }
-   std::size_t Fill(REntry &entry)
-   {
-      const std::size_t bytesWritten = entry.Append();
-      fBytesWritten += bytesWritten;
-      fOffset++;
-      return bytesWritten;
-   }
-
-   ClusterSize_t *GetOffsetPtr() { return &fOffset; }
-}; // class RCollectionNTupleWriter
-
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -20,8 +20,8 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RLogger.hxx>
+#include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleWriter.hxx>
 
 #include <TBaseClass.h>
 #include <TClass.h>
@@ -3332,7 +3332,7 @@ void ROOT::Experimental::RTupleField::RTupleDeleter::operator()(void *objPtr, bo
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RCollectionField::RCollectionField(std::string_view name,
-                                                       std::shared_ptr<RCollectionNTupleWriter> collectionWriter,
+                                                       std::shared_ptr<RNTupleCollectionWriter> collectionWriter,
                                                        std::unique_ptr<RFieldZero> collectionParent)
    : RFieldBase(name, "", ENTupleStructure::kCollection, false /* isSimple */), fCollectionWriter(collectionWriter)
 {
@@ -3375,7 +3375,7 @@ ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
 std::size_t ROOT::Experimental::RCollectionField::AppendImpl(const void *from)
 {
    // RCollectionFields are almost simple, but they return the bytes written by their subfields as accumulated by the
-   // RCollectionNTupleWriter.
+   // RNTupleCollectionWriter.
    std::size_t bytesWritten = fCollectionWriter->fBytesWritten;
    fCollectionWriter->fBytesWritten = 0;
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -15,6 +15,7 @@
 
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/StringUtils.hxx>
@@ -313,8 +314,9 @@ ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<RFieldBase> 
    return RResult<void>::Success();
 }
 
-std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental::RNTupleModel::MakeCollection(
-   std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
+std::shared_ptr<ROOT::Experimental::RNTupleCollectionWriter>
+ROOT::Experimental::RNTupleModel::MakeCollection(std::string_view fieldName,
+                                                 std::unique_ptr<RNTupleModel> collectionModel)
 {
    EnsureNotFrozen();
    EnsureValidFieldName(fieldName);
@@ -322,7 +324,7 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
       throw RException(R__FAIL("null collectionModel"));
    }
 
-   auto collectionWriter = std::make_shared<RCollectionNTupleWriter>(std::move(collectionModel->fDefaultEntry));
+   auto collectionWriter = std::make_shared<RNTupleCollectionWriter>(std::move(collectionModel->fDefaultEntry));
 
    auto field = std::make_unique<RCollectionField>(fieldName, collectionWriter, std::move(collectionModel->fFieldZero));
    field->SetDescription(collectionModel->GetDescription());

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -164,10 +164,3 @@ ROOT::Experimental::Internal::CreateRNTupleWriter(std::unique_ptr<ROOT::Experime
    return std::unique_ptr<ROOT::Experimental::RNTupleWriter>(
       new ROOT::Experimental::RNTupleWriter(std::move(model), std::move(sink)));
 }
-
-//------------------------------------------------------------------------------
-
-ROOT::Experimental::RCollectionNTupleWriter::RCollectionNTupleWriter(std::unique_ptr<REntry> defaultEntry)
-   : fOffset(0), fDefaultEntry(std::move(defaultEntry))
-{
-}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -6,6 +6,7 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RMiniFile.hxx>
+#include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleMetrics.hxx>

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -19,6 +19,7 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
@@ -179,7 +180,7 @@ private:
       RImportLeafCountCollection &operator=(const RImportLeafCountCollection &other) = delete;
       RImportLeafCountCollection &operator=(RImportLeafCountCollection &&other) = default;
       std::unique_ptr<RNTupleModel> fCollectionModel;             ///< The model for the collection itself
-      std::shared_ptr<RCollectionNTupleWriter> fCollectionWriter; ///< Used to fill the collection elements per event
+      std::shared_ptr<RNTupleCollectionWriter> fCollectionWriter; ///< Used to fill the collection elements per event
       std::unique_ptr<REntry> fCollectionEntry; ///< Keeps the memory location of the collection members
       /// The number of elements for the collection for a particular event. Used as a destination for SetBranchAddress()
       /// of the count leaf


### PR DESCRIPTION
Along the way renames RCollectionNTupleWriter class to RNTupleCollectionWriter.
