### PR TITLE
[ntuple] split RNTupleOptions header

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -31,12 +31,14 @@ HEADERS
   ROOT/RNTupleMerger.hxx
   ROOT/RNTupleMetrics.hxx
   ROOT/RNTupleModel.hxx
-  ROOT/RNTupleOptions.hxx
   ROOT/RNTupleParallelWriter.hxx
+  ROOT/RNTupleReadOptions.hxx
   ROOT/RNTupleReader.hxx
   ROOT/RNTupleSerialize.hxx
   ROOT/RNTupleUtil.hxx
   ROOT/RNTupleView.hxx
+  ROOT/RNTupleWriteOptions.hxx
+  ROOT/RNTupleWriteOptionsDaos.hxx
   ROOT/RNTupleWriter.hxx
   ROOT/RNTupleZip.hxx
   ROOT/RPage.hxx
@@ -62,11 +64,11 @@ SOURCES
   v7/src/RNTupleMerger.cxx
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx
-  v7/src/RNTupleOptions.cxx
   v7/src/RNTupleParallelWriter.cxx
   v7/src/RNTupleReader.cxx
   v7/src/RNTupleSerialize.cxx
   v7/src/RNTupleUtil.cxx
+  v7/src/RNTupleWriteOptions.cxx
   v7/src/RNTupleWriter.cxx
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -18,7 +18,6 @@
 
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleAnchor.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <string_view>
 
 #include <cstdint>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
@@ -17,7 +17,7 @@
 #define ROOT7_RNTupleParallelWriter
 
 #include <ROOT/RNTupleMetrics.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 
 #include <memory>
 #include <mutex>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
@@ -1,0 +1,53 @@
+/// \file ROOT/RNTupleReadOptions.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2024-02-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleReadOptions
+#define ROOT7_RNTupleReadOptions
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleReadOptions
+\ingroup NTuple
+\brief Common user-tunable settings for reading ntuples
+
+All page source classes need to support the common options.
+*/
+// clang-format on
+class RNTupleReadOptions {
+public:
+   enum EClusterCache {
+      kOff,
+      kOn,
+      kDefault = kOn,
+   };
+
+private:
+   EClusterCache fClusterCache = EClusterCache::kDefault;
+   unsigned int fClusterBunchSize = 1;
+
+public:
+   EClusterCache GetClusterCache() const { return fClusterCache; }
+   void SetClusterCache(EClusterCache val) { fClusterCache = val; }
+   unsigned int GetClusterBunchSize() const { return fClusterBunchSize; }
+   void SetClusterBunchSize(unsigned int val) { fClusterBunchSize = val; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -21,7 +21,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleView.hxx>
 #include <ROOT/RPageStorage.hxx>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -1,7 +1,7 @@
-/// \file ROOT/RNTupleOptions.hxx
+/// \file ROOT/RNTupleWriteOptions.hxx
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
-/// \date 2019-08-25
+/// \date 2024-02-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
@@ -13,12 +13,13 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RNTupleOptions
-#define ROOT7_RNTupleOptions
+#ifndef ROOT7_RNTupleWriteOptions
+#define ROOT7_RNTupleWriteOptions
 
 #include <Compression.h>
-#include <ROOT/RNTupleUtil.hxx>
 
+#include <cstdint>
+#include <cstddef>
 #include <memory>
 
 namespace ROOT {
@@ -62,7 +63,8 @@ public:
 
    int GetCompression() const { return fCompression; }
    void SetCompression(int val) { fCompression = val; }
-   void SetCompression(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel) {
+   void SetCompression(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel)
+   {
       fCompression = CompressionSettings(algorithm, compressionLevel);
    }
 
@@ -82,67 +84,7 @@ public:
    void SetHasSmallClusters(bool val) { fHasSmallClusters = val; }
 };
 
-// clang-format off
-/**
-\class ROOT::Experimental::RNTupleWriteOptionsDaos
-\ingroup NTuple
-\brief DAOS-specific user-tunable settings for storing ntuples
-*/
-// clang-format on
-class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
-   std::string fObjectClass{"SX"};
-   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 1MiB by default. Empirically, such a
-   /// cage size yields acceptable results in throughput and page granularity for most use cases. A `fMaxCageSize` of 0
-   /// disables the caging mechanism.
-   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fApproxUnzippedPageSize;
-
-public:
-   ~RNTupleWriteOptionsDaos() override = default;
-   std::unique_ptr<RNTupleWriteOptions> Clone() const override
-   { return std::make_unique<RNTupleWriteOptionsDaos>(*this); }
-
-   const std::string &GetObjectClass() const { return fObjectClass; }
-   /// Set the object class used to generate OIDs that relate to user data. Any
-   /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
-   /// the OC_ prefix.
-   void SetObjectClass(const std::string &val) { fObjectClass = val; }
-
-   uint32_t GetMaxCageSize() const { return fMaxCageSize; }
-   /// Set the upper bound for page concatenation into cages, in bytes. It is assumed
-   /// that cage size will be no smaller than the approximate uncompressed page size.
-   /// To disable page concatenation, set this value to 0.
-   void SetMaxCageSize(uint32_t cageSz) { fMaxCageSize = cageSz; }
-};
-
-// clang-format off
-/**
-\class ROOT::Experimental::RNTupleReadOptions
-\ingroup NTuple
-\brief Common user-tunable settings for reading ntuples
-
-All page source classes need to support the common options.
-*/
-// clang-format on
-class RNTupleReadOptions {
-public:
-   enum EClusterCache {
-      kOff,
-      kOn,
-      kDefault = kOn,
-   };
-
-private:
-   EClusterCache fClusterCache = EClusterCache::kDefault;
-   unsigned int fClusterBunchSize = 1;
-
-public:
-   EClusterCache GetClusterCache() const { return fClusterCache; }
-   void SetClusterCache(EClusterCache val) { fClusterCache = val; }
-   unsigned int GetClusterBunchSize() const  { return fClusterBunchSize; }
-   void SetClusterBunchSize(unsigned int val) { fClusterBunchSize = val; }
-};
-
 } // namespace Experimental
 } // namespace ROOT
 
-#endif
+#endif // ROOT7_RNTupleWriteOptions

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
@@ -1,0 +1,66 @@
+/// \file ROOT/RNTupleWriteOptionsDaos.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2024-02-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleWriteOptionsDaos
+#define ROOT7_RNTupleWriteOptionsDaos
+
+#include <ROOT/RNTupleWriteOptions.hxx>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleWriteOptionsDaos
+\ingroup NTuple
+\brief DAOS-specific user-tunable settings for storing ntuples
+*/
+// clang-format on
+class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
+   std::string fObjectClass{"SX"};
+   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 1MiB by default. Empirically, such a
+   /// cage size yields acceptable results in throughput and page granularity for most use cases. A `fMaxCageSize` of 0
+   /// disables the caging mechanism.
+   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fApproxUnzippedPageSize;
+
+public:
+   ~RNTupleWriteOptionsDaos() override = default;
+   std::unique_ptr<RNTupleWriteOptions> Clone() const override
+   {
+      return std::make_unique<RNTupleWriteOptionsDaos>(*this);
+   }
+
+   const std::string &GetObjectClass() const { return fObjectClass; }
+   /// Set the object class used to generate OIDs that relate to user data. Any
+   /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
+   /// the OC_ prefix.
+   void SetObjectClass(const std::string &val) { fObjectClass = val; }
+
+   uint32_t GetMaxCageSize() const { return fMaxCageSize; }
+   /// Set the upper bound for page concatenation into cages, in bytes. It is assumed
+   /// that cage size will be no smaller than the approximate uncompressed page size.
+   /// To disable page concatenation, set this value to 0.
+   void SetMaxCageSize(uint32_t cageSz) { fMaxCageSize = cageSz; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleWriteOptionsDaos

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -19,7 +19,8 @@
 #include <ROOT/RCluster.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPage.hxx>
 #include <ROOT/RPageAllocator.hxx>

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -20,7 +20,7 @@
 #include <ROOT/RLogger.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RPageStorage.hxx>
 
 #include <algorithm>

--- a/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
@@ -1,12 +1,12 @@
-/// \file RNTupleOptions.cxx
+/// \file RNTupleWriteOptions.cxx
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
-/// \date 2021-07-28
+/// \date 2024-02-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -14,7 +14,7 @@
  *************************************************************************/
 
 #include <ROOT/RError.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 
 #include <utility>
 
@@ -41,8 +41,7 @@ void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClus
 
 } // anonymous namespace
 
-std::unique_ptr<ROOT::Experimental::RNTupleWriteOptions>
-ROOT::Experimental::RNTupleWriteOptions::Clone() const
+std::unique_ptr<ROOT::Experimental::RNTupleWriteOptions> ROOT::Experimental::RNTupleWriteOptions::Clone() const
 {
    return std::make_unique<RNTupleWriteOptions>(*this);
 }

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -20,7 +20,7 @@
 #include <ROOT/RNTupleFillContext.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RPageStorageFile.hxx>

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -15,8 +15,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -16,7 +16,7 @@
 #include <ROOT/RCluster.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RLogger.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RPageSourceFriends.hxx>
 
 #include <utility>

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
+#include <ROOT/RNTupleWriteOptionsDaos.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPage.hxx>

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -6,7 +6,7 @@
 #include <ROOT/RColumnModel.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RPage.hxx>

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -8,7 +8,8 @@
 #include <ROOT/RColumnModel.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPage.hxx>

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -10,10 +10,12 @@
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleParallelWriter.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriteOptionsDaos.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageAllocator.hxx>

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -20,7 +20,7 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <string_view>
 

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -16,8 +16,8 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleImporter.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 #include <ROOT/RPageStorage.hxx>

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -1,5 +1,5 @@
 #include <ROOT/RNTupleInspector.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 
 #include <TFile.h>
 #include <ROOT/TestSupport.hxx>

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -5,8 +5,9 @@
 
 #include <ROOT/RNTupleAnchor.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
 /**

--- a/tutorials/v7/ntuple/ntpl005_introspection.C
+++ b/tutorials/v7/ntuple/ntpl005_introspection.C
@@ -15,8 +15,8 @@
 // Do not use for real data!
 
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
 #include <Compression.h>

--- a/tutorials/v7/ntuple/ntpl011_global_temperatures.C
+++ b/tutorials/v7/ntuple/ntpl011_global_temperatures.C
@@ -21,7 +21,6 @@
 
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RNTupleDS.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RCanvas.hxx>
@@ -88,9 +87,7 @@ void Ingest()
 
    // Hand-over the data model to a newly created ntuple of name "globalTempData", stored in kNTupleFileName.
    // In return, get a unique pointer to a fillable ntuple (first compress the file).
-   RNTupleWriteOptions options;
-   options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName, options);
+   auto ntuple = RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName);
 
    auto file = RRawFile::Create(kRawDataUrl);
    std::string record;


### PR DESCRIPTION
Split RNTupleOptions header in RNTupleReadOptions, RNTupleWriteOptions, and RNTupleWriteOptionsDaos.


