### PR TITLE
[DF] Change test to avoid double free on Fedora39

### DIFF
--- a/tree/dataframe/test/dataframe_vecops.cxx
+++ b/tree/dataframe/test/dataframe_vecops.cxx
@@ -94,9 +94,7 @@ void MakeTreeWithBools(const std::string &treename, const std::string &fname)
       vec[i] = value;
    }
    t.Fill();
-
-   t.Write();
-   f.Close();
+   f.Write();
 }
 
 TEST(RDFAndVecOps, RVecBool)


### PR DESCRIPTION
The following, very particular, combination triggers a test failure:
* Fedora 39
* C++20
* ROOT built in Release mode (-O3)
* The test `dataframe-vecops`, which needs to be run via ctest and using gtest infrastructure
* The test being compiled in release mode too

The failure is:
```
   730/2406 Test  #393: gtest-tree-dataframe-test-dataframe-vecops ........................................................***Failed    5.01 sec
  Running main() from /builddir/build/BUILD/googletest-1.13.0/googletest/src/gtest_main.cc
  [==========] Running 4 tests from 1 test suite.
  [----------] Global test environment set-up.
  [----------] 4 tests from RDFAndVecOps
  [ RUN      ] RDFAndVecOps.ReadStdVectorAsRVec
  [       OK ] RDFAndVecOps.ReadStdVectorAsRVec (4678 ms)
  [ RUN      ] RDFAndVecOps.DefineRVec
  [       OK ] RDFAndVecOps.DefineRVec (0 ms)
  [ RUN      ] RDFAndVecOps.SnapshotRVec
  [       OK ] RDFAndVecOps.SnapshotRVec (6 ms)
  [ RUN      ] RDFAndVecOps.RVecBool
  double free or corruption (out)
  CMake Error at /github/home/ROOT-CI/src/cmake/modules/RootTestDriver.cmake:232 (message):
    error code: Subprocess aborted
```

And gdb says:
```
0  0x00007f25d4eae834 in __pthread_kill_implementation () from /lib64/libc.so.6
1  0x00007f25d4e5c8ee in raise () from /lib64/libc.so.6
2  0x00007f25d4e448ff in abort () from /lib64/libc.so.6
3  0x00007f25d4e457d0 in __libc_message.cold () from /lib64/libc.so.6
4  0x00007f25d4eb87a5 in malloc_printerr () from /lib64/libc.so.6
5  0x00007f25d4eba840 in _int_free_merge_chunk () from /lib64/libc.so.6
6  0x00007f25d4ebd3de in free () from /lib64/libc.so.6
7  0x00007f25d6c5efa8 in TList::Delete(char const*) () from /github/home/ROOT-CI/build/lib/libCore.so
8  0x00007f25d6c56566 in THashList::Delete(char const*) () from /github/home/ROOT-CI/build/lib/libCore.so
9  0x00007f25d67235b5 in TDirectoryFile::Close(char const*) () from /github/home/ROOT-CI/build/lib/libRIO.so
10 0x00007f25d6741406 in TFile::Close(char const*) () from /github/home/ROOT-CI/build/lib/libRIO.so
11 0x00000000004324e1 in MakeTreeWithBools(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
12 0x00000000004328da in RDFAndVecOps_RVecBool_Test::TestBody() ()
13 0x00007f25d56af4a3 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) [clone .constprop.0] () from /lib64/libgtest.so.1.13.0
14 0x00007f25d569a7fe in testing::Test::Run() () from /lib64/libgtest.so.1.13.0
15 0x00007f25d569aa05 in testing::TestInfo::Run() () from /lib64/libgtest.so.1.13.0
16 0x00007f25d569ab57 in testing::TestSuite::Run() () from /lib64/libgtest.so.1.13.0
17 0x00007f25d56a8210 in testing::internal::UnitTestImpl::RunAllTests() () from /lib64/libgtest.so.1.13.0
18 0x00007f25d56a6f68 in testing::UnitTest::Run() () from /lib64/libgtest.so.1.13.0
19 0x000000000042b27f in main ()
```

Also, this particular failure is triggered by exactly the following commit (identified with `git bisect`)

https://github.com/root-project/root/commit/5ce8024d5b392410059486967e714c871d454ea9

