### PR TITLE
[TTaskGroup] Use global task arena

### DIFF
--- a/core/imt/inc/ROOT/TTaskGroup.hxx
+++ b/core/imt/inc/ROOT/TTaskGroup.hxx
@@ -29,7 +29,6 @@ class TTaskGroup {
    */
 private:
    void *fTaskContainer{nullptr};
-   std::atomic<bool> fCanRun{true};
    void ExecuteInIsolation(const std::function<void(void)> &operation);
 
 public:

--- a/core/imt/inc/ROOT/TTaskGroup.hxx
+++ b/core/imt/inc/ROOT/TTaskGroup.hxx
@@ -13,9 +13,14 @@
 #define ROOT_TTaskGroup
 
 #include <atomic>
+#include <memory>
 #include <functional>
 
 namespace ROOT {
+namespace Internal {
+class RTaskArenaWrapper;
+}
+
 namespace Experimental {
 
 class TTaskGroup {
@@ -28,6 +33,7 @@ class TTaskGroup {
    is executing.
    */
 private:
+   std::shared_ptr<ROOT::Internal::RTaskArenaWrapper> fTaskArenaW;
    void *fTaskContainer{nullptr};
    void ExecuteInIsolation(const std::function<void(void)> &operation);
 

--- a/core/imt/src/TTaskGroup.cxx
+++ b/core/imt/src/TTaskGroup.cxx
@@ -15,6 +15,7 @@
 
 #ifdef R__USE_IMT
 #include "TROOT.h"
+#define TBB_PREVIEW_ISOLATED_TASK_GROUP 1
 #include "tbb/task_group.h"
 #include "tbb/task_arena.h"
 #endif
@@ -37,10 +38,10 @@ namespace ROOT {
 namespace Internal {
 
 #ifdef R__USE_IMT
-tbb::task_group *CastToTG(void* p) {
-   return (tbb::task_group *) p;
+tbb::isolated_task_group *CastToTG(void *p)
+{
+   return (tbb::isolated_task_group *)p;
 }
-
 #endif
 
 } // namespace Internal
@@ -59,7 +60,7 @@ TTaskGroup::TTaskGroup()
    if (!ROOT::IsImplicitMTEnabled()) {
       throw std::runtime_error("Implicit parallelism not enabled. Cannot instantiate a TTaskGroup.");
    }
-   fTaskContainer = ((void *)new tbb::task_group());
+   fTaskContainer = ((void *)new tbb::isolated_task_group());
 #endif
 }
 

--- a/core/imt/src/TTaskGroup.cxx
+++ b/core/imt/src/TTaskGroup.cxx
@@ -72,7 +72,6 @@ TTaskGroup &TTaskGroup::operator=(TTaskGroup &&other)
 {
    fTaskContainer = other.fTaskContainer;
    other.fTaskContainer = nullptr;
-   fCanRun.store(other.fCanRun);
    return *this;
 }
 
@@ -91,9 +90,7 @@ TTaskGroup::~TTaskGroup()
 void TTaskGroup::Cancel()
 {
 #ifdef R__USE_IMT
-   fCanRun = false;
    CastToTG(fTaskContainer)->cancel();
-   fCanRun = true;
 #endif
 }
 
@@ -108,9 +105,6 @@ void TTaskGroup::Cancel()
 void TTaskGroup::Run(const std::function<void(void)> &closure)
 {
 #ifdef R__USE_IMT
-   while (!fCanRun)
-      /* empty */;
-
    CastToTG(fTaskContainer)->run(closure);
 #else
    closure();
@@ -123,9 +117,7 @@ void TTaskGroup::Run(const std::function<void(void)> &closure)
 void TTaskGroup::Wait()
 {
 #ifdef R__USE_IMT
-   fCanRun = false;
    CastToTG(fTaskContainer)->wait();
-   fCanRun = true;
 #endif
 }
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -43,11 +43,10 @@ class RPageSource;
 The cluster pool steers the preloading of (partial) clusters. There is a two-step pipeline: in a first step,
 compressed pages are read from clusters into a memory buffer. The second pipeline step decompresses the pages
 and pushes them into the page pool. The actual logic of reading and unzipping is implemented by the page source.
-The cluster pool only orchestrates the work queues for reading and unzipping. It uses two threads, one for
-each pipeline step. The I/O thread for reading waits for data from storage and generates no CPU load. In contrast,
-the unzip thread is supposed to submit multi-threaded, CPU heavy work to the application's task scheduler.
+The cluster pool only orchestrates the work queues for reading and unzipping. It uses one extra I/O thread for
+reading waits for data from storage and generates no CPU load.
 
-The unzipping step of the pipeline therefore behaves differently depending on whether or not implicit multi-threadin
+The unzipping step of the pipeline therefore behaves differently depending on whether or not implicit multi-threading
 is turned on. If it is turned off, i.e. in a single-threaded environment, the cluster pool will only read the
 compressed pages and the page source has to uncompresses pages at a later point when data from the page is requested.
 */
@@ -61,13 +60,6 @@ private:
       std::int64_t fBunchId = -1;
       std::promise<std::unique_ptr<RCluster>> fPromise;
       RCluster::RKey fClusterKey;
-   };
-
-   /// Request to decompress and if necessary unpack compressed pages. The unzipped pages
-   /// are supposed to be pushed into the page pool by the page source.
-   struct RUnzipItem {
-      std::unique_ptr<RCluster> fCluster;
-      std::promise<std::unique_ptr<RCluster>> fPromise;
    };
 
    /// Clusters that are currently being processed by the pipeline.  Every in-flight cluster has a corresponding
@@ -101,8 +93,8 @@ private:
    /// The cache of clusters around the currently active cluster
    std::vector<std::unique_ptr<RCluster>> fPool;
 
-   /// Protects the shared state between the main thread and the pipeline threads, namely the read and unzip
-   /// work queues and the in-flight clusters vector
+   /// Protects the shared state between the main thread and the I/O thread, namely the work queue and the in-flight
+   /// clusters vector
    std::mutex fLockWorkQueue;
    /// The clusters that were handed off to the I/O thread
    std::vector<RInFlightCluster> fInFlightClusters;
@@ -110,21 +102,11 @@ private:
    std::condition_variable fCvHasReadWork;
    /// The communication channel to the I/O thread
    std::deque<RReadItem> fReadQueue;
-   /// The lock associated with the fCvHasUnzipWork conditional variable
-   std::mutex fLockUnzipQueue;
-   /// Signals non-empty unzip work queue
-   std::condition_variable fCvHasUnzipWork;
-   /// The communication channel between the I/O thread and the unzip thread
-   std::deque<RUnzipItem> fUnzipQueue;
 
    /// The I/O thread calls RPageSource::LoadClusters() asynchronously.  The thread is mostly waiting for the
    /// data to arrive (blocked by the kernel) and therefore can safely run in addition to the application
    /// main threads.
    std::thread fThreadIo;
-   /// The unzip thread takes a loaded cluster and passes it to fPageSource->UnzipCluster() on it. If implicit
-   /// multi-threading is turned off, the UnzipCluster() call is a no-op. Otherwise, the UnzipCluster() call
-   /// schedules the unzipping of pages using the application's task scheduler.
-   std::thread fThreadUnzip;
 
    /// Every cluster id has at most one corresponding RCluster pointer in the pool
    RCluster *FindInPool(DescriptorId_t clusterId) const;
@@ -133,9 +115,6 @@ private:
    size_t FindFreeSlot() const;
    /// The I/O thread routine, there is exactly one I/O thread in-flight for every cluster pool
    void ExecReadClusters();
-   /// The unzip thread routine which takes a loaded cluster and passes it to fPageSource.UnzipCluster (which
-   /// might be a no-op if IMT is off). Marks the cluster as ready to be picked up by the main thread.
-   void ExecUnzipClusters();
    /// Returns the given cluster from the pool, which needs to contain at least the columns `physicalColumns`.
    /// Executed at the end of GetCluster when all missing data pieces have been sent to the load queue.
    /// Ideally, the function returns without blocking if the cluster is already in the pool.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleImtTaskScheduler.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleImtTaskScheduler.hxx
@@ -22,26 +22,22 @@
 #include <ROOT/TTaskGroup.hxx>
 
 #include <functional>
-#include <memory>
 #include <utility>
 
 namespace ROOT {
 namespace Experimental {
 
-class TTaskGroup;
-
 namespace Internal {
 
 class RNTupleImtTaskScheduler : public RPageStorage::RTaskScheduler {
 private:
-   std::unique_ptr<TTaskGroup> fTaskGroup;
+   TTaskGroup fTaskGroup;
 
 public:
-   RNTupleImtTaskScheduler() { Reset(); }
+   RNTupleImtTaskScheduler() = default;
    ~RNTupleImtTaskScheduler() override = default;
-   void Reset() final { fTaskGroup = std::make_unique<TTaskGroup>(); }
-   void AddTask(const std::function<void(void)> &taskFunc) final { fTaskGroup->Run(taskFunc); }
-   void Wait() final { fTaskGroup->Wait(); }
+   void AddTask(const std::function<void(void)> &taskFunc) final { fTaskGroup.Run(taskFunc); }
+   void Wait() final { fTaskGroup.Wait(); }
 };
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -71,8 +71,6 @@ public:
    class RTaskScheduler {
    public:
       virtual ~RTaskScheduler() = default;
-      /// Start a new set of tasks
-      virtual void Reset() = 0;
       /// Take a callable that represents a task
       virtual void AddTask(const std::function<void(void)> &taskFunc) = 0;
       /// Blocks until all scheduled tasks finished
@@ -119,7 +117,6 @@ protected:
       if (!fTaskScheduler)
          return;
       fTaskScheduler->Wait();
-      fTaskScheduler->Reset();
    }
 
 public:

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -838,7 +838,6 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
 void ROOT::Experimental::Internal::RPageSourceDaos::UnzipClusterImpl(RCluster *cluster)
 {
    Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-   fTaskScheduler->Reset();
 
    const auto clusterId = cluster->GetId();
    auto descriptorGuard = GetSharedDescriptorGuard();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -650,7 +650,6 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadClusters(std::span<RCluster::
 void ROOT::Experimental::Internal::RPageSourceFile::UnzipClusterImpl(RCluster *cluster)
 {
    Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-   fTaskScheduler->Reset();
 
    const auto clusterId = cluster->GetId();
    auto descriptorGuard = GetSharedDescriptorGuard();

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -449,6 +449,10 @@ TEST(RPageSinkBuf, ParallelZip) {
       EXPECT_EQ((std::vector<float>(3, fi)), viewKlassVec(i).at(0).v2.at(0));
       EXPECT_EQ("hi" + std::to_string(i), viewKlassVec(i).at(0).s);
    }
+
+#ifdef R__USE_IMT
+   ROOT::DisableImplicitMT();
+#endif
 }
 
 TEST(RPageSinkBuf, CommitSealedPageV)
@@ -456,9 +460,6 @@ TEST(RPageSinkBuf, CommitSealedPageV)
    RNTupleWriteOptions options;
    options.SetApproxUnzippedPageSize(16);
 
-#ifdef R__USE_IMT
-   ROOT::DisableImplicitMT();
-#endif
    {
       std::unique_ptr<RPageSink> sink(new RPageSinkMock(options));
       auto &counters = static_cast<RPageSinkMock *>(sink.get())->fCounters;
@@ -499,6 +500,10 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       EXPECT_EQ(0, counters.fNCommitSealedPage);
       EXPECT_EQ(1, counters.fNCommitSealedPageV);
    }
+
+#ifdef R__USE_IMT
+   ROOT::DisableImplicitMT();
+#endif
 }
 
 TEST(RPageSink, Empty)


### PR DESCRIPTION
The user expects ROOT to honor their number of threads provided as argument to `ROOT::EnableImplicitMT()`, yet facilities using `TTaskGroup` (for example RNTuple) were not using the created task arena and therefore as many resources as they could get.

This reverts commit af25fb986 ("[TTaskGroup] Isolate work with tbb::arena::isolate and not task_arena") and adds changes to use `ROOT::Internal::GetGlobalTaskArena()`.