### PR TITLE
[v6-30][win] Fix failing `std::this_thread::sleep_for` (#14786)

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -138,6 +138,12 @@ if(MSVC)
     )
   endif()
 
+  if(MSVC_VERSION GREATER_EQUAL 1939)
+    set(cling_exports ${cling_exports}
+      _Thrd_sleep_for
+    )
+  endif()
+
   set(cling_exports ${cling_exports}
     _Smtx_lock_shared
     _Smtx_unlock_shared


### PR DESCRIPTION
Fix `mt201_parallelHistoFill.C` failing with the following error:
```
779: Processing C:/root-dev/git/master/tutorials/multicore/mt201_parallelHistoFill.C...
779: [runStaticInitializersOnce]: Failed to materialize symbols: { (main, { ?_Swap@?$_Ptr_base@VTH1F@@@std@@IEAAXAEAV12@@Z,
[...]
779: [runStaticInitializersOnce]: Failed to materialize symbols: { (main, { __orc_init_func.cling-module-9 }) }
779: cling JIT session error: Failed to materialize symbols: { (main, { ?mt201_parallelHistoFill@@YAHXZ }) }
779: CMake Error at C:/root-dev/build/x64/debug/RootTestDriver.cmake:232 (message):
779:   error code: 1
```
