### PR TITLE
[skip-ci] fix typo trailing brace in docu

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -61,13 +61,13 @@
 \class TH1S
 \brief 1-D histogram with a short per channel (see TH1 documentation)
 \class TH1I
-\brief 1-D histogram with an int per channel (see TH1 documentation)}
+\brief 1-D histogram with an int per channel (see TH1 documentation)
 \class TH1L
-\brief 1-D histogram with a long64 per channel (see TH1 documentation)}
+\brief 1-D histogram with a long64 per channel (see TH1 documentation)
 \class TH1F
-\brief 1-D histogram with a float per channel (see TH1 documentation)}
+\brief 1-D histogram with a float per channel (see TH1 documentation)
 \class TH1D
-\brief 1-D histogram with a double per channel (see TH1 documentation)}
+\brief 1-D histogram with a double per channel (see TH1 documentation)
 @}
 */
 

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -37,13 +37,13 @@ ClassImp(TH2);
 \class TH2S
 \brief 2-D histogram with a short per channel (see TH1 documentation)
 \class TH2I
-\brief 2-D histogram with an int per channel (see TH1 documentation)}
+\brief 2-D histogram with an int per channel (see TH1 documentation)
 \class TH2L
-\brief 2-D histogram with a long64 per channel (see TH1 documentation)}
+\brief 2-D histogram with a long64 per channel (see TH1 documentation)
 \class TH2F
-\brief 2-D histogram with a float per channel (see TH1 documentation)}
+\brief 2-D histogram with a float per channel (see TH1 documentation)
 \class TH2D
-\brief 2-D histogram with a double per channel (see TH1 documentation)}
+\brief 2-D histogram with a double per channel (see TH1 documentation)
 @}
 */
 

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -34,13 +34,13 @@ ClassImp(TH3);
 \class TH3S
 \brief 3-D histogram with a short per channel (see TH1 documentation)
 \class TH3I
-\brief 3-D histogram with an int per channel (see TH1 documentation)}
+\brief 3-D histogram with an int per channel (see TH1 documentation)
 \class TH3L
-\brief 3-D histogram with a long64 per channel (see TH1 documentation)}
+\brief 3-D histogram with a long64 per channel (see TH1 documentation)
 \class TH3F
-\brief 3-D histogram with a float per channel (see TH1 documentation)}
+\brief 3-D histogram with a float per channel (see TH1 documentation)
 \class TH3D
-\brief 3-D histogram with a double per channel (see TH1 documentation)}
+\brief 3-D histogram with a double per channel (see TH1 documentation)
 @}
 */
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Typo trailing brace

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)


