### PR TITLE
[tree] Allow bypassing I/O when copying TTreeIndex

### DIFF
--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -395,7 +395,7 @@ std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendI
          }
       }
 
-      auto &treeIndex = finfo.fTreeIndexInfos[i];
+      const auto &treeIndex = finfo.fTreeIndexInfos[i];
       if (treeIndex) {
          auto *copyOfIndex = static_cast<TVirtualIndex *>(treeIndex->Clone());
          copyOfIndex->SetTree(frChain.get());

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -38,15 +38,21 @@ class TTreeIndex;
 class TChain;
 
 class TChainIndex : public TVirtualIndex {
-
 public:
+   // holds a description of indices of trees in the chain.
    class TChainIndexEntry {
-      // holds a description of indices of trees in the chain.
+      void Swap(TChainIndexEntry &other);
+
    public:
       TChainIndexEntry() : fMinIndexValue(0), fMinIndexValMinor(0),
                            fMaxIndexValue(0), fMaxIndexValMinor(0),
                            fTreeIndex(nullptr) {}
-
+      TChainIndexEntry(const TChainIndexEntry &other);
+      TChainIndexEntry &operator=(TChainIndexEntry other)
+      {
+         other.Swap(*this);
+         return *this;
+      }
       typedef std::pair<Long64_t, Long64_t>      IndexValPair_t;
 
       IndexValPair_t GetMinIndexValPair() const { return IndexValPair_t(fMinIndexValue, fMinIndexValMinor); }
@@ -78,7 +84,7 @@ protected:
 public:
    TChainIndex();
    TChainIndex(const TTree *T, const char *majorname, const char *minorname);
-                 ~TChainIndex() override;
+   ~TChainIndex() override;
    void           Append(const TVirtualIndex *, bool delaySort = false) override;
    Long64_t       GetEntryNumberFriend(const TTree *parent) override;
    Long64_t       GetEntryNumberWithIndex(Long64_t major, Long64_t minor) const override;
@@ -89,9 +95,9 @@ public:
    bool           IsValidFor(const TTree *parent) override;
    void           UpdateFormulaLeaves(const TTree *parent) override;
    void           SetTree(TTree *T) override;
+   TObject *Clone(const char *newname = "") const override;
 
    ClassDefOverride(TChainIndex,1)  //A Tree Index with majorname and minorname.
 };
 
 #endif
-

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -27,7 +27,6 @@
 class TTreeFormula;
 
 class TTreeIndex : public TVirtualIndex {
-
 protected:
    TString        fMajorName;           ///< Index major name
    TString        fMinorName;           ///< Index minor name
@@ -50,7 +49,7 @@ private:
 public:
    TTreeIndex();
    TTreeIndex(const TTree *T, const char *majorname, const char *minorname);
-                 ~TTreeIndex() override;
+   ~TTreeIndex() override;
    void                   Append(const TVirtualIndex *,bool delaySort = false) override;
    bool                   ConvertOldToNew();
    Long64_t               FindValues(Long64_t major, Long64_t minor) const;
@@ -69,6 +68,7 @@ public:
    void           Print(Option_t *option="") const override;
    void           UpdateFormulaLeaves(const TTree *parent) override;
    void           SetTree(TTree *T) override;
+   TObject *Clone(const char *newname = "") const override;
 
    ClassDefOverride(TTreeIndex,2);  //A Tree Index with majorname and minorname.
 };

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -27,6 +27,8 @@ and kept inside this chain index.
 #include "TFile.h"
 #include "TError.h"
 
+#include <cstring> // std::strlen
+
 ////////////////////////////////////////////////////////////////////////////////
 /// \class TChainIndex::TChainIndexEntry
 /// Holds a description of indices of trees in the chain.
@@ -37,6 +39,24 @@ void TChainIndex::TChainIndexEntry::SetMinMaxFrom(const TTreeIndex *index )
    fMinIndexValMinor = index->GetIndexValuesMinor()[0];
    fMaxIndexValue    = index->GetIndexValues()[index->GetN() - 1];
    fMaxIndexValMinor = index->GetIndexValuesMinor()[index->GetN() - 1];
+}
+
+void TChainIndex::TChainIndexEntry::Swap(TChainIndex::TChainIndexEntry &other)
+{
+   std::swap(fMinIndexValue, other.fMinIndexValue);
+   std::swap(fMinIndexValMinor, other.fMinIndexValMinor);
+   std::swap(fMaxIndexValue, other.fMaxIndexValue);
+   std::swap(fMaxIndexValMinor, other.fMaxIndexValMinor);
+   std::swap(fTreeIndex, other.fTreeIndex);
+}
+
+TChainIndex::TChainIndexEntry::TChainIndexEntry(const TChainIndex::TChainIndexEntry &other)
+{
+   fMinIndexValue = other.fMinIndexValue;
+   fMinIndexValMinor = other.fMinIndexValMinor;
+   fMaxIndexValue = other.fMaxIndexValue;
+   fMaxIndexValMinor = other.fMaxIndexValMinor;
+   fTreeIndex = (other.fTreeIndex ? static_cast<TVirtualIndex *>(other.fTreeIndex->Clone()) : nullptr);
 }
 
 ClassImp(TChainIndex);
@@ -407,3 +427,25 @@ void TChainIndex::SetTree(TTree *T)
    fTree = T;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Create a deep copy of the TChainIndex
+/// \param[in] newname A new name for the index
+///
+/// The new index is allocated on the heap without being managed. Also, it is
+/// not attached to any tree. It is the responsibility of the caller to manage
+/// its lifetime and attach it to a tree if necessary.
+TObject *TChainIndex::Clone(const char *newname) const
+{
+   auto index = new TChainIndex();
+   index->SetName(newname && std::strlen(newname) ? newname : GetName());
+   index->SetTitle(GetTitle());
+
+   // Note that the TTreeFormula * data members are not cloned since they would
+   // need the attached tree data member to function properly.
+   index->fMajorName = fMajorName;
+   index->fMinorName = fMinorName;
+
+   index->fEntries = fEntries;
+
+   return index;
+}

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -20,6 +20,8 @@ A Tree Index with majorname and minorname.
 #include "TBuffer.h"
 #include "TMath.h"
 
+#include <cstring> // std::strlen
+
 ClassImp(TTreeIndex);
 
 
@@ -638,3 +640,37 @@ void TTreeIndex::SetTree(TTree *T)
    fTree = T;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Create a deep copy of the TTreeIndex
+/// \param[in] newname A new name for the index
+///
+/// The new index is allocated on the heap without being managed. Also, it is
+/// not attached to any tree. It is the responsibility of the caller to manage
+/// its lifetime and attach it to a tree if necessary.
+TObject *TTreeIndex::Clone(const char *newname) const
+{
+   auto index = new TTreeIndex();
+   index->SetName(newname && std::strlen(newname) ? newname : GetName());
+   index->SetTitle(GetTitle());
+
+   // Note that the TTreeFormula * data members are not cloned since they would
+   // need the attached tree data member to function properly.
+   index->fMajorName = fMajorName;
+   index->fMinorName = fMinorName;
+
+   if (fN == 0)
+      return index;
+
+   index->fN = fN;
+
+   index->fIndexValues = new Long64_t[index->fN];
+   std::copy(fIndexValues, fIndexValues + fN, index->fIndexValues);
+
+   index->fIndexValuesMinor = new Long64_t[index->fN];
+   std::copy(fIndexValuesMinor, fIndexValuesMinor + fN, index->fIndexValuesMinor);
+
+   index->fIndex = new Long64_t[index->fN];
+   std::copy(fIndex, fIndex + fN, index->fIndex);
+
+   return index;
+}

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -16,3 +16,5 @@ if(imt)
       ROOT_ADD_GTEST(treeprocessormt_remotefiles treeprocmt/treeprocessormt_remotefiles.cxx LIBRARIES TreePlayer)
    endif()
 endif()
+
+ROOT_ADD_GTEST(ttreeindex_clone ttreeindex_clone.cxx LIBRARIES TreePlayer)

--- a/tree/treeplayer/test/ttreeindex_clone.cxx
+++ b/tree/treeplayer/test/ttreeindex_clone.cxx
@@ -1,0 +1,219 @@
+#include "TBranch.h"
+#include "TChain.h"
+#include "TChainIndex.h"
+#include "TFile.h"
+#include "TSystem.h"
+#include "TTree.h"
+#include "TTreeIndex.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+
+template <typename T>
+void expect_vec_eq(const std::vector<T> &v1, const std::vector<T> &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size()) << "Vectors 'v1' and 'v2' are of unequal length";
+   for (std::size_t i = 0ull; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]) << "Vectors 'v1' and 'v2' differ at index " << i;
+   }
+}
+
+void FillIndexedFriend(const char *mainfile, const char *auxfile)
+{
+   // Start by creating main Tree
+   TFile f(mainfile, "RECREATE");
+   TTree mainTree("mainTree", "mainTree");
+   int idx;
+   mainTree.Branch("idx", &idx);
+   int x;
+   mainTree.Branch("x", &x);
+
+   idx = 1;
+   x = 1;
+   mainTree.Fill();
+   idx = 1;
+   x = 2;
+   mainTree.Fill();
+   idx = 1;
+   x = 3;
+   mainTree.Fill();
+   idx = 2;
+   x = 4;
+   mainTree.Fill();
+   idx = 2;
+   x = 5;
+   mainTree.Fill();
+   mainTree.Write();
+   f.Close();
+
+   // And aux tree
+   TFile f2(auxfile, "RECREATE");
+   TTree auxTree("auxTree", "auxTree");
+   auxTree.Branch("idx", &idx);
+   int y;
+   auxTree.Branch("y", &y);
+   idx = 2;
+   y = 5;
+   auxTree.Fill();
+   idx = 1;
+   y = 7;
+   auxTree.Fill();
+   auxTree.Write();
+   f2.Close();
+}
+
+TEST(TTreeIndexClone, TChainIndex)
+{
+   auto mainFile = "IndexedFriendChain_main.root";
+   auto auxFile = "IndexedFriendChain_aux.root";
+   FillIndexedFriend(mainFile, auxFile);
+
+   TChain mainChain("mainTree", "mainTree");
+   mainChain.Add(mainFile);
+   TChain auxChain("auxTree", "auxTree");
+   auxChain.Add(auxFile);
+
+   auxChain.BuildIndex("idx");
+   mainChain.AddFriend(&auxChain);
+
+   {
+      // First check the index is reporting entry values as expected
+      int x;
+      int y;
+      int idx_main;
+      mainChain.SetBranchAddress("idx", &idx_main);
+      mainChain.SetBranchAddress("x", &x);
+      auxChain.SetBranchAddress("y", &y);
+
+      std::vector<int> vecx;
+      std::vector<int> vecy;
+
+      for (auto i = 0; i < mainChain.GetEntries(); i++) {
+         mainChain.GetEntry(i);
+         auxChain.GetEntryWithIndex(idx_main);
+         vecx.push_back(x);
+         vecy.push_back(y);
+      }
+      std::vector<int> refx{{1, 2, 3, 4, 5}};
+      expect_vec_eq(vecx, refx);
+      std::vector<int> refy{{7, 7, 7, 5, 5}};
+      expect_vec_eq(vecy, refy);
+   }
+
+   {
+      // Copy the index and check entry values again
+      auto *oldIndex = auxChain.GetTreeIndex();
+      auto *newIndex{dynamic_cast<TChainIndex *>(oldIndex->Clone())};
+      EXPECT_NE(newIndex, nullptr);
+
+      newIndex->SetTree(&auxChain);
+      auxChain.SetTreeIndex(newIndex);
+
+      delete oldIndex;
+      oldIndex = nullptr;
+
+      int x;
+      int y;
+      int idx_main;
+      mainChain.SetBranchAddress("idx", &idx_main);
+      mainChain.SetBranchAddress("x", &x);
+      auxChain.SetBranchAddress("y", &y);
+
+      std::vector<int> vecx;
+      std::vector<int> vecy;
+
+      for (auto i = 0; i < mainChain.GetEntries(); i++) {
+         mainChain.GetEntry(i);
+         auxChain.GetEntryWithIndex(idx_main);
+         vecx.push_back(x);
+         vecy.push_back(y);
+      }
+      std::vector<int> refx{{1, 2, 3, 4, 5}};
+      expect_vec_eq(vecx, refx);
+      std::vector<int> refy{{7, 7, 7, 5, 5}};
+      expect_vec_eq(vecy, refy);
+   }
+
+   gSystem->Unlink(mainFile);
+   gSystem->Unlink(auxFile);
+}
+
+TEST(TTreeIndexClone, TTreeIndex)
+{
+   auto mainFile = "IndexedFriendTree_main.root";
+   auto auxFile = "IndexedFriendTree_aux.root";
+   FillIndexedFriend(mainFile, auxFile);
+
+   TFile mainF(mainFile);
+   auto *mainTree = mainF.Get<TTree>("mainTree");
+   EXPECT_NE(mainTree, nullptr);
+
+   TFile auxF(auxFile);
+   auto *auxTree = auxF.Get<TTree>("auxTree");
+   EXPECT_NE(auxTree, nullptr);
+
+   auxTree->BuildIndex("idx");
+   mainTree->AddFriend(auxTree);
+
+   {
+      // First check the index is reporting entry values as expected
+      int x;
+      int y;
+      int idx_main;
+      mainTree->SetBranchAddress("idx", &idx_main);
+      mainTree->SetBranchAddress("x", &x);
+      auxTree->SetBranchAddress("y", &y);
+
+      std::vector<int> vecx;
+      std::vector<int> vecy;
+
+      for (auto i = 0; i < mainTree->GetEntries(); i++) {
+         mainTree->GetEntry(i);
+         auxTree->GetEntryWithIndex(idx_main);
+         vecx.push_back(x);
+         vecy.push_back(y);
+      }
+      std::vector<int> refx{{1, 2, 3, 4, 5}};
+      expect_vec_eq(vecx, refx);
+      std::vector<int> refy{{7, 7, 7, 5, 5}};
+      expect_vec_eq(vecy, refy);
+   }
+
+   {
+      // Copy the index and check entry values again
+      auto *oldIndex = auxTree->GetTreeIndex();
+      auto *newIndex{dynamic_cast<TTreeIndex *>(oldIndex->Clone())};
+      EXPECT_NE(newIndex, nullptr);
+
+      newIndex->SetTree(auxTree);
+      auxTree->SetTreeIndex(newIndex);
+
+      delete oldIndex;
+      oldIndex = nullptr;
+
+      int x;
+      int y;
+      int idx_main;
+      mainTree->SetBranchAddress("idx", &idx_main);
+      mainTree->SetBranchAddress("x", &x);
+      auxTree->SetBranchAddress("y", &y);
+
+      std::vector<int> vecx;
+      std::vector<int> vecy;
+
+      for (auto i = 0; i < mainTree->GetEntries(); i++) {
+         mainTree->GetEntry(i);
+         auxTree->GetEntryWithIndex(idx_main);
+         vecx.push_back(x);
+         vecy.push_back(y);
+      }
+      std::vector<int> refx{{1, 2, 3, 4, 5}};
+      expect_vec_eq(vecx, refx);
+      std::vector<int> refy{{7, 7, 7, 5, 5}};
+      expect_vec_eq(vecy, refy);
+   }
+
+   gSystem->Unlink(mainFile);
+   gSystem->Unlink(auxFile);
+}


### PR DESCRIPTION
The current logic for processing TTree/TChain datasets with IMT and when a TTreeIndex is involved requires a copy of each index in each thread, since their state depends on the TTree/TChain they are attached to.

Previously, the copy was done via `TObject::Clone` which inevitably makes use of I/O functions, i.e. serialising/deserialising the TTreeIndex/TChainIndex, thus making the copy more costly than necessary.

This commit introduces overloads of `Clone` for TTreeIndex and TChainIndex enabling their copy in memory.
