### PR TITLE
[cling] Allow running named macro from shared library

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -376,7 +376,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          fprintf(stderr, "ROOT ./configure options:\n%s\n", gROOT->GetConfigOptions());
          Terminate(0);
       } else if (!strcmp(argv[i], "-a")) {
-         fprintf(stderr, "ROOT splash screen is not visible with root.exe, use root instead.");
+         fprintf(stderr, "ROOT splash screen is not visible with root.exe, use root instead.\n");
          Terminate(0);
       } else if (!strcmp(argv[i], "-b")) {
          MakeBatch();
@@ -1243,7 +1243,8 @@ void TApplication::Help(const char *line)
       Printf(" ==============================================================================");
       Printf("   .L <filename>[flags]: load the given file with optional flags like\n"
              "                         + to compile or ++ to force recompile.\n"
-             "                         Type .? TSystem::CompileMacro for a list of all flags.");
+             "                         Type .? TSystem::CompileMacro for a list of all flags.\n"
+             "                         <filename> can also be a shared library; skip flags.");
       Printf("   .(x|X) <filename>[flags](args) :\n"
              "                         same as .L <filename>[flags] and runs then a function\n"
              "                         with signature: ret_type filename(args).");

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -23,4 +23,5 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
 	parser.add_argument('[file1.C...fileN.C]', help='Execute the ROOT macro file1.C ... fileN.C.\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
+	parser.add_argument('[file1_C.so...fileN_C.so]', help='Load and execute file1_C.so ... fileN_C.so (or .dll if on Windows)\nThey should be already-compiled ROOT macros (shared libraries)')
 	return parser

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -22,6 +22,6 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
-	parser.add_argument('[file1.C...fileN.C]', help='Execute the ROOT macro file1.C ... fileN.C.\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
-	parser.add_argument('[file1_C.so...fileN_C.so]', help='Load and execute file1_C.so ... fileN_C.so (or .dll if on Windows)\nThey should be already-compiled ROOT macros (shared libraries)')
+	parser.add_argument('[file1.C...fileN.C]', help='Execute the ROOT macro file1.C ... fileN.C\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
+	parser.add_argument('[file1_C.so...fileN_C.so]', help='Load and execute file1_C.so ... fileN_C.so (or .dll if on Windows)\nThey should be already-compiled ROOT macros (shared libraries) or:\nregular user shared libraries e.g. userlib.so with a function userlib(args)')
 	return parser


### PR DESCRIPTION
# This Pull request:

Allows running named macro from shared library as it was the case with CINT and was documented in users guide.
See https://root-forum.cern.ch/t/cannot-run-shared-object-in-batch-mode/58213

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/14772

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

