### PR TITLE
[cmake] Make Minuit2 build option deprecation warning less alarming

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -421,7 +421,7 @@ endforeach()
 
 foreach(opt builtin_afterimage minuit2)
   if(NOT ${opt})
-    message(DEPRECATION ">>> Option '${opt}' is deprecated and will be removed in the next release of ROOT. It should always be ON. Please contact root-dev@cern.ch should you still need it.")
+    message(DEPRECATION ">>> Option '${opt}' is deprecated: in the future it will always be set to ON. In the next release of ROOT, you will no longer be able to disable this feature. Please contact root-dev@cern.ch should you still need disabling it.")
   endif()
 endforeach()
 

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -413,13 +413,13 @@ foreach(opt afdsmgrd afs alien bonjour castor chirp cxx11 cxx14 cxx17 geocad gfa
 endforeach()
 
 #---Deprecated options------------------------------------------------------------------------
-foreach(opt cxxmodules exceptions oracle pythia6 pythia6_nolink minuit2)
+foreach(opt cxxmodules exceptions oracle pythia6 pythia6_nolink)
   if(${opt})
     message(DEPRECATION ">>> Option '${opt}' is deprecated and will be removed in the next release of ROOT. Please contact root-dev@cern.ch should you still need it.")
   endif()
 endforeach()
 
-foreach(opt builtin_afterimage)
+foreach(opt builtin_afterimage minuit2)
   if(NOT ${opt})
     message(DEPRECATION ">>> Option '${opt}' is deprecated and will be removed in the next release of ROOT. It should always be ON. Please contact root-dev@cern.ch should you still need it.")
   endif()


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

To avoid reports in the forum worrying about whether Minuit2 is gonna be removed.

See https://root-forum.cern.ch/t/will-minuit2-be-removed-from-root/58078

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

