### PR TITLE
[core] note splash screen not seen with root.exe

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -375,6 +375,9 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
       } else if (!strcmp(argv[i], "-config")) {
          fprintf(stderr, "ROOT ./configure options:\n%s\n", gROOT->GetConfigOptions());
          Terminate(0);
+      } else if (!strcmp(argv[i], "-a")) {
+         fprintf(stderr, "ROOT splash screen is not visible with root.exe, use root instead.");
+         Terminate(0);
       } else if (!strcmp(argv[i], "-b")) {
          MakeBatch();
          argv[i] = null;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`root.exe -a`
returns right now a non-understandable error message.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

