### PR TITLE
[RF] Consistent treatment of empty datasets with new CPU backend 

### DIFF
--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -119,7 +119,7 @@ protected:
   RooListProxy _coefList ;  ///<  List of coefficients
   mutable RooArgList* _snormList{nullptr};  ///<!  List of supplemental normalization factors
 
-  bool _haveLastCoef = false;    ///<  Flag indicating if last PDFs coefficient was supplied in the ctor
+  bool _haveLastCoef = false;    ///<  Flag indicating if last PDFs coefficient was supplied in the constructor
   bool _allExtendable = false;   ///<  Flag indicating if all PDF components are extendable
 
   mutable Int_t _coefErrCount ; ///<! Coefficient error counter

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -132,7 +132,7 @@ public:
   RooListProxy _coefList ;  ///<  List of coefficients
   mutable RooArgList* _snormList{nullptr};  ///<!  List of supplemental normalization factors
 
-  bool _haveLastCoef = false;  ///<  Flag indicating if last PDFs coefficient was supplied in the ctor
+  bool _haveLastCoef = false;  ///<  Flag indicating if last PDFs coefficient was supplied in the constructor
   bool _allExtendable = false; ///<  Flag indicating if all PDF components are extendable
   bool _recursive = false;     ///<  Flag indicating is fractions are treated recursively
 

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -38,7 +38,7 @@ public:
   // Ctors from DataStore
   RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> const& inputData) ;
 
-  // Empty ctor
+  // Empty constructor.
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
 

--- a/roofit/roofitcore/inc/RooCustomizer.h
+++ b/roofit/roofitcore/inc/RooCustomizer.h
@@ -96,7 +96,7 @@ protected:
   RooArgSet  _internalCloneBranchList;   ///< List of branches of internal clone
   RooArgSet* _cloneBranchList = nullptr; ///< Pointer to list of cloned branches used
 
-  // Cloned leafs are owned by the user supplied list in the ctor
+  // Cloned leaves are owned by the user supplied list in the constructor
   RooArgSet* _cloneNodeListAll = nullptr;  ///< List of all cloned nodes
   RooArgSet* _cloneNodeListOwned = nullptr;///< List of owned cloned nodes
 } ;

--- a/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
@@ -41,8 +41,7 @@ getDataSpans(RooAbsData const &data, std::string const &rangeName, RooSimultaneo
              bool takeGlobalObservablesFromData, std::stack<std::vector<double>> &buffers);
 
 std::map<RooFit::Detail::DataKey, std::size_t>
-determineOutputSizes(RooAbsArg const &topNode,
-                     std::function<std::size_t(RooFit::Detail::DataKey)> const &inputSizeFunc);
+determineOutputSizes(RooAbsArg const &topNode, std::function<int(RooFit::Detail::DataKey)> const &inputSizeFunc);
 
 } // namespace BatchModeDataHelpers
 } // namespace Detail

--- a/roofit/roofitcore/inc/RooLinkedListElem.h
+++ b/roofit/roofitcore/inc/RooLinkedListElem.h
@@ -33,7 +33,7 @@ namespace RooLinkedListImplDetails {
 
 class RooLinkedListElem {
 public:
-  // Initial element ctor
+  // Initial element constructor
   RooLinkedListElem() = default;
 
   void init(TObject* arg, RooLinkedListElem* after=nullptr) {

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -42,7 +42,7 @@ class RooDataSet;
 
 class RooMinimizer : public TObject {
 public:
-   /// Config argument to RooMinimizer ctor
+   /// Config argument to RooMinimizer constructor.
    struct Config {
 
       Config() {}
@@ -55,16 +55,16 @@ public:
       int offsetting = -1;         // RooAbsMinimizerFcn config
       const char *logf = nullptr;  // RooAbsMinimizerFcn config
 
-      // RooAbsMinimizerFcn config that can only be set in ctor, 0 means no parallelization (default),
+      // RooAbsMinimizerFcn config that can only be set in constructor, 0 means no parallelization (default),
       // -1 is parallelization with the number of workers controlled by RooFit::MultiProcess which
       // defaults to the number of available processors, n means parallelization with n CPU's
       int parallelize = 0;
 
-      // Experimental: RooAbsMinimizerFcn config that can only be set in ctor
+      // Experimental: RooAbsMinimizerFcn config that can only be set in constructor
       // argument is ignored when parallelize is 0
       bool enableParallelGradient = true;
 
-      // Experimental: RooAbsMinimizerFcn config that can only be set in ctor
+      // Experimental: RooAbsMinimizerFcn config that can only be set in constructor
       // argument is ignored when parallelize is 0
       bool enableParallelDescent = false;
 

--- a/roofit/roofitcore/inc/RooMsgService.h
+++ b/roofit/roofitcore/inc/RooMsgService.h
@@ -235,7 +235,7 @@ protected:
 
   Int_t _errorCount ;
 
-  // Private ctor -- singleton class
+  // Private constructor -- singleton class
   RooMsgService() ;
   RooMsgService(const RooMsgService&) ;
 

--- a/roofit/roofitcore/inc/RooNumConvPdf.h
+++ b/roofit/roofitcore/inc/RooNumConvPdf.h
@@ -58,7 +58,7 @@ public:
 protected:
 
   // WVE Store all properties of RooNumConvolution here so that can be take
-  // along in the copy ctor.
+  // along in the copy constructor.
 
   RooNumConvolution& conv() const { if (!_init) initialize() ; return *_conv ; }
 

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -37,7 +37,7 @@ public:
   RooTreeDataStore() ;
   RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
 
-  // Empty ctor
+  // Empty constructor
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooTreeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooTreeDataStore(*this,vars,newname) ; }

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -43,7 +43,7 @@ public:
 
   RooVectorDataStore() ;
 
-  // Empty ctor
+  // Empty constructor
   RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
 
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooVectorDataStore(*this,newname) ; }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -651,7 +651,7 @@ std::size_t RooAbsArg::getParametersSizeEstimate(const RooArgSet* nset) const
 /// ourself as top node that don't match any of the names the args in the
 /// supplied argset. Returns `true` only if something went wrong.
 /// The complement of this function is getObservables().
-/// \param[in] observables Set of leafs to ignore because they are observables and not parameters.
+/// \param[in] observables Set of leaves to ignore because they are observables and not parameters.
 /// \param[out] outputSet Output set.
 /// \param[in] stripDisconnected Allow pdf to strip parameters from list before adding it.
 
@@ -745,7 +745,7 @@ RooFit::OwningPtr<RooArgSet> RooAbsArg::getObservables(const RooArgSet* dataList
 /// The complement of this function is getParameters().
 /// \param[in] dataList Set of leaf nodes to match.
 /// \param[out] outputSet Output set.
-/// \param[in] valueOnly If this parameter is true, we only match leafs that
+/// \param[in] valueOnly If this parameter is true, we only match leaves that
 ///                      depend on the value of any arg in `dataList`.
 
 bool RooAbsArg::getObservables(const RooAbsCollection* dataList, RooArgSet& outputSet, bool valueOnly) const

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -55,8 +55,8 @@
  *     runblock.defineType("run1") ;
  *     runblock.defineType("run2") ;
  *
- *     RooArgSet splitLeafs;
- *     RooCustomizer cust(pdf,runblock,splitLeafs);
+ *     RooArgSet splitLeaves;
+ *     RooCustomizer cust(pdf,runblock,splitLeaves);
  *     cust.splitArg(alpha,runblock);
  *
  *     RooAbsPdf* pdf_run1 = cust.build("run1") ;
@@ -64,9 +64,9 @@
  *
  *     RooSimultaneous simpdf("simpdf","simpdf",RooArgSet(*pdf_run1,*pdf_run2))
  * ```
- * If the master category state is a super category, leafs may be split
+ * If the master category state is a super category, leaves may be split
  * by any subset of that master category. E.g. if the master category
- * is 'A x B', leafs may be split by A, B or AxB.
+ * is 'A x B', leaves may be split by A, B or AxB.
  *
  * In addition to replacing leaf nodes, RooCustomizer clones all branch
  * nodes that depend directly or indirectly on modified leaf nodes, so
@@ -77,7 +77,7 @@
  * composites are needed.
  *
  * Any leaf nodes that are created by the customizer will be put into
- * the leaf list that is passed into the customizers constructor (splitLeafs in
+ * the leaf list that is passed into the customizers constructor (splitLeaves in
  * the above example. The list owner is responsible for deleting these leaf
  * nodes after the customizer is deleted.
  *
@@ -86,23 +86,23 @@
  *
  * ### Reuse nodes to customise a different PDF
  * By default, the customizer clones the prototype leaf node when splitting a leaf,
- * but the user can feed pre-defined split leafs in leaf list. These leafs
+ * but the user can feed pre-defined split leaves in leaf list. These leaves
  * must have the name `<split_leaf>_<splitcat_label>` to be picked up. The list
- * of pre-supplied leafs may be partial, any missing split leafs will be auto
+ * of pre-supplied leaves may be partial, any missing split leaves will be auto
  * generated.
  *
  * Another common construction is to have two prototype PDFs, each to be customized
  * by a separate customizer instance, that share parameters. To ensure that
- * the customized clones also share their respective split leafs, i.e.
+ * the customized clones also share their respective split leaves, i.e.
  * ```
  *   PDF1(x,y, A) and PDF2(z, A) ---> PDF1_run1(x,y, A_run1) and PDF2_run1(x,y, A_run1)
  *                                    PDF1_run2(x,y, A_run2) and PDF2_run2(x,y, A_run2)
  * ```
  * feed the same split leaf list into both customizers. In that case, the second customizer
- * will pick up the split leafs instantiated by the first customizer and the link between
+ * will pick up the split leaves instantiated by the first customizer and the link between
  * the two PDFs is retained.
  *
- * ### Customising with pre-defined leafs
+ * ### Customising with pre-defined leaves
  * If leaf nodes are provided in the sets, the customiser will use them. This is a complete
  * example that customises the `yield` parameter, and splits (automatically clones) the
  * mean of the Gaussian. This is a short version of the tutorial rf514_RooCustomizer.C.
@@ -127,17 +127,17 @@
  *  sample.defineType("BBG2m2T");
  *
  *
- *  RooArgSet customisedLeafs;
- *  RooArgSet allLeafs;
+ *  RooArgSet customisedLeaves;
+ *  RooArgSet allLeaves;
  *
  *  RooRealVar mass("M", "M", 1, 0, 12000);
  *  RooFormulaVar yield1("yieldSig_BBG1m2T","sigy1","M/3.360779",mass);
  *  RooFormulaVar yield2("yieldSig_BBG2m2T","sigy2","M/2",mass);
- *  allLeafs.add(yield1);
- *  allLeafs.add(yield2);
+ *  allLeaves.add(yield1);
+ *  allLeaves.add(yield2);
  *
  *
- *  RooCustomizer cust(model, sample, customisedLeafs, &allLeafs);
+ *  RooCustomizer cust(model, sample, customisedLeaves, &allLeaves);
  *  cust.splitArg(yieldSig, sample);
  *  cust.splitArg(meanG, sample);
  *
@@ -206,24 +206,24 @@ Int_t init()
 /// replaceArg() and splitArg() functionality.
 /// \param[in] pdf Proto PDF to be customised.
 /// \param[in] masterCat Category to be used for splitting.
-/// \param[in,out] splitLeafs All nodes created in
+/// \param[in,out] splitLeaves All nodes created in
 /// the customisation process are added to this set.
 /// The user can provide nodes that are *taken*
 /// from the set if they have a name that matches `<parameterNameToBeReplaced>_<category>`.
 /// \note The set needs to own its contents if they are user-provided.
 /// Use *e.g.*
 /// ```
-///  RooArgSet customisedLeafs;
+///  RooArgSet customisedLeaves;
 ///  auto yield1 = new RooFormulaVar("yieldSig_BBG1m2T","sigy1","M/3.360779",mass);
-///  customisedLeafs.addOwned(*yield1);
+///  customisedLeaves.addOwned(*yield1);
 /// ```
-/// \param[in,out] splitLeafsAll All leafs that are used when customising are collected here.
+/// \param[in,out] splitLeavesAll All leaves that are used when customising are collected here.
 /// If this set already contains leaves, they will be used for customising if the names match
 /// as above.
 ///
 
-RooCustomizer::RooCustomizer(const RooAbsArg &pdf, const RooAbsCategoryLValue &masterCat, RooArgSet &splitLeafs,
-                             RooArgSet *splitLeafsAll)
+RooCustomizer::RooCustomizer(const RooAbsArg &pdf, const RooAbsCategoryLValue &masterCat, RooArgSet &splitLeaves,
+                             RooArgSet *splitLeavesAll)
    : _sterile(false),
      _owning(true),
      _masterPdf(const_cast<RooAbsArg *>(&pdf)),
@@ -232,8 +232,8 @@ RooCustomizer::RooCustomizer(const RooAbsArg &pdf, const RooAbsCategoryLValue &m
      _masterLeafList("masterLeafList"),
      _internalCloneBranchList("cloneBranchList"),
      _cloneBranchList(&_internalCloneBranchList),
-     _cloneNodeListAll(splitLeafsAll),
-     _cloneNodeListOwned(&splitLeafs)
+     _cloneNodeListAll(splitLeavesAll),
+     _cloneNodeListOwned(&splitLeaves)
 {
 
   initialize() ;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -919,7 +919,7 @@ std::span<const double> RooDataSet::getWeightBatch(std::size_t first, std::size_
 
   std::size_t nEntries = this->numEntries(); // for the casting to std::size_t
 
-  if(first >= nEntries || (first + len) > nEntries) {
+  if(first + len > nEntries) {
     throw std::runtime_error("RooDataSet::getWeightBatch(): requested range not valid for dataset.");
   }
 

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -100,10 +100,10 @@ void RooFuncWrapper::loadParamsAndData(RooAbsArg const *head, RooArgSet const &p
    _gradientVarBuffer.resize(_params.size());
 
    if (head) {
-      _nodeOutputSizes =
-         RooFit::Detail::BatchModeDataHelpers::determineOutputSizes(*head, [&spans](RooFit::Detail::DataKey key) {
+      _nodeOutputSizes = RooFit::Detail::BatchModeDataHelpers::determineOutputSizes(
+         *head, [&spans](RooFit::Detail::DataKey key) -> int {
             auto found = spans.find(key);
-            return found != spans.end() ? found->second.size() : 0;
+            return found != spans.end() ? found->second.size() : -1;
          });
    }
 }

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -55,7 +55,7 @@ RooGenProdProj::RooGenProdProj(const char *name, const char *title, const RooArg
   // Set expensive object cache to that of first item in prodSet
   setExpensiveObjectCache(_prodSet.first()->expensiveObjectCache()) ;
 
-  // Create owners of components created in ctor
+  // Create owners of components created in constructor
   _compSetOwnedN = std::make_unique<RooArgSet>();
   _compSetOwnedD = std::make_unique<RooArgSet>();
 

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -80,7 +80,7 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet& var
 
   // Adjust ranges of _histObsList to those of _dataHist
   for (const auto hobs : _histObsList) {
-    // Guaranteed to succeed, since checked above in ctor
+    // Guaranteed to succeed, since checked above in constructor
     RooAbsArg* dhobs = dhist.get()->find(hobs->GetName()) ;
     RooRealVar* dhreal = dynamic_cast<RooRealVar*>(dhobs) ;
     if (dhreal){
@@ -135,7 +135,7 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pd
 
   // Adjust ranges of _histObsList to those of _dataHist
   for (const auto hobs : _histObsList) {
-    // Guaranteed to succeed, since checked above in ctor
+    // Guaranteed to succeed, since checked above in constructor
     RooAbsArg* dhobs = dhist.get()->find(hobs->GetName()) ;
     RooRealVar* dhreal = dynamic_cast<RooRealVar*>(dhobs) ;
     if (dhreal){

--- a/roofit/roofitcore/src/RooObjCacheManager.cxx
+++ b/roofit/roofitcore/src/RooObjCacheManager.cxx
@@ -60,7 +60,7 @@ RooObjCacheManager::RooObjCacheManager(const RooObjCacheManager& other, RooAbsAr
   RooCacheManager<RooAbsCacheElement>(other,owner),
   _clearOnRedirect(other._clearOnRedirect),
   _allowOptimize(other._allowOptimize),
-  _optCacheModeSeen(false) // cache mode properties are not transferred in copy ctor
+  _optCacheModeSeen(false) // cache mode properties are not transferred in copy constructor
 {
 }
 

--- a/roofit/roofitcore/src/RooPolyFunc.cxx
+++ b/roofit/roofitcore/src/RooPolyFunc.cxx
@@ -260,7 +260,7 @@ RooPolyFunc::taylorExpand(const char *name, const char *title, RooAbsReal &func,
       }
    }
 
-   // Figure out the observable values around which to exapnd
+   // Figure out the observable values around which to expand
    std::vector<double> obsValues;
    if (observableValues.empty()) {
       obsValues.reserve(observables.size());

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -135,7 +135,7 @@ RooRealVar* RooVectorDataStore::weightVar(const RooArgSet& allVars, const char* 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Regular copy ctor
+/// Regular copy constructor.
 
 RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const char* newname) :
   RooAbsDataStore(other,newname),
@@ -193,7 +193,7 @@ RooVectorDataStore::RooVectorDataStore(const RooTreeDataStore& other, const RooA
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Clone ctor, must connect internal storage to given new external set of vars
+/// Clone constructor, must connect internal storage to given new external set of variables.
 
 RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname) :
   RooAbsDataStore(other,varsNoWeight(vars,other._wgtVar?other._wgtVar->GetName():nullptr),newname),
@@ -984,7 +984,7 @@ void RooVectorDataStore::attachCache(const RooAbsArg* newOwner, const RooArgSet&
   // Only applicable if a cache exists
   if (!_cache) return ;
 
-  // Clone ctor, must connect internal storage to given new external set of vars
+  // Clone constructor, must connect internal storage to given new external set of variables
   std::vector<RealVector*> cacheElements(_cache->realStoreList());
   cacheElements.insert(cacheElements.end(), _cache->_realfStoreList.begin(), _cache->_realfStoreList.end());
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1533,9 +1533,9 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
     return true ;
   }
 
-  // Require that class meets technical criteria to be persistable (i.e it has a default ctor)
-  // (We also need a default ctor of abstract classes, but cannot check that through is interface
-  //  as TClass::HasDefaultCtor only returns true for callable default ctors)
+  // Require that class meets technical criteria to be persistable (i.e it has a default constructor)
+  // (We also need a default constructor of abstract classes, but cannot check that through is interface
+  //  as TClass::HasDefaultCtor only returns true for callable default constructors)
   if (!(tc->Property() & kIsAbstract) && !tc->HasDefaultConstructor()) {
     oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING cannot import class "
                 << tc->GetName() << " : it cannot be persisted because it doesn't have a default constructor. Please fix " << endl ;

--- a/roofit/roofitcore/test/test_lib.h
+++ b/roofit/roofitcore/test/test_lib.h
@@ -55,7 +55,7 @@ generate_1D_gaussian_pdf_nll(RooWorkspace &ws, unsigned long nEvents)
 }
 
 // return two unique_ptrs, the first because nll is a pointer,
-// the second because RooArgSet doesn't have a move ctor
+// the second because RooArgSet doesn't have a move constructor
 std::tuple<std::unique_ptr<RooAbsReal>, RooAbsPdf *, std::unique_ptr<RooDataSet>, std::unique_ptr<RooArgSet>>
 generate_ND_gaussian_pdf_nll(RooWorkspace &ws, unsigned int n, unsigned long nEvents, RooFit::EvalBackend evalBackend)
 {

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -330,8 +330,8 @@ private:
    mutable ROOT::Math::IntegratorMultiDim  fIntegrator; // integrator  (mutable because Integral() is not const
    mutable std::vector<double> fXmin;    // min value of parameters (poi+nuis) -
    mutable std::vector<double> fXmax;   // max value of parameters (poi+nuis) - max poi changes so it is mutable
-   double fNorm = 1.0;                  // normalization value (computed in ctor)
-   mutable double fNormErr = 0.0;       // normalization error value (computed in ctor)
+   double fNorm = 1.0;                  // normalization value (computed in constructor)
+   mutable double fNormErr = 0.0;       // normalization error value (computed in constructor)
    double fOffset = 0;                  // offset for computing the root
    double fMaxPOI = 0;                  // maximum value of POI
    bool fHasNorm = false;               // flag to control first call to the function

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -5214,9 +5214,9 @@ xRooNode xRooNode::vars() const
       // we want
       // ensure all globs appear after robs, as we rely on this ordering for picking "x" var in "reduced" method
       xRooNode _globs;
-      RooArgSet allLeafs;
-      p->leafNodeServerList(&allLeafs);
-      for (auto &c : allLeafs) {
+      RooArgSet allLeaves;
+      p->leafNodeServerList(&allLeaves);
+      for (auto &c : allLeaves) {
          if (c->isFundamental() || (dynamic_cast<RooConstVar *>(c) && !TString(c->GetName()).IsFloat())) {
             if (!c->getAttribute("global")) {
                out.get<RooArgList>()->add(*c);


### PR DESCRIPTION
As we discovered in a CMSSW ROOT `master` sync PR, the new RooFit CPU
backend treats empty datasets differently from the legacy NLL evaluation
backend:
https://github.com/cms-sw/cmsdist/pull/9025

This commit is fixing this, in particular removing the assumption that
datasets used for fits with the new CPU backend are never empty.

A unit test that validates the behavior for empty data objects is also
added.

I set the priority to "high" because this is a blocker for CMSSW to use ROOT master.