### PR TITLE
[ntuple] specialize RField for TObject

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -817,44 +817,6 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
 };
 
-/// TObject requires special handling of the fBits and fUniqueID members
-class RTObjectField : public RFieldBase {
-   class RTObjectDeleter : public RDeleter {
-   public:
-      void operator()(void *objPtr, bool dtorOnly) final;
-   };
-
-   static TClass *GetClass();
-   static std::size_t GetOffsetOfMember(const char *name);
-   static std::size_t GetOffsetUniqueID() { return GetOffsetOfMember("fUniqueID"); }
-   static std::size_t GetOffsetBits() { return GetOffsetOfMember("fBits"); }
-
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
-   void GenerateColumnsImpl() final {}
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTObjectDeleter>(); }
-
-   std::size_t AppendImpl(const void *from) final;
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-
-   void OnConnectPageSource() final;
-
-public:
-   RTObjectField(std::string_view fieldName);
-   RTObjectField(RTObjectField &&other) = default;
-   RTObjectField &operator=(RTObjectField &&other) = default;
-   ~RTObjectField() override = default;
-
-   std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final;
-   size_t GetAlignment() const final;
-   std::uint32_t GetTypeVersion() const final;
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-};
-
 /// The field for an unscoped or scoped enum with dictionary
 class REnumField : public RFieldBase {
 private:
@@ -2463,6 +2425,47 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+/// TObject requires special handling of the fBits and fUniqueID members
+template <>
+class RField<TObject> final : public RFieldBase {
+   class RTObjectDeleter : public RDeleter {
+   public:
+      void operator()(void *objPtr, bool dtorOnly) final;
+   };
+
+   static TClass *GetClass();
+   static std::size_t GetOffsetOfMember(const char *name);
+   static std::size_t GetOffsetUniqueID() { return GetOffsetOfMember("fUniqueID"); }
+   static std::size_t GetOffsetBits() { return GetOffsetOfMember("fBits"); }
+
+protected:
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
+
+   void ConstructValue(void *where) const override;
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTObjectDeleter>(); }
+
+   std::size_t AppendImpl(const void *from) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
+
+   void OnConnectPageSource() final;
+
+public:
+   static std::string TypeName() { return "TObject"; }
+
+   RField(std::string_view fieldName);
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   std::vector<RValue> SplitValue(const RValue &value) const final;
+   size_t GetValueSize() const final;
+   size_t GetAlignment() const final;
+   std::uint32_t GetTypeVersion() const final;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
 template <typename ItemT, std::size_t N>
 class RField<std::array<ItemT, N>> : public RArrayField {
    using ContainerT = typename std::array<ItemT, N>;
@@ -2880,16 +2883,6 @@ class RField<std::atomic<ItemT>> final : public RAtomicField {
 public:
    static std::string TypeName() { return "std::atomic<" + RField<ItemT>::TypeName() + ">"; }
    explicit RField(std::string_view name) : RAtomicField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
-   RField(RField &&other) = default;
-   RField &operator=(RField &&other) = default;
-   ~RField() override = default;
-};
-
-template <>
-class RField<TObject> final : public RTObjectField {
-public:
-   static std::string TypeName() { return "TObject"; }
-   explicit RField(std::string_view name) : RTObjectField(name) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() override = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2428,11 +2428,6 @@ public:
 /// TObject requires special handling of the fBits and fUniqueID members
 template <>
 class RField<TObject> final : public RFieldBase {
-   class RTObjectDeleter : public RDeleter {
-   public:
-      void operator()(void *objPtr, bool dtorOnly) final;
-   };
-
    static std::size_t GetOffsetOfMember(const char *name);
    static std::size_t GetOffsetUniqueID() { return GetOffsetOfMember("fUniqueID"); }
    static std::size_t GetOffsetBits() { return GetOffsetOfMember("fBits"); }
@@ -2443,7 +2438,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
    void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTObjectDeleter>(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<TObject>>(); }
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2433,7 +2433,6 @@ class RField<TObject> final : public RFieldBase {
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
-   static TClass *GetClass();
    static std::size_t GetOffsetOfMember(const char *name);
    static std::size_t GetOffsetUniqueID() { return GetOffsetOfMember("fUniqueID"); }
    static std::size_t GetOffsetBits() { return GetOffsetOfMember("fBits"); }

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -50,7 +50,7 @@ public:
    virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
-   virtual void VisitTObjectField(const RTObjectField &field) { VisitField(field); }
+   virtual void VisitTObjectField(const RField<TObject> &field) { VisitField(field); }
    virtual void VisitProxiedCollectionField(const RProxiedCollectionField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
@@ -220,7 +220,7 @@ public:
    void VisitArrayField(const RArrayField &field) final;
    void VisitArrayAsRVecField(const RArrayAsRVecField &field) final;
    void VisitClassField(const RClassField &field) final;
-   void VisitTObjectField(const RTObjectField &field) final;
+   void VisitTObjectField(const RField<TObject> &field) final;
    void VisitRecordField(const RRecordField &field) final;
    void VisitProxiedCollectionField(const RProxiedCollectionField &field) final;
    void VisitVectorField(const RVectorField &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -50,6 +50,7 @@ public:
    virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
+   virtual void VisitTObjectField(const RTObjectField &field) { VisitField(field); }
    virtual void VisitProxiedCollectionField(const RProxiedCollectionField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
@@ -189,6 +190,7 @@ private:
    void PrintIndent();
    void PrintName(const RFieldBase &field);
    void PrintCollection(const RFieldBase &field);
+   void PrintRecord(const RFieldBase &field);
 
 public:
    RPrintValueVisitor(RFieldBase::RValue value, std::ostream &output, unsigned int level = 0,
@@ -218,6 +220,7 @@ public:
    void VisitArrayField(const RArrayField &field) final;
    void VisitArrayAsRVecField(const RArrayAsRVecField &field) final;
    void VisitClassField(const RClassField &field) final;
+   void VisitTObjectField(const RTObjectField &field) final;
    void VisitRecordField(const RRecordField &field) final;
    void VisitProxiedCollectionField(const RProxiedCollectionField &field) final;
    void VisitVectorField(const RVectorField &field) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1765,7 +1765,7 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
       if (strcmp(name, dataMember->GetName()) == 0)
          return dataMember->GetOffset();
    }
-   throw RException(R__FAIL("invalid data member"));
+   throw RException(R__FAIL('\'' + std::string(name) + '\'' + "is an invalid data member"));
 }
 
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -628,7 +628,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    } else if (canonicalType == "std::string") {
       result = std::make_unique<RField<std::string>>(fieldName);
    } else if (canonicalType == "TObject") {
-      result = std::make_unique<RTObjectField>(fieldName);
+      result = std::make_unique<RField<TObject>>(fieldName);
    } else if (canonicalType == "std::vector<bool>") {
       result = std::make_unique<RField<std::vector<bool>>>(fieldName);
    } else if (canonicalType.substr(0, 12) == "std::vector<") {
@@ -1754,12 +1754,12 @@ void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visit
 
 //------------------------------------------------------------------------------
 
-TClass *ROOT::Experimental::RTObjectField::GetClass()
+TClass *ROOT::Experimental::RField<TObject>::GetClass()
 {
    return TClass::GetClass("TObject");
 }
 
-std::size_t ROOT::Experimental::RTObjectField::GetOffsetOfMember(const char *name)
+std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *name)
 {
    for (auto dataMember : ROOT::Detail::TRangeStaticCast<TDataMember>(*GetClass()->GetListOfDataMembers())) {
       if (strcmp(name, dataMember->GetName()) == 0)
@@ -1768,7 +1768,7 @@ std::size_t ROOT::Experimental::RTObjectField::GetOffsetOfMember(const char *nam
    throw RException(R__FAIL("invalid data member"));
 }
 
-ROOT::Experimental::RTObjectField::RTObjectField(std::string_view fieldName)
+ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
 {
    R__ASSERT(GetClass()->GetClassVersion() == 1);
@@ -1783,14 +1783,14 @@ ROOT::Experimental::RTObjectField::RTObjectField(std::string_view fieldName)
 }
 
 std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RTObjectField::CloneImpl(std::string_view newName) const
+ROOT::Experimental::RField<TObject>::CloneImpl(std::string_view newName) const
 {
-   auto result = std::make_unique<RTObjectField>(newName);
+   auto result = std::make_unique<RField<TObject>>(newName);
    SyncFieldIDs(*this, *result);
    return result;
 }
 
-std::size_t ROOT::Experimental::RTObjectField::AppendImpl(const void *from)
+std::size_t ROOT::Experimental::RField<TObject>::AppendImpl(const void *from)
 {
    // Cf. TObject::Streamer()
 
@@ -1809,7 +1809,7 @@ std::size_t ROOT::Experimental::RTObjectField::AppendImpl(const void *from)
    return nbytes;
 }
 
-void ROOT::Experimental::RTObjectField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
+void ROOT::Experimental::RField<TObject>::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
    // Cf. TObject::Streamer()
 
@@ -1827,31 +1827,31 @@ void ROOT::Experimental::RTObjectField::ReadGlobalImpl(NTupleSize_t globalIndex,
    *reinterpret_cast<UInt_t *>(reinterpret_cast<unsigned char *>(to) + GetOffsetBits()) = bits;
 }
 
-void ROOT::Experimental::RTObjectField::OnConnectPageSource()
+void ROOT::Experimental::RField<TObject>::OnConnectPageSource()
 {
    if (GetTypeVersion() != 1) {
       throw RException(R__FAIL("unsupported on-disk version of TObject: " + std::to_string(GetTypeVersion())));
    }
 }
 
-std::uint32_t ROOT::Experimental::RTObjectField::GetTypeVersion() const
+std::uint32_t ROOT::Experimental::RField<TObject>::GetTypeVersion() const
 {
    return GetClass()->GetClassVersion();
 }
 
-void ROOT::Experimental::RTObjectField::ConstructValue(void *where) const
+void ROOT::Experimental::RField<TObject>::ConstructValue(void *where) const
 {
    GetClass()->New(where);
 }
 
-void ROOT::Experimental::RTObjectField::RTObjectDeleter::operator()(void *objPtr, bool dtorOnly)
+void ROOT::Experimental::RField<TObject>::RTObjectDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    GetClass()->Destructor(objPtr, true /* dtorOnly */);
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::RTObjectField::SplitValue(const RValue &value) const
+ROOT::Experimental::RField<TObject>::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    auto basePtr = value.GetPtr<unsigned char>().get();
@@ -1862,17 +1862,17 @@ ROOT::Experimental::RTObjectField::SplitValue(const RValue &value) const
    return result;
 }
 
-size_t ROOT::Experimental::RTObjectField::GetValueSize() const
+size_t ROOT::Experimental::RField<TObject>::GetValueSize() const
 {
    return sizeof(TObject);
 }
 
-size_t ROOT::Experimental::RTObjectField::GetAlignment() const
+size_t ROOT::Experimental::RField<TObject>::GetAlignment() const
 {
    return alignof(TObject);
 }
 
-void ROOT::Experimental::RTObjectField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RField<TObject>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitTObjectField(*this);
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1767,7 +1767,7 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
    if (auto dataMember = GetClass()->GetDataMember(name)) {
       return dataMember->GetOffset();
    }
-   throw RException(R__FAIL('\'' + std::string(name) + '\'' + "is an invalid data member"));
+   throw RException(R__FAIL('\'' + std::string(name) + '\'' + " is an invalid data member"));
 }
 
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1836,12 +1836,6 @@ void ROOT::Experimental::RField<TObject>::ConstructValue(void *where) const
    new (where) TObject();
 }
 
-void ROOT::Experimental::RField<TObject>::RTObjectDeleter::operator()(void *objPtr, bool dtorOnly)
-{
-   static_cast<TObject *>(objPtr)->~TObject();
-   RDeleter::operator()(objPtr, dtorOnly);
-}
-
 std::vector<ROOT::Experimental::RFieldBase::RValue>
 ROOT::Experimental::RField<TObject>::SplitValue(const RValue &value) const
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1757,14 +1757,9 @@ void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visit
 
 //------------------------------------------------------------------------------
 
-TClass *ROOT::Experimental::RField<TObject>::GetClass()
-{
-   return TObject::Class();
-}
-
 std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *name)
 {
-   if (auto dataMember = GetClass()->GetDataMember(name)) {
+   if (auto dataMember = TObject::Class()->GetDataMember(name)) {
       return dataMember->GetOffset();
    }
    throw RException(R__FAIL('\'' + std::string(name) + '\'' + " is an invalid data member"));
@@ -1773,11 +1768,11 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
 {
-   assert(GetClass()->GetClassVersion() == 1);
+   assert(TObject::Class()->GetClassVersion() == 1);
 
-   if (!(GetClass()->ClassProperty() & kClassHasExplicitCtor))
+   if (!(TObject::Class()->ClassProperty() & kClassHasExplicitCtor))
       fTraits |= kTraitTriviallyConstructible;
-   if (!(GetClass()->ClassProperty() & kClassHasExplicitDtor))
+   if (!(TObject::Class()->ClassProperty() & kClassHasExplicitDtor))
       fTraits |= kTraitTriviallyDestructible;
 
    Attach(std::make_unique<RField<UInt_t>>("fUniqueID"));
@@ -1838,17 +1833,17 @@ void ROOT::Experimental::RField<TObject>::OnConnectPageSource()
 
 std::uint32_t ROOT::Experimental::RField<TObject>::GetTypeVersion() const
 {
-   return GetClass()->GetClassVersion();
+   return TObject::Class()->GetClassVersion();
 }
 
 void ROOT::Experimental::RField<TObject>::ConstructValue(void *where) const
 {
-   GetClass()->New(where);
+   TObject::Class()->New(where);
 }
 
 void ROOT::Experimental::RField<TObject>::RTObjectDeleter::operator()(void *objPtr, bool dtorOnly)
 {
-   GetClass()->Destructor(objPtr, true /* dtorOnly */);
+   TObject::Class()->Destructor(objPtr, true /* dtorOnly */);
    RDeleter::operator()(objPtr, dtorOnly);
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1771,7 +1771,7 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
 {
-   R__ASSERT(GetClass()->GetClassVersion() == 1);
+   assert(GetClass()->GetClassVersion() == 1);
 
    if (!(GetClass()->ClassProperty() & kClassHasExplicitCtor))
       fTraits |= kTraitTriviallyConstructible;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1768,13 +1768,7 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
 {
-#ifndef NDEBUG
-   static const auto cl = TObject::Class();
-#endif
-   assert(cl->GetClassVersion() == 1);
-   assert(cl->ClassProperty() & kClassHasExplicitCtor);
-   assert(cl->ClassProperty() & kClassHasExplicitDtor);
-   fTraits |= kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   assert(TObject::Class()->GetClassVersion() == 1);
 
    Attach(std::make_unique<RField<UInt_t>>("fUniqueID"));
    Attach(std::make_unique<RField<UInt_t>>("fBits"));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1756,7 +1756,7 @@ void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visit
 
 TClass *ROOT::Experimental::RField<TObject>::GetClass()
 {
-   return TClass::GetClass("TObject");
+   return TObject::Class();
 }
 
 std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *name)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1761,9 +1761,8 @@ TClass *ROOT::Experimental::RField<TObject>::GetClass()
 
 std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *name)
 {
-   for (auto dataMember : ROOT::Detail::TRangeStaticCast<TDataMember>(*GetClass()->GetListOfDataMembers())) {
-      if (strcmp(name, dataMember->GetName()) == 0)
-         return dataMember->GetOffset();
+   if (auto dataMember = GetClass()->GetDataMember(name)) {
+      return dataMember->GetOffset();
    }
    throw RException(R__FAIL('\'' + std::string(name) + '\'' + "is an invalid data member"));
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1576,6 +1576,9 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    if (fClass->Property() & kIsDefinedInStd) {
       throw RException(R__FAIL(std::string(className) + " is not supported"));
    }
+   if (className == "TObject") {
+      throw RException(R__FAIL("TObject is only supported through RField<TObject>"));
+   }
    if (fClass->GetCollectionProxy()) {
       throw RException(
          R__FAIL(std::string(className) + " has an associated collection proxy; use RProxiedCollectionField instead"));

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -142,6 +142,35 @@ void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const RFieldBase &f
    fOutput << "]";
 }
 
+void ROOT::Experimental::RPrintValueVisitor::PrintRecord(const RFieldBase &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << "{";
+   auto elems = field.SplitValue(fValue);
+   for (auto iValue = elems.begin(); iValue != elems.end();) {
+      if (!fPrintOptions.fPrintSingleLine)
+         fOutput << std::endl;
+
+      RPrintOptions options;
+      options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
+      RPrintValueVisitor visitor(*iValue, fOutput, fLevel + 1, options);
+      iValue->GetField().AcceptVisitor(visitor);
+
+      if (++iValue == elems.end()) {
+         if (!fPrintOptions.fPrintSingleLine)
+            fOutput << std::endl;
+         break;
+      } else {
+         fOutput << ",";
+         if (fPrintOptions.fPrintSingleLine)
+            fOutput << " ";
+      }
+   }
+   PrintIndent();
+   fOutput << "}";
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitField(const RFieldBase &field)
 {
    PrintIndent();
@@ -304,61 +333,17 @@ void ROOT::Experimental::RPrintValueVisitor::VisitArrayAsRVecField(const RArrayA
 
 void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &field)
 {
-   PrintIndent();
-   PrintName(field);
-   fOutput << "{";
-   auto elems = field.SplitValue(fValue);
-   for (auto iValue = elems.begin(); iValue != elems.end();) {
-      if (!fPrintOptions.fPrintSingleLine)
-         fOutput << std::endl;
-
-      RPrintOptions options;
-      options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
-      RPrintValueVisitor visitor(*iValue, fOutput, fLevel + 1, options);
-      iValue->GetField().AcceptVisitor(visitor);
-
-      if (++iValue == elems.end()) {
-         if (!fPrintOptions.fPrintSingleLine)
-            fOutput << std::endl;
-         break;
-      } else {
-         fOutput << ",";
-         if (fPrintOptions.fPrintSingleLine)
-           fOutput << " ";
-      }
-   }
-   PrintIndent();
-   fOutput << "}";
+   PrintRecord(field);
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitTObjectField(const RTObjectField &field)
+{
+   PrintRecord(field);
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField &field)
 {
-   PrintIndent();
-   PrintName(field);
-   fOutput << "{";
-   auto elems = field.SplitValue(fValue);
-   for (auto iValue = elems.begin(); iValue != elems.end(); ) {
-      if (!fPrintOptions.fPrintSingleLine)
-         fOutput << std::endl;
-
-      RPrintOptions options;
-      options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
-      RPrintValueVisitor visitor(*iValue, fOutput, fLevel + 1, options);
-      iValue->GetField().AcceptVisitor(visitor);
-
-      if (++iValue == elems.end()) {
-         if (!fPrintOptions.fPrintSingleLine)
-            fOutput << std::endl;
-         break;
-      } else {
-         fOutput << ",";
-         if (fPrintOptions.fPrintSingleLine)
-           fOutput << " ";
-      }
-   }
-   PrintIndent();
-   fOutput << "}";
+   PrintRecord(field);
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableField &field)

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -336,7 +336,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &
    PrintRecord(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitTObjectField(const RTObjectField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitTObjectField(const RField<TObject> &field)
 {
    PrintRecord(field);
 }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -51,7 +51,7 @@ ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)
 
 ROOT_ADD_GTEST(rfield_blob rfield_blob.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(rfield_check rfield_check.cxx LIBRARIES ROOTNTuple CustomStruct)
-ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct Physics)
 ROOT_ADD_GTEST(rfield_string rfield_string.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_variant rfield_variant.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_vector rfield_vector.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -2,6 +2,7 @@
 #define ROOT7_RNTuple_Test_CustomStruct
 
 #include <RtypesCore.h> // for Double32_t
+#include <TObject.h>
 #include <TRootIOCtor.h>
 
 #include <chrono>
@@ -244,6 +245,19 @@ struct DuplicateBaseC : public BaseA {
 
 struct DuplicateBaseD : public DuplicateBaseB, public DuplicateBaseC {
    float d = 0.0;
+};
+
+class Left {
+public:
+   float x = 1.0;
+   virtual ~Left() = default;
+   ClassDef(Left, 1)
+};
+
+class DerivedFromLeftAndTObject : public Left, public TObject {
+public:
+   virtual ~DerivedFromLeftAndTObject() = default;
+   ClassDef(DerivedFromLeftAndTObject, 1)
 };
 
 #endif

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -257,7 +257,7 @@ public:
 class DerivedFromLeftAndTObject : public Left, public TObject {
 public:
    virtual ~DerivedFromLeftAndTObject() = default;
-   ClassDef(DerivedFromLeftAndTObject, 1)
+   ClassDefOverride(DerivedFromLeftAndTObject, 1)
 };
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -1,9 +1,5 @@
 #ifdef __CINT__
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
 #pragma link C++ enum CustomEnum;
 #pragma link C++ enum CustomEnumInt8;
 #pragma link C++ enum CustomEnumUInt8;
@@ -81,5 +77,8 @@
 #pragma link C++ class DuplicateBaseB + ;
 #pragma link C++ class DuplicateBaseC + ;
 #pragma link C++ class DuplicateBaseD + ;
+
+#pragma link C++ class Left + ;
+#pragma link C++ class DerivedFromLeftAndTObject + ;
 
 #endif

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -140,6 +140,8 @@ TEST(RTNuple, TObjectDerived)
       auto ptrRotation = model->MakeField<TRotation>("rotation");
       ptrRotation->RotateX(TMath::Pi());
       ptrRotation->SetUniqueID(137);
+      auto ptrMultiple = model->MakeField<DerivedFromLeftAndTObject>("derived");
+      ptrMultiple->SetUniqueID(137);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
    }
@@ -148,7 +150,12 @@ TEST(RTNuple, TObjectDerived)
    EXPECT_EQ(1u, reader->GetNEntries());
 
    auto ptrRotation = reader->GetModel().GetDefaultEntry().GetPtr<TRotation>("rotation");
+   auto ptrMultiple = reader->GetModel().GetDefaultEntry().GetPtr<DerivedFromLeftAndTObject>("derived");
    reader->LoadEntry(0);
+
    EXPECT_DOUBLE_EQ(1.0, ptrRotation->XX());
    EXPECT_EQ(137u, ptrRotation->GetUniqueID());
+
+   EXPECT_FLOAT_EQ(1.0, ptrMultiple->x);
+   EXPECT_EQ(137u, ptrMultiple->GetUniqueID());
 }

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -138,6 +138,8 @@ TEST(RTNuple, TObjectDerived)
 
    {
       auto model = RNTupleModel::Create();
+      // The choice of TRotation is arbitrary; it is a simple, existing class that inherits from TObject
+      // and is supported by RNTuple
       auto ptrRotation = model->MakeField<TRotation>("rotation");
       ptrRotation->RotateX(TMath::Pi());
       ptrRotation->SetUniqueID(137);

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -73,6 +73,8 @@ TEST(RTNuple, TObject)
       entry->BindRawPtr("obj", heapObj.get());
       writer->Fill(*entry);
 
+      // Saving a destructed object is here to verify that the RNTuple serialization does the same than
+      // the TObject custom streamer (i.e., ignoring the kNotDeleted flag)
       heapObj->~TObject();
       EXPECT_FALSE(heapObj->TestBit(TObject::kNotDeleted));
       writer->Fill(*entry);

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -1,8 +1,9 @@
 #include "ntuple_test.hxx"
 
+#include <TMath.h>
 #include <TObject.h>
 #include <TRef.h>
-#include <TVector2.h>
+#include <TRotation.h>
 
 #include <memory>
 #include <sstream>
@@ -136,10 +137,9 @@ TEST(RTNuple, TObjectDerived)
 
    {
       auto model = RNTupleModel::Create();
-      auto ptrVector2 = model->MakeField<TVector2>("vector2");
-      ptrVector2->SetX(1.0);
-      ptrVector2->SetY(2.0);
-      ptrVector2->SetUniqueID(137);
+      auto ptrRotation = model->MakeField<TRotation>("rotation");
+      ptrRotation->RotateX(TMath::Pi());
+      ptrRotation->SetUniqueID(137);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
    }
@@ -147,9 +147,8 @@ TEST(RTNuple, TObjectDerived)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    EXPECT_EQ(1u, reader->GetNEntries());
 
-   auto ptrVector2 = reader->GetModel().GetDefaultEntry().GetPtr<TVector2>("vector2");
+   auto ptrRotation = reader->GetModel().GetDefaultEntry().GetPtr<TRotation>("rotation");
    reader->LoadEntry(0);
-   EXPECT_DOUBLE_EQ(1.0, ptrVector2->X());
-   EXPECT_DOUBLE_EQ(2.0, ptrVector2->Y());
-   EXPECT_EQ(137u, ptrVector2->GetUniqueID());
+   EXPECT_DOUBLE_EQ(1.0, ptrRotation->XX());
+   EXPECT_EQ(137u, ptrRotation->GetUniqueID());
 }

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -2,6 +2,7 @@
 
 #include <TObject.h>
 #include <TRef.h>
+#include <TVector2.h>
 
 #include <sstream>
 
@@ -122,4 +123,28 @@ TEST(RTNuple, TObject)
    std::ostringstream os;
    reader->Show(0, os);
    EXPECT_EQ(expected, os.str());
+}
+
+TEST(RTNuple, TObjectDerived)
+{
+   FileRaii fileGuard("test_ntuple_tobject_derived.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrVector2 = model->MakeField<TVector2>("vector2");
+      ptrVector2->SetX(1.0);
+      ptrVector2->SetY(2.0);
+      ptrVector2->SetUniqueID(137);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+
+   auto ptrVector2 = reader->GetModel().GetDefaultEntry().GetPtr<TVector2>("vector2");
+   reader->LoadEntry(0);
+   EXPECT_DOUBLE_EQ(1.0, ptrVector2->X());
+   EXPECT_DOUBLE_EQ(2.0, ptrVector2->Y());
+   EXPECT_EQ(137u, ptrVector2->GetUniqueID());
 }

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -58,6 +58,7 @@ TEST(RNTuple, DiamondInheritance)
 
 TEST(RTNuple, TObject)
 {
+   // Ensure that TObject cannot be accidentally handled through the generic RClassField field
    EXPECT_THROW(std::make_unique<ROOT::Experimental::RClassField>("obj", "TObject"), RException);
 
    FileRaii fileGuard("test_ntuple_tobject.root");

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -85,9 +85,6 @@ TEST(RTNuple, TObject)
       EXPECT_FALSE(stackObj.TestBit(TObject::kIsOnHeap));
       entry->BindRawPtr("obj", &stackObj);
       writer->Fill(*entry);
-
-      stackObj.SetBit(TObject::kIsReferenced);
-      EXPECT_THROW(writer->Fill(*entry), RException);
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
@@ -113,10 +110,44 @@ TEST(RTNuple, TObject)
    EXPECT_EQ(0u, heapObj->GetUniqueID());
    EXPECT_TRUE(heapObj->TestBit(TObject::kIsOnHeap));
    EXPECT_TRUE(heapObj->TestBit(TObject::kNotDeleted));
+}
 
-   heapObj->SetBit(TObject::kIsReferenced);
-   EXPECT_THROW(reader->LoadEntry(2, *entry), RException);
+TEST(RTNuple, TObjectReferenced)
+{
+   // RNTuple does not support reading nor writing of TObject objects that are marked as referenced
+   FileRaii fileGuard("test_ntuple_tobject_referenced.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrObject = model->MakeField<TObject>("obj");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
 
+      ptrObject->SetBit(TObject::kIsReferenced);
+      EXPECT_THROW(writer->Fill(), RException);
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+   auto ptrObject = reader->GetModel().GetDefaultEntry().GetPtr<TObject>("obj");
+
+   reader->LoadEntry(0);
+   EXPECT_EQ(0u, ptrObject->GetUniqueID());
+   ptrObject->SetBit(TObject::kIsReferenced);
+   EXPECT_THROW(reader->LoadEntry(0), RException);
+}
+
+TEST(RTNuple, TObjectShow)
+{
+   FileRaii fileGuard("test_ntuple_tobject_show.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrObject = model->MakeField<TObject>("obj");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      ptrObject->SetUniqueID(137);
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    // clang-format off
    std::string expected{
       "{\n"

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -4,6 +4,7 @@
 #include <TRef.h>
 #include <TVector2.h>
 
+#include <memory>
 #include <sstream>
 
 namespace {
@@ -56,6 +57,8 @@ TEST(RNTuple, DiamondInheritance)
 
 TEST(RTNuple, TObject)
 {
+   EXPECT_THROW(std::make_unique<ROOT::Experimental::RClassField>("obj", "TObject"), RException);
+
    FileRaii fileGuard("test_ntuple_tobject.root");
    {
       auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -1,5 +1,10 @@
 #include "ntuple_test.hxx"
 
+#include <TObject.h>
+#include <TRef.h>
+
+#include <sstream>
+
 namespace {
 class RNoDictionary {};
 } // namespace
@@ -46,4 +51,75 @@ TEST(RNTuple, DiamondInheritance)
    EXPECT_FLOAT_EQ(2.0, d->b);
    EXPECT_FLOAT_EQ(3.0, d->c);
    EXPECT_FLOAT_EQ(4.0, d->d);
+}
+
+TEST(RTNuple, TObject)
+{
+   FileRaii fileGuard("test_ntuple_tobject.root");
+   {
+      auto model = RNTupleModel::Create();
+      model->MakeField<TObject>("obj");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      auto entry = writer->GetModel().CreateBareEntry();
+
+      auto heapObj = std::make_unique<TObject>();
+      EXPECT_TRUE(heapObj->TestBit(TObject::kIsOnHeap));
+      EXPECT_TRUE(heapObj->TestBit(TObject::kNotDeleted));
+      heapObj->SetUniqueID(137);
+      entry->BindRawPtr("obj", heapObj.get());
+      writer->Fill(*entry);
+
+      heapObj->~TObject();
+      EXPECT_FALSE(heapObj->TestBit(TObject::kNotDeleted));
+      writer->Fill(*entry);
+
+      TObject stackObj;
+      EXPECT_FALSE(stackObj.TestBit(TObject::kIsOnHeap));
+      entry->BindRawPtr("obj", &stackObj);
+      writer->Fill(*entry);
+
+      stackObj.SetBit(TObject::kIsReferenced);
+      EXPECT_THROW(writer->Fill(*entry), RException);
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(3u, reader->GetNEntries());
+
+   auto entry = reader->GetModel().CreateBareEntry();
+   TObject stackObj;
+   entry->BindRawPtr("obj", &stackObj);
+
+   reader->LoadEntry(0, *entry);
+   EXPECT_EQ(137u, stackObj.GetUniqueID());
+   EXPECT_FALSE(stackObj.TestBit(TObject::kIsOnHeap));
+   EXPECT_TRUE(stackObj.TestBit(TObject::kNotDeleted));
+
+   reader->LoadEntry(1, *entry);
+   EXPECT_EQ(137u, stackObj.GetUniqueID());
+   EXPECT_FALSE(stackObj.TestBit(TObject::kIsOnHeap));
+   EXPECT_TRUE(stackObj.TestBit(TObject::kNotDeleted));
+
+   auto heapObj = std::make_unique<TObject>();
+   entry->BindRawPtr("obj", heapObj.get());
+   reader->LoadEntry(2, *entry);
+   EXPECT_EQ(0u, heapObj->GetUniqueID());
+   EXPECT_TRUE(heapObj->TestBit(TObject::kIsOnHeap));
+   EXPECT_TRUE(heapObj->TestBit(TObject::kNotDeleted));
+
+   heapObj->SetBit(TObject::kIsReferenced);
+   EXPECT_THROW(reader->LoadEntry(2, *entry), RException);
+
+   // clang-format off
+   std::string expected{
+      "{\n"
+      "  \"obj\": {\n"
+      "    \"fUniqueID\": 137,\n"
+      "    \"fBits\": 33554432\n"
+      "  }\n"
+      "}\n"
+   };
+   // clang-format on
+   std::ostringstream os;
+   reader->Show(0, os);
+   EXPECT_EQ(expected, os.str());
 }


### PR DESCRIPTION
Implement special treatment for fBits. Disable RNTuple I/O for referenced objects. Locks I/O support for TObject to class version 1, assuming that TObject won't further evolve.

Fixes #14808