### PR TITLE
[ntuple] forbid RClassField I/O of unsplittable classes

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -841,6 +841,7 @@ User defined C++ classes are supported with the following limitations
   - All persistent members and base classes must be themselves types with RNTuple I/O support
   - Transient members must be marked by a `//!` comment
   - The class must not be in the `std` namespace
+  - The class must be empty or splittable (e.g., the class must not provide a custom streamer)
   - There is no support for polymorphism,
     i.e. a field of class `A` cannot store class `B` that derives from `A`
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1483,6 +1483,10 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       throw RException(
          R__FAIL(std::string(className) + " has an associated collection proxy; use RProxiedCollectionField instead"));
    }
+   // Classes with, e.g., custom streamers are not supported through this field. Empty classes, however, are.
+   if (!fClass->CanSplit() && fClass->Size() > 1) {
+      throw RException(R__FAIL(std::string(className) + " cannot be split"));
+   }
 
    if (!(fClass->ClassProperty() & kClassHasExplicitCtor))
       fTraits |= kTraitTriviallyConstructible;

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -11,6 +11,9 @@ TEST(RNTuple, TClass) {
    auto model = RNTupleModel::Create();
    auto ptrKlass = model->MakeField<CustomStruct>("klass");
 
+   // TDatime would be a supported class layout but it is unsplittable due to its custom streamer
+   EXPECT_THROW(model->MakeField<TDatime>("datime"), RException);
+
    FileRaii fileGuard("test_ntuple_tclass.root");
    auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
 }


### PR DESCRIPTION
Fixes #14809 

Note that support for unsplittable classes will be reintroduced through the `RUnsplitField` (#14728).