### PR TITLE
[cmake] Remove deprecated `minuit2` build option

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -66,7 +66,6 @@ macos_native=OFF
 mathmore=ON
 memory_termination=OFF
 minimal=OFF
-minuit2=ON
 monalisa=OFF
 mpi=OFF
 mysql=ON

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -140,7 +140,6 @@ ROOT_BUILD_OPTION(libcxx OFF "Build using libc++")
 ROOT_BUILD_OPTION(macos_native OFF "Disable looking for libraries, includes and binaries in locations other than a native installation (MacOS only)")
 ROOT_BUILD_OPTION(mathmore OFF "Build libMathMore extended math library (requires GSL) [GPL]")
 ROOT_BUILD_OPTION(memory_termination OFF "Free internal ROOT memory before process termination (experimental, used for leak checking)")
-ROOT_BUILD_OPTION(minuit2 IGNORE "Build Minuit2 minimization library (deprecated, Minuit2 is always built)")
 ROOT_BUILD_OPTION(minuit2_mpi OFF "Enable support for MPI in Minuit2")
 ROOT_BUILD_OPTION(minuit2_omp OFF "Enable support for OpenMP in Minuit2")
 ROOT_BUILD_OPTION(mpi OFF "Enable support for Message Passing Interface (MPI)")
@@ -403,7 +402,7 @@ endif()
 #---Removed options------------------------------------------------------------
 foreach(opt afdsmgrd afs alien bonjour castor chirp cxx11 cxx14 cxx17
         exceptions geocad gfal glite globus gsl_shared hdfs ios jemalloc krb5
-        ldap memstat monalisa oracle pyroot-python2 pyroot_legacy python qt
+        ldap memstat minuit2 monalisa oracle pyroot-python2 pyroot_legacy python qt
         qtgsi rfio ruby sapdb srp table tcmalloc vmc xproofd)
   if(${opt})
     message(FATAL_ERROR ">>> Option '${opt}' is no longer supported in ROOT ${ROOT_VERSION}.")
@@ -417,7 +416,7 @@ foreach(opt cxxmodules pythia6 pythia6_nolink)
   endif()
 endforeach()
 
-foreach(opt builtin_afterimage minuit2)
+foreach(opt builtin_afterimage)
   if(NOT ${opt})
     message(DEPRECATION ">>> Option '${opt}' is deprecated: in the future it will always be set to ON. In the next release of ROOT, you will no longer be able to disable this feature. Please contact root-dev@cern.ch should you still need disabling it.")
   endif()

--- a/math/mathmore/test/CMakeLists.txt
+++ b/math/mathmore/test/CMakeLists.txt
@@ -38,11 +38,6 @@ if(unuran)
   add_definitions(-DHAVE_UNURAN)
 endif()
 
-if(minuit2)
-  list(APPEND TestSource fit/testMinim.cxx)
-  list(APPEND Libraries Minuit2)
-endif()
-
 #some tests requires directly gsl
 include_directories(${GSL_INCLUDE_DIR})
 add_definitions(-DHAVE_ROOTLIBS)

--- a/roofit/roostats/test/CMakeLists.txt
+++ b/roofit/roostats/test/CMakeLists.txt
@@ -17,7 +17,7 @@ ROOT_ADD_TEST(test-stressroostats-cpu COMMAND stressRooStats -b cpu FAILREGEX "F
 if(cuda)
   ROOT_ADD_TEST(test-stressroostats-cuda COMMAND stressRooStats -b cuda FAILREGEX "FAILED|Error in" LABELS longtest)
 endif()
-if(roofit_legacy_eval_backend AND minuit2)
+if(roofit_legacy_eval_backend)
   ROOT_ADD_TEST(test-stressroostats-legacy-minuit2 COMMAND stressRooStats -minim Minuit2 -b legacy FAILREGEX "FAILED|Error in" LABELS longtest)
 endif()
 ROOT_ADD_TEST(test-stressroostats-cpu-minuit2 COMMAND stressRooStats -minim Minuit2 -b cpu FAILREGEX "FAILED|Error in" LABELS longtest)


### PR DESCRIPTION
The `minuit2` build option was deprecated in ROOT 6.30 and should be
removed for ROOT 6.32. Minuit 2 is now always built.