### PR TITLE
[DF] Add support for RNTupleHeadNode for the distributed RDF

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Ranges.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Ranges.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from itertools import accumulate
 from math import floor
 
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from DistRDF._graph_cache import ExecutionIdentifier
@@ -127,6 +127,23 @@ class TaskTreeEntries:
     processed_entries: int = 0
     trees_with_entries: Dict[str, int] = field(default_factory=dict)
 
+@dataclass
+class RNTupleFileRange(DataRange):
+    ntuplename: str
+    filenames: List[str] = field(default_factory=list)
+
+def split_equal_size(filenames: Iterable[str], npartitions: int):
+    """Function to split the list of filenames into exactly N chunks of approximately equal size."""
+    quotient, remainder = divmod(len(filenames), npartitions)
+    return (filenames[i*quotient+min(i, remainder):(i+1)*quotient+min(i+1, remainder)] for i in range(npartitions))
+
+def get_ntuple_ranges(ntuplename, filenames, npartitions, exec_id):
+
+    files_by_partition = split_equal_size(filenames, npartitions)
+    return [
+        RNTupleFileRange(exec_id, range_id, ntuplename, files_in_partition)
+        for range_id, files_in_partition in enumerate(files_by_partition)
+    ]
 
 def get_balanced_ranges(nentries, npartitions, exec_id: ExecutionIdentifier):
     """


### PR DESCRIPTION
This is a very quick fix in order to test the distributed RDF with RNTuples. It was locally tested with some tutorials and AGC, but no tests are added yet (to be done soon). 

