### PR TITLE
[ntuple] Enable binding view to external memory

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -97,6 +97,8 @@ private:
    RNTupleReader *GetDisplayReader();
    void InitPageSource();
 
+   DescriptorId_t RetrieveFieldId(std::string_view fieldName) const;
+
 public:
    // Browse through the entries
    class RIterator {
@@ -270,20 +272,27 @@ public:
    /// }
    /// ~~~
    template <typename T>
-   RNTupleView<T> GetView(std::string_view fieldName)
+   RNTupleView<T, false> GetView(std::string_view fieldName)
    {
-      auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName);
-      if (fieldId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
-                                  fSource->GetSharedDescriptorGuard()->GetName() + "'"));
-      }
-      return GetView<T>(fieldId);
+      return GetView<T>(RetrieveFieldId(fieldName));
    }
 
    template <typename T>
-   RNTupleView<T> GetView(DescriptorId_t fieldId)
+   RNTupleView<T, true> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
    {
-      return RNTupleView<T>(fieldId, fSource.get());
+      return GetView<T>(RetrieveFieldId(fieldName), objPtr);
+   }
+
+   template <typename T>
+   RNTupleView<T, false> GetView(DescriptorId_t fieldId)
+   {
+      return RNTupleView<T, false>(fieldId, fSource.get());
+   }
+
+   template <typename T>
+   RNTupleView<T, true> GetView(DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
+   {
+      return RNTupleView<T, true>(fieldId, fSource.get(), objPtr);
    }
 
    /// Raises an exception if:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -172,6 +172,15 @@ struct RNTupleLocator {
    }
 };
 
+namespace Internal {
+template <typename T>
+auto MakeAliasedSharedPtr(T *rawPtr)
+{
+   const static std::shared_ptr<T> fgRawPtrCtrlBlock;
+   return std::shared_ptr<T>(fgRawPtrCtrlBlock, rawPtr);
+}
+} // namespace Internal
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -340,10 +340,9 @@ ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
 
 void ROOT::Experimental::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 {
-   /// Empty shared pointer, used as the basis for the aliasing shared pointer constructor around rawPtr.
-   /// Note that as a result of BindRawPtr, fObjPtr will be non-empty but have use count zero.
-   static std::shared_ptr<void> fgRawPtrCtrlBlock;
-   fObjPtr = std::shared_ptr<void>(fgRawPtrCtrlBlock, rawPtr);
+   // Set fObjPtr to an aliased shared_ptr of the input raw pointer. Note that
+   // fObjPtr will be non-empty but have use count zero.
+   fObjPtr = ROOT::Experimental::Internal::MakeAliasedSharedPtr(rawPtr);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -228,3 +228,13 @@ const ROOT::Experimental::RNTupleDescriptor &ROOT::Experimental::RNTupleReader::
       fCachedDescriptor = descriptorGuard->Clone();
    return *fCachedDescriptor;
 }
+
+ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleReader::RetrieveFieldId(std::string_view fieldName) const
+{
+   auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName);
+   if (fieldId == kInvalidDescriptorId) {
+      throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
+                               fSource->GetSharedDescriptorGuard()->GetName() + "'"));
+   }
+   return fieldId;
+}

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -258,3 +258,107 @@ TEST(RNTuple, MissingViewNames)
       EXPECT_THAT(err.what(), testing::HasSubstr("no field named 'badC' in RNTuple 'myNTuple'"));
    }
 }
+
+TEST(RNTuple, ViewWithExternalAddress)
+{
+   FileRaii fileGuard("test_ntuple_viewexternal.root");
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float>("pt", 42.0);
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   // Typed shared_ptr
+   auto data_1 = std::make_shared<float>();
+   auto view_1 = reader->GetView("pt", data_1);
+   view_1(0);
+   EXPECT_FLOAT_EQ(42.0, *data_1);
+
+   // Void shared_ptr
+   std::shared_ptr<void> data_2{new float()};
+   auto view_2 = reader->GetView("pt", data_2);
+   view_2(0);
+   EXPECT_FLOAT_EQ(42.0, *static_cast<float *>(data_2.get()));
+}
+
+TEST(RNTuple, BindEmplaceTyped)
+{
+   FileRaii fileGuard("test_ntuple_bindvalueemplacetyped.root");
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float>("pt");
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      *fieldPt = 11.f;
+      writer->Fill();
+      *fieldPt = 22.f;
+      writer->Fill();
+      *fieldPt = 33.f;
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   // bind to shared_ptr
+   auto value1 = std::make_shared<float>();
+   auto view = reader->GetView<float>("pt", nullptr);
+   view.Bind(value1);
+   view(0);
+   EXPECT_FLOAT_EQ(11.f, *value1);
+
+   // bind to raw pointer
+   float value2;
+   view.BindRawPtr(&value2);
+   view(1);
+   EXPECT_FLOAT_EQ(22.f, value2);
+
+   // emplace new value
+   view.EmplaceNew();
+   EXPECT_FLOAT_EQ(33.f, view(2));
+   EXPECT_FLOAT_EQ(22.f, value2); // The previous value was not modified
+}
+
+TEST(RNTuple, BindEmplaceVoid)
+{
+   FileRaii fileGuard("test_ntuple_bindvalueemplacevoid.root");
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float>("pt");
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      *fieldPt = 11.f;
+      writer->Fill();
+      *fieldPt = 22.f;
+      writer->Fill();
+      *fieldPt = 33.f;
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   // bind to shared_ptr
+   std::shared_ptr<void> value1{new float()};
+   auto view = reader->GetView<void>("pt", nullptr);
+   view.Bind(value1);
+   view(0);
+   EXPECT_FLOAT_EQ(11.f, *reinterpret_cast<float *>(value1.get()));
+
+   // bind to raw pointer
+   float value2;
+   view.BindRawPtr(&value2);
+   view(1);
+   EXPECT_FLOAT_EQ(22.f, value2);
+
+   // emplace new value
+   view.EmplaceNew();
+   view(2);
+   EXPECT_FLOAT_EQ(33.f, view.GetValue().GetRef<float>());
+   EXPECT_FLOAT_EQ(22.f, value2); // The previous value was not modified
+}


### PR DESCRIPTION
Enable an ATLAS use case where the reading pattern is to read one specific entry of one specific field into a previously allocated memory location. Using the RNTupleView ensures only that field is actually read from disk.


@Nowakus FYI