### PR TITLE
Allow user-defined safety to be drawn in TGeoManager::CheckPoint

### DIFF
--- a/geom/geom/inc/TGeoManager.h
+++ b/geom/geom/inc/TGeoManager.h
@@ -252,7 +252,7 @@ public:
                           Option_t *option = "ob"); // *MENU*
    void CheckGeometry(Option_t *option = "");
    void CheckOverlaps(Double_t ovlp = 0.1, Option_t *option = "");                         // *MENU*
-   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = ""); // *MENU*
+   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "", Double_t safety = 0.); // *MENU*
    void CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option);
    void ConvertReflections();
    void DrawCurrentPoint(Int_t color = 2); // *MENU*

--- a/geom/geom/inc/TVirtualGeoPainter.h
+++ b/geom/geom/inc/TVirtualGeoPainter.h
@@ -58,7 +58,7 @@ public:
    virtual TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *particle) = 0;
    virtual void AddTrackPoint(Double_t *point, Double_t *box, Bool_t reset = kFALSE) = 0;
    virtual void BombTranslation(const Double_t *tr, Double_t *bombtr) = 0;
-   virtual void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "") = 0;
+   virtual void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "", Double_t safety = 0.) = 0;
    virtual void CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) = 0;
    virtual void CheckBoundaryErrors(Int_t ntracks = 1000000, Double_t radius = -1.) = 0;
    virtual void CheckBoundaryReference(Int_t icheck = -1) = 0;

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -210,7 +210,9 @@ from the painting package.
 This method is drawing the daughters of the volume containing the point one
 level down, printing the path to the deepest physical node holding this point.
 It also computes the closest distance to any boundary. The point will be drawn
-in red.
+in red, as well as a sphere having this closest distance as radius. In case a
+non-zero distance is given by the user as fifth argument of CheckPoint, this
+distance will be used as radius of the safety sphere.
 
 \image html geom_checkpoint.jpg
 
@@ -3765,9 +3767,9 @@ void TGeoManager::CheckBoundaryReference(Int_t icheck)
 ////////////////////////////////////////////////////////////////////////////////
 /// Classify a given point. See TGeoChecker::CheckPoint().
 
-void TGeoManager::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *option)
+void TGeoManager::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *option, Double_t safety)
 {
-   GetGeomPainter()->CheckPoint(x, y, z, option);
+   GetGeomPainter()->CheckPoint(x, y, z, option, safety);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geompainter/inc/TGeoChecker.h
+++ b/geom/geompainter/inc/TGeoChecker.h
@@ -70,7 +70,7 @@ public:
    void CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const;
    void CheckOverlaps(const TGeoVolume *vol, Double_t ovlp = 0.1, Option_t *option = "");
    void CheckOverlapsBySampling(TGeoVolume *vol, Double_t ovlp = 0.1, Int_t npoints = 1000000) const;
-   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "");
+   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "", Double_t safety = 0.);
    void CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option);
    Double_t CheckVoxels(TGeoVolume *vol, TGeoVoxelFinder *voxels, Double_t *xyz, Int_t npoints);
    TH2F *LegoPlot(Int_t ntheta = 60, Double_t themin = 0., Double_t themax = 180., Int_t nphi = 90,

--- a/geom/geompainter/inc/TGeoPainter.h
+++ b/geom/geompainter/inc/TGeoPainter.h
@@ -89,7 +89,7 @@ public:
                           const Double_t *vertex = nullptr) override;
    void CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const override;
    void CheckEdit();
-   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "") override;
+   void CheckPoint(Double_t x = 0, Double_t y = 0, Double_t z = 0, Option_t *option = "", Double_t safety = 0.) override;
    void CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) override;
    void CheckOverlaps(const TGeoVolume *vol, Double_t ovlp = 0.1, Option_t *option = "") const override;
    Int_t CountNodes(TGeoVolume *vol, Int_t level) const;

--- a/geom/geompainter/src/TGeoChecker.cxx
+++ b/geom/geompainter/src/TGeoChecker.cxx
@@ -1689,7 +1689,7 @@ void TGeoChecker::PrintOverlaps() const
 /// Generates a report regarding the path to the node containing this point and the distance to
 /// the closest boundary.
 
-void TGeoChecker::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *)
+void TGeoChecker::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *, Double_t safety)
 {
    Double_t point[3];
    Double_t local[3];
@@ -1712,7 +1712,7 @@ void TGeoChecker::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *)
    if (node)
       vol = node->GetVolume();
    // compute safety distance (distance to boundary ignored)
-   Double_t close = fGeoManager->Safety();
+   Double_t close = (safety > 0.) ? safety : fGeoManager->Safety();
    printf("Safety radius : %f\n", close);
    if (close > 1E-4) {
       TGeoVolume *sph = fGeoManager->MakeSphere("SAFETY", vol->GetMedium(), 0, close, 0, 180, 0, 360);

--- a/geom/geompainter/src/TGeoPainter.cxx
+++ b/geom/geompainter/src/TGeoPainter.cxx
@@ -239,9 +239,9 @@ void TGeoPainter::CheckOverlaps(const TGeoVolume *vol, Double_t ovlp, Option_t *
 ////////////////////////////////////////////////////////////////////////////////
 /// Check current point in the geometry.
 
-void TGeoPainter::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *option)
+void TGeoPainter::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *option, Double_t safety)
 {
-   fChecker->CheckPoint(x, y, z, option);
+   fChecker->CheckPoint(x, y, z, option, safety);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/webviewer/inc/ROOT/RGeoPainter.hxx
+++ b/geom/webviewer/inc/ROOT/RGeoPainter.hxx
@@ -32,7 +32,7 @@ public:
    TVirtualGeoTrack *AddTrack(Int_t, Int_t, TObject *) override { return nullptr; }
    void       AddTrackPoint(Double_t *, Double_t *, Bool_t =kFALSE) override {}
    void       BombTranslation(const Double_t *, Double_t *) override {}
-   void       CheckPoint(Double_t =0, Double_t =0, Double_t =0, Option_t * ="") override {}
+   void       CheckPoint(Double_t =0, Double_t =0, Double_t =0, Option_t * ="", Double_t = 0.) override {}
    void       CheckShape(TGeoShape *, Int_t, Int_t, Option_t *) override {}
    void       CheckBoundaryErrors(Int_t =1000000, Double_t =-1.) override {}
    void       CheckBoundaryReference(Int_t =-1) override {}


### PR DESCRIPTION
# This Pull request:
Adds an optional safety parameter to : `TGeoManager::CheckPoint(Double_t x, Double_t y, Double_t z, Option_t *option, Double_t safety)`
## Changes or fixes:
Backward-compatible interface change, allowing the user to inspect if a given distance is safe (not touching the volume surfaces neighbouring a point)

```cpp
gGeoManager->CheckPoint(4.00457, -62.4337, 4.46698);
===  Check current point : (4.00457, -62.4337, 4.46698) ===
  - path : /TOP_1
Safety radius : 35.433700
```

![root_arb8](https://github.com/root-project/root/assets/18400453/133e7f2e-a20b-4c89-b4c7-5587ba50df84)

```cpp
gGeoManager->CheckPoint(4.00457, -62.4337, 4.46698, "", 31.067 /*user-defined*/)
===  Check current point : (4.00457, -62.4337, 4.46698) ===
  - path : /TOP_1
Safety radius : 31.067000
```
![surface](https://github.com/root-project/root/assets/18400453/425f7b02-24e2-486c-b8a4-0da323d7dd1a)

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary) Updated the class reference

This PR fixes # 

