### PR TITLE
Readjust the representation of CallFunc arguments to match the callee signature

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1446,8 +1446,31 @@ void TClingCallFunc::exec(void *address, void *ret)
             // the argument is already a pointer value (points to the same thing
             // as the reference or pointing to object passed by value.
             vp_ary.push_back(fArgVals[i].getPtr());
-         } else
+         } else {
+            // Check if arguments need readjusting. This can happen if we called
+            // cling::Value::Create which instantiates to say double but the
+            // function signature requires a float.
+            // FIXME: This is a cheap operation but it could be done in SetArg
+            // but there we are not guaranteed to have the function signature.
+            if (QT->isBuiltinType()) {
+               ASTContext &C = FD->getASTContext();
+               if (!C.hasSameType(QT, fArgVals[i].getType())) {
+                  switch(QT->getAs<BuiltinType>()->getKind()) {
+                  default:
+#ifndef NDEBUG
+                     QT->dump();
+#endif // NDEBUG
+                     assert(false && "Type not supported");
+                     return;
+#define X(type, name)                                   \
+                     case BuiltinType::name: fArgVals[i] = cling::Value::Create(*fInterp, fArgVals[i].castAs<type>()); break;
+                     CLING_VALUE_BUILTIN_TYPES
+#undef X
+                  }
+               }
+            }
             vp_ary.push_back(fArgVals[i].getPtrAddress());
+         }
       }
    } // End of scope holding the lock
    (*fWrapper)(address, (int)num_args, (void **)vp_ary.data(), ret);

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -300,3 +300,27 @@ TEST(TClingCallFunc, ROOT_6523) {
     break;
   }
 }
+
+TEST(TClingCallFunc, GH_14405) {
+  gInterpreter->Declare(R"cpp(
+                          float testfunc(int a, int b, float c) {
+                            return a + b * c;
+                          }
+                          )cpp");
+
+  CallFuncRAII CfRAII("", "testfunc", "int, int, float");
+  CallFunc_t * cf = CfRAII.GetCF();
+  gInterpreter->CallFunc_SetArg(cf, 1);
+  gInterpreter->CallFunc_SetArg(cf, 2);
+  gInterpreter->CallFunc_SetArg(cf, 3.14f);
+  double result = gInterpreter->CallFunc_ExecDouble(cf, /*address=*/0);
+  EXPECT_NEAR(result, 7.28, /*abs_error=*/1e-6);
+
+  gInterpreter->CallFunc_ResetArg(cf);
+
+  gInterpreter->CallFunc_SetArg(cf, 1);
+  gInterpreter->CallFunc_SetArg(cf, 2);
+  gInterpreter->CallFunc_SetArg(cf, 3.14);
+  result = gInterpreter->CallFunc_ExecDouble(cf, /*address=*/0);
+  EXPECT_NEAR(result, 7.28, /*abs_error=*/1e-6);
+}


### PR DESCRIPTION
TClingCallFunc provides an interface between compiled and interpreted code. That is, we can create at compile time a function to be called by the interpreter and get back its result into compiled code. To do that we require connecting to a function declaration available in the interpreter and calling it by setting input arguments. However, the input arguments are set with the SetArg which can resolve to a type and argument representation different from the signature of the interpreter function we will call. This is practically not a problem integral types because their representation is mostly the same. The problem becomes visible when we call SetArg with a `double` and the function signature expects a `float`. That works out of the box when the compiler can see both ends and insert proper representation casts. Unfortunately, when crossing the compiler/interpreter boundary we use `void*` and that information is lost.

This patch adds some representation adjustments so that the compiled code (SetArg) and the interpreted code (CallFunc) can agree on the memory representation before calling.

Fixes #14405