### PR TITLE
[ntuple] Fix size calculation for projected fields

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -138,8 +138,8 @@ private:
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
 
-   std::map<int, RColumnInspector> fColumnInfo;
-   std::map<int, RFieldTreeInspector> fFieldTreeInfo;
+   std::unordered_map<int, RColumnInspector> fColumnInfo;
+   std::unordered_map<int, RFieldTreeInspector> fFieldTreeInfo;
 
    RNTupleInspector(std::unique_ptr<Internal::RPageSource> pageSource);
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -47,6 +47,9 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
    fUncompressedSize = 0;
 
    for (const auto &colDesc : fDescriptor->GetColumnIterable()) {
+      if (colDesc.IsAliasColumn())
+         continue;
+
       auto colId = colDesc.GetPhysicalId();
 
       // We generate the default memory representation for the given column type in order


### PR DESCRIPTION
`RNTupleDescriptor::GetColumnIterable` returns an iterator over all *logical* columns, causing projected fields to be considered as well in the size calculation by the RNTupleInspector. With this fix, projected fields are skipped.

- [x] tested changes locally
- [x] updated the docs (if necessary)
