### PR TITLE
[tmva] Remove supefluous EnableThreadSafety()

### DIFF
--- a/tmva/tmva/inc/TMVA/RBatchGenerator.hxx
+++ b/tmva/tmva/inc/TMVA/RBatchGenerator.hxx
@@ -161,8 +161,6 @@ public:
 
    void LoadChunks()
    {
-      ROOT::EnableThreadSafety();
-
       for (std::size_t current_chunk = 0; ((current_chunk < fMaxChunks) || fUseWholeFile) && fCurrentRow < fNumEntries;
            current_chunk++) {
 


### PR DESCRIPTION
`EnableThreadSafety()` is called in `_batchgenerator.py` making another call for it redundant and `class RBatchGenerator` depends to Internal namespace