### PR TITLE
[gpad] Implement TRatioPlot::RecursiveRemove

### DIFF
--- a/graf2d/gpad/CMakeLists.txt
+++ b/graf2d/gpad/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -58,3 +58,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Gpad
     Graf
     Hist
 )
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/graf2d/gpad/inc/TRatioPlot.h
+++ b/graf2d/gpad/inc/TRatioPlot.h
@@ -139,6 +139,8 @@ protected:
    Bool_t fIsUpdating = kFALSE; ///< Keeps track of whether its currently updating to reject other calls until done
    Bool_t fIsPadUpdating = kFALSE; ///< Keeps track whether pads are updating during resizing
 
+   Bool_t fIsObjectsDrawn = kTRUE; ///<! if created objects are drawn. If not - one have to delete some of them
+
    virtual void SyncAxesRanges();
    virtual void SetupPads();
    virtual void CreateVisualAxes();

--- a/graf2d/gpad/test/CMakeLists.txt
+++ b/graf2d/gpad/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+ROOT_ADD_GTEST(TRatioPlot ratioplot.cxx LIBRARIES Gpad)

--- a/graf2d/gpad/test/ratioplot.cxx
+++ b/graf2d/gpad/test/ratioplot.cxx
@@ -1,0 +1,39 @@
+#include "gtest/gtest.h"
+
+#include "TCanvas.h"
+#include "TRatioPlot.h"
+#include "TH1.h"
+#include "TFile.h"
+
+
+TEST(TRatioPlot, CreateFile)
+{
+   TCanvas c1("c1", "fit residual simple");
+   TH1D h1("h1", "h1", 50, -5, 5);
+   h1.FillRandom("gaus", 2000);
+   h1.Fit("gaus", "0");
+   h1.GetXaxis()->SetTitle("x");
+   TRatioPlot rp1(&h1);
+   rp1.Draw();
+   rp1.GetLowerRefYaxis()->SetTitle("ratio");
+   rp1.GetUpperRefYaxis()->SetTitle("entries");
+
+   auto f = TFile::Open("ratioplot.root", "RECREATE");
+   f->WriteObject(&c1, "ratioplot");
+   delete f;
+}
+
+TEST(TRatioPlot, ReadFile)
+{
+   TCanvas *c1 = nullptr;
+
+   auto f = TFile::Open("ratioplot.root");
+   f->GetObject("ratioplot", c1);
+
+   EXPECT_TRUE(c1 != nullptr);
+
+   delete c1;
+
+   delete f;
+}
+


### PR DESCRIPTION
`TRatioPlot` object was registered in list of cleanups, but recursive remove was not implemented.
Therefore if any internal object was deleted before - it make problem.

Fixes issue #14855
