### PR TITLE
[GUI] Silence TGFileDialog error messages

### DIFF
--- a/gui/gui/src/TGFSContainer.cxx
+++ b/gui/gui/src/TGFSContainer.cxx
@@ -813,7 +813,7 @@ TGFileItem *TGFileContainer::AddFile(const char *name,  const TGPicture *ipic,
    if (gSystem->GetPathInfo(name, sbuf)) {
       if (sbuf.fIsLink) {
          Info("AddFile", "Broken symlink of %s.", name);
-      } else {
+      } else if (errno != ENOENT) {
          TString msg;
          msg.Form("Can't read file attributes of \"%s\": %s.",
                   name, gSystem->GetError());


### PR DESCRIPTION
Silence "Can't read file attributes" with protected system files on Windows.
This addresses the following topic on the Forum:
[TGFileDialog multiple "Can't read file attributes" errors on Windows](https://root-forum.cern.ch/t/tgfiledialog-multiple-cant-read-file-attributes-errors-on-windows/58342)
