### PR TITLE
[io/ntuple] Use RRawFileTFile for non-supported protocols

### DIFF
--- a/io/io/CMakeLists.txt
+++ b/io/io/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 
 ROOT_GENERATE_DICTIONARY(G__RIO
   ROOT/RRawFile.hxx
+  ROOT/RRawFileTFile.hxx
   ${rawfile_local_headers}
   ROOT/TBufferMerger.hxx
   TArchiveFile.h

--- a/io/io/inc/ROOT/RRawFileTFile.hxx
+++ b/io/io/inc/ROOT/RRawFileTFile.hxx
@@ -1,0 +1,57 @@
+// Author: Jonas Hahnfeld
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RRawFileTFile
+#define ROOT_RRawFileTFile
+
+#include <ROOT/RRawFile.hxx>
+
+#include <TFile.h>
+
+#include <stdexcept>
+
+namespace ROOT {
+namespace Internal {
+
+/**
+ * \class RRawFileTFile RRawFileTFile.hxx
+ * \ingroup IO
+ *
+ * The RRawFileTFile wraps an open TFile, but does not take ownership.
+ */
+class RRawFileTFile : public RRawFile {
+private:
+   TFile *fFile;
+
+protected:
+   void OpenImpl() final { fOptions.fBlockSize = 0; }
+
+   size_t ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset) final
+   {
+      if (fFile->ReadBuffer(static_cast<char *>(buffer), offset, nbytes)) {
+         throw std::runtime_error("failed to read expected number of bytes");
+      }
+      return nbytes;
+   }
+
+   std::uint64_t GetSizeImpl() final { return fFile->GetSize(); }
+
+public:
+   RRawFileTFile(TFile *file) : RRawFile(file->GetEndpointUrl()->GetFile(), {}), fFile(file) {}
+
+   std::unique_ptr<ROOT::Internal::RRawFile> Clone() const final { return std::make_unique<RRawFileTFile>(fFile); }
+
+   int GetFeatures() const final { return kFeatureHasSize; }
+};
+
+} // namespace Internal
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -145,6 +145,8 @@ protected:
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);
+   RPageSourceFile(std::string_view ntupleName, std::unique_ptr<ROOT::Internal::RRawFile> file,
+                   const RNTupleReadOptions &options);
    /// Used from the RNTuple class to build a datasource if the anchor is already available.
    /// Requires the RNTuple object to be streamed from a file.
    static std::unique_ptr<RPageSourceFile>


### PR DESCRIPTION
The `RRawFileTFile` wraps an open `TFile`, but does not take ownership. This enables opening `RNTuple` anchors from `TFile`s that are not natively supported by `RRawFile`, for example `TMemFile` as used by `TBufferMerger`.