### PR TITLE
missing defaults in SaveAs overload

### DIFF
--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -206,7 +206,7 @@ public:
    TGeoNode *ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape = nullptr, TGeoMatrix *newpos = nullptr,
                          TGeoMedium *newmed = nullptr);
    void ResetTransparency(Char_t transparency = -1); // *MENU*
-   void SaveAs(const char *filename, Option_t *option = "") const override; // *MENU*
+   void SaveAs(const char *filename = "", Option_t *option = "") const override; // *MENU*
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void SelectVolume(Bool_t clear = kFALSE);
    void SetActivity(Bool_t flag = kTRUE) { TGeoAtt::SetActivity(flag); }

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -178,7 +178,7 @@ public:
    virtual Int_t         RemovePoint(); // *MENU*
    virtual Int_t         RemovePoint(Int_t ipoint);
    void                  SavePrimitive(std::ostream &out, Option_t *option = "") override;
-   void                  SaveAs(const char *filename, Option_t *option = "") const override; // *MENU*
+   void                  SaveAs(const char *filename = "graph", Option_t *option = "") const override; // *MENU*
    virtual void          Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
    virtual void          SetEditable(Bool_t editable=kTRUE); // *TOGGLE* *GETTER=GetEditable
    virtual void          SetHighlight(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsHighlight

--- a/hist/hist/inc/TSpline.h
+++ b/hist/hist/inc/TSpline.h
@@ -66,7 +66,7 @@ public:
    virtual Double_t GetXmax()  const {return fXmax;}
    void     Paint(Option_t *option="") override;
    virtual Double_t Eval(Double_t x) const=0;
-   void     SaveAs(const char * /*filename*/,Option_t * /*option*/) const override {}
+   void     SaveAs(const char * /*filename*/ = "",Option_t * /*option*/ = "") const override {}
    void             SetNpx(Int_t n) {fNpx=n;}
 
    ClassDefOverride(TSpline,2) // Spline base class
@@ -243,7 +243,7 @@ public:
       b=fPoly[i].B();c=fPoly[i].C();d=fPoly[i].D();}
    void GetKnot(Int_t i, Double_t &x, Double_t &y) const override
       {x=fPoly[i].X(); y=fPoly[i].Y();}
-    void     SaveAs(const char *filename,Option_t *option="") const override;
+    void     SaveAs(const char *filename="",Option_t *option="") const override;
     void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual  void     SetPoint(Int_t i, Double_t x, Double_t y);
    virtual  void     SetPointCoeff(Int_t i, Double_t b, Double_t c, Double_t d);
@@ -306,7 +306,7 @@ public:
       e=fPoly[i].E();f=fPoly[i].F();}
    void GetKnot(Int_t i, Double_t &x, Double_t &y) const override
       {x=fPoly[i].X(); y=fPoly[i].Y();}
-    void     SaveAs(const char *filename,Option_t *option="") const override;
+    void     SaveAs(const char *filename="",Option_t *option="") const override;
     void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual  void     SetPoint(Int_t i, Double_t x, Double_t y);
    virtual  void     SetPointCoeff(Int_t i, Double_t b, Double_t c, Double_t d,


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

@pcanal mentioned that ::SaveAs overloads should have the same number of default arguments as TObject::SaveAs, see https://github.com/root-project/root/pull/14713/files#r1508200980.

This fixes it, together with https://github.com/root-project/root/pull/14864.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

