### PR TITLE
[main] Pass full compression setting from hadd

### DIFF
--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -399,9 +399,10 @@ int main( int argc, char **argv )
          if (firstInput && !firstInput->IsZombie())
             newcomp = firstInput->GetCompressionSettings();
          else
-            newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault % 100;
+            newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
          delete firstInput;
-      } else newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault % 100; // default compression level.
+      } else
+         newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
    }
    if (verbosity > 1) {
       if (keepCompressionAsIs && !reoptimize)


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/6616

While looking into this, I noticed that the `newcomp` variable is passed down the line to `TFileMerger::OutputFile`, which is declared at https://github.com/root-project/root/blob/master/io/io/inc/TFileMerger.h#L115 with a wrongly named parameter `compressionLevel`. That is in fact the full compression setting integer. Maybe the logic in `hadd` was misguided by the parameter name, I can take care of that in a separate PR.

Sibling roottest PR at https://github.com/root-project/roottest/pull/1074
