### PR TITLE
Handle ownership in TRatioPlot

### DIFF
--- a/graf2d/gpad/CMakeLists.txt
+++ b/graf2d/gpad/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -58,3 +58,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Gpad
     Graf
     Hist
 )
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/graf2d/gpad/inc/TRatioPlot.h
+++ b/graf2d/gpad/inc/TRatioPlot.h
@@ -79,6 +79,7 @@ protected:
    TH1 *fH1 = nullptr; ///< Stores the primary histogram
    TH1 *fH2 = nullptr; ///< Stores the secondary histogram, if there is one
    TObject *fHistDrawProxy = nullptr; ///< The object which is actually drawn, this might be TH1 or THStack
+   Bool_t fHistDrawProxyStack = kFALSE; ///< If stack was assigned as proxy
 
    Int_t fMode = 0; ///< Stores which calculation is supposed to be performed as specified by user option
    Int_t fErrorMode = TRatioPlot::ErrorMode::kErrorSymmetric; ///< Stores the error mode, sym, asym or func
@@ -261,7 +262,7 @@ public:
    void SetC1(Double_t c1) { fC1 = c1; }
    void SetC2(Double_t c2) { fC2 = c2; }
 
-   ClassDefOverride(TRatioPlot, 1)  //A ratio of histograms
+   ClassDefOverride(TRatioPlot, 2)  //A ratio of histograms
 };
 
 #endif

--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -1264,84 +1264,83 @@ void TRatioPlot::CreateVisualAxes()
    if (axistop || axisright) {
 
       // only actually create them once, reuse otherwise b/c memory
-      if (!fUpperGXaxisMirror) {
-         fUpperGXaxisMirror = (TGaxis*)fUpperGXaxis->Clone();
-         if (axistop) fUpperGXaxisMirror->Draw();
+      if (!fUpperGXaxisMirror && axistop) {
+         fUpperGXaxisMirror = static_cast<TGaxis *>(fUpperGXaxis->Clone());
+         fUpperGXaxisMirror->Draw();
       }
 
-      if (!fLowerGXaxisMirror) {
-         fLowerGXaxisMirror = (TGaxis*)fLowerGXaxis->Clone();
-         if (axistop) fLowerGXaxisMirror->Draw();
+      if (!fLowerGXaxisMirror && axistop) {
+         fLowerGXaxisMirror = static_cast<TGaxis *>(fLowerGXaxis->Clone());
+         fLowerGXaxisMirror->Draw();
       }
 
-      if (!fUpperGYaxisMirror) {
-         fUpperGYaxisMirror = (TGaxis*)fUpperGYaxis->Clone();
-         if (axisright) fUpperGYaxisMirror->Draw();
+      if (!fUpperGYaxisMirror && axisright) {
+         fUpperGYaxisMirror = static_cast<TGaxis *>(fUpperGYaxis->Clone());
+         fUpperGYaxisMirror->Draw();
       }
 
-      if (!fLowerGYaxisMirror) {
-         fLowerGYaxisMirror = (TGaxis*)fLowerGYaxis->Clone();
-         if (axisright) fLowerGYaxisMirror->Draw();
+      if (!fLowerGYaxisMirror && axisright) {
+         fLowerGYaxisMirror = static_cast<TGaxis *>(fLowerGYaxis->Clone());
+         fLowerGYaxisMirror->Draw();
       }
-
-      // import attributes from shared axes
-      ImportAxisAttributes(fUpperGXaxisMirror, GetUpperRefXaxis());
-      ImportAxisAttributes(fUpperGYaxisMirror, GetUpperRefYaxis());
-      ImportAxisAttributes(fLowerGXaxisMirror, GetLowerRefXaxis());
-      ImportAxisAttributes(fLowerGYaxisMirror, GetLowerRefYaxis());
-
-      // remove titles
-      fUpperGXaxisMirror->SetTitle("");
-      fUpperGYaxisMirror->SetTitle("");
-      fLowerGXaxisMirror->SetTitle("");
-      fLowerGYaxisMirror->SetTitle("");
 
       // move them about and set required positions
-      fUpperGXaxisMirror->SetX1(upLM);
-      fUpperGXaxisMirror->SetX2(1-upRM);
-      fUpperGXaxisMirror->SetY1((1-upTM)*(1-sf)+sf);
-      fUpperGXaxisMirror->SetY2((1-upTM)*(1-sf)+sf);
-      fUpperGXaxisMirror->SetWmin(first);
-      fUpperGXaxisMirror->SetWmax(last);
+      if (fUpperGXaxisMirror) {
+         ImportAxisAttributes(fUpperGXaxisMirror, GetUpperRefXaxis());
+         fUpperGXaxisMirror->SetTitle("");
+         fUpperGXaxisMirror->SetX1(upLM);
+         fUpperGXaxisMirror->SetX2(1-upRM);
+         fUpperGXaxisMirror->SetY1((1-upTM)*(1-sf)+sf);
+         fUpperGXaxisMirror->SetY2((1-upTM)*(1-sf)+sf);
+         fUpperGXaxisMirror->SetWmin(first);
+         fUpperGXaxisMirror->SetWmax(last);
+         fUpperGXaxisMirror->SetOption("-S"+xopt);
+         fUpperGXaxisMirror->SetNdivisions(fSharedXAxis->GetNdivisions());
+         fUpperGXaxisMirror->SetLabelSize(0.);
+      }
 
-      fUpperGYaxisMirror->SetX1(1-upRM);
-      fUpperGYaxisMirror->SetX2(1-upRM);
-      fUpperGYaxisMirror->SetY1(upBM*(1-sf)+sf);
-      fUpperGYaxisMirror->SetY2( (1-upTM)*(1-sf)+sf );
-      fUpperGYaxisMirror->SetWmin(upYFirst);
-      fUpperGYaxisMirror->SetWmax(upYLast);
+      if (fUpperGYaxisMirror) {
+         ImportAxisAttributes(fUpperGYaxisMirror, GetUpperRefYaxis());
+         fUpperGYaxisMirror->SetTitle("");
+         fUpperGYaxisMirror->SetX1(1-upRM);
+         fUpperGYaxisMirror->SetX2(1-upRM);
+         fUpperGYaxisMirror->SetY1(upBM*(1-sf)+sf);
+         fUpperGYaxisMirror->SetY2( (1-upTM)*(1-sf)+sf );
+         fUpperGYaxisMirror->SetWmin(upYFirst);
+         fUpperGYaxisMirror->SetWmax(upYLast);
+         fUpperGYaxisMirror->SetOption("+S"+upyopt);
+         fUpperGYaxisMirror->SetNdivisions(fUpYaxis->GetNdivisions());
+         fUpperGYaxisMirror->SetLabelSize(0.);
+      }
 
-      fLowerGXaxisMirror->SetX1(lowLM);
-      fLowerGXaxisMirror->SetX2(1-lowRM);
-      fLowerGXaxisMirror->SetY1((1-lowTM)*sf);
-      fLowerGXaxisMirror->SetY2((1-lowTM)*sf);
-      fLowerGXaxisMirror->SetWmin(first);
-      fLowerGXaxisMirror->SetWmax(last);
+      if (fLowerGXaxisMirror) {
+         ImportAxisAttributes(fLowerGXaxisMirror, GetLowerRefXaxis());
+         fLowerGXaxisMirror->SetTitle("");
+         fLowerGXaxisMirror->SetX1(lowLM);
+         fLowerGXaxisMirror->SetX2(1-lowRM);
+         fLowerGXaxisMirror->SetY1((1-lowTM)*sf);
+         fLowerGXaxisMirror->SetY2((1-lowTM)*sf);
+         fLowerGXaxisMirror->SetWmin(first);
+         fLowerGXaxisMirror->SetWmax(last);
+         fLowerGXaxisMirror->SetOption("-S"+xopt);
+         fLowerGXaxisMirror->SetNdivisions(fSharedXAxis->GetNdivisions());
+         fLowerGXaxisMirror->SetLabelSize(0.);
+      }
 
-      fLowerGYaxisMirror->SetX1(1-lowRM);
-      fLowerGYaxisMirror->SetX2(1-lowRM);
-      fLowerGYaxisMirror->SetY1(lowBM*sf);
-      fLowerGYaxisMirror->SetY2((1-lowTM)*sf);
-      fLowerGYaxisMirror->SetWmin(lowYFirst);
-      fLowerGYaxisMirror->SetWmax(lowYLast);
-
-      // also needs normalized tick size
-      fLowerGYaxisMirror->SetTickSize(ticksize);
-
-      fUpperGXaxisMirror->SetOption("-S"+xopt);
-      fUpperGYaxisMirror->SetOption("+S"+upyopt);
-      fLowerGXaxisMirror->SetOption("-S"+xopt);
-      fLowerGYaxisMirror->SetOption("+S"+lowyopt);
-
-      fUpperGXaxisMirror->SetNdivisions(fSharedXAxis->GetNdivisions());
-      fUpperGYaxisMirror->SetNdivisions(fUpYaxis->GetNdivisions());
-      fLowerGXaxisMirror->SetNdivisions(fSharedXAxis->GetNdivisions());
-      fLowerGYaxisMirror->SetNdivisions(fLowYaxis->GetNdivisions());
-
-      fUpperGXaxisMirror->SetLabelSize(0.);
-      fLowerGXaxisMirror->SetLabelSize(0.);
-      fUpperGYaxisMirror->SetLabelSize(0.);
-      fLowerGYaxisMirror->SetLabelSize(0.);
+      if (fLowerGYaxisMirror) {
+         ImportAxisAttributes(fLowerGYaxisMirror, GetLowerRefYaxis());
+         fLowerGYaxisMirror->SetTitle("");
+         fLowerGYaxisMirror->SetX1(1-lowRM);
+         fLowerGYaxisMirror->SetX2(1-lowRM);
+         fLowerGYaxisMirror->SetY1(lowBM*sf);
+         fLowerGYaxisMirror->SetY2((1-lowTM)*sf);
+         fLowerGYaxisMirror->SetWmin(lowYFirst);
+         fLowerGYaxisMirror->SetWmax(lowYLast);
+         fLowerGYaxisMirror->SetOption("+S"+lowyopt);
+         fLowerGYaxisMirror->SetTickSize(ticksize);
+         fLowerGYaxisMirror->SetNdivisions(fLowYaxis->GetNdivisions());
+         fLowerGYaxisMirror->SetLabelSize(0.);
+      }
    }
 
 }

--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -112,6 +112,11 @@ TRatioPlot::~TRatioPlot()
    delete fSharedXAxis;
    delete fUpYaxis;
    delete fLowYaxis;
+
+   if ((fMode != TRatioPlot::CalculationMode::kFitResidual) || !fShowConfidenceIntervals) {
+      delete fConfidenceInterval1;
+      delete fConfidenceInterval2;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -96,6 +96,7 @@ is responsible for the range, which enables you to modify the range.
 \image html gpad_ratioplot.png
 */
 
+
 ////////////////////////////////////////////////////////////////////////////////
 /// TRatioPlot default constructor
 
@@ -108,34 +109,9 @@ TRatioPlot::TRatioPlot()
 
 TRatioPlot::~TRatioPlot()
 {
-
-   gROOT->GetListOfCleanups()->Remove(this);
-
-   auto safeDelete = [](TObject *obj) {
-      if (obj && !ROOT::Detail::HasBeenDeleted(obj))
-         delete obj;
-   };
-
-   safeDelete(fRatioGraph);
-   safeDelete(fConfidenceInterval1);
-   safeDelete(fConfidenceInterval2);
-
-   for (unsigned int i=0;i<fGridlines.size();++i) {
-      delete (fGridlines[i]);
-   }
-
-   safeDelete(fSharedXAxis);
-   safeDelete(fUpperGXaxis);
-   safeDelete(fLowerGXaxis);
-   safeDelete(fUpperGYaxis);
-   safeDelete(fLowerGYaxis);
-   safeDelete(fUpperGXaxisMirror);
-   safeDelete(fLowerGXaxisMirror);
-   safeDelete(fUpperGYaxisMirror);
-   safeDelete(fLowerGYaxisMirror);
-
-   safeDelete(fUpYaxis);
-   safeDelete(fLowYaxis);
+   delete fSharedXAxis;
+   delete fUpYaxis;
+   delete fLowYaxis;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -202,8 +178,6 @@ void TRatioPlot::Init(TH1* h1, TH1* h2,Option_t *option)
 TRatioPlot::TRatioPlot(TH1* h1, TH1* h2, Option_t *option)
    : fGridlines()
 {
-   gROOT->GetListOfCleanups()->Add(this);
-
    if (!h1 || !h2) {
       Warning("TRatioPlot", "Need two histograms.");
       return;
@@ -269,8 +243,6 @@ TRatioPlot::TRatioPlot(TH1* h1, Option_t *option, TFitResult *fitres)
    : fH1(h1),
      fGridlines()
 {
-   gROOT->GetListOfCleanups()->Add(this);
-
    if (!fH1) {
       Warning("TRatioPlot", "Need a histogram.");
       return;

--- a/graf2d/gpad/test/CMakeLists.txt
+++ b/graf2d/gpad/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+ROOT_ADD_GTEST(TRatioPlot ratioplot.cxx LIBRARIES Gpad)

--- a/graf2d/gpad/test/ratioplot.cxx
+++ b/graf2d/gpad/test/ratioplot.cxx
@@ -1,0 +1,43 @@
+#include "gtest/gtest.h"
+
+#include "TH1.h"
+#include "TF1.h"
+#include "TRatioPlot.h"
+#include "TCanvas.h"
+#include "TFile.h"
+
+
+TEST(TRatioPlot, CreateFile)
+{
+   TCanvas c1("c1", "fit residual simple");
+   TH1D h1("h1", "TRatioplot example", 50, 0, 10);
+   TH1D h2("h2", "TRatioplot example", 50, 0, 10);
+   TF1 f1("f1", "exp(-x/[0])");
+   f1.SetParameter(0, 3);
+   h1.FillRandom("f1", 1900);
+   h2.FillRandom("f1", 2000);
+   h1.Sumw2();
+   h2.Scale(1.9 / 2.);
+   h2.SetLineColor(kRed);
+
+   TRatioPlot rp1(&h1, &h2);
+   rp1.Draw();
+
+   auto f = TFile::Open("ratioplot.root", "RECREATE");
+   f->WriteObject(&c1, "ratioplot");
+   delete f;
+}
+
+TEST(TRatioPlot, ReadFile)
+{
+   TCanvas *c1 = nullptr;
+
+   auto f = TFile::Open("ratioplot.root");
+   f->GetObject("ratioplot", c1);
+
+   EXPECT_TRUE(c1 != nullptr);
+
+   delete c1;
+   delete f;
+}
+

--- a/graf2d/gpad/test/ratioplot.cxx
+++ b/graf2d/gpad/test/ratioplot.cxx
@@ -2,6 +2,7 @@
 
 #include "TH1.h"
 #include "TF1.h"
+#include "THStack.h"
 #include "TRatioPlot.h"
 #include "TCanvas.h"
 #include "TFile.h"
@@ -9,11 +10,12 @@
 
 TEST(TRatioPlot, CreateFile)
 {
+   TF1 f1("f1", "exp(-x/[0])");
+   f1.SetParameter(0, 3);
+
    TCanvas c1("c1", "fit residual simple");
    TH1D h1("h1", "TRatioplot example", 50, 0, 10);
    TH1D h2("h2", "TRatioplot example", 50, 0, 10);
-   TF1 f1("f1", "exp(-x/[0])");
-   f1.SetParameter(0, 3);
    h1.FillRandom("f1", 1900);
    h2.FillRandom("f1", 2000);
    h1.Sumw2();
@@ -38,6 +40,60 @@ TEST(TRatioPlot, ReadFile)
    EXPECT_TRUE(c1 != nullptr);
 
    delete c1;
+   delete f;
+}
+
+TEST(TRatioPlot, CreateFileStack)
+{
+   TF1 f1("f1", "exp(-x/[0])");
+   f1.SetParameter(0, 3);
+
+   TCanvas c1("c1", "fit residual simple");
+
+   THStack hs("hs","Stacked 1D histograms");
+   //create three 1-d histograms
+   auto h1st = new TH1D("h1st","test hstack",50, 0, 10);
+   h1st->FillRandom("f1", 1000);
+   h1st->SetFillColor(kRed);
+   h1st->SetMarkerStyle(21);
+   h1st->SetMarkerColor(kRed);
+   hs.Add(h1st);
+   auto h2st = new TH1D("h2st","test hstack",50, 0, 10);
+   h2st->FillRandom("f1",1000);
+   h2st->SetFillColor(kBlue);
+   h2st->SetMarkerStyle(21);
+   h2st->SetMarkerColor(kBlue);
+   hs.Add(h2st);
+   auto h3st = new TH1D("h3st","test hstack",50, 0, 10);
+   h3st->FillRandom("f1",1000);
+   h3st->SetFillColor(kGreen);
+   h3st->SetMarkerStyle(21);
+   h3st->SetMarkerColor(kGreen);
+   hs.Add(h3st);
+
+   TH1D h2("h2", "TRatioplot example", 50, 0, 10);
+   h2.FillRandom("f1", 2000);
+   h2.SetLineColor(kRed);
+
+   TRatioPlot rp2(&hs, &h2);
+   rp2.Draw();
+
+   auto f = TFile::Open("ratioplotstack.root", "RECREATE");
+   f->WriteObject(&c1, "ratioplotstack");
+   delete f;
+}
+
+TEST(TRatioPlot, ReadFileStack)
+{
+   TCanvas *c1 = nullptr;
+
+   auto f = TFile::Open("ratioplotstack.root");
+   f->GetObject("ratioplotstack", c1);
+
+   EXPECT_TRUE(c1 != nullptr);
+
+   delete c1;
+
    delete f;
 }
 


### PR DESCRIPTION
Delete only objects which are created by TRatioPlot and not drawn in the canvas.

All other objects like TGaxis and TGraph handled by the canvas and therefore not touched in the destructor.

Add special handling for histogram which created from THStack but may not be drawn. 
One need extra flag to handle this. Therefore increase class version.

Provide test which writes and read ratio plot from the file.

Fixes #14855