### PR TITLE
[skip-CI][ci] Simplify yml files configuring nightlies

### DIFF
--- a/.github/workflows/root-630.yml
+++ b/.github/workflows/root-630.yml
@@ -3,7 +3,7 @@ name: 'ROOT 6.30'
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1,13 * * *'
 
   workflow_dispatch:
     inputs:
@@ -30,9 +30,5 @@ on:
 
 jobs:
   run_nightlies:
-    uses: root-project/root/.github/workflows/root-ci.yml@master
-    with:
-      base_ref: 'v6-30-00-patches'
-      head_ref: 'v6-30-00-patches'
-      ref_name: 'v6-30-00-patches'
+    uses: root-project/root/.github/workflows/root-ci.yml@v6-30-00-patches
     secrets: inherit

--- a/.github/workflows/root-630.yml
+++ b/.github/workflows/root-630.yml
@@ -3,7 +3,7 @@ name: 'ROOT 6.30'
 
 on:
   schedule:
-    - cron: '0 1,13 * * *'
+    - cron: '30 1,13 * * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -21,15 +21,12 @@ on:
     inputs:
       head_ref:
         type: string
-        required: true
         default: master
       base_ref:
         type: string
-        required: true
         default: master
       ref_name:
         type: string
-        required: true
         default: master
 
   # Enables manual start of workflow

--- a/.github/workflows/root-master.yml
+++ b/.github/workflows/root-master.yml
@@ -3,7 +3,7 @@ name: 'ROOT Main'
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1,13 * * *'
 
   workflow_dispatch:
     inputs:
@@ -31,8 +31,4 @@ on:
 jobs:
   run_nightlies:
     uses: root-project/root/.github/workflows/root-ci.yml@master
-    with:
-      base_ref: 'master'
-      head_ref: 'master'
-      ref_name: 'master'
     secrets: inherit

--- a/.github/workflows/root-master.yml
+++ b/.github/workflows/root-master.yml
@@ -3,7 +3,7 @@ name: 'ROOT Main'
 
 on:
   schedule:
-    - cron: '0 1,13 * * *'
+    - cron: '30 1,13 * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
and allow to use the root-ci.yml in the v6-30-00-patches to treat the configuration of the builds of branches as regular code.