### PR TITLE
Remove the Python tutorials form the list of Namespaces

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -33,7 +33,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork
+all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork removePythonTutorialsFromNamespaces
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++14 -O2
@@ -77,6 +77,9 @@ collaborationDiagrams:
 replaceCollaborationDiagrams: doxygen collaborationDiagrams
 	bash ./modifyClassWebpages.sh -j$(NJOB)
 
+removePythonTutorialsFromNamespaces:
+	bash ./CleanNamespaces.sh
+
 tutorialWorklist_py: doxygen
 tutorialWorklist_root: doxygen
 
@@ -89,4 +92,4 @@ rootWork: tutorialWorklist_root
 	xargs -L 1 -P 12 root < $<
 
 clean:
-	rm -rf $(DOXYGEN_OUTPUT_DIRECTORY) tutorialWorklist_py tutorialWorklist_root
+	rm -rf $(DOXYGEN_OUTPUT_DIRECTORY) tutorialWorklist_py tutorialWorklist_root CleanNamespaces.sh

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -33,7 +33,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork removePythonTutorialsFromNamespaces
+all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++14 -O2
@@ -63,8 +63,7 @@ doxygen: filter pyzdoc
 	./makehtmlfooter.sh > htmlfooter.html
 	./makeinput.sh
 	doxygen
-	gzip $(DOXYGEN_IMAGE_PATH)/ROOT.tag
-	gzip $(DOXYGEN_IMAGE_PATH)/ROOT.qch
+	bash ./CleanNamespaces.sh
 	rm -rf files c1* *.ps *.eps *.png *.jpg *.tex *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt *.csv *.log *.rs
 	rm -rf listofclass.sh tmva* data* result* config* test* Roo* My* Freq*
 	rm -f Doxyfile_INPUT filter htmlfooter.html MDF.C pca.C
@@ -76,9 +75,6 @@ collaborationDiagrams:
 
 replaceCollaborationDiagrams: doxygen collaborationDiagrams
 	bash ./modifyClassWebpages.sh -j$(NJOB)
-
-removePythonTutorialsFromNamespaces:
-	bash ./CleanNamespaces.sh
 
 tutorialWorklist_py: doxygen
 tutorialWorklist_root: doxygen

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -331,7 +331,8 @@ void FilterTutorial()
       FILE *cn = fopen("CleanNamespaces.sh", "a");
       string name = gMacroName;
       ReplaceAll(name,".py","");
-      if (cn) fprintf(cn,"./modifyNamespacesWebpage.sh %s\n",name.c_str());
+      if (cn)
+         fprintf(cn,"./modifyNamespacesWebpage.sh %s\n",name.c_str());
       fclose(cn);
    }
 

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -327,6 +327,13 @@ void FilterTutorial()
    gMacroName  = gFileName.substr(i1,i2-i1+1);
    gImageName  = StringFormat("%s.%s", gMacroName.c_str(), gImageType.c_str()); // Image name
    gOutputName = StringFormat("%s.out", gMacroName.c_str()); // output name
+   if (gPython) {
+      FILE *cn = fopen("CleanNamespaces.sh", "a");
+      string name = gMacroName;
+      ReplaceAll(name,".py","");
+      if (cn) fprintf(cn,"./modifyNamespacesWebpage.sh %s\n",name.c_str());
+      fclose(cn);
+   }
 
    // Parse the source and generate the image if needed
    while (fgets(gLine,255,f)) {

--- a/documentation/doxygen/modifyNamespacesWebpage.sh
+++ b/documentation/doxygen/modifyNamespacesWebpage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# The Python tutorials appear in the Namespaces page. This script removes them from Namespaces.
+
+HTMLPATH=$DOXYGEN_OUTPUT_DIRECTORY/html
+if [ ! -d "$HTMLPATH" ]; then
+   echo "Error: DOXYGEN_OUTPUT_DIRECTORY is not exported."
+   exit 1
+fi
+
+sed -i -e /namespace$1.html/d $HTMLPATH/namespaces_dup.js
+sed -i -e /namespace$1.html/d $HTMLPATH/namespaces.html
+rm $HTMLPATH/namespace$1.html
+sed -i -e "/memberdecls/,+5d" $HTMLPATH/$1_8py.html


### PR DESCRIPTION
After doxygen is run, the Python tutorials appeared in the namespaces list. This PR remove them.
It was mentioned in this issue: https://github.com/root-project/root/issues/10317

