### PR TITLE
[math][unuran] Change default method for sampling multi-dim distributions

### DIFF
--- a/math/unuran/inc/TUnuran.h
+++ b/math/unuran/inc/TUnuran.h
@@ -140,8 +140,14 @@ public:
       <A href="http://statmath.wu-wien.ac.at/unuran/doc/unuran.html#Methods_005ffor_005fCVEC">UnuRan doc</A>
       A re-initialization is needed whenever distribution parameters have been changed.
 
+      The default method used for multi-dimensional distributions is "vnrou"
+      Note that some of the multi-dimensional continuous distribution methods like "hitro" are based on Markov-CHain sampler and
+      they are much faster for sampling but require more time to converge. Furthermore, since they are Markov-Chain methods their
+      generated sample values are correlated and cannot be used as i.i.d., one can instead use the obtained sample distribution.
+      (see also the ROOT issue: #10222 ).
+
    */
-   bool Init(const TUnuranMultiContDist & distr, const std::string & method = "hitro");
+   bool Init(const TUnuranMultiContDist & distr, const std::string & method = "vnrou");
 
 
    /**

--- a/math/unuran/src/TUnuran.cxx
+++ b/math/unuran/src/TUnuran.cxx
@@ -342,8 +342,6 @@ bool  TUnuran::SetDiscreteDistribution(const TUnuranDiscrDist & dist)
    return (ret ==0) ? true : false;
 }
 
-
-//bool TUnuran::SetMethodAndInit(const std::string & s) {
 bool TUnuran::SetMethodAndInit() {
 
    // internal function to set a method from a distribution and
@@ -374,25 +372,25 @@ bool TUnuran::SetMethodAndInit() {
    return true;
  }
 
-std::string TUnuran::GetInfo(bool extended) 
+std::string TUnuran::GetInfo(bool extended)
 {
    // get information string about Unuran generator
    if (!fGen) return std::string();
-   return std::string(unur_gen_info(fGen, extended)); 
+   return std::string(unur_gen_info(fGen, extended));
 }
 
 std::string TUnuran::GetGenId() const
 {
    // get Unuran generator ID
    if (!fGen) return std::string();
-   return std::string(unur_get_genid(fGen)); 
+   return std::string(unur_get_genid(fGen));
 }
 
 int TUnuran::GetDimension() const
 {
    // get dimension of the UNURAN generator
    if (!fGen) return 0;
-   return unur_get_dimension(fGen); 
+   return unur_get_dimension(fGen);
 }
 
 int TUnuran::GetDistType() const
@@ -402,19 +400,19 @@ int TUnuran::GetDistType() const
    return unur_distr_get_type (unur_get_distr(fGen));
 }
 
-bool TUnuran::IsDistCont() const { 
+bool TUnuran::IsDistCont() const {
    if (!fGen) return false;
    return unur_distr_is_cont (unur_get_distr(fGen));
 }
-bool TUnuran::IsDistMultiCont() const { 
+bool TUnuran::IsDistMultiCont() const {
    if (!fGen) return false;
    return unur_distr_is_cvec (unur_get_distr(fGen));
 }
-bool TUnuran::IsDistDiscrete() const { 
+bool TUnuran::IsDistDiscrete() const {
    if (!fGen) return false;
    return unur_distr_is_discr (unur_get_distr(fGen));
 }
-bool TUnuran::IsDistEmpirical() const { 
+bool TUnuran::IsDistEmpirical() const {
    if (!fGen) return false;
    return unur_distr_is_cemp (unur_get_distr(fGen));
 }

--- a/math/unuran/src/TUnuranSampler.cxx
+++ b/math/unuran/src/TUnuranSampler.cxx
@@ -54,7 +54,7 @@ bool TUnuranSampler::Init(const char * algo) {
    // try to initialize Unuran
    if (NDim() == 0)  {
       ret = fUnuran->Init(algo,"");
-      if (!ret) { 
+      if (!ret) {
          Error("TUnuranSampler::Init",
          "Unuran initialization string is invalid or the Distribution function has not been set and one needs to call SetFunction first.");
          return false;
@@ -62,7 +62,7 @@ bool TUnuranSampler::Init(const char * algo) {
       int ndim = fUnuran->GetDimension();
       assert(ndim > 0);
       fOneDim = (ndim == 1);
-      fDiscrete = fUnuran->IsDistDiscrete(); 
+      fDiscrete = fUnuran->IsDistDiscrete();
       DoSetDimension(ndim);
       return true;
    }
@@ -123,17 +123,17 @@ bool TUnuranSampler::Init(const ROOT::Math::DistSamplerOptions & opt ) {
       for ( auto & name : names) {
          std::string value = opts->NamedValue(name.c_str());
          appendOption(name,value);
-      } 
+      }
       names = opts->GetAllIntKeys();
       for ( auto & name : names) {
          std::string value = ROOT::Math::Util::ToString(opts->IValue(name.c_str()));
          appendOption(name,value);
-      } 
+      }
       names = opts->GetAllRealKeys();
       for ( auto & name : names) {
          std::string value = ROOT::Math::Util::ToString(opts->RValue(name.c_str()));
          appendOption(name,value);
-      } 
+      }
    }
    Info("Init","Initialize UNU.RAN with Method option string: %s",optionStr.c_str());
    return Init(optionStr.c_str() );
@@ -235,11 +235,6 @@ bool TUnuranSampler::DoInitND(const char * method) {
       std::vector<double> xmax(range.NDim() );
       range.GetRange(&xmin[0],&xmax[0]);
       dist.SetDomain(&xmin.front(),&xmax.front());
-//       std::cout << " range is min = ";
-//       for (int j = 0; j < NDim(); ++j) std::cout << xmin[j] << "   ";
-//       std::cout << " max = ";
-//       for (int j = 0; j < NDim(); ++j) std::cout << xmax[j] << "   ";
-//       std::cout << std::endl;
    }
    fOneDim = false;
    if (fHasMode && fNDMode.size() == dist.NDim())
@@ -297,7 +292,7 @@ void TUnuranSampler::SetMode(const std::vector<double> &mode)
    if (mode.size() == ParentPdf().NDim()) {
       if (mode.size() == 1)
          fMode = mode[0];
-      else 
+      else
          fNDMode = mode;
 
       fHasMode = true;
@@ -315,7 +310,7 @@ void TUnuranSampler::SetCdf(const ROOT::Math::IGenFunction &cdf) {
    if (NDim() == 0) DoSetDimension(1);
 }
 
-void TUnuranSampler::SetDPdf(const ROOT::Math::IGenFunction &dpdf) { 
+void TUnuranSampler::SetDPdf(const ROOT::Math::IGenFunction &dpdf) {
    fDPDF = &dpdf;
    // in case dimension has not been defined ( a pdf is not provided)
    if (NDim() == 0) DoSetDimension(1);

--- a/tutorials/unuran/unuranDemo.C
+++ b/tutorials/unuran/unuranDemo.C
@@ -52,7 +52,7 @@ using std::cout;
 using std::endl;
 
 // number of distribution generated points
-#define NGEN 1000000
+#define NGEN 100000
 
 int izone = 0;
 TCanvas * c1 = nullptr;
@@ -206,8 +206,9 @@ void testDistrMultiDim() {
 
    cout << "\nTest Multidimensional distributions\n\n";
 
-   TH3D * h1 = new TH3D("h13D","gaussian 3D distribution from Unuran",50,-10,10,50,-10,10,50,-10,10);
-   TH3D * h2 = new TH3D("h23D","gaussian 3D distribution from GetRandom",50,-10,10,50,-10,10,50,-10,10);
+   TH3D * h1 = new TH3D("h13D","gaussian 3D distribution from Unuran (vnrou)",50,-10,10,50,-10,10,50,-10,10);
+   TH3D * h2 = new TH3D("h23D","gaussian 3D distribution from Unuran (hitro)",50,-10,10,50,-10,10,50,-10,10);
+   TH3D * h3 = new TH3D("h33D","gaussian 3D distribution from GetRandom",50,-10,10,50,-10,10,50,-10,10);
 
 
 
@@ -219,10 +220,9 @@ void testDistrMultiDim() {
 
    TUnuranMultiContDist dist(f);
    TUnuran unr(gRandom);
-   //std::string method = "method=vnrou";
 
    //std::string method = "method=hitro;use_boundingrectangle=false ";
-   std::string method = "hitro";
+   std::string method = "vnrou";
    if ( !  unr.Init(dist,method) ) {
       cout << "Error initializing unuran" << endl;
       return;
@@ -245,8 +245,27 @@ void testDistrMultiDim() {
    h1->Draw();
 
 
+   // use a different UNURAN method
+
+   method = "hitro";
+   if ( !  unr.Init(dist,method) ) {
+      cout << "Error re-initializing unuran" << endl;
+      return;
+   }
+
+   w.Start();
+
+   for (int i = 0; i < NGEN; ++i) {
+      unr.SampleMulti(x);
+      h2->Fill(x[0],x[1],x[2]);
+   }
+
+   w.Stop();
+   cout << "Time using Unuran method " << unr.MethodName() << "\t=\t\t " << w.CpuTime() << endl;
+
+
    // need to set a reasonable number of points in TF1 to get acceptable quality from GetRandom to
-   int np = 200;
+   int np = 100;
    f->SetNpx(np);
    f->SetNpy(np);
    f->SetNpz(np);
@@ -254,7 +273,7 @@ void testDistrMultiDim() {
    w.Start();
    for (int i = 0; i < NGEN; ++i) {
       f->GetRandom3(x[0],x[1],x[2]);
-      h2->Fill(x[0],x[1],x[2]);
+      h3->Fill(x[0],x[1],x[2]);
    }
 
    w.Stop();
@@ -262,10 +281,12 @@ void testDistrMultiDim() {
 
 
    c1->cd(++izone);
-   h2->Draw();
+   h3->Draw();
 
-   std::cout << " chi2 test of UNURAN vs GetRandom generated histograms:  " << std::endl;
-   h1->Chi2Test(h2,"UUP");
+   std::cout << " chi2 test of UNURAN vnrou vs GetRandom generated histograms:  " << std::endl;
+   h1->Chi2Test(h3,"UUP");
+   std::cout << " chi2 test of UNURAN hitro vs GetRandom generated histograms:  " << std::endl;
+   h2->Chi2Test(h3,"UUP");
 
 }
 //_____________________________________________


### PR DESCRIPTION


The default method for chaning multi-dim distributions is now `vnrou` instead of the Markov CHain based method hitro, which generates (being a MC MC) correlated values and not iid.

Update also documentation and tutorial

This fixes ROOT #10222



