### PR TITLE
[core] Use ExpandPathName(TString&) to prevent mem leaks (ROOT-7280):

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -476,10 +476,12 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          Long_t id, flags, modtime;
          char *arg = strchr(argv[i], '(');
          if (arg) *arg = '\0';
-         char *dir = gSystem->ExpandPathName(argv[i]);
-         // ROOT-9959: we do not continue if we could not expand the path
-         if (!dir) continue;
-         TUrl udir(dir, kTRUE);
+         TString expandedDir(argv[i]);
+         if (gSystem->ExpandPathName(expandedDir)) {
+            // ROOT-9959: we do not continue if we could not expand the path
+            continue;
+         }
+         TUrl udir(expandedDir, kTRUE);
          // remove options and anchor to check the path
          TString sfx = udir.GetFileAndOptions();
          TString fln = udir.GetFile();
@@ -496,11 +498,11 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                // if directory set it in fWorkDir
                if (pwd == "") {
                   pwd = gSystem->WorkingDirectory();
-                  fWorkDir = dir;
-                  gSystem->ChangeDirectory(dir);
+                  fWorkDir = expandedDir;
+                  gSystem->ChangeDirectory(expandedDir);
                   argv[i] = null;
                } else if (!strcmp(gROOT->GetName(), "Rint")) {
-                  Warning("GetOptions", "only one directory argument can be specified (%s)", dir);
+                  Warning("GetOptions", "only one directory argument can be specified (%s)", expandedDir.Data());
                }
             } else if (size > 0) {
                // if file add to list of files to be processed
@@ -508,7 +510,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                fFiles->Add(new TObjString(path.Data()));
                argv[i] = null;
             } else {
-               Warning("GetOptions", "file %s has size 0, skipping", dir);
+               Warning("GetOptions", "file %s has size 0, skipping", expandedDir.Data());
             }
          } else {
             if (TString(udir.GetFile()).EndsWith(".root")) {
@@ -516,7 +518,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                   // file ending on .root but does not exist, likely a typo
                   // warn user if plain root...
                   if (!strcmp(gROOT->GetName(), "Rint"))
-                     Warning("GetOptions", "file %s not found", dir);
+                     Warning("GetOptions", "file %s not found", expandedDir.Data());
                } else {
                   // remote file, give it the benefit of the doubt and add it to list of files
                   if (!fFiles) fFiles = new TObjArray;
@@ -525,7 +527,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                }
             } else {
                TString mode,fargs,io;
-               TString fname = gSystem->SplitAclicMode(dir,mode,fargs,io);
+               TString fname = gSystem->SplitAclicMode(expandedDir,mode,fargs,io);
                char *mac;
                if (!fFiles) fFiles = new TObjArray;
                if ((mac = gSystem->Which(TROOT::GetMacroPath(), fname,
@@ -544,7 +546,6 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                }
             }
          }
-         delete [] dir;
       }
       // ignore unknown options
    }


### PR DESCRIPTION
Some of these cases forgot to delete the returned char[]; the TString overload takes care of that.

This is the first commit of another PR from Axel:
https://github.com/root-project/root/pull/6874

Requesting @linev as a reviewer, because he fixed several of such issues before.

See also:
https://its.cern.ch/jira/browse/ROOT-7280