### PR TITLE
[rootcling] Allow all system modules as byproducts

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3619,7 +3619,7 @@ public:
       // If we build a I/O requiring module implicitly we should display
       // an error unless the -mByproduct was specified.
       bool isByproductModule
-         = module && std::find(gOptModuleByproducts.begin(), gOptModuleByproducts.end(), moduleName) != gOptModuleByproducts.end();
+         = module && (module->IsSystem || std::find(gOptModuleByproducts.begin(), gOptModuleByproducts.end(), moduleName) != gOptModuleByproducts.end());
       if (!isByproductModule)
          fChild->HandleDiagnostic(DiagLevel, Info);
 


### PR DESCRIPTION
Commit 4ee93a229f ("[rootcling] Allow users to specify byproduct modules.") added explicit options to specify expected byproducts, but removed the implicit check for system modules. This worked a bit by accident because the interpreter includes `<new>` upon startup which already triggered building of `std.pcm` and `libc.pcm` before `rootcling` registered its error handler. This model breaks now with libc++ splitting `std` into one per public header (e.g. `std_vector`).