### PR TITLE
[ntuple] Add RFieldBase::Check(<type name>)

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -618,7 +618,7 @@ public:
    /// Factory method to resurrect a field from the stored on-disk type information
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &typeName);
-   /// Checks if the given type name is supported by RNTuple. In case of success, the result vector is empty.
+   /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error message for each failing sub field (sub type) of the form
    /// (qualified field name, type name, error).
    static std::vector<std::tuple<std::string, std::string, std::string>>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -719,6 +719,31 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+/// Used in RFieldBase::Check() to record field creation failures.
+class RInvalidField final : public RFieldBase {
+   std::string fError;
+
+protected:
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
+   {
+      return std::make_unique<RInvalidField>(newName, GetTypeName(), fError);
+   }
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
+   void ConstructValue(void *) const final {}
+
+public:
+   RInvalidField(std::string_view name, std::string_view type, std::string_view error)
+      : RFieldBase(name, type, ENTupleStructure::kLeaf, false /* isSimple */), fError(error)
+   {
+   }
+
+   std::string GetError() const { return fError; }
+
+   size_t GetValueSize() const final { return 0; }
+   size_t GetAlignment() const final { return 0; }
+}; // RInvalidField
+
 /// The field for a class with dictionary
 class RClassField : public RFieldBase {
 private:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -601,6 +601,13 @@ public:
       using deleter = std::default_delete<T>;
    };
 
+   /// Used in the return value of the Check() method
+   struct RCheckResult {
+      std::string fFieldName; ///< Qualified field name causing the error
+      std::string fTypeName;  ///< Type name corresponding to the (sub) field
+      std::string fErrMsg;    ///< Cause of the failure, e.g. unsupported type
+   };
+
    /// The constructor creates the underlying column objects and connects them to either a sink or a source.
    /// If `isSimple` is `true`, the trait `kTraitMappable` is automatically set on construction. However, the
    /// field might be demoted to non-simple if a post-read callback is set.
@@ -619,10 +626,8 @@ public:
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &typeName);
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
-   /// Otherwise there is an error message for each failing sub field (sub type) of the form
-   /// (qualified field name, type name, error).
-   static std::vector<std::tuple<std::string, std::string, std::string>>
-   Check(const std::string &fieldName, const std::string &typeName);
+   /// Otherwise there is an error record for each failing sub field (sub type).
+   static std::vector<RCheckResult> Check(const std::string &fieldName, const std::string &typeName);
    /// Check whether a given string is a valid field name
    static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -532,8 +532,8 @@ protected:
    /// normalized type name and type alias
    /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
    /// single type name
-   static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias);
+   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &canonicalType,
+                                                      const std::string &typeAlias, bool fContinueOnError = false);
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -41,6 +41,7 @@
 #include <new>
 #include <set>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <variant>
@@ -617,6 +618,11 @@ public:
    /// Factory method to resurrect a field from the stored on-disk type information
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &typeName);
+   /// Checks if the given type name is supported by RNTuple. In case of success, the result vector is empty.
+   /// Otherwise there is an error message for each failing sub field (sub type) of the form
+   /// (qualified field name, type name, error).
+   static std::vector<std::tuple<std::string, std::string, std::string>>
+   Check(const std::string &fieldName, const std::string &typeName);
    /// Check whether a given string is a valid field name
    static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -248,7 +248,7 @@ public:
       fCreateContext.fClassesOnStack.emplace_back(cl);
    }
 
-   void SetConinueOnError(bool value) { fCreateContext.fContinueOnError = value; }
+   void SetContinueOnError(bool value) { fCreateContext.fContinueOnError = value; }
 };
 
 /// Retrieve the addresses of the data members of a generic RVec from a pointer to the beginning of the RVec object.
@@ -568,7 +568,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    thread_local CreateContext createContext;
    CreateContextGuard createContextGuard(createContext);
    if (continueOnError)
-      createContextGuard.SetConinueOnError(true);
+      createContextGuard.SetContinueOnError(true);
 
    auto fnFail = [&fieldName, &canonicalType](const std::string &errMsg) -> RResult<std::unique_ptr<RFieldBase>> {
       if (createContext.GetContinueOnError()) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -540,7 +540,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    return R__FORWARD_RESULT(RFieldBase::Create(fieldName, canonicalType, typeAlias));
 }
 
-std::vector<std::tuple<std::string, std::string, std::string>>
+std::vector<ROOT::Experimental::RFieldBase::RCheckResult>
 ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::string &typeName)
 {
    auto typeAlias = GetNormalizedTypeName(typeName);
@@ -549,14 +549,14 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
    RFieldZero fieldZero;
    fieldZero.Attach(RFieldBase::Create(fieldName, canonicalType, typeAlias, true /* continueOnError */).Unwrap());
 
-   std::vector<std::tuple<std::string, std::string, std::string>> result;
+   std::vector<RCheckResult> result;
    for (const auto &f : fieldZero) {
       auto invalidField = dynamic_cast<const RInvalidField *>(&f);
       if (!invalidField)
          continue;
 
       result.emplace_back(
-         std::make_tuple(invalidField->GetQualifiedFieldName(), invalidField->GetTypeName(), invalidField->GetError()));
+         RCheckResult{invalidField->GetQualifiedFieldName(), invalidField->GetTypeName(), invalidField->GetError()});
    }
    return result;
 }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -50,6 +50,7 @@ ROOT_ADD_GTEST(ntuple_view ntuple_view.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)
 
 ROOT_ADD_GTEST(rfield_blob rfield_blob.cxx LIBRARIES ROOTNTuple)
+ROOT_ADD_GTEST(rfield_check rfield_check.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_string rfield_string.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_variant rfield_variant.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -206,11 +206,11 @@ struct StructWithIORules : StructWithIORulesBase {
    StructWithIORules(float _a, char _c[4]) : StructWithIORulesBase{_a, 0.0f}, s{{_c[0], _c[1], _c[2], _c[3]}, {}} {}
 };
 
-class Cyclic {
+struct Cyclic {
    std::vector<Cyclic> fMember;
 };
 
-class Unsupported {
+struct Unsupported {
    float a;
    std::chrono::time_point<std::chrono::system_clock> timestamp;
    float b;

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -4,9 +4,11 @@
 #include <RtypesCore.h> // for Double32_t
 #include <TRootIOCtor.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <random>
 #include <string>
 #include <variant>
 #include <vector>
@@ -206,6 +208,14 @@ struct StructWithIORules : StructWithIORulesBase {
 
 class Cyclic {
    std::vector<Cyclic> fMember;
+};
+
+class Unsupported {
+   float a;
+   std::chrono::time_point<std::chrono::system_clock> timestamp;
+   float b;
+   std::random_device rd;
+   float z;
 };
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -72,5 +72,6 @@
    "StructWithIORules" target = "c" code = "{ c = onfile.a + onfile.b; }"
 
 #pragma link C++ class Cyclic + ;
+#pragma link C++ class Unsupported + ;
 
 #endif

--- a/tree/ntuple/v7/test/rfield_check.cxx
+++ b/tree/ntuple/v7/test/rfield_check.cxx
@@ -1,0 +1,50 @@
+#include <ROOT/RField.hxx>
+
+#include <tuple>
+
+#include "CustomStruct.hxx"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+class NoDict {};
+
+TEST(RField, Check)
+{
+   using ROOT::Experimental::RFieldBase;
+
+   auto report = RFieldBase::Check("f", "CustomStruct");
+   EXPECT_TRUE(report.empty());
+
+   report = RFieldBase::Check("f", "");
+   EXPECT_EQ(1u, report.size());
+   auto [fieldName, typeName, errMsg] = report[0];
+   EXPECT_EQ("f", fieldName);
+   EXPECT_EQ("", typeName);
+   EXPECT_THAT(errMsg, testing::HasSubstr("no type name"));
+
+   report = RFieldBase::Check("f", "std::array<>");
+   EXPECT_EQ(1u, report.size());
+   std::tie(fieldName, typeName, errMsg) = report[0];
+   EXPECT_EQ("f", fieldName);
+   EXPECT_EQ("std::array<>", typeName);
+   EXPECT_THAT(errMsg, testing::HasSubstr("exactly two elements"));
+
+   report = RFieldBase::Check("f", "NoDict");
+   EXPECT_EQ(1u, report.size());
+   std::tie(fieldName, typeName, errMsg) = report[0];
+   EXPECT_EQ("f", fieldName);
+   EXPECT_EQ("NoDict", typeName);
+   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+
+   report = RFieldBase::Check("f", "Unsupported");
+   EXPECT_EQ(2u, report.size());
+   std::tie(fieldName, typeName, errMsg) = report[0];
+   EXPECT_EQ("f.timestamp", fieldName);
+   EXPECT_THAT(typeName, testing::HasSubstr("chrono::time_point"));
+   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+   std::tie(fieldName, typeName, errMsg) = report[1];
+   EXPECT_EQ("f.rd", fieldName);
+   EXPECT_THAT(typeName, testing::HasSubstr("random_device"));
+   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+}

--- a/tree/ntuple/v7/test/rfield_check.cxx
+++ b/tree/ntuple/v7/test/rfield_check.cxx
@@ -47,4 +47,9 @@ TEST(RField, Check)
    EXPECT_EQ("f.rd", fieldName);
    EXPECT_THAT(typeName, testing::HasSubstr("random_device"));
    EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+
+   report = RFieldBase::Check("f", "long double");
+   EXPECT_EQ(1u, report.size());
+   std::tie(fieldName, typeName, errMsg) = report[0];
+   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
 }

--- a/tree/ntuple/v7/test/rfield_check.cxx
+++ b/tree/ntuple/v7/test/rfield_check.cxx
@@ -1,7 +1,5 @@
 #include <ROOT/RField.hxx>
 
-#include <tuple>
-
 #include "CustomStruct.hxx"
 
 #include "gmock/gmock.h"
@@ -18,38 +16,34 @@ TEST(RField, Check)
 
    report = RFieldBase::Check("f", "");
    EXPECT_EQ(1u, report.size());
-   auto [fieldName, typeName, errMsg] = report[0];
-   EXPECT_EQ("f", fieldName);
-   EXPECT_EQ("", typeName);
-   EXPECT_THAT(errMsg, testing::HasSubstr("no type name"));
+   EXPECT_EQ("f", report[0].fFieldName);
+   EXPECT_EQ("", report[0].fTypeName);
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("no type name"));
 
    report = RFieldBase::Check("f", "std::array<>");
    EXPECT_EQ(1u, report.size());
-   std::tie(fieldName, typeName, errMsg) = report[0];
-   EXPECT_EQ("f", fieldName);
-   EXPECT_EQ("std::array<>", typeName);
-   EXPECT_THAT(errMsg, testing::HasSubstr("exactly two elements"));
+   EXPECT_EQ("f", report[0].fFieldName);
+   EXPECT_EQ("std::array<>", report[0].fTypeName);
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("exactly two elements"));
 
    report = RFieldBase::Check("f", "NoDict");
    EXPECT_EQ(1u, report.size());
-   std::tie(fieldName, typeName, errMsg) = report[0];
-   EXPECT_EQ("f", fieldName);
-   EXPECT_EQ("NoDict", typeName);
-   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+   EXPECT_EQ("f", report[0].fFieldName);
+   EXPECT_EQ("NoDict", report[0].fTypeName);
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("unknown type"));
 
    report = RFieldBase::Check("f", "Unsupported");
    EXPECT_EQ(2u, report.size());
-   std::tie(fieldName, typeName, errMsg) = report[0];
-   EXPECT_EQ("f.timestamp", fieldName);
-   EXPECT_THAT(typeName, testing::HasSubstr("chrono::time_point"));
-   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
-   std::tie(fieldName, typeName, errMsg) = report[1];
-   EXPECT_EQ("f.rd", fieldName);
-   EXPECT_THAT(typeName, testing::HasSubstr("random_device"));
-   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+   EXPECT_EQ("f.timestamp", report[0].fFieldName);
+   EXPECT_THAT(report[0].fTypeName, testing::HasSubstr("chrono::time_point"));
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("unknown type"));
+   EXPECT_EQ("f.rd", report[1].fFieldName);
+   EXPECT_THAT(report[1].fTypeName, testing::HasSubstr("random_device"));
+   EXPECT_THAT(report[1].fErrMsg, testing::HasSubstr("unknown type"));
 
    report = RFieldBase::Check("f", "long double");
    EXPECT_EQ(1u, report.size());
-   std::tie(fieldName, typeName, errMsg) = report[0];
-   EXPECT_THAT(errMsg, testing::HasSubstr("unknown type"));
+   EXPECT_EQ("f", report[0].fFieldName);
+   EXPECT_EQ("long double", report[0].fTypeName);
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("unknown type"));
 }


### PR DESCRIPTION
Adds a new static method, `RFieldBase::Check()`, that produces a support status report of a type wrt. to RNTuple I/O. The method uses `RFieldBase::Create()` internally. Instead of throwing an exception when a (sub) type fails to be constructed, in the case of `Check()`  an `RInvalidField` is inserted in the field tree instead. The invalid fields are then collected to produce a report of failures.

@Dr15Jones FYI.