### PR TITLE
[RF] Don't consider implicit MT in RooBatchCompute

### DIFF
--- a/roofit/batchcompute/CMakeLists.txt
+++ b/roofit/batchcompute/CMakeLists.txt
@@ -9,7 +9,6 @@ ROOT_LINKER_LIBRARY(RooBatchCompute
   DEPENDENCIES
     Core
     MathCore
-    Imt
     ${CudaDependencies}
 )
 

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -117,6 +117,8 @@ private:
 void RooBatchComputeClass::computeIMT(Computer computer, RestrictArr output, size_t nEvents, VarSpan vars,
                                       ArgSpan extraArgs)
 {
+   if (nEvents == 0)
+      return;
    ROOT::Internal::TExecutor ex;
    std::size_t nThreads = ex.GetPoolSize();
 


### PR DESCRIPTION
In the original implementation of the RooBatchCompute library, the
evaluation was done multi-threaded in implicit multi-threading was
enabled in ROOT with `ROOT::EnableImplicitMT()`.

This commit removes this feature now, because it was never really
validated, overlapped with other parallelization capabilities of RooFit,
and keeping it will have many unforeseen consequences on users now that
the new CPU evaluation backend is the default in RooFit.

See also:
https://github.com/cms-sw/cmsdist/pull/9047