### PR TITLE
[ntuple] fix exception handling when adding fields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -277,6 +277,7 @@ public:
       std::shared_ptr<T> ptr;
       if (fDefaultEntry)
          ptr = fDefaultEntry->AddValue<T>(*field, std::forward<ArgsT>(args)...);
+      fFieldNames.insert(field->GetFieldName());
       fFieldZero->Attach(std::move(field));
       return ptr;
    }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -186,9 +186,8 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
       nameValid.Throw();
    }
    auto fieldNameStr = std::string(fieldName);
-   if (fFieldNames.insert(fieldNameStr).second == false) {
+   if (fFieldNames.count(fieldNameStr) > 0)
       throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists in NTuple model"));
-   }
 }
 
 void ROOT::Experimental::RNTupleModel::EnsureNotFrozen() const
@@ -281,6 +280,7 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<RFieldBase> fiel
 
    if (fDefaultEntry)
       fDefaultEntry->AddValue(field->CreateValue());
+   fFieldNames.insert(field->GetFieldName());
    fFieldZero->Attach(std::move(field));
 }
 
@@ -308,9 +308,9 @@ ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<RFieldBase> 
    EnsureValidFieldName(fieldName);
    auto result = fProjectedFields->Add(std::move(field), fieldMap);
    if (!result) {
-      fFieldNames.erase(fieldName);
       return R__FORWARD_ERROR(result);
    }
+   fFieldNames.insert(fieldName);
    return RResult<void>::Success();
 }
 
@@ -332,6 +332,7 @@ ROOT::Experimental::RNTupleModel::MakeCollection(std::string_view fieldName,
    if (fDefaultEntry)
       fDefaultEntry->AddValue(field->BindValue(std::shared_ptr<void>(collectionWriter->GetOffsetPtr(), [](void *) {})));
 
+   fFieldNames.insert(field->GetFieldName());
    fFieldZero->Attach(std::move(field));
    return collectionWriter;
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -351,15 +351,7 @@ TEST(RNTupleModel, EnforceValidFieldNames)
 {
    auto model = RNTupleModel::Create();
 
-   auto field = model->MakeField<float>("pt", 42.0);
-
    // MakeField
-   try {
-      auto field2 = model->MakeField<float>("pt", 42.0);
-      FAIL() << "repeated field names should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
-   }
    try {
       auto field3 = model->MakeField<float>("", 42.0);
       FAIL() << "empty string as field name should throw";
@@ -373,9 +365,19 @@ TEST(RNTupleModel, EnforceValidFieldNames)
       EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain dot characters '.'"));
    }
 
+   // Previous failures to create 'pt' should not block the name
+   auto field = model->MakeField<float>("pt", 42.0);
+
+   try {
+      auto field2 = model->MakeField<float>("pt", 42.0);
+      FAIL() << "repeated field names should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
+   }
+
    // AddField
    try {
-      model->AddField(std::make_unique<RField<float>>(RField<float>("pt")));
+      model->AddField(std::make_unique<RField<float>>("pt"));
       FAIL() << "repeated field names should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));


### PR DESCRIPTION
The model keeps track of field names to avoid creating the same top-level field multiple times. Fix this mechanism under exceptions, so that the used field name is not registered as taken.

