### PR TITLE
[RF] Make sure RooFit legacy backend is still tested

### DIFF
--- a/roofit/CMakeLists.txt
+++ b/roofit/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-set(roofit_legacy_eval_backend ON)
+set(roofit_legacy_eval_backend ON CACHE BOOL "" FORCE)
 
 add_subdirectory(batchcompute)
 if (roofit_multiprocess)

--- a/tutorials/roostats/HybridInstructional.C
+++ b/tutorials/roostats/HybridInstructional.C
@@ -111,11 +111,12 @@ protected:
 
 ClassImp(BinCountTestStat)
 
-   // ----------------------------------
-   // The Actual Tutorial Macro
+// ----------------------------------
+// The Actual Tutorial Macro
 
-   void HybridInstructional()
+void HybridInstructional(int ntoys = 6000)
 {
+   double nToysRatio = 20;      // ratio Ntoys Null/ntoys ALT
 
    // This tutorial has 6 parts
    // Table of Contents
@@ -144,8 +145,8 @@ ClassImp(BinCountTestStat)
    // $Pois(x | s+b) * Pois(y | tau b )$
    // for Z_Gamma, use uniform prior on b.
    RooWorkspace *w = new RooWorkspace("w");
-   w->factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0,300]))");
-   w->factory("Poisson::py(y[100,0,500],prod::taub(tau[1.],b))");
+   w->factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0.1,300]))");
+   w->factory("Poisson::py(y[100,0.1,500],prod::taub(tau[1.],b))");
    w->factory("PROD::model(px,py)");
    w->factory("Uniform::prior_b(b)");
 
@@ -318,7 +319,7 @@ ClassImp(BinCountTestStat)
    ToyMCSampler *toymcs1 = (ToyMCSampler *)hc1.GetTestStatSampler();
    toymcs1->SetNEventsPerToy(1);         // because the model is in number counting form
    toymcs1->SetTestStatistic(&binCount); // set the test statistic
-   hc1.SetToys(20000, 1000);
+   hc1.SetToys(ntoys, ntoys / nToysRatio);
    hc1.ForcePriorNuisanceAlt(*w->pdf("py"));
    hc1.ForcePriorNuisanceNull(*w->pdf("py"));
    // if you wanted to use the ad hoc Gaussian prior instead
@@ -371,7 +372,7 @@ ClassImp(BinCountTestStat)
    ToyMCSampler *toymcs2 = (ToyMCSampler *)hc2.GetTestStatSampler();
    toymcs2->SetNEventsPerToy(1);
    toymcs2->SetTestStatistic(&slrts);
-   hc2.SetToys(20000, 1000);
+   hc2.SetToys(ntoys, ntoys / nToysRatio);
    hc2.ForcePriorNuisanceAlt(*w->pdf("py"));
    hc2.ForcePriorNuisanceNull(*w->pdf("py"));
    // if you wanted to use the ad hoc Gaussian prior instead
@@ -480,7 +481,7 @@ ClassImp(BinCountTestStat)
    ToyMCSampler *toymcs3 = (ToyMCSampler *)hc3.GetTestStatSampler();
    toymcs3->SetNEventsPerToy(1);
    toymcs3->SetTestStatistic(&slrts);
-   hc3.SetToys(30000, 1000);
+   hc3.SetToys(ntoys, ntoys / nToysRatio);
    hc3.ForcePriorNuisanceAlt(*w->pdf("gamma_y0"));
    hc3.ForcePriorNuisanceNull(*w->pdf("gamma_y0"));
    // if you wanted to use the ad hoc Gaussian prior instead

--- a/tutorials/roostats/HybridStandardForm.C
+++ b/tutorials/roostats/HybridStandardForm.C
@@ -134,12 +134,13 @@ protected:
 
 ClassImp(BinCountTestStat)
 
-   //-----------------------------
-   // The Actual Tutorial Macro
-   //-----------------------------
+//-----------------------------
+// The Actual Tutorial Macro
+//-----------------------------
 
-   void HybridStandardForm()
+void HybridStandardForm(int ntoys = 6000)
 {
+   double nToysRatio = 20;      // ratio Ntoys Null/ntoys ALT
 
    // This tutorial has 6 parts
    // Table of Contents
@@ -174,8 +175,8 @@ ClassImp(BinCountTestStat)
    // w->factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0,300]))");
    // with one in standard form.  Now x is encoded in event count
    w->factory("Uniform::f(m[0,1])"); // m is a dummy discriminating variable
-   w->factory("ExtendPdf::px(f,sum::splusb(s[0,0,100],b[100,0,300]))");
-   w->factory("Poisson::py(y[100,0,500],prod::taub(tau[1.],b))");
+   w->factory("ExtendPdf::px(f,sum::splusb(s[0,0,100],b[100,0.1,300]))");
+   w->factory("Poisson::py(y[100,0.1,500],prod::taub(tau[1.],b))");
    w->factory("PROD::model(px,py)");
    w->factory("Uniform::prior_b(b)");
 
@@ -310,7 +311,7 @@ ClassImp(BinCountTestStat)
    //  toymcs1->SetNEventsPerToy(1); // because the model is in number counting form
    toymcs1->SetTestStatistic(&eventCount); // set the test statistic
    //  toymcs1->SetGenerateBinned();
-   hc1.SetToys(30000, 1000);
+   hc1.SetToys(ntoys, ntoys / nToysRatio);
    hc1.ForcePriorNuisanceAlt(*w->pdf("py"));
    hc1.ForcePriorNuisanceNull(*w->pdf("py"));
    // if you wanted to use the ad hoc Gaussian prior instead
@@ -364,7 +365,7 @@ ClassImp(BinCountTestStat)
    //  toymcs2->SetNEventsPerToy(1);
    toymcs2->SetTestStatistic(&slrts);
    //  toymcs2->SetGenerateBinned();
-   hc2.SetToys(20000, 1000);
+   hc2.SetToys(ntoys, ntoys / nToysRatio);
    hc2.ForcePriorNuisanceAlt(*w->pdf("py"));
    hc2.ForcePriorNuisanceNull(*w->pdf("py"));
    // if you wanted to use the ad hoc Gaussian prior instead


### PR DESCRIPTION
I noticed that `roofit_legacy_eval_backend` variable in CMake was not
cached, and therefore it didn't propagate to the RooFit test
subdirectories. This meant several unit tests were not executed.

This commit is fixing that.

Furthermore, another commit in this PR reduces the time of the tutorial tests by reducing the number of toys in the RooStats tutorials.