### PR TITLE
[core] do not use whole std namespace, only what's needed

### DIFF
--- a/core/base/src/String.cxx
+++ b/core/base/src/String.cxx
@@ -20,7 +20,7 @@
 
 #include <string>
 
-using namespace std;
+using std::string;
 
 void std_string_streamer(TBuffer &b, void *objadd)
 {

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3327,7 +3327,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
 
    // FIXME: Switch to generic polymorphic when we make c++14 default.
    auto ForeachSharedLibDep = [](const char *lib, std::function<bool(const char *)> f) {
-      using namespace std;
+      using std::string, std::vector, std::istringstream, std::istream_iterator;
       string deps = gInterpreter->GetSharedLibDeps(lib, /*tryDyld*/ true);
       istringstream iss(deps);
       vector<string> libs{istream_iterator<std::string>{iss}, istream_iterator<string>{}};

--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -81,8 +81,6 @@ LastLink() and lnk->Prev() or by using the Before() member.
 
 #include <string>
 
-using namespace std;
-
 ClassImp(TList);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1205,7 +1203,7 @@ void TList::Streamer(TBuffer &b)
          TObject::Streamer(b);
          fName.Streamer(b);
          b >> nobjects;
-         string readOption;
+         std::string readOption;
          for (Int_t i = 0; i < nobjects; i++) {
             b >> obj;
             b >> nch;

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -135,9 +135,8 @@ const ROOT::Internal::RootCling::DriverConfig* gDriverConfig = nullptr;
 using HeadersDeclsMap_t = std::map<std::string, std::list<std::string>>;
 
 using namespace ROOT;
-using namespace TClassEdit;
 
-using namespace std;
+using std::string, std::map, std::ifstream, std::ofstream, std::endl, std::ios, std::vector;
 
 namespace genreflex {
    bool verbose = false;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -29,7 +29,7 @@
 
 #include "TSpinLockGuard.h"
 
-using namespace std;
+using std::string, std::string_view, std::vector, std::set;
 
 namespace {
    static TClassEdit::TInterpreterLookupHelper *gInterpreterHelper = nullptr;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -124,7 +124,7 @@ In order to access the name of a class within the ROOT type system, the method T
 #include "TRef.h"
 #include "TRefArray.h"
 
-using namespace std;
+using std::multimap, std::make_pair, std::string;
 
 // Mutex to protect CINT and META operations
 // (exported to be used for similar cases in related classes)

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -40,7 +40,7 @@
 
 #include <string>
 
-using namespace std;
+using std::string;
 
 const Int_t kMaxLen = 1024;
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -257,7 +257,7 @@ R__DLLEXPORT bool TCling__TEST_isInvalidDecl(ClassInfo_t *input) {
    return info->GetDecl()->isInvalidDecl();
 }
 
-using namespace std;
+using std::string, std::vector;
 using namespace clang;
 using namespace ROOT;
 

--- a/core/metacling/src/TClingBaseClassInfo.cxx
+++ b/core/metacling/src/TClingBaseClassInfo.cxx
@@ -51,7 +51,7 @@ the Clang C++ compiler, not CINT.
 
 using namespace llvm;
 using namespace clang;
-using namespace std;
+using std::string, std::ostringstream;
 
 TClingBaseClassInfo::TClingBaseClassInfo(cling::Interpreter* interp,
                                          TClingClassInfo* ci)

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -74,7 +74,7 @@ C++ interpreter and the Clang C++ compiler, not CINT.
 using namespace ROOT;
 using namespace llvm;
 using namespace clang;
-using namespace std;
+using std::string, std::map, std::ostringstream, std::make_pair;
 
 static unsigned long long gWrapperSerial = 0LL;
 static const string kIndentString("   ");

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -40,8 +40,6 @@ but the type metadata comes from the Clang C++ compiler, not CINT.
 #include <cstdio>
 #include <string>
 
-using namespace std;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 TClingTypeInfo::TClingTypeInfo(cling::Interpreter *interp, const char *name)

--- a/core/textinput/src/Getline_color.cxx
+++ b/core/textinput/src/Getline_color.cxx
@@ -22,7 +22,7 @@
 #include "textinput/Range.h"
 #include "textinput/Text.h"
 
-using namespace std;
+using std::stack;
 using namespace textinput;
 
 namespace {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This is just a suggestion to align a bit more with Clang's coding standards https://opensource.apple.com/source/lldb/lldb-112/llvm/docs/CodingStandards.html#ll_ns_std

If the change is welcome, I can extend to the rest of parts of ROOT that have this statement.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
