### PR TITLE
[PyROOT] Forward compatibility of pretty printing with CPyCppyy

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_generic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_generic.py
@@ -41,8 +41,14 @@ def pythonize_generic(klass, name):
     # Add pretty printing via setting the __str__ special function
 
     # Exclude classes which have the method __str__ already defined in C++
+    # Since version 1.12.11, CPyCppyy is internally renaming any direct C++
+    # __str__ attribute to __cpp_str and replaces __str__ with a pythonic
+    # wrapper. Therefore, the "CPPOverload" name check below doesn't work
+    # anymore with that version. Fortunately, we can just check if the
+    # __cpp_str attribute exists instead. Still, this code does both checks for
+    # maximum compatibility.
     m = getattr(klass, '__str__', None)
-    has_cpp_str = True if m is not None and type(m).__name__ == 'CPPOverload' else False
+    has_cpp_str = type(m).__name__ == "CPPOverload" or hasattr(klass, "__cpp_str")
 
     # Exclude std::string with its own pythonization from cppyy
     exclude = [ 'std::string' ]


### PR DESCRIPTION
The pretty-print pythonization should sxclude classes which have the method `__str__` already defined in C++ Since version 1.12.11, CPyCppyy is internally renaming any direct C++ `__str__` attribute to `__cpp_str` and replaces `__str__` with a pythonic wrapper [1]. Therefore, the "CPPOverload" name check below doesn't work anymore with that version. Fortunately, we can just check if the `__cpp_str` attribute exists instead. Still, this code does both checks for maximum compatibility.

[1] https://github.com/wlav/CPyCppyy/commit/10b15d8a5950125b8e1f2fbf289b1fc4398a6df6

Spinoff of the bigger synchronization PR for easier review:
https://github.com/root-project/root/pull/14507