### PR TITLE
[skip-ci][windows] disable mtbb201_parallelHistoFill.C

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -256,7 +256,7 @@ endif()
 if(MSVC)
   #---Multiproc is not supported on Windows
   set(imt_veto ${imt_veto} multicore/mp*.C multicore/mtbb201_parallelHistoFill.C)
-  if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND NOT win_broken_tests)
+  if(NOT win_broken_tests)
     # std::this_thread::sleep_for(std::chrono::duration<double, std::nano>(500));
     # fails on Windows 32 bit and Visual Studio v17.9 with the following error:
     # IncrementalExecutor::executeFunction: symbol '_Thrd_sleep_for@4' unresolved while linking [cling interface function]!


### PR DESCRIPTION
mtbb201_parallelHistoFill.C fails on Windows x86 and VS v17.9 with the following error:
```
IncrementalExecutor::executeFunction: symbol '_Thrd_sleep_for@4' unresolved while linking [cling interface function]!
```
Due to this line:
```
std::this_thread::sleep_for(std::chrono::duration<double, std::nano>(500));
```