### PR TITLE
[ntuple] Implement unbuffered parallel writing

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -73,6 +73,12 @@ public:
    }
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
+   RWrittenPage WriteSealedPage(DescriptorId_t, const RSealedPage &page) final
+   {
+      fNBytesCurrentCluster += page.fSize;
+      return {};
+   }
+   void CommitWrittenPage(DescriptorId_t, const RWrittenPage &) final {}
    void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.fSize; }
    void CommitSealedPageV(std::span<RSealedPageGroup> ranges) final
    {

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -150,6 +150,8 @@ public:
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
+   RWrittenPage WriteSealedPage(DescriptorId_t, const RSealedPage &) final;
+   void CommitWrittenPage(DescriptorId_t, const RWrittenPage &) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -107,6 +107,14 @@ public:
       }
    };
 
+   struct RWrittenPage {
+      RNTupleLocator fLocator;
+      std::uint32_t fNElements = 0;
+
+      RWrittenPage() = default;
+      RWrittenPage(const RNTupleLocator &locator, std::uint32_t nElements) : fLocator(locator), fNElements(nElements) {}
+   };
+
 protected:
    Detail::RNTupleMetrics fMetrics;
 
@@ -242,6 +250,10 @@ public:
 
    /// Write a page to the storage. The column must have been added before.
    virtual void CommitPage(ColumnHandle_t columnHandle, const RPage &page) = 0;
+   /// Write a preprocessed page's buffer to the storage.
+   virtual RWrittenPage WriteSealedPage(DescriptorId_t, const RSealedPage &) = 0;
+   /// Commit a previously written page.
+   virtual void CommitWrittenPage(DescriptorId_t, const RWrittenPage &) = 0;
    /// Write a preprocessed page to storage. The column must have been added before.
    virtual void CommitSealedPage(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) = 0;
    /// Write a vector of preprocessed pages to storage. The corresponding columns must have been added before.
@@ -377,6 +389,8 @@ public:
    void InitFromDescriptor(const RNTupleDescriptor &descriptor);
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
+   RWrittenPage WriteSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
+   void CommitWrittenPage(DescriptorId_t physicalColumnId, const RWrittenPage &writtenPage) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitCluster(NTupleSize_t nEntries) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -63,8 +63,7 @@ private:
    std::uint64_t fNBytesCurrentCluster = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
-   RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
-                                                std::size_t bytesPacked);
+   RNTupleLocator WriteSealedPageImpl(const RPageStorage::RSealedPage &sealedPage, std::size_t bytesPacked);
 
 protected:
    using RPagePersistentSink::InitImpl;

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -166,6 +166,17 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
    });
 }
 
+ROOT::Experimental::Internal::RPageStorage::RWrittenPage
+ROOT::Experimental::Internal::RPageSinkBuf::WriteSealedPage(DescriptorId_t, const RSealedPage &)
+{
+   throw RException(R__FAIL("should never commit sealed pages to RPageSinkBuf"));
+}
+
+void ROOT::Experimental::Internal::RPageSinkBuf::CommitWrittenPage(DescriptorId_t, const RWrittenPage &)
+{
+   throw RException(R__FAIL("should never commit written pages to RPageSinkBuf"));
+}
+
 void ROOT::Experimental::Internal::RPageSinkBuf::CommitSealedPage(DescriptorId_t /*physicalColumnId*/,
                                                                   const RSealedPage & /*sealedPage*/)
 {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -529,6 +529,24 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitPage(ColumnHandle_
    fOpenPageRanges.at(columnHandle.fPhysicalId).fPageInfos.emplace_back(pageInfo);
 }
 
+ROOT::Experimental::Internal::RPageStorage::RWrittenPage
+ROOT::Experimental::Internal::RPagePersistentSink::WriteSealedPage(DescriptorId_t physicalColumnId,
+                                                                   const RSealedPage &sealedPage)
+{
+   return RWrittenPage(CommitSealedPageImpl(physicalColumnId, sealedPage), sealedPage.fNElements);
+}
+
+void ROOT::Experimental::Internal::RPagePersistentSink::CommitWrittenPage(DescriptorId_t physicalColumnId,
+                                                                          const RWrittenPage &writtenPage)
+{
+   fOpenColumnRanges.at(physicalColumnId).fNElements += writtenPage.fNElements;
+
+   RClusterDescriptor::RPageRange::RPageInfo pageInfo;
+   pageInfo.fNElements = writtenPage.fNElements;
+   pageInfo.fLocator = writtenPage.fLocator;
+   fOpenPageRanges.at(physicalColumnId).fPageInfos.emplace_back(pageInfo);
+}
+
 void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPage(DescriptorId_t physicalColumnId,
                                                                          const RPageStorage::RSealedPage &sealedPage)
 {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -86,8 +86,8 @@ void ROOT::Experimental::Internal::RPageSinkFile::InitImpl(unsigned char *serial
 }
 
 inline ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
-                                                             std::size_t bytesPacked)
+ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPageImpl(const RPageStorage::RSealedPage &sealedPage,
+                                                                 std::size_t bytesPacked)
 {
    std::uint64_t offsetData;
    {
@@ -115,7 +115,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitPageImpl(ColumnHandle_t colum
    }
 
    fCounters->fSzZip.Add(page.GetNBytes());
-   return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
+   return WriteSealedPageImpl(sealedPage, element->GetPackedSize(page.GetNElements()));
 }
 
 ROOT::Experimental::RNTupleLocator
@@ -126,7 +126,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t
       fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(physicalColumnId).GetModel().GetType());
    const auto bytesPacked = (bitsOnStorage * sealedPage.fNElements + 7) / 8;
 
-   return WriteSealedPage(sealedPage, bytesPacked);
+   return WriteSealedPageImpl(sealedPage, bytesPacked);
 }
 
 std::vector<ROOT::Experimental::RNTupleLocator>

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -50,6 +50,11 @@ protected:
 
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
+   RWrittenPage WriteSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final
+   {
+      return {};
+   }
+   void CommitWrittenPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RWrittenPage &) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}
    std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -78,29 +78,25 @@ TEST(RNTupleParallelWriter, Basics)
       auto writer = RNTupleParallelWriter::Append(std::move(model), "f", *file);
       test(std::move(writer));
    }
-}
 
-TEST(RNTupleParallelWriter, Options)
-{
-   FileRaii fileGuard("test_ntuple_parallel_options.root");
-
-   RNTupleWriteOptions options;
-   options.SetUseBufferedWrite(false);
-
-   try {
+   {
       auto model = RNTupleModel::CreateBare();
-      RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
-      FAIL() << "should require buffered writing";
-   } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("parallel writing requires buffering"));
+      model->MakeField<float>("pt");
+
+      RNTupleWriteOptions options;
+      options.SetUseBufferedWrite(false);
+      auto writer = RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
+      test(std::move(writer));
    }
 
-   try {
-      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   {
       auto model = RNTupleModel::CreateBare();
-      RNTupleParallelWriter::Append(std::move(model), "f", *file, options);
-      FAIL() << "should require buffered writing";
-   } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("parallel writing requires buffering"));
+      model->MakeField<float>("pt");
+
+      RNTupleWriteOptions options;
+      options.SetUseBufferedWrite(false);
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleParallelWriter::Append(std::move(model), "f", *file, options);
+      test(std::move(writer));
    }
 }

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -36,6 +36,14 @@ protected:
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
+   RWrittenPage WriteSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final
+   {
+      return {};
+   }
+   void CommitWrittenPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RWrittenPage &) final
+   {
+      fCounters.fNCommitSealedPage++;
+   }
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final
    {
       fCounters.fNCommitSealedPage++;


### PR DESCRIPTION
Instead of using one `RPageSinkBuf` per context, implement a synchronizing page sink that compresses pages and writes them through to storage, but only commits them when the context's cluster is ready. This uses much less memory, but results in higher lock contention and very fragmented files.

---

We likely don't want to merge this because buffered writing offers better scalability *and* allows to reorder pages, resulting in better read performance. But for future reference, this is how it could be implemented.