### PR TITLE
[PyROOT] Forward compatibility of user pythonizations with newer cppyy

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -242,7 +242,8 @@ def _find_used_classes(ns, passes_filter, user_pythonizor, npars):
     for var_name, var_value in ns_vars.items():
         if str(var_value).startswith('<class cppyy.gbl.'):
             # It's a class proxy, check if name matches
-            parsed_var_name = _get_class_name(var_name)
+
+            parsed_var_name = var_name.split("::")[-1]
             if passes_filter(parsed_var_name):
                 # Pythonize right away!
                 _invoke(user_pythonizor, npars, var_value, var_value.__cpp_name__)
@@ -273,51 +274,6 @@ def _find_namespace(ns):
         ns_obj = getattr(ns_obj, ns)
 
     return ns_obj
-
-def _get_class_name(fqn):
-    '''
-    Parses and returns the class name in `fqn`.
-    Example: if `fqn` is "NS1::NS2::C", "C" is returned.
-
-    Args:
-        fqn (string): fully-qualified class name.
-
-    Returns:
-        string: class name in `fqn`.
-    '''
-
-    pos = _find_namespace_end(fqn)
-    if pos < 0: # no namespace found
-        return fqn
-    else:
-        return fqn[pos+2:]
-
-def _find_namespace_end(fqn):
-    '''
-    Find the position where the namespace in `fqn` ends.
-
-    Args:
-        fqn (string): fully-qualified class name.
-
-    Returns:
-        integer: position where the namespace in `fqn` ends, i.e. the position
-            of the last '::', or -1 if there is no '::' in `fqn`.
-    '''
-
-    last_found = -1
-    prev_c = ''
-    pos = 0
-    for c in fqn:
-        if c == ':' and prev_c == ':':
-            last_found = pos - 1
-        elif c == '<':
-            # If we found a template, this is already the class name,
-            # so we're done!
-            break
-        prev_c = c
-        pos += 1
-
-    return last_found
 
 def _register_pythonizations():
     '''


### PR DESCRIPTION
In older cppyy, template instanciations are cached by fully-qualified
name directly in the namespace. Therefore, no extra code is required to
cover template instances in the pythonization code.

With the new cppyy, this is not the case anymore, and instances are
instead cached in the `_instatiations` attribute of the template class [1].

This commit considers this, in a way that is backwards compatible also
with the older cppyy version that ROOT currently uses.

A second commit in this PR removes some not so Pythonic "C++-style" code from PyROOT.

[1] https://github.com/wlav/cppyy/commit/f2e1ea783afd2e4f195b6cbaf09d72b9fa3cd865

Spinoff of the bigger synchronization PR for easier review:
https://github.com/root-project/root/pull/14507