### PR TITLE
[non-core] do not use whole std namespace, only what's needed

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -155,7 +155,7 @@ static CPPDataMember* pp_new(PyTypeObject* pytype, PyObject*, PyObject*)
 static void pp_dealloc(CPPDataMember* pyprop)
 {
 // Deallocate memory held by this descriptor.
-    using namespace std;
+    using std::string;
     if (pyprop->fConverter && pyprop->fConverter->HasState()) delete pyprop->fConverter;
     Py_XDECREF(pyprop->fName);    // never exposed so no GC necessary
 

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -81,7 +81,7 @@
 #include <stdarg.h>
 #include <memory>
 
-using namespace std;
+using std::string, std::ios_base, std::unique_ptr;
 
 // Auxiliary functions
 void   FilterClass();

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -578,7 +578,7 @@ const TBuffer3D &TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFrame
 
 TGeoTessellated *TGeoTessellated::ImportFromObjFormat(const char *objfile, bool check, bool verbose)
 {
-   using namespace std;
+   using std::vector, std::string, std::ifstream, std::stringstream, std::endl;
 
    vector<Vertex_t> vertices;
    vector<string> sfacets;

--- a/graf3d/gl/src/TGLBoundingBox.cxx
+++ b/graf3d/gl/src/TGLBoundingBox.cxx
@@ -14,8 +14,6 @@
 #include "TGLIncludes.h"
 #include "TMathBase.h"
 
-using namespace std;
-
 /** \class TGLBoundingBox
 \ingroup opengl
 Concrete class describing an orientated (free) or axis aligned box

--- a/graf3d/gl/src/TGLBoxPainter.cxx
+++ b/graf3d/gl/src/TGLBoxPainter.cxx
@@ -204,7 +204,7 @@ void TGLBoxPainter::Pan(Int_t px, Int_t py)
 
 void TGLBoxPainter::AddOption(const TString &option)
 {
-   using namespace std;//isdigit must be in std. But ...
+   using std::isdigit;
 
    const Ssiz_t boxPos = option.Index("box");//"box" _already_ _exists_ in a string.
    if (boxPos + 3 < option.Length() && isdigit(option[boxPos + 3]))

--- a/graf3d/gl/src/TGLLegoPainter.cxx
+++ b/graf3d/gl/src/TGLLegoPainter.cxx
@@ -433,7 +433,6 @@ void TGLLegoPainter::Pan(Int_t px, Int_t py)
 
 void TGLLegoPainter::AddOption(const TString &option)
 {
-   using namespace std;
    const Ssiz_t legoPos = option.Index("lego");//"lego" _already_ _exists_ in a string.
    if (legoPos + 4 < option.Length() && isdigit(option[legoPos + 4])) {
       switch (option[legoPos + 4] - '0') {

--- a/graf3d/gl/src/TGLParametric.cxx
+++ b/graf3d/gl/src/TGLParametric.cxx
@@ -40,7 +40,6 @@ namespace
 
    void ReplaceUVNames(TString &equation)
    {
-      using namespace std;
       const Ssiz_t len = equation.Length();
       //TF2 requires 'y' in formula.
       //'v' <=> 'y', so if none 'v' was found, I'll append "+0*y" to the equation.

--- a/graf3d/gl/src/TGLPlotPainter.cxx
+++ b/graf3d/gl/src/TGLPlotPainter.cxx
@@ -231,8 +231,6 @@ void TGLPlotPainter::Paint()
 
 void TGLPlotPainter::PrintPlot()const
 {
-   using namespace std;
-
    TGLOutput::StartEmbeddedPS();
 
    FILE *output = fopen(gVirtualPS->GetName(), "a");

--- a/graf3d/gl/src/TGLSurfacePainter.cxx
+++ b/graf3d/gl/src/TGLSurfacePainter.cxx
@@ -155,7 +155,6 @@ void TGLSurfacePainter::Pan(Int_t px, Int_t py)
 
 void TGLSurfacePainter::AddOption(const TString &option)
 {
-   using namespace std;
    const Ssiz_t surfPos = option.Index("surf");//"surf" _already_ _exists_ in a string.
    if (surfPos + 4 < option.Length() && isdigit(option[surfPos + 4])) {
       switch (option[surfPos + 4] - '0') {
@@ -863,7 +862,6 @@ void TGLSurfacePainter::DrawProjections()const
 
 void TGLSurfacePainter::DrawSectionXOZ()const
 {
-   using namespace std;
    //XOZ parallel section.
    Int_t binY = -1;
    for (Int_t j = 0, e = fCoord->GetNYBins() - 1; j < e; ++j) {
@@ -914,7 +912,6 @@ void TGLSurfacePainter::DrawSectionXOZ()const
 
 void TGLSurfacePainter::DrawSectionYOZ()const
 {
-   using namespace std;
    //YOZ parallel section.
    Int_t binX = -1;
    for (Int_t i = 0, e = fCoord->GetNXBins() - 1; i < e; ++i) {
@@ -965,7 +962,6 @@ void TGLSurfacePainter::DrawSectionYOZ()const
 
 void TGLSurfacePainter::DrawSectionXOY()const
 {
-   using namespace std;
    //XOY parallel section.
    const Int_t nX = fCoord->GetNXBins();
    const Int_t nY = fCoord->GetNYBins();

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -16,7 +16,6 @@
 #include <exception>
 #include <stdexcept>
 #include <cmath>
-using namespace std;
 
 #include "CommonDefs.h"
 

--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -25,8 +25,6 @@
 
 #include <cstdio>
 
-using namespace std;
-
 Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
 {
 

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -31,7 +31,7 @@
 #include <set>
 #include <sstream>
 
-using namespace std;
+using std::map, std::pair, std::make_pair, std::list, std::max, std::string;
 
 #ifdef WIN32
 #pragma optimize("",off)

--- a/hist/hist/src/TSVDUnfold.cxx
+++ b/hist/hist/src/TSVDUnfold.cxx
@@ -68,8 +68,6 @@
 
 ClassImp(TSVDUnfold);
 
-using namespace std;
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Alternative constructor
 /// User provides data and MC test spectra, as well as detector response matrix, diagonal covariance matrix of measured spectrum built from the uncertainties on measured spectrum

--- a/hist/hist/test/test_TF123_Moments.cxx
+++ b/hist/hist/test/test_TF123_Moments.cxx
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-using namespace std;
+using std::sqrt;
 
 bool debug = false;
 

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -7,8 +7,6 @@
 
 #include <iostream>
 
-using namespace std;
-
 class MyClass {
 public:
    double operator()(double *x, double *p) { return *x + *p; };

--- a/hist/histv7/speed/histspeedtest.cxx
+++ b/hist/histv7/speed/histspeedtest.cxx
@@ -17,7 +17,7 @@
 #include "ROOT/RHistBufferedFill.hxx"
 
 using namespace ROOT;
-using namespace std;
+using std::cout, std::swap;
 
 constexpr unsigned short gRepeat = 2;
 

--- a/hist/unfold/src/TUnfoldBinning.cxx
+++ b/hist/unfold/src/TUnfoldBinning.cxx
@@ -115,7 +115,7 @@ CreateHistogramOfMigrations(). Possible bug fix with NaN in GetGlobalBinNUmber()
 
 // #define DEBUG
 
-using namespace std;
+using std::ostream;
 
 ClassImp(TUnfoldBinning);
 

--- a/hist/unfold/src/TUnfoldBinningXML.cxx
+++ b/hist/unfold/src/TUnfoldBinningXML.cxx
@@ -133,7 +133,7 @@ scheme consists of two two-dimensional distributions, signal and background.
 
 // #define DEBUG
 
-using namespace std;
+using std::ofstream, std::stringstream;
 
 ClassImp(TUnfoldBinningXML);
 

--- a/hist/unfold/src/TUnfoldDensity.cxx
+++ b/hist/unfold/src/TUnfoldDensity.cxx
@@ -158,7 +158,7 @@ whichever algorithm is used, the output has to be checked:
 //#define DEBUG
 
 #ifdef DEBUG
-using namespace std;
+using std::cout;
 #endif
 
 ClassImp(TUnfoldDensity);

--- a/io/io/src/TFilePrefetch.cxx
+++ b/io/io/src/TFilePrefetch.cxx
@@ -30,8 +30,6 @@ static const int kMAX_READ_SIZE    = 2;   //maximum size of the read list of blo
 
 inline int xtod(char c) { return (c>='0' && c<='9') ? c-'0' : ((c>='A' && c<='F') ? c-'A'+10 : ((c>='a' && c<='f') ? c-'a'+10 : 0)); }
 
-using namespace std;
-
 ClassImp(TFilePrefetch);
 
 /**

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -39,7 +39,7 @@
 #define COMMIT_FILE        ".rootcommit"
 #define JUPYTER_CONFIG     "jupyter_notebook_config.py"
 
-using namespace std;
+using std::string, std::ifstream, std::ofstream, std::ios, std::endl;
 
 #ifdef WIN32
 #include <process.h>

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -16,8 +16,6 @@
 #include <cassert>
 #include <cmath>
 
-using namespace std;
-
 namespace ROOT {
 
    namespace Fit

--- a/math/mathcore/src/ProbFuncMathCore.cxx
+++ b/math/mathcore/src/ProbFuncMathCore.cxx
@@ -9,7 +9,7 @@
 #include "Math/SpecFuncMathCore.h"
 #include <cstdio>
 #include <limits>
-using namespace std;
+
 namespace ROOT {
 namespace Math {
 

--- a/math/mathcore/src/SparseData.cxx
+++ b/math/mathcore/src/SparseData.cxx
@@ -25,7 +25,7 @@
 #include "Fit/BinData.h"
 #include "Fit/SparseData.h"
 
-using namespace std;
+using std::cout, std::endl, std::vector, std::list, std::ostream, std::ostream_iterator;
 
 namespace ROOT {
 

--- a/math/mathcore/test/binarySearchTime.cxx
+++ b/math/mathcore/test/binarySearchTime.cxx
@@ -14,7 +14,7 @@
 #include <TLegend.h>
 #include <TAxis.h>
 
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 const int npass0 = 200000;
 const int maxint = 100;//20;

--- a/math/mathcore/test/fit/SparseDataComparer.cxx
+++ b/math/mathcore/test/fit/SparseDataComparer.cxx
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <functional>
 
-using namespace std;
+using std::cout, std::cerr, std::endl, std::ostream, std::ostream_iterator, std::vector;
 
 
 double minRange[3] = { -5., -5., -5.};

--- a/math/mathcore/test/fit/SparseFit3.cxx
+++ b/math/mathcore/test/fit/SparseFit3.cxx
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <cassert>
 
-using namespace std;
+using std::cout, std::cerr, std::endl, std::ostream, std::ostream_iterator, std::vector;
 
 bool showGraphics = false;
 

--- a/math/mathcore/test/fit/SparseFit4.cxx
+++ b/math/mathcore/test/fit/SparseFit4.cxx
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <cassert>
 
-using namespace std;
+using std::cout, std::cerr, std::endl, std::ostream, std::ostream_iterator, std::vector;
 
 bool showGraphics = false;
 

--- a/math/mathcore/test/stdsort.cxx
+++ b/math/mathcore/test/stdsort.cxx
@@ -15,7 +15,7 @@
 #include <TAxis.h>
 //#include <TSystem.h>
 
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 const int npass0 = 200000;
 const int maxint = 20;

--- a/math/mathcore/test/stressTF1.cxx
+++ b/math/mathcore/test/stressTF1.cxx
@@ -8,7 +8,7 @@
 #include "TStopwatch.h"
 #include <cmath>
 
-using namespace std;
+using std::string, std::cout, std::endl;
 
 const double XMIN = 0, XMAX = 2*TMath::Pi() + 1.E-15;  // add an eps to avoid failing the search
 const Int_t NB = 100;

--- a/math/mathcore/test/testAnalyticalIntegrals.cxx
+++ b/math/mathcore/test/testAnalyticalIntegrals.cxx
@@ -1,6 +1,6 @@
 //
 //  TestAnalyticalIntegrals
-//  
+//
 //
 //  Created by Aurélie Flandi on 10.09.14.
 //
@@ -18,14 +18,14 @@
 #include <Math/Integrator.h>
 
 
-using namespace std;
+using std::cout, std::endl, std::cerr;
 
 void testAnalyticalIntegrals()
 {
 
 //compare analytical integration with numerical one
 
-   ROOT::Math::Integrator ig; 
+   ROOT::Math::Integrator ig;
 
    TCanvas * c1 = new TCanvas("pol3","pol3",800,1000);
    c1->Divide(3,3);
@@ -67,7 +67,7 @@ void testAnalyticalIntegrals()
       if (!TMath::AreEqualAbs(numInt, anaInt, 1.E-8))
          Error("TestAnalyticalIntegral","Different integral value for %s num = %f ana = %f diff = %f",f->GetTitle(),numInt,anaInt,numInt-anaInt);
 
-   }  
+   }
    {
       TF1 *f  = new TF1("MyCrystalBall","crystalball",-5.,5.);
       f -> SetParameters(2,1,0.5,2.,0.9);
@@ -84,7 +84,7 @@ void testAnalyticalIntegrals()
 
       if (!TMath::AreEqualAbs(numInt, anaInt, 1.E-8))
          Error("TestAnalyticalIntegral","Different integral value for %s num = %f ana = %f diff = %f",f->GetTitle(),numInt,anaInt,numInt-anaInt);
-      
+
    }
    {
       // CB with alpha < 0
@@ -110,7 +110,7 @@ void testAnalyticalIntegrals()
       c1->cd(++ipad);
       f ->Draw();
       ROOT::Math::WrappedTF1 wf(*f);
-      
+
       double anaInt = f->Integral(-5.,5.);
       double numInt = ig.Integral(wf,-5.,5.);
 
@@ -156,7 +156,7 @@ void testAnalyticalIntegrals()
       if (!TMath::AreEqualAbs(numInt, anaInt, 1.E-8))
          Error("TestAnalyticalIntegral","Different integral value for %s num = %f ana = %f diff = %f",f->GetTitle(),numInt,anaInt,numInt-anaInt);
 
-   }  
+   }
    {
       TF1 *f  = new TF1("MyExp","landaun",-5.,5.);
       f -> SetParameters(2.,-2.,0.3);
@@ -169,11 +169,11 @@ void testAnalyticalIntegrals()
 
       std::cout<<"analytical integral for " << f->GetTitle()  << " = " << anaInt << std::endl;
       std::cout<<"numerical  integral for " << f->GetTitle()  << " = " << numInt << std::endl;
-      
+
       if (!TMath::AreEqualAbs(numInt, anaInt, 1.E-8))
          Error("TestAnalyticalIntegral","Different integral value for %s num = %f ana = %f diff = %f",f->GetTitle(),numInt,anaInt,numInt-anaInt);
 
-   }  
+   }
 }
 
 int main(int argc, char **argv)
@@ -191,16 +191,16 @@ int main(int argc, char **argv)
          cerr << "     -g : graphics mode\n";
          cerr << "     -v : verbose  mode";
          cerr << endl;
-         return -1; 
+         return -1;
       }
    }
-   
+
    TApplication* theApp = nullptr;
    if ( showGraphics )
       theApp = new TApplication("App",&argc,argv);
-  
+
    testAnalyticalIntegrals();
-  
+
    if ( showGraphics )
    {
       theApp->Run();

--- a/math/mathcore/test/testBinarySearch.cxx
+++ b/math/mathcore/test/testBinarySearch.cxx
@@ -4,7 +4,7 @@
 #include <TRandom2.h>
 #include <TMath.h>
 
-using namespace std;
+using std::cout, std::endl;
 
 const int nn = 20;
 const int maxint = 10;

--- a/math/mathcore/test/testIntegrationMultiDim.cxx
+++ b/math/mathcore/test/testIntegrationMultiDim.cxx
@@ -32,7 +32,7 @@
 bool showGraphics = false;
 bool verbose = false;
 
-using namespace std;
+using std::cout, std::cerr, std::endl;
 
 int NMAX = 6; //maximum dimension
 

--- a/math/mathcore/test/testSortOrder.cxx
+++ b/math/mathcore/test/testSortOrder.cxx
@@ -6,7 +6,7 @@
 #include "TMath.h"
 #include "TRandom2.h"
 
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 const int maxint = 20;
 

--- a/math/mathcore/test/testSpecFuncBeta.cxx
+++ b/math/mathcore/test/testSpecFuncBeta.cxx
@@ -21,7 +21,7 @@ const int ARRAYSIZE = (int) (( MAX - MIN ) / INCREMENT) + 1;
 
 bool showGraphics = false;
 bool verbose = false;
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 TGraph* drawPoints(Double_t x[], Double_t y[], int color, int style = 1)
 {

--- a/math/mathcore/test/testSpecFuncBetaI.cxx
+++ b/math/mathcore/test/testSpecFuncBetaI.cxx
@@ -22,7 +22,7 @@ const int ARRAYSIZE = (int) (( MAX - MIN ) / INCREMENT) + 1;
 bool showGraphics = false;
 bool verbose = false;
 
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 TGraph* drawPoints(Double_t x[], Double_t y[], int color, int style = 1)
 {

--- a/math/mathcore/test/testSpecFuncErf.cxx
+++ b/math/mathcore/test/testSpecFuncErf.cxx
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <fstream>
+// #include <fstream>
 #include <vector>
 
 #include <cmath>
@@ -25,7 +25,7 @@ const int ARRAYSIZE = (int) (( MAX - MIN ) / INCREMENT) + 1;
 bool showGraphics = false;
 bool verbose = false;
 
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 TGraph* drawPoints(Double_t x[], Double_t y[], int color, int style = 1)
 {

--- a/math/mathcore/test/testSpecFuncGamma.cxx
+++ b/math/mathcore/test/testSpecFuncGamma.cxx
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <fstream>
+//#include <fstream>
 #include <vector>
 
 #include <cmath>
@@ -22,7 +22,7 @@ const int ARRAYSIZE = (int) (( MAX - MIN ) / INCREMENT) + 1;
 
 bool showGraphics = false;
 //bool verbose = false;
-using namespace std;
+using std::vector, std::cout, std::cerr, std::endl;
 
 TGraph* drawPoints(Double_t x[], Double_t y[], int color, int style = 1)
 {

--- a/math/mathcore/test/testTMath.cxx
+++ b/math/mathcore/test/testTMath.cxx
@@ -6,7 +6,7 @@
 
 #include <TMath.h>
 
-using namespace std;
+using std::cout, std::endl, std::vector, std::sort;
 using namespace TMath;
 
 bool showVector = true;

--- a/math/mathmore/test/testPermute.cxx
+++ b/math/mathmore/test/testPermute.cxx
@@ -24,9 +24,9 @@ const int maxsize = 12;
 const int maxint = 5000;
 const int arraysize = (maxsize-minsize) + 1;
 
-using namespace std;
+using std::ostream, std::cout, std::cerr, std::endl, std::vector;
 
- ostream& operator <<(ostream& os, const vector<Int_t>& v)
+ostream& operator <<(ostream& os, const vector<Int_t>& v)
 {
    os << "[ ";
    for ( vector<Int_t>::const_iterator i = v.begin(); i != v.end() ; ++i) {

--- a/math/mathmore/test/testPolynomialRoots.cxx
+++ b/math/mathmore/test/testPolynomialRoots.cxx
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 using namespace ROOT::Math;
-using namespace std;
+using std::vector, std::complex;
 
 class QuarticPolynomial : public ::testing::Test {
 

--- a/math/minuit2/inc/Minuit2/StackAllocator.h
+++ b/math/minuit2/inc/Minuit2/StackAllocator.h
@@ -34,7 +34,6 @@ class StackOverflow {
 };
 class StackError {
 };
-//  using namespace std;
 
 /** StackAllocator controls the memory allocation/deallocation of Minuit. If
     _MN_NO_THREAD_SAVE_ is defined, memory is taken from a pre-allocated piece

--- a/net/rpdutils/src/rpdpriv.cxx
+++ b/net/rpdutils/src/rpdpriv.cxx
@@ -29,7 +29,7 @@
 #include <pwd.h>
 #include <errno.h>
 #include <iostream>
-using namespace std;
+using std::cout, std::endl;
 
 #define NOUC ((uid_t)(-1))
 #define NOGC ((gid_t)(-1))

--- a/proof/proof/src/TProofServ.cxx
+++ b/proof/proof/src/TProofServ.cxx
@@ -43,8 +43,6 @@ master server.
 #include <exception>
 #include <new>
 
-using namespace std;
-
 #if (defined(__FreeBSD__) && (__FreeBSD__ < 4)) || \
     (defined(__APPLE__) && (!defined(MAC_OS_X_VERSION_10_3) || \
      (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_3)))

--- a/proof/proof/src/TProofServLite.cxx
+++ b/proof/proof/src/TProofServLite.cxx
@@ -63,8 +63,6 @@ eliminated, optimizing the number of messages exchanged and created / destroyed.
 #include "TTimeStamp.h"
 #include "compiledata.h"
 
-using namespace std;
-
 // debug hook
 static volatile Int_t gProofServDebug = 1;
 

--- a/proof/proofplayer/src/TProofDraw.cxx
+++ b/proof/proofplayer/src/TProofDraw.cxx
@@ -50,7 +50,7 @@ Implement Tree drawing using PROOF
 #include "TROOT.h"
 
 #include <algorithm>
-using namespace std;
+using std::vector;
 
 
 // Simple call to draw a canvas on the fly from applications loading

--- a/proof/xrdinc/XrdClient/XrdClientInputBuffer.hh
+++ b/proof/xrdinc/XrdClient/XrdClientInputBuffer.hh
@@ -45,8 +45,6 @@
 #include "XrdOuc/XrdOucHash.hh"
 #include "XrdClient/XrdClientVector.hh"
 
-using namespace std;
-
 class XrdClientInputBuffer {
 
 private:
@@ -72,7 +70,7 @@ public:
 
    inline bool     IsMexEmpty() { return (MexSize() == 0); }
    inline bool     IsSemEmpty() { return (SemSize() == 0); }
-   inline int      MexSize() { 
+   inline int      MexSize() {
                        XrdSysMutexHelper mtx(fMutex);
                        return fMsgQue.GetSize();
                        }

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -217,7 +217,7 @@ TChainIndex::~TChainIndex()
 
 std::pair<TVirtualIndex*, Int_t> TChainIndex::GetSubTreeIndex(Long64_t major, Long64_t minor) const
 {
-   using namespace std;
+   using std::make_pair;
    if (fEntries.empty()) {
       Warning("GetSubTreeIndex", "No subindices in the chain. The chain is probably empty");
       return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This change has no impact, it's just to align with Clang's coding standard https://opensource.apple.com/source/lldb/lldb-112/llvm/docs/CodingStandards.html#ll_ns_std and to enforce good practices in students reading / copy-pasting code.

This is part 2 of https://github.com/root-project/root/pull/14922

Part 3 will be Roofit; Part 4 TMVA, test and tutorials

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

