### PR TITLE
Deprecation of TGeoBBox::AreOverlapping

### DIFF
--- a/geom/geom/inc/TGeoBBox.h
+++ b/geom/geom/inc/TGeoBBox.h
@@ -37,7 +37,9 @@ public:
    ~TGeoBBox() override;
    // methods
    static Bool_t
-   AreOverlapping(const TGeoBBox *box1, const TGeoMatrix *mat1, const TGeoBBox *box2, const TGeoMatrix *mat2);
+   AreOverlapping(const TGeoBBox *box1, const TGeoMatrix *mat1, const TGeoBBox *box2, const TGeoMatrix *mat2)
+      R__DEPRECATED(6, 34, "DEPRECATED, DO NOT USE ! The overlap detection does not work for all cases");
+
    Double_t Capacity() const override;
    void ComputeBBox() override;
    void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;


### PR DESCRIPTION
# This Pull request:
Deprecates flawed method TGeoBBox::AreOverlapping
## Changes or fixes:
The function fails to detect some box overlaps, and it is not used inside ROOT.
Added deprecation macro after the function definition

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes [ROOT-8712](https://its.cern.ch/jira/browse/ROOT-8712)

