### PR TITLE
Make links to json spec files

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -1029,7 +1029,6 @@ FILE_PATTERNS          = *.c \
                          *.qsf \
                          *.as \
                          *.js \
-                         *.json \
                          *.pyzdoc
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should

--- a/tutorials/dataframe/df105_WBosonAnalysis.py
+++ b/tutorials/dataframe/df105_WBosonAnalysis.py
@@ -12,6 +12,8 @@
 ## By default the analysis runs on a preskimmed dataset to reduce the runtime. The full dataset can be used with
 ## the --full-dataset argument and you can also run only on a fraction of the original dataset using the argument --lumi-scale.
 ##
+## See the [corresponding spec json file](https://github.com/root-project/root/blob/master/tutorials/dataframe/df105_WBosonAnalysis.json).
+##
 ## \macro_image
 ## \macro_code
 ## \macro_output

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -16,6 +16,8 @@
 /// Systematic uncertainties for those scale factors are evaluated and the Vary function of RDataFrame is used to
 /// propagate the variations to the final four leptons mass distribution.
 ///
+/// See the [corresponding spec json file](https://github.com/root-project/root/blob/master/tutorials/dataframe/df106_HiggsToFourLeptons_spec.json).
+///
 /// \macro_code
 /// \macro_image
 ///

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -12,6 +12,8 @@
 ## Systematic errors for the MC scale factors are computed and the Vary function of RDataFrame is used for plotting.
 ## The analysis is translated to an RDataFrame workflow processing about 300 MB of simulated events and data.
 ##
+## See the [corresponding spec json file](https://github.com/root-project/root/blob/master/tutorials/dataframe/df106_HiggsToFourLeptons_spec.json).
+##
 ## \macro_image
 ## \macro_code
 ## \macro_output
@@ -168,7 +170,7 @@ class VaryHelper
     const std::vector<double> x{5.50e3, 5.52e3, 12.54e3, 17.43e3, 22.40e3, 27.48e3, 30e3, 10000e3};
     const std::vector<double> y{0.06628, 0.06395, 0.06396, 0.03372, 0.02441, 0.01403, 0, 0};
     TGraph graph;
-    
+
 public:
     VaryHelper() : graph(x.size(), x.data(), y.data()) {}
     RVec<double> operator()(const double &w, const RVecF &pt, const RVec<unsigned int> &type)

--- a/tutorials/dataframe/df107_SingleTopAnalysis.py
+++ b/tutorials/dataframe/df107_SingleTopAnalysis.py
@@ -12,6 +12,8 @@
 ## By default the analysis runs on a preskimmed dataset to reduce the runtime. The full dataset can be used with
 ## the --full-dataset argument and you can also run only on a fraction of the original dataset using the argument --lumi-scale.
 ##
+## See the [corresponding spec json file](https://github.com/root-project/root/blob/master/tutorials/dataframe/df107_SingleTopAnalysis.json).
+##
 ## \macro_image
 ## \macro_code
 ## \macro_output


### PR DESCRIPTION
The dataframe tutorials json spec files were not displayed properly. Moreover there was no direct correspondence between the code source and the json file. Those files do not have any doc in them. This PR makes a direct link to the GitHub source file. The dependency between source code and json is therefore more obvious.

