### PR TITLE
[graphics] Save memory when obtaining TImageDump instance

### DIFF
--- a/graf2d/asimage/CMakeLists.txt
+++ b/graf2d/asimage/CMakeLists.txt
@@ -33,6 +33,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ASImage
   DEPENDENCIES
     Core
     Graf
+    Postscript
   BUILTINS
     AFTERIMAGE
 )

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -61,36 +61,38 @@ ROOT tutorials: `$ROOTSYS/tutorials/image/`
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 
+#include "RConfigure.h"
+#include "TArrayD.h"
+#include "TArrayL.h"
 #include "TASImage.h"
 #include "TASImagePlugin.h"
-#include "TROOT.h"
 #include "TBuffer.h"
-#include "TMath.h"
-#include "TSystem.h"
-#include "TVirtualX.h"
-#include "TVirtualPad.h"
-#include "TArrayD.h"
-#include "TVectorD.h"
-#include "TVirtualPS.h"
-#include "TGaxis.h"
 #include "TColor.h"
-#include "TObjArray.h"
-#include "TArrayL.h"
-#include "TPoint.h"
-#include "TFrame.h"
-#include "TTF.h"
-#include "TRandom.h"
-#include <iostream>
-#include "THashTable.h"
-#include "TPluginManager.h"
 #include "TEnv.h"
+#include "TFrame.h"
+#include "TGaxis.h"
+#include "THashTable.h"
+#include "TImageDump.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TPluginManager.h"
+#include "TPoint.h"
+#include "TRandom.h"
+#include "TROOT.h"
 #include "TStyle.h"
+#include "TSystem.h"
 #include "TText.h"
-#include "RConfigure.h"
+#include "TTF.h"
+#include "TVectorD.h"
+#include "TVirtualPad.h"
 #include "TVirtualPadPainter.h"
-#include "snprintf.h"
+#include "TVirtualPS.h"
+#include "TVirtualX.h"
 
+#include <iostream>
 #include <memory>
+
+#include "snprintf.h"
 
 #ifndef WIN32
 #ifndef R__HAS_COCOA
@@ -1095,7 +1097,7 @@ void TASImage::FromPad(TVirtualPad *pad, Int_t x, Int_t y, UInt_t w, UInt_t h)
 
    if (gROOT->IsBatch()) { // in batch mode
       TVirtualPS *psave = gVirtualPS;
-      gVirtualPS = (TVirtualPS*)gROOT->ProcessLineFast("new TImageDump()");
+      gVirtualPS = new TImageDump();
       gVirtualPS->Open(pad->GetName(), 114); // in memory
       gVirtualPS->SetBit(BIT(11)); //kPrintingPS
 


### PR DESCRIPTION
by using TClass instead of the interpreter. As a side effect, the whole process is much faster. This fixes an incarnation of #14156, mitigating the overall effect of the highlighted behaviour.

NOTE: A test is available but not yet pushed to this PR and will be added in stressgraphics.

