### PR TITLE
Avoid memory leak in TROOT::GetFunction()

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1561,17 +1561,20 @@ TObject *TROOT::GetFunction(const char *name) const
    if (!name || !*name)
       return nullptr;
 
-   static bool _init_standard = false;
-
    auto f1 = fFunctions->FindObject(name);
-   if (f1 || _init_standard)
+   if (f1)
       return f1;
 
-   _init_standard = true;
+   auto init_funcs = [&f1, name, this]() {
+      gROOT->ProcessLine("TF1::InitStandardFunctions();");
+      f1 = fFunctions->FindObject(name);
+      return true;
+   };
 
-   gROOT->ProcessLine("TF1::InitStandardFunctions();");
+   // load libHist and call only once
+   [[maybe_unused]] static bool _init = init_funcs();
 
-   return fFunctions->FindObject(name);
+   return f1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1561,20 +1561,17 @@ TObject *TROOT::GetFunction(const char *name) const
    if (!name || !*name)
       return nullptr;
 
+   static std::atomic<bool> isInited = false;
+   bool wasInited = isInited.load();
+
    auto f1 = fFunctions->FindObject(name);
-   if (f1)
+   if (f1 || wasInited)
       return f1;
 
-   auto init_funcs = [&f1, name, this]() {
-      gROOT->ProcessLine("TF1::InitStandardFunctions();");
-      f1 = fFunctions->FindObject(name);
-      return true;
-   };
-
    // load libHist and call only once
-   [[maybe_unused]] static bool _init = init_funcs();
-
-   return f1;
+   gROOT->ProcessLine("TF1::InitStandardFunctions();");
+   isInited = true;
+   return fFunctions->FindObject(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1561,22 +1561,16 @@ TObject *TROOT::GetFunction(const char *name) const
    if (!name || !*name)
       return nullptr;
 
-   {
-      R__LOCKGUARD(gROOTMutex);
-      TObject *f1 = fFunctions->FindObject(name);
-      if (f1) return f1;
-   }
-
    static bool _init_standard = false;
 
-   if (_init_standard)
-      return nullptr;
+   auto f1 = fFunctions->FindObject(name);
+   if (f1 || _init_standard)
+      return f1;
 
    _init_standard = true;
 
    gROOT->ProcessLine("TF1::InitStandardFunctions();");
 
-   R__LOCKGUARD(gROOTMutex);
    return fFunctions->FindObject(name);
 }
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1558,15 +1558,21 @@ TStyle *TROOT::GetStyle(const char *name) const
 
 TObject *TROOT::GetFunction(const char *name) const
 {
-   if (name == nullptr || name[0] == 0) {
+   if (!name || !*name)
       return nullptr;
-   }
 
    {
       R__LOCKGUARD(gROOTMutex);
       TObject *f1 = fFunctions->FindObject(name);
       if (f1) return f1;
    }
+
+   static bool _init_standard = false;
+
+   if (_init_standard)
+      return nullptr;
+
+   _init_standard = true;
 
    gROOT->ProcessLine("TF1::InitStandardFunctions();");
 


### PR DESCRIPTION
If method `TROOT::GetFunction()` called multiple times 
with non-existing function name, each call causes invocation of interpreter.
If repeated many times, it may crash ROOT

Simple reproducer:
```
for (int n=0;n<100000;++n) gROOT->GetFunction("any");
```

In current ROOT it takes ~3 GB for nothing.
