### PR TITLE
Fix Load and Save in TASPaletteEditor

### DIFF
--- a/graf2d/asimage/src/TASPaletteEditor.cxx
+++ b/graf2d/asimage/src/TASPaletteEditor.cxx
@@ -434,15 +434,12 @@ void TASPaletteEditor::Save()
    if (fn.EndsWith(".pal.txt")) {
       // write into an ASCII file
       FILE *fl = fopen(fn.Data(), "w");
-      if (!fl) return;
+      if (!fl)
+         return;
       fprintf(fl, "%u\n", fPalette->fNumPoints);
       for (Int_t pt = 0; pt < Int_t(fPalette->fNumPoints); pt++)
-         fprintf(fl, "%10.9f %04hx %04hx %04hx %04hx\n",
-                 fPalette->fPoints[pt],
-                 fPalette->fColorRed[pt],
-                 fPalette->fColorGreen[pt],
-                 fPalette->fColorBlue[pt],
-                 fPalette->fColorAlpha[pt] );
+         fprintf(fl, "%10.9f %04hx %04hx %04hx %04hx\n", fPalette->fPoints[pt], fPalette->fColorRed[pt],
+                 fPalette->fColorGreen[pt], fPalette->fColorBlue[pt], fPalette->fColorAlpha[pt]);
       fclose(fl);
    } else {
       // write into a ROOT file
@@ -466,42 +463,41 @@ void TASPaletteEditor::Open()
    if (!fi.fFilename)
       return;
 
-   TImagePalette *newPalette;
+   TString fn = fi.fFilename;
 
-   if (strcmp(".pal.txt", fi.fFilename + strlen(fi.fFilename) - 8) == 0) {
-      FILE *fl = fopen(fi.fFilename, "r");
-      if (!fl) return;
-      UInt_t numPoints;
-      // coverity [Calling risky function : FALSE]
-      if (fscanf(fl, "%u\n", &numPoints)) {;}
+   TImagePalette *newPalette = nullptr;
+
+   if (fn.EndsWith(".pal.txt")) {
+      FILE *fl = fopen(fn.Data(), "r");
+      if (!fl)
+         return;
+      UInt_t numPoints = 0;
+      if (fscanf(fl, "%u\n", &numPoints) != 1)
+         Error("Open", "Failure reading num points from %s", fn.Data());
       newPalette = new TImagePalette(numPoints);
-      for (Int_t pt = 0; pt < Int_t(numPoints); pt++)
-         // coverity [Calling risky function : FALSE]
-         if (fscanf(fl, "%lf %hx %hx %hx %hx\n",
-                newPalette->fPoints + pt,
-                newPalette->fColorRed + pt,
-                newPalette->fColorGreen + pt,
-                newPalette->fColorBlue + pt,
-                    newPalette->fColorAlpha + pt )) {;}
-             fclose(fl);
+      for (UInt_t pt = 0; pt < numPoints; pt++) {
+         if (fscanf(fl, "%lf %hx %hx %hx %hx\n", newPalette->fPoints + pt, newPalette->fColorRed + pt,
+                    newPalette->fColorGreen + pt, newPalette->fColorBlue + pt, newPalette->fColorAlpha + pt) != 5)
+            Error("Open", "Failure reading point %u from %s", pt, fn.Data());
+      }
+      fclose(fl);
    } else {
       // read from a ROOT file
-      char fn[512];
-      if (strcmp(".pal.root", fi.fFilename + strlen(fi.fFilename) - 9) != 0)
-         snprintf(fn,512, "%s%s", fi.fFilename, ".pal.root");
-      else
-         strlcpy(fn, fi.fFilename,512);
+      if (!fn.EndsWith(".pal.root"))
+         fn.Append(".pal.root");
+
       TDirectory *dirsav = gDirectory;
 
-      TFile *fsave = new TFile(fn, "READ");
-      if (!fsave->IsOpen()) {
+      auto fsave = TFile::Open(fn.Data(), "READ");
+      if (!fsave || !fsave->IsOpen()) {
          delete fsave;
          return;
       }
 
-      newPalette = (TImagePalette*)fsave->Get("TImagePalette");
+      newPalette = (TImagePalette *)fsave->Get("TImagePalette");
       delete fsave;
-      if (dirsav) dirsav->cd();
+      if (dirsav)
+         dirsav->cd();
       if (!newPalette)
          return;
    }

--- a/graf2d/asimage/src/TASPaletteEditor.cxx
+++ b/graf2d/asimage/src/TASPaletteEditor.cxx
@@ -429,9 +429,11 @@ void TASPaletteEditor::Save()
    if (!fi.fFilename)
       return;
 
-   if (strcmp(".pal.txt", fi.fFilename + strlen(fi.fFilename) - 8) == 0) {
+   TString fn = fi.fFilename;
+
+   if (fn.EndsWith(".pal.txt")) {
       // write into an ASCII file
-      FILE *fl = fopen(fi.fFilename, "w");
+      FILE *fl = fopen(fn.Data(), "w");
       if (!fl) return;
       fprintf(fl, "%u\n", fPalette->fNumPoints);
       for (Int_t pt = 0; pt < Int_t(fPalette->fNumPoints); pt++)
@@ -444,13 +446,10 @@ void TASPaletteEditor::Save()
       fclose(fl);
    } else {
       // write into a ROOT file
-      char fn[512];
-      if (strcmp(".pal.root", fi.fFilename + strlen(fi.fFilename) - 9) != 0)
-         snprintf(fn,512, "%s%s", fi.fFilename, ".pal.root");
-      else
-         strlcpy(fn, fi.fFilename,512);
+      if (!fn.EndsWith(".pal.root"))
+         fn.Append(".pal.root");
 
-      gROOT->ProcessLine(TString::Format("gROOT->SaveObjectAs((TASPaletteEditor*)0x%zx,\"%s\",\"%s\");",(size_t)this,fn,"q"));
+      gROOT->SaveObjectAs(fPalette, fn.Data(), "q");
    }
 }
 


### PR DESCRIPTION
When saving palette, interpreter with wrong arguments was invoked.
Call directly `gROOT->SaveObjectAs` with correct argument.

Use TString for file name operations

When reading palette - check return values and also use TString for filename operations