### PR TITLE
Make sure the option L draws closed polygon for TH2Poly

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -1465,12 +1465,13 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
             npt++;
          }
          if (i == nloop) {
-            ComputeLogs(npt, optionZ);
+            if (optionFill) ComputeLogs(nloop, optionZ);
+            else            ComputeLogs(npt, optionZ);
             Int_t bord = gStyle->GetDrawBorder();
             if (optionR) {
                if (optionFill) {
                   gPad->PaintFillArea(npt,gyworkl.data(),gxworkl.data());
-                  if (bord) gPad->PaintPolyLine(npt,gyworkl.data(),gxworkl.data());
+                  if (bord) gPad->PaintPolyLine(nloop,gyworkl.data(),gxworkl.data());
                }
                if (optionLine) {
                   if (TMath::Abs(theGraph->GetLineWidth())>99) PaintPolyLineHatches(theGraph, npt, gyworkl.data(), gxworkl.data());
@@ -1479,7 +1480,7 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
             } else {
                if (optionFill) {
                   gPad->PaintFillArea(npt,gxworkl.data(),gyworkl.data());
-                  if (bord) gPad->PaintPolyLine(npt,gxworkl.data(),gyworkl.data());
+                  if (bord) gPad->PaintPolyLine(nloop,gxworkl.data(),gyworkl.data());
                }
                if (optionLine) {
                   if (TMath::Abs(theGraph->GetLineWidth())>99) PaintPolyLineHatches(theGraph, npt, gxworkl.data(), gyworkl.data());

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -9748,12 +9748,12 @@ void THistPainter::PaintTH2PolyBins(Option_t *option)
          g->TAttFill::Modify();
          if (line) {
             Int_t fs = g->GetFillStyle();
-            Int_t fc = g->GetFillColor();
+            Int_t db = gStyle->GetDrawBorder();
             g->SetFillStyle(0);
-            g->SetFillColor(g->GetLineColor());
+            gStyle->SetDrawBorder(1);
             g->Paint("F");
+            gStyle->SetDrawBorder(db);
             g->SetFillStyle(fs);
-            g->SetFillColor(fc);
          }
          if (fill) g->Paint("F");
          if (mark) g->Paint("P");
@@ -9772,12 +9772,12 @@ void THistPainter::PaintTH2PolyBins(Option_t *option)
             g->TAttFill::Modify();
             if (line) {
                Int_t fs = g->GetFillStyle();
-               Int_t fc = g->GetFillColor();
+               Int_t db = gStyle->GetDrawBorder();
                g->SetFillStyle(0);
-               g->SetFillColor(g->GetLineColor());
+               gStyle->SetDrawBorder(1);
                g->Paint("F");
+               gStyle->SetDrawBorder(db);
                g->SetFillStyle(fs);
-               g->SetFillColor(fc);
             }
             if (fill) g->Paint("F");
             if (mark) g->Paint("P");


### PR DESCRIPTION
TH2Poly with drawn option L did not get the line attributes correctly. This PR fixes this problem which was found here: https://github.com/couet/root/pull/new/th2poly-line
A small reproducer can be:
```
{
   TH2Poly* h2pol = new TH2Poly("p2","p2",0,4,0,4);
   Double_t x[4] = {0.5,0.,2.,2.};
   Double_t y[4] = {0.,2.,2.,0.5};
   TGraph *g = new TGraph(4,x,y);
   h2pol->AddBin(g);
   h2pol->Fill(1.,1.,3);
   g->SetLineColor(kRed);
   g->SetLineStyle(2);
   g->SetLineWidth(8);
   g->SetFillColor(kYellow);
   h2pol->Draw("L");
}
```

