### PR TITLE
[RNTuple] describe how exactly `Index` columns are relative to cluster

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -412,10 +412,8 @@ Zigzag + split
 : Used on signed integers only; it maps $x$ to $2x$ if $x$ is positive and to $-(2x+1)$ if $x$ is negative.
   Followed by split encoding.
 
-For `Index32` and `Index64`, the "counting is relative to the cluster" applies to each page individually. For
-example, if you have 18 elements in total and they are grouped as (3 elements,4 elements) in the first page 
-and (5 elements, 6 elements) in the second page, the `Index` pages would
-read: `[3, 4], [12, 6]` instead of `[3, 4], [5, 6]`.
+**Note**: these encodings always happen within each page, thus decoding should be done page-wise,
+not cluster-wise.
 
 Future versions of the file format may introduce additional column types
 without changing the minimum version of the header.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -412,6 +412,11 @@ Zigzag + split
 : Used on signed integers only; it maps $x$ to $2x$ if $x$ is positive and to $-(2x+1)$ if $x$ is negative.
   Followed by split encoding.
 
+For `Index32` and `Index64`, the "counting is relative to the cluster" applies to each page individually. For
+example, if you have 18 elements in total and they are grouped as (3 elements,4 elements) in the first page 
+and (5 elements, 6 elements) in the second page, the `Index` pages would
+read: `[3, 4], [12, 6]` instead of `[3, 4], [5, 6]`.
+
 Future versions of the file format may introduce additional column types
 without changing the minimum version of the header.
 Old readers need to ignore these columns and fields constructed from such columns.


### PR DESCRIPTION
follow up of #14949

I can see why it's not stored in cumulative format, because the "writer" can track the incremental easily (length of the current item). But I can't quite figure out why not just store the entire thing incremental 

@jblomer 
