### PR TITLE
[cling] do not use whole std namespace, only what's needed

### DIFF
--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -29,7 +29,7 @@ void g() {}
 // ==== Test UsingDirectiveDecl/UsingDecl
 // These should not be nested into a `__cling_N5xxx' namespace (but placed at
 // the TU scope) so that the declaration they name is globally available.
-using namespace std;
+using std::string;
 namespace NS { string baz("Cling"); }
 using NS::baz;
 baz

--- a/interpreter/cling/test/Lookup/func.C
+++ b/interpreter/cling/test/Lookup/func.C
@@ -19,7 +19,6 @@
 #include <cstdio>
 #include <string>
 
-using namespace std;
 using namespace llvm;
 
 void dumpDecl(const char* title, const clang::Decl* D) {

--- a/interpreter/cling/test/Lookup/scope.C
+++ b/interpreter/cling/test/Lookup/scope.C
@@ -16,7 +16,6 @@
 
 #include <cstdio>
 
-using namespace std;
 using namespace llvm;
 using namespace cling;
 

--- a/interpreter/cling/test/Lookup/template.C
+++ b/interpreter/cling/test/Lookup/template.C
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <vector>
 
-using namespace std;
 using namespace llvm;
 
 .rawInput 1

--- a/interpreter/cling/test/Lookup/type.C
+++ b/interpreter/cling/test/Lookup/type.C
@@ -13,8 +13,6 @@
 #include "cling/Interpreter/LookupHelper.h"
 #include "clang/AST/Type.h"
 
-using namespace std;
-
 //
 //  Test Data.
 //

--- a/interpreter/cling/test/Lookup/variadicFunc.C
+++ b/interpreter/cling/test/Lookup/variadicFunc.C
@@ -21,7 +21,6 @@
 #include <cstdio>
 #include <string>
 
-using namespace std;
 using namespace llvm;
 
 //


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Splitted from the other PR (https://github.com/root-project/root/pull/14986) as requested by @guitargeek 

This has no impact, it's just to align with Clang's coding standard https://opensource.apple.com/source/lldb/lldb-112/llvm/docs/CodingStandards.html#ll_ns_std and to enforce good practices in students reading the tests

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

