### PR TITLE
[skip-CI][ci] Modify scheduled build time for old branches

### DIFF
--- a/.github/workflows/root-626.yml
+++ b/.github/workflows/root-626.yml
@@ -3,7 +3,7 @@ name: 'ROOT 6.26'
 
 on:
   schedule:
-    - cron: '00 1,13 * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/root-628.yml
+++ b/.github/workflows/root-628.yml
@@ -3,7 +3,7 @@ name: 'ROOT 6.28'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1,13 * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
namely to 1 build/day for 6.26 and 2 builds/day for 6.28.


