### PR TITLE
[RF] Rename RooMomentMorph::getVal to RooMomentMorph::getValV

### DIFF
--- a/roofit/roofit/inc/RooMomentMorph.h
+++ b/roofit/roofit/inc/RooMomentMorph.h
@@ -49,7 +49,7 @@ public:
     return true ;
   }
 
-  virtual double getVal(const RooArgSet* set=nullptr) const ;
+  double getValV(const RooArgSet* set=nullptr) const override;
   RooAbsPdf* sumPdf(const RooArgSet* nset) ;
 
 
@@ -71,7 +71,7 @@ protected:
     void calculateFractions(const RooMomentMorph& self, bool verbose=true) const;
   } ;
   mutable RooObjCacheManager _cacheMgr ; //! The cache manager
-  mutable RooArgSet* _curNormSet ; //! Current normalization set
+  mutable RooArgSet* _curNormSet = nullptr; //! Current normalization set
 
   friend class CacheElem ; // Cache needs to be able to clear _norm pointer
 
@@ -87,13 +87,13 @@ protected:
   RooRealProxy m ;
   RooSetProxy  _varList ;
   RooListProxy _pdfList ;
-  mutable TVectorD* _mref;
+  mutable TVectorD* _mref = nullptr;
 
-  mutable TMatrixD* _M; //
+  mutable TMatrixD* _M = nullptr;
 
   Setting _setting;
 
-  bool _useHorizMorph;
+  bool _useHorizMorph = true;
 
   ClassDefOverride(RooMomentMorph,3);
 };

--- a/roofit/roofit/inc/RooMomentMorphFunc.h
+++ b/roofit/roofit/inc/RooMomentMorphFunc.h
@@ -51,7 +51,7 @@ public:
       return true;
    }
 
-   virtual double getVal(const RooArgSet *set = nullptr) const;
+   double getValV(const RooArgSet *set = nullptr) const override;
    RooAbsReal *sumFunc(const RooArgSet *nset);
    const RooAbsReal *sumFunc(const RooArgSet *nset) const;
 
@@ -78,7 +78,7 @@ protected:
       void calculateFractions(const RooMomentMorphFunc &self, bool verbose = true) const;
    };
    mutable RooObjCacheManager _cacheMgr; //! The cache manager
-   mutable RooArgSet *_curNormSet;       //! Current normalization set
+   mutable RooArgSet *_curNormSet = nullptr; //! Current normalization set
 
    friend class CacheElem; // Cache needs to be able to clear _norm pointer
 
@@ -94,13 +94,13 @@ protected:
    RooRealProxy m;
    RooSetProxy _varList;
    RooListProxy _pdfList;
-   mutable TVectorD *_mref;
+   mutable TVectorD *_mref = nullptr;
 
-   mutable TMatrixD *_M; //
+   mutable TMatrixD *_M = nullptr;
 
    Setting _setting;
 
-   bool _useHorizMorph;
+   bool _useHorizMorph = true;
 
    ClassDefOverride(RooMomentMorphFunc, 3);
 };

--- a/roofit/roofit/src/RooMomentMorph.cxx
+++ b/roofit/roofit/src/RooMomentMorph.cxx
@@ -36,7 +36,7 @@ ClassImp(RooMomentMorph);
 /// coverity[UNINIT_CTOR]
 
 RooMomentMorph::RooMomentMorph()
-  : _cacheMgr(this,10,true,true), _curNormSet(nullptr), _mref(nullptr), _M(nullptr), _useHorizMorph(true)
+  : _cacheMgr(this,10,true,true)
 {
 }
 
@@ -108,7 +108,6 @@ RooMomentMorph::RooMomentMorph(const char *name, const char *title, RooAbsReal &
 RooMomentMorph::RooMomentMorph(const RooMomentMorph &other, const char *name)
    : RooAbsPdf(other, name),
      _cacheMgr(other._cacheMgr, this),
-     _curNormSet(nullptr),
      m("m", this, other.m),
      _varList("varList", this, other._varList),
      _pdfList("pdfList", this, other._pdfList),
@@ -170,7 +169,7 @@ RooMomentMorph::CacheElem::CacheElem(std::unique_ptr<RooAbsPdf> && sumPdf,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooMomentMorph::CacheElem* RooMomentMorph::getCache(const RooArgSet* /*nset*/) const
+RooMomentMorph::CacheElem* RooMomentMorph::getCache(const RooArgSet* nset) const
 {
   if (auto* cache = static_cast<CacheElem*>(_cacheMgr.getObj(nullptr,static_cast<RooArgSet*>(nullptr)))) {
     return cache ;
@@ -287,6 +286,7 @@ RooMomentMorph::CacheElem* RooMomentMorph::getCache(const RooArgSet* /*nset*/) c
   else {
     theSumPdf = std::make_unique<RooAddPdf>(sumpdfName.c_str(),sumpdfName.c_str(),_pdfList,coefList);
   }
+  theSumPdf->fixCoefNormalization(*nset);
 
   // *** WVE this is important *** this declares that frac effectively depends on the morphing parameters
   // This will prevent the likelihood optimizers from erroneously declaring terms constant
@@ -319,10 +319,10 @@ RooMomentMorph::CacheElem::~CacheElem() = default;
 ////////////////////////////////////////////////////////////////////////////////
 /// Special version of getVal() overrides RooAbsReal::getVal() to save value of current normalization set
 
-double RooMomentMorph::getVal(const RooArgSet* set) const
+double RooMomentMorph::getValV(const RooArgSet* set) const
 {
   _curNormSet = set ? const_cast<RooArgSet*>(set) : const_cast<RooArgSet*>(static_cast<RooArgSet const*>(&_varList));
-  return RooAbsPdf::getVal(set) ;
+  return RooAbsPdf::getValV(set) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -36,7 +36,7 @@ ClassImp(RooMomentMorphFunc)
 
 //_____________________________________________________________________________
 RooMomentMorphFunc::RooMomentMorphFunc()
-   : _cacheMgr(this, 10, true, true), _curNormSet(nullptr), _mref(nullptr), _M(nullptr), _useHorizMorph(true)
+   : _cacheMgr(this, 10, true, true)
 {
 }
 
@@ -49,8 +49,7 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
      _varList("varList", "List of variables", this),
      _pdfList("pdfList", "List of pdfs", this),
      _mref(new TVectorD(mrefpoints)),
-     _setting(setting),
-     _useHorizMorph(true)
+     _setting(setting)
 {
    // observables
   _varList.addTyped<RooAbsReal>(varList);
@@ -71,8 +70,7 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
      _varList("varList", "List of variables", this),
      _pdfList("pdfList", "List of pdfs", this),
      _mref(new TVectorD(mrefList.size())),
-     _setting(setting),
-     _useHorizMorph(true)
+     _setting(setting)
 {
    // observables
   _varList.addTyped<RooAbsReal>(varList);
@@ -105,7 +103,6 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
 RooMomentMorphFunc::RooMomentMorphFunc(const RooMomentMorphFunc &other, const char *name)
    : RooAbsReal(other, name),
      _cacheMgr(other._cacheMgr, this),
-     _curNormSet(nullptr),
      m("m", this, other.m),
      _varList("varList", this, other._varList),
      _pdfList("pdfList", this, other._pdfList),
@@ -313,11 +310,11 @@ RooMomentMorphFunc::CacheElem::~CacheElem()
 }
 
 //_____________________________________________________________________________
-double RooMomentMorphFunc::getVal(const RooArgSet *set) const
+double RooMomentMorphFunc::getValV(const RooArgSet *set) const
 {
-   // Special version of getVal() overrides RooAbsReal::getVal() to save value of current normalization set
+   // Special version of getValV() overrides RooAbsReal::getVal() to save value of current normalization set
    _curNormSet = set ? const_cast<RooArgSet *>(set) : const_cast<RooArgSet *>(static_cast<RooArgSet const*>(&_varList));
-   return RooAbsReal::getVal(set);
+   return RooAbsReal::getValV(set);
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
The RooAbsReal::getVal function should not be overloaded. It is the getValV function that is a virtual function which might be overloaded in derived classes. Otherwise, virtual calls don't work.