### PR TITLE
[tmva][pymva] Backport in 6.28 the fix to avoid creating output file tmva.root

### DIFF
--- a/tutorials/tmva/pytorch/ClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ClassificationPyTorch.py
@@ -23,8 +23,8 @@ from torch import nn
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
-factory = TMVA.Factory('TMVAClassification', output,
+# create factory without output file since it is not needed
+factory = TMVA.Factory('TMVAClassification',
                        '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
 
 

--- a/tutorials/tmva/pytorch/MulticlassPyTorch.py
+++ b/tutorials/tmva/pytorch/MulticlassPyTorch.py
@@ -22,8 +22,8 @@ from torch import nn
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
-factory = TMVA.Factory('TMVAClassification', output,
+# create factory without output file since it is not needed
+factory = TMVA.Factory('TMVAClassification',
     '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=multiclass')
 
 

--- a/tutorials/tmva/pytorch/RegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/RegressionPyTorch.py
@@ -23,8 +23,8 @@ from torch import nn
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
-factory = TMVA.Factory('TMVARegression', output,
+# create factory without output file since it is not needed
+factory = TMVA.Factory('TMVARegression',
         '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Regression')
 
 


### PR DESCRIPTION
These tutorials don't need to create an output root file of the training. This avois potential problem of running the tutorials in parallel and writing on the same file

