### PR TITLE
[PyROOT] Do workaround for importing arrays with strides in FromPandas

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -312,6 +312,9 @@ class ROOTFacade(types.ModuleType):
                 np_dict = {}
                 for key in df.columns:
                     np_dict[key] = df[key].to_numpy()
+                # Attach the array dict as a member to the dataframe, to see if
+                # the Windows crashes are due to lifetime issues.
+                setattr(df, "_np_dict", np_dict)
                 return MakeNumpyDataFrameCopy(np_dict)
             ns.FromPandas = MakePandasDataFrame
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -312,7 +312,7 @@ class ROOTFacade(types.ModuleType):
                 np_dict = {}
                 for key in df.columns:
                     np_dict[key] = df[key].to_numpy()
-                return MakeNumpyDataFrame(np_dict)
+                return MakeNumpyDataFrameCopy(np_dict)
             ns.FromPandas = MakePandasDataFrame
 
             try:

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -844,6 +844,7 @@ if(ROOT_pyroot_FOUND)
   file(GLOB requires_numba   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} pyroot/pyroot004_NumbaDeclare.py)
   file(GLOB requires_pandas  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
       dataframe/df026_AsNumpyArrays.py
+      dataframe/df035_RDFFromPandas.py
       roofit/rf409_NumPyPandasToRooFit.py)
   file(GLOB requires_keras   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/keras/*.py)
   file(GLOB requires_torch   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/pytorch/*.py)


### PR DESCRIPTION
Columns in Pandas dataframes are *not* guaranteed to be contiguous
arrays, so we need the same workaround as in the `MakeNumpyDataFrame`
method, first copying the array to contiguous memory if it was not
contiguous.

Also, veto the tutorial test if `pandas` is not available.

This should fixes test failures on Windows.

Pinging @dpiparo, since this follows up on your PR.