### PR TITLE
[webgui] set selected pad in TWebCanvas [6.30]

### DIFF
--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1995,7 +1995,12 @@ UInt_t TWebCanvas::GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h)
 
 Bool_t TWebCanvas::PerformUpdate(Bool_t async)
 {
-   CheckCanvasModified();
+   if (CheckCanvasModified()) {
+      // configure selected pad that method like TPad::WaitPrimitive() can correctly work
+      // can be removed again once WaitPrimitive implemented differently
+      if (gPad && (gPad->GetCanvas() == Canvas()))
+         gROOT->SetSelectedPad(gPad);
+   }
 
    CheckDataToSend();
 


### PR DESCRIPTION
In TPad::WaitPrimitive method selected pad
is used to check which mouse button or key was pressed While key events already delivered to the ROOT application, only selected pad was missing to make WaitPrimitive working.

Now it will block TWebCanvas until double-click in the frame.

Editor mode will be implemented separately only in the ROOT master.
