### PR TITLE
Allow producing forward compatible file for fBits value.

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -476,6 +476,12 @@ RSA.KeyType:  1
 # Enable cross-protocol redirects
 TFile.CrossProtocolRedirects:  yes
 
+# Force the producing of files forward compatible with (unpatched) version
+# of ROOT older than v6.30 by recording the internal bits kIsOnHeap and
+# kNotDeleted; Older releases were not explicitly setting those bits to the
+# correct value but instead used verbatim the value stored in the file.
+# TFile.v630forwardCompatibility: no
+
 # List of S3 servers known to support multi-range HTTP GET requests.
 # This is the value sent back by the S3 server in the 'Server:' header
 # of the HTTP response.

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -181,6 +181,11 @@ private:
 public:
    /// TFile status bits. BIT(13) is taken up by TObject
    enum EStatusBits {
+      // Produce files forward compatible with (unpatched) version older than
+      // v6.30 by recording the internal bits kIsOnHeap and kNotDeleted; Older
+      // releases were not explicitly setting those bits to the correct value
+      // but instead used verbatim the value stored in the file.
+      k630forwardCompatibility = BIT(2),
       kRecovered     = BIT(10),
       kHasReferences = BIT(11),
       kDevNull       = BIT(12),

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -185,6 +185,8 @@ public:
       // v6.30 by recording the internal bits kIsOnHeap and kNotDeleted; Older
       // releases were not explicitly setting those bits to the correct value
       // but instead used verbatim the value stored in the file.
+      // Note that to avoid a circular dependency, this value is used
+      // hard coded in TObject.cxx.
       k630forwardCompatibility = BIT(2),
       kRecovered     = BIT(10),
       kHasReferences = BIT(11),

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -814,6 +814,11 @@ void TFile::Init(Bool_t create)
       //*-* -------------attempt recovering the file
       Bool_t tryrecover = (gEnv->GetValue("TFile.Recover", 1) == 1) ? kTRUE : kFALSE;
 
+      //*-* -------------Check if we need to enable forward compatible with version
+      //*-* -------------prior to v6.30
+      if (gEnv->GetValue("TFile.v630forwardCompatibility", 0) == 1)
+         SetBit(k630forwardCompatibility);
+
       //*-* -------------Read keys of the top directory
       if (fSeekKeys > fBEGIN && fEND <= size) {
          //normal case. Recover only if file has no keys

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -404,7 +404,12 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
          // special case for TObject::fBits in case of a referenced object
          case TStreamerInfo::kBits: { DOLOOP {
-            UInt_t *x=(UInt_t*)(arr[k]+ioffset); b << (*x & (~kIsOnHeap & ~kNotDeleted));
+            UInt_t *x=(UInt_t*)(arr[k]+ioffset);
+            const auto parent = b.GetParent();
+            if (R__unlikely(parent && parent->TestBit(TFile::k630forwardCompatibility)))
+               b << *x;
+            else
+               b << (*x & (~kIsOnHeap & ~kNotDeleted));
             if ((*x & kIsReferenced) != 0) {
                TObject *obj = (TObject*)(arr[k]+eoffset);
                TProcessID *pid = TProcessID::GetProcessWithUID(obj->GetUniqueID(),obj);


### PR DESCRIPTION
Calling `file->SetBit(TFile::k630forwardCompatibility);` will request to file to store the current value of the bit kIsOnHeap and kNotDeleted for reading in older version that were not setting their value based on the actual state of the read into object.

This fixes #14793

