### PR TITLE
Avoid the interpreter to query info for array pythonizations

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
@@ -66,7 +66,8 @@ print(rvec) # { 42.000000, 2.0000000, 3.0000000 }
 '''
 
 from . import pythonization
-from libROOTPythonizations import GetEndianess, GetDataPointer, GetSizeOfType
+from libROOTPythonizations import GetEndianess
+import cppyy
 
 
 _array_interface_dtype_map = {
@@ -86,7 +87,7 @@ def get_array_interface(self):
     for dtype in _array_interface_dtype_map:
         if cppname.endswith("<{}>".format(dtype)):
             dtype_numpy = _array_interface_dtype_map[dtype]
-            dtype_size = GetSizeOfType(dtype)
+            dtype_size = cppyy.sizeof(dtype)
             endianess = GetEndianess()
             size = self.size()
             # Numpy breaks for data pointer of 0 even though the array is empty.
@@ -94,7 +95,7 @@ def get_array_interface(self):
             if self.empty():
                 pointer = 1
             else:
-                pointer = GetDataPointer(self, cppname, "data")
+                pointer = cppyy.ll.addressof(self.data())
             return {
                 "shape": (size, ),
                 "typestr": "{}{}{}".format(endianess, dtype_numpy, dtype_size),

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_rtensor.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_rtensor.py
@@ -10,7 +10,7 @@
 
 from .. import pythonization
 from .._rvec import _array_interface_dtype_map
-from libROOTPythonizations import GetEndianess, GetDataPointer, GetSizeOfType
+from libROOTPythonizations import GetEndianess
 import cppyy
 
 def get_array_interface(self):
@@ -27,13 +27,13 @@ def get_array_interface(self):
     idx2 = cppname.find(",", idx1)
     dtype = cppname[idx1 + 8 : idx2]
     dtype_numpy = _array_interface_dtype_map[dtype]
-    dtype_size = GetSizeOfType(dtype)
+    dtype_size = cppyy.sizeof(dtype)
     endianess = GetEndianess()
     shape = self.GetShape()
     strides = self.GetStrides()
     # Numpy breaks for data pointer of 0 even though the array is empty.
     # We set the pointer to 1 but the value itself is arbitrary and never accessed.
-    pointer = GetDataPointer(self, cppname, "GetData")
+    pointer = cppyy.ll.addressof(self.GetData())
     if pointer == 0:
         pointer == 1
     return {

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -53,9 +53,6 @@ static PyMethodDef gPyROOTMethods[] = {
    {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,
     (char *)"Add pretty printing pythonization"},
    {(char *)"GetEndianess", (PyCFunction)PyROOT::GetEndianess, METH_NOARGS, (char *)"Get endianess of the system"},
-   {(char *)"GetDataPointer", (PyCFunction)PyROOT::GetDataPointer, METH_VARARGS,
-    (char *)"Get pointer to data of a C++ object"},
-   {(char *)"GetSizeOfType", (PyCFunction)PyROOT::GetSizeOfType, METH_VARARGS, (char *)"Get size of data-type"},
    {(char *)"AsRVec", (PyCFunction)PyROOT::AsRVec, METH_O, (char *)"Get object with array interface as RVec"},
 #ifdef R__HAS_DATAFRAME
    {(char *)"AsRTensor", (PyCFunction)PyROOT::AsRTensor, METH_O, (char *)"Get object with array interface as RTensor"},

--- a/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
+++ b/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
@@ -34,8 +34,6 @@ PyObject *AsRTensor(PyObject *self, PyObject *obj);
 PyObject *CPPInstanceExpand(PyObject *self, PyObject *args);
 
 PyObject *GetEndianess(PyObject *self, PyObject *args);
-PyObject *GetDataPointer(PyObject *self, PyObject *args);
-PyObject *GetSizeOfType(PyObject *self, PyObject *args);
 
 PyObject *MakeNumpyDataFrameImpl(PyObject *self, PyObject *obj);
 

--- a/bindings/pyroot/pythonizations/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot/pythonizations/src/PyzPythonHelpers.cxx
@@ -27,65 +27,6 @@ PyROOT extension module.
 #include <sstream>
 
 ////////////////////////////////////////////////////////////////////////////
-/// \brief Get size of C++ data-type
-/// \param[in] self Always null, since this is a module function.
-/// \param[in] args C++ data-type as Python string
-///
-/// This function returns the length of a C++ data-type in bytes
-/// as a Python integer.
-PyObject *PyROOT::GetSizeOfType(PyObject * /*self*/, PyObject *args)
-{
-   // Get name of data-type
-   PyObject *pydtype = PyTuple_GetItem(args, 0);
-   std::string dtype = PyUnicode_AsUTF8(pydtype);
-
-   // Call interpreter to get size of data-type using `sizeof`
-   size_t size = 0;
-   std::stringstream code;
-   code << "*((size_t*)" << std::showbase << (uintptr_t)&size << ") = (size_t)sizeof(" << dtype << ")";
-   gInterpreter->Calc(code.str().c_str());
-
-   // Return size of data-type as integer
-   PyObject *pysize = PyLong_FromLong(size);
-   return pysize;
-}
-
-////////////////////////////////////////////////////////////////////////////
-/// \brief Get pointer to the data of an object
-/// \param[in] self Always null, since this is a module function.
-/// \param[in] args [0] Python representation of the C++ object.
-///                 [1] Data-type of the C++ object as Python string.
-///                 [2] Method to be called on the C++ object to get the data pointer as Python string
-///
-/// This function returns the pointer to the data of an object as an Python
-/// integer retrieved by the given method.
-PyObject *PyROOT::GetDataPointer(PyObject * /*self*/, PyObject *args)
-{
-   // Get pointer of C++ object
-   PyObject *pyobj = PyTuple_GetItem(args, 0);
-   void* cppobj = CPyCppyy::Instance_AsVoidPtr(pyobj);
-
-   // Get name of C++ object as string
-   PyObject *pycppname = PyTuple_GetItem(args, 1);
-   std::string cppname = PyUnicode_AsUTF8(pycppname);
-
-   // Get name of method to be called to get the data pointer
-   PyObject *pymethodname = PyTuple_GetItem(args, 2);
-   std::string methodname = PyUnicode_AsUTF8(pymethodname);
-
-   // Call interpreter to get pointer to data
-   uintptr_t pointer = 0;
-   std::stringstream code;
-   code << "*((intptr_t*)" << std::showbase << (uintptr_t)&pointer << ") = reinterpret_cast<uintptr_t>(reinterpret_cast<"
-        << cppname << "*>(" << std::showbase << (uintptr_t)cppobj << ")->" << methodname << "())";
-   gInterpreter->Calc(code.str().c_str());
-
-   // Return pointer as integer
-   PyObject *pypointer = PyLong_FromUnsignedLongLong(pointer);
-   return pypointer;
-}
-
-////////////////////////////////////////////////////////////////////////////
 /// \brief Get endianess of the system
 /// \param[in] self Always null, since this is a module function.
 /// \param[in] args Pointer to an empty Python tuple.


### PR DESCRIPTION
Substitute the C++ functions GetSizeOfType and GetDataPointer in our CPython extension library for the equivalent cppyy functions.


This PR fixes #14981 

