### PR TITLE
[http] Improve syntax, avoid interpreter calls

### DIFF
--- a/net/http/inc/TRootSniffer.h
+++ b/net/http/inc/TRootSniffer.h
@@ -182,7 +182,7 @@ protected:
    ProduceMulti(const std::string &path, const std::string &options, std::string &res, Bool_t asjson = kTRUE);
 
 public:
-   TRootSniffer(const char *name, const char *objpath = "Objects");
+   TRootSniffer(const char *name = "sniff", const char *objpath = "Objects");
    virtual ~TRootSniffer();
 
    /** When readonly on (default), sniffer is not allowed to change ROOT structures

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -269,14 +269,14 @@ static int log_message_handler(const struct mg_connection *conn, const char *mes
       return engine->ProcessLog(message);
 
    // provide debug output
-   if ((gDebug > 0) || (strstr(message, "cannot bind to") != 0))
+   if ((gDebug > 0) || strstr(message, "cannot bind to"))
       fprintf(stderr, "Error in <TCivetweb::Log> %s\n", message);
 
    return 0;
 }
 
 struct TEngineHolder {
-   TCivetweb *fEngine;
+   TCivetweb *fEngine{nullptr};
    TEngineHolder(TCivetweb *engine)
    {
       fEngine = engine;

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -368,12 +368,13 @@ std::string THttpCallArg::FillHttpHeader(const char *name)
                  "Content-Length: 0\r\n"
                  "Connection: close\r\n\r\n");
    else
-      hdr.append(Form(" 200 OK\r\n"
-                      "Content-Type: %s\r\n"
-                      "Connection: keep-alive\r\n"
-                      "Content-Length: %ld\r\n"
-                      "%s\r\n",
-                      GetContentType(), GetContentLength(), fHeader.Data()));
+      hdr.append(TString::Format(" 200 OK\r\n"
+                                 "Content-Type: %s\r\n"
+                                 "Connection: keep-alive\r\n"
+                                 "Content-Length: %ld\r\n"
+                                 "%s\r\n",
+                                 GetContentType(), GetContentLength(), fHeader.Data())
+                    .Data());
 
    return hdr;
 }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -564,7 +564,7 @@ Bool_t THttpServer::VerifyFilePath(const char *fname)
 
    Int_t level = 0;
 
-   while (*fname != 0) {
+   while (*fname) {
 
       // find next slash or backslash
       const char *next = strpbrk(fname, "/\\");

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -195,11 +195,12 @@ THttpServer::THttpServer(const char *engine) : TNamed("http", "ROOT http server"
 
    TRootSniffer *sniff = nullptr;
    if (basic_sniffer) {
-      sniff = new TRootSniffer("sniff");
+      sniff = new TRootSniffer();
       sniff->SetScanGlobalDir(kFALSE);
       sniff->CreateOwnTopFolder(); // use dedicated folder
    } else {
-      sniff = (TRootSniffer *)gROOT->ProcessLineSync("new TRootSnifferFull(\"sniff\");");
+      static const TClass *snifferClass = TClass::GetClass("TRootSnifferFull");
+      sniff = (TRootSniffer *)snifferClass->New();
    }
 
    SetSniffer(sniff);

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -819,7 +819,7 @@ std::string THttpServer::BuildWSEntryPage()
          if (arr.length() > 1)
             arr.append(", ");
 
-         arr.append(Form("{ name: \"%s\", title: \"%s\" }", ws->GetName(), ws->GetTitle()));
+         arr.append(TString::Format("{ name: \"%s\", title: \"%s\" }", ws->GetName(), ws->GetTitle()).Data());
       }
    }
 
@@ -1126,7 +1126,7 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
       // only for binary data master version is important
       // it allows to detect if streamer info was modified
       const char *parname = fSniffer->IsStreamerInfoItem(arg->fPathName.Data()) ? "BVersion" : "MVersion";
-      arg->AddHeader(parname, Form("%u", (unsigned)fSniffer->GetStreamerInfoHash()));
+      arg->AddHeader(parname, TString::Format("%u", (unsigned)fSniffer->GetStreamerInfoHash()).Data());
    }
 
    // try to avoid caching on the browser

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -279,7 +279,7 @@ Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
       // now we should wait until next polling requests is processed
       // or when connection is closed or handler is shutdown
 
-      Int_t sendcnt = fSendCnt, loopcnt(0);
+      Int_t sendcnt = fSendCnt, loopcnt = 0;
 
       while (!IsDisabled() && !engine->fDisabled) {
          gSystem->ProcessEvents();

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -340,7 +340,7 @@ Bool_t TRootSnifferScanRec::GoInside(TRootSnifferScanRec &super, TObject *obj, c
    fMask = super.fMask & kActions;
    if (fRestriction == 0)
       fRestriction = super.fRestriction; // get restriction from parent
-   Bool_t topelement(kFALSE);
+   Bool_t topelement = kFALSE;
 
    if (fMask & kScan) {
       // if scanning only fields, ignore all childs
@@ -559,9 +559,8 @@ Int_t TRootSniffer::CheckRestriction(const char *full_item_name)
 
    const char *options = nullptr;
    TIter iter(&fRestrictions);
-   TObject *obj;
 
-   while ((obj = iter()) != nullptr) {
+   while (auto obj = iter()) {
       const char *title = obj->GetTitle();
 
       if (strstr(title, pattern1.Data()) == title) {
@@ -616,9 +615,8 @@ void TRootSniffer::ScanObjectMembers(TRootSnifferScanRec &rec, TClass *cl, char 
       cl->BuildRealData();
 
    // scan only real data
-   TObject *obj = nullptr;
    TIter iter(cl->GetListOfRealData());
-   while ((obj = iter()) != nullptr) {
+   while (auto obj = iter()) {
       TRealData *rdata = dynamic_cast<TRealData *>(obj);
       if (!rdata || strchr(rdata->GetName(), '.'))
          continue;
@@ -648,7 +646,7 @@ void TRootSniffer::ScanObjectMembers(TRootSnifferScanRec &rec, TClass *cl, char 
             break;
 
          const char *title = member->GetTitle();
-         if (title && (strlen(title) != 0))
+         if (title && *title)
             chld.SetField(item_prop_title, title);
 
          if (member->GetTypeName())
@@ -708,14 +706,14 @@ void TRootSniffer::ScanObjectProperties(TRootSnifferScanRec &rec, TObject *obj)
       return;
 
    pos += 7;
-   while (*pos != 0) {
+   while (*pos) {
       if (*pos == ' ') {
          pos++;
          continue;
       }
       // first locate identifier
       const char *pos0 = pos;
-      while ((*pos != 0) && (*pos != '='))
+      while (*pos && (*pos != '='))
          pos++;
       if (*pos == 0)
          return;
@@ -726,7 +724,7 @@ void TRootSniffer::ScanObjectProperties(TRootSnifferScanRec &rec, TObject *obj)
          pos++;
       pos0 = pos;
       // then value with or without quotes
-      while ((*pos != 0) && (*pos != (quotes ? '\"' : ' ')))
+      while (*pos && (*pos != (quotes ? '\"' : ' ')))
          pos++;
       TString value(pos0, pos - pos0);
       rec.SetField(name, value);
@@ -815,7 +813,7 @@ void TRootSniffer::ScanCollection(TRootSnifferScanRec &rec, TCollection *lst, co
          if (chld.SetResult(obj, obj->IsA()))
             return;
 
-         Bool_t has_kind(kFALSE), has_title(kFALSE);
+         Bool_t has_kind = kFALSE, has_title = kFALSE;
 
          ScanObjectProperties(chld, obj);
          // now properties, coded as TNamed objects, placed after object in the hierarchy
@@ -846,9 +844,8 @@ void TRootSniffer::ScanCollection(TRootSnifferScanRec &rec, TCollection *lst, co
 
    if (keys_lst) {
       TIter iter(keys_lst);
-      TObject *kobj = nullptr;
 
-      while ((kobj = iter()) != nullptr) {
+      while (auto kobj = iter()) {
          TKey *key = dynamic_cast<TKey *>(kobj);
          if (!key)
             continue;
@@ -1588,7 +1585,7 @@ TObject *TRootSniffer::GetItem(const char *fullname, TFolder *&parent, Bool_t fo
       path = fObjectsPath + "/" + path;
 
    TString tok;
-   Ssiz_t from(0);
+   Ssiz_t from = 0;
 
    while (path.Tokenize(tok, from, "/")) {
       if (tok.Length() == 0)
@@ -1730,14 +1727,13 @@ Bool_t TRootSniffer::AccessField(TFolder *parent, TObject *chld, const char *nam
 
    TIter iter(parent->GetListOfFolders());
 
-   TObject *obj = nullptr;
-   Bool_t find(kFALSE), last_find(kFALSE);
+   Bool_t find = kFALSE, last_find = kFALSE;
    // this is special case of top folder - fields are on very top
-   if (parent == chld) {
+   if (parent == chld)
       last_find = find = kTRUE;
-   }
+
    TNamed *curr = nullptr;
-   while ((obj = iter()) != nullptr) {
+   while (auto obj = iter()) {
       if (IsItemField(obj)) {
          if (last_find && obj->GetName() && !strcmp(name, obj->GetName()))
             curr = (TNamed *)obj;
@@ -1894,7 +1890,7 @@ Bool_t TRootSniffer::RegisterCommand(const char *cmdname, const char *method, co
          SetItemField(cmdname, "_fastcmd", "true");
          icon += 7;
       }
-      if (*icon != 0)
+      if (*icon)
          SetItemField(cmdname, "_icon", icon);
    }
    SetItemField(cmdname, "method", method);

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -1887,7 +1887,7 @@ const char *TRootSniffer::GetItemField(const char *fullname, const char *name)
 
 Bool_t TRootSniffer::RegisterCommand(const char *cmdname, const char *method, const char *icon)
 {
-   CreateItem(cmdname, Form("command %s", method));
+   CreateItem(cmdname, TString::Format("command %s", method).Data());
    SetItemField(cmdname, "_kind", "Command");
    if (icon) {
       if (strncmp(icon, "button;", 7) == 0) {

--- a/net/http/src/TRootSnifferStore.cxx
+++ b/net/http/src/TRootSnifferStore.cxx
@@ -60,7 +60,7 @@ void TRootSnifferStoreXml::SetField(Int_t, const char *field, const char *value,
    } else {
       fBuf.Append(TString::Format(" %s=\"", field));
       const char *v = value;
-      while (*v != 0) {
+      while (*v) {
          switch (*v) {
          case '<': fBuf.Append("&lt;"); break;
          case '>': fBuf.Append("&gt;"); break;
@@ -124,13 +124,15 @@ void TRootSnifferStoreJson::CreateNode(Int_t lvl, const char *nodename)
 void TRootSnifferStoreJson::SetField(Int_t lvl, const char *field, const char *value, Bool_t with_quotes)
 {
    fBuf.Append(",");
-   if (!fCompact) fBuf.Append("\n");
+   if (!fCompact)
+      fBuf.Append("\n");
    fBuf.Append(TString::Format("%*s\"%s\"%s", fCompact ? 0 : lvl * 4 + 2, "", field, (fCompact ? ":" : " : ")));
    if (!with_quotes) {
       fBuf.Append(value);
    } else {
       fBuf.Append("\"");
-      for (const char *v = value; *v != 0; v++) switch (*v) {
+      for (const char *v = value; *v != 0; v++)
+         switch (*v) {
          case '\n': fBuf.Append("\\n"); break;
          case '\t': fBuf.Append("\\t"); break;
          case '\"': fBuf.Append("\\\""); break;

--- a/net/httpsniff/inc/TRootSnifferFull.h
+++ b/net/httpsniff/inc/TRootSnifferFull.h
@@ -47,7 +47,7 @@ protected:
    Bool_t CallProduceImage(const std::string &kind, const std::string &path, const std::string &options, std::string &res) override;
 
 public:
-   TRootSnifferFull(const char *name, const char *objpath = "Objects");
+   TRootSnifferFull(const char *name = "sniff", const char *objpath = "Objects");
    virtual ~TRootSnifferFull();
 
    static Bool_t IsDrawableClass(TClass *cl);

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -550,7 +550,7 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
    TClass *obj_cl = nullptr;
    void *obj_ptr = FindInHierarchy(path_, &obj_cl);
    if (debug)
-      debug->append(Form("Item:%s found:%s\n", path_, obj_ptr ? "true" : "false"));
+      debug->append(TString::Format("Item:%s found:%s\n", path_, obj_ptr ? "true" : "false").Data());
    if (!obj_ptr || !obj_cl)
       return debug != nullptr;
 
@@ -562,39 +562,40 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
    TString funcname = DecodeUrlOptionValue(url.GetValueFromOptions("func"), kTRUE);
    TMethod *method = nullptr;
    TFunction *func = nullptr;
-   if (method_name != nullptr) {
+   if (method_name) {
       if (prototype.Length() == 0) {
          if (debug)
-            debug->append(Form("Search for any method with name \'%s\'\n", method_name));
+            debug->append(TString::Format("Search for any method with name \'%s\'\n", method_name).Data());
          method = obj_cl->GetMethodAllAny(method_name);
       } else {
          if (debug)
-            debug->append(Form("Search for method \'%s\' with prototype \'%s\'\n", method_name, prototype.Data()));
+            debug->append(
+               TString::Format("Search for method \'%s\' with prototype \'%s\'\n", method_name, prototype.Data())
+                  .Data());
          method = obj_cl->GetMethodWithPrototype(method_name, prototype);
       }
    }
 
    if (method) {
       if (debug)
-         debug->append(Form("Method: %s\n", method->GetPrototype()));
+         debug->append(TString::Format("Method: %s\n", method->GetPrototype()).Data());
    } else {
       if (funcname.Length() > 0) {
          if (prototype.Length() == 0) {
             if (debug)
-               debug->append(Form("Search for any function with name \'%s\'\n", funcname.Data()));
+               debug->append(TString::Format("Search for any function with name \'%s\'\n", funcname.Data()).Data());
             func = gROOT->GetGlobalFunction(funcname);
          } else {
             if (debug)
-               debug->append(
-                  Form("Search for function \'%s\' with prototype \'%s\'\n", funcname.Data(), prototype.Data()));
+               debug->append(TString::Format("Search for function \'%s\' with prototype \'%s\'\n", funcname.Data(),
+                                             prototype.Data())
+                                .Data());
             func = gROOT->GetGlobalFunctionWithPrototype(funcname, prototype);
          }
       }
 
-      if (func) {
-         if (debug)
-            debug->append(Form("Function: %s\n", func->GetPrototype()));
-      }
+      if (func && debug)
+         debug->append(TString::Format("Function: %s\n", func->GetPrototype()).Data());
    }
 
    if (!method && !func) {
@@ -626,8 +627,7 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
    TString call_args;
 
    TIter next(args);
-   TMethodArg *arg = nullptr;
-   while ((arg = (TMethodArg *)next()) != nullptr) {
+   while (auto arg = static_cast<TMethodArg *>(next())) {
 
       if ((strcmp(arg->GetName(), "rest_url_opt") == 0) && (strcmp(arg->GetFullTypeName(), "const char*") == 0) &&
           (args->GetSize() == 1)) {
@@ -710,8 +710,9 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
          val = arg->GetDefault();
 
       if (debug)
-         debug->append(Form("  Argument:%s Type:%s Value:%s \n", arg->GetName(), arg->GetFullTypeName(),
-                                       val ? val : "<missed>"));
+         debug->append(TString::Format("  Argument:%s Type:%s Value:%s \n", arg->GetName(), arg->GetFullTypeName(),
+                                       val ? val : "<missed>")
+                          .Data());
       if (!val)
          return debug != nullptr;
 
@@ -734,11 +735,11 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
    if (method != nullptr) {
       call = new TMethodCall(obj_cl, method_name, call_args.Data());
       if (debug)
-         debug->append(Form("Calling obj->%s(%s);\n", method_name, call_args.Data()));
+         debug->append(TString::Format("Calling obj->%s(%s);\n", method_name, call_args.Data()).Data());
    } else {
       call = new TMethodCall(funcname.Data(), call_args.Data());
       if (debug)
-         debug->append(Form("Calling %s(%s);\n", funcname.Data(), call_args.Data()));
+         debug->append(TString::Format("Calling %s(%s);\n", funcname.Data(), call_args.Data()).Data());
    }
 
    garbage.Add(call);
@@ -840,7 +841,7 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
       if (gDirectory)
          obj = gDirectory->Get(_ret_object_);
       if (debug)
-         debug->append(Form("Return object %s found %s\n", _ret_object_, obj ? "true" : "false"));
+         debug->append(TString::Format("Return object %s found %s\n", _ret_object_, obj ? "true" : "false").Data());
 
       if (obj == nullptr) {
          res = "null";
@@ -868,7 +869,7 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
    }
 
    if (debug)
-      debug->append(Form("Result = %s\n", res.Data()));
+      debug->append(TString::Format("Result = %s\n", res.Data()).Data());
 
    if (reskind == 1)
       res_str = res.Data();

--- a/tutorials/http/custom.C
+++ b/tutorials/http/custom.C
@@ -8,22 +8,33 @@
 ///
 /// \author Sergey Linev
 
-#include <TH1.h>
-#include <TH2.h>
-#include <THttpServer.h>
-#include <TRandom3.h>
+#include "TH1.h"
+#include "TH2.h"
+#include "THttpServer.h"
+#include "TRandom3.h"
+#include "TSystem.h"
+#include <string>
 
 void custom()
 {
    // Create two histograms
-   TH1F *hpx = new TH1F("hpx","This is the px distribution",100,-4,4);
-   TH2F *hpxpy = new TH2F("hpxpy","py vs px",40,-4,4,40,-4,4);
+   TH1F *hpx = new TH1F("hpx", "This is the px distribution", 100, -4, 4);
+   TH2F *hpxpy = new TH2F("hpxpy", "py vs px", 40, -4, 4, 40, -4, 4);
 
    // http server with port 8080, use jobname as top-folder name
-   THttpServer* serv = new THttpServer("http:8080");
+   THttpServer *serv = new THttpServer("http:8080");
+
+   // Detect macro file location to specify full path to the HTML file
+   std::string fname = __FILE__;
+   auto pos = fname.find("custom.C");
+   if (pos > 0)
+      fname.resize(pos);
+   else
+      fname.clear();
+   fname.append("custom.htm");
 
    // use custom web page as default
-   serv->SetDefaultPage("custom.htm");
+   serv->SetDefaultPage(fname);
 
    // Fill histograms randomly
    TRandom3 random;

--- a/tutorials/http/custom.htm
+++ b/tutorials/http/custom.htm
@@ -10,8 +10,8 @@
      }
 
      #draw_hpx , #draw_hpxpy {
-        width:600px;
-        height:400px;
+        width: 600px;
+        height: 400px;
      }
    </style>
 

--- a/tutorials/webgui/ping/ping.cxx
+++ b/tutorials/webgui/ping/ping.cxx
@@ -122,12 +122,15 @@ void ping(int nclients = 1, int test_mode = 0)
 
    // configure default html page
    // either HTML code can be specified or just name of file after 'file:' prefix
-   // Detect file location to specify full path to the
+   // Detect file location to specify full path to the HTML file
    std::string fname = __FILE__;
    auto pos = fname.find("ping.cxx");
-   if (pos > 0) { fname.resize(pos); fname.append("ping.html"); }
-           else fname = "ping.html";
-   window->SetDefaultPage(std::string("file:") + fname);
+   if (pos > 0)
+      fname.resize(pos);
+   else
+      fname.clear();
+   fname.append("ping.html");
+   window->SetDefaultPage("file:" + fname);
 
    // configure window geometry
    window->SetGeometry(300, 500);

--- a/tutorials/webgui/webwindow/server.cxx
+++ b/tutorials/webgui/webwindow/server.cxx
@@ -22,7 +22,7 @@ void ProcessData(unsigned connid, const std::string &arg)
 
    if (arg == "get_text") {
       // send arbitrary text message
-      window->Send(connid, Form("Message%d", counter));
+      window->Send(connid, TString::Format("Message%d", counter).Data());
    } else if (arg == "get_binary") {
       // send float array as binary
       float arr[10];
@@ -40,9 +40,18 @@ void server()
    // create window
    window = ROOT::RWebWindow::Create();
 
+   // Detect macro file location to specify full path to the HTML file
+   std::string fname = __FILE__;
+   auto pos = fname.find("server.cxx");
+   if (pos > 0)
+      fname.resize(pos);
+   else
+      fname.clear();
+   fname.append("client.html");
+
    // configure default html page
    // either HTML code can be specified or just name of file after 'file:' prefix
-   window->SetDefaultPage("file:client.html");
+   window->SetDefaultPage("file:" + fname);
 
    // this is call-back, invoked when message received from client
    window->SetDataCallBack(ProcessData);


### PR DESCRIPTION
1. Do not use plain `Form()` macro
2. Do not use `gROOT->ProcessLine()` to create sniffer instance
3. Set full paths to custom HTML files in tutorials
4. Other minimal formatting