### PR TITLE
[skip-ci] brief is for file, not for namespace

### DIFF
--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -1,3 +1,4 @@
+/// \file
 /// \brief This file contains a specialised ROOT message handler to test for diagnostic in unit tests.
 ///
 /// \author Stephan Hageboeck <stephan.hageboeck@cern.ch>


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

In https://root.cern.ch/doc/master/namespaces.html, you get:

![image](https://github.com/root-project/root/assets/10653970/e51cf920-743d-4ca1-955a-22562fee4e8d)

The description of the ROOT namespace was picked form this file brief.

Try to fix it this way. I do not know if it will work. Maybe @couet can try on his build, prior to merging.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)