### PR TITLE
[RF] Avoid deprecated `createIterator()` function in RooStats tutorials

### DIFF
--- a/tutorials/histfactory/ModifyInterpolation.C
+++ b/tutorials/histfactory/ModifyInterpolation.C
@@ -75,11 +75,7 @@ void ModifyInterpolation(){
 }
 
 void ModifyInterpolationForAll(RooWorkspace* ws, int code){
-  RooArgSet funcs = ws->allFunctions();
-  TIter it = funcs.createIterator();
-  TObject* tempObj = nullptr;
-  while((tempObj=it.Next())){
-    FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
+  for (auto *flex : dynamic_range_cast<FlexibleInterpVar*>(ws->allFunctions())) {
     if(flex){
       flex->setAllInterpCodes(code);
     }
@@ -88,16 +84,11 @@ void ModifyInterpolationForAll(RooWorkspace* ws, int code){
 
 void ModifyInterpolationForSet(RooArgSet* modifySet, int code){
 
-  TIter it = modifySet->createIterator();
-  RooRealVar* alpha = nullptr;
-  while((alpha=(RooRealVar*)it.Next())){
-    TIter serverIt = alpha->clientIterator();
-    TObject* tempObj = nullptr;
-    while((tempObj=serverIt.Next())){
-      FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
+  for (RooAbsArg *alpha : *modifySet) {
+    for (auto *flex : dynamic_range_cast<FlexibleInterpVar*>(alpha->clients())) {
       if(flex){
          flex->printAllInterpCodes();
-         flex->setInterpCode(*alpha,code);
+         flex->setInterpCode(static_cast<RooAbsReal &>(*alpha),code);
          flex->printAllInterpCodes();
       }
     }
@@ -107,11 +98,7 @@ void ModifyInterpolationForSet(RooArgSet* modifySet, int code){
 
 
 void CheckInterpolation(RooWorkspace* ws){
-  RooArgSet funcs = ws->allFunctions();
-  TIter it = funcs.createIterator();
-  TObject* tempObj=0;
-  while((tempObj=it.Next())){
-    FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
+  for (auto *flex : dynamic_range_cast<FlexibleInterpVar*>(ws->allFunctions())) {
     if(flex){
       flex->printAllInterpCodes();
     }

--- a/tutorials/roostats/ModelInspector.C
+++ b/tutorials/roostats/ModelInspector.C
@@ -202,8 +202,6 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
    RooArgSet parameters;
    parameters.add(*fMC->GetParametersOfInterest());
    parameters.add(*fMC->GetNuisanceParameters());
-   TIter it = parameters.createIterator();
-   RooRealVar *param = nullptr;
 
    // BB: This is the part needed in order to have scrollbars
    fCan = new TGCanvas(this, 100, 100, kFixedSize);
@@ -213,7 +211,7 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
    // And that't it!
    // Obviously, the parent of other subframes is now fVFrame instead of "this"...
 
-   while ((param = (RooRealVar *)it.Next())) {
+   for (auto *param : static_range_cast<RooRealVar *>(parameters)) {
       cout << "Adding Slider for " << param->GetName() << endl;
       TGHorizontalFrame *hframek = new TGHorizontalFrame(fVFrame, 0, 0, 0);
 

--- a/tutorials/roostats/StandardBayesianMCMCDemo.C
+++ b/tutorials/roostats/StandardBayesianMCMCDemo.C
@@ -178,10 +178,8 @@ void StandardBayesianMCMCDemo(const char *infile = "", const char *workspaceName
    }
 
    // draw a scatter plot of chain results for poi vs each nuisance parameters
-   TIter it = mc->GetNuisanceParameters()->createIterator();
-   RooRealVar *nuis = NULL;
    int iPad = 1; // iPad, that's funny
-   while ((nuis = (RooRealVar *)it.Next())) {
+   for (auto *nuis : static_range_cast<RooRealVar *>(*mc->GetNuisanceParameters())) {
       c2->cd(iPad++);
       plot.DrawChainScatter(*firstPOI, *nuis);
    }

--- a/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
+++ b/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
@@ -172,9 +172,7 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
    int nPlots = 0;
    if (!simPdf) {
 
-      TIter it = mc->GetNuisanceParameters()->createIterator();
-      RooRealVar *var = NULL;
-      while ((var = (RooRealVar *)it.Next()) != NULL) {
+      for (auto *var : static_range_cast<RooRealVar *>(*mc->GetNuisanceParameters())) {
          RooPlot *frame = obs->frame();
          frame->SetYTitle(var->GetName());
          data->plotOn(frame, MarkerSize(1));


### PR DESCRIPTION
Thanks @ferdymercury for noticing this!

https://github.com/root-project/root/pull/14993#issuecomment-2007683434