### PR TITLE
[RF] Re-implement `MakeNumpyDataFrame` with no interpreter calls

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -15,8 +15,6 @@ if(dataframe)
         ROOT/_pythonization/_rdfdescription.py
         ROOT/_pythonization/_rdf_conversion_maps.py
         ROOT/_pythonization/_rdf_pyz.py)
-    list(APPEND PYROOT_EXTRA_HEADERS
-        inc/RNumpyDS.hxx)
 endif()
 
 if(roofit)

--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -51,7 +51,6 @@ class DataFrameFromNumpy(unittest.TestCase):
 
         df = ROOT.RDF.FromNumpy(data)
         gc.collect()
-        self.assertTrue(hasattr(df, "__data__"))
         self.assertEqual(sys.getrefcount(df), 2)
 
         self.assertEqual(sys.getrefcount(data["x"]), 3)

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
   HEADERS
     ROOT/RCsvDS.hxx
+    ROOT/RVecDS.hxx
     ROOT/RDataFrame.hxx
     ROOT/RDataSource.hxx
     ROOT/RDFHelpers.hxx


### PR DESCRIPTION
Re-implement `MakeNumpyDataFrame` with no interpreter calls, and avoid a
explicit lifetime management of Python objects in the RDNumpyDS helper.

Like this, the former `RNumpyDS.hxx` helper could be moved to
`tree/dataframe`, as it doesn't import `Python.h` anymore.

The `RNumpyDS` also got renamed to `RVecDS`, because it takes RVecs and
not NumPy arrays directly.

