### PR TITLE
[io] Validate ZSTD target/source sizes and compr level

### DIFF
--- a/core/zstd/src/ZipZSTD.cxx
+++ b/core/zstd/src/ZipZSTD.cxx
@@ -24,6 +24,15 @@ static const size_t errorCodeSmallBuffer = (size_t)-70;
 
 void R__zipZSTD(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep)
 {
+
+    if (*tgtsize <= 0) {
+       return;
+    }
+
+    if (*srcsize > 0xffffff || *srcsize < 0) {
+       return;
+    }
+
     using Ctx_ptr = std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)>;
     Ctx_ptr fCtx{ZSTD_createCCtx(), &ZSTD_freeCCtx};
 


### PR DESCRIPTION
This PR fixes #9334



