### PR TITLE
Do not undef HAVE_STDLIB_H in export.c for libAfterImage

### DIFF
--- a/graf2d/asimage/src/libAfterImage/export.c
+++ b/graf2d/asimage/src/libAfterImage/export.c
@@ -43,7 +43,6 @@
 #endif
 #ifdef HAVE_JPEG
 /* Include file for users of jpg library. */
-# undef HAVE_STDLIB_H
 # ifndef X_DISPLAY_MISSING
 #  include <X11/Xmd.h>
 # endif

--- a/graf2d/asimage/src/libAfterImage/import.c
+++ b/graf2d/asimage/src/libAfterImage/import.c
@@ -51,7 +51,6 @@
 #endif
 #ifdef HAVE_JPEG
 /* Include file for users of png library. */
-# undef HAVE_STDLIB_H
 # ifndef X_DISPLAY_MISSING
 #  include <X11/Xmd.h>
 # endif
@@ -75,7 +74,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
+#endif
 #ifdef HAVE_STDARG_H
 #include <stdarg.h>
 #endif


### PR DESCRIPTION
## Changes or fixes:
- When building in MacOS with afterimage (building ROOT from spack), I consistently get the following error:

```
export.c:159:18: error: call to undeclared library function 'malloc' with type 'void *(unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                realfilename = safemalloc( dirname_len+filename_len+1 );
                               ^
./asim_afterbase.h:220:24: note: expanded from macro 'safemalloc'
#define safemalloc(s)   malloc(s)
                        ^
export.c:159:18: note: include the header <stdlib.h> or explicitly provide a declaration for 'malloc'
./asim_afterbase.h:220:24: note: expanded from macro 'safemalloc'
#define safemalloc(s)   malloc(s)
                        ^
export.c:177:2: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        free( realfilename );
        ^
export.c:177:2: note: include the header <stdlib.h> or explicitly provide a declaration for 'free'
export.c:404:11: error: call to undeclared library function 'calloc' with type 'void *(unsigned long, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   curr = calloc(*size, 1);
          ^
export.c:404:11: note: include the header <stdlib.h> or explicitly provide a declaration for 'calloc'
export.c:676:19: error: call to undeclared library function 'realloc' with type 'void *(void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        buff->buffer = realloc( buff->buffer, buff->allocated_size );
                                       ^
export.c:676:19: note: include the header <stdlib.h> or explicitly provide a declaration for 'realloc'
4 errors generated.
make[3]: *** [Makefile:346: export.o] Error 1
make[3]: *** Waiting for unfinished jobs....
~

```

In this PR I'm removing an undef that I think it shouldn't be there; if that variable is not defined then stdlib.h is never included when compiling `export.c` (see [HAVE_STDLIB_H check](https://github.com/root-project/root/blob/master/graf2d/asimage/src/libAfterImage/export.c#L71)). Including `stdlib.h` is what the error message tells you to do and fixes the build for me.


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)