### PR TITLE
[Backport 6.30][runtime_cxxmodules] Allow for changing the modulemap name to match the overlay

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -609,7 +609,7 @@ namespace {
       llvm::sys::path::append(systemLoc, modulemapFilename);
       // Check if we need to mount a custom modulemap. We may have it, for
       // instance when we are on osx or using libc++.
-      if (AllowModulemapOverride &&llvm::sys::fs::exists(systemLoc.str())) {
+      if (AllowModulemapOverride && llvm::sys::fs::exists(systemLoc.str())) {
         if (HSOpts.Verbose)
           cling::log() << "Loading '" << systemLoc.str() << "'\n";
 
@@ -692,6 +692,12 @@ namespace {
                             clingIncLoc.str().str(), MOverlay,
                             /*RegisterModuleMap=*/ true,
                             /*AllowModulemapOverride=*/ false);
+#elif __APPLE__
+    if (Triple.isMacOSX() && CI.getTarget().getSDKVersion() >= VersionTuple(14, 4))
+      maybeAppendOverlayEntry(stdIncLoc.str(), "std_darwin.modulemap",
+                              clingIncLoc.str().str(), MOverlay,
+                              /*RegisterModuleMap=*/ true,
+                              /*AllowModulemapOverride=*/ false);
 #else
     maybeAppendOverlayEntry(cIncLoc.str(), "libc.modulemap",
                             clingIncLoc.str().str(), MOverlay,
@@ -701,11 +707,6 @@ namespace {
                             clingIncLoc.str().str(), MOverlay,
                             /*RegisterModuleMap=*/ true,
                             /*AllowModulemapOverride=*/true);
-    if (Triple.isMacOSX() && CI.getTarget().getSDKVersion() >= VersionTuple(14, 4))
-      maybeAppendOverlayEntry(stdIncLoc.str(), "std_darwin.modulemap",
-                              clingIncLoc.str().str(), MOverlay,
-                              /*RegisterModuleMap=*/ true,
-                              /*AllowModulemapOverride=*/ false);
 #endif // _WIN32
 
     if (!tinyxml2IncLoc.empty())

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -630,7 +630,7 @@ namespace {
         cling::log() << "'" << systemLoc << "' does not exist. Mounting '"
                      << originalLoc.str() << "' as '" << systemLoc << "'\n";
 
-      if (!HSOpts.ImplicitModuleMaps && !llvm::sys::fs::exists(systemLoc.str())) {
+      if (!HSOpts.ImplicitModuleMaps) {
          modulemapFilename = Filename;
          llvm::sys::path::remove_filename(systemLoc);
          llvm::sys::path::append(systemLoc, modulemapFilename);


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/15043 and https://github.com/root-project/root/pull/14974

