### PR TITLE
[RF] Improve parameter management in `RooEvaluatorWrapper`

### DIFF
--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -733,14 +733,14 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, const Ro
           evalBackend == RooFit::EvalBackend::Value::CodegenNoGrad) {
          bool createGradient = evalBackend == RooFit::EvalBackend::Value::Codegen;
          auto simPdf = dynamic_cast<RooSimultaneous const *>(pdfClone.get());
-         nllWrapper = std::make_unique<RooFuncWrapper>("nll_func_wrapper", "nll_func_wrapper", *nll, &data,
-                                                       simPdf, true);
-         if(createGradient) static_cast<RooFuncWrapper&>(*nllWrapper).createGradient();
+         nllWrapper =
+            std::make_unique<RooFuncWrapper>("nll_func_wrapper", "nll_func_wrapper", *nll, &data, simPdf, true);
+         if (createGradient)
+            static_cast<RooFuncWrapper &>(*nllWrapper).createGradient();
       } else {
-         auto evaluator = std::make_unique<RooFit::Evaluator>(*nll, evalBackend == RooFit::EvalBackend::Value::Cuda);
-         nllWrapper = std::make_unique<RooEvaluatorWrapper>(*nll, std::move(evaluator), rangeName ? rangeName : "",
-                                                            pdfClone.get(), takeGlobalObservablesFromData);
-         nllWrapper->setData(data, false);
+         nllWrapper = std::make_unique<RooEvaluatorWrapper>(
+            *nll, &data, evalBackend == RooFit::EvalBackend::Value::Cuda, rangeName ? rangeName : "", pdfClone.get(),
+            takeGlobalObservablesFromData);
       }
 
       nllWrapper->addOwnedComponents(std::move(nll));

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
@@ -25,24 +25,31 @@ Wraps a RooFit::Evaluator that evaluates a RooAbsReal back into a RooAbsReal.
 
 #include <RooAbsData.h>
 #include <RooAbsPdf.h>
-#include <RooAbsReal.h>
+#include <RooConstVar.h>
 #include <RooHelpers.h>
 #include <RooMsgService.h>
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
 
-#include <TList.h>
-
-RooEvaluatorWrapper::RooEvaluatorWrapper(RooAbsReal &topNode, std::unique_ptr<RooFit::Evaluator> evaluator,
+RooEvaluatorWrapper::RooEvaluatorWrapper(RooAbsReal &topNode, RooAbsData *data, bool useGPU,
                                          std::string const &rangeName, RooAbsPdf const *pdf,
                                          bool takeGlobalObservablesFromData)
    : RooAbsReal{"RooEvaluatorWrapper", "RooEvaluatorWrapper"},
-     _evaluator{std::move(evaluator)},
-     _topNode("topNode", "top node", this, topNode),
+     _evaluator{std::make_unique<RooFit::Evaluator>(topNode, useGPU)},
+     _topNode("topNode", "top node", this, topNode, false, false),
+     _data{data},
+     _paramSet("paramSet", "Set of parameters", this),
      _rangeName{rangeName},
      _pdf{pdf},
      _takeGlobalObservablesFromData{takeGlobalObservablesFromData}
 {
+   if (data) {
+      setData(*data, false);
+   }
+   _paramSet.add(_evaluator->getParameters());
+   for (auto const &item : _dataSpans) {
+      _paramSet.remove(*_paramSet.find(item.first->GetName()));
+   }
 }
 
 RooEvaluatorWrapper::RooEvaluatorWrapper(const RooEvaluatorWrapper &other, const char *name)
@@ -50,11 +57,13 @@ RooEvaluatorWrapper::RooEvaluatorWrapper(const RooEvaluatorWrapper &other, const
      _evaluator{other._evaluator},
      _topNode("topNode", this, other._topNode),
      _data{other._data},
+     _paramSet("paramSet", "Set of parameters", this),
      _rangeName{other._rangeName},
      _pdf{other._pdf},
      _takeGlobalObservablesFromData{other._takeGlobalObservablesFromData},
      _dataSpans{other._dataSpans}
 {
+   _paramSet.add(other._paramSet);
 }
 
 bool RooEvaluatorWrapper::getParameters(const RooArgSet *observables, RooArgSet &outputSet,
@@ -86,14 +95,32 @@ bool RooEvaluatorWrapper::getParameters(const RooArgSet *observables, RooArgSet 
 
 bool RooEvaluatorWrapper::setData(RooAbsData &data, bool /*cloneData*/)
 {
+   // To make things easiear for RooFit, we only support resetting with
+   // datasets that have the same structure, e.g. the same columns and global
+   // observables. This is anyway the usecase: resetting same-structured data
+   // when iterating over toys.
+   constexpr auto errMsg = "Error in RooAbsReal::setData(): only resetting with same-structured data is supported.";
+
    _data = &data;
+   bool isInitializing = _paramSet.empty();
+   const std::size_t oldSize = _dataSpans.size();
+
    std::stack<std::vector<double>>{}.swap(_vectorBuffers);
    bool skipZeroWeights = !_pdf || !_pdf->getAttribute("BinnedLikelihoodActive");
    _dataSpans = RooFit::Detail::BatchModeDataHelpers::getDataSpans(
       *_data, _rangeName, dynamic_cast<RooSimultaneous const *>(_pdf), skipZeroWeights, _takeGlobalObservablesFromData,
       _vectorBuffers);
+   if (!isInitializing && _dataSpans.size() != oldSize) {
+      coutE(DataHandling) << errMsg << std::endl;
+      throw std::runtime_error(errMsg);
+   }
    for (auto const &item : _dataSpans) {
-      _evaluator->setInput(item.first->GetName(), item.second, false);
+      const char *name = item.first->GetName();
+      _evaluator->setInput(name, item.second, false);
+      if (_paramSet.find(name)) {
+         coutE(DataHandling) << errMsg << std::endl;
+         throw std::runtime_error(errMsg);
+      }
    }
    return true;
 }

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.h
@@ -17,10 +17,11 @@
 
 #include <RooAbsData.h>
 #include <RooFit/EvalContext.h>
+#include <RooFit/Evaluator.h>
 #include <RooGlobalFunc.h>
 #include <RooHelpers.h>
 #include <RooRealProxy.h>
-#include <RooFit/Evaluator.h>
+#include <RooSetProxy.h>
 
 #include "RooFit/Detail/BatchModeDataHelpers.h"
 #include "RooFit/Detail/Buffers.h"
@@ -35,7 +36,7 @@ class RooAbsPdf;
 
 class RooEvaluatorWrapper final : public RooAbsReal {
 public:
-   RooEvaluatorWrapper(RooAbsReal &topNode, std::unique_ptr<RooFit::Evaluator> evaluator, std::string const &rangeName,
+   RooEvaluatorWrapper(RooAbsReal &topNode, RooAbsData *data, bool useGPU, std::string const &rangeName,
                        RooAbsPdf const *simPdf, bool takeGlobalObservablesFromData);
 
    RooEvaluatorWrapper(const RooEvaluatorWrapper &other, const char *name = nullptr);
@@ -68,7 +69,7 @@ private:
    std::shared_ptr<RooFit::Evaluator> _evaluator;
    RooRealProxy _topNode;
    RooAbsData *_data = nullptr;
-   RooArgSet _parameters;
+   RooSetProxy _paramSet;
    std::string _rangeName;
    RooAbsPdf const *_pdf = nullptr;
    const bool _takeGlobalObservablesFromData;

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -31,12 +31,7 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, RooAbsReal &
    : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
 {
    if (useEvaluator) {
-      auto absReal =
-         std::make_unique<RooEvaluatorWrapper>(obj, std::make_unique<RooFit::Evaluator>(obj), "", simPdf, false);
-      if (data) {
-         absReal->setData(const_cast<RooAbsData &>(*data), false);
-      }
-      _absReal = std::move(absReal);
+      _absReal = std::make_unique<RooEvaluatorWrapper>(obj, const_cast<RooAbsData *>(data), false, "", simPdf, false);
    }
 
    std::string func;

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -281,12 +281,6 @@ void RooNLLVarNew::doEval(RooFit::EvalContext &ctx) const
    output[0] = finalizeResult({nllOut.nllSum, nllOut.nllSumCarry}, _sumWeight);
 }
 
-void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *params, bool /*stripDisconnected*/) const
-{
-   // strip away the special variables
-   params->remove(RooArgList{*_weightVar, *_weightSquaredVar}, true, true);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Sets the prefix for the special variables of this NLL, like weights or bin
 /// volumes.

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -35,8 +35,6 @@ public:
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
-   void getParametersHook(const RooArgSet *nset, RooArgSet *list, bool stripDisconnected) const override;
-
    /// Return default level for MINUIT error analysis.
    double defaultErrorLevel() const override { return 0.5; }
 

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -8,6 +8,7 @@
 #include <RooFitResult.h>
 #include <RooGenericPdf.h>
 #include <RooHelpers.h>
+#include <RooMinimizer.h>
 #include <RooProdPdf.h>
 #include <RooRandom.h>
 #include <RooRealVar.h>
@@ -18,50 +19,6 @@
 #include "gtest_wrapper.h"
 
 #include <memory>
-
-/// GitHub issue #8307.
-/// A likelihood with a model wrapped in a RooSimultaneous in one category
-/// should give the same results as the likelihood with the model directly.
-TEST(RooSimultaneous, SingleChannelCrossCheck)
-{
-   using namespace RooFit;
-
-   // silence log output
-   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
-
-   RooWorkspace ws;
-   ws.factory("Gaussian::gauss1(x[0, 10], mean[1., 0., 10.], width[1, 0.1, 10])");
-   ws.factory("AddPdf::model({gauss1}, {nsig[500, 100, 1000]})");
-   ws.factory("Gaussian::fconstraint(2.0, mean, 0.2)");
-   ws.factory("ProdPdf::modelConstrained({model, fconstraint})");
-
-   RooRealVar &x = *ws.var("x");
-   RooAbsPdf &model = *ws.pdf("model");
-   RooAbsPdf &modelConstrained = *ws.pdf("modelConstrained");
-
-   RooCategory cat("cat", "cat");
-   cat.defineType("physics");
-
-   RooSimultaneous modelSim("modelSim", "modelSim", RooArgList{modelConstrained}, cat);
-
-   std::unique_ptr<RooDataSet> data{model.generate(x)};
-   RooDataSet combData("combData", "combData", x, Index(cat), Import("physics", *data));
-
-   using AbsRealPtr = std::unique_ptr<RooAbsReal>;
-
-   AbsRealPtr nllDirectBatch{modelConstrained.createNLL(combData, EvalBackend::Cpu())};
-   AbsRealPtr nllSimWrappedBatch{modelSim.createNLL(combData, EvalBackend::Cpu())};
-
-   EXPECT_FLOAT_EQ(nllDirectBatch->getVal(), nllSimWrappedBatch->getVal()) << "Inconsistency in BatchMode";
-
-#ifdef ROOFIT_LEGACY_EVAL_BACKEND
-   AbsRealPtr nllDirect{modelConstrained.createNLL(combData, EvalBackend::Legacy())};
-   AbsRealPtr nllSimWrapped{modelSim.createNLL(combData, EvalBackend::Legacy())};
-
-   EXPECT_FLOAT_EQ(nllDirect->getVal(), nllSimWrapped->getVal()) << "Inconsistency in old RooFit";
-   EXPECT_FLOAT_EQ(nllDirect->getVal(), nllDirectBatch->getVal()) << "Old RooFit and BatchMode don't agree";
-#endif
-}
 
 /// Forum issue
 /// https://root-forum.cern.ch/t/roofit-failed-to-create-nll-for-simultaneous-pdfs-with-multiple-range-names/49363.
@@ -229,6 +186,65 @@ private:
    std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
+/// GitHub issue #8307.
+/// A likelihood with a model wrapped in a RooSimultaneous in one category
+/// should give the same results as the likelihood with the model directly. We
+/// also test that things go well if you wrap the simultaneous NLL again in
+/// another class, which can happen in user frameworks.
+TEST_P(TestStatisticTest, RooSimultaneousSingleChannelCrossCheck)
+{
+   using namespace RooFit;
+
+   // silence log output
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooWorkspace ws;
+   ws.factory("Gaussian::gauss1(x[0, 10], mean[1., 0., 10.], width[1, 0.1, 10])");
+   ws.factory("AddPdf::model({gauss1}, {nsig[500, 100, 1000]})");
+   ws.factory("Gaussian::fconstraint(2.0, mean, 0.2)");
+   ws.factory("ProdPdf::modelConstrained({model, fconstraint})");
+
+   RooRealVar &x = *ws.var("x");
+   RooAbsPdf &model = *ws.pdf("model");
+   RooAbsPdf &modelConstrained = *ws.pdf("modelConstrained");
+
+   RooCategory cat("cat", "cat");
+   cat.defineType("physics");
+
+   RooSimultaneous modelSim("modelSim", "modelSim", RooArgList{modelConstrained}, cat);
+
+   std::unique_ptr<RooDataSet> data{model.generate(x)};
+
+   RooArgSet params;
+   RooArgSet initialParams;
+   modelConstrained.getParameters(data->get(), params);
+   params.snapshot(initialParams);
+
+   RooDataSet combData("combData", "combData", x, Index(cat), Import("physics", *data));
+
+   using AbsRealPtr = std::unique_ptr<RooAbsReal>;
+
+   AbsRealPtr nllDirect{modelConstrained.createNLL(combData, _evalBackend)};
+   AbsRealPtr nllSimWrapped{modelSim.createNLL(combData, _evalBackend)};
+   RooAddition nllAdditionWrapped{"nll_wrapped_cpu", "nll_wrapped_cpu", {*nllSimWrapped}};
+
+   auto minimize = [&](RooAbsReal &nll) {
+      params.assign(initialParams);
+      RooMinimizer minim{nll};
+      minim.setPrintLevel(-1);
+      minim.minimize("", "");
+      return std::unique_ptr<RooFitResult>{minim.save()};
+   };
+
+   std::unique_ptr<RooFitResult> resDirect{minimize(*nllDirect)};
+   std::unique_ptr<RooFitResult> resSimWrapped{minimize(*nllSimWrapped)};
+   std::unique_ptr<RooFitResult> resAdditionWrapped{minimize(nllAdditionWrapped)};
+
+   EXPECT_TRUE(resSimWrapped->isIdentical(*resDirect)) << "Inconsistency in RooSimultaneous wrapping";
+   EXPECT_TRUE(resAdditionWrapped->isIdentical(*resDirect))
+      << "Inconsistency in RooSimultaneous + RooAddition wrapping";
+}
+
 /// Checks that the Range() command argument for fitTo can be used to select
 /// specific components from a RooSimultaneous. Covers GitHub issue #8231.
 TEST_P(TestStatisticTest, RangedCategory)
@@ -283,8 +299,7 @@ TEST_P(TestStatisticTest, RangedCategory)
    // Function to do the fit
    auto doFit = [&](RooAbsPdf &pdf, RooAbsData &dataset, const char *range = nullptr) {
       resetParameters();
-      std::unique_ptr<RooFitResult> res{
-         pdf.fitTo(dataset, Range(range), Save(), PrintLevel(-1), _evalBackend)};
+      std::unique_ptr<RooFitResult> res{pdf.fitTo(dataset, Range(range), Save(), PrintLevel(-1), _evalBackend)};
       resetParameters();
       return res;
    };


### PR DESCRIPTION
Only register actual observables as value servers in the `RooEvaluatorWrapper` this avoids that spurious variables appear in user code, which were only meant to be used internally by the new CPU evaluation backend.

To make the management of the parameter easier, impose the new reasonable constraint that when resetting the data via `setData()`, the new dataset needs to have the same structure as the old one.

It was confirmed with an ATLAS model provided by Will that this commit is fixing the problem of spurious variables.

A unit test is also implemented.

FYI @will-cern