### PR TITLE
[cppyy] Fix `missing-field-initializers` with Python 3.12

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -307,6 +307,9 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -289,6 +289,9 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                            // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -1086,6 +1086,9 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1052,6 +1052,9 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                                // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -707,6 +707,9 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -161,6 +161,9 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                  // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                  // tp_watched
+#endif
 };
 
 
@@ -196,7 +199,10 @@ static PyTypeObject PyDefault_t_Type = {
     , 0                  // tp_finalize
 #endif
 #if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
+    , 0                 // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                 // tp_watched
 #endif
 };
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -167,6 +167,9 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -335,6 +338,9 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 
@@ -388,6 +394,9 @@ PyTypeObject IndexIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 
@@ -450,6 +459,9 @@ PyTypeObject VectorIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
@@ -956,6 +956,9 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                            // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -960,6 +960,9 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                                // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
@@ -117,6 +117,9 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 
@@ -247,6 +250,9 @@ PyTypeObject TupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 

--- a/bindings/pyroot/cppyy/sync-upstream
+++ b/bindings/pyroot/cppyy/sync-upstream
@@ -30,6 +30,7 @@ rebase_topic () {
 rebase_topic guitargeek/exceptions
 rebase_topic guitargeek/converter_control
 rebase_topic guitargeek/string_converters
+rebase_topic guitargeek/py12_warnings
 
 cd ..
 


### PR DESCRIPTION
Adapting to a new field in Python 3.12:
https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_watched

Corresponding CPyCppyy PR: https://github.com/wlav/CPyCppyy/pull/24