### PR TITLE
[RF] Fix dirty state propagation for offsetting with new CPU backend

### DIFF
--- a/roofit/roofitcore/inc/RooFit/EvalContext.h
+++ b/roofit/roofitcore/inc/RooFit/EvalContext.h
@@ -20,6 +20,8 @@
 #include <TNamed.h>
 #include <TObject.h>
 
+#include <Math/Util.h>
+
 #include <map>
 #include <stdexcept>
 #include <sstream>
@@ -81,6 +83,8 @@ namespace RooFit {
 
 class EvalContext {
 public:
+   enum class OffsetMode { WithoutOffset, WithOffset, OnlyOffset };
+
    auto size() const { return _ctx.size(); }
    void resize(std::size_t n);
 
@@ -107,10 +111,13 @@ public:
    void resetVectorBuffers() { _bufferIdx = 0; }
    std::span<double> output() { return _currentOutput; }
 
-private:
+   void setOutputWithOffset(RooAbsArg const *arg, ROOT::Math::KahanSum<double> val,
+                            ROOT::Math::KahanSum<double> const &offset);
 
+private:
    friend class Evaluator;
 
+   OffsetMode _offsetMode = OffsetMode::WithoutOffset;
    std::span<double> _currentOutput;
    std::vector<std::span<const double>> _ctx;
    bool _enableVectorBuffers = false;

--- a/roofit/roofitcore/inc/RooFit/Evaluator.h
+++ b/roofit/roofitcore/inc/RooFit/Evaluator.h
@@ -47,6 +47,8 @@ public:
    RooArgSet getParameters() const;
    void print(std::ostream &os);
 
+   void setOffsetMode(RooFit::EvalContext::OffsetMode);
+
 private:
    void processVariable(NodeInfo &nodeInfo);
    void setClientsDirty(NodeInfo &nodeInfo);

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
@@ -57,6 +57,17 @@ RooEvaluatorWrapper::RooEvaluatorWrapper(const RooEvaluatorWrapper &other, const
 {
 }
 
+double RooEvaluatorWrapper::evaluate() const
+{
+   if (!_evaluator)
+      return 0.0;
+
+   _evaluator->setOffsetMode(hideOffset() ? RooFit::EvalContext::OffsetMode::WithoutOffset
+                                          : RooFit::EvalContext::OffsetMode::WithOffset);
+
+   return _evaluator->run()[0];
+}
+
 bool RooEvaluatorWrapper::getParameters(const RooArgSet *observables, RooArgSet &outputSet,
                                         bool /*stripDisconnected*/) const
 {

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.h
@@ -62,7 +62,7 @@ public:
    void constOptimizeTestStatistic(ConstOpCode /*opcode*/, bool /*doAlsoTrackingOpt*/) override {}
 
 protected:
-   double evaluate() const override { return _evaluator ? _evaluator->run()[0] : 0.0; }
+   double evaluate() const override;
 
 private:
    std::shared_ptr<RooFit::Evaluator> _evaluator;

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -684,4 +684,28 @@ RooArgSet Evaluator::getParameters() const
    return parameters;
 }
 
+/// \brief Sets the offset mode for evaluation.
+///
+/// This function sets the offset mode for evaluation to the specified mode.
+/// It updates the offset mode for both CPU and CUDA evaluation contexts.
+///
+/// \param mode The offset mode to be set.
+///
+/// \note This function marks reducer nodes as dirty if the offset mode is
+///       changed, because only reducer nodes can use offsetting.
+void Evaluator::setOffsetMode(RooFit::EvalContext::OffsetMode mode)
+{
+   if (mode == _evalContextCPU._offsetMode)
+      return;
+
+   _evalContextCPU._offsetMode = mode;
+   _evalContextCUDA._offsetMode = mode;
+
+   for (auto &nodeInfo : _nodes) {
+      if (nodeInfo.absArg->isReducerNode()) {
+         nodeInfo.isDirty = true;
+      }
+   }
+}
+
 } // namespace RooFit

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -59,9 +59,9 @@ public:
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
-   double finalizeResult(ROOT::Math::KahanSum<double> result, double weightSum) const;
+   void finalizeResult(RooFit::EvalContext &, ROOT::Math::KahanSum<double> result, double weightSum) const;
    void fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf, RooArgSet const &observables);
-   double doEvalBinnedL(std::span<const double> preds, std::span<const double> weights) const;
+   void doEvalBinnedL(RooFit::EvalContext &, std::span<const double> preds, std::span<const double> weights) const;
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooTemplateProxy<RooAbsReal> _weightVar;


### PR DESCRIPTION
The logic that determined the offset hiding of not was coded inside the `RooNLLVarNew` evaluation function so far.

This caused trouble, because a change in the global `RooAbsReal::hideOffset()` state did not mark the NLL as dirty. Therefore, it was unpredictable if the offset was actually hidden or not.

This commit suggests an improved logic:

  * Reducer nodes like the NLL always register a value and an offset to the `EvalContext`

  * The evaluator decides whether to subtract the offset or not

  * A change in `hideOffset()` makes the evaluator wrapper set all reducer nodes to dirty

A new unit test to cover this was also implemented.

FYI, @will-cern 