### PR TITLE
[ntuple] Add initial `RNTupleProcessor` prototype

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -33,6 +33,7 @@ HEADERS
   ROOT/RNTupleMetrics.hxx
   ROOT/RNTupleModel.hxx
   ROOT/RNTupleParallelWriter.hxx
+  ROOT/RNTupleProcessor.hxx
   ROOT/RNTupleReadOptions.hxx
   ROOT/RNTupleReader.hxx
   ROOT/RNTupleSerialize.hxx
@@ -66,6 +67,7 @@ SOURCES
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx
   v7/src/RNTupleParallelWriter.cxx
+  v7/src/RNTupleProcessor.cxx
   v7/src/RNTupleReader.cxx
   v7/src/RNTupleSerialize.cxx
   v7/src/RNTupleUtil.cxx

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -82,6 +82,11 @@ private:
       return ptr;
    }
 
+   /// Update the RValue for a field in the entry. To be used when its underlying RFieldBase changes, which typically
+   /// happens when page source the field values are read from changes.
+   void UpdateValue(RFieldToken token, RFieldBase::RValue &&value) { std::swap(fValues.at(token.fIndex), value); }
+   void UpdateValue(RFieldToken token, RFieldBase::RValue &value) { std::swap(fValues.at(token.fIndex), value); }
+
    void Read(NTupleSize_t index)
    {
       for (auto &v : fValues) {

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -32,6 +32,10 @@
 namespace ROOT {
 namespace Experimental {
 
+namespace Internal {
+class RNTupleProcessor;
+}
+
 // clang-format off
 /**
 \class ROOT::Experimental::REntry
@@ -47,6 +51,7 @@ class REntry {
    friend class RNTupleModel;
    friend class RNTupleReader;
    friend class RNTupleFillContext;
+   friend class Internal::RNTupleProcessor;
 
 public:
    /// The field token identifies a top-level field in this entry. It can be used for fast indexing in REntry's

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -1,0 +1,270 @@
+/// \file ROOT/RNTupleProcessor.hxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2024-03-26
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleProcessor
+#define ROOT7_RNTupleProcessor
+
+#include <ROOT/REntry.hxx>
+#include <ROOT/RError.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RSpan.hxx>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+
+/// Helper type representing the name and storage location of an RNTuple.
+struct RNTupleSourceSpec {
+   std::string fName;
+   std::string fLocation;
+
+   RNTupleSourceSpec() = default;
+   RNTupleSourceSpec(std::string_view n, std::string_view s) : fName(n), fLocation(s) {}
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleProcessor
+\ingroup NTuple
+\brief Interface for iterating over entries of RNTuples and vertically concatenated RNTuples (chains).
+
+Example usage (see ntpl012_processor.C for a full example):
+
+~~~{.cpp}
+#include <ROOT/RNTupleProcessor.hxx>
+using ROOT::Experimental::RNTupleProcessor;
+using ROOT::Experimental::RNTupleSourceSpec;
+
+std::vector<RNTupleSourceSpec> ntuples = {{"ntuple1", "ntuple1.root"}, {"ntuple2", "ntuple2.root"}};
+RNTupleProcessor processor(ntuples);
+auto ptrPt = processor.GetEntry().GetPtr<float>("pt");
+
+for (const auto &entry : processor) {
+   std::cout << "pt = " << *ptrPt << std::endl;
+}
+~~~
+
+An RNTupleProcessor is created by providing one or more RNTupleSourceSpecs, each of which contains the name and storage
+location of a single RNTuple. The RNTuples are subsequently processed in the order in which they were provided.
+
+The default model of the RNTuple that is provided first will be used to construct the fields in the entry that will be
+filled in each iteration. This entry is owned by the RNTupleProcessor.
+If subsequently processed RNTuples contain additional fields, they will be ignored.
+Conversely, if a field that was present in the first RNTuple is not found in a subsequent one, an error will be thrown.
+
+The object returned by the RNTupleProcessor iterator is a view on the current state of the processor, and provides
+access to the global entry index (i.e., the entry index taking into account all processed ntuples), local entry index
+(i.e. the entry index for only the currently processed ntuple), the index of the ntuple currently being processed (with
+respect to the order of provided RNTupleSpecs) and the actual REntry containing the values for the current entry.
+*/
+// clang-format on
+class RNTupleProcessor {
+private:
+   // clang-format off
+   /**
+   \class ROOT::Experimental::RNTupleProcessor::RFieldContext
+   \ingroup NTuple
+   \brief Manager for a field as part of the RNTupleProcessor.
+
+   An RFieldContext contains two fields: a proto-field which is not connected to any page source but serves as the
+   blueprint for this particular field, and a concrete field that is connected to the page source currently connected
+   to the RNTupleProcessor object for reading. When a new page source is connected, the concrete field gets reset by
+   cloning the proto-field and connecting it to the new page source.
+
+   Apart from the fields themselves, the RFieldContext object also manages the pointer to the value for this particular
+   field that's read by the processor.
+   */
+   // clang-format on
+   class RFieldContext {
+      friend class RNTupleProcessor;
+
+   private:
+      std::unique_ptr<RFieldBase> fProtoField;
+      std::unique_ptr<RFieldBase> fConcreteField;
+      REntry::RFieldToken fToken;
+      std::shared_ptr<void> fValuePtr;
+
+   public:
+      RFieldContext(std::unique_ptr<RFieldBase> protoField, REntry::RFieldToken token)
+         : fProtoField(std::move(protoField)), fToken(token)
+      {
+      }
+
+      const RFieldBase &GetProtoField() const { return *fProtoField; }
+      /// We need to disconnect the concrete fields before swapping the page sources
+      void ResetConcreteField() { fConcreteField = nullptr; }
+      void SetConcreteField() { fConcreteField = fProtoField->Clone(fProtoField->GetFieldName()); }
+      RFieldBase &GetConcreteField() const { return *fConcreteField; }
+      const REntry::RFieldToken &GetToken() const { return fToken; }
+   };
+
+   std::vector<RNTupleSourceSpec> fNTuples;
+   std::unique_ptr<REntry> fEntry;
+   std::unique_ptr<Internal::RPageSource> fPageSource;
+   std::vector<RFieldContext> fFieldContexts;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect an RNTuple for processing.
+   ///
+   /// \param[in] ntuple The RNTupleSourceSpec describing the RNTuple to connect.
+   ///
+   /// \return The number of entries in the newly-connected RNTuple.
+   ///
+   /// Creates and attaches new page source for the specified RNTuple, and connects the fields that are known by
+   /// the processor to it.
+   NTupleSize_t ConnectNTuple(const RNTupleSourceSpec &ntuple);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Creates and connects concrete fields to the current page source, based on the proto-fields.
+   void ConnectFields();
+
+public:
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Returns a reference to the entry used by the processor.
+   ///
+   /// \return A reference to the entry used by the processor.
+   ///
+   const REntry &GetEntry() const { return *fEntry; }
+
+   // clang-format off
+   /**
+   \class ROOT::Experimental::RNTupleProcessor::RIterator
+   \ingroup NTuple
+   \brief Iterator over the entries of an RNTuple, or vertical concatenation thereof.
+   */
+   // clang-format on
+   class RIterator {
+   public:
+      // clang-format off
+      /**
+      \class ROOT::Experimental::RNTupleProcessor::RIterator::RState
+      \ingroup NTuple
+      \brief View on the RNTupleProcessor iterator state.
+      */
+      // clang-format on
+      class RState {
+         friend class RIterator;
+
+      private:
+         const REntry &fEntry;
+         NTupleSize_t fGlobalEntryIndex;
+         NTupleSize_t fLocalEntryIndex;
+         /// Index of the currently open RNTuple in the chain of ntuples
+         std::size_t fNTupleIndex;
+
+      public:
+         RState(const REntry &entry, NTupleSize_t globalEntryIndex, NTupleSize_t localEntryIndex,
+                std::size_t ntupleIndex)
+            : fEntry(entry),
+              fGlobalEntryIndex(globalEntryIndex),
+              fLocalEntryIndex(localEntryIndex),
+              fNTupleIndex(ntupleIndex)
+         {
+         }
+
+         const REntry *operator->() const { return &fEntry; }
+         const REntry &GetEntry() const { return fEntry; }
+         NTupleSize_t GetGlobalEntryIndex() const { return fGlobalEntryIndex; }
+         NTupleSize_t GetLocalEntryIndex() const { return fLocalEntryIndex; }
+         std::size_t GetNTupleIndex() const { return fNTupleIndex; }
+      };
+
+   private:
+      RNTupleProcessor &fProcessor;
+      RState fState;
+
+   public:
+      using iterator_category = std::forward_iterator_tag;
+      using iterator = RIterator;
+      using value_type = RState;
+      using difference_type = std::ptrdiff_t;
+      using pointer = RState *;
+      using reference = const RState &;
+
+      RIterator(RNTupleProcessor &processor, std::size_t ntupleIndex, NTupleSize_t globalEntryIndex)
+         : fProcessor(processor), fState(processor.GetEntry(), globalEntryIndex, 0, ntupleIndex)
+      {
+      }
+
+      //////////////////////////////////////////////////////////////////////////
+      /// \brief Increments the entry index.
+      ///
+      /// Checks if the end of the currently connected RNTuple is reached. If this is the case, either the next RNTuple
+      /// is connected or the iterator has reached the end.
+      void Advance()
+      {
+         ++fState.fGlobalEntryIndex;
+
+         if (++fState.fLocalEntryIndex >= fProcessor.fPageSource->GetNEntries()) {
+            do {
+               if (++fState.fNTupleIndex >= fProcessor.fNTuples.size()) {
+                  fState.fGlobalEntryIndex = kInvalidNTupleIndex;
+                  return;
+               }
+               // Skip over empty ntuples we might encounter.
+            } while (fProcessor.ConnectNTuple(fProcessor.fNTuples.at(fState.fNTupleIndex)) == 0);
+
+            fState.fLocalEntryIndex = 0;
+         }
+      }
+
+      iterator operator++()
+      {
+         Advance();
+         return *this;
+      }
+
+      iterator operator++(int)
+      {
+         auto obj = *this;
+         Advance();
+         return obj;
+      }
+
+      reference operator*()
+      {
+         fProcessor.fEntry->Read(fState.fLocalEntryIndex);
+         return fState;
+      }
+
+      bool operator!=(const iterator &rh) const { return fState.fGlobalEntryIndex != rh.fState.fGlobalEntryIndex; }
+      bool operator==(const iterator &rh) const { return fState.fGlobalEntryIndex == rh.fState.fGlobalEntryIndex; }
+   };
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Constructs a new RNTupleProcessor.
+   ///
+   /// \param[in] ntuples The source specification (name and storage location) for each RNTuple to process.
+   ///
+   /// RNTuples are processed in the order in which they are specified.
+   RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples);
+
+   RIterator begin() { return RIterator(*this, 0, 0); }
+   RIterator end() { return RIterator(*this, fNTuples.size(), kInvalidNTupleIndex); }
+};
+
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleProcessor

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -1,0 +1,88 @@
+/// \file RNTupleProcessor.cxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2024-03-26
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleProcessor.hxx>
+
+#include <ROOT/RField.hxx>
+
+ROOT::Experimental::NTupleSize_t
+ROOT::Experimental::Internal::RNTupleProcessor::ConnectNTuple(const RNTupleSourceSpec &ntuple)
+{
+   for (auto &fieldContext : fFieldContexts) {
+      fieldContext.ResetConcreteField();
+   }
+   fPageSource = Internal::RPageSource::Create(ntuple.fName, ntuple.fLocation);
+   fPageSource->Attach();
+   ConnectFields();
+   return fPageSource->GetNEntries();
+}
+
+void ROOT::Experimental::Internal::RNTupleProcessor::ConnectFields()
+{
+   auto desc = fPageSource->GetSharedDescriptorGuard();
+
+   for (auto &fieldContext : fFieldContexts) {
+      auto fieldId = desc->FindFieldId(fieldContext.GetProtoField().GetFieldName());
+      if (fieldId == kInvalidDescriptorId) {
+         throw RException(
+            R__FAIL("field \"" + fieldContext.GetProtoField().GetFieldName() + "\" not found in current RNTuple"));
+      }
+
+      fieldContext.SetConcreteField();
+      fieldContext.GetConcreteField().SetOnDiskId(desc->FindFieldId(fieldContext.GetProtoField().GetFieldName()));
+      Internal::CallConnectPageSourceOnField(fieldContext.GetConcreteField(), *fPageSource);
+
+      if (fieldContext.fValuePtr) {
+         fEntry->UpdateValue(fieldContext.GetToken(),
+                             fieldContext.GetConcreteField().BindValue(fieldContext.fValuePtr));
+      } else {
+         auto value = fieldContext.GetConcreteField().CreateValue();
+         fieldContext.fValuePtr = value.GetPtr<void>();
+         fEntry->UpdateValue(fieldContext.GetToken(), value);
+      }
+   }
+}
+
+ROOT::Experimental::Internal::RNTupleProcessor::RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples)
+   : fNTuples(ntuples)
+{
+   if (fNTuples.empty())
+      throw RException(R__FAIL("at least one RNTuple must be provided"));
+
+   fPageSource = Internal::RPageSource::Create(fNTuples[0].fName, fNTuples[0].fLocation);
+   fPageSource->Attach();
+
+   if (fPageSource->GetNEntries() == 0) {
+      throw RException(R__FAIL("first RNTuple does not contain any entries"));
+   }
+
+   fEntry = std::unique_ptr<REntry>(new REntry());
+
+   auto desc = fPageSource->GetSharedDescriptorGuard();
+
+   for (const auto &fieldDesc : desc->GetTopLevelFields()) {
+      auto fieldOrException = RFieldBase::Create(fieldDesc.GetFieldName(), fieldDesc.GetTypeName());
+      if (fieldOrException) {
+         auto field = fieldOrException.Unwrap();
+         fEntry->AddValue(field->CreateValue());
+         fFieldContexts.emplace_back(std::move(field), fEntry->GetToken(fieldDesc.GetFieldName()));
+      } else {
+         throw RException(R__FAIL("could not create field \"" + fieldDesc.GetFieldName() + "\" with type \"" +
+                                  fieldDesc.GetTypeName() + "\""));
+      }
+   }
+
+   ConnectFields();
+}

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -35,6 +35,7 @@ ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple CustomStru
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_processor ntuple_processor.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_project ntuple_project.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_modelext ntuple_modelext.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_serialize ntuple_serialize.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -1,0 +1,196 @@
+#include "ntuple_test.hxx"
+
+#include <ROOT/RNTupleProcessor.hxx>
+
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Internal::RNTupleProcessor;
+using ROOT::Experimental::Internal::RNTupleSourceSpec;
+
+TEST(RNTupleProcessor, Basic)
+{
+   FileRaii fileGuard("test_ntuple_processor_basic.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (unsigned i = 0; i < 10; ++i) {
+         *fldX = static_cast<float>(i);
+         ntuple->Fill();
+      }
+   }
+
+   std::vector<RNTupleSourceSpec> ntuples;
+   try {
+      RNTupleProcessor proc(ntuples);
+      FAIL() << "creating a processor without at least one RNTuple should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("at least one RNTuple must be provided"));
+   }
+
+   ntuples = {{"ntuple", fileGuard.GetPath()}};
+
+   int nEntries = 0;
+   for (const auto &entry : RNTupleProcessor(ntuples)) {
+      auto x = entry->GetPtr<float>("x");
+      EXPECT_EQ(static_cast<float>(entry.GetGlobalEntryIndex()), *x);
+      ++nEntries;
+   }
+   EXPECT_EQ(nEntries, 10);
+}
+
+TEST(RNTupleProcessor, SimpleChain)
+{
+   FileRaii fileGuard1("test_ntuple_processor_simple_chain1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto fldY = model->MakeField<std::vector<float>>("y");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+
+      for (unsigned i = 0; i < 5; ++i) {
+         *fldX = static_cast<float>(i);
+         *fldY = {static_cast<float>(i), static_cast<float>(i * 2)};
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_processor_simple_chain2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto fldY = model->MakeField<std::vector<float>>("y");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+
+      for (unsigned i = 5; i < 8; ++i) {
+         *fldX = static_cast<float>(i);
+         *fldY = {static_cast<float>(i), static_cast<float>(i * 2)};
+         ntuple->Fill();
+      }
+   }
+
+   std::vector<RNTupleSourceSpec> ntuples = {{"ntuple", fileGuard1.GetPath()}, {"ntuple", fileGuard2.GetPath()}};
+
+   std::uint64_t nEntries = 0;
+   for (const auto &entry : RNTupleProcessor(ntuples)) {
+      auto x = entry->GetPtr<float>("x");
+      EXPECT_EQ(static_cast<float>(entry.GetGlobalEntryIndex()), *x);
+
+      auto y = entry->GetPtr<std::vector<float>>("y");
+      std::vector<float> yExp = {static_cast<float>(entry.GetGlobalEntryIndex()), static_cast<float>(nEntries * 2)};
+      EXPECT_EQ(yExp, *y);
+
+      if (entry.GetLocalEntryIndex() == 0) {
+         EXPECT_THAT(entry.GetGlobalEntryIndex(), testing::AnyOf(0, 5));
+      }
+
+      ++nEntries;
+   }
+   EXPECT_EQ(nEntries, 8);
+}
+
+TEST(RNTupleProcessor, EmptyNTuples)
+{
+   FileRaii fileGuard1("test_ntuple_processor_empty_ntuples1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+   }
+   FileRaii fileGuard2("test_ntuple_processor_empty_ntuples2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+
+      for (unsigned i = 0; i < 2; ++i) {
+         *fldX = static_cast<float>(i);
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard3("test_ntuple_processor_empty_ntuples3.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard3.GetPath());
+   }
+   FileRaii fileGuard4("test_ntuple_processor_empty_ntuples4.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard4.GetPath());
+
+      for (unsigned i = 2; i < 5; ++i) {
+         *fldX = static_cast<float>(i);
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard5("test_ntuple_processor_empty_ntuples5.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard5.GetPath());
+   }
+
+   std::vector<RNTupleSourceSpec> ntuples = {{"ntuple", fileGuard1.GetPath()},
+                                             {"ntuple", fileGuard2.GetPath()},
+                                             {"ntuple", fileGuard3.GetPath()},
+                                             {"ntuple", fileGuard4.GetPath()},
+                                             {"ntuple", fileGuard5.GetPath()}};
+
+   std::uint64_t nEntries = 0;
+
+   try {
+      RNTupleProcessor proc(ntuples);
+      FAIL() << "creating a processor where the first RNTuple does not contain any entries should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("first RNTuple does not contain any entries"));
+   }
+
+   ntuples = {{"ntuple", fileGuard2.GetPath()},
+              {"ntuple", fileGuard3.GetPath()},
+              {"ntuple", fileGuard4.GetPath()},
+              {"ntuple", fileGuard5.GetPath()}};
+
+   for (const auto &entry : RNTupleProcessor(ntuples)) {
+      auto x = entry->GetPtr<float>("x");
+      EXPECT_EQ(static_cast<float>(nEntries), *x);
+      ++nEntries;
+   }
+   EXPECT_EQ(nEntries, 5);
+}
+
+TEST(RNTupleProcessor, ChainUnalignedModels)
+{
+   FileRaii fileGuard1("test_ntuple_processor_simple_chain1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x", 0.);
+      auto fldY = model->MakeField<char>("y", 'a');
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      ntuple->Fill();
+   }
+   FileRaii fileGuard2("test_ntuple_processor_simple_chain2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<float>("x", 1.);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      ntuple->Fill();
+   }
+
+   std::vector<RNTupleSourceSpec> ntuples = {{"ntuple", fileGuard1.GetPath()}, {"ntuple", fileGuard2.GetPath()}};
+
+   auto proc = RNTupleProcessor(ntuples);
+   auto entry = proc.begin();
+   auto x = (*entry)->GetPtr<float>("x");
+   auto y = (*entry)->GetPtr<char>("y");
+   EXPECT_EQ(0., *x);
+   EXPECT_EQ('a', *y);
+
+   try {
+      entry++;
+      FAIL() << "trying to connect a new page source containing additional (unknown) fields is not supported";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field \"y\" not found in current RNTuple"));
+   }
+}

--- a/tutorials/v7/ntuple/ntpl012_processor.C
+++ b/tutorials/v7/ntuple/ntpl012_processor.C
@@ -1,0 +1,103 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Demonstrate the RNTupleProcessor using multiple RNTuples
+///
+/// \macro_image
+/// \macro_code
+///
+/// \date April 2024
+/// \author The ROOT Team
+
+// NOTE: The RNTuple classes are experimental at this point.
+// Functionality, interface, and data format is still subject to changes.
+// Do not use for real data!
+
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RNTupleProcessor.hxx>
+
+#include <TCanvas.h>
+#include <TH1F.h>
+#include <TRandom.h>
+
+// Import classes from the `Experimental` namespace for the time being.
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Internal::RNTupleProcessor;
+using ROOT::Experimental::Internal::RNTupleSourceSpec;
+
+// Number of events to generate for each ntuple.
+constexpr int kNEvents = 10000;
+
+void Write(std::string_view ntupleName, std::string_view ntupleFileName)
+{
+   auto model = RNTupleModel::Create();
+
+   auto fldVpx = model->MakeField<std::vector<float>>("vpx");
+   auto fldVpy = model->MakeField<std::vector<float>>("vpy");
+   auto fldVpz = model->MakeField<std::vector<float>>("vpz");
+   auto fldN = model->MakeField<std::uint64_t>("vn");
+
+   auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
+
+   for (int i = 0; i < kNEvents; ++i) {
+      fldVpx->clear();
+      fldVpy->clear();
+      fldVpz->clear();
+
+      *fldN = gRandom->Integer(15);
+      for (int j = 0; j < *fldN; ++j) {
+         float px, py, pz;
+         gRandom->Rannor(px, py);
+         pz = px * px + py * py;
+
+         fldVpx->emplace_back(px);
+         fldVpy->emplace_back(py);
+         fldVpz->emplace_back(pz);
+      }
+
+      ntuple->Fill();
+   }
+}
+
+void Read(const std::vector<RNTupleSourceSpec> &ntuples)
+{
+   auto c = new TCanvas("c", "RNTupleProcessor Example", 200, 10, 700, 500);
+   TH1F hPx("h", "This is the px distribution", 100, -4, 4);
+   hPx.SetFillColor(48);
+
+   RNTupleProcessor processor(ntuples);
+   auto ptrPx = processor.GetEntry().GetPtr<std::vector<float>>("vpx");
+
+   for (const auto &entry : processor) {
+      // The RNTupleProcessor iterator provides some additional bookkeeping information. The local entry index pertains
+      // only to the ntuple currently being processed, whereas the global entry index also considers the previously
+      // processed ntuples.
+      if (entry.GetLocalEntryIndex() == 0) {
+         std::cout << "Processing " << ntuples.at(entry.GetNTupleIndex()).fName << " (" << entry.GetGlobalEntryIndex()
+                   << " total entries processed so far)" << std::endl;
+      }
+
+      // From the entry returned by the RNTupleProcessor iterator, we can get a pointer to the field we want to read.
+      for (auto x : *ptrPx) {
+         hPx.Fill(x);
+      }
+   }
+
+   hPx.DrawCopy();
+}
+
+void ntpl012_processor()
+{
+   // The ntuples to generate and subsequently process. The model of the first ntuple will be used to construct the
+   // entry used by the processor.
+   std::vector<RNTupleSourceSpec> ntuples = {
+      {"ntuple1", "ntuple1.root"}, {"ntuple2", "ntuple2.root"}, {"ntuple3", "ntuple3.root"}};
+
+   for (const auto &ntuple : ntuples) {
+      Write(ntuple.fName, ntuple.fLocation);
+   }
+
+   Read(ntuples);
+}


### PR DESCRIPTION
This PR provides the first steps to the `RNTupleProcessor`, which is envisioned as an interface for reading vertically and horizontally composed RNTuples (i.e., chains and friends), and combinations thereof. The interface provides an iterator which gives access to the `REntry` containing the field values of the current entry index, as well as some additional bookkeeping information.

At this point, only vertically composed RNTuples (i.e., chains) are supported. Horizontal compositions in the form of (unaligned) friends and the ability to combine vertical and horizontal compositions will be addressed in a future PR.
Other additions that will be accounted for in one or more follow-up PRs include:
- The possibility for users to provide their own entries/value pointers to the processor.
- The possibility for users to specify the `RNTupleModel` used to construct the processor entry.
  - An extension to this involves the ability to specify multiple models, together with the ability to "enable" certain models while iterating. This would enable the possibility to read from certain fields conditionally, e.g. after a cut.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)