### PR TITLE
Properly clone `AsNumpyResult` objects

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
@@ -18,7 +18,7 @@ from functools import singledispatch
 from typing import Iterable, Set, Tuple
 
 import ROOT
-from ROOT._pythonization._rdataframe import AsNumpyResult
+from ROOT._pythonization._rdataframe import AsNumpyResult, _clone_asnumpyresult
 
 from DistRDF.PythonMergeables import SnapshotResult
 
@@ -254,11 +254,7 @@ def clone_action(result_promise, _):
 
 @clone_action.register(AsNumpyResult)
 def _(asnumpyres, _):
-    asnumpyres._result_ptrs = {
-        col: ROOT.Internal.RDF.CloneResultAndAction(ptr)
-        for (col, ptr) in asnumpyres._result_ptrs.items()
-    }
-    return asnumpyres
+    return _clone_asnumpyresult(asnumpyres)
 
 
 @clone_action.register(SnapshotResult)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
@@ -345,6 +345,21 @@ class AsNumpyResult(object):
         self._py_arrays = state
 
 
+def _clone_asnumpyresult(res: AsNumpyResult) -> AsNumpyResult:
+    """
+    Clones the internal actions held by the input result and returns a new
+    result.
+    """
+    import ROOT
+    return AsNumpyResult(
+        {
+            col: ROOT.Internal.RDF.CloneResultAndAction(ptr)
+            for (col, ptr) in res._result_ptrs.items()
+        },
+        res._columns
+    )
+
+
 class HistoProfileWrapper(MethodTemplateWrapper):
     """
     Subclass of MethodTemplateWrapper that pythonizes HistoXD and ProfileXD


### PR DESCRIPTION
Motivated by the distributed execution use case