### PR TITLE
[reve] Print warning on missing  eve element dictionary

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
@@ -83,6 +83,10 @@ public:
    void AddInstance(Float_t a, Float_t b, Float_t c);
    void AddInstanceMat4(const Float_t* mat4);
 
+   void AddBox(const Float_t* verts) { AddFreeBox(verts); }
+   void AddBox(Float_t a, Float_t b, Float_t c, Float_t w, Float_t h, Float_t d) { AddInstanceScaled(a, b, c, w, h, d); }
+   void AddBox(Float_t a, Float_t b, Float_t c) { AddInstance(a, b, c);}
+
    void AddCone(const REveVector& pos, const REveVector& dir, Float_t r);
    void AddEllipticCone(const REveVector& pos, const REveVector& dir, Float_t r, Float_t r2, Float_t angle=0);
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -401,11 +401,6 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
       jm["c"] = meth->GetClass()->GetName();
       j["fPublicFunctions"].push_back(jm);
 
-      if (m.Contains("charge"))
-      {
-         printf("FOUND chargw methos %s %d\n\n", m.Data(), cnt);
-      }
-
       cnt++;
    }
 }

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -359,7 +359,6 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
    j["fPublicFunctions"] = nlohmann::json::array();
    TMethod *meth;
    TIter next(fItemClass->GetListOfAllPublicMethods());
-   int cnt = 0;
    while ((meth = (TMethod *)next())) {
       // Filter out ctor, dtor, some ROOT stuff.
 
@@ -400,8 +399,6 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
       jm["r"] = meth->GetReturnTypeName();
       jm["c"] = meth->GetClass()->GetName();
       j["fPublicFunctions"].push_back(jm);
-
-      cnt++;
    }
 }
 

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -549,10 +549,17 @@ void REveElement::CheckReferenceCount(const std::string& from)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return class for this element
+/// Return REveElement class in case dicitonary is not exisiting
+////////////////////////////////////////////////////////////////////////////////
 
 TClass *REveElement::IsA() const
 {
-   return TClass::GetClass(typeid(*this), kTRUE, kTRUE);
+   TClass* res = TClass::GetClass(typeid(*this), kTRUE, kTRUE);
+   if (!res) {
+      R__LOG_WARNING(REveLog()) << "REveElement::IsA() no dictionary found for " << typeid(*this).name();
+      res = TClass::GetClass("ROOT::Experimental::REveElement");
+   }
+   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tutorials/eve7/calorimeters.C
+++ b/tutorials/eve7/calorimeters.C
@@ -75,6 +75,7 @@ void calorimeters()
    auto b1 = new REveGeoShape("Barrel 1");
    b1->SetShape(new TGeoTube(kR_min, kR_max, kZ_d));
    b1->SetMainColor(kCyan);
+   b1->SetMainTransparency(90);
    b1->SetNSegments(80);
    eveMng->GetGlobalScene()->AddElement(b1);
 

--- a/ui5/eve7/lib/EveElementsRCore.js
+++ b/ui5/eve7/lib/EveElementsRCore.js
@@ -414,9 +414,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function (EveManager)
          let idxBuff = eve_el.render_data.idxBuff;
          // let bin =  idxBuff[idx*2 + 1];
          let val = eve_el.render_data.nrmBuff[idx];
-         let caloData =  this.top_obj.scene.mgr.GetElement(eve_el.dataId);
          let slice = idxBuff[idx*2];
-         let sname = caloData.sliceInfos[slice].name;
+         let sname = "Slice " + slice;
 
          let vbuff =  eve_el.render_data.vtxBuff;
          let p = idx*12;

--- a/ui5/eve7/lib/GlViewerRCore.js
+++ b/ui5/eve7/lib/GlViewerRCore.js
@@ -132,8 +132,8 @@ sap.ui.define([
          let eveView = this.controller.mgr.GetElement(this.controller.eveViewerId);
          if (eveView.BlackBg)
          {
-            this.fgCol =  new RC.Color(0,0,0);
-            this.bgCol = new RC.Color(1,1,1);
+            this.bgCol =  new RC.Color(0,0,0);
+            this.fgCol = new RC.Color(1,1,1);
          }
          else
          {

--- a/ui5/eve7/view/EveTable.view.xml
+++ b/ui5/eve7/view/EveTable.view.xml
@@ -17,7 +17,6 @@
     </Toolbar>
     <m:FlexBox direction="Column" height="100%">
     <layout:VerticalLayout id="header" width="100%" >
-      <m:Label text="Choose Collection:" />
       <layout:HorizontalLayout id="gedHeader">
         <m:ComboBox id="ccombo" change="collectionChanged"
                     items="{
@@ -26,7 +25,7 @@
           <core:Item key="{collections>key}" text="{collections>text}" />
         </m:ComboBox>
 
-        <m:Label text="Edit table:" labelFor="toggleButtonId"/>
+        <m:Label text="Edit columns:" labelFor="toggleButtonId"/>
         <m:Button icon="sap-icon://edit" id="toggleButtonId" press="toggleTableEdit" tooltip="toggle table edit"/>
       </layout:HorizontalLayout  >
     </layout:VerticalLayout >


### PR DESCRIPTION
Print warning if eve element does not have a dictionary. The commit   264404b also fixes the crash on streaming to client when element's dictionary is not existing and does not need non-REveElement remote method invocation. 

The other 3 commits contains minor corrections to the problems located in testing of CMS event display (table view layout, debug prints, background color setting at connect time).