### PR TITLE
[RF] Fixup work around deleted move constructor in `std::span` backport

### DIFF
--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -572,7 +572,7 @@ void Evaluator::assignToGPU(NodeInfo &info)
       buffer = info.buffer->gpuWritePtr();
    }
    assignSpan(_evalContextCUDA._currentOutput, {buffer, nOut});
-   _evalContextCUDA.set(node, _evalContextCUDA._currentOutput);
+   _evalContextCUDA.set(node, {buffer, nOut});
    node->doEval(_evalContextCUDA);
    CudaInterface::cudaEventRecord(*info.event, *info.stream);
    if (info.copyAfterEvaluation) {


### PR DESCRIPTION
This is a followup to #15089, where I missed a second change.

Closes #15087.