### PR TITLE
Relaxed rvec utils

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2872,10 +2872,10 @@ RVec<Common_t> Concatenate(const RVec<T0> &v0, const RVec<T1> &v1)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T>
-T DeltaPhi(T v1, T v2, const T c = M_PI)
+template <typename T0, typename T1, typename Common_t = std::common_type_t<T0, T1>>
+Common_t DeltaPhi(T0 v1, T1 v2, const Common_t c = M_PI)
 {
-   static_assert(std::is_floating_point<T>::value,
+   static_assert(std::is_floating_point<T0>::value && std::is_floating_point<T1>::value,
                  "DeltaPhi must be called with floating point values.");
    auto r = std::fmod(v2 - v1, 2.0 * c);
    if (r < -c) {
@@ -2893,12 +2893,12 @@ T DeltaPhi(T v1, T v2, const T c = M_PI)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
+template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+RVec<Common_t> DeltaPhi(const RVec<T0>& v1, const RVec<T1>& v2, const Common_t c = M_PI)
 {
-   using size_type = typename RVec<T>::size_type;
+   using size_type = typename RVec<T0>::size_type;
    const size_type size = v1.size();
-   auto r = RVec<T>(size);
+   auto r = RVec<Common_t>(size);
    for (size_type i = 0; i < size; i++) {
       r[i] = DeltaPhi(v1[i], v2[i], c);
    }
@@ -2911,12 +2911,12 @@ RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
+template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+RVec<Common_t> DeltaPhi(const RVec<T0>& v1, T1 v2, const Common_t c = M_PI)
 {
-   using size_type = typename RVec<T>::size_type;
+   using size_type = typename RVec<T0>::size_type;
    const size_type size = v1.size();
-   auto r = RVec<T>(size);
+   auto r = RVec<Common_t>(size);
    for (size_type i = 0; i < size; i++) {
       r[i] = DeltaPhi(v1[i], v2, c);
    }
@@ -2929,12 +2929,12 @@ RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T>
-RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
+template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+RVec<Common_t> DeltaPhi(T0 v1, const RVec<T1>& v2, const Common_t c = M_PI)
 {
-   using size_type = typename RVec<T>::size_type;
+   using size_type = typename RVec<T1>::size_type;
    const size_type size = v2.size();
-   auto r = RVec<T>(size);
+   auto r = RVec<Common_t>(size);
    for (size_type i = 0; i < size; i++) {
       r[i] = DeltaPhi(v1, v2[i], c);
    }

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2987,17 +2987,18 @@ Common_t DeltaR(T0 eta1, T1 eta2, T2 phi1, T3 phi2, const Common_t c = M_PI)
 ///
 /// The function computes the invariant mass of two particles with the four-vectors
 /// (pt1, eta2, phi1, mass1) and (pt2, eta2, phi2, mass2).
-template <typename T>
-RVec<T> InvariantMasses(
-        const RVec<T>& pt1, const RVec<T>& eta1, const RVec<T>& phi1, const RVec<T>& mass1,
-        const RVec<T>& pt2, const RVec<T>& eta2, const RVec<T>& phi2, const RVec<T>& mass2)
+template <typename T0, typename T1, typename T2, typename T3, typename T4,
+          typename T5, typename T6, typename T7, typename Common_t = std::common_type_t<T0, T1, T2, T3, T4, T5, T6, T7>>
+RVec<Common_t> InvariantMasses(
+   const RVec<T0>& pt1, const RVec<T1>& eta1, const RVec<T2>& phi1, const RVec<T3>& mass1,
+   const RVec<T4>& pt2, const RVec<T5>& eta2, const RVec<T6>& phi2, const RVec<T7>& mass2)
 {
    std::size_t size = pt1.size();
 
    R__ASSERT(eta1.size() == size && phi1.size() == size && mass1.size() == size);
    R__ASSERT(pt2.size() == size && phi2.size() == size && mass2.size() == size);
 
-   RVec<T> inv_masses(size);
+   RVec<Common_t> inv_masses(size);
 
    for (std::size_t i = 0u; i < size; ++i) {
       // Conversion from (pt, eta, phi, mass) to (x, y, z, e) coordinate system
@@ -3029,17 +3030,17 @@ RVec<T> InvariantMasses(
 ///
 /// The function computes the invariant mass of multiple particles with the
 /// four-vectors (pt, eta, phi, mass).
-template <typename T>
-T InvariantMass(const RVec<T>& pt, const RVec<T>& eta, const RVec<T>& phi, const RVec<T>& mass)
+template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+Common_t InvariantMass(const RVec<T0>& pt, const RVec<T1>& eta, const RVec<T2>& phi, const RVec<T3>& mass)
 {
    const std::size_t size = pt.size();
 
    R__ASSERT(eta.size() == size && phi.size() == size && mass.size() == size);
 
-   T x_sum = 0.;
-   T y_sum = 0.;
-   T z_sum = 0.;
-   T e_sum = 0.;
+   Common_t x_sum = 0.;
+   Common_t y_sum = 0.;
+   Common_t z_sum = 0.;
+   Common_t e_sum = 0.;
 
    for (std::size_t i = 0u; i < size; ++ i) {
       // Convert to (e, x, y, z) coordinate system and update sums

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2872,7 +2872,7 @@ RVec<Common_t> Concatenate(const RVec<T0> &v0, const RVec<T1> &v1)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T0, typename T1, typename Common_t = std::common_type_t<T0, T1>>
+template <typename T0, typename T1 = T0, typename Common_t = std::common_type_t<T0, T1>>
 Common_t DeltaPhi(T0 v1, T1 v2, const Common_t c = M_PI)
 {
    static_assert(std::is_floating_point<T0>::value && std::is_floating_point<T1>::value,
@@ -2893,7 +2893,7 @@ Common_t DeltaPhi(T0 v1, T1 v2, const Common_t c = M_PI)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+template <typename T0, typename T1 = T0, typename Common_t = typename std::common_type_t<T0, T1>>
 RVec<Common_t> DeltaPhi(const RVec<T0>& v1, const RVec<T1>& v2, const Common_t c = M_PI)
 {
    using size_type = typename RVec<T0>::size_type;
@@ -2911,7 +2911,7 @@ RVec<Common_t> DeltaPhi(const RVec<T0>& v1, const RVec<T1>& v2, const Common_t c
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+template <typename T0, typename T1 = T0, typename Common_t = typename std::common_type_t<T0, T1>>
 RVec<Common_t> DeltaPhi(const RVec<T0>& v1, T1 v2, const Common_t c = M_PI)
 {
    using size_type = typename RVec<T0>::size_type;
@@ -2929,7 +2929,7 @@ RVec<Common_t> DeltaPhi(const RVec<T0>& v1, T1 v2, const Common_t c = M_PI)
 /// therefore in the range \f$[-\pi, \pi]\f$.
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
-template <typename T0, typename T1, typename Common_t = typename std::common_type_t<T0, T1>>
+template <typename T0, typename T1 = T0, typename Common_t = typename std::common_type_t<T0, T1>>
 RVec<Common_t> DeltaPhi(T0 v1, const RVec<T1>& v2, const Common_t c = M_PI)
 {
    using size_type = typename RVec<T1>::size_type;
@@ -2948,7 +2948,7 @@ RVec<Common_t> DeltaPhi(T0 v1, const RVec<T1>& v2, const Common_t c = M_PI)
 /// of the given collections eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+template <typename T0, typename T1 = T0, typename T2 = T0, typename T3 = T0, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
 RVec<Common_t> DeltaR2(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2>& phi1, const RVec<T3>& phi2, const Common_t c = M_PI)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
@@ -2962,7 +2962,7 @@ RVec<Common_t> DeltaR2(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2
 /// of the given collections eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+template <typename T0, typename T1 = T0, typename T2 = T0, typename T3 = T0, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
 RVec<Common_t> DeltaR(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2>& phi1, const RVec<T3>& phi2, const Common_t c = M_PI)
 {
    return sqrt(DeltaR2(eta1, eta2, phi1, phi2, c));
@@ -2975,7 +2975,7 @@ RVec<Common_t> DeltaR(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2>
 /// of the given scalars eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+template <typename T0, typename T1 = T0, typename T2 = T0, typename T3 = T0, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
 Common_t DeltaR(T0 eta1, T1 eta2, T2 phi1, T3 phi2, const Common_t c = M_PI)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
@@ -2987,8 +2987,8 @@ Common_t DeltaR(T0 eta1, T1 eta2, T2 phi1, T3 phi2, const Common_t c = M_PI)
 ///
 /// The function computes the invariant mass of two particles with the four-vectors
 /// (pt1, eta2, phi1, mass1) and (pt2, eta2, phi2, mass2).
-template <typename T0, typename T1, typename T2, typename T3, typename T4,
-          typename T5, typename T6, typename T7, typename Common_t = std::common_type_t<T0, T1, T2, T3, T4, T5, T6, T7>>
+template <typename T0, typename T1 = T0, typename T2 = T0, typename T3 = T0, typename T4 = T0,
+          typename T5 = T0, typename T6 = T0, typename T7 = T0, typename Common_t = std::common_type_t<T0, T1, T2, T3, T4, T5, T6, T7>>
 RVec<Common_t> InvariantMasses(
    const RVec<T0>& pt1, const RVec<T1>& eta1, const RVec<T2>& phi1, const RVec<T3>& mass1,
    const RVec<T4>& pt2, const RVec<T5>& eta2, const RVec<T6>& phi2, const RVec<T7>& mass2)
@@ -3030,7 +3030,7 @@ RVec<Common_t> InvariantMasses(
 ///
 /// The function computes the invariant mass of multiple particles with the
 /// four-vectors (pt, eta, phi, mass).
-template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+template <typename T0, typename T1 = T0, typename T2 = T0, typename T3 = T0, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
 Common_t InvariantMass(const RVec<T0>& pt, const RVec<T1>& eta, const RVec<T2>& phi, const RVec<T3>& mass)
 {
    const std::size_t size = pt.size();

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2948,8 +2948,8 @@ RVec<Common_t> DeltaPhi(T0 v1, const RVec<T1>& v2, const Common_t c = M_PI)
 /// of the given collections eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T>
-RVec<T> DeltaR2(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
+template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+RVec<Common_t> DeltaR2(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2>& phi1, const RVec<T3>& phi2, const Common_t c = M_PI)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
    return (eta1 - eta2) * (eta1 - eta2) + dphi * dphi;
@@ -2962,8 +2962,8 @@ RVec<T> DeltaR2(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, c
 /// of the given collections eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T>
-RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
+template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+RVec<Common_t> DeltaR(const RVec<T0>& eta1, const RVec<T1>& eta2, const RVec<T2>& phi1, const RVec<T3>& phi2, const Common_t c = M_PI)
 {
    return sqrt(DeltaR2(eta1, eta2, phi1, phi2, c));
 }
@@ -2975,8 +2975,8 @@ RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, co
 /// of the given scalars eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
-template <typename T>
-T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = M_PI)
+template <typename T0, typename T1, typename T2, typename T3, typename Common_t = std::common_type_t<T0, T1, T2, T3>>
+Common_t DeltaR(T0 eta1, T1 eta2, T2 phi1, T3 phi2, const Common_t c = M_PI)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
    return std::sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1283,6 +1283,26 @@ TEST(VecOps, InvariantMass)
    }
 
    EXPECT_NEAR(p5.M(), invMass3, 1e-4);
+
+   // Check that calling with different argument types works and yields the
+   // expected return types and values
+   RVec<float> pt1f =   {0.f, 5.f, 5.f, 10.f, 10.f};
+   RVec<float> eta2f =  {0.f, 0.f, 0.5f, 0.4f, 1.2f};
+   const auto invMassF = InvariantMasses(pt1f, eta1, phi1, mass1, pt2, eta2f, phi2, mass2);
+   static_assert(std::is_same_v<decltype(invMassF), const RVec<double>>,
+                 "InvariantMasses should return double if one of the arguments is double");
+   for (size_t i = 0; i < invMass.size(); ++i) {
+      // We use the full double result here as reference and allow for some
+      // jitter introduced by the floating point promotion that happens along
+      // the way (in deterministic but different places depending on the types
+      // of the arguments)
+      EXPECT_NEAR(invMassF[i], invMass[i], 1e-7);
+   }
+
+   const auto invMass2F = InvariantMass(pt1f, eta1, phi1, mass1);
+   static_assert(std::is_same_v<decltype(invMass2F), const double>,
+                 "InvariantMass should return double if one of the arguments is double");
+   EXPECT_EQ(invMass2F, invMass2);
 }
 
 TEST(VecOps, DeltaR)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1212,6 +1212,26 @@ TEST(VecOps, DeltaPhi)
    auto dphi4 = DeltaPhi(v4, v3);
    auto r4 = -1.f * r3;
    CheckEqual(dphi4, r4);
+
+   // Checks that calling with different argument types works and yields the
+   // expected return types and values
+   static_assert(std::is_same_v<decltype(DeltaPhi(0.f, 0.0)), double>,
+                 "DeltaPhi should return double if one of the arguments is double");
+   EXPECT_EQ(DeltaPhi(0.f, 2.0), 2.0);
+   EXPECT_EQ(DeltaPhi(1.0, 0.0, 180.f), -1.0);
+
+   RVec<double> v1d = {0.0, 1.0, -0.5, 0.0, 0.0, 0.0, 0.0};
+   auto dphiMixed = DeltaPhi(v1d, v2);
+   static_assert(std::is_same_v<decltype(dphiMixed), RVec<double>>,
+                 "DeltaPhi should return double if one of the arguments is double");
+   const RVec<double> r1d = {2.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0};
+   for (size_t i = 0; i < dphiMixed.size(); ++i) {
+      // We use the full double result here as reference and allow for some
+      // jitter introduced by the floating point promotion that happens along
+      // the way (in deterministic but different places depending on the types
+      // of the arguments)
+       EXPECT_NEAR(dphiMixed[i], r1d[i], 1e-6);
+   }
 }
 
 TEST(VecOps, InvariantMass)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1308,6 +1308,20 @@ TEST(VecOps, DeltaR)
       auto dr4 = DeltaR(eta1[i], eta2[i], phi1[i], phi2[i]);
       EXPECT_NEAR(dr3, dr4, 1e-6);
    }
+
+   // Check that calling with different argument types works and yields the
+   // expected return types and values
+   RVec<float> etaf = {0.1f, -1.f, -1.f, 0.5f, -2.5f};
+   auto drf = DeltaR(etaf, eta2, phi1, phi2);
+   static_assert(std::is_same_v<decltype(drf), RVec<double>>,
+                 "DeltaR should return double if one of the arguments is double");
+   for (std::size_t i = 0; i < etaf.size(); ++i) {
+      // We use the full double result here as reference and allow for some
+      // jitter introduced by the floating point promotion that happens along
+      // the way (in deterministic but different places depending on the types
+      // of the arguments)
+      EXPECT_NEAR(dr[i], drf[i], 1e-7);
+   }
 }
 
 TEST(VecOps, Map)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1215,15 +1215,13 @@ TEST(VecOps, DeltaPhi)
 
    // Checks that calling with different argument types works and yields the
    // expected return types and values
-   static_assert(std::is_same_v<decltype(DeltaPhi(0.f, 0.0)), double>,
-                 "DeltaPhi should return double if one of the arguments is double");
+   EXPECT_TRUE((std::is_same_v<decltype(DeltaPhi(0.f, 0.0)), double>)) << "DeltaPhi should return double if one of the arguments is double";
    EXPECT_EQ(DeltaPhi(0.f, 2.0), 2.0);
    EXPECT_EQ(DeltaPhi(1.0, 0.0, 180.f), -1.0);
 
    RVec<double> v1d = {0.0, 1.0, -0.5, 0.0, 0.0, 0.0, 0.0};
    auto dphiMixed = DeltaPhi(v1d, v2);
-   static_assert(std::is_same_v<decltype(dphiMixed), RVec<double>>,
-                 "DeltaPhi should return double if one of the arguments is double");
+   EXPECT_TRUE((std::is_same_v<decltype(dphiMixed), RVec<double>>)) << "DeltaPhi should return double if one of the arguments is double";
    const RVec<double> r1d = {2.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0};
    for (size_t i = 0; i < dphiMixed.size(); ++i) {
       // We use the full double result here as reference and allow for some
@@ -1289,8 +1287,7 @@ TEST(VecOps, InvariantMass)
    RVec<float> pt1f =   {0.f, 5.f, 5.f, 10.f, 10.f};
    RVec<float> eta2f =  {0.f, 0.f, 0.5f, 0.4f, 1.2f};
    const auto invMassF = InvariantMasses(pt1f, eta1, phi1, mass1, pt2, eta2f, phi2, mass2);
-   static_assert(std::is_same_v<decltype(invMassF), const RVec<double>>,
-                 "InvariantMasses should return double if one of the arguments is double");
+   EXPECT_TRUE((std::is_same_v<decltype(invMassF), const RVec<double>>)) << "InvariantMasses should return double if one of the arguments is double";
    for (size_t i = 0; i < invMass.size(); ++i) {
       // We use the full double result here as reference and allow for some
       // jitter introduced by the floating point promotion that happens along
@@ -1300,8 +1297,7 @@ TEST(VecOps, InvariantMass)
    }
 
    const auto invMass2F = InvariantMass(pt1f, eta1, phi1, mass1);
-   static_assert(std::is_same_v<decltype(invMass2F), const double>,
-                 "InvariantMass should return double if one of the arguments is double");
+   EXPECT_TRUE((std::is_same_v<decltype(invMass2F), const double>)) << "InvariantMass should return double if one of the arguments is double";
    EXPECT_EQ(invMass2F, invMass2);
 }
 
@@ -1333,8 +1329,7 @@ TEST(VecOps, DeltaR)
    // expected return types and values
    RVec<float> etaf = {0.1f, -1.f, -1.f, 0.5f, -2.5f};
    auto drf = DeltaR(etaf, eta2, phi1, phi2);
-   static_assert(std::is_same_v<decltype(drf), RVec<double>>,
-                 "DeltaR should return double if one of the arguments is double");
+   EXPECT_TRUE((std::is_same_v<decltype(drf), RVec<double>>)) << "DeltaR should return double if one of the arguments is double";
    for (std::size_t i = 0; i < etaf.size(); ++i) {
       // We use the full double result here as reference and allow for some
       // jitter introduced by the floating point promotion that happens along


### PR DESCRIPTION
# This Pull request:

Makes it possible to call `VecOps::DeltaPhi`, `VecOps::DeltaR`, `VecOps::DeltaR2`, `VecOps::InvariantMass` and `VecOps::InvariantMasses` with different floating point types.

## Changes or fixes:

Previously all arguments where deduced to be the same types which does not allow to call these with mixed floating point type arguments. Now each argument get's its own template type, making it possible to call them with mixed floating point types. The return type and any intermediate calculations will be done by the largest necessary floating point type, as determined via `std::common_type`.

I tried to follow existing conventions, e.g. using `Common_t` as an additional defaulted template argument for a bit less typing in the implementations. This also requires at least c++14 as it uses the `common_type_t` helper type for a bit less typing.

Some of the functions now are quite heavily templated, I am not entirely sure the full combinatorial explosion is necessary for all of them.

I haven't added tests yet. There are some pre-existing where I could "attach" them. I could also just stick a bunch of `static_assert`s for the return types etc into the implementation directly if you prefer that.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #15077 
