### PR TITLE
[minuit2] make letter case consistent

### DIFF
--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -703,7 +703,7 @@ void Minuit2Minimizer::PrintResults()
             std::cout << "+/-  " << par.Error() << std::endl;
       }
    } else {
-      std::cout << "Minuit2Minimizer : Invalid Minimum - status = " << fStatus << std::endl;
+      std::cout << "Minuit2Minimizer : Invalid minimum - status = " << fStatus << std::endl;
       std::cout << "FVAL  = " << fState.Fval() << std::endl;
       std::cout << "Edm   = " << fState.Edm() << std::endl;
       std::cout << "Nfcn  = " << fState.NFcn() << std::endl;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Changes the letter case in the minuit2 status report when the minimum is invalid such that the report is consistent with the case when the minimum is valid. Currently, I get the following output when grep my logs:
```
Minuit2Minimizer : Invalid Minimum - status = 3
Minuit2Minimizer : Valid minimum - status = 0
```