### PR TITLE
[ntuple] Add initial in-memory index prototype

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -30,6 +30,7 @@ HEADERS
   ROOT/RNTupleFillContext.hxx
   ROOT/RNTupleFillStatus.hxx
   ROOT/RNTupleImtTaskScheduler.hxx
+  ROOT/RNTupleIndex.hxx
   ROOT/RNTupleMerger.hxx
   ROOT/RNTupleMetrics.hxx
   ROOT/RNTupleModel.hxx
@@ -64,6 +65,7 @@ SOURCES
   v7/src/RNTupleDescriptor.cxx
   v7/src/RNTupleDescriptorFmt.cxx
   v7/src/RNTupleFillContext.cxx
+  v7/src/RNTupleIndex.cxx
   v7/src/RNTupleMerger.cxx
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx

--- a/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
@@ -1,0 +1,202 @@
+/// \file ROOT/RNTupleIndex.hxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2024-04-02
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleIndex
+#define ROOT7_RNTupleIndex
+
+#include <ROOT/RField.hxx>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+// clang-format off
+/**
+\class ROOT::Experimental::Internal::RNTupleIndex
+\ingroup NTuple
+\brief Builds an index on one or several fields of an RNTuple so it can be joined onto other RNTuples.
+*/
+// clang-format on
+class RNTupleIndex {
+public:
+   using NTupleIndexValue_t = std::uint64_t;
+
+private:
+   /////////////////////////////////////////////////////////////////////////////
+   /// Container for the hashes of the indexed fields.
+   class RIndexValue {
+   public:
+      std::vector<NTupleIndexValue_t> fFieldValues;
+      RIndexValue(const std::vector<NTupleIndexValue_t> &fieldValues)
+      {
+         fFieldValues.reserve(fieldValues.size());
+         fFieldValues = fieldValues;
+      }
+      inline bool operator==(const RIndexValue &other) const { return other.fFieldValues == fFieldValues; }
+   };
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// Hash combinining the individual index value hashes from RIndexValue. Uses the implementation from
+   /// `boost::hash_combine` (see
+   /// https://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine).
+   struct RIndexValueHash {
+      inline std::size_t operator()(const RIndexValue &indexValue) const
+      {
+         std::size_t combinedHash = 0;
+         for (const auto &fieldVal : indexValue.fFieldValues) {
+            combinedHash ^= fieldVal + 0x9e3779b9 + (fieldVal << 6) + (fieldVal >> 2);
+         }
+         return combinedHash;
+      }
+   };
+
+   /// The index itself. Maps field values (or combinations thereof in case the index is defined for multiple fields) to
+   /// their respsective entry numbers.
+   std::unordered_map<RIndexValue, std::vector<NTupleSize_t>, RIndexValueHash> fIndex;
+
+   /// The page source belonging to the RNTuple for which to build the index.
+   std::unique_ptr<RPageSource> fPageSource;
+
+   /// The fields for which the index is built. Used to compute the hashes for each entry value.
+   std::vector<std::unique_ptr<RFieldBase>> fIndexFields;
+
+   /// Only built indexes can be queried.
+   bool fIsBuilt = false;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Create an a new RNTupleIndex for the RNTuple represented by the provided page source.
+   ///
+   /// \param[in] fieldNames The names of the fields to index. Only integral-type fields can be specified as index
+   /// fields.
+   /// \param[in] pageSource The page source.
+   RNTupleIndex(const std::vector<std::string> &fieldNames, const RPageSource &pageSource);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Ensure the RNTupleIndex has been built.
+   ///
+   /// \throws RException If the index has not been built, and can therefore not be used yet.
+   void EnsureBuilt() const;
+
+public:
+   RNTupleIndex(const RNTupleIndex &other) = delete;
+   RNTupleIndex &operator=(const RNTupleIndex &other) = delete;
+   RNTupleIndex(RNTupleIndex &&other) = delete;
+   RNTupleIndex &operator=(RNTupleIndex &&other) = delete;
+   ~RNTupleIndex() = default;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Create an RNTupleIndex from an existing RNTuple.
+   ///
+   /// \param[in] fieldNames The names of the fields to index. Only integral-type fields can be specified as index
+   /// fields.
+   /// \param[in] pageSource The page source.
+   /// \param[in] deferBuild When set to `true`, an empty index will be created. A call to RNTupleIndex::Build is
+   /// required before the index can actually be used.
+   ///
+   /// \return A pointer to the newly-created index.
+   static std::unique_ptr<RNTupleIndex>
+   Create(const std::vector<std::string> &fieldNames, const RPageSource &pageSource, bool deferBuild = false);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Build the index.
+   ///
+   /// Only a built index can be queried (with RNTupleIndex::GetFirstEntryNumber or RNTupleIndex::GetAllEntryNumbers).
+   void Build();
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the number of indexed values.
+   ///
+   /// \return The number of indexed values.
+   ///
+   /// \note This does not have to correspond to the number of entries in the original RNTuple. If the original RNTuple
+   /// contains duplicate index values, they are counted as one.
+   std::size_t GetSize() const
+   {
+      EnsureBuilt();
+      return fIndex.size();
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Whether the index has been built (and therefore ready to be used).
+   ///
+   /// \return `true` if the index has been built.
+   ///
+   /// Only built indexes can be queried.
+   bool IsBuilt() const { return fIsBuilt; }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the first entry number containing the given index value.
+   ///
+   /// \param[in] valuePtrs A vector of pointers to the index values to look up.
+   ///
+   /// \return The first entry number that corresponds to `valuePtrs`. When no such entry exists, `kInvalidNTupleIndex`
+   /// is returned.
+   ///
+   /// Note that in case multiple entries corresponding to the provided index value exist, the first occurrence is
+   /// returned. Use RNTupleIndex::GetAllEntryNumbers to get all entries.
+   NTupleSize_t GetFirstEntryNumber(const std::vector<void *> &valuePtrs) const;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the entry number containing the given index value.
+   ///
+   /// \sa GetFirstEntryNumber(std::vector<void *> valuePtrs)
+   template <typename... Ts>
+   NTupleSize_t GetFirstEntryNumber(Ts... values) const
+   {
+      if (sizeof...(Ts) != fIndexFields.size())
+         throw RException(R__FAIL("Number of values must match number of indexed fields."));
+
+      std::vector<void *> valuePtrs;
+      valuePtrs.reserve(sizeof...(Ts));
+      ([&] { valuePtrs.push_back(&values); }(), ...);
+
+      return GetFirstEntryNumber(valuePtrs);
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get all entry numbers for the given index.
+   ///
+   /// \param[in] valuePtrs A vector of pointers to the index values to look up.
+   ///
+   /// \return The entry numbers that corresponds to `valuePtrs`. When no such entry exists, an empty vector is
+   /// returned.
+   const std::vector<NTupleSize_t> *GetAllEntryNumbers(const std::vector<void *> &valuePtrs) const;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get all entry numbers for the given index.
+   ///
+   /// \sa GetAllEntryNumbers(std::vector<void *> valuePtrs)
+   template <typename... Ts>
+   const std::vector<NTupleSize_t> *GetAllEntryNumbers(Ts... values) const
+   {
+      if (sizeof...(Ts) != fIndexFields.size())
+         throw RException(R__FAIL("Number of values must match number of indexed fields."));
+
+      std::vector<void *> valuePtrs;
+      valuePtrs.reserve(sizeof...(Ts));
+      ([&] { valuePtrs.push_back(&values); }(), ...);
+
+      return GetAllEntryNumbers(valuePtrs);
+   }
+};
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleIndex

--- a/tree/ntuple/v7/src/RNTupleIndex.cxx
+++ b/tree/ntuple/v7/src/RNTupleIndex.cxx
@@ -1,0 +1,145 @@
+/// \file RNTupleIndex.cxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2024-04-02
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleIndex.hxx>
+
+namespace {
+ROOT::Experimental::Internal::RNTupleIndex::NTupleIndexValue_t
+CastValuePtr(void *valuePtr, const ROOT::Experimental::RFieldBase &field)
+{
+   ROOT::Experimental::Internal::RNTupleIndex::NTupleIndexValue_t value;
+
+   switch (field.GetValueSize()) {
+   case 1: value = *reinterpret_cast<std::uint8_t *>(valuePtr); break;
+   case 2: value = *reinterpret_cast<std::uint16_t *>(valuePtr); break;
+   case 4: value = *reinterpret_cast<std::uint32_t *>(valuePtr); break;
+   case 8: value = *reinterpret_cast<std::uint64_t *>(valuePtr); break;
+   default: throw ROOT::Experimental::RException(R__FAIL("value size not supported"));
+   }
+
+   return value;
+}
+} // anonymous namespace
+
+ROOT::Experimental::Internal::RNTupleIndex::RNTupleIndex(const std::vector<std::string> &fieldNames,
+                                                         const RPageSource &pageSource)
+   : fPageSource(pageSource.Clone())
+{
+   fPageSource->Attach();
+   auto desc = fPageSource->GetSharedDescriptorGuard();
+
+   fIndexFields.reserve(fieldNames.size());
+
+   for (const auto &fieldName : fieldNames) {
+      auto fieldId = desc->FindFieldId(fieldName);
+      if (fieldId == kInvalidDescriptorId)
+         throw RException(R__FAIL("Could not find field \"" + std::string(fieldName) + "."));
+
+      const auto &fieldDesc = desc->GetFieldDescriptor(fieldId);
+      auto field = fieldDesc.CreateField(desc.GetRef());
+
+      CallConnectPageSourceOnField(*field, *fPageSource);
+
+      fIndexFields.push_back(std::move(field));
+   }
+}
+
+void ROOT::Experimental::Internal::RNTupleIndex::EnsureBuilt() const
+{
+   if (!fIsBuilt)
+      throw RException(R__FAIL("Index has not been built yet"));
+}
+
+std::unique_ptr<ROOT::Experimental::Internal::RNTupleIndex>
+ROOT::Experimental::Internal::RNTupleIndex::Create(const std::vector<std::string> &fieldNames,
+                                                   const RPageSource &pageSource, bool deferBuild)
+{
+   auto index = std::unique_ptr<RNTupleIndex>(new RNTupleIndex(fieldNames, pageSource));
+
+   if (!deferBuild)
+      index->Build();
+
+   return index;
+}
+
+void ROOT::Experimental::Internal::RNTupleIndex::Build()
+{
+   if (fIsBuilt)
+      return;
+
+   static const std::unordered_set<std::string> allowedTypes = {"std::int8_t",   "std::int16_t", "std::int32_t",
+                                                                "std::int64_t",  "std::uint8_t", "std::uint16_t",
+                                                                "std::uint32_t", "std::uint64_t"};
+
+   std::vector<RFieldBase::RValue> fieldValues;
+   fieldValues.reserve(fIndexFields.size());
+
+   for (const auto &field : fIndexFields) {
+      if (allowedTypes.find(field->GetTypeName()) == allowedTypes.end()) {
+         throw RException(R__FAIL("Cannot use field \"" + field->GetFieldName() + "\" with type \"" +
+                                  field->GetTypeName() + "\" for indexing. Only integral types are allowed."));
+      }
+      fieldValues.emplace_back(field->CreateValue());
+   }
+
+   std::vector<NTupleIndexValue_t> indexValues;
+   indexValues.reserve(fIndexFields.size());
+
+   for (unsigned i = 0; i < fPageSource->GetNEntries(); ++i) {
+      indexValues.clear();
+      for (auto &fieldValue : fieldValues) {
+         // TODO(fdegeus): use bulk reading
+         fieldValue.Read(i);
+
+         auto valuePtr = fieldValue.GetPtr<void>();
+         indexValues.push_back(CastValuePtr(valuePtr.get(), fieldValue.GetField()));
+      }
+      fIndex[RIndexValue(indexValues)].push_back(i);
+   }
+
+   fIsBuilt = true;
+}
+
+ROOT::Experimental::NTupleSize_t
+ROOT::Experimental::Internal::RNTupleIndex::GetFirstEntryNumber(const std::vector<void *> &valuePtrs) const
+{
+   const auto entryIndices = GetAllEntryNumbers(valuePtrs);
+   if (!entryIndices)
+      return kInvalidNTupleIndex;
+   return entryIndices->front();
+}
+
+const std::vector<ROOT::Experimental::NTupleSize_t> *
+ROOT::Experimental::Internal::RNTupleIndex::GetAllEntryNumbers(const std::vector<void *> &valuePtrs) const
+{
+   if (valuePtrs.size() != fIndexFields.size())
+      throw RException(R__FAIL("Number of value pointers must match number of indexed fields."));
+
+   EnsureBuilt();
+
+   std::vector<NTupleIndexValue_t> indexValues;
+   indexValues.reserve(fIndexFields.size());
+
+   for (unsigned i = 0; i < valuePtrs.size(); ++i) {
+      indexValues.push_back(CastValuePtr(valuePtrs[i], *fIndexFields[i]));
+   }
+
+   auto entryNumber = fIndex.find(RIndexValue(indexValues));
+
+   if (entryNumber == fIndex.end())
+      return nullptr;
+
+   return &(entryNumber->second);
+}

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -36,6 +36,7 @@ ROOT_GENERATE_DICTIONARY(RNTupleDescriptorDict ${CMAKE_CURRENT_SOURCE_DIR}/RNTup
                        DEPENDENCIES RIO CustomStruct)
 ROOT_ADD_GTEST(ntuple_endian ntuple_endian.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_friends ntuple_friends.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_index ntuple_index.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_model ntuple_model.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_index.cxx
+++ b/tree/ntuple/v7/test/ntuple_index.cxx
@@ -1,0 +1,259 @@
+#include "ntuple_test.hxx"
+#include "CustomStruct.hxx"
+
+TEST(RNTupleIndex, Basic)
+{
+   FileRaii fileGuard("test_ntuple_index_basic.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fld = model->MakeField<std::uint64_t>("fld");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (int i = 0; i < 10; ++i) {
+         *fld = i * 2;
+         ntuple->Fill();
+      }
+   }
+
+   auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto index = RNTupleIndex::Create({"fld"}, *pageSource);
+
+   EXPECT_EQ(10UL, index->GetSize());
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   auto fld = ntuple->GetView<std::uint64_t>("fld");
+
+   for (unsigned i = 0; i < ntuple->GetNEntries(); ++i) {
+      auto fldValue = fld(i);
+      EXPECT_EQ(fldValue, i * 2);
+      EXPECT_EQ(index->GetFirstEntryNumber({&fldValue}), i);
+   }
+}
+
+TEST(RNTupleIndex, DeferBuild)
+{
+   FileRaii fileGuard("test_ntuple_index_defer_build.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fld = model->MakeField<std::uint64_t>("fld");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (int i = 0; i < 10; ++i) {
+         *fld = i * 2;
+         ntuple->Fill();
+      }
+   }
+
+   auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto index = RNTupleIndex::Create({"fld"}, *pageSource, true /* deferBuild */);
+   EXPECT_FALSE(index->IsBuilt());
+
+   try {
+      index->GetFirstEntryNumber<std::uint64_t>(0);
+      FAIL() << "querying an unbuilt index should not be possible";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("Index has not been built yet"));
+   }
+
+   index->Build();
+   EXPECT_TRUE(index->IsBuilt());
+
+   EXPECT_EQ(0, index->GetFirstEntryNumber<std::uint64_t>(0));
+}
+
+TEST(RNTupleIndex, InvalidTypes)
+{
+   FileRaii fileGuard("test_ntuple_index_invalid_types.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldInt = model->MakeField<std::int8_t>("fldInt", 99);
+      auto fldFloat = model->MakeField<float>("fldFloat", 2.5);
+      auto fldString = model->MakeField<std::string>("fldString", "foo");
+      auto fldStruct = model->MakeField<CustomStruct>(
+         "fldStruct", CustomStruct{0.1, {2.f, 4.f}, {{1.f}, {3.f, 5.f}}, "bar", std::byte(8)});
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      ntuple->Fill();
+   }
+
+   auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
+
+   auto intIndex = RNTupleIndex::Create({"fldInt"}, *pageSource);
+   EXPECT_EQ(1UL, intIndex->GetSize());
+
+   try {
+      RNTupleIndex::Create({"fldFloat"}, *pageSource);
+      FAIL() << "non-integral-type field should not be allowed as index fields";
+   } catch (const RException &err) {
+      EXPECT_THAT(
+         err.what(),
+         testing::HasSubstr(
+            "Cannot use field \"fldFloat\" with type \"float\" for indexing. Only integral types are allowed."));
+   }
+
+   try {
+      RNTupleIndex::Create({"fldString"}, *pageSource);
+      FAIL() << "non-integral-type field should not be allowed as index fields";
+   } catch (const RException &err) {
+      EXPECT_THAT(
+         err.what(),
+         testing::HasSubstr(
+            "Cannot use field \"fldString\" with type \"std::string\" for indexing. Only integral types are allowed."));
+   }
+
+   try {
+      RNTupleIndex::Create({"fldStruct"}, *pageSource);
+      FAIL() << "non-integral-type field should not be allowed as index fields";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("Cannot use field \"fldStruct\" with type \"CustomStruct\" for "
+                                                 "indexing. Only integral types are allowed."));
+   }
+}
+
+TEST(RNTupleIndex, SparseSecondary)
+{
+   FileRaii fileGuardMain("test_ntuple_index_sparse_secondary1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldEvent = model->MakeField<std::uint64_t>("event");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "primary", fileGuardMain.GetPath());
+
+      for (int i = 0; i < 10; ++i) {
+         *fldEvent = i;
+         ntuple->Fill();
+      }
+   }
+
+   FileRaii fileGuardSecondary("test_ntuple_index_sparse_secondary2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldEvent = model->MakeField<std::uint64_t>("event");
+      auto fldX = model->MakeField<float>("x");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "secondary", fileGuardSecondary.GetPath());
+
+      for (int i = 0; i < 5; ++i) {
+         *fldEvent = i * 2;
+         *fldX = static_cast<float>(i) / 3.14;
+         ntuple->Fill();
+      }
+   }
+
+   auto mainNtuple = RNTupleReader::Open("primary", fileGuardMain.GetPath());
+   auto fldEvent = mainNtuple->GetView<std::uint64_t>("event");
+
+   auto secondaryPageSource = RPageSource::Create("secondary", fileGuardSecondary.GetPath());
+   auto index = RNTupleIndex::Create({"event"}, *secondaryPageSource);
+   auto secondaryNTuple = RNTupleReader::Open("secondary", fileGuardSecondary.GetPath());
+   auto fldX = secondaryNTuple->GetView<float>("x");
+
+   for (unsigned i = 0; i < mainNtuple->GetNEntries(); ++i) {
+      auto event = fldEvent(i);
+
+      if (i % 2 == 1) {
+         EXPECT_EQ(index->GetFirstEntryNumber<std::uint64_t>(event), ROOT::Experimental::kInvalidNTupleIndex)
+            << "entry should not be present in the index";
+      } else {
+         auto idx = index->GetFirstEntryNumber<std::uint64_t>(event);
+         EXPECT_EQ(idx, i / 2);
+         EXPECT_FLOAT_EQ(fldX(idx), static_cast<float>(idx) / 3.14);
+      }
+   }
+}
+
+TEST(RNTupleIndex, MultipleFields)
+{
+   FileRaii fileGuard("test_ntuple_index_multiple_fields.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldRun = model->MakeField<std::int16_t>("run");
+      auto fldEvent = model->MakeField<std::uint64_t>("event");
+      auto fldX = model->MakeField<float>("x");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (int i = 0; i < 3; ++i) {
+         *fldRun = i;
+         for (int j = 0; j < 5; ++j) {
+            *fldEvent = j;
+            *fldX = static_cast<float>(i + j) / 3.14;
+            ntuple->Fill();
+         }
+      }
+   }
+
+   auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto index = RNTupleIndex::Create({"run", "event"}, *pageSource);
+
+   EXPECT_EQ(15ULL, index->GetSize());
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   auto fld = ntuple->GetView<float>("x");
+
+   std::int16_t run;
+   std::uint64_t event;
+   for (std::uint64_t i = 0; i < pageSource->GetNEntries(); ++i) {
+      run = i / 5;
+      event = i % 5;
+      auto entryIdx = index->GetFirstEntryNumber({&run, &event});
+      EXPECT_EQ(fld(entryIdx), fld(i));
+   }
+
+   auto idx1 = index->GetFirstEntryNumber<std::int16_t, std::uint64_t>(2, 1);
+   auto idx2 = index->GetFirstEntryNumber<std::int16_t, std::uint64_t>(1, 2);
+   EXPECT_NE(idx1, idx2);
+
+   try {
+      index->GetAllEntryNumbers<std::int16_t, std::uint64_t, std::uint64_t>(0, 2, 3);
+      FAIL() << "querying the index with more values than index values should not be possible";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("Number of values must match number of indexed fields."));
+   }
+
+   try {
+      index->GetAllEntryNumbers({0});
+      FAIL() << "querying the index with fewer values than index values should not be possible";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("Number of value pointers must match number of indexed fields."));
+   }
+}
+
+TEST(RNTupleIndex, MultipleMatches)
+{
+   FileRaii fileGuard("test_ntuple_index_multiple_matches.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldRun = model->MakeField<std::uint64_t>("run");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      *fldRun = 1;
+      for (int i = 0; i < 10; ++i) {
+         if (i > 4)
+            *fldRun = 2;
+         if (i > 7)
+            *fldRun = 3;
+         ntuple->Fill();
+      }
+   }
+
+   auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto index = RNTupleIndex::Create({"run"}, *pageSource);
+
+   EXPECT_EQ(3ULL, index->GetSize());
+
+   auto entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(1);
+   auto expected = std::vector<std::uint64_t>{0, 1, 2, 3, 4};
+   EXPECT_EQ(expected, *entryIdxs);
+   entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(2);
+   expected = {5, 6, 7};
+   EXPECT_EQ(expected, *entryIdxs);
+   entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(3);
+   expected = {8, 9};
+   EXPECT_EQ(expected, *entryIdxs);
+   entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(4);
+   EXPECT_EQ(nullptr, entryIdxs);
+}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -9,6 +9,7 @@
 #include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleFillStatus.hxx>
+#include <ROOT/RNTupleIndex.hxx>
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -86,6 +87,7 @@ using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
 using RNTupleFillStatus = ROOT::Experimental::RNTupleFillStatus;
 using RNTupleDescriptorBuilder = ROOT::Experimental::Internal::RNTupleDescriptorBuilder;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
+using RNTupleIndex = ROOT::Experimental::Internal::RNTupleIndex;
 using RNTupleParallelWriter = ROOT::Experimental::RNTupleParallelWriter;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;


### PR DESCRIPTION
This PR adds (a first version of) the `RNTupleIndex`, which is an in-memory structure that maps RNTuple field values (or combinations thereof) to an entry index in the RNTuple for which the index was built. Currently, the index only resides in memory and thus has to be (re)build each time. `RNTupleIndex` will be used by the `RNTupleProcessor` to enable dataset joins and will be as transparent as possible to users. Currently, no public interface is foreseen.

At this point, no persistification is foreseen, but this might be added in the future. The implementation of the `RNTupleIndex` in this PR is hash-based. An implementation that is vector-based (but with the same interface) will also be considered.

The idea is to benchmark and evaluate both implementations (and potentially more). Based on the results we can decide which one to actually use (or alternatively make multiple implementations available if they show clear tradeoffs in different use cases).