### PR TITLE
[io] Clean up RRawFile implementation

### DIFF
--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -42,8 +42,6 @@ namespace Internal {
  */
 class RRawFile {
 public:
-   /// Derived classes do not necessarily need to provide file size information but they can return "not known" instead
-   static constexpr std::uint64_t kUnknownFileSize = std::uint64_t(-1);
    /// kAuto detects the line break from the first line, kSystem picks the system's default
    enum class ELineBreaks { kAuto, kSystem, kUnix, kWindows };
 
@@ -113,6 +111,8 @@ private:
    RBlockBuffer fBlockBuffers[kNumBlockBuffers];
    /// Memory block containing the block buffers consecutively
    std::unique_ptr<unsigned char[]> fBufferSpace;
+   /// Used as a marker that the file size was not yet queried
+   static constexpr std::uint64_t kUnknownFileSize = std::uint64_t(-1);
    /// The cached file size
    std::uint64_t fFileSize = kUnknownFileSize;
    /// Files are opened lazily and only when required; the open state is kept by this flag

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -52,8 +52,6 @@ public:
    static constexpr int kFeatureHasSize = 0x01;
    /// Map() and Unmap() are implemented
    static constexpr int kFeatureHasMmap = 0x02;
-   /// File supports async IO
-   static constexpr int kFeatureHasAsyncIo = 0x04;
 
    /// On construction, an ROptions parameter can customize the RRawFile behavior
    struct ROptions {

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -50,8 +50,6 @@ public:
    // Combination of flags provided by derived classes about the nature of the file
    /// GetSize() does not return kUnknownFileSize
    static constexpr int kFeatureHasSize = 0x01;
-   /// Map() and Unmap() are implemented
-   static constexpr int kFeatureHasMmap = 0x02;
 
    /// On construction, an ROptions parameter can customize the RRawFile behavior
    struct ROptions {
@@ -145,12 +143,6 @@ protected:
    /// Derived classes should return the file size or kUnknownFileSize
    virtual std::uint64_t GetSizeImpl() = 0;
 
-   /// If a derived class supports mmap, the MapImpl and UnmapImpl calls are supposed to be implemented, too
-   /// The default implementation throws an error
-   virtual void *MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset);
-   /// Derived classes with mmap support must be able to unmap the memory area handed out by Map()
-   virtual void UnmapImpl(void *region, size_t nbytes);
-
    /// By default implemented as a loop of ReadAt calls but can be overwritten, e.g. XRootD or DAVIX implementations
    virtual void ReadVImpl(RIOVec *ioVec, unsigned int nReq);
 
@@ -193,13 +185,6 @@ public:
    void ReadV(RIOVec *ioVec, unsigned int nReq);
    /// Returns the limits regarding the ioVec input to ReadV for this specific file; may open the file as a side-effect.
    virtual RIOVecLimits GetReadVLimits() { return RIOVecLimits(); }
-
-   /// Memory mapping according to POSIX standard; in particular, new mappings of the same range replace older ones.
-   /// Mappings need to be aligned at page boundaries, therefore the real offset can be smaller than the desired value.
-   /// Users become owner of the address returned by Map() and are responsible for calling Unmap() with the full length.
-   void *Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset);
-   /// Receives a pointer returned by Map() and should have nbytes set to the full length of the mapping
-   void Unmap(void *region, size_t nbytes);
 
    /// Derived classes shall inform the user about the supported functionality, which can possibly depend
    /// on the file at hand

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -113,7 +113,7 @@ private:
    /// An active buffer and a shadow buffer, which supports "jumping back" to a previously used location in the file
    RBlockBuffer fBlockBuffers[kNumBlockBuffers];
    /// Memory block containing the block buffers consecutively
-   unsigned char *fBufferSpace;
+   std::unique_ptr<unsigned char[]> fBufferSpace;
    /// The cached file size
    std::uint64_t fFileSize;
    /// Files are opened lazily and only when required; the open state is kept by this flag
@@ -149,7 +149,7 @@ public:
    RRawFile(std::string_view url, ROptions options);
    RRawFile(const RRawFile &) = delete;
    RRawFile &operator=(const RRawFile &) = delete;
-   virtual ~RRawFile();
+   virtual ~RRawFile() = default;
 
    /// Create a new RawFile that accesses the same resource.  The file pointer is reset to zero.
    virtual std::unique_ptr<RRawFile> Clone() const = 0;

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -47,10 +47,6 @@ public:
    /// kAuto detects the line break from the first line, kSystem picks the system's default
    enum class ELineBreaks { kAuto, kSystem, kUnix, kWindows };
 
-   // Combination of flags provided by derived classes about the nature of the file
-   /// GetSize() does not return kUnknownFileSize
-   static constexpr int kFeatureHasSize = 0x01;
-
    /// On construction, an ROptions parameter can customize the RRawFile behavior
    struct ROptions {
       ELineBreaks fLineBreak;
@@ -140,7 +136,7 @@ protected:
     * therefore derived classes should return nbytes bytes if available.
     */
    virtual size_t ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset) = 0;
-   /// Derived classes should return the file size or kUnknownFileSize
+   /// Derived classes should return the file size
    virtual std::uint64_t GetSizeImpl() = 0;
 
    /// By default implemented as a loop of ReadAt calls but can be overwritten, e.g. XRootD or DAVIX implementations
@@ -185,10 +181,6 @@ public:
    void ReadV(RIOVec *ioVec, unsigned int nReq);
    /// Returns the limits regarding the ioVec input to ReadV for this specific file; may open the file as a side-effect.
    virtual RIOVecLimits GetReadVLimits() { return RIOVecLimits(); }
-
-   /// Derived classes shall inform the user about the supported functionality, which can possibly depend
-   /// on the file at hand
-   virtual int GetFeatures() const = 0;
 
    /// Read the next line starting from the current value of fFilePos. Returns false if the end of the file is reached.
    bool Readln(std::string &line);

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -50,10 +50,8 @@ public:
    /// On construction, an ROptions parameter can customize the RRawFile behavior
    struct ROptions {
       ELineBreaks fLineBreak = ELineBreaks::kAuto;
-      /**
-       * Read at least fBlockSize bytes at a time. A value of zero turns off I/O buffering. A negative value indicates
-       * that the protocol-dependent default block size should be used.
-       */
+      /// Read at least fBlockSize bytes at a time. A value of zero turns off I/O buffering. A negative value indicates
+      /// that the protocol-dependent default block size should be used.
       int fBlockSize = -1;
       // Define an empty constructor to work around a bug in Clang: https://github.com/llvm/llvm-project/issues/36032
       ROptions() {}
@@ -126,16 +124,12 @@ protected:
    /// The current position in the file, which can be changed by Seek, Read, and Readln
    std::uint64_t fFilePos = 0;
 
-   /**
-    * OpenImpl() is called at most once and before any call to either DoReadAt or DoGetSize. If fOptions.fBlocksize
-    * is negative, derived classes are responsible to set a sensible value. After a call to OpenImpl(),
-    * fOptions.fBlocksize must be larger or equal to zero.
-    */
+   /// OpenImpl() is called at most once and before any call to either DoReadAt or DoGetSize. If fOptions.fBlocksize
+   /// is negative, derived classes are responsible to set a sensible value. After a call to OpenImpl(),
+   /// fOptions.fBlocksize must be larger or equal to zero.
    virtual void OpenImpl() = 0;
-   /**
-    * Derived classes should implement low-level reading without buffering. Short reads indicate the end of the file,
-    * therefore derived classes should return nbytes bytes if available.
-    */
+   /// Derived classes should implement low-level reading without buffering. Short reads indicate the end of the file,
+   /// therefore derived classes should return nbytes bytes if available.
    virtual size_t ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset) = 0;
    /// Derived classes should return the file size
    virtual std::uint64_t GetSizeImpl() = 0;
@@ -162,10 +156,8 @@ public:
    /// Returns only the transport protocol in lower case, e.g. "http" for HTTP://server/file
    static std::string GetTransport(std::string_view url);
 
-   /**
-    * Buffered read from a random position. Returns the actual number of bytes read.
-    * Short reads indicate the end of the file
-    */
+   /// Buffered read from a random position. Returns the actual number of bytes read.
+   /// Short reads indicate the end of the file
    size_t ReadAt(void *buffer, size_t nbytes, std::uint64_t offset);
    /// Read from fFilePos offset. Returns the actual number of bytes read.
    size_t Read(void *buffer, size_t nbytes);

--- a/io/io/inc/ROOT/RRawFileTFile.hxx
+++ b/io/io/inc/ROOT/RRawFileTFile.hxx
@@ -47,8 +47,6 @@ public:
    RRawFileTFile(TFile *file) : RRawFile(file->GetEndpointUrl()->GetFile(), {}), fFile(file) {}
 
    std::unique_ptr<ROOT::Internal::RRawFile> Clone() const final { return std::make_unique<RRawFileTFile>(fFile); }
-
-   int GetFeatures() const final { return kFeatureHasSize; }
 };
 
 } // namespace Internal

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -37,8 +37,6 @@ protected:
    size_t ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset) final;
    void ReadVImpl(RIOVec *ioVec, unsigned int nReq) final;
    std::uint64_t GetSizeImpl() final;
-   void *MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset) final;
-   void UnmapImpl(void *region, size_t nbytes) final;
 
 public:
    RRawFileUnix(std::string_view url, RRawFile::ROptions options);

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -30,7 +30,7 @@ namespace Internal {
  */
 class RRawFileUnix : public RRawFile {
 private:
-   int fFileDes;
+   int fFileDes = -1;
 
 protected:
    void OpenImpl() final;

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -42,7 +42,6 @@ public:
    RRawFileUnix(std::string_view url, RRawFile::ROptions options);
    ~RRawFileUnix() override;
    std::unique_ptr<RRawFile> Clone() const final;
-   int GetFeatures() const final;
    int GetFd() const { return fFileDes; }
 };
 

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -43,7 +43,6 @@ public:
    RRawFileWin(std::string_view url, RRawFile::ROptions options);
    ~RRawFileWin() override;
    std::unique_ptr<RRawFile> Clone() const final;
-   int GetFeatures() const final { return kFeatureHasSize; }
 };
 
 } // namespace Internal

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -31,7 +31,7 @@ namespace Internal {
  */
 class RRawFileWin : public RRawFile {
 private:
-   FILE *fFilePtr;
+   FILE *fFilePtr = nullptr;
    void Seek(long offset, int whence);
 
 protected:

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -105,22 +105,11 @@ void ROOT::Internal::RRawFile::EnsureOpen()
    fIsOpen = true;
 }
 
-void *ROOT::Internal::RRawFile::MapImpl(size_t /* nbytes */, std::uint64_t /* offset */,
-   std::uint64_t& /* mapdOffset */)
-{
-   throw std::runtime_error("Memory mapping unsupported");
-}
-
 void ROOT::Internal::RRawFile::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    for (unsigned i = 0; i < nReq; ++i) {
       ioVec[i].fOutBytes = ReadAt(ioVec[i].fBuffer, ioVec[i].fSize, ioVec[i].fOffset);
    }
-}
-
-void ROOT::Internal::RRawFile::UnmapImpl(void * /* region */, size_t /* nbytes */)
-{
-   throw std::runtime_error("Memory mapping unsupported");
 }
 
 std::string ROOT::Internal::RRawFile::GetLocation(std::string_view url)
@@ -153,12 +142,6 @@ std::string ROOT::Internal::RRawFile::GetTransport(std::string_view url)
    std::string transport(url.substr(0, idx));
    std::transform(transport.begin(), transport.end(), transport.begin(), ::tolower);
    return transport;
-}
-
-void *ROOT::Internal::RRawFile::Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
-{
-   EnsureOpen();
-   return MapImpl(nbytes, offset, mapdOffset);
 }
 
 size_t ROOT::Internal::RRawFile::Read(void *buffer, size_t nbytes)
@@ -254,11 +237,4 @@ bool ROOT::Internal::RRawFile::Readln(std::string &line)
 void ROOT::Internal::RRawFile::Seek(std::uint64_t offset)
 {
    fFilePos = offset;
-}
-
-void ROOT::Internal::RRawFile::Unmap(void *region, size_t nbytes)
-{
-   if (!fIsOpen)
-      throw std::runtime_error("Cannot unmap, file not open");
-   UnmapImpl(region, nbytes);
 }

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -59,14 +59,9 @@ size_t ROOT::Internal::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbyte
 }
 
 ROOT::Internal::RRawFile::RRawFile(std::string_view url, ROptions options)
-   : fBlockBufferIdx(0), fBufferSpace(nullptr), fFileSize(kUnknownFileSize), fIsOpen(false), fUrl(url),
+   : fBlockBufferIdx(0), fFileSize(kUnknownFileSize), fIsOpen(false), fUrl(url),
      fOptions(options), fFilePos(0)
 {
-}
-
-ROOT::Internal::RRawFile::~RRawFile()
-{
-   delete[] fBufferSpace;
 }
 
 std::unique_ptr<ROOT::Internal::RRawFile>
@@ -160,10 +155,10 @@ size_t ROOT::Internal::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64
    if (nbytes > static_cast<unsigned int>(fOptions.fBlockSize))
       return ReadAtImpl(buffer, nbytes, offset);
 
-   if (fBufferSpace == nullptr) {
-      fBufferSpace = new unsigned char[kNumBlockBuffers * fOptions.fBlockSize];
+   if (!fBufferSpace) {
+      fBufferSpace.reset(new unsigned char[kNumBlockBuffers * fOptions.fBlockSize]);
       for (unsigned int i = 0; i < kNumBlockBuffers; ++i)
-         fBlockBuffers[i].fBuffer = fBufferSpace + i * fOptions.fBlockSize;
+         fBlockBuffers[i].fBuffer = fBufferSpace.get() + i * fOptions.fBlockSize;
    }
 
    size_t totalBytes = 0;

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -147,9 +147,15 @@ size_t ROOT::Internal::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64
    EnsureOpen();
    R__ASSERT(fOptions.fBlockSize >= 0);
 
-   // "Large" reads are served directly, bypassing the cache
+   // Early return for empty requests
+   if (nbytes == 0)
+      return 0;
+
+   // "Large" reads are served directly, bypassing the cache; since nbytes > 0, fBlockSize == 0 is also handled here
    if (nbytes > static_cast<unsigned int>(fOptions.fBlockSize))
       return ReadAtImpl(buffer, nbytes, offset);
+
+   R__ASSERT(fOptions.fBlockSize > 0);
 
    if (!fBufferSpace) {
       fBufferSpace.reset(new unsigned char[kNumBlockBuffers * fOptions.fBlockSize]);

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -58,11 +58,7 @@ size_t ROOT::Internal::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbyte
    return copiedBytes;
 }
 
-ROOT::Internal::RRawFile::RRawFile(std::string_view url, ROptions options)
-   : fBlockBufferIdx(0), fFileSize(kUnknownFileSize), fIsOpen(false), fUrl(url),
-     fOptions(options), fFilePos(0)
-{
-}
+ROOT::Internal::RRawFile::RRawFile(std::string_view url, ROptions options) : fUrl(url), fOptions(options) {}
 
 std::unique_ptr<ROOT::Internal::RRawFile>
 ROOT::Internal::RRawFile::Create(std::string_view url, ROptions options)

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -34,10 +34,7 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // If fstat() does not provide a block size hint, use this value instead
 } // anonymous namespace
 
-ROOT::Internal::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
-   : RRawFile(url, options), fFileDes(-1)
-{
-}
+ROOT::Internal::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options) : RRawFile(url, options) {}
 
 ROOT::Internal::RRawFileUnix::~RRawFileUnix()
 {

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -50,10 +50,6 @@ std::unique_ptr<ROOT::Internal::RRawFile> ROOT::Internal::RRawFileUnix::Clone() 
    return std::make_unique<RRawFileUnix>(fUrl, fOptions);
 }
 
-int ROOT::Internal::RRawFileUnix::GetFeatures() const {
-   return kFeatureHasSize;
-}
-
 std::uint64_t ROOT::Internal::RRawFileUnix::GetSizeImpl()
 {
 #ifdef R__SEEK64

--- a/io/io/src/RRawFileWin.cxx
+++ b/io/io/src/RRawFileWin.cxx
@@ -26,10 +26,7 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // Read files in 4k pages unless told otherwise
 } // anonymous namespace
 
-ROOT::Internal::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
-   : RRawFile(url, options), fFilePtr(nullptr)
-{
-}
+ROOT::Internal::RRawFileWin::RRawFileWin(std::string_view url, ROptions options) : RRawFile(url, options) {}
 
 ROOT::Internal::RRawFileWin::~RRawFileWin()
 {

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -39,8 +39,6 @@ public:
    }
 
    std::uint64_t GetSizeImpl() final { return fContent.size(); }
-
-   int GetFeatures() const final { return kFeatureHasSize; }
 };
 
 } // anonymous namespace
@@ -51,7 +49,6 @@ TEST(RRawFile, Empty)
    FileRaii emptyGuard("test_rrawfile_empty", "");
    auto f = RRawFile::Create(emptyGuard.GetPath());
    EXPECT_FALSE(f->IsOpen());
-   EXPECT_TRUE(f->GetFeatures() & RRawFile::kFeatureHasSize);
    EXPECT_EQ(0u, f->GetSize());
    EXPECT_EQ(0u, f->GetFilePos());
    EXPECT_EQ(0u, f->Read(nullptr, 0));

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -214,28 +214,6 @@ TEST(RRawFile, ReadBuffered)
    EXPECT_EQ(1u, f->fNumReadAt); f->fNumReadAt = 0;
 }
 
-
-TEST(RRawFile, Mmap)
-{
-   std::uint64_t mapdOffset;
-   std::unique_ptr<RRawFileMock> m(new RRawFileMock("", RRawFile::ROptions()));
-   EXPECT_FALSE(m->GetFeatures() & RRawFile::kFeatureHasMmap);
-   EXPECT_THROW(m->Map(1, 0, mapdOffset), std::runtime_error);
-   EXPECT_THROW(m->Unmap(this, 1), std::runtime_error);
-
-   void *region;
-   FileRaii mmapGuard("test_rawfile_mmap", "foo");
-   auto f = RRawFile::Create(mmapGuard.GetPath());
-   if (!(f->GetFeatures() & RRawFile::kFeatureHasMmap))
-      return;
-   region = f->Map(2, 1, mapdOffset);
-   auto innerOffset = 1 - mapdOffset;
-   ASSERT_NE(region, nullptr);
-   EXPECT_EQ("oo", std::string(reinterpret_cast<char *>(region) + innerOffset, 2));
-   auto mapdLength = 2 + innerOffset;
-   f->Unmap(region, mapdLength);
-}
-
 TEST(RRawFileTFile, TFile)
 {
    FileRaii tfileGuard("test_rawfile_tfile.root", "");

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -56,6 +56,12 @@ TEST(RRawFile, Empty)
    std::string line;
    EXPECT_FALSE(f->Readln(line));
    EXPECT_TRUE(f->IsOpen());
+
+   RRawFile::ROptions options;
+   options.fBlockSize = 0;
+   f = RRawFile::Create(emptyGuard.GetPath(), options);
+   EXPECT_EQ(0u, f->Read(nullptr, 0));
+   EXPECT_EQ(0u, f->ReadAt(nullptr, 0, 1));
 }
 
 

--- a/net/davix/inc/ROOT/RRawFileDavix.hxx
+++ b/net/davix/inc/ROOT/RRawFileDavix.hxx
@@ -46,7 +46,6 @@ public:
    RRawFileDavix(std::string_view url, RRawFile::ROptions options);
    ~RRawFileDavix();
    std::unique_ptr<RRawFile> Clone() const final;
-   int GetFeatures() const final { return kFeatureHasSize; }
 };
 
 } // namespace Internal

--- a/net/netxng/inc/ROOT/RRawFileNetXNG.hxx
+++ b/net/netxng/inc/ROOT/RRawFileNetXNG.hxx
@@ -45,7 +45,7 @@ public:
    RRawFileNetXNG(std::string_view url, RRawFile::ROptions options);
    ~RRawFileNetXNG();
    std::unique_ptr<RRawFile> Clone() const final;
-   int GetFeatures() const final { return kFeatureHasSize | kFeatureHasAsyncIo; }
+   int GetFeatures() const final { return kFeatureHasSize; }
    RIOVecLimits GetReadVLimits() final;
 };
 

--- a/net/netxng/inc/ROOT/RRawFileNetXNG.hxx
+++ b/net/netxng/inc/ROOT/RRawFileNetXNG.hxx
@@ -45,7 +45,6 @@ public:
    RRawFileNetXNG(std::string_view url, RRawFile::ROptions options);
    ~RRawFileNetXNG();
    std::unique_ptr<RRawFile> Clone() const final;
-   int GetFeatures() const final { return kFeatureHasSize; }
    RIOVecLimits GetReadVLimits() final;
 };
 

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -196,11 +196,6 @@ int VfsRdOnlyOpen(sqlite3_vfs * /*vfs*/, const char *zName, sqlite3_file *pFile,
       return SQLITE_IOERR;
    }
 
-   if (!(p->fRawFile->GetFeatures() & ROOT::Internal::RRawFile::kFeatureHasSize)) {
-      ::Error("VfsRdOnlyOpen", "cannot determine file size of %s\n", zName);
-      return SQLITE_IOERR;
-   }
-
    p->pFile.pMethods = &io_methods;
    return SQLITE_OK;
 }


### PR DESCRIPTION
Remove unused or unnecessary code (`RRawFile::Map()` and `RRawFile::GetFeatures()`), modernize class members (`unique_ptr` and default initialization), and improve handling of empty requests.