### PR TITLE
[skip-ci] [pyroot] Use raw string to allow escaped character in docstring

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
@@ -462,7 +462,7 @@ _numpy_data = {}
 
 
 def _MakeNumpyDataFrame(np_dict):
-    """
+    r"""
     Make an RDataFrame from a dictionary of numpy arrays
 
     \param[in] self Always null, since this is a module function.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
@@ -92,7 +92,7 @@ def _get_cpp_type_from_numpy_type(dtype):
 
 
 def _AsRVec(arr):
-    """
+    r"""
     Adopt memory of a Python object with array interface using an RVec.
 
     \param[in] self self object

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_rtensor.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_rtensor.py
@@ -14,7 +14,7 @@ import sys
 
 
 def _AsRTensor(arr):
-    """
+    r"""
     Adopt memory of a Python object with array interface using an RTensor.
 
     \param[in] self Always null, since this is a module function.


### PR DESCRIPTION
To avoid warnings such as `_rvec.py:95: SyntaxWarning: invalid escape sequence '\p'`
