### PR TITLE
[cmake] Set the permissions for etc and other folders that are in the source tree when installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Set permissions for installed folders and subfolders that come from the source tree in case
+# the permissions in the source tree are wrong since the install command will preserve them
+set(DIR_PERMISSIONS DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
 # Before setting ROOTSYS, make sure that the environment isn't polluted by a different
 # ROOT build. This is significant e,g. for roottest, which will otherwise have libraries
 # of a different ROOT build available / visible / reachable.
@@ -642,20 +646,21 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
     list(APPEND ETC_PATT_EXCL PATTERN RooFitHS3_wsfactoryexpressions.json EXCLUDE)
   endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
+                         ${DIR_PERMISSIONS}
                          ${ETC_PATT_EXCL}
                          PATTERN "system.rootrc" EXCLUDE
                          PATTERN "system.rootauthrc" EXCLUDE
                          PATTERN "system.rootdaemonrc" EXCLUDE
                          PATTERN "root.mimes" EXCLUDE
                          PATTERN "*.in" EXCLUDE)
-  install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR})
-  install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR})
-  install(DIRECTORY macros/ DESTINATION ${CMAKE_INSTALL_MACRODIR})
+  install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR} ${DIR_PERMISSIONS})
+  install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR} ${DIR_PERMISSIONS})
+  install(DIRECTORY macros/ DESTINATION ${CMAKE_INSTALL_MACRODIR} ${DIR_PERMISSIONS})
   if(http)
-     install(DIRECTORY js/     DESTINATION ${CMAKE_INSTALL_JSROOTDIR})
+     install(DIRECTORY js/     DESTINATION ${CMAKE_INSTALL_JSROOTDIR} ${DIR_PERMISSIONS})
   endif()
   if(webgui)
-     install(DIRECTORY ui5/    DESTINATION ${CMAKE_INSTALL_OPENUI5DIR})
+     install(DIRECTORY ui5/    DESTINATION ${CMAKE_INSTALL_OPENUI5DIR} ${DIR_PERMISSIONS})
   endif()
   set(MAN_PATT_EXCL)
   if(NOT fortran OR NOT CMAKE_Fortran_COMPILER)
@@ -665,8 +670,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
   if(NOT roofit)
     list(APPEND MAN_PATT_EXCL PATTERN prepareHistFactory.1 EXCLUDE)
   endif()
-  install(DIRECTORY man/    DESTINATION ${CMAKE_INSTALL_MANDIR} ${MAN_PATT_EXCL})
-  install(DIRECTORY tutorials/ DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)
+  install(DIRECTORY man/    DESTINATION ${CMAKE_INSTALL_MANDIR} ${DIR_PERMISSIONS} ${MAN_PATT_EXCL})
+  install(DIRECTORY tutorials/ DESTINATION ${CMAKE_INSTALL_TUTDIR} ${DIR_PERMISSIONS} COMPONENT tests)
   install(FILES
     cmake/modules/RootMacros.cmake
     cmake/modules/RootTestDriver.cmake


### PR DESCRIPTION
# This Pull request:
fixes an issue when installing as root changes the permissions of the `etc` folder and makes the installation unusable for other users. This happened because `etc` didn't have enough permissions in the source tree for other users and those are preserved in the installation directory.
## Changes or fixes:
The issue is the following, if `etc` has permissions, for example, 700 in the source tree, after compiling as a user and then using `sudo ninja install`, the folder `etc` keeps the same permissions. This is an ls of the installation folder when I install to `/usr/local`:
```
Permissions Size User Date Modified Name
drwxr-xr-x     - root  3 Apr 18:08  bin
drwxr-xr-x     - root  3 Apr 18:08  cmake
drwxr-xr-x     - root  3 Apr 18:08  config
drwx------     - root  3 Apr 18:08  etc
drwxr-xr-x     - root 28 Jan 09:45  fonts
drwxr-xr-x     - root 28 Jan 09:45  icons
drwxr-xr-x     - root  3 Apr 18:08  include
drwxr-xr-x     - root  3 Apr 18:08  js
drwxr-xr-x     - root  3 Apr 18:08  lib
.rw-r--r--   847 root 29 Oct  2023  LICENSE
drwxr-xr-x     - root 28 Jan 09:45  macros
drwxr-xr-x     - root 28 Jan 09:44  man
drwxr-xr-x     - root 28 Jan 09:45  README
drwxr-xr-x     - root  3 Apr 18:08  tutorials
drwxr-xr-x     - root 28 Jan 09:45  ui
```
This PR fixes it by setting the right permissions at installation time, so that the permissions in the source tree don't matter.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


I'm using CMake 3.29 and compiling ROOT 6.30.06 but this has been happening for a while for different versions of CMake and ROOT.