### PR TITLE
[TFile] Create dir if necessary

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -94,6 +94,11 @@ The structure of a directory is shown in TDirectoryFile::TDirectoryFile
 #   include <sys/types.h>
 #endif
 
+#if __cplusplus >= 201703L
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
 #include "Bytes.h"
 #include "Compression.h"
 #include "RConfigure.h"
@@ -519,6 +524,16 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
 
    // Connect to file system stream
    if (create || update) {
+#if __cplusplus >= 201703L
+       const auto dir = fs::path(fname.Data()).parent_path();
+       if (not fs::exists(dir)) {
+           if (not fs::create_directories(dir)) {
+               fD = -1;
+               zombify();
+               return;
+           }
+       }
+#endif
 #ifndef WIN32
       fD = TFile::SysOpen(fname.Data(), O_RDWR | O_CREAT, 0644);
 #else


### PR DESCRIPTION

[pr.log](https://github.com/root-project/root/files/14873477/pr.log)
This pull request changes the behavior of the create and recreate functions of the `TFile` class. When a new ROOT file is created, the underlying path may not exist. This commit modifies the logic of `TFile.cxx` such that the underlying path is explicitly created. It works only if `TFile.cxx` is compiled with the C++17 standard, otherwise the relevant code is excluded by the means of the preprocessor.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

## Quick test
I prepared a small program in C++ (requires C++17) to quickly test the pull request (see at the bottom of the message). In log, with the patched ROOT version the output looks like thit:
```
Attempt to (re)createa/b/c/test.root
Ok.
```
while with the ROOT version 6.28 the output looks like this:
```
Attempt to (re)createa/b/c/test.root
SysError in <TFile::TFile>: file XXXXXX/ftest/XXYqNIoC/a/b/c/test.root can not be opened No such file or directory
Fail.
```

The program:
```c++
#include "TFile.h"
#include <filesystem>
#include <cstdlib>
#include <iostream>
namespace fs = std::filesystem;

char tmpname[] = "XXXXXXXX";

char E[] = "test.root";
char F[] = "a/b/c/test.root";
char H[] = "a/b/d/atest.root";

void ok(char *fname)
{
    if (fs::exists(fs::path(fname)))
        std::cout << "Ok." << std::endl;
    else
        std::cout << "Fail." << std::endl;
}

int main()
{
    char *tmpnm = mkdtemp(tmpname);
    if (tmpnm == NULL) {
        std::cout << "Error while creating tmp dir" << std::endl;
        return -1;
    }
    const auto tmp = fs::path(tmpnm);
    const auto prev = fs::current_path();

    fs::current_path(tmp);
    std::cout << "Attempt to (re)create" << E << std::endl;
    TFile e(E, "recreate"); e.Close(); ok(E);
    std::cout << "Attempt to (re)create" << F << std::endl;
    TFile f(F, "recreate"); f.Close(); ok(F);
    std::cout << "Attempt to open" << F << std::endl;
    TFile g(F); g.Close(); ok(F);
    std::cout << "Attempt to open" << H << std::endl;
    TFile h(H); h.Close(); ok(H);

    std::cout << "List temporary directory tree:" << std::endl;
    std::system("tree");

    fs::current_path(prev);
    fs::remove_all(tmp);
    if (not fs::exists(tmp))
        std::cout << "Temporary directory deleted" << std::endl;
    else
        std::cerr << "Failed to delete temporary directory" << std::endl;
    return 0;
}
```