### PR TITLE
[PyROOT] Sync with upstream cppyy

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPEnum.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPEnum.cxx
@@ -2,6 +2,7 @@
 #include "CPyCppyy.h"
 #include "CPPEnum.h"
 #include "PyStrings.h"
+#include "TypeManip.h"
 #include "Utility.h"
 
 
@@ -166,6 +167,14 @@ CPyCppyy::CPPEnum* CPyCppyy::CPPEnum_New(const std::string& name, Cppyy::TCppSco
         PyObject* pyresolved = CPyCppyy_PyText_FromString(resolved.c_str());
         PyDict_SetItem(dct, PyStrings::gUnderlying, pyresolved);
         Py_DECREF(pyresolved);
+
+    // add the __module__ to allow pickling
+        std::string modname = TypeManip::extract_namespace(ename);
+        TypeManip::cppscope_to_pyscope(modname);      // :: -> .
+        if (!modname.empty()) modname = "."+modname;
+        PyObject* pymodname = CPyCppyy_PyText_FromString(("cppyy.gbl"+modname).c_str());
+        PyDict_SetItem(dct, PyStrings::gModule, pymodname);
+        Py_DECREF(pymodname);
 
     // create the actual enum class
         args = Py_BuildValue((char*)"sOO", name.c_str(), pybases, dct);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -247,11 +247,7 @@ PyTypeObject CPPExcInstance_Type = {
         Py_TPFLAGS_BASETYPE |
         Py_TPFLAGS_BASE_EXC_SUBCLASS |
         Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_CHECKTYPES
-#if PY_VERSION_HEX >= 0x03120000
-        | Py_TPFLAGS_MANAGED_DICT
-#endif
-        ,                          // tp_flags
+        Py_TPFLAGS_CHECKTYPES,     // tp_flags
     (char*)"cppyy exception object proxy (internal)", // tp_doc
     (traverseproc)ep_traverse,     // tp_traverse
     (inquiry)ep_clear,             // tp_clear

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -230,6 +230,13 @@ void CPyCppyy::op_dealloc_nofree(CPPInstance* pyobj) {
 
 namespace CPyCppyy {
 
+//----------------------------------------------------------------------------
+static int op_traverse(CPPInstance* /*pyobj*/, visitproc /*visit*/, void* /*arg*/)
+{
+    return 0;
+}
+
+
 //= CPyCppyy object proxy null-ness checking =================================
 static int op_nonzero(CPPInstance* self)
 {
@@ -1053,13 +1060,10 @@ PyTypeObject CPPInstance_Type = {
     0,                             // tp_as_buffer
     Py_TPFLAGS_DEFAULT |
         Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_CHECKTYPES
-#if PY_VERSION_HEX >= 0x03120000
-        | Py_TPFLAGS_MANAGED_DICT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_MANAGED_WEAKREF
-#endif
-        ,                          // tp_flags
+        Py_TPFLAGS_CHECKTYPES |
+        Py_TPFLAGS_HAVE_GC,        // tp_flags
     (char*)"cppyy object proxy (internal)", // tp_doc
-    0,                             // tp_traverse
+    (traverseproc)op_traverse,     // tp_traverse
     (inquiry)op_clear,             // tp_clear
     (richcmpfunc)op_richcompare,   // tp_richcompare
     0,                             // tp_weaklistoffset

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -666,9 +666,6 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03040000
         | Py_TPFLAGS_TYPE_SUBCLASS
 #endif
-#if PY_VERSION_HEX >= 0x03120000
-        | Py_TPFLAGS_MANAGED_DICT | Py_TPFLAGS_HAVE_GC
-#endif
         ,                          // tp_flags
     (char*)"CPyCppyy metatype (internal)",        // tp_doc
     0,                             // tp_traverse

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -887,9 +887,11 @@ static PyObject* SetMemoryPolicy(PyObject*, PyObject* args)
     if (!PyArg_ParseTuple(args, const_cast<char*>("O!"), &PyInt_Type, &policy))
         return nullptr;
 
+    long old = (long)CallContext::sMemoryPolicy;
+
     long l = PyInt_AS_LONG(policy);
     if (CallContext::SetMemoryPolicy((CallContext::ECallFlags)l)) {
-        Py_RETURN_NONE;
+        return PyInt_FromLong(old);
     }
 
     PyErr_Format(PyExc_ValueError, "Unknown policy %ld", l);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -358,7 +358,7 @@ static bool FillVector(PyObject* vecin, PyObject* args, ItemGetter* getter)
                         eb_args = PyTuple_New(1);
                         PyTuple_SET_ITEM(eb_args, 0, item);
                     } else if (PyTuple_CheckExact(item)) {
-                            eb_args = item;
+                        eb_args = item;
                     } else if (PyList_CheckExact(item)) {
                         Py_ssize_t isz = PyList_GET_SIZE(item);
                         eb_args = PyTuple_New(isz);
@@ -1411,7 +1411,6 @@ PyObject* StringViewInit(PyObject* self, PyObject* args, PyObject* /* kwds */)
     }
     return nullptr;
 }
-
 
 
 //- STL iterator behavior ----------------------------------------------------

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -919,9 +919,6 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
         | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR
 #endif
-#if PY_VERSION_HEX >= 0x03120000
-        | Py_TPFLAGS_MANAGED_WEAKREF
-#endif
         ,                              // tp_flags
     (char*)"cppyy template proxy (internal)",     // tp_doc
     (traverseproc)tpp_traverse,        // tp_traverse

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
@@ -92,7 +92,7 @@ PyTypeObject InstanceArrayIter_Type = {
     sizeof(ia_iterobject),        // tp_basicsize
     0,
     (destructor)PyObject_GC_Del,  // tp_dealloc
-    0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0,
     &ia_as_mapping,               // tp_as_mapping
     0, 0, 0, 0, 0, 0,
     Py_TPFLAGS_DEFAULT |

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Utility.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Utility.cxx
@@ -821,6 +821,9 @@ Py_ssize_t CPyCppyy::Utility::GetBuffer(PyObject* pyobject, char tc, int size, v
 
 // new-style buffer interface
     if (PyObject_CheckBuffer(pyobject)) {
+        if (PySequence_Check(pyobject) && !PySequence_Size(pyobject))
+            return 0;   // PyObject_GetBuffer() crashes on some platforms for some zero-sized seqeunces
+
         Py_buffer bufinfo;
         memset(&bufinfo, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(pyobject, &bufinfo, PyBUF_FORMAT) == 0) {

--- a/bindings/pyroot/cppyy/cppyy/doc/source/changelog.rst
+++ b/bindings/pyroot/cppyy/cppyy/doc/source/changelog.rst
@@ -10,6 +10,19 @@ See :doc:`packages <packages>`, for details on the package structure.
 PyPy support lags CPython support.
 
 
+master
+------
+
+* Fix buffering problems with std::string_view's on Python str objects
+* Fix potential buffering problems in creation of initializer lists
+* Improved overload selection for classes with deep hierarchies
+* Fixed regression when calling static methods with default args on instances
+* Fixed regression for pickling enums (in global scope only)
+* Auto-cast elements of std::vector<T*>, with T a class type
+* Add a ``Sequence_Check()`` method to the public API
+* Fix offset calculation of ``std::vector<unsigned>`` datamember on Mac arm
+
+
 2023-11-15: 3.1.2
 -----------------
 

--- a/bindings/pyroot/cppyy/cppyy/doc/source/conf.py
+++ b/bindings/pyroot/cppyy/cppyy/doc/source/conf.py
@@ -29,7 +29,9 @@ import shlex
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx_rtd_theme',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/bindings/pyroot/cppyy/cppyy/etc/valgrind-cppyy-cling.supp
+++ b/bindings/pyroot/cppyy/cppyy/etc/valgrind-cppyy-cling.supp
@@ -573,3 +573,186 @@
    ...
    fun:_PyObject_GC_NewVar
 }
+
+#
+# Leaks (including possible leaks)
+#    Hmmm, I wonder if this masks some real leaks.  I think it does.
+#    Will need to fix that.
+#
+
+{
+   Suppress leaking the GIL.  Happens once per process, see comment in ceval.c.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_InitThreads
+}
+
+{
+   Suppress leaking the GIL after a fork.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_ReInitThreads
+}
+
+{
+   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_create_key
+   fun:_PyGILState_Init
+   fun:Py_InitializeEx
+   fun:Py_Main
+}
+
+{
+   Hmmm, is this a real leak or like the GIL?
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_ReInitTLS
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+#
+# Non-python specific leaks
+#
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:memalign
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+###
+### All the suppressions below are for errors that occur within libraries
+### that Python uses.  The problems to not appear to be related to Python's
+### use of the libraries.
+###
+
+{
+   Generic ubuntu ld problems
+   Memcheck:Addr8
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+}
+
+{
+   Generic gentoo ld problems
+   Memcheck:Cond
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_close
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Value8
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   GDBM problems, see test_gdbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:gdbm_open
+
+}
+
+{
+   ZLIB problems, see test_gzip
+   Memcheck:Cond
+   obj:/lib/libz.so.1.2.3
+   obj:/lib/libz.so.1.2.3
+   fun:deflate
+}
+
+{
+   Avoid problems w/readline doing a putenv and leaking on exit
+   Memcheck:Leak
+   fun:malloc
+   fun:xmalloc
+   fun:sh_set_lines_and_columns
+   fun:_rl_get_screen_size
+   fun:_rl_init_terminal_io
+   obj:/lib/libreadline.so.4.3
+   fun:rl_initialize
+}

--- a/bindings/pyroot/cppyy/cppyy/test/Makefile
+++ b/bindings/pyroot/cppyy/cppyy/test/Makefile
@@ -21,7 +21,7 @@ cppflags=$(shell cling-config --cppflags) $(genreflex_flags) -O3 -fPIC -I$(shell
 
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM),Darwin)
-  cppflags+=-dynamiclib -single_module -undefined dynamic_lookup -Wno-delete-non-virtual-dtor
+  cppflags+=-dynamiclib -undefined dynamic_lookup -Wno-delete-non-virtual-dtor
 endif
 
 %Dict.so: %_rflx.cpp %.cxx

--- a/bindings/pyroot/cppyy/cppyy/test/advancedcpp.h
+++ b/bindings/pyroot/cppyy/cppyy/test/advancedcpp.h
@@ -2,7 +2,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
-
+#include <cstdint>
 
 //===========================================================================
 #define DECLARE_DEFAULTERS(type, tname)                                     \

--- a/bindings/pyroot/cppyy/cppyy/test/stltypes.cxx
+++ b/bindings/pyroot/cppyy/cppyy/test/stltypes.cxx
@@ -3,23 +3,6 @@
 #include <string.h>
 
 
-//- explicit instantiations of used comparisons
-#if defined __clang__ || defined(__GNUC__) || defined(__GNUG__)
-#if defined __clang__
-namespace std {
-#define ns_prefix std::
-#elif defined(__GNUC__) || defined(__GNUG__)
-namespace __gnu_cxx {
-#define ns_prefix
-#endif
-template bool ns_prefix operator==(const std::vector<int>::iterator&,
-                         const std::vector<int>::iterator&);
-template bool ns_prefix operator!=(const std::vector<int>::iterator&,
-                         const std::vector<int>::iterator&);
-}
-#endif
-
-
 //- adverse effect of implicit conversion on vector<string>
 int vectest_ol1(const std::vector<std::string>&) { return 1; }
 int vectest_ol1(std::string) { return 2; }

--- a/bindings/pyroot/cppyy/cppyy/test/test_api.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_api.py
@@ -192,3 +192,33 @@ class TestAPI:
         assert a4
         assert type(a4) == cppyy.gbl.APICheck4
         assert not a4.wasExecutorCalled();
+
+    def test06_custom_executor(self):
+        """Custom type executor"""
+
+        import cppyy
+
+        cppyy.cppdef("""
+        #include "CPyCppyy/API.h"
+
+        namespace ArrayLike {
+        class MyClass{};
+        MyClass* my = nullptr;
+        MyClass  myA[5];
+
+        class MyArray {
+        public:
+            int operator[](int) { return 42; }
+        }; }""")
+
+        ns = cppyy.gbl.ArrayLike;
+        Sequence_Check = cppyy.gbl.CPyCppyy.Sequence_Check
+
+        assert not Sequence_Check(ns.my)
+        assert     Sequence_Check(ns.myA)
+        assert not Sequence_Check(ns.MyClass())
+        assert     Sequence_Check(ns.MyArray())
+        assert     Sequence_Check(tuple())
+        assert     Sequence_Check(cppyy.gbl.std.vector[ns.MyClass]())
+        assert not Sequence_Check(cppyy.gbl.std.list[ns.MyClass]())
+

--- a/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
@@ -226,3 +226,23 @@ class TestLEAKCHECK:
         import cppyy
 
         self.check_func(cppyy.gbl, '__dir__', cppyy.gbl)
+
+    def test07_string_handling(self):
+
+        import cppyy
+
+        cppyy.cppdef("""\
+        namespace LeakCheck {
+        class Leaker {
+        public:
+             const std::string leak_string(std::size_t size) const {
+                  std::string result;
+                  result.reserve(size);
+                  return result;
+             }
+        }; }""")
+
+        ns = cppyy.gbl.LeakCheck
+
+        obj = ns.Leaker()
+        self.check_func(obj, 'leak_string', 2048)

--- a/bindings/pyroot/cppyy/cppyy/test/test_regression.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_regression.py
@@ -1289,3 +1289,49 @@ class TestREGRESSION:
 
         obj.smethod("one", "two")
         obj.smethod("one")        # used to fail with vectorcall
+
+    def test44_heuristic_mem_policy(self):
+        """Ownership of arguments with heuristic memory policy"""
+
+        import cppyy
+
+        cppyy.cppdef("""\
+        namespace MemTester {
+           void CallRef( std::string&) {}
+           void CallConstRef( const std::string&) {}
+           void CallPtr( std::string*) {}
+           void CallConstPtr( const std::string*) {}
+        };
+        """)
+
+        try:
+            # The scope with the heuristic memory policy is in a try-except-finally block
+            # to ensure the memory policy is always reset.
+            old_memory_policy = cppyy._backend.SetMemoryPolicy(cppyy._backend.kMemoryHeuristics)
+
+            # Validate the intended behavior for different argument types:
+            #   const ref : caller keeps ownership
+            #   const ptr : caller keeps ownership
+            #   ref       : caller keeps ownership
+            #   ptr       : caller passed ownership to callee
+
+            # The actual type doesn't matter
+            args = [cppyy.gbl.std.string() for i in range(4)]
+
+            cppyy.gbl.MemTester.CallConstRef(args[0])
+            assert args[0].__python_owns__
+
+            cppyy.gbl.MemTester.CallConstPtr(args[1])
+            assert args[1].__python_owns__
+
+            cppyy.gbl.MemTester.CallRef(args[2])
+            assert args[2].__python_owns__
+
+            cppyy.gbl.MemTester.CallPtr(args[3])
+            assert not args[3].__python_owns__
+            # Let's give back the ownership to Python here so there is no leak
+            cppyy._backend.SetOwnership(args[3], True)
+        except:
+            raise # rethrow the exception
+        finally:
+            cppyy._backend.SetMemoryPolicy(old_memory_policy)

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-Fix-bugs-introduced-by-73cbd9bde436afbc6e4d39.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-Fix-bugs-introduced-by-73cbd9bde436afbc6e4d39.patch
@@ -1,0 +1,206 @@
+From 32835b66b0453affc8f0b7c159867305c0e5ff43 Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Thu, 8 Aug 2024 13:28:30 +0200
+Subject: [PATCH] Revert "Fix bugs introduced by
+ 73cbd9bde436afbc6e4d3973f1abe3617e40bff7 (PR #14)"
+
+This reverts commit fce87d5e0125bb9e84ea3472dae6643faa5b8aed.
+---
+ src/Converters.cxx      | 115 ++++++++++++++++------------------------
+ src/DeclareConverters.h |  23 +++-----
+ 2 files changed, 53 insertions(+), 85 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+index 83a5e22..215df92 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+@@ -1866,7 +1866,53 @@ bool CPyCppyy::name##Converter::ToMemory(                                    \
+ }
+ 
+ CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLString, std::string, c_str, size)
++#if __cplusplus > 201402L
++CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLStringViewBase, std::string_view, data, size)
++bool CPyCppyy::STLStringViewConverter::SetArg(
++    PyObject* pyobject, Parameter& para, CallContext* ctxt)
++{
++    if (this->STLStringViewBaseConverter::SetArg(pyobject, para, ctxt)) {
++        // One extra step compared to the regular std::string converter:
++        // Create a corresponding std::string_view and set the parameter value
++        // accordingly.
++        fStringView = *reinterpret_cast<std::string*>(para.fValue.fVoidp);
++        para.fValue.fVoidp = &fStringView;
++        return true;
++    }
++
++    if (!CPPInstance_Check(pyobject))
++        return false;
+ 
++    static Cppyy::TCppScope_t sStringID = Cppyy::GetScope("std::string");
++    CPPInstance* pyobj = (CPPInstance*)pyobject;
++    if (pyobj->ObjectIsA() == sStringID) {
++        void* ptr = pyobj->GetObject();
++        if (!ptr)
++            return false;
++
++        // Copy the string to ensure the lifetime of the string_view and the
++        // underlying string is identical.
++        fStringBuffer = *((std::string*)ptr);
++        // Create the string_view on the copy
++        fStringView = fStringBuffer;
++        para.fValue.fVoidp = &fStringView;
++        para.fTypeCode = 'V';
++        return true;
++    }
++
++    return false;
++}
++bool CPyCppyy::STLStringViewConverter::ToMemory(
++    PyObject* value, void* address, PyObject* ctxt)
++{
++    if (CPyCppyy_PyUnicodeAsBytes2Buffer(value, fStringBuffer)) {
++        fStringView = fStringBuffer;
++        *reinterpret_cast<std::string_view*>(address) = fStringView;
++        return true;
++    }
++    return InstanceConverter::ToMemory(value, address, ctxt);
++}
++#endif
+ 
+ CPyCppyy::STLWStringConverter::STLWStringConverter(bool keepControl) :
+     InstanceConverter(Cppyy::GetScope("std::wstring"), keepControl) {}
+@@ -1931,75 +1977,6 @@ bool CPyCppyy::STLWStringConverter::ToMemory(PyObject* value, void* address, PyO
+ }
+ 
+ 
+-#if __cplusplus > 201402L
+-CPyCppyy::STLStringViewConverter::STLStringViewConverter(bool keepControl) :
+-    InstanceConverter(Cppyy::GetScope("std::string_view"), keepControl) {}
+-
+-bool CPyCppyy::STLStringViewConverter::SetArg(
+-    PyObject* pyobject, Parameter& para, CallContext* ctxt)
+-{
+-// normal instance convertion (ie. string_view object passed)
+-    if (!PyInt_Check(pyobject) && !PyLong_Check(pyobject) && \
+-            InstanceConverter::SetArg(pyobject, para, ctxt)) {
+-        para.fTypeCode = 'V';
+-        return true;
+-    }
+-    PyErr_Clear();
+-
+-// for Python str object: convert to single char string in buffer and take a view
+-    if (CPyCppyy_PyUnicodeAsBytes2Buffer(pyobject, fStringBuffer)) {
+-        fStringViewBuffer = fStringBuffer;
+-        para.fValue.fVoidp = &fStringViewBuffer;
+-        para.fTypeCode = 'V';
+-        return true;
+-    }
+-
+-    if (!CPPInstance_Check(pyobject))
+-        return false;
+-
+-// for C++ std::string object: buffer the string and take a view
+-    if (CPPInstance_Check(pyobject)) {
+-        static Cppyy::TCppScope_t sStringID = Cppyy::GetScope("std::string");
+-        CPPInstance* pyobj = (CPPInstance*)pyobject;
+-        if (pyobj->ObjectIsA() == sStringID) {
+-            void* ptr = pyobj->GetObject();
+-            if (!ptr)
+-                return false;     // leaves prior conversion error for report
+-
+-            PyErr_Clear();
+-
+-            fStringBuffer = *((std::string*)ptr);
+-            fStringViewBuffer = fStringBuffer;
+-            para.fValue.fVoidp = &fStringViewBuffer;
+-            para.fTypeCode = 'V';
+-            return true;
+-        }
+-    }
+-
+-    return false;
+-}
+-
+-PyObject* CPyCppyy::STLStringViewConverter::FromMemory(void* address)
+-{
+-    if (address)
+-        return InstanceConverter::FromMemory(address);
+-    auto* empty = new std::string_view();
+-    return BindCppObjectNoCast(empty, fClass, CPPInstance::kIsOwner);
+-}
+-
+-bool CPyCppyy::STLStringViewConverter::ToMemory(
+-    PyObject* value, void* address, PyObject* ctxt)
+-{
+-    if (CPyCppyy_PyUnicodeAsBytes2Buffer(value, fStringBuffer)) {
+-        fStringViewBuffer = fStringBuffer;
+-        *reinterpret_cast<std::string_view*>(address) = fStringViewBuffer;
+-        return true;
+-    }
+-    return InstanceConverter::ToMemory(value, address, ctxt);
+-}
+-#endif
+-
+-
+ bool CPyCppyy::STLStringMoveConverter::SetArg(
+     PyObject* pyobject, Parameter& para, CallContext* ctxt)
+ {
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+index 44b62b4..a0985a7 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+@@ -335,8 +335,6 @@ public:
+ class VoidPtrPtrConverter : public Converter {
+ public:
+     VoidPtrPtrConverter(cdims_t dims);
+-
+-public:
+     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+     virtual PyObject* FromMemory(void* address);
+     virtual bool HasState() { return true; }
+@@ -353,36 +351,29 @@ CPPYY_DECLARE_BASIC_CONVERTER(PyObject);
+ class name##Converter : public InstanceConverter {                           \
+ public:                                                                      \
+     name##Converter(bool keepControl = true);                                \
+-                                                                             \
+-public:                                                                      \
+     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
+     virtual PyObject* FromMemory(void* address);                             \
+     virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
+     virtual bool HasState() { return true; }                                 \
+-                                                                             \
+ protected:                                                                   \
+     strtype fStringBuffer;                                                   \
+ }
+ 
+ CPPYY_DECLARE_STRING_CONVERTER(STLString, std::string);
+-CPPYY_DECLARE_STRING_CONVERTER(STLWString, std::wstring);
+-
+ #if __cplusplus > 201402L
+-class STLStringViewConverter : public InstanceConverter {
+-public:
+-    STLStringViewConverter(bool keepControl = true);
+-
++// The buffer type needs to be std::string also in the string_view case,
++// otherwise the pointed-to string might not live long enough. See also:
++// https://github.com/wlav/CPyCppyy/issues/13
++CPPYY_DECLARE_STRING_CONVERTER(STLStringViewBase, std::string);
++class STLStringViewConverter : public STLStringViewBaseConverter {
+ public:
+     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+-    virtual PyObject* FromMemory(void* address);
+     virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
+-    virtual bool HasState() { return true; }
+-
+ private:
+-    std::string fStringBuffer;              // converted str data
+-    std::string_view fStringViewBuffer;     // view on converted data
++    std::string_view fStringView;
+ };
+ #endif
++CPPYY_DECLARE_STRING_CONVERTER(STLWString, std::wstring);
+ 
+ class STLStringMoveConverter : public STLStringConverter {
+ public:
+-- 
+2.46.0
+

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-do-not-allow-implicit-conversions-to-an-std-s.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-do-not-allow-implicit-conversions-to-an-std-s.patch
@@ -1,0 +1,98 @@
+From 40210f3b2590b7b88de4c333e79850c7c53016f5 Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Thu, 8 Aug 2024 13:03:39 +0200
+Subject: [PATCH] Revert "do not allow implicit conversions to an
+ std::string_view, as that by-passes the lifetime management"
+
+This reverts commit c06170389ea6e37fc6f25f9f0e44940fb1035625.
+---
+ src/CallContext.h  | 18 ------------------
+ src/Converters.cxx | 23 +++++++++++++----------
+ 2 files changed, 13 insertions(+), 28 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h a/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h
+index 63a6afe..3ea8f65 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h
+@@ -154,24 +154,6 @@ inline bool UseStrictOwnership(CallContext* ctxt) {
+     return CallContext::sMemoryPolicy == CallContext::kUseStrict;
+ }
+ 
+-template<CallContext::ECallFlags F>
+-class CallContextRAII {
+-public:
+-    CallContextRAII(CallContext* ctxt) : fCtxt(ctxt) {
+-        fPrior = fCtxt->fFlags & F;
+-        fCtxt->fFlags |= F;
+-    }
+-    CallContextRAII(const CallContextRAII&) = delete;
+-    CallContextRAII& operator=(const CallContextRAII&) = delete;
+-    ~CallContextRAII() {
+-        if (fPrior) fCtxt->fFlags &= ~F;
+-    }
+-
+-private:
+-    CallContext* fCtxt;
+-    bool fPrior;
+-};
+-
+ } // namespace CPyCppyy
+ 
+ #endif // !CPYCPPYY_CALLCONTEXT_H
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+index 35077f3..83a5e22 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+@@ -1938,15 +1938,13 @@ CPyCppyy::STLStringViewConverter::STLStringViewConverter(bool keepControl) :
+ bool CPyCppyy::STLStringViewConverter::SetArg(
+     PyObject* pyobject, Parameter& para, CallContext* ctxt)
+ {
+-// normal instance convertion (eg. string_view object passed)
+-    if (!PyInt_Check(pyobject) && !PyLong_Check(pyobject)) {
+-        CallContextRAII<CallContext::kNoImplicit> noimp(ctxt);
+-        if (InstanceConverter::SetArg(pyobject, para, ctxt)) {
+-            para.fTypeCode = 'V';
+-            return true;
+-        } else
+-            PyErr_Clear();
++// normal instance convertion (ie. string_view object passed)
++    if (!PyInt_Check(pyobject) && !PyLong_Check(pyobject) && \
++            InstanceConverter::SetArg(pyobject, para, ctxt)) {
++        para.fTypeCode = 'V';
++        return true;
+     }
++    PyErr_Clear();
+ 
+ // for Python str object: convert to single char string in buffer and take a view
+     if (CPyCppyy_PyUnicodeAsBytes2Buffer(pyobject, fStringBuffer)) {
+@@ -2738,9 +2736,12 @@ bool CPyCppyy::StdFunctionConverter::SetArg(
+     PyObject* pyobject, Parameter& para, CallContext* ctxt)
+ {
+ // prefer normal "object" conversion
+-    CallContextRAII<CallContext::kNoImplicit> noimp(ctxt);
+-    if (fConverter->SetArg(pyobject, para, ctxt))
++    bool rf = ctxt->fFlags & CallContext::kNoImplicit;
++    ctxt->fFlags |= CallContext::kNoImplicit;
++    if (fConverter->SetArg(pyobject, para, ctxt)) {
++        if (!rf) ctxt->fFlags &= ~CallContext::kNoImplicit;
+         return true;
++    }
+ 
+     PyErr_Clear();
+ 
+@@ -2754,10 +2755,12 @@ bool CPyCppyy::StdFunctionConverter::SetArg(
+             bool result = fConverter->SetArg(func, para, ctxt);
+             if (result) ctxt->AddTemporary(func);
+             else Py_DECREF(func);
++            if (!rf) ctxt->fFlags &= ~CallContext::kNoImplicit;
+             return result;
+         }
+     }
+ 
++    if (!rf) ctxt->fFlags &= ~CallContext::kNoImplicit;
+     return false;
+ }
+ 
+-- 
+2.46.0
+

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-don-t-allow-implicit-conversions-for-string_v.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Revert-don-t-allow-implicit-conversions-for-string_v.patch
@@ -1,0 +1,143 @@
+From 98e0739a511fbfc3795c0bb119962fd310ae26e4 Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Thu, 8 Aug 2024 13:03:28 +0200
+Subject: [PATCH] Revert "don't allow implicit conversions for string_view to
+ prevent taking"
+
+This reverts commit b62b2561322b6c1fdc37ac525077524ea5b02fa0.
+---
+ src/Converters.cxx      | 46 +++++++++++++++--------------------------
+ src/DeclareConverters.h | 18 ++++++++++++++--
+ 2 files changed, 33 insertions(+), 31 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+index 4fa4768..35077f3 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+@@ -1833,8 +1833,8 @@ CPyCppyy::name##Converter::name##Converter(bool keepControl) :               \
+ bool CPyCppyy::name##Converter::SetArg(                                      \
+     PyObject* pyobject, Parameter& para, CallContext* ctxt)                  \
+ {                                                                            \
+-    if (CPyCppyy_PyUnicodeAsBytes2Buffer(pyobject, fBuffer)) {               \
+-        para.fValue.fVoidp = &fBuffer;                                       \
++    if (CPyCppyy_PyUnicodeAsBytes2Buffer(pyobject, fStringBuffer)) {         \
++        para.fValue.fVoidp = &fStringBuffer;                                 \
+         para.fTypeCode = 'V';                                                \
+         return true;                                                         \
+     }                                                                        \
+@@ -1876,9 +1876,9 @@ bool CPyCppyy::STLWStringConverter::SetArg(
+ {
+     if (PyUnicode_Check(pyobject)) {
+         Py_ssize_t len = CPyCppyy_PyUnicode_GET_SIZE(pyobject);
+-        fBuffer.resize(len);
+-        CPyCppyy_PyUnicode_AsWideChar(pyobject, &fBuffer[0], len);
+-        para.fValue.fVoidp = &fBuffer;
++        fStringBuffer.resize(len);
++        CPyCppyy_PyUnicode_AsWideChar(pyobject, &fStringBuffer[0], len);
++        para.fValue.fVoidp = &fStringBuffer;
+         para.fTypeCode = 'V';
+         return true;
+     }
+@@ -1948,13 +1948,10 @@ bool CPyCppyy::STLStringViewConverter::SetArg(
+             PyErr_Clear();
+     }
+ 
+-// passing of a Python string; buffering done Python-side b/c str is immutable
+-    Py_ssize_t len;
+-    const char* cstr = CPyCppyy_PyText_AsStringAndSize(pyobject, &len);
+-    if (cstr) {
+-        SetLifeLine(ctxt->fPyContext, pyobject, (intptr_t)this);
+-        fBuffer = std::string_view(cstr, (std::string_view::size_type)len);
+-        para.fValue.fVoidp = &fBuffer;
++// for Python str object: convert to single char string in buffer and take a view
++    if (CPyCppyy_PyUnicodeAsBytes2Buffer(pyobject, fStringBuffer)) {
++        fStringViewBuffer = fStringBuffer;
++        para.fValue.fVoidp = &fStringViewBuffer;
+         para.fTypeCode = 'V';
+         return true;
+     }
+@@ -1962,8 +1959,7 @@ bool CPyCppyy::STLStringViewConverter::SetArg(
+     if (!CPPInstance_Check(pyobject))
+         return false;
+ 
+-// special case of a C++ std::string object; life-time management is left to
+-// the caller to ensure any external changes propagate correctly
++// for C++ std::string object: buffer the string and take a view
+     if (CPPInstance_Check(pyobject)) {
+         static Cppyy::TCppScope_t sStringID = Cppyy::GetScope("std::string");
+         CPPInstance* pyobj = (CPPInstance*)pyobject;
+@@ -1974,8 +1970,9 @@ bool CPyCppyy::STLStringViewConverter::SetArg(
+ 
+             PyErr_Clear();
+ 
+-            fBuffer = *((std::string*)ptr);
+-            para.fValue.fVoidp = &fBuffer;
++            fStringBuffer = *((std::string*)ptr);
++            fStringViewBuffer = fStringBuffer;
++            para.fValue.fVoidp = &fStringViewBuffer;
+             para.fTypeCode = 'V';
+             return true;
+         }
+@@ -1995,21 +1992,12 @@ PyObject* CPyCppyy::STLStringViewConverter::FromMemory(void* address)
+ bool CPyCppyy::STLStringViewConverter::ToMemory(
+     PyObject* value, void* address, PyObject* ctxt)
+ {
+-// common case of simple object assignment
+-    if (InstanceConverter::ToMemory(value, address, ctxt))
+-        return true;
+-
+-// assignment of a Python string; buffering done Python-side b/c str is immutable
+-    Py_ssize_t len;
+-    const char* cstr = CPyCppyy_PyText_AsStringAndSize(value, &len);
+-    if (cstr) {
+-        SetLifeLine(ctxt, value, (intptr_t)this);
+-        *reinterpret_cast<std::string_view*>(address) = \
+-            std::string_view(cstr, (std::string_view::size_type)len);
++    if (CPyCppyy_PyUnicodeAsBytes2Buffer(value, fStringBuffer)) {
++        fStringViewBuffer = fStringBuffer;
++        *reinterpret_cast<std::string_view*>(address) = fStringViewBuffer;
+         return true;
+     }
+-
+-    return false;
++    return InstanceConverter::ToMemory(value, address, ctxt);
+ }
+ #endif
+ 
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+index a08c091..44b62b4 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
++++ a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+@@ -361,13 +361,27 @@ public:                                                                      \
+     virtual bool HasState() { return true; }                                 \
+                                                                              \
+ protected:                                                                   \
+-    strtype fBuffer;                                                         \
++    strtype fStringBuffer;                                                   \
+ }
+ 
+ CPPYY_DECLARE_STRING_CONVERTER(STLString, std::string);
+ CPPYY_DECLARE_STRING_CONVERTER(STLWString, std::wstring);
++
+ #if __cplusplus > 201402L
+-CPPYY_DECLARE_STRING_CONVERTER(STLStringView, std::string_view);
++class STLStringViewConverter : public InstanceConverter {
++public:
++    STLStringViewConverter(bool keepControl = true);
++
++public:
++    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
++    virtual PyObject* FromMemory(void* address);
++    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
++    virtual bool HasState() { return true; }
++
++private:
++    std::string fStringBuffer;              // converted str data
++    std::string_view fStringViewBuffer;     // view on converted data
++};
+ #endif
+ 
+ class STLStringMoveConverter : public STLStringConverter {
+-- 
+2.46.0
+

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-TString_converter.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-TString_converter.patch
@@ -1,7 +1,7 @@
-From 95aaee5281cdf82af20ecc3d62145c3ec924944b Mon Sep 17 00:00:00 2001
+From c25b52ff20bae61607f46161ec598464cffcc84d Mon Sep 17 00:00:00 2001
 From: Jonas Rembser <jonas.rembser@cern.ch>
-Date: Wed, 31 Jan 2024 19:34:00 +0100
-Subject: [PATCH] [CPyCppyy] Add `TString` converters
+Date: Thu, 8 Aug 2024 13:39:50 +0200
+Subject: [PATCH] [CPyCppyy] Add`TString` converters
 
 ---
  bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx      | 4 ++++
@@ -9,10 +9,10 @@ Subject: [PATCH] [CPyCppyy] Add `TString` converters
  2 files changed, 8 insertions(+)
 
 diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
-index b31d27cbb0..2906ab1a05 100644
+index f1e54496d58..1083c924522 100644
 --- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
 +++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
-@@ -1865,6 +1865,7 @@ bool CPyCppyy::name##Converter::ToMemory(                                    \
+@@ -1889,6 +1889,7 @@ bool CPyCppyy::name##Converter::ToMemory(                                    \
      return InstanceConverter::ToMemory(value, address, ctxt);                \
  }
  
@@ -20,8 +20,8 @@ index b31d27cbb0..2906ab1a05 100644
  CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLString, std::string, c_str, size)
  #if __cplusplus > 201402L
  CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLStringViewBase, std::string_view, data, size)
-@@ -3433,6 +3434,9 @@ public:
-         gf["const Double32_t&"] =           gf["const double&"];
+@@ -3471,6 +3472,9 @@ public:
+         gf[CCOMPLEX_D " ptr"] =             gf["std::complex<double> ptr"];
  
      // factories for special cases
 +        gf["TString"] =                     (cf_t)+[](cdims_t) { return new TStringConverter{}; };
@@ -31,7 +31,7 @@ index b31d27cbb0..2906ab1a05 100644
          gf["const char*"] =                 (cf_t)+[](cdims_t) { return new CStringConverter{}; };
          gf["const signed char*"] =          gf["const char*"];
 diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h b/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
-index a0985a7b28..d903c8d08e 100644
+index 6062e6d4b81..24f3633614c 100644
 --- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
 +++ b/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
 @@ -9,6 +9,9 @@
@@ -44,7 +44,7 @@ index a0985a7b28..d903c8d08e 100644
  
  namespace CPyCppyy {
  
-@@ -359,6 +362,7 @@ protected:                                                                   \
+@@ -360,6 +363,7 @@ protected:                                                                   \
      strtype fStringBuffer;                                                   \
  }
  
@@ -53,5 +53,5 @@ index a0985a7b28..d903c8d08e 100644
  #if __cplusplus > 201402L
  // The buffer type needs to be std::string also in the string_view case,
 -- 
-2.44.0
+2.46.0
 

--- a/bindings/pyroot/cppyy/sync-upstream
+++ b/bindings/pyroot/cppyy/sync-upstream
@@ -4,8 +4,8 @@
 
 # We will keep our own CMakeLists.txt files
 
-mv CPyCppyy/CMakeLists.txt CPyCppyy_CMakeLists.txt 
-mv cppyy/CMakeLists.txt cppyy_CMakeLists.txt 
+mv CPyCppyy/CMakeLists.txt CPyCppyy_CMakeLists.txt
+mv cppyy/CMakeLists.txt cppyy_CMakeLists.txt
 
 rm -rf CPyCppyy
 rm -rf cppyy
@@ -27,10 +27,7 @@ rebase_topic () {
   git rebase sync $1 && git branch -D sync && git checkout -b sync
 }
 
-rebase_topic guitargeek/exceptions
-rebase_topic guitargeek/converter_control
 rebase_topic guitargeek/string_converters
-rebase_topic guitargeek/py12_warnings
 
 cd ..
 
@@ -39,17 +36,19 @@ rm -rf cppyy/.git
 
 # Move back CMakeLists.txt files
 
-mv CPyCppyy_CMakeLists.txt CPyCppyy/CMakeLists.txt 
-mv cppyy_CMakeLists.txt cppyy/CMakeLists.txt 
+mv CPyCppyy_CMakeLists.txt CPyCppyy/CMakeLists.txt
+mv cppyy_CMakeLists.txt cppyy/CMakeLists.txt
 
 # Apply patches (they were created with git format-patch -1 HEAD)
 # Alternatively, one can also use "git am" to create individual commits
 git apply patches/CPyCppyy-Disable-initializer-style-construction.patch
-git apply patches/CPyCppyy-Add-converters-and-executors-for-ROOT-types.patch
-git apply patches/CPyCppyy-TString_converter.patch
 git apply patches/CPyCppyy-Adapt-to-no-std-in-ROOT.patch
 git apply patches/CPyCppyy-Always-convert-returned-std-string.patch
 git apply patches/CPyCppyy-Disable-implicit-conversion-to-smart-ptr.patch
+git apply patches/CPyCppyy-Revert-don-t-allow-implicit-conversions-for-string_v.patch
+git apply patches/CPyCppyy-Revert-do-not-allow-implicit-conversions-to-an-std-s.patch
+git apply patches/CPyCppyy-Revert-Fix-bugs-introduced-by-73cbd9bde436afbc6e4d39.patch
+git apply patches/CPyCppyy-TString_converter.patch
 git apply patches/cppyy-No-CppyyLegacy-namespace.patch
 git apply patches/cppyy-Remove-Windows-workaround.patch
 git apply patches/cppyy-Don-t-enable-cling-autoloading.patch


### PR DESCRIPTION
Closes #15104.

Thank you very much @wlav for helping out here!

Also adds revert patches for a sequence of upstream commits that broke our `string_view` conversion usecases. Needs to be followed-up later.

Needs to be backported to 6.32.
