### PR TITLE
Cluster-based scheduling of RNTuple processing in distributed mode

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -825,7 +825,7 @@ class RNTupleHeadNode(HeadNode):
         super().__init__(backend, npartitions, localdf)
 
         self.mainntuplename = args[0]
-        self.inputfiles = args[1]
+        self.inputfiles = [args[1]] if isinstance(args[1], str) else args[1]
         # Keep this in accordance with the implementation of TTree for now
         self.subnames = [self.mainntuplename] * len(self.inputfiles)
 
@@ -838,8 +838,8 @@ class RNTupleHeadNode(HeadNode):
         # RDataFrame instance is going to process RNTuple data and the computation
         # graph needs to be recreated at every task
         self.exec_id = _graph_cache.ExecutionIdentifier("RNTuple", self.exec_id.graph_uuid)
-        return Ranges.get_ntuple_ranges(self.mainntuplename, self.inputfiles, self.npartitions, self.exec_id)
-    
+        return Ranges.get_percentage_ranges(self.subnames, self.inputfiles, self.npartitions, None, self.exec_id)
+
     def _generate_rdf_creator(self) -> Callable[[Ranges.DataRange], TaskObjects]:
         """
         Generates a function that is responsible for building an instance of
@@ -847,19 +847,26 @@ class RNTupleHeadNode(HeadNode):
         the RNtuple data source.
         """
 
-        def build_rdf_from_range(current_range: Ranges.get_ntuple_ranges) -> TaskObjects:
+        def build_rdf_from_range(current_range: Ranges.TreeRangePerc) -> TaskObjects:
             """
             Builds an RDataFrame instance for a distributed mapper.
 
             The function creates a TChain from the information contained in the
             input range object. If the chain cannot be built, returns None.
             """
-            ntuplename, filenames = current_range.ntuplename, current_range.filenames            
-            if not filenames:
-                return TaskObjects(None, None)
+            clustered_range, entries_in_rntuples = Ranges.get_clustered_range_from_percs(
+                current_range)
 
-            rdf_toprocess = ROOT.RDF.Experimental.FromRNTuple(ntuplename, filenames)
-            return TaskObjects(rdf_toprocess, None)
+
+            if clustered_range is None:
+                return TaskObjects(None, entries_in_rntuples)
+
+            rdf_toprocess = ROOT.Internal.RDF.FromRNTuple(
+                clustered_range.treenames[0], # Only one RNTuple name for the whole dataset
+                clustered_range.filenames,
+                (clustered_range.globalstart, clustered_range.globalend)
+            )
+            return TaskObjects(rdf_toprocess, entries_in_rntuples)
 
         return build_rdf_from_range
 
@@ -873,4 +880,29 @@ class RNTupleHeadNode(HeadNode):
             raise RuntimeError("The distributed execution returned no values. "
                                "This can happen if all files in your dataset contain empty trees.")
 
-        return values.mergeables        
+        # User could have requested to read the same file multiple times indeed
+        input_files_and_trees = [
+            f"{filename}/{ntuplename}" for filename, ntuplename in zip(self.inputfiles, self.subnames)
+        ]
+        files_counts = Counter(input_files_and_trees)
+
+        entries_in_rntuples = values.entries_in_trees
+        # Keys should be exactly the same
+        if files_counts.keys() != entries_in_rntuples.trees_with_entries.keys():
+            raise RuntimeError("The specified input files and the files that were "
+                               "actually processed are not the same:\n"
+                               f"Input files: {list(files_counts.keys())}\n"
+                               f"Processed files: {list(entries_in_rntuples.trees_with_entries.keys())}")
+
+        # Multiply the entries of each tree by the number of times it was
+        # requested by the user
+        for fullpath in files_counts:
+            entries_in_rntuples.trees_with_entries[fullpath] *= files_counts[fullpath]
+
+        total_dataset_entries = sum(
+            entries_in_rntuples.trees_with_entries.values())
+        if entries_in_rntuples.processed_entries != total_dataset_entries:
+            raise RuntimeError(f"The dataset has {total_dataset_entries} entries, "
+                               f"but {entries_in_rntuples.processed_entries} were processed.")
+
+        return values.mergeables

--- a/bindings/experimental/distrdf/test/test_ranges.py
+++ b/bindings/experimental/distrdf/test/test_ranges.py
@@ -6,6 +6,10 @@ from DistRDF import Ranges
 
 import ROOT
 
+from collections import namedtuple
+
+# Use a dummy execution identifier to test for TTree-based clustered ranges
+Dummy = namedtuple("Dummy", ["rdf_uuid"])
 
 def emptysourceranges_to_tuples(ranges):
     """Convert EmptySourceRange objects to tuples with the shape (start, end)"""
@@ -34,11 +38,11 @@ class EmptySourceRanges(unittest.TestCase):
         npartitions_large = 10
 
         # First case
-        rng = Ranges.get_balanced_ranges(nentries_small, npartitions_small, exec_id=None)
+        rng = Ranges.get_balanced_ranges(nentries_small, npartitions_small, exec_id=Dummy("dummy"))
         ranges_small = emptysourceranges_to_tuples(rng)
 
         # Second case
-        rng = Ranges.get_balanced_ranges(nentries_large, npartitions_large, exec_id=None)
+        rng = Ranges.get_balanced_ranges(nentries_large, npartitions_large, exec_id=Dummy("dummy"))
         ranges_large = emptysourceranges_to_tuples(rng)
 
         ranges_small_reqd = [(0, 2), (2, 4), (4, 6), (6, 8), (8, 10)]
@@ -70,12 +74,12 @@ class EmptySourceRanges(unittest.TestCase):
 
         # Example in which fractional part of
         # (nentries/npartitions) >= 0.5
-        rng = Ranges.get_balanced_ranges(nentries_1, npartitions, exec_id=None)
+        rng = Ranges.get_balanced_ranges(nentries_1, npartitions, exec_id=Dummy("dummy"))
         ranges_1 = emptysourceranges_to_tuples(rng)
 
         # Example in which fractional part of
         # (nentries/npartitions) < 0.5
-        rng = Ranges.get_balanced_ranges(nentries_2, npartitions, exec_id=None)
+        rng = Ranges.get_balanced_ranges(nentries_2, npartitions, exec_id=Dummy("dummy"))
         ranges_2 = emptysourceranges_to_tuples(rng)
 
         # Required output pairs
@@ -94,7 +98,7 @@ class EmptySourceRanges(unittest.TestCase):
         nentries = 5
         npartitions = 7
 
-        rng = Ranges.get_balanced_ranges(nentries, npartitions, exec_id=None)
+        rng = Ranges.get_balanced_ranges(nentries, npartitions, exec_id=Dummy("dummy"))
         ranges = emptysourceranges_to_tuples(rng)
 
         ranges_reqd = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
@@ -157,7 +161,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/Slimmed_ntuple.root"]
         npartitions = 1
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -180,7 +184,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/Slimmed_ntuple.root"]
         npartitions = 2
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         # We return one task per partition
@@ -204,7 +208,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/2clusters.root"]
         npartitions = 2
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
         ranges = treeranges_to_tuples(clusteredranges)
 
@@ -227,7 +231,7 @@ class TreeRanges(unittest.TestCase):
         expected_inputfiles = ["backend/2clusters.root"]
         extracted_inputfiles = rdf.inputfiles
 
-        percranges = Ranges.get_percentage_ranges([treename], extracted_inputfiles, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges([treename], extracted_inputfiles, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
         ranges = treeranges_to_tuples(clusteredranges)
 
@@ -258,7 +262,7 @@ class TreeRanges(unittest.TestCase):
         extracted_filenames = rdf.inputfiles
 
         percranges = Ranges.get_percentage_ranges(
-            extracted_subtreenames, extracted_filenames, npartitions, friendinfo=None, exec_id=None)
+            extracted_subtreenames, extracted_filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
         ranges = treeranges_to_tuples(clusteredranges)
 
@@ -281,7 +285,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/4clusters.root"]
         npartitions = 4
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -304,7 +308,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/1000clusters.root"]
         npartitions = 4
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -327,7 +331,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/1000clusters.root"]
         npartitions = 1000
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -349,7 +353,7 @@ class TreeRanges(unittest.TestCase):
         filenames = ["backend/2clusters.root", "backend/4clusters.root"]
         npartitions = 2
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -366,7 +370,7 @@ class TreeRanges(unittest.TestCase):
         filenames = [f"distrdf_unittests_file_{i}.root" for i in range(nfiles)]
         npartitions = 1
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -382,7 +386,7 @@ class TreeRanges(unittest.TestCase):
         filenames = [f"distrdf_unittests_file_{i}.root" for i in range(nfiles)]
         npartitions = nfiles
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -398,7 +402,7 @@ class TreeRanges(unittest.TestCase):
         treenames = [f"tree_{i}" for i in range(nfiles)]
         filenames = [f"distrdf_unittests_file_{i}.root" for i in range(nfiles)]
         npartitions = nfiles * 2
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -425,7 +429,7 @@ class TreeRanges(unittest.TestCase):
         filenames = [f"distrdf_unittests_file_{i}.root" for i in range(nfiles)]
         npartitions = nfiles * 10  # trees have 10 clusters
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         ranges = treeranges_to_tuples(clusteredranges)
@@ -473,7 +477,7 @@ class TreeRanges(unittest.TestCase):
         filenames = [f"distrdf_unittests_file_{i}.root" for i in range(nfiles)]
         npartitions = 42
 
-        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=None)
+        percranges = Ranges.get_percentage_ranges(treenames, filenames, npartitions, friendinfo=None, exec_id=Dummy("dummy"))
         clusteredranges = [Ranges.get_clustered_range_from_percs(percrange)[0] for percrange in percranges]
 
         # We return one task per partition

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -488,17 +488,11 @@ void RNTupleDS::PrepareNextRanges()
       if (i == (nRemainingFiles - 1))
          nSlotsPerFile = fNSlots - fNextRanges.size();
 
-      std::vector<std::pair<ULong64_t, ULong64_t>> rangesByCluster;
-      {
-         auto descriptorGuard = source->GetSharedDescriptorGuard();
-         auto clusterId = descriptorGuard->FindClusterId(0, 0);
-         while (clusterId != kInvalidDescriptorId) {
-            const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterId);
-            rangesByCluster.emplace_back(std::make_pair<ULong64_t, ULong64_t>(
-               clusterDesc.GetFirstEntryIndex(), clusterDesc.GetFirstEntryIndex() + clusterDesc.GetNEntries()));
-            clusterId = descriptorGuard->FindNextClusterId(clusterId);
-         }
-      }
+      const auto rangesByCluster = [&source]() {
+         // Take the shared lock of the descriptor just for the time necessary
+         const auto descGuard = source->GetSharedDescriptorGuard();
+         return descGuard->GetClusterBoundaries();
+      }();
       const unsigned int nRangesByCluster = rangesByCluster.size();
 
       // Distribute slots equidistantly over the entry range, aligned on cluster boundaries

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -775,6 +775,8 @@ public:
    NTupleSize_t GetNEntries() const { return fNEntries; }
    NTupleSize_t GetNElements(DescriptorId_t physicalColumnId) const;
 
+   std::vector<std::pair<NTupleSize_t, NTupleSize_t>> GetClusterBoundaries() const;
+
    /// Returns the logical parent of all top-level NTuple data fields.
    DescriptorId_t GetFieldZeroId() const;
    const RFieldDescriptor &GetFieldZero() const { return GetFieldDescriptor(GetFieldZeroId()); }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -241,6 +241,22 @@ ROOT::Experimental::RNTupleDescriptor::GetNElements(DescriptorId_t physicalColum
    return result;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Return the cluster boundaries for each cluster in this RNTuple.
+std::vector<std::pair<ROOT::Experimental::NTupleSize_t, ROOT::Experimental::NTupleSize_t>>
+ROOT::Experimental::RNTupleDescriptor::GetClusterBoundaries() const
+{
+   std::vector<std::pair<ROOT::Experimental::NTupleSize_t, ROOT::Experimental::NTupleSize_t>> clusterBoundaries;
+   clusterBoundaries.reserve(GetNClusters());
+   auto clusterId = FindClusterId(0, 0);
+   while (clusterId != ROOT::Experimental::kInvalidDescriptorId) {
+      const auto &clusterDesc = GetClusterDescriptor(clusterId);
+      clusterBoundaries.emplace_back(clusterDesc.GetFirstEntryIndex(),
+                                     clusterDesc.GetFirstEntryIndex() + clusterDesc.GetNEntries());
+      clusterId = FindNextClusterId(clusterId);
+   }
+   return clusterBoundaries;
+}
 
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const


### PR DESCRIPTION
The logic in `RNTupleDS::PrepareNextRanges` and `RNTupleDS::GetRanges` had to be changed a bit to accommodate the new case, I think it could be streamlined but I didn't want to change too many things in the same PR.