### PR TITLE
[CMake] Remove `builtin_libafterimage` option

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -4,7 +4,6 @@ arrow=OFF
 asan=OFF
 asimage=ON
 asserts=OFF
-builtin_afterimage=ON
 builtin_cfitsio=OFF
 builtin_clang=ON
 builtin_cling=ON

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -80,7 +80,6 @@ endfunction()
 ROOT_BUILD_OPTION(arrow OFF "Enable support for Apache Arrow")
 ROOT_BUILD_OPTION(asimage ON "Enable support for image processing via libAfterImage")
 ROOT_BUILD_OPTION(asserts OFF "Enable asserts (defaults to ON for CMAKE_BUILD_TYPE=Debug and/or dev=ON)")
-ROOT_BUILD_OPTION(builtin_afterimage ON "Build bundled copy of libAfterImage (flag is deprecated, this should be always enabled)")
 ROOT_BUILD_OPTION(builtin_cfitsio OFF "Build CFITSIO internally (requires network)")
 ROOT_BUILD_OPTION(builtin_clang ON "Build bundled copy of Clang")
 ROOT_BUILD_OPTION(builtin_cling ON "Build bundled copy of Cling. Only build with an external cling if you know what you are doing: associating ROOT commits with cling commits is tricky.")
@@ -269,7 +268,6 @@ endif()
 
 #--- The 'builtin_all' option switches ON all the built in options but GPL-------------------------------
 if(builtin_all)
-  set(builtin_afterimage_defvalue ON)
   set(builtin_cfitsio_defvalue ON)
   set(builtin_clang_defvalue ON)
   set(builtin_cling_defvalue ON)
@@ -411,10 +409,6 @@ foreach(opt cxxmodules)
   endif()
 endforeach()
 
-
-if(cocoa OR x11 AND  NOT builtin_afterimage)
-  message(DEPRECATION ">>> Option builtin_afterimage is deprecated: in the future it will always be set to ON. In the next release of ROOT, you will no longer be able to disable this feature. Please contact root-dev@cern.ch should you still need disabling it.")
-endif()
 
 foreach(opt minuit2_omp minuit2_mpi)
   if(${opt})

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -221,7 +221,6 @@ set(arrowlib ${ARROW_LIBRARY})
 set(arrowincdir ${ARROW_INCLUDE_DIR})
 
 set(buildasimage ${value${asimage}})
-set(builtinafterimage ${builtin_afterimage})
 set(asextralib ${ASEXTRA_LIBRARIES})
 set(asextralibdir)
 set(asjpegincdir ${JPEG_INCLUDE_DIR})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -408,21 +408,8 @@ if(asimage)
   endif()
 endif()
 
-#---Check for AfterImage---------------------------------------------------------------
-if(asimage AND NOT builtin_afterimage)
-  message(STATUS "Looking for AfterImage")
-  if(fail-on-missing)
-    find_package(AfterImage REQUIRED)
-  else()
-    find_package(AfterImage)
-    if(NOT AFTERIMAGE_FOUND)
-      message(STATUS "AfterImage not found. Switching on builtin_afterimage option")
-      set(builtin_afterimage ON CACHE BOOL "Enabled because asimage requested and AfterImage not found (${builtin_afterimage_description})" FORCE)
-    endif()
-  endif()
-endif()
-
-if(builtin_afterimage)
+#---AfterImage---------------------------------------------------------------
+if(TRUE)
   set(AFTERIMAGE_LIBRARIES ${CMAKE_BINARY_DIR}/lib/libAfterImage${CMAKE_STATIC_LIBRARY_SUFFIX})
   if(WIN32)
     if(winrtdebug)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -200,7 +200,6 @@ SRMIFCEINCDIR  := $(filter-out /usr/include, @srmifceincdir@)
 GLIB2INCDIR    := $(filter-out /usr/include, @glib2incdir@)
 
 BUILDASIMAGE   := @buildasimage@
-BUILTINASIMAGE := @builtinafterimage@
 ASEXTRALIB     := @asextralib@
 ASEXTRALIBDIR  := @asextralibdir@
 ASJPEGINCDIR   := $(filter-out /usr/include, @asjpegincdir@)


### PR DESCRIPTION
The option was deprecated in ROOT 6.32 and should be removed for the next release, as anticipated by the deprecation warnings in 6.32.

Follows up on https://github.com/root-project/root/pull/14395.