### PR TITLE
[cling] Add plugin support

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/InvocationOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/InvocationOptions.h
@@ -74,6 +74,9 @@ namespace cling {
     ///\brief The remaining arguments to pass to clang.
     ///
     std::vector<const char*> Remaining;
+
+    /// A list of arguments to forward to LLVM's option processing.
+    std::vector<std::string> LLVMArgs;
   };
 
   class InvocationOptions {

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -223,6 +223,18 @@ namespace cling {
     // Load any requested plugins.
     getCI()->LoadRequestedPlugins();
 
+    // Honor set of `-mllvm` options. This should happen AFTER plugins have been
+    // loaded!
+    if (!m_Opts.CompilerOpts.LLVMArgs.empty()) {
+      unsigned NumArgs = m_Opts.CompilerOpts.LLVMArgs.size();
+      auto Args = std::make_unique<const char*[]>(NumArgs + 2);
+      Args[0] = "cling (LLVM option parsing)";
+      for (unsigned i = 0; i != NumArgs; ++i)
+        Args[i + 1] = m_Opts.CompilerOpts.LLVMArgs[i].c_str();
+      Args[NumArgs + 1] = nullptr;
+      llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
+    }
+
     // Initialize the opt level to what CodeGenOpts says.
     if (m_OptLevel == -1)
       setDefaultOptLevel(getCI()->getCodeGenOpts().OptimizationLevel);

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -220,6 +220,9 @@ namespace cling {
     if (!m_IncrParser->isValid(false))
       return;
 
+    // Load any requested plugins.
+    getCI()->LoadRequestedPlugins();
+
     // Initialize the opt level to what CodeGenOpts says.
     if (m_OptLevel == -1)
       setDefaultOptLevel(getCI()->getCodeGenOpts().OptimizationLevel);

--- a/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
+++ b/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
@@ -159,9 +159,6 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
                     MissingArgCount, 0,
                     options::NoDriverOption | options::CLOption | options::DXCOption));
 
-  std::vector<const char*> LLVMArgs;
-  LLVMArgs.push_back("cling (LLVM option parsing)");
-
   for (const Arg* arg : Args) {
     switch (arg->getOption().getID()) {
       // case options::OPT_d_Flag:
@@ -201,12 +198,6 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
           Inputs->push_back(arg->getValue());
         break;
     }
-  }
-
-  // Check that there were LLVM arguments, other than the first dummy entry.
-  if (LLVMArgs.size() > 1) {
-    LLVMArgs.push_back(nullptr);
-    llvm::cl::ParseCommandLineOptions(LLVMArgs.size() - 1, LLVMArgs.data());
   }
 }
 


### PR DESCRIPTION
# This Pull request:

Adds plugin support to cling. This patch enables loading clang/pass plugins with the flag: 

`EXTRA_CLING_ARGS="-fplugin=path/to/plugin.so -fpass-plugin=path/to/plugin.so"`

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

