### PR TITLE
[tmva] Cleanup RModel classes layout

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -9,7 +9,7 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
-class RModel: public RModel_Base {
+class RModel final: public RModel_Base {
 
 private:
 
@@ -28,16 +28,18 @@ private:
 
 public:
 
-    //explicit move ctor/assn
+    // Rule of five: explicitly define move semantics, disallow copy
     RModel(RModel&& other);
-
     RModel& operator=(RModel&& other);
-
-    //disallow copy
     RModel(const RModel& other) = delete;
     RModel& operator=(const RModel& other) = delete;
+    ~RModel() = default;
 
-    RModel() {}
+    /**
+        Default constructor. Needed to allow serialization of ROOT objects. See
+        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+    */
+    RModel() = default;
     RModel(std::string name, std::string parsedtime): RModel_Base(name, parsedtime) {}
 
     // For GNN Functions usage
@@ -137,9 +139,8 @@ public:
         return fUseSession;
     }
 
-    ~RModel() {}
-
-    ClassDef(RModel,1);
+    // Use the ClassDef macro to allow definition of custom streaming
+    ClassDefNV(RModel, 2);
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -9,142 +9,138 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
-class RModel final: public RModel_Base {
+class RModel final : public RModel_Base {
 
 private:
+   std::unordered_map<std::string, InputTensorInfo>
+      fInputTensorInfos; // input tensors where shape is not defined or other graph inputs?
+   std::unordered_map<std::string, TensorInfo> fReadyInputTensorInfos; // input tensors where shape is full defined
+   std::unordered_map<std::string, InitializedTensor> fInitializedTensors;
+   std::unordered_map<std::string, TensorInfo> fIntermediateTensorInfos;
+   std::unordered_map<std::string, DynamicTensorInfo> fDynamicTensorInfos;
+   std::unordered_map<std::string, std::string>
+      fShapeParams; // parameters defining the dynamic shape (e.g. batch size), store also its default value
+   std::vector<std::string> fOutputTensorNames;
+   std::vector<std::string> fInputTensorNames; // input tensor names using ONNX order
 
-    std::unordered_map<std::string, InputTensorInfo> fInputTensorInfos; //input tensors where shape is not defined or other graph inputs?
-    std::unordered_map<std::string, TensorInfo> fReadyInputTensorInfos;  // input tensors where shape is full defined
-    std::unordered_map<std::string, InitializedTensor> fInitializedTensors;
-    std::unordered_map<std::string, TensorInfo> fIntermediateTensorInfos;
-    std::unordered_map<std::string, DynamicTensorInfo> fDynamicTensorInfos;
-    std::unordered_map<std::string, std::string> fShapeParams; // parameters defining the dynamic shape (e.g. batch size), store also its default value
-    std::vector<std::string> fOutputTensorNames;
-    std::vector<std::string> fInputTensorNames;  //input tensor names using ONNX order
+   std::vector<std::unique_ptr<ROperator>> fOperators;
 
-    std::vector<std::unique_ptr<ROperator>> fOperators;
-
-    const std::string SP = "   ";
+   const std::string SP = "   ";
 
 public:
+   // Rule of five: explicitly define move semantics, disallow copy
+   RModel(RModel &&other);
+   RModel &operator=(RModel &&other);
+   RModel(const RModel &other) = delete;
+   RModel &operator=(const RModel &other) = delete;
+   ~RModel() = default;
 
-    // Rule of five: explicitly define move semantics, disallow copy
-    RModel(RModel&& other);
-    RModel& operator=(RModel&& other);
-    RModel(const RModel& other) = delete;
-    RModel& operator=(const RModel& other) = delete;
-    ~RModel() = default;
+   /**
+       Default constructor. Needed to allow serialization of ROOT objects. See
+       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+   */
+   RModel() = default;
+   RModel(std::string name, std::string parsedtime) : RModel_Base(name, parsedtime) {}
 
-    /**
-        Default constructor. Needed to allow serialization of ROOT objects. See
-        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-    */
-    RModel() = default;
-    RModel(std::string name, std::string parsedtime): RModel_Base(name, parsedtime) {}
+   // For GNN Functions usage
+   RModel(std::string function_name) : RModel_Base(function_name) {}
 
-    // For GNN Functions usage
-    RModel(std::string function_name):RModel_Base(function_name) {}
+   const std::vector<size_t> &GetTensorShape(std::string name);
+   std::vector<Dim> GetDynamicTensorShape(std::string name);
+   const ETensorType &GetTensorType(std::string name);
 
-    const std::vector<size_t>& GetTensorShape(std::string name);
-    std::vector<Dim> GetDynamicTensorShape(std::string name);
-    const ETensorType& GetTensorType(std::string name);
+   bool CheckIfTensorAlreadyExist(std::string tensor_name);
+   void AddInputTensorInfo(std::string input_name, ETensorType type, std::vector<Dim> shape);
+   void AddInputTensorInfo(std::string input_name, ETensorType type, std::vector<size_t> shape);
+   void AddOperator(std::unique_ptr<ROperator> op, int order_execution = -1);
+   void AddOperatorReference(ROperator *op, int order_execution = -1)
+   {
+      std::unique_ptr<ROperator> tmp(op);
+      AddOperator(std::move(tmp), order_execution);
+   }
+   void AddInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape,
+                             std::shared_ptr<void> data);
 
-    bool CheckIfTensorAlreadyExist(std::string tensor_name);
-    void AddInputTensorInfo(std::string input_name, ETensorType type, std::vector<Dim> shape);
-    void AddInputTensorInfo(std::string input_name, ETensorType type, std::vector<size_t> shape);
-    void AddOperator(std::unique_ptr<ROperator> op, int order_execution = -1);
-    void AddOperatorReference(ROperator* op, int order_execution = -1) {
-        std::unique_ptr<ROperator> tmp(op);
-        AddOperator(std::move(tmp), order_execution);
-    }
-    void AddInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data);
+   template <typename T>
+   void AddInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, T *raw_data)
+   {
+      int size = 1;
+      for (auto item : shape) {
+         size *= (int)item;
+      }
+      std::shared_ptr<void> data(malloc(size * sizeof(T)), free);
+      std::memcpy(data.get(), raw_data, size * sizeof(T));
+      AddInitializedTensor(tensor_name, type, shape, data);
+   }
 
-    template <typename T>
-    void AddInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, T* raw_data) {
-        int size=1;
-        for(auto item:shape) {
-            size*=(int)item;
-        }
-        std::shared_ptr<void> data(malloc(size * sizeof(T)), free);
-        std::memcpy(data.get(), raw_data, size * sizeof(T));
-        AddInitializedTensor(tensor_name, type, shape, data);
-    }
+   // Check if a tensor is initialized
+   bool IsInitializedTensor(const std::string &name) const;
+   bool IsDynamicTensor(const std::string &name) const;
+   bool IsInputTensor(const std::string &name) const;
 
-    // Check if a tensor is initialized
-    bool IsInitializedTensor(const std::string& name) const;
-    bool IsDynamicTensor(const std::string& name) const;
-    bool IsInputTensor(const std::string& name) const;
+   // Add intermediate tensor
+   void AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<Dim> dim_shape);
+   void AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape);
+   // Add an intermediate dynamic tensor
+   void AddDynamicTensor(std::string tensor_name, ETensorType type, std::vector<Dim> shape);
 
-    // Add intermediate tensor
-    void AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<Dim> dim_shape);
-    void AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape);
-    // Add an intermediate dynamic tensor
-    void AddDynamicTensor(std::string tensor_name, ETensorType type, std::vector<Dim> shape);
+   void AddInputTensorName(std::string name);
+   void AddOutputTensorNameList(std::vector<std::string> output_tensor_names);
+   void
+   UpdateOutputTensorList(std::vector<std::string> curr_output_tensor, std::vector<std::string> modify_output_tensor);
+   void UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape,
+                                std::shared_ptr<void> data);
+   std::shared_ptr<void> GetInitializedTensorData(std::string tensor_name);
 
-    void AddInputTensorName(std::string name);
-    void AddOutputTensorNameList(std::vector<std::string> output_tensor_names);
-    void UpdateOutputTensorList(std::vector<std::string> curr_output_tensor, std::vector<std::string> modify_output_tensor);
-    void UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data);
-    std::shared_ptr<void> GetInitializedTensorData(std::string tensor_name);
+   void Initialize(int batchSize = -1, bool verbose = false);
+   void GenerateInitializedTensorInfo();
+   void GenerateIntermediateTensorInfo();
+   void GenerateDynamicTensorInfo();
+   void GenerateOutput();
+   void Generate(std::underlying_type_t<Options> options, int batchSize = -1, long pos = 0);
+   void Generate(Options options = Options::kDefault, int batchSize = -1, int pos = 0)
+   {
+      Generate(static_cast<std::underlying_type_t<Options>>(options), batchSize, pos);
+   }
 
-    void Initialize(int batchSize = -1, bool verbose = false);
-    void GenerateInitializedTensorInfo();
-    void GenerateIntermediateTensorInfo();
-    void GenerateDynamicTensorInfo();
-    void GenerateOutput();
-    void Generate(std::underlying_type_t<Options> options, int batchSize = -1, long pos = 0);
-    void Generate(Options options = Options::kDefault, int batchSize = -1, int pos = 0) {
-        Generate(static_cast<std::underlying_type_t<Options>>(options), batchSize, pos);
-    }
+   const std::vector<std::string> &GetInputTensorNames() const { return fInputTensorNames; }
+   const std::vector<std::string> &GetOutputTensorNames() const { return fOutputTensorNames; }
 
-    const std::vector<std::string> & GetInputTensorNames() const {
-        return fInputTensorNames;
-    }
-    const std::vector<std::string> & GetOutputTensorNames() const {
-        return fOutputTensorNames;
-    }
+   void ReadInitializedTensorsFromFile(long);
+   long WriteInitializedTensorsToFile(std::string filename = "");
 
-    void ReadInitializedTensorsFromFile(long);
-    long WriteInitializedTensorsToFile(std::string filename = "");
+   void PrintIntermediateTensors();
+   void PrintOutputTensors();
+   void OutputGenerated(std::string filename = "", bool append = false);
+   std::vector<std::string> GetOutputTensorNames() { return fOutputTensorNames; }
+   void SetFilename(std::string filename) { fName = filename; }
 
-    void PrintIntermediateTensors();
-    void PrintOutputTensors();
-    void OutputGenerated(std::string filename = "", bool append = false);
-    std::vector<std::string> GetOutputTensorNames() {
-        return fOutputTensorNames;
-    }
-    void SetFilename(std::string filename) {
-        fName = filename;
-    }
+   /*
+      template <typename T>
+      void AddInitializedTensor(std::string tensor_name, RTensor<T> new_tensor){
+         //a view only
+         T obj;
+         if (fInitializedTensors.find(tensor_name) != fInitializedTensors.end()){
+            throw std::runtime_error("TMVA-SOFIE: initialized tensor with name " + tensor_name + " already exists \n");
+         }
+         InitializedTensor new_tensor_ {GetTemplatedType(obj), new_tensor.GetShape() ,
+      static_cast<void>(new_tensor.GetData())}; fInitializedTensors[tensor_name] = new_tensor_;
+      }
+   */
 
-    /*
-       template <typename T>
-       void AddInitializedTensor(std::string tensor_name, RTensor<T> new_tensor){
-          //a view only
-          T obj;
-          if (fInitializedTensors.find(tensor_name) != fInitializedTensors.end()){
-             throw std::runtime_error("TMVA-SOFIE: initialized tensor with name " + tensor_name + " already exists \n");
-          }
-          InitializedTensor new_tensor_ {GetTemplatedType(obj), new_tensor.GetShape() , static_cast<void>(new_tensor.GetData())};
-          fInitializedTensors[tensor_name] = new_tensor_;
-       }
-    */
+   void PrintRequiredInputTensors();
+   void PrintInitializedTensors();
+   void PrintDynamicTensors();
+   void HeadInitializedTensors(std::string name, int n_print = 50);
 
-    void PrintRequiredInputTensors();
-    void PrintInitializedTensors();
-    void PrintDynamicTensors();
-    void HeadInitializedTensors(std::string name, int n_print = 50);
+   bool UseSession() const { return fUseSession; }
 
-    bool UseSession() const {
-        return fUseSession;
-    }
-
-    // Use the ClassDef macro to allow definition of custom streaming
-    ClassDefNV(RModel, 2);
+   // Use the ClassDef macro to allow definition of custom streaming
+   ClassDefNV(RModel, 2);
 };
 
-}//SOFIE
-}//Experimental
-}//TMVA
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
-#endif //TMVA_SOFIE_RMODEL
+#endif // TMVA_SOFIE_RMODEL

--- a/tmva/sofie/inc/TMVA/RModel_Base.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_Base.hxx
@@ -20,15 +20,15 @@ namespace Experimental {
 namespace SOFIE {
 
 enum class Options {
-    kDefault = 0x0,
-    kNoSession = 0x1,
-    kNoWeightFile = 0x2,
-    kRootBinaryWeightFile = 0x4,
-    kGNN = 0x8,
-    kGNNComponent = 0x10,
+   kDefault = 0x0,
+   kNoSession = 0x1,
+   kNoWeightFile = 0x2,
+   kRootBinaryWeightFile = 0x4,
+   kGNN = 0x8,
+   kGNNComponent = 0x10,
 };
 
-enum class WeightFileType {None, RootBinary, Text};
+enum class WeightFileType { None, RootBinary, Text };
 
 std::underlying_type_t<Options> operator|(Options opA, Options opB);
 std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, Options opB);
@@ -36,97 +36,78 @@ std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, O
 class RModel_Base {
 
 protected:
-    std::string fFileName; //file name of original model file for identification
-    std::string fParseTime; //UTC date and time string at parsing
+   std::string fFileName;  // file name of original model file for identification
+   std::string fParseTime; // UTC date and time string at parsing
 
-    WeightFileType fWeightFile = WeightFileType::Text;
+   WeightFileType fWeightFile = WeightFileType::Text;
 
-    std::unordered_set<std::string> fNeededBlasRoutines;
+   std::unordered_set<std::string> fNeededBlasRoutines;
 
-    const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath"};
-    std::unordered_set<std::string> fNeededStdLib = {"vector"};
-    std::unordered_set<std::string> fCustomOpHeaders;
+   const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath"};
+   std::unordered_set<std::string> fNeededStdLib = {"vector"};
+   std::unordered_set<std::string> fCustomOpHeaders;
 
-    std::string fName="UnnamedModel";
-    std::string fGC; //generated code
-    bool fUseWeightFile = true;
-    bool fUseSession = true;
-    bool fIsGNN = false;
-    bool fIsGNNComponent = false;
+   std::string fName = "UnnamedModel";
+   std::string fGC; // generated code
+   bool fUseWeightFile = true;
+   bool fUseSession = true;
+   bool fIsGNN = false;
+   bool fIsGNNComponent = false;
 
 public:
-    /**
-        Default constructor. Needed to allow serialization of ROOT objects. See
-        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-    */
-    RModel_Base() = default;
+   /**
+       Default constructor. Needed to allow serialization of ROOT objects. See
+       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+   */
+   RModel_Base() = default;
 
-    RModel_Base(std::string name, std::string parsedtime);
+   RModel_Base(std::string name, std::string parsedtime);
 
-    // For GNN Functions usage
-    RModel_Base(std::string function_name):fName(function_name) {}
+   // For GNN Functions usage
+   RModel_Base(std::string function_name) : fName(function_name) {}
 
-    void AddBlasRoutines(std::vector<std::string> routines) {
-        for (auto &routine : routines) {
-            fNeededBlasRoutines.insert(routine);
-        }
-    }
-    void AddNeededStdLib(std::string libname) {
-        if (fAllowedStdLib.find(libname) != fAllowedStdLib.end()) {
-            fNeededStdLib.insert(libname);
-        }
-    }
-    void AddNeededCustomHeader(std::string filename) {
-        fCustomOpHeaders.insert(filename);
-    }
-    void GenerateHeaderInfo(std::string& hgname);
-    void PrintGenerated() {
-        std::cout << fGC;
-    }
+   void AddBlasRoutines(std::vector<std::string> routines)
+   {
+      for (auto &routine : routines) {
+         fNeededBlasRoutines.insert(routine);
+      }
+   }
+   void AddNeededStdLib(std::string libname)
+   {
+      if (fAllowedStdLib.find(libname) != fAllowedStdLib.end()) {
+         fNeededStdLib.insert(libname);
+      }
+   }
+   void AddNeededCustomHeader(std::string filename) { fCustomOpHeaders.insert(filename); }
+   void GenerateHeaderInfo(std::string &hgname);
+   void PrintGenerated() { std::cout << fGC; }
 
-    std::string ReturnGenerated() {
-        return fGC;
-    }
-    void OutputGenerated(std::string filename = "", bool append = false);
-    void SetFilename(std::string filename) {
-        fName = filename;
-    }
-    std::string GetFilename() {
-        return fName;
-    }
-
+   std::string ReturnGenerated() { return fGC; }
+   void OutputGenerated(std::string filename = "", bool append = false);
+   void SetFilename(std::string filename) { fName = filename; }
+   std::string GetFilename() { return fName; }
 };
 
-enum class GraphType {
-    INVALID=0, GNN=1, GraphIndependent=2
-};
+enum class GraphType { INVALID = 0, GNN = 1, GraphIndependent = 2 };
 
-enum class FunctionType {
-    UPDATE=0, AGGREGATE=1
-};
-enum class FunctionTarget {
-    INVALID=0, NODES=1, EDGES=2, GLOBALS=3
-};
-enum class FunctionReducer {
-    INVALID=0, SUM=1, MEAN=2
-};
-enum class FunctionRelation {
-    INVALID=0, NODES_EDGES=1, NODES_GLOBALS=2, EDGES_GLOBALS=3
-};
+enum class FunctionType { UPDATE = 0, AGGREGATE = 1 };
+enum class FunctionTarget { INVALID = 0, NODES = 1, EDGES = 2, GLOBALS = 3 };
+enum class FunctionReducer { INVALID = 0, SUM = 1, MEAN = 2 };
+enum class FunctionRelation { INVALID = 0, NODES_EDGES = 1, NODES_GLOBALS = 2, EDGES_GLOBALS = 3 };
 
-class RModel_GNNBase: public RModel_Base {
+class RModel_GNNBase : public RModel_Base {
 public:
-    /**
-        Default constructor. Needed to allow serialization of ROOT objects. See
-        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-    */
-    RModel_GNNBase() = default;
-    virtual void Generate() = 0;
-    virtual ~RModel_GNNBase() = default;
+   /**
+       Default constructor. Needed to allow serialization of ROOT objects. See
+       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+   */
+   RModel_GNNBase() = default;
+   virtual void Generate() = 0;
+   virtual ~RModel_GNNBase() = default;
 };
 
-}//SOFIE
-}//Experimental
-}//TMVA
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
-#endif //TMVA_SOFIE_RMODEL_BASE
+#endif // TMVA_SOFIE_RMODEL_BASE

--- a/tmva/sofie/inc/TMVA/RModel_Base.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_Base.hxx
@@ -33,7 +33,7 @@ enum class WeightFileType {None, RootBinary, Text};
 std::underlying_type_t<Options> operator|(Options opA, Options opB);
 std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, Options opB);
 
-class RModel_Base: public TObject {
+class RModel_Base {
 
 protected:
     std::string fFileName; //file name of original model file for identification
@@ -55,7 +55,11 @@ protected:
     bool fIsGNNComponent = false;
 
 public:
-    RModel_Base() {}
+    /**
+        Default constructor. Needed to allow serialization of ROOT objects. See
+        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+    */
+    RModel_Base() = default;
 
     RModel_Base(std::string name, std::string parsedtime);
 
@@ -91,8 +95,6 @@ public:
         return fName;
     }
 
-    ClassDef(RModel_Base,1);
-
 };
 
 enum class GraphType {
@@ -114,8 +116,13 @@ enum class FunctionRelation {
 
 class RModel_GNNBase: public RModel_Base {
 public:
-    RModel_GNNBase() {}
+    /**
+        Default constructor. Needed to allow serialization of ROOT objects. See
+        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+    */
+    RModel_GNNBase() = default;
     virtual void Generate() = 0;
+    virtual ~RModel_GNNBase() = default;
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/RModel_GNN.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GNN.hxx
@@ -88,7 +88,7 @@ struct GNN_Init {
 
 };
 
-class RModel_GNN: public RModel_GNNBase {
+class RModel_GNN final: public RModel_GNNBase {
 
 private:
 
@@ -110,23 +110,21 @@ private:
     std::size_t num_global_features;
 
 public:
+    /**
+        Default constructor. Needed to allow serialization of ROOT objects. See
+        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+    */
+    RModel_GNN() = default;
+    RModel_GNN(GNN_Init& graph_input_struct);
 
-    //explicit move ctor/assn
+    // Rule of five: explicitly define move semantics, disallow copy
     RModel_GNN(RModel_GNN&& other);
-
     RModel_GNN& operator=(RModel_GNN&& other);
-
-    //disallow copy
     RModel_GNN(const RModel_GNN& other) = delete;
     RModel_GNN& operator=(const RModel_GNN& other) = delete;
+    ~RModel_GNN() final = default;
 
-    RModel_GNN(GNN_Init& graph_input_struct);
-    RModel_GNN() {}
-
-    void Generate();
-
-    ~RModel_GNN() {}
-//    ClassDef(RModel_GNN,1);
+    void Generate() final;
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/RModel_GNN.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GNN.hxx
@@ -15,120 +15,121 @@ class RFunction_Update;
 class RFunction_Aggregate;
 
 struct GNN_Init {
-    // update blocks
-    std::unique_ptr<RFunction_Update> edges_update_block;
-    std::unique_ptr<RFunction_Update> nodes_update_block;
-    std::unique_ptr<RFunction_Update> globals_update_block;
+   // update blocks
+   std::unique_ptr<RFunction_Update> edges_update_block;
+   std::unique_ptr<RFunction_Update> nodes_update_block;
+   std::unique_ptr<RFunction_Update> globals_update_block;
 
-    // aggregation blocks
-    std::unique_ptr<RFunction_Aggregate> edge_node_agg_block;
-    std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
-    std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
+   // aggregation blocks
+   std::unique_ptr<RFunction_Aggregate> edge_node_agg_block;
+   std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
+   std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
 
-    std::size_t num_nodes;
-    std::vector<std::pair<int,int>> edges;
+   std::size_t num_nodes;
+   std::vector<std::pair<int, int>> edges;
 
-    std::size_t num_node_features;
-    std::size_t num_edge_features;
-    std::size_t num_global_features;
+   std::size_t num_node_features;
+   std::size_t num_edge_features;
+   std::size_t num_global_features;
 
-    std::string filename;
+   std::string filename;
 
-    ~GNN_Init() {
-        edges_update_block.reset();
-        nodes_update_block.reset();
-        globals_update_block.reset();
+   ~GNN_Init()
+   {
+      edges_update_block.reset();
+      nodes_update_block.reset();
+      globals_update_block.reset();
 
-        edge_node_agg_block.reset();
-        edge_global_agg_block.reset();
-        node_global_agg_block.reset();
-    }
+      edge_node_agg_block.reset();
+      edge_global_agg_block.reset();
+      node_global_agg_block.reset();
+   }
 
-    template <typename T>
-    void createUpdateFunction(T& updateFunction) {
-        switch(updateFunction.GetFunctionTarget()) {
-        case FunctionTarget::EDGES: {
-            edges_update_block.reset(new T(updateFunction));
-            break;
-        }
-        case FunctionTarget::NODES: {
-            nodes_update_block.reset(new T(updateFunction));
-            break;
-        }
-        case FunctionTarget::GLOBALS: {
-            globals_update_block.reset(new T(updateFunction));
-            break;
-        }
-        default: {
-            throw std::runtime_error("TMVA SOFIE: Invalid Update function supplied for creating GNN function block.");
-        }
-        }
-    }
+   template <typename T>
+   void createUpdateFunction(T &updateFunction)
+   {
+      switch (updateFunction.GetFunctionTarget()) {
+      case FunctionTarget::EDGES: {
+         edges_update_block.reset(new T(updateFunction));
+         break;
+      }
+      case FunctionTarget::NODES: {
+         nodes_update_block.reset(new T(updateFunction));
+         break;
+      }
+      case FunctionTarget::GLOBALS: {
+         globals_update_block.reset(new T(updateFunction));
+         break;
+      }
+      default: {
+         throw std::runtime_error("TMVA SOFIE: Invalid Update function supplied for creating GNN function block.");
+      }
+      }
+   }
 
-    template <typename T>
-    void createAggregateFunction(T& aggFunction, FunctionRelation relation) {
-        switch(relation) {
-        case FunctionRelation::NODES_EDGES : {
-            edge_node_agg_block.reset(new T(aggFunction));
-            break;
-        }
-        case FunctionRelation::NODES_GLOBALS: {
-            node_global_agg_block.reset(new T(aggFunction));
-            break;
-        }
-        case FunctionRelation::EDGES_GLOBALS: {
-            edge_global_agg_block.reset(new T(aggFunction));
-            break;
-        }
-        default: {
-            throw std::runtime_error("TMVA SOFIE: Invalid Aggregate function supplied for creating GNN function block.");
-        }
-        }
-    }
-
+   template <typename T>
+   void createAggregateFunction(T &aggFunction, FunctionRelation relation)
+   {
+      switch (relation) {
+      case FunctionRelation::NODES_EDGES: {
+         edge_node_agg_block.reset(new T(aggFunction));
+         break;
+      }
+      case FunctionRelation::NODES_GLOBALS: {
+         node_global_agg_block.reset(new T(aggFunction));
+         break;
+      }
+      case FunctionRelation::EDGES_GLOBALS: {
+         edge_global_agg_block.reset(new T(aggFunction));
+         break;
+      }
+      default: {
+         throw std::runtime_error("TMVA SOFIE: Invalid Aggregate function supplied for creating GNN function block.");
+      }
+      }
+   }
 };
 
-class RModel_GNN final: public RModel_GNNBase {
+class RModel_GNN final : public RModel_GNNBase {
 
 private:
+   // update function for edges, nodes & global attributes
+   std::unique_ptr<RFunction_Update> edges_update_block;
+   std::unique_ptr<RFunction_Update> nodes_update_block;
+   std::unique_ptr<RFunction_Update> globals_update_block;
 
-    // update function for edges, nodes & global attributes
-    std::unique_ptr<RFunction_Update> edges_update_block;
-    std::unique_ptr<RFunction_Update> nodes_update_block;
-    std::unique_ptr<RFunction_Update> globals_update_block;
+   // aggregation function for edges, nodes & global attributes
+   std::unique_ptr<RFunction_Aggregate> edge_node_agg_block;
+   std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
+   std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
 
-    // aggregation function for edges, nodes & global attributes
-    std::unique_ptr<RFunction_Aggregate> edge_node_agg_block;
-    std::unique_ptr<RFunction_Aggregate> edge_global_agg_block;
-    std::unique_ptr<RFunction_Aggregate> node_global_agg_block;
+   std::size_t num_nodes; // maximum number of nodes
+   std::size_t num_edges; // maximum number of edges
 
-    std::size_t num_nodes;   // maximum number of nodes
-    std::size_t num_edges;   // maximum number of edges
-
-    std::size_t num_node_features;
-    std::size_t num_edge_features;
-    std::size_t num_global_features;
+   std::size_t num_node_features;
+   std::size_t num_edge_features;
+   std::size_t num_global_features;
 
 public:
-    /**
-        Default constructor. Needed to allow serialization of ROOT objects. See
-        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-    */
-    RModel_GNN() = default;
-    RModel_GNN(GNN_Init& graph_input_struct);
+   /**
+       Default constructor. Needed to allow serialization of ROOT objects. See
+       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+   */
+   RModel_GNN() = default;
+   RModel_GNN(GNN_Init &graph_input_struct);
 
-    // Rule of five: explicitly define move semantics, disallow copy
-    RModel_GNN(RModel_GNN&& other);
-    RModel_GNN& operator=(RModel_GNN&& other);
-    RModel_GNN(const RModel_GNN& other) = delete;
-    RModel_GNN& operator=(const RModel_GNN& other) = delete;
-    ~RModel_GNN() final = default;
+   // Rule of five: explicitly define move semantics, disallow copy
+   RModel_GNN(RModel_GNN &&other);
+   RModel_GNN &operator=(RModel_GNN &&other);
+   RModel_GNN(const RModel_GNN &other) = delete;
+   RModel_GNN &operator=(const RModel_GNN &other) = delete;
+   ~RModel_GNN() final = default;
 
-    void Generate() final;
+   void Generate() final;
 };
 
-}//SOFIE
-}//Experimental
-}//TMVA
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
-#endif //TMVA_SOFIE_RMODEL_GNN
+#endif // TMVA_SOFIE_RMODEL_GNN

--- a/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
@@ -56,7 +56,7 @@ struct GraphIndependent_Init {
     }
 };
 
-class RModel_GraphIndependent: public RModel_GNNBase {
+class RModel_GraphIndependent final: public RModel_GNNBase {
 
 private:
 
@@ -73,23 +73,21 @@ private:
     std::size_t num_global_features;
 
 public:
+    /**
+        Default constructor. Needed to allow serialization of ROOT objects. See
+        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+    */
+    RModel_GraphIndependent() = default;
+    RModel_GraphIndependent(GraphIndependent_Init& graph_input_struct);
 
-    //explicit move ctor/assn
+    // Rule of five: explicitly define move semantics, disallow copy
     RModel_GraphIndependent(RModel_GraphIndependent&& other);
-
     RModel_GraphIndependent& operator=(RModel_GraphIndependent&& other);
-
-    //disallow copy
     RModel_GraphIndependent(const RModel_GraphIndependent& other) = delete;
     RModel_GraphIndependent& operator=(const RModel_GraphIndependent& other) = delete;
+    ~RModel_GraphIndependent() final = default;
 
-    RModel_GraphIndependent(GraphIndependent_Init& graph_input_struct);
-    RModel_GraphIndependent() {}
-
-    void Generate();
-
-    ~RModel_GraphIndependent() {}
-//    ClassDef(RModel_GNN,1);
+    void Generate() final;
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
@@ -14,84 +14,86 @@ namespace SOFIE {
 class RFunction_Update;
 
 struct GraphIndependent_Init {
-    // update blocks
-    std::unique_ptr<RFunction_Update> edges_update_block;
-    std::unique_ptr<RFunction_Update> nodes_update_block;
-    std::unique_ptr<RFunction_Update> globals_update_block;
+   // update blocks
+   std::unique_ptr<RFunction_Update> edges_update_block;
+   std::unique_ptr<RFunction_Update> nodes_update_block;
+   std::unique_ptr<RFunction_Update> globals_update_block;
 
-    std::size_t num_nodes;
-    std::vector<std::pair<int,int>> edges;
+   std::size_t num_nodes;
+   std::vector<std::pair<int, int>> edges;
 
-    int num_node_features;
-    int num_edge_features;
-    int num_global_features;
+   int num_node_features;
+   int num_edge_features;
+   int num_global_features;
 
-    std::string filename;
+   std::string filename;
 
-    template <typename T>
-    void createUpdateFunction(T& updateFunction) {
-        switch(updateFunction.GetFunctionTarget()) {
-        case FunctionTarget::EDGES: {
-            edges_update_block.reset(new T(updateFunction));
-            break;
-        }
-        case FunctionTarget::NODES: {
-            nodes_update_block.reset(new T(updateFunction));
-            break;
-        }
-        case FunctionTarget::GLOBALS: {
-            globals_update_block.reset(new T(updateFunction));
-            break;
-        }
-        default: {
-            throw std::runtime_error("TMVA SOFIE: Invalid Update function supplied for creating GraphIndependent function block.");
-        }
-        }
-    }
+   template <typename T>
+   void createUpdateFunction(T &updateFunction)
+   {
+      switch (updateFunction.GetFunctionTarget()) {
+      case FunctionTarget::EDGES: {
+         edges_update_block.reset(new T(updateFunction));
+         break;
+      }
+      case FunctionTarget::NODES: {
+         nodes_update_block.reset(new T(updateFunction));
+         break;
+      }
+      case FunctionTarget::GLOBALS: {
+         globals_update_block.reset(new T(updateFunction));
+         break;
+      }
+      default: {
+         throw std::runtime_error(
+            "TMVA SOFIE: Invalid Update function supplied for creating GraphIndependent function block.");
+      }
+      }
+   }
 
-    ~GraphIndependent_Init() {
-        edges_update_block.reset();
-        nodes_update_block.reset();
-        globals_update_block.reset();
-    }
+   ~GraphIndependent_Init()
+   {
+      edges_update_block.reset();
+      nodes_update_block.reset();
+      globals_update_block.reset();
+   }
 };
 
-class RModel_GraphIndependent final: public RModel_GNNBase {
+class RModel_GraphIndependent final : public RModel_GNNBase {
 
 private:
+   // updation function for edges, nodes & global attributes
+   std::unique_ptr<RFunction_Update> edges_update_block;
+   std::unique_ptr<RFunction_Update> nodes_update_block;
+   std::unique_ptr<RFunction_Update> globals_update_block;
 
-    // updation function for edges, nodes & global attributes
-    std::unique_ptr<RFunction_Update> edges_update_block;
-    std::unique_ptr<RFunction_Update> nodes_update_block;
-    std::unique_ptr<RFunction_Update> globals_update_block;
+   std::size_t num_nodes;
+   std::size_t num_edges;
 
-    std::size_t num_nodes;
-    std::size_t num_edges;
-
-    std::size_t num_node_features;
-    std::size_t num_edge_features;
-    std::size_t num_global_features;
+   std::size_t num_node_features;
+   std::size_t num_edge_features;
+   std::size_t num_global_features;
 
 public:
-    /**
-        Default constructor. Needed to allow serialization of ROOT objects. See
-        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-    */
-    RModel_GraphIndependent() = default;
-    RModel_GraphIndependent(GraphIndependent_Init& graph_input_struct);
+   /**
+       Default constructor. Needed to allow serialization of ROOT objects. See
+       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
+   */
+   RModel_GraphIndependent() = default;
+   RModel_GraphIndependent(GraphIndependent_Init &graph_input_struct);
 
-    // Rule of five: explicitly define move semantics, disallow copy
-    RModel_GraphIndependent(RModel_GraphIndependent&& other);
-    RModel_GraphIndependent& operator=(RModel_GraphIndependent&& other);
-    RModel_GraphIndependent(const RModel_GraphIndependent& other) = delete;
-    RModel_GraphIndependent& operator=(const RModel_GraphIndependent& other) = delete;
-    ~RModel_GraphIndependent() final = default;
+   // Rule of five: explicitly define move semantics, disallow copy
+   RModel_GraphIndependent(RModel_GraphIndependent &&other);
+   RModel_GraphIndependent &operator=(RModel_GraphIndependent &&other);
+   RModel_GraphIndependent(const RModel_GraphIndependent &other) = delete;
+   RModel_GraphIndependent &operator=(const RModel_GraphIndependent &other) = delete;
+   ~RModel_GraphIndependent() final = default;
 
-    void Generate() final;
+   void Generate() final;
 };
 
-}//SOFIE
-}//Experimental
-}//TMVA
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
-#endif //TMVA_SOFIE_RMODEL_GNN
+#endif // TMVA_SOFIE_RMODEL_GNN

--- a/tmva/sofie/test/EmitFromRoot.cxx.in
+++ b/tmva/sofie/test/EmitFromRoot.cxx.in
@@ -17,7 +17,7 @@ int EmitModel(std::string inputfile, std::string outname){
    RModelParser_ONNX parser;
    RModel model = parser.Parse(inputfile);
    TFile fileWrite((outname+"_FromROOT.root").c_str(),"RECREATE");
-   model.Write("model");
+   fileWrite.WriteObject(&model, "model");
    fileWrite.Close();
    TFile fileRead((outname+"_FromROOT.root").c_str(),"READ");
    RModel *modelPtr;


### PR DESCRIPTION
As a followup to https://github.com/root-project/root/pull/15163 and in relation to https://github.com/root-project/root/issues/15156

* Apply rule of five
* Use correct `ClassDef` macro only when necessary
* Remove relationship to `TObject` from `RModel_Base`
* Properly implement virtual hierarchy for `RModel_GNNBase` and derived

Also apply clang-format changes in a separate commit

