### PR TITLE
Revert "[ToRevert] Suppress diagnostics due to missing PCMs on Windows."

### DIFF
--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -50,12 +50,6 @@ static struct ForbidDiagnostics {
          ::abort();
       }
 
-      // FIXME: Windows has problem finding PCMs.
-      if (level == kError && strcmp(location, "TCling::LoadPCM") == 0 && strstr(msg, "file does not exist") != nullptr) {
-        std::cerr << "Error in " << location << " " << msg << std::endl;
-        return;
-      }
-
       // FIXME: RNTuple warns that it's in beta stage.
       if (level == kWarning
           && strstr(msg, "The RNTuple file format will change. Do not store real data with this version of RNTuple!") != nullptr) {

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -8,7 +8,6 @@
 #include "TLeafElement.h"
 #include "TRandom.h"
 
-#include "ROOT/TestSupport.hxx"
 #include "gtest/gtest.h"
 
 // Backward compatibility for gtest version < 1.10.0
@@ -21,16 +20,6 @@
 class TOffsetGeneration : public ::testing::Test {
 protected:
    static constexpr int fEventCount = 10000;
-
-   // FIXME: Global suppression of PCM-related warnings for windows
-   static void SetUpTestSuite() {
-      // Suppress file-related warning on Windows throughout
-      // this entire test suite
-      static ROOT::TestSupport::CheckDiagsRAII diags;
-      diags.optionalDiag(kError,
-         "TCling::LoadPCM",
-         "ROOT PCM", false);
-   }
 
    void SetUp() override
    {


### PR DESCRIPTION
Closes #9354.

This reverts commit e3f2ed26b7903ff540a37e77f6c026b8502db747.