### PR TITLE
[v626][TMVA] Disable `rbdt_xgboost` test

### DIFF
--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -31,9 +31,11 @@ if(dataframe)
     ROOT_ADD_GTEST(rbdt rbdt.cxx LIBRARIES ROOTVecOps TMVA)
 endif()
 
-if(dataframe AND NOT pyroot_legacy)
-  find_python_module(xgboost QUIET)
-  if (PY_XGBOOST_FOUND)
-    ROOT_ADD_PYUNITTEST(rbdt_xgboost rbdt_xgboost.py)
-  endif()
-endif()
+# Disabled because RBDT doesn't support the imbalanced tree structure of
+# XGBoost models.
+# if(dataframe AND NOT pyroot_legacy)
+#   find_python_module(xgboost QUIET)
+#   if (PY_XGBOOST_FOUND)
+#     ROOT_ADD_PYUNITTEST(rbdt_xgboost rbdt_xgboost.py)
+#   endif()
+# endif()


### PR DESCRIPTION
Disabled because RBDT doesn't support the imbalanced tree structure of XGBoost models.

We need to disable this test right now, because we have now installed XGBoost on the GitHub action runners, and this test will be red.

This test never worked, we just never noticed because XGBoost was not installed on any CI platform.

Backport of a commit from #15183.