### PR TITLE
[pyroot] Add rstring to remove warning in python 3.12

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/_cppyy_generator.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/_cppyy_generator.py
@@ -664,7 +664,7 @@ def getBuiltinHeaderPath(library_path):
 
 
 def main(argv=None):
-    """
+    r"""
     Takes a set of C++ header files and generate a JSON output file describing
     the objects found in them. This output is intended to support more
     convenient access to a set of cppyy-supported bindings.


### PR DESCRIPTION
Fix cmake warning for python 3.12.
Also the PR was submitted to https://github.com/wlav/cppyy-backend/tree/master

