### PR TITLE
[core] tab completion: insert match but do not replace the content after it

### DIFF
--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1364,27 +1364,28 @@ Int_t TTabCom::Complete(const TRegexp & re,
    // 4. finally write text into the buffer.
    // ---------------------------------------
    {
-      int i = strlen(fBuf);     // old EOL position is i
-      int l = strlen(match) - (loc - start);  // new EOL position will be i+L
+      const int old_len = strlen(fBuf);                 // old EOL position is i
+      const int match_len = strlen(match);
+      const int added_len = match_len - (loc - start);  // new EOL position will be i+L
 
       // first check for overflow
-      if (strlen(fBuf) + strlen(match) + 1 > BUF_SIZE) {
+      if (old_len + added_len + 1 > BUF_SIZE || start > loc || start + match_len + 1 > BUF_SIZE) {
          Error("TTabCom::Complete", "buffer overflow");
          pos = -2;
          goto done;             /* RETURN */
       }
       // debugging output
-      IfDebug(std::cerr << "  i=" << i << std::endl);
-      IfDebug(std::cerr << "  L=" << l << std::endl);
+      IfDebug(std::cerr << "  i=" << old_len << std::endl);
+      IfDebug(std::cerr << "  L=" << added_len << std::endl);
       IfDebug(std::cerr << "loc=" << loc << std::endl);
 
       // slide everything (including the null terminator) over to make space
-      for (; i >= loc; i -= 1) {
-         fBuf[i + l] = fBuf[i];
+      for (int i = old_len; i >= loc; i -= 1) {
+         fBuf[i + added_len] = fBuf[i];
       }
 
       // insert match
-      strncpy(fBuf + start, match, strlen(match));
+      strncpy(fBuf + start, match, match_len);
 
       // the "get"->"Get" case of TString::kIgnore sets pos to -2
       // and falls through to update the buffer; we need to return
@@ -1397,7 +1398,7 @@ Int_t TTabCom::Complete(const TRegexp & re,
             pos = start;
          }
       }
-      *fpLoc = loc + l;         // new cursor position
+      *fpLoc = loc + added_len;    // new cursor position
    }
 
 done:                         // <----- goto label

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1384,7 +1384,7 @@ Int_t TTabCom::Complete(const TRegexp & re,
       }
 
       // insert match
-      strlcpy(fBuf + start, match, BUF_SIZE - start);
+      strncpy(fBuf + start, match, strlen(match));
 
       // the "get"->"Get" case of TString::kIgnore sets pos to -2
       // and falls through to update the buffer; we need to return

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1385,7 +1385,7 @@ Int_t TTabCom::Complete(const TRegexp & re,
       }
 
       // insert match
-      strncpy(fBuf + start, match, match_len);
+      memcpy(fBuf + start, match, match_len);
 
       // the "get"->"Get" case of TString::kIgnore sets pos to -2
       // and falls through to update the buffer; we need to return

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1364,9 +1364,9 @@ Int_t TTabCom::Complete(const TRegexp & re,
    // 4. finally write text into the buffer.
    // ---------------------------------------
    {
-      const int old_len = strlen(fBuf);                 // old EOL position is i
+      const int old_len = strlen(fBuf);                 // old EOL position is old_len
       const int match_len = strlen(match);
-      const int added_len = match_len - (loc - start);  // new EOL position will be i+L
+      const int added_len = match_len - (loc - start);  // new EOL position will be old_len+added_len
 
       // first check for overflow
       if (old_len + added_len + 1 > BUF_SIZE || start > loc || start + match_len + 1 > BUF_SIZE) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/11238

Reverts https://github.com/root-project/root/pull/2585
Reverts https://github.com/root-project/root/commit/9d459ce6141daf108587d85737bdc50e70c775d3
Re-Fixes https://its.cern.ch/jira/browse/ROOT-9597

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)