### PR TITLE
[Tree] Fix globbing of ? when also used as query

### DIFF
--- a/tree/tree/test/TChainParsing.cxx
+++ b/tree/tree/test/TChainParsing.cxx
@@ -238,6 +238,7 @@ TEST(TChainParsing, RecursiveGlob)
    TChain none;
    TChain nested;
    TChain globDir;
+   TChain regex;
 
    nodir.Add("*");
    const auto *nodirFiles = nodir.GetListOfFiles();
@@ -272,6 +273,17 @@ TEST(TChainParsing, RecursiveGlob)
    for (std::size_t i = 0; i < expectedFileNamesGlobDir.size(); i++) {
       EXPECT_EQ(globDirChainFileNames[i], expectedFileNamesGlobDir[i]);
    }
+
+   regex.Add("test*/subdir?/[0-9]?.root?#events");
+   const auto *regexChainFiles = regex.GetListOfFiles();
+   ASSERT_TRUE(regexChainFiles);
+   EXPECT_EQ(regexChainFiles->GetEntries(), 3);
+   std::vector<std::string> expectedFileNamesRegex{
+      ConcatUnixFileName(cwd, "testglob/subdir1/1a.root"),
+      ConcatUnixFileName(cwd, "testglob/subdir1/1b.root"),
+      ConcatUnixFileName(cwd, "testglob/subdir3/3a.root")};
+   auto regexChainFileNames = GetFileNamesVec(regexChainFiles);
+   EXPECT_VEC_EQ(regexChainFileNames, expectedFileNamesRegex);
 }
 
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)

--- a/tree/tree/test/TChainParsing.cxx
+++ b/tree/tree/test/TChainParsing.cxx
@@ -278,10 +278,9 @@ TEST(TChainParsing, RecursiveGlob)
    const auto *regexChainFiles = regex.GetListOfFiles();
    ASSERT_TRUE(regexChainFiles);
    EXPECT_EQ(regexChainFiles->GetEntries(), 3);
-   std::vector<std::string> expectedFileNamesRegex{
-      ConcatUnixFileName(cwd, "testglob/subdir1/1a.root"),
-      ConcatUnixFileName(cwd, "testglob/subdir1/1b.root"),
-      ConcatUnixFileName(cwd, "testglob/subdir3/3a.root")};
+   std::vector<std::string> expectedFileNamesRegex{ConcatUnixFileName(cwd, "testglob/subdir1/1a.root"),
+                                                   ConcatUnixFileName(cwd, "testglob/subdir1/1b.root"),
+                                                   ConcatUnixFileName(cwd, "testglob/subdir3/3a.root")};
    auto regexChainFileNames = GetFileNamesVec(regexChainFiles);
    EXPECT_VEC_EQ(regexChainFileNames, expectedFileNamesRegex);
 }


### PR DESCRIPTION
# This Pull request:

When ? is used in TChain::Add in both the filename for globbing and as a starter for a string, TChain::Add fails to find the file, because everything after the ? is interpreted as the query string.

This commit changes the behaviour so that `?` characters before the _last_ (should it be the first or something else?) '.root' are wildcard characters.

## Changes or fixes:
This PR fixes #10239 

## Checklist:
- [x] tested changes locally
- [ ] updated the docs (if necessary)



