### PR TITLE
[TGraphErrors] add AddPointError method

### DIFF
--- a/hist/hist/inc/TGraph2DAsymmErrors.h
+++ b/hist/hist/inc/TGraph2DAsymmErrors.h
@@ -47,6 +47,8 @@ public:
    TGraph2DAsymmErrors(const TGraph2DAsymmErrors&);
    TGraph2DAsymmErrors& operator=(const TGraph2DAsymmErrors&);
    ~TGraph2DAsymmErrors() override;
+   virtual void AddPointError(Double_t x, Double_t y, Double_t z, Double_t exl = 0., Double_t exh = 0.,
+                              Double_t eyl = 0., Double_t eyh = 0., Double_t ezl = 0., Double_t ezh = 0.);
    Double_t        GetErrorX(Int_t bin) const override;
    Double_t        GetErrorY(Int_t bin) const override;
    Double_t        GetErrorZ(Int_t bin) const override;

--- a/hist/hist/inc/TGraph2DErrors.h
+++ b/hist/hist/inc/TGraph2DErrors.h
@@ -38,6 +38,7 @@ public:
    TGraph2DErrors(const TGraph2DErrors&);
    TGraph2DErrors& operator=(const TGraph2DErrors&);
    ~TGraph2DErrors() override;
+   virtual void AddPointError(Double_t x, Double_t y, Double_t z, Double_t ex = 0., Double_t ey = 0., Double_t ez = 0.);
    Double_t        GetErrorX(Int_t bin) const override;
    Double_t        GetErrorY(Int_t bin) const override;
    Double_t        GetErrorZ(Int_t bin) const override;

--- a/hist/hist/inc/TGraphAsymmErrors.h
+++ b/hist/hist/inc/TGraphAsymmErrors.h
@@ -59,6 +59,8 @@ public:
 
    ~TGraphAsymmErrors() override;
 
+   virtual void
+   AddPointError(Double_t x, Double_t y, Double_t exl = 0., Double_t exh = 0., Double_t eyl = 0., Double_t eyh = 0.);
    void    Apply(TF1 *f) override;
    virtual void    BayesDivide(const TH1* pass, const TH1* total, Option_t *opt="");
    virtual void    Divide(const TH1* pass, const TH1* total, Option_t *opt="cp");

--- a/hist/hist/inc/TGraphBentErrors.h
+++ b/hist/hist/inc/TGraphBentErrors.h
@@ -66,6 +66,8 @@ public:
                     const Double_t *eyld=nullptr, const Double_t *eyhd=nullptr);
    TGraphBentErrors(const TGraphBentErrors &gr);
    ~TGraphBentErrors() override;
+   virtual void AddPointError(Double_t x, Double_t y, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh,
+                              Double_t exld = 0, Double_t exhd = 0, Double_t eyld = 0, Double_t eyhd = 0);
    void    Apply(TF1 *f) override;
    void    ComputeRange(Double_t &xmin, Double_t &ymin,
                                 Double_t &xmax, Double_t &ymax) const override;

--- a/hist/hist/inc/TGraphErrors.h
+++ b/hist/hist/inc/TGraphErrors.h
@@ -55,8 +55,7 @@ public:
    TGraphErrors(const TH1 *h);
    TGraphErrors(const char *filename, const char *format="%lg %lg %lg %lg", Option_t *option="");
    ~TGraphErrors() override;
-   virtual void AddPointError(Double_t x, Double_t y, Double_t ex = 0.,
-                              Double_t ey = 0.); ///< Append a new point with errorbars (default to zero) to the graph.
+   virtual void AddPointError(Double_t x, Double_t y, Double_t ex = 0., Double_t ey = 0.);
    void    Apply(TF1 *f) override;
    virtual void    ApplyX(TF1 *f);
    static Int_t    CalculateScanfFields(const char *fmt);

--- a/hist/hist/inc/TGraphErrors.h
+++ b/hist/hist/inc/TGraphErrors.h
@@ -55,6 +55,8 @@ public:
    TGraphErrors(const TH1 *h);
    TGraphErrors(const char *filename, const char *format="%lg %lg %lg %lg", Option_t *option="");
    ~TGraphErrors() override;
+   virtual void AddPointError(Double_t x, Double_t y, Double_t ex = 0.,
+                              Double_t ey = 0.); ///< Append a new point with errorbars (default to zero) to the graph.
    void    Apply(TF1 *f) override;
    virtual void    ApplyX(TF1 *f);
    static Int_t    CalculateScanfFields(const char *fmt);

--- a/hist/hist/src/TGraph2DAsymmErrors.cxx
+++ b/hist/hist/src/TGraph2DAsymmErrors.cxx
@@ -232,6 +232,16 @@ TGraph2DAsymmErrors & TGraph2DAsymmErrors::operator=(const TGraph2DAsymmErrors &
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Add a 3D point with asymmetric errorbars to an existing graph
+
+void TGraph2DAsymmErrors::AddPointError(Double_t x, Double_t y, Double_t z, Double_t exl, Double_t exh, Double_t eyl,
+                                        Double_t eyh, Double_t ezl, Double_t ezh)
+{
+   AddPoint(x, y, z);
+   SetPointError(fNpoints - 1, exl, exh, eyl, eyh, ezl, ezh);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Returns the combined error along X at point i by computing the average
 /// of the lower and upper variance.
 

--- a/hist/hist/src/TGraph2DErrors.cxx
+++ b/hist/hist/src/TGraph2DErrors.cxx
@@ -193,7 +193,7 @@ TGraph2DErrors &TGraph2DErrors::operator=(const TGraph2DErrors &g)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// This function adds to existing plot one point with errorbars
+/// Add a point with errorbars to the graph.
 
 void TGraph2DErrors::AddPointError(Double_t x, Double_t y, Double_t z, Double_t ex, Double_t ey, Double_t ez)
 {

--- a/hist/hist/src/TGraph2DErrors.cxx
+++ b/hist/hist/src/TGraph2DErrors.cxx
@@ -194,7 +194,6 @@ TGraph2DErrors &TGraph2DErrors::operator=(const TGraph2DErrors &g)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// This function adds to existing plot one point with errorbars
-/// It returns the error along X at point i.
 
 void TGraph2DErrors::AddPointError(Double_t x, Double_t y, Double_t z, Double_t ex, Double_t ey, Double_t ez)
 {

--- a/hist/hist/src/TGraph2DErrors.cxx
+++ b/hist/hist/src/TGraph2DErrors.cxx
@@ -191,6 +191,17 @@ TGraph2DErrors &TGraph2DErrors::operator=(const TGraph2DErrors &g)
    }
    return *this;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// This function adds to existing plot one point with errorbars
+/// It returns the error along X at point i.
+
+void TGraph2DErrors::AddPointError(Double_t x, Double_t y, Double_t z, Double_t ex, Double_t ey, Double_t ez)
+{
+   AddPoint(x, y, z); // this will increase fNpoints by one
+   SetPointError(fNpoints - 1, ex, ey, ez);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// This function is called by Graph2DFitChisquare.
 /// It returns the error along X at point i.

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -450,7 +450,7 @@ Double_t** TGraphAsymmErrors::Allocate(Int_t size) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add a point with asymmetric errorbars to an existing plot
+/// Add a point with asymmetric errorbars to the graph.
 
 void TGraphAsymmErrors::AddPointError(Double_t x, Double_t y, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh)
 {

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -450,6 +450,15 @@ Double_t** TGraphAsymmErrors::Allocate(Int_t size) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Add a point with asymmetric errorbars to an existing plot
+
+void TGraphAsymmErrors::AddPointError(Double_t x, Double_t y, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh)
+{
+   AddPoint(x, y);
+   SetPointError(fNpoints - 1, exl, exh, eyl, eyh);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Apply a function to all data points \f$ y = f(x,y) \f$
 ///
 /// Errors are calculated as \f$ eyh = f(x,y+eyh)-f(x,y) \f$ and

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -186,6 +186,15 @@ TGraphBentErrors::~TGraphBentErrors()
    delete [] fEYhighd;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Add one point with bent errors to the graph
+
+void TGraphBentErrors::AddPointError(Double_t x, Double_t y, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh,
+                                     Double_t exld, Double_t exhd, Double_t eyld, Double_t eyhd)
+{
+   AddPoint(x, y);
+   SetPointError(fNpoints - 1, exl, exh, eyl, eyh, exld, exhd, eyld, eyhd);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Apply a function to all data points \f$ y = f(x,y) \f$.

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -187,7 +187,7 @@ TGraphBentErrors::~TGraphBentErrors()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add one point with bent errors to the graph
+/// Add a point with bent errors to the graph.
 
 void TGraphBentErrors::AddPointError(Double_t x, Double_t y, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh,
                                      Double_t exld, Double_t exhd, Double_t eyld, Double_t eyhd)

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -371,6 +371,11 @@ TGraphErrors::~TGraphErrors()
    delete [] fEY;
 }
 
+void TGraphErrors::AddPointError(Double_t x, Double_t y, Double_t ex, Double_t ey)
+{
+   SetPoint(fNpoints, x, y); // fNpoints will increase
+   SetPointError(fNpoints - 1, ex, ey);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Apply function to all the data points \f$ y = f(x,y) \f$.

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -371,6 +371,9 @@ TGraphErrors::~TGraphErrors()
    delete [] fEY;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Add a point with errorbars to the graph.
+
 void TGraphErrors::AddPointError(Double_t x, Double_t y, Double_t ex, Double_t ey)
 {
    AddPoint(x, y); // fNpoints will increase automatically

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -373,7 +373,7 @@ TGraphErrors::~TGraphErrors()
 
 void TGraphErrors::AddPointError(Double_t x, Double_t y, Double_t ex, Double_t ey)
 {
-   SetPoint(fNpoints, x, y); // fNpoints will increase
+   AddPoint(x, y); // fNpoints will increase
    SetPointError(fNpoints - 1, ex, ey);
 }
 

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -373,7 +373,7 @@ TGraphErrors::~TGraphErrors()
 
 void TGraphErrors::AddPointError(Double_t x, Double_t y, Double_t ex, Double_t ey)
 {
-   AddPoint(x, y); // fNpoints will increase
+   AddPoint(x, y); // fNpoints will increase automatically
    SetPointError(fNpoints - 1, ex, ey);
 }
 


### PR DESCRIPTION
# This Pull request:

Extends the functionality of `TGraphErrors` class on the manner of the `TGraph` class such that one does not need to prepare arrays with data before creating the `TGraphErrors` class and simply add points one-by-one.

## Changes or fixes:

The pull request adds a new method to the class `TGraphErrors` called `AddPointError`

## Checklist:

- [x] tested changes locally
- [x] updated the docs (added a doxygen line)

## Code to test functionality:
(run as a root script)

```c++
void apge() {
    TCanvas *c1 = new TCanvas("c1","A Simple Graph Example",200,10,700,500);

    c1->SetGrid();

    const Int_t n = 20;
    TGraphErrors *gr = new TGraphErrors;
    for (Int_t i=0;i<n;i++) {
        Double_t x = i*0.1;
        gr->AddPointError(i*0.1, 10*sin(x+0.2), 0.3/(x*x+3.), x*x/(x*x + 8.));
    }
    gr->SetTitle("a simple graph");
    gr->GetXaxis()->SetTitle("X title");
    gr->GetYaxis()->SetTitle("Y title");
    gr->Draw("AP");

    // TCanvas::Update() draws the frame, after which one can change it
    c1->Update();
    c1->GetFrame()->SetBorderSize(12);
    c1->Modified();
}
```