### PR TITLE
[win] echo without newline in `root-config.bat`

### DIFF
--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -204,7 +204,7 @@ if "!out!"=="" (
    echo.
    goto print_help
 )
-echo !out!
+echo|set /p=!out!
 
 exit /b !err!
 


### PR DESCRIPTION
Should fix a problem when using `root-config.bat` in `execute_process`
when the output of `root-config.bat` contains a newline
