### PR TITLE
[ntuple] Add FillNoCommit method and RNTupleFillStatus

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -28,6 +28,7 @@ HEADERS
   ROOT/RNTupleCollectionWriter.hxx
   ROOT/RNTupleDescriptor.hxx
   ROOT/RNTupleFillContext.hxx
+  ROOT/RNTupleFillStatus.hxx
   ROOT/RNTupleImtTaskScheduler.hxx
   ROOT/RNTupleMerger.hxx
   ROOT/RNTupleMetrics.hxx

--- a/tree/ntuple/v7/doc/architecture.md
+++ b/tree/ntuple/v7/doc/architecture.md
@@ -334,8 +334,10 @@ The caller has to ensure that the lifetime of the object lasts during the I/O op
 
 An RNTuple writer that is constructed without a `TFile` object (`RNTupleWriter::Recreate()`) assumes exclusive access to the underlying file.
 An RNTuple writer that uses a `TFile` for writing (`RNTupleWriter::Append()`) assumes that the `TFile` object outlives the writer's lifetime.
-The serial writer assumes exclusive access to the underlying file during construction, destruction and `Fill()`.
-The parallel writer assumes exclusive access to the underlying file during the entire lifetime of the writer.
+The serial writer assumes exclusive access to the underlying file during construction, destruction and `Fill()` as well as `CommitCluster()`.
+For `FillNoCommit()`, the sequential writer assumes exclusive access only if buffered writing is turned off.
+The parallel writer assumes exclusive access to the underlying file during all operations on the writer (e.g. construction and destruction) and all operations on any created fill context (e.g. `Fill()` and `CommitCluster()`).
+A notable exception is `FillNoCommit()` which is guaranteed to never access the underlying `TFile` during parallel writing (which is always buffered).
 
 A `TFile` does not take ownership of any `RNTuple` objects.
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
@@ -1,0 +1,62 @@
+/// \file ROOT/RNTupleFillStatus.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
+/// \date 2024-04-15
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleFillStatus
+#define ROOT7_RNTupleFillStatus
+
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <cstddef>
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleFillStatus
+\ingroup NTuple
+\brief A status object after filling an entry
+
+After passing an instance to RNTupleWriter::FillNoCommit or RNTupleFillContext::FillNoCommit, the caller must check
+ShouldCommitCluster and call RNTupleWriter::CommitCluster or RNTupleFillContext::CommitCluster if necessary.
+*/
+// clang-format on
+class RNTupleFillStatus {
+   friend class RNTupleFillContext;
+
+private:
+   /// Number of entries written into the current cluster
+   NTupleSize_t fNEntriesSinceLastCommit = 0;
+   /// Number of bytes written into the current cluster
+   std::size_t fUnzippedClusterSize = 0;
+   /// Number of bytes written for the last entry
+   std::size_t fLastEntrySize = 0;
+   bool fShouldCommitCluster = false;
+
+public:
+   /// Return the number of entries written into the current cluster.
+   NTupleSize_t GetNEntries() const { return fNEntriesSinceLastCommit; }
+   /// Return the number of bytes written into the current cluster.
+   std::size_t GetUnzippedClusterSize() const { return fUnzippedClusterSize; }
+   /// Return the number of bytes for the last entry.
+   std::size_t GetLastEntrySize() const { return fLastEntrySize; }
+   /// Return true if the caller should call CommitCluster.
+   bool ShouldCommitCluster() const { return fShouldCommitCluster; }
+}; // class RNTupleFillContext
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleFillStatus

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleFillContext.hxx>
+#include <ROOT/RNTupleFillStatus.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
@@ -106,6 +107,9 @@ public:
    /// a light check whether the entry comes from the ntuple's own model.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(REntry &entry) { return fFillContext.Fill(entry); }
+   /// Fill an entry into this ntuple, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
+   /// and check RNTupleFillStatus::ShouldCommitCluster.
+   void FillNoCommit(REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoCommit(entry, status); }
    /// Ensure that the data from the so far seen Fill calls has been written to storage
    void CommitCluster(bool commitClusterGroup = false)
    {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -324,6 +324,27 @@ TEST(RNTuple, ClusterEntries)
    EXPECT_EQ(20, ntuple->GetDescriptor().GetNClusters());
 }
 
+TEST(RNTuple, ClusterEntriesAuto)
+{
+   FileRaii fileGuard("test_ntuple_cluster_entries_auto.root");
+   auto model = RNTupleModel::Create();
+   auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+
+   {
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      options.SetApproxZippedClusterSize(5 * sizeof(float));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
+      for (int i = 0; i < 100; i++) {
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   // 100 entries / 5 entries per cluster
+   EXPECT_EQ(20, ntuple->GetDescriptor().GetNClusters());
+}
+
 TEST(RNTuple, PageSize)
 {
    FileRaii fileGuard("test_ntuple_elements_per_page.root");

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -314,7 +314,7 @@ TEST(RNTuple, ClusterEntries)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opt);
       for (int i = 0; i < 100; i++) {
          ntuple->Fill();
-         if (i && ((i % 5) == 0))
+         if (((i + 1) % 5) == 0)
             ntuple->CommitCluster();
       }
    }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -8,6 +8,7 @@
 #include <ROOT/RMiniFile.hxx>
 #include <ROOT/RNTupleCollectionWriter.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleFillStatus.hxx>
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -77,6 +78,7 @@ using RNTupleCalcPerf = ROOT::Experimental::Detail::RNTupleCalcPerf;
 using RNTupleCompressor = ROOT::Experimental::Internal::RNTupleCompressor;
 using RNTupleDecompressor = ROOT::Experimental::Internal::RNTupleDecompressor;
 using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
+using RNTupleFillStatus = ROOT::Experimental::RNTupleFillStatus;
 using RNTupleDescriptorBuilder = ROOT::Experimental::Internal::RNTupleDescriptorBuilder;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
 using RNTupleParallelWriter = ROOT::Experimental::RNTupleParallelWriter;


### PR DESCRIPTION
This method can be called instead of `Fill` if the `RNTupleWriter` or `RNTupleFillContext` should not commit the cluster automatically. Instead the calling code must check `ShouldCommitCluster()` and call it explicitly if necessary.

FYI @makortel this should be the interface that we were discussing some time ago, and should also allow to append multiple RNTuples into a single `TFile` using parallel writing: The framework must only call `FillNoCommit` and manually synchronize access to the underlying `TFile` while explicitly invoking `CommitCluster`.