### PR TITLE
Add Jupyter kernels for C++20 and C++2b (Nb: C++2b is a working draft of C++23)

### DIFF
--- a/interpreter/cling/tools/Jupyter/kernel/cling-cpp20/kernel.json
+++ b/interpreter/cling/tools/Jupyter/kernel/cling-cpp20/kernel.json
@@ -1,0 +1,10 @@
+{
+  "display_name": "C++20",
+  "argv": [
+      "jupyter-cling-kernel",
+      "-f",
+      "{connection_file}",
+      "--std=c++20"
+  ],
+  "language": "C++"
+}

--- a/interpreter/cling/tools/Jupyter/kernel/cling-cpp2b/kernel.json
+++ b/interpreter/cling/tools/Jupyter/kernel/cling-cpp2b/kernel.json
@@ -1,0 +1,10 @@
+{
+  "display_name": "C++2b",
+  "argv": [
+      "jupyter-cling-kernel",
+      "-f",
+      "{connection_file}",
+      "--std=c++2b"
+  ],
+  "language": "C++"
+}

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -92,8 +92,8 @@ class ClingKernel(Kernel):
     flush_interval = Float(0.25, config=True)
 
     std = CaselessStrEnum(default_value='c++11',
-            values = ['c++11', 'c++14', 'c++1z', 'c++17'],
-            help="C++ standard to use, either c++17, c++1z, c++14 or c++11").tag(config=True);
+            values = ['c++11', 'c++14', 'c++1z', 'c++17', 'c++20', 'c++2b'],
+            help="C++ standard to use, either c++2b, c++20, c++17, c++1z, c++14 or c++11").tag(config=True);
 
     def __init__(self, **kwargs):
         super(ClingKernel, self).__init__(**kwargs)


### PR DESCRIPTION
## Changes or fixes:

I built from source using the default "ROOT-llvm16" branch of root-project/llvm-project. I didn't have to do much work to allow the creation of updated Jupyter kernels (C++20 and C++2b). I thought I might as well share the result. All the best, Daniel.

(Nb: I moved this pull request from the root/cling mirror site as suggested by @ferdymercury )

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)
