### PR TITLE
[ntuple] Improve handling of large numbers of fields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -436,6 +436,8 @@ private:
    std::uint64_t fNClusters = 0;        ///< Updated by the descriptor builder when the cluster groups are added
    std::uint64_t fNPhysicalColumns = 0; ///< Updated by the descriptor builder when columns are added
 
+   DescriptorId_t fFieldZeroId = kInvalidDescriptorId; ///< Set by the descriptor builder
+
    /**
     * Once constructed by an RNTupleDescriptorBuilder, the descriptor is mostly immutable except for set of
     * active the page locations.  During the lifetime of the descriptor, page location information for clusters
@@ -779,7 +781,7 @@ public:
    NTupleSize_t GetNElements(DescriptorId_t physicalColumnId) const;
 
    /// Returns the logical parent of all top-level NTuple data fields.
-   DescriptorId_t GetFieldZeroId() const;
+   DescriptorId_t GetFieldZeroId() const { return fFieldZeroId; }
    const RFieldDescriptor &GetFieldZero() const { return GetFieldDescriptor(GetFieldZeroId()); }
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    /// Searches for a top-level field

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -91,6 +91,8 @@ private:
    /// The pointers in the other direction from parent to children. They are serialized, too, to keep the
    /// order of sub fields.
    std::vector<DescriptorId_t> fLinkIds;
+   /// The ordered list of columns attached to this field
+   std::vector<DescriptorId_t> fLogicalColumnIds;
 
 public:
    RFieldDescriptor() = default;
@@ -117,6 +119,7 @@ public:
    ENTupleStructure GetStructure() const { return fStructure; }
    DescriptorId_t GetParentId() const { return fParentId; }
    const std::vector<DescriptorId_t> &GetLinkIds() const { return fLinkIds; }
+   const std::vector<DescriptorId_t> &GetLogicalColumnIds() const { return fLogicalColumnIds; }
 };
 
 
@@ -1081,6 +1084,9 @@ class RNTupleDescriptorBuilder {
 private:
    RNTupleDescriptor fDescriptor;
    RResult<void> EnsureFieldExists(DescriptorId_t fieldId) const;
+   // Called by AddColumn() to populate the fLogicalFieldIds member of the field descriptor
+   RResult<void> AttachColumn(DescriptorId_t fieldId, const RColumnDescriptor &columnDesc);
+
 public:
    /// Checks whether invariants hold:
    /// * NTuple name is valid
@@ -1100,8 +1106,10 @@ public:
    void AddField(const RFieldDescriptor& fieldDesc);
    RResult<void> AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
 
-   void AddColumn(DescriptorId_t logicalId, DescriptorId_t physicalId, DescriptorId_t fieldId,
-                  const RColumnModel &model, std::uint32_t index, std::uint64_t firstElementIdx = 0U);
+   // For both AddColumn() methods, the field has to be already available. For fields with multiple columns,
+   // the columns need to be added in order of the column index
+   RResult<void> AddColumn(DescriptorId_t logicalId, DescriptorId_t physicalId, DescriptorId_t fieldId,
+                           const RColumnModel &model, std::uint32_t index, std::uint64_t firstElementIdx = 0U);
    RResult<void> AddColumn(RColumnDescriptor &&columnDesc);
 
    RResult<void> AddClusterGroup(RClusterGroupDescriptor &&clusterGroup);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -291,7 +291,7 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) c
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindLogicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const
 {
-   decltype(fFieldDescriptors)::const_iterator itr = fFieldDescriptors.find(fieldId);
+   auto itr = fFieldDescriptors.find(fieldId);
    if (itr == fFieldDescriptors.cend())
       return kInvalidDescriptorId;
    if (itr->second.GetLogicalColumnIds().size() <= columnIndex)

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -295,11 +295,12 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) c
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindLogicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const
 {
-   for (const auto &cd : fColumnDescriptors) {
-      if (cd.second.GetFieldId() == fieldId && cd.second.GetIndex() == columnIndex)
-         return cd.second.GetLogicalId();
-   }
-   return kInvalidDescriptorId;
+   decltype(fFieldDescriptors)::const_iterator itr = fFieldDescriptors.find(fieldId);
+   if (itr == fFieldDescriptors.cend())
+      return kInvalidDescriptorId;
+   if (itr->second.GetLogicalColumnIds().size() <= columnIndex)
+      return kInvalidDescriptorId;
+   return itr->second.GetLogicalColumnIds().at(columnIndex);
 }
 
 ROOT::Experimental::DescriptorId_t

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -102,7 +102,7 @@ TEST(RNTupleDescriptorBuilder, CatchBadColumnDescriptors)
    }
 
    RColumnDescriptorBuilder colBuilder3;
-   colBuilder3.LogicalColumnId(0).PhysicalColumnId(0).Model(colModel).FieldId(2).Index(0);
+   colBuilder3.LogicalColumnId(0).PhysicalColumnId(0).Model(colModel).FieldId(1).Index(0);
    try {
       descBuilder.AddColumn(colBuilder3.MakeDescriptor().Unwrap()).ThrowOnError();
    } catch (const RException &err) {

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -14,11 +14,11 @@
 
 TEST(RNTuple, DISABLED_Limits_ManyFields)
 {
-   // Writing and reading a model with 20k integer fields takes around 1.5s and seems to have more than linear
-   // complexity (40k fields take 7s).
+   // Writing and reading a model with 40k integer fields takes around 2s and seems to have more than linear
+   // complexity (80k fields take 9s).
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
-   static constexpr int NumFields = 20'000;
+   static constexpr int NumFields = 40'000;
 
    {
       auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -14,11 +14,11 @@
 
 TEST(RNTuple, DISABLED_Limits_ManyFields)
 {
-   // Writing and reading a model with 10k integer fields takes around 30s and seems to have more than quadratic
-   // complexity (5k fields take 6s).
+   // Writing and reading a model with 20k integer fields takes around 4s and seems to have more than quadratic
+   // complexity (10k fields take 1s).
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
-   static constexpr int NumFields = 10'000;
+   static constexpr int NumFields = 20'000;
 
    {
       auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -14,8 +14,8 @@
 
 TEST(RNTuple, DISABLED_Limits_ManyFields)
 {
-   // Writing and reading a model with 20k integer fields takes around 4s and seems to have more than quadratic
-   // complexity (10k fields take 1s).
+   // Writing and reading a model with 20k integer fields takes around 1.5s and seems to have more than linear
+   // complexity (40k fields take 7s).
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
    static constexpr int NumFields = 20'000;


### PR DESCRIPTION
Several fixes to meta-data handling that grew quadratic in the number of fields. The RNTuple limits tests is adjusted from 10k to 40k fields (30s --> 2s).

Finding pages in the RPagePool is a remaining contributor to a noticeable slowdown with a growing number of fields. That will be addressed in a follow-up PR.