### PR TITLE
[gpad] Remove variable redeclaration

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -584,7 +584,7 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
             leg = new TLegend(x1, y1, x2, y2, title);
          TList * hlist = ((THStack *)o)->GetHists();
          TIter nexthist(hlist);
-         while (auto obj = nexthist()) {
+         while ((obj = nexthist())) {
             TH1 *hist = (TH1*) obj;
             if (strlen(hist->GetTitle()))
                mes = hist->GetTitle();


### PR DESCRIPTION
The declaration of `obj` has been moved to an outer scope in PR #15179, resulting in a warning (or error) from `-Wshadow`.


