### PR TITLE
[ntuple] Don't use RRawFile cache for page reads

### DIFF
--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -50,8 +50,8 @@ public:
       ELineBreaks fLineBreak = ELineBreaks::kAuto;
       /// Read at least fBlockSize bytes at a time. A value of zero turns off I/O buffering. A negative value indicates
       /// that the protocol-dependent default block size should be used.
-      /// After construction, a negative block size is used to store the block size value when caching is turned off
-      /// (see `[Enable|Disable]Buffering()`).
+      /// After construction, a negative block size is used to store the block size value when buffering is turned off
+      /// (see `SetBuffering()`).
       int fBlockSize = -1;
       // Define an empty constructor to work around a bug in Clang: https://github.com/llvm/llvm-project/issues/36032
       ROptions() {}

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -50,6 +50,8 @@ public:
       ELineBreaks fLineBreak = ELineBreaks::kAuto;
       /// Read at least fBlockSize bytes at a time. A value of zero turns off I/O buffering. A negative value indicates
       /// that the protocol-dependent default block size should be used.
+      /// After construction, a negative block size is used to store the block size value when caching is turned off
+      /// (see `[Enable|Disable]Buffering()`).
       int fBlockSize = -1;
       // Define an empty constructor to work around a bug in Clang: https://github.com/llvm/llvm-project/issues/36032
       ROptions() {}
@@ -174,6 +176,11 @@ public:
    void ReadV(RIOVec *ioVec, unsigned int nReq);
    /// Returns the limits regarding the ioVec input to ReadV for this specific file; may open the file as a side-effect.
    virtual RIOVecLimits GetReadVLimits() { return RIOVecLimits(); }
+
+   /// Turn off buffered reads; all scalar read requests go directly to the implementation. Buffering can be turned
+   /// back on.
+   void SetIsBuffering(bool value);
+   bool IsBuffering() const { return fOptions.fBlockSize > 0; }
 
    /// Read the next line starting from the current value of fFilePos. Returns false if the end of the file is reached.
    bool Readln(std::string &line);

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -179,7 +179,7 @@ public:
 
    /// Turn off buffered reads; all scalar read requests go directly to the implementation. Buffering can be turned
    /// back on.
-   void SetIsBuffering(bool value);
+   void SetBuffering(bool value);
    bool IsBuffering() const { return fOptions.fBlockSize > 0; }
 
    /// Read the next line starting from the current value of fFilePos. Returns false if the end of the file is reached.

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -199,7 +199,7 @@ void ROOT::Internal::RRawFile::ReadV(RIOVec *ioVec, unsigned int nReq)
    ReadVImpl(ioVec, nReq);
 }
 
-void ROOT::Internal::RRawFile::SetIsBuffering(bool value)
+void ROOT::Internal::RRawFile::SetBuffering(bool value)
 {
    if (value) {
       if (fOptions.fBlockSize < 0) {

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -72,7 +72,7 @@ void ROOT::Internal::RRawFileUnix::OpenImpl()
       throw std::runtime_error("Cannot open '" + fUrl + "', error: " + std::string(strerror(errno)));
    }
 
-   if (fOptions.fBlockSize >= 0)
+   if (fOptions.fBlockSize != ROptions::kUseDefaultBlockSize)
       return;
 
 #ifdef R__SEEK64

--- a/io/io/src/RRawFileWin.cxx
+++ b/io/io/src/RRawFileWin.cxx
@@ -58,7 +58,7 @@ void ROOT::Internal::RRawFileWin::OpenImpl()
    // Prevent double buffering
    int res = setvbuf(fFilePtr, nullptr, _IONBF, 0);
    R__ASSERT(res == 0);
-   if (fOptions.fBlockSize < 0)
+   if (fOptions.fBlockSize == ROptions::kUseDefaultBlockSize)
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -217,6 +217,39 @@ TEST(RRawFile, ReadBuffered)
    EXPECT_EQ(1u, f->fNumReadAt); f->fNumReadAt = 0;
 }
 
+TEST(RRawFile, SetBuffering)
+{
+   char buffer[3];
+   RRawFile::ROptions options;
+   options.fBlockSize = 2;
+   std::unique_ptr<RRawFileMock> f(new RRawFileMock("abcd", options));
+
+   buffer[2] = '\0';
+   EXPECT_EQ(1u, f->ReadAt(buffer, 1, 0));
+   EXPECT_EQ(1u, f->ReadAt(buffer + 1, 1, 1));
+   EXPECT_STREQ("ab", buffer);
+   EXPECT_EQ(1u, f->fNumReadAt);
+   f->fNumReadAt = 0;
+
+   f->SetIsBuffering(false);
+   // idempotent
+   f->SetIsBuffering(false);
+   EXPECT_EQ(1u, f->ReadAt(buffer, 1, 0));
+   EXPECT_EQ(1u, f->ReadAt(buffer + 1, 1, 1));
+   EXPECT_STREQ("ab", buffer);
+   EXPECT_EQ(2u, f->fNumReadAt);
+   f->fNumReadAt = 0;
+
+   f->SetIsBuffering(true);
+   // idempotent
+   f->SetIsBuffering(true);
+   EXPECT_EQ(1u, f->ReadAt(buffer, 1, 2));
+   EXPECT_EQ(1u, f->ReadAt(buffer + 1, 1, 3));
+   EXPECT_STREQ("cd", buffer);
+   EXPECT_EQ(1u, f->fNumReadAt);
+   f->fNumReadAt = 0;
+}
+
 TEST(RRawFileTFile, TFile)
 {
    FileRaii tfileGuard("test_rawfile_tfile.root", "");

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -231,18 +231,18 @@ TEST(RRawFile, SetBuffering)
    EXPECT_EQ(1u, f->fNumReadAt);
    f->fNumReadAt = 0;
 
-   f->SetIsBuffering(false);
+   f->SetBuffering(false);
    // idempotent
-   f->SetIsBuffering(false);
+   f->SetBuffering(false);
    EXPECT_EQ(1u, f->ReadAt(buffer, 1, 0));
    EXPECT_EQ(1u, f->ReadAt(buffer + 1, 1, 1));
    EXPECT_STREQ("ab", buffer);
    EXPECT_EQ(2u, f->fNumReadAt);
    f->fNumReadAt = 0;
 
-   f->SetIsBuffering(true);
+   f->SetBuffering(true);
    // idempotent
-   f->SetIsBuffering(true);
+   f->SetBuffering(true);
    EXPECT_EQ(1u, f->ReadAt(buffer, 1, 2));
    EXPECT_EQ(1u, f->ReadAt(buffer + 1, 1, 3));
    EXPECT_STREQ("cd", buffer);

--- a/net/davix/src/RRawFileDavix.cxx
+++ b/net/davix/src/RRawFileDavix.cxx
@@ -75,7 +75,7 @@ void ROOT::Internal::RRawFileDavix::OpenImpl()
    if (fFileDes->fd == nullptr) {
       throw std::runtime_error("Cannot open '" + fUrl + "', error: " + err->getErrMsg());
    }
-   if (fOptions.fBlockSize < 0)
+   if (fOptions.fBlockSize == ROptions::kUseDefaultBlockSize)
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 

--- a/net/netxng/src/RRawFileNetXNG.cxx
+++ b/net/netxng/src/RRawFileNetXNG.cxx
@@ -77,7 +77,8 @@ void ROOT::Internal::RRawFileNetXNG::OpenImpl()
    if( !st.IsOK() )
      throw std::runtime_error( "Cannot open '" + fUrl + "', " +
                                st.ToString() + "; " + st.GetErrorMessage() );
-   if( fOptions.fBlockSize < 0 ) fOptions.fBlockSize = kDefaultBlockSize;
+   if (fOptions.fBlockSize == ROptions::kUseDefaultBlockSize)
+      fOptions.fBlockSize = kDefaultBlockSize;
 }
 
 size_t ROOT::Internal::RRawFileNetXNG::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -127,7 +127,6 @@ private:
    /// Deserialized header and footer into a minimal descriptor held by fDescriptorBuilder
    void InitDescriptor(const RNTuple &anchor);
 
-   static ROOT::Internal::RRawFile::ROptions GetDefaultRawfileOptions();
    RPageSourceFile(std::string_view ntupleName, const RNTupleReadOptions &options);
 
    RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -127,6 +127,7 @@ private:
    /// Deserialized header and footer into a minimal descriptor held by fDescriptorBuilder
    void InitDescriptor(const RNTuple &anchor);
 
+   static ROOT::Internal::RRawFile::ROptions GetDefaultRawfileOptions();
    RPageSourceFile(std::string_view ntupleName, const RNTupleReadOptions &options);
 
    RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -331,7 +331,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
    }
 
    // For the page reads, we rely on the I/O scheduler to define the read requests
-   fFile->SetIsBuffering(false);
+   fFile->SetBuffering(false);
 
    return desc;
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -224,6 +224,14 @@ void ROOT::Experimental::Internal::RPageSinkFile::ReleasePage(RPage &page)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ROOT::Internal::RRawFile::ROptions ROOT::Experimental::Internal::RPageSourceFile::GetDefaultRawfileOptions()
+{
+   ROOT::Internal::RRawFile::ROptions options;
+   // No additional caching, the page source gets full control over the read byte ranges
+   options.fBlockSize = 0;
+   return options;
+}
+
 ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view ntupleName,
                                                                const RNTupleReadOptions &options)
    : RPageSource(ntupleName, options),
@@ -246,7 +254,7 @@ ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view 
 
 ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view ntupleName, std::string_view path,
                                                                const RNTupleReadOptions &options)
-   : RPageSourceFile(ntupleName, ROOT::Internal::RRawFile::Create(path), options)
+   : RPageSourceFile(ntupleName, ROOT::Internal::RRawFile::Create(path, GetDefaultRawfileOptions()), options)
 {
 }
 
@@ -293,9 +301,9 @@ ROOT::Experimental::Internal::RPageSourceFile::CreateFromAnchor(const RNTuple &a
    auto url = anchor.fFile->GetEndpointUrl();
    auto protocol = std::string(url->GetProtocol());
    if (className == "TFile") {
-      rawFile = ROOT::Internal::RRawFile::Create(url->GetFile());
+      rawFile = ROOT::Internal::RRawFile::Create(url->GetFile(), GetDefaultRawfileOptions());
    } else if (className == "TDavixFile" || className == "TNetXNGFile") {
-      rawFile = ROOT::Internal::RRawFile::Create(url->GetUrl());
+      rawFile = ROOT::Internal::RRawFile::Create(url->GetUrl(), GetDefaultRawfileOptions());
    } else {
       rawFile.reset(new ROOT::Internal::RRawFileTFile(anchor.fFile));
    }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -224,14 +224,6 @@ void ROOT::Experimental::Internal::RPageSinkFile::ReleasePage(RPage &page)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::Internal::RRawFile::ROptions ROOT::Experimental::Internal::RPageSourceFile::GetDefaultRawfileOptions()
-{
-   ROOT::Internal::RRawFile::ROptions options;
-   // No additional caching, the page source gets full control over the read byte ranges
-   options.fBlockSize = 0;
-   return options;
-}
-
 ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view ntupleName,
                                                                const RNTupleReadOptions &options)
    : RPageSource(ntupleName, options),
@@ -254,7 +246,7 @@ ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view 
 
 ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view ntupleName, std::string_view path,
                                                                const RNTupleReadOptions &options)
-   : RPageSourceFile(ntupleName, ROOT::Internal::RRawFile::Create(path, GetDefaultRawfileOptions()), options)
+   : RPageSourceFile(ntupleName, ROOT::Internal::RRawFile::Create(path), options)
 {
 }
 
@@ -301,9 +293,9 @@ ROOT::Experimental::Internal::RPageSourceFile::CreateFromAnchor(const RNTuple &a
    auto url = anchor.fFile->GetEndpointUrl();
    auto protocol = std::string(url->GetProtocol());
    if (className == "TFile") {
-      rawFile = ROOT::Internal::RRawFile::Create(url->GetFile(), GetDefaultRawfileOptions());
+      rawFile = ROOT::Internal::RRawFile::Create(url->GetFile());
    } else if (className == "TDavixFile" || className == "TNetXNGFile") {
-      rawFile = ROOT::Internal::RRawFile::Create(url->GetUrl(), GetDefaultRawfileOptions());
+      rawFile = ROOT::Internal::RRawFile::Create(url->GetUrl());
    } else {
       rawFile.reset(new ROOT::Internal::RRawFileTFile(anchor.fFile));
    }
@@ -337,6 +329,9 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
 
       RNTupleSerializer::DeserializePageList(buffer.get(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc);
    }
+
+   // For the page reads, we rely on the I/O scheduler to define the read requests
+   fFile->SetIsBuffering(false);
 
    return desc;
 }


### PR DESCRIPTION
The RPageSourceFile's use of RRawFile should not use the raw file's block cache layer for the page reads. The page source knows exactly which byte ranges are required. It makes itself I/O scheduling decisions (e.g., coalescing, vector reads) to optimize the read pattern.

For opening the file, getting the RNTuple anchor and meta-data, however, we keep the buffered reads.
