### PR TITLE
[cmake] Add back cxx_std_ compile feature [v6.32]

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -915,6 +915,10 @@ function(ROOT_LINKER_LIBRARY library)
     target_link_libraries(${library} PUBLIC ${ARG_LIBRARIES} ${ARG_DEPENDENCIES})
   endif()
 
+  if(DEFINED CMAKE_CXX_STANDARD)
+    target_compile_features(${library} INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
+  endif()
+
   if(PROJECT_NAME STREQUAL "ROOT")
     if(NOT TARGET ROOT::${library})
       add_library(ROOT::${library} ALIAS ${library})


### PR DESCRIPTION
Partially revert commit d487a42b311 ("[cmake] Set CMAKE_CXX_STANDARD explicitly in RootUseFile.cmake") because this is required to propagate the C++ standard via CMake library targets, as advertised on the website.

Fixes #15253

(cherry picked from commit 9e67151fac9c9d61692375c27604370451b7148b; backport of https://github.com/root-project/root/pull/15254)