### PR TITLE
Reduce the memory footprint of the computation graph

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -101,6 +101,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RActionBase.cxx
     src/RCsvDS.cxx
     src/RDefineBase.cxx
+    src/RDefineReader.cxx
     src/RCutFlowReport.cxx
     src/RDataFrame.cxx
     src/RDatasetSpec.cxx
@@ -125,6 +126,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RSample.cxx
     src/RResultPtr.cxx
     src/RVariationBase.cxx
+    src/RVariationReader.cxx
     src/RVariationsDescription.cxx
     src/RRootDS.cxx
     src/RTrivialDS.cxx

--- a/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
@@ -131,7 +131,19 @@ public:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Adds the column defined up to the node
-   void AddDefinedColumns(const std::vector<std::string> &columns) { fDefinedColumns = columns; }
+   void AddDefinedColumns(const std::vector<std::string_view> &columns)
+   {
+      // TODO: Converting the string_views for backward compatibility.
+      // Since they are names of defined columns, they were added to the
+      // register of column names of the RLoopManager object by the
+      // RColumnRegister, so we could also change fDefinedColumns to only
+      // store string_views
+      fDefinedColumns.clear();
+      fDefinedColumns.reserve(columns.size());
+      for (const auto &col : columns) {
+         fDefinedColumns.push_back(std::string(col));
+      };
+   }
 
    std::string GetColor() const { return fColor; }
    unsigned int GetID() const { return fID; }

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -143,7 +143,7 @@ public:
 
       auto upmostNode = AddDefinesToGraph(thisNode, GetColRegister(), prevColumns, visitedMap);
 
-      thisNode->AddDefinedColumns(GetColRegister().GetNames());
+      thisNode->AddDefinedColumns(GetColRegister().GenerateColumnNames());
       upmostNode->SetPrevNode(prevNode);
       return thisNode;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -1,7 +1,8 @@
 // Author: Enrico Guiraud, Danilo Piparo, Massimo Tumolo CERN  06/2018
+// Author: Vincenzo Eduardo Padulano CERN 05/2024
 
 /*************************************************************************
- * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -17,7 +18,9 @@
 #include <unordered_map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
+#include <utility>
 
 namespace ROOT {
 namespace RDF {
@@ -36,38 +39,10 @@ namespace RDF {
 
 namespace RDFDetail = ROOT::Detail::RDF;
 
-class RDefineReader;
 class RVariationBase;
 class RVariationReader;
-
-/// A helper type that keeps track of RDefine objects and their corresponding RDefineReaders.
-class RDefinesWithReaders {
-   using RDefineBase = RDFDetail::RDefineBase;
-
-   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
-   // (see BookDefineJit). it is never null.
-   std::shared_ptr<RDefineBase> fDefine;
-   // Column readers per variation (in the map) per slot (in the vector).
-   std::vector<std::unordered_map<std::string, std::unique_ptr<RDefineReader>>> fReadersPerVariation;
-
-public:
-   RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
-   RDefineBase &GetDefine() const { return *fDefine; }
-   RDefineReader &GetReader(unsigned int slot, const std::string &variationName);
-};
-
-class RVariationsWithReaders {
-   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
-   // (see BookVariationJit). it is never null.
-   std::shared_ptr<RVariationBase> fVariation;
-   // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
-   std::vector<std::unordered_map<std::string, std::unique_ptr<RVariationReader>>> fReadersPerVariation;
-
-public:
-   RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
-   RVariationBase &GetVariation() const { return *fVariation; }
-   RVariationReader &GetReader(unsigned int slot, const std::string &colName, const std::string &variationName);
-};
+class RDefinesWithReaders;
+class RVariationsWithReaders;
 
 /**
  * \class ROOT::Internal::RDF::RColumnRegister
@@ -85,46 +60,48 @@ public:
  * between one node and the next, then the new node contains a new instance of a RColumnRegister that shares all data
  * members with the previous instance except for the one data member that needed updating, which is replaced with a new
  * updated instance.
+ *
+ * The contents of the collections that keep track of other objects of the computation graph are not owned by the
+ * RColumnRegister object. They are registered centrally by the RLoopManager and only accessed via reference in the
+ * RColumnRegister.
  */
 class RColumnRegister {
-   using ColumnNames_t = std::vector<std::string>;
-   using DefinesMap_t = std::unordered_map<std::string, std::shared_ptr<RDefinesWithReaders>>;
-   /// See fVariations for more information on this type.
-   using VariationsMap_t = std::unordered_multimap<std::string, std::shared_ptr<RVariationsWithReaders>>;
+   using VariationsMap_t = std::unordered_multimap<std::string_view, ROOT::Internal::RDF::RVariationsWithReaders *>;
+   using DefinesMap_t = std::vector<std::pair<std::string_view, ROOT::Internal::RDF::RDefinesWithReaders *>>;
+   using AliasesMap_t = std::vector<std::pair<std::string_view, std::string_view>>;
 
-   std::shared_ptr<RDFDetail::RLoopManager> fLoopManager;
+   /// The head node of the computation graph this register belongs to. Never null.
+   ROOT::Detail::RDF::RLoopManager *fLoopManager;
 
+   /// Immutable multimap of Variations, can be shared among several nodes.
+   /// The key is the name of an existing column, the values are all variations
+   /// that affect that column. Variations that affect multiple columns are
+   /// inserted in the map multiple times, once per column, and conversely each
+   /// column (i.e. each key) can have several associated variations.
+   std::shared_ptr<const VariationsMap_t> fVariations;
    /// Immutable collection of Defines, can be shared among several nodes.
    /// The pointee changes if a new Define node is added to the RColumnRegister.
-   std::shared_ptr<DefinesMap_t> fDefines;
+   /// It is a vector because we rely on insertion order to recreate the branch
+   /// of the computation graph where necessary.
+   std::shared_ptr<const DefinesMap_t> fDefines;
    /// Immutable map of Aliases, can be shared among several nodes.
-   std::shared_ptr<const std::unordered_map<std::string, std::string>> fAliases;
-   /// Immutable multimap of Variations, can be shared among several nodes.
-   /// The key is the name of an existing column, the values are all variations that affect that column.
-   /// Variations that affect multiple columns are inserted in the map multiple times, once per column,
-   /// and conversely each column (i.e. each key) can have several associated variations.
-   std::shared_ptr<VariationsMap_t> fVariations;
-   std::shared_ptr<const ColumnNames_t> fColumnNames; ///< Names of Defines and Aliases registered so far.
-
-   void AddName(std::string_view name);
+   /// The pointee changes if a new Alias node is added to the RColumnRegister.
+   /// It is a vector because we rely on insertion order to recreate the branch
+   /// of the computation graph where necessary.
+   std::shared_ptr<const AliasesMap_t> fAliases;
 
    RVariationsWithReaders *FindVariationAndReaders(const std::string &colName, const std::string &variationName);
 
 public:
-   RColumnRegister(const RColumnRegister &) = default;
-   RColumnRegister(RColumnRegister &&) = default;
-   RColumnRegister &operator=(const RColumnRegister &) = default;
-
-   explicit RColumnRegister(std::shared_ptr<RDFDetail::RLoopManager> lm);
-   ~RColumnRegister();
+   explicit RColumnRegister(ROOT::Detail::RDF::RLoopManager *lm);
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Return the list of the names of the defined columns (Defines + Aliases).
-   ColumnNames_t GetNames() const { return *fColumnNames; }
+   std::vector<std::string_view> GenerateColumnNames() const;
 
-   ColumnNames_t BuildDefineNames() const;
+   std::vector<std::string_view> BuildDefineNames() const;
 
-   RDFDetail::RDefineBase *GetDefine(const std::string &colName) const;
+   RDFDetail::RDefineBase *GetDefine(std::string_view colName) const;
 
    bool IsDefineOrAlias(std::string_view name) const;
 
@@ -132,9 +109,10 @@ public:
 
    void AddAlias(std::string_view alias, std::string_view colName);
 
-   bool IsAlias(const std::string &name) const;
+   bool IsAlias(std::string_view name) const;
+   bool IsDefine(std::string_view name) const;
 
-   std::string ResolveAlias(std::string_view alias) const;
+   std::string_view ResolveAlias(std::string_view alias) const;
 
    void AddVariation(std::shared_ptr<RVariationBase> variation);
 
@@ -142,7 +120,7 @@ public:
 
    std::vector<std::string> GetVariationDeps(const std::string &column) const;
 
-   std::vector<std::string> GetVariationDeps(const ColumnNames_t &columns) const;
+   std::vector<std::string> GetVariationDeps(const std::vector<std::string> &columns) const;
 
    ROOT::RDF::RVariationsDescription BuildVariationsDescription() const;
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -39,8 +39,9 @@ class R__CLING_PTRCHECK(off) RDefinePerSample final : public RDefineBase {
 
 public:
    RDefinePerSample(std::string_view name, std::string_view type, F expression, RLoopManager &lm)
-      : RDefineBase(name, type, RDFInternal::RColumnRegister{nullptr}, lm, /*columnNames*/ {}),
-        fExpression(std::move(expression)), fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<RetType_t>())
+      : RDefineBase(name, type, RDFInternal::RColumnRegister{&lm}, lm, /*columnNames*/ {}),
+        fExpression(std::move(expression)),
+        fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<RetType_t>())
    {
       fLoopManager->Register(this);
       auto callUpdate = [this](unsigned int slot, const ROOT::RDF::RSampleInfo &id) { this->Update(slot, id); };

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -18,6 +18,12 @@
 #include <limits>
 #include <type_traits>
 
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
 namespace ROOT {
 namespace Internal {
 namespace RDF {
@@ -48,8 +54,27 @@ public:
    }
 };
 
-}
-}
+/// A helper type that keeps track of RDefine objects and their corresponding RDefineReaders.
+class RDefinesWithReaders {
+
+   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
+   // (see BookDefineJit). it is never null.
+   std::shared_ptr<ROOT::Detail::RDF::RDefineBase> fDefine;
+   // Column readers per variation (in the map) per slot (in the vector).
+   std::vector<std::unordered_map<std::string_view, std::unique_ptr<RDefineReader>>> fReadersPerVariation;
+
+   // Strings that were already used to represent column names in this RDataFrame instance.
+   std::unordered_set<std::string> &fCachedColNames;
+
+public:
+   RDefinesWithReaders(std::shared_ptr<ROOT::Detail::RDF::RDefineBase> define, unsigned int nSlots,
+                       std::unordered_set<std::string> &cachedColNames);
+   ROOT::Detail::RDF::RDefineBase &GetDefine() const { return *fDefine; }
+   ROOT::Internal::RDF::RDefineReader &GetReader(unsigned int slot, std::string_view variationName);
+};
+
+} // namespace RDF
+} // namespace Internal
 }
 
 #endif

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -181,7 +181,7 @@ public:
       auto upmostNode = AddDefinesToGraph(thisNode, fColRegister, prevColumns, visitedMap);
 
       // Keep track of the columns defined up to this point.
-      thisNode->AddDefinedColumns(fColRegister.GetNames());
+      thisNode->AddDefinedColumns(fColRegister.GenerateColumnNames());
 
       upmostNode->SetPrevNode(prevNode);
       return thisNode;

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1207,7 +1207,7 @@ public:
                                                  std::string_view columnNameRegexp = "",
                                                  const RSnapshotOptions &options = RSnapshotOptions())
    {
-      const auto definedColumns = fColRegister.GetNames();
+      const auto definedColumns = fColRegister.GenerateColumnNames();
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
@@ -1350,7 +1350,7 @@ public:
    /// is empty, all columns are selected. See the previous overloads for more information.
    RInterface<RLoopManager> Cache(std::string_view columnNameRegexp = "")
    {
-      const auto definedColumns = fColRegister.GetNames();
+      const auto definedColumns = fColRegister.GenerateColumnNames();
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames =
          tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
@@ -2628,7 +2628,7 @@ public:
       // certainly does not contain named filters.
       // The number 4 takes into account the implicit columns for entry and slot number
       // and their aliases (2 + 2, i.e. {r,t}dfentry_ and {r,t}dfslot_)
-      if (std::is_same<Proxied, RLoopManager>::value && fColRegister.GetNames().size() > 4)
+      if (std::is_same<Proxied, RLoopManager>::value && fColRegister.GenerateColumnNames().size() > 4)
          returnEmptyReport = true;
 
       auto rep = std::make_shared<RCutFlowReport>();

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -52,7 +52,7 @@ namespace RDFInternal = ROOT::Internal::RDF;
 class RInterfaceBase {
 protected:
    ///< The RLoopManager at the root of this computation graph. Never null.
-   RDFDetail::RLoopManager *fLoopManager;
+   std::shared_ptr<ROOT::Detail::RDF::RLoopManager> fLoopManager;
    /// Non-owning pointer to a data-source object. Null if no data-source. RLoopManager has ownership of the object.
    RDataSource *fDataSource = nullptr;
 
@@ -125,7 +125,7 @@ protected:
       }
    }
 
-   RDFDetail::RLoopManager *GetLoopManager() const { return fLoopManager; }
+   RDFDetail::RLoopManager *GetLoopManager() const { return fLoopManager.get(); }
 
    ColumnNames_t GetValidatedColumnNames(const unsigned int nColumns, const ColumnNames_t &columns)
    {

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -22,8 +22,11 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // forward declarations
@@ -44,6 +47,8 @@ std::vector<std::string> GetBranchNames(TTree &t, bool allowDuplicates = true);
 class GraphNode;
 class RActionBase;
 class RVariationBase;
+class RDefinesWithReaders;
+class RVariationsWithReaders;
 
 namespace GraphDrawing {
 class GraphCreatorHelper;
@@ -176,14 +181,26 @@ class RLoopManager : public RNodeBase {
    void UpdateSampleInfo(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
    void UpdateSampleInfo(unsigned int slot, TTreeReader &r);
 
+   std::unordered_set<std::string> fCachedColNames;
+   std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RDefinesWithReaders>>>
+      fUniqueDefinesWithReaders;
+   std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RVariationsWithReaders>>>
+      fUniqueVariationsWithReaders;
+
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
    RLoopManager(std::unique_ptr<TTree> tree, const ColumnNames_t &defaultBranches);
    RLoopManager(ULong64_t nEmptyEntries);
    RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches);
    RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec);
+
+   // Rule of five
+
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
+   RLoopManager(RLoopManager &&) = delete;
+   RLoopManager &operator=(RLoopManager &&) = delete;
+   ~RLoopManager() = default;
 
    void JitDeclarations();
    void Jit();
@@ -243,6 +260,18 @@ public:
 
    void SetEmptyEntryRange(std::pair<ULong64_t, ULong64_t> &&newRange);
    void ChangeSpec(ROOT::RDF::Experimental::RDatasetSpec &&spec);
+
+   std::unordered_set<std::string> &GetColumnNamesCache() { return fCachedColNames; }
+   std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RDefinesWithReaders>>> &
+   GetUniqueDefinesWithReaders()
+   {
+      return fUniqueDefinesWithReaders;
+   }
+   std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RVariationsWithReaders>>> &
+   GetUniqueVariationsWithReaders()
+   {
+      return fUniqueVariationsWithReaders;
+   }
 };
 
 /// \brief Create an RLoopManager that reads a TChain.

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -18,6 +18,9 @@
 
 #include <cassert>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace ROOT {
 
@@ -132,7 +135,15 @@ public:
       // Ranges don't keep track of Defines (they have no RColumnRegister data member).
       // Let's pretend that the Defines of this node are the same as the node above, so that in the graph
       // the Defines will just appear below the Range instead (no functional change).
-      thisNode->AddDefinedColumns(prevColumns);
+      // TODO: Converting the string_views for backward compatibility.
+      // Since they are names of defined columns, they were added to the
+      // register of column names of the RLoopManager object by the
+      // RColumnRegister, so we could also change GetDefinedColumns to return string_views directly
+      std::vector<std::string_view> colsViews;
+      colsViews.reserve(prevColumns.size());
+      for (const auto &col : prevColumns)
+         colsViews.push_back(col);
+      thisNode->AddDefinedColumns(colsViews);
 
       return thisNode;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
@@ -46,6 +46,19 @@ public:
    }
 };
 
+class RVariationsWithReaders {
+   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
+   // (see BookVariationJit). it is never null.
+   std::shared_ptr<RVariationBase> fVariation;
+   // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
+   std::vector<std::unordered_map<std::string, std::unique_ptr<RVariationReader>>> fReadersPerVariation;
+
+public:
+   RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
+   RVariationBase &GetVariation() const { return *fVariation; }
+   RVariationReader &GetReader(unsigned int slot, const std::string &colName, const std::string &variationName);
+};
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -212,7 +212,7 @@ public:
 
       auto upmostNode = AddDefinesToGraph(thisNode, GetColRegister(), prevColumns, visitedMap);
 
-      thisNode->AddDefinedColumns(GetColRegister().GetNames());
+      thisNode->AddDefinedColumns(GetColRegister().GenerateColumnNames());
       upmostNode->SetPrevNode(prevNode);
       return thisNode;
    }

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -22,105 +22,36 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 
-RDefinesWithReaders::RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots)
-   : fDefine(std::move(define)), fReadersPerVariation(nSlots)
+RColumnRegister::RColumnRegister(ROOT::Detail::RDF::RLoopManager *lm)
+   : fLoopManager(lm),
+     fVariations(std::make_shared<const VariationsMap_t>()),
+     fDefines(std::make_shared<const DefinesMap_t>()),
+     fAliases(std::make_shared<const AliasesMap_t>())
 {
-   assert(fDefine != nullptr);
-}
-
-RDefineReader &RDefinesWithReaders::GetReader(unsigned int slot, const std::string &variationName)
-{
-   auto &defineReaders = fReadersPerVariation[slot];
-
-   auto it = defineReaders.find(variationName);
-   if (it != defineReaders.end())
-      return *it->second;
-
-   auto *define = fDefine.get();
-   if (variationName != "nominal")
-      define = &define->GetVariedDefine(variationName);
-
-#if !defined(__clang__) && __GNUC__ >= 7 && __GNUC_MINOR__ >= 3
-   const auto insertion = defineReaders.insert({variationName, std::make_unique<RDefineReader>(slot, *define)});
-   return *insertion.first->second;
-#else
-   // gcc < 7.3 has issues with passing the non-movable std::pair temporary into the insert call
-   auto reader = std::make_unique<RDefineReader>(slot, *define);
-   auto &ret = *reader;
-   defineReaders[variationName] = std::move(reader);
-   return ret;
-#endif
-}
-
-RVariationsWithReaders::RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots)
-   : fVariation(std::move(variation)), fReadersPerVariation(nSlots)
-{
-   assert(fVariation != nullptr);
-}
-
-////////////////////////////////////////////////////////////////////////////
-/// Return a column reader for the given slot, column and variation.
-RVariationReader &
-RVariationsWithReaders::GetReader(unsigned int slot, const std::string &colName, const std::string &variationName)
-{
-   assert(IsStrInVec(variationName, fVariation->GetVariationNames()));
-   assert(IsStrInVec(colName, fVariation->GetColumnNames()));
-
-   auto &varReaders = fReadersPerVariation[slot];
-
-   auto it = varReaders.find(variationName);
-   if (it != varReaders.end())
-      return *it->second;
-
-#if !defined(__clang__) && __GNUC__ >= 7 && __GNUC_MINOR__ >= 3
-   const auto insertion =
-      varReaders.insert({variationName, std::make_unique<RVariationReader>(slot, colName, variationName, *fVariation)});
-   return *insertion.first->second;
-#else
-   // gcc < 7.3 has issues with passing the non-movable std::pair temporary into the insert call
-   auto reader = std::make_unique<RVariationReader>(slot, colName, variationName, *fVariation);
-   auto &ret = *reader;
-   varReaders[variationName] = std::move(reader);
-   return ret;
-#endif
-}
-
-RColumnRegister::RColumnRegister(std::shared_ptr<RDFDetail::RLoopManager> lm)
-   : fLoopManager(lm), fDefines(std::make_shared<DefinesMap_t>()),
-     fAliases(std::make_shared<std::unordered_map<std::string, std::string>>()),
-     fVariations(std::make_shared<VariationsMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
-{
-}
-
-RColumnRegister::~RColumnRegister()
-{
-   // Explicitly empty the containers to decrement the reference count of the
-   // various shared_ptr's, which might cause destructors to be called. For
-   // this, we need the RLoopManager to stay around and we do not want to rely
-   // on the order during member destruction.
-   fAliases.reset();
-   fDefines.reset();
-   fVariations.reset();
-   fColumnNames.reset();
+   // TODO: The RLoopManager could be taken by reference.
+   // We cannot do it now because it would prevent RColumRegister from
+   // being copiable, and that is currently done.
+   assert(fLoopManager != nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Return the list of the names of defined columns (no aliases).
-ColumnNames_t RColumnRegister::BuildDefineNames() const
+std::vector<std::string_view> RColumnRegister::BuildDefineNames() const
 {
-   ColumnNames_t names;
+   std::vector<std::string_view> names;
    names.reserve(fDefines->size());
-   for (auto &kv : *fDefines) {
-      names.emplace_back(kv.first);
+   for (const auto &kv : *fDefines) {
+      names.push_back(kv.first);
    }
    return names;
 }
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Return the RDefine for the requested column name, or nullptr.
-RDFDetail::RDefineBase *RColumnRegister::GetDefine(const std::string &colName) const
+RDFDetail::RDefineBase *RColumnRegister::GetDefine(std::string_view colName) const
 {
-   auto it = fDefines->find(colName);
+   auto it = std::find_if(fDefines->begin(), fDefines->end(),
+                          [&colName](const DefinesMap_t::value_type &kv) { return kv.first == colName; });
    return it == fDefines->end() ? nullptr : &it->second->GetDefine();
 }
 
@@ -128,23 +59,36 @@ RDFDetail::RDefineBase *RColumnRegister::GetDefine(const std::string &colName) c
 /// \brief Check if the provided name is tracked in the names list
 bool RColumnRegister::IsDefineOrAlias(std::string_view name) const
 {
-   const auto ccolnamesEnd = fColumnNames->end();
-   return ccolnamesEnd != std::find(fColumnNames->begin(), ccolnamesEnd, name);
+   return IsDefine(name) || IsAlias(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Add a new defined column.
-/// Internally it recreates the map with the new column, and swaps it with the old one.
+/// Registers the pair (columnName, columnReader) with the current RDataFrame,
+/// then keeps a reference to the inserted objects to keep track of the
+/// available columns for this node. Internally it recreates the collection with
+/// the new column, and swaps it with the old one.
 void RColumnRegister::AddDefine(std::shared_ptr<RDFDetail::RDefineBase> define)
 {
+   auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(define->GetName());
+   auto insertion_defs = fLoopManager->GetUniqueDefinesWithReaders().insert(
+      {*colIt, std::make_unique<ROOT::Internal::RDF::RDefinesWithReaders>(define, fLoopManager->GetNSlots(),
+                                                                          fLoopManager->GetColumnNamesCache())});
+
    auto newDefines = std::make_shared<DefinesMap_t>(*fDefines);
-   const std::string &colName = define->GetName();
-
-   // this will assign over a pre-existing element in case this AddDefine is due to a Redefine
-   (*newDefines)[colName] = std::make_shared<RDefinesWithReaders>(define, fLoopManager->GetNSlots());
-
+   // Structured bindings cannot be used in lambda captures (until C++20)
+   // so we explicitly define variable names here
+   const auto &colAndDefIt = insertion_defs.first;
+   // If there is a Redefine, we need to reinsert the new pointer to the readers into the same element
+   if (auto previousDefIt =
+          std::find_if(newDefines->begin(), newDefines->end(),
+                       [&colAndDefIt](const DefinesMap_t::value_type &kv) { return kv.first == colAndDefIt->first; });
+       previousDefIt != newDefines->end()) {
+      previousDefIt->second = colAndDefIt->second.get();
+   } else {
+      newDefines->push_back({colAndDefIt->first, colAndDefIt->second.get()});
+   }
    fDefines = std::move(newDefines);
-   AddName(colName);
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -153,8 +97,15 @@ void RColumnRegister::AddVariation(std::shared_ptr<RVariationBase> variation)
 {
    auto newVariations = std::make_shared<VariationsMap_t>(*fVariations);
    const std::vector<std::string> &colNames = variation->GetColumnNames();
-   for (auto &colName : colNames)
-      newVariations->insert({colName, std::make_shared<RVariationsWithReaders>(variation, fLoopManager->GetNSlots())});
+
+   // Cache column names for this variation and store views for later use
+   for (const auto &colName : colNames) {
+      auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(colName);
+      auto [colAndVariationsIt, _2] = fLoopManager->GetUniqueVariationsWithReaders().insert(
+         {*colIt, std::make_unique<ROOT::Internal::RDF::RVariationsWithReaders>(variation, fLoopManager->GetNSlots())});
+      newVariations->insert({colAndVariationsIt->first, colAndVariationsIt->second.get()});
+   }
+
    fVariations = std::move(newVariations);
 }
 
@@ -186,7 +137,7 @@ std::vector<std::string> RColumnRegister::GetVariationDeps(const std::string &co
 ///
 /// This list includes variations applied to the columns as well as variations applied to other
 /// columns on which the value of any of these columns depend (typically via Define expressions).
-std::vector<std::string> RColumnRegister::GetVariationDeps(const ColumnNames_t &columns) const
+std::vector<std::string> RColumnRegister::GetVariationDeps(const std::vector<std::string> &columns) const
 {
    // here we assume that columns do not contain aliases, they must have already been resolved
    std::set<std::string> variationNames;
@@ -197,7 +148,8 @@ std::vector<std::string> RColumnRegister::GetVariationDeps(const ColumnNames_t &
          variationNames.insert(var);
 
       // For Define'd columns, add the systematic variations they depend on to the set
-      auto defineIt = fDefines->find(col);
+      auto defineIt = std::find_if(fDefines->begin(), fDefines->end(),
+                                   [&col](const DefinesMap_t::value_type &kv) { return kv.first == col; });
       if (defineIt != fDefines->end()) {
          for (const auto &v : defineIt->second->GetDefine().GetVariations())
             variationNames.insert(v);
@@ -218,7 +170,7 @@ RColumnRegister::FindVariationAndReaders(const std::string &colName, const std::
       return nullptr;
    for (auto it = range.first; it != range.second; ++it) {
       if (IsStrInVec(variationName, it->second->GetVariation().GetVariationNames()))
-         return it->second.get();
+         return it->second;
    }
 
    return nullptr;
@@ -235,39 +187,50 @@ ROOT::RDF::RVariationsDescription RColumnRegister::BuildVariationsDescription() 
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/// \brief Add a new name to the list returned by `GetNames` without booking a new column.
-///
-/// This is needed because we abuse fColumnNames to also keep track of the aliases defined
-/// in each branch of the computation graph.
-/// Internally it recreates the vector with the new name, and swaps it with the old one.
-void RColumnRegister::AddName(std::string_view name)
-{
-   const auto &names = *fColumnNames;
-   if (std::find(names.begin(), names.end(), name) != names.end())
-      return; // must be a Redefine of an existing column. Nothing to do.
-
-   auto newColsNames = std::make_shared<ColumnNames_t>(names);
-   newColsNames->emplace_back(std::string(name));
-   fColumnNames = newColsNames;
-}
-
-////////////////////////////////////////////////////////////////////////////
 /// \brief Add a new alias to the ledger.
+/// Registers the strings alias, colName with the current RDataFrame, then uses
+/// references to those string to create the new pair for the collection of
+/// aliases of this node.
 void RColumnRegister::AddAlias(std::string_view alias, std::string_view colName)
 {
    // at this point validation of alias and colName has already happened, we trust that
    // this is a new, valid alias.
-   auto newAliases = std::make_shared<std::unordered_map<std::string, std::string>>(*fAliases);
-   (*newAliases)[std::string(alias)] = ResolveAlias(colName);
+   auto &colNamesCache = fLoopManager->GetColumnNamesCache();
+   auto insertion_alias = colNamesCache.insert(std::string(alias));
+   auto insertion_col = colNamesCache.insert(std::string(colName));
+
+   auto newAliases = std::make_shared<AliasesMap_t>(*fAliases);
+   // Structured bindings cannot be used in lambda captures (until C++20)
+   // so we explicitly define variable names here
+   const auto &aliasIt = insertion_alias.first;
+   const auto &colIt = insertion_col.first;
+   // If an alias was already present we need to substitute it with the new one
+   if (auto previousAliasIt =
+          std::find_if(newAliases->begin(), newAliases->end(),
+                       [&aliasIt](const AliasesMap_t::value_type &kv) { return kv.first == *aliasIt; });
+       previousAliasIt != newAliases->end()) {
+      previousAliasIt->second = ResolveAlias(*colIt);
+   } else {
+      newAliases->push_back({*aliasIt, ResolveAlias(*colIt)});
+   }
+
    fAliases = std::move(newAliases);
-   AddName(alias);
 }
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Return true if the given column name is an existing alias.
-bool RColumnRegister::IsAlias(const std::string &name) const
+bool RColumnRegister::IsAlias(std::string_view name) const
 {
-   return fAliases->find(name) != fAliases->end();
+   return std::find_if(fAliases->begin(), fAliases->end(),
+                       [&name](const AliasesMap_t::value_type &kv) { return kv.first == name; }) != fAliases->end();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Return true if the given column name is an existing defined column.
+bool RColumnRegister::IsDefine(std::string_view name) const
+{
+   return std::find_if(fDefines->begin(), fDefines->end(),
+                       [&name](const DefinesMap_t::value_type &kv) { return kv.first == name; }) != fDefines->end();
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -275,19 +238,23 @@ bool RColumnRegister::IsAlias(const std::string &name) const
 /// Drills through multiple levels of aliasing if needed.
 /// Returns the input in case it's not an alias.
 /// Expands `#%var` to `R_rdf_sizeof_var` (the #%var columns are implicitly-defined aliases).
-std::string RColumnRegister::ResolveAlias(std::string_view alias) const
+std::string_view RColumnRegister::ResolveAlias(std::string_view alias) const
 {
-   std::string aliasStr{alias};
 
    // #var is an alias for R_rdf_sizeof_var
-   if (aliasStr.size() > 1 && aliasStr[0] == '#')
-      return "R_rdf_sizeof_" + aliasStr.substr(1);
+   if (alias.size() > 1 && alias[0] == '#') {
+      std::string sizeof_colname{"R_rdf_sizeof_"};
+      sizeof_colname.append(alias.substr(1));
+      auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(sizeof_colname);
+      return *colIt;
+   }
 
-   auto it = fAliases->find(aliasStr);
-   if (it != fAliases->end())
+   if (auto it = std::find_if(fAliases->begin(), fAliases->end(),
+                              [&alias](const AliasesMap_t::value_type &kv) { return kv.first == alias; });
+       it != fAliases->end())
       return it->second;
 
-   return aliasStr; // not an alias, i.e. already resolved
+   return alias; // not an alias, i.e. already resolved
 }
 
 /// Return a RDefineReader or a RVariationReader, or nullptr if not available.
@@ -307,7 +274,8 @@ RDFDetail::RColumnReaderBase *RColumnRegister::GetReader(unsigned int slot, cons
    }
 
    // otherwise try defines
-   auto it = fDefines->find(colName);
+   auto it = std::find_if(fDefines->begin(), fDefines->end(),
+                          [&colName](const DefinesMap_t::value_type &kv) { return kv.first == colName; });
    if (it != fDefines->end()) {
       const auto &actualType = it->second->GetDefine().GetTypeId();
       CheckReaderTypeMatches(actualType, requestedType, colName);
@@ -320,3 +288,14 @@ RDFDetail::RColumnReaderBase *RColumnRegister::GetReader(unsigned int slot, cons
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT
+
+std::vector<std::string_view> ROOT::Internal::RDF::RColumnRegister::GenerateColumnNames() const
+{
+   std::vector<std::string_view> ret;
+   ret.reserve(fDefines->size() + fAliases->size());
+   for (const auto &kv : *fDefines)
+      ret.push_back(kv.first);
+   for (const auto &kv : *fAliases)
+      ret.push_back(kv.first);
+   return ret;
+}

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -71,10 +71,10 @@ GraphDrawing::AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRe
                                 std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap)
 {
    auto upmostNode = node;
-   const auto &defineNames = colRegister.GetNames();
+   const auto &defineNames = colRegister.GenerateColumnNames();
    for (auto i = int(defineNames.size()) - 1; i >= 0; --i) { // walk backwards through the names of defined columns
       const auto colName = defineNames[i];
-      const bool isAlias = colRegister.IsDefineOrAlias(colName) && colRegister.GetDefine(colName) == nullptr;
+      const bool isAlias = colRegister.IsAlias(colName);
       if (isAlias || IsInternalColumn(colName))
          continue; // aliases appear in the list of defineNames but we don't support them yet
       const bool isANewDefine =
@@ -83,7 +83,8 @@ GraphDrawing::AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRe
          break; // we walked back through all new defines, the rest is stuff that was already in the graph
 
       // create a node for this new Define
-      auto defineNode = RDFGraphDrawing::CreateDefineNode(colName, colRegister.GetDefine(colName), visitedMap);
+      auto defineNode =
+         RDFGraphDrawing::CreateDefineNode(std::string(colName), colRegister.GetDefine(colName), visitedMap);
       upmostNode->SetPrevNode(defineNode);
       upmostNode = defineNode;
    }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -171,7 +171,7 @@ TString ResolveAliases(const TString &expr, const ColumnNames_t &usedAliases,
    for (const auto &alias : usedAliases) {
       const auto &col = colRegister.ResolveAlias(alias);
       TPRegexp replacer("\\b" + EscapeDots(alias) + "\\b");
-      replacer.Substitute(out, col, "g");
+      replacer.Substitute(out, col.data(), "g");
    }
 
    return out;
@@ -486,26 +486,25 @@ ConvertRegexToColumns(const ColumnNames_t &colNames, std::string_view columnName
 void CheckForRedefinition(const std::string &where, std::string_view definedColView, const RColumnRegister &colRegister,
                           const ColumnNames_t &treeColumns, const ColumnNames_t &dataSourceColumns)
 {
-   const std::string definedCol(definedColView); // convert to std::string
 
-   std::string error;
-   if (colRegister.IsAlias(definedCol))
-      error = "An alias with that name, pointing to column \"" + colRegister.ResolveAlias(definedCol) +
+   std::string error{};
+   if (colRegister.IsAlias(definedColView))
+      error = "An alias with that name, pointing to column \"" + std::string(colRegister.ResolveAlias(definedColView)) +
               "\", already exists in this branch of the computation graph.";
-   else if (colRegister.IsDefineOrAlias(definedCol))
+   else if (colRegister.IsDefineOrAlias(definedColView))
       error = "A column with that name has already been Define'd. Use Redefine to force redefinition.";
-   // else, check if definedCol is in the list of tree branches. This is a bit better than interrogating the TTree
+   // else, check if definedColView is in the list of tree branches. This is a bit better than interrogating the TTree
    // directly because correct usage of GetBranch, FindBranch, GetLeaf and FindLeaf can be tricky; so let's assume we
    // got it right when we collected the list of available branches.
-   else if (std::find(treeColumns.begin(), treeColumns.end(), definedCol) != treeColumns.end())
+   else if (std::find(treeColumns.begin(), treeColumns.end(), definedColView) != treeColumns.end())
       error =
          "A branch with that name is already present in the input TTree/TChain. Use Redefine to force redefinition.";
-   else if (std::find(dataSourceColumns.begin(), dataSourceColumns.end(), definedCol) != dataSourceColumns.end())
+   else if (std::find(dataSourceColumns.begin(), dataSourceColumns.end(), definedColView) != dataSourceColumns.end())
       error =
          "A column with that name is already present in the input data source. Use Redefine to force redefinition.";
 
    if (!error.empty()) {
-      error = "RDataFrame::" + where + ": cannot define column \"" + definedCol + "\". " + error;
+      error = "RDataFrame::" + where + ": cannot define column \"" + std::string(definedColView) + "\". " + error;
       throw std::runtime_error(error);
    }
 }
@@ -514,29 +513,29 @@ void CheckForRedefinition(const std::string &where, std::string_view definedColV
 void CheckForDefinition(const std::string &where, std::string_view definedColView, const RColumnRegister &colRegister,
                         const ColumnNames_t &treeColumns, const ColumnNames_t &dataSourceColumns)
 {
-   const std::string definedCol(definedColView); // convert to std::string
-   std::string error;
+   std::string error{};
 
-   if (colRegister.IsAlias(definedCol)) {
-      error = "An alias with that name, pointing to column \"" + colRegister.ResolveAlias(definedCol) +
+   if (colRegister.IsAlias(definedColView)) {
+      error = "An alias with that name, pointing to column \"" + std::string(colRegister.ResolveAlias(definedColView)) +
               "\", already exists. Aliases cannot be Redefined or Varied.";
    }
 
    if (error.empty()) {
-      const bool isAlreadyDefined = colRegister.IsDefineOrAlias(definedCol);
+      const bool isAlreadyDefined = colRegister.IsDefineOrAlias(definedColView);
       // check if definedCol is in the list of tree branches. This is a bit better than interrogating the TTree
       // directly because correct usage of GetBranch, FindBranch, GetLeaf and FindLeaf can be tricky; so let's assume we
       // got it right when we collected the list of available branches.
-      const bool isABranch = std::find(treeColumns.begin(), treeColumns.end(), definedCol) != treeColumns.end();
+      const bool isABranch = std::find(treeColumns.begin(), treeColumns.end(), definedColView) != treeColumns.end();
       const bool isADSColumn =
-         std::find(dataSourceColumns.begin(), dataSourceColumns.end(), definedCol) != dataSourceColumns.end();
+         std::find(dataSourceColumns.begin(), dataSourceColumns.end(), definedColView) != dataSourceColumns.end();
 
       if (!isAlreadyDefined && !isABranch && !isADSColumn)
          error = "No column with that name was found in the dataset. Use Define to create a new column.";
    }
 
    if (!error.empty()) {
-      error = "RDataFrame::" + where + ": cannot redefine or vary column \"" + definedCol + "\". " + error;
+      error =
+         "RDataFrame::" + where + ": cannot redefine or vary column \"" + std::string(definedColView) + "\". " + error;
       throw std::runtime_error(error);
    }
 }

--- a/tree/dataframe/src/RDefineReader.cxx
+++ b/tree/dataframe/src/RDefineReader.cxx
@@ -1,0 +1,50 @@
+/**
+ \author Vincenzo Eduardo Padulano
+ \date 2024-04
+*/
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+#include <cassert>
+
+#include "ROOT/RDF/RDefineReader.hxx"
+
+ROOT::Internal::RDF::RDefinesWithReaders::RDefinesWithReaders(std::shared_ptr<ROOT::Detail::RDF::RDefineBase> define,
+                                                              unsigned int nSlots,
+                                                              std::unordered_set<std::string> &cachedColNames)
+   : fDefine(std::move(define)), fReadersPerVariation(nSlots), fCachedColNames(cachedColNames)
+{
+   assert(fDefine != nullptr);
+}
+
+ROOT::Internal::RDF::RDefineReader &
+ROOT::Internal::RDF::RDefinesWithReaders::GetReader(unsigned int slot, std::string_view variationName)
+{
+   auto [nameIt, _] = fCachedColNames.insert(std::string(variationName));
+   auto &defineReaders = fReadersPerVariation[slot];
+
+   auto it = defineReaders.find(*nameIt);
+   if (it != defineReaders.end())
+      return *it->second;
+
+   auto *define = fDefine.get();
+   if (*nameIt != "nominal")
+      define = &define->GetVariedDefine(std::string(variationName));
+
+#if !defined(__clang__) && __GNUC__ >= 7 && __GNUC_MINOR__ >= 3
+   const auto insertion =
+      defineReaders.insert({*nameIt, std::make_unique<ROOT::Internal::RDF::RDefineReader>(slot, *define)});
+   return *insertion.first->second;
+#else
+   // gcc < 7.3 has issues with passing the non-movable std::pair temporary into the insert call
+   auto reader = std::make_unique<ROOT::Internal::RDF::RDefineReader>(slot, *define);
+   auto &ret = *reader;
+   defineReaders[*nameIt] = std::move(reader);
+   return ret;
+#endif
+}

--- a/tree/dataframe/src/RInterfaceBase.cxx
+++ b/tree/dataframe/src/RInterfaceBase.cxx
@@ -119,13 +119,15 @@ std::string ROOT::RDF::RInterfaceBase::DescribeDataset() const
 }
 
 ROOT::RDF::RInterfaceBase::RInterfaceBase(std::shared_ptr<RDFDetail::RLoopManager> lm)
-   : fLoopManager(lm.get()), fDataSource(lm->GetDataSource()), fColRegister(std::move(lm))
+   : fLoopManager(lm), fDataSource(lm->GetDataSource()), fColRegister(lm.get())
 {
    AddDefaultColumns();
 }
 
 ROOT::RDF::RInterfaceBase::RInterfaceBase(RDFDetail::RLoopManager &lm, const RDFInternal::RColumnRegister &colRegister)
-   : fLoopManager(&lm), fDataSource(lm.GetDataSource()), fColRegister(colRegister)
+   : fLoopManager(std::shared_ptr<ROOT::Detail::RDF::RLoopManager>{&lm, [](ROOT::Detail::RDF::RLoopManager *) {}}),
+     fDataSource(lm.GetDataSource()),
+     fColRegister(colRegister)
 {
 }
 
@@ -152,7 +154,7 @@ ROOT::RDF::ColumnNames_t ROOT::RDF::RInterfaceBase::GetColumnNames()
          allColumns.emplace(colName);
    };
 
-   auto definedColumns = fColRegister.GetNames();
+   auto definedColumns = fColRegister.GenerateColumnNames();
 
    std::for_each(definedColumns.begin(), definedColumns.end(), addIfNotInternal);
 
@@ -189,13 +191,13 @@ ROOT::RDF::ColumnNames_t ROOT::RDF::RInterfaceBase::GetColumnNames()
 ///
 std::string ROOT::RDF::RInterfaceBase::GetColumnType(std::string_view column)
 {
-   const auto col = fColRegister.ResolveAlias(std::string(column));
+   const auto col = fColRegister.ResolveAlias(column);
 
    RDFDetail::RDefineBase *define = fColRegister.GetDefine(col);
 
    const bool convertVector2RVec = true;
-   return RDFInternal::ColumnName2ColumnTypeName(col, fLoopManager->GetTree(), fLoopManager->GetDataSource(), define,
-                                                 convertVector2RVec);
+   return RDFInternal::ColumnName2ColumnTypeName(std::string(col), fLoopManager->GetTree(),
+                                                 fLoopManager->GetDataSource(), define, convertVector2RVec);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -18,7 +18,7 @@
 using namespace ROOT::Detail::RDF;
 
 RJittedFilter::RJittedFilter(RLoopManager *lm, std::string_view name, const std::vector<std::string> &variations)
-   : RFilterBase(lm, name, lm->GetNSlots(), RDFInternal::RColumnRegister(nullptr), /*columnNames*/ {}, variations)
+   : RFilterBase(lm, name, lm->GetNSlots(), RDFInternal::RColumnRegister(lm), /*columnNames*/ {}, variations)
 {
    // Jitted nodes of the computation graph (e.g. RJittedAction, RJittedDefine) usually don't need to register
    // themselves with the RLoopManager: the _concrete_ nodes will be registered with the RLoopManager right before

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -12,10 +12,12 @@
 #include "ROOT/InternalTreeUtils.hxx" // GetTreeFullPaths
 #include "ROOT/RDF/RActionBase.hxx"
 #include "ROOT/RDF/RDefineBase.hxx"
+#include "ROOT/RDF/RDefineReader.hxx" // RDefinesWithReaders
 #include "ROOT/RDF/RFilterBase.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRangeBase.hxx"
 #include "ROOT/RDF/RVariationBase.hxx"
+#include "ROOT/RDF/RVariationReader.hxx" // RVariationsWithReaders
 #include "ROOT/RLogger.hxx"
 #include "RtypesCore.h" // Long64_t
 #include "TStopwatch.h"

--- a/tree/dataframe/src/RVariationReader.cxx
+++ b/tree/dataframe/src/RVariationReader.cxx
@@ -1,0 +1,51 @@
+/**
+ \author Vincenzo Eduardo Padulano
+ \date 2024-04
+*/
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+#include <cassert>
+
+#include "ROOT/RDF/RVariationReader.hxx"
+#include "ROOT/RDF/Utils.hxx" // IsStrInVec
+
+ROOT::Internal::RDF::RVariationsWithReaders::RVariationsWithReaders(
+   std::shared_ptr<ROOT::Internal::RDF::RVariationBase> variation, unsigned int nSlots)
+   : fVariation(std::move(variation)), fReadersPerVariation(nSlots)
+{
+   assert(fVariation != nullptr);
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// Return a column reader for the given slot, column and variation.
+ROOT::Internal::RDF::RVariationReader &
+ROOT::Internal::RDF::RVariationsWithReaders::GetReader(unsigned int slot, const std::string &colName,
+                                                       const std::string &variationName)
+{
+   assert(ROOT::Internal::RDF::IsStrInVec(variationName, fVariation->GetVariationNames()));
+   assert(ROOT::Internal::RDF::IsStrInVec(colName, fVariation->GetColumnNames()));
+
+   auto &varReaders = fReadersPerVariation[slot];
+
+   auto it = varReaders.find(variationName);
+   if (it != varReaders.end())
+      return *it->second;
+
+#if !defined(__clang__) && __GNUC__ >= 7 && __GNUC_MINOR__ >= 3
+   const auto insertion = varReaders.insert({variationName, std::make_unique<ROOT::Internal::RDF::RVariationReader>(
+                                                               slot, colName, variationName, *fVariation)});
+   return *insertion.first->second;
+#else
+   // gcc < 7.3 has issues with passing the non-movable std::pair temporary into the insert call
+   auto reader = std::make_unique<ROOT::Internal::RDF::RVariationReader>(slot, colName, variationName, *fVariation);
+   auto &ret = *reader;
+   varReaders[variationName] = std::move(reader);
+   return ret;
+#endif
+}

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -136,7 +136,8 @@ TEST(RDataFrameUtils, FindUnknownColumns)
    TTree t("t", "t");
    t.Branch("a", &i);
 
-   RDFInt::RColumnRegister defs(nullptr);
+   ROOT::Detail::RDF::RLoopManager lm{1};
+   RDFInt::RColumnRegister defs(&lm);
    defs.AddAlias("b", "a");
 
    auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), defs, {});
@@ -151,7 +152,8 @@ TEST(RDataFrameUtils, FindUnknownColumnsWithDataSource)
    TTree t("t", "t");
    t.Branch("a", &i);
 
-   RDFInt::RColumnRegister defs(nullptr);
+   ROOT::Detail::RDF::RLoopManager lm{1};
+   RDFInt::RColumnRegister defs(&lm);
    defs.AddAlias("b", "a");
 
    auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), defs, {"c"});
@@ -170,8 +172,9 @@ TEST(RDataFrameUtils, FindUnknownColumnsNestedNames)
    DummyStruct s{1, 2};
    t.Branch("s", &s, "a/I:b/I");
 
+   ROOT::Detail::RDF::RLoopManager lm{1};
    auto unknownCols = RDFInt::FindUnknownColumns({"s.a", "s.b", "s", "s.", ".s", "_asd_"}, RDFInt::GetBranchNames(t),
-                                                 RDFInt::RColumnRegister{nullptr}, {});
+                                                 RDFInt::RColumnRegister{&lm}, {});
    const auto trueUnknownCols = std::vector<std::string>({"s", "s.", ".s", "_asd_"});
    EXPECT_EQ(unknownCols, trueUnknownCols);
 }
@@ -198,8 +201,9 @@ TEST(RDataFrameUtils, FindUnknownColumnsFriendTrees)
    t1.AddFriend(&t2);
    t1.AddFriend(&t4);
 
+   ROOT::Detail::RDF::RLoopManager lm{1};
    auto ncols =
-      RDFInt::FindUnknownColumns({"c2", "c3", "c4"}, RDFInt::GetBranchNames(t1), RDFInt::RColumnRegister{nullptr}, {});
+      RDFInt::FindUnknownColumns({"c2", "c3", "c4"}, RDFInt::GetBranchNames(t1), RDFInt::RColumnRegister{&lm}, {});
    EXPECT_EQ(ncols.size(), 0u) << "Cannot find column in friend trees.";
 }
 


### PR DESCRIPTION
Move the actual creation of an RDefineReader and the relative string representing its column name to a centralized register in the RLoopManager. The RColumnRegister only holds references to that.

Fixes #14510