### PR TITLE
[xrootd] fix setting readv limits for raw file

### DIFF
--- a/net/netxng/src/RRawFileNetXNG.cxx
+++ b/net/netxng/src/RRawFileNetXNG.cxx
@@ -157,16 +157,16 @@ ROOT::Internal::RRawFile::RIOVecLimits ROOT::Internal::RRawFileNetXNG::GetReadVL
    strmResponse.str(response->ToString());
    delete response;
 
-   std::string readvIorMax;
-   std::string readvIovMax;
-   if (!std::getline(strmResponse, readvIorMax) || !std::getline(strmResponse, readvIovMax)) {
+   std::string readvMaxSingleSize;
+   std::string readvMaxReqs;
+   if (!std::getline(strmResponse, readvMaxSingleSize) || !std::getline(strmResponse, readvMaxReqs)) {
       if (gDebug >= 1)
          Info("GetReadVLimits", "unexpected response from querying readv limits, using default values");
       return *fIOVecLimits;
    }
 
-   if (!readvIovMax.empty() && std::isdigit(readvIovMax[0])) {
-      std::size_t val = std::stoi(readvIovMax);
+   if (!readvMaxReqs.empty() && std::isdigit(readvMaxReqs[0])) {
+      std::size_t val = std::stoi(readvMaxReqs);
       // Workaround a dCache bug reported here: https://sft.its.cern.ch/jira/browse/ROOT-6639
       if (val == 0x7FFFFFFF)
          return *fIOVecLimits;
@@ -174,8 +174,8 @@ ROOT::Internal::RRawFile::RIOVecLimits ROOT::Internal::RRawFileNetXNG::GetReadVL
       fIOVecLimits->fMaxReqs = val;
    }
 
-   if (!readvIorMax.empty() && std::isdigit(readvIorMax[0])) {
-      fIOVecLimits->fMaxSingleSize = std::stoi(readvIorMax);
+   if (!readvMaxSingleSize.empty() && std::isdigit(readvMaxSingleSize[0])) {
+      fIOVecLimits->fMaxSingleSize = std::stoi(readvMaxSingleSize);
    }
 
    return *fIOVecLimits;

--- a/net/netxng/src/RRawFileNetXNG.cxx
+++ b/net/netxng/src/RRawFileNetXNG.cxx
@@ -171,11 +171,11 @@ ROOT::Internal::RRawFile::RIOVecLimits ROOT::Internal::RRawFileNetXNG::GetReadVL
       if (val == 0x7FFFFFFF)
          return *fIOVecLimits;
 
-      fIOVecLimits->fMaxSingleSize = val;
+      fIOVecLimits->fMaxReqs = val;
    }
 
    if (!readvIorMax.empty() && std::isdigit(readvIorMax[0])) {
-      fIOVecLimits->fMaxReqs = std::stoi(readvIorMax);
+      fIOVecLimits->fMaxSingleSize = std::stoi(readvIorMax);
    }
 
    return *fIOVecLimits;


### PR DESCRIPTION
The maximum number of requests per vector read and the maximum size of a single request in that vector read were mixed up.  As a result, for a typical server, requests >1kB would not end up in a vector read.

This PR is fixing it.