### PR TITLE
[RF] Remove warning about unused variables in `RooFormula`

### DIFF
--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -201,13 +201,6 @@ RooFormula::RooFormula(const char* name, const char* formula, const RooArgList& 
   _isCategory = findCategoryServers(_origList);
 
   installFormulaOrThrow(formula);
-
-  RooArgList useList = usedVariables();
-  if (checkVariables && _origList.size() != useList.size()) {
-    coutI(InputArguments) << "The formula " << GetName() << " claims to use the variables " << _origList
-        << " but only " << useList << " seem to be in use."
-        << "\n  inputs:         " << formula << std::endl;
-  }
 }
 
 


### PR DESCRIPTION
After commit a27e60a6d4f, it is not important anymore that only the variables used by the expression are passed to RooFormula.

Removing the corresponding warnings helps to get rid of useless warnings in the case where you want to try out variations of the formula that omit certain terms, and in particular it helps in
`RooAbsData::reduce()`, where the formula is always passed all the varaiables in the dataset, whether the reduction uses them or not.

To be backported to 6.32.