### PR TITLE
[RF] Fix double-ownership in RooRealIntegral copy constructor

### DIFF
--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -536,8 +536,11 @@ bool RooAbsCollection::replace(const RooAbsCollection &other)
 {
   // check that this isn't a copy of a list
   if(_ownCont) {
-    coutE(ObjectHandling) << "RooAbsCollection: cannot replace variables in a copied list" << std::endl;
-    return false;
+    std::stringstream errMsg;
+    errMsg << "RooAbsCollection: cannot replace variables in a copied list";
+    coutE(ObjectHandling) << errMsg.str() << std::endl;
+    // better than returning "false" and leaving the collection in a broken state:
+    throw std::invalid_argument(errMsg.str());
   }
 
   // loop over elements in the other list
@@ -561,8 +564,11 @@ bool RooAbsCollection::replace(const RooAbsArg& var1, const RooAbsArg& var2)
 {
   // check that this isn't a copy of a list
   if(_ownCont) {
-    coutE(ObjectHandling) << "RooAbsCollection: cannot replace variables in a copied list" << std::endl;
-    return false;
+    std::stringstream errMsg;
+    errMsg << "RooAbsCollection: cannot replace variables in a copied list";
+    coutE(ObjectHandling) << errMsg.str() << std::endl;
+    // better than returning "false" and leaving the collection in a broken state:
+    throw std::invalid_argument(errMsg.str());
   }
 
   // is var1 already in this list?

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -715,7 +715,7 @@ RooRealIntegral::RooRealIntegral(const RooRealIntegral &other, const char *name)
      _intList("!intList", this, other._intList),
      _anaList("!anaList", this, other._anaList),
      _jacList("!jacList", this, other._jacList),
-     _facList("!facList", "Variables independent of function", this, false, true),
+     _facList("!facList", this, other._facList),
      _function("!func", this, other._function),
      _iconfig(other._iconfig),
      _sumCat("!sumCat", this, other._sumCat),
@@ -726,12 +726,6 @@ RooRealIntegral::RooRealIntegral(const RooRealIntegral &other, const char *name)
  if(other._funcNormSet) {
    _funcNormSet = std::make_unique<RooArgSet>();
    other._funcNormSet->snapshot(*_funcNormSet, false);
- }
-
- for (const auto arg : other._facList) {
-   std::unique_ptr<RooAbsArg> argClone{static_cast<RooAbsArg*>(arg->Clone())};
-   _facList.addOwned(*argClone);
-   addOwnedComponents(std::move(argClone));
  }
 
  other._intList.snapshot(_saveInt) ;


### PR DESCRIPTION
Needs to be backported to 6.32.