### PR TITLE
[PyROOT] Remove broken `pyroot_dependency_versions` test

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -15,9 +15,21 @@ endif()
 ROOT_ADD_PYUNITTEST(pyroot_root_module root_module.py)
 
 # Test versions of Python dependencies
-if(NOT MSVC)
-    ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
-endif()
+# This test is disabled because it is broken in ctest!
+# Even if you install all dependencies in a fresh virtual env with:
+#   pip install -r requirements.txt
+# it will not notice that some requirements like pytorch or tensorflow are
+# there. This is observed on both macOS and Linux.
+# Just running the test with python dependency_versions.py works fine, so the
+# problem relates to the ctest configuration.
+# It is likely that the problem comes also from the usage of the deprecated
+# pkg_resources module:
+# https://setuptools.pypa.io/en/latest/pkg_resources.html
+# If one wants to fix the tests, it's probably worth to first try to
+# re-implement it with non-deprecated Python libraries.
+# if(NOT MSVC)
+#     ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
+# endif()
 
 # @pythonization decorator
 ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)


### PR DESCRIPTION
This test is disabled because it is broken in ctest! Even if you install all dependencies in a fresh virtual env with:
```
pip install -r requirements.txt
```
it will not notice that some requirements like pytorch or tensorflow are there. This is observed on both macOS and Linux.
Just running the test with python dependency_versions.py works fine, so the problem relates to the ctest configuration.

Here is the output when I ran the test with Python in a fresh environment with all dependencies installed:
```
/home/rembserj/spaces/master/root/src/root/bindings/pyroot/pythonizations/test/dependency_versions.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
Attempting requirement 'numpy>=1.4.1'
Attempting requirement 'scikit-learn'
Attempting requirement 'xgboost'
Attempting requirement 'tensorflow'
Attempting requirement 'torch'
Attempting requirement 'numba>=0.47.0; python_version < "3.11"'
Attempting requirement 'numba>=0.57.0; python_version >= "3.11" and python_version < "3.12"'
Attempting requirement 'cffi>=1.9.1'
Attempting requirement 'notebook>=4.4.1'
Attempting requirement 'metakernel>=0.20.0'
Ignore dependency pyspark>=2.4
Ignore dependency dask>=2022.08.1; python_version >= "3.8"
Ignore dependency distributed>=2022.08.1; python_version >= "3.8"
.
----------------------------------------------------------------------
Ran 1 test in 0.149s

OK
```

And here is the output with ctest:
```
AILED (errors=1)
Attempting requirement 'numpy>=1.4.1'
Attempting requirement 'scikit-learn'
Attempting requirement 'xgboost'
Attempting requirement 'tensorflow'
Attempting requirement 'torch'
Attempting requirement 'numba>=0.47.0; python_version < "3.11"'
Attempting requirement 'numba>=0.57.0; python_version >= "3.11" and python_version < "3.12"'
Attempting requirement 'cffi>=1.9.1'
Attempting requirement 'notebook>=4.4.1'
Attempting requirement 'metakernel>=0.20.0'
Ignore dependency pyspark>=2.4
Ignore dependency dask>=2022.08.1; python_version >= "3.8"
Ignore dependency distributed>=2022.08.1; python_version >= "3.8"

Full path to requirements.txt: /home/rembserj/code/root/requirements.txt
Details about not matched dependencies:
 - The 'tensorflow' distribution was not found and is required by the application
 - The 'torch' distribution was not found and is required by the application
 - The 'metakernel>=0.20.0' distribution was not found and is required by the application
CMake Error at /home/rembserj/code/root/cmake/modules/RootTestDriver.cmake:232 (message):
  error code: 1
```

Needs backport up to 6.28.
