### PR TITLE
[tree] Warn about too long TTreeFormula and double limit

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -839,7 +839,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool f
    }
    if (leafname_len > kMaxLen - 1) {
       Error("TTreeFormula",
-            "Length of leafname (%d) exceeds maximum allowed by the buffer (%d), output will be truncated.",
+            "Length of leafname (%d) exceeds maximum allowed by the buffer (%d), formula will be truncated.",
              leafname_len, kMaxLen - 1);
    }
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -52,7 +52,7 @@
 #include <typeinfo>
 #include <algorithm>
 
-const Int_t kMaxLen     = 1024;
+const Int_t kMaxLen     = 2048;
 
 /** \class TTreeFormula
 Used to pass a selection expression to the Tree drawing routine. See TTree::Draw

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -841,6 +841,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool f
       Error("TTreeFormula",
             "Length of leafname (%d) exceeds maximum allowed by the buffer (%d), formula will be truncated.",
              leafname_len, kMaxLen - 1);
+      return -1;
    }
 
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -828,8 +828,21 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool f
          alias = fTree->GetFriendAlias(leaf->GetBranch()->GetTree());
       }
    }
-   if (alias) snprintf(scratch,kMaxLen-1,"%s.%s",alias,leaf->GetName());
-   else if (leaf) strlcpy(scratch,leaf->GetName(),kMaxLen);
+   Int_t leafname_len = 0;
+   if (alias) {
+      leafname_len = strlen(alias) + strlen(leaf->GetName()) + 1;
+      snprintf(scratch,kMaxLen-1,"%s.%s",alias,leaf->GetName()); // does not null-terminate if truncation happens
+   }
+   else if (leaf) {
+      leafname_len = strlen(leaf->GetName());
+      strlcpy(scratch,leaf->GetName(),kMaxLen); // null-terminates if truncation happens
+   }
+   if (leafname_len > kMaxLen - 1) {
+      Error("TTreeFormula",
+            "Length of leafname (%d) exceeds maximum allowed by the buffer (%d), output will be truncated.",
+             leafname_len, kMaxLen - 1);
+   }
+
 
    TTree *tleaf = realtree;
    if (leaf) {

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -4820,7 +4820,7 @@ char *TTreeFormula::PrintValue(Int_t mode) const
 
 char *TTreeFormula::PrintValue(Int_t mode, Int_t instance, const char *decform) const
 {
-   const int kMAXLENGTH = 1024;
+   const int kMAXLENGTH = kMaxLen;
    static char value[kMAXLENGTH];
 
    if (mode == -2) {

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -2689,9 +2689,9 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
 ///  - Leaf_name[index].Action().OtherAction(param)
 ///  - Leaf_name[index].Action()[val].OtherAction(param)
 ///
-/// The expected returns values are
+/// The expected returned values are
 /// -  -2 :  the name has been recognized but won't be usable
-/// -  -1 :  the name has not been recognized
+/// -  -1 :  the name has not been recognized, or is too long, or tree does not exist.
 /// -  >=0 :  the name has been recognized, return the internal code for this name.
 
 Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
@@ -2701,7 +2701,10 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
    if (!fTree) return -1;
 
    fNpar = 0;
-   if (name.Length() > kMaxLen) return -1;
+   if (name.Length() > kMaxLen) {
+        Error("TTreeFormula", "The length of the variable name (%d) exceeds the maximum allowed (%d)", name.Length(), kMaxLen);
+        return -1;
+   }
    Int_t i,k;
 
    if (name == "Entry$") {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-8256

With the change, you would get error messages of this type:

`Error in <TTreeFormula::TTreeFormula>: The length of the formula (1035) exceeds the maximum allowed (1024)`

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

