### PR TITLE
avoid memory copy in TDecompChol::TDecompChol

### DIFF
--- a/math/matrix/src/TDecompChol.cxx
+++ b/math/matrix/src/TDecompChol.cxx
@@ -63,8 +63,11 @@ TDecompChol::TDecompChol(const TMatrixDSym &a,Double_t tol)
 
    fRowLwb = a.GetRowLwb();
    fColLwb = a.GetColLwb();
+   const Int_t nRow = a.GetNrows();
+   const Int_t nCol = a.GetNcols();
+
    fU.ResizeTo(a);
-   fU = a;
+   memcpy(fU.GetMatrixArray(),a.GetMatrixArray(),nRow*nCol*sizeof(Double_t));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/matrix/src/TDecompChol.cxx
+++ b/math/matrix/src/TDecompChol.cxx
@@ -67,7 +67,7 @@ TDecompChol::TDecompChol(const TMatrixDSym &a,Double_t tol)
    const Int_t nCol = a.GetNcols();
 
    fU.ResizeTo(a);
-   memcpy(fU.GetMatrixArray(),a.GetMatrixArray(),nRow*nCol*sizeof(Double_t));
+   memcpy(fU.GetMatrixArray(), a.GetMatrixArray(), nRow * nCol * sizeof(Double_t));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Change avoids extra memory allocation in TDecompChol::TDecompChol. I have copied what is done in other TDecomp* classes.


