### PR TITLE
remove repeatative divisions in TDecompChol::Decompose

### DIFF
--- a/math/matrix/src/TDecompChol.cxx
+++ b/math/matrix/src/TDecompChol.cxx
@@ -130,7 +130,7 @@ Bool_t TDecompChol::Decompose()
       }
       ujj = TMath::Sqrt(ujj);
       pU[rowOff+icol] = ujj;
-      Double_t inv_ujj = 1.0 / ujj;
+      const Double_t inv_ujj = 1.0 / ujj;
 
       if (icol < n-1) {
          for (j = icol+1; j < n; j++) {

--- a/math/matrix/src/TDecompChol.cxx
+++ b/math/matrix/src/TDecompChol.cxx
@@ -130,6 +130,7 @@ Bool_t TDecompChol::Decompose()
       }
       ujj = TMath::Sqrt(ujj);
       pU[rowOff+icol] = ujj;
+      Double_t inv_ujj = 1.0 / ujj;
 
       if (icol < n-1) {
          for (j = icol+1; j < n; j++) {
@@ -139,7 +140,7 @@ Bool_t TDecompChol::Decompose()
             }
          }
          for (j = icol+1; j < n; j++)
-            pU[rowOff+j] /= ujj;
+	    pU[rowOff + j] /= inv_ujj;
       }
    }
 

--- a/math/matrix/src/TDecompChol.cxx
+++ b/math/matrix/src/TDecompChol.cxx
@@ -140,7 +140,7 @@ Bool_t TDecompChol::Decompose()
             }
          }
          for (j = icol+1; j < n; j++)
-	    pU[rowOff + j] /= inv_ujj;
+	    pU[rowOff + j] *= inv_ujj;
       }
    }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Replace repeated divisions by multiplications of 1/x

