### PR TITLE
[TMVA] Avoid torch-cppyy symbol clashing problem in tmva tutorials

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -22,16 +22,32 @@
 ## The difference between signal and background is in the gaussian width.
 ## The width for the background gaussian is slightly larger than the signal width by few % values
 
+import os
+import importlib.util
+
+tf_spec = importlib.util.find_spec("tensorflow")
+if tf_spec is None:
+    useKerasCNN = False
+    print("TMVA_CNN_Classificaton","Skip using Keras since tensorflow is not installed")
+else:
+    import tensorflow
+
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
+torch_spec = importlib.util.find_spec("torch")
+if torch_spec is None:
+    usePyTorchCNN = False
+    print("TMVA_CNN_Classificaton","Skip using PyTorch since torch is not installed")
+else:
+    import torch
+
 
 import ROOT
 
 
 TMVA = ROOT.TMVA
 TFile = ROOT.TFile
-
-
-import os
-import importlib
 
 TMVA.Tools.Instance()
 
@@ -124,16 +140,6 @@ if not "tmva-pymva" in ROOT.gROOT.GetConfigFeatures():
     usePyTorchCNN = False
 else:
     TMVA.PyMethodBase.PyInitialize()
-
-tf_spec = importlib.util.find_spec("tensorflow")
-if tf_spec is None:
-    useKerasCNN = False
-    ROOT.Warning("TMVA_CNN_Classificaton","Skip using Keras since tensorflow is not installed")
-
-torch_spec = importlib.util.find_spec("torch")
-if torch_spec is None:
-    usePyTorchCNN = False
-    ROOT.Warning("TMVA_CNN_Classificaton","Skip using PyTorch since torch is not installed")
 
 if not useTMVACNN:
     ROOT.Warning(

--- a/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
@@ -10,6 +10,11 @@
 ## \author Anirudh Dagar <anirudhdagar6@gmail.com> - IIT, Roorkee
 
 
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
+import torch
+
 from ROOT import TMVA, TFile, TString
 from array import array
 from subprocess import call

--- a/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
@@ -10,6 +10,11 @@
 ## \author Anirudh Dagar <anirudhdagar6@gmail.com> - IIT, Roorkee
 
 
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
+import torch
+
 from ROOT import TMVA, TFile, TString
 from array import array
 from subprocess import call

--- a/tutorials/tmva/pytorch/ClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ClassificationPyTorch.py
@@ -11,12 +11,15 @@
 ## \author Anirudh Dagar <anirudhdagar6@gmail.com> - IIT, Roorkee
 
 
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
+import torch
+from torch import nn
+
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call
 from os.path import isfile
-
-import torch
-from torch import nn
 
 
 # Setup TMVA

--- a/tutorials/tmva/pytorch/MulticlassPyTorch.py
+++ b/tutorials/tmva/pytorch/MulticlassPyTorch.py
@@ -11,11 +11,14 @@
 ## \author Anirudh Dagar <anirudhdagar6@gmail.com> - IIT, Roorkee
 
 
-from ROOT import TMVA, TFile, TTree, TCut, gROOT
-from os.path import isfile
-
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
 import torch
 from torch import nn
+
+from ROOT import TMVA, TFile, TTree, TCut, gROOT
+from os.path import isfile
 
 
 # Setup TMVA

--- a/tutorials/tmva/pytorch/RegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/RegressionPyTorch.py
@@ -11,12 +11,15 @@
 ## \author Anirudh Dagar <anirudhdagar6@gmail.com> - IIT, Roorkee
 
 
+# PyTorch has to be imported before ROOT to avoid crashes because of clashing
+# std::regexp symbols that are exported by cppyy.
+# See also: https://github.com/wlav/cppyy/issues/227
+import torch
+from torch import nn
+
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call
 from os.path import isfile
-
-import torch
-from torch import nn
 
 
 # Setup TMVA


### PR DESCRIPTION
Apply the same fix as in a561a9fe09, but for PyTorch.

Needs to be backported up to 6.28.