### PR TITLE
requirements.txt: Skip tensorflow with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ onnx
 
 # TMVA: PyMVA interfaces
 scikit-learn
-tensorflow<2.16
+tensorflow<2.16 ; python_version < "3.12"
 torch
 xgboost
 


### PR DESCRIPTION
Only TensorFlow 2.16 is compatible with Python 3.12, but not with ROOT (see commit e30dc626a6).