### PR TITLE
[v632][tutorials] Fix `tensorflow` and `pytorch` detection in TMVA tutorial

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -25,6 +25,13 @@
 import os
 import importlib.util
 
+opt = [1, 1, 1, 1, 1]
+useTMVACNN = opt[0] if len(opt) > 0  else False
+useKerasCNN = opt[1] if len(opt) > 1 else False
+useTMVADNN = opt[2] if len(opt) > 2 else False
+useTMVABDT = opt[3] if len(opt) > 3 else False
+usePyTorchCNN = opt[4] if len(opt) > 4 else False
+
 tf_spec = importlib.util.find_spec("tensorflow")
 if tf_spec is None:
     useKerasCNN = False
@@ -123,12 +130,6 @@ hasGPU = "tmva-gpu" in ROOT.gROOT.GetConfigFeatures()
 hasCPU = "tmva-cpu" in ROOT.gROOT.GetConfigFeatures()
 
 nevt = 1000    # use a larger value to get better results
-opt = [1, 1, 1, 1, 1]
-useTMVACNN = opt[0] if len(opt) > 0  else False
-useKerasCNN = opt[1] if len(opt) > 1 else False
-useTMVADNN = opt[2] if len(opt) > 2 else False
-useTMVABDT = opt[3] if len(opt) > 3 else False
-usePyTorchCNN = opt[4] if len(opt) > 4 else False
 
 if (not hasCPU and not hasGPU) :
     ROOT.Warning("TMVA_CNN_Classificaton","ROOT is not supporting tmva-cpu and tmva-gpu skip using TMVA-DNN and TMVA-CNN")


### PR DESCRIPTION
This is a follow-up on 872886bcc.

That commit was reordering code in the wrong way: the initialization of the `useKerasCNN` and `usePyTorchCNN` variables should have also been moved to the top.

This fixes the current failures on Windows.