### PR TITLE
[tree] Treeformula has many clang-tidy warnings

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -1468,7 +1468,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool f
                   fHasMultipleVarDim[code] = true;
                   numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                }
-               previnfo->fNext = leafinfo;
+               if (previnfo)
+                  previnfo->fNext = leafinfo;
                previnfo = leafinfo;
                leafinfo = nullptr;
             }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This solves a couple, but not all of them. Maybe related: https://github.com/root-project/root/issues/14682

There are still:

```
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2436:28: Value stored to 'foundAtSign' is never read
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:5700:13: Value stored to 'last' is never read
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1279:12: warning: Value stored to 'prevUseReferenceObject' during its initialization is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'prevUseReferenceObject' during its initialization is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1279
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1445:13: warning: Value stored to 'prevUseCollectionObject' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'prevUseCollectionObject' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1445
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1446:13: warning: Value stored to 'prevUseReferenceObject' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'prevUseReferenceObject' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1446
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1535:19: warning: Value stored to 'prevUseReferenceObject' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'prevUseReferenceObject' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1535
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1909:25: warning: Value stored to 'prevUseReferenceObject' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'prevUseReferenceObject' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:1909
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2026:7: warning: Value stored to 'numberOfVarDim' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'numberOfVarDim' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2026
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2436:28: warning: Value stored to 'foundAtSign' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'foundAtSign' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2436
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2448:16: warning: Value stored to 'foundAtSign' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'foundAtSign' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2448
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2562:16: warning: Value stored to 'foundAtSign' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'foundAtSign' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:2562
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4045:53: warning: Division by zero [clang-analyzer-core.DivideZero]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Initializing to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4012
 5: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 7: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 9: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
11: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
13: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
15: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
16: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
17: Control jumps to 'case kModulo:'  at line 4042 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
18: The value -1 is assigned to 'pos' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4042
19: 'int2' initialized to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4044
20: Division by zero in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4045
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4079:49: warning: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 5: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 7: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
 9: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
11: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
13: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
15: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
16: Control jumps to 'case kstrstr:'  at line 4079 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
17: The value -2 is assigned to 'pos2' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4079
18: 1st function call argument is an uninitialized value in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4079
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4122:56: warning: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 5: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 7: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
 9: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
11: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
13: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
15: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
16: Control jumps to 'case kStringEqual:'  at line 4122 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
17: 1st function call argument is an uninitialized value in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4122
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4122:56: warning: 2nd function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 5: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 7: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
 9: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
11: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Assuming 'newaction' is >= kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
13: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Assuming 'newaction' is not equal to kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4227
15: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4227
16: Control jumps to 'case kAliasString:'  at line 4299 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4284
17: Assuming 'subform' is non-null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
18: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:120
19: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
20: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:120
21: Loop condition is false.  Exiting loop in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
22: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:119
23:  Execution continues on line 4022 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4307
24: 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
25: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
26: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
27: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
28: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
29: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
30: Control jumps to 'case kStringEqual:'  at line 4122 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
31: The value -1 is assigned to 'pos2' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4122
32: 2nd function call argument is an uninitialized value in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4122
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4125:56: warning: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 5: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 7: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
 9: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
11: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
13: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
15: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
16: Control jumps to 'case kStringNotEqual:'  at line 4125 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
17: 1st function call argument is an uninitialized value in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4125
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4125:56: warning: 2nd function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
 1: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3949
 2: Assuming field 'fNoper' is not equal to 1 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 3: Left side of '&&' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:3950
 4: Assuming 'stringStackArg' is null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 5: '?' condition is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4015
 6: Assuming 'instance' is not equal to 0 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 7: Left side of '||' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4017
 8: Assuming 'willLoad' is false in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
 9: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4018
10: Assuming 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
11: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
12: Assuming 'newaction' is >= kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
13: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
14: Assuming 'newaction' is not equal to kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4227
15: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4227
16: Control jumps to 'case kAliasString:'  at line 4299 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4284
17: Assuming 'subform' is non-null in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
18: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:120
19: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
20: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:120
21: Loop condition is false.  Exiting loop in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4302
22: expanded from macro 'R__ASSERT' in /opt/root_src/core/foundation/inc/TError.h:119
23:  Execution continues on line 4022 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4307
24: 'i' is < field 'fNoper' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
25: Loop condition is true.  Entering loop body in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4022
26: Assuming 'newaction' is < kDefinedVariable in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
27: Taking true branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4027
28: Assuming 'newaction' is not equal to kConstant in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
29: Taking false branch in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4031
30: Control jumps to 'case kStringNotEqual:'  at line 4125 in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4033
31: The value -1 is assigned to 'pos2' in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4125
32: 2nd function call argument is an uninitialized value in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:4125
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:5700:13: warning: Value stored to 'last' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'last' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:5700
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:5728:13: warning: Value stored to 'last' is never read [clang-analyzer-deadcode.DeadStores]
 1: Value stored to 'last' is never read in /opt/root_src/tree/treeplayer/src/TTreeFormula.cxx:5728
/opt/root_src/tree/treeplayer/src/TTreeFormula.cxx
```

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)