### PR TITLE
[v632][CI] Disable `tmva-cpu` on `alma9` to avoid openblas clashes with NumPy

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,3 +1,4 @@
 builtin_nlohmannjson=ON
 builtin_vdt=On
 tmva-sofie=On
+tmva-cpu=OFF

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -299,6 +299,11 @@ else()
     list(APPEND tmva_veto tmva/TMVA_SOFIE_RSofieReader.C)
     list(APPEND tmva_veto tmva/RBatchGenerator_TensorFlow.py)
   endif()
+  # The TMVA_SOFIE_RSofieReader test is disabled because it uses two differnt
+  # openblas versions via SOFIE and NumPy (indirectly from Keras) at the same
+  # time. This can cause crashes, for example on alma9.
+  # TODO: remove the next line once this problem is fixed.
+  list(APPEND tmva_veto tmva/TMVA_SOFIE_RSofieReader.C)
   if (NOT PY_SKLEARN_FOUND)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_Models.py)
   endif()


### PR DESCRIPTION
The `tmva-cpu` BLAS-accelerated TMVA backend uses the openblas version found on the system, but NumPy also ships its own `openblas` library when installed with pip.

If both openblas versions are loaded, segfaults can occur if they are incompatible. We currently see this on the `alma9` CI runners.

The minimal remedy for this is to just disable the TMVA BLAS backend. Nobody is using the CPU to train neural nets nowadays anyway.

Like this, we don't have to disable features like PyMVA or RBDT.

Backport of https://github.com/root-project/root/pull/15302.