### PR TITLE
[CI] Set `arrow=ON` to test the RDataFrame Arrow data source

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -1,6 +1,6 @@
 alien=OFF
 all=OFF
-arrow=OFF
+arrow=ON
 asan=OFF
 asimage=ON
 asserts=OFF


### PR DESCRIPTION
We should not leave anything untested in the CI if we can.