### PR TITLE
[tree] Fix subscript overflow in cumulSizes

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -5311,7 +5311,7 @@ void TTreeFormula::ResetDimensions() {
       }
 
       // Add up the cumulative size
-      for (k = fNdimensions[i]; (k > 0); k--) {
+      for (k = fNdimensions[i] - 1; (k > 0); k--) {
          // NOTE: When support for inside variable dimension is added this
          // will become inaccurate (since one of the value in the middle of the chain
          // is unknown until GetNdata is called.


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-10923

k starts at 0 and should go at max until Ndim-1

This bug was here since 24y :)
https://github.com/root-project/root/commit/6b5ac6dbb79d33682e7e3b815abf6ca4eb3db03e#diff-76114d41c696ac3adf8349c86c2be74751b8ed81cebf74a075144aa727654372

At that point, there was fUsedCumulSizes which had a size of MAXDIM+1 instead of MAXDIM