### PR TITLE
[RF] Add codegen+AD support for `RooUniform` and `RooRecursiveFraction`

### DIFF
--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -34,6 +34,10 @@ public:
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+  std::string
+  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   RooListProxy x ;

--- a/roofit/roofit/src/RooUniform.cxx
+++ b/roofit/roofit/src/RooUniform.cxx
@@ -50,6 +50,11 @@ double RooUniform::evaluate() const
   return 1 ;
 }
 
+void RooUniform::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   ctx.addResult(this, "1.0");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Advertise analytical integral
 
@@ -86,6 +91,14 @@ double RooUniform::analyticalIntegral(Int_t code, const char* rangeName) const
     }
   }
   return ret ;
+}
+
+std::string RooUniform::buildCallToAnalyticIntegral(Int_t code, const char *rangeName,
+                                                    RooFit::Detail::CodeSquashContext & /*ctx*/) const
+{
+   // The integral of a uniform distribution is static, so we can just hardcode
+   // the result in a string.
+   return std::to_string(analyticalIntegral(code, rangeName));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -288,6 +288,17 @@ inline double nllEvaluate(double pdf, double weight, int binnedL, int doBinOffse
    }
 }
 
+inline double recursiveFractionEvaluate(double *a, unsigned int n)
+{
+   double prod = a[0];
+
+   for (unsigned int i = 1; i < n; ++i) {
+      prod *= 1.0 - a[i];
+   }
+
+   return prod;
+}
+
 } // namespace EvaluateFuncs
 
 } // namespace Detail

--- a/roofit/roofitcore/inc/RooRecursiveFraction.h
+++ b/roofit/roofitcore/inc/RooRecursiveFraction.h
@@ -31,6 +31,8 @@ public:
   RooRecursiveFraction(const RooRecursiveFraction& other, const char *name = nullptr);
   TObject* clone(const char* newname) const override { return new RooRecursiveFraction(*this, newname); }
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   RooListProxy _list ;

--- a/roofit/roofitcore/src/RooRecursiveFraction.cxx
+++ b/roofit/roofitcore/src/RooRecursiveFraction.cxx
@@ -35,6 +35,8 @@ from a set of recursive fractions: for a given set of input fractions
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 
+#include <RooFit/Detail/EvaluateFuncs.h>
+
 ClassImp(RooRecursiveFraction);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -84,4 +86,9 @@ double RooRecursiveFraction::evaluate() const
   }
 
   return prod ;
+}
+
+void RooRecursiveFraction::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   ctx.addResult(this, ctx.buildCall("RooFit::Detail::EvaluateFuncs::recursiveFractionEvaluate", _list, _list.size()));
 }


### PR DESCRIPTION
These classes are used in the CMS Higgs discovery analysis, that's why we want to support this now.