### PR TITLE
[tree] public method should be safe against fImpl = null

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -32,7 +32,7 @@ Base class of TTreeReaderArray.
                            TDictionary* dict):
          TTreeReaderValueBase(reader, branchname, dict) {}
 
-      std::size_t GetSize() const { return fImpl->GetSize(GetProxy()); }
+      std::size_t GetSize() const { return fImpl ? fImpl->GetSize(GetProxy()) : 0; }
       bool IsEmpty() const { return !GetSize(); }
 
       EReadStatus GetReadStatus() const override { return fImpl ? fImpl->fReadStatus : kReadError; }


### PR DESCRIPTION
as is the case with function GetReadStatus

This prevents the crash on line 35 (stack trace by @amadio on https://its.cern.ch/jira/browse/ROOT-11006):

# This Pull request:

## Changes or fixes:

The test for this PR is the same as in https://github.com/root-project/root/pull/15317/files

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

