### PR TITLE
[RF] Consider `_isPdfMode` member in RooMomentMorphFuncND copy constructor

### DIFF
--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -181,7 +181,8 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const RooMomentMorphFuncND &other, co
      _referenceGrid(other._referenceGrid),
      _pdfList("pdfList", this, other._pdfList),
      _setting(other._setting),
-     _useHorizMorph(other._useHorizMorph)
+     _useHorizMorph(other._useHorizMorph),
+     _isPdfMode{other._isPdfMode}
 {
    // general initialization
    initialize();


### PR DESCRIPTION
The `_pdfMode` data member was added for ROOT 6.30,and I forgot to consider it in the copy constructor. A classic mistake.

This fix needs to be backported up to ROOT 6.30.

Thanks to this forum post for noticing the problem:
https://root-forum.cern.ch/t/using-roomomentmorphfuncnd/58889