### PR TITLE
[io] Remove wrong comment in RRawFile

### DIFF
--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -51,8 +51,6 @@ public:
 
       ELineBreaks fLineBreak = ELineBreaks::kAuto;
       /// Read at least fBlockSize bytes at a time. A value of zero turns off I/O buffering.
-      /// After construction, a negative block size is used to store the block size value when buffering is turned off
-      /// (see `SetBuffering()`).
       size_t fBlockSize = kUseDefaultBlockSize;
       // Define an empty constructor to work around a bug in Clang: https://github.com/llvm/llvm-project/issues/36032
       ROptions() {}


### PR DESCRIPTION
This was changed in commit 09010c5ed5 ("[io] make buffering state explicit in RRawFile").