### PR TITLE
[tree] prevent crash due to null access in clones

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -1327,7 +1327,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool f
 
                   clones = (TClonesArray*)clonesinfo->GetLocalValuePointer(leaf,0);
                }
-               TClass * inside_cl = clones->GetClass();
+               TClass * inside_cl = clones ? clones->GetClass() : nullptr;
                cl = inside_cl;
 
             }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Avoids the crash reported in https://its.cern.ch/jira/browse/ROOT-10795

It does not solve the underlying cause, which is that TFormLeafInfo line 219 is called, that returns type = 64. Then:
switch (type) reaches the default and returns a null:

![image](https://github.com/root-project/root/assets/10653970/60f61a1b-613f-4b38-98c0-6336ed27a2dc)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
