### PR TITLE
[skip-ci][ci][docu] Generate Doxygen docs with Makefile + GitHub Actions

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -89,10 +89,6 @@ def main():
     # The sha1 of the build option string is used to find existing artifacts
     # with matching build options on s3 storage.
     option_hash = sha1(options.encode('utf-8')).hexdigest()
-
-    # TEMPORARY: force incremental build for faster debugging
-    option_hash = "a2bf4e78066e394ef22a80d94500b4a252512440"
-
     obj_prefix = f'{args.platform}/{args.base_ref}/{args.buildtype}/{option_hash}'
 
     # Make testing of CI in forks not impact artifacts
@@ -139,12 +135,6 @@ def main():
 
     if not WINDOWS:
         show_node_state()
-
-    # TEMPORARY: force incremental build for faster debugging
-    result = subprocess_with_log(f"""
-        rm -rf {os.path.join(WORKDIR, "build", "CMakeCache.txt")}
-    """)
-    cmake_configure(options, args.buildtype)
 
     build(options, args.buildtype)
 

--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -89,6 +89,10 @@ def main():
     # The sha1 of the build option string is used to find existing artifacts
     # with matching build options on s3 storage.
     option_hash = sha1(options.encode('utf-8')).hexdigest()
+
+    # TEMPORARY: force incremental build for faster debugging
+    option_hash = "a2bf4e78066e394ef22a80d94500b4a252512440"
+
     obj_prefix = f'{args.platform}/{args.base_ref}/{args.buildtype}/{option_hash}'
 
     # Make testing of CI in forks not impact artifacts
@@ -135,6 +139,12 @@ def main():
 
     if not WINDOWS:
         show_node_state()
+
+    # TEMPORARY: force incremental build for faster debugging
+    result = subprocess_with_log(f"""
+        rm -rf {os.path.join(WORKDIR, "build", "CMakeCache.txt")}
+    """)
+    cmake_configure(options, args.buildtype)
 
     build(options, args.buildtype)
 

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -205,12 +205,13 @@ jobs:
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive
       run: |
-        tar -czvf /github/home/rootdoc.tar /github/home/rootdoc
+        tar -xvzf /github/home/rootdoc.tar.gz /github/home/rootdoc
 
+    # TODO: upload to website instead
     - name: Upload artifact
       if:   ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: rootdoc.tar
-        path: /github/home/rootdoc.tar
+        path: /github/home/rootdoc.tar.gz
 

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -62,7 +62,7 @@ on:
         required: false
 
 jobs:
-  gen-docs:
+  build-docs:
     runs-on:
       - self-hosted
       - linux
@@ -105,13 +105,13 @@ jobs:
       run : |
         mkdir -p ${{ github.workspace }}/doxygen
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
+        echo PATH=$PATH:${{ github.workspace }}/doxygen/install/bin >> $GITHUB_ENV
 
+    # TEMPORARY: force incremental build for faster debugging
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}
       env:
-        #TODO: DOXYGEN_EXECUTABLE doesn't have to be specified anymore if we have a valid version in PATH
-        OVERRIDES: "DOXYGEN_EXECUTABLE=${{ github.workspace }}/doxygen/bin/doxygen
-                    testing=off roottest=off" # can be removed if this workflow is merged with root-ci.yml
+        OVERRIDES: "testing=off roottest=off" # can be removed if this workflow is merged with root-ci.yml
         CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma9.txt'
       shell: bash
       run: |
@@ -183,13 +183,16 @@ jobs:
 
     - name: Run Doxygen
       env:
-        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc
+        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc_TMP
       shell: bash
       run: |
         source /github/home/ROOT-CI/build/bin/thisroot.sh
         cd /github/home/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${DOXYGEN_OUTPUT_DIRECTORY}
+        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html /github/home/rootdoc
+        if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
+          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks /github/home/rootdoc/notebooks
+        fi
 
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -100,14 +100,14 @@ jobs:
       # code of the `if`.
       run: 'if [ -d /py-venv/ROOT-CI/bin/ ]; then . /py-venv/ROOT-CI/bin/activate && echo PATH=$PATH >> $GITHUB_ENV; fi'
 
-    # TODO: install latest version (in image)?
+    # TODO: install latest version in image on root-ci-images
+    # TODO: install qhelpgenerator
     - name: Install Doxygen 1.10.0
       run : |
         mkdir -p ${{ github.workspace }}/doxygen
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
         echo PATH=$PATH:${{ github.workspace }}/doxygen/bin >> $GITHUB_ENV
 
-    # TEMPORARY: force incremental build for faster debugging
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}
       env:
@@ -149,7 +149,7 @@ jobs:
                   --platform        alma9
                   --image           registry.cern.ch/root-ci/alma9:buildready
                   --dockeropts      '--security-opt label=disable --rm'
-                  --incremental     true
+                  --incremental     $INCREMENTAL
                   --base_ref        ${{ github.base_ref }}
                   --sha             ${{ github.sha }}
                   --pull_repository ${{ github.event.pull_request.head.repo.clone_url }}
@@ -158,16 +158,16 @@ jobs:
                   --repository      ${{ github.server_url }}/${{ github.repository }}
             "
 
-      # - name: Nightly build
-      #   if:   github.event_name == 'schedule'
-      #   run: ".github/workflows/root-ci-config/build_root.py
-      #               --buildtype      Release
-      #               --platform       alma9
-      #               --incremental    false
-      #               --binaries       true
-      #               --base_ref       ${{ inputs.ref_name }}
-      #               --repository     ${{ github.server_url }}/${{ github.repository }}
-      #         "
+    # - name: Nightly build
+    #   if:   github.event_name == 'schedule'
+    #   run: ".github/workflows/root-ci-config/build_root.py
+    #               --buildtype      Release
+    #               --platform       alma9
+    #               --incremental    false
+    #               --binaries       false
+    #               --base_ref       ${{ inputs.ref_name }}
+    #               --repository     ${{ github.server_url }}/${{ github.repository }}
+    #         "
 
     - name: Workflow dispatch
       if:   github.event_name == 'workflow_dispatch'
@@ -183,15 +183,18 @@ jobs:
 
     - name: Run Doxygen
       env:
-        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc_TMP
+        WORK_DIR: /github/home/
+        DOC_DIR: rootdoc
       shell: bash
       run: |
-        source /github/home/ROOT-CI/build/bin/thisroot.sh
-        cd /github/home/ROOT-CI/src/documentation/doxygen
+        source ${WORK_DIR}/ROOT-CI/build/bin/thisroot.sh
+        export DOXYGEN_OUTPUT_DIRECTORY=${WORK_DIR}/${DOC_DIR}_TMP
+
+        cd ${WORK_DIR}/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html /github/home/rootdoc
+        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
         if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
-          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks /github/home/rootdoc/notebooks
+          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${WORK_DIR}/${DOC_DIR}/notebooks
         fi
 
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
@@ -201,7 +204,8 @@ jobs:
 
     - name: Upload artifact
       if:   ${{ !cancelled() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rootdoc
         path: /github/home/rootdoc.gz
+

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -107,7 +107,6 @@ jobs:
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
         echo PATH=$PATH:${{ github.workspace }}/doxygen/bin >> $GITHUB_ENV
 
-    # TEMPORARY: force incremental build for faster debugging
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}
       env:
@@ -135,9 +134,10 @@ jobs:
 
 
     - name: Print debug info
-      run:  'printf "%s@%s\\n" "$(whoami)" "$(hostname)";
-              ls -la
-            '
+      run: |
+        printf "%s@%s\\n" "$(whoami)" "$(hostname)";
+        ls -la
+        doxygen --version
 
     - name: Pull Request Build
       if: github.event_name == 'pull_request'
@@ -183,18 +183,21 @@ jobs:
 
     - name: Run Doxygen
       env:
-        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc_TMP
+        WORK_DIR: /github/home/
+        DOC_DIR: rootdoc
       shell: bash
       run: |
-        source /github/home/ROOT-CI/build/bin/thisroot.sh
-        cd /github/home/ROOT-CI/src/documentation/doxygen
+        source ${WORK_DIR}/ROOT-CI/build/bin/thisroot.sh
+        export DOXYGEN_OUTPUT_DIRECTORY=${WORK_DIR}/${DOC_DIR}_TMP
+
+        cd ${WORK_DIR}/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html /github/home/rootdoc
+        cd ${WORK_DIR}
+        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
         if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
-          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks /github/home/rootdoc/notebooks
+          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${WORK_DIR}/${DOC_DIR}/notebooks
         fi
 
-    # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive
       run: |
         tar -czvf /github/home/rootdoc.gz /github/home/rootdoc

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -203,7 +203,7 @@ jobs:
 
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archives
-      working-directory: ${DOC_LOCATION}
+      working-directory: ${{ env.DOC_LOCATION }}
       shell: bash
       run: |
         tarnamegz=${DOC_DIR}.tar.gz

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -197,7 +197,7 @@ jobs:
 
         cd ${WORK_DIR}/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
+        mv -f ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
         if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
           mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${WORK_DIR}/${DOC_DIR}/notebooks
         fi

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -205,12 +205,12 @@ jobs:
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive
       run: |
-        tar -czvf /github/home/rootdoc.gz /github/home/rootdoc
+        tar -czvf /github/home/rootdoc.tar /github/home/rootdoc
 
     - name: Upload artifact
       if:   ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: rootdoc
-        path: /github/home/rootdoc.gz
+        name: rootdoc.tar
+        path: /github/home/rootdoc.tar
 

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}
       env:
-        OVERRIDES: "testing=off roottest=off" # can be removed if this workflow is merged with root-ci.yml
+        OVERRIDES: "testing=off roottest=off minimal=on" # can be removed if this workflow is merged with root-ci.yml
         CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma9.txt'
       shell: bash
       run: |
@@ -202,7 +202,8 @@ jobs:
         fi
 
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
-    - name: Create documentation archive
+    - name: Create documentation archives
+      working-directory: ${DOC_LOCATION}
       shell: bash
       run: |
         tarnamegz=${DOC_DIR}.tar.gz
@@ -210,20 +211,19 @@ jobs:
         tarnamexz1=${DOC_DIR}.tar
         tar cf $tarnamexz1 ${DOC_DIR}
         xz -T5 -f $tarnamexz1
-        tarnamexz2=${DOC_DIR}tar.xz
 
     # TODO: upload to website instead
-    - name: Upload artifact
+    - name: Upload tar.gz
       if:   ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${DOC_DIR}.tar.gz
-        path: ${DOC_DIR}.tar.gz
+        name: ${DOC_LOCATION}/${DOC_DIR}.tar.gz
+        path: ${DOC_LOCATION}/${DOC_DIR}.tar.gz
 
-    - name: Upload artifact
+    - name: Upload tar.xz
       if:   ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${DOC_DIR}.tar.xz
-        path: ${DOC_DIR}.tar.xz
+        name: ${DOC_LOCATION}/${DOC_DIR}.tar.xz
+        path: ${DOC_LOCATION}/${DOC_DIR}.tar.xz
 

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -105,7 +105,7 @@ jobs:
       run : |
         mkdir -p ${{ github.workspace }}/doxygen
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
-        echo PATH=$PATH:${{ github.workspace }}/doxygen/install/bin >> $GITHUB_ENV
+        echo PATH=$PATH:${{ github.workspace }}/doxygen/bin >> $GITHUB_ENV
 
     # TEMPORARY: force incremental build for faster debugging
     - name: Apply option overrides

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -100,13 +100,18 @@ jobs:
       # code of the `if`.
       run: 'if [ -d /py-venv/ROOT-CI/bin/ ]; then . /py-venv/ROOT-CI/bin/activate && echo PATH=$PATH >> $GITHUB_ENV; fi'
 
-    # TODO: install latest version in image on root-ci-images
-    # TODO: install qhelpgenerator
+    # TODO: install latest versions in image on root-ci-images
     - name: Install Doxygen 1.10.0
       run : |
         mkdir -p ${{ github.workspace }}/doxygen
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
         echo PATH=$PATH:${{ github.workspace }}/doxygen/bin >> $GITHUB_ENV
+    - name: Install qhelpgenerator
+      run : |
+        dnf update -y && dnf install -y sudo
+        sudo dnf update -y
+        sudo dnf upgrade -y
+        sudo dnf install -y qt5-qhelpgenerator
 
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -1,0 +1,204 @@
+name: 'ROOT Docs'
+
+on:
+  # https://github.com/root-project/root/pull/12112#issuecomment-1411004278
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'doc/**'
+      - 'documentation/**'
+
+  # Allows nightly builds to trigger one run for each branch easily, by
+  # providing the relevant branch as "default" value here:
+  workflow_call:
+    inputs:
+      head_ref:
+        type: string
+        default: master
+      base_ref:
+        type: string
+        default: master
+      ref_name:
+        type: string
+        default: master
+
+  workflow_dispatch:
+    inputs:
+      head_ref:
+        description: rebase from ...
+        type: string
+        required: true
+        default: master
+      base_ref:
+        description: ... to ... (can have same value)
+        type: string
+        required: true
+        default: master
+      incremental:
+        description: 'Do incremental build'
+        type: boolean
+        required: true
+        default: true
+      binaries:
+        description: Create binary packages and upload them as artifacts
+        type: boolean
+        required: true
+        default: false
+      buildtype:
+        description: The CMAKE_BUILD_TYPE to use for non-Windows.
+        type: choice
+        options:
+        - Debug
+        - RelWithDebInfo
+        - Release
+        - MinSizeRel
+        default: Debug
+        required: true
+      docu_input:
+        description: Folders to build documentation for. All folders are built if empty.
+        type: string
+        default: ""
+        required: false
+
+jobs:
+  gen-docs:
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+
+    # TODO: it would be nice to use some global var for the platform, this doesn't work though :(
+    # env:
+    #   platform: alma9
+
+    permissions:
+      contents: read
+
+    container:
+      image: registry.cern.ch/root-ci/alma9:buildready # ALSO UPDATE BELOW!
+      options: '--security-opt label=disable --rm' # ALSO UPDATE BELOW!
+      env:
+        OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
+        OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        OS_AUTH_TYPE: 'v3applicationcredential'
+        OS_AUTH_URL: 'https://keystone.cern.ch/v3'
+        OS_IDENTITY_API_VERSION: 3
+        OS_INTERFACE: 'public'
+        OS_REGION_NAME: 'cern'
+        PYTHONUNBUFFERED: true
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python Virtual Env
+      # if the `if` expr is false, `if` still has exit code 0.
+      # if the `if` block is entered, the block's exit code becomes the exit
+      # code of the `if`.
+      run: 'if [ -d /py-venv/ROOT-CI/bin/ ]; then . /py-venv/ROOT-CI/bin/activate && echo PATH=$PATH >> $GITHUB_ENV; fi'
+
+    # TODO: install latest version (in image)?
+    - name: Install Doxygen 1.10.0
+      run : |
+        mkdir -p ${{ github.workspace }}/doxygen
+        curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
+
+    - name: Apply option overrides
+      if: ${{ github.event_name != 'schedule' }}
+      env:
+        #TODO: DOXYGEN_EXECUTABLE doesn't have to be specified anymore if we have a valid version in PATH
+        OVERRIDES: "DOXYGEN_EXECUTABLE=${{ github.workspace }}/doxygen/bin/doxygen
+                    testing=off roottest=off" # can be removed if this workflow is merged with root-ci.yml
+        CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma9.txt'
+      shell: bash
+      run: |
+        set -x
+        echo '' >> "$CONFIGFILE"
+        for ENTRY in $OVERRIDES; do
+            KEY=$( echo "$ENTRY" | cut -d '=' -f 1 )
+            # Add entry to file if not exists, otherwise replace
+            if grep -q "$KEY=" "$CONFIGFILE"; then
+                sed -i "s/$KEY=.*\$/$ENTRY/" "$CONFIGFILE"
+            else
+                echo "$ENTRY" >> "$CONFIGFILE"
+            fi
+        done
+        cat "$CONFIGFILE" || true
+
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
+
+    - name: Print debug info
+      run:  'printf "%s@%s\\n" "$(whoami)" "$(hostname)";
+              ls -la
+            '
+
+    - name: Pull Request Build
+      if: github.event_name == 'pull_request'
+      env:
+        INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') }}
+        GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
+      run: ".github/workflows/root-ci-config/build_root.py
+                  --buildtype       Release
+                  --platform        alma9
+                  --image           registry.cern.ch/root-ci/alma9:buildready
+                  --dockeropts      '--security-opt label=disable --rm'
+                  --incremental     true
+                  --base_ref        ${{ github.base_ref }}
+                  --sha             ${{ github.sha }}
+                  --pull_repository ${{ github.event.pull_request.head.repo.clone_url }}
+                  --head_ref        refs/pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
+                  --head_sha        ${{ github.event.pull_request.head.sha }}
+                  --repository      ${{ github.server_url }}/${{ github.repository }}
+            "
+
+      # - name: Nightly build
+      #   if:   github.event_name == 'schedule'
+      #   run: ".github/workflows/root-ci-config/build_root.py
+      #               --buildtype      Release
+      #               --platform       alma9
+      #               --incremental    false
+      #               --binaries       true
+      #               --base_ref       ${{ inputs.ref_name }}
+      #               --repository     ${{ github.server_url }}/${{ github.repository }}
+      #         "
+
+    - name: Workflow dispatch
+      if:   github.event_name == 'workflow_dispatch'
+      run: ".github/workflows/root-ci-config/build_root.py
+                  --buildtype      Release
+                  --platform       alma9
+                  --incremental    ${{ inputs.incremental }}
+                  --base_ref       ${{ inputs.base_ref }}
+                  --head_ref       ${{ inputs.head_ref }}
+                  --binaries       ${{ inputs.binaries }}
+                  --repository     ${{ github.server_url }}/${{ github.repository }}
+           "
+
+    - name: Run Doxygen
+      env:
+        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc
+      shell: bash
+      run: |
+        source /github/home/ROOT-CI/build/bin/thisroot.sh
+        cd /github/home/ROOT-CI/src/documentation/doxygen
+        make -j$(nproc)
+        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${DOXYGEN_OUTPUT_DIRECTORY}
+
+    # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
+    - name: Create documentation archive
+      run: |
+        tar -czvf /github/home/rootdoc.gz /github/home/rootdoc
+
+    - name: Upload artifact
+      if:   ${{ !cancelled() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: rootdoc
+        path: /github/home/rootdoc.gz

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -55,7 +55,7 @@ on:
         - MinSizeRel
         default: Debug
         required: true
-      docu_input:
+      docu_input: # TODO: overwrite makeinput.sh with these args
         description: Folders to build documentation for. All folders are built if empty.
         type: string
         default: ""
@@ -69,8 +69,10 @@ jobs:
       - x64
 
     # TODO: it would be nice to use some global var for the platform, this doesn't work though :(
-    # env:
-    #   platform: alma9
+    env:
+      PLATFORM: alma9
+      DOC_DIR: rootdoc
+      DOC_LOCATION: /github/home
 
     permissions:
       contents: read
@@ -187,31 +189,41 @@ jobs:
            "
 
     - name: Run Doxygen
-      env:
-        WORK_DIR: /github/home/
-        DOC_DIR: rootdoc
       shell: bash
       run: |
-        source ${WORK_DIR}/ROOT-CI/build/bin/thisroot.sh
-        export DOXYGEN_OUTPUT_DIRECTORY=${WORK_DIR}/${DOC_DIR}_TMP
+        source ${DOC_LOCATION}/ROOT-CI/build/bin/thisroot.sh
+        export DOXYGEN_OUTPUT_DIRECTORY=${DOC_LOCATION}/${DOC_DIR}_TMP
 
-        cd ${WORK_DIR}/ROOT-CI/src/documentation/doxygen
+        cd ${DOC_LOCATION}/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        mv -f ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
+        mv -f ${DOXYGEN_OUTPUT_DIRECTORY}/html ${DOC_LOCATION}/${DOC_DIR}
         if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
-          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${WORK_DIR}/${DOC_DIR}/notebooks
+          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${DOC_LOCATION}/${DOC_DIR}/notebooks
         fi
 
     # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive
+      shell: bash
       run: |
-        tar -xvzf /github/home/rootdoc.tar.gz /github/home/rootdoc
+        tarnamegz=${DOC_DIR}.tar.gz
+        tar zcf $tarnamegz ${DOC_DIR}
+        tarnamexz1=${DOC_DIR}.tar
+        tar cf $tarnamexz1 ${DOC_DIR}
+        xz -T5 -f $tarnamexz1
+        tarnamexz2=${DOC_DIR}tar.xz
 
     # TODO: upload to website instead
     - name: Upload artifact
       if:   ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: rootdoc.tar
-        path: /github/home/rootdoc.tar.gz
+        name: ${DOC_DIR}.tar.gz
+        path: ${DOC_DIR}.tar.gz
+
+    - name: Upload artifact
+      if:   ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${DOC_DIR}.tar.xz
+        path: ${DOC_DIR}.tar.xz
 

--- a/.github/workflows/root-docs.yml
+++ b/.github/workflows/root-docs.yml
@@ -107,6 +107,7 @@ jobs:
         curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar -xz -C ${{ github.workspace }}/doxygen/ --strip-components=1
         echo PATH=$PATH:${{ github.workspace }}/doxygen/bin >> $GITHUB_ENV
 
+    # TEMPORARY: force incremental build for faster debugging
     - name: Apply option overrides
       if: ${{ github.event_name != 'schedule' }}
       env:
@@ -134,10 +135,9 @@ jobs:
 
 
     - name: Print debug info
-      run: |
-        printf "%s@%s\\n" "$(whoami)" "$(hostname)";
-        ls -la
-        doxygen --version
+      run:  'printf "%s@%s\\n" "$(whoami)" "$(hostname)";
+              ls -la
+            '
 
     - name: Pull Request Build
       if: github.event_name == 'pull_request'
@@ -183,21 +183,18 @@ jobs:
 
     - name: Run Doxygen
       env:
-        WORK_DIR: /github/home/
-        DOC_DIR: rootdoc
+        DOXYGEN_OUTPUT_DIRECTORY: /github/home/rootdoc_TMP
       shell: bash
       run: |
-        source ${WORK_DIR}/ROOT-CI/build/bin/thisroot.sh
-        export DOXYGEN_OUTPUT_DIRECTORY=${WORK_DIR}/${DOC_DIR}_TMP
-
-        cd ${WORK_DIR}/ROOT-CI/src/documentation/doxygen
+        source /github/home/ROOT-CI/build/bin/thisroot.sh
+        cd /github/home/ROOT-CI/src/documentation/doxygen
         make -j$(nproc)
-        cd ${WORK_DIR}
-        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html ${WORK_DIR}/${DOC_DIR}
+        mv ${DOXYGEN_OUTPUT_DIRECTORY}/html /github/home/rootdoc
         if [ -d ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ]; then
-          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks ${WORK_DIR}/${DOC_DIR}/notebooks
+          mv ${DOXYGEN_OUTPUT_DIRECTORY}/notebooks /github/home/rootdoc/notebooks
         fi
 
+    # The output DOCU_LOCATION set in documentation/doxygen/CMakeLists.txt
     - name: Create documentation archive
       run: |
         tar -czvf /github/home/rootdoc.gz /github/home/rootdoc

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -33,7 +33,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax js images doxygen replaceCollaborationDiagrams
+all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++14 -O2
@@ -63,12 +63,12 @@ doxygen: filter pyzdoc
 	./makehtmlfooter.sh > htmlfooter.html
 	./makeinput.sh
 	doxygen
+	bash ./CleanNamespaces.sh
 	rm -rf files c1* *.ps *.eps *.png *.jpg *.tex *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt *.csv *.log *.rs
 	rm -rf listofclass.sh tmva* data* result* config* test* Roo* My* Freq*
 	rm -f Doxyfile_INPUT filter htmlfooter.html MDF.C pca.C
 	rm -f greek.gif hsumanim.gif mathsymb.gif parallelcoordtrans.gif
 	rm -rf files c1* *.ps *.png *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt listofclass.sh
-# bash ./CleanNamespaces.sh
 
 collaborationDiagrams:
 	bash ./makeCollaborationDiagrams.sh

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -63,12 +63,12 @@ doxygen: filter pyzdoc
 	./makehtmlfooter.sh > htmlfooter.html
 	./makeinput.sh
 	doxygen
-	bash ./CleanNamespaces.sh
 	rm -rf files c1* *.ps *.eps *.png *.jpg *.tex *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt *.csv *.log *.rs
 	rm -rf listofclass.sh tmva* data* result* config* test* Roo* My* Freq*
 	rm -f Doxyfile_INPUT filter htmlfooter.html MDF.C pca.C
 	rm -f greek.gif hsumanim.gif mathsymb.gif parallelcoordtrans.gif
 	rm -rf files c1* *.ps *.png *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt listofclass.sh
+# bash ./CleanNamespaces.sh
 
 collaborationDiagrams:
 	bash ./makeCollaborationDiagrams.sh

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -33,7 +33,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork
+all: filter folders mathjax js images doxygen replaceCollaborationDiagrams
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++14 -O2
@@ -63,7 +63,6 @@ doxygen: filter pyzdoc
 	./makehtmlfooter.sh > htmlfooter.html
 	./makeinput.sh
 	doxygen
-	bash ./CleanNamespaces.sh
 	rm -rf files c1* *.ps *.eps *.png *.jpg *.tex *.svg *.pdf *.root *.xpm *.out *.dat *.dtd *.dot *.txt *.csv *.log *.rs
 	rm -rf listofclass.sh tmva* data* result* config* test* Roo* My* Freq*
 	rm -f Doxyfile_INPUT filter htmlfooter.html MDF.C pca.C

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -33,7 +33,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax js images doxygen replaceCollaborationDiagrams notebooks rootWork
+all: filter folders mathjax js images doxygen replaceCollaborationDiagrams
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++14 -O2

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -25,52 +25,52 @@ echo "        ../../core/unix/                 \\" >> Doxyfile_INPUT
 echo "        ../../core/winnt/                \\" >> Doxyfile_INPUT
 echo "        ../../core/imt/                  \\" >> Doxyfile_INPUT
 echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
-echo "        ../../geom/                      \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
-echo "        ../../gui/                       \\" >> Doxyfile_INPUT
-echo "        ../../hist/                      \\" >> Doxyfile_INPUT
-echo "        ../../html/                      \\" >> Doxyfile_INPUT
-echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
-echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
-echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
-echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
-echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
-echo "        ../../math/                      \\" >> Doxyfile_INPUT
-echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
-echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
-echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
-echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
-echo "        ../../proof/                     \\" >> Doxyfile_INPUT
-echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
-echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
-echo "        ../../tree/                      \\" >> Doxyfile_INPUT
-echo "        ../../sql/                       \\" >> Doxyfile_INPUT
-echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
-echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
-echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
-echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
+# echo "        ../../geom/                      \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
+# echo "        ../../gui/                       \\" >> Doxyfile_INPUT
+# echo "        ../../hist/                      \\" >> Doxyfile_INPUT
+# echo "        ../../html/                      \\" >> Doxyfile_INPUT
+# echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
+# echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
+# echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
+# echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
+# echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
+# echo "        ../../math/                      \\" >> Doxyfile_INPUT
+# echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
+# echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
+# echo "        ../../proof/                     \\" >> Doxyfile_INPUT
+# echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
+# echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
+# echo "        ../../tree/                      \\" >> Doxyfile_INPUT
+# echo "        ../../sql/                       \\" >> Doxyfile_INPUT
+# echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/lzma/                 \\" >> Doxyfile_INPUT

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -25,52 +25,52 @@ echo "        ../../core/unix/                 \\" >> Doxyfile_INPUT
 echo "        ../../core/winnt/                \\" >> Doxyfile_INPUT
 echo "        ../../core/imt/                  \\" >> Doxyfile_INPUT
 echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
-# echo "        ../../geom/                      \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
-# echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
-# echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
-# echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
-# echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
-# echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
-# echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
-# echo "        ../../gui/                       \\" >> Doxyfile_INPUT
-# echo "        ../../hist/                      \\" >> Doxyfile_INPUT
-# echo "        ../../html/                      \\" >> Doxyfile_INPUT
-# echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
-# echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
-# echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
-# echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
-# echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
-# echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
-# echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
-# echo "        ../../math/                      \\" >> Doxyfile_INPUT
-# echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
-# echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
-# echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
-# echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
-# echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
-# echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
-# echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
-# echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
-# echo "        ../../proof/                     \\" >> Doxyfile_INPUT
-# echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
-# echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
-# echo "        ../../tree/                      \\" >> Doxyfile_INPUT
-# echo "        ../../sql/                       \\" >> Doxyfile_INPUT
-# echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
-# echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
-# echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
-# echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
+echo "        ../../geom/                      \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
+echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
+echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
+echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
+echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
+echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
+echo "        ../../gui/                       \\" >> Doxyfile_INPUT
+echo "        ../../hist/                      \\" >> Doxyfile_INPUT
+echo "        ../../html/                      \\" >> Doxyfile_INPUT
+echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
+echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
+echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
+echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
+echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
+echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
+echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
+echo "        ../../math/                      \\" >> Doxyfile_INPUT
+echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
+echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
+echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
+echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
+echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
+echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
+echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
+echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
+echo "        ../../proof/                     \\" >> Doxyfile_INPUT
+echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
+echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
+echo "        ../../tree/                      \\" >> Doxyfile_INPUT
+echo "        ../../sql/                       \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
+echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
+echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
+echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/lzma/                 \\" >> Doxyfile_INPUT

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -67,7 +67,7 @@ echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
 # echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
 # echo "        ../../tree/                      \\" >> Doxyfile_INPUT
 # echo "        ../../sql/                       \\" >> Doxyfile_INPUT
-echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
+# echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
 # echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
 # echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
 # echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -25,52 +25,52 @@ echo "        ../../core/unix/                 \\" >> Doxyfile_INPUT
 echo "        ../../core/winnt/                \\" >> Doxyfile_INPUT
 echo "        ../../core/imt/                  \\" >> Doxyfile_INPUT
 echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
-echo "        ../../geom/                      \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
-echo "        ../../gui/                       \\" >> Doxyfile_INPUT
-echo "        ../../hist/                      \\" >> Doxyfile_INPUT
-echo "        ../../html/                      \\" >> Doxyfile_INPUT
-echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
-echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
-echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
-echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
-echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
-echo "        ../../math/                      \\" >> Doxyfile_INPUT
-echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
-echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
-echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
-echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
-echo "        ../../proof/                     \\" >> Doxyfile_INPUT
-echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
-echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
-echo "        ../../tree/                      \\" >> Doxyfile_INPUT
-echo "        ../../sql/                       \\" >> Doxyfile_INPUT
+# echo "        ../../geom/                      \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
+# echo "        ../../gui/                       \\" >> Doxyfile_INPUT
+# echo "        ../../hist/                      \\" >> Doxyfile_INPUT
+# echo "        ../../html/                      \\" >> Doxyfile_INPUT
+# echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
+# echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
+# echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
+# echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
+# echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
+# echo "        ../../math/                      \\" >> Doxyfile_INPUT
+# echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
+# echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
+# echo "        ../../proof/                     \\" >> Doxyfile_INPUT
+# echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
+# echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
+# echo "        ../../tree/                      \\" >> Doxyfile_INPUT
+# echo "        ../../sql/                       \\" >> Doxyfile_INPUT
 echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
-echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
-echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
-echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/lzma/                 \\" >> Doxyfile_INPUT


### PR DESCRIPTION
# This Pull request:
This draft PR for testing the doxygen generation github action with our self-hosted runners.
Uses our existing Makefile setup.

## Status
Succeeded with building only docs for `core`.
The workflow first builds `root` without tests and then makes the doxygen documentation

## Checklist:
- [x] **Test with build from scratch and all documentation folders**
- [ ] Install latest version of `doxygen`, `qhelpgenerator` and other required packages in image at https://github.com/root-project/root-ci-images
- [ ] Upload result to website/S3
- [ ] Nightlies for different releases
- [ ] OPTIMIZATION: use build from existing build workflows instead of building again in this workflow. We could for example add a job in `root-master.yml` that only builds documentation after the `run_nightlies` job. Github actions supports defining dependencies between jobs: https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs


