### PR TITLE
[webgui] check local displays first

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -15,7 +15,6 @@ if(proof)
 endif()
 
 if(webgui)
-   add_subdirectory(webdisplay)
    if(cefweb)
       add_subdirectory(cefdisplay)
    endif()
@@ -25,6 +24,9 @@ if(webgui)
    if(qt6web)
       add_subdirectory(qt6webdisplay)
    endif()
+
+   add_subdirectory(webdisplay)
+
    add_subdirectory(webgui6)
 
    if(root7)

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -693,15 +693,22 @@ bool RWebDisplayHandle::NeedHttpServer(const RWebDisplayArgs &args)
       return false;
 
    if (!args.IsHeadless() && (args.GetBrowserKind() == RWebDisplayArgs::kOn)) {
+
+#ifdef WITH_QT6WEB
       auto &qt6 = FindCreator("qt6", "libROOTQt6WebDisplay");
       if (qt6 && qt6->IsActive())
          return false;
+#endif
+#ifdef WITH_QT5WEB
       auto &qt5 = FindCreator("qt5", "libROOTQt5WebDisplay");
       if (qt5 && qt5->IsActive())
          return false;
+#endif
+#ifdef WITH_CEFWEB
       auto &cef = FindCreator("cef", "libROOTCefDisplay");
       if (cef && cef->IsActive())
          return false;
+#endif
    }
 
    return true;


### PR DESCRIPTION
Check qt5/qt6/cef in cmake before building ROOTWebDisplay library

Required to correctly detect if such displays can be used by default


