### PR TITLE
Globally assume at least GTest version 1.10.0

### DIFF
--- a/core/base/test/TBitsTests.cxx
+++ b/core/base/test/TBitsTests.cxx
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "TBits.h"
 

--- a/core/base/test/TNamedTests.cxx
+++ b/core/base/test/TNamedTests.cxx
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "TNamed.h"
 

--- a/core/base/test/TQObjectTests.cxx
+++ b/core/base/test/TQObjectTests.cxx
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "Rtypes.h"
 #include "TQObject.h"

--- a/core/meta/test/testTEnum.cxx
+++ b/core/meta/test/testTEnum.cxx
@@ -2,8 +2,8 @@
 #include "TInterpreter.h"
 
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
+#include <climits>
 #include <type_traits>
 
 TEST(TEnum, UnderlyingType)

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -12,7 +12,6 @@
 #include "TError.h"
 
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 using namespace ROOT;
 

--- a/hist/hist/test/test_THBinIterator.cxx
+++ b/hist/hist/test/test_THBinIterator.cxx
@@ -1,11 +1,5 @@
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define SetUpTestSuite SetUpTestCase
-#define TearDownTestSuite TearDownTestCase
-#endif
-
 // test iterating histogram bins and using the new THistRange and
 // THBinIterator classes
 

--- a/math/mathcore/test/stress/testGenVector.cxx
+++ b/math/mathcore/test/stress/testGenVector.cxx
@@ -4,19 +4,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 #include "StatFunction.h"
 #include "TestHelper.h"
 #include "VectorTest.h"

--- a/math/mathcore/test/stress/testSMatrix.cxx
+++ b/math/mathcore/test/stress/testSMatrix.cxx
@@ -7,19 +7,6 @@
 #include "TestHelper.h"
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 #include "VectorTest.h"
 #include "TROOT.h"
 #include "TSystem.h"

--- a/math/mathcore/test/stress/testVector.cxx
+++ b/math/mathcore/test/stress/testVector.cxx
@@ -4,19 +4,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 #include "StatFunction.h"
 #include "TestHelper.h"
 #include "VectorTest.h"

--- a/math/mathcore/test/stress/testVector34.cxx
+++ b/math/mathcore/test/stress/testVector34.cxx
@@ -4,19 +4,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 #include "StatFunction.h"
 #include "VectorTest.h"
 

--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -22,11 +22,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE
-#define TYPED_TEST_SUITE TYPED_TEST_CASE
-#endif
-
 #include <chrono>
 #include <iostream>
 #include <string>

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -13,19 +13,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 #include <iostream>
 #include <string>
 

--- a/math/mathmore/test/testStress.cxx
+++ b/math/mathmore/test/testStress.cxx
@@ -26,19 +26,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE_P
-#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef REGISTER_TYPED_TEST_SUITE_P
-#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
-#endif
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TYPED_TEST_SUITE_P
-#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
-#endif
-
 using ::testing::TestWithParam;
 using ::testing::Values;
 

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -13,11 +13,6 @@
 #include <sstream>
 #include <cmath>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 using namespace ROOT;
 using namespace ROOT::VecOps;
 using namespace ROOT::Detail::VecOps; // for `IsSmall` and `IsAdopting`

--- a/roofit/multiprocess/test/test_Job.cxx
+++ b/roofit/multiprocess/test/test_Job.cxx
@@ -25,11 +25,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include "utils.h"
 
 class xSquaredPlusBVectorSerial {

--- a/roofit/roofitZMQ/test/test_ZMQ.cpp
+++ b/roofit/roofitZMQ/test/test_ZMQ.cpp
@@ -16,11 +16,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include <unistd.h> // fork, usleep
 
 #include <sstream>

--- a/roofit/roofitcore/test/gtest_wrapper.h
+++ b/roofit/roofitcore/test/gtest_wrapper.h
@@ -3,11 +3,6 @@
 
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
 #define ROOFIT_EVAL_BACKEND_LEGACY RooFit::EvalBackend::Legacy(),
 #else

--- a/tmva/tmva/test/DNN/RNN/TestRecurrentForwardPass.cxx
+++ b/tmva/tmva/test/DNN/RNN/TestRecurrentForwardPass.cxx
@@ -17,7 +17,6 @@
 #include "TMVA/DNN/Architectures/Reference.h"
 #include "TestRecurrentForwardPass.h"
 //#include "gtest/gtest.h"
-//#include "gmock/gmock.h"
 
 using namespace TMVA::DNN;
 using namespace TMVA::DNN::RNN;

--- a/tmva/tmva/test/DNN/RNN/TestRecurrentForwardPassCpu.cxx
+++ b/tmva/tmva/test/DNN/RNN/TestRecurrentForwardPassCpu.cxx
@@ -18,7 +18,6 @@
 #include "TestRecurrentForwardPass.h"
 #include "TMath.h"
 //#include "gtest/gtest.h"
-//#include "gmock/gmock.h"
 
 using namespace TMVA::DNN;
 using namespace TMVA::DNN::RNN;

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -1,10 +1,5 @@
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RVec.hxx>
 #include <ROOT/RDFHelpers.hxx>

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -6,11 +6,6 @@
 
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include <atomic>
 #include <memory>
 #include <thread> // std::thread::hardware_concurrency

--- a/tree/dataframe/test/dataframe_regression.cxx
+++ b/tree/dataframe/test/dataframe_regression.cxx
@@ -10,11 +10,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 // Fixture for all tests in this file. If parameter is true, run with implicit MT, else run sequentially
 class RDFRegressionTests : public ::testing::TestWithParam<bool> {
 protected:

--- a/tree/dataframe/test/dataframe_samplecallback.cxx
+++ b/tree/dataframe/test/dataframe_samplecallback.cxx
@@ -11,11 +11,6 @@
 
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include <algorithm> // std::min
 #include <memory>
 #include <mutex>

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -1,11 +1,6 @@
 /****** Run RDataFrame tests both with and without IMT enabled *******/
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 #include <ROOT/TestSupport.hxx>
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/TSeq.hxx>

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -12,11 +12,6 @@
 
 #include <gtest/gtest.h>
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 using ROOT::RDF::Experimental::VariationsFor;
 
 class RDFVary : public ::testing::TestWithParam<bool> {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -36,11 +36,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef TYPED_TEST_SUITE
-#define TYPED_TEST_SUITE TYPED_TEST_CASE
-#endif
-
 #include "CustomStruct.hxx"
 
 #include <array>

--- a/tree/readspeed/test/readspeed_general.cxx
+++ b/tree/readspeed/test/readspeed_general.cxx
@@ -1,11 +1,5 @@
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define SetUpTestSuite SetUpTestCase
-#define TearDownTestSuite TearDownTestCase
-#endif
-
 #include "ReadSpeed.hxx"
 #include "ReadSpeedCLI.hxx"
 

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -11,11 +11,6 @@
 #include "ROOT/TestSupport.hxx"
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define SetUpTestSuite SetUpTestCase
-#endif
-
 #include "ElementStruct.h"
 
 class TOffsetGeneration : public ::testing::Test {

--- a/tree/tree/test/friendinfo.cxx
+++ b/tree/tree/test/friendinfo.cxx
@@ -11,11 +11,6 @@
 
 #include "gtest/gtest.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
-
 namespace {
 
 template <typename T>


### PR DESCRIPTION
It appears ROOT already depends on at least GTest 1.10.0, by using the following in some places without compatibility code:
 * `GTEST_SKIP`
 * `TestWithParam` with non-default constructible type
 * The new "test suite" naming instead of the old "test case" (I found at least `TYPED_TEST_SUITE` and `SetUpTestSuite` + `TearDownTestSuite`).

Given that an older version is only found on EL8, where we have been using `builtin_gtest` since a while, I propose to drop the remaining compatibility code.