### PR TITLE
Add Python 3.12-compatible `numba` version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,7 @@ xgboost
 # PyROOT: ROOT.Numba.Declare decorator
 numba>=0.47.0 ; python_version < "3.11" # See https://github.com/numba/numba/issues/8304
 numba>=0.57.0 ; python_version >= "3.11" and python_version < "3.12"
-# Not yet released.
-# numba>=0.59 ; python_version >= "3.12"
+numba>=0.59.0 ; python_version >= "3.12"
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel


### PR DESCRIPTION
Numba 0.59 with Python 3.12 was already released:
https://github.com/numba/numba/releases

With this change, we make sure the numba features in ROOT are still tested in environments with Python 3.12 (like for example Ubuntu 24.04 or Arch Linux as of today).