### PR TITLE
[PyROOT] Don't import `libcppyy` directly in PyROOT

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_cppinstance.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_cppinstance.py
@@ -8,11 +8,11 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-import libcppyy
-from libROOTPythonizations import AddCPPInstancePickling
-
 def pythonize_cppinstance():
-    klass = libcppyy.CPPInstance
+    import cppyy
+    from libROOTPythonizations import AddCPPInstancePickling
+
+    klass = cppyy._backend.CPPInstance
 
     AddCPPInstancePickling(klass)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_drawables.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_drawables.py
@@ -10,10 +10,12 @@
 
 from . import pythonization
 from cppyy.gbl import kCanDelete
-from libcppyy import SetOwnership
 
 
 def _Draw(self, *args):
+
+    import ROOT
+
     # Parameters:
     # self: Object being drawn
     # args: arguments for Draw
@@ -31,11 +33,14 @@ def _Draw(self, *args):
     # their constructors. Later, when being drawn, they are appended to
     # the list of primitives of gPad.
     if self.TestBit(kCanDelete):
-        SetOwnership(self, False)
+        ROOT.SetOwnership(self, False)
 
     self.Draw = self._OriginalDraw
 
 def _init(self, *args):
+
+    import ROOT
+
     # Parameters:
     # self: Object being initialized
     # args: arguments for __init__
@@ -47,7 +52,7 @@ def _init(self, *args):
     # Therefore, we need to set the ownership here and not in Draw
     # (TSlider does not need to be drawn). This is ROOT-10095.
     if self.TestBit(kCanDelete):
-        SetOwnership(self, False)
+        ROOT.SetOwnership(self, False)
         # We have already set the ownership while initializing,
         # so we do not need the custom Draw inherited from TPad to
         # do it again in case it is executed.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
@@ -11,8 +11,6 @@ import re
 import typing
 from .._numbadeclare import _NumbaDeclareDecorator
 
-import libcppyy
-
 class FunctionJitter:
     """
     This class allows to jit a python callable with Numba, being able to infer the signature of the function from the types of the RDF columns.
@@ -275,8 +273,10 @@ def _handle_cpp_callables(func, original_template, *args):
     three cases above, None otherwise
     """
 
-    is_cpp_functor  = lambda : isinstance(getattr(func, '__call__', None), libcppyy.CPPOverload)
-    is_std_function = lambda : isinstance(getattr(func, 'target_type', None), libcppyy.CPPOverload)
+    import cppyy
+
+    is_cpp_functor  = lambda : isinstance(getattr(func, '__call__', None), cppyy._backend.CPPOverload)
+    is_std_function = lambda : isinstance(getattr(func, 'target_type', None), cppyy._backend.CPPOverload)
 
     if is_cpp_functor() or is_std_function():
         return original_template[type(func)](*args)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
@@ -12,7 +12,6 @@
 
 
 from ._utils import _kwargs_to_roocmdargs, cpp_signature
-from libcppyy import SetOwnership
 
 
 class RooAbsCollection(object):
@@ -28,6 +27,9 @@ class RooAbsCollection(object):
     """
 
     def addClone(self, arg, silent=False):
+
+        import ROOT
+
         clonedArg = self._addClone(arg, silent)
         # There are two overloads of RooAbsCollection::addClone():
         #
@@ -42,11 +44,14 @@ class RooAbsCollection(object):
         # need to change any ownership flags (in fact, calling
         # SetOwnership(None, False) would cause a crash).
         if clonedArg is not None:
-            SetOwnership(clonedArg, False)
+            ROOT.SetOwnership(clonedArg, False)
 
     def addOwned(self, arg, silent=False):
+
+        import ROOT
+
         self._addOwned(arg, silent)
-        SetOwnership(arg, False)
+        ROOT.SetOwnership(arg, False)
 
     @cpp_signature(
         "RooAbsCollection::printLatex(const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_utils.py
@@ -23,11 +23,11 @@ def _kwargs_to_roocmdargs(*args, **kwargs):
 
         # We have to use ROOT here and not cppy.gbl, because the RooFit namespace is pythonized itself.
         import ROOT
-        import libcppyy
+        import cppyy
 
         func = getattr(ROOT.RooFit, k)
 
-        if isinstance(func, libcppyy.CPPOverload):
+        if isinstance(func, cppyy._backend.CPPOverload):
             # Pythonization for functions that don't pass any RooCmdArgs like ShiftToZero() and MoveToBack(). For Eg,
             # Default bindings: pdf.plotOn(frame, ROOT.RooFit.MoveToBack())
             # With pythonizations: pdf.plotOn(frame, MoveToBack=True)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -73,7 +73,6 @@ statement, you can use the context manager functionality offered by TContext.
 '''
 
 from . import pythonization
-from libcppyy import bind_object
 
 
 def _TFileConstructor(self, *args):
@@ -90,6 +89,9 @@ def _TFileConstructor(self, *args):
 
 
 def _TFileOpen(klass, *args):
+
+    import ROOT
+
     # Redefinition of ROOT.TFile.Open(str, ...):
     # check if the instance of TFile is a C++ nullptr and raise a
     # OSError if this is the case.
@@ -97,7 +99,7 @@ def _TFileOpen(klass, *args):
     # klass: TFile class
     # *args: arguments passed to the constructor
     f = klass._OriginalOpen(*args)
-    if f == bind_object(0, klass):
+    if f == ROOT.bind_object(0, klass):
         # args[0] can be either a string or a TFileOpenHandle
         raise OSError('Failed to open file {}'.format(str(args[0])))
     return f

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tseqcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tseqcollection.py
@@ -9,7 +9,6 @@
 ################################################################################
 
 from . import pythonization
-from libcppyy import SetOwnership
 
 import sys
 
@@ -75,6 +74,9 @@ def _remove_at(self, idx):
     return self.Remove(lnk)
 
 def _setitem_pyz(self, idx, val):
+
+    import ROOT
+
     # Parameters:
     # - self: collection where to set item/s
     # - idx: index/slice of the item/s
@@ -94,7 +96,7 @@ def _setitem_pyz(self, idx, val):
             # Prevent this new Python proxy from owning the C++ object
             # Otherwise we get an 'already deleted' error in
             # TList::Clear when the application ends
-            SetOwnership(elem, False)
+            ROOT.SetOwnership(elem, False)
             try:
                 i = next(it)
                 self[i] = elem

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -120,9 +120,6 @@ extern "C" PyObject* PyInit_libROOTPythonizations()
    // keep gRootModule, but do not increase its reference count even as it is borrowed,
    // or a self-referencing cycle would be created
 
-   // Make sure libcppyy has been imported
-   PyImport_ImportModule("libcppyy");
-
    // setup PyROOT
    PyROOT::Init();
 

--- a/bindings/pyroot/pythonizations/test/tcollection_iterable.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_iterable.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TCollectionIterable(unittest.TestCase):
@@ -21,7 +20,7 @@ class TCollectionIterable(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             c.Add(o)
 
         return c

--- a/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TCollectionListMethods(unittest.TestCase):
@@ -18,7 +17,7 @@ class TCollectionListMethods(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             c.Add(o)
 
         return c

--- a/bindings/pyroot/pythonizations/test/tcollection_operators.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_operators.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TCollectionOperators(unittest.TestCase):
@@ -19,7 +18,7 @@ class TCollectionOperators(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             c.Add(o)
 
         return c

--- a/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
+++ b/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TDirectoryReadWrite(unittest.TestCase):
@@ -18,19 +17,19 @@ class TDirectoryReadWrite(unittest.TestCase):
     def setUpClass(cls):
         cls.dir0 = ROOT.TDirectory("dir0", "dir0")
         h = ROOT.TH1F("h", "h", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h, False)
+        ROOT.SetOwnership(h, False)
         # this must be there otherwise the histogram is not attached to dir0
         h.SetDirectory(cls.dir0)
 
         dir1 = cls.dir0.mkdir("dir1")
         dir1.cd()
         h1 = ROOT.TH1F("h1", "h1", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h1, False)
+        ROOT.SetOwnership(h1, False)
 
         dir2 = dir1.mkdir("dir2")
         dir2.cd()
         h2 = ROOT.TH1F("h2", "h2", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h2, False)
+        ROOT.SetOwnership(h2, False)
 
     def checkHisto(self, h):
         xaxis = h.GetXaxis()

--- a/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
+++ b/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TDirectoryFileReadWrite(unittest.TestCase):
@@ -18,19 +17,19 @@ class TDirectoryFileReadWrite(unittest.TestCase):
     def setUpClass(cls):
         cls.dir0 = ROOT.TDirectoryFile("dir0", "dir0")
         h = ROOT.TH1F("h", "h", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h, False)
+        ROOT.SetOwnership(h, False)
         # this must be there otherwise the histogram is not attached to dir0
         h.SetDirectory(cls.dir0)
 
         dir1 = cls.dir0.mkdir("dir1")
         dir1.cd()
         h1 = ROOT.TH1F("h1", "h1", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h1, False)
+        ROOT.SetOwnership(h1, False)
 
         dir2 = dir1.mkdir("dir2")
         dir2.cd()
         h2 = ROOT.TH1F("h2", "h2", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h2, False)
+        ROOT.SetOwnership(h2, False)
 
     def checkHisto(self, h):
         xaxis = h.GetXaxis()

--- a/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TFileOpenReadWrite(unittest.TestCase):
@@ -19,19 +18,19 @@ class TFileOpenReadWrite(unittest.TestCase):
     def setUpClass(cls):
         f = ROOT.TFile.Open(cls.filename, "RECREATE")
         h = ROOT.TH1F("h", "h", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h, False)
+        ROOT.SetOwnership(h, False)
         f.WriteObject(h, "h")
 
         dir1 = f.mkdir("dir1")
         dir1.cd()
         h1 = ROOT.TH1F("h1", "h1", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h1, False)
+        ROOT.SetOwnership(h1, False)
         h1.Write()
 
         dir2 = dir1.mkdir("dir2")
         dir2.cd()
         h2 = ROOT.TH1F("h2", "h2", cls.nbins, cls.xmin, cls.xmax)
-        SetOwnership(h2, False)
+        ROOT.SetOwnership(h2, False)
         h2.Write()
 
         f.Close()

--- a/bindings/pyroot/pythonizations/test/titer_iterator.py
+++ b/bindings/pyroot/pythonizations/test/titer_iterator.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TIterIterator(unittest.TestCase):
@@ -18,7 +17,7 @@ class TIterIterator(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             c.Add(o)
 
         return c

--- a/bindings/pyroot/pythonizations/test/tobject_contains.py
+++ b/bindings/pyroot/pythonizations/test/tobject_contains.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TObjectContains(unittest.TestCase):
@@ -21,7 +20,7 @@ class TObjectContains(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             l.Add(o)
 
         return l

--- a/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TSeqCollectionItemAccess(unittest.TestCase):
@@ -19,7 +18,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         for _ in range(self.num_elems):
             o = ROOT.TObject()
             # Prevent immediate deletion of C++ TObjects
-            SetOwnership(o, False)
+            ROOT.SetOwnership(o, False)
             sc.Add(o)
 
         return sc

--- a/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TSeqCollectionListMethods(unittest.TestCase):

--- a/bindings/pyroot/pythonizations/test/ttree_branch_attr.py
+++ b/bindings/pyroot/pythonizations/test/ttree_branch_attr.py
@@ -1,7 +1,6 @@
 import unittest
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TTreeBranchAttr(unittest.TestCase):
@@ -41,7 +40,7 @@ class TTreeBranchAttr(unittest.TestCase):
         f = ROOT.TFile(self.filename)
         t = f.Get(self.treename)
         # Prevent double deletion of the tree (Python and C++ TFile)
-        SetOwnership(t, False)
+        ROOT.SetOwnership(t, False)
 
         c = ROOT.TChain(self.treename)
         c.Add(self.filename)
@@ -57,10 +56,10 @@ class TTreeBranchAttr(unittest.TestCase):
         f = ROOT.TFile(self.filename)
 
         nt = f.Get(self.tuplename)
-        SetOwnership(nt, False)
+        ROOT.SetOwnership(nt, False)
 
         ntd = f.Get(self.tuplename + 'D')
-        SetOwnership(ntd, False)
+        ROOT.SetOwnership(ntd, False)
 
         # Read first entry
         for ds in nt,ntd:

--- a/bindings/pyroot/pythonizations/test/ttree_iterable.py
+++ b/bindings/pyroot/pythonizations/test/ttree_iterable.py
@@ -2,7 +2,6 @@ import unittest
 from array import array
 
 import ROOT
-from libcppyy import SetOwnership
 
 
 class TTreeIterable(unittest.TestCase):
@@ -44,7 +43,7 @@ class TTreeIterable(unittest.TestCase):
         f = ROOT.TFile(self.filename)
         t = f.Get(self.treename)
         # Prevent double deletion of the tree (Python and C++ TFile)
-        SetOwnership(t, False)
+        ROOT.SetOwnership(t, False)
 
         c = ROOT.TChain(self.treename)
         c.Add(self.filename)
@@ -56,10 +55,10 @@ class TTreeIterable(unittest.TestCase):
         f = ROOT.TFile(self.filename)
 
         nt = f.Get(self.tuplename)
-        SetOwnership(nt, False)
+        ROOT.SetOwnership(nt, False)
 
         ntd = f.Get(self.tuplename + 'D')
-        SetOwnership(ntd, False)
+        ROOT.SetOwnership(ntd, False)
 
         return f,nt,ntd
 

--- a/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
+++ b/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
@@ -2,7 +2,6 @@ import unittest
 from array import array
 
 import ROOT
-from libcppyy import SetOwnership
 import numpy as np
 
 
@@ -45,7 +44,7 @@ class TTreeSetBranchAddress(unittest.TestCase):
         f = ROOT.TFile(self.filename)
         t = f.Get(self.treename)
         # Prevent double deletion of the tree (Python and C++ TFile)
-        SetOwnership(t, False)
+        ROOT.SetOwnership(t, False)
 
         c = ROOT.TChain(self.treename)
         c.Add(self.filename)
@@ -57,10 +56,10 @@ class TTreeSetBranchAddress(unittest.TestCase):
         f = ROOT.TFile(self.filename)
 
         nt = f.Get(self.tuplename)
-        SetOwnership(nt, False)
+        ROOT.SetOwnership(nt, False)
 
         ntd = f.Get(self.tuplename + 'D')
-        SetOwnership(ntd, False)
+        ROOT.SetOwnership(ntd, False)
 
         return f,nt,ntd
 


### PR DESCRIPTION
The `libcppyy` is an implementation detail of `cppyy` that we should not include directly.

This is done to anticipate more refactoring later.