### PR TITLE
[cmake] Fix distsrc script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,7 @@ add_custom_target(version COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build
 endif()
 
 #---distribution commands------------------------------------------------------------------------
-add_custom_target(distsrc COMMAND ${CMAKE_SOURCE_DIR}/build/unix/makedistsrc.sh "${ROOT_FULL_VERSION}" "${GIT_DESCRIBE_ALWAYS}" "${CMAKE_SOURCE_DIR}")
+add_custom_target(distsrc COMMAND ${CMAKE_SOURCE_DIR}/build/unix/makedistsrc.sh "${ROOT_FULL_VERSION}" "${CMAKE_SOURCE_DIR}")
 add_custom_target(dist COMMAND cpack --config CPackConfig.cmake)
 
 #---Configure and install various files neded later and for clients -----------------------------

--- a/build/unix/makedistsrc.sh
+++ b/build/unix/makedistsrc.sh
@@ -1,11 +1,13 @@
 #! /bin/sh
 
 FILEVERS=$1
-GITTAG=$2
-ROOTSRCDIR=$3
+ROOTSRCDIR=$2
 
+# FILEVERS is M.mm.pp, GITTAG must be M-mm-pp
+GITTAG=`echo $FILEVERS | tr '.' '-'`
 TARFILE=root_v$FILEVERS.source.tar
 
+rm -f ../$TARFILE ../${TARFILE}.gz
 cd $ROOTSRCDIR \
-&& git archive -v -o ../$TARFILE --prefix=root-$FILEVERS/ $GITTAG \
-&& gzip $TARFILE
+&& git archive -v -o ../$TARFILE --prefix=root-$FILEVERS/ v$GITTAG \
+&& gzip ../$TARFILE


### PR DESCRIPTION
Fixes the `make distsrc` command in the release checklist, so far working until 6.30
