### PR TITLE
[skip-ci][ci] Remove Fedora 38 builds

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora38.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora38.txt
@@ -1,5 +1,0 @@
-builtin_nlohmannjson=ON
-builtin_vdt=On
-pythia8=Off
-tmva-pymva=Off
-test_distrdf_pyspark=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -346,8 +346,6 @@ jobs:
         include:
           - image: fedora39
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
-          - image: fedora38
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20", "CMAKE_BUILD_TYPE=Debug"]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9


### PR DESCRIPTION
The distribution is at its EOL.

[I tried to resubmit the PR and test automatic backporting]