### PR TITLE
[core] Remove never used code from the callbacks.

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -1059,19 +1059,6 @@ void TClingCallbacks::DefinitionShadowed(const clang::NamedDecl *D) {
    TCling__InvalidateGlobal(D);
 }
 
-void TClingCallbacks::DeclDeserialized(const clang::Decl* D) {
-   if (const RecordDecl* RD = dyn_cast<RecordDecl>(D)) {
-      // FIXME: Our AutoLoading doesn't work (load the library) when the looked
-      // up decl is found in the PCH/PCM. We have to do that extra step, which
-      // loads the corresponding library when a decl was deserialized.
-      //
-      // Unfortunately we cannot do that with the current implementation,
-      // because the library load will pull in the header files of the library
-      // as well, even though they are in the PCH/PCM and available.
-      (void)RD;//TCling__AutoLoadCallback(RD->getNameAsString().c_str());
-   }
-}
-
 void TClingCallbacks::LibraryLoaded(const void* dyLibHandle,
                                     llvm::StringRef canonicalName) {
    TCling__LibraryLoadedRTTI(dyLibHandle, canonicalName);

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -112,10 +112,6 @@ public:
    /// data about the old (global) decl.
    void DefinitionShadowed(const clang::NamedDecl *D) override;
 
-   // Used to inform client about a new decl read by the ASTReader.
-   //
-   void DeclDeserialized(const clang::Decl *D) override;
-
    void LibraryLoaded(const void *dyLibHandle, llvm::StringRef canonicalName) override;
    void LibraryUnloaded(const void *dyLibHandle, llvm::StringRef canonicalName) override;
 

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -19,7 +19,6 @@
 #include <memory>
 
 namespace clang {
-  class ASTDeserializationListener;
   class Decl;
   class DeclContext;
   class DeclarationName;
@@ -37,7 +36,6 @@ namespace clang {
 namespace cling {
   class Interpreter;
   class InterpreterCallbacks;
-  class InterpreterDeserializationListener;
   class InterpreterExternalSemaSource;
   class InterpreterPPCallbacks;
   class Transaction;
@@ -56,12 +54,6 @@ namespace cling {
     /// callbacks. RefOwned by Sema & ASTContext.
     ///
     InterpreterExternalSemaSource* m_ExternalSemaSource;
-
-    ///\brief Our custom ASTDeserializationListener, translating interesting
-    /// events into callbacks.
-    ///
-    std::unique_ptr
-    <InterpreterDeserializationListener> m_DeserializationListener;
 
     ///\brief Our custom PPCallbacks, translating interesting
     /// events into interpreter callbacks.
@@ -83,24 +75,17 @@ namespace cling {
     ///\param[in] interp - an interpreter.
     ///\param[in] enableExternalSemaSourceCallbacks  - creates a default
     ///           InterpreterExternalSemaSource and attaches it to Sema.
-    ///\param[in] enableDeserializationListenerCallbacks - creates a default
-    ///           InterpreterDeserializationListener and attaches it to the
-    ///           ModuleManager if it is set.
     ///\param[in] enablePPCallbacks  - creates a default InterpreterPPCallbacks
     ///           and attaches it to the Preprocessor.
     ///
     InterpreterCallbacks(Interpreter* interp,
                          bool enableExternalSemaSourceCallbacks = false,
-                         bool enableDeserializationListenerCallbacks = false,
                          bool enablePPCallbacks = false);
 
     virtual ~InterpreterCallbacks();
 
     cling::Interpreter* getInterpreter() const { return m_Interpreter; }
     clang::ExternalSemaSource* getInterpreterExternalSemaSource() const;
-
-    clang::ASTDeserializationListener*
-    getInterpreterDeserializationListener() const;
 
    virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/,
                                    const clang::Token& /*IncludeTok*/,
@@ -173,16 +158,6 @@ namespace cling {
     ///
     ///\param[in] - The declaration that has been shadowed.
     virtual void DefinitionShadowed(const clang::NamedDecl*) {}
-
-    /// \brief Used to inform client about a new decl read by the ASTReader.
-    ///
-    ///\param[in] - The Decl read by the ASTReader.
-    virtual void DeclDeserialized(const clang::Decl*) {}
-
-    /// \brief Used to inform client about a new type read by the ASTReader.
-    ///
-    ///\param[in] - The Type read by the ASTReader.
-    virtual void TypeDeserialized(const clang::Type*) {}
 
     virtual void LibraryLoaded(const void*, llvm::StringRef) {}
     virtual void LibraryUnloaded(const void*, llvm::StringRef) {}

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -21,7 +21,7 @@ namespace cling {
 
   public:
     MultiplexInterpreterCallbacks(Interpreter* interp)
-      : InterpreterCallbacks(interp, true, true, true) {}
+      : InterpreterCallbacks(interp, true, true) {}
 
     void addCallback(std::unique_ptr<InterpreterCallbacks> newCb) {
       m_Callbacks.push_back(std::move(newCb));
@@ -119,18 +119,6 @@ namespace cling {
      void DefinitionShadowed(const clang::NamedDecl* D) override {
        for (auto&& cb : m_Callbacks) {
          cb->DefinitionShadowed(D);
-       }
-     }
-
-     void DeclDeserialized(const clang::Decl* D) override {
-       for (auto&& cb : m_Callbacks) {
-         cb->DeclDeserialized(D);
-       }
-     }
-
-     void TypeDeserialized(const clang::Type* Ty) override {
-       for (auto&& cb : m_Callbacks) {
-         cb->TypeDeserialized(Ty);
        }
      }
 


### PR DESCRIPTION
This will allow us to simplify our ASTConsumer model instead of creating many multiplexers that are not needed. That should simplify adoption of latest versions of clad.