### PR TITLE
[df] Avoid memory leak in JIT when the execution is not triggered

### DIFF
--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -52,6 +52,14 @@ public:
    RDataFrame(ULong64_t numEntries);
    RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource>, const ColumnNames_t &defaultColumns = {});
    RDataFrame(ROOT::RDF::Experimental::RDatasetSpec spec);
+
+   // Rule of five
+
+   RDataFrame(const RDataFrame &) = default;
+   RDataFrame &operator=(const RDataFrame &) = default;
+   RDataFrame(RDataFrame &&) = default;
+   RDataFrame &operator=(RDataFrame &&) = default;
+   ~RDataFrame();
 };
 
 namespace RDF {

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1666,6 +1666,17 @@ RDataFrame::RDataFrame(ROOT::RDF::Experimental::RDatasetSpec spec)
 {
 }
 
+RDataFrame::~RDataFrame()
+{
+   // If any node of the computation graph associated with this RDataFrame
+   // declared code to jit, we need to make sure the compilation actually
+   // happens. For example, a jitted Define could have been booked but
+   // if the computation graph is not actually run then the code of the
+   // Define node is not jitted. This in turn would cause memory leaks.
+   // See https://github.com/root-project/root/issues/15399
+   fLoopManager->Jit();
+}
+
 namespace RDF {
 namespace Experimental {
 


### PR DESCRIPTION
If a node of the computation graph needs JITting, it will allocate objects on the heap which are only freed if the JITting happens. In case the computation graph is never triggered, previously the code to be JITted was not run. Fix it by making sure that at destruction time an RDataFrame calls the JIT compilation through its RLoopManager. Also, move to a better read/write locking with the more modern ROOT::gCoreMutex.

Fixes https://github.com/root-project/root/issues/15399

