### PR TITLE
[PyROOT] Merge `libROOTPythonizations` and `libJupyROOT`

### DIFF
--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -30,35 +30,11 @@ set(py_sources
 set(JupyROOTPySrcDir python/JupyROOT)
 file(COPY ${JupyROOTPySrcDir} DESTINATION ${localruntimedir})
 
-set(libname JupyROOT)
-
-# libJupyROOT uses ROOT headers from source dirs and depends on Core
-add_library(${libname} SHARED src/IOHandler.cxx)
-# Set the suffix to '.so' and the prefix to 'lib'
-set_target_properties(${libname} PROPERTIES  ${ROOT_LIBRARY_PROPERTIES})
-if(MSVC)
-  set_target_properties(${libname} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-  set_target_properties(${libname} PROPERTIES SUFFIX ".pyd")
-  target_link_libraries(${libname} PUBLIC Core Python3::Python)
-elseif(APPLE)
-  target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-w -Wl,-undefined -Wl,dynamic_lookup Core)
-else()
-  target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all Core)
-endif()
-
-target_include_directories(${libname} SYSTEM PRIVATE ${Python3_INCLUDE_DIRS})
-
 # Compile .py files
 foreach(py_source ${py_sources})
   install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -m py_compile ${localruntimedir}/${py_source})")
   install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -O -m py_compile ${localruntimedir}/${py_source})")
 endforeach()
-
-# Install library
-install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
-                            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
-                            LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHONDIR} COMPONENT libraries
-                            ARCHIVE DESTINATION ${CMAKE_INSTALL_PYTHONDIR} COMPONENT libraries)
 
 # Install Python sources and bytecode
 install(DIRECTORY ${localruntimedir}/JupyROOT

--- a/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
@@ -19,7 +19,7 @@ from os import path
 import queue
 
 from JupyROOT import helpers
-import libJupyROOT as _lib
+import libROOTPythonizations as _lib
 
 
 class IOHandler(object):

--- a/bindings/pyroot/pythonizations/src/IOHandler.cxx
+++ b/bindings/pyroot/pythonizations/src/IOHandler.cxx
@@ -34,9 +34,6 @@
 // MODULE FUNCTIONALITY //
 //////////////////////////
 
-bool JupyROOTExecutorImpl(const char *code);
-bool JupyROOTDeclarerImpl(const char *code);
-
 class JupyROOTExecutorHandler {
 private:
    bool fCapturing = false;
@@ -268,70 +265,4 @@ PyObject *JupyROOTExecutorHandler_Dtor(PyObject * /*self*/, PyObject * /*args*/)
    JupyROOTExecutorHandler_ptr = nullptr;
 
    Py_RETURN_NONE;
-}
-
-
-//////////////////////
-// MODULE INTERFACE //
-//////////////////////
-
-PyObject *gJupyRootModule = 0;
-
-// Methods offered by the interface
-static PyMethodDef gJupyROOTMethods[] = {
-   {(char *)"JupyROOTExecutor", (PyCFunction)JupyROOTExecutor, METH_VARARGS,
-    (char *)"Create JupyROOTExecutor"},
-   {(char *)"JupyROOTDeclarer", (PyCFunction)JupyROOTDeclarer, METH_VARARGS,
-    (char *)"Create JupyROOTDeclarer"},
-   {(char *)"JupyROOTExecutorHandler_Clear", (PyCFunction)JupyROOTExecutorHandler_Clear, METH_NOARGS,
-    (char *)"Clear JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_Ctor", (PyCFunction)JupyROOTExecutorHandler_Ctor, METH_NOARGS,
-    (char *)"Create JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_Poll", (PyCFunction)JupyROOTExecutorHandler_Poll, METH_NOARGS,
-    (char *)"Poll JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_EndCapture", (PyCFunction)JupyROOTExecutorHandler_EndCapture, METH_NOARGS,
-    (char *)"End capture JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_InitCapture", (PyCFunction)JupyROOTExecutorHandler_InitCapture, METH_NOARGS,
-    (char *)"Init capture JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_GetStdout", (PyCFunction)JupyROOTExecutorHandler_GetStdout, METH_NOARGS,
-    (char *)"Get stdout JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_GetStderr", (PyCFunction)JupyROOTExecutorHandler_GetStderr, METH_NOARGS,
-    (char *)"Get stderr JupyROOTExecutorHandler"},
-   {(char *)"JupyROOTExecutorHandler_Dtor", (PyCFunction)JupyROOTExecutorHandler_Dtor, METH_NOARGS,
-    (char *)"Destruct JupyROOTExecutorHandler"},
-   {NULL, NULL, 0, NULL}};
-
-struct module_state {
-   PyObject *error;
-};
-
-#define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
-
-static int jupyrootmodule_traverse(PyObject *m, visitproc visit, void *arg)
-{
-   Py_VISIT(GETSTATE(m)->error);
-   return 0;
-}
-
-static int jupyrootmodule_clear(PyObject *m)
-{
-   Py_CLEAR(GETSTATE(m)->error);
-   return 0;
-}
-
-static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,       "libJupyROOT",        NULL,
-                                       sizeof(struct module_state), gJupyROOTMethods,     NULL,
-                                       jupyrootmodule_traverse,     jupyrootmodule_clear, NULL};
-
-/// Initialization of extension module libJupyROOT
-
-extern "C" PyObject *PyInit_libJupyROOT()
-{
-// setup PyROOT
-   gJupyRootModule = PyModule_Create(&moduledef);
-   if (!gJupyRootModule)
-      return nullptr;
-
-   Py_INCREF(gJupyRootModule);
-   return gJupyRootModule;
 }

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -30,6 +30,8 @@
 #include <utility>
 #include <vector>
 
+#include "IOHandler.cxx"
+
 using namespace CPyCppyy;
 
 namespace PyROOT {
@@ -60,6 +62,26 @@ static PyMethodDef gPyROOTMethods[] = {
     (char *)"Deserialize a pickled object"},
    {(char *)"ClearProxiedObjects", (PyCFunction)PyROOT::ClearProxiedObjects, METH_NOARGS,
     (char *)"Clear proxied objects regulated by PyROOT"},
+   {(char *)"JupyROOTExecutor", (PyCFunction)JupyROOTExecutor, METH_VARARGS,
+    (char *)"Create JupyROOTExecutor"},
+   {(char *)"JupyROOTDeclarer", (PyCFunction)JupyROOTDeclarer, METH_VARARGS,
+    (char *)"Create JupyROOTDeclarer"},
+   {(char *)"JupyROOTExecutorHandler_Clear", (PyCFunction)JupyROOTExecutorHandler_Clear, METH_NOARGS,
+    (char *)"Clear JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Ctor", (PyCFunction)JupyROOTExecutorHandler_Ctor, METH_NOARGS,
+    (char *)"Create JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Poll", (PyCFunction)JupyROOTExecutorHandler_Poll, METH_NOARGS,
+    (char *)"Poll JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_EndCapture", (PyCFunction)JupyROOTExecutorHandler_EndCapture, METH_NOARGS,
+    (char *)"End capture JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_InitCapture", (PyCFunction)JupyROOTExecutorHandler_InitCapture, METH_NOARGS,
+    (char *)"Init capture JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_GetStdout", (PyCFunction)JupyROOTExecutorHandler_GetStdout, METH_NOARGS,
+    (char *)"Get stdout JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_GetStderr", (PyCFunction)JupyROOTExecutorHandler_GetStderr, METH_NOARGS,
+    (char *)"Get stderr JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Dtor", (PyCFunction)JupyROOTExecutorHandler_Dtor, METH_NOARGS,
+    (char *)"Destruct JupyROOTExecutorHandler"},
    {NULL, NULL, 0, NULL}};
 
 struct module_state {


### PR DESCRIPTION
Having only one CPython extension for PyROOT definitely makes things easier. The `libJupyROOT` was very small.