### PR TITLE
[ci] Introduce the category of special builds

### DIFF
--- a/.github/workflows/root-ci-config/build_utils.py
+++ b/.github/workflows/root-ci-config/build_utils.py
@@ -157,7 +157,13 @@ def load_config(filename) -> dict:
             if '=' not in line:
                 continue
 
-            key, val = line.rstrip().split('=')
+            split_line = line.rstrip().split('=')
+
+            if len(split_line) == 2:
+               key, val = split_line
+            else:
+               key = split_line[0]
+               val = split_line[1]+'='+split_line[2]
 
             if val.lower() in ["on", "off"]:
                 val = val.lower()

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -1,4 +1,5 @@
 
+
 name: 'ROOT CI'
 
 on:
@@ -358,12 +359,17 @@ jobs:
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
           - image: debian125
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
+          # Special builds
+          - image: alma9
+            property: march_native
+            overrides: ["CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native"]
+
     runs-on:
       - self-hosted
       - linux
       - x64
 
-    name: ${{ matrix.image }} ${{ join( matrix.overrides, ', ' ) }}
+    name: ${{ matrix.image }} ${{ matrix.property }} ${{ join( matrix.overrides, ', ' ) }}
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready # ALSO UPDATE BELOW!

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -364,6 +364,10 @@ jobs:
             is_special: true
             property: march_native
             overrides: ["CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native"]
+          - image: alma9
+            is_special: true
+            property: modules_off
+            overrides: ["runtime_cxxmodules=Off"]
 
     runs-on:
       - self-hosted

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -361,6 +361,7 @@ jobs:
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
           # Special builds
           - image: alma9
+            is_special: true
             property: march_native
             overrides: ["CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native"]
 
@@ -453,7 +454,7 @@ jobs:
               "
 
       - name: Workflow dispatch
-        if:   github.event_name == 'workflow_dispatch'
+        if:   ${{ github.event_name == 'workflow_dispatch' && !matrix.is_special }}
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      ${{ inputs.buildtype }}
                     --platform       ${{ matrix.image }}
@@ -497,7 +498,7 @@ jobs:
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
         uses: actions/upload-artifact@v3
         with:
-          name: Binaries ${{ matrix.image }}
+          name: Binaries ${{ matrix.image }} ${{ matrix.property }}
           path: /github/home/ROOT-CI/packages/root_v*
           if-no-files-found: error
 

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1362,6 +1362,11 @@ namespace {
       argvCompile.push_back("-fno-omit-frame-pointer");
 #endif
 
+#ifdef __cpp_sized_deallocation
+      // Propagate the setting of the compiler to the interpreter
+      argvCompile.push_back("-fsized-deallocation");
+#endif
+
     // Disable optimizations and keep frame pointer when debugging, overriding
     // other optimization options that might be in argv
     if (debuggingEnabled) {

--- a/math/mathcore/test/stress/testGenVector.cxx
+++ b/math/mathcore/test/stress/testGenVector.cxx
@@ -79,7 +79,7 @@ TYPED_TEST_P(GenVectorTest, TestGenVectors)
    scale = this->fDim * 20;
    if (this->fDim == 3 && this->V2Name() == "RhoEtaPhiVector") scale *= 12; // for problem with RhoEtaPhi
    if (this->fDim == 4 && ( this->V2Name() == "PtEtaPhiMVector"  || this->V2Name() == "PxPyPzMVector")) {
-#if (defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(__s390x__))
+#if (defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(__s390x__) || defined(__FMA__))
       scale *= 1.E7;
 #else
       scale *= 10;

--- a/test/stressMathCore.cxx
+++ b/test/stressMathCore.cxx
@@ -1120,7 +1120,7 @@ int testVector(int ngen, bool testio=false) {
    scale = Dim*20;
    if (Dim==3 && VecType<V2>::name() == "RhoEtaPhiVector") scale *= 12; // for problem with RhoEtaPhi
    if (Dim==4 && ( VecType<V2>::name() == "PtEtaPhiMVector" || VecType<V2>::name() == "PxPyPzMVector")) {
-#if (defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(__s390x__))
+#if (defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(__s390x__) || defined(__FMA__))
       scale *= 1.E7;
 #else
       scale *= 10;


### PR DESCRIPTION
Special builds are those builds that test particular configurations, which are not meant to be considered for binaries of releases.

Besides the new category, two special builds are introduced:
- The "march=native" build, that fixes #12291
- The "runtime modules off" build

