### PR TITLE
[core] Fallback to urandom for increased compatibility

### DIFF
--- a/core/unix/CMakeLists.txt
+++ b/core/unix/CMakeLists.txt
@@ -51,7 +51,34 @@ else()
       message(STATUS "Found getrandom in sys/random.h")
       target_compile_definitions(Core PRIVATE R__GETRANDOM_CLIB)
     else()
-      message(FATAL_ERROR "Fail to detect cryptographic random generator")
+      CHECK_CXX_SOURCE_RUNS("
+      #include <fstream>
+
+      int main() {
+          std::ifstream urandom{\"/dev/urandom\"};
+          if (!urandom) {
+              // This will make the CMake command fail
+              return 1;
+          }
+      
+          constexpr int len{32};
+          char buf[len];
+          for (int n = 0; n < len; n++) buf[n] = 0;
+          urandom.read(buf, len);
+      
+          int nmatch = 0;
+          for (int n = 0; n < len; n++)
+              if (buf[n] == 0) nmatch++;
+      
+          // Fail if no values have changed
+          return nmatch != len ? 0 : 1;
+      }" found_urandom)
+      if(found_urandom)
+        message(STATUS "Found random device in /dev/urandom")
+        target_compile_definitions(Core PRIVATE R__USE_URANDOM)
+      else()
+        message(FATAL_ERROR "Fail to detect cryptographic random generator")
+      endif()
     endif()
   endif()
 endif()

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -744,6 +744,12 @@ Int_t TUnixSystem::GetCryptoRandom(void *buf, Int_t len)
    return len;
 #elif defined(R__GETRANDOM_CLIB)
    return getrandom(buf, len, GRND_NONBLOCK);
+#elif defined(R__USE_URANDOM)
+   std::ifstream urandom{"/dev/urandom"};
+   if (!urandom)
+      return -1;
+   urandom.read(reinterpret_cast<char *>(buf), len);
+   return len;
 #else
 #error "Reliable cryptographic random function not defined"
    return -1;


### PR DESCRIPTION
Systems with older versions of glibc do not have modern functions to get cryptographically secure random numbers. Introduce a fallback to using `/dev/urandom` in such cases. A notable example is the conda-build environment which is based on Centos7 where the glibc version is 2.17


This change is *required* to fix the conda build, so it must be backported to 6.32