### PR TITLE
[PyROOT] Correct JsMVA module path and always include JsMVA in build 

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -49,12 +49,6 @@ endif()
 
 if(tmva)
     list(APPEND PYROOT_EXTRA_PYTHON_SOURCES
-        ROOT/JsMVA/DataLoader.py
-        ROOT/JsMVA/Factory.py
-        ROOT/JsMVA/JPyInterface.py
-        ROOT/JsMVA/JsMVAMagic.py
-        ROOT/JsMVA/OutputTransformer.py
-        ROOT/JsMVA/__init__.py
         ROOT/_pythonization/_tmva/_crossvalidation.py
         ROOT/_pythonization/_tmva/_dataloader.py
         ROOT/_pythonization/_tmva/_factory.py
@@ -74,6 +68,12 @@ list(APPEND PYROOT_EXTRA_HEADERS
      inc/TPyDispatcher.h)
 
 set(py_sources
+  ROOT/JsMVA/DataLoader.py
+  ROOT/JsMVA/Factory.py
+  ROOT/JsMVA/JPyInterface.py
+  ROOT/JsMVA/JsMVAMagic.py
+  ROOT/JsMVA/OutputTransformer.py
+  ROOT/JsMVA/__init__.py
   ROOT/_application.py
   ROOT/_asan.py
   ROOT/_facade.py

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/__init__.py
@@ -11,7 +11,7 @@ from IPython.core.extensions import ExtensionManager
 def loadExtensions():
     ip = get_ipython()
     extMgr = ExtensionManager(ip)
-    extMgr.load_extension("JsMVA.JsMVAMagic")
+    extMgr.load_extension("ROOT.JsMVA.JsMVAMagic")
 
 
 loadExtensions()


### PR DESCRIPTION
Follow-up to 38ac97e5a.

Before that commit, the `JsMVA` Python sources were always included in
the build, even if `tmva=OFF`. This was accidentally changed, and breaks
`import ROOT` in a notebook if `tmva` is not enabled.