### PR TITLE
[CMake] Don't support `builtin_openssl` on Linux

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -283,7 +283,9 @@ if(builtin_all)
   set(builtin_lz4_defvalue ON)
   set(builtin_lzma_defvalue ON)
   set(builtin_nlohmannjson_defvalue ON)
-  set(builtin_openssl_defvalue ON)
+  if(APPLE)
+    set(builtin_openssl_defvalue ON)
+  endif()
   set(builtin_openui5_defvalue ON)
   set(builtin_pcre_defvalue ON)
   set(builtin_tbb_defvalue ON)
@@ -324,6 +326,11 @@ endif()
 #---Modules are disabled on aarch64 platform (due ODR violations)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)
   set(runtime_cxxmodules_defvalue OFF)
+endif()
+
+# builtin_openssl is only supported on macOS
+if(builtin_openssl AND NOT APPLE)
+    message(FATAL_ERROR ">>> Option 'builtin_openssl' is only supported on macOS.")
 endif()
 
 # MultiProcess is not possible on Windows, so fail if it is manually set:

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -651,9 +651,9 @@ if(ssl AND NOT builtin_openssl)
   else()
     find_package(OpenSSL)
     if(NOT OPENSSL_FOUND)
-      if(WIN32) # builtin OpenSSL does not work on Windows
+      if(NOT APPLE) # builtin OpenSSL is only supported on macOS
         message(STATUS "Switching OFF 'ssl' option.")
-        set(ssl OFF CACHE BOOL "Disabled because OpenSSL not found and builtin version does not work on Windows (${ssl_description})" FORCE)
+        set(ssl OFF CACHE BOOL "Disabled because OpenSSL not found and builtin version only works on macOS (${ssl_description})" FORCE)
       else()
         if(NO_CONNECTION)
           if(fail-on-missing)


### PR DESCRIPTION
The `builtin_openssl` option was specifically introduced with ROOT 6.06 for macOS support:

  * https://root.cern.ch/doc/v606/release-notes.html

  * https://github.com/root-project/root/commit/e113fd8e9c56f5cdf23f2fd7d5f2504234ffca0e

For Linux or Windows, it is not needed.

@jblomer 