### PR TITLE
Update JsMVA imports

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/DataLoader.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/DataLoader.py
@@ -5,7 +5,7 @@
 
 
 from ROOT import TH1F, TMVA, TBufferJSON
-from JsMVA import JPyInterface
+from . import JPyInterface
 import ROOT
 
 

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/Factory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/Factory.py
@@ -6,7 +6,7 @@
 
 import ROOT
 from ROOT import TMVA
-from JsMVA import JPyInterface
+from . import JPyInterface
 from xml.etree.ElementTree import ElementTree
 import json
 from IPython.core.display import display, HTML, clear_output

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JPyInterface.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JPyInterface.py
@@ -9,8 +9,8 @@ from IPython.core.display import display, HTML
 from string import Template
 import ROOT
 import sys
-from JsMVA import DataLoader, Factory
-from JsMVA import OutputTransformer
+from . import DataLoader, Factory
+from . import OutputTransformer
 
 
 ## Function inserter class

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/OutputTransformer.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/OutputTransformer.py
@@ -3,7 +3,7 @@
 #  @author Attila Bagoly <battila93@gmail.com>
 # This class will transform the TMVA original output to HTML formated output.
 
-from JsMVA import DataLoader
+from . import DataLoader
 import cgi
 import re
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

JsMVA was moved to ROOT.JsMVA, so "from JsMVA import ..." no longer works

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
