### PR TITLE
[CMake] Disable `builtin_glew` on macOS

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
@@ -5,7 +5,6 @@ builtin_fftw3=ON
 builtin_freetype=ON
 builtin_ftgl=ON
 builtin_gl2ps=ON
-builtin_glew=ON
 builtin_gsl=ON
 builtin_gtest=ON
 builtin_lz4=ON

--- a/.github/workflows/root-ci-config/buildconfig/mac13.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac13.txt
@@ -5,7 +5,6 @@ builtin_fftw3=ON
 builtin_freetype=ON
 builtin_ftgl=ON
 builtin_gl2ps=ON
-builtin_glew=ON
 builtin_gsl=ON
 builtin_gtest=ON
 builtin_lz4=ON

--- a/.github/workflows/root-ci-config/buildconfig/mac14.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac14.txt
@@ -5,7 +5,6 @@ builtin_fftw3=ON
 builtin_freetype=ON
 builtin_ftgl=ON
 builtin_gl2ps=ON
-builtin_glew=ON
 builtin_gsl=ON
 builtin_gtest=ON
 builtin_lz4=ON

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -574,13 +574,7 @@ if(opengl AND NOT builtin_glew)
     find_package(GLEW REQUIRED)
   else()
     find_package(GLEW)
-    # Bug was reported on newer version of CMake on Mac OS X:
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/19662
-    # https://github.com/microsoft/vcpkg/pull/7967
-    if(GLEW_FOUND AND APPLE AND CMAKE_VERSION VERSION_GREATER 3.15)
-      message(FATAL_ERROR "Please enable builtin Glew due bug in latest CMake (use cmake option -Dbuiltin_glew=ON).")
-      unset(GLEW_FOUND)
-    elseif(GLEW_FOUND AND NOT TARGET GLEW::GLEW)
+    if(GLEW_FOUND AND NOT TARGET GLEW::GLEW)
       add_library(GLEW::GLEW UNKNOWN IMPORTED)
       set_target_properties(GLEW::GLEW PROPERTIES
       IMPORTED_LOCATION "${GLEW_LIBRARIES}"


### PR DESCRIPTION
The CMake issue that made is necessary to use `builtin_glew` was apparently fixed last year:
https://gitlab.kitware.com/cmake/cmake/-/commit/a31b27078595fce911b2469937ac12934555644a

I checked that the CMake versions on all the three macOS platforms include the fix.

The workaround that this commit reverts was introduced here:
https://github.com/root-project/root/pull/5458
