### PR TITLE
[TMVA] Enable again all tests on `alma9` and `fedora39`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,4 +1,4 @@
 builtin_nlohmannjson=ON
 builtin_vdt=On
 tmva-sofie=On
-tmva-cpu=OFF
+BLA_VENDOR=OpenBLAS

--- a/.github/workflows/root-ci-config/buildconfig/fedora39.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora39.txt
@@ -1,4 +1,3 @@
 builtin_nlohmannjson=On
 builtin_vdt=On
 pythia8=Off
-tmva-pymva=Off

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -297,11 +297,6 @@ else()
     list(APPEND tmva_veto tmva/TMVA_SOFIE_RSofieReader.C)
     list(APPEND tmva_veto tmva/RBatchGenerator_TensorFlow.py)
   endif()
-  # The TMVA_SOFIE_RSofieReader test is disabled because it uses two differnt
-  # openblas versions via SOFIE and NumPy (indirectly from Keras) at the same
-  # time. This can cause crashes, for example on alma9.
-  # TODO: remove the next line once this problem is fixed.
-  list(APPEND tmva_veto tmva/TMVA_SOFIE_RSofieReader.C)
   if (NOT PY_SKLEARN_FOUND)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_Models.py)
   endif()


### PR DESCRIPTION
Now that we're using a system-compatible version of NumPy on the CI images for these platforms, the TMVA tests should all pass again.