### PR TITLE
[skip-ci] fix deprecation warnings in macros

### DIFF
--- a/core/base/src/TAttFill.cxx
+++ b/core/base/src/TAttFill.cxx
@@ -96,7 +96,7 @@ in your code instead of hardcoded color numbers, eg:
 Begin_Macro
 {
    TColorWheel *w = new TColorWheel();
-   cw = new TCanvas("cw","cw",0,0,400,400);
+   auto cw = new TCanvas("cw","cw",0,0,400,400);
    w->SetCanvas(cw);
    w->Draw();
 }

--- a/core/base/src/TAttMarker.cxx
+++ b/core/base/src/TAttMarker.cxx
@@ -181,7 +181,7 @@ method `GetMarkerSize`.
 
 Begin_Macro
 {
-   c = new TCanvas("c","Marker sizes",0,0,500,200);
+   auto c = new TCanvas("c","Marker sizes",0,0,500,200);
    TMarker marker;
    marker.SetMarkerStyle(3);
    Double_t x = 0;

--- a/graf2d/gpad/src/TColorWheel.cxx
+++ b/graf2d/gpad/src/TColorWheel.cxx
@@ -52,7 +52,7 @@ in your code instead of hardcoded color numbers, e.g.:
 Begin_Macro
 {
    TColorWheel *w = new TColorWheel();
-   cw = new TCanvas("cw","cw",0,0,400,400);
+   auto cw = new TCanvas("cw","cw",0,0,400,400);
    w->SetCanvas(cw);
    w->Draw();
 }

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -600,7 +600,7 @@ So the complete macro is:
 
 Begin_Macro(source)
 {
-   c1 = new TCanvas("c1","Examples of TGaxis",10,10,700,100);
+   auto c1 = new TCanvas("c1","Examples of TGaxis",10,10,700,100);
    c1->Range(-10,-1,10,1);
 
    TGaxis *axis = new TGaxis(-8,0.,8,0.,-100000,150000,2405,"tS");
@@ -628,7 +628,7 @@ will produce the following axis:
 
 Begin_Macro
 {
-   c1 = new TCanvas("c1","Examples of TGaxis",10,10,700,100);
+   auto c1 = new TCanvas("c1","Examples of TGaxis",10,10,700,100);
    c1->Range(-10,-1,10,1);
 
    TGaxis *axis = new TGaxis(-8,0.,8,0.,-100000,150000,2405,"tS");

--- a/graf3d/g3d/src/TPolyLine3D.cxx
+++ b/graf3d/g3d/src/TPolyLine3D.cxx
@@ -75,7 +75,7 @@ Begin_Macro(source)
    TView *view = TView::CreateView(1);
    view->SetRange(0,0,0,2,2,2);
    const Int_t n = 500;
-   r = new TRandom();
+   auto r = new TRandom();
    Double_t x, y, z;
    TPolyLine3D *l = new TPolyLine3D(n);
    for (Int_t i=0;i<n;i++) {

--- a/graf3d/g3d/src/TView3D.cxx
+++ b/graf3d/g3d/src/TView3D.cxx
@@ -57,7 +57,7 @@ The following macro gives an example:
 
 Begin_Macro(source)
 {
-   cV3D = new TCanvas("cV3D","PolyLine3D & PolyMarker3D Window",200,10,500,500);
+   auto cV3D = new TCanvas("cV3D","PolyLine3D & PolyMarker3D Window",200,10,500,500);
 
    // Creating a view
    TView3D *view = (TView3D*) TView::CreateView(1);

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -144,7 +144,7 @@ Begin_Macro(source)
       x[i] = i*0.1;
       y[i] = 10*sin(x[i]+0.2);
    }
-   gr = new TGraph(n,x,y);
+   auto gr = new TGraph(n,x,y);
    gr->SetLineColor(2);
    gr->SetLineWidth(4);
    gr->SetMarkerColor(4);

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -2335,7 +2335,7 @@ Double_t TMath::FDistI(Double_t F, Double_t N, Double_t M)
 ///   gdist->SetLineColor(6);
 ///   TF1 *gdist4 = gdist->DrawCopy("LSAME");
 ///
-///   legend = new TLegend(0.15, 0.15, 0.5, 0.35);
+///   auto legend = new TLegend(0.15, 0.15, 0.5, 0.35);
 ///   legend->AddEntry(gdist1, "gamma = 0.5, mu = 0, beta = 1", "L");
 ///   legend->AddEntry(gdist2, "gamma = 1.0, mu = 0, beta = 1", "L");
 ///   legend->AddEntry(gdist3, "gamma = 2.0, mu = 0, beta = 1", "L");
@@ -2425,7 +2425,7 @@ Double_t TMath::LaplaceDistI(Double_t x, Double_t alpha, Double_t beta)
 ///   logn->SetLineColor(6);
 ///   TF1 *logn4 = logn->DrawCopy("LSAME");
 ///
-///   legend = new TLegend(0.15, 0.15, 0.5, 0.35);
+///   auto legend = new TLegend(0.15, 0.15, 0.5, 0.35);
 ///   legend->AddEntry(logn1, "sigma = 0.5, theta = 0, m = 1", "L");
 ///   legend->AddEntry(logn2, "sigma = 1.0, theta = 0, m = 1", "L");
 ///   legend->AddEntry(logn3, "sigma = 2.0, theta = 0, m = 1", "L");
@@ -2766,7 +2766,7 @@ Double_t TMath::StudentQuantile(Double_t p, Double_t ndf, Bool_t lower_tail)
 ///   vavilov->SetLineColor(6);
 ///   TF1 *vavilov4 = vavilov->DrawCopy("LSAME");
 ///
-///   legend = new TLegend(0.5, 0.65, 0.85, 0.85);
+///   auto legend = new TLegend(0.5, 0.65, 0.85, 0.85);
 ///   legend->AddEntry(vavilov1, "kappa = 0.5, beta2 = 0", "L");
 ///   legend->AddEntry(vavilov2, "kappa = 0.3, beta2 = 0", "L");
 ///   legend->AddEntry(vavilov3, "kappa = 0.2, beta2 = 0", "L");

--- a/tutorials/legacy/rootenv.C
+++ b/tutorials/legacy/rootenv.C
@@ -9,7 +9,7 @@
 
 {
    gROOT->Reset();
-   c1 = new TCanvas("c1","ROOT Environment Canvas",720,840);
+   auto c1 = new TCanvas("c1","ROOT Environment Canvas",720,840);
    c1->Range(0,-0.25,19,29);
    TPaveLabel title(3,27.1,15,28.7,"ROOT Environment and Tools");
    title.SetFillColor(42);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

warning: declaration without the 'auto' keyword is deprecated: function '...' [-Wdeprecated-declarations]

