### PR TITLE
[RF] Fix behaviour of getAllConstraints

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -167,13 +167,13 @@ public:
 
   // Constraint management
   virtual RooArgSet* getConstraints(const RooArgSet& /*observables*/, RooArgSet& /*constrainedParams*/,
-                                    bool /*stripDisconnected*/, bool /*removeConstraintsFromPdf*/=false) const
+                                    bool /*stripDisconnected*/) const
   {
     // Interface to retrieve constraint terms on this pdf. Default implementation returns null
     return nullptr ;
   }
   RooArgSet* getAllConstraints(const RooArgSet& observables, RooArgSet& constrainedParams,
-                               bool stripDisconnected=true, bool removeConstraintsFromPdf=false) const ;
+                               bool stripDisconnected=true) const ;
 
   // Project p.d.f into lower dimensional p.d.f
   virtual RooAbsPdf* createProjection(const RooArgSet& iset) ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -166,8 +166,7 @@ public:
   }
 
   // Constraint management
-  virtual RooArgSet* getConstraints(const RooArgSet& /*observables*/, RooArgSet& /*constrainedParams*/,
-                                    bool /*stripDisconnected*/) const
+  virtual RooArgSet* getConstraints(const RooArgSet& /*observables*/, RooArgSet const& /*constrainedParams*/, RooArgSet& /*pdfParams*/) const
   {
     // Interface to retrieve constraint terms on this pdf. Default implementation returns null
     return nullptr ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -76,7 +76,7 @@ public:
 
   // Constraint management
   RooArgSet* getConstraints(const RooArgSet& observables, RooArgSet& constrainedParams,
-                            bool stripDisconnected, bool removeConstraintsFromPdf=false) const override ;
+                            bool stripDisconnected) const override ;
 
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;
   std::list<double>* binBoundaries(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -75,8 +75,7 @@ public:
   bool isDirectGenSafe(const RooAbsArg& arg) const override ;
 
   // Constraint management
-  RooArgSet* getConstraints(const RooArgSet& observables, RooArgSet& constrainedParams,
-                            bool stripDisconnected) const override ;
+  RooArgSet* getConstraints(const RooArgSet& observables, RooArgSet const& constrainedParams, RooArgSet &pdfParams) const override ;
 
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;
   std::list<double>* binBoundaries(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -92,13 +92,11 @@ getGlobalObservables(RooAbsPdf const &pdf, RooArgSet const *globalObservables, c
 ///            `globalObservables` or `globalObservablesTag` parameters, the
 ///            values of all global observables that are not stored in the
 ///            dataset are taken from the model.
-/// \param[in] removeConstraintsFromPdf If true, the constraints that are extracted
-///            from the PDF are removed from the original PDF.
 std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbsPdf const &pdf, RooAbsData const &data,
                                                  RooArgSet const *constrainedParameters,
                                                  RooArgSet const *externalConstraints,
                                                  RooArgSet const *globalObservables, const char *globalObservablesTag,
-                                                 bool takeGlobalObservablesFromData, bool removeConstraintsFromPdf)
+                                                 bool takeGlobalObservablesFromData)
 {
    RooArgSet const &observables = *data.get();
 
@@ -123,7 +121,7 @@ std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbs
 
    if (!cPars.empty()) {
       std::unique_ptr<RooArgSet> internalConstraints{
-         pdf.getAllConstraints(observables, cPars, doStripDisconnected, removeConstraintsFromPdf)};
+         pdf.getAllConstraints(observables, cPars, doStripDisconnected)};
       allConstraints.add(*internalConstraints);
    }
    if (externalConstraints) {

--- a/roofit/roofitcore/src/ConstraintHelpers.h
+++ b/roofit/roofitcore/src/ConstraintHelpers.h
@@ -19,6 +19,6 @@ std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbs
                                                  RooArgSet const *constrainedParameters,
                                                  RooArgSet const *externalConstraints,
                                                  RooArgSet const *globalObservables, const char *globalObservablesTag,
-                                                 bool takeGlobalObservablesFromData, bool removeConstraintsFromPdf);
+                                                 bool takeGlobalObservablesFromData);
 
 #endif

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -708,7 +708,7 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, const Ro
    // Lambda function to create the correct constraint term for a PDF. In old
    // RooFit, we use this PDF itself as the argument, for the new BatchMode
    // we're passing a clone.
-   auto createConstr = [&](bool removeConstraintsFromPdf = false) -> std::unique_ptr<RooAbsReal> {
+   auto createConstr = [&]() -> std::unique_ptr<RooAbsReal> {
       return createConstraintTerm(baseName + "_constr",                    // name
                                   pdf,                                     // pdf
                                   data,                                    // data
@@ -716,8 +716,7 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, const Ro
                                   pc.getSet("extCons"),                    // ExternalConstraints RooCmdArg
                                   pc.getSet("glObs"),                      // GlobalObservables RooCmdArg
                                   pc.getString("globstag", nullptr, true), // GlobalObservablesTag RooCmdArg
-                                  takeGlobalObservablesFromData,           // From GlobalObservablesSource RooCmdArg
-                                  removeConstraintsFromPdf);
+                                  takeGlobalObservablesFromData);          // From GlobalObservablesSource RooCmdArg
    };
 
    auto evalBackend = static_cast<RooFit::EvalBackend::Value>(pc.getInt("EvalBackend"));

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2560,7 +2560,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createScanCdf(const RooArgSet& iset, co
 /// and returns a RooArgSet with all those terms.
 
 RooArgSet* RooAbsPdf::getAllConstraints(const RooArgSet& observables, RooArgSet& constrainedParams,
-                                        bool stripDisconnected, bool removeConstraintsFromPdf) const
+                                        bool stripDisconnected) const
 {
   RooArgSet* ret = new RooArgSet("AllConstraints") ;
 
@@ -2569,7 +2569,7 @@ RooArgSet* RooAbsPdf::getAllConstraints(const RooArgSet& observables, RooArgSet&
     auto pdf = dynamic_cast<const RooAbsPdf*>(arg) ;
     if (pdf && !ret->find(pdf->GetName())) {
       std::unique_ptr<RooArgSet> compRet(
-              pdf->getConstraints(observables,constrainedParams,stripDisconnected,removeConstraintsFromPdf));
+              pdf->getConstraints(observables,constrainedParams,stripDisconnected));
       if (compRet) {
         ret->add(*compRet,false) ;
       }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1960,7 +1960,7 @@ bool sortedNamePtrsOverlap(std::vector<TNamed const*> const& ptrsA, std::vector<
 /// of parameters only, which can serve as constraints p.d.f.s
 
 RooArgSet* RooProdPdf::getConstraints(const RooArgSet& observables, RooArgSet& constrainedParams,
-                                      bool stripDisconnected, bool removeConstraintsFromPdf) const
+                                      bool stripDisconnected) const
 {
   RooArgSet constraints ;
   RooArgSet pdfParams;
@@ -2010,11 +2010,6 @@ RooArgSet* RooProdPdf::getConstraints(const RooArgSet& observables, RooArgSet& c
       tmp.remove(observables, /*silent=*/false, /*matchByNameOnly=*/true);
       pdfParams.add(tmp,true) ;
     }
-  }
-
-  // Remove the constraints now from the PDF if the caller requested it
-  if(removeConstraintsFromPdf) {
-    const_cast<RooProdPdf*>(this)->removePdfs(constraints);
   }
 
   // Strip any constraints that are completely decoupled from the other product terms

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -26,6 +26,8 @@
 
 #include <ROOT/TestSupport.hxx>
 
+#include <TMath.h>
+
 #include "gtest_wrapper.h"
 
 #include <cmath>
@@ -754,4 +756,56 @@ TEST(NLL, SetData)
    // The dataset was built in such a way that the updated NLL is shifted by
    // 0.5, so this is what we analytically expect.
    EXPECT_DOUBLE_EQ(valSimB, valSimA + 0.5);
+}
+
+// In some frameworks like CMS combine, all constraints are contained in a
+// single RooProdPdf, even if the constrained parameters are not used in this
+// pdf. The RooFit logic to figure out constrained parameters should however
+// now be confused by this, and not strip away these parameters from the list
+// of constrained parameters.
+TEST(CreateNLL, CombineStyleConstraints)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooWorkspace ws;
+   ws.factory("Gaussian::g_main_1(x_1[0., -10, 10], mu_1[0., -10, 10], 1.0)");
+   ws.factory("Gaussian::g_main_2(x_2[0., -10, 10], mu_2[0., -10, 10], 1.0)");
+   ws.factory("Gaussian::g_constr_1(mu_1, 0.0, 1.0)");
+   ws.factory("Gaussian::g_constr_2(mu_2, 0.0, 1.0)");
+
+   // The RooProdPdf model_1 will contain all the constraints, also the one
+   // that applies to g_main_1. This is the corner case that this test is
+   // covering.
+   ws.factory("PROD::model_1(g_main_1, g_constr_1, g_constr_2)");
+   ws.factory("PROD::model_2(g_main_2)");
+   ws.factory("SIMUL::model(cat[A=0, B=1], A=model_1, B=model_2)");
+
+   auto &x1 = *ws.var("x_1");
+   auto &x2 = *ws.var("x_2");
+   auto &cat = *ws.cat("cat");
+   auto &model = static_cast<RooSimultaneous &>(*ws.pdf("model"));
+
+   RooArgSet vars{x1, x2, cat};
+   RooDataSet data{"data", "data", vars};
+   cat.setIndex(0);
+   data.add(vars);
+   cat.setIndex(1);
+   data.add(vars);
+
+   RooArgSet parameters;
+   model.getParameters(data.get(), parameters);
+
+   model.getAllConstraints(*data.get(), parameters, true);
+
+   EXPECT_EQ(parameters.size(), 2);
+   EXPECT_EQ(parameters.find("mu_1"), ws.var("mu_1"));
+   EXPECT_EQ(parameters.find("mu_2"), ws.var("mu_2"));
+
+   // Now, try it out in the context of createNLL
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(data)};
+   const double proba = TMath::Gaus(0, 0, 1, true);
+   const double nChannels = model.indexCat().size();
+   //                                     main Gaussians                one constraint per channel
+   const double refNllVal = -nChannels * (std::log(proba / nChannels) + std::log(proba));
+   EXPECT_FLOAT_EQ(nll->getVal(), refNllVal);
 }


### PR DESCRIPTION
In trying to debug the fit to the CMS higgs discovery workspace, I found that the way the constraintTerm is determined will be buggy if doing a stripDisconnected determination of the constraint terms (i.e. not using the `Constrain` option). The cause is that the RooArgSet of parameters passed to `RooAbsPdf::getConstraints` gets modified, and therefore subsequent components don't see the full list of parameters of the parent pdf, so the list of constraint terms ends up being incomplete.

I think this PR fixes things