### PR TITLE
[RF] Implement `reduce()` also for concrete RooAbsData classes

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -216,6 +216,24 @@ public:
   std::string declWeightArrayForCodeSquash(RooAbsArg const *klass, RooFit::Detail::CodeSquashContext &ctx,
                                            bool correctForBinSize) const;
 
+   /// Forwards to RooAbsData::reduce(), only with the return value casted to
+   /// the actual RooDataHist type.
+   template <typename... Args>
+   inline RooFit::OwningPtr<RooDataHist> reduce(Args && ...args)
+   {
+      return RooFit::OwningPtr<RooDataHist>{&dynamic_cast<RooDataHist &>(
+         *std::unique_ptr<RooAbsData>{RooAbsData::reduce(std::forward<Args>(args)...)}.release())};
+   }
+
+   /// Forwards to RooAbsData::reduce(), only with the return value casted to
+   /// the actual RooDataHist type.
+   template <typename... Args>
+   inline RooFit::OwningPtr<RooDataHist> reduce(RooArgSet const &varSubset, Args &&...args)
+   {
+      return RooFit::OwningPtr<RooDataHist>{&dynamic_cast<RooDataHist &>(
+         *std::unique_ptr<RooAbsData>{RooAbsData::reduce(varSubset, std::forward<Args>(args)...)}.release())};
+   }
+
   protected:
   friend class RooDataHistSliceIter ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -162,6 +162,24 @@ public:
 
   void convertToTreeStore() override;
 
+   /// Forwards to RooAbsData::reduce(), only with the return value casted to
+   /// the actual RooDataSet type.
+   template <typename... Args>
+   inline RooFit::OwningPtr<RooDataSet> reduce(Args && ...args)
+   {
+      return RooFit::OwningPtr<RooDataSet>{&dynamic_cast<RooDataSet &>(
+         *std::unique_ptr<RooAbsData>{RooAbsData::reduce(std::forward<Args>(args)...)}.release())};
+   }
+
+   /// Forwards to RooAbsData::reduce(), only with the return value casted to
+   /// the actual RooDataHist type.
+   template <typename... Args>
+   inline RooFit::OwningPtr<RooDataSet> reduce(RooArgSet const &varSubset, Args &&...args)
+   {
+      return RooFit::OwningPtr<RooDataSet>{&dynamic_cast<RooDataSet &>(
+         *std::unique_ptr<RooAbsData>{RooAbsData::reduce(varSubset, std::forward<Args>(args)...)}.release())};
+   }
+
 protected:
 
   friend class RooProdGenContext ;

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -1460,10 +1460,10 @@ public:
       // ---------------------------------------------------------------------------------------------
 
       // Make subset of experimental data with only y values
-      std::unique_ptr<RooAbsData> expDataY{expDataXY->reduce(y)};
+      std::unique_ptr<RooDataSet> expDataY{expDataXY->reduce(y)};
 
       // Generate 10000 events in x obtained from _conditional_ model(x|y) with y values taken from experimental data
-      std::unique_ptr<RooDataSet> data{model.generate(x, ProtoData(static_cast<RooDataSet &>(*expDataY)))};
+      std::unique_ptr<RooDataSet> data{model.generate(x, ProtoData(*expDataY))};
 
       // F i t   c o n d i t i o n a l   p . d . f   m o d e l ( x | y )   t o   d a t a
       // ---------------------------------------------------------------------------------------------
@@ -1479,12 +1479,12 @@ public:
       model.plotOn(xframe, ProjWData(*expDataY));
 
       // Speed up (and approximate) projection by using binned clone of data for projection
-      std::unique_ptr<RooAbsData> binnedDataY{static_cast<RooDataSet &>(*expDataY).binnedClone()};
+      std::unique_ptr<RooAbsData> binnedDataY{expDataY->binnedClone()};
       model.plotOn(xframe, ProjWData(*binnedDataY), LineColor(kCyan), LineStyle(kDotted), Name("Alt1"));
 
       // Show effect of projection with too coarse binning
       static_cast<RooRealVar *>(expDataY->get()->find("y"))->setBins(5);
-      std::unique_ptr<RooAbsData> binnedDataY2{static_cast<RooDataSet &>(*expDataY).binnedClone()};
+      std::unique_ptr<RooAbsData> binnedDataY2{expDataY->binnedClone()};
       model.plotOn(xframe, ProjWData(*binnedDataY2), LineColor(kRed), Name("Alt2"));
 
       regPlot(xframe, "rf303_plot1");
@@ -2333,11 +2333,11 @@ public:
 
       // Calculate LL ratio for each generated event and select MC events with llratio)0.7
       mcprojData->addColumn(llratio_func);
-      std::unique_ptr<RooAbsData> mcprojDataSel{mcprojData->reduce(Cut("llratio>0.7"))};
+      std::unique_ptr<RooDataSet> mcprojDataSel{mcprojData->reduce(Cut("llratio>0.7"))};
 
       // Project model on x, integrating projected observables (y,z) with Monte Carlo technique
       // on set of events with the same llratio cut as was applied to data
-      model.plotOn(frame2, ProjWData(static_cast<RooDataSet &>(*mcprojDataSel)));
+      model.plotOn(frame2, ProjWData(*mcprojDataSel));
 
       regPlot(frame, "rf316_plot1");
       regPlot(frame2, "rf316_plot2");
@@ -2391,19 +2391,19 @@ public:
       // -------------------------------------------------------------
 
       // The reduce() function returns a new dataset which is a subset of the original
-      std::unique_ptr<RooAbsData> d1{d.reduce(RooArgSet(x, c))};
-      std::unique_ptr<RooAbsData> d2{d.reduce(RooArgSet(y))};
-      std::unique_ptr<RooAbsData> d3{d.reduce("y>5.17")};
-      std::unique_ptr<RooAbsData> d4{d.reduce(RooArgSet(x, c), "y>5.17")};
+      std::unique_ptr<RooDataSet> d1{d.reduce({x, c})};
+      std::unique_ptr<RooDataSet> d2{d.reduce({y})};
+      std::unique_ptr<RooDataSet> d3{d.reduce("y>5.17")};
+      std::unique_ptr<RooDataSet> d4{d.reduce({x, c}, "y>5.17")};
 
       regValue(d3->numEntries(), "rf403_nd3");
       regValue(d4->numEntries(), "rf403_nd4");
 
       // The merge() function adds two data set column-wise
-      static_cast<RooDataSet &>(*d1).merge(static_cast<RooDataSet *>(d2.get()));
+      d1->merge(d2.get());
 
       // The append() function adds two datasets row-wise
-      static_cast<RooDataSet &>(*d1).append(static_cast<RooDataSet &>(*d3));
+      d1->append(*d3);
 
       regValue(d1->numEntries(), "rf403_nd1");
 

--- a/tutorials/roofit/rf303_conditional.C
+++ b/tutorials/roofit/rf303_conditional.C
@@ -53,8 +53,7 @@ void rf303_conditional()
    // ---------------------------------------------------------------------------------------------
 
    // Make subset of experimental data with only y values
-   std::unique_ptr<RooAbsData> expAbsDataY{expDataXY->reduce(y)};
-   RooDataSet *expDataY = static_cast<RooDataSet*>(expAbsDataY.get());
+   std::unique_ptr<RooDataSet> expDataY{expDataXY->reduce(y)};
 
    // Generate 10000 events in x obtained from _conditional_ model(x|y) with y values taken from experimental data
    std::unique_ptr<RooDataSet> data{model.generate(x, ProtoData(*expDataY))};

--- a/tutorials/roofit/rf402_datahandling.C
+++ b/tutorials/roofit/rf402_datahandling.C
@@ -78,29 +78,29 @@ void rf402_datahandling()
 
    // The reduce() function returns a new dataset which is a subset of the original
    cout << endl << ">> d1 has only columns x,c" << endl;
-   std::unique_ptr<RooAbsData> d1{d.reduce({x, c})};
+   std::unique_ptr<RooDataSet> d1{d.reduce({x, c})};
    d1->Print("v");
 
    cout << endl << ">> d2 has only column y" << endl;
-   std::unique_ptr<RooAbsData> d2{d.reduce({y})};
+   std::unique_ptr<RooDataSet> d2{d.reduce({y})};
    d2->Print("v");
 
    cout << endl << ">> d3 has only the points with y>5.17" << endl;
-   std::unique_ptr<RooAbsData> d3{d.reduce("y>5.17")};
+   std::unique_ptr<RooDataSet> d3{d.reduce("y>5.17")};
    d3->Print("v");
 
    cout << endl << ">> d4 has only columns x,c for data points with y>5.17" << endl;
-   std::unique_ptr<RooAbsData> d4{d.reduce({x, c}, "y>5.17")};
+   std::unique_ptr<RooDataSet> d4{d.reduce({x, c}, "y>5.17")};
    d4->Print("v");
 
    // The merge() function adds two data set column-wise
    cout << endl << ">> merge d2(y) with d1(x,c) to form d1(x,c,y)" << endl;
-   static_cast<RooDataSet&>(*d1).merge(&static_cast<RooDataSet&>(*d2));
+   d1->merge(d2.get());
    d1->Print("v");
 
    // The append() function adds two datasets row-wise
    cout << endl << ">> append data points of d3 to d1" << endl;
-   static_cast<RooDataSet&>(*d1).append(static_cast<RooDataSet&>(*d3));
+   d1->append(*d3);
    d1->Print("v");
 
    // O p e r a t i o n s   o n   b i n n e d   d a t a s e t s

--- a/tutorials/roofit/rf404_categories.C
+++ b/tutorials/roofit/rf404_categories.C
@@ -128,6 +128,6 @@ void rf404_categories()
    tagCat.addToRange("soso", "NetTagger-2");
 
    // Use category range in dataset reduction specification
-   std::unique_ptr<RooAbsData> goodData{data->reduce(CutRange("good"))};
-   static_cast<RooDataSet&>(*goodData).table(tagCat)->Print("v");
+   std::unique_ptr<RooDataSet> goodData{data->reduce(CutRange("good"))};
+   goodData->table(tagCat)->Print("v");
 }

--- a/tutorials/roofit/rf602_chi2fit.C
+++ b/tutorials/roofit/rf602_chi2fit.C
@@ -68,8 +68,8 @@ void rf602_chi2fit()
    // Note that entries with zero bins are _not_ allowed
    // for a proper chi^2 calculation and will give error
    // messages
-   std::unique_ptr<RooAbsData> dsmall{d->reduce(EventRange(1, 100))};
-   std::unique_ptr<RooDataHist> dhsmall{static_cast<RooDataSet&>(*dsmall).binnedClone()};
+   std::unique_ptr<RooDataSet> dsmall{d->reduce(EventRange(1, 100))};
+   std::unique_ptr<RooDataHist> dhsmall{dsmall->binnedClone()};
    std::unique_ptr<RooAbsReal> chi2_lowstat{model.createChi2(*dhsmall)};
    cout << chi2_lowstat->getVal() << endl;
 }


### PR DESCRIPTION
Add member functions to RooAbsData and RooDataHist that forward to `RooAbsData::reduce()`, but cast the return value to the actual type.

This is not that useful now except for avoiding some boiler plate code, but will be crucial once we change the return type to `std::unique_ptr` to fix memory leaks: in that case, PyROOT doesn't do the automatic conversion to the actual type anymore, and we would end up with RooDataHists or RooDataSets where we can't call their member functions (unless they are overrides of RooAbsData methods).