### PR TITLE
[skip-ci] fix doxygen parnames

### DIFF
--- a/core/foundation/inc/ROOT/StringUtils.hxx
+++ b/core/foundation/inc/ROOT/StringUtils.hxx
@@ -26,7 +26,7 @@ std::vector<std::string> Split(std::string_view str, std::string_view delims, bo
 
 /**
  * \brief Concatenate a list of strings with a separator
- * \tparm Any container of strings (vector, initializer_list, ...)
+ * \tparam StringCollection_t Any container of strings (vector, initializer_list, ...)
  * \param[in] sep Separator inbetween the strings.
  * \param[in] strings container of strings
  * \return the sep-delimited concatenation of strings

--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
@@ -55,12 +55,12 @@ public:
 
    /*! \brief Constructor of ROperator_ConvTranspose from the attributes
     *
-    * \param auto_pad padding
+    * \param autopad padding
     * \param dilations dilations of the kernel
     * \param group number of groups
-    * \param kernel_shape shape of the kernel
-    * \param output_padding padding of the output
-    * \param output_shape shape of the output
+    * \param kernelShape shape of the kernel
+    * \param outputPadding padding of the output
+    * \param outputShape shape of the output
     * \param pads padding of the input
     * \param strides strides
     * \param nameX name of the input


### PR DESCRIPTION
to avoid warnings when building docu