### PR TITLE
[cmake] Fix issue #15447

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -345,7 +345,7 @@ endif()
 
 #---Apply minimal or gminimal------------------------------------------------------------------
 foreach(opt ${root_build_options})
-  if(NOT opt MATCHES "builtin_llvm|builtin_clang|builtin_cling|shared")
+  if(NOT opt MATCHES "builtin_llvm|builtin_clang|builtin_cling|shared|runtime_cxxmodules")
     if(minimal)
       set(${opt}_defvalue OFF)
     elseif(gminimal AND NOT opt MATCHES "x11|cocoa")


### PR DESCRIPTION
Don't disable the runtime C++ modules when specifying `-Dminimal=ON`
