### PR TITLE
[RF] Implement code generation for `RooCBShape`

### DIFF
--- a/roofit/roofit/inc/RooCBShape.h
+++ b/roofit/roofit/inc/RooCBShape.h
@@ -38,6 +38,10 @@ public:
   Int_t getMaxVal(const RooArgSet& vars) const override ;
   double maxVal(Int_t code) const override ;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+  std::string
+  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   double ApproxErf(double arg) const ;

--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -26,24 +26,14 @@ PDF implementing the Crystal Ball line shape.
 #include "RooMath.h"
 #include "RooBatchCompute.h"
 
+#include <RooFit/Detail/AnalyticalIntegrals.h>
+#include <RooFit/Detail/EvaluateFuncs.h>
+
 #include "TMath.h"
 
 #include <cmath>
 
 ClassImp(RooCBShape);
-
-////////////////////////////////////////////////////////////////////////////////
-
-double RooCBShape::ApproxErf(double arg) const
-{
-  static const double erflim = 5.0;
-  if( arg > erflim )
-    return 1.0;
-  if( arg < -erflim )
-    return -1.0;
-
-  return RooMath::erf(arg);
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -70,21 +60,14 @@ RooCBShape::RooCBShape(const RooCBShape& other, const char* name) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooCBShape::evaluate() const {
-  double t = (m-m0)/sigma;
-  if (alpha < 0) t = -t;
+double RooCBShape::evaluate() const
+{
+   return RooFit::Detail::EvaluateFuncs::cbShapeEvaluate(m, m0, sigma, alpha, n);
+}
 
-  double absAlpha = std::abs((double)alpha);
-
-  if (t >= -absAlpha) {
-    return exp(-0.5*t*t);
-  }
-  else {
-    double a =  TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
-    double b= n/absAlpha - absAlpha;
-
-    return a/TMath::Power(b - t, n);
-  }
+void RooCBShape::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   ctx.addResult(this, ctx.buildCall("RooFit::Detail::EvaluateFuncs::cbShapeEvaluate", m, m0, sigma, alpha, n));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -107,68 +90,17 @@ Int_t RooCBShape::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
+double RooCBShape::analyticalIntegral(Int_t code, const char *rangeName) const
 {
-  static const double sqrtPiOver2 = 1.2533141373;
-  static const double sqrt2 = 1.4142135624;
+   using namespace RooFit::Detail::AnalyticalIntegrals;
+   return cbShapeIntegral(m.min(rangeName), m.max(rangeName), m0, sigma, alpha, n);
+}
 
-  R__ASSERT(code==1);
-  double result = 0.0;
-  bool useLog = false;
-
-  if( std::abs(n-1.0) < 1.0e-05 )
-    useLog = true;
-
-  double sig = std::abs((double)sigma);
-
-  double tmin = (m.min(rangeName)-m0)/sig;
-  double tmax = (m.max(rangeName)-m0)/sig;
-
-  if(alpha < 0) {
-    double tmp = tmin;
-    tmin = -tmax;
-    tmax = -tmp;
-  }
-
-  double absAlpha = std::abs((double)alpha);
-
-  if( tmin >= -absAlpha ) {
-    result += sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
-                                - ApproxErf(tmin/sqrt2) );
-  }
-  else if( tmax <= -absAlpha ) {
-    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
-    double b = n/absAlpha - absAlpha;
-
-    if(useLog) {
-      result += a*sig*( log(b-tmin) - log(b-tmax) );
-    }
-    else {
-      result += a*sig/(1.0-n)*(   1.0/(TMath::Power(b-tmin,n-1.0))
-                                - 1.0/(TMath::Power(b-tmax,n-1.0)) );
-    }
-  }
-  else {
-    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
-    double b = n/absAlpha - absAlpha;
-
-    double term1 = 0.0;
-    if(useLog) {
-      term1 = a*sig*(  log(b-tmin) - log(n/absAlpha));
-    }
-    else {
-      term1 = a*sig/(1.0-n)*(   1.0/(TMath::Power(b-tmin,n-1.0))
-                              - 1.0/(TMath::Power(n/absAlpha,n-1.0)) );
-    }
-
-    double term2 = sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
-                                     - ApproxErf(-absAlpha/sqrt2) );
-
-
-    result += term1 + term2;
-  }
-
-  return result != 0. ? result : 1.E-300;
+std::string
+RooCBShape::buildCallToAnalyticIntegral(Int_t /*code*/, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const
+{
+   return ctx.buildCall("RooFit::Detail::AnalyticalIntegrals::cbShapeIntegral",
+                        m.min(rangeName), m.max(rangeName), m0, sigma, alpha, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -34,7 +34,8 @@ inline double gaussianEvaluate(double x, double mean, double sigma)
 }
 
 // RooRatio evaluate function.
-inline double ratioEvaluate(double numerator, double denominator) {
+inline double ratioEvaluate(double numerator, double denominator)
+{
    return numerator / denominator;
 }
 
@@ -42,7 +43,8 @@ inline double bifurGaussEvaluate(double x, double mean, double sigmaL, double si
 {
    // Note: this simplification does not work with Clad as of v1.1!
    // return gaussianEvaluate(x, mean, x < mean ? sigmaL : sigmaR);
-   if(x < mean) return gaussianEvaluate(x, mean, sigmaL);
+   if (x < mean)
+      return gaussianEvaluate(x, mean, sigmaL);
    return gaussianEvaluate(x, mean, sigmaR);
 }
 
@@ -266,15 +268,16 @@ inline double logNormalEvaluateStandard(double x, double sigma, double mu)
    return ROOT::Math::lognormal_pdf(x, mu, std::abs(sigma));
 }
 
-inline double effProdEvaluate(double eff, double pdf) {
+inline double effProdEvaluate(double eff, double pdf)
+{
    return eff * pdf;
 }
 
 inline double nllEvaluate(double pdf, double weight, int binnedL, int doBinOffset)
 {
    if (binnedL) {
-      // Special handling of this case since log(Poisson(0,0)=0 but can't be
-      // calculated with usual log-formula since log(mu)=0. No update of result
+      // Special handling of this case since std::log(Poisson(0,0)=0 but can't be
+      // calculated with usual log-formula since std::log(mu)=0. No update of result
       // is required since term=0.
       if (std::abs(pdf) < 1e-10 && std::abs(weight) < 1e-10) {
          return 0.0;
@@ -297,6 +300,24 @@ inline double recursiveFractionEvaluate(double *a, unsigned int n)
    }
 
    return prod;
+}
+
+inline double cbShapeEvaluate(double m, double m0, double sigma, double alpha, double n)
+{
+   double t = (m - m0) / sigma;
+   if (alpha < 0)
+      t = -t;
+
+   double absAlpha = std::abs((double)alpha);
+
+   if (t >= -absAlpha) {
+      return std::exp(-0.5 * t * t);
+   } else {
+      double a = std::pow(n / absAlpha, n) * std::exp(-0.5 * absAlpha * absAlpha);
+      double b = n / absAlpha - absAlpha;
+
+      return a / std::pow(b - t, n);
+   }
 }
 
 } // namespace EvaluateFuncs

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -621,12 +621,30 @@ FactoryTestParams param15{"RecursiveFraction",
                           5e-3,
                           /*randomizeParameters=*/true};
 
+FactoryTestParams param16{"RooCBShape",
+                          [](RooWorkspace &ws) {
+                             ws.factory("CBShape::model(x[0., -200., 200.], x0[100., -200., 200.], sigma[2., 1.E-6, "
+                                        "100.], alpha[1., 1.E-6, 100.], n[1., 1.E-6, 100.])");
+
+                             ws.defineSet("observables", "x");
+                          },
+                          [](RooAbsPdf &pdf, RooAbsData &data, RooWorkspace &, RooFit::EvalBackend backend) {
+                             using namespace RooFit;
+                             return std::unique_ptr<RooAbsReal>{pdf.createNLL(data, backend)};
+                          },
+                          5e-3,
+                          /*randomizeParameters=*/true};
+
 auto testValues = testing::Values(param1, param2,
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
                                   param3,
 #endif
                                   param4, param5, param6, param7, param8, param8p1, param9, param10, param11, param12,
-                                  param13, param15);
+                                  param13, param15
+                                  // TODO: the RooCBShape test is disabled for now,
+                                  // because the gradient doesn't work with Clad v1.4.
+                                  // , param16
+                                  );
 
 INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest, testValues,
                          [](testing::TestParamInfo<FactoryTest::ParamType> const &paramInfo) {


### PR DESCRIPTION
The test of using the code in the RooFit AD backend is not enabled yet, because it doesn't seem to work with the current version of Clad in ROOT.

However, the code is reused also for the normal `evaluate()` function, which is tested by `testRooCrystalBall.cxx`. So it would be good to integrate this change now, such that we can easily test in the CI if the `RooCBShape` works with a future version of Clad.