### PR TITLE
[v632] TEnum::GetUnderlying add support for typedefs.

### DIFF
--- a/core/meta/test/testTEnum.cxx
+++ b/core/meta/test/testTEnum.cxx
@@ -40,6 +40,9 @@ enum class ECull: unsigned long long { kOne };
 enum class ECsll: signed long long { kOne };
 
 enum class ECcl: short;
+
+enum class ECtsll : Long64_t { kEtsllOne };
+enum class ECtss : int16_t { kEtsllOne };
 )CODE"
 			);
 
@@ -63,6 +66,9 @@ enum class ECcl: short;
    EXPECT_EQ(TEnum::GetEnum("Eull")->GetUnderlyingType(), kULong64_t);
    EXPECT_EQ(TEnum::GetEnum("Esll")->GetUnderlyingType(), kLong64_t);
    EXPECT_EQ(TEnum::GetEnum("Ecl")->GetUnderlyingType(), kShort_t);
+
+   EXPECT_EQ(TEnum::GetEnum("ECtsll")->GetUnderlyingType(), kLong64_t);
+   EXPECT_EQ(TEnum::GetEnum("ECtss")->GetUnderlyingType(), kShort_t);
 }
 
 

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -844,6 +844,8 @@ EDataType TClingClassInfo::GetUnderlyingType() const
    if (auto ED = llvm::dyn_cast<EnumDecl>(GetDecl())) {
       R__LOCKGUARD(gInterpreterMutex);
       auto Ty = ED->getIntegerType().getTypePtrOrNull();
+      if (Ty)
+         Ty = Ty->getUnqualifiedDesugaredType();
       if (auto BTy = llvm::dyn_cast_or_null<BuiltinType>(Ty)) {
          switch (BTy->getKind()) {
          case BuiltinType::Bool:


### PR DESCRIPTION
This fixes #15460.

Extend the test accordingly.

