### PR TITLE
[v630] TEnum::GetEnum normalize name before search.

### DIFF
--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -277,8 +277,21 @@ TEnum *TEnum::GetEnum(const char *enumName, ESearchAction sa)
       return nullptr;
    }
 
-   // Keep the state consistent.  I particular prevent change in the state of AutoLoading and AutoParsing allowance
-   // and gROOT->GetListOfClasses() and the later update/modification to the autoparsing state.
+   std::string normalizedName;
+   {
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
+      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
+      TClassEdit::GetNormalizedName(normalizedName, enumName);
+   }
+
+   if (normalizedName != enumName) {
+      enumName = normalizedName.c_str();
+      lastPos = TClassEdit::GetUnqualifiedName(enumName);
+   }
+
+   // Keep the state consistent.  In particular prevent change in the state of
+   // AutoLoading and AutoParsing allowance and gROOT->GetListOfClasses()
+   // and the later update/modification to the autoparsing state.
    R__READ_LOCKGUARD(ROOT::gCoreMutex);
 
    if (lastPos != enumName) {

--- a/core/meta/test/testTEnum.cxx
+++ b/core/meta/test/testTEnum.cxx
@@ -40,6 +40,9 @@ enum class ECull: unsigned long long { kOne };
 enum class ECsll: signed long long { kOne };
 
 enum class ECcl: short;
+
+enum class ECtsll : Long64_t { kEtsllOne };
+enum class ECtss : int16_t { kEtsllOne };
 )CODE"
 			);
 
@@ -63,6 +66,9 @@ enum class ECcl: short;
    EXPECT_EQ(TEnum::GetEnum("Eull")->GetUnderlyingType(), kULong64_t);
    EXPECT_EQ(TEnum::GetEnum("Esll")->GetUnderlyingType(), kLong64_t);
    EXPECT_EQ(TEnum::GetEnum("Ecl")->GetUnderlyingType(), kShort_t);
+
+   EXPECT_EQ(TEnum::GetEnum("ECtsll")->GetUnderlyingType(), kLong64_t);
+   EXPECT_EQ(TEnum::GetEnum("ECtss")->GetUnderlyingType(), kShort_t);
 }
 
 

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -840,6 +840,8 @@ EDataType TClingClassInfo::GetUnderlyingType() const
    if (auto ED = llvm::dyn_cast<EnumDecl>(GetDecl())) {
       R__LOCKGUARD(gInterpreterMutex);
       auto Ty = ED->getIntegerType().getTypePtrOrNull();
+      if (Ty)
+         Ty = Ty->getUnqualifiedDesugaredType();
       if (auto BTy = llvm::dyn_cast_or_null<BuiltinType>(Ty)) {
          switch (BTy->getKind()) {
          case BuiltinType::Bool:


### PR DESCRIPTION
This allows to resolve using statement and find the target enum.

This fixes #15406# This Pull request:

