### PR TITLE
[CMake] Don't treat DistRDF tests as features

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -217,8 +217,6 @@ if(all)
  set(cefweb_defvalue ON)
  set(clad_defvalue ON)
  set(dataframe_defvalue ON)
- set(test_distrdf_pyspark_defvalue ON)
- set(test_distrdf_dask_defvalue ON)
  set(davix_defvalue ON)
  set(dcache_defvalue ON)
  set(fftw3_defvalue ON)
@@ -481,14 +479,6 @@ endif()
 
 
 #---distributed RDataFrame pyspark tests require both dataframe and pyroot----------------------------------
-if(test_distrdf_pyspark OR test_distrdf_dask)
-
-  if(NOT dataframe OR NOT pyroot)
-    message(STATUS "Running the tests for distributed RDataFrame requires both RDataFrame and PyROOT to be enabled")
-    message(STATUS "    Switching OFF the tests because either pyroot or dataframe option is disabled")
-    message(STATUS "    pyroot is set to ${pyroot} and dataframe is set to ${dataframe}")
-    set(test_distrdf_pyspark OFF CACHE BOOL "Disabled because either dataframe or pyroot were disabled" FORCE)
-    set(test_distrdf_dask OFF CACHE BOOL "Disabled because either dataframe or pyroot were disabled" FORCE)
-  endif()
-
+if(test_distrdf_pyspark OR test_distrdf_dask AND (NOT dataframe OR NOT pyroot))
+    message(FATAL_ERROR "Running the tests for distributed RDataFrame requires both RDataFrame and PyROOT to be enabled (build with -Ddataframe=ON and -Dpyroot=ON)")
 endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -2013,38 +2013,12 @@ endif()
 # Needed to run tests of the distributed RDataFrame module that use pyspark.
 # The functionality has been tested with pyspark 2.4 and above.
 if(test_distrdf_pyspark)
-  message(STATUS "Looking for PySpark")
-
-  if(fail-on-missing)
-    find_package(PySpark 2.4 REQUIRED)
-  else()
-
-    find_package(PySpark 2.4)
-    if(NOT PySpark_FOUND)
-      message(STATUS "Switching OFF 'test_distrdf_pyspark' option")
-      set(test_distrdf_pyspark OFF CACHE BOOL "Disabled because PySpark not found" FORCE)
-    endif()
-
-  endif()
-
+  find_package(PySpark 2.4 REQUIRED)
 endif()
 
 #------------------------------------------------------------------------------------
 # Check if the dask package is installed on the system.
 # Needed to run tests of the distributed RDataFrame module that use dask.
 if(test_distrdf_dask)
-  message(STATUS "Looking for Dask")
-
-  if(fail-on-missing)
-    find_package(Dask 2022.08.1 REQUIRED)
-  else()
-
-    find_package(Dask 2022.08.1)
-    if(NOT Dask_FOUND)
-      message(STATUS "Switching OFF 'test_distrdf_dask' option")
-      set(test_distrdf_dask OFF CACHE BOOL "Disabled because Dask not found" FORCE)
-    endif()
-
-  endif()
-
+  find_package(Dask 2022.08.1 REQUIRED)
 endif()


### PR DESCRIPTION
The `-Dall` option is for enabling all ROOT features, which should not include dedicated tests. The DistRDF tests should only be used by developers and packagers, so it's not a "feature" that should automatically be enabled.

Also, if someone enables these tests it's clearly intentional. If the requirements for the tests are not present, there should therefore be a configuration failure, no matter if `fail-on-missing` is enabled or not.