### PR TITLE
[tree] Remove trailing whitespaces that trigger warnings at config time

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -3757,7 +3757,7 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
          R__LoadBranch(br,tentry,fQuickLoad);                                                   \
       } else {                                                                                  \
         Error("TTreeFormula::TT_EVAL_INIT",                                                     \
-          "Could not init branch associated to this leaf (%s).", leaf->GetName());              \ 
+          "Could not init branch associated to this leaf (%s).", leaf->GetName());              \
       }                                                                                         \
    }                                                                                            \
                                                                                                 \
@@ -3826,7 +3826,7 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
          } else {                                                                               \
             Error("TTreeFormula::TT_EVAL_INIT_LOOP",                                            \
                   "Could not init branch associated to this leaf (%s).", leaf->GetName());      \
-         }                                                                                      \                                           
+         }                                                                                      \
       }                                                                                         \
    }                                                                                            \
    if (real_instance>=fNdata[code]) return 0;


### PR DESCRIPTION
Remove trailing whitespaces to avoid warnings like these:
```
/home/rembserj/code/root/tree/treeplayer/src/TTreeFormula.cxx:3760:97: warning: backslash and newline separated by space
 3760 |           "Could not init branch associated to this leaf (%s).", leaf->GetName());              \
      |
/home/rembserj/code/root/tree/treeplayer/src/TTreeFormula.cxx:3829:97: warning: backslash and newline separated by space
 3829 |          }                                                                                      \
      |
```