### PR TITLE
[core] Pass TString by value to TNamed ctor

### DIFF
--- a/core/base/inc/TNamed.h
+++ b/core/base/inc/TNamed.h
@@ -35,7 +35,7 @@ protected:
 public:
    TNamed(): fName(), fTitle() { } // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TNamed(const char *name, const char *title) : fName(name), fTitle(title) { }
-   TNamed(const TString &name, const TString &title) : fName(name), fTitle(title) { }
+   TNamed(TString name, TString title) : fName(std::move(name)), fTitle(std::move(title)) {}
    TNamed(const TNamed &named);
    TNamed& operator=(const TNamed& rhs);
    virtual ~TNamed();


### PR DESCRIPTION
# This Pull request:

Passing by const-reference can mean two constructions (once on the caller, once in the ctor using the TString copy ctor).

Instead passing by value and using move semantics in the ctor can reduce this to one construction on the caller and one move in the ctor.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

fixes: #15434

