### PR TITLE
[skip-ci] define missing doxygen groups

### DIFF
--- a/core/base/doc/index.md
+++ b/core/base/doc/index.md
@@ -13,3 +13,6 @@ plugin handler, run-config resource processor, etc. etc.
 
 \defgroup StdExt std Extension classes
 \brief Extension classes within libCore to backport or complement missing std:: features
+
+\defgroup Parallelism Parallelized classes
+\brief Classes implement parallelism within ROOT

--- a/core/base/doc/index.md
+++ b/core/base/doc/index.md
@@ -11,3 +11,5 @@ classes providing basic services like strings, regular expression,
 timers, date/time, md5 checksumming, signal/slots event handling,
 plugin handler, run-config resource processor, etc. etc.
 
+\defgroup StdExt std Extension classes
+\brief Extension classes within libCore to backport or complement missing std:: features

--- a/core/foundation/res/TSpinLockGuard.h
+++ b/core/foundation/res/TSpinLockGuard.h
@@ -20,7 +20,7 @@ namespace Internal {
 /**
 * \class ROOT::Internal::TSpinLockGuard
 * \brief A spin mutex-as-code-guard class.
-* \ingroup Foundation
+* \ingroup Parallelism
 * This class allows to acquire spin locks in combination with a std::atomic_flag variable.
 * For example:
 * ~~~{.cpp}

--- a/core/thread/inc/ROOT/TSpinMutex.hxx
+++ b/core/thread/inc/ROOT/TSpinMutex.hxx
@@ -19,7 +19,7 @@ namespace ROOT {
    /**
     * \class ROOT::TSpinMutex
     * \brief A spin mutex class which respects the STL interface for mutexes.
-    * \ingroup Multicore
+    * \ingroup Parallelism
     * This class allows to acquire spin locks also in combination with templates in the STL such as
     * <a href="http://en.cppreference.com/w/cpp/thread/unique_lock">std::unique_lock</a> or
     * <a href="http://en.cppreference.com/w/cpp/thread/condition_variable_any">std::condition_variable_any</a>.

--- a/core/thread/inc/ROOT/TThreadedObject.hxx
+++ b/core/thread/inc/ROOT/TThreadedObject.hxx
@@ -136,7 +136,7 @@ namespace ROOT {
     * \class ROOT::TThreadedObject
     * \brief A wrapper to make object instances thread private, lazily.
     * \tparam T Class of the object to be made thread private (e.g. TH1F)
-    * \ingroup Multicore
+    * \ingroup Parallelism
     *
     * A wrapper which makes objects thread private. The methods of the underlying
     * object can be invoked via the arrow operator. The object is created in

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -16,6 +16,10 @@
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 
+/**
+ * \defgroup REve Event display with ROOT7
+ * \brief Modern version of "Event display" using ROOT7
+ */
 
 /** \class REveException
 \ingroup REve

--- a/graf3d/gl/src/TGLSelectRecord.cxx
+++ b/graf3d/gl/src/TGLSelectRecord.cxx
@@ -15,7 +15,7 @@
 #include <cstring>
 
 /** \class TGLSelectRecordBase
-\ingroup opengl TGLSelectRecordBase
+\ingroup opengl
 Base class for select records.
 Supports initialization from a raw GL record (UInt_t*) and
 copies the name-data into internal array.

--- a/gui/qt6webdisplay/index.md
+++ b/gui/qt6webdisplay/index.md
@@ -1,0 +1,3 @@
+\defgroup qt6webdisplay QT6 Web Display
+\ingroup webdisplay
+\brief Classes for web display using QT6

--- a/hist/hist/src/TGraphSmooth.cxx
+++ b/hist/hist/src/TGraphSmooth.cxx
@@ -28,7 +28,7 @@ ClassImp(TGraphSmooth);
 
 //______________________________________________________________________
 /** \class TGraphSmooth
-    \ingroup Graph
+    \ingroup Graphs
 A helper class to smooth TGraph.
 see examples in $ROOTSYS/tutorials/graphs/motorcycle.C and approx.C
 */

--- a/hist/histv7/inc/ROOT/RHistView.hxx
+++ b/hist/histv7/inc/ROOT/RHistView.hxx
@@ -1,5 +1,5 @@
 /// \file ROOT/RHistView.hxx
-/// \ingroup HistV
+/// \ingroup HistV7
 /// \author Axel Naumann <axel@cern.ch>
 /// \date 2015-08-06
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/math/mathcore/inc/Math/ParamFunctor.h
+++ b/math/mathcore/inc/Math/ParamFunctor.h
@@ -32,6 +32,10 @@ namespace ROOT {
 
 namespace Math {
 
+/**
+ * \defgroup ParamFunctor_int N-D parametric functions
+ * \brief Multi-dimensional parametric functions
+ */
 
 /** class defining the signature for multi-dim parametric functions
 

--- a/math/mathmore/src/GSLMultiRootFunctionWrapper.h
+++ b/math/mathmore/src/GSLMultiRootFunctionWrapper.h
@@ -53,8 +53,6 @@ namespace Math {
 /**
    wrapper to a multi-dim function without  derivatives for multi roots
    algorithm
-
-   @ingroup MultiRoots
 */
 class GSLMultiRootFunctionWrapper {
 

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -46,7 +46,7 @@ namespace ROOT {
    TMinuitMinimizer class:
    ROOT::Math::Minimizer implementation based on TMinuit
 
-   @ingroup TMinuit
+   @ingroup MinuitOld
 */
 class TMinuitMinimizer  : public ROOT::Math::Minimizer {
 

--- a/math/unuran/inc/TUnuranBaseDist.h
+++ b/math/unuran/inc/TUnuranBaseDist.h
@@ -23,7 +23,7 @@
    TUnuranBaseDist, base class for Unuran distribution classes such as
    TUnuranContDist (for one-dimension) or TUnuranMultiContDist (multi-dimension)
 
-   \ingroup Unnuran
+   \ingroup Unuran
 */
 ///////////////////////////////////////////////////////////////////////
 class TUnuranBaseDist  {

--- a/roofit/batchcompute/res/RooBatchCompute.h
+++ b/roofit/batchcompute/res/RooBatchCompute.h
@@ -118,7 +118,7 @@ struct ReduceNLLOutput {
 
 /**
  * \class RooBatchComputeInterface
- * \ingroup Roobatchcompute
+ * \ingroup roofit_dev_docs_batchcompute
  * \brief The interface which should be implemented to provide optimised computation functions for implementations of
  * RooAbsReal::doEval().
  *

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -14,7 +14,7 @@
 \file Batches.h
 \class Batch
 \class Batches
-\ingroup RooBatchCompute
+\ingroup roofit_dev_docs_batchcompute
 
 These classes encapsulate the necessary data for the computations.
 They are lightweight objects designed to be passed by value and also flexible,

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -12,7 +12,7 @@
 
 /**
 \file ComputeFunctions.cxx
-\ingroup Roobatchcompute
+\ingroup roofit_dev_docs_batchcompute
 
 This file contains vectorizable computation functions for PDFs and other Roofit objects.
 The same source file can also be compiled with nvcc. All functions have a single `Batches`

--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -13,7 +13,7 @@
 /**
 \file RooBatchCompute.cu
 \class RbcClass
-\ingroup Roobatchcompute
+\ingroup roofit_dev_docs_batchcompute
 
 This file contains the code for cuda computations using the RooBatchCompute library.
 **/

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -13,7 +13,7 @@
 /**
 \file RooBatchCompute.cxx
 \class RbcClass
-\ingroup Roobatchcompute
+\ingroup roofit_dev_docs_batchcompute
 
 This file contains the code for cpu computations using the RooBatchCompute library.
 **/

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -62,7 +62,6 @@ PiecewiseInterpolation::PiecewiseInterpolation() : _normIntMgr(this)
 /// \param lowSet  Set of down variations.
 /// \param highSet Set of up variations.
 /// \param paramSet Parameters that control the interpolation.
-/// \param takeOwnership If true, the PiecewiseInterpolation object will take ownership of the arguments in the low, high and parameter sets.
 PiecewiseInterpolation::PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal &nominal,
                                                const RooArgList &lowSet, const RooArgList &highSet,
                                                const RooArgList &paramSet)

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -41,7 +41,7 @@
 #include <stdexcept>
 
 /** \class RooJSONFactoryWSTool
-\ingroup roofit
+\ingroup roofit_dev_docs_hs3
 
 When using \ref Roofitmain, statistical models can be conveniently handled and
 stored as a RooWorkspace. However, for the sake of interoperability

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -12,7 +12,7 @@
 #define RooFit_RooAbsSelfCachedReal_h
 
 /**
-\file RooAbsSelfCached.h
+\file RooAbsSelfCachedReal.h
 \class RooAbsSelfCached
 \ingroup Roofitcore
 

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -92,7 +92,7 @@ getGlobalObservables(RooAbsPdf const &pdf, RooArgSet const *globalObservables, c
 ///            `globalObservables` or `globalObservablesTag` parameters, the
 ///            values of all global observables that are not stored in the
 ///            dataset are taken from the model.
-/// \param[in] removeConstraintsPdf If true, the constraints that are extracted
+/// \param[in] removeConstraintsFromPdf If true, the constraints that are extracted
 ///            from the PDF are removed from the original PDF.
 std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbsPdf const &pdf, RooAbsData const &data,
                                                  RooArgSet const *constrainedParameters,

--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -10,7 +10,7 @@
 
 /** Memory pool for RooArgSet and RooDataSet.
  * \class MemPoolForRooSets
- * \ingroup roofitcore
+ * \ingroup Roofitcore
  * RooArgSet and RooDataSet were using a mempool that guarantees that allocating,
  * de-allocating and re-allocating a set does not yield the same pointer.
  * RooFit relies on this, unfortunately, because it compares the pointers of RooArgSets

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -2533,8 +2533,6 @@ double RooAbsData::sumEntriesW2() const {
 /// Write information to retrieve data columns into `evalData.spans`.
 /// All spans belonging to variables of this dataset are overwritten. Spans to other
 /// variables remain intact.
-/// \param[out] evalData Store references to all data batches in this struct's `spans`.
-/// The key to retrieve an item is the pointer of the variable that owns the data.
 /// \param begin Index of first event that ends up in the batch.
 /// \param len   Number of events in each batch.
 RooAbsData::RealSpans RooAbsData::getBatches(std::size_t begin, std::size_t len) const {

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -683,7 +683,7 @@ void RooAbsPdf::getLogProbabilities(std::span<const double> pdfValues, double * 
 /// it is extendable by overloading `canBeExtended()`, and must
 /// implement the `expectedEvents()` function.
 ///
-/// \param[in] observed The number of observed events.
+/// \param[in] sumEntries The number of observed events.
 /// \param[in] nset The normalization set when asking the pdf for the expected
 ///            number of events.
 /// \param[in] observedSumW2 The number of observed events when weighting with

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -397,7 +397,6 @@ void RooAddPdf::fixCoefRange(const char* rangeName)
 /// Retrieve cache element for the computation of the PDF normalisation.
 /// \param[in] nset Current normalisation set (integration over these variables yields 1).
 /// \param[in] iset Integration set. Variables to be integrated over (if integrations are performed).
-/// \param[in] rangeName Reference range for the integrals.
 ///
 /// If a cache element does not exist, create and fill it on the fly. The cache also contains
 /// - Supplemental normalization terms (in case not all added p.d.f.s have the same observables)

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -53,7 +53,6 @@ ClassImp(RooAddition);
 /// \param[in] name Name of the PDF
 /// \param[in] title Title
 /// \param[in] sumSet The value of the function will be the sum of the values in this set
-/// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in `sumSet`
 
 RooAddition::RooAddition(const char *name, const char *title, const RooArgList &sumSet)
    : RooAbsReal(name, title), _set("!set", "set of components", this), _cacheMgr(this, 10)
@@ -75,7 +74,6 @@ RooAddition::RooAddition(const char *name, const char *title, const RooArgList &
 /// \param[in] title Title
 /// \param[in] sumSet1 Left-hand element of the pair-wise products
 /// \param[in] sumSet2 Right-hand element of the pair-wise products
-/// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in the `sumSets`
 ///
 RooAddition::RooAddition(const char *name, const char *title, const RooArgList &sumSet1, const RooArgList &sumSet2)
    : RooAbsReal(name, title), _set("!set", "set of components", this), _cacheMgr(this, 10)

--- a/tree/ntuple/v7/doc/README.md
+++ b/tree/ntuple/v7/doc/README.md
@@ -70,5 +70,4 @@ Related classes
 \brief Interfaces and classes designed for future ROOT version 7 (experimental!)
 
 \defgroup NTuple NTuple-related classes
-\ingroup ROOT7
 \brief tuple classes designed for future ROOT version 7  (experimental!)

--- a/tree/ntuple/v7/doc/README.md
+++ b/tree/ntuple/v7/doc/README.md
@@ -62,3 +62,13 @@ At this point, the only provided backend stores the pages in ROOT files.
 RNTuples are further grouped into **clusters**, which are, like TTree clusters, self-contained blocks of
 consecutive entries.  Clusters provide a unit of writing and will provide the means for parallel writing of data
 in a future version of RNTuple.
+
+Related classes
+---------------
+
+\defgroup ROOT7 ROOT7 classes
+\brief Interfaces and classes designed for future ROOT version 7 (experimental!)
+
+\defgroup NTuple NTuple-related classes
+\ingroup ROOT7
+\brief tuple classes designed for future ROOT version 7  (experimental!)

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -1,4 +1,4 @@
-/// \file ROOT/RNTuplerImporter.hxx
+/// \file ROOT/RNTupleImporter.hxx
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2022-11-22

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -1,4 +1,4 @@
-/// \file ROOT/RNTuplerInspector.hxx
+/// \file ROOT/RNTupleInspector.hxx
 /// \ingroup NTuple ROOT7
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2023-01-09

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -9,6 +9,14 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+/**
+ * \defgroup treeplayer TreePlayer Library
+ * \brief It contains utilities to plot data stored in a TTree.
+ * \sa Tree package documentation
+ * \sa Chapter about Trees and Selectors in the Users Guide
+ * \sa ROOT examples in tutorials and test directories: Event application, benchmarks
+ */
+
 /** \class TTreePlayer
 
 Implement some of the functionality of the class TTree requiring access to

--- a/tutorials/graphs/graphreverse.C
+++ b/tutorials/graphs/graphreverse.C
@@ -2,7 +2,7 @@
 /// \ingroup tutorial_graphs
 /// \notebook
 /// This example test all the various case of reverse graphs
-/// combined with logarithmic scale..
+/// combined with logarithmic scale.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/graphs/hlGraph1.C
+++ b/tutorials/graphs/hlGraph1.C
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_graPads
+/// \ingroup tutorial_graphs
 ///
 /// This tutorial demonstrates how to use the highlight mode on graph.
 ///

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -62,6 +62,10 @@ The `$ROOTSYS/tutorials` directory includes several sub-directories:
 \ingroup Tutorials
 \brief Examples showing the "Event display classes" usage.
 
+\defgroup tutorial_eve7 Event display ROOT7 tutorials
+\ingroup Tutorials
+\brief Examples showing the "Event display classes" usage with ROOT7.
+
 \defgroup tutorial_geom Geometry tutorials
 \ingroup Tutorials
 \brief Various ROOT geometry package examples.
@@ -197,6 +201,10 @@ The `$ROOTSYS/tutorials` directory includes several sub-directories:
 \defgroup tutorial_proof Proof tutorials
 \ingroup Tutorials
 \brief These examples aim to illustrate the usage of PROOF
+
+\defgroup tutorial_webgui Webgui tutorials
+\ingroup Tutorials
+\brief Webgui examples
 
 \defgroup tutorial_legacy Legacy tutorials
 \ingroup Tutorials

--- a/tutorials/proof/ProofNtuple.C
+++ b/tutorials/proof/ProofNtuple.C
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_proofntuple
+/// \ingroup tutorial_legacy
 ///
 /// Selector to fill a simple ntuple
 ///

--- a/tutorials/proof/ProofNtuple.h
+++ b/tutorials/proof/ProofNtuple.h
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_proofntuple
+/// \ingroup tutorial_legacy
 ///
 /// Selector to fill a simple ntuple
 ///

--- a/tutorials/proof/ProofPythia.C
+++ b/tutorials/proof/ProofPythia.C
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_proofpythia
+/// \ingroup tutorial_legacy
 ///
 /// Selector to generate Monte Carlo events with Pythia8
 ///

--- a/tutorials/proof/ProofPythia.h
+++ b/tutorials/proof/ProofPythia.h
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_proofpythia
+/// \ingroup tutorial_legacy
 ///
 /// Selector to generate Monte Carlo events with Pythia8
 ///


### PR DESCRIPTION
we get otherwise about 300 warnings of this type when building docu:

warning: Found non-existing group 'ROOT7' for the command '@ingroup', ignoring command
warning: Found non-existing group 'NTuple' for the command '@ingroup', ignoring command