### PR TITLE
[CMake] Don't check if Python headers are found in `RootBuildOptions`

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -314,12 +314,6 @@ elseif(APPLE)
   set(x11_defvalue OFF)
 endif()
 
-# Pyroot requires Python development package; force to OFF if it was not found
-if(NOT Python3_Development_FOUND)
-  set(pyroot_defvalue OFF)
-  set(tmva-pymva_defvalue OFF)
-endif()
-
 # Current limitations for modules:
 #---Modules are disabled on aarch64 platform (due ODR violations)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)


### PR DESCRIPTION
This is a followup to 5e424e4, where the Python finding was moved into `SearchInstalledSoftware.cmake`.

However, what I missed is that there was a check in `RootBuildOptions` that disabled PyROOT by default if Python is not found, which is now not the case at that point! Therefore, ROOT builds won't have PyROOT by default anymore, which is a bad mistake.

Fortunately, the check is entirely redundant and this commit suggests to remove it. There is already a check in `SearchInstalledSoftware` where PyROOT (and `tmva-pymva`) are disabled when the Python development headers where not found.

Also, this kind of logic to conditionally change the defaults it bad because it doesn't go well with the "fail on missing" paradigm (if `fail-on-missing` is enabled).