### PR TITLE
Distributed RDataFrame: add support for NodeProxy.GetColumnNames 

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -253,9 +253,6 @@ class HeadNode(Node, ABC):
         # Set the value of every action node
         for node, value in zip(local_nodes, final_values):
             Utils.set_value_on_node(value, node, self.backend)
-            
-    def GetColumnNames(self) -> Iterable[str]:
-        return self._localdf.GetColumnNames()
 
 
 def get_headnode(backend: BaseBackend, npartitions: int, *args) -> HeadNode:

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -57,6 +57,10 @@ def execute_graph(node: Node) -> None:
             # the workers is contained in the head node
             node.get_head().execute_graph()
 
+def _update_internal_df_with_transformation(node:Node, operation: Operation) -> None:
+    """Propagate transform operations to the headnode internal RDataFrame"""
+    rdf_operation = getattr(node.get_head()._localdf, operation.name)
+    node.get_head()._localdf = rdf_operation(*operation.args, **operation.kwargs)
 
 def _create_new_node(parent: Node, operation: Operation.Operation) -> Node:
     """Creates a new node and inserts it in the computation graph"""
@@ -247,6 +251,10 @@ class NodeProxy(Proxy):
                     )
                 raise AttributeError(msg)
 
+    def GetColumnNames(self):
+        """Forward call to the internal RDataFrame object"""
+        return self.proxied_node.get_head()._localdf.GetColumnNames()
+
     def _create_new_op(self, *args, **kwargs):
         """
         Handles an operation call to the current node and returns the new node
@@ -260,6 +268,7 @@ class NodeProxy(Proxy):
 @singledispatch
 def get_proxy_for(operation: Operation.Transformation, node: Node) -> NodeProxy:
     """"Returns appropriate proxy for the input node"""
+    _update_internal_df_with_transformation(node, operation)
     return NodeProxy(node)
 
 

--- a/bindings/experimental/distrdf/test/test_proxy.py
+++ b/bindings/experimental/distrdf/test/test_proxy.py
@@ -173,6 +173,23 @@ class AttrReadTest(unittest.TestCase):
 
         self.assertEqual(proxy.val(21), 144)
 
+    def test_getcolnames(self):
+        """
+        Check newly defined columns are available also locally.
+        """
+
+        node = create_dummy_headnode(1)
+        proxy = Proxy.NodeProxy(node)
+
+        cols_before = proxy.GetColumnNames()
+        self.assertSequenceEqual(cols_before, [])
+
+        proxy = proxy.Define("x", "42").Define("y", "43").Define("z", "44")
+
+        cols_after = proxy.GetColumnNames()
+
+        self.assertSequenceEqual(cols_after, ["x", "y", "z"])
+
 
 class GetValueTests(unittest.TestCase):
     """Check 'GetValue' instance method in Proxy."""


### PR DESCRIPTION
# This Pull request:
Update the distributed RDataFrame to use the HeadNode _localrdf to keep track of transform operations, and add the ability to call GetColumnNames on a NodeProxy object. 

## Changes or fixes:
- Add GetColumnNames method to NodeProxy which calls the HeadNode GetColumnNames method
- Propagate transform operations to the HeadNode _localrdf, mainly to keep track of user-defined columns 

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #15442

