### PR TITLE
[df] Delete allocated node before throwing error

### DIFF
--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -777,10 +777,14 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
    const auto funcName = DeclareFunction(parsedExpr.fExpr, parsedExpr.fVarNames, exprVarTypes);
    const auto type = RetTypeOfFunc(funcName);
 
-   if (type.rfind("ROOT::VecOps::RVec", 0) != 0)
+   if (type.rfind("ROOT::VecOps::RVec", 0) != 0) {
+      // Avoid leak
+      delete upcastNodeOnHeap;
+      upcastNodeOnHeap = nullptr;
       throw std::runtime_error(
          "Jitted Vary expressions must return an RVec object. The following expression returns a " + type +
          " instead:\n" + parsedExpr.fExpr);
+   }
 
    auto colRegisterCopy = new RColumnRegister(colRegister);
    const auto colRegisterAddr = PrettyPrintAddr(colRegisterCopy);


### PR DESCRIPTION
In the jitted version of the `Vary` transformation a node is allocated on the heap and its address is passed down to the function `JitVariationHelper`, which is also responsible for deleting the allocated memory. In case a mismatch in the return type of the jitted function given to the Vary call is detected, we throw an error to inform the user they should return an RVec for the Vary to properly work. This means that the call to JitVariationHelper does not happen, thus the memory of the node is not deallocated. This commit corrects that behaviour by properly deleting the pointer before throwing the exception.

Thanks to the address sanitizer:
```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f28c78d9e28 in operator new(unsigned long) (/lib64/libasan.so.8+0xd9e28) (BuildId: 2b657470ea196ba4342e3bd8a3cc138b1e200599)
    #1 0xb711e0 in std::shared_ptr<ROOT::Detail::RDF::RNodeBase>* ROOT::Internal::RDF::MakeSharedOnHeap<ROOT::Detail::RDF::RNodeBase>(std::shared_ptr<ROOT::Detail::RDF::RNodeBase> const&) /home/vpadulan/Programs/rootproject/rootbuild/master-a73f11dfc5-testing-asan/include/ROOT/RDF/InterfaceUtils.hxx:370
    #2 0xb843a8 in ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager, void>::JittedVaryImpl(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::basic_string_view<char, std::char_traits<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::basic_string_view<char, std::char_traits<char> >, bool) /home/vpadulan/Programs/rootproject/rootbuild/master-a73f11dfc5-testing-asan/include/ROOT/RDF/RInterface.hxx:3108
```

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

