### PR TITLE
[RF] Add back accidentally removed docs for `RooFit::Extended()`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,6 @@
 [default.extend-identifiers]
 BaBar = "BaBar"
+YtoAbsPixel = "YtoAbsPixel"
 exportJSONtoString = "exportJSONtoString" # Maybe it's worth to rename this function to consistent camelCase
 fChannelObservMap = "fChannelObservMap"
 fG2ndDerivative = "fG2ndDerivative"

--- a/roofit/roofit/test/testRooGaussian.cxx
+++ b/roofit/roofit/test/testRooGaussian.cxx
@@ -13,7 +13,7 @@ TEST(RooGaussian, AnalyticalIntegral)
   constexpr double prec = 1.E-8;
   constexpr double oneSig = 0.682689492137;
   constexpr double twoSig = 0.954499736104;
-  constexpr double thrSig = 0.997300203937;
+  constexpr double thresholdSig = 0.997300203937;
 
   RooRealVar x("x", "x", 0.);
   RooRealVar mean("mean", "mean", 0.);
@@ -44,13 +44,13 @@ TEST(RooGaussian, AnalyticalIntegral)
       //Test central quantiles
       runTest(-1., 1., oneSig);
       runTest(-2., 2., twoSig);
-      runTest(-3., 3., thrSig);
+      runTest(-3., 3., thresholdSig);
 
       //Positive & negative, but one close to zero:
       runTest(0., 1., oneSig/2.);
       runTest(-0., 1., oneSig/2.);
       runTest(-2., 1.E-8, twoSig/2.);
-      runTest(-1.E-9, 3., thrSig/2.);
+      runTest(-1.E-9, 3., thresholdSig/2.);
 
       //Far from zero
       runTest(5., 11., 2.8665157E-7);

--- a/roofit/roofitZMQ/src/ZeroMQPoller.cpp
+++ b/roofit/roofitZMQ/src/ZeroMQPoller.cpp
@@ -206,10 +206,10 @@ size_t ZeroMQPoller::unregister_socket(zmq::socket_t &socket)
    m_sockets.erase(it);
 
    // Remove from m_items
-   auto iit = std::find_if(begin(m_items), end(m_items),
+   auto found = std::find_if(begin(m_items), end(m_items),
                            [&it_first](const zmq::pollitem_t &item) { return it_first == item.socket; });
-   assert(iit != end(m_items));
-   m_items.erase(iit);
+   assert(found != end(m_items));
+   m_items.erase(found);
 
    return index;
 }
@@ -235,10 +235,10 @@ size_t ZeroMQPoller::unregister_socket(int fd)
    m_fds.erase(it);
 
    // Remove from m_items
-   auto iit = std::find_if(begin(m_items), end(m_items),
+   auto found = std::find_if(begin(m_items), end(m_items),
                            [&it_first](const zmq::pollitem_t &item) { return it_first == item.fd; });
-   assert(iit != end(m_items));
-   m_items.erase(iit);
+   assert(found != end(m_items));
+   m_items.erase(found);
 
    return index;
 }

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1012,40 +1012,40 @@ RooFit::OwningPtr<TMatrixDSym> RooAbsData::corrcovMatrix(const RooArgList& vars,
     if (select && select->eval()==0) continue ;
     if (cutRange && dvars->allInRange(cutRange)) continue ;
 
-    for(std::size_t ix = 0; ix < varList.size(); ++ix) {
-      auto varx = static_cast<RooRealVar const&>(varList[ix]);
-      xsum[ix] += weight() * varx.getVal() ;
+    for(std::size_t iX = 0; iX < varList.size(); ++iX) {
+      auto varx = static_cast<RooRealVar const&>(varList[iX]);
+      xsum[iX] += weight() * varx.getVal() ;
       if (corr) {
-        x2sum[ix] += weight() * varx.getVal() * varx.getVal();
+        x2sum[iX] += weight() * varx.getVal() * varx.getVal();
       }
 
-      for(std::size_t iy = ix; iy < varList.size(); ++iy) {
-        auto vary = static_cast<RooRealVar const&>(varList[iy]);
-        xysum(ix,iy) += weight() * varx.getVal() * vary.getVal();
-        xysum(iy,ix) = xysum(ix,iy) ;
+      for(std::size_t iY = iX; iY < varList.size(); ++iY) {
+        auto vary = static_cast<RooRealVar const&>(varList[iY]);
+        xysum(iX,iY) += weight() * varx.getVal() * vary.getVal();
+        xysum(iY,iX) = xysum(iX,iY) ;
       }
     }
 
   }
 
   // Normalize sums
-  for (std::size_t ix=0 ; ix<varList.size() ; ix++) {
-    xsum[ix] /= sumEntries(cutSpec, cutRange) ;
+  for (std::size_t iX=0 ; iX<varList.size() ; iX++) {
+    xsum[iX] /= sumEntries(cutSpec, cutRange) ;
     if (corr) {
-      x2sum[ix] /= sumEntries(cutSpec, cutRange) ;
+      x2sum[iX] /= sumEntries(cutSpec, cutRange) ;
     }
-    for (std::size_t iy=0 ; iy<varList.size() ; iy++) {
-      xysum(ix,iy) /= sumEntries(cutSpec, cutRange) ;
+    for (std::size_t iY=0 ; iY<varList.size() ; iY++) {
+      xysum(iX,iY) /= sumEntries(cutSpec, cutRange) ;
     }
   }
 
   // Calculate covariance matrix
   auto C = std::make_unique<TMatrixDSym>(varList.size()) ;
-  for (std::size_t ix=0 ; ix<varList.size() ; ix++) {
-    for (std::size_t iy=0 ; iy<varList.size() ; iy++) {
-      (*C)(ix,iy) = xysum(ix,iy)-xsum[ix]*xsum[iy] ;
+  for (std::size_t iX=0 ; iX<varList.size() ; iX++) {
+    for (std::size_t iY=0 ; iY<varList.size() ; iY++) {
+      (*C)(iX,iY) = xysum(iX,iY)-xsum[iX]*xsum[iY] ;
       if (corr) {
-   (*C)(ix,iy) /= std::sqrt((x2sum[ix]-(xsum[ix]*xsum[ix]))*(x2sum[iy]-(xsum[iy]*xsum[iy]))) ;
+   (*C)(iX,iY) /= std::sqrt((x2sum[iX]-(xsum[iX]*xsum[iX]))*(x2sum[iY]-(xsum[iY]*xsum[iY]))) ;
       }
     }
   }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -827,6 +827,7 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
  * <tr><th> Type of CmdArg    <th>    Effect on NLL
  * <tr><td> `ConditionalObservables(Args_t &&... argsOrArgSet)`  <td>  Do not normalize PDF over listed observables.
  *                                                 Arguments can either be multiple RooRealVar or a single RooArgSet containing them.
+ * <tr><td> `Extended(bool flag)`             <td> Add extended likelihood term, off by default.
  * <tr><td> `Range(const char* name)`         <td>  Fit only data inside range with given name. Multiple comma-separated range names can be specified.
  *                                                  In this case, the unnormalized PDF \f$f(x)\f$ is normalized by the integral over all ranges \f$r_i\f$:
  *                                                  \f[

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -812,7 +812,7 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
    if (!_allExtendable) {
       // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
       // a conditional pdf and we don't need to do any transformation. See also
-      // RooAddPdf::compleForNormSet() for more explanations on a similar logic.
+      // RooAddPdf::compileForNormSet() for more explanations on a similar logic.
       if (!_refCoefNorm.empty() && !nset->equals(_refCoefNorm)) {
          prodList.addOwned(std::unique_ptr<RooAbsReal>{createIntegral(*nset, _refCoefNorm)});
       }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -401,28 +401,28 @@ void RooDataHist::importTH1(const RooArgList& vars, const TH1& histo, double wgt
     zmin = offset[2] ;
   }
 
-  Int_t ix(0);
-  Int_t iy(0);
+  Int_t iX(0);
+  Int_t iY(0);
   Int_t iz(0);
-  for (ix=0 ; ix < xvar->getBins() ; ix++) {
-    xvar->setBin(ix) ;
+  for (iX=0 ; iX < xvar->getBins() ; iX++) {
+    xvar->setBin(iX) ;
     if (yvar) {
-      for (iy=0 ; iy < yvar->getBins() ; iy++) {
-        yvar->setBin(iy) ;
+      for (iY=0 ; iY < yvar->getBins() ; iY++) {
+        yvar->setBin(iY) ;
         if (zvar) {
           for (iz=0 ; iz < zvar->getBins() ; iz++) {
             zvar->setBin(iz) ;
             double bv = doDensityCorrection ? binVolume(vset) : 1;
-            add(vset,bv*histo.GetBinContent(ix+1+xmin,iy+1+ymin,iz+1+zmin)*wgt,bv*TMath::Power(histo.GetBinError(ix+1+xmin,iy+1+ymin,iz+1+zmin)*wgt,2)) ;
+            add(vset,bv*histo.GetBinContent(iX+1+xmin,iY+1+ymin,iz+1+zmin)*wgt,bv*TMath::Power(histo.GetBinError(iX+1+xmin,iY+1+ymin,iz+1+zmin)*wgt,2)) ;
           }
         } else {
           double bv = doDensityCorrection ? binVolume(vset) : 1;
-          add(vset,bv*histo.GetBinContent(ix+1+xmin,iy+1+ymin)*wgt,bv*TMath::Power(histo.GetBinError(ix+1+xmin,iy+1+ymin)*wgt,2)) ;
+          add(vset,bv*histo.GetBinContent(iX+1+xmin,iY+1+ymin)*wgt,bv*TMath::Power(histo.GetBinError(iX+1+xmin,iY+1+ymin)*wgt,2)) ;
         }
       }
     } else {
       double bv = doDensityCorrection ? binVolume(vset) : 1 ;
-      add(vset,bv*histo.GetBinContent(ix+1+xmin)*wgt,bv*TMath::Power(histo.GetBinError(ix+1+xmin)*wgt,2)) ;
+      add(vset,bv*histo.GetBinContent(iX+1+xmin)*wgt,bv*TMath::Power(histo.GetBinError(iX+1+xmin)*wgt,2)) ;
     }
   }
 
@@ -564,31 +564,31 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
   double avgBV = volume / numEntries() ;
 
   Int_t ic(0);
-  Int_t ix(0);
-  Int_t iy(0);
+  Int_t iX(0);
+  Int_t iY(0);
   Int_t iz(0);
   for (ic=0 ; ic < icat->numBins(nullptr) ; ic++) {
     icat->setBin(ic) ;
     histo = hmap[icat->getCurrentLabel()] ;
-    for (ix=0 ; ix < xvar->getBins() ; ix++) {
-      xvar->setBin(ix) ;
+    for (iX=0 ; iX < xvar->getBins() ; iX++) {
+      xvar->setBin(iX) ;
       if (yvar) {
-        for (iy=0 ; iy < yvar->getBins() ; iy++) {
-          yvar->setBin(iy) ;
+        for (iY=0 ; iY < yvar->getBins() ; iY++) {
+          yvar->setBin(iY) ;
           if (zvar) {
             for (iz=0 ; iz < zvar->getBins() ; iz++) {
               zvar->setBin(iz) ;
               double bv = doDensityCorrection ? binVolume(vset)/avgBV : 1;
-              add(vset,bv*histo->GetBinContent(ix+1+xmin,iy+1+ymin,iz+1+zmin)*wgt,bv*TMath::Power(histo->GetBinError(ix+1+xmin,iy+1+ymin,iz+1+zmin)*wgt,2)) ;
+              add(vset,bv*histo->GetBinContent(iX+1+xmin,iY+1+ymin,iz+1+zmin)*wgt,bv*TMath::Power(histo->GetBinError(iX+1+xmin,iY+1+ymin,iz+1+zmin)*wgt,2)) ;
             }
           } else {
             double bv = doDensityCorrection ? binVolume(vset)/avgBV : 1;
-            add(vset,bv*histo->GetBinContent(ix+1+xmin,iy+1+ymin)*wgt,bv*TMath::Power(histo->GetBinError(ix+1+xmin,iy+1+ymin)*wgt,2)) ;
+            add(vset,bv*histo->GetBinContent(iX+1+xmin,iY+1+ymin)*wgt,bv*TMath::Power(histo->GetBinError(iX+1+xmin,iY+1+ymin)*wgt,2)) ;
           }
         }
       } else {
         double bv = doDensityCorrection ? binVolume(vset)/avgBV : 1;
-        add(vset,bv*histo->GetBinContent(ix+1+xmin)*wgt,bv*TMath::Power(histo->GetBinError(ix+1+xmin)*wgt,2)) ;
+        add(vset,bv*histo->GetBinContent(iX+1+xmin)*wgt,bv*TMath::Power(histo->GetBinError(iX+1+xmin)*wgt,2)) ;
       }
     }
   }

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -2708,7 +2708,7 @@ public:
       // Define range "alt" as including bins 1,3,5,7,9
       xb->setRange("alt", "x_coarse_bin1,x_coarse_bin3,x_coarse_bin5,x_coarse_bin7,x_coarse_bin9");
 
-      // Construct subset of data matching range "alt" but only for the first 5000 events and plot it on the fram
+      // Construct subset of data matching range "alt" but only for the first 5000 events and plot it on the frame
       std::unique_ptr<RooAbsData> dataSel{data->reduce(CutRange("alt"), EventRange(0, 5000))};
       //   dataSel->plotOn(xframe,MarkerColor(kGreen),LineColor(kGreen),Name("data_sel")) ;
 

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -67,9 +67,9 @@ TEST(RooSimultaneous, CategoriesWithNoPdf)
 
    RooRealVar x("x", "", 0, 1);
    RooRealVar rnd("rnd", "", 0, 1);
-   RooThresholdCategory catThr("cat", "", rnd, "v2", 2);
-   catThr.addThreshold(1. / 3, "v0", 0);
-   catThr.addThreshold(2. / 3, "v1", 1);
+   RooThresholdCategory catThreshold("cat", "", rnd, "v2", 2);
+   catThreshold.addThreshold(1. / 3, "v0", 0);
+   catThreshold.addThreshold(2. / 3, "v1", 1);
 
    RooRealVar m0("m0", "", 0.5, 0, 1);
    RooRealVar m1("m1", "", 0.5, 0, 1);
@@ -79,7 +79,7 @@ TEST(RooSimultaneous, CategoriesWithNoPdf)
    RooProdPdf pdf("pdf", "", RooArgSet(g0, rndPdf));
 
    std::unique_ptr<RooDataSet> ds{pdf.generate(RooArgSet(x, rnd), RooFit::Name("ds"), RooFit::NumEvents(100))};
-   auto cat = dynamic_cast<RooCategory *>(ds->addColumn(catThr));
+   auto cat = dynamic_cast<RooCategory *>(ds->addColumn(catThreshold));
 
    RooSimultaneous sim("sim", "", *cat);
    sim.addPdf(g0, "v0");

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -312,8 +312,8 @@ bool LikelihoodInterval::FindLimits(const RooRealVar & param, double &lower, dou
    std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
    RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   int ix = params.index(&param);
-   if (ix < 0 ) {
+   int iX = params.index(&param);
+   if (iX < 0 ) {
       ccoutE(InputArguments) << "Error - invalid parameter " << param.GetName() << " specified for finding the interval limits " << std::endl;
       return false;
    }
@@ -332,7 +332,7 @@ bool LikelihoodInterval::FindLimits(const RooRealVar & param, double &lower, dou
    err_level = err_level/2; // since we are using -log LR
    fMinimizer->SetErrorDef(err_level);
 
-   unsigned int ivarX = ix;
+   unsigned int ivarX = iX;
 
    double elow = 0;
    double eup = 0;
@@ -371,9 +371,9 @@ Int_t LikelihoodInterval::GetContourPoints(const RooRealVar & paramX, const RooR
    std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
    RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   int ix = params.index(&paramX);
-   int iy = params.index(&paramY);
-   if (ix < 0 || iy < 0) {
+   int iX = params.index(&paramX);
+   int iY = params.index(&paramY);
+   if (iX < 0 || iY < 0) {
       coutE(InputArguments) << "LikelihoodInterval - Error - invalid parameters specified for finding the contours; parX = " << paramX.GetName()
              << " parY = " << paramY.GetName() << std::endl;
          return 0;
@@ -394,8 +394,8 @@ Int_t LikelihoodInterval::GetContourPoints(const RooRealVar & paramX, const RooR
    fMinimizer->SetErrorDef(cont_level);
 
    unsigned int ncp = npoints;
-   unsigned int ivarX = ix;
-   unsigned int ivarY = iy;
+   unsigned int ivarX = iX;
+   unsigned int ivarY = iY;
    coutI(Minimization)  << "LikelihoodInterval - Finding the contour of " << paramX.GetName() << " ( " << ivarX << " ) and " << paramY.GetName() << " ( " << ivarY << " ) " << std::endl;
    ret = fMinimizer->Contour(ivarX, ivarY, ncp, x, y );
    if (!ret) {

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -2092,7 +2092,7 @@ xRooNode xRooNode::Add(const xRooNode &child, Option_t *opt)
       child.convertForAcquisition(*this);
       if (child.get()) {
          if (auto _d = child.get<RooAbsData>()) {
-            // don't use acquire method to import, because that adds datasets as Embeddded
+            // don't use acquire method to import, because that adds datasets as Embedded
             if (!w->import(*_d)) {
                return xRooNode(child.GetName(), *w->data(child.GetName()), *this);
             } else {
@@ -10330,7 +10330,7 @@ void xRooNode::Draw(Option_t *opt)
                   }
                   hh->SetTitle(TString(hh->GetTitle())
                                   .ReplaceAll(TString(chan->get()->GetName()) + "_",
-                                              "")); // remove occurance of channelname_ in title (usually prefix)
+                                              "")); // remove occurrence of channelname_ in title (usually prefix)
                   titleMatchName &= (TString(samp->GetName()) == hh->GetTitle() ||
                                      TString(hh->GetTitle()).BeginsWith(TString(samp->GetName()) + "_"));
                   hh->SetBinContent(hh->GetXaxis()->FindFixBin(chanName), samp->GetContent());


### PR DESCRIPTION
Thanks to this forum post:
https://root-forum.cern.ch/t/extended-option-removed-from-fitto-and-createnll/59283

Needs to be backported to 6.32 and 6.30.
