### PR TITLE
[proof] Remove call to deprecated `TList` constructor

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -48,6 +48,7 @@ The following people have contributed to this new version:
 - Support for wildcard imports like `from ROOT import *` is dropped from PyROOT
 - Support for external (ie. non-builtin) libAfterImage is now deprecated and it will be removed in next release 6.34.
 - The `TList::TList(TObject*)` constructor is deprecated and will be removed in ROOT 6.34
+- The deprecated `TProofOutputList::TProofOutputList(TObject *o)` constructor was removed
 
 ## Core Libraries
 

--- a/proof/proof/inc/TProofOutputList.h
+++ b/proof/proof/inc/TProofOutputList.h
@@ -30,7 +30,6 @@ private:
 
 public:
    TProofOutputList(const char *dontshow = "PROOF_*");
-TProofOutputList(TObject *o) : TList(o), fDontShow(0) { } // for backward compatibility, don't use
    ~TProofOutputList() override;
 
    void AttachList(TList *alist);


### PR DESCRIPTION
This is a follow-up on c97ec173ee589ab2.

In particular, this will avoid a flood of warnings on Jenkins, i.e. for roottest, where proof is still enabled, like here:
https://github.com/root-project/roottest/pull/1125

To be backported to 6.32, where this `TList` constructor is already deprecated.