### PR TITLE
[ntuple] add fMaxKeySize field to RNTuple anchor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -65,7 +65,7 @@ private:
    RNTuple CreateAnchor(std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor,
                         std::uint16_t versionPatch, std::uint64_t seekHeader, std::uint64_t nbytesHeader,
                         std::uint64_t lenHeader, std::uint64_t seekFooter, std::uint64_t nbytesFooter,
-                        std::uint64_t lenFooter, std::uint64_t checksum);
+                        std::uint64_t lenFooter, std::uint64_t maxKeySize, std::uint64_t checksum);
 
 public:
    RMiniFileReader() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -93,6 +93,8 @@ private:
    std::uint64_t fNBytesFooter = 0;
    /// The size of the uncompressed ntuple footer
    std::uint64_t fLenFooter = 0;
+   /// The maximum size for a TKey payload. Payloads bigger than this size will be chained as multiple blobs.
+   std::uint64_t fMaxKeySize = 0;
    /// The xxhash3 checksum of the serialized other members of the struct (excluding byte count and class version).
    /// This member can only be interpreted during streaming.
    /// When adding new members to the class, this member must remain the last one.
@@ -116,6 +118,7 @@ public:
    std::uint64_t GetSeekFooter() const { return fSeekFooter; }
    std::uint64_t GetNBytesFooter() const { return fNBytesFooter; }
    std::uint64_t GetLenFooter() const { return fLenFooter; }
+   std::uint64_t GetMaxKeySize() const { return fMaxKeySize; }
 
    std::uint64_t GetChecksum() const { return fChecksum; }
 
@@ -123,7 +126,11 @@ public:
    /// Merge this NTuple with the input list entries
    Long64_t Merge(TCollection *input, TFileMergeInfo *mergeInfo);
 
-   ClassDefNV(RNTuple, 4);
+   /// NOTE: if you change this version you also need to update:
+   ///    - RTFNTuple::fClassVersion in RMiniFile.cxx
+   ///    - RTFStreamerInfoObject::fVersionRNTuple in RMiniFile.cxx
+   ///    - RTFStreamerInfoObject::fStreamers in RMiniFile.cxx
+   ClassDefNV(RNTuple, 5);
 }; // class RNTuple
 
 } // namespace Experimental

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -146,6 +146,8 @@ constexpr std::int32_t ChecksumRNTupleClass()
                         "unsigned long"
                         "fLenFooter"
                         "unsigned long"
+                        "fMaxKeySize"
+                        "unsigned long"
                         "fChecksum"
                         "unsigned long";
    std::int32_t id = 0;
@@ -681,6 +683,26 @@ struct RTFStreamerElementLenFooter {
    char fTypeName[13]{'u', 'n', 's', 'i', 'g', 'n', 'e', 'd', ' ', 'l', 'o', 'n', 'g'};
 };
 
+struct RTFStreamerElementMaxKeySize {
+   RUInt32BE fByteCount{0x40000000 | (sizeof(RTFStreamerElementMaxKeySize) - sizeof(RUInt32BE))};
+   RUInt16BE fVersion{4};
+
+   RUInt32BE fByteCountNamed{0x40000000 | (sizeof(RUInt16BE) + sizeof(RTFObject) + 13)};
+   RUInt16BE fVersionNamed{1};
+   RTFObject fObjectNamed{0x02000000 | 0x01000000};
+   char fLName = 11;
+   char fName[11]{'f', 'M', 'a', 'x', 'K', 'e', 'y', 'S', 'i', 'z', 'e'};
+   char fLTitle = 0;
+
+   RUInt32BE fType{14};
+   RUInt32BE fSize{8};
+   RUInt32BE fArrLength{0};
+   RUInt32BE fArrDim{0};
+   char fMaxIndex[20]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+   char fLTypeName = 13;
+   char fTypeName[13]{'u', 'n', 's', 'i', 'g', 'n', 'e', 'd', ' ', 'l', 'o', 'n', 'g'};
+};
+
 /// Streamer info for data member RNTuple::fChecksum
 struct RTFStreamerElementChecksum {
    RUInt32BE fByteCount{0x40000000 | (sizeof(RTFStreamerElementChecksum) - sizeof(RUInt32BE))};
@@ -794,6 +816,15 @@ struct RTFStreamerLenFooter {
    RTFStreamerElementLenFooter fStreamerElementLenFooter;
 };
 
+/// Streamer info frame for data member RNTuple::fLenFooter
+struct RTFStreamerMaxKeySize {
+   RUInt32BE fByteCount{0x40000000 | (sizeof(RTFStreamerMaxKeySize) - sizeof(RUInt32BE))};
+   RUInt32BE fClassTag{0x80000000}; // Fix-up after construction, or'd with 0x80000000
+   RUInt32BE fByteCountRemaining{0x40000000 | (sizeof(RTFStreamerMaxKeySize) - 3 * sizeof(RUInt32BE))};
+   RUInt16BE fVersion{2};
+   RTFStreamerElementMaxKeySize fStreamerElementMaxKeySize;
+};
+
 /// Streamer info frame for data member RNTuple::fChecksum
 struct RTFStreamerChecksum {
    RUInt32BE fByteCount{0x40000000 | (sizeof(RTFStreamerChecksum) - sizeof(RUInt32BE))};
@@ -822,7 +853,8 @@ struct RTFStreamerInfoObject {
    char fLTitle = 0;
 
    RInt32BE fChecksum{ChecksumRNTupleClass()};
-   RUInt32BE fVersionRNTuple{4};
+   /// NOTE: this needs to be kept in sync with the RNTuple version in RNTuple.hxx
+   RUInt32BE fVersionRNTuple{5};
 
    RUInt32BE fByteCountObjArr{0x40000000 |
                               (sizeof(RUInt32BE) + 10 /* strlen(TObjArray) + 1 */ + sizeof(RUInt32BE) +
@@ -835,7 +867,7 @@ struct RTFStreamerInfoObject {
    RTFObject fObjectObjArr{0x02000000};
    char fNameObjArr{0};
 
-   RUInt32BE fNObjects{11};
+   RUInt32BE fNObjects{12};
    RUInt32BE fLowerBound{0};
 
    struct {
@@ -849,6 +881,7 @@ struct RTFStreamerInfoObject {
       RTFStreamerSeekFooter fStreamerSeekFooter;
       RTFStreamerNBytesFooter fStreamerNBytesFooter;
       RTFStreamerLenFooter fStreamerLenFooter;
+      RTFStreamerMaxKeySize fStreamerMaxKeySize;
       RTFStreamerChecksum fStreamerChecksum;
    } fStreamers;
 };
@@ -936,9 +969,13 @@ struct RTFUUID {
 };
 
 /// A streamed RNTuple class
+///
+/// NOTE: this must be kept in sync with RNTuple.hxx.
+/// Aside ensuring consistency between the two classes' members, you need to make sure
+/// that fVersionClass matches the class version of RNTuple.
 struct RTFNTuple {
    RUInt32BE fByteCount{0x40000000 | (sizeof(RTFNTuple) - sizeof(fByteCount))};
-   RUInt16BE fVersionClass{4};
+   RUInt16BE fVersionClass{5};
    RUInt16BE fVersionEpoch{0};
    RUInt16BE fVersionMajor{0};
    RUInt16BE fVersionMinor{0};
@@ -949,6 +986,7 @@ struct RTFNTuple {
    RUInt64BE fSeekFooter{0};
    RUInt64BE fNBytesFooter{0};
    RUInt64BE fLenFooter{0};
+   RUInt64BE fMaxKeySize{0};
    RUInt64BE fChecksum{0};
 
    RTFNTuple() = default;
@@ -964,6 +1002,7 @@ struct RTFNTuple {
       fSeekFooter = inMemoryAnchor.GetSeekFooter();
       fNBytesFooter = inMemoryAnchor.GetNBytesFooter();
       fLenFooter = inMemoryAnchor.GetLenFooter();
+      fMaxKeySize = inMemoryAnchor.GetMaxKeySize();
       fChecksum = XXH3_64bits(GetPtrCkData(), GetSizeCkData());
    }
    std::uint32_t GetSize() const { return sizeof(RTFNTuple); }
@@ -1031,7 +1070,7 @@ ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(ROOT::Internal::R
 ROOT::Experimental::RNTuple ROOT::Experimental::Internal::RMiniFileReader::CreateAnchor(
    std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor, std::uint16_t versionPatch,
    std::uint64_t seekHeader, std::uint64_t nbytesHeader, std::uint64_t lenHeader, std::uint64_t seekFooter,
-   std::uint64_t nbytesFooter, std::uint64_t lenFooter, std::uint64_t checksum)
+   std::uint64_t nbytesFooter, std::uint64_t lenFooter, std::uint64_t maxKeySize, std::uint64_t checksum)
 {
    RNTuple ntuple;
    ntuple.fVersionEpoch = versionEpoch;
@@ -1044,6 +1083,7 @@ ROOT::Experimental::RNTuple ROOT::Experimental::Internal::RMiniFileReader::Creat
    ntuple.fSeekFooter = seekFooter;
    ntuple.fNBytesFooter = nbytesFooter;
    ntuple.fLenFooter = lenFooter;
+   ntuple.fMaxKeySize = maxKeySize;
    ntuple.fChecksum = checksum;
    return ntuple;
 }
@@ -1141,7 +1181,7 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
 
    return CreateAnchor(ntuple->fVersionEpoch, ntuple->fVersionMajor, ntuple->fVersionMinor, ntuple->fVersionPatch,
                        ntuple->fSeekHeader, ntuple->fNBytesHeader, ntuple->fLenHeader, ntuple->fSeekFooter,
-                       ntuple->fNBytesFooter, ntuple->fLenFooter, ntuple->fChecksum);
+                       ntuple->fNBytesFooter, ntuple->fLenFooter, ntuple->fMaxKeySize, ntuple->fChecksum);
 }
 
 ROOT::Experimental::RResult<ROOT::Experimental::RNTuple>
@@ -1167,7 +1207,7 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleBare(std::string_view nt
       return R__FAIL("RNTuple bare file: anchor checksum mismatch");
    return CreateAnchor(ntuple.fVersionEpoch, ntuple.fVersionMajor, ntuple.fVersionMinor, ntuple.fVersionPatch,
                        ntuple.fSeekHeader, ntuple.fNBytesHeader, ntuple.fLenHeader, ntuple.fSeekFooter,
-                       ntuple.fNBytesFooter, ntuple.fLenFooter, ntuple.fChecksum);
+                       ntuple.fNBytesFooter, ntuple.fLenFooter, ntuple.fMaxKeySize, ntuple.fChecksum);
 }
 
 void ROOT::Experimental::Internal::RMiniFileReader::ReadBuffer(void *buffer, size_t nbytes, std::uint64_t offset)
@@ -1453,6 +1493,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileStreamerInfo()
    streamerInfo.fStreamerInfo.fStreamers.fStreamerSeekFooter.fClassTag = 0x80000000 | classTagOffset;
    streamerInfo.fStreamerInfo.fStreamers.fStreamerNBytesFooter.fClassTag = 0x80000000 | classTagOffset;
    streamerInfo.fStreamerInfo.fStreamers.fStreamerLenFooter.fClassTag = 0x80000000 | classTagOffset;
+   streamerInfo.fStreamerInfo.fStreamers.fStreamerMaxKeySize.fClassTag = 0x80000000 | classTagOffset;
    streamerInfo.fStreamerInfo.fStreamers.fStreamerChecksum.fClassTag = 0x80000000 | classTagOffset;
    RNTupleCompressor compressor;
    auto szStreamerInfo = compressor.Zip(&streamerInfo, streamerInfo.GetSize(), 1);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -42,7 +42,19 @@ void ROOT::Experimental::RNTuple::Streamer(TBuffer &buf)
       auto offCkData = offClassBuf + sizeof(UInt_t) + sizeof(Version_t);
       auto checksum = XXH3_64bits(buf.Buffer() + offCkData, lenCkData);
 
-      buf.ReadClassBuffer(RNTuple::Class(), this, classVersion, offClassBuf, bcnt);
+      buf >> fVersionEpoch;
+      buf >> fVersionMajor;
+      buf >> fVersionMinor;
+      buf >> fVersionPatch;
+      buf >> fSeekHeader;
+      buf >> fNBytesHeader;
+      buf >> fLenHeader;
+      buf >> fSeekFooter;
+      buf >> fNBytesFooter;
+      buf >> fLenFooter;
+      if (classVersion > 4)
+         buf >> fMaxKeySize;
+      buf >> fChecksum;
 
       if (checksum != fChecksum)
          throw RException(R__FAIL("checksum mismatch in RNTuple anchor"));
@@ -62,6 +74,7 @@ void ROOT::Experimental::RNTuple::Streamer(TBuffer &buf)
       buf << fSeekFooter;
       buf << fNBytesFooter;
       buf << fLenFooter;
+      buf << fMaxKeySize;
       fChecksum = XXH3_64bits(buf.Buffer() + offCkData, buf.Length() - offCkData);
       buf << fChecksum;
       buf.SetByteCount(offBcnt, kTRUE /* packInVersion */);

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -10,7 +10,7 @@ bool IsEqual(const ROOT::Experimental::RNTuple &a, const ROOT::Experimental::RNT
           a.GetSeekHeader() == b.GetSeekHeader() && a.GetNBytesHeader() == b.GetNBytesHeader() &&
           a.GetLenHeader() == b.GetLenHeader() && a.GetSeekFooter() == b.GetSeekFooter() &&
           a.GetNBytesFooter() == b.GetNBytesFooter() && a.GetLenFooter() == b.GetLenFooter() &&
-          a.GetChecksum() == b.GetChecksum();
+          a.GetMaxKeySize() == b.GetMaxKeySize() && a.GetChecksum() == b.GetChecksum();
 }
 
 struct RNTupleTester {


### PR DESCRIPTION
# This Pull request:
* Adds a `std::uint64_t fMaxKeySize` field to the RNTuple struct
* Adds the necessary machinery to serialize that field to the StreamerInfo
* Bumps the RNTuple class version from 4 to 5

## TODO
* Update documentation
* Actually use the new field to do header chaining when size exceeds maxKeySize 
* Consider adding a fwd compatibility test (read version 5 on disk from version 4 in memory)

## Checklist:

- [x] tested changes locally (one test currently fails due to the tested file missing proper StreamerInfo)
- [ ] updated the docs (if necessary)

