### PR TITLE
[TMVA] Add missing TMVA python dependencies to requirements.txt

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -119,7 +119,9 @@ if (dataframe)
 endif()
 
 # SOFIE-GNN pythonizations
-if (tmva)
+# TODO: GNN tests are right now hardcoded to never run, because it is not clear
+# if they will pass on the new CI. Please revert this.
+if (FALSE AND tmva)
     if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 4 OR win_broken_tests)
         find_python_module(sonnet QUIET)
         find_python_module(graph_nets QUIET)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 numpy>=1.4.1
 
 # TMVA: SOFIE
-# graph_nets
+graph_nets
 onnx
-# sonnet # used for GNNs
+sonnet # used for GNNs
 
 # TMVA: PyMVA interfaces
 scikit-learn
@@ -28,6 +28,9 @@ metakernel>=0.20.0
 pyspark>=2.4 # Spark backend
 dask>=2022.08.1 ; python_version >= "3.8" # Dask backend
 distributed>=2022.08.1 ; python_version >= "3.8" # Dask backend
+
+# JsMVA: Jupyter notebook magic for TMVA
+ipywidgets
 
 # Look for CPU-only versions of PyTorch to avoid pulling CUDA in the CI docker images.
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -304,7 +304,9 @@ else()
   endif()
   #veto this tutorial since it is added directly
   list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Parser.py)
-  if (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND)
+  # TODO: GNN tutorials are right now hardcoded to never run, because it is not
+  # clear if they will pass on the new CI. Please revert this.
+  if (TRUE OR (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND))
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN.py)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Parser.py)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Application.C)


### PR DESCRIPTION
Closes https://github.com/root-project/root/issues/14553.

This PR adds the dependencies for the TMVA GNN unit tests to the
docker images via the `requirements.txt`. However, this will only have a
delayed effect until the images are re-built. Therefore, we can't
validate for now that the tests actually work.

Once the missing packages make it into the CI images, a PR should be
opened to revert this commit.

For the JsMVA dependency, we don't have to worry about anything.
The JsMVA tests have already been temporarily disabled by @dpiparo 7 years ago:
https://github.com/root-project/roottest/blame/master/python/JsMVA/CMakeLists.txt

Note: adding the new dependencies only grows the environment by 20 MB, which is less then 1 % of a size increase (the size of the environment is currently 2.3 GB).