### PR TITLE
[ntuple] Fix warning about hidden virtual function

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1280,6 +1280,7 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final { R__ASSERT(false && "RArrayAsRVec fields must only be used for reading"); }
+   using RFieldBase::GenerateColumnsImpl;
 
    void ConstructValue(void *where) const final;
    /// Returns an RRVecField::RRVecDeleter


### PR DESCRIPTION
Commit 05167a99e0 ("Provide default RFieldBase::GenerateColumnsImpl") introduced compiler warnings with GCC because `RArrayAsRVecField` only overrides one of the two overloads with default implementations.