### PR TITLE
[ntuple] Manually read RNTuple fields in Streamer()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_RNTuple
 #define ROOT7_RNTuple
 
+#include "RtypesCore.h"
 #include <Rtypes.h>
 
 #include <cstdint>
@@ -99,6 +100,8 @@ private:
    std::uint64_t fChecksum = 0;
 
    TFile *fFile = nullptr; ///<! The file from which the ntuple was streamed, registered in the custom streamer
+
+   static std::size_t ExpectedDeserializedBytes(Version_t ntupleVersion);
 
 public:
    RNTuple() = default;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -42,7 +42,22 @@ void ROOT::Experimental::RNTuple::Streamer(TBuffer &buf)
       auto offCkData = offClassBuf + sizeof(UInt_t) + sizeof(Version_t);
       auto checksum = XXH3_64bits(buf.Buffer() + offCkData, lenCkData);
 
-      buf.ReadClassBuffer(RNTuple::Class(), this, classVersion, offClassBuf, bcnt);
+      buf >> fVersionEpoch;
+      buf >> fVersionMajor;
+      buf >> fVersionMinor;
+      buf >> fVersionPatch;
+      buf >> fSeekHeader;
+      buf >> fNBytesHeader;
+      buf >> fLenHeader;
+      buf >> fSeekFooter;
+      buf >> fNBytesFooter;
+      buf >> fLenFooter;
+      // New versions may add members here ...
+      // ... so we skip all but the last 8 bytes for fwd compatibility.
+      // NOTE: bcnt doesn't include its own size, so we need to skip an additional
+      // sizeof(UInt_t) bytes to reach the end of the class.
+      buf.SetBufferOffset(offClassBuf + sizeof(UInt_t) + bcnt - sizeof(fChecksum));
+      buf >> fChecksum;
 
       if (checksum != fChecksum)
          throw RException(R__FAIL("checksum mismatch in RNTuple anchor"));


### PR DESCRIPTION
...instead of relying on ReadClassBuffer(). This is necessary for schema evolution with RNTuple's custom streamer.

## Changes or fixes:
Using `TBuffer::ReadClassBuffer` in `RNTuple::Streamer` is wrong because it doesn't handle cases where the schema of RNTuple changes. To do that, we need to manually read back the fields depending on the class version.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary) - not necessary

