### PR TITLE
[gpad] Change TCanvas::SetName() implementation

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -64,8 +64,11 @@ const Size_t kDefaultCanvasSize   = 20;
 ClassImpQ(TCanvas)
 
 
-auto GetNewCanvasName()
+TString GetNewCanvasName(const char *arg = nullptr)
 {
+   if (arg && *arg)
+      return arg;
+
    const char *defcanvas = gROOT->GetDefCanvasName();
    TString cdef = defcanvas;
 
@@ -176,7 +179,7 @@ TCanvas::TCanvas(Bool_t build) : TPad(), fDoubleBuffer(0)
    if (!build || TClass::IsCallingNew() != TClass::kRealNew) {
       Constructor();
    } else {
-      TString cdef = GetNewCanvasName();
+      auto cdef = GetNewCanvasName();
 
       Constructor(cdef.Data(), cdef.Data(), 1);
    }
@@ -1513,9 +1516,9 @@ void TCanvas::ls(Option_t *option) const
 
 TCanvas *TCanvas::MakeDefCanvas()
 {
-   TString cdef = GetNewCanvasName();
+   auto cdef = GetNewCanvasName();
 
-   TCanvas *c = new TCanvas(cdef.Data(), cdef.Data(), 1);
+   auto c = new TCanvas(cdef.Data(), cdef.Data(), 1);
 
    ::Info("TCanvas::MakeDefCanvas"," created default TCanvas with name %s", cdef.Data());
    return c;
@@ -2046,10 +2049,7 @@ void TCanvas::SetFolder(Bool_t isfolder)
 
 void TCanvas::SetName(const char *name)
 {
-   if (name && *name)
-      fName = name;
-   else
-      fName = GetNewCanvasName();
+   fName = GetNewCanvasName(name);
 
    if (gPad && TestBit(kMustCleanup))
       gPad->Modified();

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2046,13 +2046,13 @@ void TCanvas::SetFolder(Bool_t isfolder)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set canvas name. In case `name` is an empty string, a default name is set.
+/// Canvas automatically marked as modified when SetName method called
 
 void TCanvas::SetName(const char *name)
 {
    fName = GetNewCanvasName(name);
 
-   if (gPad && TestBit(kMustCleanup))
-      gPad->Modified();
+   Modified();
 }
 
 

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1823,23 +1823,25 @@ void TCanvas::SaveSource(const char *filename, Option_t * /*option*/)
    gROOT->ResetClassSaved();
 
    char quote = '"';
-   std::ofstream out;
-   TString fname;
-   const char *cname = GetName();
+   TString cname0 = GetName();
    Bool_t invalid = kFALSE;
-   //    if filename is given, open this file, otherwise create a file
-   //    with a name equal to the canvasname.C
-   if (filename && (strlen(filename) > 0)) {
+
+   TString cname = cname0.Strip(TString::kBoth);
+   if (cname.IsNull()) {
+      invalid = kTRUE;
+      cname = "c1";
+   }
+
+   //  if filename is given, open this file, otherwise create a file
+   //  with a name equal to the canvasname.C
+   TString fname;
+   if (filename && *filename) {
       fname = filename;
    } else {
-      fname = cname;
-      fname = fname.Strip(TString::kBoth);
-      if (fname.IsNull()) {
-         invalid = kTRUE;
-         fname = "c1";
-      }
-      fname.Append(".C");
+      fname = cname + ".C";
    }
+
+   std::ofstream out;
    out.open(fname.Data(), std::ios::out);
    if (!out.good()) {
       Error("SaveSource", "Cannot open file: %s", fname.Data());
@@ -1931,7 +1933,7 @@ void TCanvas::SaveSource(const char *filename, Option_t * /*option*/)
 
    //   Now recursively scan all pads of this canvas
    cd();
-   if (invalid) SetName("c1");
+   if (invalid) fName = cname;
    TPad::SavePrimitive(out,"toplevel");
 
    //   Write canvas options related to pad editor
@@ -1939,7 +1941,7 @@ void TCanvas::SaveSource(const char *filename, Option_t * /*option*/)
    if (GetShowToolBar()) {
       out<<"   "<<GetName()<<"->ToggleToolBar();"<<std::endl;
    }
-   if (invalid) SetName(" ");
+   if (invalid) fName = cname0;
 
    out <<"}"<<std::endl;
    out.close();

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -250,7 +250,7 @@ TCanvas::TCanvas(const char *name, Int_t ww, Int_t wh, Int_t winid) : TPad(), fD
    if (!fCanvasImp) return;
 
    CreatePainter();
-   SetName(name);
+   fName = GetNewCanvasName(name); // avoid Modified() signal from SetName
    Build();
 }
 
@@ -350,7 +350,7 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t form)
 
    CreatePainter();
 
-   SetName(name);
+   fName = GetNewCanvasName(name); // avoid Modified() signal from SetName
    SetTitle(title); // requires fCanvasImp set
    Build();
 
@@ -436,7 +436,7 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t ww, Int_t w
 
    CreatePainter();
 
-   SetName(name);
+   fName = GetNewCanvasName(name); // avoid Modified() signal from SetName
    SetTitle(title); // requires fCanvasImp set
    Build();
 
@@ -523,7 +523,7 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t wtopx,
 
    CreatePainter();
 
-   SetName(name);
+   fName = GetNewCanvasName(name); // avoid Modified() signal from SetName
    SetTitle(title); // requires fCanvasImp set
    Build();
 


### PR DESCRIPTION
Call `Modified()` method for the canvas itself - there are no logical reasons why `gPad->Modified()`  was called

Instead calling `SetName(name)` directly set `fName` member in all TCanvas constructors. 
This avoids triggering of `Modified()` signal from the constructor itself.

Fix logic around empty canvas name in `TCanvas::SaveSource`. 
There also use direct assignment of `fName` member.

