### PR TITLE
[webgui] Fix CEF handler, reduce debug output

### DIFF
--- a/gui/cefdisplay/src/gui_handler.cxx
+++ b/gui/cefdisplay/src/gui_handler.cxx
@@ -20,6 +20,7 @@
 #include "simple_app.h"
 
 #include <sstream>
+#include <fstream>
 #include <string>
 
 #include "include/base/cef_bind.h"
@@ -365,8 +366,9 @@ CefRefPtr<CefResourceHandler> GuiHandler::GetResourceHandler(
   if (serv->IsFileRequested(inp_path, fname)) {
      // process file - no need for special requests handling
 
-     // when file not exists - return nullptr
-     if (gSystem->AccessPathName(fname.Data()))
+     std::ifstream ifs(fname.Data());
+     // when file not exists - return default handler otherwise CEF terminates
+     if (!ifs)
         return new TGuiResourceHandler(serv, true);
 
      const char *mime = THttpServer::GetMimeType(fname.Data());

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -543,7 +543,7 @@ bool RWebWindow::_CanTrustIn(std::shared_ptr<WebConn> &conn, const std::string &
       return (conn->fKey.empty() && hash.empty()) || (hash == conn->fKey) || (hash == expected);
 
    // for local connection simple key can be used
-   if (!remote && (hash == conn->fKey))
+   if (!remote && ((hash == conn->fKey) || (hash == expected)))
       return true;
 
    if (hash == expected) {

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1883,7 +1883,7 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          std::stringstream exec;
          exec << "((" << obj->ClassName() << " *) " << std::hex << std::showbase << (size_t)obj
               << ")->" << buf << ";";
-         if (gDebug > 1)
+         if (gDebug > 0)
             Info("ProcessData", "Obj %s Exec %s", obj->GetName(), exec.str().c_str());
 
          auto res = gROOT->ProcessLine(exec.str().c_str());
@@ -2326,7 +2326,8 @@ TPad *TWebCanvas::ProcessObjectOptions(TWebObjectOptions &item, TPad *pad, int i
          std::stringstream exec;
          exec << "((" << obj->ClassName() << " *) " << std::hex << std::showbase
                       << (size_t)obj << ")->" << item.opt << ";";
-         Info("ProcessObjectOptions", "Obj %s Execute %s", obj->GetName(), exec.str().c_str());
+         if (gDebug > 0)
+            Info("ProcessObjectOptions", "Obj %s Execute %s", obj->GetName(), exec.str().c_str());
          gROOT->ProcessLine(exec.str().c_str());
       } else {
          Error("ProcessObjectOptions", "Fail to execute %s for object %p %s", item.opt.c_str(), obj, obj ? obj->ClassName() : "---");
@@ -2341,7 +2342,7 @@ TPad *TWebCanvas::ProcessObjectOptions(TWebObjectOptions &item, TPad *pad, int i
       auto pos = item.opt.find(";;use_"); // special coding of extra options
       if (pos != std::string::npos) item.opt.resize(pos);
 
-      if (gDebug > 1)
+      if (gDebug > 0)
          Info("ProcessObjectOptions", "Set draw option %s for object %s %s", item.opt.c_str(),
                obj->ClassName(), obj->GetName());
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -687,8 +687,6 @@ Bool_t THttpServer::SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run
       return kTRUE;
    }
 
-   printf("Calling SubmitHttp\n");
-
    // add call arg to the list
    std::unique_lock<std::mutex> lk(fMutex);
    fArgs.push(arg);


### PR DESCRIPTION
1. Do not use `gSystem->AccessPath` from CEF handler, may block because of mutex usage
2. Remove debug output from THttpServer and TWebCanvas
3. Properly handle `local` connection in auth check