### PR TITLE
[skip ci][ci] New string to skip CI

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -80,10 +80,10 @@ concurrency:
 jobs:
   build-macos:
     # For any event that is not a PR, the CI will always run. In PRs, the CI
-    # can be skipped if the tag [skip-ci] is written in the title.
+    # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
     if: |
         (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
-        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
 
     permissions:
       contents: read
@@ -212,10 +212,10 @@ jobs:
 
   build-windows:
     # For any event that is not a PR, the CI will always run. In PRs, the CI
-    # can be skipped if the tag [skip-ci] is written in the title.
+    # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
     if: |
         (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
-        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
 
     permissions:
       contents: read
@@ -327,10 +327,10 @@ jobs:
 
   build-linux:
     # For any event that is not a PR, the CI will always run. In PRs, the CI
-    # can be skipped if the tag [skip-ci] is written in the title.
+    # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
     if: |
         (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
-        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
 
     permissions:
       contents: read
@@ -496,10 +496,10 @@ jobs:
 
   event_file:
     # For any event that is not a PR, the CI will always run. In PRs, the CI
-    # can be skipped if the tag [skip-ci] is written in the title.
+    # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
     if: |
         (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
-        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
 
     name: "Upload Event Payload"
     runs-on: ubuntu-latest


### PR DESCRIPTION
if "[skip ci]" is detected in the PR title, the CI does not start. This is done to have at least one string in common with the ones the GH CI uses for commits.
The test of this PR is that the CI does not start given its title.
