### PR TITLE
[rntuple] Default initialize data member of RNTupleLocator

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -154,7 +154,7 @@ struct RNTupleLocator {
 
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
-   std::variant<std::uint64_t, std::string, RNTupleLocatorObject64> fPosition;
+   std::variant<std::uint64_t, std::string, RNTupleLocatorObject64> fPosition{};
    std::uint32_t fBytesOnStorage = 0;
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.


### PR DESCRIPTION
This avoids the following type of warning (obtained when compiling ROOT with -fsanitize=thread)

```
    inlined from ‘virtual std::vector<ROOT::Experimental::RNTupleLocator> ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::__ROOT::span<ROOT::Experimental::Internal::RPageStorage::RSealedPageGroup>)’ at /rootproject/rootsrc/tree/ntuple/v7/src/RPageStorageDaos.cxx:417:28:
/usr/include/c++/13/bits/basic_string.h:1079:16: warning: ‘*(const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)((char*)&locator + offsetof(ROOT::Experimental::RNTupleLocator, ROOT::Experimental::RNTupleLocator::fPosition.std::variant<long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Variant_base<long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Move_assign_base<false, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Copy_assign_base<false, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Move_ctor_base<false, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Copy_ctor_base<false, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::<unnamed>.std::__detail::__variant::_Variant_storage<false, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ROOT::Experimental::RNTupleLocatorObject64>::_M_u)).std::__cxx11::basic_string<char>::_M_string_length’ may be used uninitialized [-Wmaybe-uninitialized]
 1079 |       { return _M_string_length; }
      |                ^~~~~~~~~~~~~~~~
/rootproject/rootsrc/tree/ntuple/v7/src/RPageStorageDaos.cxx: In member function ‘virtual std::vector<ROOT::Experimental::RNTupleLocator> ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::__ROOT::span<ROOT::Experimental::Internal::RPageStorage::RSealedPageGroup>)’:
/rootproject/rootsrc/tree/ntuple/v7/src/RPageStorageDaos.cxx:412:25: note: ‘locator’ declared here
  412 |          RNTupleLocator locator;
```


