### PR TITLE
[RF] Optimize code generated from `PiecewiseInterpolation` for use in AD

### DIFF
--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -102,6 +102,9 @@ public:
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
   std::string
   buildCallToAnalyticIntegral(int code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+
+  RooArgSet const &variables() const { return _depList; }
+
 protected:
 
   bool importWorkspaceHook(RooWorkspace& ws) override ;


### PR DESCRIPTION
The PiecewiseInterpolation class is used in the context of HistFactory models, where is is always used the same way: all RooAbsReals in _lowSet, _histSet, and also nominal are 1D RooHistFuncs with with same structure.

Therefore, we can make a big optimization: we get the bin index ony once here in the generated code for PiecewiseInterpolation. Then, we also rearrange the histogram data in such a way that we can always pass the same arrays to the free function that implements the interpolation, just with a dynamic offset calculated from the bin index.

This change is covered by the `testHistFactory` unit test.

Together with the change suggested in the other draft PR, where the generated code is split up into separate functions for each channel, this PR addresses the plan of work item "Reduce JITting time for AD in RooFit". Different from that optimization, this one doesn't depend on the upcoming Clad 1.5, so it can be merged without upgrading Clad.