### PR TITLE
[webgui] fix handling of local displays like qt5 or cef

### DIFF
--- a/etc/runfirefox.sh
+++ b/etc/runfirefox.sh
@@ -8,7 +8,7 @@ firefox=$1
 shift
 
 if [ "$profile" != "<dummy>" ]; then
-   trap "rm -rf $profile; echo remove $profile at exit" 0 1 2 3 6
+   trap "rm -rf $profile" 0 1 2 3 6
 fi
 
 args=

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -187,8 +187,6 @@ private:
 
    std::shared_ptr<WebConn> RemoveConnection(unsigned wsid);
 
-   std::shared_ptr<WebConn> _FindConnWithKey(const std::string &key) const;
-
    bool _CanTrustIn(std::shared_ptr<WebConn> &conn, const std::string &key, const std::string &ntry, bool remote, bool test_first_time);
 
    std::string _MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid);
@@ -203,7 +201,7 @@ private:
 
    void CheckDataToSend(bool only_once = false);
 
-   bool HasKey(const std::string &key) const;
+   bool HasKey(const std::string &key, bool also_newkey = false) const;
 
    void RemoveKey(const std::string &key);
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -498,27 +498,6 @@ unsigned RWebWindow::AddDisplayHandle(bool headless_mode, const std::string &key
    return fConnCnt;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
-/// Find connection with specified key.
-/// Must be used under connection mutex lock
-
-std::shared_ptr<RWebWindow::WebConn> RWebWindow::_FindConnWithKey(const std::string &key) const
-{
-   if (key.empty())
-      return nullptr;
-
-   for (auto &entry : fPendingConn) {
-      if (entry->fKey == key)
-         return entry;
-   }
-
-   for (auto &conn : fConn) {
-      if (conn->fKey == key)
-         return conn;
-   }
-
-   return nullptr;
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Check if provided hash, ntry parameters from the connection request could be accepted
@@ -572,14 +551,28 @@ bool RWebWindow::_CanTrustIn(std::shared_ptr<WebConn> &conn, const std::string &
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Returns true if provided key value already exists (in processes map or in existing connections)
+/// In special cases one also can check if key value exists as newkey
 
-bool RWebWindow::HasKey(const std::string &key) const
+bool RWebWindow::HasKey(const std::string &key, bool also_newkey) const
 {
+   if (key.empty())
+      return false;
+
    std::lock_guard<std::mutex> grd(fConnMutex);
 
-   auto conn = _FindConnWithKey(key);
+   for (auto &entry : fPendingConn) {
+      if (entry->fKey == key)
+         return true;
+   }
 
-   return conn ? true : false;
+   for (auto &conn : fConn) {
+      if (conn->fKey == key)
+         return true;
+      if (also_newkey && (conn->fNewKey == key))
+         return true;
+   }
+
+   return false;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -952,7 +945,7 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
       return false;
    }
 
-   if (oper_seq <= conn->fRecvSeq) {
+   if (is_remote && (oper_seq <= conn->fRecvSeq)) {
       R__LOG_ERROR(WebGUILog()) << "supply same package again - MiM attacker?";
       return false;
    }

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -54,7 +54,7 @@ protected:
          TUrl url;
          url.SetOptions(arg->GetQuery());
          TString key = url.GetValueFromOptions("key");
-         if (key.IsNull() || !fWindow.HasKey(key.Data())) {
+         if (key.IsNull() || !fWindow.HasKey(key.Data(), true)) {
             // refuce loading of default web page without valid key
             arg->SetContent("refused");
             arg->Set404();


### PR DESCRIPTION
When reloading web widget in QT5/QT6/CEF widget,
new widget loads faster than old connection is closed.
Therefore allow new key checks when loading HTML page

Remove debug output from firefox start script