### PR TITLE
Use data source label in distributed HeadNode factory

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -89,6 +89,7 @@ class GraphCreatorHelper;
 void ChangeEmptyEntryRange(const ROOT::RDF::RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
 void ChangeSpec(const ROOT::RDF::RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
 void TriggerRun(ROOT::RDF::RNode node);
+std::string GetDataSourceLabel(const ROOT::RDF::RNode &node);
 } // namespace RDF
 } // namespace Internal
 
@@ -121,7 +122,7 @@ class RInterface : public RInterfaceBase {
    friend void RDFInternal::TriggerRun(RNode node);
    friend void RDFInternal::ChangeEmptyEntryRange(const RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
    friend void RDFInternal::ChangeSpec(const RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
-
+   friend std::string ROOT::Internal::RDF::GetDataSourceLabel(const RNode &node);
    std::shared_ptr<Proxied> fProxiedPtr; ///< Smart pointer to the graph node encapsulated by this RInterface.
 
 public:

--- a/tree/dataframe/src/RInterface.cxx
+++ b/tree/dataframe/src/RInterface.cxx
@@ -39,3 +39,14 @@ void ROOT::Internal::RDF::TriggerRun(ROOT::RDF::RNode node)
 {
    node.fLoopManager->Run();
 }
+
+std::string ROOT::Internal::RDF::GetDataSourceLabel(const ROOT::RDF::RNode &node)
+{
+   if (node.fLoopManager->GetTree()) {
+      return "TTreeDS";
+   } else if (node.fDataSource) {
+      return node.fDataSource->GetLabel();
+   } else {
+      return "EmptyDS";
+   }
+}


### PR DESCRIPTION
Introduce a new method to get a label for the data source that the current RDataFrame is processing. There are three major types:
* The dataframe will process a TTree dataset
* The dataframe will process an empty dataset
* The dataframe will process data from an RDataSource

The function returns a label with the suffix "DS" also for the first two cases, to be aligned as much as possible with the RDataSource infrastructure.

Make use of this function in distributed RDataFrame to create the headnode of the Python computation graph. This also avoids extra parsing in the factory function which includes opening the first input file once more to distinguish between TTree or RNTuple input (in case the first input argument is a string).
