### PR TITLE
[ntuple] store streamer info of unsplit fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -467,11 +467,11 @@ The type information record frame has the following contents
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
++                       Content Identifier                      +
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Type Version From                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                         Type Version To                       |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-+                       Content Identifier                      +
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
@@ -484,12 +484,7 @@ The following kinds of content are supported:
 
 | Content identifier  | Meaning of content                                  |
 |---------------------|-----------------------------------------------------|
-| 0x00                | Serialized ROOT streamer info; see notes            |
-
-The serialized ROOT streamer info is not bound to a specific type.
-It is the combined streamer information from all the unsplit fields.
-Writers set version from/to to zero and use an empty type name.
-Readers should ignore the type-specific information.
+| 0x01                | String: C++ definition of the type                  |
 
 
 ### Footer Envelope

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -484,7 +484,12 @@ The following kinds of content are supported:
 
 | Content identifier  | Meaning of content                                  |
 |---------------------|-----------------------------------------------------|
-| 0x01                | String: C++ definition of the type                  |
+| 0x00                | Serialized ROOT streamer info; see notes            |
+
+The serialized ROOT streamer info is not bound to a specific type.
+It is the combined streamer information from all the unsplit fields.
+Writers set version from/to to zero and use an empty type name.
+Readers should ignore the type-specific information.
 
 
 ### Footer Envelope

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.1.0
+# RNTuple Reference Specifications 0.2.2.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 
@@ -484,8 +484,13 @@ The following kinds of content are supported:
 
 | Content identifier  | Meaning of content                                  |
 |---------------------|-----------------------------------------------------|
-| 0x01                | String: C++ definition of the type                  |
+| 0x00                | Serialized ROOT streamer info; see notes            |
 
+The serialized ROOT streamer info is not bound to a specific type.
+It is the combined streamer information from all the unsplit fields.
+Writers set version from/to to zero and use an empty type name.
+Readers should ignore the type-specific information.
+The format of the content is a ROOT streamed TList of TStreamerInfo objects.
 
 ### Footer Envelope
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -47,11 +47,13 @@
 #include <typeinfo>
 #include <variant>
 #include <vector>
+#include <unordered_map>
 #include <utility>
 
 class TClass;
 class TEnum;
 class TObject;
+class TVirtualStreamerInfo;
 
 namespace ROOT {
 
@@ -826,6 +828,7 @@ private:
    };
 
    TClass *fClass = nullptr;
+   std::unordered_map<Int_t, TVirtualStreamerInfo *> fStreamerInfos; ///< streamer info records seen during writing
    ClusterSize_t fIndex; ///< number of bytes written in the current cluster
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -530,8 +530,7 @@ protected:
    /// Add a new subfield to the list of nested fields
    void Attach(std::unique_ptr<RFieldBase> child);
 
-   /// Called by `ConnectPageSource()` only once connected; derived classes may override this
-   /// as appropriate
+   /// Called by `ConnectPageSource()` once connected; derived classes may override this as appropriate
    virtual void OnConnectPageSource() {}
 
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -398,7 +398,7 @@ public:
 };
 
 /// Used in RExtraTypeInfoDescriptor
-enum class EExtraTypeInfoIds { kStreamerInfo, kInvalid };
+enum class EExtraTypeInfoIds { kInvalid, kStreamerInfo };
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -397,6 +397,9 @@ public:
    bool HasClusterDetails() const { return !fClusterIds.empty(); }
 };
 
+/// Used in RExtraTypeInfoDescriptor
+enum class EExtraTypeInfoIds { kStreamerInfo, kInvalid };
+
 // clang-format off
 /**
 \class ROOT::Experimental::RExtraTypeInfoDescriptor
@@ -409,12 +412,9 @@ Currently only used by unsplit fields to store RNTuple-wide list of streamer inf
 class RExtraTypeInfoDescriptor {
    friend class Internal::RExtraTypeInfoDescriptorBuilder;
 
-public:
-   enum class EContentIds { kStreamerInfo, kInvalid };
-
 private:
    /// Specifies the meaning of the extra information
-   EContentIds fContentId = EContentIds::kInvalid;
+   EExtraTypeInfoIds fContentId = EExtraTypeInfoIds::kInvalid;
    /// Extra type information restricted to a certain version range of the type
    std::uint32_t fTypeVersionFrom = 0;
    std::uint32_t fTypeVersionTo = 0;
@@ -434,7 +434,7 @@ public:
 
    RExtraTypeInfoDescriptor Clone() const;
 
-   EContentIds GetContentId() const { return fContentId; }
+   EExtraTypeInfoIds GetContentId() const { return fContentId; }
    std::uint32_t GetTypeVersionFrom() const { return fTypeVersionFrom; }
    std::uint32_t GetTypeVersionTo() const { return fTypeVersionTo; }
    std::string GetTypeName() const { return fTypeName; }
@@ -1184,7 +1184,7 @@ private:
 public:
    RExtraTypeInfoDescriptorBuilder() = default;
 
-   RExtraTypeInfoDescriptorBuilder &ContentId(RExtraTypeInfoDescriptor::EContentIds contentId)
+   RExtraTypeInfoDescriptorBuilder &ContentId(EExtraTypeInfoIds contentId)
    {
       fExtraTypeInfo.fContentId = contentId;
       return *this;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -30,6 +30,7 @@ namespace ROOT {
 namespace Experimental {
 
 enum class EColumnType;
+enum class EExtraTypeInfoIds;
 class RClusterDescriptor;
 class RNTupleDescriptor;
 
@@ -195,10 +196,14 @@ public:
 
    /// While we could just interpret the enums as ints, we make the translation explicit
    /// in order to avoid accidentally changing the on-disk numbers when adjusting the enum classes.
-   static std::uint16_t SerializeFieldStructure(ROOT::Experimental::ENTupleStructure structure, void *buffer);
-   static std::uint16_t SerializeColumnType(ROOT::Experimental::EColumnType type, void *buffer);
-   static RResult<std::uint16_t> DeserializeFieldStructure(const void *buffer, ROOT::Experimental::ENTupleStructure &structure);
-   static RResult<std::uint16_t> DeserializeColumnType(const void *buffer, ROOT::Experimental::EColumnType &type);
+   static std::uint32_t SerializeFieldStructure(ROOT::Experimental::ENTupleStructure structure, void *buffer);
+   static std::uint32_t SerializeColumnType(ROOT::Experimental::EColumnType type, void *buffer);
+   static std::uint32_t SerializeExtraTypeInfoId(ROOT::Experimental::EExtraTypeInfoIds id, void *buffer);
+   static RResult<std::uint32_t>
+   DeserializeFieldStructure(const void *buffer, ROOT::Experimental::ENTupleStructure &structure);
+   static RResult<std::uint32_t> DeserializeColumnType(const void *buffer, ROOT::Experimental::EColumnType &type);
+   static RResult<std::uint32_t>
+   DeserializeExtraTypeInfoId(const void *buffer, ROOT::Experimental::EExtraTypeInfoIds &id);
 
    static std::uint32_t SerializeEnvelopePreamble(std::uint16_t envelopeType, void *buffer);
    static std::uint32_t SerializeEnvelopePostscript(unsigned char *envelope, std::uint64_t size);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -21,10 +21,15 @@
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RSpan.hxx>
 
+#include <Rtypes.h>
+
 #include <cstdint>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+class TVirtualStreamerInfo;
 
 namespace ROOT {
 namespace Experimental {
@@ -67,6 +72,10 @@ public:
    static constexpr std::uint32_t kFlagDeferredColumn    = 0x08;
 
    static constexpr DescriptorId_t kZeroFieldId = std::uint64_t(-2);
+
+   // In the page sink and the unsplit field, the seen streamer infos are stored in a map
+   // with the unique streamer info number being the key.
+   using StreamerInfoMap_t = std::unordered_map<Int_t, TVirtualStreamerInfo *>;
 
    struct REnvelopeLink {
       std::uint64_t fLength = 0;
@@ -261,6 +270,10 @@ public:
    // The clusters vector must be initialized with the cluster summaries corresponding to the page list
    static RResult<void> DeserializePageList(const void *buffer, std::uint64_t bufSize, DescriptorId_t clusterGroupId,
                                             RNTupleDescriptor &desc);
+
+   // Helper functions to (de-)serialize the streamer info type extra information
+   static std::string SerializeStreamerInfos(const StreamerInfoMap_t &infos);
+   static RResult<StreamerInfoMap_t> DeserializeStreamerInfos(const std::string &extraTypeInfoContent);
 }; // class RNTupleSerializer
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -90,7 +90,7 @@ public:
       return bytes;
    }
    void CommitClusterGroup() final {}
-   void CommitDataset() final {}
+   void CommitDatasetImpl() final {}
 };
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -71,6 +71,7 @@ public:
    {
       ConnectFields(changeset.fAddedFields, firstEntry);
    }
+   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
    void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.fSize; }

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -145,6 +145,7 @@ public:
 
    void InitImpl(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
+   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -35,9 +35,6 @@ namespace Internal {
 \class ROOT::Experimental::Internal::RPageSinkBuf
 \ingroup NTuple
 \brief Wrapper sink that coalesces cluster column page writes
-*
-* TODO(jblomer): The interplay of derived class and RPageSink is not yet optimally designed for page storage wrapper
-* classes like this one. Header and footer serialization, e.g., are done twice.  To be revised.
 */
 // clang-format on
 class RPageSinkBuf : public RPageSink {
@@ -154,7 +151,7 @@ public:
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final;
    void CommitClusterGroup() final;
-   void CommitDataset() final;
+   void CommitDatasetImpl() final;
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -244,6 +244,11 @@ public:
    /// added after the initial call to `RPageSink::Init(RNTupleModel &)`.
    /// `firstEntry` specifies the global index for the first stored element in the added columns.
    virtual void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) = 0;
+   /// Adds an extra type information record to schema. The extra type information will be written to the
+   /// extension header. The information in the record will be merged with the existing information, e.g.
+   /// duplicate streamer info records will be removed. This method is called by the "on commit dataset" callback
+   /// registered by specific fields (e.g., unsplit field).
+   virtual void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) = 0;
 
    /// Write a page to the storage. The column must have been added before.
    virtual void CommitPage(ColumnHandle_t columnHandle, const RPage &page) = 0;
@@ -380,6 +385,7 @@ public:
    /// Updates the descriptor and calls InitImpl() that handles the backend-specific details (file, DAOS, etc.)
    void InitImpl(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
+   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
    /// Initialize sink based on an existing descriptor and fill into the descriptor builder.
    void InitFromDescriptor(const RNTupleDescriptor &descriptor);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleReadOptions.hxx>
+#include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPage.hxx>
@@ -322,6 +323,9 @@ private:
    std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;
    /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
+
+   /// Union of the streamer info records that are sent from unsplit fields to the sink before committing the dataset.
+   RNTupleSerializer::StreamerInfoMap_t fStreamerInfos;
 
 protected:
    Internal::RNTupleDescriptorBuilder fDescriptorBuilder;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -130,6 +130,7 @@ protected:
    std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
+   using RPagePersistentSink::CommitDatasetImpl;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
    void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
    void WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -75,6 +75,7 @@ protected:
    std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
+   using RPagePersistentSink::CommitDatasetImpl;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
 
 public:

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -219,6 +219,18 @@ ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::C
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ROOT::Experimental::RExtraTypeInfoDescriptor ROOT::Experimental::RExtraTypeInfoDescriptor::Clone() const
+{
+   RExtraTypeInfoDescriptor clone;
+   clone.fContentId = fContentId;
+   clone.fTypeVersionFrom = fTypeVersionFrom;
+   clone.fTypeVersionTo = fTypeVersionTo;
+   clone.fTypeName = fTypeName;
+   clone.fContent = fContent;
+   return clone;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const
 {
@@ -656,6 +668,18 @@ ROOT::Experimental::Internal::RColumnGroupDescriptorBuilder::MoveDescriptor()
       return R__FAIL("unset column group ID");
    RColumnGroupDescriptor result;
    std::swap(result, fColumnGroup);
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+ROOT::Experimental::RResult<ROOT::Experimental::RExtraTypeInfoDescriptor>
+ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder::MoveDescriptor()
+{
+   if (fExtraTypeInfo.fContentId == RExtraTypeInfoDescriptor::EContentIds::kInvalid)
+      throw RException(R__FAIL("invalid extra type info content id"));
+   RExtraTypeInfoDescriptor result;
+   std::swap(result, fExtraTypeInfo);
    return result;
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -684,7 +684,7 @@ ROOT::Experimental::Internal::RColumnGroupDescriptorBuilder::MoveDescriptor()
 ROOT::Experimental::RResult<ROOT::Experimental::RExtraTypeInfoDescriptor>
 ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder::MoveDescriptor()
 {
-   if (fExtraTypeInfo.fContentId == RExtraTypeInfoDescriptor::EContentIds::kInvalid)
+   if (fExtraTypeInfo.fContentId == EExtraTypeInfoIds::kInvalid)
       throw RException(R__FAIL("invalid extra type info content id"));
    RExtraTypeInfoDescriptor result;
    std::swap(result, fExtraTypeInfo);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -219,6 +219,12 @@ ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::C
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool ROOT::Experimental::RExtraTypeInfoDescriptor::operator==(const RExtraTypeInfoDescriptor &other) const
+{
+   return fContentId == other.fContentId && fTypeName == other.fTypeName &&
+          fTypeVersionFrom == other.fTypeVersionFrom && fTypeVersionTo == other.fTypeVersionTo;
+}
+
 ROOT::Experimental::RExtraTypeInfoDescriptor ROOT::Experimental::RExtraTypeInfoDescriptor::Clone() const
 {
    RExtraTypeInfoDescriptor clone;
@@ -504,6 +510,8 @@ std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTup
       clone->fClusterGroupDescriptors.emplace(d.first, d.second.Clone());
    for (const auto &d : fClusterDescriptors)
       clone->fClusterDescriptors.emplace(d.first, d.second.Clone());
+   for (const auto &d : fExtraTypeInfoDescriptors)
+      clone->fExtraTypeInfoDescriptors.emplace_back(d.Clone());
    if (fHeaderExtension)
       clone->fHeaderExtension = std::make_unique<RHeaderExtension>(*fHeaderExtension);
    return clone;
@@ -937,5 +945,17 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddCluster(RClusterDescr
    if (fDescriptor.fClusterDescriptors.count(clusterId) > 0)
       return R__FAIL("cluster id clash");
    fDescriptor.fClusterDescriptors.emplace(clusterId, std::move(clusterDesc));
+   return RResult<void>::Success();
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
+{
+   // Make sure we have no duplicates
+   if (std::find(fDescriptor.fExtraTypeInfoDescriptors.begin(), fDescriptor.fExtraTypeInfoDescriptors.end(),
+                 extraTypeInfoDesc) != fDescriptor.fExtraTypeInfoDescriptors.end()) {
+      return R__FAIL("extra type info duplicates");
+   }
+   fDescriptor.fExtraTypeInfoDescriptors.emplace_back(std::move(extraTypeInfoDesc));
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -26,6 +26,7 @@ namespace {
 using ROOT::Experimental::DescriptorId_t;
 using ROOT::Experimental::NTupleSize_t;
 using ROOT::Experimental::RException;
+using ROOT::Experimental::RExtraTypeInfoDescriptor;
 using ROOT::Experimental::RNTupleDescriptor;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::Internal::RColumn;
@@ -75,6 +76,10 @@ public:
    void UpdateSchema(const RNTupleModelChangeset &, NTupleSize_t) final
    {
       throw RException(R__FAIL("UpdateSchema not supported via RPageSynchronizingSink"));
+   }
+   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final
+   {
+      throw RException(R__FAIL("UpdateExtraTypeInfo not supported via RPageSynchronizingSink"));
    }
 
    void CommitPage(ColumnHandle_t, const RPage &) final

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -94,7 +94,10 @@ public:
    {
       throw RException(R__FAIL("should never commit cluster group via RPageSynchronizingSink"));
    }
-   void CommitDataset() final { throw RException(R__FAIL("should never commit dataset via RPageSynchronizingSink")); }
+   void CommitDatasetImpl() final
+   {
+      throw RException(R__FAIL("should never commit dataset via RPageSynchronizingSink"));
+   }
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final
    {

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -129,6 +129,13 @@ void ROOT::Experimental::Internal::RPageSinkBuf::UpdateSchema(const RNTupleModel
    fInnerSink->UpdateSchema(innerChangeset, firstEntry);
 }
 
+void ROOT::Experimental::Internal::RPageSinkBuf::UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo)
+{
+   RPageSink::RSinkGuard g(fInnerSink->GetSinkGuard());
+   Detail::RNTuplePlainTimer timer(fCounters->fTimeWallCriticalSection, fCounters->fTimeCpuCriticalSection);
+   fInnerSink->UpdateExtraTypeInfo(extraTypeInfo);
+}
+
 void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
 {
    auto colId = columnHandle.fPhysicalId;

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -210,7 +210,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitClusterGroup()
    fInnerSink->CommitClusterGroup();
 }
 
-void ROOT::Experimental::Internal::RPageSinkBuf::CommitDataset()
+void ROOT::Experimental::Internal::RPageSinkBuf::CommitDatasetImpl()
 {
    RPageSink::RSinkGuard g(fInnerSink->GetSinkGuard());
    Detail::RNTuplePlainTimer timer(fCounters->fTimeWallCriticalSection, fCounters->fTimeCpuCriticalSection);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -360,6 +360,13 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColu
    return SealPage(page, element, compressionSetting, fCompressor->GetZipBuffer());
 }
 
+void ROOT::Experimental::Internal::RPageSink::CommitDataset()
+{
+   for (auto cb : fOnDatasetCommitCallbacks)
+      cb(*this);
+   CommitDatasetImpl();
+}
+
 //------------------------------------------------------------------------------
 
 std::unique_ptr<ROOT::Experimental::Internal::RPageSink>
@@ -632,7 +639,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitClusterGroup()
    fNextClusterInGroup = nClusters;
 }
 
-void ROOT::Experimental::Internal::RPagePersistentSink::CommitDataset()
+void ROOT::Experimental::Internal::RPagePersistentSink::CommitDatasetImpl()
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -466,6 +466,14 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
       fSerializationContext.MapSchema(descriptor, /*forHeaderExtension=*/true);
 }
 
+void ROOT::Experimental::Internal::RPagePersistentSink::UpdateExtraTypeInfo(
+   const RExtraTypeInfoDescriptor &extraTypeInfo)
+{
+   switch (extraTypeInfo.GetContentId()) {
+   default: throw RException(R__FAIL("Not yet implemented"));
+   }
+}
+
 void ROOT::Experimental::Internal::RPagePersistentSink::InitImpl(RNTupleModel &model)
 {
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -362,7 +362,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColu
 
 void ROOT::Experimental::Internal::RPageSink::CommitDataset()
 {
-   for (auto cb : fOnDatasetCommitCallbacks)
+   for (const auto &cb : fOnDatasetCommitCallbacks)
       cb(*this);
    CommitDatasetImpl();
 }

--- a/tree/ntuple/v7/test/Unsplit.hxx
+++ b/tree/ntuple/v7/test/Unsplit.hxx
@@ -3,6 +3,7 @@
 
 #include <Rtypes.h>
 
+#include <memory>
 #include <vector>
 
 struct CyclicMember {
@@ -32,6 +33,25 @@ struct CustomStreamerForceUnsplit {
 // For the time being, RNTuple ignores the unsplit comment marker and does _not_ use an RUnsplitField for such members.
 class IgnoreUnsplitComment {
    std::vector<float> v; //||
+};
+
+// Test unsplit storage of polymorphic type
+
+struct PolyBase {
+   virtual ~PolyBase() {}
+   int x;
+};
+
+struct PolyA : public PolyBase {
+   int a;
+};
+
+struct PolyB : public PolyBase {
+   int b;
+};
+
+struct PolyContainer {
+   std::unique_ptr<PolyBase> fPoly;
 };
 
 #endif // ROOT7_RNTuple_Test_Unsplit

--- a/tree/ntuple/v7/test/UnsplitLinkDef.h
+++ b/tree/ntuple/v7/test/UnsplitLinkDef.h
@@ -7,4 +7,9 @@
 #pragma link C++ options = rntupleSplit(false) class CustomStreamerForceUnsplit + ;
 #pragma link C++ class IgnoreUnsplitComment + ;
 
+#pragma link C++ class PolyBase + ;
+#pragma link C++ class PolyA + ;
+#pragma link C++ class PolyB + ;
+#pragma link C++ options = rntupleSplit(false) class PolyContainer + ;
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -55,7 +55,7 @@ protected:
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}
    std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }
    void CommitClusterGroup() final {}
-   void CommitDataset() final {}
+   void CommitDatasetImpl() final {}
 
    RPage ReservePage(ColumnHandle_t, std::size_t) final { return {}; }
    void ReleasePage(RPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -51,6 +51,7 @@ protected:
 
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
+   void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}
    std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -101,6 +101,32 @@ TEST(RNTuple, SerializeFieldStructure)
    }
 }
 
+TEST(RNTuple, SerializeExtraTypeInfoId)
+{
+   EExtraTypeInfoIds id{EExtraTypeInfoIds::kInvalid};
+
+   unsigned char buffer[4];
+
+   try {
+      RNTupleSerializer::SerializeExtraTypeInfoId(id, buffer);
+      FAIL() << "unexpected field structure value should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("unexpected extra type info"));
+   }
+
+   RNTupleSerializer::SerializeUInt32(5000, buffer);
+   // unexpected on-disk ID should set the output value to "invalid"
+   id = EExtraTypeInfoIds::kStreamerInfo;
+   RNTupleSerializer::DeserializeExtraTypeInfoId(buffer, id).Unwrap();
+   EXPECT_EQ(EExtraTypeInfoIds::kInvalid, id);
+
+   for (int i = 0; i < static_cast<int>(EExtraTypeInfoIds::kInvalid); ++i) {
+      RNTupleSerializer::SerializeExtraTypeInfoId(static_cast<EExtraTypeInfoIds>(i), buffer);
+      RNTupleSerializer::DeserializeExtraTypeInfoId(buffer, id);
+      EXPECT_EQ(i, static_cast<int>(id));
+   }
+}
+
 TEST(RNTuple, SerializeEnvelope)
 {
    try {
@@ -567,6 +593,11 @@ TEST(RNTuple, SerializeHeader)
    builder.AddColumn(100, 23, 24, RColumnModel(EColumnType::kReal32, false), 0);
    builder.AddColumn(17, 17, 137, RColumnModel(EColumnType::kIndex32, true), 0);
    builder.AddColumn(40, 40, 137, RColumnModel(EColumnType::kByte, true), 1);
+   builder.AddExtraTypeInfo(RExtraTypeInfoDescriptorBuilder()
+                               .ContentId(EExtraTypeInfoIds::kStreamerInfo)
+                               .Content("xyz")
+                               .MoveDescriptor()
+                               .Unwrap());
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
@@ -582,6 +613,13 @@ TEST(RNTuple, SerializeHeader)
    EXPECT_TRUE(desc.GetColumnDescriptor(colId).IsAliasColumn());
    auto ptFieldId = desc.FindFieldId("pt");
    EXPECT_EQ(desc.FindLogicalColumnId(ptFieldId, 0), desc.GetColumnDescriptor(colId).GetPhysicalId());
+   EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
+   const auto &extraTypeInfoDesc = *desc.GetExtraTypeInfoIterable().begin();
+   EXPECT_EQ(EExtraTypeInfoIds::kStreamerInfo, extraTypeInfoDesc.GetContentId());
+   EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersionFrom());
+   EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersionTo());
+   EXPECT_TRUE(extraTypeInfoDesc.GetTypeName().empty());
+   EXPECT_STREQ("xyz", extraTypeInfoDesc.GetContent().c_str());
 }
 
 
@@ -748,6 +786,11 @@ TEST(RNTuple, SerializeFooterXHeader)
                        .Unwrap());
    builder.AddFieldLink(0, 46);
    builder.AddColumn(20, 18, 46, RColumnModel(EColumnType::kReal32, true), 0);
+   builder.AddExtraTypeInfo(RExtraTypeInfoDescriptorBuilder()
+                               .ContentId(EExtraTypeInfoIds::kStreamerInfo)
+                               .Content("xyz")
+                               .MoveDescriptor()
+                               .Unwrap());
 
    // Make sure late-added fields and the corresponding columns get an on-disk ID
    context.MapSchema(builder.GetDescriptor(), /*forHeaderExtension=*/true);
@@ -790,4 +833,12 @@ TEST(RNTuple, SerializeFooterXHeader)
       counter++;
    }
    EXPECT_EQ(2U, counter);
+
+   EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
+   const auto &extraTypeInfoDesc = *desc.GetExtraTypeInfoIterable().begin();
+   EXPECT_EQ(EExtraTypeInfoIds::kStreamerInfo, extraTypeInfoDesc.GetContentId());
+   EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersionFrom());
+   EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersionTo());
+   EXPECT_TRUE(extraTypeInfoDesc.GetTypeName().empty());
+   EXPECT_STREQ("xyz", extraTypeInfoDesc.GetContent().c_str());
 }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -1,6 +1,7 @@
 #include "ntuple_test.hxx"
 
 #include <Byteswap.h>
+#include <TVirtualStreamerInfo.h>
 
 TEST(RNTuple, SerializeInt)
 {
@@ -841,4 +842,18 @@ TEST(RNTuple, SerializeFooterXHeader)
    EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersionTo());
    EXPECT_TRUE(extraTypeInfoDesc.GetTypeName().empty());
    EXPECT_STREQ("xyz", extraTypeInfoDesc.GetContent().c_str());
+}
+
+TEST(RNTuple, SerializeStreamerInfos)
+{
+   RNTupleSerializer::StreamerInfoMap_t infos;
+   auto content = RNTupleSerializer::SerializeStreamerInfos(infos);
+   EXPECT_TRUE(RNTupleSerializer::DeserializeStreamerInfos(content).Unwrap().empty());
+
+   auto streamerInfo = RNTuple::Class()->GetStreamerInfo();
+   infos[streamerInfo->GetNumber()] = streamerInfo;
+   content = RNTupleSerializer::SerializeStreamerInfos(infos);
+   auto result = RNTupleSerializer::DeserializeStreamerInfos(content).Unwrap();
+   EXPECT_EQ(1u, result.size());
+   EXPECT_STREQ("ROOT::Experimental::RNTuple", std::string(result.begin()->second->GetName()).c_str());
 }

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -35,6 +35,7 @@ protected:
 
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
+   void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final
    {

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -46,7 +46,7 @@ protected:
    }
    std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }
    void CommitClusterGroup() final {}
-   void CommitDataset() final {}
+   void CommitDatasetImpl() final {}
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final
    {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -55,6 +55,7 @@
 using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 using DescriptorId_t = ROOT::Experimental::DescriptorId_t;
 using EColumnType = ROOT::Experimental::EColumnType;
+using ROOT::Experimental::EExtraTypeInfoIds;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;
@@ -62,6 +63,7 @@ using RClusterIndex = ROOT::Experimental::RClusterIndex;
 using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescriptorBuilder;
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
 using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;
+using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
 using RException = ROOT::Experimental::RException;
 template <class T>


### PR DESCRIPTION
Follow-up of #14728

Stores the streamer info records seen during serialization of unsplit fields in the extra type information of the extension header. To this end, proper serialization and deserialization of the extra type information frame in the header / extension header is implemented.

This will be accompanied by a roottest PR (TODO)