### PR TITLE
Add doc comments to R__ASSERT/CHECK 

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -122,17 +122,19 @@ R__EXTERN const char *kCheckMsg;
  *     For those cases, prefer a regular `assert()`;
  *   - depending on `gErrorIgnoreLevel`, this might not terminate the program, \see ::Fatal.
  */
-#define R__ASSERT(e)                                                     \
-   do {                                                                  \
-      if (R__unlikely(!(e))) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
+#define R__ASSERT(e)                                              \
+   do {                                                           \
+      if (R__unlikely(!(e)))                                      \
+         ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 
 /*! Checks condition `e` and reports a warning message if it's false.
  * \warning this check is NOT stripped in release mode, so it should not be used for hot paths.
  */
-#define R__CHECK(e)                                                       \
-   do {                                                                   \
-      if (R__unlikely(!(e))) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
+#define R__CHECK(e)                                                \
+   do {                                                            \
+      if (R__unlikely(!(e)))                                       \
+         ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 
 R__EXTERN Int_t  gErrorIgnoreLevel;

--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -119,7 +119,7 @@ R__EXTERN const char *kCheckMsg;
 /*! Checks condition `e` and reports a fatal error if it's false.
  * \warning
  *   - this check is NOT stripped in release mode, so it should not be used for hot paths.
- *     For those cases, prefer a regular assert();
+ *     For those cases, prefer a regular `assert()`;
  *   - depending on `gErrorIgnoreLevel`, this might not terminate the program, \see ::Fatal.
  */
 #define R__ASSERT(e)                                                     \

--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -124,7 +124,7 @@ R__EXTERN const char *kCheckMsg;
  */
 #define R__ASSERT(e)                                                     \
    do {                                                                  \
-      if (!(R__likely(e))) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
+      if (R__unlikely(!(e))) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 
 /*! Checks condition `e` and reports a warning message if it's false.
@@ -132,7 +132,7 @@ R__EXTERN const char *kCheckMsg;
  */
 #define R__CHECK(e)                                                       \
    do {                                                                   \
-      if (!(R__likely(e))) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
+      if (R__unlikely(!(e))) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 
 R__EXTERN Int_t  gErrorIgnoreLevel;

--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -32,6 +32,7 @@
 
 #include <DllImport.h> // for R__EXTERN
 #include "RtypesCore.h"
+#include <ROOT/RConfig.hxx>
 
 #include <cstdarg>
 #include <functional>
@@ -115,13 +116,23 @@ extern void Obsolete(const char *function, const char *asOfVers, const char *rem
 R__EXTERN const char *kAssertMsg;
 R__EXTERN const char *kCheckMsg;
 
+/*! Checks condition `e` and reports a fatal error if it's false.
+ * \warning
+ *   - this check is NOT stripped in release mode, so it should not be used for hot paths.
+ *     For those cases, prefer a regular assert();
+ *   - depending on `gErrorIgnoreLevel`, this might not terminate the program, \see ::Fatal.
+ */
 #define R__ASSERT(e)                                                     \
    do {                                                                  \
-      if (!(e)) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
+      if (!(R__likely(e))) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
+
+/*! Checks condition `e` and reports a warning message if it's false.
+ * \warning this check is NOT stripped in release mode, so it should not be used for hot paths.
+ */
 #define R__CHECK(e)                                                       \
    do {                                                                   \
-      if (!(e)) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
+      if (!(R__likely(e))) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 
 R__EXTERN Int_t  gErrorIgnoreLevel;


### PR DESCRIPTION
# This Pull request:
Adds brief documentation to `R__ASSERT` and `R__CHECK` underlining how they do not get stripped in release mode (which might be unexpected for some users).
Additionally, it uses `R__likely` for the check itself, since the condition is expected to be true.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


