### PR TITLE
Fix one scenario of RDataFrame JIT and explicit multithreading

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -805,18 +805,25 @@ void RLoopManager::CleanUpTask(TTreeReader *r, unsigned int slot)
 /// This method also clears the contents of GetCodeToJit().
 void RLoopManager::Jit()
 {
-   {
+   auto noCodeToJit = []() {
       R__READ_LOCKGUARD(ROOT::gCoreMutex);
-      if (GetCodeToJit().empty()) {
-         R__LOG_INFO(RDFLogChannel()) << "Nothing to jit and execute.";
-         return;
-      }
+      return GetCodeToJit().empty();
+   };
+
+   if (noCodeToJit()) {
+      R__LOG_INFO(RDFLogChannel()) << "Nothing to jit and execute.";
+      return;
    }
 
-   const std::string code = []() {
-      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
-      return std::move(GetCodeToJit());
-   }();
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
+   // Check again if another thread has already cleared the global string
+   // with the code to JIT. Without this check, we could end up calling
+   // InterpreterCalc with an empty string, which would raise an exception.
+   if (noCodeToJit()) {
+      R__LOG_INFO(RDFLogChannel()) << "Nothing to jit and execute.";
+      return;
+   }
+   const std::string code = std::move(GetCodeToJit());
 
    TStopwatch s;
    s.Start();

--- a/tree/dataframe/test/dataframe_concurrency.cxx
+++ b/tree/dataframe/test/dataframe_concurrency.cxx
@@ -15,6 +15,15 @@ static const auto NUM_THREADS = 8u;
 static const auto NUM_THREADS = 0u;
 #endif
 
+template <typename T>
+void expect_vec_eq(const std::vector<T> &v1, const std::vector<T> &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size()) << "Vectors 'v1' and 'v2' are of unequal length";
+   for (decltype(v1.size()) i{}; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]) << "Vectors 'v1' and 'v2' differ at index " << i;
+   }
+}
+
 #ifdef R__USE_IMT
 TEST(RDFConcurrency, NestedParallelismBetweenDefineCalls)
 {
@@ -234,5 +243,32 @@ TEST(RDFConcurrency, ParallelRDFCachesEnableImplicitMT)
    ParallelRDFCaches();
    ROOT::DisableImplicitMT();
 }
-
 #endif
+
+// Check that multiple RDF can JIT at the same time without interfering
+// with each other
+TEST(RDFConcurrency, JITWithManyThreads)
+{
+   ROOT::EnableThreadSafety();
+
+   std::vector<int> expected(25);
+   for (int i = 0; i < 25; i++)
+      expected[i] = i;
+
+   std::vector<int> results(25);
+   auto do_work = [&results](int slot) {
+      for (int i = slot * 5; i < (slot * 5 + 5); i++) {
+         results[i] = ROOT::RDataFrame{1}.Define("x", std::to_string(i)).Sum<int>("x").GetValue();
+      }
+   };
+
+   std::vector<std::thread> threads;
+   threads.reserve(5);
+   for (int i = 0; i < 5; i++)
+      threads.emplace_back(do_work, i);
+
+   for (auto &&t : threads)
+      t.join();
+
+   expect_vec_eq(results, expected);
+}


### PR DESCRIPTION
For now just add a test for the specific scenario, see description in the commit message. The test will likely fail on many platforms, for reference I leave a log with the RDataFrame verbosity turned up

[many_threads.log](https://github.com/root-project/root/files/15387003/many_threads.log)

Look for the lines with `Jitting and executing the following code`, there will be (at least) one like
```
Info in <[ROOT.RDF] Debug /Users/vpadulan/Programs/rootproject/rootsrc/tree/dataframe/src/RDFUtils.cxx:329 in Long64_t ROOT::Internal::RDF::InterpreterCalc(const std::string &, const std::string &)>: Jitting and executing the following code:



Info in <[ROOT.RDF] Info /Users/vpadulan/Programs/rootproject/rootsrc/tree/dataframe/src/RLoopManager.cxx:917 in void ROOT::Detail::RDF::RLoopManager::Run(bool)>: Finished event loop number 0 (0s CPU, 0.000169039s elapsed).
```

Note that after the line there is an empty space. This means that the thread is trying to JIT an empty string, which will trigger an exception, as it boils down to doing
```
root [0] TInterpreter::EErrorCode errorCode(TInterpreter::kNoError);
root [1] gInterpreter->Calc("", &errorCode);
root [2] errorCode
(TInterpreter::EErrorCode) (TInterpreter::kDangerous) : (unsigned int) 2
```
And RDF throws always unless the return code is `kNoError`.


**Note**: I will introduce the commit with the fix after a first round of failing tests