### PR TITLE
[ntuple] Make RNTupleFileWriter::Recreate/Append return unique_ptr

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -77,7 +77,6 @@ public:
    void ReadBuffer(void *buffer, size_t nbytes, std::uint64_t offset);
 };
 
-
 // clang-format off
 /**
 \class ROOT::Experimental::Internal::RNTupleFileWriter
@@ -114,8 +113,8 @@ private:
       RFileSimple() = default;
       RFileSimple(const RFileSimple &other) = delete;
       RFileSimple(RFileSimple &&other) = delete;
-      RFileSimple &operator =(const RFileSimple &other) = delete;
-      RFileSimple &operator =(RFileSimple &&other) = delete;
+      RFileSimple &operator=(const RFileSimple &other) = delete;
+      RFileSimple &operator=(RFileSimple &&other) = delete;
       ~RFileSimple();
 
       /// Writes bytes in the open stream, either at fFilePos or at the given offset
@@ -123,10 +122,8 @@ private:
       /// Writes a TKey including the data record, given by buffer, into fFile; returns the file offset to the payload.
       /// The payload is already compressed
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
-                             std::uint64_t directoryOffset = 100,
-                             const std::string &className = "",
-                             const std::string &objectName = "",
-                             const std::string &title = "");
+                             std::uint64_t directoryOffset = 100, const std::string &className = "",
+                             const std::string &objectName = "", const std::string &title = "");
       operator bool() const { return fFile; }
    };
 
@@ -169,15 +166,15 @@ public:
 
    /// Create or truncate the local file given by path with the new empty RNTuple identified by ntupleName.
    /// Uses a C stream for writing
-   static RNTupleFileWriter *Recreate(std::string_view ntupleName, std::string_view path, int defaultCompression,
-                                      EContainerFormat containerFormat);
+   static std::unique_ptr<RNTupleFileWriter> Recreate(std::string_view ntupleName, std::string_view path,
+                                                      int defaultCompression, EContainerFormat containerFormat);
    /// Add a new RNTuple identified by ntupleName to the existing TFile.
-   static RNTupleFileWriter *Append(std::string_view ntupleName, TFile &file);
+   static std::unique_ptr<RNTupleFileWriter> Append(std::string_view ntupleName, TFile &file);
 
    RNTupleFileWriter(const RNTupleFileWriter &other) = delete;
    RNTupleFileWriter(RNTupleFileWriter &&other) = delete;
-   RNTupleFileWriter &operator =(const RNTupleFileWriter &other) = delete;
-   RNTupleFileWriter &operator =(RNTupleFileWriter &&other) = delete;
+   RNTupleFileWriter &operator=(const RNTupleFileWriter &other) = delete;
+   RNTupleFileWriter &operator=(RNTupleFileWriter &&other) = delete;
    ~RNTupleFileWriter();
 
    /// Writes the compressed header and registeres its location; lenHeader is the size of the uncompressed header.

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -31,11 +31,8 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <memory>
-#include <new>
 #include <string>
-#include <utility>
 #include <chrono>
 
 namespace {
@@ -1282,7 +1279,7 @@ ROOT::Experimental::Internal::RNTupleFileWriter::RNTupleFileWriter(std::string_v
 
 ROOT::Experimental::Internal::RNTupleFileWriter::~RNTupleFileWriter() {}
 
-ROOT::Experimental::Internal::RNTupleFileWriter *
+std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
 ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupleName, std::string_view path,
                                                           int defaultCompression, EContainerFormat containerFormat)
 {
@@ -1298,7 +1295,7 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupl
 #endif
    R__ASSERT(fileStream);
 
-   auto writer = new RNTupleFileWriter(ntupleName);
+   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName));
    writer->fFileSimple.fFile = fileStream;
    writer->fFileName = fileName;
 
@@ -1314,10 +1311,10 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupl
    return writer;
 }
 
-ROOT::Experimental::Internal::RNTupleFileWriter *
+std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
 ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TFile &file)
 {
-   auto writer = new RNTupleFileWriter(ntupleName);
+   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName));
    writer->fFileProper.fFile = &file;
    return writer;
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -25,8 +25,8 @@ TEST(MiniFile, Raw)
 {
    FileRaii fileGuard("test_ntuple_minifile_raw.ntuple");
 
-   auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kBare));
+   auto writer =
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kBare);
    char header = 'h';
    char footer = 'f';
    char blob = 'b';
@@ -50,13 +50,12 @@ TEST(MiniFile, Raw)
    EXPECT_EQ(footer, buf);
 }
 
-
 TEST(MiniFile, Stream)
 {
    FileRaii fileGuard("test_ntuple_minifile_stream.root");
 
-   auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
+   auto writer =
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile);
    char header = 'h';
    char footer = 'f';
    char blob = 'b';
@@ -85,13 +84,12 @@ TEST(MiniFile, Stream)
    EXPECT_TRUE(IsEqual(ntuple, RNTupleTester(*k).GetAnchor()));
 }
 
-
 TEST(MiniFile, Proper)
 {
    FileRaii fileGuard("test_ntuple_minifile_proper.root");
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
-   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("MyNTuple", *file));
+   auto writer = RNTupleFileWriter::Append("MyNTuple", *file);
 
    char header = 'h';
    char footer = 'f';
@@ -120,8 +118,8 @@ TEST(MiniFile, SimpleKeys)
 {
    FileRaii fileGuard("test_ntuple_minifile_simple_keys.root");
 
-   auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
+   auto writer =
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile);
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
@@ -226,7 +224,7 @@ TEST(MiniFile, ProperKeys)
    FileRaii fileGuard("test_ntuple_minifile_proper_keys.root");
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
-   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("MyNTuple", *file));
+   auto writer = RNTupleFileWriter::Append("MyNTuple", *file);
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
@@ -335,7 +333,7 @@ TEST(MiniFile, LongString)
       "store in a TFile header. For longer strings, a length of 255 is special and means that the first length byte is "
       "followed by an integer length.";
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE", LongString));
-   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("ntuple", *file));
+   auto writer = RNTupleFileWriter::Append("ntuple", *file);
 
    char header = 'h';
    char footer = 'f';
@@ -355,9 +353,8 @@ TEST(MiniFile, Multi)
    FileRaii fileGuard("test_ntuple_minifile_multi.root");
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
-   auto writer1 =
-      std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("FirstNTuple", *file));
-   auto writer2 = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Append("SecondNTuple", *file));
+   auto writer1 = RNTupleFileWriter::Append("FirstNTuple", *file);
+   auto writer2 = RNTupleFileWriter::Append("SecondNTuple", *file);
 
    char header1 = 'h';
    char footer1 = 'f';
@@ -398,7 +395,6 @@ TEST(MiniFile, Multi)
    EXPECT_EQ(footer2, buf);
 }
 
-
 TEST(MiniFile, Failures)
 {
    // TODO(jblomer): failures should be exceptions
@@ -407,8 +403,8 @@ TEST(MiniFile, Failures)
 
    FileRaii fileGuard("test_ntuple_minifile_failures.root");
 
-   auto writer = std::unique_ptr<RNTupleFileWriter>(
-      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile));
+   auto writer =
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, RNTupleFileWriter::EContainerFormat::kTFile);
    char header = 'h';
    char footer = 'f';
    char blob = 'b';
@@ -423,7 +419,7 @@ TEST(MiniFile, Failures)
    try {
       anchor = reader.GetNTuple("No such RNTuple").Inspect();
       FAIL() << "bad RNTuple names should throw";
-   } catch (const RException& err) {
+   } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("no RNTuple named 'No such RNTuple' in file '" + fileGuard.GetPath()));
    }
 }


### PR DESCRIPTION
Also apply clang-format to the involved files in the process.

## Changes or fixes:
`RNTupleFileWriter::Recreate` and `RNTupleFileWriter::Append ` now return a `unique_ptr` rather than a raw pointer, to make it obvious that the caller gets ownership of that pointer.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

