### PR TITLE
[v630][TMVA] Add missing TMVA python dependencies to requirements.txt

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -121,7 +121,9 @@ if (dataframe)
 endif()
 
 # SOFIE-GNN pythonizations
-if (tmva)
+# TODO: GNN tests are right now hardcoded to never run, because it is not clear
+# if they will pass on the new CI. Please revert this.
+if (FALSE AND tmva)
     if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 4 OR win_broken_tests AND (PYTHON_VERSION_STRING_Development_Main VERSION_GREATER_EQUAL 3.8))
         find_python_module(sonnet QUIET)
         find_python_module(graph_nets QUIET)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 numpy>=1.4.1
 
 # TMVA: SOFIE
-# graph_nets
+graph_nets
 onnx
-# sonnet # used for GNNs
+sonnet # used for GNNs
 
 # TMVA: PyMVA interfaces
 scikit-learn
@@ -29,3 +29,6 @@ metakernel>=0.20.0
 pyspark>=2.4 # Spark backend
 dask>=2022.08.1 ; python_version >= "3.8" # Dask backend
 distributed>=2022.08.1 ; python_version >= "3.8" # Dask backend
+
+# JsMVA: Jupyter notebook magic for TMVA
+ipywidgets

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -344,7 +344,9 @@ else()
     list(APPEND tmva_veto tmva/TMVA_SOFIE_PyTorch.C)
     list(APPEND tmva_veto tmva/RBatchGenerator_PyTorch.py)
   endif()
-  if (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND)
+  # TODO: GNN tutorials are right now hardcoded to never run, because it is not
+  # clear if they will pass on the new CI. Please revert this.
+  if (TRUE OR (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND))
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN.py)
   endif()
   if (NOT tmva-sofie)


### PR DESCRIPTION
The last commit adds the dependencies for the TMVA GNN unit tests to the docker images via the `requirements.txt`. However, this will only have a delayed effect until the images are re-built. Therefore, we can't validate for now that the tests actually work.

Once the missing packages make it into the CI images, a PR should be opened to revert this commit.

Backport of https://github.com/root-project/root/pull/15512.