### PR TITLE
[v632][RF] Small fixup for using RooFit with new Clad 1.5

### DIFF
--- a/roofit/histfactory/src/FlexibleInterpVar.cxx
+++ b/roofit/histfactory/src/FlexibleInterpVar.cxx
@@ -241,7 +241,7 @@ void FlexibleInterpVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
    }
 
    std::string const &resName = ctx.buildCall("RooFit::Detail::MathFuncs::flexibleInterp", interpCode,
-                                              _paramList, n, _low, _high, _interpBoundary, _nominal);
+                                              _paramList, n, _low, _high, _interpBoundary, _nominal, 1.0);
    ctx.addResult(this, resName);
 }
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -239,8 +239,8 @@ void PiecewiseInterpolation::translate(RooFit::Detail::CodeSquashContext &ctx) c
    code += "double * " + highName + " = " + valsHighStr + " + " + nStr + " * " + idxName + ";\n";
    code += "double " + nominalName + " = *(" + valsNominalStr + " + " + idxName + ");\n";
 
-   std::string funcCall = ctx.buildCall("RooFit::Detail::MathFuncs::flexibleInterp<false>", _interpCode[0], _paramSet,
-                                        n, lowName, highName, 1.0, nominalName);
+   std::string funcCall = ctx.buildCall("RooFit::Detail::MathFuncs::flexibleInterp", _interpCode[0], _paramSet, n,
+                                        lowName, highName, 1.0, nominalName, 0.0);
    code += "double " + resName + " = " + funcCall + ";\n";
 
    if (_positiveDefinite)

--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -285,16 +285,15 @@ inline double flexibleInterpSingle(unsigned int code, double low, double high, d
    return 0.0;
 }
 
-template <bool cutoff = true>
 inline double flexibleInterp(unsigned int code, double *params, unsigned int n, double *low, double *high,
-                             double boundary, double nominal)
+                             double boundary, double nominal, int doCutoff)
 {
    double total = nominal;
    for (std::size_t i = 0; i < n; ++i) {
       total += flexibleInterpSingle(code, low[i], high[i], boundary, nominal, params[i], total);
    }
 
-   return cutoff && total <= 0 ? TMath::Limits<double>::Min() : total;
+   return doCutoff && total <= 0 ? TMath::Limits<double>::Min() : total;
 }
 
 inline double landau(double x, double mu, double sigma)


### PR DESCRIPTION
Using template functions in the generated code can cause linker errors, which is avoided with this suggested commit.

Backport of https://github.com/root-project/root/pull/15502.

