### PR TITLE
Revert "[TO REVERT] Never run TMVA GNN tests and tutorials as unit tests"

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -119,9 +119,7 @@ if (dataframe)
 endif()
 
 # SOFIE-GNN pythonizations
-# TODO: GNN tests are right now hardcoded to never run, because it is not clear
-# if they will pass on the new CI. Please revert this.
-if (FALSE AND tmva)
+if (tmva)
     if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 4 OR win_broken_tests)
         find_python_module(sonnet QUIET)
         find_python_module(graph_nets QUIET)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -309,9 +309,7 @@ else()
   endif()
   #veto this tutorial since it is added directly
   list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Parser.py)
-  # TODO: GNN tutorials are right now hardcoded to never run, because it is not
-  # clear if they will pass on the new CI. Please revert this.
-  if (TRUE OR (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND))
+  if (NOT PY_SONNET_FOUND OR NOT PY_GRAPH_NETS_FOUND)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN.py)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Parser.py)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_GNN_Application.C)


### PR DESCRIPTION
This reverts commit baf092324e6e2a9301daff36a780cd064b232c2d.

We can either merge this as-is if the tests pass, or if they don't I'll close this PR without merging and open a GitHub issue about fixing these tests.