### PR TITLE
[CMake] Fix version detection in `FindCUDNN.cmake`

### DIFF
--- a/cmake/modules/FindCUDNN.cmake
+++ b/cmake/modules/FindCUDNN.cmake
@@ -42,7 +42,11 @@ find_package_handle_standard_args(
 
 if(CUDNN_FOUND)
     # get cuDNN version
-  file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)
+    if(EXISTS ${CUDNN_INCLUDE_DIR}/cudnn_version.h)
+      file(READ ${CUDNN_INCLUDE_DIR}/cudnn_version.h CUDNN_HEADER_CONTENTS)
+    else()
+      file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)
+    endif()
     string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
                  CUDNN_VERSION_MAJOR "${CUDNN_HEADER_CONTENTS}")
     string(REGEX REPLACE "define CUDNN_MAJOR * +([0-9]+)" "\\1"


### PR DESCRIPTION
The CUDNN version is defined in `cudnn_version.h` and not `cudnn.h` anymore for newer CUDNN versions.

This is the same fix that is also done in PyTorch: https://github.com/pytorch/pytorch/blob/main/cmake/Modules_CUDA_fix/FindCUDNN.cmake