### PR TITLE
[webcanvas] improve TF1 saved points handling

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -105,7 +105,7 @@ protected:
    UInt_t fStyleHash{0};           ///<! last hash of gStyle
    Long64_t fColorsVersion{0};     ///<! current colors/palette version, checked every time when new snapshot created
    UInt_t fColorsHash{0};          ///<! last hash of colors/palette
-   Bool_t fTF1UseSave{kFALSE};     ///<! use save buffer for TF1/TF2, need when evaluation failed on client side
+   Int_t fTF1UseSave{1};           ///<! use save buffer for TF1/TF2, 0:off, 1:prefer, 2:force
    std::vector<int> fWindowGeometry; ///<! last received window geometry
    Bool_t fFixedSize{kFALSE};      ///<! is canvas size fixed
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,6 +1,6 @@
 # JSROOT changelog
 
-## Changes in dev
+## Changes in 7.7.0
 1. Let plot current time, file creation or modification time with `&optdate=[1,2,3]` URL parameters
 2. Let plot file name, full file name or item name with `&optfile=[1,2,3]` URL parameters
 3. Let define date and file name position with `&datex=0.03&datey=0.03` URL parameters
@@ -9,22 +9,28 @@
 6. Let configure custom storage prefix with `&storage_prefix=name` URL #290
 7. Let customize URL for "Show in new tab" menu command
 8. Support both new and old TRatioPlot drawings
-9. Fully integrate svg2pdf.js into jsroot repo
 10. Synchronize X/Y range selection with native ROOT
 11. Proper handle attributes from TH2Poly bins, support "p" for markers drawing
 12. Correctly scale size of axis ticks - take into account NDC axis length
-13. Remove source_dir output in node.js #296
-14. Set name and userData in geometry `build()` function #303
-15. Draw histogram title afterwards - place in front of stats box
-16. Upgrade three.js r158 -> r162, last with WebGL1 support
-17. Split extras into three_addons.mjs, provide jsroot geometry build without three.js
-18. Fix - correctly draw only grids with AXIG draw option
-19. Fix - let read object from TFile with empty name
-20. Fix - graph drawing fix custom labels on X axis #297
-21. Fix - draw at least line for TGraphErrors ROOT-8131
-22. Fix - log scales on TH3 drawings #306
-23. Fix - preserve attributes and draw options when call drawingJSON() #307
-24. Fix - draw geometry top node volume if all childs not visible #308
+13. Set name and userData in geometry `build()` function #303
+14. Draw histogram title afterwards - place in front of stats box
+15. Upgrade three.js r158 -> r162, last with WebGL1 support
+16. Split extras into three_addons.mjs, provide jsroot geometry build without three.js
+17. Fix - correctly draw only grids with AXIG draw option
+18. Fix - log scales on TH3 drawings #306
+19. Fix - draw geometry top node volume if all childs not visible #308
+20. Fix - properly process 206 server response without Accept-Ranges header https://root-forum.cern.ch/t/59426/
+
+
+## Changes in 7.6.1
+1. Remove source_dir output in node.js #296
+2. Fully integrate svg2pdf.js into jsroot repo
+3. Fix - support plain TRI option for TGraph2D
+4. Fix - let read object from ROOT file with empty name
+5. Fix - graph drawing fix custom labels on X axis #297
+6. Fix - draw at least line for TGraphErrors ROOT-8131
+7. Fix - preserve attributes and draw options when call drawingJSON() #307
+8. Fix - menu for text align selection typo
 
 
 ## Changes in 7.6.0

--- a/js/index.htm
+++ b/js/index.htm
@@ -33,6 +33,11 @@ Several URL parameters could be specified when opening page:
    palette   - id of default color palette, 51..123 - new ROOT6 palette  (default 57)
    style     - TStyle object itemname or JSON file name
    toolbar   - configure position and orientation of pad toolbar, combine 'right','vert','off'
+   optdate   - plot specified date on the canvas, 1 - current time, 2 - file creation date, 3 - file modification date
+   optfile   - plot file name on the canvas, 1 - file name, 2 - full file URL, 3 - object item name
+   datex     - X position of date
+   datey     - Y position of date
+   opttitle  - plot item name on the canvas
    dark      - enables dark mode
 
 Example:

--- a/js/modules/base/ObjectPainter.mjs
+++ b/js/modules/base/ObjectPainter.mjs
@@ -1674,9 +1674,9 @@ const EAxisBits = {
    kIsInteger: BIT(22),
    kMoreLogLabels: BIT(23),
    kOppositeTitle: BIT(32) // atrificial bit, not possible to set in ROOT
-};
+}, kAxisLabels = 'labels', kAxisNormal = 'normal', kAxisFunc = 'func', kAxisTime = 'time';
 
 
 export { getElementCanvPainter, getElementMainPainter, drawingJSON,
          selectActivePad, getActivePad, cleanup, resize,
-         ObjectPainter, drawRawText, EAxisBits };
+         ObjectPainter, drawRawText, EAxisBits, kAxisLabels, kAxisNormal, kAxisFunc, kAxisTime };

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -1,10 +1,10 @@
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = 'dev',
+const version_id = '7.7.0',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '17/05/2024',
+version_date = '22/05/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/RFramePainter.mjs
+++ b/js/modules/gpad/RFramePainter.mjs
@@ -1018,7 +1018,7 @@ class RFramePainter extends RObjectPainter {
 
       menu.add('Unzoom', () => this.unzoom(kind));
 
-      // if (this[kind+'_kind'] === 'normal')
+      // if (this[kind+'_kind'] === kAxisNormal)
       //   menu.addchk(this['log'+kind], 'SetLog'+kind, this.toggleAxisLog.bind(this, kind));
 
       // here should be all axes attributes in offline

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -1,7 +1,7 @@
 import { gStyle, settings, isFunc, isStr, postponePromise, browser, clTAxis, kNoZoom } from '../core.mjs';
 import { select as d3_select, pointer as d3_pointer, pointers as d3_pointers, drag as d3_drag } from '../d3.mjs';
 import { getElementRect, getAbsPosInCanvas, makeTranslate, addHighlightStyle } from '../base/BasePainter.mjs';
-import { getActivePad, ObjectPainter, EAxisBits } from '../base/ObjectPainter.mjs';
+import { getActivePad, ObjectPainter, EAxisBits, kAxisLabels } from '../base/ObjectPainter.mjs';
 import { getSvgLineStyle } from '../base/TAttLineHandler.mjs';
 import { TAxisPainter } from './TAxisPainter.mjs';
 import { FontHandler } from '../base/FontHandler.mjs';
@@ -2552,7 +2552,7 @@ class TFramePainter extends ObjectPainter {
          else if (this.swap_xy && axis === 'y')
             axis = 'x';
          const handle = this[`${axis}_handle`];
-         if (handle?.kind === 'labels') return;
+         if (handle?.kind === kAxisLabels) return;
       }
 
       if ((value === 'toggle') || (value === undefined))
@@ -2623,7 +2623,7 @@ class TFramePainter extends ObjectPainter {
          if ((kind === 'z') && isFunc(main?.fillPaletteMenu))
             main.fillPaletteMenu(menu, !is_pal);
 
-         if ((handle?.kind === 'labels') && (faxis.fNbins > 20)) {
+         if ((handle?.kind === kAxisLabels) && (faxis.fNbins > 20)) {
             menu.add('Find label', () => menu.input('Label id').then(id => {
                if (!id) return;
                for (let bin = 0; bin < faxis.fNbins; ++bin) {

--- a/js/modules/hist/TF3Painter.mjs
+++ b/js/modules/hist/TF3Painter.mjs
@@ -1,7 +1,7 @@
 import { createHistogram, setHistogramTitle, kNoStats, settings, clTF3, clTH2F, isStr } from '../core.mjs';
 import { TH2Painter } from '../hist/TH2Painter.mjs';
 import { proivdeEvalPar } from '../base/func.mjs';
-import { produceTAxisLogScale } from '../hist/TF1Painter.mjs';
+import { produceTAxisLogScale, scanTF1Options } from '../hist/TF1Painter.mjs';
 import { ObjectPainter, getElementMainPainter } from '../base/ObjectPainter.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
 import { THistPainter } from '../hist2d/THistPainter.mjs';
@@ -74,7 +74,7 @@ class TF3Painter extends TH2Painter {
    createTF3Histogram(func, hist) {
       const nsave = func.fSave.length - 9;
 
-      this._use_saved_points = (nsave > 0) && (settings.PreferSavedPoints || this.force_saved);
+      this._use_saved_points = (nsave > 0) && (settings.PreferSavedPoints || (this.use_saved > 1));
 
       const fp = this.getFramePainter(),
             pad = this.getPadPainter()?.getRootPad(true),
@@ -238,25 +238,17 @@ class TF3Painter extends TH2Painter {
    }
 
    /** @summary fill information for TWebCanvas
+    * @desc Used to inform webcanvas when evaluation failed
      * @private */
    fillWebObjectOptions(opt) {
-      // mark that saved points are used or evaluation failed
-      opt.fcust = this._fail_eval ? 'func_fail' : '';
+      opt.fcust = this._fail_eval && !this.use_saved ? 'func_fail' : '';
    }
 
    /** @summary draw TF3 object */
    static async draw(dom, tf3, opt) {
-      if (!isStr(opt)) opt = '';
-      let p = opt.indexOf(';webcanv_hist'), webcanv_hist = false, force_saved = false;
-      if (p >= 0) {
-         webcanv_hist = true;
-         opt = opt.slice(0, p);
-      }
-      p = opt.indexOf(';force_saved');
-      if (p >= 0) {
-         force_saved = true;
-         opt = opt.slice(0, p);
-      }
+      const web = scanTF1Options(opt);
+      opt = web.opt;
+      delete web.opt;
 
       const d = new DrawOptions(opt);
       if (d.empty() || (opt === 'gl'))
@@ -271,7 +263,7 @@ class TF3Painter extends TH2Painter {
 
       let hist;
 
-      if (webcanv_hist) {
+      if (web.webcanv_hist) {
          const dummy = new ObjectPainter(dom);
          hist = dummy.getPadPainter()?.findInPrimitives('Func', clTH2F);
       }
@@ -284,8 +276,7 @@ class TF3Painter extends TH2Painter {
       const painter = new TF3Painter(dom, hist);
 
       painter.$func = tf3;
-      painter.webcanv_hist = webcanv_hist;
-      painter.force_saved = force_saved;
+      Object.assign(painter, web);
       painter.createTF3Histogram(tf3, hist);
       return THistPainter._drawHist(painter, opt);
    }

--- a/js/modules/hist2d/RHistPainter.mjs
+++ b/js/modules/hist2d/RHistPainter.mjs
@@ -1,4 +1,5 @@
 import { gStyle, settings, isObject, isFunc, isStr, nsREX, getPromise } from '../core.mjs';
+import { kAxisLabels, kAxisTime } from '../base/ObjectPainter.mjs';
 import { RObjectPainter } from '../base/RObjectPainter.mjs';
 
 
@@ -359,12 +360,12 @@ class RHistPainter extends RObjectPainter {
           axis = this.getAxis(name),
           x1 = axis.GetBinCoord(bin);
 
-      if (handle.kind === 'labels')
+      if (handle.kind === kAxisLabels)
          return pmain.axisAsText(name, x1);
 
       const x2 = axis.GetBinCoord(bin+(step || 1));
 
-      if (handle.kind === 'time')
+      if (handle.kind === kAxisTime)
          return pmain.axisAsText(name, (x1+x2)/2);
 
       return `[${pmain.axisAsText(name, x1)}, ${pmain.axisAsText(name, x2)})`;

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -2,7 +2,7 @@ import { gStyle, BIT, settings, create, createHistogram, setHistogramTitle, isFu
          clTPaveStats, clTCutG, clTH1I, clTH2I, clTF1, clTF2, clTPad, kNoZoom, kNoStats } from '../core.mjs';
 import { select as d3_select } from '../d3.mjs';
 import { DrawOptions, buildSvgCurve, makeTranslate, addHighlightStyle } from '../base/BasePainter.mjs';
-import { ObjectPainter } from '../base/ObjectPainter.mjs';
+import { ObjectPainter, kAxisNormal } from '../base/ObjectPainter.mjs';
 import { FunctionsHandler } from './THistPainter.mjs';
 import { TH1Painter, PadDrawOptions } from './TH1Painter.mjs';
 import { kBlack, kWhite } from '../base/colors.mjs';
@@ -432,13 +432,13 @@ class TGraphPainter extends ObjectPainter {
          lines.push('x = ' + funcs.axisAsText('x', d.x), 'y = ' + funcs.axisAsText('y', d.y));
          if (gme)
             lines.push('error x = -' + funcs.axisAsText('x', gme.fExL[d.indx]) + '/+' + funcs.axisAsText('x', gme.fExH[d.indx]));
-         else if (this.options.Errors && (funcs.x_handle.kind === 'normal') && (d.exlow || d.exhigh))
+         else if (this.options.Errors && (funcs.x_handle.kind === kAxisNormal) && (d.exlow || d.exhigh))
             lines.push('error x = -' + funcs.axisAsText('x', d.exlow) + '/+' + funcs.axisAsText('x', d.exhigh));
 
          if (gme) {
             for (let ny = 0; ny < gme.fNYErrors; ++ny)
                lines.push(`error y${ny} = -${funcs.axisAsText('y', gme.fEyL[ny][d.indx])}/+${funcs.axisAsText('y', gme.fEyH[ny][d.indx])}`);
-         } else if ((this.options.Errors || (this.options.EF > 0)) && (funcs.y_handle.kind === 'normal') && (d.eylow || d.eyhigh))
+         } else if ((this.options.Errors || (this.options.EF > 0)) && (funcs.y_handle.kind === kAxisNormal) && (d.eylow || d.eyhigh))
             lines.push('error y = -' + funcs.axisAsText('y', d.eylow) + '/+' + funcs.axisAsText('y', d.eyhigh));
       }
       return lines;

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -3,7 +3,7 @@ import { gStyle, BIT, settings, constants, create, isObject, isFunc, isStr, getP
          clTAxis, clTF1, clTF2, clTProfile, kNoZoom, clTCutG, kNoStats, kTitle } from '../core.mjs';
 import { getColor, getColorPalette } from '../base/colors.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
-import { ObjectPainter, EAxisBits } from '../base/ObjectPainter.mjs';
+import { ObjectPainter, EAxisBits, kAxisTime, kAxisLabels } from '../base/ObjectPainter.mjs';
 import { TPavePainter } from '../hist/TPavePainter.mjs';
 import { ensureTCanvas } from '../gpad/TCanvasPainter.mjs';
 
@@ -2369,12 +2369,12 @@ class THistPainter extends ObjectPainter {
             handle = funcs[`${name}_handle`],
             x1 = axis.GetBinLowEdge(bin+1);
 
-      if (handle.kind === 'labels')
+      if (handle.kind === kAxisLabels)
          return funcs.axisAsText(name, x1);
 
       const x2 = axis.GetBinLowEdge(bin+2);
 
-      if ((handle.kind === 'time') || this.isTF1())
+      if ((handle.kind === kAxisTime) || this.isTF1())
          return funcs.axisAsText(name, (x1+x2)/2);
 
       return `[${funcs.axisAsText(name, x1)}, ${funcs.axisAsText(name, x2)})`;

--- a/js/modules/io.mjs
+++ b/js/modules/io.mjs
@@ -2782,16 +2782,14 @@ class TFile {
          }
 
          if (res && first_req) {
-            if (file.fAcceptRanges && !first_req.getResponseHeader('Accept-Ranges')) {
-               file.fAcceptRanges = false;
-               if (res?.byteLength === place[1]) {
-                  // special case with cernbox, let try to get full size content
-                  console.warn(`First block is ${place[1]} bytes but browser does not provides access to header - try to read full file`);
-                  first_block_retry = true;
-                  return send_new_request();
-               }
+            // special workaround for servers like cernbox blocking access to some response headers
+            // as result, it is not possible to parse multipart responses
+            if (file.fAcceptRanges && (first_req.status === 206) && (res?.byteLength === place[1]) && !first_req.getResponseHeader('Content-Range') && (file.fMaxRanges > 1)) {
+               console.warn('Server response with 206 code but browser does not provide access to Content-Range header - setting fMaxRanges = 1, consider to load full file with "filename.root+" argument or adjust server configurations');
+               file.fMaxRanges = 1;
             }
 
+            // workaround for simpleHTTP
             const kind = browser.isFirefox ? first_req.getResponseHeader('Server') : '';
             if (isStr(kind) && kind.indexOf('SimpleHTTP') === 0) {
                file.fMaxRanges = 1;
@@ -2801,7 +2799,6 @@ class TFile {
 
          if (res && first_block && !file.fFileContent) {
             // special case - keep content of first request (could be complete file) in memory
-
             file.fFileContent = new TBuffer(isStr(res) ? res : new DataView(res));
 
             if (!file.fAcceptRanges)


### PR DESCRIPTION
By default saved points is fallback solution when evaluation on the client fails.
But one can force usage of saved points with "WebGui.TF1UseSave: 2"
Or one can disable saved points usage "WebGui.TF1UseSave: 0"

Update JSROOT to v 7.7.0 which will be reference for 6.32 release