### PR TITLE
[PyROOT] Replace `sonnet` with `dm-sonnet` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.4.1
 # TMVA: SOFIE
 graph_nets
 onnx
-sonnet # used for GNNs
+dm-sonnet # used for GNNs
 
 # TMVA: PyMVA interfaces
 scikit-learn


### PR DESCRIPTION
The name of the most up-to-date `sonnet` packge is actually `dm-sonnet`:

https://github.com/google-deepmind/sonnet

The old `sonnet` can't be used, because it maximally supports Python 3.8. With ROOT, we want to support all Python versions starting from 3.8.

Follows up on 7d83c00605c4.

I tested locally that the GNN tests work in the updated Python environment.