### PR TITLE
[matrix] Fast element setter method

### DIFF
--- a/math/matrix/inc/TMatrixT.h
+++ b/math/matrix/inc/TMatrixT.h
@@ -31,6 +31,7 @@
 #include "Rtypes.h"
 #include "TError.h"
 
+#include <cassert>
 
 template<class Element> class TMatrixTSym;
 template<class Element> class TMatrixTSparse;
@@ -106,6 +107,8 @@ public:
    void MultT(const TMatrixT   <Element> &a,const TMatrixTSym<Element> &b) { Mult(a,b); }
    void MultT(const TMatrixTSym<Element> &a,const TMatrixT   <Element> &b);
    void MultT(const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b) { Mult(a,b); }
+
+   inline void SetElement(Int_t rown, Int_t coln, Element val);
 
    const Element *GetMatrixArray  () const override;
          Element *GetMatrixArray  () override;
@@ -281,6 +284,21 @@ template <class Element> inline Element &TMatrixT<Element>::operator()(Int_t row
       return TMatrixTBase<Element>::NaNValue();
    }
    return (fElements[arown*this->fNcols+acoln]);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Efficiently sets element (rown,coln) equal to val
+/// Index bound checks can be deactivated by defining NDEBUG
+
+template <class Element>
+inline void TMatrixT<Element>::SetElement(Int_t rown, Int_t coln, Element val)
+{
+   assert(this->IsValid());
+   rown = rown - this->fRowLwb;
+   coln = coln - this->fColLwb;
+   assert((rown < this->fNrows && rown >= 0) && "SetElement() error: row index outside matrix range");
+   assert((coln < this->fNcols && coln >= 0) && "SetElement() error: column index outside matrix range");
+   fElements[rown * this->fNcols + coln] = val;
 }
 
 inline namespace TMatrixTAutoloadOps {

--- a/math/matrix/inc/TMatrixTSym.h
+++ b/math/matrix/inc/TMatrixTSym.h
@@ -27,6 +27,8 @@
 #include "TMatrixTBase.h"
 #include "TMatrixTUtils.h"
 
+#include <cassert>
+
 template<class Element>class TMatrixT;
 template<class Element>class TMatrixTSymLazy;
 template<class Element>class TVectorT;
@@ -78,6 +80,8 @@ public:
 
    void Plus (const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b);
    void Minus(const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b);
+
+   inline void SetElement(Int_t rown, Int_t coln, Element val);
 
    const Element *GetMatrixArray  () const override;
          Element *GetMatrixArray  () override;
@@ -233,6 +237,21 @@ template <class Element> inline Element &TMatrixTSym<Element>::operator()(Int_t 
       return TMatrixTBase<Element>::NaNValue();
    }
    return (fElements[arown*this->fNcols+acoln]);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Efficiently sets element (rown,coln) equal to val
+/// Index bound checks can be deactivated by defining NDEBUG
+
+template <class Element>
+inline void TMatrixTSym<Element>::SetElement(Int_t rown, Int_t coln, Element val)
+{
+   assert(this->IsValid());
+   rown = rown - this->fRowLwb;
+   coln = coln - this->fColLwb;
+   assert((rown < this->fNrows && rown >= 0) && "SetElement() error: row index outside matrix range");
+   assert((coln < this->fNcols && coln >= 0) && "SetElement() error: column index outside matrix range");
+   fElements[rown * this->fNcols + coln] = val;
 }
 
 template <class Element> Bool_t                operator== (const TMatrixTSym<Element> &source1,const TMatrixTSym<Element>  &source2);

--- a/math/matrix/test/testMatrixT.cxx
+++ b/math/matrix/test/testMatrixT.cxx
@@ -160,6 +160,22 @@ TYPED_TEST(testMatrix, Invert)
    CompareTMatrix(c, TestFixture::eye);
 }
 
+TYPED_TEST(testMatrix, SetElement)
+{
+   TypeParam b(n, n);
+   TypeParam c(n, n);
+
+   for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+         b(i, j) = n * i + j + 1 * (i == j);
+
+   for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+         c.SetElement(i, j, n * i + j + 1 * (i == j));
+
+   CompareTMatrix(b, c);
+}
+
 class testMatrixD : public testing::Test {
 protected:
    void SetUp() override


### PR DESCRIPTION
# This Pull request:

This PR defines a new method `SetElement()` that allows to efficiently set matrix elements. 

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes [#15285](https://github.com/root-project/root/issues/15285)

