### PR TITLE
[PyROOT] Fix memory leak in TTree `__getattr__` pythonization

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/Factory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/Factory.py
@@ -391,7 +391,7 @@ def DrawCutEfficiencies(fac, datasetName, methodName):
     sSig = ROOT.TH1F(ssigname, ssigname, nbins, low, high)
     effpurS = ROOT.TH1F(epname, epname, nbins, low, high)
 
-    # formating the style of histograms
+    # formatting the style of histograms
     # chop off useless stuff
     sigE.SetTitle("Cut efficiencies for " + methodName + " classifier")
 
@@ -472,7 +472,7 @@ def DrawCutEfficiencies(fac, datasetName, methodName):
 
     effpurS.Draw("sameaxis")
 
-    # Adding labels and other informations to plots.
+    # Adding labels and other information to plots.
 
     legend1 = ROOT.TLegend(
         c.GetLeftMargin(), 1 - c.GetTopMargin(), c.GetLeftMargin() + 0.4, 1 - c.GetTopMargin() + 0.12

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JPyInterface.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JPyInterface.py
@@ -268,7 +268,7 @@ jsmva.$funcName('$divid', '$dat');
         )
 
     ## Inserts the draw area and drawing JavaScript to output
-    # @param obj ROOT object (will be converted to JSON) or JSON string containing the data to be drawed
+    # @param obj ROOT object (will be converted to JSON) or JSON string containing the data to be drawn
     # @param jsDrawMethod the JsMVA JavaScrip object method name to be used for drawing
     # @param objIsJSON obj is ROOT object or JSON
     @staticmethod

--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/OutputTransformer.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/OutputTransformer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-## @package JsMVA.FormatedOutput
+## @package JsMVA.FormattedOutput
 #  @author Attila Bagoly <battila93@gmail.com>
-# This class will transform the TMVA original output to HTML formated output.
+# This class will transform the TMVA original output to HTML formatted output.
 
 from . import DataLoader
 import cgi
@@ -131,7 +131,7 @@ class transformTMVAOutputToHTML:
         rstr += "</table>"
         return (count, rstr)
 
-    ## Transform Variable related informations to table.
+    ## Transform Variable related information to table.
     # @param self object pointer
     # @param headerMatch re.match object for the first line
     # @param startIndex it defines where we are in self.lines array

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -252,7 +252,7 @@ def _find_used_classes(ns, passes_filter, user_pythonizor, npars):
 
         if str(var_value).startswith('<cppyy.Template'):
             # If this is a template, pythonize the instances. Note that in
-            # older cppyy, template instanciations are cached by
+            # older cppyy, template instantiations are cached by
             # fully-qualified name directly in the namespace, so they are
             # covered by the code branch above.
             instantiations = getattr(var_value, "_instantiations", {})

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
@@ -460,7 +460,7 @@ def _make_name_rvec_pair(key, value):
     return ROOT.std.pair["std::string", type(pyvec)](key, ROOT.std.move(pyvec))
 
 
-# For refernces to keep alive the NumPy arrays that are read by
+# For references to keep alive the NumPy arrays that are read by
 # MakeNumpyDataFrame.
 _numpy_data = {}
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
@@ -13,7 +13,7 @@ from ._rvec import add_array_interface_property
 
 def _data_vec_char(self):
     # vector<char>::data() returns char*.
-    # Cppyy attemps to convert char* into Python string, but if the
+    # Cppyy attempts to convert char* into Python string, but if the
     # character sequence is not null-terminated the conversion fails.
     # This is likely to happen with the result of vector<char>::data().
     # For the conversion char* -> str to succeed when calling data(),

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_crossvalidation.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_crossvalidation.py
@@ -35,7 +35,7 @@ class CrossValidation(object):
         "TMVA::CrossValidation::CrossValidation(TString jobName, TMVA::DataLoader *dataloader, TString options)"
     )
     def __init__(self, *args, **kwargs):
-        # Redefinition of `CrossValidtion` constructor for keyword arguments.
+        # Redefinition of `CrossValidation` constructor for keyword arguments.
         # The keywords must correspond to the CmdArg of the constructor function.
 
         args, kwargs = _kwargs_to_tmva_cmdargs(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/src/IOHandler.cxx
+++ b/bindings/pyroot/pythonizations/src/IOHandler.cxx
@@ -29,7 +29,6 @@
 #include <iostream>
 #include "TInterpreter.h"
 
-
 //////////////////////////
 // MODULE FUNCTIONALITY //
 //////////////////////////
@@ -39,10 +38,11 @@ private:
    bool fCapturing = false;
    std::string fStdoutpipe;
    std::string fStderrpipe;
-   int fStdout_pipe[2] = {0,0};
-   int fStderr_pipe[2] = {0,0};
+   int fStdout_pipe[2] = {0, 0};
+   int fStderr_pipe[2] = {0, 0};
    int fSaved_stderr = 0;
    int fSaved_stdout = 0;
+
 public:
    JupyROOTExecutorHandler();
    void Poll();
@@ -53,18 +53,16 @@ public:
    std::string &GetStderr();
 };
 
-
 #ifndef F_LINUX_SPECIFIC_BASE
-#define F_LINUX_SPECIFIC_BASE       1024
+#define F_LINUX_SPECIFIC_BASE 1024
 #endif
 #ifndef F_SETPIPE_SZ
-#define F_SETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 7)
+#define F_SETPIPE_SZ (F_LINUX_SPECIFIC_BASE + 7)
 #endif
 
 constexpr long MAX_PIPE_SIZE = 1048575;
 
 JupyROOTExecutorHandler::JupyROOTExecutorHandler() {}
-
 
 static void PollImpl(FILE *stdStream, int *pipeHandle, std::string &pipeContent)
 {
@@ -84,7 +82,8 @@ static void PollImpl(FILE *stdStream, int *pipeHandle, std::string &pipeContent)
       buf_read = read(pipeHandle[0], &ch, 1);
       if (buf_read == 1) {
          pipeContent += ch;
-      } else break;
+      } else
+         break;
    }
 #endif
 }
@@ -103,7 +102,8 @@ static void InitCaptureImpl(int &savedStdStream, int *pipeHandle, int FILENO)
    }
 #ifndef _MSC_VER
    long flags_stdout = fcntl(pipeHandle[0], F_GETFL);
-   if (flags_stdout == -1) return;
+   if (flags_stdout == -1)
+      return;
    flags_stdout |= O_NONBLOCK;
    fcntl(pipeHandle[0], F_SETFL, flags_stdout);
    fcntl(pipeHandle[0], F_SETPIPE_SZ, MAX_PIPE_SIZE);
@@ -113,7 +113,7 @@ static void InitCaptureImpl(int &savedStdStream, int *pipeHandle, int FILENO)
 
 void JupyROOTExecutorHandler::InitCapture()
 {
-   if (!fCapturing)  {
+   if (!fCapturing) {
       InitCaptureImpl(fSaved_stdout, fStdout_pipe, STDOUT_FILENO);
       InitCaptureImpl(fSaved_stderr, fStderr_pipe, STDERR_FILENO);
       fCapturing = true;
@@ -122,7 +122,7 @@ void JupyROOTExecutorHandler::InitCapture()
 
 void JupyROOTExecutorHandler::EndCapture()
 {
-   if (fCapturing)  {
+   if (fCapturing) {
       Poll();
       dup2(fSaved_stdout, STDOUT_FILENO);
       dup2(fSaved_stderr, STDERR_FILENO);
@@ -187,7 +187,7 @@ bool JupyROOTDeclarerImpl(const char *code)
    return status;
 }
 
-PyObject *JupyROOTExecutor(PyObject * /*self*/, PyObject * args)
+PyObject *JupyROOTExecutor(PyObject * /*self*/, PyObject *args)
 {
    const char *code;
    if (!PyArg_ParseTuple(args, "s", &code))

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -42,7 +42,7 @@ PyObject *gRootModule = 0;
 static PyMethodDef gPyROOTMethods[] = {
    {(char *)"AddCPPInstancePickling", (PyCFunction)PyROOT::AddCPPInstancePickling, METH_VARARGS,
     (char *)"Add a custom pickling mechanism for Cppyy Python proxy objects"},
-   {(char *)"AddBranchAttrSyntax", (PyCFunction)PyROOT::AddBranchAttrSyntax, METH_VARARGS,
+   {(char *)"GetBranchAttr", (PyCFunction)PyROOT::GetBranchAttr, METH_VARARGS,
     (char *)"Allow to access branches as tree attributes"},
    {(char *)"AddTClassDynamicCastPyz", (PyCFunction)PyROOT::AddTClassDynamicCastPyz, METH_VARARGS,
     (char *)"Cast the void* returned by TClass::DynamicCast to the right type"},

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -62,10 +62,8 @@ static PyMethodDef gPyROOTMethods[] = {
     (char *)"Deserialize a pickled object"},
    {(char *)"ClearProxiedObjects", (PyCFunction)PyROOT::ClearProxiedObjects, METH_NOARGS,
     (char *)"Clear proxied objects regulated by PyROOT"},
-   {(char *)"JupyROOTExecutor", (PyCFunction)JupyROOTExecutor, METH_VARARGS,
-    (char *)"Create JupyROOTExecutor"},
-   {(char *)"JupyROOTDeclarer", (PyCFunction)JupyROOTDeclarer, METH_VARARGS,
-    (char *)"Create JupyROOTDeclarer"},
+   {(char *)"JupyROOTExecutor", (PyCFunction)JupyROOTExecutor, METH_VARARGS, (char *)"Create JupyROOTExecutor"},
+   {(char *)"JupyROOTDeclarer", (PyCFunction)JupyROOTDeclarer, METH_VARARGS, (char *)"Create JupyROOTDeclarer"},
    {(char *)"JupyROOTExecutorHandler_Clear", (PyCFunction)JupyROOTExecutorHandler_Clear, METH_NOARGS,
     (char *)"Clear JupyROOTExecutorHandler"},
    {(char *)"JupyROOTExecutorHandler_Ctor", (PyCFunction)JupyROOTExecutorHandler_Ctor, METH_NOARGS,
@@ -102,17 +100,17 @@ static int rootmodule_clear(PyObject *m)
    return 0;
 }
 
-static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,       "libROOTPythonizations",  NULL,
-                                       sizeof(struct module_state), gPyROOTMethods,   NULL,
-                                       rootmodule_traverse,         rootmodule_clear, NULL};
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,       "libROOTPythonizations", NULL,
+                                       sizeof(struct module_state), gPyROOTMethods,          NULL,
+                                       rootmodule_traverse,         rootmodule_clear,        NULL};
 
 /// Initialization of extension module libROOTPythonizations
 
-extern "C" PyObject* PyInit_libROOTPythonizations()
+extern "C" PyObject *PyInit_libROOTPythonizations()
 {
    using namespace PyROOT;
 
-// setup PyROOT
+   // setup PyROOT
    gRootModule = PyModule_Create(&moduledef);
    if (!gRootModule)
       return nullptr;

--- a/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
+++ b/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
@@ -20,7 +20,7 @@ PyObject *AddCPPInstancePickling(PyObject *self, PyObject *args);
 
 PyObject *AddPrettyPrintingPyz(PyObject *self, PyObject *args);
 
-PyObject *AddBranchAttrSyntax(PyObject *self, PyObject *args);
+PyObject *GetBranchAttr(PyObject *self, PyObject *args);
 PyObject *BranchPyz(PyObject *self, PyObject *args);
 PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 

--- a/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
@@ -31,7 +31,7 @@ using namespace PyROOT;
 
 namespace {
 
-static void AddToGlobalScope(const char *label, TObject *obj, const char * classname)
+static void AddToGlobalScope(const char *label, TObject *obj, const char *classname)
 {
    // Bind the given object with the given class in the global scope with the
    // given label for its reference.

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -165,7 +165,8 @@ PyObject *PyROOT::RPyROOTApplication::InitApplication(PyObject * /*self*/, PyObj
 /// \param[in] name Application class name.
 /// \param[in] argc Number of arguments.
 /// \param[in] argv Arguments.
-PyROOT::RPyROOTApplication::RPyROOTApplication(const char *name, int *argc, char **argv) : TApplication(name, argc, argv)
+PyROOT::RPyROOTApplication::RPyROOTApplication(const char *name, int *argc, char **argv)
+   : TApplication(name, argc, argv)
 {
    // Save current interpreter context
    gInterpreter->SaveContext();

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -162,10 +162,10 @@ PyObject *PyROOT::RPyROOTApplication::InitApplication(PyObject * /*self*/, PyObj
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Construct a TApplication for PyROOT.
-/// \param[in] acn Application class name.
+/// \param[in] name Application class name.
 /// \param[in] argc Number of arguments.
 /// \param[in] argv Arguments.
-PyROOT::RPyROOTApplication::RPyROOTApplication(const char *acn, int *argc, char **argv) : TApplication(acn, argc, argv)
+PyROOT::RPyROOTApplication::RPyROOTApplication(const char *name, int *argc, char **argv) : TApplication(name, argc, argv)
 {
    // Save current interpreter context
    gInterpreter->SaveContext();

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.h
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.h
@@ -33,7 +33,7 @@ public:
    static PyObject *InitApplication(PyObject *self, PyObject *args);
    static PyObject *InstallGUIEventInputHook(PyObject *self, PyObject *args);
 
-   RPyROOTApplication(const char *acn, int *argc, char **argv);
+   RPyROOTApplication(const char *name, int *argc, char **argv);
    virtual ~RPyROOTApplication() {}
 
 private:

--- a/bindings/pyroot/pythonizations/src/TClassPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TClassPyz.cxx
@@ -30,10 +30,7 @@ PyObject *TClassDynamicCastPyz(PyObject *self, PyObject *args)
    PyObject *pyclass = nullptr;
    PyObject *pyobject = nullptr;
    int up = 1;
-   if (!PyArg_ParseTuple(args, "O!O|i:DynamicCast",
-                         &CPPInstance_Type, &pyclass,
-                         &pyobject,
-                         &up))
+   if (!PyArg_ParseTuple(args, "O!O|i:DynamicCast", &CPPInstance_Type, &pyclass, &pyobject, &up))
       return nullptr;
 
    // Perform actual cast - calls default implementation of DynamicCast
@@ -52,7 +49,7 @@ PyObject *TClassDynamicCastPyz(PyObject *self, PyObject *args)
 
    // Now use binding to return a usable class. Upcast: result is a base.
    // Downcast: result is a derived.
-   Cppyy::TCppType_t cpptype = ((CPyCppyy::CPPInstance*)(up ? pyclass : self))->ObjectIsA();
+   Cppyy::TCppType_t cpptype = ((CPyCppyy::CPPInstance *)(up ? pyclass : self))->ObjectIsA();
    TClass *tcl = TClass::GetClass(Cppyy::GetScopedFinalName(cpptype).c_str());
    TClass *klass = (TClass *)tcl->DynamicCast(TClass::Class(), up ? CPyCppyy::Instance_AsVoidPtr(pyclass) : cl1);
 

--- a/bindings/pyroot/pythonizations/src/TTreePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TTreePyz.cxx
@@ -42,7 +42,7 @@ namespace {
 // Get the TClass of the C++ object proxied by pyobj
 TClass *GetTClass(const PyObject *pyobj)
 {
-   return TClass::GetClass(Cppyy::GetScopedFinalName(((CPyCppyy::CPPInstance*)pyobj)->ObjectIsA()).c_str());
+   return TClass::GetClass(Cppyy::GetScopedFinalName(((CPyCppyy::CPPInstance *)pyobj)->ObjectIsA()).c_str());
 }
 
 } // namespace
@@ -108,10 +108,10 @@ static PyObject *WrapLeaf(TLeaf *leaf)
       // array types
       std::string typeName = leaf->GetTypeName();
 #ifdef CPYCPPYY_VERSION_HEX
-      dim_t dimsArr[]{ leaf->GetNdata() };
+      dim_t dimsArr[]{leaf->GetNdata()};
       CPyCppyy::Dimensions dims{1, dimsArr};
 #else
-      dim_t dims[]{ 1, leaf->GetNdata() }; // first entry is the number of dims
+      dim_t dims[]{1, leaf->GetNdata()}; // first entry is the number of dims
 #endif
       Converter *pcnv = CreateConverter(typeName + (isStatic ? "[]" : "*"), dims);
 
@@ -222,7 +222,7 @@ PyObject *PyROOT::SetBranchAddressPyz(PyObject * /* self */, PyObject *args)
 
    int argc = PyTuple_GET_SIZE(args);
 
-// Look for the (const char*, void*) overload
+   // Look for the (const char*, void*) overload
    auto argParseStr = "OUO:SetBranchAddress";
    if (argc == 3 && PyArg_ParseTuple(args, argParseStr, &treeObj, &name, &address)) {
 
@@ -274,12 +274,8 @@ PyObject *TryBranchLeafListOverload(int argc, PyObject *args)
    PyObject *treeObj = nullptr;
    PyObject *name = nullptr, *address = nullptr, *leaflist = nullptr, *bufsize = nullptr;
 
-   if (PyArg_ParseTuple(args, "OO!OO!|O!:Branch",
-                        &treeObj,
-                        &PyUnicode_Type, &name,
-                        &address,
-                        &PyUnicode_Type, &leaflist,
-                        &PyInt_Type, &bufsize)) {
+   if (PyArg_ParseTuple(args, "OO!OO!|O!:Branch", &treeObj, &PyUnicode_Type, &name, &address, &PyUnicode_Type,
+                        &leaflist, &PyInt_Type, &bufsize)) {
 
       auto tree = (TTree *)GetTClass(treeObj)->DynamicCast(TTree::Class(), CPyCppyy::Instance_AsVoidPtr(treeObj));
       if (!tree) {
@@ -296,8 +292,7 @@ PyObject *TryBranchLeafListOverload(int argc, PyObject *args)
       if (buf) {
          TBranch *branch = nullptr;
          if (argc == 5) {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), buf, PyUnicode_AsUTF8(leaflist),
-                                  PyInt_AS_LONG(bufsize));
+            branch = tree->Branch(PyUnicode_AsUTF8(name), buf, PyUnicode_AsUTF8(leaflist), PyInt_AS_LONG(bufsize));
          } else {
             branch = tree->Branch(PyUnicode_AsUTF8(name), buf, PyUnicode_AsUTF8(leaflist));
          }
@@ -323,21 +318,12 @@ PyObject *TryBranchPtrToPtrOverloads(int argc, PyObject *args)
    PyObject *name = nullptr, *clName = nullptr, *address = nullptr, *bufsize = nullptr, *splitlevel = nullptr;
 
    auto bIsMatch = false;
-   if (PyArg_ParseTuple(args, "OO!O!O|O!O!:Branch",
-                        &treeObj,
-                        &PyUnicode_Type, &name,
-                        &PyUnicode_Type, &clName,
-                        &address,
-                        &PyInt_Type, &bufsize,
-                        &PyInt_Type, &splitlevel)) {
+   if (PyArg_ParseTuple(args, "OO!O!O|O!O!:Branch", &treeObj, &PyUnicode_Type, &name, &PyUnicode_Type, &clName,
+                        &address, &PyInt_Type, &bufsize, &PyInt_Type, &splitlevel)) {
       bIsMatch = true;
    } else {
       PyErr_Clear();
-      if (PyArg_ParseTuple(args, "OO!O|O!O!",
-                           &treeObj,
-                           &PyUnicode_Type, &name,
-                           &address,
-                           &PyInt_Type, &bufsize,
+      if (PyArg_ParseTuple(args, "OO!O|O!O!", &treeObj, &PyUnicode_Type, &name, &address, &PyInt_Type, &bufsize,
                            &PyInt_Type, &splitlevel)) {
          bIsMatch = true;
       } else {

--- a/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
@@ -136,7 +136,7 @@ class TestRooAbsCollection(unittest.TestCase):
         self.assertEqual(ROOT.RooArgSet(var0)["var0"], var0)
 
     def test_clone_collection(self):
-        # Check explicitely that both overloads of addClone work.
+        # Check explicitly that both overloads of addClone work.
         x = ROOT.RooRealVar("x", "x", 1.0)
         s1 = ROOT.RooArgSet(x)
         s2 = ROOT.RooArgSet()

--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -136,7 +136,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         cat.defineType("plus", +1)
 
         # Use manual loop because we had some problems with numpys boolean
-        # comparisions in the past (see GitHub issue #12162).
+        # comparisons in the past (see GitHub issue #12162).
         n_in_range = 0
         for i in range(n_events):
             in_x_range = data["x"][i] <= x.getMax() and data["x"][i] >= x.getMin()
@@ -150,7 +150,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         self.assertEqual(dataset_numpy.numEntries(), n_in_range)
 
     def test_non_contiguous_arrays(self):
-        """Test whether the import also works with non-continguous arrays.
+        """Test whether the import also works with non-contiguous arrays.
         Covers GitHub issue #13605.
         """
 


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/15610

As reported on the forum:
https://root-forum.cern.ch/t/memory-leak-in-pyroot-when-using-user-defined-c-macros-from-python-and-ttree-friends/59432

According to that post, the problem is present at least since 6.26/04, but I suspect it has been there forever (at least 6.22 with with cppyy upgrade in 2019). 

I fixed the memory leak in the Pythonization is in the usual way how I fix problems with the PyROOT CPython extension: re-implementing the offending parts in Python and hoping that the problem is gone. Which it is!

Note that the code also had no obvious memory leak before. where it was
using the `CPyCppyy::Instance_FromVoidPtr` function from the CPyCppyy
API. If similar problems appear, this function might have to be
investigated in more detail.

But for this commit it is not relevant: moving more Pythonization logic
into the Python layer is better anyway.

The problem can be reproduced with a variation of the forum reproducer:
```python
import ROOT
import numpy as np

ROOT.gInterpreter.Declare(
    """
template<class T>
void * MyGetAddress(T * b) {
   return *(void**)b->GetAddress();
}
"""
)


def macro(tree, *args, **kwargs):

    import cppyy.ll

    # manually
    v1 = cppyy.ll.cast[tree.GetBranch("value1").GetClassName() + "*"](ROOT.MyGetAddress(tree.GetBranch("value1")))
    # using the Pythonization
    v2 = getattr(tree, "value2")
    return None


pinfo = ROOT.ProcInfo_t()


def print_memory(i):
    ROOT.gSystem.GetProcInfo(pinfo)
    print(i, "memory usage", pinfo.fMemResident, pinfo.fMemVirtual)


class reTupler:
    def __init__(self, tree_name, new_file, src_file):
        self.src_file = ROOT.TFile.Open(src_file)
        self.src_tree = self.src_file.Get(tree_name)

        self.new_file = ROOT.TFile.Open(new_file, "recreate")
        self.new_tree = ROOT.TTree(tree_name, tree_name)

        # To access branches in 'src_tree' from 'new_tree':
        self.new_tree.AddFriend(self.src_tree)

        # To keep track of new branches and store values:
        self.new_branches = {}

    def add_branch(self, name, f, value_type="float"):
        self.new_branches[name] = {}
        self.new_branches[name]["f"] = f
        self.new_branches[name]["name"] = name
        self.new_branches[name]["value_type"] = value_type
        self.new_branches[name]["value"] = value = ROOT.std.vector(value_type)()
        self.new_branches[name]["tbranch"] = self.new_tree.Branch(name, value)

    def run(self):
        nentries = self.src_tree.GetEntries()
        for i in range(nentries):
            # Get entry and make sure src_tree and new_tree are synced
            self.src_tree.GetEntry(i)
            self.new_tree.GetEntry(i)

            # Now loop on all the branches that have been added:
            for branch_name, branch_dict in self.new_branches.items():
                branch_dict["value"].clear()
                # self.new_tree
                branch_dict["f"](self.new_tree)
                # [branch_dict['value'].push_back(result) for result in branch_dict['f'](self.new_tree)]

            # Fill entry with all computed branches
            self.new_tree.Fill()

            if i % 10000 == 0:
                print_memory(i)

        self.new_tree.Write()
        self.new_file.Close()
        self.src_file.Close()


file_path = "_src.root"

file = ROOT.TFile.Open(file_path, "recreate")
tree = ROOT.TTree("DDTree", "DDTree")

# Branch: value1
value1_value = ROOT.std.vector("float")()
value1_branch = tree.Branch("value1", value1_value)

# Branch: value2
value2_value = ROOT.std.vector("float")()
value2_branch = tree.Branch("value2", value2_value)


value_length = 20
nentries = 100000
for i in range(nentries):
    tree.GetEntry(i)

    value1_value.clear()
    [value1_value.push_back(result) for result in np.random.uniform(-999, 999, value_length)]

    value2_value.clear()
    [value2_value.push_back(result) for result in np.random.uniform(-99, 999, value_length)]

    tree.Fill()

file.Write()
file.Close()

tree_name = "DDTree"
src_path = "_src.root"
new_path = "_new.root"

retupler = reTupler("DDTree", new_path, src_path)
retupler.add_branch("new_branch", macro, "float")

retupler.run()
```

Output without this PR:
```txt
0 memory usage 361424 1544100
10000 memory usage 380580 1548912
20000 memory usage 386148 1554504
30000 memory usage 391332 1559540
40000 memory usage 396324 1565324
50000 memory usage 402084 1572740
60000 memory usage 407652 1577572
70000 memory usage 413028 1582796
80000 memory usage 418596 1588976
90000 memory usage 423780 1594012

________________________________________________________
Executed in    3.40 secs    fish           external
   usr time    3.33 secs  399.00 micros    3.33 secs
   sys time    1.96 secs  106.00 micros    1.96 secs
```

Output with this PR:
```txt
0 memory usage 361396 1544116
10000 memory usage 375848 1544304
20000 memory usage 375848 1544304
30000 memory usage 375848 1544304
40000 memory usage 375848 1544304
50000 memory usage 375848 1544304
60000 memory usage 375848 1544304
70000 memory usage 375848 1544304
80000 memory usage 375848 1544304
90000 memory usage 375848 1544304

________________________________________________________
Executed in    2.08 secs    fish           external
   usr time    2.06 secs  471.00 micros    2.06 secs
   sys time    1.99 secs  126.00 micros    1.99 secs
```

The time measurements exclude the toy data generation. The new implementation is also almost twice as fast as the old one, so a win-win!

~~**Note:** I''m pretty sure there was also a JIRA issue about this problem, I can't find it anymore...~~
*Edit:* no, the issue I had in mind was not really the same: https://its.cern.ch/jira/browse/ROOT-9875.