### PR TITLE
New Method TH1::SetColors

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -384,7 +384,7 @@ public:
    virtual void     SetContent(const Double_t *content);
    virtual void     SetContour(Int_t nlevels, const Double_t *levels = nullptr);
    virtual void     SetContourLevel(Int_t level, Double_t value);
-   virtual void     SetColor(Color_t linecolor = -1, Color_t markercolor = -1, Color_t fillcolor = -1);
+   virtual void     SetColors(Color_t linecolor = -1, Color_t markercolor = -1, Color_t fillcolor = -1);
    static  void     SetDefaultBufferSize(Int_t buffersize=1000);
    static  void     SetDefaultSumw2(Bool_t sumw2=kTRUE);
    virtual void     SetDirectory(TDirectory *dir);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -384,6 +384,7 @@ public:
    virtual void     SetContent(const Double_t *content);
    virtual void     SetContour(Int_t nlevels, const Double_t *levels = nullptr);
    virtual void     SetContourLevel(Int_t level, Double_t value);
+   virtual void     SetColor(Color_t linecolor = -1, Color_t markercolor = -1, Color_t fillcolor = -1);
    static  void     SetDefaultBufferSize(Int_t buffersize=1000);
    static  void     SetDefaultSumw2(Bool_t sumw2=kTRUE);
    virtual void     SetDirectory(TDirectory *dir);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4468,9 +4468,12 @@ Double_t TH1::GetEffectiveEntries() const
 
 void TH1::SetColors(Color_t linecolor, Color_t markercolor, Color_t fillcolor)
 {
-   if (linecolor >= 0) SetLineColor(linecolor);
-   if (markercolor >= 0) SetMarkerColor(markercolor);
-   if (fillcolor >= 0) SetFillColor(fillcolor);
+   if (linecolor >= 0)
+      SetLineColor(linecolor);
+   if (markercolor >= 0)
+      SetMarkerColor(markercolor);
+   if (fillcolor >= 0)
+      SetFillColor(fillcolor);
 }
 
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4455,7 +4455,7 @@ Double_t TH1::GetEffectiveEntries() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Shortcut to set the four histogram colors with a single call.
+/// Shortcut to set the three histogram colors with a single call.
 ///
 /// By default: linecolor = markercolor = fillcolor = -1
 /// If a color is < 0 this method does not change the corresponding color if positive or null it set the color.
@@ -4466,7 +4466,7 @@ Double_t TH1::GetEffectiveEntries() const
 /// ~~~
 /// will set the line color and the marker color to red.
 
-void TH1::SetColor(Color_t linecolor, Color_t markercolor, Color_t fillcolor)
+void TH1::SetColors(Color_t linecolor, Color_t markercolor, Color_t fillcolor)
 {
    if (linecolor >= 0) SetLineColor(linecolor);
    if (markercolor >= 0) SetMarkerColor(markercolor);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4462,7 +4462,7 @@ Double_t TH1::GetEffectiveEntries() const
 ///
 /// For instance:
 /// ~~~ {.cpp}
-/// h->SetColor(kRed, kRed);
+/// h->SetColors(kRed, kRed);
 /// ~~~
 /// will set the line color and the marker color to red.
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4455,6 +4455,26 @@ Double_t TH1::GetEffectiveEntries() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Shortcut to set the four histogram colors with a single call.
+///
+/// By default: linecolor = markercolor = fillcolor = -1
+/// If a color is < 0 this method does not change the corresponding color if positive or null it set the color.
+///
+/// For instance:
+/// ~~~ {.cpp}
+/// h->SetColor(kRed, kRed);
+/// ~~~
+/// will set the line color and the marker color to red.
+
+void TH1::SetColor(Color_t linecolor, Color_t markercolor, Color_t fillcolor)
+{
+   if (linecolor >= 0) SetLineColor(linecolor);
+   if (markercolor >= 0) SetMarkerColor(markercolor);
+   if (fillcolor >= 0) SetFillColor(fillcolor);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set highlight (enable/disable) mode for the histogram
 /// by default highlight mode is disable
 


### PR DESCRIPTION
Implement the method requested here: https://root-forum.cern.ch/t/a-few-new-member-functions-for-various-classes/59434/3

By default: linecolor = markercolor = fillcolor = -1
If a color is < 0 this method does not change the corresponding color if positive or null it set the color.

For instance:

```
 h->SetColor(kRed, kRed);
```
will set the line color and the marker color to red.

