### PR TITLE
[io] Update TKey::Sizeof doc comment

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -1330,16 +1330,17 @@ void TKey::Reset()
 /// An explaination about the nbytes (Int_t nbytes) variable used in the
 /// function. The size of fSeekKey and fSeekPdir is 8 instead of 4 if version is
 /// greater than 1000.
-/// | Component         | Sizeof |
-/// |-------------------|--------|
-/// | fNbytes           | 4      |
-/// | sizeof(Version_t) | 2      |
-/// | fObjlen           | 4      |
-/// | fKeylen           | 2      |
-/// | fCycle            | 2      |
-/// | fSeekKey          | 4 or 8 |
-/// | fSeekPdir         | 4 or 8 |
-/// | **TOTAL**         |   22   |
+/// | Component         | Sizeof   |
+/// |-------------------|----------|
+/// | fNbytes           | 4        |
+/// | sizeof(Version_t) | 2        |
+/// | fObjlen           | 4        |
+/// | fDatime           | 4        |
+/// | fKeylen           | 2        |
+/// | fCycle            | 2        |
+/// | fSeekKey          | 4 or 8   |
+/// | fSeekPdir         | 4 or 8   |
+/// | **TOTAL**         | 26 or 34 |
 
 Int_t TKey::Sizeof() const
 {

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -1327,20 +1327,24 @@ void TKey::Reset()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the size in bytes of the key header structure.
 ///
-/// An explaination about the nbytes (Int_t nbytes) variable used in the
+/// An explanation about the nbytes (Int_t nbytes) variable used in the
 /// function. The size of fSeekKey and fSeekPdir is 8 instead of 4 if version is
 /// greater than 1000.
-/// | Component         | Sizeof   |
-/// |-------------------|----------|
-/// | fNbytes           | 4        |
-/// | sizeof(Version_t) | 2        |
-/// | fObjlen           | 4        |
-/// | fDatime           | 4        |
-/// | fKeylen           | 2        |
-/// | fCycle            | 2        |
-/// | fSeekKey          | 4 or 8   |
-/// | fSeekPdir         | 4 or 8   |
-/// | **TOTAL**         | 26 or 34 |
+/// | Component         | Sizeof     |
+/// |-------------------|------------|
+/// | fNbytes           | 4          |
+/// | sizeof(Version_t) | 2          |
+/// | fObjlen           | 4          |
+/// | fDatime           | 4          |
+/// | fKeylen           | 2          |
+/// | fCycle            | 2          |
+/// | fSeekKey          | 4 or 8     |
+/// | fSeekPdir         | 4 or 8     |
+/// | **FIXED TOTAL**   | 26 or 34   |
+/// | fClassName        | 1+ bytes   |
+/// | fName             | 1+ bytes   |
+/// | fTitle            | 1+ bytes   |
+/// | **TOTAL**         | 29+ or 37+ |
 
 Int_t TKey::Sizeof() const
 {


### PR DESCRIPTION
The comment was not considering fDatime, thus reporting the wrong format and size.

