### PR TITLE
[geom] Fix registered identity matrix removal warning

### DIFF
--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -2439,8 +2439,10 @@ TGeoHMatrix &TGeoHMatrix::operator=(const TGeoMatrix &matrix)
    Clear();
    Bool_t registered = TestBit(kGeoRegistered);
    TNamed::operator=(matrix);
-   if (matrix.IsIdentity())
+   if (matrix.IsIdentity()) {
+      SetBit(kGeoRegistered, registered);
       return *this;
+   }
    if (matrix.IsTranslation())
       memcpy(fTranslation, matrix.GetTranslation(), kN3);
    if (matrix.IsRotation())


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
When copying the registered identity transformation, the registered flag was not reset appropriately. Observed when rotating overlapping volumes in the pad.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

