### PR TITLE
[tree] Avoid buffer overflow in TBranch

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -350,7 +350,7 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
          }
          if (lenName == 0 || ctype == leafname) {
             Warning("TBranch","No name was given to the leaf number '%d' in the leaflist of the branch '%s'.",fNleaves,name);
-            snprintf(leafname,640,"__noname%d",fNleaves);
+            snprintf(leafname, len + 1, "__noname%d", fNleaves);
          }
          TLeaf* leaf = nullptr;
          if (leaftype[1] == '[' && !strchr(leaftype, ',')) {


### PR DESCRIPTION
Introduced by https://github.com/root-project/root/commit/617f5fb4fab9b92b2a95e506b4801364473672bc

The change to a variable length size was not properly propagated to the rest of the `TBranch::Init` function.

Fixes the recent ubuntu24 failures of the type
```
  2400/2509 Test #2432: roottest-root-tree-branches-make ..................................................................***Failed    1.79 sec
  -- TEST COMMAND -- 
  cd /github/home/ROOT-CI/roottest/root/tree/branches
  /usr/bin/timeout -s USR2 1770s /usr/bin/gmake cleantest
  -- BEGIN TEST OUTPUT --
  /usr/bin/gmake -f Makefile test
  gmake[1]: Entering directory '/github/home/ROOT-CI/roottest/root/tree/branches'
  
  Processing runnoname.C...
  Warning in <TBranch::TBranch>: No name was given to the leaf number '1' in the leaflist of the branch 'nhitshcal'.
  *** buffer overflow detected ***: terminated
  Aborted (core dumped)
  gmake[1]: Leaving directory '/github/home/ROOT-CI/roottest/root/tree/branches'
```

as seen for example [here](https://github.com/root-project/root/actions/runs/9201038116/job/25308591312#step:11:26510)