### PR TITLE
[6.32] Backport of #15620

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -350,7 +350,7 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
          }
          if (lenName == 0 || ctype == leafname) {
             Warning("TBranch","No name was given to the leaf number '%d' in the leaflist of the branch '%s'.",fNleaves,name);
-            snprintf(leafname,640,"__noname%d",fNleaves);
+            snprintf(leafname, len + 1, "__noname%d", fNleaves);
          }
          TLeaf* leaf = nullptr;
          if (leaftype[1] == '[' && !strchr(leaftype, ',')) {


### PR DESCRIPTION
Introduced by https://github.com/root-project/root/commit/617f5fb4fab9b92b2a95e506b4801364473672bc

The change to a variable length size was not properly propagated to the rest of the `TBranch::Init` function.

Related to https://github.com/root-project/root/issues/15621