### PR TITLE
[RDF] Make df106_HiggsToFourLeptons.C run properly when compiled

### DIFF
--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -99,9 +99,13 @@ void df106_HiggsToFourLeptons()
 #ifndef __CLING__
    // If this tutorial is compiled, rather than run as a ROOT macro, the interpreter needs to be fed the signatures
    // of all the functions we want to JIT in our analysis, as well as any type used in those signatures.
-   gInterpreter->Declare("using ROOT::RVecF;");
-   gInterpreter->Declare(STRINGIFY(GoodElectronsAndMuons_Signature) ";");
-   gInterpreter->Declare(STRINGIFY(ComputeInvariantMass_Signature) ";");
+   // clang-format off
+   gInterpreter->Declare(
+      "using ROOT::RVecF;"
+      STRINGIFY(GoodElectronsAndMuons_Signature) ";"
+      STRINGIFY(ComputeInvariantMass_Signature)  ";"
+   );
+   // clang-format on
 #endif
 
    // Perform the analysis

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -46,7 +46,7 @@ using namespace ROOT::RDF::Experimental;
 
 // Define functions needed in the analysis
 // Select events for the analysis
-bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e, \
+bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e,
                            const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0)
 {
    for (size_t i = 0; i < type.size(); i++) {

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -44,16 +44,10 @@ using ROOT::RVecF;
 using ROOT::RDF::RSampleInfo;
 using namespace ROOT::RDF::Experimental;
 
-#define STRINGIFY_(x) #x
-#define STRINGIFY(x) STRINGIFY_(x)
-
-#define GoodElectronsAndMuons_Signature \
-   bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e, \
-                              const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0)
-
 // Define functions needed in the analysis
 // Select events for the analysis
-GoodElectronsAndMuons_Signature
+bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e, \
+                           const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0)
 {
    for (size_t i = 0; i < type.size(); i++) {
       PtEtaPhiEVectorF p(0.001 * pt[i], eta[i], phi[i], 0.001 * e[i]);
@@ -69,11 +63,8 @@ GoodElectronsAndMuons_Signature
    return true;
 }
 
-#define ComputeInvariantMass_Signature \
-   float ComputeInvariantMass(const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e)
-
 // Compute the invariant mass of a four-lepton-system.
-ComputeInvariantMass_Signature
+float ComputeInvariantMass(const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e)
 {
    PtEtaPhiEVectorF p1(pt[0], eta[0], phi[0], e[0]);
    PtEtaPhiEVectorF p2(pt[1], eta[1], phi[1], e[1]);
@@ -102,8 +93,9 @@ void df106_HiggsToFourLeptons()
    // clang-format off
    gInterpreter->Declare(
       "using ROOT::RVecF;"
-      STRINGIFY(GoodElectronsAndMuons_Signature) ";"
-      STRINGIFY(ComputeInvariantMass_Signature)  ";"
+      "bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e,"
+                           "const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0);"
+      "float ComputeInvariantMass(const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e);"
    );
    // clang-format on
 #endif


### PR DESCRIPTION
# This Pull request:
Explicitly declares the signatures of types that are used in jitted expressions so that the tutorial runs properly even when compiled AOT.

## Changes or fixes:
Partially fixes https://github.com/root-project/root/issues/15638

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
