### PR TITLE
Detect and act upon incomplete TTree entries in RDataFrame

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -62,6 +62,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RNewSampleNotifier.hxx
     ROOT/RDF/RSampleInfo.hxx
     ROOT/RDF/RDefineBase.hxx
+    ROOT/RDF/RDefaultValueFor.hxx
     ROOT/RDF/RDefine.hxx
     ROOT/RDF/RDefinePerSample.hxx
     ROOT/RDF/RDefineReader.hxx
@@ -87,6 +88,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RRange.hxx
     ROOT/RDF/RResultMap.hxx
     ROOT/RDF/RSample.hxx
+    ROOT/RDF/RFilterWithMissingValues.hxx
     ROOT/RDF/RTreeColumnReader.hxx
     ROOT/RDF/RVariation.hxx
     ROOT/RDF/RVariationBase.hxx

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -98,11 +98,24 @@ public:
       fHelper.InitTask(r, slot);
    }
 
+   template <typename ColType>
+   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, Long64_t entry) -> ColType &
+   {
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(entry))
+         return *val;
+
+      throw std::out_of_range{"RDataFrame: Action (" + fHelper.GetActionName() +
+                              ") could not retrieve value for column '" + fColumnNames[readerIdx] + "' for entry " +
+                              std::to_string(entry) +
+                              ". You can use the DefaultValueFor operation to provide a default value, or "
+                              "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
+   }
+
    template <typename... ColTypes, std::size_t... S>
    void CallExec(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
       ROOT::Internal::RDF::CallGuaranteedOrder{[&](auto &&...args) { return fHelper.Exec(slot, args...); },
-                                               fValues[slot][S]->template Get<ColTypes>(entry)...};
+                                               GetValueChecked<ColTypes>(slot, S, entry)...};
       (void)entry; // avoid unused parameter warning (gcc 12.1)
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -42,11 +42,11 @@ protected:
    /// A raw pointer to the RLoopManager at the root of this functional graph.
    /// Never null: children nodes have shared ownership of parent nodes in the graph.
    RLoopManager *fLoopManager;
+   const ColumnNames_t fColumnNames;
 
 private:
    const unsigned int fNSlots; ///< Number of thread slots used by this node.
    bool fHasRun = false;
-   const ColumnNames_t fColumnNames;
    /// List of systematic variations that affect the result of this action ("nominal" excluded).
    std::vector<std::string> fVariations;
 

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -32,10 +32,13 @@ public:
    /// Return the column value for the given entry.
    /// \tparam T The column type
    /// \param entry The entry number
+   ///
+   /// The caller is responsible for checking that the returned value actually
+   /// exists.
    template <typename T>
-   T &Get(Long64_t entry)
+   T *TryGet(Long64_t entry)
    {
-      return *static_cast<T *>(GetImpl(entry));
+      return static_cast<T *>(GetImpl(entry));
    }
 
 private:

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -126,6 +126,9 @@ public:
 
    RDFDetail::RColumnReaderBase *GetReader(unsigned int slot, const std::string &colName,
                                            const std::string &variationName, const std::type_info &tid);
+
+   RDFDetail::RColumnReaderBase *
+   GetReaderUnchecked(unsigned int slot, const std::string &colName, const std::string &variationName);
 };
 
 } // Namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
@@ -1,0 +1,166 @@
+// Author: Vincenzo Eduardo Padulano, CERN 09/2024
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDefaultValueFor
+#define ROOT_RDF_RDefaultValueFor
+
+#include "ROOT/RDF/ColumnReaderUtils.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
+#include "ROOT/RDF/RDefineBase.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
+#include "ROOT/RDF/Utils.hxx"
+#include <string_view>
+#include "ROOT/TypeTraits.hxx"
+#include "RtypesCore.h"
+
+#include <deque>
+#include <type_traits>
+#include <utility> // std::index_sequence
+#include <vector>
+
+class TTreeReader;
+
+namespace ROOT {
+namespace Detail {
+namespace RDF {
+
+using namespace ROOT::TypeTraits;
+
+/**
+ * \brief The implementation of the DefaultValueFor transformation.
+ *
+ * The class takes in the default value provided by the user to fill-in missing
+ * values of the input column. During the Update step, the class checks for the
+ * presence of the value of the column at the current event. If that value is
+ * missing, it will return the default value to requesting nodes of the graph.
+ */
+template <typename T>
+class R__CLING_PTRCHECK(off) RDefaultValueFor final : public RDefineBase {
+   using ColumnTypes_t = ROOT::TypeTraits::TypeList<T>;
+   using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
+   // Avoid instantiating vector<bool> as `operator[]` returns temporaries in that case. Use std::deque instead.
+   using ValuesPerSlot_t = std::conditional_t<std::is_same<T, bool>::value, std::deque<T>, std::vector<T>>;
+
+   T fDefaultValue;
+   ValuesPerSlot_t fLastResults;
+   // One column reader per slot
+   std::vector<RColumnReaderBase *> fValues;
+
+   /// Define objects corresponding to systematic variations other than nominal for this defined column.
+   /// The map key is the full variation name, e.g. "pt:up".
+   std::unordered_map<std::string, std::unique_ptr<RDefineBase>> fVariedDefines;
+
+   T &GetValueOrDefault(unsigned int slot, Long64_t entry)
+   {
+      if (auto *value = fValues[slot]->template TryGet<T>(entry))
+         return *value;
+      else
+         return fDefaultValue;
+   };
+
+public:
+   RDefaultValueFor(std::string_view name, std::string_view type, const T &defaultValue,
+                    const ROOT::RDF::ColumnNames_t &columns, const RDFInternal::RColumnRegister &colRegister,
+                    RLoopManager &lm, const std::string &variationName = "nominal")
+      : RDefineBase(name, type, colRegister, lm, columns, variationName),
+        fDefaultValue(defaultValue),
+        fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<T>()),
+        fValues(lm.GetNSlots())
+   {
+      fLoopManager->Register(this);
+      // We suppress errors that TTreeReader prints regarding the missing branch
+      fLoopManager->GetSuppressErrorsForMissingBranches().push_back(fColumnNames[0]);
+   }
+
+   RDefaultValueFor(const RDefaultValueFor &) = delete;
+   RDefaultValueFor &operator=(const RDefaultValueFor &) = delete;
+   RDefaultValueFor(RDefaultValueFor &&) = delete;
+   RDefaultValueFor &operator=(RDefaultValueFor &&) = delete;
+   ~RDefaultValueFor()
+   {
+      fLoopManager->Deregister(this);
+      ROOT::Internal::RDF::Erase(fColumnNames[0], fLoopManager->GetSuppressErrorsForMissingBranches());
+   }
+
+   void InitSlot(TTreeReader *r, unsigned int slot) final
+   {
+      fValues[slot] = RDFInternal::GetColumnReader<T>(
+         slot, fColRegister.GetReader(slot, fColumnNames[0], fVariation, typeid(T)), *fLoopManager, r, fColumnNames[0]);
+      fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
+   }
+
+   /// Return the (type-erased) address of the Define'd value for the given processing slot.
+   void *GetValuePtr(unsigned int slot) final
+   {
+      return static_cast<void *>(&fLastResults[slot * RDFInternal::CacheLineStep<T>()]);
+   }
+
+   /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
+   void Update(unsigned int slot, Long64_t entry) final
+   {
+      if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
+         // evaluate this define expression, cache the result
+         fLastResults[slot * RDFInternal::CacheLineStep<T>()] = GetValueOrDefault(slot, entry);
+         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+      }
+   }
+
+   void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo & /*id*/) final {}
+
+   const std::type_info &GetTypeId() const final { return typeid(T); }
+
+   /// Clean-up operations to be performed at the end of a task.
+   void FinalizeSlot(unsigned int slot) final
+   {
+      fValues[slot] = nullptr;
+
+      for (auto &e : fVariedDefines)
+         e.second->FinalizeSlot(slot);
+   }
+
+   /// Create clones of this Define that work with values in varied "universes".
+   void MakeVariations(const std::vector<std::string> &variations) final
+   {
+      for (const auto &variation : variations) {
+         if (std::find(fVariationDeps.begin(), fVariationDeps.end(), variation) == fVariationDeps.end()) {
+            // this Defined quantity does not depend on this variation, so no need to create a varied RDefine
+            continue;
+         }
+         if (fVariedDefines.find(variation) != fVariedDefines.end())
+            continue; // we already have this variation stored
+
+         // the varied defines get a copy of the callable object.
+         // TODO document this
+         auto variedDefine = std::unique_ptr<RDefineBase>(
+            new RDefaultValueFor(fName, fType, fDefaultValue, fColumnNames, fColRegister, *fLoopManager, variation));
+         fVariedDefines.insert({variation, std::move(variedDefine)});
+      }
+   }
+
+   /// Return a clone of this Define that works with values in the variationName "universe".
+   RDefineBase &GetVariedDefine(const std::string &variationName) final
+   {
+      auto it = fVariedDefines.find(variationName);
+      if (it == fVariedDefines.end()) {
+         // We don't have a varied RDefine for this variation.
+         // This means we don't depend on it and we can return ourselves, i.e. the RDefine for the nominal universe.
+         assert(std::find(fVariationDeps.begin(), fVariationDeps.end(), variationName) == fVariationDeps.end());
+         return *this;
+      }
+
+      return *(it->second);
+   }
+};
+
+} // namespace RDF
+} // namespace Detail
+} // namespace ROOT
+
+#endif // ROOT_RDF_RDefaultValueFor

--- a/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
@@ -1,0 +1,248 @@
+// Author: Vincenzo Eduardo Padulano CERN 09/2024
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RFilterWithMissingValues
+#define ROOT_RDF_RFilterWithMissingValues
+
+#include "ROOT/RDF/ColumnReaderUtils.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
+#include "ROOT/RDF/RCutFlowReport.hxx"
+#include "ROOT/RDF/Utils.hxx"
+#include "ROOT/RDF/RFilterBase.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
+#include "ROOT/RDF/RTreeColumnReader.hxx"
+#include "ROOT/TypeTraits.hxx"
+#include "RtypesCore.h"
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility> // std::index_sequence
+#include <vector>
+
+// fwd decls for RFilterWithMissingValues
+namespace ROOT::Internal::RDF::GraphDrawing {
+std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr,
+                                            std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
+
+std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node,
+                                             const ROOT::Internal::RDF::RColumnRegister &colRegister,
+                                             const std::vector<std::string> &prevNodeDefines,
+                                             std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
+} // namespace ROOT::Internal::RDF::GraphDrawing
+
+namespace ROOT::Detail::RDF {
+
+namespace RDFGraphDrawing = ROOT::Internal::RDF::GraphDrawing;
+class RJittedFilter;
+
+/**
+ * \brief implementation of FilterAvailable and FilterMissing operations
+ *
+ * The filter evaluates if the entry is missing a value for the input column.
+ * Depending on which function was called by the user, the entry with the
+ * missing value:
+ * - will be discarded in case the user called FilterAvailable
+ * - will be kept in case the user called FilterMissing
+ */
+template <typename PrevNodeRaw>
+class R__CLING_PTRCHECK(off) RFilterWithMissingValues final : public RFilterBase {
+
+   // If the PrevNode is a RJittedFilter, treat it as a more generic RFilterBase: when dealing with systematic
+   // variations we'll have a RJittedFilter node for the nominal case but other "universes" will use concrete filters,
+   // so we normalize the "previous node type" to the base type RFilterBase.
+   using PrevNode_t = std::conditional_t<std::is_same<PrevNodeRaw, RJittedFilter>::value, RFilterBase, PrevNodeRaw>;
+   const std::shared_ptr<PrevNode_t> fPrevNodePtr;
+
+   // One column reader per slot
+   std::vector<RColumnReaderBase *> fValues;
+
+   // Whether the entry should be kept in case of missing value for the input column
+   bool fDiscardEntryWithMissingValue;
+
+public:
+   RFilterWithMissingValues(bool discardEntry, std::shared_ptr<PrevNode_t> pd,
+                            const RDFInternal::RColumnRegister &colRegister, const ColumnNames_t &columns,
+                            std::string_view filterName = "", const std::string &variationName = "nominal")
+      : RFilterBase(pd->GetLoopManagerUnchecked(), filterName, pd->GetLoopManagerUnchecked()->GetNSlots(), colRegister,
+                    columns, pd->GetVariations(), variationName),
+        fPrevNodePtr(std::move(pd)),
+        fValues(fPrevNodePtr->GetLoopManagerUnchecked()->GetNSlots()),
+        fDiscardEntryWithMissingValue(discardEntry)
+   {
+      fLoopManager->Register(this);
+      // We suppress errors that TTreeReader prints regarding the missing branch
+      fLoopManager->GetSuppressErrorsForMissingBranches().push_back(fColumnNames[0]);
+   }
+
+   RFilterWithMissingValues(const RFilterWithMissingValues &) = delete;
+   RFilterWithMissingValues &operator=(const RFilterWithMissingValues &) = delete;
+   RFilterWithMissingValues(RFilterWithMissingValues &&) = delete;
+   RFilterWithMissingValues &operator=(RFilterWithMissingValues &&) = delete;
+   ~RFilterWithMissingValues() final
+   {
+      // must Deregister objects from the RLoopManager here, before the fPrevNodePtr data member is destroyed:
+      // otherwise if fPrevNodePtr is the RLoopManager, it will be destroyed before the calls to Deregister happen.
+      fLoopManager->Deregister(this);
+      ROOT::Internal::RDF::Erase(fColumnNames[0], fLoopManager->GetSuppressErrorsForMissingBranches());
+   }
+
+   bool CheckFilters(unsigned int slot, Long64_t entry) final
+   {
+      constexpr static auto cacheLineStepLong64_t = RDFInternal::CacheLineStep<Long64_t>();
+      constexpr static auto cacheLineStepint = RDFInternal::CacheLineStep<int>();
+      constexpr static auto cacheLineStepULong64_t = RDFInternal::CacheLineStep<ULong64_t>();
+
+      if (entry != fLastCheckedEntry[slot * cacheLineStepLong64_t]) {
+         if (!fPrevNodePtr->CheckFilters(slot, entry)) {
+            // a filter upstream returned false, cache the result
+            fLastResult[slot * cacheLineStepint] = false;
+         } else {
+            // evaluate this filter, cache the result
+            const bool valueIsMissing = fValues[slot]->template TryGet<void>(entry) == nullptr;
+            if (fDiscardEntryWithMissingValue) {
+               valueIsMissing ? ++fRejected[slot * cacheLineStepULong64_t] : ++fAccepted[slot * cacheLineStepULong64_t];
+               fLastResult[slot * cacheLineStepint] = !valueIsMissing;
+            } else {
+               valueIsMissing ? ++fAccepted[slot * cacheLineStepULong64_t] : ++fRejected[slot * cacheLineStepULong64_t];
+               fLastResult[slot * cacheLineStepint] = valueIsMissing;
+            }
+         }
+         fLastCheckedEntry[slot * cacheLineStepLong64_t] = entry;
+      }
+      return fLastResult[slot * cacheLineStepint];
+   }
+
+   ROOT::Detail::RDF::RColumnReaderBase *GetOrCreateColumnReader(TTreeReader *r, unsigned int slot)
+   {
+      // Try to check if there is an available reader from the column register first
+      // We do not check that the type of the reader matches the type of the input column of this node,
+      // because this node does not keep track of that anyway
+      if (auto *defineOrVariationReader = fColRegister.GetReaderUnchecked(slot, fColumnNames[0], fVariation))
+         return defineOrVariationReader;
+
+      // Check if we already inserted a reader for this column in the dataset column readers (RDataSource or Tree/TChain
+      // readers)
+      if (auto *datasetColReader = fLoopManager->GetDatasetColumnReader(slot, fColumnNames[0], typeid(void)))
+         return datasetColReader;
+
+      // Create a column reader that does not need type information. It is used only to check if an entry of the
+      // column can be read validly.
+      return fLoopManager->AddTreeColumnReader(
+         slot, fColumnNames[0], std::make_unique<ROOT::Internal::RDF::RTreeOpaqueColumnReader>(*r, fColumnNames[0]),
+         typeid(void));
+   }
+
+   void InitSlot(TTreeReader *r, unsigned int slot) final
+   {
+      fValues[slot] = GetOrCreateColumnReader(r, slot);
+      fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
+   }
+
+   // recursive chain of `Report`s
+   void Report(ROOT::RDF::RCutFlowReport &rep) const final { PartialReport(rep); }
+
+   void PartialReport(ROOT::RDF::RCutFlowReport &rep) const final
+   {
+      fPrevNodePtr->PartialReport(rep);
+      FillReport(rep);
+   }
+
+   void StopProcessing() final
+   {
+      ++fNStopsReceived;
+      if (fNStopsReceived == fNChildren)
+         fPrevNodePtr->StopProcessing();
+   }
+
+   void IncrChildrenCount() final
+   {
+      ++fNChildren;
+      // propagate "children activation" upstream. named filters do the propagation via `TriggerChildrenCount`.
+      if (fNChildren == 1 && fName.empty())
+         fPrevNodePtr->IncrChildrenCount();
+   }
+
+   void TriggerChildrenCount() final
+   {
+      assert(!fName.empty()); // this method is to only be called on named filters
+      fPrevNodePtr->IncrChildrenCount();
+   }
+
+   void AddFilterName(std::vector<std::string> &filters) final
+   {
+      fPrevNodePtr->AddFilterName(filters);
+      auto name = (HasName() ? fName : fDiscardEntryWithMissingValue ? "FilterAvailable" : "FilterMissing");
+      filters.push_back(name);
+   }
+
+   /// Clean-up operations to be performed at the end of a task.
+   void FinalizeSlot(unsigned int slot) final { fValues[slot] = nullptr; }
+
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final
+   {
+      // Recursively call for the previous node.
+      auto prevNode = fPrevNodePtr->GetGraph(visitedMap);
+      const auto &prevColumns = prevNode->GetDefinedColumns();
+
+      auto thisNode = RDFGraphDrawing::CreateFilterNode(this, visitedMap);
+
+      /* If the returned node is not new, there is no need to perform any other operation.
+       * This is a likely scenario when building the entire graph in which branches share
+       * some nodes. */
+      if (!thisNode->IsNew()) {
+         return thisNode;
+      }
+
+      auto upmostNode = AddDefinesToGraph(thisNode, fColRegister, prevColumns, visitedMap);
+
+      // Keep track of the columns defined up to this point.
+      thisNode->AddDefinedColumns(fColRegister.GenerateColumnNames());
+
+      upmostNode->SetPrevNode(prevNode);
+      return thisNode;
+   }
+
+   /// Return a clone of this Filter that works with values in the variationName "universe".
+   std::shared_ptr<RNodeBase> GetVariedFilter(const std::string &variationName) final
+   {
+      // Only the nominal filter should be asked to produce varied filters
+      assert(fVariation == "nominal");
+      // nobody should ask for a varied filter for the nominal variation: they can just
+      // use the nominal filter!
+      assert(variationName != "nominal");
+      // nobody should ask for a varied filter for a variation on which this filter does not depend:
+      // they can just use the nominal filter.
+      assert(RDFInternal::IsStrInVec(variationName, fVariations));
+
+      auto it = fVariedFilters.find(variationName);
+      if (it != fVariedFilters.end())
+         return it->second;
+
+      auto prevNode = fPrevNodePtr;
+      if (static_cast<RNodeBase *>(fPrevNodePtr.get()) != static_cast<RNodeBase *>(fLoopManager) &&
+          RDFInternal::IsStrInVec(variationName, prevNode->GetVariations()))
+         prevNode = std::static_pointer_cast<PrevNode_t>(prevNode->GetVariedFilter(variationName));
+
+      // the varied filters get a copy of the callable object.
+      // TODO document this
+      auto variedFilter = std::unique_ptr<RFilterBase>(new RFilterWithMissingValues<PrevNode_t>(
+         fDiscardEntryWithMissingValue, std::move(prevNode), fColRegister, fColumnNames, fName, variationName));
+      auto e = fVariedFilters.insert({variationName, std::move(variedFilter)});
+      return e.first->second;
+   }
+};
+
+} // namespace ROOT::Detail::RDF
+
+#endif // ROOT_RDF_RFilterWithMissingValues

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -16,6 +16,7 @@
 #include "ROOT/RDF/HistoModels.hxx"
 #include "ROOT/RDF/InterfaceUtils.hxx"
 #include "ROOT/RDF/RColumnRegister.hxx"
+#include "ROOT/RDF/RDefaultValueFor.hxx"
 #include "ROOT/RDF/RDefine.hxx"
 #include "ROOT/RDF/RDefinePerSample.hxx"
 #include "ROOT/RDF/RFilter.hxx"
@@ -24,6 +25,7 @@
 #include "ROOT/RDF/RLazyDSImpl.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRange.hxx"
+#include "ROOT/RDF/RFilterWithMissingValues.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RDF/RDFDescription.hxx"
 #include "ROOT/RDF/RVariationsDescription.hxx"
@@ -296,6 +298,106 @@ public:
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), *fLoopManager, fColRegister);
    }
 
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Discard entries with missing values
+   /// \param[in] column Column name whose entries with missing values should be discarded
+   /// \return The filter node of the computation graph
+   ///
+   /// This operation is useful in case an entry of the dataset is incomplete,
+   /// i.e. if one or more of the columns do not have valid values. If the value
+   /// of the input column is missing for an entry, the entire entry will be
+   /// discarded from the rest of this branch of the computation graph.
+   ///
+   /// Use cases include:
+   /// * When processing multiple files, one or more of them is missing a column
+   /// * In horizontal joining with entry matching, a certain dataset has no
+   ///   match for the current entry.
+   ///
+   /// ### Example usage:
+   ///
+   /// \code{.py}
+   /// # Assume a dataset with columns [idx, x] matching another dataset with
+   /// # columns [idx, y]. For idx == 42, the right-hand dataset has no match
+   /// df = ROOT.RDataFrame(dataset)
+   /// df_nomissing = df.FilterAvailable("idx").Define("z", "x + y")
+   /// colz = df_nomissing.Take[int]("z")
+   /// \endcode
+   ///
+   /// \code{.cpp}
+   /// // Assume a dataset with columns [idx, x] matching another dataset with
+   /// // columns [idx, y]. For idx == 42, the right-hand dataset has no match
+   /// ROOT::RDataFrame df{dataset};
+   /// auto df_nomissing = df.FilterAvailable("idx")
+   ///                       .Define("z", [](int x, int y) { return x + y; }, {"x", "y"});
+   /// auto colz = df_nomissing.Take<int>("z");
+   /// \endcode
+   ///
+   /// \note See FilterMissing() if you want to keep only the entries with
+   ///       missing values instead.
+   RInterface<RDFDetail::RFilterWithMissingValues<Proxied>, DS_t> FilterAvailable(std::string_view column)
+   {
+      const auto columns = ColumnNames_t{column.data()};
+      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
+      // For now disable this functionality in case of an empty data source and
+      // the column name was not defined previously.
+      if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
+         GetValidatedColumnNames(1, columns);
+      using F_t = RDFDetail::RFilterWithMissingValues<Proxied>;
+      auto filterPtr = std::make_shared<F_t>(/*discardEntry*/ true, fProxiedPtr, fColRegister, columns);
+      return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, fColRegister);
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Keep only the entries that have missing values.
+   /// \param[in] column Column name whose entries with missing values should be kept
+   /// \return The filter node of the computation graph
+   ///
+   /// This operation is useful in case an entry of the dataset is incomplete,
+   /// i.e. if one or more of the columns do not have valid values. It only
+   /// keeps the entries for which the value of the input column is missing.
+   ///
+   /// Use cases include:
+   /// * When processing multiple files, one or more of them is missing a column
+   /// * In horizontal joining with entry matching, a certain dataset has no
+   ///   match for the current entry.
+   ///
+   /// ### Example usage:
+   ///
+   /// \code{.py}
+   /// # Assume a dataset made of two files vertically chained together, one has
+   /// # column "x" and the other has column "y"
+   /// df = ROOT.RDataFrame(dataset)
+   /// df_valid_col_x = df.FilterMissing("y")
+   /// df_valid_col_y = df.FilterMissing("x")
+   /// display_x = df_valid_col_x.Display(("x",))
+   /// display_y = df_valid_col_y.Display(("y",))
+   /// \endcode
+   ///
+   /// \code{.cpp}
+   /// // Assume a dataset made of two files vertically chained together, one has
+   /// // column "x" and the other has column "y"
+   /// ROOT.RDataFrame df{dataset};
+   /// auto df_valid_col_x = df.FilterMissing("y");
+   /// auto df_valid_col_y = df.FilterMissing("x");
+   /// auto display_x = df_valid_col_x.Display<int>({"x"});
+   /// auto display_y = df_valid_col_y.Display<int>({"y"});
+   /// \endcode
+   ///
+   /// \note See FilterAvailable() if you want to discard the entries in case
+   ///       there is a missing value instead.
+   RInterface<RDFDetail::RFilterWithMissingValues<Proxied>, DS_t> FilterMissing(std::string_view column)
+   {
+      const auto columns = ColumnNames_t{column.data()};
+      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
+      // For now disable this functionality in case of an empty data source and
+      // the column name was not defined previously.
+      if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
+         GetValidatedColumnNames(1, columns);
+      using F_t = RDFDetail::RFilterWithMissingValues<Proxied>;
+      auto filterPtr = std::make_shared<F_t>(/*discardEntry*/ false, fProxiedPtr, fColRegister, columns);
+      return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, fColRegister);
+   }
+
    // clang-format off
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Define a new column.
@@ -529,6 +631,72 @@ public:
       newCols.AddDefine(std::move(jittedDefine));
 
       RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols));
+
+      return newInterface;
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief In case the value in the given column is missing, provide a default value
+   /// \tparam T The type of the column
+   /// \param[in] column Column name where missing values should be replaced by the given default value
+   /// \param[in] defaultValue Value to provide instead of a missing value
+   /// \return The node of the graph that will provide a default value
+   ///
+   /// This operation is useful in case an entry of the dataset is incomplete,
+   /// i.e. if one or more of the columns do not have valid values. It does not
+   /// modify the values of the column, but in case any entry is missing, it
+   /// will provide the default value to downstream nodes instead.
+   ///
+   /// Use cases include:
+   /// * When processing multiple files, one or more of them is missing a column
+   /// * In horizontal joining with entry matching, a certain dataset has no
+   ///   match for the current entry.
+   ///
+   /// ### Example usage:
+   ///
+   /// \code{.cpp}
+   /// // Assume a dataset with columns [idx, x] matching another dataset with
+   /// // columns [idx, y]. For idx == 42, the right-hand dataset has no match
+   /// ROOT::RDataFrame df{dataset};
+   /// auto df_default = df.DefaultValueFor("y", 33)
+   ///                     .Define("z", [](int x, int y) { return x + y; }, {"x", "y"});
+   /// auto colz = df_default.Take<int>("z");
+   /// \endcode
+   ///
+   /// \code{.py}
+   /// df = ROOT.RDataFrame(dataset)
+   /// df_default = df.DefaultValueFor("y", 33).Define("z", "x + y")
+   /// colz = df_default.Take[int]("z")
+   /// \endcode
+   template <typename T>
+   RInterface<Proxied, DS_t> DefaultValueFor(std::string_view column, const T &defaultValue)
+   {
+      constexpr auto where{"DefaultValueFor"};
+      RDFInternal::CheckForNoVariations(where, column, fColRegister);
+      // For now disable this functionality in case of an empty data source and
+      // the column name was not defined previously.
+      if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
+         RDFInternal::CheckForDefinition(where, column, fColRegister, fLoopManager->GetBranchNames(),
+                                         fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+      const auto validColumnNames = ColumnNames_t{column.data()};
+      CheckAndFillDSColumns(validColumnNames, TTraits::TypeList<T>{});
+
+      // Declare return type to the interpreter, for future use by jitted actions
+      auto retTypeName = RDFInternal::TypeID2TypeName(typeid(T));
+      if (retTypeName.empty()) {
+         // The type is not known to the interpreter.
+         // We must not error out here, but if/when this column is used in jitted code
+         const auto demangledType = RDFInternal::DemangleTypeIdName(typeid(T));
+         retTypeName = "CLING_UNKNOWN_TYPE_" + demangledType;
+      }
+
+      auto newColumn = std::make_shared<ROOT::Internal::RDF::RDefaultValueFor<T>>(
+         column, retTypeName, defaultValue, validColumnNames, fColRegister, *fLoopManager);
+
+      RDFInternal::RColumnRegister newCols(fColRegister);
+      newCols.AddDefine(std::move(newColumn));
+
+      RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols));
 
       return newInterface;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -182,6 +182,10 @@ class RLoopManager : public RNodeBase {
    void UpdateSampleInfo(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
    void UpdateSampleInfo(unsigned int slot, TTreeReader &r);
 
+   // List of branches for which we want to suppress the printed error about
+   // missing branch when switching to a new tree. This is modified by readers,
+   // so must be declared before them in this class.
+   std::vector<std::string> fSuppressErrorsForMissingBranches{};
    ROOT::Internal::RDF::RStringCache fCachedColNames;
    std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RDefinesWithReaders>>>
       fUniqueDefinesWithReaders;
@@ -272,6 +276,12 @@ public:
    GetUniqueVariationsWithReaders()
    {
       return fUniqueVariationsWithReaders;
+   }
+
+   std::vector<std::string> &GetSuppressErrorsForMissingBranches() { return fSuppressErrorsForMissingBranches; }
+   const std::vector<std::string> &GetSuppressErrorsForMissingBranches() const
+   {
+      return fSuppressErrorsForMissingBranches;
    }
 };
 

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -16,8 +16,11 @@ using namespace ROOT::Internal::RDF;
 
 RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RColumnRegister &colRegister,
                          const std::vector<std::string> &prevVariations)
-   : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames),
-     fVariations(Union(prevVariations, colRegister.GetVariationDeps(fColumnNames))), fColRegister(colRegister)
+   : fLoopManager(lm),
+     fColumnNames(colNames),
+     fNSlots(lm->GetNSlots()),
+     fVariations(Union(prevVariations, colRegister.GetVariationDeps(fColumnNames))),
+     fColRegister(colRegister)
 {
 }
 

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -281,6 +281,28 @@ RDFDetail::RColumnReaderBase *RColumnRegister::GetReader(unsigned int slot, cons
    return nullptr;
 }
 
+/// Return a RDefineReader or a RVariationReader, or nullptr if not available.
+/// No type checking is done on the requested reader.
+RDFDetail::RColumnReaderBase *
+RColumnRegister::GetReaderUnchecked(unsigned int slot, const std::string &colName, const std::string &variationName)
+{
+   // try variations first
+   if (variationName != "nominal") {
+      if (auto *variationAndReaders = FindVariationAndReaders(colName, variationName)) {
+         return &variationAndReaders->GetReader(slot, colName, variationName);
+      }
+   }
+
+   // otherwise try defines
+   if (auto it =
+          std::find_if(fDefines->begin(), fDefines->end(), [&colName](const auto &kv) { return kv.first == colName; });
+       it != fDefines->end()) {
+      return &it->second->GetReader(slot, variationName);
+   }
+
+   return nullptr;
+}
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -84,6 +84,7 @@ You can directly see RDataFrame in action in our [tutorials](https://root.cern/d
    - [Activating RDataFrame execution logs](\ref rdf-logging)
    - [Creating an RDataFrame from a dataset specification file](\ref rdf-from-spec)
    - [Adding a progress bar](\ref progressbar)
+   - [Working with missing values in the dataset](\ref missing-values)
 - [Efficient analysis in Python](\ref python)
 - <a class="el" href="classROOT_1_1RDataFrame.html#reference" onclick="javascript:toggleInherit('pub_methods_classROOT_1_1RDF_1_1RInterface')">Class reference</a>
 
@@ -97,11 +98,14 @@ Transformations are a way to manipulate the data.
 | **Transformation** | **Description** |
 |------------------|--------------------|
 | Alias() | Introduce an alias for a particular column name. |
+| DefaultValueFor() | If the value of the input column is missing, provide a default value instead. |
 | Define() | Create a new column in the dataset. Example usages include adding a column that contains the invariant mass of a particle, or a selection of elements of an array (e.g. only the `pt`s of "good" muons). |
 | DefinePerSample() | Define a new column that is updated when the input sample changes, e.g. when switching tree being processed in a chain. |
 | DefineSlot() | Same as Define(), but the user-defined function must take an extra `unsigned int slot` as its first parameter. `slot` will take a different value, `0` to `nThreads - 1`, for each thread of execution. This is meant as a helper in writing thread-safe Define() transformation when using RDataFrame after ROOT::EnableImplicitMT(). DefineSlot() works just as well with single-thread execution: in that case `slot` will always be `0`.  |
 | DefineSlotEntry() | Same as DefineSlot(), but the entry number is passed in addition to the slot number. This is meant as a helper in case the expression depends on the entry number. For details about entry numbers in multi-threaded runs, see [here](\ref helper-cols). |
 | Filter() | Filter rows based on user-defined conditions. |
+| FilterAvailable() | Specialized Filter. If the value of the input column is available, keep the entry, otherwise discard it. |
+| FilterMissing() | Specialized Filter. If the value of the input column is missing, keep the entry, otherwise discard it. |
 | Range() | Filter rows based on entry number (single-thread only). |
 | Redefine() | Overwrite the value and/or type of an existing column. See Define() for more information. |
 | RedefineSlot() | Overwrite the value and/or type of an existing column. See DefineSlot() for more information. |
@@ -1572,6 +1576,143 @@ auto df_1 = ROOT::RDF::RNode(df.Filter("x>1"));
 ROOT::RDF::Experimental::AddProgressBar(df_1);
 ~~~
 Examples of implemented progress bars can be seen by running [Higgs to Four Lepton tutorial](https://root.cern/doc/master/df106__HiggsToFourLeptons_8py_source.html) and [Dimuon tutorial](https://root.cern/doc/master/df102__NanoAODDimuonAnalysis_8C.html). 
+
+\anchor missing-values
+### Working with missing values in the dataset
+
+In certain situations a dataset might be missing one or more values at one or
+more of its entries. For example:
+
+- If the dataset is composed of multiple files and one or more files is
+  missing one or more columns required by the analysis.
+- When joining different datasets horizontally according to some index value
+  (e.g. the event number), if the index does not find a match in one or more
+  other datasets for a certain entry.
+
+For example, suppose that column "y" does not have a value for entry 42:
+
+\code{.unparsed}
++-------+---+---+
+| Entry | x | y |
++-------+---+---+
+| 42    | 1 |   |
++-------+---+---+
+\endcode
+
+If the RDataFrame application reads that column, for example if a Take() action
+was requested, the default behaviour is to throw an exception indicating
+that that column is missing an entry.
+
+The following paragraphs discuss the functionalities provided by RDataFrame to
+work with missing values in the dataset.
+
+#### FilterAvailable and FilterMissing
+
+FilterAvailable and FilterMissing are specialized RDataFrame Filter operations.
+They take as input argument the name of a column of the dataset to watch for
+missing values. Like Filter, they will either keep or discard an entire entry
+based on whether a condition returns true or false. Specifically:
+
+- FilterAvailable: the condition is whether the value of the column is present.
+  If so, the entry is kept. Otherwise if the value is missing the entry is
+  discarded.
+- FilterMissing: the condition is whether the value of the column is missing. If
+  so, the entry is kept. Otherwise if the value is present the entry is
+  discarded.
+
+\code{.py}
+df = ROOT.RDataFrame(dataset)
+
+# Anytime an entry from "col" is missing, the entire entry will be filtered out
+df_available = df.FilterAvailable("col")
+df_available = df_available.Define("twice", "col * 2")
+
+# Conversely, if we want to select the entries for which the column has missing
+# values, we do the following
+df_missingcol = df.FilterMissing("col")
+# Following operations in the same branch of the computation graph clearly
+# cannot access that same column, since there would be no value to read
+df_missingcol = df_missingcol.Define("observable", "othercolumn * 2")
+\endcode
+
+\code{.cpp}
+ROOT::RDataFrame df{dataset};
+
+// Anytime an entry from "col" is missing, the entire entry will be filtered out
+auto df_available = df.FilterAvailable("col");
+auto df_twicecol = df_available.Define("twice", "col * 2");
+
+// Conversely, if we want to select the entries for which the column has missing
+// values, we do the following
+auto df_missingcol = df.FilterMissing("col");
+// Following operations in the same branch of the computation graph clearly
+// cannot access that same column, since there would be no value to read
+auto df_observable = df_missingcol.Define("observable", "othercolumn * 2");
+\endcode
+
+#### DefaultValueFor
+
+DefaultValueFor creates a node of the computation graph which just forwards the
+values of the columns necessary for other downstream nodes, when they are
+available. In case a value of the input column passed to this function is not
+available, the node will provide the default value passed to this function call
+instead. Example:
+
+\code{.py}
+df = ROOT.RDataFrame(dataset)
+# Anytime an entry from "col" is missing, the value will be the default one
+default_value = ... # Some sensible default value here
+df = df.DefaultValueFor("col", default_value) 
+df = df.Define("twice", "col * 2")
+\endcode
+
+\code{.cpp}
+ROOT::RDataFrame df{dataset};
+// Anytime an entry from "col" is missing, the value will be the default one
+constexpr auto default_value = ... // Some sensible default value here
+auto df_default = df.DefaultValueFor("col", default_value);
+auto df_col = df_default.Define("twice", "col * 2");
+\endcode
+
+#### Mixing different strategies to work with missing values in the same RDataFrame
+
+All the operations presented above only act on the particular branch of the
+computation graph where they are called, so that different results can be
+obtained by mixing and matching the filtering or providing a default value
+strategies:
+
+\code{.py}
+df = ROOT.RDataFrame(dataset)
+# Anytime an entry from "col" is missing, the value will be the default one
+default_value = ... # Some sensible default value here
+df_default = df.DefaultValueFor("col", default_value).Define("twice", "col * 2")
+df_filtered = df.FilterAvailable("col").Define("twice", "col * 2")
+
+# Same number of total entries as the input dataset, with defaulted values
+df_default.Display(["twice"]).Print()
+# Only keep the entries where "col" has values
+df_filtered.Display(["twice"]).Print()
+\endcode
+
+\code{.cpp}
+ROOT::RDataFrame df{dataset};
+
+// Anytime an entry from "col" is missing, the value will be the default one
+constexpr auto default_value = ... // Some sensible default value here
+auto df_default = df.DefaultValueFor("col", default_value).Define("twice", "col * 2");
+auto df_filtered = df.FilterAvailable("col").Define("twice", "col * 2");
+
+// Same number of total entries as the input dataset, with defaulted values
+df_default.Display({"twice"})->Print();
+// Only keep the entries where "col" has values
+df_filtered.Display({"twice"})->Print();
+\endcode
+
+#### Further considerations
+
+Note that working with missing values is currently supported with a TTree-based
+data source. Support of this functionality for other data sources may come in
+the future.
 
 */
 // clang-format on

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -350,10 +350,13 @@ ColumnNames_t ROOT::Internal::RDF::GetBranchNames(TTree &t, bool allowDuplicates
 }
 
 RLoopManager::RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches)
-   : fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
+   : fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})),
+     fDefaultColumns(defaultBranches),
      fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles),
-     fNewSampleNotifier(fNSlots), fSampleInfos(fNSlots), fDatasetColumnReaders(fNSlots)
+     fNewSampleNotifier(fNSlots),
+     fSampleInfos(fNSlots),
+     fDatasetColumnReaders(fNSlots)
 {
 }
 
@@ -379,9 +382,13 @@ RLoopManager::RLoopManager(ULong64_t nEmptyEntries)
 }
 
 RLoopManager::RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches)
-   : fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
+   : fDefaultColumns(defaultBranches),
+     fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kDataSourceMT : ELoopType::kDataSource),
-     fDataSource(std::move(ds)), fNewSampleNotifier(fNSlots), fSampleInfos(fNSlots), fDatasetColumnReaders(fNSlots)
+     fDataSource(std::move(ds)),
+     fNewSampleNotifier(fNSlots),
+     fSampleInfos(fNSlots),
+     fDatasetColumnReaders(fNSlots)
 {
    fDataSource->SetNSlots(fNSlots);
 }
@@ -513,6 +520,31 @@ void RLoopManager::RunEmptySource()
    }
 }
 
+namespace {
+/// Return true on succesful entry read.
+///
+/// TTreeReader encodes successful reads in the `kEntryValid` enum value, but
+/// there can be other situations where the read is still valid. For now, these
+/// are:
+/// - If there was no match of the current entry in one or more friend trees
+///   according to their respective indexes.
+/// - If there was a missing branch at the start of a new tree in the dataset.
+///
+/// In such situations, although the entry is not complete, the processing
+/// should not be aborted and nodes of the computation graph will take action
+/// accordingly.
+bool validTTreeReaderRead(TTreeReader &treeReader)
+{
+   treeReader.Next();
+   switch (treeReader.GetEntryStatus()) {
+   case TTreeReader::kEntryValid: return true;
+   case TTreeReader::kIndexedFriendNoMatch: return true;
+   case TTreeReader::kMissingBranchWhenSwitchingTree: return true;
+   default: return false;
+   }
+}
+} // namespace
+
 /// Run event loop over one or multiple ROOT files, in parallel.
 void RLoopManager::RunTreeProcessorMT()
 {
@@ -521,9 +553,11 @@ void RLoopManager::RunTreeProcessorMT()
       return;
    ROOT::Internal::RSlotStack slotStack(fNSlots);
    const auto &entryList = fTree->GetEntryList() ? *fTree->GetEntryList() : TEntryList();
-   auto tp = (fBeginEntry != 0 || fEndEntry != std::numeric_limits<Long64_t>::max())
-                ? std::make_unique<ROOT::TTreeProcessorMT>(*fTree, fNSlots, std::make_pair(fBeginEntry, fEndEntry))
-                : std::make_unique<ROOT::TTreeProcessorMT>(*fTree, entryList, fNSlots);
+   auto tp =
+      (fBeginEntry != 0 || fEndEntry != std::numeric_limits<Long64_t>::max())
+         ? std::make_unique<ROOT::TTreeProcessorMT>(*fTree, fNSlots, std::make_pair(fBeginEntry, fEndEntry),
+                                                    fSuppressErrorsForMissingBranches)
+         : std::make_unique<ROOT::TTreeProcessorMT>(*fTree, entryList, fNSlots, fSuppressErrorsForMissingBranches);
 
    std::atomic<ULong64_t> entryCount(0ull);
 
@@ -538,7 +572,7 @@ void RLoopManager::RunTreeProcessorMT()
       auto count = entryCount.fetch_add(nEntries);
       try {
          // recursive call to check filters and conditionally execute actions
-         while (r.Next()) {
+         while (validTTreeReaderRead(r)) {
             if (fNewSampleNotifier.CheckFlag(slot)) {
                UpdateSampleInfo(slot, r);
             }
@@ -562,7 +596,8 @@ void RLoopManager::RunTreeProcessorMT()
 /// Run event loop over one or multiple ROOT files, in sequence.
 void RLoopManager::RunTreeReader()
 {
-   TTreeReader r(fTree.get(), fTree->GetEntryList());
+   TTreeReader r(fTree.get(), fTree->GetEntryList(), /*warnAboutLongerFriends*/ true,
+                 fSuppressErrorsForMissingBranches);
    if (0 == fTree->GetEntriesFast() || fBeginEntry == fEndEntry)
       return;
    // Apply the range if there is any
@@ -579,7 +614,7 @@ void RLoopManager::RunTreeReader()
    // recursive call to check filters and conditionally execute actions
    // in the non-MT case processing can be stopped early by ranges, hence the check on fNStopsReceived
    try {
-      while (r.Next() && fNStopsReceived < fNChildren) {
+      while (validTTreeReaderRead(r) && fNStopsReceived < fNChildren) {
          if (fNewSampleNotifier.CheckFlag(0)) {
             UpdateSampleInfo(/*slot*/0, r);
          }

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -18,6 +18,8 @@ ROOT_ADD_GTEST(dataframe_nodes dataframe_nodes.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics ROOTDataFrame GenVector)
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_report dataframe_report.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_incomplete_entries dataframe_incomplete_entries.cxx LIBRARIES ROOTDataFrame)
+
 
 if(MSVC)
   set_property(TARGET dataframe_cache APPEND_STRING PROPERTY LINK_FLAGS " -STACK:10000000")

--- a/tree/dataframe/test/dataframe_incomplete_entries.cxx
+++ b/tree/dataframe/test/dataframe_incomplete_entries.cxx
@@ -1,0 +1,1108 @@
+#include <TChain.h>
+#include <TFile.h>
+#include <TROOT.h>
+#include <TTree.h>
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RDFHelpers.hxx>
+#include <ROOT/RVec.hxx>
+#include <ROOT/TestSupport.hxx>
+
+#include <gtest/gtest.h>
+
+#include <numeric> // std::numeric_limits
+#include <thread>  // std::thread::hardware_concurrency
+
+template <typename T0, typename T1>
+void expect_vec_eq(const T0 &v1, const T1 &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size()) << "Vectors 'v1' and 'v2' are of unequal length";
+   for (std::size_t i = 0ull; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]) << "Vectors 'v1' and 'v2' differ at index " << i;
+   }
+}
+
+TEST(RDefaultValueFor, EmptyDataSourceAndNonExistingColumnName)
+{
+   // We disable the functionality in case of empty data source and no previously
+   // defined column
+   ROOT::RDataFrame df{1};
+   EXPECT_THROW(
+      try { df.DefaultValueFor("rndm", 1); } catch (const std::runtime_error &err) {
+         const auto msg = "RDataFrame::DefaultValueFor: cannot provide default values for column \"rndm\". No column "
+                          "with that name was found in the dataset. Use Define to create a new column.";
+         EXPECT_STREQ(err.what(), msg);
+         throw;
+      },
+      std::runtime_error);
+}
+
+TEST(RDefaultValueFor, VaryDefaultValueFor)
+{
+   // Vary a column then try to provide a default value --> not legal since
+   // the first Vary operation implies the column always has a value.
+   ROOT::RDataFrame df{1};
+   EXPECT_THROW(
+      try {
+         auto df1 = df.Define("x", [] { return 42; }).Vary("x", [] { return ROOT::RVecI{32, 52}; }, {}, {"up", "down"});
+         df1.DefaultValueFor("x", 100);
+      } catch (const std::runtime_error &err) {
+         constexpr auto msg{
+            "RDataFrame::DefaultValueFor: cannot provide a default value for column \"x\". The column depends on one "
+            "or more systematic variations and it should not be possible to have missing values in varied columns."};
+         EXPECT_STREQ(err.what(), msg);
+         throw;
+      },
+      std::runtime_error);
+}
+
+TEST(FilterWithMissingValues, EmptyDataSourceAndNonExistingColumnName)
+{
+   // We disable the functionality in case of empty data source and no previously
+   // defined column
+   ROOT::RDataFrame df{1};
+   EXPECT_THROW(
+      try { df.FilterAvailable("rndm"); } catch (const std::runtime_error &err) {
+         const auto msg = "Unknown column: \"rndm\"";
+         EXPECT_STREQ(err.what(), msg);
+         throw;
+      },
+      std::runtime_error);
+
+   EXPECT_THROW(
+      try { df.FilterMissing("rndm"); } catch (const std::runtime_error &err) {
+         const auto msg = "Unknown column: \"rndm\"";
+         EXPECT_STREQ(err.what(), msg);
+         throw;
+      },
+      std::runtime_error);
+}
+
+struct RDFMissingBranches : public ::testing::TestWithParam<bool> {
+   constexpr static std::array<const char *, 3> fFileNames{"dataframe_incomplete_entries_missing_branches_1.root",
+                                                           "dataframe_incomplete_entries_missing_branches_2.root",
+                                                           "dataframe_incomplete_entries_missing_branches_3.root"};
+   constexpr static std::array<const char *, 3> fTreeNames{"tree_1", "tree_2", "tree_3"};
+   constexpr static auto fTreeEntries{5};
+   const unsigned int fNSlots;
+
+   RDFMissingBranches() : fNSlots(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
+   {
+      if (GetParam())
+         ROOT::EnableImplicitMT(fNSlots);
+   }
+
+   ~RDFMissingBranches() override
+   {
+      if (GetParam())
+         ROOT::DisableImplicitMT();
+   }
+
+   static void SetUpTestSuite()
+   {
+      {
+         TFile f(fFileNames[0], "RECREATE");
+         TTree t(fTreeNames[0], fTreeNames[0]);
+         int x{};
+         int y{};
+         t.Branch("x", &x, "x/I");
+         t.Branch("y", &y, "y/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            x = i;
+            y = 2 * i;
+            t.Fill();
+            t.FlushBaskets();
+         }
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[1], "RECREATE");
+         TTree t(fTreeNames[1], fTreeNames[1]);
+         int y{};
+         t.Branch("y", &y, "y/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            y = 3 * i;
+            t.Fill();
+            t.FlushBaskets();
+         }
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[2], "RECREATE");
+         TTree t(fTreeNames[2], fTreeNames[2]);
+         int x{};
+         t.Branch("x", &x, "x/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            x = 4 * i;
+            t.Fill();
+            t.FlushBaskets();
+         }
+         t.Write();
+      }
+   }
+
+   static void TearDownTestSuite()
+   {
+      for (auto &&fileName : fFileNames)
+         std::remove(fileName);
+   }
+};
+
+TEST_P(RDFMissingBranches, TwoMissingBranches)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+   std::string fullpath_3 = std::string(fFileNames[2]) + "?#" + fTreeNames[2];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+   c.Add(fullpath_3.c_str());
+
+   ROOT::RDataFrame df{c};
+
+   std::vector<int> expected_withdefault_x{1, 2, 3, 4, 5, 42, 42, 42, 42, 42, 4, 8, 12, 16, 20};
+   auto take_withdefault_x = df.DefaultValueFor("x", 42).Take<int>("x");
+
+   std::vector<int> expected_skip_x{1, 2, 3, 4, 5, 4, 8, 12, 16, 20};
+   auto take_skip_x = df.FilterAvailable("x").Take<int>("x");
+
+   std::vector<int> expected_withdefault_y{2, 4, 6, 8, 10, 3, 6, 9, 12, 15, 99, 99, 99, 99, 99};
+   auto take_withdefault_y = df.DefaultValueFor("y", 99).Take<int>("y");
+
+   std::vector<int> expected_skip_y{2, 4, 6, 8, 10, 3, 6, 9, 12, 15};
+   auto take_skip_y = df.FilterAvailable("y").Take<int>("y");
+
+   std::vector<int> expected_missing_y{4, 8, 12, 16, 20};
+   auto take_keep_missing_y = df.FilterMissing("y").Take<int>("x");
+
+   if (GetParam()) {
+      // MT processing scrumbles result order
+      auto take_withdefault_x_val = *take_withdefault_x;
+      auto take_skip_x_val = *take_skip_x;
+      auto take_withdefault_y_val = *take_withdefault_y;
+      auto take_skip_y_val = *take_skip_y;
+      auto take_keep_missing_y_val = *take_keep_missing_y;
+
+      // Sort expected vectors
+      std::sort(expected_withdefault_x.begin(), expected_withdefault_x.end());
+      std::sort(expected_skip_x.begin(), expected_skip_x.end());
+      std::sort(expected_withdefault_y.begin(), expected_withdefault_y.end());
+      std::sort(expected_skip_y.begin(), expected_skip_y.end());
+      std::sort(expected_missing_y.begin(), expected_missing_y.end());
+
+      // Sort result vectors
+      std::sort(take_withdefault_x_val.begin(), take_withdefault_x_val.end());
+      std::sort(take_skip_x_val.begin(), take_skip_x_val.end());
+      std::sort(take_withdefault_y_val.begin(), take_withdefault_y_val.end());
+      std::sort(take_skip_y_val.begin(), take_skip_y_val.end());
+      std::sort(take_keep_missing_y_val.begin(), take_keep_missing_y_val.end());
+
+      expect_vec_eq(expected_withdefault_x, take_withdefault_x_val);
+      expect_vec_eq(expected_skip_x, take_skip_x_val);
+      expect_vec_eq(expected_withdefault_y, take_withdefault_y_val);
+      expect_vec_eq(expected_skip_y, take_skip_y_val);
+      expect_vec_eq(expected_missing_y, take_keep_missing_y_val);
+   } else {
+      expect_vec_eq(expected_withdefault_x, *take_withdefault_x);
+      expect_vec_eq(expected_skip_x, *take_skip_x);
+      expect_vec_eq(expected_withdefault_y, *take_withdefault_y);
+      expect_vec_eq(expected_skip_y, *take_skip_y);
+      expect_vec_eq(expected_missing_y, *take_keep_missing_y);
+   }
+}
+
+TEST_P(RDFMissingBranches, MissingBranchFirstTree)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+   std::string fullpath_3 = std::string(fFileNames[2]) + "?#" + fTreeNames[2];
+
+   c.Add(fullpath_2.c_str());
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_3.c_str());
+
+   ROOT::RDataFrame df{c};
+
+   std::vector<int> expected_withdefault{42, 42, 42, 42, 42, 1, 2, 3, 4, 5, 4, 8, 12, 16, 20};
+   auto take_withdefault = df.DefaultValueFor("x", 42).Take<int>("x");
+
+   std::vector<int> expected_skip{1, 2, 3, 4, 5, 4, 8, 12, 16, 20};
+   auto take_skip = df.FilterAvailable("x").Take<int>("x");
+
+   if (GetParam()) {
+      auto take_withdefault_val = *take_withdefault;
+      auto take_skip_val = *take_skip;
+      // Sort expected vectors
+      std::sort(expected_withdefault.begin(), expected_withdefault.end());
+      std::sort(expected_skip.begin(), expected_skip.end());
+      // Sort result vectors
+      std::sort(take_withdefault_val.begin(), take_withdefault_val.end());
+      std::sort(take_skip_val.begin(), take_skip_val.end());
+      expect_vec_eq(expected_withdefault, take_withdefault_val);
+      expect_vec_eq(expected_skip, take_skip_val);
+   } else {
+      expect_vec_eq(expected_withdefault, *take_withdefault);
+      expect_vec_eq(expected_skip, *take_skip);
+   }
+}
+
+TEST_P(RDFMissingBranches, MissingBranchAllTrees)
+{
+   TChain c{};
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+
+   c.Add(fullpath_2.c_str());
+   c.Add(fullpath_2.c_str());
+
+   ROOT::RDataFrame df{c};
+
+   std::vector<int> expected_withdefault{42, 42, 42, 42, 42, 42, 42, 42, 42, 42};
+   auto take_withdefault = df.DefaultValueFor("x", 42).Take<int>("x");
+
+   std::vector<int> expected_skip{};
+   auto take_skip = df.FilterAvailable("x").Take<int>("x");
+
+   if (GetParam()) {
+      auto take_withdefault_val = *take_withdefault;
+      auto take_skip_val = *take_skip;
+      // Sort expected vectors
+      std::sort(expected_withdefault.begin(), expected_withdefault.end());
+      std::sort(expected_skip.begin(), expected_skip.end());
+      // Sort result vectors
+      std::sort(take_withdefault_val.begin(), take_withdefault_val.end());
+      std::sort(take_skip_val.begin(), take_skip_val.end());
+      expect_vec_eq(expected_withdefault, take_withdefault_val);
+      expect_vec_eq(expected_skip, take_skip_val);
+   } else {
+      expect_vec_eq(expected_withdefault, *take_withdefault);
+      expect_vec_eq(expected_skip, *take_skip);
+   }
+}
+
+TEST_P(RDFMissingBranches, DefaultValueForAndFilterAvailable)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+   std::string fullpath_3 = std::string(fFileNames[2]) + "?#" + fTreeNames[2];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+   c.Add(fullpath_3.c_str());
+
+   ROOT::RDataFrame df{c};
+
+   constexpr static auto maxint = std::numeric_limits<int>::max();
+
+   std::vector<int> expected_1{1, 2, 3, 4, 5, maxint, maxint, maxint, maxint, maxint, 4, 8, 12, 16, 20};
+   auto take_1 = df.DefaultValueFor("x", maxint).FilterAvailable("x").Take<int>("x");
+
+   std::vector<int> expected_2{1, 2, 3, 4, 5, 4, 8, 12, 16, 20};
+   auto take_2 = df.FilterAvailable("x").DefaultValueFor("x", maxint).Take<int>("x");
+
+   if (GetParam()) {
+      auto take_1_val = *take_1;
+      auto take_2_val = *take_2;
+      // Sort expected vectors
+      std::sort(expected_1.begin(), expected_1.end());
+      std::sort(expected_2.begin(), expected_2.end());
+      // Sort result vectors
+      std::sort(take_1_val.begin(), take_1_val.end());
+      std::sort(take_2_val.begin(), take_2_val.end());
+
+      expect_vec_eq(expected_1, take_1_val);
+      expect_vec_eq(expected_2, take_2_val);
+   } else {
+      expect_vec_eq(expected_1, *take_1);
+      expect_vec_eq(expected_2, *take_2);
+   }
+}
+
+TEST_P(RDFMissingBranches, DefaultValueForAndFilterMissing)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+   std::string fullpath_3 = std::string(fFileNames[2]) + "?#" + fTreeNames[2];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+   c.Add(fullpath_3.c_str());
+
+   ROOT::RDataFrame df{c};
+
+   constexpr static auto maxint = std::numeric_limits<int>::max();
+
+   std::vector<int> expected_1{};
+   auto take_1 = df.DefaultValueFor("x", maxint).FilterMissing("x").Take<int>("x");
+
+   std::vector<int> expected_2{maxint, maxint, maxint, maxint, maxint};
+   auto take_2 = df.FilterMissing("x").DefaultValueFor("x", maxint).Take<int>("x");
+
+   if (GetParam()) {
+      auto take_1_val = *take_1;
+      auto take_2_val = *take_2;
+      // Sort expected vectors
+      std::sort(expected_1.begin(), expected_1.end());
+      std::sort(expected_2.begin(), expected_2.end());
+      // Sort result vectors
+      std::sort(take_1_val.begin(), take_1_val.end());
+      std::sort(take_2_val.begin(), take_2_val.end());
+
+      expect_vec_eq(expected_1, take_1_val);
+      expect_vec_eq(expected_2, take_2_val);
+   } else {
+      expect_vec_eq(expected_1, *take_1);
+      expect_vec_eq(expected_2, *take_2);
+   }
+}
+
+TEST_P(RDFMissingBranches, MissingValueExceptionAction)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+
+   // Various error message that may be printed by TTreeReader depending on
+   // whether we are running with IMT or not
+   ROOT::TestSupport::CheckDiagsRAII diagRAII;
+   diagRAII.optionalDiag(
+      kError, "TTreeReaderValueBase::CreateProxy()",
+      "The tree does not have a branch called x. You could check with TTree::Print() for available branches.");
+   diagRAII.optionalDiag(kError, "TBranchProxy::Setup()",
+                         std::string("Branch 'x' is not available from tree '") + fTreeNames[1] + "' in file '" +
+                            fFileNames[1] + "'.");
+   diagRAII.optionalDiag(kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies.");
+
+   // Exception from action
+   EXPECT_THROW(
+      try {
+         ROOT::RDataFrame df{c};
+         *df.Take<int>("x");
+      } catch (const std::out_of_range &err) {
+         const std::string errmsg{err.what()};
+         EXPECT_TRUE(errmsg.find("Action (Take) could not retrieve value for column 'x' for entry") !=
+                     std::string::npos)
+            << "Actual error message: " << errmsg;
+         throw;
+      },
+      std::out_of_range);
+}
+
+TEST_P(RDFMissingBranches, MissingValueExceptionDefine)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+
+   // Various error message that may be printed by TTreeReader depending on
+   // whether we are running with IMT or not
+   ROOT::TestSupport::CheckDiagsRAII diagRAII;
+   diagRAII.optionalDiag(
+      kError, "TTreeReaderValueBase::CreateProxy()",
+      "The tree does not have a branch called x. You could check with TTree::Print() for available branches.");
+   diagRAII.optionalDiag(kError, "TBranchProxy::Setup()",
+                         std::string("Branch 'x' is not available from tree '") + fTreeNames[1] + "' in file '" +
+                            fFileNames[1] + "'.");
+   diagRAII.optionalDiag(kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies.");
+
+   // Exception from Define
+   EXPECT_THROW(
+      try {
+         ROOT::RDataFrame df{c};
+         auto def = df.Define("newcol", [](int x) { return x * 2; }, {"x"});
+         *def.Take<int>("newcol");
+      } catch (const std::out_of_range &err) {
+         const std::string errmsg{err.what()};
+         EXPECT_TRUE(errmsg.find("Define could not retrieve value for column 'x' for entry") != std::string::npos)
+            << "Actual error message: " << errmsg;
+         throw;
+      },
+      std::out_of_range);
+}
+
+TEST_P(RDFMissingBranches, MissingValueExceptionFilter)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+
+   // Various error message that may be printed by TTreeReader depending on
+   // whether we are running with IMT or not
+   ROOT::TestSupport::CheckDiagsRAII diagRAII;
+   diagRAII.optionalDiag(
+      kError, "TTreeReaderValueBase::CreateProxy()",
+      "The tree does not have a branch called x. You could check with TTree::Print() for available branches.");
+   diagRAII.optionalDiag(kError, "TBranchProxy::Setup()",
+                         std::string("Branch 'x' is not available from tree '") + fTreeNames[1] + "' in file '" +
+                            fFileNames[1] + "'.");
+   diagRAII.optionalDiag(kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies.");
+
+   // Exception from filter
+   EXPECT_THROW(
+      try {
+         ROOT::RDataFrame df{c};
+         auto filt = df.Filter([](int x) { return x < 2; }, {"x"});
+         *filt.Take<int>("x");
+      } catch (const std::out_of_range &err) {
+         const std::string errmsg{err.what()};
+         EXPECT_TRUE(errmsg.find("Filter could not retrieve value for column 'x' for entry") != std::string::npos)
+            << "Actual error message: " << errmsg;
+         throw;
+      },
+      std::out_of_range);
+}
+
+TEST_P(RDFMissingBranches, MissingValueExceptionVariedAction)
+{
+   TChain c{};
+   std::string fullpath_1 = std::string(fFileNames[0]) + "?#" + fTreeNames[0];
+   std::string fullpath_2 = std::string(fFileNames[1]) + "?#" + fTreeNames[1];
+
+   c.Add(fullpath_1.c_str());
+   c.Add(fullpath_2.c_str());
+
+   // Various error message that may be printed by TTreeReader depending on
+   // whether we are running with IMT or not
+   ROOT::TestSupport::CheckDiagsRAII diagRAII;
+   diagRAII.optionalDiag(
+      kError, "TTreeReaderValueBase::CreateProxy()",
+      "The tree does not have a branch called x. You could check with TTree::Print() for available branches.");
+   diagRAII.optionalDiag(kError, "TBranchProxy::Setup()",
+                         std::string("Branch 'x' is not available from tree '") + fTreeNames[1] + "' in file '" +
+                            fFileNames[1] + "'.");
+   diagRAII.optionalDiag(kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies.");
+
+   // Exception with a varied action
+   EXPECT_THROW(
+      try {
+         ROOT::RDataFrame df{c};
+         auto vary = df.Vary("x",
+                             [](int x) {
+                                return ROOT::RVecI{-1 * x, 2 * x};
+                             },
+                             {"x"}, {"down", "up"})
+                        .Take<int>("x");
+         auto variations = ROOT::RDF::Experimental::VariationsFor(vary);
+         variations["x:down"];
+      } catch (const std::out_of_range &err) {
+         const std::string errmsg{err.what()};
+         // The nominal action is the first one encountering the missing value, so it will throw the exception first
+         EXPECT_TRUE(errmsg.find("Action (Take) could not retrieve value for column 'x' for entry") !=
+                     std::string::npos)
+            << "Actual error message: " << errmsg;
+         throw;
+      },
+      std::out_of_range);
+}
+
+struct RDFIndexNoMatchSimple : public ::testing::TestWithParam<std::pair<bool, bool>> {
+   constexpr static auto fMainFile{"main.root"};
+   constexpr static auto fAuxFile1{"aux_1.root"};
+   constexpr static auto fAuxFile2{"aux_2.root"};
+   constexpr static auto fMainTreeName{"events"};
+   constexpr static auto fAuxTreeName1{"auxdata_1"};
+   constexpr static auto fAuxTreeName2{"auxdata_2"};
+   const unsigned int fNSlots;
+
+   RDFIndexNoMatchSimple() : fNSlots(GetParam().first ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
+   {
+      if (GetParam().first) {
+         ROOT::EnableImplicitMT(fNSlots);
+      }
+   }
+
+   ~RDFIndexNoMatchSimple()
+   {
+      if (GetParam().first)
+         ROOT::DisableImplicitMT();
+   }
+
+   static void SetUpTestSuite()
+   {
+      {
+         // Main dataset:
+         // idx: 1, 2, 3, 4, 5
+         // x: 1, 2, 3, 4, 5
+         // 1 entry per cluster to better exercise MT runs
+         TFile f(fMainFile, "RECREATE");
+         TTree mainTree(fMainTreeName, fMainTreeName);
+         int idx;
+         int x;
+         mainTree.Branch("idx", &idx);
+         mainTree.Branch("x", &x);
+
+         std::vector<int> idxs{1, 2, 3, 4, 5};
+         std::vector<int> xs = idxs;
+         for (std::size_t i = 0; i < idxs.size(); i++) {
+            idx = idxs[i];
+            x = xs[i];
+            mainTree.Fill();
+            mainTree.FlushBaskets();
+         }
+
+         mainTree.Write();
+      }
+      {
+         // First auxiliary dataset
+         // idx: 1, 2
+         // y: 11, 22
+         // 1 entry per cluster to better exercise MT runs
+         TFile f(fAuxFile1, "RECREATE");
+         TTree auxTree(fAuxTreeName1, fAuxTreeName1);
+         int y;
+         int idx;
+         auxTree.Branch("idx", &idx);
+         auxTree.Branch("y", &y);
+
+         std::vector<int> idxs{1, 2};
+         std::vector<int> ys = {11, 22};
+         for (std::size_t i = 0; i < idxs.size(); i++) {
+            idx = idxs[i];
+            y = ys[i];
+            auxTree.Fill();
+            auxTree.FlushBaskets();
+         }
+
+         auxTree.Write();
+      }
+      {
+         // Second auxiliary dataset:
+         // idx: 1, 3, 5
+         // z: 111, 333, 555
+         // 1 entry per cluster to better exercise MT runs
+         TFile f(fAuxFile2, "RECREATE");
+         TTree auxTree(fAuxTreeName2, fAuxTreeName2);
+         int z;
+         int idx;
+         auxTree.Branch("idx", &idx);
+         auxTree.Branch("z", &z);
+
+         std::vector<int> idxs{1, 3, 5};
+         std::vector<int> zs = {111, 333, 555};
+         for (std::size_t i = 0; i < idxs.size(); i++) {
+            idx = idxs[i];
+            z = zs[i];
+            auxTree.Fill();
+            auxTree.FlushBaskets();
+         }
+
+         auxTree.Write();
+      }
+   }
+
+   static void TearDownTestSuite()
+   {
+      std::remove(fMainFile);
+      std::remove(fAuxFile1);
+      std::remove(fAuxFile2);
+   }
+};
+
+void testAllDefaults(ROOT::RDF::RNode df, bool imt)
+{
+   // Provide default values for all columns that might have missing values
+   auto dfAllDefaults = df.DefaultValueFor("y", -2).DefaultValueFor("z", -4);
+
+   // Take values of columns from all datasets
+   std::vector<int> expected_x{1, 2, 3, 4, 5};
+   std::vector<int> expected_y{11, 22, -2, -2, -2};
+   std::vector<int> expected_z{111, -4, 333, -4, 555};
+
+   auto take_x = dfAllDefaults.Take<int>("x");
+   auto take_y = dfAllDefaults.Take<int>("y");
+   auto take_z = dfAllDefaults.Take<int>("z");
+
+   if (imt) {
+      auto take_x_val = *take_x;
+      auto take_y_val = *take_y;
+      auto take_z_val = *take_z;
+      std::sort(expected_x.begin(), expected_x.end());
+      std::sort(expected_y.begin(), expected_y.end());
+      std::sort(expected_z.begin(), expected_z.end());
+      std::sort(take_x_val.begin(), take_x_val.end());
+      std::sort(take_y_val.begin(), take_y_val.end());
+      std::sort(take_z_val.begin(), take_z_val.end());
+
+      expect_vec_eq(expected_x, take_x_val);
+      expect_vec_eq(expected_y, take_y_val);
+      expect_vec_eq(expected_z, take_z_val);
+   } else {
+      expect_vec_eq(expected_x, *take_x);
+      expect_vec_eq(expected_y, *take_y);
+      expect_vec_eq(expected_z, *take_z);
+   }
+}
+
+TEST_P(RDFIndexNoMatchSimple, AllDefaults)
+{
+   const auto &[imt, ttree] = GetParam();
+
+   if (ttree) {
+      std::unique_ptr<TFile> mainfile{TFile::Open(fMainFile)};
+      std::unique_ptr<TTree> maintree{mainfile->Get<TTree>(fMainTreeName)};
+
+      std::unique_ptr<TFile> auxfile1{TFile::Open(fAuxFile1)};
+      std::unique_ptr<TTree> auxtree1{auxfile1->Get<TTree>(fAuxTreeName1)};
+      auxtree1->BuildIndex("idx");
+
+      std::unique_ptr<TFile> auxfile2{TFile::Open(fAuxFile2)};
+      std::unique_ptr<TTree> auxtree2{auxfile2->Get<TTree>(fAuxTreeName2)};
+      auxtree2->BuildIndex("idx");
+
+      maintree->AddFriend(auxtree1.get());
+      maintree->AddFriend(auxtree2.get());
+      testAllDefaults(ROOT::RDataFrame{*maintree}, imt);
+   } else {
+      TChain mainChain{fMainTreeName};
+      mainChain.Add(fMainFile);
+
+      TChain auxChain1(fAuxTreeName1);
+      auxChain1.Add(fAuxFile1);
+      auxChain1.BuildIndex("idx");
+
+      TChain auxChain2(fAuxTreeName2);
+      auxChain2.Add(fAuxFile2);
+      auxChain2.BuildIndex("idx");
+
+      mainChain.AddFriend(&auxChain1);
+      mainChain.AddFriend(&auxChain2);
+
+      testAllDefaults(ROOT::RDataFrame{mainChain}, imt);
+   }
+}
+
+void testSkipAux1KeepAux2(ROOT::RDF::RNode df, bool imt)
+{
+   // Discard missing values from the first auxiliary tree but keep those from the second
+   auto dfSkipAux1KeepAux2 = df.FilterAvailable("y").DefaultValueFor("z", -4);
+
+   // Take values of columns from all datasets
+   std::vector<int> expected_x{1, 2};
+   std::vector<int> expected_y{11, 22};
+   std::vector<int> expected_z{111, -4};
+
+   auto take_x = dfSkipAux1KeepAux2.Take<int>("x");
+   auto take_y = dfSkipAux1KeepAux2.Take<int>("y");
+   auto take_z = dfSkipAux1KeepAux2.Take<int>("z");
+
+   if (imt) {
+      auto take_x_val = *take_x;
+      auto take_y_val = *take_y;
+      auto take_z_val = *take_z;
+      std::sort(expected_x.begin(), expected_x.end());
+      std::sort(expected_y.begin(), expected_y.end());
+      std::sort(expected_z.begin(), expected_z.end());
+      std::sort(take_x_val.begin(), take_x_val.end());
+      std::sort(take_y_val.begin(), take_y_val.end());
+      std::sort(take_z_val.begin(), take_z_val.end());
+
+      expect_vec_eq(expected_x, take_x_val);
+      expect_vec_eq(expected_y, take_y_val);
+      expect_vec_eq(expected_z, take_z_val);
+   } else {
+      expect_vec_eq(expected_x, *take_x);
+      expect_vec_eq(expected_y, *take_y);
+      expect_vec_eq(expected_z, *take_z);
+   }
+}
+
+TEST_P(RDFIndexNoMatchSimple, SkipAux1KeepAux2)
+{
+   const auto &[imt, ttree] = GetParam();
+
+   if (ttree) {
+      std::unique_ptr<TFile> mainfile{TFile::Open(fMainFile)};
+      std::unique_ptr<TTree> maintree{mainfile->Get<TTree>(fMainTreeName)};
+
+      std::unique_ptr<TFile> auxfile1{TFile::Open(fAuxFile1)};
+      std::unique_ptr<TTree> auxtree1{auxfile1->Get<TTree>(fAuxTreeName1)};
+      auxtree1->BuildIndex("idx");
+
+      std::unique_ptr<TFile> auxfile2{TFile::Open(fAuxFile2)};
+      std::unique_ptr<TTree> auxtree2{auxfile2->Get<TTree>(fAuxTreeName2)};
+      auxtree2->BuildIndex("idx");
+
+      maintree->AddFriend(auxtree1.get());
+      maintree->AddFriend(auxtree2.get());
+      testSkipAux1KeepAux2(ROOT::RDataFrame{*maintree}, imt);
+   } else {
+      TChain mainChain{fMainTreeName};
+      mainChain.Add(fMainFile);
+
+      TChain auxChain1(fAuxTreeName1);
+      auxChain1.Add(fAuxFile1);
+      auxChain1.BuildIndex("idx");
+
+      TChain auxChain2(fAuxTreeName2);
+      auxChain2.Add(fAuxFile2);
+      auxChain2.BuildIndex("idx");
+
+      mainChain.AddFriend(&auxChain1);
+      mainChain.AddFriend(&auxChain2);
+
+      testSkipAux1KeepAux2(ROOT::RDataFrame{mainChain}, imt);
+   }
+}
+
+struct RDFMissingBranchesVec : public ::testing::TestWithParam<bool> {
+   constexpr static std::array<const char *, 3> fFileNames{"dataframe_incomplete_entries_missing_branches_vec_1.root",
+                                                           "dataframe_incomplete_entries_missing_branches_vec_2.root",
+                                                           "dataframe_incomplete_entries_missing_branches_vec_3.root"};
+   constexpr static auto fTreeName{"events"};
+   constexpr static auto fTreeEntries{5};
+   const unsigned int fNSlots;
+
+   RDFMissingBranchesVec() : fNSlots(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
+   {
+      if (GetParam())
+         ROOT::EnableImplicitMT(fNSlots);
+   }
+
+   ~RDFMissingBranchesVec() override
+   {
+      if (GetParam())
+         ROOT::DisableImplicitMT();
+   }
+
+   static void SetUpTestSuite()
+   {
+      {
+         TFile f(fFileNames[0], "RECREATE");
+         TTree t(fTreeName, fTreeName);
+         std::vector<std::vector<int>> xs{{1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+         std::vector<std::vector<int>> ys{{11, 12, 13, 14, 15}, {7, 8, 9, 10}, {4, 5, 6}, {2, 3}, {1}};
+         std::vector<int> vecx;
+         std::vector<int> vecy;
+
+         t.Branch("vecx", &vecx);
+         t.Branch("vecy", &vecy);
+
+         for (int i = 0; i < fTreeEntries; i++) {
+            vecx = xs[i];
+            vecy = ys[i];
+            t.Fill();
+            t.FlushBaskets();
+         }
+
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[1], "RECREATE");
+         TTree t(fTreeName, fTreeName);
+         std::vector<std::vector<int>> xs{{10}, {20, 30}, {40, 50, 60}, {70, 80, 90, 100}, {110, 120, 130, 140, 150}};
+         std::vector<int> vecx;
+
+         t.Branch("vecx", &vecx);
+
+         for (int i = 0; i < fTreeEntries; i++) {
+            vecx = xs[i];
+            t.Fill();
+            t.FlushBaskets();
+         }
+
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[2], "RECREATE");
+         TTree t(fTreeName, fTreeName);
+         std::vector<std::vector<int>> ys{{110, 120, 130, 140, 150}, {70, 80, 90, 100}, {40, 50, 60}, {20, 30}, {10}};
+         std::vector<int> vecy;
+
+         t.Branch("vecy", &vecy);
+
+         for (int i = 0; i < fTreeEntries; i++) {
+            vecy = ys[i];
+            t.Fill();
+            t.FlushBaskets();
+         }
+
+         t.Write();
+      }
+   }
+
+   static void TearDownTestSuite()
+   {
+      for (auto &&fileName : fFileNames)
+         std::remove(fileName);
+   }
+};
+
+TEST_P(RDFMissingBranchesVec, DefaultValueForAndRVecTake)
+{
+   ROOT::RDataFrame df{fTreeName, {fFileNames[0], fFileNames[1], fFileNames[2]}};
+   auto df_withcols = df.DefaultValueFor("vecy", ROOT::RVecI{700, 800, 900})
+                         .DefaultValueFor("vecx", ROOT::RVecI{400, 500, 600})
+                         .Define("vecz",
+                                 [](const ROOT::RVecI &vec1, const ROOT::RVecI &vec2) {
+                                    return vec1 + ROOT::VecOps::Take(vec2, vec1.size(), 10);
+                                 },
+                                 {"vecx", "vecy"});
+
+   std::vector<std::vector<int>> expected_xs{// first file
+                                             {1},
+                                             {2, 3},
+                                             {4, 5, 6},
+                                             {7, 8, 9, 10},
+                                             {11, 12, 13, 14, 15},
+                                             // second file
+                                             {10},
+                                             {20, 30},
+                                             {40, 50, 60},
+                                             {70, 80, 90, 100},
+                                             {110, 120, 130, 140, 150},
+                                             // third file
+                                             {400, 500, 600},
+                                             {400, 500, 600},
+                                             {400, 500, 600},
+                                             {400, 500, 600},
+                                             {400, 500, 600}};
+
+   std::vector<std::vector<int>> expected_ys{// first file
+                                             {11, 12, 13, 14, 15},
+                                             {7, 8, 9, 10},
+                                             {4, 5, 6},
+                                             {2, 3},
+                                             {1},
+                                             // second file
+                                             {700, 800, 900},
+                                             {700, 800, 900},
+                                             {700, 800, 900},
+                                             {700, 800, 900},
+                                             {700, 800, 900},
+                                             // third file
+                                             {110, 120, 130, 140, 150},
+                                             {70, 80, 90, 100},
+                                             {40, 50, 60},
+                                             {20, 30},
+                                             {10}};
+
+   std::vector<std::vector<int>> expected_zs{// first file
+                                             {12},
+                                             {9, 11},
+                                             {8, 10, 12},
+                                             {9, 11, 19, 20},
+                                             {12, 22, 23, 24, 25},
+                                             // second file
+                                             {710},
+                                             {720, 830},
+                                             {740, 850, 960},
+                                             {770, 880, 990, 110},
+                                             {810, 920, 1030, 150, 160},
+                                             // third file
+                                             {510, 620, 730},
+                                             {470, 580, 690},
+                                             {440, 550, 660},
+                                             {420, 530, 610},
+                                             {410, 510, 610}};
+
+   auto take_x = df_withcols.Take<ROOT::RVecI>("vecx");
+   auto take_y = df_withcols.Take<ROOT::RVecI>("vecy");
+   auto take_z = df_withcols.Take<ROOT::RVecI>("vecz");
+
+   if (GetParam()) {
+      // Easiest way to check for equality of outputs is to sort the expected
+      // vectors and the output vectors from Take the same way
+      std::vector<std::vector<int>> take_x_val;
+      take_x_val.reserve(take_x->size());
+      for (auto &&rvec : take_x) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_x_val.push_back(vec);
+      }
+      std::vector<std::vector<int>> take_y_val;
+      take_y_val.reserve(take_y->size());
+      for (auto &&rvec : take_y) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_y_val.push_back(vec);
+      }
+      std::vector<std::vector<int>> take_z_val;
+      take_z_val.reserve(take_z->size());
+      for (auto &&rvec : take_z) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_z_val.push_back(vec);
+      }
+      std::sort(take_x_val.begin(), take_x_val.end());
+      std::sort(take_y_val.begin(), take_y_val.end());
+      std::sort(take_z_val.begin(), take_z_val.end());
+      std::sort(expected_xs.begin(), expected_xs.end());
+      std::sort(expected_ys.begin(), expected_ys.end());
+      std::sort(expected_zs.begin(), expected_zs.end());
+
+      for (std::size_t i = 0; i < expected_xs.size(); i++) {
+         expect_vec_eq(expected_xs[i], take_x_val[i]);
+      }
+      for (std::size_t i = 0; i < expected_ys.size(); i++) {
+         expect_vec_eq(expected_ys[i], take_y_val[i]);
+      }
+      for (std::size_t i = 0; i < expected_zs.size(); i++) {
+         expect_vec_eq(expected_zs[i], take_z_val[i]);
+      }
+
+   } else {
+      auto take_x_val = *take_x;
+      auto take_y_val = *take_y;
+      auto take_z_val = *take_z;
+
+      for (std::size_t i = 0; i < expected_xs.size(); i++) {
+         expect_vec_eq(expected_xs[i], take_x_val[i]);
+      }
+      for (std::size_t i = 0; i < expected_ys.size(); i++) {
+         expect_vec_eq(expected_ys[i], take_y_val[i]);
+      }
+      for (std::size_t i = 0; i < expected_zs.size(); i++) {
+         expect_vec_eq(expected_zs[i], take_z_val[i]);
+      }
+   }
+}
+
+TEST_P(RDFMissingBranchesVec, DefaultValueForSimpleVariation)
+{
+   ROOT::RDataFrame df{fTreeName, {fFileNames[0], fFileNames[1], fFileNames[2]}};
+
+   auto varyfn = [](const ROOT::RVecI &invec) { return ROOT::RVec<ROOT::RVecI>{invec - 1, invec + 2}; };
+
+   auto df_withcols =
+      df.DefaultValueFor("vecx", ROOT::RVecI{400, 500, 600}).Vary("vecx", varyfn, {"vecx"}, {"down", "up"});
+
+   std::vector<std::vector<int>> expected_xs_nominal{// first file
+                                                     {1},
+                                                     {2, 3},
+                                                     {4, 5, 6},
+                                                     {7, 8, 9, 10},
+                                                     {11, 12, 13, 14, 15},
+                                                     // second file
+                                                     {10},
+                                                     {20, 30},
+                                                     {40, 50, 60},
+                                                     {70, 80, 90, 100},
+                                                     {110, 120, 130, 140, 150},
+                                                     // third file
+                                                     {400, 500, 600},
+                                                     {400, 500, 600},
+                                                     {400, 500, 600},
+                                                     {400, 500, 600},
+                                                     {400, 500, 600}};
+
+   // Expected values for variation up
+   std::vector<std::vector<int>> expected_xs_up(expected_xs_nominal.size());
+   std::transform(expected_xs_nominal.cbegin(), expected_xs_nominal.cend(), expected_xs_up.begin(),
+                  [](const std::vector<int> &val) {
+                     std::vector<int> ret(val.size());
+                     std::transform(val.cbegin(), val.cend(), ret.begin(),
+                                    std::bind(std::plus<int>(), 2, std::placeholders::_1));
+                     return ret;
+                  });
+
+   // Expected values for variation down
+   std::vector<std::vector<int>> expected_xs_down(expected_xs_nominal.size());
+   std::transform(expected_xs_nominal.cbegin(), expected_xs_nominal.cend(), expected_xs_down.begin(),
+                  [](const std::vector<int> &val) {
+                     std::vector<int> ret(val.size());
+                     std::transform(val.cbegin(), val.cend(), ret.begin(),
+                                    std::bind(std::plus<int>(), -1, std::placeholders::_1));
+                     return ret;
+                  });
+
+   auto take_x = df_withcols.Take<ROOT::RVecI>("vecx");
+   auto take_x_vars = ROOT::RDF::Experimental::VariationsFor(take_x);
+
+   if (GetParam()) {
+      // Easiest way to check for equality of outputs is to sort the expected
+      // vectors and the output vectors from Take the same way
+      std::vector<std::vector<int>> take_x_val_nominal;
+      take_x_val_nominal.reserve(take_x_vars["nominal"].size());
+      for (auto &&rvec : take_x_vars["nominal"]) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_x_val_nominal.push_back(vec);
+      }
+      std::vector<std::vector<int>> take_x_val_up;
+      take_x_val_up.reserve(take_x_vars["vecx:up"].size());
+      for (auto &&rvec : take_x_vars["vecx:up"]) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_x_val_up.push_back(vec);
+      }
+      std::vector<std::vector<int>> take_x_val_down;
+      take_x_val_down.reserve(take_x_vars["vecx:down"].size());
+      for (auto &&rvec : take_x_vars["vecx:down"]) {
+         std::vector<int> vec;
+         vec.reserve(rvec.size());
+         for (auto &&v : rvec)
+            vec.push_back(v);
+         take_x_val_down.push_back(vec);
+      }
+
+      std::sort(take_x_val_nominal.begin(), take_x_val_nominal.end());
+      std::sort(take_x_val_up.begin(), take_x_val_up.end());
+      std::sort(take_x_val_down.begin(), take_x_val_down.end());
+
+      std::sort(expected_xs_nominal.begin(), expected_xs_nominal.end());
+      std::sort(expected_xs_up.begin(), expected_xs_up.end());
+      std::sort(expected_xs_down.begin(), expected_xs_down.end());
+
+      for (std::size_t i = 0; i < expected_xs_nominal.size(); i++) {
+         expect_vec_eq(expected_xs_nominal[i], take_x_val_nominal[i]);
+      }
+      for (std::size_t i = 0; i < expected_xs_up.size(); i++) {
+         expect_vec_eq(expected_xs_up[i], take_x_val_up[i]);
+      }
+      for (std::size_t i = 0; i < expected_xs_down.size(); i++) {
+         expect_vec_eq(expected_xs_down[i], take_x_val_down[i]);
+      }
+
+   } else {
+
+      for (std::size_t i = 0; i < expected_xs_nominal.size(); i++) {
+         expect_vec_eq(expected_xs_nominal[i], take_x_vars["nominal"][i]);
+      }
+      for (std::size_t i = 0; i < expected_xs_up.size(); i++) {
+         expect_vec_eq(expected_xs_up[i], take_x_vars["vecx:up"][i]);
+      }
+      for (std::size_t i = 0; i < expected_xs_down.size(); i++) {
+         expect_vec_eq(expected_xs_down[i], take_x_vars["vecx:down"][i]);
+      }
+   }
+}
+
+// run single-thread tests
+INSTANTIATE_TEST_SUITE_P(Seq, RDFMissingBranches, ::testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(Seq, RDFIndexNoMatchSimple,
+                         ::testing::Values(std::make_pair(false, false), std::make_pair(false, true)));
+INSTANTIATE_TEST_SUITE_P(Seq, RDFMissingBranchesVec, ::testing::Values(false));
+
+// run multi-thread tests
+#ifdef R__USE_IMT
+INSTANTIATE_TEST_SUITE_P(MT, RDFMissingBranches, ::testing::Values(true));
+INSTANTIATE_TEST_SUITE_P(MT, RDFIndexNoMatchSimple,
+                         ::testing::Values(std::make_pair(true, false), std::make_pair(true, true)));
+INSTANTIATE_TEST_SUITE_P(MT, RDFMissingBranchesVec, ::testing::Values(true));
+#endif

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -71,7 +71,8 @@ public:
    std::unique_ptr<TTreeReader> GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeName,
                                               const std::vector<std::string> &fileNames,
                                               const ROOT::TreeUtils::RFriendInfo &friendInfo,
-                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries);
+                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
+                                              const std::vector<std::string> &suppressErrorsForMissingBranches);
    void Reset();
 };
 } // End of namespace Internal
@@ -94,6 +95,10 @@ private:
 
    std::pair<Long64_t, Long64_t> fGlobalRange{0, std::numeric_limits<Long64_t>::max()};
 
+   // List of branches for which we want to suppress the printed error about
+   // missing branch when switching to a new tree
+   std::vector<std::string> fSuppressErrorsForMissingBranches{};
+
 public:
    TTreeProcessorMT(std::string_view filename, std::string_view treename = "", UInt_t nThreads = 0u,
                     const std::pair<Long64_t, Long64_t> &globalRange = {0, std::numeric_limits<Long64_t>::max()});
@@ -103,9 +108,11 @@ public:
    TTreeProcessorMT(std::initializer_list<std::string_view> filenames, std::string_view treename = "", UInt_t nThreads = 0u,
                     const std::pair<Long64_t, Long64_t> &globalRange = {0, std::numeric_limits<Long64_t>::max()}):
                     TTreeProcessorMT(std::vector<std::string_view>(filenames), treename, nThreads, globalRange) {}
-   TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads = 0u);
+   TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads = 0u,
+                    const std::vector<std::string> &suppressErrorsForMissingBranches = {});
    TTreeProcessorMT(TTree &tree, UInt_t nThreads = 0u,
-                    const std::pair<Long64_t, Long64_t> &globalRange = {0, std::numeric_limits<Long64_t>::max()});
+                    const std::pair<Long64_t, Long64_t> &globalRange = {0, std::numeric_limits<Long64_t>::max()},
+                    const std::vector<std::string> &suppressErrorsForMissingBranches = {});
 
    void Process(std::function<void(TTreeReader &)> func);
 

--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -40,8 +40,8 @@ Base class of TTreeReaderArray.
    protected:
       void *UntypedAt(std::size_t idx) const { return fImpl->At(GetProxy(), idx); }
       void CreateProxy() override;
-      bool GetBranchAndLeaf(TBranch* &branch, TLeaf* &myLeaf,
-                            TDictionary* &branchActualType);
+      bool GetBranchAndLeaf(TBranch *&branch, TLeaf *&myLeaf, TDictionary *&branchActualType,
+                            bool suppressErrorsForMissingBranch = false);
       void SetImpl(TBranch* branch, TLeaf* myLeaf);
       const char* GetBranchContentDataType(TBranch* branch,
                                            TString& contentTypeName,

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -42,14 +42,26 @@ namespace Internal {
 
    class TNamedBranchProxy {
    public:
-      TNamedBranchProxy(): fDict(nullptr), fContentDict(nullptr) {}
-      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* membername):
-         fProxy(boss, fullname, branch, membername), fDict(nullptr), fContentDict(nullptr), fFullName(fullname) {}
+      TNamedBranchProxy() : fDict(nullptr), fContentDict(nullptr) {}
+      TNamedBranchProxy(TBranchProxyDirector *boss, TBranch *branch, const char *fullname, const char *membername,
+                        bool suppressMissingBranchError)
+         : fProxy(boss, fullname, branch, membername, suppressMissingBranchError),
+           fDict(nullptr),
+           fContentDict(nullptr),
+           fFullName(fullname)
+      {
+      }
 
       // Constructor for friend case, the fullname (containing the name of the friend tree) may be different
       // from the lookup name (without the name of the friend)
-      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* proxyname, const char* membername):
-         fProxy(boss, proxyname, branch, membername), fDict(nullptr), fContentDict(nullptr), fFullName(fullname) {}
+      TNamedBranchProxy(TBranchProxyDirector *boss, TBranch *branch, const char *fullname, const char *proxyname,
+                        const char *membername, bool suppressMissingBranchError)
+         : fProxy(boss, proxyname, branch, membername, suppressMissingBranchError),
+           fDict(nullptr),
+           fContentDict(nullptr),
+           fFullName(fullname)
+      {
+      }
 
       const char* GetName() const { return fFullName.c_str(); }
       const Detail::TBranchProxy* GetProxy() const { return &fProxy; }

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -165,13 +165,30 @@ static std::string GetFriendBranchName(TTree* directorTree, TBranch* branch, con
 /// Constructor taking the branch name, possibly of a friended tree.
 /// Used by TTreeReaderValue in place of TFriendProxy.
 
-ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char* branchname, TBranch* branch, const char* membername) :
-   fDirector(boss), fInitialized(false), fIsMember(membername != nullptr && membername[0]), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(GetFriendBranchName(boss->GetTree(), branch, branchname)), fParent(nullptr), fDataMember(membername),
-   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(nullptr), fBranchCount(nullptr),
-   fNotify(this),
-   fRead(-1), fWhere(nullptr),fCollection(nullptr)
+ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector *boss, const char *branchname, TBranch *branch,
+                                         const char *membername, bool suppressMissingBranchError)
+   : fDirector(boss),
+     fInitialized(false),
+     fIsMember(membername != nullptr && membername[0]),
+     fIsClone(false),
+     fIsaPointer(false),
+     fHasLeafCount(false),
+     fSuppressMissingBranchError(suppressMissingBranchError),
+     fBranchName(GetFriendBranchName(boss->GetTree(), branch, branchname)),
+     fParent(nullptr),
+     fDataMember(membername),
+     fClassName(""),
+     fClass(nullptr),
+     fElement(nullptr),
+     fMemberOffset(0),
+     fOffset(0),
+     fArrayLength(1),
+     fBranch(nullptr),
+     fBranchCount(nullptr),
+     fNotify(this),
+     fRead(-1),
+     fWhere(nullptr),
+     fCollection(nullptr)
 {
    // Constructor.
 
@@ -302,7 +319,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
       // its mother's name
       fBranch = fDirector->GetTree()->GetBranch(fBranchName.Data());
       if (!fBranch) {
-         if (!AreThereSubBranches(fBranchName.View(), *fDirector->GetTree())) {
+         if (!fSuppressMissingBranchError && !AreThereSubBranches(fBranchName.View(), *fDirector->GetTree())) {
             // The next error refers specifically to the situation where the branch identified by fBranchName
             // is not present and that is not expected. An example is when traversing a chain of files, the branch
             // is missing from the file that we are switching into.

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -287,7 +287,8 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
 std::unique_ptr<TTreeReader>
 TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeNames,
                          const std::vector<std::string> &fileNames, const ROOT::TreeUtils::RFriendInfo &friendInfo,
-                         const TEntryList &entryList, const std::vector<Long64_t> &nEntries)
+                         const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
+                         const std::vector<std::string> &suppressErrorsForMissingBranches)
 {
    const bool hasEntryList = entryList.GetN() > 0;
    const bool usingLocalEntries = friendInfo.fFriendNames.empty() && !hasEntryList;
@@ -306,7 +307,8 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
          }
       }
    }
-   auto reader = std::make_unique<TTreeReader>(fChain.get(), fEntryList.get(), /*warnAboutLongerFriends*/ false);
+   auto reader = std::make_unique<TTreeReader>(fChain.get(), fEntryList.get(), /*warnAboutLongerFriends*/ false,
+                                               suppressErrorsForMissingBranches);
    reader->SetEntriesRange(start, end);
    return reader;
 }
@@ -409,12 +411,14 @@ TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filename
 /// \param[in] entries List of entry numbers to process.
 /// \param[in] nThreads Number of threads to create in the underlying thread-pool. The semantics of this argument are
 ///                     the same as for TThreadExecutor.
-TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads)
+TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads,
+                                   const std::vector<std::string> &suppressErrorsForMissingBranches)
    : fFileNames(Internal::TreeUtils::GetFileNamesFromTree(tree)),
      fTreeNames(Internal::TreeUtils::GetTreeFullPaths(tree)),
      fEntryList(entries),
      fFriendInfo(Internal::TreeUtils::GetFriendInfo(tree, /*retrieveEntries*/ true)),
-     fPool(nThreads)
+     fPool(nThreads),
+     fSuppressErrorsForMissingBranches(suppressErrorsForMissingBranches)
 {
    ROOT::EnableThreadSafety();
 }
@@ -425,12 +429,14 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_
 /// \param[in] nThreads Number of threads to create in the underlying thread-pool. The semantics of this argument are
 ///                     the same as for TThreadExecutor.
 /// \param[in] globalRange Global entry range to process, {begin (inclusive), end (exclusive)}.
-TTreeProcessorMT::TTreeProcessorMT(TTree &tree, UInt_t nThreads, const EntryRange &globalRange)
+TTreeProcessorMT::TTreeProcessorMT(TTree &tree, UInt_t nThreads, const EntryRange &globalRange,
+                                   const std::vector<std::string> &suppressErrorsForMissingBranches)
    : fFileNames(Internal::TreeUtils::GetFileNamesFromTree(tree)),
      fTreeNames(Internal::TreeUtils::GetTreeFullPaths(tree)),
      fFriendInfo(Internal::TreeUtils::GetFriendInfo(tree, /*retrieveEntries*/ true)),
      fPool(nThreads),
-     fGlobalRange(globalRange)
+     fGlobalRange(globalRange),
+     fSuppressErrorsForMissingBranches(suppressErrorsForMissingBranches)
 {
 }
 
@@ -478,8 +484,8 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    // Per-file processing in case we retrieved all cluster info upfront
    auto processFileUsingGlobalClusters = [&](std::size_t fileIdx) {
       auto processCluster = [&](const EntryRange &c) {
-         auto r =
-            fTreeView->GetTreeReader(c.first, c.second, fTreeNames, fFileNames, fFriendInfo, fEntryList, allEntries);
+         auto r = fTreeView->GetTreeReader(c.first, c.second, fTreeNames, fFileNames, fFriendInfo, fEntryList,
+                                           allEntries, fSuppressErrorsForMissingBranches);
          func(*r);
       };
       fPool.Foreach(processCluster, allClusters[fileIdx]);
@@ -494,7 +500,8 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       const auto &clusters = clustersAndEntries.first[0];
       const auto &entries = clustersAndEntries.second[0];
       auto processCluster = [&](const EntryRange &c) {
-         auto r = fTreeView->GetTreeReader(c.first, c.second, treeNames, fileNames, fFriendInfo, fEntryList, {entries});
+         auto r = fTreeView->GetTreeReader(c.first, c.second, treeNames, fileNames, fFriendInfo, fEntryList, {entries},
+                                           fSuppressErrorsForMissingBranches);
          func(*r);
       };
       fPool.Foreach(processCluster, clusters);

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -31,6 +31,7 @@
 #include "TRegexp.h"
 
 #include <memory>
+#include <optional>
 
 // pin vtable
 ROOT::Internal::TVirtualCollectionReader::~TVirtualCollectionReader() {}
@@ -45,7 +46,8 @@ namespace {
       TClonesArray* GetCA(ROOT::Detail::TBranchProxy* proxy) {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
-            Error("TClonesReader::GetCA()", "Read error in TBranchProxy.");
+            if (!proxy->GetSuppressErrorsForMissingBranch())
+               Error("TClonesReader::GetCA()", "Read error in TBranchProxy.");
             return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
@@ -74,7 +76,8 @@ namespace {
       TVirtualCollectionProxy* GetCP(ROOT::Detail::TBranchProxy* proxy) {
          if (!proxy->Read()) {
             fReadStatus = TTreeReaderValueBase::kReadError;
-            Error("TSTLReader::GetCP()", "Read error in TBranchProxy.");
+            if (!proxy->GetSuppressErrorsForMissingBranch())
+               Error("TSTLReader::GetCP()", "Read error in TBranchProxy.");
             return nullptr;
          }
          if (!proxy->GetWhere()) {
@@ -112,7 +115,8 @@ namespace {
       TVirtualCollectionProxy* GetCP(ROOT::Detail::TBranchProxy* proxy) {
          if (!proxy->Read()) {
             fReadStatus = TTreeReaderValueBase::kReadError;
-            Error("TCollectionLessSTLReader::GetCP()", "Read error in TBranchProxy.");
+            if (!proxy->GetSuppressErrorsForMissingBranch())
+               Error("TCollectionLessSTLReader::GetCP()", "Read error in TBranchProxy.");
             return nullptr;
          }
          if (!proxy->GetWhere()) {
@@ -161,7 +165,8 @@ namespace {
       TVirtualCollectionProxy* GetCP(ROOT::Detail::TBranchProxy* proxy) {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
-            Error("TObjectArrayReader::GetCP()", "Read error in TBranchProxy.");
+            if (!proxy->GetSuppressErrorsForMissingBranch())
+               Error("TObjectArrayReader::GetCP()", "Read error in TBranchProxy.");
             return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
@@ -313,7 +318,8 @@ namespace {
       TVirtualCollectionProxy* GetCP (ROOT::Detail::TBranchProxy *proxy) {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
-            Error("TBasicTypeArrayReader::GetCP()", "Read error in TBranchProxy.");
+            if (!proxy->GetSuppressErrorsForMissingBranch())
+               Error("TBasicTypeArrayReader::GetCP()", "Read error in TBranchProxy.");
             return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
@@ -427,10 +433,17 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
    // Search for the branchname, determine what it contains, and wire the
    // TBranchProxy representing it to us so we can access its data.
 
+   // Tell the branch proxy to suppress the errors for missing branch if this
+   // branch name is found in the list of suppressions
+   const bool suppressErrorsForThisBranch =
+      (std::find(fTreeReader->fSuppressErrorsForMissingBranches.cbegin(),
+                 fTreeReader->fSuppressErrorsForMissingBranches.cend(),
+                 fBranchName.Data()) != fTreeReader->fSuppressErrorsForMissingBranches.cend());
+
    TDictionary* branchActualType = nullptr;
    TBranch* branch = nullptr;
    TLeaf *myLeaf = nullptr;
-   if (!GetBranchAndLeaf(branch, myLeaf, branchActualType))
+   if (!GetBranchAndLeaf(branch, myLeaf, branchActualType, suppressErrorsForThisBranch))
       return;
 
    if (!fDict) {
@@ -470,39 +483,35 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
             membername = branch->GetName();
          }
       }
-      auto director = fTreeReader->fDirector.get();
+      auto *director = fTreeReader->fDirector.get();
       // Determine if the branch is actually in a Friend TTree and if so which.
       if (branch->GetTree() != fTreeReader->GetTree()->GetTree()) {
          // It is in a friend, let's find the 'index' in the list of friend ...
-         int index = -1;
-         int current = 0;
-         for(auto fe : TRangeDynCast<TFriendElement>( fTreeReader->GetTree()->GetTree()->GetListOfFriends())) {
+         std::optional<std::size_t> index;
+         std::size_t current{};
+         auto &&friends = fTreeReader->GetTree()->GetTree()->GetListOfFriends();
+         for (auto fe : TRangeDynCast<TFriendElement>(friends)) {
             if (branch->GetTree() == fe->GetTree()) {
                index = current;
                break;
             }
             ++current;
          }
-         if (index == -1) {
-            Error("TTreeReaderArrayBase::CreateProxy()", "The branch %s is contained in a Friend TTree that is not directly attached to the main.\n"
+         if (!index.has_value()) {
+            Error("TTreeReaderArrayBase::CreateProxy()",
+                  "The branch %s is contained in a Friend TTree that is not directly attached to the main.\n"
                   "This is not yet supported by TTreeReader.",
                   fBranchName.Data());
             return;
          }
-         TFriendProxy *feproxy = nullptr;
-         if ((size_t)index < fTreeReader->fFriendProxies.size()) {
-            feproxy = fTreeReader->fFriendProxies.at(index).get();
-         }
-         if (!feproxy) {
-            fTreeReader->fFriendProxies.resize(index+1);
-            fTreeReader->fFriendProxies.at(index) =
-               std::make_unique<ROOT::Internal::TFriendProxy>(director, fTreeReader->GetTree(), index);
-            feproxy = fTreeReader->fFriendProxies.at(index).get();
-         }
-         director = feproxy->GetDirector();
+
+         auto &&friendProxy = fTreeReader->AddFriendProxy(index.value());
+         director = friendProxy.GetDirector();
       }
-      namedProxy = new TNamedBranchProxy(director, branch, fBranchName, membername);
-      fTreeReader->AddProxy(namedProxy);
+      fTreeReader->AddProxy(
+         std::make_unique<TNamedBranchProxy>(director, branch, fBranchName, membername, suppressErrorsForThisBranch));
+
+      namedProxy = fTreeReader->FindProxy(fBranchName);
       fProxy = namedProxy->GetProxy();
       if (fProxy)
          fSetupStatus = kSetupMatch;
@@ -583,15 +592,21 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
 ////////////////////////////////////////////////////////////////////////////////
 /// Determine the branch / leaf and its type; reset fProxy / fSetupStatus on error.
 
-bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TLeaf* &myLeaf,
-                                                            TDictionary* &branchActualType) {
+bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch *&branch, TLeaf *&myLeaf,
+                                                            TDictionary *&branchActualType,
+                                                            bool suppressErrorsForMissingBranch)
+{
    myLeaf = nullptr;
    branch = fTreeReader->GetTree()->GetBranch(fBranchName);
    if (branch)
       return true;
 
    if (!fBranchName.Contains(".")) {
-      Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
+      if (!suppressErrorsForMissingBranch) {
+         Error("TTreeReaderArrayBase::GetBranchAndLeaf()",
+               "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.",
+               fBranchName.Data());
+      }
       fSetupStatus = kSetupMissingBranch;
       fProxy = nullptr;
       return false;
@@ -601,8 +616,12 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    TString leafName (fBranchName(leafNameExpression));
    TString branchName = fBranchName(0, fBranchName.Length() - leafName.Length());
    branch = fTreeReader->GetTree()->GetBranch(branchName);
-   if (!branch){
-      Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
+   if (!branch) {
+      if (!suppressErrorsForMissingBranch) {
+         Error("TTreeReaderArrayBase::GetBranchAndLeaf()",
+               "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.",
+               fBranchName.Data());
+      }
       fSetupStatus = kSetupMissingBranch;
       fProxy = nullptr;
       return false;
@@ -610,7 +629,12 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
 
    myLeaf = branch->GetLeaf(TString(leafName(1, leafName.Length())));
    if (!myLeaf){
-      Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch, nor a sub-branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
+      if (!suppressErrorsForMissingBranch) {
+         Error("TTreeReaderArrayBase::GetBranchAndLeaf()",
+               "The tree does not have a branch, nor a sub-branch called %s. You could check with TTree::Print() for "
+               "available branches.",
+               fBranchName.Data());
+      }
       fSetupStatus = kSetupMissingBranch;
       fProxy = nullptr;
       return false;
@@ -641,9 +665,6 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    }
    return true;
 }
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create the TVirtualCollectionReader object for our branch.

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -29,6 +29,8 @@
 #include "TStreamerElement.h"
 #include "TNtuple.h"
 #include "TROOT.h"
+
+#include <optional>
 #include <vector>
 
 // clang-format off
@@ -52,15 +54,15 @@ ClassImp(ROOT::Internal::TTreeReaderValueBase);
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct a tree value reader and register it with the reader object.
 
-ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(TTreeReader* reader /*= 0*/,
-                                                 const char* branchname /*= 0*/,
-                                                 TDictionary* dict /*= 0*/):
-   fHaveLeaf(false),
-   fHaveStaticClassOffsets(false),
-   fReadStatus(kReadNothingYet),
-   fBranchName(branchname),
-   fTreeReader(reader),
-   fDict(dict)
+ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(TTreeReader *reader /*= 0*/, const char *branchname /*= 0*/,
+                                                           TDictionary *dict /*= 0*/, bool opaqueRead)
+   : fHaveLeaf(false),
+     fHaveStaticClassOffsets(false),
+     fReadStatus(kReadNothingYet),
+     fBranchName(branchname),
+     fTreeReader(reader),
+     fDict(dict),
+     fOpaqueRead(opaqueRead)
 {
    RegisterWithTreeReader();
 }
@@ -251,6 +253,14 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
 /// Returns the memory address of the object being read.
 
 void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
+
+   // If an indexed friend did not match the current entry and if this reader
+   // is associated with that friend (i.e. its active read entry is -1), avoid
+   // reading altogether
+   if (fTreeReader->GetEntryStatus() == TTreeReader::kIndexedFriendNoMatch && fProxy &&
+       fProxy->fDirector->GetReadEntry() == -1)
+      return nullptr;
+
    if (ProxyRead() != kReadSuccess) return nullptr;
 
    if (fHaveLeaf){
@@ -458,15 +468,25 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       branchFromFullName = fTreeReader->GetTree()->FindBranch(fBranchName);
 
    if (!fDict) {
-      const char* brDataType = "{UNDETERMINED}";
-      if (branchFromFullName) {
-         TDictionary* brDictUnused = nullptr;
-         brDataType = GetBranchDataType(branchFromFullName, brDictUnused, fDict);
+      if (!fOpaqueRead) {
+         const char *brDataType = "{UNDETERMINED}";
+         if (branchFromFullName) {
+            TDictionary *brDictUnused = nullptr;
+            brDataType = GetBranchDataType(branchFromFullName, brDictUnused, fDict);
+         }
+         Error(errPrefix,
+               "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known "
+               "to ROOT. You will need to create a dictionary for it.",
+               GetDerivedTypeName(), fBranchName.Data(), brDataType);
+         fSetupStatus = kSetupMissingDictionary;
+         return;
+      } else {
+         // We do not care about the branch data type in this case, so we can
+         // generate the dictionary from the branch directly
+         if (branchFromFullName) {
+            GetBranchDataType(branchFromFullName, fDict, nullptr);
+         }
       }
-      Error(errPrefix, "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known to ROOT. You will need to create a dictionary for it.",
-            GetDerivedTypeName(), fBranchName.Data(), brDataType);
-      fSetupStatus = kSetupMissingDictionary;
-      return;
    }
 
    // Search for the branchname, determine what it contains, and wire the
@@ -507,14 +527,34 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       }
    }
 
+   // Check whether the user wants to suppress errors for this specific branch
+   // if it is missing. We have to use this information differently in two
+   // different situations:
+   // - If the branch was present in the first tree of the chain, but missing
+   //   when switching to a new tree
+   // - If the branch is missing from the first tree already. In this case we
+   //   also need to postpone the creation of the branch proxy until at least
+   //   one tree in the chain has that branch
+   const auto &suppressErrorsForMissingBranches = fTreeReader->fSuppressErrorsForMissingBranches;
+   const bool suppressErrorsForThisBranch =
+      (std::find(suppressErrorsForMissingBranches.cbegin(), suppressErrorsForMissingBranches.cend(),
+                 originalBranchName) != suppressErrorsForMissingBranches.cend());
+
    if (!branch) {
       // We had an error, the branch name had no "." or we simply did not find anything.
       // We check if we had a branch found with the full name with a dot in it.
       branch = branchFromFullName;
       if (!branch) {
-         // Also that one was empty. We need to error out. We do it properly: at
-         // first we check if the routine to find branches with names with a "."
-         // provided a specific error message. If not, we go with a generic message.
+         // Also that one was empty. We need to error out, but only if the user
+         // did not explicitly request to avoid errors about missing branches
+         fSetupStatus = kSetupMissingBranch;
+         fProxy = nullptr;
+         if (suppressErrorsForThisBranch)
+            return;
+
+         // Now we error out, first checking if we did not get a more specific
+         // error message from SearchBranchWithCompositeName. If not, we go with
+         // a generic message.
          if (errMsg.empty()) {
             errMsg = "The tree does not have a branch called ";
             errMsg += fBranchName.Data();
@@ -529,13 +569,12 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
 #pragma GCC diagnostic pop
 #endif
          return;
-      } else {
-         // The branch found with the simplest search approach was successful.
-         // We reset the state, we continue
-         fSetupStatus = kSetupInternalError;
-         fStaticClassOffsets = {};
-         fHaveStaticClassOffsets = false;
       }
+      // The branch found with the simplest search approach was successful.
+      // We reset the state, we continue
+      fSetupStatus = kSetupInternalError;
+      fStaticClassOffsets = {};
+      fHaveStaticClassOffsets = false;
    }
 
    if (!myLeaf && !fHaveStaticClassOffsets) {
@@ -605,36 +644,32 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       // Determine if the branch is actually in a Friend TTree and if so which.
       if (branch->GetTree() != fTreeReader->GetTree()->GetTree()) {
          // It is in a friend, let's find the 'index' in the list of friend ...
-         int index = -1;
-         int current = 0;
-         for(auto fe : TRangeDynCast<TFriendElement>( fTreeReader->GetTree()->GetTree()->GetListOfFriends())) {
+         std::optional<std::size_t> index;
+         std::size_t current{};
+         auto &&friends = fTreeReader->GetTree()->GetTree()->GetListOfFriends();
+         for (auto fe : TRangeDynCast<TFriendElement>(friends)) {
             if (branch->GetTree() == fe->GetTree()) {
                index = current;
                break;
             }
             ++current;
          }
-         if (index == -1) {
-            Error(errPrefix, "The branch %s is contained in a Friend TTree that is not directly attached to the main.\n"
+         if (!index.has_value()) {
+            Error(errPrefix,
+                  "The branch %s is contained in a Friend TTree that is not directly attached to the main.\n"
                   "This is not yet supported by TTreeReader.",
                   fBranchName.Data());
             return;
          }
-         TFriendProxy *feproxy = nullptr;
-         if ((size_t)index < fTreeReader->fFriendProxies.size()) {
-            feproxy = fTreeReader->fFriendProxies.at(index).get();
-         }
-         if (!feproxy) {
-            fTreeReader->fFriendProxies.resize(index+1);
-            fTreeReader->fFriendProxies.at(index) =
-               std::make_unique<ROOT::Internal::TFriendProxy>(director, fTreeReader->GetTree(), index);
-            feproxy = fTreeReader->fFriendProxies.at(index).get();
-         }
-         namedProxy = new TNamedBranchProxy(feproxy->GetDirector(), branch, originalBranchName.c_str(), branch->GetName(), membername);
+         auto &&friendProxy = fTreeReader->AddFriendProxy(index.value());
+         fTreeReader->AddProxy(std::make_unique<TNamedBranchProxy>(friendProxy.GetDirector(), branch,
+                                                                   originalBranchName.c_str(), branch->GetName(),
+                                                                   membername, suppressErrorsForThisBranch));
       } else {
-         namedProxy = new TNamedBranchProxy(director, branch, originalBranchName.c_str(), membername);
+         fTreeReader->AddProxy(std::make_unique<TNamedBranchProxy>(director, branch, originalBranchName.c_str(),
+                                                                   membername, suppressErrorsForThisBranch));
       }
-      fTreeReader->AddProxy(namedProxy);
+      namedProxy = fTreeReader->FindProxy(originalBranchName.c_str());
    }
 
    // Update named proxy's dictionary
@@ -776,6 +811,16 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
    }
 
    return nullptr;
+}
+
+void ROOT::Internal::TTreeReaderValueBase::ErrorAboutMissingProxyIfNeeded()
+{
+   // Print the error only if the branch name does not appear in the list of
+   // missing proxies that the user explicitly requested not to error about
+   if (std::find(fTreeReader->fMissingProxies.cbegin(), fTreeReader->fMissingProxies.cend(), fBranchName.Data()) ==
+       fTreeReader->fMissingProxies.cend())
+      Error("TTreeReaderValue::Get()", "Value reader not properly initialized, did you call "
+                                       "TTreeReader::Set(Next)Entry() or TTreeReader::Next()?");
 }
 
 namespace cling {

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -469,8 +469,8 @@ TEST(TTreeReaderBasic, InfLoop)
 // ROOT-10019
 TEST(TTreeReaderBasic, DisappearingBranch)
 {
-   ROOT::TestSupport::CheckDiagsRAII diags{ kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies." };
-   diags.requiredDiag(kWarning, "TTreeReader::SetEntryBase()", "Unexpected error '-6' in TChain::LoadTree");
+   ROOT::TestSupport::CheckDiagsRAII diags{kError, "TTreeReader::SetEntryBase()",
+                                           "There was an error while notifying the proxies."};
 
    auto createFile = [](const char *fileName, int ncols) {
       // auto r = ROOT::RDataFrame(1).Define("col0",[](){return 0;}).Snapshot<int>("t","f1.root",{"col0"});

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -77,12 +77,18 @@ if(NOT clad)
   )
 endif()
 
-# RBatchGenerator tutorials don't work on Windows at the moment.
 if(MSVC AND NOT win_broken_tests)
+  # RBatchGenerator tutorials don't work on Windows at the moment.
   list(APPEND dataframe_veto tmva/RBatchGenerator_NumPy.py)
   list(APPEND dataframe_veto tmva/RBatchGenerator_TensorFlow.py)
   list(APPEND dataframe_veto tmva/RBatchGenerator_PyTorch.py)
   list(APPEND dataframe_veto tmva/RBatchGenerator_filters_vectors.py)
+  # df036* and df037* seem to trigger OS errors when trying to delete the
+  # test files created in the tutorials. It is unclear why.
+  list(APPEND dataframe_veto dataframe/df036_missingBranches.C)
+  list(APPEND dataframe_veto dataframe/df036_missingBranches.py)
+  list(APPEND dataframe_veto dataframe/df037_TTreeEventMatching.C)
+  list(APPEND dataframe_veto dataframe/df037_TTreeEventMatching.py)
 endif()
 
 if (NOT dataframe)

--- a/tutorials/dataframe/df036_missingBranches.C
+++ b/tutorials/dataframe/df036_missingBranches.C
@@ -1,0 +1,124 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+///
+/// This example shows how to process a dataset where entries might be
+/// incomplete due to one or more missing branches in one or more of the files
+/// in the dataset. It shows usage of the FilterAvailable and DefaultValueFor
+/// RDataFrame functionalities to act upon the missing entries.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date September 2024
+/// \author Vincenzo Eduardo Padulano (CERN)
+#include <ROOT/RDataFrame.hxx>
+#include <TChain.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <numeric>
+
+// A helper class to create the dataset for the tutorial below.
+struct Dataset {
+
+   constexpr static std::array<const char *, 3> fFileNames{"df036_missingBranches_C_file_1.root",
+                                                           "df036_missingBranches_C_file_2.root",
+                                                           "df036_missingBranches_C_file_3.root"};
+   constexpr static std::array<const char *, 3> fTreeNames{"tree_1", "tree_2", "tree_3"};
+   constexpr static auto fTreeEntries{5};
+
+   Dataset()
+   {
+      {
+         TFile f(fFileNames[0], "RECREATE");
+         TTree t(fTreeNames[0], fTreeNames[0]);
+         int x{};
+         int y{};
+         t.Branch("x", &x, "x/I");
+         t.Branch("y", &y, "y/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            x = i;
+            y = 2 * i;
+            t.Fill();
+         }
+
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[1], "RECREATE");
+         TTree t(fTreeNames[1], fTreeNames[1]);
+         int y{};
+         t.Branch("y", &y, "y/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            y = 3 * i;
+            t.Fill();
+         }
+
+         t.Write();
+      }
+
+      {
+         TFile f(fFileNames[2], "RECREATE");
+         TTree t(fTreeNames[2], fTreeNames[2]);
+         int x{};
+         t.Branch("x", &x, "x/I");
+         for (int i = 1; i <= fTreeEntries; i++) {
+            x = 4 * i;
+            t.Fill();
+         }
+
+         t.Write();
+      }
+   }
+
+   ~Dataset()
+   {
+      for (auto &&fileName : fFileNames)
+         std::remove(fileName);
+   }
+};
+
+void df036_missingBranches()
+{
+   // Create the example dataset. Three files are created with one TTree each.
+   // The first contains branches (x, y), the second only branch y, the third
+   // only branch x.
+   Dataset trees{};
+
+   // The TChain will process the three files, encountering a different missing
+   // branch when switching to the next tree
+   TChain c{};
+   for (auto i = 0; i < trees.fFileNames.size(); i++) {
+      const auto fullPath = std::string(trees.fFileNames[i]) + "?#" + trees.fTreeNames[i];
+      c.Add(fullPath.c_str());
+   }
+
+   ROOT::RDataFrame df{c};
+
+   constexpr static auto defaultValue = std::numeric_limits<int>::min();
+
+   // Example 1: provide a default value for all missing branches
+   auto display1 = df.DefaultValueFor("x", defaultValue)
+                      .DefaultValueFor("y", defaultValue)
+                      .Display<int, int>({"x", "y"}, /*nRows*/ 15);
+
+   // Example 2: provide a default value for branch y, but skip events where
+   // branch x is missing
+   auto display2 =
+      df.DefaultValueFor("y", defaultValue).FilterAvailable("x").Display<int, int>({"x", "y"}, /*nRows*/ 15);
+
+   // Example 3: only keep events where branch y is missing and display values for branch x
+   auto display3 = df.FilterMissing("y").Display<int>({"x"}, /*nRows*/ 15);
+
+   std::cout << "Example 1: provide a default value for all missing branches\n";
+   display1->Print();
+
+   std::cout << "Example 2: provide a default value for branch y, but skip events where branch x is missing\n";
+   display2->Print();
+
+   std::cout << "Example 3: only keep events where branch y is missing and display values for branch x\n";
+   display3->Print();
+}

--- a/tutorials/dataframe/df036_missingBranches.py
+++ b/tutorials/dataframe/df036_missingBranches.py
@@ -1,0 +1,122 @@
+# \file
+# \ingroup tutorial_dataframe
+# \notebook -nodraw
+#
+# This example shows how to process a dataset where entries might be
+# incomplete due to one or more missing branches in one or more of the files
+# in the dataset. It shows usage of the FilterAvailable and DefaultValueFor
+# RDataFrame functionalities to act upon the missing entries.
+#
+# \macro_code
+# \macro_output
+#
+# \date September 2024
+# \author Vincenzo Eduardo Padulano (CERN)
+import os
+import ROOT
+import numpy
+
+
+class DatasetContext:
+    """A helper class to create the dataset for the tutorial below."""
+
+    filenames = [
+        "df036_missingBranches_py_file_1.root",
+        "df036_missingBranches_py_file_2.root",
+        "df036_missingBranches_py_file_3.root"
+    ]
+    treenames = ["tree_1", "tree_2", "tree_3"]
+    nentries = 5
+
+    def __init__(self):
+        with ROOT.TFile(self.filenames[0], "RECREATE") as f:
+            t = ROOT.TTree(self.treenames[0], self.treenames[0])
+            x = numpy.array([0], dtype=int)
+            y = numpy.array([0], dtype=int)
+            t.Branch("x", x, "x/I")
+            t.Branch("y", y, "y/I")
+
+            for i in range(1, self.nentries + 1):
+                x[0] = i
+                y[0] = 2 * i
+                t.Fill()
+
+            t.Write()
+
+        with ROOT.TFile(self.filenames[1], "RECREATE") as f:
+            t = ROOT.TTree(self.treenames[1], self.treenames[1])
+            y = numpy.array([0], dtype=int)
+            t.Branch("y", y, "y/I")
+
+            for i in range(1, self.nentries + 1):
+                y[0] = 3 * i
+                t.Fill()
+
+            t.Write()
+
+        with ROOT.TFile(self.filenames[2], "RECREATE") as f:
+            t = ROOT.TTree(self.treenames[2], self.treenames[2])
+            x = numpy.array([0], dtype=int)
+            t.Branch("x", x, "x/I")
+
+            for i in range(1, self.nentries + 1):
+                x[0] = 4 * i
+                t.Fill()
+
+            t.Write()
+
+    def __enter__(self):
+        """Enable using the class as a context manager."""
+        return self
+
+    def __exit__(self, *_):
+        """
+        Enable using the class as a context manager. At the end of the context,
+        remove the files created.
+        """
+        for filename in self.filenames:
+            os.remove(filename)
+
+
+def df036_missingBranches(dataset: DatasetContext):
+    # The input dataset contains three files, with one TTree each.
+    # The first contains branches (x, y), the second only branch y, the third
+    # only branch x. The TChain will process the three files, encountering a
+    # different missing branch when switching to the next tree
+    chain = ROOT.TChain()
+    for fname, tname in zip(dataset.filenames, dataset.treenames):
+        chain.Add(fname + "?#" + tname)
+
+    df = ROOT.RDataFrame(chain)
+
+    default_value = ROOT.std.numeric_limits[int].min()
+
+    # Example 1: provide a default value for all missing branches
+    display_1 = (
+        df.DefaultValueFor("x", default_value)
+        .DefaultValueFor("y", default_value)
+        .Display(columnList=("x", "y"), nRows=15)
+    )
+
+    # Example 2: provide a default value for branch y, but skip events where
+    # branch x is missing
+    display_2 = (
+        df.DefaultValueFor("y", default_value)
+        .FilterAvailable("x")
+        .Display(columnList=("x", "y"), nRows=15)
+    )
+
+    # Example 3: only keep events where branch y is missing and display values for branch x
+    display_3 = df.FilterMissing("y").Display(columnList=("x",), nRows=15)
+
+    print("Example 1: provide a default value for all missing branches")
+    display_1.Print()
+    print("Example 2: provide a default value for branch y, but skip events where branch x is missing")
+    display_2.Print()
+    print("Example 3: only keep events where branch y is missing and display values for branch x")
+    display_3.Print()
+
+
+if __name__ == "__main__":
+    with DatasetContext() as dataset:
+        df036_missingBranches(dataset)

--- a/tutorials/dataframe/df037_TTreeEventMatching.C
+++ b/tutorials/dataframe/df037_TTreeEventMatching.C
@@ -1,0 +1,167 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+///
+/// This example shows processing of a TTree-based dataset with horizontal
+/// concatenations (friends) and event matching (based on TTreeIndex). In case
+/// the current event being processed does not match one (or more) of the friend
+/// datasets, one can use the FilterAvailable and DefaultValueFor functionalities
+/// to act upon the situation.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date September 2024
+/// \author Vincenzo Eduardo Padulano (CERN)
+#include <TChain.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TTreeIndex.h>
+
+#include <ROOT/RDataFrame.hxx>
+
+#include <iostream>
+#include <numeric>
+
+// A helper class to create the dataset for the tutorial below.
+struct Dataset {
+
+   constexpr static auto fMainFile{"df037_TTreeEventMatching_C_main.root"};
+   constexpr static auto fAuxFile1{"df037_TTreeEventMatching_C_aux_1.root"};
+   constexpr static auto fAuxFile2{"df037_TTreeEventMatching_C_aux_2.root"};
+   constexpr static auto fMainTreeName{"events"};
+   constexpr static auto fAuxTreeName1{"auxdata_1"};
+   constexpr static auto fAuxTreeName2{"auxdata_2"};
+
+   Dataset()
+   {
+      {
+         TFile f(fMainFile, "RECREATE");
+         TTree mainTree(fMainTreeName, fMainTreeName);
+         int idx;
+         int x;
+         mainTree.Branch("idx", &idx, "idx/I");
+         mainTree.Branch("x", &x, "x/I");
+
+         idx = 1;
+         x = 1;
+         mainTree.Fill();
+         idx = 2;
+         x = 2;
+         mainTree.Fill();
+         idx = 3;
+         x = 3;
+         mainTree.Fill();
+
+         mainTree.Write();
+      }
+      {
+         // The first auxiliary file has matching indices 1 and 2, but not 3
+         TFile f(fAuxFile1, "RECREATE");
+         TTree auxTree(fAuxTreeName1, fAuxTreeName1);
+         int y;
+         int idx;
+         auxTree.Branch("idx", &idx, "idx/I");
+         auxTree.Branch("y", &y, "y/I");
+
+         idx = 1;
+         y = 4;
+         auxTree.Fill();
+         idx = 2;
+         y = 5;
+         auxTree.Fill();
+
+         auxTree.Write();
+      }
+      {
+         // The second auxiliary file has matching indices 1 and 3, but not 2
+         TFile f(fAuxFile2, "RECREATE");
+         TTree auxTree(fAuxTreeName2, fAuxTreeName2);
+         int z;
+         int idx;
+         auxTree.Branch("idx", &idx, "idx/I");
+         auxTree.Branch("z", &z, "z/I");
+
+         idx = 1;
+         z = 6;
+         auxTree.Fill();
+         idx = 3;
+         z = 7;
+         auxTree.Fill();
+
+         auxTree.Write();
+      }
+   }
+
+   ~Dataset()
+   {
+      std::remove(fMainFile);
+      std::remove(fAuxFile1);
+      std::remove(fAuxFile2);
+   }
+};
+
+void df037_TTreeEventMatching()
+{
+   // Create the dataset: one main TTree and two auxiliary. The 'idx' branch
+   // is used as the index to match events between the trees.
+   // - The main tree has 3 entries, with 'idx' values (1, 2, 3).
+   // - The first auxiliary tree has 2 entries, with 'idx' values (1, 2).
+   // - The second auxiliary tree has 2 entries, with 'idx' values (1, 3).
+   // The two auxiliary trees are concatenated horizontally with the main one.
+   Dataset dataset{};
+   TChain mainChain{dataset.fMainTreeName};
+   mainChain.Add(dataset.fMainFile);
+
+   TChain auxChain1(dataset.fAuxTreeName1);
+   auxChain1.Add(dataset.fAuxFile1);
+   auxChain1.BuildIndex("idx");
+
+   TChain auxChain2(dataset.fAuxTreeName2);
+   auxChain2.Add(dataset.fAuxFile2);
+   auxChain2.BuildIndex("idx");
+
+   mainChain.AddFriend(&auxChain1);
+   mainChain.AddFriend(&auxChain2);
+
+   // Create an RDataFrame to process the input dataset. The DefaultValueFor and
+   // FilterAvailable functionalities can be used to decide what to do for
+   // the events that do not match entirely according to the index column 'idx'
+   ROOT::RDataFrame df{mainChain};
+
+   const std::string auxTree1ColIdx = std::string(dataset.fAuxTreeName1) + ".idx";
+   const std::string auxTree1ColY = std::string(dataset.fAuxTreeName1) + ".y";
+   const std::string auxTree2ColIdx = std::string(dataset.fAuxTreeName2) + ".idx";
+   const std::string auxTree2ColZ = std::string(dataset.fAuxTreeName2) + ".z";
+
+   constexpr static auto defaultValue = std::numeric_limits<int>::min();
+
+   // Example 1: provide default values for all columns in case there was no
+   // match
+   auto display1 = df.DefaultValueFor(auxTree1ColIdx, defaultValue)
+                      .DefaultValueFor(auxTree1ColY, defaultValue)
+                      .DefaultValueFor(auxTree2ColIdx, defaultValue)
+                      .DefaultValueFor(auxTree2ColZ, defaultValue)
+                      .Display<int, int, int, int, int, int>(
+                         {"idx", auxTree1ColIdx, auxTree2ColIdx, "x", auxTree1ColY, auxTree2ColZ});
+
+   // Example 2: skip the entire entry when there was no match for a column
+   // in the first auxiliary tree, but keep the entries when there is no match
+   // in the second auxiliary tree and provide a default value for those
+   auto display2 = df.DefaultValueFor(auxTree2ColIdx, defaultValue)
+                      .DefaultValueFor(auxTree2ColZ, defaultValue)
+                      .FilterAvailable(auxTree1ColY)
+                      .Display<int, int, int, int, int, int>(
+                         {"idx", auxTree1ColIdx, auxTree2ColIdx, "x", auxTree1ColY, auxTree2ColZ});
+
+   // Example 3: Keep entries from the main tree for which there is no
+   // corresponding match in entries of the first auxiliary tree
+   auto display3 = df.FilterMissing(auxTree1ColIdx).Display<int, int>({"idx", "x"});
+
+   std::cout << "Example 1: provide default values for all columns\n";
+   display1->Print();
+   std::cout << "Example 2: skip the entry only when the first auxiliary tree does not match\n";
+   display2->Print();
+   std::cout << "Example 3: keep entries from the main tree for which there is no match in the auxiliary tree\n";
+   display3->Print();
+}

--- a/tutorials/dataframe/df037_TTreeEventMatching.py
+++ b/tutorials/dataframe/df037_TTreeEventMatching.py
@@ -1,0 +1,163 @@
+# \file
+# \ingroup tutorial_dataframe
+# \notebook -nodraw
+#
+# This example shows processing of a TTree-based dataset with horizontal
+# concatenations (friends) and event matching (based on TTreeIndex). In case
+# the current event being processed does not match one (or more) of the friend
+# datasets, one can use the FilterAvailable and DefaultValueFor functionalities
+# to act upon the situation.
+#
+# \macro_code
+# \macro_output
+#
+# \date September 2024
+# \author Vincenzo Eduardo Padulano (CERN)
+import os
+import ROOT
+import numpy
+
+
+class DatasetContext:
+    """A helper class to create the dataset for the tutorial below."""
+
+    main_file = "df037_TTreeEventMatching_py_main.root"
+    aux_file_1 = "df037_TTreeEventMatching_py_aux_1.root"
+    aux_file_2 = "df037_TTreeEventMatching_py_aux_2.root"
+    main_tree_name = "events"
+    aux_tree_name_1 = "auxdata_1"
+    aux_tree_name_2 = "auxdata_2"
+
+    def __init__(self):
+        with ROOT.TFile(self.main_file, "RECREATE") as f:
+            main_tree = ROOT.TTree(self.main_tree_name, self.main_tree_name)
+            idx = numpy.array([0], dtype=int)
+            x = numpy.array([0], dtype=int)
+            main_tree.Branch("idx", idx, "idx/I")
+            main_tree.Branch("x", x, "x/I")
+
+            idx[0] = 1
+            x[0] = 1
+            main_tree.Fill()
+            idx[0] = 2
+            x[0] = 2
+            main_tree.Fill()
+            idx[0] = 3
+            x[0] = 3
+            main_tree.Fill()
+
+            main_tree.Write()
+
+        # The first auxiliary file has matching indices 1 and 2, but not 3
+        with ROOT.TFile(self.aux_file_1, "RECREATE") as f:
+            aux_tree_1 = ROOT.TTree(self.aux_tree_name_1, self.aux_tree_name_1)
+            idx = numpy.array([0], dtype=int)
+            y = numpy.array([0], dtype=int)
+            aux_tree_1.Branch("idx", idx, "idx/I")
+            aux_tree_1.Branch("y", y, "y/I")
+
+            idx[0] = 1
+            y[0] = 4
+            aux_tree_1.Fill()
+            idx[0] = 2
+            y[0] = 5
+            aux_tree_1.Fill()
+
+            aux_tree_1.Write()
+
+        # The second auxiliary file has matching indices 1 and 3, but not 2
+        with ROOT.TFile(self.aux_file_2, "RECREATE") as f:
+            aux_tree_2 = ROOT.TTree(self.aux_tree_name_2, self.aux_tree_name_2)
+            idx = numpy.array([0], dtype=int)
+            z = numpy.array([0], dtype=int)
+            aux_tree_2.Branch("idx", idx, "idx/I")
+            aux_tree_2.Branch("z", z, "z/I")
+
+            idx[0] = 1
+            z[0] = 6
+            aux_tree_2.Fill()
+            idx[0] = 3
+            z[0] = 7
+            aux_tree_2.Fill()
+
+            aux_tree_2.Write()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        os.remove(self.main_file)
+        os.remove(self.aux_file_1)
+        os.remove(self.aux_file_2)
+
+
+def df037_TTreeEventMatching(dataset: DatasetContext):
+    # The input dataset has one main TTree and two auxiliary. The 'idx' branch
+    # is used as the index to match events between the trees.
+    # - The main tree has 3 entries, with 'idx' values(1, 2, 3).
+    # - The first auxiliary tree has 2 entries, with 'idx' values(1, 2).
+    # - The second auxiliary tree has 2 entries, with 'idx' values(1, 3).
+    # The two auxiliary trees are concatenated horizontally with the main one.
+    main_chain = ROOT.TChain(dataset.main_tree_name)
+    main_chain.Add(dataset.main_file)
+
+    aux_chain_1 = ROOT.TChain(dataset.aux_tree_name_1)
+    aux_chain_1.Add(dataset.aux_file_1)
+    aux_chain_1.BuildIndex("idx")
+
+    aux_chain_2 = ROOT.TChain(dataset.aux_tree_name_2)
+    aux_chain_2.Add(dataset.aux_file_2)
+    aux_chain_2.BuildIndex("idx")
+
+    main_chain.AddFriend(aux_chain_1)
+    main_chain.AddFriend(aux_chain_2)
+
+    # Create an RDataFrame to process the input dataset. The DefaultValueFor and
+    # FilterAvailable functionalities can be used to decide what to do for
+    # the events that do not match entirely according to the index column 'idx'
+    df = ROOT.RDataFrame(main_chain)
+
+    aux_tree_1_colidx = dataset.aux_tree_name_1 + ".idx"
+    aux_tree_1_coly = dataset.aux_tree_name_1 + ".y"
+    aux_tree_2_colidx = dataset.aux_tree_name_2 + ".idx"
+    aux_tree_2_colz = dataset.aux_tree_name_2 + ".z"
+
+    default_value = ROOT.std.numeric_limits[int].min()
+
+    # Example 1: provide default values for all columns in case there was no
+    # match
+    display_1 = (
+        df.DefaultValueFor(aux_tree_1_colidx, default_value)
+        .DefaultValueFor(aux_tree_1_coly, default_value)
+        .DefaultValueFor(aux_tree_2_colidx, default_value)
+        .DefaultValueFor(aux_tree_2_colz, default_value)
+        .Display(
+            ("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
+    )
+
+    # Example 2: skip the entire entry when there was no match for a column
+    # in the first auxiliary tree, but keep the entries when there is no match
+    # in the second auxiliary tree and provide a default value for those
+    display_2 = (
+        df.DefaultValueFor(aux_tree_2_colidx, default_value)
+        .DefaultValueFor(aux_tree_2_colz, default_value)
+        .FilterAvailable(aux_tree_1_coly)
+        .Display(
+                ("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
+    )
+
+   # Example 3: Keep entries from the main tree for which there is no
+   # corresponding match in entries of the first auxiliary tree
+    display_3 = df.FilterMissing(aux_tree_1_colidx).Display(("idx", "x"))
+
+    print("Example 1: provide default values for all columns")
+    display_1.Print()
+    print("Example 2: always skip the entry when there is no match")
+    display_2.Print()
+    print("Example 3: keep entries from the main tree for which there is no match in the auxiliary tree")
+    display_3.Print()
+
+
+if __name__ == "__main__":
+    with DatasetContext() as dataset:
+        df037_TTreeEventMatching(dataset)


### PR DESCRIPTION
This PR introduces the logic necessary in TTreeReader to detect when an entry being read is "incomplete" for the following situations:
* When switching to a new tree in the chain, if a branch that was expected to be found is not available
* When doing event matching with TTreeIndex, in case one or more of the friend trees did not match the index value for the current entry.

It also introduces new functionality in RDataFrame to allow users to act upon the situations described above:
* `DefaultValueFor(colname, defaultval)`: lets the user provide one default value for the current entry of the input column, in case the value is missing.
* `FilterAvailable(colname)`: works in the same way as the traditional `Filter` operation, where the "expression" is "is the value available?". If so, the entry is kept, if not, it is discarded.
* `FilterMissing(colname)`: works in the same way as the traditional `Filter` operation, where the "expression" is "is the value missing?". If so, the entry is kept, if not, it is discarded.

The tutorials `df036_missingBranches` and `df037_TTreeEventMatching` show example usage of the new functionalities.