### PR TITLE
[RF] Improve binBoundaries method of ParamHistFunc

### DIFF
--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -726,8 +726,8 @@ std::list<double>* ParamHistFunc::binBoundaries(RooAbsRealLValue& obs, double xl
 
   // look for variable in the DataHist, and if found, return the binning
   std::string varName = dynamic_cast<TObject*>(lvarg)->GetName();
-  auto& vars = _dataSet->getVariables();
-  auto& binnings = _dataSet->getBinnings();
+  auto& vars = _dataSet.getVariables();
+  auto& binnings = _dataSet.getBinnings();
   for(size_t i=0; i < vars.size(); i++ ) {
     if(varName == vars.at(i)->GetName()) {
       // found the variable, return its binning

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -718,31 +718,29 @@ std::list<double>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double
 /// as the recursive division strategy of RooCurve cannot deal efficiently
 /// with the vertical lines that occur in a non-interpolated histogram
 
-std::list<double>* ParamHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
-                    double xhi) const
+std::list<double> *ParamHistFunc::binBoundaries(RooAbsRealLValue &obs, double xlo, double xhi) const
 {
-  // copied and edited from RooHistFunc
-  RooAbsLValue* lvarg = &obs;
+   // copied and edited from RooHistFunc
+   RooAbsLValue *lvarg = &obs;
 
-  // look for variable in the DataHist, and if found, return the binning
-  std::string varName = dynamic_cast<TObject*>(lvarg)->GetName();
-  auto& vars = _dataSet.getVariables();
-  auto& binnings = _dataSet.getBinnings();
-  for(size_t i=0; i < vars.size(); i++ ) {
-    if(varName == vars.at(i)->GetName()) {
-      // found the variable, return its binning
-      const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
-      double* boundaries = binnings.at(i)->array();
-      std::list<double>* hint = new std::list<double> ;
-      for (Int_t i=0 ; i<binnings.at(i)->numBoundaries() ; i++) {
-        if (boundaries[i]>=xlo && boundaries[i]<=xhi) {
-          hint->push_back(boundaries[i]) ;
-        }
+   // look for variable in the DataHist, and if found, return the binning
+   std::string varName = dynamic_cast<TObject *>(lvarg)->GetName();
+   RooArgSet const &vars = *_dataSet.get();
+   auto &binnings = _dataSet.getBinnings();
+   for (size_t i = 0; i < vars.size(); i++) {
+      if (varName == vars[i]->GetName()) {
+         // found the variable, return its binning
+         const RooAbsBinning *binning = lvarg->getBinningPtr(nullptr);
+         double *boundaries = binnings.at(i)->array();
+         std::list<double> *hint = new std::list<double>;
+         for (Int_t i = 0; i < binnings.at(i)->numBoundaries(); i++) {
+            if (boundaries[i] >= xlo && boundaries[i] <= xhi) {
+               hint->push_back(boundaries[i]);
+            }
+         }
+         return hint;
       }
-      return hint ;
-    }
-  }
-  // variable not found, return null
-  return nullptr;
-  
+   }
+   // variable not found, return null
+   return nullptr;
 }

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -725,12 +725,11 @@ std::list<double> *ParamHistFunc::binBoundaries(RooAbsRealLValue &obs, double xl
 
    // look for variable in the DataHist, and if found, return the binning
    std::string varName = dynamic_cast<TObject *>(lvarg)->GetName();
-   RooArgSet const &vars = *_dataSet.get();
+   RooArgSet const &vars = *_dataSet.get(); // guaranteed to be in the same order as the binnings vector
    auto &binnings = _dataSet.getBinnings();
    for (size_t i = 0; i < vars.size(); i++) {
       if (varName == vars[i]->GetName()) {
          // found the variable, return its binning
-         const RooAbsBinning *binning = lvarg->getBinningPtr(nullptr);
          double *boundaries = binnings.at(i)->array();
          std::list<double> *hint = new std::list<double>;
          for (Int_t i = 0; i < binnings.at(i)->numBoundaries(); i++) {

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -732,9 +732,9 @@ std::list<double> *ParamHistFunc::binBoundaries(RooAbsRealLValue &obs, double xl
          // found the variable, return its binning
          double *boundaries = binnings.at(i)->array();
          std::list<double> *hint = new std::list<double>;
-         for (Int_t i = 0; i < binnings.at(i)->numBoundaries(); i++) {
-            if (boundaries[i] >= xlo && boundaries[i] <= xhi) {
-               hint->push_back(boundaries[i]);
+         for (int j = 0; j < binnings.at(i)->numBoundaries(); j++) {
+            if (boundaries[j] >= xlo && boundaries[j] <= xhi) {
+               hint->push_back(boundaries[j]);
             }
          }
          return hint;

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -724,19 +724,25 @@ std::list<double>* ParamHistFunc::binBoundaries(RooAbsRealLValue& obs, double xl
   // copied and edited from RooHistFunc
   RooAbsLValue* lvarg = &obs;
 
-  // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
-  double* boundaries = binning->array() ;
-
-  std::list<double>* hint = new std::list<double> ;
-
-  // Construct array with pairs of points positioned epsilon to the left and
-  // right of the bin boundaries
-  for (Int_t i=0 ; i<binning->numBoundaries() ; i++) {
-    if (boundaries[i]>=xlo && boundaries[i]<=xhi) {
-      hint->push_back(boundaries[i]) ;
+  // look for variable in the DataHist, and if found, return the binning
+  std::string varName = dynamic_cast<TObject*>(lvarg)->GetName();
+  auto& vars = _dataSet->getVariables();
+  auto& binnings = _dataSet->getBinnings();
+  for(size_t i=0; i < vars.size(); i++ ) {
+    if(varName == vars.at(i)->GetName()) {
+      // found the variable, return its binning
+      const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
+      double* boundaries = binnings.at(i)->array();
+      std::list<double>* hint = new std::list<double> ;
+      for (Int_t i=0 ; i<binnings.at(i)->numBoundaries() ; i++) {
+        if (boundaries[i]>=xlo && boundaries[i]<=xhi) {
+          hint->push_back(boundaries[i]) ;
+        }
+      }
+      return hint ;
     }
   }
-
-  return hint ;
+  // variable not found, return null
+  return nullptr;
+  
 }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -205,6 +205,7 @@ public:
   };
 
   std::vector<std::unique_ptr<const RooAbsBinning>> const& getBinnings() const { return _lvbins; }
+  std::vector<RooAbsLValue*> const& getVariables() const { return _lvvars; }
 
   double const* weightArray()   const { return _wgt; }
   double const* wgtErrLoArray() const { return _errLo; }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -205,7 +205,6 @@ public:
   };
 
   std::vector<std::unique_ptr<const RooAbsBinning>> const& getBinnings() const { return _lvbins; }
-  std::vector<RooAbsLValue*> const& getVariables() const { return _lvvars; }
 
   double const* weightArray()   const { return _wgt; }
   double const* wgtErrLoArray() const { return _errLo; }


### PR DESCRIPTION
ParamHistFunc currently does not adhere to the convention that if it is independent of the variable passed to binBoundaries method that it should return nullptr. This is fixed, along with more correct obtaining of the bin boundaries, from the RooDataHist itself.