### PR TITLE
[ntuple] Various fixes for big-endian

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -641,8 +641,9 @@ public:
       std::uint16_t *uint16Array = reinterpret_cast<std::uint16_t *>(src);
 
       for (std::size_t i = 0; i < count; ++i) {
-         ByteSwapIfNecessary(floatArray[i]);
-         floatArray[i] = HalfToFloat(uint16Array[i]);
+         std::uint16_t val = uint16Array[i];
+         ByteSwapIfNecessary(val);
+         floatArray[i] = HalfToFloat(val);
       }
    }
 };

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -580,7 +580,7 @@ public:
          RSwitchElement element{srcArray[i].GetIndex(), srcArray[i].GetTag()};
 #if R__LITTLE_ENDIAN == 0
          element.fIndex = RByteSwap<8>::bswap(element.fIndex);
-         element.fTag = RByteSwap<8>::bswap(element.fTag);
+         element.fTag = RByteSwap<4>::bswap(element.fTag);
 #endif
          memcpy(dstArray + i * 12, &element, 12);
       }
@@ -595,7 +595,7 @@ public:
          memcpy(&element, srcArray + i * 12, 12);
 #if R__LITTLE_ENDIAN == 0
          element.fIndex = RByteSwap<8>::bswap(element.fIndex);
-         element.fTag = RByteSwap<8>::bswap(element.fTag);
+         element.fTag = RByteSwap<4>::bswap(element.fTag);
 #endif
          dstArray[i] = ROOT::Experimental::RColumnSwitch(ClusterSize_t{element.fIndex}, element.fTag);
       }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -56,7 +56,7 @@ private:
    static std::uint16_t Swap(std::uint16_t val)
    {
 #if R__LITTLE_ENDIAN == 1
-      return RByteSwap<sizeof(fValBE)>::bswap(val);
+      return RByteSwap<sizeof(val)>::bswap(val);
 #else
       return val;
 #endif
@@ -80,7 +80,7 @@ private:
    static std::uint32_t Swap(std::uint32_t val)
    {
 #if R__LITTLE_ENDIAN == 1
-      return RByteSwap<sizeof(fValBE)>::bswap(val);
+      return RByteSwap<sizeof(val)>::bswap(val);
 #else
       return val;
 #endif
@@ -104,7 +104,7 @@ private:
    static std::int32_t Swap(std::int32_t val)
    {
 #if R__LITTLE_ENDIAN == 1
-      return RByteSwap<sizeof(fValBE)>::bswap(val);
+      return RByteSwap<sizeof(val)>::bswap(val);
 #else
       return val;
 #endif
@@ -128,7 +128,7 @@ private:
    static std::uint64_t Swap(std::uint64_t val)
    {
 #if R__LITTLE_ENDIAN == 1
-      return RByteSwap<sizeof(fValBE)>::bswap(val);
+      return RByteSwap<sizeof(val)>::bswap(val);
 #else
       return val;
 #endif

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -21,6 +21,7 @@
 #include <ROOT/RRawFile.hxx>
 #include <ROOT/RNTupleZip.hxx>
 
+#include <Byteswap.h>
 #include <TError.h>
 #include <TFile.h>
 #include <TKey.h>
@@ -35,6 +36,15 @@
 #include <string>
 #include <chrono>
 
+#ifndef R__LITTLE_ENDIAN
+#ifdef R__BYTESWAP
+// `R__BYTESWAP` is defined in RConfig.hxx for little-endian architectures; undefined otherwise
+#define R__LITTLE_ENDIAN 1
+#else
+#define R__LITTLE_ENDIAN 0
+#endif
+#endif /* R__LITTLE_ENDIAN */
+
 namespace {
 
 // The following types are used to read and write the TFile binary format
@@ -43,7 +53,14 @@ namespace {
 class RUInt16BE {
 private:
    std::uint16_t fValBE = 0;
-   static std::uint16_t Swap(std::uint16_t val) { return (val & 0x00FF) << 8 | (val & 0xFF00) >> 8; }
+   static std::uint16_t Swap(std::uint16_t val)
+   {
+#if R__LITTLE_ENDIAN == 1
+      return RByteSwap<sizeof(fValBE)>::bswap(val);
+#else
+      return val;
+#endif
+   }
 
 public:
    RUInt16BE() = default;
@@ -62,8 +79,11 @@ private:
    std::uint32_t fValBE = 0;
    static std::uint32_t Swap(std::uint32_t val)
    {
-      auto x = (val & 0x0000FFFF) << 16 | (val & 0xFFFF0000) >> 16;
-      return (x & 0x00FF00FF) << 8 | (x & 0xFF00FF00) >> 8;
+#if R__LITTLE_ENDIAN == 1
+      return RByteSwap<sizeof(fValBE)>::bswap(val);
+#else
+      return val;
+#endif
    }
 
 public:
@@ -83,8 +103,11 @@ private:
    std::int32_t fValBE = 0;
    static std::int32_t Swap(std::int32_t val)
    {
-      auto x = (val & 0x0000FFFF) << 16 | (val & 0xFFFF0000) >> 16;
-      return (x & 0x00FF00FF) << 8 | (x & 0xFF00FF00) >> 8;
+#if R__LITTLE_ENDIAN == 1
+      return RByteSwap<sizeof(fValBE)>::bswap(val);
+#else
+      return val;
+#endif
    }
 
 public:
@@ -104,9 +127,11 @@ private:
    std::uint64_t fValBE = 0;
    static std::uint64_t Swap(std::uint64_t val)
    {
-      auto x = (val & 0x00000000FFFFFFFF) << 32 | (val & 0xFFFFFFFF00000000) >> 32;
-      x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
-      return (x & 0x00FF00FF00FF00FF) << 8 | (x & 0xFF00FF00FF00FF00) >> 8;
+#if R__LITTLE_ENDIAN == 1
+      return RByteSwap<sizeof(fValBE)>::bswap(val);
+#else
+      return val;
+#endif
    }
 
 public:

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -1,4 +1,5 @@
 // Override endianness detection in RColumnElement.hxx; assume big-endian machine
+// These tests are simulating a big endian machine; we will turn them off on an actual big endian node.
 #define R__LITTLE_ENDIAN 0
 
 #include "gtest/gtest.h"
@@ -104,6 +105,9 @@ public:
 
 TEST(RColumnElementEndian, ByteCopy)
 {
+#ifndef R__BYTESWAP
+   GTEST_SKIP() << "Skipping test on big endian node";
+#else
    ROOT::Experimental::Internal::RColumnElement<float, EColumnType::kReal32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
@@ -121,10 +125,14 @@ TEST(RColumnElementEndian, ByteCopy)
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
    std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+#endif
 }
 
 TEST(RColumnElementEndian, Cast)
 {
+#ifndef R__BYTESWAP
+   GTEST_SKIP() << "Skipping test on big endian node";
+#else
    ROOT::Experimental::Internal::RColumnElement<std::int64_t, EColumnType::kInt32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
@@ -146,10 +154,14 @@ TEST(RColumnElementEndian, Cast)
                        "\x00\x01\x02\x03\x00\x00\x00\x00\x04\x05\x06\x07\x00\x00\x00\x00"
                        "\x08\x09\x0a\x0b\x00\x00\x00\x00\x0c\x0d\x0e\x0f\x00\x00\x00\x00",
                        32));
+#endif
 }
 
 TEST(RColumnElementEndian, Split)
 {
+#ifndef R__BYTESWAP
+   GTEST_SKIP() << "Skipping test on big endian node";
+#else
    ROOT::Experimental::Internal::RColumnElement<double, EColumnType::kSplitReal64> splitElement;
 
    RPageSinkMock sink1(splitElement);
@@ -166,10 +178,14 @@ TEST(RColumnElementEndian, Split)
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
    std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+#endif
 }
 
 TEST(RColumnElementEndian, DeltaSplit)
 {
+#ifndef R__BYTESWAP
+   GTEST_SKIP() << "Skipping test on big endian node";
+#else
    using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 
    ROOT::Experimental::Internal::RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element;
@@ -193,4 +209,5 @@ TEST(RColumnElementEndian, DeltaSplit)
                        "\x00\x01\x02\x03\x00\x00\x00\x00\x04\x05\x06\x07\x00\x00\x00\x00"
                        "\x08\x09\x0a\x0b\x00\x00\x00\x00\x0c\x0d\x0e\x0f\x00\x00\x00\x00",
                        32));
+#endif
 }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -97,11 +97,13 @@ TEST(Packing, HalfPrecisionFloat)
    element.Unpack(nullptr, nullptr, 0);
 
    float in = 3.14;
-   std::uint16_t b = 0;
-   element.Pack(&b, &in, 1);
-   EXPECT_EQ(0x4248, b); // Expected bit representation: 0b01000010 01001000
+   unsigned char buf[2] = {0, 0};
+   element.Pack(buf, &in, 1);
+   // Expected bit representation: 0b01000010 01001000
+   EXPECT_EQ(0x48, buf[0]);
+   EXPECT_EQ(0x42, buf[1]);
    float out = 0.;
-   element.Unpack(&out, &b, 1);
+   element.Unpack(&out, buf, 1);
    EXPECT_FLOAT_EQ(3.140625, out);
 
    float in4[] = {0.1, 0.2, 0.3, 0.4};
@@ -124,10 +126,10 @@ TEST(Packing, RColumnSwitch)
    element.Unpack(nullptr, nullptr, 0);
 
    ROOT::Experimental::RColumnSwitch s1(ClusterSize_t{0xaa}, 0x55);
-   std::pair<std::uint64_t, std::uint32_t> out;
-   element.Pack(&out, &s1, 1);
+   unsigned char out[12];
+   element.Pack(out, &s1, 1);
    ROOT::Experimental::RColumnSwitch s2;
-   element.Unpack(&s2, &out, 1);
+   element.Unpack(&s2, out, 1);
    EXPECT_EQ(0xaa, s2.GetIndex());
    EXPECT_EQ(0x55, s2.GetTag());
 }


### PR DESCRIPTION
Addresses several bugs on big-endian architecture, some in the testing code only, some in the actual code. Tested manually on Power8/EL7. Also tested that RNTuple data written on little-endian can be read on big-endian and vice versa.

Fixes #12426

