### PR TITLE
Make string caching in RLoopManager thread-safe

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -13,6 +13,7 @@
 
 #include "RColumnReaderBase.hxx"
 #include "RDefineBase.hxx"
+#include "Utils.hxx"
 #include <Rtypes.h>  // Long64_t, R__CLING_PTRCHECK
 
 #include <limits>
@@ -64,11 +65,11 @@ class RDefinesWithReaders {
    std::vector<std::unordered_map<std::string_view, std::unique_ptr<RDefineReader>>> fReadersPerVariation;
 
    // Strings that were already used to represent column names in this RDataFrame instance.
-   std::unordered_set<std::string> &fCachedColNames;
+   ROOT::Internal::RDF::RStringCache &fCachedColNames;
 
 public:
    RDefinesWithReaders(std::shared_ptr<ROOT::Detail::RDF::RDefineBase> define, unsigned int nSlots,
-                       std::unordered_set<std::string> &cachedColNames);
+                       ROOT::Internal::RDF::RStringCache &cachedColNames);
    ROOT::Detail::RDF::RDefineBase &GetDefine() const { return *fDefine; }
    ROOT::Internal::RDF::RDefineReader &GetReader(unsigned int slot, std::string_view variationName);
 };

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -17,6 +17,7 @@
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "ROOT/RDF/RNewSampleNotifier.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
+#include "ROOT/RDF/Utils.hxx"
 
 #include <functional>
 #include <limits>
@@ -181,7 +182,7 @@ class RLoopManager : public RNodeBase {
    void UpdateSampleInfo(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
    void UpdateSampleInfo(unsigned int slot, TTreeReader &r);
 
-   std::unordered_set<std::string> fCachedColNames;
+   ROOT::Internal::RDF::RStringCache fCachedColNames;
    std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RDefinesWithReaders>>>
       fUniqueDefinesWithReaders;
    std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RVariationsWithReaders>>>
@@ -261,7 +262,7 @@ public:
    void SetEmptyEntryRange(std::pair<ULong64_t, ULong64_t> &&newRange);
    void ChangeSpec(ROOT::RDF::Experimental::RDatasetSpec &&spec);
 
-   std::unordered_set<std::string> &GetColumnNamesCache() { return fCachedColNames; }
+   ROOT::Internal::RDF::RStringCache &GetColumnNamesCache() { return fCachedColNames; }
    std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RDefinesWithReaders>>> &
    GetUniqueDefinesWithReaders()
    {

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -22,6 +22,8 @@
 #include <functional>
 #include <memory>
 #include <new> // std::hardware_destructive_interference_size
+#include <unordered_set>
+#include <shared_mutex>
 #include <string>
 #include <type_traits> // std::decay, std::false_type
 #include <vector>
@@ -274,6 +276,29 @@ std::vector<T> Union(const std::vector<T> &v1, const std::vector<T> &v2)
 
    return res;
 }
+
+/**
+ * \brief A Thread-safe cache for strings.
+ *
+ * This is used to generically store strings that are created in the computation
+ * graph machinery, for example when adding a new node.
+ */
+class RStringCache {
+   std::unordered_set<std::string> fStrings{};
+   std::shared_mutex fMutex{};
+
+public:
+   /**
+    * \brief Inserts the input string in the cache and returns an iterator to the cached string.
+    *
+    * The function implements the following strategy for thread-safety:
+    * 1. Take a shared lock and early return if the string is already in the cache.
+    * 2. Release the shared lock and take an exclusive lock.
+    * 3. Check again if another thread filled the cache meanwhile. If so, return the cached value.
+    * 4. Insert the new value in the cache and return.
+    */
+   auto Insert(const std::string &string) -> decltype(fStrings)::const_iterator;
+};
 
 } // end NS RDF
 } // end NS Internal

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -70,7 +70,7 @@ bool RColumnRegister::IsDefineOrAlias(std::string_view name) const
 /// the new column, and swaps it with the old one.
 void RColumnRegister::AddDefine(std::shared_ptr<RDFDetail::RDefineBase> define)
 {
-   auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(define->GetName());
+   const auto colIt = fLoopManager->GetColumnNamesCache().Insert(define->GetName());
    auto insertion_defs = fLoopManager->GetUniqueDefinesWithReaders().insert(
       {*colIt, std::make_unique<ROOT::Internal::RDF::RDefinesWithReaders>(define, fLoopManager->GetNSlots(),
                                                                           fLoopManager->GetColumnNamesCache())});
@@ -100,7 +100,7 @@ void RColumnRegister::AddVariation(std::shared_ptr<RVariationBase> variation)
 
    // Cache column names for this variation and store views for later use
    for (const auto &colName : colNames) {
-      auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(colName);
+      auto colIt = fLoopManager->GetColumnNamesCache().Insert(colName);
       auto [colAndVariationsIt, _2] = fLoopManager->GetUniqueVariationsWithReaders().insert(
          {*colIt, std::make_unique<ROOT::Internal::RDF::RVariationsWithReaders>(variation, fLoopManager->GetNSlots())});
       newVariations->insert({colAndVariationsIt->first, colAndVariationsIt->second.get()});
@@ -196,14 +196,10 @@ void RColumnRegister::AddAlias(std::string_view alias, std::string_view colName)
    // at this point validation of alias and colName has already happened, we trust that
    // this is a new, valid alias.
    auto &colNamesCache = fLoopManager->GetColumnNamesCache();
-   auto insertion_alias = colNamesCache.insert(std::string(alias));
-   auto insertion_col = colNamesCache.insert(std::string(colName));
+   auto aliasIt = colNamesCache.Insert(std::string(alias));
+   auto colIt = colNamesCache.Insert(std::string(colName));
 
    auto newAliases = std::make_shared<AliasesMap_t>(*fAliases);
-   // Structured bindings cannot be used in lambda captures (until C++20)
-   // so we explicitly define variable names here
-   const auto &aliasIt = insertion_alias.first;
-   const auto &colIt = insertion_col.first;
    // If an alias was already present we need to substitute it with the new one
    if (auto previousAliasIt =
           std::find_if(newAliases->begin(), newAliases->end(),
@@ -245,7 +241,7 @@ std::string_view RColumnRegister::ResolveAlias(std::string_view alias) const
    if (alias.size() > 1 && alias[0] == '#') {
       std::string sizeof_colname{"R_rdf_sizeof_"};
       sizeof_colname.append(alias.substr(1));
-      auto [colIt, _1] = fLoopManager->GetColumnNamesCache().insert(sizeof_colname);
+      auto colIt = fLoopManager->GetColumnNamesCache().Insert(sizeof_colname);
       return *colIt;
    }
 

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -426,6 +426,22 @@ bool IsStrInVec(const std::string &str, const std::vector<std::string> &vec)
    return std::find(vec.cbegin(), vec.cend(), str) != vec.cend();
 }
 
+auto RStringCache::Insert(const std::string &string) -> decltype(fStrings)::const_iterator
+{
+   {
+      std::shared_lock l{fMutex};
+      if (auto it = fStrings.find(string); it != fStrings.end())
+         return it;
+   }
+
+   // TODO: Would be nicer to use a lock upgrade strategy a-la TVirtualRWMutex
+   // but that is unfortunately not usable outside the already available ROOT mutexes
+   std::unique_lock l{fMutex};
+   if (auto it = fStrings.find(string); it != fStrings.end())
+      return it;
+
+   return fStrings.insert(string).first;
+}
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/dataframe/src/RDefineReader.cxx
+++ b/tree/dataframe/src/RDefineReader.cxx
@@ -16,7 +16,7 @@
 
 ROOT::Internal::RDF::RDefinesWithReaders::RDefinesWithReaders(std::shared_ptr<ROOT::Detail::RDF::RDefineBase> define,
                                                               unsigned int nSlots,
-                                                              std::unordered_set<std::string> &cachedColNames)
+                                                              ROOT::Internal::RDF::RStringCache &cachedColNames)
    : fDefine(std::move(define)), fReadersPerVariation(nSlots), fCachedColNames(cachedColNames)
 {
    assert(fDefine != nullptr);
@@ -25,7 +25,7 @@ ROOT::Internal::RDF::RDefinesWithReaders::RDefinesWithReaders(std::shared_ptr<RO
 ROOT::Internal::RDF::RDefineReader &
 ROOT::Internal::RDF::RDefinesWithReaders::GetReader(unsigned int slot, std::string_view variationName)
 {
-   auto [nameIt, _] = fCachedColNames.insert(std::string(variationName));
+   auto nameIt = fCachedColNames.Insert(std::string(variationName));
    auto &defineReaders = fReadersPerVariation[slot];
 
    auto it = defineReaders.find(*nameIt);


### PR DESCRIPTION
Implement and use a thread-safe container for caching strings that are created and used in the computation graph. Notably, these include the strings representing column names generated by `Define`.

This fixes the recent failures seen on MacOS in the `dataframe-vary` unittest. Since that underlines a thread-safety issue in the overall initialisation phase of MT RDF runs, it should be backported to 6.32
