### PR TITLE
[DF] Correctly return number of files in `RDFDescription`

### DIFF
--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -83,6 +83,7 @@ public:
           std::unordered_map<std::string, char> &&colTypes = {});
    void Finalize() final;
    ~RCsvDS();
+   std::size_t GetNFiles() const final { return 1; }
    const std::vector<std::string> &GetColumnNames() const final;
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final;
    std::string GetTypeName(std::string_view colName) const final;

--- a/tree/dataframe/inc/ROOT/RDF/RDFDescription.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDFDescription.hxx
@@ -31,7 +31,6 @@ class RDFDescription {
    unsigned int fFileCount;
 
 public:
-   RDFDescription(const std::string &briefDescription, const std::string &fullDescription);
    RDFDescription(const std::string &briefDescription, const std::string &fullDescription, unsigned int filecount);
 
    std::string AsString(bool shortFormat = false) const;

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -124,6 +124,9 @@ public:
    // clang-format on
    virtual void SetNSlots(unsigned int nSlots) = 0;
 
+   /// \brief Returns the number of files from which the dataset is constructed
+   virtual std::size_t GetNFiles() const { return 0; }
+
    // clang-format off
    /// \brief Returns a reference to the collection of the dataset's column names
    // clang-format on

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -124,6 +124,7 @@ public:
    ~RNTupleDS();
 
    void SetNSlots(unsigned int nSlots) final;
+   std::size_t GetNFiles() const final { return fFileNames.empty() ? 1 : fFileNames.size(); }
    const std::vector<std::string> &GetColumnNames() const final { return fColumnNames; }
    bool HasColumn(std::string_view colName) const final;
    std::string GetTypeName(std::string_view colName) const final;

--- a/tree/dataframe/inc/ROOT/RRootDS.hxx
+++ b/tree/dataframe/inc/ROOT/RRootDS.hxx
@@ -45,6 +45,7 @@ protected:
 public:
    RRootDS(std::string_view treeName, std::string_view fileNameGlob);
    ~RRootDS();
+   std::size_t GetNFiles() const final;
    std::string GetTypeName(std::string_view colName) const final;
    const std::vector<std::string> &GetColumnNames() const final;
    bool HasColumn(std::string_view colName) const final;

--- a/tree/dataframe/src/RDFDescription.cxx
+++ b/tree/dataframe/src/RDFDescription.cxx
@@ -14,9 +14,6 @@
 namespace ROOT {
 namespace RDF {
 
-RDFDescription::RDFDescription(const std::string &briefDescription, const std::string &fullDescription)
-   : fBriefDescription(briefDescription), fFullDescription(fullDescription){};
-
 RDFDescription::RDFDescription(const std::string &briefDescription, const std::string &fullDescription,
                                unsigned int filecount)
    : fBriefDescription(briefDescription), fFullDescription(fullDescription), fFileCount(filecount){};

--- a/tree/dataframe/src/RInterfaceBase.cxx
+++ b/tree/dataframe/src/RInterfaceBase.cxx
@@ -29,9 +29,13 @@ unsigned int ROOT::RDF::RInterfaceBase::GetNFiles()
    // TTree/TChain as input
    const auto tree = fLoopManager->GetTree();
 
-   if (tree) {
+   if (tree && tree->GetCurrentFile()) {
       const auto files = ROOT::Internal::TreeUtils::GetFileNamesFromTree(*tree);
       return files.size();
+   }
+   // Datasource as input
+   if (fDataSource) {
+      return fDataSource->GetNFiles();
    }
    return 0;
 }
@@ -283,7 +287,7 @@ ROOT::RDF::RDFDescription ROOT::RDF::RInterfaceBase::Describe()
    }
    // Use the string returned from DescribeDataset() as the 'brief' description
    // Use the converted to string stringstream ss as the 'full' description
-   return RDFDescription(DescribeDataset(), ss.str());
+   return RDFDescription(DescribeDataset(), ss.str(), GetNFiles());
 }
 
 /// \brief Returns the names of the defined columns.

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -61,6 +61,13 @@ RRootDS::~RRootDS()
    }
 }
 
+std::size_t RRootDS::GetNFiles() const
+{
+   if (auto files = fModelChain.GetListOfFiles())
+      return files->GetEntries();
+   return 0;
+}
+
 std::string RRootDS::GetTypeName(std::string_view colName) const
 {
    if (!HasColumn(colName)) {

--- a/tree/dataframe/test/datasource_csv.cxx
+++ b/tree/dataframe/test/datasource_csv.cxx
@@ -62,6 +62,12 @@ TEST(RCsvDS, EmptyFile)
    EXPECT_THROW(RCsvDS(fileName2, false), std::runtime_error);
 }
 
+TEST(RCsvDS, NFiles)
+{
+   RCsvDS tds(fileName1, false);
+   EXPECT_EQ(1, tds.GetNFiles());
+}
+
 TEST(RCsvDS, EntryRanges)
 {
    RCsvDS tds(fileName0);

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -217,6 +217,7 @@ static void ChainTest(const std::string &name, const std::string &fname)
 
    auto df3 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(
       "chain", std::vector<std::string>{guardFile1.GetPath(), guardFile2.GetPath(), guardFile3.GetPath()}));
+   EXPECT_EQ(3, df3.Describe().GetNFiles());
    auto sumElectronPt =
       df3.Aggregate([](float &acc, const Electron &e) { acc += e.pt; }, [](float a, float b) { return a + b; }, "e");
    EXPECT_FLOAT_EQ(6.0, sumElectronPt.GetValue());

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -85,6 +85,12 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    EXPECT_STREQ("ROOT::VecOps::RVec<std::int32_t>", ds.GetTypeName("rvec").c_str());
 }
 
+TEST_F(RNTupleDSTest, NFiles)
+{
+   RNTupleDS ds(fNtplName, fFileName);
+
+   EXPECT_EQ(1, ds.GetNFiles());
+}
 
 TEST_F(RNTupleDSTest, CardinalityColumn)
 {


### PR DESCRIPTION
This PR fixes #15617, where the number of files is incorrectly returned by `RInterfaceBase`/`RDFDescription` for RDF's constructed from an `RDataSource`. It involves the addition of `GetNFiles` to the public interface of `RDataSource` and calling it in the relevant places.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


