### PR TITLE
[ntuple] Improve inspector error for compression setting mismatch

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -75,7 +75,8 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
             // could change in the future.
             throw RException(R__FAIL("compression setting mismatch between column ranges (" +
                                      std::to_string(fCompressionSettings) + " vs " +
-                                     std::to_string(columnRange.fCompressionSettings) + ")"));
+                                     std::to_string(columnRange.fCompressionSettings) +
+                                     ") for column with physical ID " + std::to_string(colId)));
          }
 
          const auto &pageRange = clusterDescriptor.GetPageRange(colId);


### PR DESCRIPTION
Add the physical column ID to the error message shown when a different compression setting than expected is encountered. This should help in locating potential bugs/mistakes.