### PR TITLE
Revert "[ntuple] add ClassDefInline to RKeyBlob"

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -13,7 +13,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "Rtypes.h"
 #include <ROOT/RConfig.hxx>
 #include <ROOT/RError.hxx>
 
@@ -959,8 +958,6 @@ constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
 /// like a TBasket.
 class RKeyBlob : public TKey {
 public:
-   RKeyBlob() = default;
-
    explicit RKeyBlob(TFile *file) : TKey(file)
    {
       fClassName = kBlobClassName;
@@ -974,8 +971,6 @@ public:
       Create(nbytes);
       *seekKey = fSeekKey;
    }
-
-   ClassDefInline(RKeyBlob, 3)
 };
 
 } // anonymous namespace


### PR DESCRIPTION
This reverts commit 19caf55b88d16ac67d9bfb39380a4d1c89f935e6.

which was failing on Windows and is breaking master