### PR TITLE
[ntuple] add ClassDef to RKeyBlob

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -957,6 +957,18 @@ constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
 
 } // anonymous namespace
 
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+/// If a TFile container is written by a C stream (simple file), on dataset commit, the file header
+/// and the TFile record need to be updated
+struct RTFileControlBlock {
+   RTFHeader fHeader;
+   RTFFile fFileRecord;
+   std::uint64_t fSeekNTuple{0}; // Remember the offset for the keys list
+   std::uint64_t fSeekFileRecord{0};
+};
+
 /// The RKeyBlob writes an invisible key into a TFile.  That is, a key that is not indexed in the list of keys,
 /// like a TBasket.
 /// NOTE: out of anonymous namespace because otherwise ClassDefInline fails to compile
@@ -982,17 +994,6 @@ public:
    ClassDefInlineOverride(RKeyBlob, 0)
 };
 
-namespace ROOT {
-namespace Experimental {
-namespace Internal {
-/// If a TFile container is written by a C stream (simple file), on dataset commit, the file header
-/// and the TFile record need to be updated
-struct RTFileControlBlock {
-   RTFHeader fHeader;
-   RTFFile fFileRecord;
-   std::uint64_t fSeekNTuple{0}; // Remember the offset for the keys list
-   std::uint64_t fSeekFileRecord{0};
-};
 } // namespace Internal
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -964,7 +964,7 @@ constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
 class RKeyBlob : public TKey {
 public:
    RKeyBlob() = default;
-   
+
    explicit RKeyBlob(TFile *file) : TKey(file)
    {
       fClassName = kBlobClassName;
@@ -979,9 +979,8 @@ public:
       *seekKey = fSeekKey;
    }
 
-   ClassDefInline(RKeyBlob, 0)
+   ClassDefInlineOverride(RKeyBlob, 0)
 };
-
 
 namespace ROOT {
 namespace Experimental {

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -13,6 +13,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include "Rtypes.h"
 #include <ROOT/RConfig.hxx>
 #include <ROOT/RError.hxx>
 
@@ -954,10 +955,16 @@ constexpr char const *kBlobClassName = "RBlob";
 /// The class name of the RNTuple anchor
 constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
 
+} // anonymous namespace
+
 /// The RKeyBlob writes an invisible key into a TFile.  That is, a key that is not indexed in the list of keys,
 /// like a TBasket.
+/// NOTE: out of anonymous namespace because otherwise ClassDefInline fails to compile
+/// on some platforms.
 class RKeyBlob : public TKey {
 public:
+   RKeyBlob() = default;
+   
    explicit RKeyBlob(TFile *file) : TKey(file)
    {
       fClassName = kBlobClassName;
@@ -971,9 +978,10 @@ public:
       Create(nbytes);
       *seekKey = fSeekKey;
    }
+
+   ClassDefInline(RKeyBlob, 0)
 };
 
-} // anonymous namespace
 
 namespace ROOT {
 namespace Experimental {


### PR DESCRIPTION
Same as https://github.com/root-project/root/commit/19caf55b88d16ac67d9bfb39380a4d1c89f935e6 but this time moving RKeyBlob out of the anon namespace which causes compile errors on windows (I missed this in the previous commit, now reverted).

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

