### PR TITLE
[ntuple] RMiniFile cleanups

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1099,7 +1099,6 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
       return R__FAIL("no RNTuple named '" + std::string(ntupleName) + "' in file '" + fRawFile->GetUrl() + "'");
    }
 
-   ReadBuffer(&key, sizeof(key), key.GetSeekKey());
    offset = key.GetSeekKey() + key.fKeyLen;
 
    if (key.fObjLen < sizeof(RTFNTuple)) {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -117,12 +117,22 @@ using RResult = ROOT::Experimental::RResult<T>;
 class FileRaii {
 private:
    std::string fPath;
+   bool fPreserveFile = false;
+
 public:
-   explicit FileRaii(const std::string &path) : fPath(path) { }
-   FileRaii(const FileRaii&) = delete;
-   FileRaii& operator=(const FileRaii&) = delete;
-   ~FileRaii() { std::remove(fPath.c_str()); }
+   explicit FileRaii(const std::string &path) : fPath(path) {}
+   FileRaii(const FileRaii &) = delete;
+   FileRaii &operator=(const FileRaii &) = delete;
+   ~FileRaii()
+   {
+      if (!fPreserveFile)
+         std::remove(fPath.c_str());
+   }
    std::string GetPath() const { return fPath; }
+
+   // Useful if you want to keep a test file after the test has finished running
+   // for debugging purposes. Should only be used locally and never pushed.
+   void PreserveFile() { fPreserveFile = true; }
 };
 
 #endif


### PR DESCRIPTION
# This Pull request:
- Removes some dead or redundant code from RMiniFile.cxx (see commit comment for more details)
- adds a utility to FileRaii to preserve the file after running. Useful to quickly debug a test file locally without having to recompile ntuple_test.hxx or doing some weird tricks.

- [x] tested changes locally
- [ ] updated the docs (if necessary)

