### PR TITLE
Fix problem with timeonaxis tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -484,9 +484,6 @@ set(returncode_1 fit/fit2a.C
                  graphics/earth.C
                  graphics/pavetext.C
                  graphics/tmathtext.C graphics/tmathtext2.C
-                 graphs/timeonaxis.C
-                 graphs/timeonaxis2.C
-                 graphs/timeonaxis3.C
                  graphs/exclusiongraph.C
                  graphs/graphstruct.C
                  hist/ContourList.C


### PR DESCRIPTION
After last modification they should be removed from list of tutorials returning not void value.

PR fixes recent problem in CI

See 6.32 Backport here https://github.com/root-project/root/pull/15680