### PR TITLE
[CMake] Do not allow linking with mold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,6 +767,10 @@ if(testing)
   endif()
 endif()
 
+if(LLVM_LINKER_IS_MOLD)
+  message(FATAL_ERROR "The mold linker is not supported by ROOT. Please use a different linker")
+endif()
+
 cmake_host_system_information(RESULT PROCESSOR QUERY PROCESSOR_DESCRIPTION)
 
 message(STATUS "ROOT Configuration \n


### PR DESCRIPTION
# This Pull request:
Disallows linking with mold, which doesn't work. Even when building is possible by changing some CMake, the build seems to be broken. See  https://github.com/root-project/root/issues/15473.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)