### PR TITLE
[hist] Don't define default `w=1.0` parameter in `TProfile2D::Fill()`

### DIFF
--- a/hist/hist/inc/TProfile2D.h
+++ b/hist/hist/inc/TProfile2D.h
@@ -101,10 +101,15 @@ public:
    Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override; // *MENU*
    void      ExtendAxis(Double_t x, TAxis *axis) override;
    Int_t             Fill(Double_t x, Double_t y, Double_t z) override;
-   virtual Int_t     Fill(Double_t x, const char *namey, Double_t z, Double_t w = 1.);
-   virtual Int_t     Fill(const char *namex, Double_t y, Double_t z, Double_t w = 1.);
-   virtual Int_t     Fill(const char *namex, const char *namey, Double_t z, Double_t w = 1.);
+   // Don't use a default w=1.0 in the Fill functions, but instead declare
+   // inlined no-weight overloads to correctly override TH2 methods.
+   virtual Int_t     Fill(Double_t x, const char *namey, Double_t z, Double_t w);
+   virtual Int_t     Fill(const char *namex, Double_t y, Double_t z, Double_t w);
+   virtual Int_t     Fill(const char *namex, const char *namey, Double_t z, Double_t w);
    virtual Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t w);
+   inline  Int_t     Fill(Double_t x, const char *namey, Double_t z) override { return Fill(x, namey, z, 1.0); }
+   inline  Int_t     Fill(const char *namex, Double_t y, Double_t z) override { return Fill(namex, y, z, 1.0); }
+   inline  Int_t     Fill(const char *namex, const char *namey, Double_t z) override { return Fill(namex, namey, z, 1.0); }
    Double_t  GetBinContent(Int_t bin) const override;
    Double_t  GetBinContent(Int_t binx, Int_t biny) const override {return GetBinContent(GetBin(binx,biny));}
    Double_t  GetBinContent(Int_t binx, Int_t biny, Int_t) const override {return GetBinContent(GetBin(binx,biny));}


### PR DESCRIPTION
Don't use a default w=1.0 in the Fill functions, but instead declare inlined no-weight overloads to correctly override TH2 methods.

Note that the overrides are actually quite questionable, because they don't respect the actual TH2 interface, where the third parameter is the weight "w" and not an additional coordinate "z". However, that's how the TProfile2D interface was defined a long time ago, so these overrides are preserved for backwards compatibility. The better design would have been to give the function a different name, or always require an explicit `w` parameter such that the signatures are always different.

Closes #15688.