### PR TITLE
[ntuple] Add `kUnknownCompressionSettings`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -231,7 +231,7 @@ public:
       ClusterSize_t fNElements = kInvalidClusterIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
-      std::int64_t fCompressionSettings = 0;
+      int fCompressionSettings = kUnknownCompressionSettings;
 
       // TODO(jblomer): we perhaps want to store summary information, such as average, min/max, etc.
       // Should this be done on the field level?

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -63,6 +63,8 @@ struct RClusterSize {
 using ClusterSize_t = RClusterSize;
 constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
+constexpr int kUnknownCompressionSettings = -1;
+
 /// Helper types to present an offset column as array of collection sizes.
 /// See RField<RNTupleCardinality<SizeT>> for details.
 template <typename SizeT>


### PR DESCRIPTION
Currently, the default compression setting for a column range is `0`, which is an actual, valid compression setting (i.e., no compression has been applied). We should distinguish between "no compression has been applied" and "we don't know the compression" (for example in the case of columns created through late model extension, where some ranges may not come from a physical storage location). This PR partly addresses #15661.