### PR TITLE
[ntuple] Fix column range construction for extended fields

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -580,9 +580,14 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddDeferredColumnRanges
                const DescriptorId_t physicalId = c.GetPhysicalId();
                auto &columnRange = fCluster.fColumnRanges[physicalId];
                auto &pageRange = fCluster.fPageRanges[physicalId];
-               // Initialize a RColumnRange for `physicalId` if it was not there
+               // Initialize a RColumnRange for `physicalId` if it was not there. Columns that were created during model
+               // extension won't have on-disk metadata for the clusters that were already committed before the model
+               // was extended. Therefore, these need to be synthetically initialized upon reading.
                if (columnRange.fPhysicalColumnId == kInvalidDescriptorId) {
                   columnRange.fPhysicalColumnId = physicalId;
+                  columnRange.fFirstElementIndex = 0;
+                  columnRange.fNElements = 0;
+
                   pageRange.fPhysicalColumnId = physicalId;
                }
                // Fixup the RColumnRange and RPageRange in deferred columns.  We know what the first element index and

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -239,6 +239,57 @@ TEST(RNTuple, ModelExtensionProject)
    EXPECT_EQ(refVec, aliasVec(1));
 }
 
+TEST(RNTuple, ModelExtensionSubFields)
+{
+   FileRaii fileGuard("test_ntuple_modelext_cluster_boundaries.root");
+   CustomStruct refStruct{42.0, {1., 2., 3.}, {{4., 5.}, {}, {6.}}, "foo"};
+   {
+      auto model = RNTupleModel::Create();
+
+      auto structFld = model->MakeField<CustomStruct>("structFld", refStruct);
+
+      RNTupleWriteOptions opts;
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+
+      for (unsigned i = 0; i < 2; ++i) {
+         for (unsigned j = 0; j < 3; ++j) {
+            ntuple->Fill();
+         }
+         ntuple->CommitCluster();
+      }
+
+      ntuple->Fill();
+
+      auto modelUpdater = ntuple->CreateModelUpdater();
+
+      modelUpdater->BeginUpdate();
+      auto extStructField = modelUpdater->MakeField<CustomStruct>("extStructFld", refStruct);
+      modelUpdater->CommitUpdate();
+
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   auto &desc = ntuple->GetDescriptor();
+
+   EXPECT_EQ(3, desc.GetNClusters());
+   EXPECT_EQ(8, desc.GetNEntries());
+
+   auto structFldView = ntuple->GetView<CustomStruct>("structFld");
+   auto extStructFldView = ntuple->GetView<CustomStruct>("extStructFld");
+
+   EXPECT_EQ(structFldView(7), extStructFldView(7));
+
+   // Check that the column ranges for model-extended subfields are properly constructed by iterating over their view.
+   // For improper column ranges, the global field range would go until the value of kInvalidClusterIndex and result in
+   // an out-of-bounds error.
+   auto vecStructElemView = ntuple->GetView<float>("structFld.v2._0._0");
+   auto extVecStructElemView = ntuple->GetView<float>("extStructFld.v2._0._0");
+   for (const auto i : extVecStructElemView.GetFieldRange()) {
+      EXPECT_EQ(vecStructElemView(i), extVecStructElemView(i));
+   }
+}
+
 // Based on the RealWorld1 test in `ntuple_extended.cxx`, but here some fields are added after the fact
 TEST(RNTuple, ModelExtensionRealWorld1)
 {


### PR DESCRIPTION
For deferred columns (i.e. columns created during late model extension) for subfields that have been created after one or more clusters have already been written, their (synthetic) column ranges were not properly initialized upon read back. This resulted in incorrect metadata and problems reading back the data in the subfields only (so not the complete field they are part of). This PR partly addresses #15661.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
