### PR TITLE
[skip-ci][ntuple] update RNTuple anchor doc

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -93,7 +93,7 @@ When serialized to disk, a 64 bit checksum is appended to the anchor, calculated
 all the (serialized) fields of the anchor object.
 
 Note that, since the anchor is serialized as a "classic" TFile key, all integers in the anchor, as well
-as the checksum, are encoded in **big-endian**, and not little-endian like in the RNTuple payload.
+as the checksum, are encoded in **big-endian**, unlike the RNTuple payload which is encoded in little-endian.
 
 The anchor may evolve in future versions only by appending new fields to the existing schema, but
 fields will not be removed, renamed or reordered.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -91,6 +91,10 @@ The current (class version 5) **ROOT::Experimental::RNTuple** object has the fol
 
 When serialized to disk, a 64 bit checksum is appended to the anchor, calculated as the XXH3 hash of
 all the (serialized) fields of the anchor object.
+
+Note that, since the anchor is serialized as a "classic" TFile key, all integers in the anchor, as well
+as the checksum, are encoded in **big-endian**, and not little-endian like in the RNTuple payload.
+
 The anchor may evolve in future versions only by appending new fields to the existing schema, but
 fields will not be removed, renamed or reordered.
 


### PR DESCRIPTION
Explicitly specify that integers in the RNTuple anchor are encoded in big-endian.


## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

