### PR TITLE
[io] fix memory leak in TKey constructor

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -262,6 +262,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
          else               bufmax = kMAXZIPBUF;
          R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
+            delete[] fBuffer;
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
             fBufferRef->SetBufferOffset(0);

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -353,6 +353,7 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
          else               bufmax = kMAXZIPBUF;
          R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
+            delete[] fBuffer;
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
             fBufferRef->SetBufferOffset(0);

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -263,6 +263,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
          R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
             delete[] fBuffer;
+            bufcur = nullptr;
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
             fBufferRef->SetBufferOffset(0);
@@ -355,6 +356,7 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
          R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
             delete[] fBuffer;
+            bufcur = nullptr;
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
             fBufferRef->SetBufferOffset(0);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/7236

This bug has been there since >24y.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
