### PR TITLE
[reve] Rename function ExportToCINT to ExportToInterpreter (remake of #15705)

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -190,7 +190,7 @@ public:
 
    TClass *IsA() const;
 
-   virtual void ExportToCINT(const char *var_name); // *MENU*
+   virtual void ExportToInterpreter(const char *var_name); // *MENU*
 
    virtual Bool_t AcceptElement(REveElement *el);
 

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -565,7 +565,7 @@ TClass *REveElement::IsA() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Export render-element to CINT with variable name var_name.
 
-void REveElement::ExportToCINT(const char *var_name)
+void REveElement::ExportToInterpreter(const char *var_name)
 {
    const char* cname = IsA()->GetName();
    gROOT->ProcessLine(TString::Format("%s* %s = (%s*)0x%zx;", cname, var_name, cname, (size_t)this));

--- a/tutorials/eve7/error_ellipse.C
+++ b/tutorials/eve7/error_ellipse.C
@@ -85,7 +85,28 @@ void error_ellipse()
    ellipse->SetBaseVectors(v[0], v[1], v[2]);
    ellipse->Outline();
    event->AddElement(ellipse);
-   
+
+   // add TGeoSphere
+   auto sph = new REveGeoShape("Sphere");
+   sph->SetShape(new TGeoSphere(0.99f, 1.f));
+   sph->SetMainColor(kGreen);
+   sph->SetMainTransparency(80);
+   sph->SetNSegments(80);
+
+   float m0 = v[0].Mag();
+   v[0].Normalize();
+   float m1 = v[1].Mag();
+   v[1].Normalize();
+   float m2 = v[2].Mag();
+   v[2].Normalize();
+
+   sph->InitMainTrans();
+   sph->RefMainTrans().SetBaseVec(1, v[0].fX, v[0].fY, v[0].fZ);
+   sph->RefMainTrans().SetBaseVec(2, v[1].fX, v[1].fY, v[1].fZ);
+   sph->RefMainTrans().SetBaseVec(3, v[2].fX, v[2].fY, v[2].fZ);
+   sph->RefMainTrans().SetScale(m0, m1, m2);
+   event->AddElement(sph);
+
    auto ps = new REvePointSet("Vertices");
    ps->SetMainColor(kYellow);
    ps->SetNextPoint(pos[0], pos[1], pos[2]);


### PR DESCRIPTION
This PR:

Removes CINT from function name
Minor improvement in error ellipsoid example