### PR TITLE
[ntuple] fix merging of unsplit fields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -248,7 +248,7 @@ public:
    /// Adds an extra type information record to schema. The extra type information will be written to the
    /// extension header. The information in the record will be merged with the existing information, e.g.
    /// duplicate streamer info records will be removed. This method is called by the "on commit dataset" callback
-   /// registered by specific fields (e.g., unsplit field).
+   /// registered by specific fields (e.g., unsplit field) and during merging.
    virtual void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) = 0;
 
    /// Write a page to the storage. The column must have been added before.

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -165,6 +165,8 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
       CollectColumns(destination.GetDescriptor());
    }
 
+   std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple
+
    // Append the sources to the destination one-by-one
    for (const auto &source : sources) {
       source->Attach();
@@ -183,7 +185,7 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
       // Create sink from the input model if not initialized
       if (!destination.IsInitialized()) {
-         auto model = descriptor->CreateModel();
+         model = descriptor->CreateModel();
          destination.Init(*model.get());
       }
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -171,11 +171,6 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
    for (const auto &source : sources) {
       source->Attach();
 
-      // Make sure the source contains events to be merged
-      if (source->GetNEntries() == 0) {
-         continue;
-      }
-
       // Get a handle on the descriptor (metadata)
       auto descriptor = source->GetSharedDescriptorGuard();
 
@@ -187,6 +182,15 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
       if (!destination.IsInitialized()) {
          model = descriptor->CreateModel();
          destination.Init(*model.get());
+      }
+
+      for (const auto &extraTypeInfoDesc : descriptor->GetExtraTypeInfoIterable()) {
+         destination.UpdateExtraTypeInfo(extraTypeInfoDesc);
+      }
+
+      // Make sure the source contains events to be merged
+      if (source->GetNEntries() == 0) {
+         continue;
       }
 
       // Now loop over all clusters in this file


### PR DESCRIPTION
Unsplit fields update the extra type info block in the RNTuple meta-data, which needs to be explicitly merged. Also, the unsplit field revealed a lifetime issue with the output model, which is now fixed.