### PR TITLE
Correct format - warnings seen on 32 bit architectures

### DIFF
--- a/core/clib/src/mmapsup.c
+++ b/core/clib/src/mmapsup.c
@@ -174,7 +174,7 @@ PTR __mmalloc_mmap_morecore(struct mdesc *mdp, int size)
             if (mdp -> top != PAGE_ALIGN(mdp -> top)) {
               fprintf(stderr,
                       "mmap_morecore error: base memory location (%p) is not aligned with %zu as required.\n",
-                      mdp -> top, (long)pagesize);
+                      mdp -> top, pagesize);
               return result;
             }
             mapto = mmap (mdp -> top, mapbytes, PROT_READ | PROT_WRITE,

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -11075,7 +11075,7 @@ std::string cling::printValue(const xRooNode *v)
             out += "{";
          out += n->GetName();
          if (out.length() > 100 && left > 0) {
-            out += TString::Format(",... and %lu more", left);
+            out += TString::Format(",... and %zu more", left);
             break;
          }
       }

--- a/tree/dataframe/src/RDFDisplay.cxx
+++ b/tree/dataframe/src/RDFDisplay.cxx
@@ -232,12 +232,12 @@ void RDisplay::Print() const
                // Thus, the first column is only the Row column and the actual first column is printed
          columnsToPrint = 2;
       }
-      Info("Print", "Only showing %lu columns out of %lu\n", columnsToPrint, fNColumns);
+      Info("Print", "Only showing %zu columns out of %zu\n", columnsToPrint, fNColumns);
       allColumnsFit = false;
    }
 
    if (fNMaxCollectionElements < 1)
-      Info("Print", "No collections shown since fNMaxCollectionElements is %lu\n", fNMaxCollectionElements);
+      Info("Print", "No collections shown since fNMaxCollectionElements is %zu\n", fNMaxCollectionElements);
 
    auto nrRows = fTable.size();
    std::cout << DashesBetweenLines(columnsToPrint, allColumnsFit); // Print dashes in the top of the table

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -74,7 +74,7 @@ unsigned int ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
    const unsigned int nToRun =
       std::count_if(handles.begin(), handles.end(), [](const auto &h) { return !h.IsReady(); });
    if (nToRun < handles.size()) {
-      Warning("RunGraphs", "Got %lu handles from which %lu link to results which are already ready.", handles.size(),
+      Warning("RunGraphs", "Got %zu handles from which %zu link to results which are already ready.", handles.size(),
               handles.size() - nToRun);
    }
    if (nToRun == 0u)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes compiler warnings from format strings (size_t not using %z).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

