### PR TITLE
[RF] Avoid using transient `std::unique_ptr`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -221,7 +221,7 @@ protected:
   static const decltype(_stateNames)::value_type& invalidCategory();
 
 private:
-  std::unique_ptr<TreeReadBuffer> _treeReadBuffer; //! A buffer for reading values from trees
+  TreeReadBuffer *_treeReadBuffer = nullptr; //! A buffer for reading values from trees
 
   ClassDefOverride(RooAbsCategory, 4) // Abstract discrete variable
 };

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -443,7 +443,7 @@ private:
   bool replaceImpl(const RooAbsArg& var1, const RooAbsArg& var2);
 
   using HashAssistedFind = RooFit::Detail::HashAssistedFind;
-  mutable std::unique_ptr<HashAssistedFind> _hashAssistedFind; ///<!
+  mutable HashAssistedFind *_hashAssistedFind = nullptr; ///<!
   std::size_t _sizeThresholdForMapSearch = 100; ///<!
 
   void insert(RooAbsArg*);

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -545,7 +545,7 @@ private:
    TString _label;                                         ///< Plot label for objects value
    bool _forceNumInt = false;                              ///< Force numerical integration if flag set
    std::unique_ptr<RooNumIntConfig> _specIntegratorConfig; // Numeric integrator configuration specific for this object
-   std::unique_ptr<TreeReadBuffer> _treeReadBuffer;        //! A buffer for reading values from trees
+   TreeReadBuffer *_treeReadBuffer = nullptr;              //! A buffer for reading values from trees
    bool _selectComp = true;                                //! Component selection flag for RooAbsPdf::plotCompOn
    mutable RooFit::UniqueId<RooArgSet>::Value_t _lastNormSetId = RooFit::UniqueId<RooArgSet>::nullval; ///<!
 

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -107,7 +107,10 @@ RooAbsCategory::RooAbsCategory(const RooAbsCategory& other,const char* name) :
 
 RooAbsCategory::~RooAbsCategory()
 {
-
+   if (_treeReadBuffer) {
+      delete _treeReadBuffer;
+   }
+   _treeReadBuffer = nullptr;
 }
 
 
@@ -486,8 +489,11 @@ void RooAbsCategory::attachToTree(TTree& tree, Int_t bufSize)
     if (typeDetails != typeMap.end()) {
       coutI(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") TTree " << typeName << " branch \"" << cleanName
                   << "\" will be converted to int." << std::endl;
-      _treeReadBuffer = typeDetails->second();
+      _treeReadBuffer = typeDetails->second().release();
     } else {
+      if (_treeReadBuffer) {
+         delete _treeReadBuffer;
+      }
       _treeReadBuffer = nullptr;
 
       if (typeName == "Int_t") {

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -178,6 +178,10 @@ RooAbsCollection::~RooAbsCollection()
   if(_ownCont){
     deleteList() ;
   }
+  if (_hashAssistedFind) {
+    delete _hashAssistedFind;
+  }
+  _hashAssistedFind = nullptr;
 }
 
 
@@ -189,6 +193,9 @@ RooAbsCollection::~RooAbsCollection()
 
 void RooAbsCollection::deleteList()
 {
+  if (_hashAssistedFind) {
+    delete _hashAssistedFind;
+  }
   _hashAssistedFind = nullptr;
 
   // Built-in delete remaining elements
@@ -748,6 +755,9 @@ bool RooAbsCollection::remove(const RooAbsCollection& list, bool /*silent*/, boo
 
 void RooAbsCollection::removeAll()
 {
+  if (_hashAssistedFind) {
+    delete _hashAssistedFind;
+  }
   _hashAssistedFind = nullptr;
 
   if(_ownCont) {
@@ -920,7 +930,7 @@ RooAbsArg * RooAbsCollection::find(const char *name) const
 
   if (_hashAssistedFind || _list.size() >= _sizeThresholdForMapSearch) {
     if (!_hashAssistedFind || !_hashAssistedFind->isValid()) {
-      _hashAssistedFind = std::make_unique<HashAssistedFind>(_list.begin(), _list.end());
+      _hashAssistedFind = new HashAssistedFind{_list.begin(), _list.end()};
     }
 
     return _hashAssistedFind->find(nptr);
@@ -940,7 +950,7 @@ RooAbsArg * RooAbsCollection::find(const RooAbsArg& arg) const
 
   if (_hashAssistedFind || _list.size() >= _sizeThresholdForMapSearch) {
     if (!_hashAssistedFind || !_hashAssistedFind->isValid()) {
-      _hashAssistedFind = std::make_unique<HashAssistedFind>(_list.begin(), _list.end());
+      _hashAssistedFind = new HashAssistedFind{_list.begin(), _list.end()};
     }
 
     return _hashAssistedFind->find(nptr);
@@ -1617,10 +1627,13 @@ void RooAbsCollection::useHashMapForFind(bool flag) const
       throw std::runtime_error(msg.str());
    }
 #endif
-   if (flag && !_hashAssistedFind)
-      _hashAssistedFind = std::make_unique<HashAssistedFind>(_list.begin(), _list.end());
-   if (!flag)
+   if (flag && !_hashAssistedFind) {
+      _hashAssistedFind = new HashAssistedFind{_list.begin(), _list.end()};
+   }
+   if (!flag && _hashAssistedFind) {
+      delete _hashAssistedFind;
       _hashAssistedFind = nullptr;
+   }
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -219,7 +219,13 @@ RooAbsReal::RooAbsReal(const RooAbsReal& other, const char* name) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
-RooAbsReal::~RooAbsReal() {}
+RooAbsReal::~RooAbsReal()
+{
+   if (_treeReadBuffer) {
+      delete _treeReadBuffer;
+   }
+   _treeReadBuffer = nullptr;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3153,8 +3159,11 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
       coutI(DataHandling) << "RooAbsReal::attachToTree(" << GetName() << ") TTree " << typeDetails->first << " branch " << GetName()
                   << " will be converted to double precision." << std::endl ;
       setAttribute(typeDetails->second.first.c_str(), true);
-      _treeReadBuffer = typeDetails->second.second();
+      _treeReadBuffer = typeDetails->second.second().release();
     } else {
+      if (_treeReadBuffer) {
+         delete _treeReadBuffer;
+      }
       _treeReadBuffer = nullptr;
 
       if (!typeName.CompareTo("Double_t")) {


### PR DESCRIPTION
Harmless change to circumvent errors like these when building RooFit standalone:

```
Error in <TProtoClass::FindDataMember>: data member with index 0 is not found in class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> >
Error in <CreateRealData>: Cannot find data member # 0 of class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> > for parent RooAddPdf!
Error in <TProtoClass::FindDataMember>: data member with index 1 is not found in class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> >
Error in <CreateRealData>: Cannot find data member # 1 of class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> > for parent RooAddPdf!
Error in <TProtoClass::FindDataMember>: data member with index 0 is not found in class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> >
Error in <CreateRealData>: Cannot find data member # 0 of class tuple<TreeReadBuffer*,default_delete<TreeReadBuffer> > for parent RooPolynomial!
```