### PR TITLE
Fix test failure on ppc64le and s390x

### DIFF
--- a/hist/hist/test/test_tprofile2poly.cxx
+++ b/hist/hist/test/test_tprofile2poly.cxx
@@ -25,10 +25,16 @@ void FillForTest(TProfile2D* tp2d, TProfile2Poly* tpp, TRandom& ran) {
 }
 
 void globalStatsCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
+   const double relTol = 1e-12;
+   double cont1, cont2;
    for(Int_t c=1; c<=3; ++c) {
       ASSERT_DOUBLE_EQ(tp2d->GetMean(c), tpp->GetMean(c));
-      ASSERT_DOUBLE_EQ(tp2d->GetMeanError(c), tpp->GetMeanError(c));
-      ASSERT_DOUBLE_EQ(tp2d->GetStdDev(c), tpp->GetStdDev(c));
+      cont1 = tp2d->GetMeanError(c);
+      cont2 = tpp->GetMeanError(c);
+      ASSERT_NEAR(cont1, cont2, relTol * cont2);
+      cont1 = tp2d->GetStdDev(c);
+      cont2 = tpp->GetStdDev(c);
+      ASSERT_NEAR(cont1, cont2, relTol * cont2);
    }
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

```
 167/1341 Test  #120: gtest-hist-hist-test-testTProfile2Poly ....................................***Failed   11.00 sec
Running main() from /builddir/build/BUILD/googletest-1.14.0/googletest/src/gtest_main.cc
Note: Google Test filter = -RCsvDS.Remote:RNTuple.OpenHTTP:RRawFile.Remote:RSqliteDS.Davix:TChainParsing.DoubleSlash:TChainParsing.RemoteGlob:TFile.ReadWithoutGlobalRegistrationNet:TFile.ReadWithoutGlobalRegistrationWeb
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from TProfile2Poly
[ RUN      ] TProfile2Poly.GlobalCompare
/builddir/build/BUILD/root-6.32.00-build/root-6.32.00/hist/hist/test/test_tprofile2poly.cxx:30: Failure
Expected equality of these values:
  tp2d->GetMeanError(c)
    Which is: 0.0030918045191081229
  tpp->GetMeanError(c)
    Which is: 0.0030918045191081199
[  FAILED  ] TProfile2Poly.GlobalCompare (3076 ms)
[ RUN      ] TProfile2Poly.BinContentCompare
[       OK ] TProfile2Poly.BinContentCompare (2575 ms)
[ RUN      ] TProfile2Poly.BinErrorSpreadCompare
[       OK ] TProfile2Poly.BinErrorSpreadCompare (2820 ms)
[ RUN      ] TProfile2Poly.BinErrorMeanCompare
[       OK ] TProfile2Poly.BinErrorMeanCompare (2387 ms)
[----------] 4 tests from TProfile2Poly (10861 ms total)
[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (10861 ms total)
[  PASSED  ] 3 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TProfile2Poly.GlobalCompare
 1 FAILED TEST
```

The proposed change is based on a similar code in the same source file.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
