### PR TITLE
[webcanvas] properly handle THStack zooming

### DIFF
--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1435,7 +1435,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
          Double_t hmin = 0., hmax = 0.;
 
          if (r.zx1 == r.zx2)
-            hist->GetXaxis()->SetRange(0,0);
+            hist->GetXaxis()->SetRange(0, 0);
          else
             hist->GetXaxis()->SetRangeUser(r.zx1, r.zx2);
 
@@ -1448,7 +1448,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
                hmax = pad->fLogy ? TMath::Power(pad->fLogy < 2 ? 10 : pad->fLogy, r.uy2) : r.uy2;
             }
          } else if (r.zy1 == r.zy2) {
-            hist->GetYaxis()->SetRange(0., 0.);
+            hist->GetYaxis()->SetRange(0, 0);
          } else {
             hist->GetYaxis()->SetRangeUser(r.zy1, r.zy2);
          }
@@ -1463,7 +1463,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
             }
          } else if (hist->GetDimension() == 3) {
             if (r.zz1 == r.zz2) {
-               hist->GetZaxis()->SetRange(0., 0.);
+               hist->GetZaxis()->SetRange(0, 0);
             } else {
               hist->GetZaxis()->SetRangeUser(r.zz1, r.zz2);
             }
@@ -1472,7 +1472,14 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
          if (hmin == hmax)
             hmin = hmax = -1111;
 
-         if (!hist_holder || (hist_holder->IsA() == TScatter::Class())) {
+         if (hist_holder && (hist_holder->IsA() == THStack::Class())) {
+            TString opt = objlnk->GetOption();
+            if (!opt.Contains("nostack", TString::kIgnoreCase) && !opt.Contains("lego", TString::kIgnoreCase)) {
+               hist->SetMinimum(hmin);
+               hist->SetMaximum(hmax);
+               hist->SetBit(TH1::kIsZoomed, hmin != hmax);
+            }
+         } else if (!hist_holder || (hist_holder->IsA() == TScatter::Class())) {
             hist->SetMinimum(hmin);
             hist->SetMaximum(hmax);
          } else {
@@ -2502,7 +2509,7 @@ TObject *TWebCanvas::FindPrimitive(const std::string &sid, int idcnt, TPad *pad,
                obj = getHistogram(gr);
             else if (mg)
                obj = getHistogram(mg);
-            else if (hs)
+            else if (hs && (hs->GetNhists() > 0))
                obj = getHistogram(hs);
             else if (scatter)
                obj = getHistogram(scatter);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1439,6 +1439,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
             hist_holder = nullptr;
 
          Bool_t no_entries = hist->GetEntries();
+         Bool_t is_stack = hist_holder && (hist_holder->IsA() == THStack::Class());
 
          Double_t hmin = 0., hmax = 0.;
 
@@ -1450,7 +1451,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
          if (hist->GetDimension() == 1) {
             hmin = r.zy1;
             hmax = r.zy2;
-            if ((hmin == hmax) && !no_entries) {
+            if ((hmin == hmax) && !no_entries && !is_stack) {
                // if there are no zooming on Y and histogram has no entries, hmin/hmax should be set to full range
                hmin = pad->fLogy ? TMath::Power(pad->fLogy < 2 ? 10 : pad->fLogy, r.uy1) : r.uy1;
                hmax = pad->fLogy ? TMath::Power(pad->fLogy < 2 ? 10 : pad->fLogy, r.uy2) : r.uy2;
@@ -1480,7 +1481,7 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
          if (hmin == hmax)
             hmin = hmax = -1111;
 
-         if (hist_holder && (hist_holder->IsA() == THStack::Class())) {
+         if (is_stack) {
             TString opt = objlnk->GetOption();
             if (!opt.Contains("nostack", TString::kIgnoreCase) && !opt.Contains("lego", TString::kIgnoreCase)) {
                hist->SetMinimum(hmin);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -847,6 +847,14 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
          paddata.NewPrimitive(obj, iter.GetOption()).SetSnapshot(TWebSnapshot::kObject, obj);
 
          first_obj = false;
+      } else if (obj->InheritsFrom(THStack::Class())) {
+         flush_master();
+
+         THStack *hs = static_cast<THStack *>(obj);
+
+         paddata.NewPrimitive(obj, iter.GetOption()).SetSnapshot(TWebSnapshot::kObject, obj);
+
+         first_obj = hs->GetNhists() > 0; // real drawing only if there are histograms
       } else if (obj->InheritsFrom(TScatter::Class())) {
          flush_master();
 

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '4/06/2024',
+version_date = '5/06/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -110911,18 +110911,25 @@ class THStackPainter extends ObjectPainter {
    /** @summary Redraw THStack
      * @desc Do something if previous update had changed number of histograms */
    redraw(reason) {
-      if (this.did_update === 1) {
-         delete this.did_update;
-         return this.drawNextHisto(0, this.options.pads ? this.getPadPainter() : null);
-      } else if (this.did_update === 2) {
-         delete this.did_update;
+      if (!this.did_update)
+         return;
+
+      const full_redraw = this.did_update === 1;
+      delete this.did_update;
+
+      const pr = this.firstpainter ? this.firstpainter.redraw(reason) : Promise.resolve(this);
+
+      return pr.then(() => {
+         if (full_redraw)
+            return this.drawNextHisto(0, this.options.pads ? this.getPadPainter() : null);
+
          const redrawSub = indx => {
             if (indx >= this.painters.length)
-               return Promise.resolve(this);
+               return this;
             return this.painters[indx].redraw(reason).then(() => redrawSub(indx+1));
          };
          return redrawSub(0);
-      }
+      });
    }
 
    /** @summary Fill hstack context menu */

--- a/js/changes.md
+++ b/js/changes.md
@@ -3,6 +3,7 @@
 ## Changes in dev
 1. Let use custom time zone for time display, support '&utc' and '&cet' in URL parameters
 2. Fix - hide empty title on the canvas
+3. Fix - properly handle zooming in THStack histogram
 
 
 ## Changes in 7.7.1

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '3/06/2024',
+version_date = '4/06/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '4/06/2024',
+version_date = '5/06/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/hist/THStackPainter.mjs
+++ b/js/modules/hist/THStackPainter.mjs
@@ -388,18 +388,25 @@ class THStackPainter extends ObjectPainter {
    /** @summary Redraw THStack
      * @desc Do something if previous update had changed number of histograms */
    redraw(reason) {
-      if (this.did_update === 1) {
-         delete this.did_update;
-         return this.drawNextHisto(0, this.options.pads ? this.getPadPainter() : null);
-      } else if (this.did_update === 2) {
-         delete this.did_update;
+      if (!this.did_update)
+         return;
+
+      const full_redraw = this.did_update === 1;
+      delete this.did_update;
+
+      const pr = this.firstpainter ? this.firstpainter.redraw(reason) : Promise.resolve(this);
+
+      return pr.then(() => {
+         if (full_redraw)
+            return this.drawNextHisto(0, this.options.pads ? this.getPadPainter() : null);
+
          const redrawSub = indx => {
             if (indx >= this.painters.length)
-               return Promise.resolve(this);
+               return this;
             return this.painters[indx].redraw(reason).then(() => redrawSub(indx+1));
          };
          return redrawSub(0);
-      }
+      });
    }
 
    /** @summary Fill hstack context menu */

--- a/js/modules/hist2d/TH1Painter.mjs
+++ b/js/modules/hist2d/TH1Painter.mjs
@@ -111,7 +111,7 @@ class TH1Painter extends THistPainter {
 
       let set_zoom = false;
 
-      if (this.draw_content || (this.isMainPainter() && (this.options.Axis > 0) && !this.options.ohmin && !this.options.ohmax && histo.fMinimum === kNoZoom && histo.fMaximum === kNoZoom)) {
+      if (this.draw_content || (this.isMainPainter() && (this.options.Axis > 0) && !this.options.ohmin && !this.options.ohmax && (histo.fMinimum === kNoZoom) && (histo.fMaximum === kNoZoom))) {
          if (hmin >= hmax) {
             if (hmin === 0) {
                this.ymin = 0; this.ymax = 1;
@@ -137,15 +137,19 @@ class TH1Painter extends THistPainter {
             this.ymin = 0;
          else {
             const positive = (this.ymin >= 0);
-            this.ymin -= gStyle.fHistTopMargin*(this.ymax-this.ymin);
+            this.ymin -= gStyle.fHistTopMargin*(this.ymax - this.ymin);
             if (positive && (this.ymin < 0))
                this.ymin = 0;
          }
-         this.ymax += gStyle.fHistTopMargin*(this.ymax-this.ymin);
+         this.ymax += gStyle.fHistTopMargin*(this.ymax - this.ymin);
       }
 
-      hmin = this.options.minimum;
-      hmax = this.options.maximum;
+      if (this.options.ignore_min_max)
+         hmin = hmax = kNoZoom;
+      else {
+         hmin = this.options.minimum;
+         hmax = this.options.maximum;
+      }
 
       if ((hmin === hmax) && (hmin !== kNoZoom)) {
          if (hmin < 0) {
@@ -158,7 +162,10 @@ class TH1Painter extends THistPainter {
 
       this._set_y_range = false;
 
-      if ((hmin !== kNoZoom) && (hmax !== kNoZoom) && !this.draw_content &&
+      if (this.options.ohmin && this.options.ohmax && !this.draw_content) {
+         // case of hstack drawing - histogram range used for zooming, but only for stack
+         set_zoom = !this.options.ignore_min_max;
+      } else if ((hmin !== kNoZoom) && (hmax !== kNoZoom) && !this.draw_content &&
           ((this.ymin === this.ymax) || (this.ymin > hmin) || (this.ymax < hmax))) {
          this.ymin = hmin;
          this.ymax = hmax;


### PR DESCRIPTION
1. Handle Y-axis zooming from stack histogram
2. Ignore drawing of empty stack
3. Properly update `kIsZooming` bit on server side
4. Adjust JSROOT code 

Fully resolves #14051