### PR TITLE
Revert "[rbrowser] Make fCleanupHandle a pointer to TObject"

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -51,7 +51,7 @@ class RBrowserData {
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
-   std::unique_ptr<TObject> fCleanupHandle;              ///<! cleanup handle for RecursiveRemove
+   std::unique_ptr<RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
 
    void ResetLastRequestData(bool with_element);
 


### PR DESCRIPTION
I'd like to start testing again the case highlighted by https://github.com/root-project/root/issues/13361

Note at the beginning: the issue arose with `runtime_cxxmodules=OFF` and I'm not sure we have that in the CI so we might not see errors right away