### PR TITLE
[DF] Add initial implementation for snapshotting to RNTuple

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1506,8 +1506,11 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
    }
 }
 
-void ValidateSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string &treeName,
-                                 const std::string &fileName);
+/// Ensure that the TTree with the resulting snapshot can be written to the target TFile. This means checking that the
+/// TFile can be opened in the mode specified in `opts`, deleting any existing TTrees in case
+/// `opts.fOverwriteIfExists = true`, or throwing an error otherwise.
+void EnsureValidSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string &treeName,
+                                    const std::string &fileName);
 
 /// Helper object for a single-thread TTree-based Snapshot action
 template <typename... ColTypes>
@@ -1543,7 +1546,7 @@ public:
         fBranchAddresses(vbnames.size(), nullptr),
         fIsDefine(std::move(isDefine))
    {
-      ValidateSnapshotTTreeOutput(fOptions, fTreeName, fFileName);
+      EnsureValidSnapshotTTreeOutput(fOptions, fTreeName, fFileName);
    }
 
    SnapshotTTreeHelper(const SnapshotTTreeHelper &) = delete;
@@ -1718,7 +1721,7 @@ public:
         fOutputBranches(fNSlots),
         fIsDefine(std::move(isDefine))
    {
-      ValidateSnapshotTTreeOutput(fOptions, fTreeName, fFileName);
+      EnsureValidSnapshotTTreeOutput(fOptions, fTreeName, fFileName);
    }
    SnapshotTTreeHelperMT(const SnapshotTTreeHelperMT &) = delete;
    SnapshotTTreeHelperMT(SnapshotTTreeHelperMT &&) = default;
@@ -1881,8 +1884,11 @@ public:
 };
 
 #ifdef R__HAS_ROOT7
-void ValidateSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
-                                   const std::string &fileName);
+/// Ensure that the RNTuple with the resulting snapshot can be written to the target TFile. This means checking that the
+/// TFile can be opened in the mode specified in `opts`, deleting any existing RNTuples in case
+/// `opts.fOverwriteIfExists = true`, or throwing an error otherwise.
+void EnsureValidSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
+                                      const std::string &fileName);
 
 /// Helper function to update the value of an RNTuple's field in the provided entry.
 template <typename T>
@@ -1922,7 +1928,7 @@ public:
         fOutputFieldNames(ReplaceDotWithUnderscore(fnames)),
         fIsDefine(std::move(isDefine))
    {
-      ValidateSnapshotRNTupleOutput(fOptions, fNTupleName, fFileName);
+      EnsureValidSnapshotRNTupleOutput(fOptions, fNTupleName, fFileName);
    }
 
    SnapshotRNTupleHelper(const SnapshotRNTupleHelper &) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -35,7 +35,7 @@
 #include "TClassRef.h"
 #include "TDirectory.h"
 #include "TError.h" // for R__ASSERT, Warning
-#include "TFile.h" // for SnapshotHelper
+#include "TFile.h"  // for SnapshotHelper
 #include "TH1.h"
 #include "TGraph.h"
 #include "TGraphAsymmErrors.h"
@@ -46,6 +46,12 @@
 #include "TStatistic.h"
 #include "ROOT/RDF/RActionImpl.hxx"
 #include "ROOT/RDF/RMergeableValue.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
+
+#ifdef R__HAS_ROOT7
+#include "ROOT/RNTupleDS.hxx"
+#include "ROOT/RNTupleWriter.hxx" // for SnapshotRNTupleHelper
+#endif
 
 #include <algorithm>
 #include <functional>
@@ -1391,8 +1397,8 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
    branchAddress = nullptr;
 }
 
-/// Helper function for SnapshotHelper and SnapshotHelperMT. It creates new branches for the output TTree of a Snapshot.
-/// This overload is called for columns of type `RVec<T>`. For RDF, these can represent:
+/// Helper function for SnapshotHelper and SnapshotHelperMT. It creates new branches for the output TTree of a
+/// Snapshot. This overload is called for columns of type `RVec<T>`. For RDF, these can represent:
 /// 1. c-style arrays in ROOT files, so we are sure that there are input trees to which we can ask the correct branch
 /// title
 /// 2. RVecs coming from a custom column or the input file/data-source
@@ -1502,7 +1508,7 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
 
 void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName);
 
-/// Helper object for a single-thread Snapshot action
+/// Helper object for a single-thread TTree-based Snapshot action
 template <typename... ColTypes>
 class R__CLING_PTRCHECK(off) SnapshotHelper : public RActionImpl<SnapshotHelper<ColTypes...>> {
    std::string fFileName;
@@ -1526,9 +1532,15 @@ public:
    SnapshotHelper(std::string_view filename, std::string_view dirname, std::string_view treename,
                   const ColumnNames_t &vbnames, const ColumnNames_t &bnames, const RSnapshotOptions &options,
                   std::vector<bool> &&isDefine)
-      : fFileName(filename), fDirName(dirname), fTreeName(treename), fOptions(options), fInputBranchNames(vbnames),
-        fOutputBranchNames(ReplaceDotWithUnderscore(bnames)), fBranches(vbnames.size(), nullptr),
-        fBranchAddresses(vbnames.size(), nullptr), fIsDefine(std::move(isDefine))
+      : fFileName(filename),
+        fDirName(dirname),
+        fTreeName(treename),
+        fOptions(options),
+        fInputBranchNames(vbnames),
+        fOutputBranchNames(ReplaceDotWithUnderscore(bnames)),
+        fBranches(vbnames.size(), nullptr),
+        fBranchAddresses(vbnames.size(), nullptr),
+        fIsDefine(std::move(isDefine))
    {
       ValidateSnapshotOutput(fOptions, fTreeName, fFileName);
    }
@@ -1662,7 +1674,7 @@ public:
    }
 };
 
-/// Helper object for a multi-thread Snapshot action
+/// Helper object for a multi-thread TTree-based Snapshot action
 template <typename... ColTypes>
 class R__CLING_PTRCHECK(off) SnapshotHelperMT : public RActionImpl<SnapshotHelperMT<ColTypes...>> {
    unsigned int fNSlots;
@@ -1689,11 +1701,20 @@ public:
    SnapshotHelperMT(const unsigned int nSlots, std::string_view filename, std::string_view dirname,
                     std::string_view treename, const ColumnNames_t &vbnames, const ColumnNames_t &bnames,
                     const RSnapshotOptions &options, std::vector<bool> &&isDefine)
-      : fNSlots(nSlots), fOutputFiles(fNSlots), fOutputTrees(fNSlots), fBranchAddressesNeedReset(fNSlots, 1),
-        fFileName(filename), fDirName(dirname), fTreeName(treename), fOptions(options), fInputBranchNames(vbnames),
-        fOutputBranchNames(ReplaceDotWithUnderscore(bnames)), fInputTrees(fNSlots),
+      : fNSlots(nSlots),
+        fOutputFiles(fNSlots),
+        fOutputTrees(fNSlots),
+        fBranchAddressesNeedReset(fNSlots, 1),
+        fFileName(filename),
+        fDirName(dirname),
+        fTreeName(treename),
+        fOptions(options),
+        fInputBranchNames(vbnames),
+        fOutputBranchNames(ReplaceDotWithUnderscore(bnames)),
+        fInputTrees(fNSlots),
         fBranches(fNSlots, std::vector<TBranch *>(vbnames.size(), nullptr)),
-        fBranchAddresses(fNSlots, std::vector<void *>(vbnames.size(), nullptr)), fOutputBranches(fNSlots),
+        fBranchAddresses(fNSlots, std::vector<void *>(vbnames.size(), nullptr)),
+        fOutputBranches(fNSlots),
         fIsDefine(std::move(isDefine))
    {
       ValidateSnapshotOutput(fOptions, fTreeName, fFileName);
@@ -1857,6 +1878,148 @@ public:
                               fInputBranchNames, fOutputBranchNames, fOptions, std::vector<bool>(fIsDefine)};
    }
 };
+
+#ifdef R__HAS_ROOT7
+void ValidateSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
+                                   const std::string &fileName);
+
+/// Helper function to update the value of an RNTuple's field in the provided entry.
+template <typename T>
+void SetFieldsHelper(T &value, std::string_view fieldName, ROOT::Experimental::REntry *entry)
+{
+   entry->BindRawPtr(fieldName, &value);
+}
+
+/// Helper object for a single-thread RNTuple-based Snapshot action
+template <typename... ColTypes>
+class R__CLING_PTRCHECK(off) SnapshotRNTupleHelper : public RActionImpl<SnapshotRNTupleHelper<ColTypes...>> {
+   std::string fFileName;
+   std::string fNTupleName;
+
+   std::unique_ptr<TFile> fOutputFile{nullptr};
+
+   RSnapshotOptions fOptions;
+   ROOT::Detail::RDF::RLoopManager *fLoopManager;
+   ColumnNames_t fInputFieldNames; // This contains the resolved aliases
+   ColumnNames_t fOutputFieldNames;
+   std::unique_ptr<ROOT::Experimental::RNTupleWriter> fWriter{nullptr};
+
+   ROOT::Experimental::REntry *fOutputEntry;
+
+   std::vector<bool> fIsDefine;
+
+public:
+   using ColumnTypes_t = TypeList<ColTypes...>;
+   SnapshotRNTupleHelper(std::string_view filename, std::string_view ntuplename, const ColumnNames_t &vfnames,
+                         const ColumnNames_t &fnames, const RSnapshotOptions &options,
+                         ROOT::Detail::RDF::RLoopManager *lm, std::vector<bool> &&isDefine)
+      : fFileName(filename),
+        fNTupleName(ntuplename),
+        fOptions(options),
+        fLoopManager(lm),
+        fInputFieldNames(vfnames),
+        fOutputFieldNames(ReplaceDotWithUnderscore(fnames)),
+        fIsDefine(std::move(isDefine))
+   {
+      ValidateSnapshotRNTupleOutput(fOptions, fNTupleName, fFileName);
+   }
+
+   SnapshotRNTupleHelper(const SnapshotRNTupleHelper &) = delete;
+   SnapshotRNTupleHelper &operator=(const SnapshotRNTupleHelper &) = delete;
+   SnapshotRNTupleHelper(SnapshotRNTupleHelper &&) = default;
+   SnapshotRNTupleHelper &operator=(SnapshotRNTupleHelper &&) = default;
+   ~SnapshotRNTupleHelper()
+   {
+      if (!fNTupleName.empty() && !fLoopManager->GetDataSource() && fOptions.fLazy)
+         Warning("Snapshot", "A lazy Snapshot action was booked but never triggered.");
+   }
+
+   void InitTask(TTreeReader *, unsigned int /* slot */) {}
+
+   void Exec(unsigned int /* slot */, ColTypes &...values)
+   {
+      using ind_t = std::index_sequence_for<ColTypes...>;
+
+      SetFields(values..., ind_t{});
+      fWriter->Fill();
+   }
+
+   template <std::size_t... S>
+   void SetFields(ColTypes &...values, std::index_sequence<S...> /*dummy*/)
+   {
+      int expander[] = {(SetFieldsHelper(values, fOutputFieldNames[S], fOutputEntry), 0)..., 0};
+      (void)expander; // avoid unused variable warnings for older compilers (gcc 14.1)
+   }
+
+   void Initialize()
+   {
+      using ind_t = std::index_sequence_for<ColTypes...>;
+
+      auto model = ROOT::Experimental::RNTupleModel::Create();
+      MakeFields(*model, ind_t{});
+      fOutputEntry = &model->GetDefaultEntry();
+
+      ROOT::RNTupleWriteOptions writeOptions;
+      writeOptions.SetCompression(fOptions.fCompressionAlgorithm, fOptions.fCompressionLevel);
+
+      TString checkupdate = fOptions.fMode;
+      checkupdate.ToLower();
+
+      if (checkupdate == "update") {
+         fOutputFile = std::unique_ptr<TFile>(TFile::Open(fFileName.c_str(), fOptions.fMode.c_str()));
+         if (!fOutputFile)
+            throw std::runtime_error("Snapshot: could not create output file " + fFileName);
+         fWriter = ROOT::Experimental::RNTupleWriter::Append(std::move(model), fNTupleName, *fOutputFile, writeOptions);
+      } else {
+         fWriter = ROOT::Experimental::RNTupleWriter::Recreate(std::move(model), fNTupleName, fFileName, writeOptions);
+      }
+   }
+
+   template <std::size_t... S>
+   void MakeFields(ROOT::Experimental::RNTupleModel &model, std::index_sequence<S...> /*dummy*/)
+   {
+      int expander[] = {(model.MakeField<ColTypes>(fOutputFieldNames[S]), 0)..., 0};
+      (void)expander; // avoid unused variable warnings for older compilers (gcc 14.1)
+   }
+
+   void Finalize()
+   {
+      fWriter.reset();
+      // We can now set the data source of the loop manager for the RDataFrame that is returned by the Snapshot call.
+      fLoopManager->SetDataSource(std::make_unique<ROOT::Experimental::RNTupleDS>(fNTupleName, fFileName));
+   }
+
+   std::string GetActionName() { return "Snapshot"; }
+
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final
+   {
+      return [](unsigned int, const RSampleInfo &) mutable {};
+   }
+
+   /**
+    * @brief Create a new SnapshotRNTupleHelper with a different output file name
+    *
+    * @param newName A type-erased string with the output file name
+    * @return SnapshotRNTupleHelper
+    *
+    * This MakeNew implementation is tied to the cloning feature of actions
+    * of the computation graph. In particular, cloning a Snapshot node usually
+    * also involves changing the name of the output file, otherwise the cloned
+    * Snapshot would overwrite the same file.
+    */
+   SnapshotRNTupleHelper MakeNew(void *newName)
+   {
+      const std::string finalName = *reinterpret_cast<const std::string *>(newName);
+      return SnapshotRNTupleHelper{finalName,
+                                   fNTupleName,
+                                   fInputFieldNames,
+                                   fOutputFieldNames,
+                                   fOptions,
+                                   fLoopManager,
+                                   std::vector<bool>(fIsDefine)};
+   }
+};
+#endif
 
 template <typename Acc, typename Merge, typename R, typename T, typename U,
           bool MustCopyAssign = std::is_same<R, U>::value>

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -254,7 +254,7 @@ struct SnapshotHelperArgs {
    bool fToNTuple;
 };
 
-// Snapshot action
+// SnapshotTTree action
 template <typename... ColTypes, typename PrevNodeType>
 std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperArgs> &snapHelperArgs,
@@ -293,14 +293,14 @@ BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperA
    } else {
       if (!ROOT::IsImplicitMTEnabled()) {
          // single-thread snapshot
-         using Helper_t = SnapshotHelper<ColTypes...>;
+         using Helper_t = SnapshotTTreeHelper<ColTypes...>;
          using Action_t = RAction<Helper_t, PrevNodeType>;
          actionPtr.reset(
             new Action_t(Helper_t(filename, dirname, treename, colNames, outputColNames, options, std::move(isDefine)),
                          colNames, prevNode, colRegister));
       } else {
          // multi-thread snapshot
-         using Helper_t = SnapshotHelperMT<ColTypes...>;
+         using Helper_t = SnapshotTTreeHelperMT<ColTypes...>;
          using Action_t = RAction<Helper_t, PrevNodeType>;
          actionPtr.reset(new Action_t(
             Helper_t(nSlots, filename, dirname, treename, colNames, outputColNames, options, std::move(isDefine)),

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -287,8 +287,9 @@ BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperA
 
       return actionPtr;
 #else
-      throw std::runtime_error("Cannot snapshot to RNTuple: this installation of ROOT has not been build with ROOT7 "
-                               "components enabled.");
+      throw std::runtime_error(
+         "RDataFrame: Cannot snapshot to RNTuple - this installation of ROOT has not been build with ROOT7 "
+         "components enabled.");
 #endif
    } else {
       if (!ROOT::IsImplicitMTEnabled()) {

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -298,7 +298,7 @@ public:
       RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, *fLoopManager, fColRegister);
       const auto jittedFilter =
          RDFInternal::BookFilterJit(upcastNodeOnHeap, name, expression, fLoopManager->GetBranchNames(), fColRegister,
-                                    fLoopManager->GetTree(), fDataSource);
+                                    fLoopManager->GetTree(), GetDataSource());
 
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), *fLoopManager, fColRegister);
    }
@@ -536,10 +536,10 @@ public:
       RDFInternal::CheckValidCppVarName(name, where);
       // these checks must be done before jitting lest we throw exceptions in jitted code
       RDFInternal::CheckForRedefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
-                                        fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                        GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
-      auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fColRegister,
+      auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, GetDataSource(), fColRegister,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
 
       RDFInternal::RColumnRegister newCols(fColRegister);
@@ -625,11 +625,11 @@ public:
       constexpr auto where = "Redefine";
       RDFInternal::CheckValidCppVarName(name, where);
       RDFInternal::CheckForDefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
-                                      fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                      GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
       RDFInternal::CheckForNoVariations(where, name, fColRegister);
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
-      auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fColRegister,
+      auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, GetDataSource(), fColRegister,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
 
       RDFInternal::RColumnRegister newCols(fColRegister);
@@ -682,7 +682,7 @@ public:
       // the column name was not defined previously.
       if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
          RDFInternal::CheckForDefinition(where, column, fColRegister, fLoopManager->GetBranchNames(),
-                                         fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                         GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
       const auto validColumnNames = ColumnNames_t{column.data()};
       CheckAndFillDSColumns(validColumnNames, TTraits::TypeList<T>{});
 
@@ -741,7 +741,7 @@ public:
    {
       RDFInternal::CheckValidCppVarName(name, "DefinePerSample");
       RDFInternal::CheckForRedefinition("DefinePerSample", name, fColRegister, fLoopManager->GetBranchNames(),
-                                        fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                        GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
 
       auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType_t));
       if (retTypeName.empty()) {
@@ -803,7 +803,7 @@ public:
       RDFInternal::CheckValidCppVarName(name, "DefinePerSample");
       // these checks must be done before jitting lest we throw exceptions in jitted code
       RDFInternal::CheckForRedefinition("DefinePerSample", name, fColRegister, fLoopManager->GetBranchNames(),
-                                        fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                        GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine =
@@ -1223,7 +1223,7 @@ public:
       // - Make aliases accessible based on chains and not globally
 
       // Helper to find out if a name is a column
-      auto &dsColumnNames = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      auto &dsColumnNames = GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{};
 
       constexpr auto where = "Alias";
       RDFInternal::CheckValidCppVarName(alias, where);
@@ -1384,7 +1384,7 @@ public:
       const auto definedColumns = fColRegister.GenerateColumnNames();
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
-      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      const auto dsColumns = GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
       std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
@@ -1499,8 +1499,8 @@ public:
 
       const auto validColumnNames =
          GetValidatedColumnNames(columnListWithoutSizeColumns.size(), columnListWithoutSizeColumns);
-      const auto colTypes = GetValidatedArgTypes(validColumnNames, fColRegister, fLoopManager->GetTree(), fDataSource,
-                                                 "Cache", /*vector2RVec=*/false);
+      const auto colTypes = GetValidatedArgTypes(validColumnNames, fColRegister, fLoopManager->GetTree(),
+                                                 GetDataSource(), "Cache", /*vector2RVec=*/false);
       for (const auto &colType : colTypes)
          cacheCall << colType << ", ";
       if (!columnListWithoutSizeColumns.empty())
@@ -1528,7 +1528,7 @@ public:
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames =
          tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
-      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      const auto dsColumns = GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
       std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
@@ -3120,10 +3120,10 @@ private:
       if (where.compare(0, 8, "Redefine") != 0) { // not a Redefine
          RDFInternal::CheckValidCppVarName(name, where);
          RDFInternal::CheckForRedefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
-                                           fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                           GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
       } else {
          RDFInternal::CheckForDefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
-                                         fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                         GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
          RDFInternal::CheckForNoVariations(where, name, fColRegister);
       }
 
@@ -3281,7 +3281,7 @@ private:
       for (auto &colName : colNames) {
          RDFInternal::CheckValidCppVarName(colName, "Vary");
          RDFInternal::CheckForDefinition("Vary", colName, fColRegister, fLoopManager->GetBranchNames(),
-                                         fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+                                         GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
       }
       RDFInternal::CheckValidCppVarName(variationName, "Vary");
 
@@ -3293,9 +3293,9 @@ private:
       }
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
-      auto jittedVariation =
-         RDFInternal::BookVariationJit(colNames, variationName, variationTags, expression, *fLoopManager, fDataSource,
-                                       fColRegister, fLoopManager->GetBranchNames(), upcastNodeOnHeap, isSingleColumn);
+      auto jittedVariation = RDFInternal::BookVariationJit(
+         colNames, variationName, variationTags, expression, *fLoopManager, GetDataSource(), fColRegister,
+         fLoopManager->GetBranchNames(), upcastNodeOnHeap, isSingleColumn);
 
       RDFInternal::RColumnRegister newColRegister(fColRegister);
       newColRegister.AddVariation(std::move(jittedVariation));

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1375,8 +1375,9 @@ public:
             colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr,
             colListNoAliasesWithSizeBranches.size());
 #else
-         throw std::runtime_error("Cannot snapshot to RNTuple: this installation of ROOT has not been build with ROOT7 "
-                                  "components enabled.");
+         throw std::runtime_error(
+            "RDataFrame: Cannot snapshot to RNTuple - this installation of ROOT has not been build with ROOT7 "
+            "components enabled.");
 #endif
       } else {
          // The CreateLMFromTTree function by default opens the file passed as input
@@ -3267,8 +3268,9 @@ private:
          resPtr = CreateAction<RDFInternal::ActionTags::Snapshot, ColumnTypes...>(validCols, newRDF, snapHelperArgs,
                                                                                   fProxiedPtr);
 #else
-         throw std::runtime_error("Cannot snapshot to RNTuple: this installation of ROOT has not been build with ROOT7 "
-                                  "components enabled.");
+         throw std::runtime_error(
+            "RDataFrame: Cannot snapshot to RNTuple - this installation of ROOT has not been build with ROOT7 "
+            "components enabled.");
 #endif
       } else {
          // The CreateLMFromTTree function by default opens the file passed as input

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1344,10 +1344,7 @@ public:
 
       RResultPtr<RInterface<RLoopManager>> resPtr;
 
-      bool isBasedOnRNTuple = RDFInternal::GetDataSourceLabel(*this) == "RNTupleDS";
-
-      if (options.fOutputFormat == ESnapshotOutputFormat::kRNTuple ||
-          (options.fOutputFormat == ESnapshotOutputFormat::kDefault && isBasedOnRNTuple)) {
+      if (options.fOutputFormat == ESnapshotOutputFormat::kRNTuple) {
 #ifdef R__HAS_ROOT7
          if (fLoopManager->GetTree()) {
             throw std::runtime_error("Snapshotting from TTree to RNTuple is not yet supported. The current recommended "
@@ -1380,6 +1377,14 @@ public:
             "components enabled.");
 #endif
       } else {
+         if (RDFInternal::GetDataSourceLabel(*this) == "RNTupleDS" &&
+             options.fOutputFormat == ESnapshotOutputFormat::kDefault) {
+            Warning("Snapshot",
+                    "The default Snapshot output data format is TTree, but the input data format is RNTuple. If you "
+                    "want to Snapshot to RNTuple or suppress this warning, set the appropriate fOutputFormat option in "
+                    "RSnapshotOptions. Note that this current default behaviour might change in the future.");
+         }
+
          // The CreateLMFromTTree function by default opens the file passed as input
          // to check for the presence of the TTree inside. But at this moment the
          // filename we are using here corresponds to a file which does not exist yet,
@@ -3240,10 +3245,7 @@ private:
 
       RResultPtr<RInterface<RLoopManager>> resPtr;
 
-      bool isBasedOnRNTuple = RDFInternal::GetDataSourceLabel(*this) == "RNTupleDS";
-
-      if (options.fOutputFormat == ESnapshotOutputFormat::kRNTuple ||
-          (options.fOutputFormat == ESnapshotOutputFormat::kDefault && isBasedOnRNTuple)) {
+      if (options.fOutputFormat == ESnapshotOutputFormat::kRNTuple) {
 #ifdef R__HAS_ROOT7
          if (fLoopManager->GetTree()) {
             throw std::runtime_error("Snapshotting from TTree to RNTuple is not yet supported. The current recommended "
@@ -3273,6 +3275,14 @@ private:
             "components enabled.");
 #endif
       } else {
+         if (RDFInternal::GetDataSourceLabel(*this) == "RNTupleDS" &&
+             options.fOutputFormat == ESnapshotOutputFormat::kDefault) {
+            Warning("Snapshot",
+                    "The default Snapshot output data format is TTree, but the input data format is RNTuple. If you "
+                    "want to Snapshot to RNTuple or suppress this warning, set the appropriate fOutputFormat option in "
+                    "RSnapshotOptions. Note that this current default behaviour might change in the future.");
+         }
+
          // The CreateLMFromTTree function by default opens the file passed as input
          // to check for the presence of the TTree inside. But at this moment the
          // filename we are using here corresponds to a file which does not exist yet,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1354,6 +1354,11 @@ public:
                                      "way to convert TTrees to RNTuple is through the RNTupleImporter.");
          }
 
+         if (!dirname.empty()) {
+            throw std::runtime_error(
+               "RDataFrame: Snapshotting an RNTuple to a TFile sub-directory is currently not supported.");
+         }
+
          // The data source of the RNTuple resulting from the Snapshot action does not exist yet here, so we create one
          // without a data source for now, and set it once the actual data source can be created (i.e., after
          // writing the RNTuple).
@@ -3242,6 +3247,11 @@ private:
          if (fLoopManager->GetTree()) {
             throw std::runtime_error("Snapshotting from TTree to RNTuple is not yet supported. The current recommended "
                                      "way to convert TTrees to RNTuple is through the RNTupleImporter.");
+         }
+
+         if (!dirname.empty()) {
+            throw std::runtime_error(
+               "RDataFrame: Snapshotting an RNTuple to a TFile sub-directory is currently not supported.");
          }
 
          auto newRDF =

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -17,7 +17,6 @@
 #ifndef ROOT_RNTupleDS
 #define ROOT_RNTupleDS
 
-#include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDataSource.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
@@ -204,13 +203,14 @@ protected:
 
 } // namespace Experimental
 
+class RDataFrame;
+
 namespace RDF {
 namespace Experimental {
 RDataFrame FromRNTuple(std::string_view ntupleName, std::string_view fileName);
 RDataFrame FromRNTuple(std::string_view ntupleName, const std::vector<std::string> &fileNames);
 } // namespace Experimental
 } // namespace RDF
-
-} // ns ROOT
+} // namespace ROOT
 
 #endif

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -19,6 +19,12 @@
 namespace ROOT {
 
 namespace RDF {
+enum class ESnapshotOutputFormat {
+   kDefault,
+   kTTree,
+   kRNTuple
+};
+
 /// A collection of options to steer the creation of the dataset on file
 struct RSnapshotOptions {
    using ECAlgo = ROOT::RCompressionSetting::EAlgorithm::EValues;
@@ -27,7 +33,8 @@ struct RSnapshotOptions {
    RSnapshotOptions(RSnapshotOptions &&) = default;
    RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy,
                     bool overwriteIfExists = false, bool vector2RVec = true,
-                    const std::optional<int> &basketSize = std::nullopt)
+                    const std::optional<int> &basketSize = std::nullopt,
+                    ESnapshotOutputFormat outputFormat = ESnapshotOutputFormat::kDefault)
       : fMode(mode),
         fCompressionAlgorithm(comprAlgo),
         fCompressionLevel{comprLevel},
@@ -36,7 +43,8 @@ struct RSnapshotOptions {
         fLazy(lazy),
         fOverwriteIfExists(overwriteIfExists),
         fVector2RVec(vector2RVec),
-        fBasketSize(basketSize)
+        fBasketSize(basketSize),
+        fOutputFormat(outputFormat)
    {
    }
    std::string fMode = "RECREATE"; ///< Mode of creation of output file
@@ -46,10 +54,11 @@ struct RSnapshotOptions {
    int fAutoFlush = 0;                              ///< AutoFlush value for output tree
    int fSplitLevel = 99;                            ///< Split level of output tree
    bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
-   bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
-   bool fVector2RVec = true;        ///< If set to true will convert std::vector columns to RVec when saving to disk
+   bool fOverwriteIfExists = false;  ///< If fMode is "UPDATE", overwrite object in output file if it already exists
+   bool fVector2RVec = true;         ///< If set to true will convert std::vector columns to RVec when saving to disk
    std::optional<int> fBasketSize{}; ///< Set a custom basket size option. For more details, see
                                      ///< https://root.cern/manual/trees/#baskets-clusters-and-the-tree-header
+   ESnapshotOutputFormat fOutputFormat = ESnapshotOutputFormat::kDefault; ///< Which data format to write to
 };
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -212,7 +212,8 @@ template class TakeHelper<float, float, std::vector<float>>;
 template class TakeHelper<double, double, std::vector<double>>;
 #endif
 
-void ValidateSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName)
+void EnsureValidSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string &treeName,
+                                    const std::string &fileName)
 {
    TString fileMode = opts.fMode;
    fileMode.ToLower();
@@ -244,8 +245,8 @@ void ValidateSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string
 }
 
 #ifdef R__HAS_ROOT7
-void ValidateSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
-                                   const std::string &fileName)
+void EnsureValidSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
+                                      const std::string &fileName)
 {
    TString fileMode = opts.fMode;
    fileMode.ToLower();

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -10,6 +10,7 @@
 
 #include "ROOT/RDF/ActionHelpers.hxx"
 #include "ROOT/RDF/Utils.hxx" // CacheLineStep
+#include "ROOT/RNTuple.hxx"   // ValidateSnapshotRNTupleOutput
 
 namespace ROOT {
 namespace Internal {
@@ -241,6 +242,56 @@ void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &tre
       throw std::invalid_argument(msg);
    }
 }
+
+#ifdef R__HAS_ROOT7
+void ValidateSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::string &ntupleName,
+                                   const std::string &fileName)
+{
+   TString fileMode = opts.fMode;
+   fileMode.ToLower();
+   if (fileMode != "update")
+      return;
+
+   // output file opened in "update" mode: must check whether output RNTuple is already present in file
+   std::unique_ptr<TFile> outFile{TFile::Open(fileName.c_str(), "update")};
+   if (!outFile || outFile->IsZombie())
+      throw std::invalid_argument("Snapshot: cannot open file \"" + fileName + "\" in update mode");
+
+   auto *outNTuple = outFile->Get<ROOT::RNTuple>(ntupleName.c_str());
+
+   if (outNTuple) {
+      if (opts.fOverwriteIfExists) {
+         outFile->Delete((ntupleName + ";*").c_str());
+         return;
+      } else {
+         const std::string msg = "Snapshot: RNTuple \"" + ntupleName + "\" already present in file \"" + fileName +
+                                 "\". If you want to delete the original ntuple and write another, please set "
+                                 "the 'fOverwriteIfExists' option to true in RSnapshotOptions.";
+         throw std::invalid_argument(msg);
+      }
+   }
+
+   // Also check if there is any object other than an RNTuple with the provided ntupleName.
+   TObject *outObj = outFile->Get(ntupleName.c_str());
+
+   if (!outObj)
+      return;
+
+   // An object called ntupleName is already present in the file.
+   if (opts.fOverwriteIfExists) {
+      if (auto tree = dynamic_cast<TTree *>(outObj)) {
+         tree->Delete("all");
+      } else {
+         outFile->Delete((ntupleName + ";*").c_str());
+      }
+   } else {
+      const std::string msg = "Snapshot: object \"" + ntupleName + "\" already present in file \"" + fileName +
+                              "\". If you want to delete the original object and write a new RNTuple, please set "
+                              "the 'fOverwriteIfExists' option to true in RSnapshotOptions.";
+      throw std::invalid_argument(msg);
+   }
+}
+#endif
 
 } // end NS RDF
 } // end NS Internal

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -212,7 +212,7 @@ template class TakeHelper<float, float, std::vector<float>>;
 template class TakeHelper<double, double, std::vector<double>>;
 #endif
 
-void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName)
+void ValidateSnapshotTTreeOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName)
 {
    TString fileMode = opts.fMode;
    fileMode.ToLower();

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -1007,7 +1007,7 @@ AddSizeBranches(const std::vector<std::string> &branches, TTree *tree, std::vect
    assert(colsWithoutAliases.size() == colsWithAliases.size());
 
    auto nCols = colsWithoutAliases.size();
-   // Use index-iteration as we modify the vector during the iteration. 
+   // Use index-iteration as we modify the vector during the iteration.
    for (std::size_t i = 0u; i < nCols; ++i) {
       const auto &colName = colsWithoutAliases[i];
       if (!IsStrInVec(colName, branches))
@@ -1044,6 +1044,25 @@ void RemoveDuplicates(ColumnNames_t &columnNames)
       columnNames.end());
 }
 
+#ifdef R__HAS_ROOT7
+void RemoveRNTupleSubFields(ColumnNames_t &columnNames)
+{
+   ColumnNames_t parentFields;
+
+   std::copy_if(columnNames.cbegin(), columnNames.cend(), std::back_inserter(parentFields),
+                [](const std::string &colName) { return colName.find('.') == std::string::npos; });
+
+   columnNames.erase(std::remove_if(columnNames.begin(), columnNames.end(),
+                                    [&parentFields](const std::string &colName) {
+                                       if (colName.find('.') == std::string::npos)
+                                          return false;
+                                       const auto parentFieldName = colName.substr(0, colName.find_first_of('.'));
+                                       return std::find(parentFields.cbegin(), parentFields.cend(), parentFieldName) !=
+                                              parentFields.end();
+                                    }),
+                     columnNames.end());
+}
+#endif
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -2072,7 +2072,7 @@ std::string printValue(ROOT::RDataFrame *df)
             }
          }
       }
-   } else if (auto ds = df->fDataSource) {
+   } else if (auto ds = df->GetDataSource()) {
       ret << "A data frame associated to the data source \"" << cling::printValue(ds) << "\"";
    } else {
       ret << "An empty data frame that will create " << lm->GetNEmptyEntries() << " entries\n";

--- a/tree/dataframe/src/RInterface.cxx
+++ b/tree/dataframe/src/RInterface.cxx
@@ -50,8 +50,8 @@ std::string ROOT::Internal::RDF::GetDataSourceLabel(const ROOT::RDF::RNode &node
 {
    if (node.fLoopManager->GetTree()) {
       return "TTreeDS";
-   } else if (node.fDataSource) {
-      return node.fDataSource->GetLabel();
+   } else if (node.GetDataSource()) {
+      return node.GetDataSource()->GetLabel();
    } else {
       return "EmptyDS";
    }

--- a/tree/dataframe/src/RInterfaceBase.cxx
+++ b/tree/dataframe/src/RInterfaceBase.cxx
@@ -35,8 +35,8 @@ unsigned int ROOT::RDF::RInterfaceBase::GetNFiles()
       return ROOT::Internal::TreeUtils::GetFileNamesFromTree(*tree).size();
    }
    // Datasource as input
-   if (fDataSource) {
-      return fDataSource->GetNFiles();
+   if (auto dataSource = GetDataSource()) {
+      return dataSource->GetNFiles();
    }
    return 0;
 }
@@ -108,8 +108,8 @@ std::string ROOT::RDF::RInterfaceBase::DescribeDataset() const
       return ss.str();
    }
    // Datasource as input
-   else if (fDataSource) {
-      const auto datasourceLabel = fDataSource->GetLabel();
+   else if (auto dataSource = GetDataSource()) {
+      const auto datasourceLabel = dataSource->GetLabel();
       return "Dataframe from datasource " + datasourceLabel;
    }
    // Trivial/empty datasource
@@ -124,14 +124,13 @@ std::string ROOT::RDF::RInterfaceBase::DescribeDataset() const
 }
 
 ROOT::RDF::RInterfaceBase::RInterfaceBase(std::shared_ptr<RDFDetail::RLoopManager> lm)
-   : fLoopManager(lm), fDataSource(lm->GetDataSource()), fColRegister(lm.get())
+   : fLoopManager(lm), fColRegister(lm.get())
 {
    AddDefaultColumns();
 }
 
 ROOT::RDF::RInterfaceBase::RInterfaceBase(RDFDetail::RLoopManager &lm, const RDFInternal::RColumnRegister &colRegister)
    : fLoopManager(std::shared_ptr<ROOT::Detail::RDF::RLoopManager>{&lm, [](ROOT::Detail::RDF::RLoopManager *) {}}),
-     fDataSource(lm.GetDataSource()),
      fColRegister(colRegister)
 {
 }
@@ -169,8 +168,8 @@ ROOT::RDF::ColumnNames_t ROOT::RDF::RInterfaceBase::GetColumnNames()
          allColumns.emplace(bName);
    }
 
-   if (fDataSource) {
-      for (const auto &s : fDataSource->GetColumnNames()) {
+   if (auto dataSource = GetDataSource()) {
+      for (const auto &s : dataSource->GetColumnNames()) {
          if (s.rfind("R_rdf_sizeof", 0) != 0)
             allColumns.emplace(s);
       }
@@ -362,7 +361,7 @@ bool ROOT::RDF::RInterfaceBase::HasColumn(std::string_view columnName)
          return true;
    }
 
-   if (fDataSource && fDataSource->HasColumn(columnName))
+   if (GetDataSource() && GetDataSource()->HasColumn(columnName))
       return true;
 
    return false;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -15,6 +15,7 @@
  *************************************************************************/
 
 #include <ROOT/RDF/RColumnReaderBase.hxx>
+#include <ROOT/RDataFrame.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldUtils.hxx>
 #include <ROOT/RPageStorageFile.hxx>

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -106,6 +106,10 @@ endif()
 if(root7)
   ROOT_ADD_GTEST(datasource_ntuple datasource_ntuple.cxx LIBRARIES ROOTDataFrame)
 
+  if(NOT MSVC OR win_broken_tests)
+    ROOT_ADD_GTEST(dataframe_snapshot_ntuple dataframe_snapshot_ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTupleUtil)
+  endif()
+
   ROOT_STANDARD_LIBRARY_PACKAGE(NTupleStruct
                                 NO_INSTALL_HEADERS
                                 HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/NTupleStruct.hxx

--- a/tree/dataframe/test/NTupleStruct.hxx
+++ b/tree/dataframe/test/NTupleStruct.hxx
@@ -2,6 +2,7 @@
 #define ROOT7_RDataFrame_Test_NTupleStruct
 
 #include <set>
+#include <vector>
 
 /**
  * Used to test serialization and deserialization of classes in RNTuple with TClass
@@ -10,6 +11,10 @@ struct Electron {
    float pt;
 
    friend bool operator<(const Electron &left, const Electron &right) { return left.pt < right.pt; }
+};
+
+struct Jet {
+   std::vector<Electron> electrons;
 };
 
 #endif

--- a/tree/dataframe/test/NTupleStructLinkDef.h
+++ b/tree/dataframe/test/NTupleStructLinkDef.h
@@ -9,4 +9,6 @@
 #pragma link C++ class std::set < std::set < Electron>> + ;
 #pragma link C++ class std::set < std::vector < Electron>> + ;
 
+#pragma link C++ class Jet + ;
+
 #endif

--- a/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
@@ -1,0 +1,461 @@
+#include "ROOT/TestSupport.hxx"
+#include "ROOT/RDataFrame.hxx"
+
+#include "ROOT/RNTupleModel.hxx"
+#include "ROOT/RNTupleWriter.hxx"
+#include "ROOT/RNTupleReader.hxx"
+#include "ROOT/RNTupleInspector.hxx" // For testing compression settings
+
+#include "TROOT.h"
+#include "TSystem.h"
+
+#include "gtest/gtest.h"
+
+#include "NTupleStruct.hxx"
+
+using ROOT::Experimental::RNTupleInspector;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriter;
+
+using namespace ROOT::RDF;
+
+TEST(RDFSnapshotRNTuple, FromScratchTemplated)
+{
+   const auto filename = "RDFSnapshotRNTuple_from_scratch_templated.root";
+   const std::vector<std::string> columns = {"x"};
+
+   auto df = ROOT::RDataFrame(25ull).Define("x", [] { return 10; });
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+
+   auto sdf = df.Snapshot<int>("ntuple", filename, columns, opts);
+
+   EXPECT_EQ(columns, sdf->GetColumnNames());
+
+   auto ntuple = RNTupleReader::Open("ntuple", filename);
+   EXPECT_EQ(25ull, ntuple->GetNEntries());
+
+   auto x = ntuple->GetView<int>("x");
+   for (const auto i : ntuple->GetEntryRange()) {
+      EXPECT_EQ(10, x(i));
+   }
+}
+
+TEST(RDFSnapshotRNTuple, FromScratchJITted)
+{
+   const auto filename = "RDFSnapshotRNTuple_from_scratch_jitted.root";
+   const std::vector<std::string> columns = {"x"};
+
+   auto df = ROOT::RDataFrame(25ull).Define("x", [] { return 10; });
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+
+   auto sdf = df.Snapshot("ntuple", filename, "x", opts);
+
+   EXPECT_EQ(columns, sdf->GetColumnNames());
+
+   auto ntuple = RNTupleReader::Open("ntuple", filename);
+   EXPECT_EQ(25ull, ntuple->GetNEntries());
+
+   auto x = ntuple->GetView<int>("x");
+   for (const auto i : ntuple->GetEntryRange()) {
+      EXPECT_EQ(10, x(i));
+   }
+}
+
+void BookLazySnapshot()
+{
+   auto d = ROOT::RDataFrame(1);
+   ROOT::RDF::RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+   opts.fLazy = true;
+   d.Snapshot<ULong64_t>("t", "lazysnapshotnottriggered_shouldnotbecreated.root", {"rdfentry_"}, opts);
+}
+
+TEST(RDFSnapshotRNTuple, LazyNotTriggered)
+{
+   ROOT_EXPECT_WARNING(BookLazySnapshot(), "Snapshot", "A lazy Snapshot action was booked but never triggered.");
+   // This returns FALSE if the file IS there.
+   // TODO(fdegeus) use std::filesystem::exists once supported on all platforms.
+   EXPECT_TRUE(gSystem->AccessPathName("lazysnapshotnottriggered_shouldnotbecreated.root"));
+}
+
+TEST(RDFSnapshotRNTuple, Compression)
+{
+   const auto filename = "RDFSnapshotRNTuple_compression.root";
+   const std::vector<std::string> columns = {"x"};
+
+   auto df = ROOT::RDataFrame(25ull).Define("x", [] { return 10; });
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+   opts.fCompressionAlgorithm = ROOT::RCompressionSetting::EAlgorithm::kLZ4;
+   opts.fCompressionLevel = 4;
+
+   auto sdf = df.Snapshot("ntuple", filename, "x", opts);
+
+   EXPECT_EQ(columns, sdf->GetColumnNames());
+
+   auto inspector = RNTupleInspector::Create("ntuple", filename);
+   EXPECT_EQ(404, inspector->GetCompressionSettings());
+}
+
+class RDFSnapshotRNTupleTest : public ::testing::Test {
+protected:
+   const std::string fFileName = "RDFSnapshotRNTuple.root";
+   const std::string fNtplName = "ntuple";
+
+   void SetUp() override
+   {
+      auto model = RNTupleModel::Create();
+      *model->MakeField<float>("pt") = 42.f;
+      *model->MakeField<std::string>("tag") = "xyz";
+      auto fldNnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
+      fldNnlo->push_back(std::vector<float>());
+      fldNnlo->push_back(std::vector<float>{1.0});
+      fldNnlo->push_back(std::vector<float>{1.0, 2.0, 4.0, 8.0});
+      *model->MakeField<ROOT::RVecI>("rvec") = ROOT::RVecI{1, 2, 3};
+      auto fldElectron = model->MakeField<Electron>("electron");
+      fldElectron->pt = 137.0;
+      auto fldElectrons = model->MakeField<std::vector<Electron>>("electrons");
+      fldElectrons->push_back(*fldElectron);
+      fldElectrons->push_back(*fldElectron);
+      auto fldJets = model->MakeField<std::vector<Jet>>("jets");
+      fldJets->push_back(Jet{*fldElectrons});
+      {
+         auto ntuple = RNTupleWriter::Recreate(std::move(model), fNtplName, fFileName);
+         ntuple->Fill();
+      }
+   }
+
+   void TearDown() override { std::remove(fFileName.c_str()); }
+};
+
+TEST_F(RDFSnapshotRNTupleTest, DefaultToRNTupleTemplated)
+{
+   const auto filename = "RDFSnapshotRNTuple_snap_templated.root";
+
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Define("x", [] { return 10; }).Snapshot<float, int>("ntuple", filename, {"pt", "x"});
+
+   auto ntuple = RNTupleReader::Open("ntuple", filename);
+   EXPECT_EQ(1ull, ntuple->GetNEntries());
+
+   auto pt = ntuple->GetView<float>("pt");
+   auto x = ntuple->GetView<int>("x");
+
+   EXPECT_FLOAT_EQ(42.0, pt(0));
+   EXPECT_EQ(10, x(0));
+}
+
+TEST_F(RDFSnapshotRNTupleTest, DefaultToRNTupleJITted)
+{
+   const auto filename = "RDFSnapshotRNTuple_snap_jitted.root";
+
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Define("x", [] { return 10; }).Snapshot("ntuple", filename, {"pt", "x"});
+
+   auto ntuple = RNTupleReader::Open("ntuple", filename);
+   EXPECT_EQ(1ull, ntuple->GetNEntries());
+
+   auto pt = ntuple->GetView<float>("pt");
+   auto x = ntuple->GetView<int>("x");
+
+   EXPECT_FLOAT_EQ(42.0, pt(0));
+   EXPECT_EQ(10, x(0));
+}
+
+TEST_F(RDFSnapshotRNTupleTest, ToTTreeTemplated)
+{
+   const auto filename = "RDFSnapshotRNTuple_to_ttree_templated.root";
+
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kTTree;
+
+   auto sdf = df.Define("x", [] { return 10; }).Snapshot<float, int>("tree", filename, {"pt", "x"}, opts);
+
+   TFile file(filename);
+   auto tree = file.Get<TTree>("tree");
+   EXPECT_EQ(1ull, tree->GetEntries());
+
+   float pt;
+   int x;
+
+   tree->SetBranchAddress("pt", &pt);
+   tree->SetBranchAddress("x", &x);
+
+   tree->GetEntry(0);
+
+   EXPECT_FLOAT_EQ(42.0, pt);
+   EXPECT_EQ(10, x);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, ToTTreeJITted)
+{
+   const auto filename = "RDFSnapshotRNTuple_to_ttree_jitted.root";
+
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kTTree;
+
+   auto sdf = df.Define("x", [] { return 10; }).Snapshot("tree", filename, {"pt", "x"}, opts);
+
+   TFile file(filename);
+   auto tree = file.Get<TTree>("tree");
+   EXPECT_EQ(1ull, tree->GetEntries());
+
+   float pt;
+   int x;
+
+   tree->SetBranchAddress("pt", &pt);
+   tree->SetBranchAddress("x", &x);
+
+   tree->GetEntry(0);
+
+   EXPECT_FLOAT_EQ(42.0, pt);
+   EXPECT_EQ(10, x);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, ScalarFields)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Snapshot("ntuple", "RDFSnapshotRNTuple_scalar_fields.root", "pt");
+
+   std::vector<std::string> expected = {"pt"};
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+
+   auto maxPt = sdf->Max<float>("pt").GetValue();
+   EXPECT_FLOAT_EQ(42.f, maxPt);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, VectorFields)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Snapshot("ntuple", "RDFSnapshotRNTuple_all_fields.root", "nnlo");
+
+   std::vector<std::string> expected = {"nnlo"};
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+
+   auto nnloMax = sdf->Define("nnloMax",
+                              [](const ROOT::RVec<ROOT::RVec<float>> &nnlo) {
+                                 auto innerMax = ROOT::VecOps::Map(
+                                    nnlo, [](ROOT::RVec<float> innerNnlo) { return ROOT::VecOps::Max(innerNnlo); });
+                                 return ROOT::VecOps::Max(innerMax);
+                              },
+                              {"nnlo"})
+                     .Max("nnloMax")
+                     .GetValue();
+   EXPECT_FLOAT_EQ(8.f, nnloMax);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, ComplexFields)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Snapshot("ntuple", "RDFSnapshotRNTuple_complex_fields.root", "electrons");
+
+   std::vector<std::string> expected = {"electrons", "electrons.pt"};
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+
+   auto electronsPtMax =
+      sdf->Define("electronsPtMax", [](const ROOT::RVec<float> &electronPt) { return ROOT::VecOps::Max(electronPt); },
+                  {"electrons.pt"})
+         .Max("electronsPtMax")
+         .GetValue();
+   EXPECT_FLOAT_EQ(137.f, electronsPtMax);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, InnerFields)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+
+   auto sdf1 = df.Snapshot("ntuple", "RDFSnapshotRNTuple_inner_fields.root", "electron.pt");
+
+   std::vector<std::string> expected = {"electron_pt"};
+   EXPECT_EQ(expected, sdf1->GetColumnNames());
+
+   auto electronPtMax = sdf1->Max("electron_pt").GetValue();
+   EXPECT_FLOAT_EQ(137.f, electronPtMax);
+
+   auto sdf2 = df.Snapshot("ntuple", "RDFSnapshotRNTuple_inner_fields.root", "jets.electrons");
+
+   expected = {"jets_electrons", "jets_electrons.pt"};
+   EXPECT_EQ(expected, sdf2->GetColumnNames());
+
+   auto jetsElectronsPtMax =
+      sdf2
+         ->Define("jetsElectronsPtMax",
+                  [](const ROOT::RVec<ROOT::RVec<float>> &jetsElectronsPt) {
+                     auto innerMax = ROOT::VecOps::Map(jetsElectronsPt, [](const ROOT::RVec<float> &electronsPt) {
+                        return ROOT::VecOps::Max(electronsPt);
+                     });
+                     return ROOT::VecOps::Max(innerMax);
+                  },
+                  {"jets_electrons.pt"})
+         .Max("jetsElectronsPtMax")
+         .GetValue();
+   EXPECT_FLOAT_EQ(137.f, jetsElectronsPtMax);
+}
+
+TEST_F(RDFSnapshotRNTupleTest, AllFields)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Snapshot("ntuple", "RDFSnapshotRNTuple_all_fields.root");
+
+   EXPECT_EQ(df.GetColumnNames(), sdf->GetColumnNames());
+}
+
+TEST_F(RDFSnapshotRNTupleTest, WithDefines)
+{
+   auto df = ROOT::RDataFrame(fNtplName, fFileName);
+   auto sdf = df.Define("x", [] { return 10; }).Snapshot("ntuple", "RDFSnapshotRNTuple_with_defines.root");
+
+   std::vector<std::string> expected = df.GetColumnNames();
+   expected.push_back("x");
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+}
+
+TEST(RDFSnapshotRNTuple, WithFilters)
+{
+   const auto filename = "RDFSnapshotRNTuple_defines_and_filters.root";
+
+   {
+      auto df = ROOT::RDataFrame(10ull).DefineSlotEntry("x", [](unsigned int, std::uint64_t entry) { return entry; });
+
+      RSnapshotOptions opts;
+      opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+
+      df.Snapshot("ntuple", filename, "x", opts);
+   }
+
+   auto df = ROOT::RDataFrame("ntuple", filename).Filter("x % 2 == 0");
+   auto sdf = df.Snapshot("ntuple", "snap_ntuple_filtered.root");
+   auto ntuple = RNTupleReader::Open("ntuple", "snap_ntuple_filtered.root");
+   EXPECT_EQ(5ull, ntuple->GetNEntries());
+
+   auto x = ntuple->GetView<std::uint64_t>("x");
+   for (const auto i : ntuple->GetEntryRange()) {
+      EXPECT_FLOAT_EQ(i * 2, x(i));
+   }
+}
+
+TEST(RDFSnapshotRNTuple, UpdateDifferentName)
+{
+   const auto filename = "RDFSnapshotRNTuple_update_different_name.root";
+
+   {
+      auto df = ROOT::RDataFrame(25ull).Define("x", [] { return 10; });
+      RSnapshotOptions opts;
+      opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+      auto sdf = df.Snapshot("ntuple", filename, "x", opts);
+   }
+
+   auto df = ROOT::RDataFrame("ntuple", filename);
+
+   RSnapshotOptions opts;
+   opts.fMode = "UPDATE";
+
+   auto sdf = df.Define("y", [] { return 42; }).Snapshot("ntuple_snap", filename, "", opts);
+
+   std::vector<std::string> expected = {"x", "y"};
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+
+   auto ntupleOriginal = RNTupleReader::Open("ntuple", filename);
+   EXPECT_EQ(25ull, ntupleOriginal->GetNEntries());
+
+   auto ntupleSnap = RNTupleReader::Open("ntuple_snap", filename);
+   EXPECT_EQ(25ull, ntupleSnap->GetNEntries());
+}
+
+TEST(RDFSnapshotRNTuple, UpdateSameName)
+{
+   const auto filename = "RDFSnapshotRNTuple_update_same_name.root";
+
+   {
+      auto df = ROOT::RDataFrame(25ull).Define("x", [] { return 10; });
+      RSnapshotOptions opts;
+      opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+      auto sdf = df.Snapshot("ntuple", filename, "x", opts);
+   }
+
+   auto df = ROOT::RDataFrame("ntuple", filename);
+
+   RSnapshotOptions opts;
+   opts.fMode = "UPDATE";
+
+   try {
+      auto sdf = df.Define("y", [] { return 42; }).Snapshot<int, int>("ntuple", filename, {"x", "y"}, opts);
+      FAIL() << "snapshotting in \"UPDATE\" mode to the same ntuple name without `fOverwriteIfExists` is not allowed ";
+   } catch (const std::invalid_argument &err) {
+      EXPECT_STREQ(err.what(),
+                   "Snapshot: RNTuple \"ntuple\" already present in file "
+                   "\"RDFSnapshotRNTuple_update_same_name.root\". If you want to delete the original "
+                   "ntuple and write another, please set the 'fOverwriteIfExists' option to true in RSnapshotOptions.");
+   }
+
+   opts.fOverwriteIfExists = true;
+   auto sdf = df.Define("y", [] { return 42; }).Snapshot("ntuple", filename, "", opts);
+
+   std::vector<std::string> expected = {"x", "y"};
+   EXPECT_EQ(expected, sdf->GetColumnNames());
+}
+
+void WriteTestTree(const std::string &tname, const std::string &fname)
+{
+   TFile file(fname.c_str(), "RECREATE");
+   TTree t(tname.c_str(), tname.c_str());
+   float pt;
+   t.Branch("pt", &pt);
+
+   pt = 42.0;
+   t.Fill();
+
+   t.Write();
+}
+
+TEST(RDFSnapshotRNTuple, DisallowFromTTreeTemplated)
+{
+   const auto treename = "tree";
+   const auto filename = "RDFSnapshotRNTuple_disallow_from_ttree_templated.root";
+
+   WriteTestTree(treename, filename);
+
+   auto df = ROOT::RDataFrame(treename, filename);
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+
+   try {
+      auto sdf = df.Define("x", [] { return 10; }).Snapshot<float, int>("ntuple", filename, {"pt", "x"}, opts);
+      FAIL() << "snapshotting from RNTuple to TTree is not (yet) possible";
+   } catch (const std::runtime_error &err) {
+      EXPECT_STREQ(err.what(), "Snapshotting from TTree to RNTuple is not yet supported. The current recommended way "
+                               "to convert TTrees to RNTuple is through the RNTupleImporter.");
+   }
+}
+
+TEST(RDFSnapshotRNTuple, DisallowFromTTreeJITted)
+{
+   const auto treename = "tree";
+   const auto filename = "RDFSnapshotRNTuple_disallow_from_ttree_jitted.root";
+
+   WriteTestTree(treename, filename);
+
+   auto df = ROOT::RDataFrame(treename, filename);
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
+
+   try {
+      auto sdf = df.Define("x", [] { return 10; }).Snapshot("ntuple", filename, {"pt", "x"}, opts);
+      FAIL() << "snapshotting from RNTuple to TTree is not (yet) possible";
+   } catch (const std::runtime_error &err) {
+      EXPECT_STREQ(err.what(), "Snapshotting from TTree to RNTuple is not yet supported. The current recommended way "
+                               "to convert TTrees to RNTuple is through the RNTupleImporter.");
+   }
+}

--- a/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
@@ -1,6 +1,7 @@
 #include "ROOT/TestSupport.hxx"
 #include "ROOT/RDataFrame.hxx"
 
+#include "ROOT/RNTuple.hxx"
 #include "ROOT/RNTupleModel.hxx"
 #include "ROOT/RNTupleWriter.hxx"
 #include "ROOT/RNTupleReader.hxx"
@@ -427,6 +428,24 @@ TEST(RDFSnapshotRNTuple, UpdateSameName)
 
    std::vector<std::string> expected = {"x", "y"};
    EXPECT_EQ(expected, sdf->GetColumnNames());
+}
+
+TEST(RDFSnapshotRNTuple, TDirectory)
+{
+   FileRAII fileGuard{"RDFSnapshotRNTuple_snap_tdirectory.root"};
+
+   auto df = ROOT::RDataFrame(1);
+
+   RSnapshotOptions opts;
+   opts.fOutputFormat = ESnapshotOutputFormat::kRNTuple;
+
+   try {
+      auto sdf = df.Define("x", [] { return 10; }).Snapshot<int>("dir/ntuple", fileGuard.GetPath(), {"x"}, opts);
+      FAIL() << "attempting to snapshot a RNTuple to a TFile sub-directory should fail";
+   } catch (const std::runtime_error &err) {
+      EXPECT_STREQ(err.what(),
+                   "RDataFrame: Snapshotting an RNTuple to a TFile sub-directory is currently not supported.");
+   }
 }
 
 void WriteTestTree(const std::string &tname, const std::string &fname)


### PR DESCRIPTION
This PR adds a first iteration of snapshotting to RNTuple from an RDataFrame. It uses the existing `Snapshot` interface, with an addition to `RSnapshotOptions`, `kOutputFormat`. This option can be set to write to either TTree, RNTuple, or take the default choice. Currently the default choice means that TTree will be used as the output format, also if the input format is RNTuple. In this case, a warning will be issued to the user. With the changes in this PR, snapshotting from TTree to RNTuple is not yet possible, because it requires additional conversion for certain branch types considered out of scope for this PR, similar to what is currently done with the RNTupleImport. Using this functionality a follow-up PR will add support for Snapshots from TTree to RNTuple.

## Implementation
As mentioned, the existing `Snapshot` interface is used. A new `SnapshotRNTupleHelper` has been created to handle the creation and writing of the RNTuple, akin to the existing `SnapshotHelper` (which has been renamed to `SnapshotTTreeHelper` for consistency).

### RLoopManager data source initialization (rev bbf221f)
The snapshot action creates a new loop manager which manages the snapshotted data set. The loop manager gets initialized before the actual snapshotting takes place. Originally, the pointer to the data source owned by the loop manager was marked as `const`. Because the RNTuple's data source _has_ to be created after the loop manager, for this PR the `const` qualifier has been dropped.

## Current limitations and follow-ups
This PR adds the minimal functionality for (single-threaded) snapshotting to RNTuple. A number of follow-ups are foreseen:

### RNTuple write options
Currently no RNTuple-specific write options have been added to `RSnapshotOptions` yet, except for compression settings which were already present as an option. Adding (a subset) of the other `RNTupleWriteOptions` is trivial.

### Default compression settings
`RSnapshotOptions`' default compression setting is 101 (Zlib). However, RNTuple's default compression setting is 505 (zstd). We could change the default compression setting to `kInherit` and decide which settings to use according to the target data format (unless explicitly set by the user, of course).

### Multithreaded snapshotting
This PR only adds single-threaded RNTuple snapshotting. Multithreaded (and parallel) snapshotting will be addressed in a follow-up PR.

## Tests

Corresponding `roottest` PR: https://github.com/root-project/roottest/pull/1178

Tests for Windows have been disabled, due to permission denied-errors related to trying to recreate currently open TFiles. The regular snapshot tests have also been disabled for Windows, presumably for the same reason.
