### PR TITLE
Fix one more broken import in JsMVA

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JsMVAMagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/JsMVA/JsMVAMagic.py
@@ -23,7 +23,7 @@ class JsMVAMagic(Magics):
     @magic_arguments()
     @argument("arg", nargs="?", default="on", help="Enable/Disable JavaScript visualisation for TMVA")
     def jsmva(self, line):
-        from JsMVA.JPyInterface import functions
+        from .JPyInterface import functions
 
         args = parse_argstring(self.jsmva, line)
         if args.arg == "on":


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fix an import error in JsMVA:

```
$ ipython
Python 3.12.3 (main, Apr 17 2024, 00:00:00) [GCC 14.0.1 20240411 (Red Hat 14.0.1-0)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.23.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from ROOT.JsMVA import JsMVAMagic

In [2]: %jsmva on
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[2], line 1
----> 1 get_ipython().run_line_magic('jsmva', 'on')

File /usr/lib/python3.12/site-packages/IPython/core/interactiveshell.py:2480, in InteractiveShell.run_line_magic(self, magic_name, line, _stack_depth)
   2478     kwargs['local_ns'] = self.get_local_scope(stack_depth)
   2479 with self.builtin_trap:
-> 2480     result = fn(*args, **kwargs)
   2482 # The code below prevents the output from being displayed
   2483 # when using magics with decorator @output_can_be_silenced
   2484 # when the last Python token in the expression is a ';'.
   2485 if getattr(fn, magic.MAGIC_OUTPUT_CAN_BE_SILENCED, False):

File /usr/lib64/python3.12/site-packages/ROOT/JsMVA/JsMVAMagic.py:26, in JsMVAMagic.jsmva(self, line)
     22 @line_magic
     23 @magic_arguments()
     24 @argument("arg", nargs="?", default="on", help="Enable/Disable JavaScript visualisation for TMVA")
     25 def jsmva(self, line):
---> 26     from JsMVA.JPyInterface import functions
     28     args = parse_argstring(self.jsmva, line)
     29     if args.arg == "on":

ModuleNotFoundError: No module named 'JsMVA'

```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
