### PR TITLE
Improve `df106` tutorials

### DIFF
--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -209,18 +209,21 @@ void df106_HiggsToFourLeptons()
    pad->cd();
 
    // Draw stack with MC contributions
-   auto stack = new THStack("stack", "");
-   auto h_other = df_other.GetPtr();
-   h_other->SetFillColor(kViolet - 9);
-   stack->Add(h_other);
-   auto h_zz = df_zz.GetPtr();
-   h_zz->SetFillColor(kAzure - 9);
-   stack->Add(h_zz);
-   auto h_higgs = df_higgs.GetPtr();
-   h_higgs->SetFillColor(kRed + 2);
-   stack->Add(h_higgs);
+   // Draw cloned histograms to preserve graphics when original objects goes out of scope
+   df_other->SetFillColor(kViolet - 9);
+   df_zz->SetFillColor(kAzure - 9);
+   df_higgs->SetFillColor(kRed + 2);
 
+   auto stack = new THStack("stack", "");
+   auto h_other = static_cast<TH1 *>(df_other->Clone());
+   stack->Add(h_other);
+   auto h_zz = static_cast<TH1 *>(df_zz->Clone());
+   stack->Add(h_zz);
+   auto h_higgs = static_cast<TH1 *>(df_higgs->Clone());
+   stack->Add(h_higgs);
    stack->Draw("HIST");
+
+   // stack histogram can be accessed only after drawing
    stack->GetHistogram()->SetTitle("");
    stack->GetHistogram()->GetXaxis()->SetLabelSize(0.035);
    stack->GetHistogram()->GetXaxis()->SetTitleSize(0.045);
@@ -231,45 +234,39 @@ void df106_HiggsToFourLeptons()
    stack->GetHistogram()->GetYaxis()->SetTitle("Events");
    stack->SetMaximum(35);
    stack->GetHistogram()->GetYaxis()->ChangeLabel(1, -1, 0);
-   stack->DrawClone(
-      "HIST"); // DrawClone() method is necessary to draw a TObject in case the original object goes out of scope
 
    // Draw MC scale factor and variations
-   histos_mc["nominal"].SetStats(false);
    histos_mc["nominal"].SetFillColor(kBlack);
    histos_mc["nominal"].SetFillStyle(3254);
-   histos_mc["nominal"].DrawClone("E2 sames");
+   auto h_nominal = histos_mc["nominal"].DrawClone("E2 same");
    histos_mc["weight:up"].SetLineColor(kGreen + 2);
-   histos_mc["weight:up"].SetStats(false);
-   histos_mc["weight:up"].DrawClone("HIST sames");
+   auto h_weight_up = histos_mc["weight:up"].DrawClone("HIST same");
    histos_mc["weight:down"].SetLineColor(kBlue + 2);
-   histos_mc["weight:down"].SetStats(false);
-   histos_mc["weight:down"].DrawClone("HIST sames");
+   auto h_weight_down = histos_mc["weight:down"].DrawClone("HIST same");
 
    // Draw data histogram
-   auto h_data = df_h_mass_data.GetPtr();
-   h_data->SetMarkerStyle(20);
-   h_data->SetMarkerSize(1.);
-   h_data->SetLineWidth(2);
-   h_data->SetLineColor(kBlack);
-   h_data->SetStats(false);
-   h_data->DrawClone("E sames");
+   df_h_mass_data->SetMarkerStyle(20);
+   df_h_mass_data->SetMarkerSize(1.);
+   df_h_mass_data->SetLineWidth(2);
+   df_h_mass_data->SetLineColor(kBlack);
+   df_h_mass_data->SetStats(false);
+   auto h_mass_data = df_h_mass_data->DrawClone("E sames");
 
    // Add legend
-   TLegend legend(0.57, 0.65, 0.94, 0.94);
-   legend.SetTextFont(42);
-   legend.SetFillStyle(0);
-   legend.SetBorderSize(0);
-   legend.SetTextSize(0.025);
-   legend.SetTextAlign(32);
-   legend.AddEntry(h_data, "Data", "lep");
-   legend.AddEntry(h_higgs, "Higgs MC", "f");
-   legend.AddEntry(h_zz, "ZZ MC", "f");
-   legend.AddEntry(h_other, "Other MC", "f");
-   legend.AddEntry(&(histos_mc["weight:down"]), "Total MC Variations Down", "l");
-   legend.AddEntry(&(histos_mc["weight:up"]), "Total MC Variations Up", "l");
-   legend.AddEntry(&(histos_mc["nominal"]), "Total MC Uncertainty", "f");
-   legend.DrawClone("Same");
+   auto legend = new TLegend(0.57, 0.65, 0.94, 0.94);
+   legend->SetTextFont(42);
+   legend->SetFillStyle(0);
+   legend->SetBorderSize(0);
+   legend->SetTextSize(0.025);
+   legend->SetTextAlign(32);
+   legend->AddEntry(h_mass_data, "Data", "lep");
+   legend->AddEntry(h_higgs, "Higgs MC", "f");
+   legend->AddEntry(h_zz, "ZZ MC", "f");
+   legend->AddEntry(h_other, "Other MC", "f");
+   legend->AddEntry(h_weight_down, "Total MC Variations Down", "l");
+   legend->AddEntry(h_weight_up, "Total MC Variations Up", "l");
+   legend->AddEntry(h_nominal, "Total MC Uncertainty", "f");
+   legend->Draw();
 
    // Add ATLAS label
    TLatex atlas_label;

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -210,20 +210,6 @@ for i in range(0, histos_mc["nominal"].GetXaxis().GetNbins()):
 # Set styles
 ROOT.gROOT.SetStyle("ATLAS")
 
-
-# Function to add ATLAS label
-def draw_atlas_label():
-    text = ROOT.TLatex()
-    text.SetNDC()
-    text.SetTextFont(72)
-    text.SetTextSize(0.04)
-    text.DrawLatex(0.19, 0.85, "ATLAS")
-    text.SetTextFont(42)
-    text.DrawLatex(0.19 + 0.15, 0.85, "Open Data")
-    text.SetTextSize(0.035)
-    text.DrawLatex(0.21, 0.80, "#sqrt{s} = 13 TeV, 10 fb^{-1}")
-
-
 # Create canvas with pad
 c1 = ROOT.TCanvas("c", "", 600, 600)
 pad = ROOT.TPad("upper_pad", "", 0, 0, 1, 1)
@@ -236,11 +222,12 @@ pad.cd()
 stack = ROOT.THStack()
 
 # Retrieve values of the data and MC histograms in order to plot them.
+# Draw cloned histograms to preserve graphics when original objects goes out of scope
 # Note: GetValue() action operation is performed after all lazy actions of the RDF were defined first.
-h_data = histos[0].GetValue()
-h_higgs = histos[1].GetValue()
-h_zz = histos[2].GetValue()
-h_other = histos[3].GetValue()
+h_data = histos[0].GetValue().Clone()
+h_higgs = histos[1].GetValue().Clone()
+h_zz = histos[2].GetValue().Clone()
+h_other = histos[3].GetValue().Clone()
 
 for h, color in zip([h_other, h_zz, h_higgs], [ROOT.kViolet - 9, ROOT.kAzure - 9, ROOT.kRed + 2]):
     h.SetLineWidth(1)
@@ -258,28 +245,22 @@ stack.GetYaxis().SetTitleSize(0.045)
 stack.GetYaxis().SetTitle("Events")
 stack.SetMaximum(35)
 stack.GetYaxis().ChangeLabel(1, -1, 0)
-stack.DrawClone(
-    "HIST"
-)  # DrawClone() method is necessary to draw a TObject in case the original object goes out of scope, needed for the interactive root session
 
 # Draw MC scale factor and variations
-histos_mc["nominal"].SetStats(0)
 histos_mc["nominal"].SetFillColor(ROOT.kBlack)
 histos_mc["nominal"].SetFillStyle(3254)
-histos_mc["nominal"].DrawClone("E2 sames")
-histos_mc["weight:up"].SetStats(0)
+h_nominal = histos_mc["nominal"].DrawClone("E2 same")
 histos_mc["weight:up"].SetLineColor(ROOT.kGreen + 2)
-histos_mc["weight:up"].DrawClone("HIST SAME")
+h_weight_up = histos_mc["weight:up"].DrawClone("HIST SAME")
 histos_mc["weight:down"].SetLineColor(ROOT.kBlue + 2)
-histos_mc["weight:down"].SetStats(0)
-histos_mc["weight:down"].DrawClone("HIST SAME")
+h_weight_down = histos_mc["weight:down"].DrawClone("HIST SAME")
 
 # Draw data histogram
 h_data.SetMarkerStyle(20)
 h_data.SetMarkerSize(1.2)
 h_data.SetLineWidth(2)
 h_data.SetLineColor(ROOT.kBlack)
-h_data.DrawClone("E SAME")  # Draw raw data with errorbars
+h_data.Draw("E SAME")  # Draw raw data with errorbars
 
 # Add legend
 legend = ROOT.TLegend(0.57, 0.65, 0.94, 0.94)
@@ -292,12 +273,19 @@ legend.AddEntry(h_data, "Data", "lep")
 legend.AddEntry(h_higgs, "Higgs MC", "f")
 legend.AddEntry(h_zz, "ZZ MC", "f")
 legend.AddEntry(h_other, "Other MC", "f")
-legend.AddEntry((histos_mc["weight:down"]), "Total MC Variations Down", "l")
-legend.AddEntry((histos_mc["weight:up"]), "Total MC Variations Up", "l")
-legend.AddEntry((histos_mc["nominal"]), "Total MC Uncertainty", "f")
-legend.Draw("SAME")
+legend.AddEntry(h_weight_down, "Total MC Variations Down", "l")
+legend.AddEntry(h_weight_up, "Total MC Variations Up", "l")
+legend.AddEntry(h_nominal, "Total MC Uncertainty", "f")
+legend.Draw()
 
-draw_atlas_label()
+text = ROOT.TLatex()
+text.SetTextFont(72)
+text.SetTextSize(0.04)
+text.DrawLatexNDC(0.19, 0.85, "ATLAS")
+text.SetTextFont(42)
+text.DrawLatexNDC(0.19 + 0.15, 0.85, "Open Data")
+text.SetTextSize(0.035)
+text.DrawLatexNDC(0.21, 0.80, "#sqrt{s} = 13 TeV, 10 fb^{-1}")
 
 c1.Update()
 


### PR DESCRIPTION
Main problem - stack was drawn twice and only while histograms in original stack were destroyed 
producing canvas had nice look. 

Changes:
* do not draw stack twice.
* clone histograms once and use in stack and in legend
* do not use sames - make no sense when calling `SetStats(false)` at the same time
* simplify text drawing
* make C++ and Python macro closer to each other

