### PR TITLE
[ntuple] Ignore unkown compression settings in the `RNTupleInspector` construction

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -69,7 +69,8 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 
          if (fCompressionSettings == -1) {
             fCompressionSettings = columnRange.fCompressionSettings;
-         } else if (fCompressionSettings != columnRange.fCompressionSettings) {
+         } else if (fCompressionSettings != columnRange.fCompressionSettings &&
+                    columnRange.fCompressionSettings != kUnknownCompressionSettings) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
             // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.


### PR DESCRIPTION
Upon creating an RNTupleInspector, we check whether the compression settings are consistent across all columns. Some column ranges may have been constructed upon read (e.g. in the context of late model extension) and therefore have no compression settings to begin with. These column ranges should not cause the RNTupleInspector to throw. This PR partially addresses #15661.

- [x] tested changes locally
- [x] updated the docs (if necessary)


