### PR TITLE
[ntuple] add fMaxKeySize field to RNTuple

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.2.0
+# RNTuple Reference Specifications 0.2.3.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 
@@ -84,6 +84,10 @@ The current (class version 5) **ROOT::Experimental::RNTuple** object has the fol
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               | 
 +                         Len Footer                            +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               | 
++                        Max Key Size                           +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -65,7 +65,7 @@ private:
    RNTuple CreateAnchor(std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor,
                         std::uint16_t versionPatch, std::uint64_t seekHeader, std::uint64_t nbytesHeader,
                         std::uint64_t lenHeader, std::uint64_t seekFooter, std::uint64_t nbytesFooter,
-                        std::uint64_t lenFooter);
+                        std::uint64_t lenFooter, std::uint64_t maxKeySize);
 
 public:
    RMiniFileReader() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -93,6 +93,8 @@ private:
    std::uint64_t fNBytesFooter = 0;
    /// The size of the uncompressed ntuple footer
    std::uint64_t fLenFooter = 0;
+   /// The maximum size for a TKey payload. Payloads bigger than this size will be chained as multiple blobs.
+   std::uint64_t fMaxKeySize = 0;
 
    TFile *fFile = nullptr; ///<! The file from which the ntuple was streamed, registered in the custom streamer
 
@@ -112,12 +114,17 @@ public:
    std::uint64_t GetSeekFooter() const { return fSeekFooter; }
    std::uint64_t GetNBytesFooter() const { return fNBytesFooter; }
    std::uint64_t GetLenFooter() const { return fLenFooter; }
+   std::uint64_t GetMaxKeySize() const { return fMaxKeySize; }
 
    /// RNTuple implements the hadd MergeFile interface
    /// Merge this NTuple with the input list entries
    Long64_t Merge(TCollection *input, TFileMergeInfo *mergeInfo);
 
-   ClassDefNV(RNTuple, 5);
+   /// NOTE: if you change this version you also need to update:
+   ///    - RTFNTuple::fClassVersion in RMiniFile.cxx
+   ///    - RTFStreamerInfoObject::fVersionRNTuple in RMiniFile.cxx
+   ///    - RTFStreamerInfoObject::fStreamers in RMiniFile.cxx
+   ClassDefNV(RNTuple, 6);
 }; // class RNTuple
 
 } // namespace Experimental

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -57,7 +57,6 @@ void ROOT::Experimental::RNTuple::Streamer(TBuffer &buf)
          if (bcnt != expectedBytes)
             throw RException(R__FAIL("byte count mismatch in RNTuple anchor v4: expected=" +
                                      std::to_string(expectedBytes) + ", got=" + std::to_string(bcnt)));
-
          buf >> fVersionEpoch;
          buf >> fVersionMajor;
          buf >> fVersionMinor;

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -9,7 +9,8 @@ bool IsEqual(const ROOT::Experimental::RNTuple &a, const ROOT::Experimental::RNT
           a.GetVersionMinor() == b.GetVersionMinor() && a.GetVersionPatch() == b.GetVersionPatch() &&
           a.GetSeekHeader() == b.GetSeekHeader() && a.GetNBytesHeader() == b.GetNBytesHeader() &&
           a.GetLenHeader() == b.GetLenHeader() && a.GetSeekFooter() == b.GetSeekFooter() &&
-          a.GetNBytesFooter() == b.GetNBytesFooter() && a.GetLenFooter() == b.GetLenFooter();
+          a.GetNBytesFooter() == b.GetNBytesFooter() && a.GetLenFooter() == b.GetLenFooter() &&
+          a.GetMaxKeySize() == b.GetMaxKeySize();
 }
 
 struct RNTupleTester {


### PR DESCRIPTION
# This Pull request:
adds a field in the RNTuple anchor that specifies the max key size, i.e. the biggest payload that can be stored in a TKey.
This will allow the RNTuple readers and writers to handle payloads bigger than that limit (currently 1 GiB) by splitting it into multiple TKeys.

Bumped RNTuple class version to 6.

**NOTE**: this change doesn't break forward compatibility because old readers weren't able to read payloads larger than `maxKeySize` anyway. 

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


