### PR TITLE
[ntuple] Distinguish between extended and deferred columns

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1082,10 +1082,10 @@ public:
    RResult<void> CommitColumnRange(DescriptorId_t physicalId, std::uint64_t firstElementIndex,
                                    std::uint32_t compressionSettings, const RClusterDescriptor::RPageRange &pageRange);
 
-   /// Add column and page ranges for deferred columns missing in this cluster.  The locator type for the synthesized
-   /// page ranges is `kTypePageZero`.  All the page sources must be able to populate the 'zero' page from such locator.
-   /// Any call to `CommitColumnRange()` should happen before calling this function.
-   RClusterDescriptorBuilder &AddDeferredColumnRanges(const RNTupleDescriptor &desc);
+   /// Add column and page ranges for columns created during late model extension missing in this cluster.  The locator
+   /// type for the synthesized page ranges is `kTypePageZero`.  All the page sources must be able to populate the
+   /// 'zero' page from such locator. Any call to `CommitColumnRange()` should happen before calling this function.
+   RClusterDescriptorBuilder &AddExtendedColumnRanges(const RNTupleDescriptor &desc);
 
    /// Move out the full cluster descriptor including page locations
    RResult<RClusterDescriptor> MoveDescriptor();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -572,7 +572,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RClusterDescript
 }
 
 ROOT::Experimental::Internal::RClusterDescriptorBuilder &
-ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddDeferredColumnRanges(const RNTupleDescriptor &desc)
+ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges(const RNTupleDescriptor &desc)
 {
    /// Carries out a depth-first traversal of a field subtree rooted at `rootFieldId`.  For each field, `visitField` is
    /// called passing the field ID and the number of overall repetitions, taking into account the repetitions of each
@@ -586,7 +586,7 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddDeferredColumnRanges
       }
    };
 
-   // Deferred columns can only be part of the header extension
+   // Extended columns can only be part of the header extension
    auto xHeader = desc.GetHeaderExtension();
    if (!xHeader)
       return *this;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1752,7 +1752,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageList(const void 
 
       bytes = outerFrame + outerFrameSize;
 
-      clusterBuilders[i].AddDeferredColumnRanges(desc);
+      clusterBuilders[i].AddExtendedColumnRanges(desc);
       clusters.emplace_back(clusterBuilders[i].MoveDescriptor().Unwrap());
    } // loop over clusters
    desc.AddClusterGroupDetails(clusterGroupId, clusters);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -449,8 +449,8 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
       RClusterDescriptor::RColumnRange columnRange;
       columnRange.fPhysicalColumnId = i;
       // We set the first element index in the current cluster to the first element that is part of a materialized page
-      // (i.e., that is part of a page list). For deferred columns, however, the column range is fixed up as needed by
-      // `RClusterDescriptorBuilder::AddDeferredColumnRanges()` on read back.
+      // (i.e., that is part of a page list). For columns created during late model extension, however, the column range
+      // is fixed up as needed by `RClusterDescriptorBuilder::AddExtendedColumnRanges()` on read back.
       columnRange.fFirstElementIndex = descriptor.GetColumnDescriptor(i).GetFirstElementIndex();
       columnRange.fNElements = 0;
       columnRange.fCompressionSettings = GetWriteOptions().GetCompression();

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -416,8 +416,8 @@ TEST(RNTuple, ModelExtensionComplex)
          ntuple->Fill();
       }
 
-      // Force the serialization of a page list which will not know about the deferred columns coming later.
-      // `RClusterDescriptorBuilder::AddDeferredColumnRanges()` should thus make up page ranges for the missing columns
+      // Force the serialization of a page list which will not know about the extended columns coming later.
+      // `RClusterDescriptorBuilder::AddExtendedColumnRanges()` should thus make up page ranges for the missing columns
       ntuple->CommitCluster(true /* commitClusterGroup */);
 
       modelUpdater->BeginUpdate();


### PR DESCRIPTION
All columns created during late model extension need to have their page and column ranges synthesized during reading. However, only *deferred* columns (i.e., principal columns of top-level fields) also require zero pages. This change aims to make this distinction more clear.

- [x] tested changes locally
- [x] updated the docs (if necessary)

