### PR TITLE
[ntuple] Add page checksums

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -682,8 +682,8 @@ Every inner item (that describes a page) has the following structure:
 ```
 
 Followed by a locator for the page.
-_C(hecksum)_: If set, an XxHash-3 64bit checksum of the uncompressed page data is stored just after the page.
-This bit should be interpreted as the sign bit of the size, i.e. negative values indicate pages with checksums.
+_C(hecksum)_: If set, an XxHash-3 64bit checksum of the compressed page data is stored just after the page.
+This bit should be interpreted as the sign bit of the number of elements, i.e. negative values indicate pages with checksums.
 
 Depending on the number of pages per column per cluster, every page induces
 a total of 28-36 Bytes of data to be stored in the page list envelope.

--- a/tree/ntuple/v7/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCluster.hxx
@@ -43,7 +43,7 @@ class ROnDiskPage {
 private:
    /// The memory location of the bytes
    const void *fAddress = nullptr;
-   /// The compressed and packed size of the page
+   /// The compressed and packed size of the page plus 8 bytes for the checksum, if available
    std::uint32_t fSize = 0;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -266,6 +266,8 @@ public:
          std::uint32_t fNElements = std::uint32_t(-1);
          /// The meaning of fLocator depends on the storage backend.
          RNTupleLocator fLocator;
+         /// If true, the 8 bytes following the serialized page are an xxhash of the on-disk page data
+         bool fHasChecksum = false;
 
          bool operator==(const RPageInfo &other) const {
             return fNElements == other.fNElements && fLocator == other.fLocator;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -64,6 +64,8 @@ protected:
    /// If set, 64bit index columns are replaced by 32bit index columns. This limits the cluster size to 512MB
    /// but it can result in smaller file sizes for data sets with many collections and lz4 or no compression.
    bool fHasSmallClusters = false;
+   /// If set, checksums will be calculated and written for every page.
+   bool fEnablePageChecksums = true;
 
 public:
    /// A maximum size of 512MB still allows for a vector of bool to be stored in a small cluster.  This is the
@@ -101,6 +103,9 @@ public:
 
    bool GetHasSmallClusters() const { return fHasSmallClusters; }
    void SetHasSmallClusters(bool val) { fHasSmallClusters = val; }
+
+   bool GetEnablePageChecksums() const { return fEnablePageChecksums; }
+   void SetEnablePageChecksums(bool val) { fEnablePageChecksums = val; }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -74,12 +74,15 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
-   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.GetSize(); }
+   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final
+   {
+      fNBytesCurrentCluster += page.GetBufferSize();
+   }
    void CommitSealedPageV(std::span<RSealedPageGroup> ranges) final
    {
       for (auto &range : ranges) {
          for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-            fNBytesCurrentCluster += sealedPageIt->GetSize();
+            fNBytesCurrentCluster += sealedPageIt->GetBufferSize();
          }
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -74,12 +74,12 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
-   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.fSize; }
+   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.GetSize(); }
    void CommitSealedPageV(std::span<RSealedPageGroup> ranges) final
    {
       for (auto &range : ranges) {
          for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-            fNBytesCurrentCluster += sealedPageIt->fSize;
+            fNBytesCurrentCluster += sealedPageIt->GetSize();
          }
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -90,8 +90,8 @@ public:
 
       RSealedPage() = default;
       RSealedPage(const void *b, std::uint32_t s, std::uint32_t n) : fBuffer(b), fSize(s), fNElements(n) {}
-      RSealedPage(const RSealedPage &other) = delete;
-      RSealedPage& operator =(const RSealedPage &other) = delete;
+      RSealedPage(const RSealedPage &other) = default;
+      RSealedPage &operator=(const RSealedPage &other) = default;
       RSealedPage(RSealedPage &&other) = default;
       RSealedPage& operator =(RSealedPage &&other) = default;
    };

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -218,6 +218,9 @@ protected:
       const RPage &fPage; ///< input page to be sealed
       const RColumnElementBase &fElement; ///< Corresponds to the page's elements, used for size calculation etc.
       int fCompressionSetting = 0; ///< Compression algorithm and level to apply
+      /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
+      /// to store the additional 8 bytes.
+      bool fWriteChecksum = true;
       /// If false, the output buffer must not point to the input page buffer, which would otherwise be an option
       /// if the page is mappable and should not be compressed
       bool fAllowAlias = true;
@@ -229,9 +232,9 @@ protected:
    };
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
-   /// compressionSetting is 0 (uncompressed) and the page is mappable, the returned sealed page will
-   /// point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
-   /// of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
+   /// compressionSetting is 0 (uncompressed) and the page is mappable and no checksumming is used, the returned
+   /// sealed page will point directly to the input page buffer.  Otherwise, the sealed page references an
+   /// internal buffer of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
    /// Usage of this method requires construction of fCompressor.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -118,6 +118,7 @@ public:
       bool GetHasChecksum() const { return fHasChecksum; }
       void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
 
+      void ChecksumIfEnabled();
       void VerifyChecksumIfEnabled() const;
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -213,6 +213,21 @@ protected:
    /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
+   /// Input for the SealPage() method
+   struct RSealPageConfig {
+      const RPage &fPage; ///< input page to be sealed
+      const RColumnElementBase &fElement; ///< Corresponds to the page's elements, used for size calculation etc.
+      int fCompressionSetting = 0; ///< Compression algorithm and level to apply
+      /// If false, the output buffer must not point to the input page buffer, which would otherwise be an option
+      /// if the page is mappable and should not be compressed
+      bool fAllowAlias = true;
+      /// Location for sealed output. The memory buffer has to be large enough for the compressed output and the
+      /// checksum (if checksumming is turned on)
+      void *fBuffer = nullptr;
+
+      RSealPageConfig(const RPage &page, const RColumnElementBase &element) : fPage(page), fElement(element) {}
+   };
+
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable, the returned sealed page will
    /// point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
@@ -220,9 +235,8 @@ protected:
    /// Usage of this method requires construction of fCompressor.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
-   /// Seal a page using the provided buffer.
-   static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting, void *buf,
-                               bool allowAlias = true);
+   /// Seal a page using the provided info.
+   static RSealedPage SealPage(const RSealPageConfig &sealPageConfig);
 
 private:
    /// Flag if sink was initialized

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -69,6 +69,9 @@ an ntuple.  Concrete implementations can use a TFile, a raw file, an object stor
 // clang-format on
 class RPageStorage {
 public:
+   /// The page checksum is a 64bit xxhash3
+   static constexpr std::size_t kNBytesPageChecksum = sizeof(std::uint64_t);
+
    /// The interface of a task scheduler to schedule page (de)compression tasks
    class RTaskScheduler {
    public:
@@ -108,7 +111,7 @@ public:
       void *GetWritableBuffer() const { return fBuffer; }
       void SetWritableBuffer(void *buffer) { fBuffer = buffer; }
 
-      std::uint32_t GetDataSize() const { return fBufferSize - fHasChecksum * sizeof(std::uint64_t); }
+      std::uint32_t GetDataSize() const { return fBufferSize - fHasChecksum * kNBytesPageChecksum; }
       std::uint32_t GetBufferSize() const { return fBufferSize; }
       void SetBufferSize(std::uint32_t bufferSize) { fBufferSize = bufferSize; }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -218,7 +218,7 @@ protected:
    /// point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
    /// of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
    /// Usage of this method requires construction of fCompressor.
-   RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting);
+   RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
    /// Seal a page using the provided buffer.
    static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting, void *buf,

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -50,6 +50,7 @@ class RColumnElementBase;
 class RNTupleCompressor;
 class RNTupleDecompressor;
 struct RNTupleModelChangeset;
+class RPagePool;
 
 enum class EPageStorageType {
    kSink,
@@ -516,11 +517,12 @@ protected:
    /// Not all page sources need a decompressor (e.g. virtual ones for chains and friends don't), thus we
    /// leave it up to the derived class whether or not the decompressor gets constructed.
    std::unique_ptr<RNTupleDecompressor> fDecompressor;
+   /// Populated pages might be shared; the page pool might, at some point, be used by multiple page sources
+   std::shared_ptr<RPagePool> fPagePool;
 
    virtual RNTupleDescriptor AttachImpl() = 0;
    // Only called if a task scheduler is set. No-op be default.
-   virtual void UnzipClusterImpl(RCluster * /* cluster */)
-      { }
+   virtual void UnzipClusterImpl(RCluster *cluster);
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -83,17 +83,33 @@ public:
    /// as an input to UnsealPages() as well as to transfer pages between different storage media.
    /// RSealedPage does _not_ own the buffer it is pointing to in order to not interfere with the memory management
    /// of concrete page sink and page source implementations.
-   struct RSealedPage {
-      const void *fBuffer = nullptr;
+   /// The sealed page can be read-only (used to write out pages) or writable when it get populated from on-disk data.
+   class RSealedPage {
+      void *fBuffer = nullptr; /// This may be a const-casted read-only buffer.
       std::uint32_t fSize = 0;
       std::uint32_t fNElements = 0;
 
+   public:
       RSealedPage() = default;
-      RSealedPage(const void *b, std::uint32_t s, std::uint32_t n) : fBuffer(b), fSize(s), fNElements(n) {}
+      RSealedPage(const void *b, std::uint32_t s, std::uint32_t n)
+         : fBuffer(const_cast<void *>(b)), fSize(s), fNElements(n) {}
+      RSealedPage(void *b, std::uint32_t s, std::uint32_t n) : fBuffer(b), fSize(s), fNElements(n) {}
       RSealedPage(const RSealedPage &other) = default;
-      RSealedPage &operator=(const RSealedPage &other) = default;
+      RSealedPage& operator =(const RSealedPage &other) = default;
       RSealedPage(RSealedPage &&other) = default;
       RSealedPage& operator =(RSealedPage &&other) = default;
+
+      const void *GetBuffer() const { return fBuffer; }
+      void SetBuffer(const void *buffer) { fBuffer = const_cast<void *>(buffer); }
+
+      void *GetWritableBuffer() const { return fBuffer; }
+      void SetWritableBuffer(void *buffer) { fBuffer = buffer; }
+
+      std::uint32_t GetSize() const { return fSize; }
+      void SetSize(std::uint32_t size) { fSize = size; }
+
+      std::uint32_t GetNElements() const { return fNElements; }
+      void SetNElements(std::uint32_t nElements) { fNElements = nElements; }
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -649,7 +649,8 @@ public:
    /// The optimization of directly mapping pages is left to the concrete page source implementations.
    /// Usage of this method requires construction of fDecompressor. Memory is allocated via
    /// `RPageAllocatorHeap`; use `RPageAllocatorHeap::DeletePage()` to deallocate returned pages.
-   RPage UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
+   RResult<RPage> UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element,
+                             DescriptorId_t physicalColumnId);
 
    /// Populates all the pages of the given cluster ids and columns; it is possible that some columns do not
    /// contain any pages.  The page source may load more columns than the minimal necessary set from `columns`.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RPageStorage
 
 #include <ROOT/RCluster.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleReadOptions.hxx>
@@ -122,7 +123,7 @@ public:
       void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
 
       void ChecksumIfEnabled();
-      void VerifyChecksumIfEnabled() const;
+      RResult<void> VerifyChecksumIfEnabled() const;
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -117,6 +117,8 @@ public:
 
       bool GetHasChecksum() const { return fHasChecksum; }
       void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
+
+      void VerifyChecksumIfEnabled() const;
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -40,7 +40,6 @@ class RClusterPool;
 class RDaosPool;
 class RDaosContainer;
 class RPageAllocatorHeap;
-class RPagePool;
 enum EDaosLocatorFlags {
    // Indicates that the referenced page is "caged", i.e. it is stored in a larger blob that contains multiple pages.
    kCagedPage = 0x01,
@@ -165,8 +164,6 @@ private:
 
    ntuple_index_t fNTupleIndex{0};
 
-   /// Populated pages might be shared; the page pool might, at some point, be used by multiple page sources
-   std::shared_ptr<RPagePool> fPagePool;
    /// The last cluster from which a page got populated.  Points into fClusterPool->fPool
    RCluster *fCurrentCluster = nullptr;
    /// A container that stores object data (header/footer, pages, etc.)
@@ -183,7 +180,6 @@ private:
 
 protected:
    RNTupleDescriptor AttachImpl() final;
-   void UnzipClusterImpl(RCluster *cluster) final;
 
 public:
    RPageSourceDaos(std::string_view ntupleName, std::string_view uri, const RNTupleReadOptions &options);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -43,7 +43,6 @@ class RNTuple; // for making RPageSourceFile a friend of RNTuple
 namespace Internal {
 class RClusterPool;
 class RPageAllocatorHeap;
-class RPagePool;
 
 // clang-format off
 /**
@@ -112,8 +111,6 @@ private:
       std::uint64_t fColumnOffset = 0;
    };
 
-   /// Populated pages might be shared; the page pool might, at some point, be used by multiple page sources
-   std::shared_ptr<RPagePool> fPagePool;
    /// The last cluster from which a page got populated.  Points into fClusterPool->fPool
    RCluster *fCurrentCluster = nullptr;
    /// An RRawFile is used to request the necessary byte ranges from a local or a remote file
@@ -143,7 +140,6 @@ private:
 
 protected:
    RNTupleDescriptor AttachImpl() final;
-   void UnzipClusterImpl(RCluster *cluster) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -234,8 +234,8 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
                // The way LoadSealedPage works might require a double call
                // See the implementation. Here we do this in any case...
-               auto buffer = std::make_unique<unsigned char[]>(sealedPage.fSize);
-               sealedPage.fBuffer = buffer.get();
+               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+               sealedPage.SetBuffer(buffer.get());
                source->LoadSealedPage(columnId, clusterIndex, sealedPage);
 
                buffers.push_back(std::move(buffer));

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -234,7 +234,7 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
                // The way LoadSealedPage works might require a double call
                // See the implementation. Here we do this in any case...
-               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
                sealedPage.SetBuffer(buffer.get());
                source->LoadSealedPage(columnId, clusterIndex, sealedPage);
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -148,7 +148,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
    auto &zipItem = fBufferedColumns.at(colId).BufferPage(columnHandle);
    // The compressed size cannot be larger than the uncompressed size. Add 8 bytes for the checksum if necessary.
    zipItem.AllocateSealedPageBuf(page.GetNBytes() +
-                                 (GetWriteOptions().GetEnablePageChecksums() ? sizeof(std::uint64_t) : 0));
+                                 (GetWriteOptions().GetEnablePageChecksums() ? kNBytesPageChecksum : 0));
    R__ASSERT(zipItem.fBuf);
    auto &sealedPage = fBufferedColumns.at(colId).RegisterSealedPage();
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -91,7 +91,7 @@ bool ROOT::Experimental::Internal::RPageSource::REntryRange::IntersectsWith(cons
 }
 
 ROOT::Experimental::Internal::RPageSource::RPageSource(std::string_view name, const RNTupleReadOptions &options)
-   : RPageStorage(name), fOptions(options)
+   : RPageStorage(name), fOptions(options), fPagePool(std::make_shared<RPagePool>())
 {
 }
 
@@ -160,6 +160,53 @@ void ROOT::Experimental::Internal::RPageSource::UnzipCluster(RCluster *cluster)
 {
    if (fTaskScheduler)
       UnzipClusterImpl(cluster);
+}
+
+void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *cluster)
+{
+   Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
+
+   const auto clusterId = cluster->GetId();
+   auto descriptorGuard = GetSharedDescriptorGuard();
+   const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
+
+   std::vector<std::unique_ptr<RColumnElementBase>> allElements;
+
+   const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
+   for (const auto columnId : columnsInCluster) {
+      const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
+
+      allElements.emplace_back(RColumnElementBase::Generate(columnDesc.GetModel().GetType()));
+
+      const auto &pageRange = clusterDescriptor.GetPageRange(columnId);
+      std::uint64_t pageNo = 0;
+      std::uint64_t firstInPage = 0;
+      for (const auto &pi : pageRange.fPageInfos) {
+         ROnDiskPage::Key key(columnId, pageNo);
+         auto onDiskPage = cluster->GetOnDiskPage(key);
+         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
+
+         auto taskFunc = [this, columnId, clusterId, firstInPage, onDiskPage, element = allElements.back().get(),
+                          nElements = pi.fNElements,
+                          indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
+            auto newPage = UnsealPage({onDiskPage->GetAddress(), onDiskPage->GetSize(), nElements}, *element, columnId);
+            fCounters->fSzUnzip.Add(element->GetSize() * nElements);
+
+            newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
+            fPagePool->PreloadPage(
+               newPage, RPageDeleter([](const RPage &page, void *) { RPageAllocatorHeap::DeletePage(page); }, nullptr));
+         };
+
+         fTaskScheduler->AddTask(taskFunc);
+
+         firstInPage += pi.fNElements;
+         pageNo++;
+      } // for all pages in column
+   }    // for all columns in cluster
+
+   fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
+
+   fTaskScheduler->Wait();
 }
 
 void ROOT::Experimental::Internal::RPageSource::PrepareLoadCluster(

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -39,6 +39,17 @@ ROOT::Experimental::Internal::RPageStorage::RPageStorage(std::string_view name) 
 
 ROOT::Experimental::Internal::RPageStorage::~RPageStorage() {}
 
+void ROOT::Experimental::Internal::RPageStorage::RSealedPage::VerifyChecksumIfEnabled() const
+{
+   if (!fHasChecksum)
+      return;
+
+   auto result = RNTupleSerializer::VerifyXxHash3(reinterpret_cast<unsigned char *>(fBuffer), GetDataSize());
+   if (!result) {
+      throw RException(R__FAIL("page checksum verification failed, data corruption detected"));
+   }
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::Internal::RPageSource::RActivePhysicalColumns::Insert(DescriptorId_t physicalColumnID)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -341,8 +341,8 @@ ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedP
    const auto bytesPacked = element.GetPackedSize(sealedPage.GetNElements());
    using Allocator_t = RPageAllocatorHeap;
    auto page = Allocator_t::NewPage(physicalColumnId, element.GetSize(), sealedPage.GetNElements());
-   if (sealedPage.GetSize() != bytesPacked) {
-      fDecompressor->Unzip(sealedPage.GetBuffer(), sealedPage.GetSize(), bytesPacked, page.GetBuffer());
+   if (sealedPage.GetDataSize() != bytesPacked) {
+      fDecompressor->Unzip(sealedPage.GetBuffer(), sealedPage.GetDataSize(), bytesPacked, page.GetBuffer());
    } else {
       // We cannot simply map the sealed page as we don't know its life time. Specialized page sources
       // may decide to implement to not use UnsealPage but to custom mapping / decompression code.

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -207,7 +207,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
          ROnDiskPage::Key key(columnId, pageNo);
          auto onDiskPage = cluster->GetOnDiskPage(key);
          R__ASSERT(onDiskPage && ((onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage) ||
-                   (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage + sizeof(std::uint64_t))));
+                   (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage + kNBytesPageChecksum)));
          RSealedPage sealedPage{onDiskPage->GetAddress(), onDiskPage->GetSize(), pi.fNElements, pi.fHasChecksum};
 
          auto taskFunc = [this, columnId, clusterId, firstInPage, sealedPage, element = allElements.back().get(),
@@ -401,7 +401,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &sealPag
    unsigned char *pageBuf = reinterpret_cast<unsigned char *>(sealPageConfig.fPage.GetBuffer());
    bool isAdoptedBuffer = true;
    auto nBytesPacked = sealPageConfig.fPage.GetNBytes();
-   auto nBytesChecksum = sealPageConfig.fWriteChecksum ? sizeof(std::uint64_t) : 0;
+   auto nBytesChecksum = sealPageConfig.fWriteChecksum ? kNBytesPageChecksum : 0;
 
    if (!sealPageConfig.fElement.IsMappable()) {
       nBytesPacked = sealPageConfig.fElement.GetPackedSize(sealPageConfig.fPage.GetNElements());

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -400,11 +400,10 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColu
 }
 
 ROOT::Experimental::Internal::RPageStorage::RSealedPage
-ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element,
-                                                  int compressionSetting)
+ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element)
 {
    R__ASSERT(fCompressor);
-   return SealPage(page, element, compressionSetting, fCompressor->GetZipBuffer());
+   return SealPage(page, element, GetWriteOptions().GetCompression(), fCompressor->GetZipBuffer());
 }
 
 void ROOT::Experimental::Internal::RPageSink::CommitDataset()

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -517,7 +517,6 @@ void ROOT::Experimental::Internal::RPageSinkDaos::ReleasePage(RPage &page)
 ROOT::Experimental::Internal::RPageSourceDaos::RPageSourceDaos(std::string_view ntupleName, std::string_view uri,
                                                                const RNTupleReadOptions &options)
    : RPageSource(ntupleName, options),
-     fPagePool(std::make_shared<RPagePool>()),
      fURI(uri),
      fClusterPool(std::make_unique<RClusterPool>(*this, options.GetClusterBunchSize()))
 {
@@ -833,51 +832,4 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
    fCounters->fNRead.Add(readRequests.size());
 
    return clusters;
-}
-
-void ROOT::Experimental::Internal::RPageSourceDaos::UnzipClusterImpl(RCluster *cluster)
-{
-   Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-
-   const auto clusterId = cluster->GetId();
-   auto descriptorGuard = GetSharedDescriptorGuard();
-   const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
-
-   std::vector<std::unique_ptr<RColumnElementBase>> allElements;
-
-   const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
-   for (const auto columnId : columnsInCluster) {
-      const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
-
-      allElements.emplace_back(RColumnElementBase::Generate(columnDesc.GetModel().GetType()));
-
-      const auto &pageRange = clusterDescriptor.GetPageRange(columnId);
-      std::uint64_t pageNo = 0;
-      std::uint64_t firstInPage = 0;
-      for (const auto &pi : pageRange.fPageInfos) {
-         ROnDiskPage::Key key(columnId, pageNo);
-         auto onDiskPage = cluster->GetOnDiskPage(key);
-         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
-
-         auto taskFunc = [this, columnId, clusterId, firstInPage, onDiskPage, element = allElements.back().get(),
-                          nElements = pi.fNElements,
-                          indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
-            auto newPage = UnsealPage({onDiskPage->GetAddress(), onDiskPage->GetSize(), nElements}, *element, columnId);
-            fCounters->fSzUnzip.Add(element->GetSize() * nElements);
-
-            newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-            fPagePool->PreloadPage(
-               newPage, RPageDeleter([](const RPage &page, void *) { RPageAllocatorHeap::DeletePage(page); }, nullptr));
-         };
-
-         fTaskScheduler->AddTask(taskFunc);
-
-         firstInPage += pi.fNElements;
-         pageNo++;
-      } // for all pages in column
-   }    // for all columns in cluster
-
-   fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
-
-   fTaskScheduler->Wait();
 }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -333,7 +333,7 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitPageImpl(ColumnHandle_t colum
    RPageStorage::RSealedPage sealedPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
+      sealedPage = SealPage(page, *element);
    }
 
    fCounters->fSzZip.Add(page.GetNBytes());

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -350,17 +350,17 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageImpl(DescriptorId_t
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
       RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, physicalColumnId, offsetData);
-      fDaosContainer->WriteSingleAkey(sealedPage.GetBuffer(), sealedPage.GetSize(), daosKey.fOid, daosKey.fDkey,
+      fDaosContainer->WriteSingleAkey(sealedPage.GetBuffer(), sealedPage.GetBufferSize(), daosKey.fOid, daosKey.fDkey,
                                       daosKey.fAkey);
    }
 
    RNTupleLocator result;
    result.fPosition = EncodeDaosPagePosition(offsetData);
-   result.fBytesOnStorage = sealedPage.GetSize();
+   result.fBytesOnStorage = sealedPage.GetDataSize();
    result.fType = RNTupleLocator::kTypeDAOS;
    fCounters->fNPageCommitted.Inc();
-   fCounters->fSzWritePayload.Add(sealedPage.GetSize());
-   fNBytesCurrentCluster += sealedPage.GetSize();
+   fCounters->fSzWritePayload.Add(sealedPage.GetBufferSize());
+   fNBytesCurrentCluster += sealedPage.GetBufferSize();
    return result;
 }
 
@@ -396,13 +396,13 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
 
          const RPageStorage::RSealedPage &s = *sealedPageIt;
 
-         if (positionOffset + s.GetSize() > maxCageSz) {
+         if (positionOffset + s.GetBufferSize() > maxCageSz) {
             positionOffset = 0;
             positionIndex = fPageId.fetch_add(1);
          }
 
          d_iov_t pageIov;
-         d_iov_set(&pageIov, s.GetWritableBuffer(), s.GetSize());
+         d_iov_set(&pageIov, s.GetWritableBuffer(), s.GetBufferSize());
 
          RDaosKey daosKey =
             GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fPhysicalColumnId, positionIndex);
@@ -412,13 +412,13 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
 
          RNTupleLocator locator;
          locator.fPosition = EncodeDaosPagePosition(positionIndex, positionOffset);
-         locator.fBytesOnStorage = s.GetSize();
+         locator.fBytesOnStorage = s.GetDataSize();
          locator.fType = RNTupleLocator::kTypeDAOS;
          locator.fReserved = locatorFlags;
          locators.push_back(locator);
 
-         positionOffset += s.GetSize();
-         payloadSz += s.GetSize();
+         positionOffset += s.GetBufferSize();
+         payloadSz += s.GetBufferSize();
       }
    }
    fNBytesCurrentCluster += payloadSz;
@@ -590,7 +590,7 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(DescriptorId_
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
-   sealedPage.SetSize(bytesOnStorage);
+   sealedPage.SetBufferSize(bytesOnStorage);
    sealedPage.SetNElements(pageInfo.fNElements);
    if (!sealedPage.GetBuffer())
       return;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -773,7 +773,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
 
                             auto sizeOfPageAndChecksum = pageLocator.fBytesOnStorage;
                             if (pageInfo.fHasChecksum)
-                               sizeOfPageAndChecksum += sizeof(std::uint64_t);
+                               sizeOfPageAndChecksum += kNBytesPageChecksum;
                             itLoc->second.push_back({clusterId, physicalColumnId, pageNo, position, offset,
                                                      pageLocator.fBytesOnStorage, sizeOfPageAndChecksum});
                             ++nPages;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -663,7 +663,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::PopulatePageFromCluster(ColumnHan
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId);
+      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -745,7 +745,8 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
       NTupleSize_t fPageNo = 0;
       std::uint64_t fPosition = 0;
       std::uint64_t fCageOffset = 0;
-      std::uint64_t fSize = 0;
+      std::uint64_t fDataSize = 0; // page payload
+      std::uint64_t fBufferSize = 0; // page payload + checksum (if available)
    };
 
    // Prepares read requests for a single cluster; `readRequests` is modified by this function.  Requests are coalesced
@@ -770,10 +771,13 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
                                DecodeDaosPagePosition(pageLocator.GetPosition<RNTupleLocatorObject64>());
                             auto [itLoc, _] = onDiskPages.emplace(position, std::vector<RDaosSealedPageLocator>());
 
-                            itLoc->second.push_back(
-                               {clusterId, physicalColumnId, pageNo, position, offset, pageLocator.fBytesOnStorage});
+                            auto sizeOfPageAndChecksum = pageLocator.fBytesOnStorage;
+                            if (pageInfo.fHasChecksum)
+                               sizeOfPageAndChecksum += sizeof(std::uint64_t);
+                            itLoc->second.push_back({clusterId, physicalColumnId, pageNo, position, offset,
+                                                     pageLocator.fBytesOnStorage, sizeOfPageAndChecksum});
                             ++nPages;
-                            clusterBufSz += pageLocator.fBytesOnStorage;
+                            clusterBufSz += sizeOfPageAndChecksum;
                          });
 
       auto clusterBuffer = new unsigned char[clusterBufSz];
@@ -790,8 +794,8 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
             assert(cageIndex == s.fPosition);
             // Register the on disk pages in a page map
             ROnDiskPage::Key key(s.fColumnId, s.fPageNo);
-            pageMap->Register(key, ROnDiskPage(cageBuffer + s.fCageOffset, s.fSize));
-            cageSz += s.fSize;
+            pageMap->Register(key, ROnDiskPage(cageBuffer + s.fCageOffset, s.fDataSize));
+            cageSz += s.fBufferSize;
          }
 
          // Prepare new read request batched up by object ID and distribution key

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -655,7 +655,8 @@ ROOT::Experimental::Internal::RPageSourceDaos::PopulatePageFromCluster(ColumnHan
 
       ROnDiskPage::Key key(columnId, pageInfo.fPageNo);
       auto onDiskPage = fCurrentCluster->GetOnDiskPage(key);
-      R__ASSERT(onDiskPage && (bytesOnStorage == onDiskPage->GetSize()));
+      R__ASSERT(onDiskPage && ((bytesOnStorage == onDiskPage->GetSize()) ||
+                (bytesOnStorage + kNBytesPageChecksum == onDiskPage->GetSize())));
       sealedPageBuffer = onDiskPage->GetAddress();
    }
 
@@ -794,7 +795,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
             assert(cageIndex == s.fPosition);
             // Register the on disk pages in a page map
             ROnDiskPage::Key key(s.fColumnId, s.fPageNo);
-            pageMap->Register(key, ROnDiskPage(cageBuffer + s.fCageOffset, s.fDataSize));
+            pageMap->Register(key, ROnDiskPage(cageBuffer + s.fCageOffset, s.fBufferSize));
             cageSz += s.fBufferSize;
          }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -350,16 +350,17 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageImpl(DescriptorId_t
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
       RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, physicalColumnId, offsetData);
-      fDaosContainer->WriteSingleAkey(sealedPage.fBuffer, sealedPage.fSize, daosKey.fOid, daosKey.fDkey, daosKey.fAkey);
+      fDaosContainer->WriteSingleAkey(sealedPage.GetBuffer(), sealedPage.GetSize(), daosKey.fOid, daosKey.fDkey,
+                                      daosKey.fAkey);
    }
 
    RNTupleLocator result;
    result.fPosition = EncodeDaosPagePosition(offsetData);
-   result.fBytesOnStorage = sealedPage.fSize;
+   result.fBytesOnStorage = sealedPage.GetSize();
    result.fType = RNTupleLocator::kTypeDAOS;
    fCounters->fNPageCommitted.Inc();
-   fCounters->fSzWritePayload.Add(sealedPage.fSize);
-   fNBytesCurrentCluster += sealedPage.fSize;
+   fCounters->fSzWritePayload.Add(sealedPage.GetSize());
+   fNBytesCurrentCluster += sealedPage.GetSize();
    return result;
 }
 
@@ -395,13 +396,13 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
 
          const RPageStorage::RSealedPage &s = *sealedPageIt;
 
-         if (positionOffset + s.fSize > maxCageSz) {
+         if (positionOffset + s.GetSize() > maxCageSz) {
             positionOffset = 0;
             positionIndex = fPageId.fetch_add(1);
          }
 
          d_iov_t pageIov;
-         d_iov_set(&pageIov, const_cast<void *>(s.fBuffer), s.fSize);
+         d_iov_set(&pageIov, s.GetWritableBuffer(), s.GetSize());
 
          RDaosKey daosKey =
             GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fPhysicalColumnId, positionIndex);
@@ -411,13 +412,13 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
 
          RNTupleLocator locator;
          locator.fPosition = EncodeDaosPagePosition(positionIndex, positionOffset);
-         locator.fBytesOnStorage = s.fSize;
+         locator.fBytesOnStorage = s.GetSize();
          locator.fType = RNTupleLocator::kTypeDAOS;
          locator.fReserved = locatorFlags;
          locators.push_back(locator);
 
-         positionOffset += s.fSize;
-         payloadSz += s.fSize;
+         positionOffset += s.GetSize();
+         payloadSz += s.GetSize();
       }
    }
    fNBytesCurrentCluster += payloadSz;
@@ -589,17 +590,17 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(DescriptorId_
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
-   sealedPage.fSize = bytesOnStorage;
-   sealedPage.fNElements = pageInfo.fNElements;
-   if (!sealedPage.fBuffer)
+   sealedPage.SetSize(bytesOnStorage);
+   sealedPage.SetNElements(pageInfo.fNElements);
+   if (!sealedPage.GetBuffer())
       return;
    if (pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero) {
       RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(
          fNTupleIndex, clusterId, physicalColumnId, pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().fLocation);
-      fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage, daosKey.fOid,
-                                     daosKey.fDkey, daosKey.fAkey);
+      fDaosContainer->ReadSingleAkey(sealedPage.GetWritableBuffer(), bytesOnStorage, daosKey.fOid, daosKey.fDkey,
+                                     daosKey.fAkey);
    } else {
-      memcpy(const_cast<void *>(sealedPage.fBuffer), RPage::GetPageZeroBuffer(), bytesOnStorage);
+      memcpy(sealedPage.GetWritableBuffer(), RPage::GetPageZeroBuffer(), bytesOnStorage);
    }
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -106,7 +106,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitPageImpl(ColumnHandle_t colum
    RPageStorage::RSealedPage sealedPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
+      sealedPage = SealPage(page, *element);
    }
 
    fCounters->fSzZip.Add(page.GetNBytes());

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -87,15 +87,15 @@ ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage:
    std::uint64_t offsetData;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetSize(), bytesPacked);
+      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetBufferSize(), bytesPacked);
    }
 
    RNTupleLocator result;
    result.fPosition = offsetData;
-   result.fBytesOnStorage = sealedPage.GetSize();
+   result.fBytesOnStorage = sealedPage.GetDataSize();
    fCounters->fNPageCommitted.Inc();
-   fCounters->fSzWritePayload.Add(sealedPage.GetSize());
-   fNBytesCurrentCluster += sealedPage.GetSize();
+   fCounters->fSzWritePayload.Add(sealedPage.GetBufferSize());
+   fNBytesCurrentCluster += sealedPage.GetBufferSize();
    return result;
 }
 
@@ -137,7 +137,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
       const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
          fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(range.fPhysicalColumnId).GetModel().GetType());
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         size += sealedPageIt->GetSize();
+         size += sealedPageIt->GetBufferSize();
          bytesPacked += (bitsOnStorage * sealedPageIt->GetNElements() + 7) / 8;
       }
    }
@@ -155,12 +155,12 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         fWriter->WriteIntoReservedBlob(sealedPageIt->GetBuffer(), sealedPageIt->GetSize(), offset);
+         fWriter->WriteIntoReservedBlob(sealedPageIt->GetBuffer(), sealedPageIt->GetBufferSize(), offset);
          RNTupleLocator locator;
          locator.fPosition = offset;
-         locator.fBytesOnStorage = sealedPageIt->GetSize();
+         locator.fBytesOnStorage = sealedPageIt->GetDataSize();
          locators.push_back(locator);
-         offset += sealedPageIt->GetSize();
+         offset += sealedPageIt->GetBufferSize();
       }
    }
 
@@ -342,12 +342,12 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
-   sealedPage.SetSize(bytesOnStorage);
+   sealedPage.SetBufferSize(bytesOnStorage);
    sealedPage.SetNElements(pageInfo.fNElements);
    if (!sealedPage.GetBuffer())
       return;
    if (pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero) {
-      fReader.ReadBuffer(sealedPage.GetWritableBuffer(), bytesOnStorage,
+      fReader.ReadBuffer(sealedPage.GetWritableBuffer(), sealedPage.GetBufferSize(),
                          pageInfo.fLocator.GetPosition<std::uint64_t>());
    } else {
       memcpy(sealedPage.GetWritableBuffer(), RPage::GetPageZeroBuffer(), bytesOnStorage);

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -87,15 +87,15 @@ ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage:
    std::uint64_t offsetData;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      offsetData = fWriter->WriteBlob(sealedPage.fBuffer, sealedPage.fSize, bytesPacked);
+      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetSize(), bytesPacked);
    }
 
    RNTupleLocator result;
    result.fPosition = offsetData;
-   result.fBytesOnStorage = sealedPage.fSize;
+   result.fBytesOnStorage = sealedPage.GetSize();
    fCounters->fNPageCommitted.Inc();
-   fCounters->fSzWritePayload.Add(sealedPage.fSize);
-   fNBytesCurrentCluster += sealedPage.fSize;
+   fCounters->fSzWritePayload.Add(sealedPage.GetSize());
+   fNBytesCurrentCluster += sealedPage.GetSize();
    return result;
 }
 
@@ -119,7 +119,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t
 {
    const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
       fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(physicalColumnId).GetModel().GetType());
-   const auto bytesPacked = (bitsOnStorage * sealedPage.fNElements + 7) / 8;
+   const auto bytesPacked = (bitsOnStorage * sealedPage.GetNElements() + 7) / 8;
 
    return WriteSealedPage(sealedPage, bytesPacked);
 }
@@ -137,8 +137,8 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
       const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
          fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(range.fPhysicalColumnId).GetModel().GetType());
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         size += sealedPageIt->fSize;
-         bytesPacked += (bitsOnStorage * sealedPageIt->fNElements + 7) / 8;
+         size += sealedPageIt->GetSize();
+         bytesPacked += (bitsOnStorage * sealedPageIt->GetNElements() + 7) / 8;
       }
    }
    if (size >= std::numeric_limits<std::int32_t>::max() || bytesPacked >= std::numeric_limits<std::int32_t>::max()) {
@@ -155,12 +155,12 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         fWriter->WriteIntoReservedBlob(sealedPageIt->fBuffer, sealedPageIt->fSize, offset);
+         fWriter->WriteIntoReservedBlob(sealedPageIt->GetBuffer(), sealedPageIt->GetSize(), offset);
          RNTupleLocator locator;
          locator.fPosition = offset;
-         locator.fBytesOnStorage = sealedPageIt->fSize;
+         locator.fBytesOnStorage = sealedPageIt->GetSize();
          locators.push_back(locator);
-         offset += sealedPageIt->fSize;
+         offset += sealedPageIt->GetSize();
       }
    }
 
@@ -342,15 +342,15 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
-   sealedPage.fSize = bytesOnStorage;
-   sealedPage.fNElements = pageInfo.fNElements;
-   if (!sealedPage.fBuffer)
+   sealedPage.SetSize(bytesOnStorage);
+   sealedPage.SetNElements(pageInfo.fNElements);
+   if (!sealedPage.GetBuffer())
       return;
    if (pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero) {
-      fReader.ReadBuffer(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage,
+      fReader.ReadBuffer(sealedPage.GetWritableBuffer(), bytesOnStorage,
                          pageInfo.fLocator.GetPosition<std::uint64_t>());
    } else {
-      memcpy(const_cast<void *>(sealedPage.fBuffer), RPage::GetPageZeroBuffer(), bytesOnStorage);
+      memcpy(sealedPage.GetWritableBuffer(), RPage::GetPageZeroBuffer(), bytesOnStorage);
    }
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -221,7 +221,6 @@ void ROOT::Experimental::Internal::RPageSinkFile::ReleasePage(RPage &page)
 ROOT::Experimental::Internal::RPageSourceFile::RPageSourceFile(std::string_view ntupleName,
                                                                const RNTupleReadOptions &options)
    : RPageSource(ntupleName, options),
-     fPagePool(std::make_shared<RPagePool>()),
      fClusterPool(std::make_unique<RClusterPool>(*this, options.GetClusterBunchSize()))
 {
    fDecompressor = std::make_unique<RNTupleDecompressor>();
@@ -643,51 +642,4 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadClusters(std::span<RCluster::
    }
 
    return clusters;
-}
-
-void ROOT::Experimental::Internal::RPageSourceFile::UnzipClusterImpl(RCluster *cluster)
-{
-   Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-
-   const auto clusterId = cluster->GetId();
-   auto descriptorGuard = GetSharedDescriptorGuard();
-   const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
-
-   std::vector<std::unique_ptr<RColumnElementBase>> allElements;
-
-   const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
-   for (const auto columnId : columnsInCluster) {
-      const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
-
-      allElements.emplace_back(RColumnElementBase::Generate(columnDesc.GetModel().GetType()));
-
-      const auto &pageRange = clusterDescriptor.GetPageRange(columnId);
-      std::uint64_t pageNo = 0;
-      std::uint64_t firstInPage = 0;
-      for (const auto &pi : pageRange.fPageInfos) {
-         ROnDiskPage::Key key(columnId, pageNo);
-         auto onDiskPage = cluster->GetOnDiskPage(key);
-         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
-
-         auto taskFunc = [this, columnId, clusterId, firstInPage, onDiskPage, element = allElements.back().get(),
-                          nElements = pi.fNElements,
-                          indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
-            auto newPage = UnsealPage({onDiskPage->GetAddress(), onDiskPage->GetSize(), nElements}, *element, columnId);
-            fCounters->fSzUnzip.Add(element->GetSize() * nElements);
-
-            newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-            fPagePool->PreloadPage(
-               newPage, RPageDeleter([](const RPage &page, void *) { RPageAllocatorHeap::DeletePage(page); }, nullptr));
-         };
-
-         fTaskScheduler->AddTask(taskFunc);
-
-         firstInPage += pi.fNElements;
-         pageNo++;
-      } // for all pages in column
-   }    // for all columns in cluster
-
-   fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
-
-   fTaskScheduler->Wait();
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -357,7 +357,7 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
       memcpy(sealedPage.GetWritableBuffer(), RPage::GetPageZeroBuffer(), bytesOnStorage);
    }
 
-   sealedPage.VerifyChecksumIfEnabled();
+   sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
 }
 
 ROOT::Experimental::Internal::RPage

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -413,7 +413,7 @@ ROOT::Experimental::Internal::RPageSourceFile::PopulatePageFromCluster(ColumnHan
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage(sealedPage, *element, columnId);
+      newPage = UnsealPage(sealedPage, *element, columnId).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -341,7 +341,11 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
       pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(clusterIndex.GetIndex());
    }
 
-   const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
+   auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
+   if (pageInfo.fHasChecksum) {
+      bytesOnStorage += sizeof(std::uint64_t);
+      sealedPage.SetHasChecksum(true);
+   }
    sealedPage.SetBufferSize(bytesOnStorage);
    sealedPage.SetNElements(pageInfo.fNElements);
    if (!sealedPage.GetBuffer())
@@ -352,6 +356,8 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
    } else {
       memcpy(sealedPage.GetWritableBuffer(), RPage::GetPageZeroBuffer(), bytesOnStorage);
    }
+
+   sealedPage.VerifyChecksumIfEnabled();
 }
 
 ROOT::Experimental::Internal::RPage

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -343,6 +343,7 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
 
    auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
    if (pageInfo.fHasChecksum) {
+      assert(pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero);
       bytesOnStorage += kNBytesPageChecksum;
       sealedPage.SetHasChecksum(true);
    }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 ROOT_ADD_GTEST(ntuple_basics ntuple_basics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_bulk ntuple_bulk.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_cluster ntuple_cluster.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_compat ntuple_compat.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_descriptor ntuple_descriptor.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -110,7 +110,7 @@ if(daos OR daos_mock)
     set(daos_test_pool ntuple-daos-test-pool)
   endif()
 
-  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
+  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx ntuple_test.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
   target_compile_definitions(ntuple_storage_daos PRIVATE R__DAOS_TEST_POOL="${daos_test_pool}")
 
   if(daos_mock)

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 ROOT_ADD_GTEST(ntuple_basics ntuple_basics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_bulk ntuple_bulk.cxx LIBRARIES ROOTNTuple CustomStruct)
-ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx LIBRARIES ROOTNTuple)
+ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx ntuple_test.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_cluster ntuple_cluster.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_compat ntuple_compat.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_descriptor ntuple_descriptor.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -333,6 +333,7 @@ TEST(RNTuple, ClusterEntriesAuto)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       for (int i = 0; i < 100; i++) {
@@ -357,6 +358,7 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
 
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto entry = ntuple->CreateEntry();

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -1,0 +1,42 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTupleChecksum, Verify)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrPx = model->MakeField<float>("px", 1.0);
+      auto ptrPy = model->MakeField<float>("py", 2.0);
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+      writer->Fill();
+   }
+
+   {
+      auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+      pageSource->Attach();
+      auto descGuard = pageSource->GetSharedDescriptorGuard();
+      const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+      const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+      const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
+      const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
+      EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
+      EXPECT_TRUE(pageInfo.fHasChecksum);
+
+      std::uint64_t wrongChecksum = 0;
+      FILE *f = fopen(fileGuard.GetPath().c_str(), "r+b");
+      fseek(f, pageInfo.fLocator.GetPosition<std::uint64_t>() + 4, SEEK_SET);
+      fwrite(&wrongChecksum, sizeof(wrongChecksum), 1, f);
+      fclose(f);
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+
+   auto viewPx = reader->GetView<float>("px");
+   auto viewPy = reader->GetView<float>("py");
+   EXPECT_THROW(viewPx(0), RException);
+   EXPECT_FLOAT_EQ(2.0, viewPy(0));
+}

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -1,42 +1,145 @@
 #include "ntuple_test.hxx"
 
-TEST(RNTupleChecksum, Verify)
+namespace {
+
+void CreateCorruptedFile(const std::string &fileName)
 {
-   FileRaii fileGuard("test_ntuple_checksum_verify.root");
+   auto model = RNTupleModel::Create();
+   auto ptrPx = model->MakeField<float>("px", 1.0);
+   auto ptrPy = model->MakeField<float>("py", 2.0);
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileName, options);
+   writer->Fill();
+   writer.reset();
 
-   {
-      auto model = RNTupleModel::Create();
-      auto ptrPx = model->MakeField<float>("px", 1.0);
-      auto ptrPy = model->MakeField<float>("py", 2.0);
-      RNTupleWriteOptions options;
-      options.SetCompression(0);
-      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
-      writer->Fill();
+   auto pageSource = RPageSource::Create("ntpl", fileName);
+   pageSource->Attach();
+   auto descGuard = pageSource->GetSharedDescriptorGuard();
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+   const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
+   const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
+   EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
+   EXPECT_TRUE(pageInfo.fHasChecksum);
+
+   std::uint64_t wrongChecksum = 0;
+   FILE *f = fopen(fileName.c_str(), "r+b");
+   fseek(f, pageInfo.fLocator.GetPosition<std::uint64_t>() + 4, SEEK_SET);
+   fwrite(&wrongChecksum, sizeof(wrongChecksum), 1, f);
+   fclose(f);
+}
+
+#ifdef R__USE_IMT
+struct IMTRAII {
+   IMTRAII() { ROOT::EnableImplicitMT(); }
+   ~IMTRAII() { ROOT::DisableImplicitMT(); }
+};
+#endif
+
+} // anonymous namespace
+
+TEST(RNTupleChecksum, VerifyOnRead)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
+
+   CreateCorruptedFile(fileGuard.GetPath());
+
+   for (auto co : {RNTupleReadOptions::EClusterCache::kOn, RNTupleReadOptions::EClusterCache::kOff}) {
+      RNTupleReadOptions options;
+      options.SetClusterCache(co);
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath(), options);
+      EXPECT_EQ(1u, reader->GetNEntries());
+
+      // TODO(jblomer): check that now even reading py fails because pages are unsealed in parallel
+      // Requires fixing the cluster scheduler.
    }
+}
 
+#ifdef R__USE_IMT
+TEST(RNTupleChecksum, VerifyOnReadImt)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
+
+   CreateCorruptedFile(fileGuard.GetPath());
+
+   IMTRAII _;
+
+   for (auto co : {RNTupleReadOptions::EClusterCache::kOn, RNTupleReadOptions::EClusterCache::kOff}) {
+      RNTupleReadOptions options;
+      options.SetClusterCache(co);
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath(), options);
+      EXPECT_EQ(1u, reader->GetNEntries());
+
+      auto viewPx = reader->GetView<float>("px");
+      auto viewPy = reader->GetView<float>("py");
+      EXPECT_THROW(viewPx(0), RException);
+      EXPECT_FLOAT_EQ(2.0, viewPy(0));
+   }
+}
+#endif // R__USE_IMT
+
+TEST(RNTupleChecksum, VerifyOnLoad)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_load.root");
+
+   CreateCorruptedFile(fileGuard.GetPath());
+
+   RPageStorage::RSealedPage sealedPage;
+   DescriptorId_t pxColId;
+   DescriptorId_t pyColId;
+   DescriptorId_t clusterId;
+   auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+   pageSource->Attach();
    {
-      auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
-      pageSource->Attach();
       auto descGuard = pageSource->GetSharedDescriptorGuard();
-      const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
-      const auto clusterId = descGuard->FindClusterId(pxColId, 0);
-      const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
-      const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
-      EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
-      EXPECT_TRUE(pageInfo.fHasChecksum);
-
-      std::uint64_t wrongChecksum = 0;
-      FILE *f = fopen(fileGuard.GetPath().c_str(), "r+b");
-      fseek(f, pageInfo.fLocator.GetPosition<std::uint64_t>() + 4, SEEK_SET);
-      fwrite(&wrongChecksum, sizeof(wrongChecksum), 1, f);
-      fclose(f);
+      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+      clusterId = descGuard->FindClusterId(pxColId, 0);
    }
+   RClusterIndex index{clusterId, 0};
+
+   constexpr std::size_t bufSize = 12;
+   pageSource->LoadSealedPage(pyColId, index, sealedPage);
+   EXPECT_EQ(bufSize, sealedPage.GetBufferSize());
+   unsigned char buffer[bufSize];
+   sealedPage.SetBuffer(buffer);
+   // no exception
+   pageSource->LoadSealedPage(pyColId, index, sealedPage);
+
+   EXPECT_THROW(pageSource->LoadSealedPage(pxColId, index, sealedPage), RException);
+}
+
+TEST(RNTupleChecksum, OmitPageChecksum)
+{
+   FileRaii fileGuard("test_ntuple_omit_page_checksum.root");
+
+   auto model = RNTupleModel::Create();
+   auto ptrPx = model->MakeField<float>("px", 1.0);
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+   options.SetEnablePageChecksums(false);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+   writer->Fill();
+   writer.reset();
+
+   auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+   pageSource->Attach();
+   auto descGuard = pageSource->GetSharedDescriptorGuard();
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+   const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
+   const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
+   EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
+   EXPECT_FALSE(pageInfo.fHasChecksum);
+
+   RPageStorage::RSealedPage sealedPage;
+   pageSource->LoadSealedPage(pxColId, RClusterIndex{clusterId, 0}, sealedPage);
+   EXPECT_FALSE(sealedPage.GetHasChecksum());
+   EXPECT_EQ(4u, sealedPage.GetBufferSize());
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    EXPECT_EQ(1u, reader->GetNEntries());
-
    auto viewPx = reader->GetView<float>("px");
-   auto viewPy = reader->GetView<float>("py");
-   EXPECT_THROW(viewPx(0), RException);
-   EXPECT_FLOAT_EQ(2.0, viewPy(0));
+   EXPECT_FLOAT_EQ(1.0, viewPx(0));
 }

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -1,33 +1,58 @@
 #include "ntuple_test.hxx"
 
+#include <cstring>
+
 namespace {
 
-void CreateCorruptedFile(const std::string &fileName)
+void CreateCorruptedFile(const std::string &uri)
 {
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+
    auto model = RNTupleModel::Create();
    auto ptrPx = model->MakeField<float>("px", 1.0);
    auto ptrPy = model->MakeField<float>("py", 2.0);
-   RNTupleWriteOptions options;
-   options.SetCompression(0);
-   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileName, options);
+   model->Freeze();
+   auto modelClone = model->Clone(); // required later to write the corrupted version
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);
    writer->Fill();
    writer.reset();
 
-   auto pageSource = RPageSource::Create("ntpl", fileName);
+   // Load sealed pages to memory
+   auto pageSource = RPageSource::Create("ntpl", uri);
    pageSource->Attach();
    auto descGuard = pageSource->GetSharedDescriptorGuard();
    const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
-   const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
-   const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
-   EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
-   EXPECT_TRUE(pageInfo.fHasChecksum);
+   RClusterIndex index{clusterId, 0};
 
-   std::uint64_t wrongChecksum = 0;
-   FILE *f = fopen(fileName.c_str(), "r+b");
-   fseek(f, pageInfo.fLocator.GetPosition<std::uint64_t>() + 4, SEEK_SET);
-   fwrite(&wrongChecksum, sizeof(wrongChecksum), 1, f);
-   fclose(f);
+   constexpr std::size_t bufSize = sizeof(float) + RPageStorage::kNBytesPageChecksum;
+   unsigned char pxBuffer[bufSize];
+   RPageStorage::RSealedPage pxSealedPage;
+   pxSealedPage.SetBufferSize(bufSize);
+   pxSealedPage.SetBuffer(pxBuffer);
+   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
+   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
+   unsigned char pyBuffer[bufSize];
+   RPageStorage::RSealedPage pySealedPage;
+   pySealedPage.SetBufferSize(bufSize);
+   pySealedPage.SetBuffer(pyBuffer);
+   pageSource->LoadSealedPage(pyColId, index, pySealedPage);
+   EXPECT_EQ(bufSize, pySealedPage.GetBufferSize());
+
+   // Corrupt px sealed page's checksum
+   memset(pxBuffer + sizeof(float), 0, RPageStorage::kNBytesPageChecksum);
+
+   // Rewrite RNTuple with valid py page and corrupted px page
+   auto pageSink = ROOT::Experimental::Internal::RPagePersistentSink::Create("ntpl", uri, options);
+   pageSink->Init(*modelClone);
+   pageSink->CommitSealedPage(pxColId, pxSealedPage);
+   pageSink->CommitSealedPage(pyColId, pySealedPage);
+   pageSink->CommitCluster(1);
+   pageSink->CommitClusterGroup();
+   pageSink->CommitDataset();
+   modelClone.reset();
 }
 
 #ifdef R__USE_IMT

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -2,73 +2,11 @@
 
 #include <cstring>
 
-namespace {
-
-void CreateCorruptedFile(const std::string &uri)
-{
-   RNTupleWriteOptions options;
-   options.SetCompression(0);
-
-   auto model = RNTupleModel::Create();
-   auto ptrPx = model->MakeField<float>("px", 1.0);
-   auto ptrPy = model->MakeField<float>("py", 2.0);
-   model->Freeze();
-   auto modelClone = model->Clone(); // required later to write the corrupted version
-   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);
-   writer->Fill();
-   writer.reset();
-
-   // Load sealed pages to memory
-   auto pageSource = RPageSource::Create("ntpl", uri);
-   pageSource->Attach();
-   auto descGuard = pageSource->GetSharedDescriptorGuard();
-   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
-   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
-   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
-   RClusterIndex index{clusterId, 0};
-
-   constexpr std::size_t bufSize = sizeof(float) + RPageStorage::kNBytesPageChecksum;
-   unsigned char pxBuffer[bufSize];
-   RPageStorage::RSealedPage pxSealedPage;
-   pxSealedPage.SetBufferSize(bufSize);
-   pxSealedPage.SetBuffer(pxBuffer);
-   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
-   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
-   unsigned char pyBuffer[bufSize];
-   RPageStorage::RSealedPage pySealedPage;
-   pySealedPage.SetBufferSize(bufSize);
-   pySealedPage.SetBuffer(pyBuffer);
-   pageSource->LoadSealedPage(pyColId, index, pySealedPage);
-   EXPECT_EQ(bufSize, pySealedPage.GetBufferSize());
-
-   // Corrupt px sealed page's checksum
-   memset(pxBuffer + sizeof(float), 0, RPageStorage::kNBytesPageChecksum);
-
-   // Rewrite RNTuple with valid py page and corrupted px page
-   auto pageSink = ROOT::Experimental::Internal::RPagePersistentSink::Create("ntpl", uri, options);
-   pageSink->Init(*modelClone);
-   pageSink->CommitSealedPage(pxColId, pxSealedPage);
-   pageSink->CommitSealedPage(pyColId, pySealedPage);
-   pageSink->CommitCluster(1);
-   pageSink->CommitClusterGroup();
-   pageSink->CommitDataset();
-   modelClone.reset();
-}
-
-#ifdef R__USE_IMT
-struct IMTRAII {
-   IMTRAII() { ROOT::EnableImplicitMT(); }
-   ~IMTRAII() { ROOT::DisableImplicitMT(); }
-};
-#endif
-
-} // anonymous namespace
-
 TEST(RNTupleChecksum, VerifyOnRead)
 {
    FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
 
-   CreateCorruptedFile(fileGuard.GetPath());
+   CreateCorruptedRNTuple(fileGuard.GetPath());
 
    for (auto co : {RNTupleReadOptions::EClusterCache::kOn, RNTupleReadOptions::EClusterCache::kOff}) {
       RNTupleReadOptions options;
@@ -88,7 +26,7 @@ TEST(RNTupleChecksum, VerifyOnReadImt)
 {
    FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
 
-   CreateCorruptedFile(fileGuard.GetPath());
+   CreateCorruptedRNTuple(fileGuard.GetPath());
 
    IMTRAII _;
 
@@ -112,7 +50,7 @@ TEST(RNTupleChecksum, VerifyOnLoad)
 {
    FileRaii fileGuard("test_ntuple_checksum_verify_load.root");
 
-   CreateCorruptedFile(fileGuard.GetPath());
+   CreateCorruptedRNTuple(fileGuard.GetPath());
 
    RPageStorage::RSealedPage sealedPage;
    DescriptorId_t pxColId;
@@ -181,7 +119,7 @@ TEST(RNTupleChecksum, Merge)
    RNTupleWriteOptions options;
    options.SetCompression(0);
 
-   CreateCorruptedFile(fileGuard1.GetPath());
+   CreateCorruptedRNTuple(fileGuard1.GetPath());
 
    {
       auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -70,7 +70,7 @@ public:
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage &page) final
    {
       auto P = SealPage(page, fElement, /*compressionSetting=*/0);
-      fPages.emplace_back(P.fBuffer, P.fSize, P.fNElements);
+      fPages.emplace_back(P.GetBuffer(), P.GetSize(), P.GetNElements());
    }
 
    const std::vector<RPageStorage::RSealedPage> &GetPages() const { return fPages; }
@@ -119,8 +119,8 @@ TEST(RColumnElementEndian, ByteCopy)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -145,8 +145,8 @@ TEST(RColumnElementEndian, Cast)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -172,8 +172,8 @@ TEST(RColumnElementEndian, Split)
    page1.GrowUnchecked(2);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
 
    RPageSourceMock source1(sink1.GetPages(), splitElement);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -200,8 +200,8 @@ TEST(RColumnElementEndian, DeltaSplit)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x04\x04\x04\x02\x04\x04\x04\x01\x04\x04\x04\x00\x04\x04\x04", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x04\x04\x04\x02\x04\x04\x04\x01\x04\x04\x04\x00\x04\x04\x04", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -69,7 +69,7 @@ public:
    }
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage &page) final
    {
-      fPages.emplace_back(SealPage(page, fElement, /*compressionSetting=*/0));
+      fPages.emplace_back(SealPage(page, fElement));
    }
 
    const std::vector<RPageStorage::RSealedPage> &GetPages() const { return fPages; }

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -69,8 +69,7 @@ public:
    }
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage &page) final
    {
-      auto P = SealPage(page, fElement, /*compressionSetting=*/0);
-      fPages.emplace_back(P.GetBuffer(), P.GetSize(), P.GetNElements());
+      fPages.emplace_back(SealPage(page, fElement, /*compressionSetting=*/0));
    }
 
    const std::vector<RPageStorage::RSealedPage> &GetPages() const { return fPages; }

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -94,7 +94,7 @@ public:
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
-      return RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId);
+      return RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId).Unwrap();
    }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPage(); }
    void ReleasePage(RPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -89,6 +89,7 @@ TEST(RNTuple, RandomAccess)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(nEvents * sizeof(std::int32_t) / 10);
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath(), options);
       for (unsigned int i = 0; i < nEvents; ++i)

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -50,14 +50,14 @@ TEST(RPageStorage, ReadSealedPages)
    RClusterIndex index(source.GetSharedDescriptorGuard()->FindClusterId(columnId, 0), 0);
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
-   ASSERT_EQ(1U, sealedPage.fNElements);
-   ASSERT_EQ(4U, sealedPage.fSize);
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.fSize);
-   sealedPage.fBuffer = buffer.get();
+   ASSERT_EQ(1U, sealedPage.GetNElements());
+   ASSERT_EQ(4U, sealedPage.GetSize());
+   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+   sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
-   ASSERT_EQ(1U, sealedPage.fNElements);
-   ASSERT_EQ(4U, sealedPage.fSize);
-   EXPECT_EQ(42, ReadRawInt(sealedPage.fBuffer));
+   ASSERT_EQ(1U, sealedPage.GetNElements());
+   ASSERT_EQ(4U, sealedPage.GetSize());
+   EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 
    // Check second, big cluster
    auto clusterId = source.GetSharedDescriptorGuard()->FindClusterId(columnId, 1);
@@ -68,10 +68,10 @@ TEST(RPageStorage, ReadSealedPages)
    std::uint32_t firstElementInPage = 0;
    for (const auto &pi : pageRange.fPageInfos) {
       buffer = std::make_unique<unsigned char[]>(pi.fLocator.fBytesOnStorage);
-      sealedPage.fBuffer = buffer.get();
+      sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      ASSERT_GE(sealedPage.fSize, 4U);
-      EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.fBuffer));
+      ASSERT_GE(sealedPage.GetSize(), 4U);
+      EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
       firstElementInPage += pi.fNElements;
    }
 }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -51,13 +51,13 @@ TEST(RPageStorage, ReadSealedPages)
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(12U, sealedPage.GetBufferSize());
    ASSERT_EQ(4U, sealedPage.GetDataSize());
    auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(12U, sealedPage.GetBufferSize());
    ASSERT_EQ(4U, sealedPage.GetDataSize());
    EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -51,12 +51,14 @@ TEST(RPageStorage, ReadSealedPages)
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetSize());
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(4U, sealedPage.GetDataSize());
+   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetSize());
+   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(4U, sealedPage.GetDataSize());
    EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 
    // Check second, big cluster
@@ -70,7 +72,8 @@ TEST(RPageStorage, ReadSealedPages)
       buffer = std::make_unique<unsigned char[]>(pi.fLocator.fBytesOnStorage);
       sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      ASSERT_GE(sealedPage.GetSize(), 4U);
+      ASSERT_GE(sealedPage.GetBufferSize(), 4U);
+      ASSERT_GE(sealedPage.GetDataSize(), 4U);
       EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
       firstElementInPage += pi.fNElements;
    }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -283,51 +283,51 @@ TEST(Packing, OnDiskEncoding)
 
    source->LoadSealedPage(fnGetColumnId("int16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt16[] = {0x02, 0x05, 0x00, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt16, sizeof(expInt16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt16, sizeof(expInt16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("int32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt32[] = {0x06, 0x0d, 0x04, 0x0c, 0x02, 0x0a, 0x00, 0x08};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt32, sizeof(expInt32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt32, sizeof(expInt32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("int64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt64[] = {0x0e, 0x1d, 0x0c, 0x1c, 0x0a, 0x1a, 0x08, 0x18,
                                0x06, 0x16, 0x04, 0x14, 0x02, 0x12, 0x00, 0x10};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt64, sizeof(expInt64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt64, sizeof(expInt64)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt16[] = {0x01, 0x02, 0x00, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt16, sizeof(expUInt16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt16, sizeof(expUInt16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt32[] = {0x03, 0x07, 0x02, 0x06, 0x01, 0x05, 0x00, 0x04};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt32, sizeof(expUInt32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt32, sizeof(expUInt32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt64[] = {0x07, 0x0f, 0x06, 0x0e, 0x05, 0x0d, 0x04, 0x0c,
                                 0x03, 0x0b, 0x02, 0x0a, 0x01, 0x09, 0x00, 0x08};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt64, sizeof(expUInt64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt64, sizeof(expUInt64)), 0);
 
    source->LoadSealedPage(fnGetColumnId("float"), RClusterIndex(0, 0), sealedPage);
    unsigned char expFloat[] = {0x01, 0xff, 0x00, 0xff, 0x80, 0x7f, 0x3f, 0x3f};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expFloat, sizeof(expFloat)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expFloat, sizeof(expFloat)), 0);
 
    source->LoadSealedPage(fnGetColumnId("float16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expFloat16[] = {0x00, 0x3c, 0x66, 0x2e};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expFloat16, sizeof(expFloat16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expFloat16, sizeof(expFloat16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("double"), RClusterIndex(0, 0), sealedPage);
    unsigned char expDouble[] = {0x01, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
                                 0x00, 0xff, 0x00, 0xff, 0xf0, 0xef, 0x3f, 0x7f};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expDouble, sizeof(expDouble)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expDouble, sizeof(expDouble)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expIndex32[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex32, sizeof(expIndex32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expIndex32, sizeof(expIndex32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expIndex64[] = {0x00, 0x0D, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00,
                                  0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(EColumnType::kIndex64, reader->GetModel().GetField("str").GetColumnRepresentative()[0]);

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -277,16 +277,26 @@ TEST_F(RPageStorageDaos, CagedPages)
 
 TEST_F(RPageStorageDaos, Checksum)
 {
-   IMTRAII _;
-
    std::string daosUri = RegisterLabel("ntuple-test-checksum");
    CreateCorruptedRNTuple(daosUri);
+
+   {
+      IMTRAII _;
+
+      auto reader = RNTupleReader::Open("ntpl", daosUri);
+      EXPECT_EQ(1u, reader->GetNEntries());
+
+      auto viewPx = reader->GetView<float>("px");
+      auto viewPy = reader->GetView<float>("py");
+      EXPECT_THROW(viewPy(0), RException); // we run under IMT, even the valid column should fail
+   }
 
    auto reader = RNTupleReader::Open("ntpl", daosUri);
    EXPECT_EQ(1u, reader->GetNEntries());
 
    auto viewPx = reader->GetView<float>("px");
    auto viewPy = reader->GetView<float>("py");
-   EXPECT_THROW(viewPy(0), RException); // we run under IMT, even the valid column should fail
+   EXPECT_THROW(viewPx(0), RException);
+   EXPECT_FLOAT_EQ(2.0, viewPy(0));
 }
 #endif

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -298,5 +298,22 @@ TEST_F(RPageStorageDaos, Checksum)
    auto viewPy = reader->GetView<float>("py");
    EXPECT_THROW(viewPx(0), RException);
    EXPECT_FLOAT_EQ(2.0, viewPy(0));
+
+   DescriptorId_t pxColId;
+   DescriptorId_t clusterId;
+   auto pageSource = RPageSource::Create("ntpl", daosUri);
+   pageSource->Attach();
+   {
+      auto descGuard = pageSource->GetSharedDescriptorGuard();
+      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+      clusterId = descGuard->FindClusterId(pxColId, 0);
+   }
+   RClusterIndex index{clusterId, 0};
+
+   RPageStorage::RSealedPage sealedPage;
+   constexpr std::size_t bufSize = 12;
+   unsigned char buffer[bufSize];
+   sealedPage.SetBuffer(buffer);
+   EXPECT_THROW(pageSource->LoadSealedPage(pxColId, index, sealedPage), RException);
 }
 #endif

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -274,4 +274,19 @@ TEST_F(RPageStorageDaos, CagedPages)
       EXPECT_THROW(ntuple->LoadEntry(1), ROOT::Experimental::RException);
    }
 }
+
+TEST_F(RPageStorageDaos, Checksum)
+{
+   IMTRAII _;
+
+   std::string daosUri = RegisterLabel("ntuple-test-checksum");
+   CreateCorruptedRNTuple(daosUri);
+
+   auto reader = RNTupleReader::Open("ntpl", daosUri);
+   EXPECT_EQ(1u, reader->GetNEntries());
+
+   auto viewPx = reader->GetView<float>("px");
+   auto viewPy = reader->GetView<float>("py");
+   EXPECT_THROW(viewPy(0), RException); // we run under IMT, even the valid column should fail
+}
 #endif

--- a/tree/ntuple/v7/test/ntuple_test.cxx
+++ b/tree/ntuple/v7/test/ntuple_test.cxx
@@ -1,0 +1,54 @@
+#include "ntuple_test.hxx"
+
+#include <cstring> // for memset
+
+void CreateCorruptedRNTuple(const std::string &uri)
+{
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+
+   auto model = RNTupleModel::Create();
+   auto ptrPx = model->MakeField<float>("px", 1.0);
+   auto ptrPy = model->MakeField<float>("py", 2.0);
+   model->Freeze();
+   auto modelClone = model->Clone(); // required later to write the corrupted version
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);
+   writer->Fill();
+   writer.reset();
+
+   // Load sealed pages to memory
+   auto pageSource = RPageSource::Create("ntpl", uri);
+   pageSource->Attach();
+   auto descGuard = pageSource->GetSharedDescriptorGuard();
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+   RClusterIndex index{clusterId, 0};
+
+   constexpr std::size_t bufSize = sizeof(float) + RPageStorage::kNBytesPageChecksum;
+   unsigned char pxBuffer[bufSize];
+   RPageStorage::RSealedPage pxSealedPage;
+   pxSealedPage.SetBufferSize(bufSize);
+   pxSealedPage.SetBuffer(pxBuffer);
+   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
+   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
+   unsigned char pyBuffer[bufSize];
+   RPageStorage::RSealedPage pySealedPage;
+   pySealedPage.SetBufferSize(bufSize);
+   pySealedPage.SetBuffer(pyBuffer);
+   pageSource->LoadSealedPage(pyColId, index, pySealedPage);
+   EXPECT_EQ(bufSize, pySealedPage.GetBufferSize());
+
+   // Corrupt px sealed page's checksum
+   memset(pxBuffer + sizeof(float), 0, RPageStorage::kNBytesPageChecksum);
+
+   // Rewrite RNTuple with valid py page and corrupted px page
+   auto pageSink = ROOT::Experimental::Internal::RPagePersistentSink::Create("ntpl", uri, options);
+   pageSink->Init(*modelClone);
+   pageSink->CommitSealedPage(pxColId, pxSealedPage);
+   pageSink->CommitSealedPage(pyColId, pySealedPage);
+   pageSink->CommitCluster(1);
+   pageSink->CommitClusterGroup();
+   pageSink->CommitDataset();
+   modelClone.reset();
+}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -137,4 +137,15 @@ public:
    void PreserveFile() { fPreserveFile = true; }
 };
 
+#ifdef R__USE_IMT
+struct IMTRAII {
+   IMTRAII() { ROOT::EnableImplicitMT(); }
+   ~IMTRAII() { ROOT::DisableImplicitMT(); }
+};
+#endif
+
+/// Creates an uncompressed RNTuple called "ntpl" with two float fields, px and py, with a single entry.
+/// The page of px has a wrong checksum. The function is backend agnostic (file, DAOS, ...).
+void CreateCorruptedRNTuple(const std::string &uri);
+
 #endif


### PR DESCRIPTION
# This Pull request:

Implements writing page checksums and checksum verification on read.
Page checksums are written on `SealPage`. They are verified on `LoadSealedPage()` and on `UnsealPage()`.

Note that the page size stored in locators does not change. Pages flagged as having a checksum are serialized with additional trailing 8 bytes.

Still some commit cleanup todo. Depends on #15767 

