### PR TITLE
[ntuple] fix unbuffered compression of large pages

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -204,6 +204,7 @@ private:
    /// Flag if sink was initialized
    bool fIsInitialized = false;
    std::vector<Callback_t> fOnDatasetCommitCallbacks;
+   std::vector<unsigned char> fSealPageBuffer; ///< Used as destination buffer in the simple SealPage overload
 
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -356,8 +356,9 @@ ROOT::Experimental::Internal::RPageStorage::RSealedPage
 ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element,
                                                   int compressionSetting)
 {
-   R__ASSERT(fCompressor);
-   return SealPage(page, element, compressionSetting, fCompressor->GetZipBuffer());
+   if (fSealPageBuffer.size() < page.GetNBytes())
+      fSealPageBuffer.resize(page.GetNBytes());
+   return SealPage(page, element, compressionSetting, fSealPageBuffer.data());
 }
 
 void ROOT::Experimental::Internal::RPageSink::CommitDataset()

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -5,6 +5,8 @@
 #include <TRandom3.h>
 #include <TROOT.h>
 
+#include <random>
+
 TEST(RNTuple, RealWorld1)
 {
 #ifdef R__USE_IMT
@@ -268,6 +270,44 @@ TEST(RNTuple, LargeFile2)
    }
 }
 #endif
+
+TEST(RNTuple, LargePages)
+{
+   FileRaii fileGuard("test_ntuple_large_pages.root");
+
+   for (const auto useBufferedWrite : {true, false}) {
+      {
+         auto model = RNTupleModel::Create();
+         auto fldRnd = model->MakeField<std::uint32_t>("rnd");
+         RNTupleWriteOptions options;
+         // Larger than the 16MB compression block limit
+         options.SetApproxUnzippedPageSize(32 * 1024 * 1024);
+         options.SetUseBufferedWrite(useBufferedWrite);
+         auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+
+         std::mt19937 gen;
+         std::uniform_int_distribution<std::uint32_t> distrib;
+         for (int i = 0; i < 25 * 1000 * 1000; ++i) { // 100 MB of int data
+            *fldRnd = distrib(gen);
+            writer->Fill();
+         }
+         writer.reset();
+      }
+
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      const auto &desc = reader->GetDescriptor();
+      const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0);
+      const auto &clusterDesc = desc.GetClusterDescriptor(desc.FindClusterId(rndColId, 0));
+      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.fBytesOnStorage, kMAXZIPBUF);
+
+      auto viewRnd = reader->GetView<std::uint32_t>("rnd");
+      std::mt19937 gen;
+      std::uniform_int_distribution<std::uint32_t> distrib;
+      for (const auto i : reader->GetEntryRange()) {
+         EXPECT_EQ(distrib(gen), viewRnd(i));
+      }
+   }
+}
 
 // FIXME: apparently, this test continues to be broken for some CI configs, which needs to be investigated carefully;
 // thus disable temporarily.


### PR DESCRIPTION
So far, non-vectorized committing of pages misuses the compressor buffer as a temporary storage. The compressor buffer is limited to `kMAXZIPBUF` (16MB) and a page can be larger.
