### PR TITLE
[RF] MultiProcess error handling

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -184,6 +184,8 @@ private:
    void initMinimizerFirstPart();
    void initMinimizerFcnDependentPart(double defaultErrorLevel);
 
+   void determineStatus(bool fitterReturnValue);
+
    int _status = -99;
    bool _profileStart = false;
    bool _loggingToDataSet = false;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -39,13 +39,11 @@ class RooRealVar;
 class RooArgSet;
 class RooPlot;
 class RooDataSet;
-#ifdef ROOFIT_MULTIPROCESS
 namespace RooFit {
 namespace TestStatistics {
 class LikelihoodGradientJob;
 }
 } // namespace RooFit
-#endif // ROOFIT_MULTIPROCESS
 
 class RooMinimizer : public TObject {
 public:
@@ -163,9 +161,7 @@ public:
 private:
    friend class RooAbsMinimizerFcn;
    friend class RooMinimizerFcn;
-#ifdef ROOFIT_MULTIPROCESS
    friend class RooFit::TestStatistics::LikelihoodGradientJob;
-#endif // ROOFIT_MULTIPROCESS
 
    std::unique_ptr<RooAbsReal::EvalErrorContext> makeEvalErrorContext() const;
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -39,6 +39,13 @@ class RooRealVar;
 class RooArgSet;
 class RooPlot;
 class RooDataSet;
+#ifdef ROOFIT_MULTIPROCESS
+namespace RooFit {
+namespace TestStatistics {
+class LikelihoodGradientJob;
+}
+} // namespace RooFit
+#endif // ROOFIT_MULTIPROCESS
 
 class RooMinimizer : public TObject {
 public:
@@ -68,10 +75,10 @@ public:
       // argument is ignored when parallelize is 0
       bool enableParallelDescent = false;
 
-      bool verbose = false;           // local config
-      bool profile = false;           // local config
-      bool timingAnalysis = false;    // local config
-      std::string minimizerType;      // local config
+      bool verbose = false;        // local config
+      bool profile = false;        // local config
+      bool timingAnalysis = false; // local config
+      std::string minimizerType;   // local config
    private:
       int getDefaultWorkers();
    };
@@ -136,16 +143,10 @@ public:
    static RooFit::OwningPtr<RooFitResult> lastMinuitFit();
    static RooFit::OwningPtr<RooFitResult> lastMinuitFit(const RooArgList &varList);
 
-   void saveStatus(const char *label, int status)
-   {
-      _statusHistory.emplace_back(label, status);
-   }
+   void saveStatus(const char *label, int status) { _statusHistory.emplace_back(label, status); }
 
    /// Clears the Minuit status history.
-   void clearStatusHistory()
-   {
-      _statusHistory.clear();
-   }
+   void clearStatusHistory() { _statusHistory.clear(); }
 
    int evalCounter() const;
    void zeroEvalCount();
@@ -162,6 +163,9 @@ public:
 private:
    friend class RooAbsMinimizerFcn;
    friend class RooMinimizerFcn;
+#ifdef ROOFIT_MULTIPROCESS
+   friend class RooFit::TestStatistics::LikelihoodGradientJob;
+#endif // ROOFIT_MULTIPROCESS
 
    std::unique_ptr<RooAbsReal::EvalErrorContext> makeEvalErrorContext() const;
 
@@ -172,6 +176,7 @@ private:
 
    std::ofstream *logfile();
    double &maxFCN();
+   double &fcnOffset() const;
 
    bool fitFcn() const;
 

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -76,10 +76,17 @@ RooAbsMinimizerFcn::RooAbsMinimizerFcn(RooArgList paramList, RooMinimizer *conte
 }
 
 RooAbsMinimizerFcn::RooAbsMinimizerFcn(const RooAbsMinimizerFcn &other)
-   : _context(other._context), _maxFCN(other._maxFCN), _funcOffset(other._funcOffset), _numBadNLL(other._numBadNLL),
-     _evalCounter(other._evalCounter), _nDim(other._nDim), _optConst(other._optConst),
-     _floatParamList(new RooArgList(*other._floatParamList)), _constParamList(new RooArgList(*other._constParamList)),
-     _initFloatParamList(std::make_unique<RooArgList>()), _initConstParamList(std::make_unique<RooArgList>()),
+   : _context(other._context),
+     _maxFCN(other._maxFCN),
+     _funcOffset(other._funcOffset),
+     _numBadNLL(other._numBadNLL),
+     _evalCounter(other._evalCounter),
+     _nDim(other._nDim),
+     _optConst(other._optConst),
+     _floatParamList(new RooArgList(*other._floatParamList)),
+     _constParamList(new RooArgList(*other._constParamList)),
+     _initFloatParamList(std::make_unique<RooArgList>()),
+     _initConstParamList(std::make_unique<RooArgList>()),
      _logfile(other._logfile)
 {
    other._initFloatParamList->snapshot(*_initFloatParamList, false);

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -83,8 +83,8 @@ RooAbsMinimizerFcn::RooAbsMinimizerFcn(const RooAbsMinimizerFcn &other)
      _evalCounter(other._evalCounter),
      _nDim(other._nDim),
      _optConst(other._optConst),
-     _floatParamList(new RooArgList(*other._floatParamList)),
-     _constParamList(new RooArgList(*other._constParamList)),
+     _floatParamList(std::make_unique<RooArgList>(*other._floatParamList)),
+     _constParamList(std::make_unique<RooArgList>(*other._constParamList)),
      _initFloatParamList(std::make_unique<RooArgList>()),
      _initConstParamList(std::make_unique<RooArgList>()),
      _logfile(other._logfile)

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -107,6 +107,7 @@ protected:
 
    void printEvalErrors() const;
 
+   double applyEvalErrorHandling(double fvalue) const;
    void finishDoEval() const;
 
    // members
@@ -118,6 +119,10 @@ protected:
    mutable double _funcOffset{0.};
    mutable int _numBadNLL = 0;
    mutable int _evalCounter{0};
+   // PB: these mutables signal a suboptimal design. A separate error handling
+   // object containing all this would clean up this class. It would allow const
+   // functions to be actually const (even though state still changes in the
+   // error handling object).
 
    unsigned int _nDim = 0;
 

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -58,7 +58,7 @@ public:
    Int_t evalCounter() const { return _evalCounter; }
    void zeroEvalCount() { _evalCounter = 0; }
    /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
-   double getOffset() const { return _funcOffset; }
+   double &getOffset() const { return _funcOffset; }
 
    /// Put Minuit results back into RooFit objects.
    void BackProp(const ROOT::Fit::FitResult &results);

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -307,7 +307,8 @@ void RooMinimizer::determineStatus(bool fitterReturnValue)
 
    // RooFit-based additional failed state information:
    if (evalCounter() <= _fcn->GetNumInvalidNLL()) {
-      coutE(Minimization) << "RooMinimizer: all function calls during minimization gave invalid NLL values!" << std::endl;
+      coutE(Minimization) << "RooMinimizer: all function calls during minimization gave invalid NLL values!"
+                          << std::endl;
    }
 }
 
@@ -770,8 +771,7 @@ void RooMinimizer::addParamsToProcessTimer()
    }
    RooFit::MultiProcess::ProcessTimer::add_metadata(parameter_names);
 #else
-   coutI(Minimization) << "Not adding parameters to processtimer because multiprocessing "
-                       << "is not enabled." << std::endl;
+   coutI(Minimization) << "Not adding parameters to processtimer because multiprocessing is not enabled." << std::endl;
 #endif
 }
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -300,6 +300,17 @@ bool RooMinimizer::fitFcn() const
    return _theFitter->FitFCN(*_fcn->getMultiGenFcn());
 }
 
+void RooMinimizer::determineStatus(bool fitterReturnValue)
+{
+   // Minuit-given status:
+   _status = ((fitterReturnValue) ? _theFitter->Result().Status() : -1);
+
+   // RooFit-based additional failed state information:
+   if (evalCounter() <= _fcn->GetNumInvalidNLL()) {
+      coutE(Minimization) << "RooMinimizer: all function calls during minimization gave invalid NLL values!" << std::endl;
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Minimise the function passed in the constructor.
 /// \param[in] type Type of fitter to use, e.g. "Minuit" "Minuit2". Passing an
@@ -329,7 +340,7 @@ int RooMinimizer::minimize(const char *type, const char *alg)
       auto ctx = makeEvalErrorContext();
 
       bool ret = fitFcn();
-      _status = ((ret) ? _theFitter->Result().Status() : -1);
+      determineStatus(ret);
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -354,7 +365,7 @@ int RooMinimizer::migrad()
 
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "migrad");
       bool ret = fitFcn();
-      _status = ((ret) ? _theFitter->Result().Status() : -1);
+      determineStatus(ret);
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -384,7 +395,7 @@ int RooMinimizer::hesse()
 
          _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str());
          bool ret = _theFitter->CalculateHessErrors();
-         _status = ((ret) ? _theFitter->Result().Status() : -1);
+         determineStatus(ret);
       }
       profileStop();
       _fcn->BackProp(_theFitter->Result());
@@ -415,7 +426,7 @@ int RooMinimizer::minos()
 
          _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str());
          bool ret = _theFitter->CalculateMinosErrors();
-         _status = ((ret) ? _theFitter->Result().Status() : -1);
+         determineStatus(ret);
       }
 
       profileStop();
@@ -461,7 +472,7 @@ int RooMinimizer::minos(const RooArgSet &minosParamList)
 
             _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str());
             bool ret = _theFitter->CalculateMinosErrors();
-            _status = ((ret) ? _theFitter->Result().Status() : -1);
+            determineStatus(ret);
             // to avoid that following minimization computes automatically the Minos errors
             _theFitter->Config().SetMinosErrors(false);
          }
@@ -490,7 +501,7 @@ int RooMinimizer::seek()
 
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "seek");
       bool ret = fitFcn();
-      _status = ((ret) ? _theFitter->Result().Status() : -1);
+      determineStatus(ret);
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -515,7 +526,7 @@ int RooMinimizer::simplex()
 
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "simplex");
       bool ret = fitFcn();
-      _status = ((ret) ? _theFitter->Result().Status() : -1);
+      determineStatus(ret);
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -540,7 +551,7 @@ int RooMinimizer::improve()
 
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "migradimproved");
       bool ret = fitFcn();
-      _status = ((ret) ? _theFitter->Result().Status() : -1);
+      determineStatus(ret);
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -956,6 +956,10 @@ double &RooMinimizer::maxFCN()
 {
    return _fcn->GetMaxFCN();
 }
+double &RooMinimizer::fcnOffset() const
+{
+   return _fcn->getOffset();
+}
 
 int RooMinimizer::Config::getDefaultWorkers()
 {

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -82,25 +82,7 @@ double RooMinimizerFcn::operator()(const double *x) const
    double fvalue = _funct->getVal();
    RooAbsReal::setHideOffset(true);
 
-   if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
-      printEvalErrors();
-      RooAbsReal::clearEvalErrorLog();
-      _numBadNLL++;
-
-      if (cfg().doEEWall) {
-         const double badness = RooNaNPacker::unpackNaN(fvalue);
-         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + cfg().recoverFromNaN * badness;
-      }
-   } else {
-      if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
-         // This is the first time we get a valid function value; while before, the
-         // function was always invalid. For invalid  cases, we returned values > 0.
-         // Now, we offset valid values such that they are < 0.
-         _funcOffset = -fvalue;
-      }
-      fvalue += _funcOffset;
-      _maxFCN = std::max(fvalue, _maxFCN);
-   }
+   fvalue = applyEvalErrorHandling(fvalue);
 
    // Optional logging
    if (_logfile)

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -128,12 +128,13 @@ void LikelihoodGradientJob::update_workers_state()
    if (shared_offset_.offsets() != offsets_previous_) {
       zmq::message_t offsets_message(shared_offset_.offsets().begin(), shared_offset_.offsets().end());
       get_manager()->messenger().publish_from_master_to_workers(
-         id_, state_id_, isCalculating_, maxFCN, fcnOffset, std::move(gradient_message), std::move(minuit_internal_x_message),
-         std::move(offsets_message));
+         id_, state_id_, isCalculating_, maxFCN, fcnOffset, std::move(gradient_message),
+         std::move(minuit_internal_x_message), std::move(offsets_message));
       offsets_previous_ = shared_offset_.offsets();
    } else {
-      get_manager()->messenger().publish_from_master_to_workers(
-         id_, state_id_, isCalculating_, maxFCN, fcnOffset, std::move(gradient_message), std::move(minuit_internal_x_message));
+      get_manager()->messenger().publish_from_master_to_workers(id_, state_id_, isCalculating_, maxFCN, fcnOffset,
+                                                                std::move(gradient_message),
+                                                                std::move(minuit_internal_x_message));
    }
 }
 

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -121,17 +121,19 @@ void LikelihoodGradientJob::update_workers_state()
    // TODO optimization: only send changed parameters (now sending all)
    zmq::message_t gradient_message(grad_.begin(), grad_.end());
    zmq::message_t minuit_internal_x_message(minuit_internal_x_.begin(), minuit_internal_x_.end());
+   double maxFCN = minimizer_->maxFCN();
+   double fcnOffset = minimizer_->fcnOffset();
    ++state_id_;
 
    if (shared_offset_.offsets() != offsets_previous_) {
       zmq::message_t offsets_message(shared_offset_.offsets().begin(), shared_offset_.offsets().end());
       get_manager()->messenger().publish_from_master_to_workers(
-         id_, state_id_, isCalculating_, std::move(gradient_message), std::move(minuit_internal_x_message),
+         id_, state_id_, isCalculating_, maxFCN, fcnOffset, std::move(gradient_message), std::move(minuit_internal_x_message),
          std::move(offsets_message));
       offsets_previous_ = shared_offset_.offsets();
    } else {
       get_manager()->messenger().publish_from_master_to_workers(
-         id_, state_id_, isCalculating_, std::move(gradient_message), std::move(minuit_internal_x_message));
+         id_, state_id_, isCalculating_, maxFCN, fcnOffset, std::move(gradient_message), std::move(minuit_internal_x_message));
    }
 }
 
@@ -146,10 +148,18 @@ void LikelihoodGradientJob::update_state()
    bool more;
 
    state_id_ = get_manager()->messenger().receive_from_master_on_worker<MultiProcess::State>(&more);
-
+   assert(more);
    isCalculating_ = get_manager()->messenger().receive_from_master_on_worker<bool>(&more);
 
    if (more) {
+      auto maxFCN = get_manager()->messenger().receive_from_master_on_worker<double>(&more);
+      minimizer_->maxFCN() = maxFCN;
+      assert(more);
+
+      auto fcnOffset = get_manager()->messenger().receive_from_master_on_worker<double>(&more);
+      minimizer_->fcnOffset() = fcnOffset;
+      assert(more);
+
       auto gradient_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
       assert(more);
       auto gradient_message_begin = gradient_message.data<ROOT::Minuit2::DerivatorElement>();

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
@@ -57,6 +57,7 @@ public:
       std::size_t job_id; // job ID must always be the first part of any result message/type
       double value;
       double carry;
+      bool has_errors;
    };
 
    void send_back_task_result_from_worker(std::size_t task) override;

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -15,6 +15,7 @@
 #include "RooMinimizer.h"
 #include "RooMsgService.h"
 #include "RooAbsPdf.h"
+#include "RooNaNPacker.h"
 
 #include <iomanip> // std::setprecision
 
@@ -133,58 +134,34 @@ void MinuitFcnGrad::syncOffsets() const
 
 double MinuitFcnGrad::operator()(const double *x) const
 {
-   bool parameters_changed = syncParameterValuesFromMinuitCalls(x, false);
+   syncParameterValuesFromMinuitCalls(x, false);
 
    syncOffsets();
 
    // Calculate the function for these parameters
-   //   RooAbsReal::setHideOffset(false);
    auto &likelihoodHere(_likelihoodInGradient && _gradient->isCalculating() ? *_likelihoodInGradient : *_likelihood);
    likelihoodHere.evaluate();
    double fvalue = likelihoodHere.getResult().Sum();
    _calculationIsClean->likelihood = true;
-   //   RooAbsReal::setHideOffset(true);
-
-   if (!parameters_changed) {
-      return fvalue;
-   }
 
    if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
-
-      if (cfg().printEvalErrors >= 0) {
-
-         if (cfg().doEEWall) {
-            oocoutW(nullptr, Eval) << "MinuitFcnGrad: Minimized function has error status." << std::endl
-                                   << "Returning maximum FCN so far (" << _maxFCN
-                                   << ") to force MIGRAD to back out of this region. Error log follows" << std::endl;
-         } else {
-            oocoutW(nullptr, Eval) << "MinuitFcnGrad: Minimized function has error status but is ignored" << std::endl;
-         }
-
-         bool first(true);
-         ooccoutW(nullptr, Eval) << "Parameter values: ";
-         for (auto *var : static_range_cast<const RooRealVar *>(*_floatParamList)) {
-            if (first) {
-               first = false;
-            } else {
-               ooccoutW(nullptr, Eval) << ", ";
-            }
-            ooccoutW(nullptr, Eval) << var->GetName() << "=" << var->getVal();
-         }
-         ooccoutW(nullptr, Eval) << std::endl;
-
-         RooAbsReal::printEvalErrors(ooccoutW(nullptr, Eval), cfg().printEvalErrors);
-         ooccoutW(nullptr, Eval) << std::endl;
-      }
-
-      if (cfg().doEEWall) {
-         fvalue = _maxFCN + 1;
-      }
-
+      printEvalErrors();
       RooAbsReal::clearEvalErrorLog();
       _numBadNLL++;
-   } else if (fvalue > _maxFCN) {
-      _maxFCN = fvalue;
+
+      if (cfg().doEEWall) {
+         const double badness = RooNaNPacker::unpackNaN(fvalue);
+         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + cfg().recoverFromNaN * badness;
+      }
+   } else {
+      if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
+         // This is the first time we get a valid function value; while before, the
+         // function was always invalid. For invalid  cases, we returned values > 0.
+         // Now, we offset valid values such that they are < 0.
+         _funcOffset = -fvalue;
+      }
+      fvalue += _funcOffset;
+      _maxFCN = std::max(fvalue, _maxFCN);
    }
 
    // Optional logging

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -144,25 +144,7 @@ double MinuitFcnGrad::operator()(const double *x) const
    double fvalue = likelihoodHere.getResult().Sum();
    _calculationIsClean->likelihood = true;
 
-   if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
-      printEvalErrors();
-      RooAbsReal::clearEvalErrorLog();
-      _numBadNLL++;
-
-      if (cfg().doEEWall) {
-         const double badness = RooNaNPacker::unpackNaN(fvalue);
-         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + cfg().recoverFromNaN * badness;
-      }
-   } else {
-      if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
-         // This is the first time we get a valid function value; while before, the
-         // function was always invalid. For invalid  cases, we returned values > 0.
-         // Now, we offset valid values such that they are < 0.
-         _funcOffset = -fvalue;
-      }
-      fvalue += _funcOffset;
-      _maxFCN = std::max(fvalue, _maxFCN);
-   }
+   fvalue = applyEvalErrorHandling(fvalue);
 
    // Optional logging
    if (cfg().verbose) {

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -115,10 +115,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
       if (mu <= 0 && N > 0) {
 
          // Catch error condition: data present where zero events are predicted
-//         logEvalError(Form("Observed %f events in bin %d with zero event yield", N, i));
-         // TODO: check if using regular stream vs logEvalError error gathering is ok
-         oocoutI(nullptr, Minimization)
-            << "Observed " << N << " events in bin " << i << " with zero event yield" << std::endl;
+         RooAbsReal::logEvalError(nullptr, GetName().c_str(), Form("Observed %f events in bin %zu with zero event yield", N, i));
 
       } else if (std::abs(mu) < 1e-10 && std::abs(N) < 1e-10) {
 

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -98,7 +98,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
        (cachedResult_.Sum() != 0 || cachedResult_.Carry() != 0))
       return cachedResult_;
 
-//   data->store()->recalculateCache(_projDeps, firstEvent, lastEvent, stepSize, (_binnedPdf?false:true));
+   //   data->store()->recalculateCache(_projDeps, firstEvent, lastEvent, stepSize, (_binnedPdf?false:true));
    // TODO: check when we might need _projDeps (it seems to be mostly empty); ties in with TODO below
    data_->store()->recalculateCache(nullptr, bins.begin(N_events_), bins.end(N_events_), 1, false);
 

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -52,8 +52,8 @@ RooBinnedL::RooBinnedL(RooAbsPdf *pdf, RooAbsData *data)
    pdf->setAttribute("BinnedLikelihoodActive");
 
    RooArgSet params;
-   pdf->getParameters(data->get(), params) ;
-   paramTracker_ = std::make_unique<RooChangeTracker>("chtracker","change tracker",params,true);
+   pdf->getParameters(data->get(), params);
+   paramTracker_ = std::make_unique<RooChangeTracker>("chtracker", "change tracker", params, true);
 
    std::unique_ptr<RooArgSet> obs(pdf->getObservables(data));
    if (obs->size() != 1) {
@@ -94,13 +94,16 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
    ROOT::Math::KahanSum<double> result;
 
    // Do not reevaluate likelihood if parameters nor event range have changed
-   if (!paramTracker_->hasChanged(true) && bins == lastSection_ && (cachedResult_.Sum() != 0 || cachedResult_.Carry() != 0)) return cachedResult_;
+   if (!paramTracker_->hasChanged(true) && bins == lastSection_ &&
+       (cachedResult_.Sum() != 0 || cachedResult_.Carry() != 0))
+      return cachedResult_;
 
 //   data->store()->recalculateCache(_projDeps, firstEvent, lastEvent, stepSize, (_binnedPdf?false:true));
    // TODO: check when we might need _projDeps (it seems to be mostly empty); ties in with TODO below
    data_->store()->recalculateCache(nullptr, bins.begin(N_events_), bins.end(N_events_), 1, false);
 
    ROOT::Math::KahanSum<double> sumWeight;
+   auto numEvalErrorsBefore = RooAbsReal::numEvalErrors();
 
    for (std::size_t i = bins.begin(N_events_); i < bins.end(N_events_); ++i) {
 
@@ -143,8 +146,12 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
       pdf_->wireAllCaches();
    }
 
-   cachedResult_ = result;
-   lastSection_ = bins;
+   if ((RooAbsReal::evalErrorLoggingMode() == RooAbsReal::CollectErrors ||
+        RooAbsReal::evalErrorLoggingMode() == RooAbsReal::CountErrors) &&
+       numEvalErrorsBefore == RooAbsReal::numEvalErrors()) {
+      cachedResult_ = result;
+      lastSection_ = bins;
+   }
    return result;
 }
 

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -118,7 +118,8 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
       if (mu <= 0 && N > 0) {
 
          // Catch error condition: data present where zero events are predicted
-         RooAbsReal::logEvalError(nullptr, GetName().c_str(), Form("Observed %f events in bin %zu with zero event yield", N, i));
+         RooAbsReal::logEvalError(nullptr, GetName().c_str(),
+                                  TString::Format("Observed %f events in bin %zu with zero event yield", N, i));
 
       } else if (std::abs(mu) < 1e-10 && std::abs(N) < 1e-10) {
 

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -192,6 +192,7 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
    // expensive than that, we tolerate the additional cost...
    ROOT::Math::KahanSum<double> result;
    double sumWeight;
+   auto numEvalErrorsBefore = RooAbsReal::numEvalErrors();
 
    // Do not reevaluate likelihood if parameters nor event range have changed
    if (!paramTracker_->hasChanged(true) && events == lastSection_ &&
@@ -228,8 +229,12 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
       pdf_->wireAllCaches();
    }
 
-   cachedResult_ = result;
-   lastSection_ = events;
+   if ((RooAbsReal::evalErrorLoggingMode() == RooAbsReal::CollectErrors ||
+        RooAbsReal::evalErrorLoggingMode() == RooAbsReal::CountErrors) &&
+       numEvalErrorsBefore == RooAbsReal::numEvalErrors()) {
+      cachedResult_ = result;
+      lastSection_ = events;
+   }
    return result;
 }
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -22,6 +22,7 @@
 #include "RooHelpers.h"
 #include "RooMinimizer.h"
 #include "RooFitResult.h"
+#include "RooGenericPdf.h"
 #include "RooFit/TestStatistics/LikelihoodWrapper.h"
 #include "RooFit/TestStatistics/RooUnbinnedL.h"
 #include "RooFit/TestStatistics/RooRealL.h"
@@ -29,8 +30,17 @@
 #include "RooFit/MultiProcess/JobManager.h"
 #include "RooFit/MultiProcess/Config.h"
 
+// for MinuitFcnGrad test:
+#include "RooFit/ModelConfig.h"
+#include "TFile.h"
+#include "RooRealSumPdf.h"
+#include "../../src/RooMinimizerFcn.h"
+#include "../../src/TestStatistics/MinuitFcnGrad.h"
+// end for MinuitFcnGrad test
+
 #include <ROOT/TestSupport.hxx>
 
+#include "TH1D.h"
 #include "Math/Minimizer.h"
 
 #include <stdexcept> // runtime_error
@@ -578,3 +588,421 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    }
 }
 #undef EXPECT_NEAR_REL
+
+class LikelihoodGradientJobErrorTest
+   : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t, bool, bool>> {
+   void SetUp() override
+   {
+      NWorkers = std::get<0>(GetParam());
+      seed = std::get<1>(GetParam());
+      parallelLikelihood = std::get<2>(GetParam());
+      binned = std::get<3>(GetParam());
+
+      RooRandom::randomGenerator()->SetSeed(seed);
+
+      // we want to split only over components so we can test component-offsets precisely
+      // (event-offsets give more variation)
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks = 1000000; // assuming components < 1000000: each component = 1 separate task
+   }
+
+   void TearDown() override
+   {
+      // reset static variables to automatic
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+         RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+         RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+
+      // cleanup to make sure JobManager is shut down after any test
+      RooMinimizer::cleanup();
+   }
+
+protected:
+   std::size_t NWorkers = 0;
+   std::size_t seed = 0;
+   bool parallelLikelihood = false;
+   bool binned = false;
+};
+
+TEST_P(LikelihoodGradientJobErrorTest, ErrorHandling)
+{
+   // In this test, we setup a model that we know will give evaluation errors, because Minuit will try parameters
+   // outside of the physical range during line search. Using the error handling mechanism in RooMinimizerFcn and
+   // MinuitFcnGrad, Minuit should get sent out of this area again.
+   // Specifically, this test triggers the classic error handling mechanism (logEvalError).
+
+   RooWorkspace w("w");
+   w.factory("ArgusBG::model(m[5.2,5.3],m0[5.28,5.2,5.3],c[-2,-10,0])");
+
+   RooAbsPdf *pdf = w.pdf("model");
+   std::unique_ptr<RooAbsData> data;
+   if (binned) {
+      data.reset(pdf->generateBinned(*w.var("m"), 10000));
+   } else {
+      data.reset(pdf->generate(*w.var("m"), 10000));
+   }
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::EvalBackend::Legacy())};
+
+   // if m0 were constant (i.e. setConstant(true)), the fit would converge without errors, because m0 outside of the
+   // physical area of the Argus distribution is what causes the errors in the line search phase of the fit
+   w.var("m0")->setConstant(false);
+
+   RooArgSet values{*w.var("m"), *w.var("m0"), *w.var("c"), "values"};
+   RooArgSet savedValues;
+   values.snapshot(savedValues);
+
+   RooMinimizer m0{*nll};
+
+   m0.setStrategy(0);
+   m0.setPrintLevel(-1);
+   m0.setVerbose(false);
+//   m0.setPrintEvalErrors(200);
+
+   m0.minimize("Minuit2", "migrad");
+
+   std::unique_ptr<RooFitResult> m0result{m0.save()};
+   double minNll0 = m0result->minNll();
+   double edm0 = m0result->edm();
+   double m_0 = w.var("m")->getVal();
+   double m0_0 = w.var("m0")->getVal();
+   double c_0 = w.var("c")->getVal();
+
+   values.assign(savedValues);
+
+   std::unique_ptr<RooAbsReal> likelihoodAbsReal{pdf->createNLL(*data, RooFit::ModularL(true))};
+
+   RooMinimizer::Config cfg;
+   cfg.parallelize = NWorkers;
+   cfg.enableParallelDescent = parallelLikelihood;
+//   cfg.printEvalErrors = 200;
+   RooMinimizer m1(*likelihoodAbsReal, cfg);
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
+
+   m1.setVerbose(false);
+
+   m1.minimize("Minuit2", "migrad");
+
+   std::unique_ptr<RooFitResult> m1result{m1.save()};
+   double minNll1 = m1result->minNll();
+   double edm1 = m1result->edm();
+   double m_1 = w.var("m")->getVal();
+   double m0_1 = w.var("m0")->getVal();
+   double c_1 = w.var("c")->getVal();
+
+   EXPECT_EQ(minNll0, minNll1);
+   EXPECT_EQ(edm0, edm1);
+   EXPECT_EQ(m_0, m_1);
+   EXPECT_EQ(m0_0, m0_1);
+   EXPECT_EQ(c_0, c_1);
+}
+
+// TODO: https://github.com/root-project/root/pull/12328 meenemen!
+
+/// Fit a simple linear function, that starts in the negative. Triggers RooNaNPacker error handling.
+TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
+{
+   RooRealVar x("x", "x", -10, 10);
+   RooRealVar a1("a1", "a1", 12., -5., 15.);
+   RooGenericPdf pdf("pdf", "a1 + x", RooArgSet(x, a1));
+   std::unique_ptr<RooAbsData> data;
+   if (binned) {
+      data.reset(pdf.generateBinned(x, 1000));
+   } else {
+      data.reset(pdf.generate(x, 1000));
+   }
+   std::unique_ptr<RooAbsReal> nll(pdf.createNLL(*data, RooFit::EvalBackend::Legacy()));
+
+   RooArgSet normSet{x};
+   ASSERT_FALSE(std::isnan(pdf.getVal(normSet)));
+   a1.setVal(-9.);
+   ASSERT_TRUE(std::isnan(pdf.getVal(normSet)));
+
+   RooMinimizer minim(*nll);
+   minim.setPrintLevel(-1);
+   minim.setVerbose(false);
+//   minim.setPrintEvalErrors(200);
+   minim.migrad();
+   minim.hesse();
+   std::unique_ptr<RooFitResult> fitResult{minim.save()};
+   auto a1Result = a1.getVal();
+
+   // now with multiprocess
+   std::unique_ptr<RooAbsReal> nll_mp(pdf.createNLL(*data, RooFit::ModularL(true)));
+
+   a1.setVal(-9.);
+   a1.removeError();
+   ASSERT_TRUE(std::isnan(pdf.getVal(normSet)));
+
+   RooMinimizer::Config cfg;
+   cfg.parallelize = NWorkers;
+   cfg.enableParallelDescent = parallelLikelihood;
+//   cfg.printEvalErrors = 200;
+
+   RooMinimizer minim_mp(*nll_mp, cfg);
+   minim_mp.setPrintLevel(-1);
+   minim_mp.setStrategy(0);
+   minim_mp.setVerbose(false);
+   minim_mp.migrad();
+   minim_mp.hesse();
+   std::unique_ptr<RooFitResult> fitResult_mp{minim_mp.save()};
+   auto a1Result_mp = a1.getVal();
+
+   EXPECT_EQ(fitResult_mp->status(), 0);
+   EXPECT_EQ(a1Result, a1Result_mp);
+   EXPECT_EQ(a1Result - a1Result_mp, 0);
+}
+
+// TODO: add error handling tests that trigger the RooNaNPacker error handling paths (see testNaNPacker for example
+//       setups). In particular a fit of a simultaneous or constrained likelihood to trigger the RooSumL path which has
+//       additional handling of the packed NaNs that isn't tested now.
+
+INSTANTIATE_TEST_SUITE_P(LikelihoodGradientJob, LikelihoodGradientJobErrorTest,
+                         ::testing::Combine(::testing::Values(1, 2, 3),      // number of workers
+                                            ::testing::Values(2, 3),         // random seed
+                                            ::testing::Values(false, true),  // with or without LikelihoodJob
+                                            ::testing::Values(false, true)), // binned or not
+                         [](testing::TestParamInfo<LikelihoodGradientJobErrorTest::ParamType> const &paramInfo) {
+                            std::stringstream ss;
+                            ss << std::get<0>(paramInfo.param) << "workers_seed" << std::get<1>(paramInfo.param)
+                               << (std::get<2>(paramInfo.param) ? "AlsoWithLikelihoodJob" : "NoLikelihoodJob")
+                               << (std::get<3>(paramInfo.param) ? "_Binned" : "_Unbinned");
+                            return ss.str();
+                         });
+
+class LikelihoodGradientJobBinnedErrorTest : public ::testing::TestWithParam<std::tuple<bool, std::size_t, bool>> {
+   void SetUp() override
+   {
+      do_error = std::get<0>(GetParam());
+      NWorkers = std::get<1>(GetParam());
+      parallelLikelihood = std::get<2>(GetParam());
+
+      RooRandom::randomGenerator()->SetSeed(20);
+
+      // we want to split only over components so we can test component-offsets precisely
+      // (event-offsets give more variation)
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+         1; // just one events task (i.e. don't split over events)
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+         1000000; // assuming components < 1000000: each component = 1 separate task
+   }
+
+   void TearDown() override
+   {
+      // reset static variables to automatic
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+         RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+         RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+
+      // cleanup to make sure JobManager is shut down after any test
+      RooMinimizer::cleanup();
+   }
+
+protected:
+   bool do_error = false;
+   std::size_t NWorkers = 0;
+   bool parallelLikelihood = false;
+};
+
+TEST_P(LikelihoodGradientJobBinnedErrorTest, TriggerMuLEZero)
+{
+   auto th_data = std::make_unique<TH1D>("h_data", "data", 10, 0, 10);
+   auto th_sig = std::make_unique<TH1D>("h_sig", "signal", 10, 0, 10);
+   auto th_bkg = std::make_unique<TH1D>("h_bkg", "background", 10, 0, 10);
+
+   for (int i = 0; i < 10; i++) {
+      th_data->SetBinContent(i + 1, i + 1);
+      th_sig->SetBinContent(i + 1, i);
+      th_bkg->SetBinContent(i + 1, 1);
+   }
+
+   if (do_error) {
+      // Trigger error condition by setting both sig and bkg
+      // to zero in bin zero, thus triggering a likelihood
+      // error since Poisson(N|0) is undefined
+      th_sig->SetBinContent(1, 0);
+      th_bkg->SetBinContent(1, 0);
+   }
+
+   RooWorkspace w("w");
+   auto x = w.factory("x[0,10]");
+   w.factory("index[A,B]");
+
+   dynamic_cast<RooRealVar *>(x)->setBins(10);
+
+   // we have to build a simultaneous binned likelihood to trigger the "binnedL" evaluation path
+
+   RooDataHist h_sigA("h_sigA", "h_sigA", *w.var("x"), th_sig.get());
+   RooDataHist h_sigB("h_sigB", "h_sigB", *w.var("x"), th_sig.get());
+   RooDataHist h_bkg("h_bkg", "h_bkg", *w.var("x"), th_bkg.get());
+
+   w.import(h_sigA);
+   w.import(h_sigB);
+   w.import(h_bkg);
+   w.factory("HistPdf::sigA(x,h_sigA)");
+   w.factory("HistPdf::sigB(x,h_sigB)");
+   w.factory("HistPdf::bkg(x,h_bkg)");
+
+   w.factory("ASUM::model_A(mu_sig[1,-1,10]*sigA,mu_bkg_A[1,-1,10]*bkg)");
+   w.factory("ASUM::model_B(mu_sig*sigB,mu_bkg_B[1,-1,10]*bkg)");
+
+   w.pdf("model_A")->setAttribute("BinnedLikelihood");
+   w.pdf("model_B")->setAttribute("BinnedLikelihood");
+
+   // Construct simulatenous pdf
+   w.factory("SIMUL::model(index[A,B],A=model_A,B=model_B)");
+
+   // Construct dataset
+   std::map<std::string, TH1 *> th_data_2D;
+   th_data_2D["A"] = th_data.get();
+   th_data_2D["B"] = th_data.get();
+   RooDataHist h_data("h_data", "h_data", *w.var("x"), *w.cat("index"), th_data_2D);
+
+   // store initial parameters for reuse in second fit
+   std::unique_ptr<RooArgSet> values(w.pdf("model")->getParameters(h_data));
+   RooArgSet savedValues;
+   values->snapshot(savedValues);
+
+   // legacy RooFit fit
+   std::unique_ptr<RooAbsReal> nll(w.pdf("model")->createNLL(h_data, RooFit::EvalBackend::Legacy()));
+   RooMinimizer m0{*nll};
+
+   double nll0BeforeFit = nll->getVal();
+
+   m0.setStrategy(0);
+   m0.setPrintLevel(-1);
+   m0.setVerbose(false);
+   //   m0.setPrintEvalErrors(200);
+
+   m0.minimize("Minuit2", "migrad");
+
+   std::unique_ptr<RooFitResult> m0result{m0.save()};
+   double minNll0 = m0result->minNll();
+   double mu_sig0 = w.var("mu_sig")->getVal();
+   double mu_bkg_A0 = w.var("mu_bkg_A")->getVal();
+   double mu_bkg_B0 = w.var("mu_bkg_B")->getVal();
+
+   values->assign(savedValues);
+
+   std::unique_ptr<RooAbsReal> likelihoodAbsReal{w.pdf("model")->createNLL(h_data, RooFit::ModularL(true))};
+
+   RooMinimizer::Config cfg;
+   cfg.parallelize = NWorkers;
+   cfg.enableParallelDescent = parallelLikelihood;
+//   cfg.printEvalErrors = 200;
+   RooMinimizer m1(*likelihoodAbsReal, cfg);
+
+   double nll1BeforeFit = likelihoodAbsReal->getVal();
+
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
+
+   m1.setVerbose(false);
+
+   m1.minimize("Minuit2", "migrad");
+
+   std::unique_ptr<RooFitResult> m1result{m1.save()};
+   double minNll1 = m1result->minNll();
+   double mu_sig1 = w.var("mu_sig")->getVal();
+   double mu_bkg_A1 = w.var("mu_bkg_A")->getVal();
+   double mu_bkg_B1 = w.var("mu_bkg_B")->getVal();
+
+   EXPECT_EQ(minNll0, minNll1);
+   if (do_error) {
+      EXPECT_NE(nll0BeforeFit, minNll0);
+   } else {
+      // These really should be equal, but on most platforms/builds, for some reason it
+      // isn't exactly. The exceptions are Apple ARM builds and some builds on x64 when
+      // using -march=native.
+      EXPECT_DOUBLE_EQ(nll0BeforeFit, minNll0);
+   }
+   EXPECT_EQ(nll0BeforeFit, nll1BeforeFit);
+   EXPECT_EQ(mu_sig0, mu_sig1);
+   EXPECT_EQ(mu_bkg_A0, mu_bkg_A1);
+   EXPECT_EQ(mu_bkg_B0, mu_bkg_B1);
+}
+
+INSTANTIATE_TEST_SUITE_P(LikelihoodGradientJob, LikelihoodGradientJobBinnedErrorTest,
+                         ::testing::Combine(::testing::Values(false, true), // trigger error or don't
+                                            ::testing::Values(1, 2, 3),     // number of workers
+                                            ::testing::Values(false, true)  // with or without LikelihoodJob
+                                            ),
+                         [](testing::TestParamInfo<LikelihoodGradientJobBinnedErrorTest::ParamType> const &paramInfo) {
+                            std::stringstream ss;
+                            ss << std::get<1>(paramInfo.param) << "workers"
+                               << (std::get<2>(paramInfo.param) ? "AlsoWithLikelihoodJob" : "NoLikelihoodJob")
+                               << (std::get<0>(paramInfo.param) ? "ErrorTriggered" : "");
+                            return ss.str();
+                         });
+
+TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
+{
+   const char* fname = "/Users/pbos/projects/roofit-ssi/benchmark_roofit/data/workspaces/HZy_split.root";
+   const char* dataset_name = "combData";
+
+   TFile *f = TFile::Open(fname);
+
+   RooWorkspace* w = (RooWorkspace*)f->Get("combWS");
+
+   // Fixes for known features, binned likelihood optimization
+   for (RooAbsArg *arg : w->components()) {
+      if (arg->IsA() == RooRealSumPdf::Class()) {
+         arg->setAttribute("BinnedLikelihood");
+         std::cout << "Activating binned likelihood attribute for "
+                   << arg->GetName() << std::endl;
+      }
+   }
+
+   RooAbsData* data = w->data(dataset_name);
+   auto mc = dynamic_cast<RooFit::ModelConfig *>(w->genobj("ModelConfig"));
+   auto global_observables = mc->GetGlobalObservables();
+   auto nuisance_parameters = mc->GetNuisanceParameters();
+   auto pdf = w->pdf(mc->GetPdf()->GetName());
+
+   std::unique_ptr<RooAbsReal> nll_modularL{pdf->createNLL(
+      *data, RooFit::Constrain(*nuisance_parameters),
+      RooFit::GlobalObservables(*global_observables), RooFit::ModularL(true))};
+
+   std::unique_ptr<RooAbsReal> nll_vanilla{pdf->createNLL(
+      *data, RooFit::Constrain(*nuisance_parameters),
+      RooFit::GlobalObservables(*global_observables), RooFit::EvalBackend::Legacy()
+      /*, RooFit::Offset(true)*/)};
+
+   double vanilla_val = nll_vanilla->getVal();
+   double modular_val = nll_modularL->getVal();
+
+   // sanity check
+   EXPECT_EQ(modular_val, vanilla_val);
+
+   // set up minimizers
+   RooMinimizer m_vanilla(*nll_vanilla);
+   // we want to split only over components so we can test component-offsets
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks = 1000000; // assuming components < 1000000: each component = 1 separate task
+   RooMinimizer::Config cfg;
+   cfg.parallelize = 1;
+   cfg.enableParallelDescent = false;
+   cfg.enableParallelGradient = true;
+   RooMinimizer m_modularL(*nll_modularL, cfg);
+
+   // now use these minimizers to build the corresponding external RooAbsMinimizerFcns
+   auto nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll_modularL.get());
+   RooFit::TestStatistics::MinuitFcnGrad modularL_fcn(nll_real->getRooAbsL(), &m_modularL,
+                                                      m_modularL.fitter()->Config().ParamsSettings(),
+                                                      cfg.enableParallelDescent ? RooFit::TestStatistics::LikelihoodMode::multiprocess : RooFit::TestStatistics::LikelihoodMode::serial,
+                                                      RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizerFcn vanilla_fcn(nll_vanilla.get(), &m_vanilla);
+
+   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()), modularL_fcn(modularL_fcn.getParameterValues().data()));
+   // let's also check with absolutely certain same parameter values, both of them
+   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()), modularL_fcn(vanilla_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(modularL_fcn.getParameterValues().data()), modularL_fcn(modularL_fcn.getParameterValues().data()));
+
+   // reset static variables to automatic
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+      RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+}

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -81,16 +81,27 @@ int main(int argc, char **argv)
    return RUN_ALL_TESTS();
 }
 
-class LikelihoodGradientJobTest : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t, bool>> {};
+class LikelihoodGradientJobTest : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t, bool>> {
+   void SetUp() override
+   {
+      NWorkers = std::get<0>(GetParam());
+      seed = std::get<1>(GetParam());
+      offsetting = std::get<2>(GetParam());
+
+      RooRandom::randomGenerator()->SetSeed(seed);
+   }
+
+   void TearDown() override { RooMinimizer::cleanup(); }
+
+protected:
+   std::size_t NWorkers = 0;
+   std::size_t seed = 0;
+   bool offsetting = false;
+};
 
 TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 {
    // do a minimization, but now using GradMinimizer and its MP version
-
-   // parameters
-   std::size_t NWorkers = std::get<0>(GetParam());
-   std::size_t seed = std::get<1>(GetParam());
-   bool offsetting = std::get<2>(GetParam());
 
    // in the 1D Gaussian tests, we suppress the positive definiteness
    // warnings coming from Minuit2 with offsetting; they are errors both
@@ -99,8 +110,6 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
    if (offsetting) {
       checkDiag.requiredDiag(kError, "Minuit2", "VariableMetricBuilder Initial matrix not pos.def.");
    }
-
-   RooRandom::randomGenerator()->SetSeed(seed);
 
    RooWorkspace w = RooWorkspace();
 
@@ -208,14 +217,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 {
    // do a minimization, but now using GradMinimizer and its MP version
 
-   // parameters
-   std::size_t NWorkers = std::get<0>(GetParam());
-   std::size_t seed = std::get<1>(GetParam());
-   bool offsetting = std::get<2>(GetParam());
-
    unsigned int N = 4;
-
-   RooRandom::randomGenerator()->SetSeed(seed);
 
    RooWorkspace w = RooWorkspace();
 
@@ -500,11 +502,6 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
 {
    // do a minimization, but now using GradMinimizer and its MP version
 
-   // parameters
-   std::size_t NWorkers = std::get<0>(GetParam());
-   std::size_t seed = std::get<1>(GetParam());
-   bool offsetting = std::get<2>(GetParam());
-
    // in the 1D Gaussian tests, we suppress the positive definiteness
    // warnings coming from Minuit2 with offsetting; they are errors both
    // in serial RooFit and in the MultiProcess-enabled back-end
@@ -512,8 +509,6 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    if (offsetting) {
       checkDiag.requiredDiag(kError, "Minuit2", "VariableMetricBuilder Initial matrix not pos.def.");
    }
-
-   RooRandom::randomGenerator()->SetSeed(seed);
 
    RooWorkspace w = RooWorkspace();
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -602,8 +602,10 @@ class LikelihoodGradientJobErrorTest
 
       // we want to split only over components so we can test component-offsets precisely
       // (event-offsets give more variation)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks = 1000000; // assuming components < 1000000: each component = 1 separate task
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+         1; // just one events task (i.e. don't split over events)
+      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+         1000000; // assuming components < 1000000: each component = 1 separate task
    }
 
    void TearDown() override
@@ -657,7 +659,7 @@ TEST_P(LikelihoodGradientJobErrorTest, ErrorHandling)
    m0.setStrategy(0);
    m0.setPrintLevel(-1);
    m0.setVerbose(false);
-//   m0.setPrintEvalErrors(200);
+   //   m0.setPrintEvalErrors(200);
 
    m0.minimize("Minuit2", "migrad");
 
@@ -675,7 +677,7 @@ TEST_P(LikelihoodGradientJobErrorTest, ErrorHandling)
    RooMinimizer::Config cfg;
    cfg.parallelize = NWorkers;
    cfg.enableParallelDescent = parallelLikelihood;
-//   cfg.printEvalErrors = 200;
+   //   cfg.printEvalErrors = 200;
    RooMinimizer m1(*likelihoodAbsReal, cfg);
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
@@ -722,7 +724,7 @@ TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
    RooMinimizer minim(*nll);
    minim.setPrintLevel(-1);
    minim.setVerbose(false);
-//   minim.setPrintEvalErrors(200);
+   //   minim.setPrintEvalErrors(200);
    minim.migrad();
    minim.hesse();
    std::unique_ptr<RooFitResult> fitResult{minim.save()};
@@ -738,7 +740,7 @@ TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
    RooMinimizer::Config cfg;
    cfg.parallelize = NWorkers;
    cfg.enableParallelDescent = parallelLikelihood;
-//   cfg.printEvalErrors = 200;
+   //   cfg.printEvalErrors = 200;
 
    RooMinimizer minim_mp(*nll_mp, cfg);
    minim_mp.setPrintLevel(-1);
@@ -891,7 +893,7 @@ TEST_P(LikelihoodGradientJobBinnedErrorTest, TriggerMuLEZero)
    RooMinimizer::Config cfg;
    cfg.parallelize = NWorkers;
    cfg.enableParallelDescent = parallelLikelihood;
-//   cfg.printEvalErrors = 200;
+   //   cfg.printEvalErrors = 200;
    RooMinimizer m1(*likelihoodAbsReal, cfg);
 
    double nll1BeforeFit = likelihoodAbsReal->getVal();
@@ -939,36 +941,35 @@ INSTANTIATE_TEST_SUITE_P(LikelihoodGradientJob, LikelihoodGradientJobBinnedError
 
 TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
 {
-   const char* fname = "/Users/pbos/projects/roofit-ssi/benchmark_roofit/data/workspaces/HZy_split.root";
-   const char* dataset_name = "combData";
+   const char *fname = "/Users/pbos/projects/roofit-ssi/benchmark_roofit/data/workspaces/HZy_split.root";
+   const char *dataset_name = "combData";
 
    TFile *f = TFile::Open(fname);
 
-   RooWorkspace* w = (RooWorkspace*)f->Get("combWS");
+   RooWorkspace *w = (RooWorkspace *)f->Get("combWS");
 
    // Fixes for known features, binned likelihood optimization
    for (RooAbsArg *arg : w->components()) {
       if (arg->IsA() == RooRealSumPdf::Class()) {
          arg->setAttribute("BinnedLikelihood");
-         std::cout << "Activating binned likelihood attribute for "
-                   << arg->GetName() << std::endl;
+         std::cout << "Activating binned likelihood attribute for " << arg->GetName() << std::endl;
       }
    }
 
-   RooAbsData* data = w->data(dataset_name);
+   RooAbsData *data = w->data(dataset_name);
    auto mc = dynamic_cast<RooFit::ModelConfig *>(w->genobj("ModelConfig"));
    auto global_observables = mc->GetGlobalObservables();
    auto nuisance_parameters = mc->GetNuisanceParameters();
    auto pdf = w->pdf(mc->GetPdf()->GetName());
 
-   std::unique_ptr<RooAbsReal> nll_modularL{pdf->createNLL(
-      *data, RooFit::Constrain(*nuisance_parameters),
-      RooFit::GlobalObservables(*global_observables), RooFit::ModularL(true))};
+   std::unique_ptr<RooAbsReal> nll_modularL{pdf->createNLL(*data, RooFit::Constrain(*nuisance_parameters),
+                                                           RooFit::GlobalObservables(*global_observables),
+                                                           RooFit::ModularL(true))};
 
-   std::unique_ptr<RooAbsReal> nll_vanilla{pdf->createNLL(
-      *data, RooFit::Constrain(*nuisance_parameters),
-      RooFit::GlobalObservables(*global_observables), RooFit::EvalBackend::Legacy()
-      /*, RooFit::Offset(true)*/)};
+   std::unique_ptr<RooAbsReal> nll_vanilla{pdf->createNLL(*data, RooFit::Constrain(*nuisance_parameters),
+                                                          RooFit::GlobalObservables(*global_observables),
+                                                          RooFit::EvalBackend::Legacy()
+                                                          /*, RooFit::Offset(true)*/)};
 
    double vanilla_val = nll_vanilla->getVal();
    double modular_val = nll_modularL->getVal();
@@ -979,8 +980,10 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
    // set up minimizers
    RooMinimizer m_vanilla(*nll_vanilla);
    // we want to split only over components so we can test component-offsets
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks = 1000000; // assuming components < 1000000: each component = 1 separate task
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+      1; // just one events task (i.e. don't split over events)
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      1000000; // assuming components < 1000000: each component = 1 separate task
    RooMinimizer::Config cfg;
    cfg.parallelize = 1;
    cfg.enableParallelDescent = false;
@@ -989,16 +992,20 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
 
    // now use these minimizers to build the corresponding external RooAbsMinimizerFcns
    auto nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll_modularL.get());
-   RooFit::TestStatistics::MinuitFcnGrad modularL_fcn(nll_real->getRooAbsL(), &m_modularL,
-                                                      m_modularL.fitter()->Config().ParamsSettings(),
-                                                      cfg.enableParallelDescent ? RooFit::TestStatistics::LikelihoodMode::multiprocess : RooFit::TestStatistics::LikelihoodMode::serial,
-                                                      RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooFit::TestStatistics::MinuitFcnGrad modularL_fcn(
+      nll_real->getRooAbsL(), &m_modularL, m_modularL.fitter()->Config().ParamsSettings(),
+      cfg.enableParallelDescent ? RooFit::TestStatistics::LikelihoodMode::multiprocess
+                                : RooFit::TestStatistics::LikelihoodMode::serial,
+      RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
    RooMinimizerFcn vanilla_fcn(nll_vanilla.get(), &m_vanilla);
 
-   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()), modularL_fcn(modularL_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()),
+             modularL_fcn(modularL_fcn.getParameterValues().data()));
    // let's also check with absolutely certain same parameter values, both of them
-   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()), modularL_fcn(vanilla_fcn.getParameterValues().data()));
-   EXPECT_EQ(vanilla_fcn(modularL_fcn.getParameterValues().data()), modularL_fcn(modularL_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()),
+             modularL_fcn(vanilla_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(modularL_fcn.getParameterValues().data()),
+             modularL_fcn(modularL_fcn.getParameterValues().data()));
 
    // reset static variables to automatic
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -141,13 +141,12 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 
    values->assign(savedValues);
 
-   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
                                                std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    // Convert to RooRealL to enter into minimizer
    RooMinimizer::Config cfg1;
-   cfg1.parallelize = -1;
+   cfg1.parallelize = NWorkers;
    RooMinimizer m1(likelihood, cfg1);
 
    m1.setStrategy(0);
@@ -192,11 +191,10 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
 
    // --------
 
-   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
                                                std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
-   cfg.parallelize = -1;
+   cfg.parallelize = NWorkers;
    RooMinimizer m1(likelihood, cfg);
 
    m1.setStrategy(0);
@@ -264,11 +262,10 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 
    // --------
 
-   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
                                                std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg1;
-   cfg1.parallelize = -1;
+   cfg1.parallelize = NWorkers;
    RooMinimizer m1(likelihood, cfg1);
 
    m1.setStrategy(0);
@@ -450,13 +447,11 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
 
    values->assign(savedValues);
 
-   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
-
    std::unique_ptr<RooAbsReal> likelihoodAbsReal{pdf->createNLL(
       *data, Constrain(*w.var("alpha_bkg_A")), GlobalObservables(*w.var("alpha_bkg_obs_B")), ModularL(true))};
 
    RooMinimizer::Config cfg1;
-   cfg1.parallelize = -1;
+   cfg1.parallelize = NWorkers;
    cfg1.enableParallelDescent = parallelLikelihood;
    RooMinimizer m1(*likelihoodAbsReal, cfg1);
 
@@ -541,11 +536,10 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
 
    values->assign(savedValues);
 
-   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
                                                std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
-   cfg.parallelize = -1;
+   cfg.parallelize = NWorkers;
    cfg.enableParallelDescent = true;
    RooMinimizer m1(likelihood, cfg);
    m1.setStrategy(0);

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cxx
@@ -76,9 +76,8 @@ public:
 
       // Creating a minimizer and explicitly setting type of parallelization
       std::size_t nWorkers = 1;
-      RooFit::MultiProcess::Config::setDefaultNWorkers(nWorkers);
       RooMinimizer::Config cfg;
-      cfg.parallelize = -1;
+      cfg.parallelize = nWorkers;
       cfg.enableParallelDescent = false;
       cfg.enableParallelGradient = true;
       RooMinimizer m(*likelihood, cfg);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR mainly adds error handling to the `MultiProcess`-based fitting stack. Error signaling in RooFit happens through two mechanisms: `logEvalError` calls and `RooNaNPacker`-enhanced `nan` doubles. Both are now implemented and working.

With this addition, we can now (finally!) run the most recent ATLAS Higgs combination fits again without issues.

The actual error handling is implemented in the 5th commit of this PR.

The first two commits are really unrelated, minor refactorings of existing code. I add them in this PR because I touched these while working on the error handling and just wanted to rebase to keep history clean and don't think they need a separate PR, since they are quite trivial changes.

The same goes for the last commit; it's a refactoring that could have been done in a different PR, but I hope you will permit this shortcut for these three trivial commits ;)

Finally, commit 3 and 4 add tests. I kept these commits separate mainly for reviewing and also for my testing convenience (I wanted to double check they indeed fail before applying commit 5). If you prefer, we can squash commits 3, 4 and 5 before we merge.

## Checklist:

- [x] tested changes locally
- [ ] ~updated the docs (if necessary)~ _There are no user-facing changes (except that more things now work), everything happens behind the scenes, so no documentation updates are necessary._

Thanks to @Zeff020 and @guitargeek for help in getting this done!