### PR TITLE
[pyroot] Add __firstlineno__ and __static_attributes__ to blacklist

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
@@ -122,7 +122,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
     any of its base classes (except for `object`).
     """
 
-    blacklist = ["__dict__", "__doc__", "__hash__", "__module__", "__weakref__"]
+    blacklist = ["__dict__", "__doc__", "__hash__", "__module__", "__weakref__", "__firstlineno__", "__static_attributes__"]
 
     if not consider_base_classes:
         return sorted([attr for attr in klass.__dict__.keys() if attr not in blacklist])

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
@@ -69,7 +69,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
     any of its base classes (except for `object`).
     """
 
-    blacklist = ["__dict__", "__doc__", "__hash__", "__module__", "__weakref__"]
+    blacklist = ["__dict__", "__doc__", "__hash__", "__module__", "__weakref__", "__firstlineno__", "__static_attributes__"]
 
     if not consider_base_classes:
         return sorted([attr for attr in klass.__dict__.keys() if attr not in blacklist])


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

For compatibility with Python 3.13

See: https://docs.python.org/3.13/whatsnew/3.13.html

From the above page:

* Classes have a new __firstlineno__ attribute, populated by the compiler, with the line number of the first line of the class definition. (Contributed by Serhiy Storchaka in gh-118465.)

* Classes have a new __static_attributes__ attribute, populated by the compiler, with a tuple of names of attributes of this class which are accessed through self.X from any function in its body. (Contributed by Irit Katriel in gh-115775.)

Without adding the new attributes to the blacklist there are errors:

AttributeError: 'int' object attribute 'doc' is read-only from the __firstlineno__ attribute.

AttributeError: 'tuple' object attribute 'doc' is read-only from the __static_attributes__ attribute.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #15430
