### PR TITLE
[ci] Optimize total build action time acting on compression of artifacts and releases

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -46,8 +46,7 @@ except Exception as exc:
 
 WINDOWS = (os.name == 'nt')
 WORKDIR = (os.environ['HOME'] + '/ROOT-CI') if not WINDOWS else 'C:/ROOT-CI'
-COMPRESSIONLEVEL = 6 if not WINDOWS else 1
-
+COMPRESSIONLEVEL = 1 if WINDOWS else 2
 
 def main():
     # openstack.enable_logging(debug=True)

--- a/cmake/modules/RootCPack.cmake
+++ b/cmake/modules/RootCPack.cmake
@@ -146,8 +146,9 @@ elseif(APPLE)
   set(CPACK_GENERATOR "TGZ;productbuild")
   set(CPACK_SOURCE_GENERATOR "TGZ;TBZ2")
 else()
-  set(CPACK_GENERATOR "TGZ")
-  set(CPACK_SOURCE_GENERATOR "TGZ;TBZ2")
+  set(CPACK_THREADS 8)
+  set(CPACK_GENERATOR "ZSTD")
+  set(CPACK_SOURCE_GENERATOR "ZSTD")
 endif()
 
 #----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Two optimizations fro the ci:
1) Use zstd with 8 threads to compress ROOT builds for nightlies and releases.
2) Use gzip compression level 2 instead of level 6 to compress artifacts.