### PR TITLE
[PyROOT] Implement TTree SetBranchAddress pythonization in Python

### DIFF
--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -48,8 +48,6 @@ static PyMethodDef gPyROOTMethods[] = {
     (char *)"Cast the void* returned by TClass::DynamicCast to the right type"},
    {(char *)"AddTObjectEqNePyz", (PyCFunction)PyROOT::AddTObjectEqNePyz, METH_VARARGS,
     (char *)"Add equality and inequality comparison operators to TObject"},
-   {(char *)"SetBranchAddressPyz", (PyCFunction)PyROOT::SetBranchAddressPyz, METH_VARARGS,
-    (char *)"Fully enable the use of TTree::SetBranchAddress from Python"},
    {(char *)"BranchPyz", (PyCFunction)PyROOT::BranchPyz, METH_VARARGS,
     (char *)"Fully enable the use of TTree::Branch from Python"},
    {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,

--- a/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
+++ b/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
@@ -22,7 +22,6 @@ PyObject *AddPrettyPrintingPyz(PyObject *self, PyObject *args);
 
 PyObject *GetBranchAttr(PyObject *self, PyObject *args);
 PyObject *BranchPyz(PyObject *self, PyObject *args);
-PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 
 PyObject *AddTClassDynamicCastPyz(PyObject *self, PyObject *args);
 


### PR DESCRIPTION
The pythonization of `TTree::SetBranchAddress` was implemented in C++, hacking into CPyCppy by using implementation details like data member caches (this call: `((CPPInstance *)address)GetDatamemberCache()`). Not too surprising that it apparently breaks with the upcoming Python 3.13.

It's better to implement the pythonizations in Python and also manage the lifetime of the necessary data in Python. This is done in this commit.

The pythonization is extensively tested in `ttree_setbranchaddress.py`.

Closes #15799.