### PR TITLE
[RF] Clean HS3 roundtripping of RooExponential and RooLogNormal

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -181,11 +181,7 @@ public:
 
    void queueExport(RooAbsArg const &arg) { _serversToExport.push_back(&arg); }
 
-   RooFit::Detail::JSONNode &createAdHoc(const std::string &toplevel, const std::string &name);
-   RooAbsReal *importTransformed(const std::string &name, const std::string &tag, const std::string &operation_name,
-                                 const std::string &formula);
-   std::string exportTransformed(const RooAbsReal *original, const std::string &tag, const std::string &operation_name,
-                                 const std::string &formula);
+   std::string exportTransformed(const RooAbsReal *original, const std::string &suffix, const std::string &formula);
 
    void setAttribute(const std::string &obj, const std::string &attrib);
    bool hasAttribute(const std::string &obj, const std::string &attrib);

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -194,6 +194,20 @@ private:
 
    void exportObject(RooAbsArg const &func, std::set<std::string> &exportedObjectNames);
 
+   // To export multiple objects sorted alphabetically
+   template <class T>
+   void exportObjects(T const &args, std::set<std::string> &exportedObjectNames)
+   {
+      RooArgSet argSet;
+      for (RooAbsArg const *arg : args) {
+         argSet.add(*arg);
+      }
+      argSet.sort();
+      for (RooAbsArg *arg : argSet) {
+         exportObject(*arg, exportedObjectNames);
+      }
+   }
+
    void exportData(RooAbsData const &data);
    RooJSONFactoryWSTool::CombinedData exportCombinedData(RooAbsData const &data);
 

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -35,6 +35,8 @@
 #include <RooTFnBinding.h>
 #include <RooWorkspace.h>
 
+#include "JSONIOUtils.h"
+
 #include <TF1.h>
 #include <TH1.h>
 
@@ -237,12 +239,18 @@ public:
    {
       std::string name(RooJSONFactoryWSTool::name(p));
       RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
-      RooAbsReal *mu = tool->requestArg<RooAbsReal>(p, "mu");
-      RooAbsReal *sigma = tool->requestArg<RooAbsReal>(p, "sigma");
 
-      // TODO: check if the pdf was originally exported by ROOT, in which case
-      // it can be imported back without using the standard parametrization.
-      tool->wsEmplace<RooLognormal>(name, *x, *mu, *sigma, true);
+      // Same mechanism to undo the parameter transformation as in the
+      // RooExponentialFactory (see comments in that class for more info).
+      const std::string muName = p["mu"].val();
+      const std::string sigmaName = p["sigma"].val();
+      const bool isTransformed = endsWith(muName, "_lognormal_log");
+      const std::string suffixToRemove = isTransformed ? "_lognormal_log" : "";
+      RooAbsReal *mu = tool->request<RooAbsReal>(removeSuffix(muName, suffixToRemove), name);
+      RooAbsReal *sigma = tool->request<RooAbsReal>(removeSuffix(sigmaName, suffixToRemove), name);
+
+      tool->wsEmplace<RooLognormal>(name, *x, *mu, *sigma, !isTransformed);
+
       return true;
    }
 };
@@ -253,11 +261,45 @@ public:
    {
       std::string name(RooJSONFactoryWSTool::name(p));
       RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
-      RooAbsReal *c = tool->requestArg<RooAbsReal>(p, "c");
 
-      // TODO: check if the pdf was originally exported by ROOT, in which case
-      // it can be imported back without using the standard parametrization.
-      tool->wsEmplace<RooExponential>(name, *x, *c, true);
+      // If the parameter name ends with the "_exponential_inverted" suffix,
+      // this means that it was exported from a RooFit object where the
+      // parameter first needed to be transformed on export to match the HS3
+      // specification. But when re-importing such a parameter, we can simply
+      // skip the transformation and use the original RooFit parameter without
+      // the suffix.
+      //
+      // A concrete example: take the following RooFit pdf in the factory language:
+      //
+      //    "Exponential::exponential_1(x[0, 10], c[-0.1])"
+      //
+      //  It defines en exponential exp(c * x). However, in HS3 the exponential
+      //  is defined as exp(-c * x), to RooFit would export these dictionaries
+      //  to the JSON:
+      //
+      //  {
+      //      "name": "exponential_1",             // HS3 exponential_dist with transformed parameter
+      //      "type": "exponential_dist",
+      //      "x": "x",
+      //      "c": "c_exponential_inverted"
+      //  },
+      //  {
+      //      "name": "c_exponential_inverted",    // transformation function created on-the-fly on export
+      //      "type": "generic_function",
+      //      "expression": "-c"
+      //  }
+      //
+      //  On import, we can directly take the non-transformed parameter, which is
+      //  we check for the suffix and optionally remove it from the requested
+      //  name next:
+
+      const std::string constParamName = p["c"].val();
+      const bool isInverted = endsWith(constParamName, "_exponential_inverted");
+      const std::string suffixToRemove = isInverted ? "_exponential_inverted" : "";
+      RooAbsReal *c = tool->request<RooAbsReal>(removeSuffix(constParamName, suffixToRemove), name);
+
+      tool->wsEmplace<RooExponential>(name, *x, *c, !isInverted);
+
       return true;
    }
 };
@@ -562,12 +604,12 @@ public:
       auto &m0 = pdf->getMedian();
       auto &k = pdf->getShapeK();
 
-      if(pdf->useStandardParametrization()) {
+      if (pdf->useStandardParametrization()) {
          elem["mu"] << m0.GetName();
          elem["sigma"] << k.GetName();
       } else {
-         elem["mu"] << tool->exportTransformed(&m0, "lognormal", "log", "log(%s)");
-         elem["sigma"] << tool->exportTransformed(&k, "lognormal", "log", "log(%s)");
+         elem["mu"] << tool->exportTransformed(&m0, "_lognormal_log", "log(%s)");
+         elem["sigma"] << tool->exportTransformed(&k, "_lognormal_log", "log(%s)");
       }
 
       return true;
@@ -586,7 +628,7 @@ public:
       if (pdf->negateCoefficient()) {
          elem["c"] << c.GetName();
       } else {
-         elem["c"] << tool->exportTransformed(&c, "exponential", "inverted", "-%s");
+         elem["c"] << tool->exportTransformed(&c, "_exponential_inverted", "-%s");
       }
 
       return true;

--- a/roofit/hs3/src/JSONIOUtils.cxx
+++ b/roofit/hs3/src/JSONIOUtils.cxx
@@ -1,5 +1,7 @@
 #include "JSONIOUtils.h"
 
+#include <string>
+
 using RooFit::Detail::JSONNode;
 using RooFit::Detail::JSONTree;
 
@@ -11,6 +13,21 @@ bool startsWith(std::string_view str, std::string_view prefix)
 bool endsWith(std::string_view str, std::string_view suffix)
 {
    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+std::string removePrefix(std::string_view str, std::string_view prefix)
+{
+   std::string out;
+   out += str;
+   out = out.substr(prefix.length());
+   return out;
+}
+std::string removeSuffix(std::string_view str, std::string_view suffix)
+{
+   std::string out;
+   out += str;
+   out = out.substr(0, out.length() - suffix.length());
+   return out;
 }
 
 std::unique_ptr<RooFit::Detail::JSONTree> varJSONString(const JSONNode &treeRoot)

--- a/roofit/hs3/src/JSONIOUtils.h
+++ b/roofit/hs3/src/JSONIOUtils.h
@@ -6,6 +6,8 @@
 
 bool startsWith(std::string_view str, std::string_view prefix);
 bool endsWith(std::string_view str, std::string_view suffix);
+std::string removePrefix(std::string_view str, std::string_view prefix);
+std::string removeSuffix(std::string_view str, std::string_view suffix);
 std::unique_ptr<RooFit::Detail::JSONTree> varJSONString(const RooFit::Detail::JSONNode &treeRoot);
 
 #endif

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -606,8 +606,7 @@ void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, cons
    std::vector<std::string> nllDistNames = valsToStringVec((*nllNode)["distributions"]);
    RooArgSet extConstraints;
    for (auto &nameNode : (*nllNode)["aux_distributions"].children()) {
-      RooAbsArg *extConstraint = workspace.arg(nameNode.val());
-      if (extConstraint) {
+      if (RooAbsArg *extConstraint = workspace.arg(nameNode.val())) {
          extConstraints.add(*extConstraint);
       }
    }
@@ -989,9 +988,7 @@ void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::str
    if (auto simPdf = dynamic_cast<RooSimultaneous const *>(&func)) {
       // RooSimultaneous is not used in the HS3 standard, we only export the
       // dependents and some ROOT internal information.
-      for (RooAbsArg *s : func.servers()) {
-         this->exportObject(*s, exportedObjectNames);
-      }
+      exportObjects(func.servers(), exportedObjectNames);
 
       std::vector<std::string> channelNames;
       for (auto const &item : simPdf->indexCat()) {
@@ -1040,13 +1037,9 @@ void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::str
             continue;
          }
          if (exp->autoExportDependants()) {
-            for (RooAbsArg *s : func.servers()) {
-               this->exportObject(*s, exportedObjectNames);
-            }
+            exportObjects(func.servers(), exportedObjectNames);
          } else {
-            for (RooAbsArg const *s : _serversToExport) {
-               this->exportObject(*s, exportedObjectNames);
-            }
+            exportObjects(_serversToExport, exportedObjectNames);
          }
          return;
       }
@@ -1758,9 +1751,7 @@ void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
    }
    sortByName(allpdfs);
    std::set<std::string> exportedObjectNames;
-   for (RooAbsPdf *p : allpdfs) {
-      this->exportObject(*p, exportedObjectNames);
-   }
+   exportObjects(allpdfs, exportedObjectNames);
 
    // export attributes of all objects
    for (RooAbsArg *arg : _workspace.components()) {

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -37,10 +37,6 @@ public:
          virtual bool equal(const Impl &other) const = 0;
       };
 
-   private:
-      std::unique_ptr<Impl> it;
-
-   public:
       child_iterator_t(std::unique_ptr<Impl> impl) : it(std::move(impl)) {}
       child_iterator_t(const child_iterator_t &other) : it(std::move(other.it->clone())) {}
 
@@ -65,6 +61,9 @@ public:
       {
          return lhs.it->equal(*rhs.it);
       }
+
+   private:
+      std::unique_ptr<Impl> it;
    };
 
    using child_iterator = child_iterator_t<JSONNode>;


### PR DESCRIPTION
Make sure that when transforming workspaces with these classes, roundtripping from RooFit -> JSON -> RooFit -> JSON leaves both the RooFit workspace and the JSON unchanged.

Closes #15756.