### PR TITLE
[math] Use correct type when invoking the GSLIntegrator

### DIFF
--- a/math/mathcore/src/Integrator.cxx
+++ b/math/mathcore/src/Integrator.cxx
@@ -163,7 +163,7 @@ VirtualIntegratorOneDim * IntegratorOneDim::CreateIntegrator(IntegrationOneDim::
          // plugin manager requires a string
          std::string typeName = GetName(type);
 
-         ig = reinterpret_cast<ROOT::Math::VirtualIntegratorOneDim *>( h->ExecPlugin(5,typeName.c_str(), rule, absTol, relTol, size ) );
+         ig = reinterpret_cast<ROOT::Math::VirtualIntegratorOneDim *>( h->ExecPlugin(5,typeName.c_str(), rule, absTol, relTol, (size_t) size ) );
          assert(ig != nullptr);
       }
 #ifdef DEBUG


### PR DESCRIPTION
plugin, otherwise heavy checks in the PluginHandler take place that perform interpreter lookups.

Fixes #15579

