### PR TITLE
Deprecate ECompressionAlgorithm

### DIFF
--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -13,6 +13,7 @@
 #define ROOT_Compression
 
 #include "RtypesCore.h"
+#include "ROOT/RConfig.hxx"
 
 #include <string>
 
@@ -52,7 +53,8 @@ struct RCompressionSetting {
          kUseCompiledDefault = 101,
          /// Use the default analysis setting; fast reading but poor compression ratio
          kUseAnalysis = 404,
-         /// Use the new recommended general-purpose setting; it is a best trade-off between compression ratio/decompression speed
+         /// Use the new recommended general-purpose setting; it is a best trade-off between compression
+         /// ratio/decompression speed
          kUseGeneralPurpose = 505,
          /// Use the setting that results in the smallest files; very slow read and write
          kUseSmallest = 207,
@@ -72,7 +74,8 @@ struct RCompressionSetting {
          kDefaultZLIB = 1,
          /// Compression level reserved for LZ4 compression algorithm (trade-off between file ratio/decompression speed)
          kDefaultLZ4 = 4,
-         /// Compression level reserved for ZSTD compression algorithm (trade-off between file ratio/decompression speed)
+         /// Compression level reserved for ZSTD compression algorithm (trade-off between file ratio/decompression
+         /// speed)
          kDefaultZSTD = 5,
          /// Compression level reserved for old ROOT compression algorithm
          kDefaultOld = 6,
@@ -81,7 +84,7 @@ struct RCompressionSetting {
       };
    };
    struct EAlgorithm { /// Note: this is only temporarily a struct and will become a enum class hence the name
-                        /// convention used.
+                       /// convention used.
       enum EValues {
          /// Some objects use this value to denote that the compression algorithm
          /// should be inherited from the parent object (e.g., TBranch should get the algorithm from the TTree)
@@ -106,28 +109,24 @@ struct RCompressionSetting {
    static std::string AlgorithmToString(EAlgorithm::EValues algorithm);
 };
 
-enum ECompressionAlgorithm {
-   /// Deprecated name, do *not* use:
-   kUseGlobalCompressionSetting = RCompressionSetting::EAlgorithm::kUseGlobal,
-   /// Deprecated name, do *not* use:
-   kUseGlobalSetting = RCompressionSetting::EAlgorithm::kUseGlobal,
-   /// Deprecated name, do *not* use:
-   kZLIB = RCompressionSetting::EAlgorithm::kZLIB,
-   /// Deprecated name, do *not* use:
-   kLZMA = RCompressionSetting::EAlgorithm::kLZMA,
-   /// Deprecated name, do *not* use:
-   kOldCompressionAlgo = RCompressionSetting::EAlgorithm::kOldCompressionAlgo,
-   /// Deprecated name, do *not* use:
-   kLZ4 = RCompressionSetting::EAlgorithm::kLZ4,
-   /// Deprecated name, do *not* use:
-   kZSTD = RCompressionSetting::EAlgorithm::kZSTD,
-   /// Deprecated name, do *not* use:
-   kUndefinedCompressionAlgorithm = RCompressionSetting::EAlgorithm::kUndefined
+// clang-format off
+enum R__DEPRECATED(6, 34, "Use RCompressionSetting instead") ECompressionAlgorithm {
+   kUseGlobalCompressionSetting = static_cast<int>(RCompressionSetting::EAlgorithm::kUseGlobal),
+   kUseGlobalSetting = static_cast<int>(RCompressionSetting::EAlgorithm::kUseGlobal),
+   kZLIB = static_cast<int>(RCompressionSetting::EAlgorithm::kZLIB),
+   kLZMA = static_cast<int>(RCompressionSetting::EAlgorithm::kLZMA),
+   kOldCompressionAlgo = static_cast<int>(RCompressionSetting::EAlgorithm::kOldCompressionAlgo),
+   kLZ4 = static_cast<int>(RCompressionSetting::EAlgorithm::kLZ4),
+   kZSTD = static_cast<int>(RCompressionSetting::EAlgorithm::kZSTD),
+   kUndefinedCompressionAlgorithm = static_cast<int>(RCompressionSetting::EAlgorithm::kUndefined)
 };
 
 int CompressionSettings(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel);
-/// Deprecated name, do *not* use:
-int CompressionSettings(ROOT::ECompressionAlgorithm algorithm, int compressionLevel);
+
+int CompressionSettings(ROOT::ECompressionAlgorithm algorithm, int compressionLevel)
+   R__DEPRECATED(6, 34, "Use the overload accepting RCompressionSetting::EAlgorithm instead");
+// clang-format on
+
 } // namespace ROOT
 
 #endif

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -1247,7 +1247,7 @@ void stress10()
       snprintf(filename,20,"Event_%d.root",file);
       chfile[file] = new TFile(filename,"recreate");
       if (file>=5) {
-         chfile[file]->SetCompressionAlgorithm(ROOT::kLZMA);
+         chfile[file]->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
       }
       chTree[file] = (TTree*)tree->CloneTree(0);
    }

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -35,14 +35,6 @@ struct RSnapshotOptions {
         fOverwriteIfExists(overwriteIfExists)
    {
    }
-   [[deprecated("Use the overload accepting a ROOT::RCompressionSetting::EAlgorithm for the `comprAlgo` parameter "
-                "instead")]] RSnapshotOptions(std::string_view mode, Int_t comprAlgo, int comprLevel, int autoFlush,
-                                              int splitLevel, bool lazy, bool overwriteIfExists = false)
-      : RSnapshotOptions(mode, static_cast<ECAlgo>(comprAlgo), comprLevel, autoFlush, splitLevel, lazy,
-
-                         overwriteIfExists)
-   {
-   }
    std::string fMode = "RECREATE"; ///< Mode of creation of output file
    ECAlgo fCompressionAlgorithm =
       ROOT::RCompressionSetting::EAlgorithm::kZLIB; ///< Compression algorithm of output file

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -20,7 +20,7 @@ namespace ROOT {
 namespace RDF {
 /// A collection of options to steer the creation of the dataset on file
 struct RSnapshotOptions {
-   using ECAlgo = ROOT::ECompressionAlgorithm;
+   using ECAlgo = ROOT::RCompressionSetting::EAlgorithm::EValues;
    RSnapshotOptions() = default;
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
@@ -35,12 +35,21 @@ struct RSnapshotOptions {
         fOverwriteIfExists(overwriteIfExists)
    {
    }
-   std::string fMode = "RECREATE";             ///< Mode of creation of output file
-   ECAlgo fCompressionAlgorithm = ROOT::kZLIB; ///< Compression algorithm of output file
-   int fCompressionLevel = 1;                  ///< Compression level of output file
-   int fAutoFlush = 0;                         ///< AutoFlush value for output tree
-   int fSplitLevel = 99;                       ///< Split level of output tree
-   bool fLazy = false;                         ///< Do not start the event loop when Snapshot is called
+   [[deprecated("Use the overload accepting a ROOT::RCompressionSetting::EAlgorithm for the `comprAlgo` parameter "
+                "instead")]] RSnapshotOptions(std::string_view mode, Int_t comprAlgo, int comprLevel, int autoFlush,
+                                              int splitLevel, bool lazy, bool overwriteIfExists = false)
+      : RSnapshotOptions(mode, static_cast<ECAlgo>(comprAlgo), comprLevel, autoFlush, splitLevel, lazy,
+
+                         overwriteIfExists)
+   {
+   }
+   std::string fMode = "RECREATE"; ///< Mode of creation of output file
+   ECAlgo fCompressionAlgorithm =
+      ROOT::RCompressionSetting::EAlgorithm::kZLIB; ///< Compression algorithm of output file
+   int fCompressionLevel = 1;                       ///< Compression level of output file
+   int fAutoFlush = 0;                              ///< AutoFlush value for output tree
+   int fSplitLevel = 99;                            ///< Split level of output tree
+   bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
    bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
 };
 } // namespace RDF

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 ROOT_ADD_GTEST(dataframe_splitcoll_arrayview dataframe_splitcoll_arrayview.cxx LIBRARIES ROOTDataFrame)
 target_include_directories(dataframe_splitcoll_arrayview PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-ROOT_GENERATE_DICTIONARY(TwoFloatsDict ${CMAKE_CURRENT_SOURCE_DIR}/TwoFloats.h MODULE dataframe_splitcoll_arrayview LINKDEF TwoFloatsLinkDef.h OPTIONS -inlineInputHeader)
+ROOT_GENERATE_DICTIONARY(TwoFloatsDict ${CMAKE_CURRENT_SOURCE_DIR}/TwoFloats.h MODULE dataframe_splitcoll_arrayview LINKDEF TwoFloatsLinkDef.h OPTIONS -inlineInputHeader DEPENDENCIES RIO)
 
 ROOT_ADD_GTEST(dataframe_redefine dataframe_redefine.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_definepersample dataframe_definepersample.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/dataframe_cache.cxx
+++ b/tree/dataframe/test/dataframe_cache.cxx
@@ -1,6 +1,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/TSeq.hxx"
 #include "ROOT/RTrivialDS.hxx"
+#include "Compression.h"
 #include "TH1F.h"
 #include "TRandom.h"
 #include "TSystem.h"
@@ -142,7 +143,8 @@ TEST(Cache, InternalColumnsSnapshot)
    auto colName = "tdfMySecretcol_";
    auto orig = tdf.Define(colName, [&f]() { return f++; }).Define("dummy", []() { return 0.f; });
    auto cached = orig.Cache<float, float>({colName, "dummy"});
-   auto snapshot = cached.Snapshot("t", "InternalColumnsSnapshot.root", "", {"RECREATE", ROOT::kZLIB, 0, 0, 99, false});
+   auto snapshot = cached.Snapshot("t", "InternalColumnsSnapshot.root", "",
+                                   {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kZLIB, 0, 0, 99, false});
 
    auto op = [&]() {
       testing::internal::CaptureStderr();

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -21,6 +21,7 @@
 #include <set>
 #include <random>
 
+#include "Compression.h"
 #include "MaxSlotHelper.h"
 #include "SimpleFiller.h"
 
@@ -821,7 +822,8 @@ TEST_P(RDFSimpleTests, DifferentTreesInDifferentThreads)
       auto df = RDataFrame(64)
                    .Define("x", []() { return 1; })
                    .Define("y", []() { return 1; })
-                   .Snapshot<int, int>(treename, filename, {"x", "y"}, {"RECREATE", ROOT::kZLIB, 4, 2, 99, false});
+                   .Snapshot<int, int>(treename, filename, {"x", "y"},
+                                       {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kZLIB, 4, 2, 99, false});
    }
 
    TFile f(filename);
@@ -859,7 +861,8 @@ TEST_P(RDFSimpleTests, ManyRangesPerWorker)
    {
       ROOT::RDataFrame(184)
          .Define("i", []() { return 0; })
-         .Snapshot<int>("t", filename, {"i"}, {"RECREATE", ROOT::kZLIB, 1, 1, 99, false});
+         .Snapshot<int>("t", filename, {"i"},
+                        {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kZLIB, 1, 1, 99, false});
    }
    ROOT::RDataFrame("t", filename).Mean<int>("i");
    gSystem->Unlink(filename);

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -2,6 +2,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RTrivialDS.hxx"
 #include "ROOT/TSeq.hxx"
+#include "Compression.h"
 #include "TFile.h"
 #include "TROOT.h"
 #include "TSystem.h"
@@ -231,7 +232,8 @@ void test_snapshot_options(RInterface<RLoopManager> &tdf)
    opts.fCompressionLevel = 6;
 
    const auto outfile = "snapshot_test_opts.root";
-   for (auto algorithm : {ROOT::kZLIB, ROOT::kLZMA, ROOT::kLZ4, ROOT::kZSTD}) {
+   using RCAlgo = ROOT::RCompressionSetting::EAlgorithm;
+   for (auto algorithm : {RCAlgo::kZLIB, RCAlgo::kLZMA, RCAlgo::kLZ4, RCAlgo::kZSTD}) {
       opts.fCompressionAlgorithm = algorithm;
 
       auto s = tdf.Snapshot<int>("t", outfile, {"ans"}, opts);
@@ -673,7 +675,7 @@ TEST(RDFSnapshotMore, Lazy)
       ++v;
       return 42;
    };
-   RSnapshotOptions opts = {"RECREATE", ROOT::kZLIB, 0, 0, 99, true};
+   RSnapshotOptions opts = {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kZLIB, 0, 0, 99, true};
    auto ds = d.Define("c0", genf).Snapshot<int>(treename, fname0, {"c0"}, opts);
    EXPECT_EQ(v, 0U);
    EXPECT_TRUE(gSystem->AccessPathName(fname0)); // This returns FALSE if the file IS there
@@ -695,7 +697,7 @@ TEST(RDFSnapshotMore, LazyJitted)
    // make sure the file is not here beforehand
    gSystem->Unlink(fname);
    RDataFrame d(1);
-   RSnapshotOptions opts = {"RECREATE", ROOT::kZLIB, 0, 0, 99, true};
+   RSnapshotOptions opts = {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kZLIB, 0, 0, 99, true};
    auto ds = d.Alias("c0", "rdfentry_").Snapshot(treename, fname, {"c0"}, opts);
    EXPECT_TRUE(gSystem->AccessPathName(fname)); // This returns FALSE if the file IS there
    *ds;


### PR DESCRIPTION
# This Pull request:
is the first half of #15714. It deprecates `ECompressionAlgorithm` in favor of `RCompressionSetting::EAlgorithm` and fixes the code to use the new enum.
This PR should be much safer and less problematic to merge than #15714, so we can start with this and later discuss about changing the `RCompressionSetting` enums to enum classes.

Depends on #15820 

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


