### PR TITLE
[gpad] Introduce `TPad::Add()`, `TPad::AddFirst()` and `TPad::Remove()` methods

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -79,6 +79,8 @@ public:
    virtual void     AbsCoordinates(Bool_t set) = 0;
    virtual Double_t AbsPixeltoX(Int_t px) = 0;
    virtual Double_t AbsPixeltoY(Int_t py) = 0;
+   virtual void     Add(TObject *obj, Option_t *opt = "", Bool_t modified = kTRUE) = 0;
+   virtual void     AddFirst(TObject *obj, Option_t *opt = "", Bool_t modified = kTRUE) = 0;
    virtual void     AddExec(const char *name, const char *command) = 0;
    virtual TLegend *BuildLegend(Double_t x1=0.3, Double_t y1=0.21, Double_t x2=0.3, Double_t y2=0.21, const char *title="", Option_t *option = "") = 0;
    virtual TVirtualPad* cd(Int_t subpadnumber=0) = 0;
@@ -200,6 +202,7 @@ public:
    virtual void     RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) = 0;
    virtual void     RangeAxisChanged() { Emit("RangeAxisChanged()"); } // *SIGNAL*
            void     RecursiveRemove(TObject *obj) override = 0;
+   virtual TObject *Remove(TObject *obj, Bool_t modified = kTRUE) = 0;
    virtual void     RedrawAxis(Option_t *option="") = 0;
    virtual void     ResetView3D(TObject *view = nullptr) = 0;
    virtual void     ResizePad(Option_t *option="") = 0;

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -183,13 +183,14 @@ void TObject::AddToTObjectTable(TObject *op)
 
 void TObject::AppendPad(Option_t *option)
 {
-   if (!gPad) {
+   if (!gPad)
       gROOT->MakeDefCanvas();
-   }
-   if (!gPad->IsEditable()) return;
+
+   if (!gPad->IsEditable())
+      return;
+
    SetBit(kMustCleanup);
-   gPad->GetListOfPrimitives()->Add(this,option);
-   gPad->Modified(kTRUE);
+   gPad->Add(this, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -311,8 +312,7 @@ TObject *TObject::DrawClone(Option_t *option) const
       option = GetDrawOption();
 
    if (pad) {
-      pad->GetListOfPrimitives()->Add(newobj, option);
-      pad->Modified(kTRUE);
+      pad->Add(newobj, option);
       pad->Update();
    } else {
       newobj->Draw(option);
@@ -615,17 +615,18 @@ void TObject::Paint(Option_t *)
 
 void TObject::Pop()
 {
-   if (!gPad) return;
+   if (!gPad || !gPad->GetListOfPrimitives())
+      return;
 
-   if (this == gPad->GetListOfPrimitives()->Last()) return;
+   if (this == gPad->GetListOfPrimitives()->Last())
+      return;
 
    TListIter next(gPad->GetListOfPrimitives());
    while (auto obj = next())
       if (obj == this) {
          TString opt = next.GetOption();
-         gPad->GetListOfPrimitives()->Remove((TObject*)this);
-         gPad->GetListOfPrimitives()->AddLast(this, opt.Data());
-         gPad->Modified();
+         gPad->Remove(this, kFALSE); // do not issue modified by remove
+         gPad->Add(this, opt.Data());
          return;
       }
 }

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -168,6 +168,8 @@ public:
    Double_t          AbsPixeltoX(Int_t px) override { return fAbsPixeltoXk + px*fPixeltoX; }
    Double_t          AbsPixeltoY(Int_t py) override { return fAbsPixeltoYk + py*fPixeltoY; }
    virtual void      AbsPixeltoXY(Int_t xpixel, Int_t ypixel, Double_t &x, Double_t &y);
+   void              Add(TObject *obj, Option_t *opt = "", Bool_t modified = kTRUE) override;
+   void              AddFirst(TObject *obj, Option_t *opt = "", Bool_t modified = kTRUE) override;
    void              AddExec(const char *name, const char *command) override;
    virtual void      AutoExec();
    void              Browse(TBrowser *b) override;
@@ -314,6 +316,7 @@ public:
    virtual void      RangeChanged() { Emit("RangeChanged()"); } // *SIGNAL*
    void              RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override;
    void              RecursiveRemove(TObject *obj) override;
+   TObject          *Remove(TObject *obj, Bool_t modified = kTRUE) override;
    void              RedrawAxis(Option_t *option="") override;
    void              ResetView3D(TObject *view=nullptr) override { fPadView3D=view; }
    void              ResizePad(Option_t *option="") override;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -960,8 +960,7 @@ TObject *TCanvas::DrawClonePad()
    TIter next(GetListOfPrimitives());
    while (auto obj = next()) {
       pad->cd();
-      auto clone = obj->Clone();
-      pad->GetListOfPrimitives()->Add(clone, next.GetOption());
+      pad->Add(obj->Clone(), next.GetOption(), kFALSE); // do not issue modified for each object
    }
    pad->ResizePad();
    pad->Modified();

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -400,6 +400,55 @@ TPad::~TPad()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Add an object to list of primitives with speicified draw option
+/// When \par modified set to kTRUE (default) pad will be marked as modified
+/// Let avoid usage of gPad when drawing object(s) in canvas or in subpads.
+///
+/// ~~~{.cpp}
+/// auto c1 = new TCanvas("c1","Canvas with subpoads", 600, 600);
+/// c1->Divide(2,2);
+///
+/// for (Int_t n = 1; n <= 4; ++n) {
+///    auto h1 = new TH1I(TString::Format("hist_%d",n), "Random hist", 100, -5, 5);
+///    h1->FillRandom("gaus", 2000 + n*1000);
+///    c1->GetPad(n)->Add(h1);
+/// }
+/// ~~~
+
+void TPad::Add(TObject *obj, Option_t *opt, Bool_t modified)
+{
+   if (!obj)
+      return;
+
+   if (!fPrimitives)
+      fPrimitives = new TList;
+
+   fPrimitives->Add(obj, opt);
+
+   if (modified)
+      Modified();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Add an object as first in list of primitives with speicified draw option
+/// When \par modified set to kTRUE (default) pad will be marked as modified
+/// Let avoid usage of gPad when drawing object(s) in canvas or in subpads.
+
+void TPad::AddFirst(TObject *obj, Option_t *opt, Bool_t modified)
+{
+   if (!obj)
+      return;
+
+   if (!fPrimitives)
+      fPrimitives = new TList;
+
+   fPrimitives->AddFirst(obj, opt);
+
+   if (modified)
+      Modified();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Add a new TExec object to the list of Execs.
 ///
 /// When an event occurs in the pad (mouse click, etc) the list of C++ commands
@@ -5342,6 +5391,21 @@ void TPad::RecursiveRemove(TObject *obj)
    Int_t nold = fPrimitives->GetSize();
    fPrimitives->RecursiveRemove(obj);
    if (nold != fPrimitives->GetSize()) fModified = kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Remove object from list of primitives
+/// When \par modified set to kTRUE (default) pad will be marked as modified - if object really removed
+/// Returns result of GetListOfPrimitives()->Remove(obj) or nullptr if list of primitives not exists
+
+TObject *TPad::Remove(TObject *obj, Bool_t modified)
+{
+   TObject *res = nullptr;
+   if (fPrimitives)
+      res = fPrimitives->Remove(obj);
+   if (res && modified)
+      Modified();
+   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -792,7 +792,7 @@ void TRatioPlot::CreateGridlines()
    while (fGridlines.size() < fGridlinePositions.size()) {
       TLine *newline = new TLine(0, 0, 0, 0);
       newline->SetLineStyle(2);
-      fLowerPad->GetListOfPrimitives()->Add(newline);
+      fLowerPad->Add(newline);
       fGridlines.emplace_back(newline);
    }
 
@@ -1111,22 +1111,22 @@ void TRatioPlot::CreateVisualAxes()
 
    if (!fUpperGXaxis) {
       fUpperGXaxis = new TGaxis(0, 0, 1, 1, 0, 1, 510, "+U");
-      fTopPad->GetListOfPrimitives()->Add(fUpperGXaxis);
+      fTopPad->Add(fUpperGXaxis);
    }
 
    if (!fUpperGYaxis) {
       fUpperGYaxis = new TGaxis(0, 0, 1, 1, upYFirst, upYLast, 510, "S");
-      fTopPad->GetListOfPrimitives()->Add(fUpperGYaxis);
+      fTopPad->Add(fUpperGYaxis);
    }
 
    if (!fLowerGXaxis) {
       fLowerGXaxis = new TGaxis(0, 0, 1, 1, first, last, 510, "+S");
-      fTopPad->GetListOfPrimitives()->Add(fLowerGXaxis);
+      fTopPad->Add(fLowerGXaxis);
    }
 
    if (!fLowerGYaxis) {
       fLowerGYaxis = new TGaxis(0, 0, 1, 1, lowYFirst, lowYLast, 510, "-S");
-      fTopPad->GetListOfPrimitives()->Add(fLowerGYaxis);
+      fTopPad->Add(fLowerGYaxis);
    }
 
    // Create the axes on the other sides of the graphs
@@ -1134,22 +1134,22 @@ void TRatioPlot::CreateVisualAxes()
 
    if (!fUpperGXaxisMirror && axistop) {
       fUpperGXaxisMirror = static_cast<TGaxis *>(fUpperGXaxis->Clone());
-      fTopPad->GetListOfPrimitives()->Add(fUpperGXaxisMirror);
+      fTopPad->Add(fUpperGXaxisMirror);
    }
 
    if (!fLowerGXaxisMirror && axistop) {
       fLowerGXaxisMirror = static_cast<TGaxis *>(fLowerGXaxis->Clone());
-      fTopPad->GetListOfPrimitives()->Add(fLowerGXaxisMirror);
+      fTopPad->Add(fLowerGXaxisMirror);
    }
 
    if (!fUpperGYaxisMirror && axisright) {
       fUpperGYaxisMirror = static_cast<TGaxis *>(fUpperGYaxis->Clone());
-      fTopPad->GetListOfPrimitives()->Add(fUpperGYaxisMirror);
+      fTopPad->Add(fUpperGYaxisMirror);
    }
 
    if (!fLowerGYaxisMirror && axisright) {
       fLowerGYaxisMirror = static_cast<TGaxis *>(fLowerGYaxis->Clone());
-      fTopPad->GetListOfPrimitives()->Add(fLowerGYaxisMirror);
+      fTopPad->Add(fLowerGYaxisMirror);
    }
 
    UpdateVisualAxes();

--- a/gui/browsable/src/TLeafDraw6Provider.cxx
+++ b/gui/browsable/src/TLeafDraw6Provider.cxx
@@ -20,7 +20,7 @@ public:
       if (!hist)
          return false;
 
-      pad->GetListOfPrimitives()->Add(hist, opt.c_str());
+      pad->Add(hist, opt.c_str());
 
       return true;
    }

--- a/gui/browsable/src/TObjectDraw6Provider.cxx
+++ b/gui/browsable/src/TObjectDraw6Provider.cxx
@@ -32,7 +32,7 @@ public:
             tobj->SetBit(TObject::kMustCleanup); // TCanvas should care about cleanup
          }
 
-         pad->GetListOfPrimitives()->Add(tobj, opt.c_str());
+         pad->Add(tobj, opt.c_str());
 
          return true;
       });

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1992,9 +1992,8 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
             while (auto o = next())
                if (obj == o) {
                   TString opt = next.GetOption();
-                  pad->GetListOfPrimitives()->Remove(obj);
-                  pad->GetListOfPrimitives()->AddLast(obj, opt.Data());
-                  pad->Modified();
+                  pad->Remove(obj, kFALSE);
+                  pad->Add(obj, opt.Data());
                   break;
                }
          }

--- a/tutorials/webgui/qtweb/ExampleWidget.cpp
+++ b/tutorials/webgui/qtweb/ExampleWidget.cpp
@@ -251,10 +251,10 @@ void ExampleWidget::DrawGeometryInCanvas()
    auto canv = fxTCanvasWidget->getCanvas();
    canv->Clear();
 
-   canv->GetListOfPrimitives()->Add(geom,"");
+   canv->Add(geom);
 
    // create a first PolyMarker3D
-   TPolyMarker3D *pm = new TPolyMarker3D(21);
+   auto pm = new TPolyMarker3D(21);
 
    for (int n=0;n<21;n++)
       pm->SetPoint(n, -120 + n*10, -20, 25);
@@ -264,9 +264,9 @@ void ExampleWidget::DrawGeometryInCanvas()
    pm->SetMarkerColor(4);
    pm->SetMarkerStyle(2);
 
-   canv->GetListOfPrimitives()->Add(pm,"");
+   canv->Add(pm);
 
-   TPolyLine3D *pl = new TPolyLine3D(5);
+   auto pl = new TPolyLine3D(5);
 
    // set points
    pl->SetPoint(0, -120, -20, -30);
@@ -278,9 +278,8 @@ void ExampleWidget::DrawGeometryInCanvas()
    pl->SetLineWidth(3);
    pl->SetLineColor(2);
 
-   canv->GetListOfPrimitives()->Add(pl,"");
+   canv->Add(pl);
 
-   canv->Modified();
    canv->Update();
 }
 


### PR DESCRIPTION
Let add and remove primitives from the pad without set of `gPad` pointer.

Automatically set modified flag when primitives are changing.

Use methods in `TObject::Draw()`, `TObject::DrawClone()`, `TObject::Pop()` methods

Also in webgui and `graf2d/gpad` classes