### PR TITLE
[df] Shorten jitted expression in test

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -626,11 +626,13 @@ TEST(RDataFrameInterface, JittedExprWithMultipleReturns)
 
 TEST(RDataFrameInterface, JittedExprWithManyVars)
 {
-   std::string expr = "x + x + x + x";
-   for (int i = 0; i < 10; ++i) {
-      expr = expr + '+' + expr;
-   }
-   expr = expr + ">0";
+   // Build expression "x + x + ... + x > 0"
+   // With 100 occurences of 'x'
+   std::string expr{"x"};
+   for (int i = 0; i < 99; ++i)
+      expr += " + x";
+   expr += " > 0";
+
    const auto counts = ROOT::RDataFrame(1)
                           .Define("x", [] { return 1; })
                           .Filter(expr)


### PR DESCRIPTION
The test previously build an expression with 4096 occurrences of the 'x' variable. This was causing a segfault with the address sanitizer that is independent of RDataFrame and tracked at
https://github.com/root-project/root/issues/15818.

Shorten the test expression to 100 occurences of 'x' which still represents a realistically long one-line expression and better decouples the clang-related asan issue from the rest of the RDataFrame testing infrastructure.
