### PR TITLE
[gpad] Always set `kMustCleanup` bit when object add to pad

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -189,7 +189,6 @@ void TObject::AppendPad(Option_t *option)
    if (!gPad->IsEditable())
       return;
 
-   SetBit(kMustCleanup);
    gPad->Add(this, option);
 }
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -423,6 +423,8 @@ void TPad::Add(TObject *obj, Option_t *opt, Bool_t modified)
    if (!fPrimitives)
       fPrimitives = new TList;
 
+   obj->SetBit(kMustCleanup);
+
    fPrimitives->Add(obj, opt);
 
    if (modified)
@@ -441,6 +443,8 @@ void TPad::AddFirst(TObject *obj, Option_t *opt, Bool_t modified)
 
    if (!fPrimitives)
       fPrimitives = new TList;
+
+   obj->SetBit(kMustCleanup);
 
    fPrimitives->AddFirst(obj, opt);
 


### PR DESCRIPTION
Set such bit in new `TPad::Add()` and `TPad::AddFirst()` methods. 
Bit was already set in `TObject::AppendPad()`,
now it also will be set for other use cases where `TPad::Add()` is used

