### PR TITLE
[ci] Add back the march=native build

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -21,7 +21,6 @@ import shutil
 import subprocess
 import sys
 import tarfile
-from hashlib import sha1
 
 import openstack
 
@@ -29,6 +28,7 @@ from build_utils import (
     die,
     github_log_group,
     load_config,
+    calc_options_hash,
     subprocess_with_log,
     subprocess_with_capture,
     upload_file
@@ -83,10 +83,10 @@ def main():
         if args.architecture == 'x86':
             options = "-AWin32 " + options
 
-    # The sha1 of the build option string is used to find existing artifacts
+    # The hash of the build option string is used to find existing artifacts
     # with matching build options on s3 storage.
-    option_hash = sha1(options.encode('utf-8')).hexdigest()
-    obj_prefix = f'{args.platform}/{args.base_ref}/{args.buildtype}/{option_hash}'
+    options_hash = calc_options_hash(options)
+    obj_prefix = f'{args.platform}/{args.base_ref}/{args.buildtype}/{options_hash}'
 
     # Make testing of CI in forks not impact artifacts
     if 'root-project/root' not in args.repository:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -1,5 +1,3 @@
-
-
 name: 'ROOT CI'
 
 on:
@@ -364,6 +362,10 @@ jobs:
             is_special: true
             property: modules_off
             overrides: ["runtime_cxxmodules=Off"]
+          - image: alma9
+            is_special: true
+            property: march_native
+            overrides: ["CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native"]
 
     runs-on:
       - self-hosted
@@ -405,8 +407,8 @@ jobs:
                ls -la
               '
 
-      - name: Apply option overrides from matrix for this job for non-release builds
-        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && matrix.overrides != NaN }}
+      - name: Apply option overrides from matrix for this job for all builds except non-special nightlies and releases
+        if: ${{ ( github.event_name != 'schedule' || matrix.is_special) && github.event_name != 'workflow_dispatch' && matrix.overrides != NaN }}
         env:
           OVERRIDES: ${{ join( matrix.overrides, ' ') }}
           CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/${{ matrix.image }}.txt'


### PR DESCRIPTION
The preprocessor defines enabled by the `march=native` flag are made part of the string of options to be hashed to create the artifact tarball names, therewith avoiding incompatible binaries. Moreover, the special builds preserve their overrides also for nightly builds.

