### PR TITLE
[cmake] Add asan options to ACLiC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ if(asan)
   endforeach()
   #add_link_options() not available in our CMake version:
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_EXTRA_SHARED_LINKER_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_EXTRA_EXE_LINKER_FLAGS}")
 endif()
 
 #---Enable CTest package -----------------------------------------------------------------------

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -714,6 +714,11 @@ if(WIN32)
 else()
   # Needed by ACLIC, while in ROOT we are using everywhere C++ standard via CMake features that are requested to build target
   set(CMAKE_CXX_ACLIC_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
+  if(asan)
+    # Replace the semicolon with space so that the produced compiler invokation still makes sense
+    string (REPLACE ";" " " ASAN_EXTRA_CXX_FLAGS_STR "${ASAN_EXTRA_CXX_FLAGS}")
+    set(CMAKE_CXX_ACLIC_FLAGS "${CMAKE_CXX_ACLIC_FLAGS} ${ASAN_EXTRA_CXX_FLAGS_STR}")
+  endif()
   execute_process(COMMAND ${CMAKE_SOURCE_DIR}/build/unix/compiledata.sh
     ${CMAKE_BINARY_DIR}/ginclude/compiledata.h "${CMAKE_CXX_COMPILER}"
         "${CMAKE_CXX_FLAGS_RELEASE}" "${CMAKE_CXX_FLAGS_DEBUG}" "${CMAKE_CXX_ACLIC_FLAGS}"


### PR DESCRIPTION
The compiler invokations run by ACLiC were not updated in case of a build with address sanitizer options enabled. This resulted in spurious warnings of the sort:

```
$: root -q -l -b test.C+

Processing test.C+...
Info in <TUnixSystem::ACLiC>: creating shared library /tmp/./test_C.so
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tempnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tmpnam_r' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tempnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib64/libasan.so.8: warning: the use of `tmpnam_r' is dangerous, better use `mkstemp'
```
