### PR TITLE
Improving `TGraphTime` class

### DIFF
--- a/hist/hist/inc/TGraphTime.h
+++ b/hist/hist/inc/TGraphTime.h
@@ -29,15 +29,15 @@ class TObjArray;
 class TGraphTime : public TNamed {
 
 protected:
-
-   Int_t              fSleepTime; ///< Time (msec) to wait between time steps
-   Int_t              fNsteps;    ///< Number of time steps
-   Double_t           fXmin;      ///< Minimum for X axis
-   Double_t           fXmax;      ///< Maximum for X axis
-   Double_t           fYmin;      ///< Minimum for Y axis
-   Double_t           fYmax;      ///< Maximum for Y axis
-   TObjArray         *fSteps;     ///< Array of TLists for each time step
-   TH1               *fFrame;     ///< TH1 object used for the pad range
+   Int_t fSleepTime = 0;        ///< Time (msec) to wait between time steps
+   Int_t fNsteps = 0;           ///< Number of time steps
+   Double_t fXmin = 0.;         ///< Minimum for X axis
+   Double_t fXmax = 0.;         ///< Maximum for X axis
+   Double_t fYmin = 0.;         ///< Minimum for Y axis
+   Double_t fYmax = 0.;         ///< Maximum for Y axis
+   TObjArray *fSteps = nullptr; ///< Array of TLists for each time step
+   TH1 *fFrame = nullptr;       ///< TH1 object used for the pad range
+   Int_t fAnimateCnt = -1;      ///<! counter used in Animate() method
 
    Bool_t DrawStep(Int_t nstep) const;
 
@@ -49,8 +49,10 @@ public:
    ~TGraphTime() override;
 
    virtual Int_t Add(const TObject *obj, Int_t slot, Option_t *option = "");
+   void Animate(Bool_t enable = kTRUE);
    void Draw(Option_t *chopt = "") override;
    TObjArray *GetSteps() const { return fSteps; }
+   Bool_t Notify() override;
    void Paint(Option_t *chopt = "") override;
    virtual void SaveAnimatedGif(const char *filename = "") const;
    virtual void SetSleepTime(Int_t stime = 0) { fSleepTime = stime; }

--- a/hist/hist/inc/TGraphTime.h
+++ b/hist/hist/inc/TGraphTime.h
@@ -39,6 +39,8 @@ protected:
    TObjArray         *fSteps;     ///< Array of TLists for each time step
    TH1               *fFrame;     ///< TH1 object used for the pad range
 
+   Bool_t DrawStep(Int_t nstep) const;
+
 public:
 
    TGraphTime();
@@ -46,12 +48,12 @@ public:
    TGraphTime(const TGraphTime &gr);
    ~TGraphTime() override;
 
-   virtual Int_t   Add(const TObject *obj, Int_t slot, Option_t *option="");
-   void    Draw(Option_t *chopt="") override;
-   TObjArray      *GetSteps() const {return fSteps;}
-   void    Paint(Option_t *chopt="") override;
-   virtual void    SaveAnimatedGif(const char *filename="") const;
-   virtual void    SetSleepTime(Int_t stime=0) {fSleepTime = stime;}
+   virtual Int_t Add(const TObject *obj, Int_t slot, Option_t *option = "");
+   void Draw(Option_t *chopt = "") override;
+   TObjArray *GetSteps() const { return fSteps; }
+   void Paint(Option_t *chopt = "") override;
+   virtual void SaveAnimatedGif(const char *filename = "") const;
+   virtual void SetSleepTime(Int_t stime = 0) { fSleepTime = stime; }
 
    ClassDefOverride(TGraphTime,1)  //An array of objects evolving with time
 };

--- a/hist/hist/inc/TGraphTime.h
+++ b/hist/hist/inc/TGraphTime.h
@@ -25,6 +25,7 @@
 
 class TH1;
 class TObjArray;
+class TTimer;
 
 class TGraphTime : public TNamed {
 
@@ -38,6 +39,7 @@ protected:
    TObjArray *fSteps = nullptr; ///< Array of TLists for each time step
    TH1 *fFrame = nullptr;       ///< TH1 object used for the pad range
    Int_t fAnimateCnt = -1;      ///<! counter used in Animate() method
+   TTimer *fAnimateTimer = nullptr; ///<! timer to implement animation
 
    Bool_t DrawStep(Int_t nstep) const;
 
@@ -52,7 +54,7 @@ public:
    void Animate(Bool_t enable = kTRUE);
    void Draw(Option_t *chopt = "") override;
    TObjArray *GetSteps() const { return fSteps; }
-   Bool_t Notify() override;
+   Bool_t HandleTimer(TTimer *) override;
    void Paint(Option_t *chopt = "") override;
    virtual void SaveAnimatedGif(const char *filename = "") const;
    virtual void SetSleepTime(Int_t stime = 0) { fSleepTime = stime; }

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -123,7 +123,7 @@ Int_t TGraphTime::Add(const TObject *obj, Int_t slot, Option_t *option)
 /// Draw this TGraphTime.
 /// for each time step the list of objects added to this step are drawn.
 
-void TGraphTime::Draw(Option_t *option)
+void TGraphTime::Draw(Option_t *)
 {
    if (!gPad) {
       gROOT->MakeDefCanvas();
@@ -131,12 +131,16 @@ void TGraphTime::Draw(Option_t *option)
       gPad->SetFrameFillColor(19);
       gPad->SetGrid();
    }
-   if (fFrame) {
+   if (fFrame)
       fFrame->SetTitle(GetTitle());
-      gPad->Add(fFrame);
-   }
 
-   Paint(option);
+   for (Int_t s = 0; s < fNsteps; s++) {
+      if (DrawStep(s)) {
+         gPad->Update();
+         if (fSleepTime > 0)
+            gSystem->Sleep(fSleepTime);
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -172,18 +176,7 @@ Bool_t TGraphTime::DrawStep(Int_t nstep) const
 
 void TGraphTime::Paint(Option_t *)
 {
-   if (!gPad) {
-      Error("Paint", "Not possible to Paint without gPad");
-      return;
-   }
-
-   for (Int_t s = 0; s < fNsteps; s++) {
-      if (DrawStep(s)) {
-         gPad->Update();
-         if (fSleepTime > 0)
-            gSystem->Sleep(fSleepTime);
-      }
-   }
+   Error("Paint", "Not implemented, use Draw() instead");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -199,16 +192,14 @@ void TGraphTime::SaveAnimatedGif(const char *filename) const
    }
 
    if (gPad->IsWeb()) {
-      Error("SaveAnimatedGif", "Not possible to created animated GIF with web canvas");
+      Error("SaveAnimatedGif", "Not possible to create animated GIF with web canvas");
       return;
    }
 
    TString farg = TString::Format("%s+", filename && *filename ? filename : GetName());
 
    for (Int_t s = 0; s < fNsteps; s++) {
-      if (DrawStep(s)) {
-         gPad->Update();
+      if (DrawStep(s))
          gPad->Print(farg.Data());
-      }
    }
 }

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -140,6 +140,34 @@ void TGraphTime::Draw(Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw single step
+
+Bool_t TGraphTime::DrawStep(Int_t nstep) const
+{
+   if (!fSteps)
+      return kFALSE;
+
+   auto list = static_cast<TList *>(fSteps->UncheckedAt(nstep));
+   if (!list)
+      return kFALSE;
+
+   if (fFrame)
+      gPad->Remove(fFrame);
+   gPad->GetListOfPrimitives()->Clear();
+   if (fFrame)
+      gPad->Add(fFrame);
+
+   auto lnk = list->FirstLink();
+   while(lnk) {
+      gPad->Add(lnk->GetObject(), lnk->GetAddOption());
+      lnk = lnk->Next();
+   }
+
+   return kTRUE;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Paint all objects added to each time step
 
 void TGraphTime::Paint(Option_t *)
@@ -149,19 +177,8 @@ void TGraphTime::Paint(Option_t *)
       return;
    }
 
-   auto frame = gPad->GetPrimitive("frame");
-
    for (Int_t s = 0; s < fNsteps; s++) {
-      auto list = static_cast<TList *>(fSteps->UncheckedAt(s));
-      if (list) {
-         gPad->Remove(frame);
-         gPad->GetListOfPrimitives()->Clear();
-         if (frame) gPad->Add(frame);
-         auto lnk = list->FirstLink();
-         while(lnk) {
-            gPad->Add(lnk->GetObject(), lnk->GetAddOption());
-            lnk = lnk->Next();
-         }
+      if (DrawStep(s)) {
          gPad->Update();
          if (fSleepTime > 0)
             gSystem->Sleep(fSleepTime);
@@ -186,21 +203,10 @@ void TGraphTime::SaveAnimatedGif(const char *filename) const
       return;
    }
 
-   auto frame = gPad->GetPrimitive("frame");
-
    TString farg = TString::Format("%s+", filename && *filename ? filename : GetName());
 
    for (Int_t s = 0; s < fNsteps; s++) {
-      auto list = static_cast<TList *>(fSteps->UncheckedAt(s));
-      if (list) {
-         gPad->Remove(frame);
-         gPad->GetListOfPrimitives()->Clear();
-         if (frame) gPad->Add(frame);
-         auto lnk = list->FirstLink();
-         while(lnk) {
-            gPad->Add(lnk->GetObject(), lnk->GetAddOption());
-            lnk = lnk->Next();
-         }
+      if (DrawStep(s)) {
          gPad->Update();
          gPad->Print(farg.Data());
       }

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -194,8 +194,6 @@ void TGraphTime::SaveAnimatedGif(const char *filename) const
             gPad->Print(TString::Format("%s+", filename));
          else
             gPad->Print(TString::Format("%s+", GetName()));
-         if (fSleepTime > 0)
-            gSystem->Sleep(fSleepTime);
       }
    }
 }

--- a/tutorials/graphs/gtime.C
+++ b/tutorials/graphs/gtime.C
@@ -14,50 +14,61 @@
 #include "TText.h"
 #include "TArrow.h"
 #include "TGraphTime.h"
-#include "TROOT.h"
+#include <vector>
 
-void gtime(Int_t nsteps = 500, Int_t np=100) {
+void gtime(Int_t nsteps = 500, Int_t np = 100)
+{
    if (np > 1000) np = 1000;
-   Int_t color[1000];
-   Double_t rr[1000], phi[1000], dr[1000], size[1000];
+   std::vector<Int_t> color(np);
+   std::vector<Double_t> rr(np), phi(np), dr(np), size(np);
    TRandom3 r;
    Double_t xmin = -10, xmax = 10, ymin = -10, ymax = 10;
-   TGraphTime *g = new TGraphTime(nsteps,xmin,ymin,xmax,ymax);
+   auto g = new TGraphTime(nsteps, xmin, ymin, xmax, ymax);
    g->SetTitle("TGraphTime demo;X domain;Y domain");
-   Int_t i,s;
-   for (i=0;i<np;i++) { //calculate some object parameters
-      rr[i]  = r.Uniform(0.1*xmax,0.2*xmax);
-      phi[i] = r.Uniform(0,2*TMath::Pi());
-      dr[i]  = r.Uniform(0,1)*0.9*xmax/Double_t(nsteps);
+   for (Int_t i = 0; i < np; i++) { // calculate some object parameters
+      rr[i] = r.Uniform(0.1 * xmax, 0.2 * xmax);
+      phi[i] = r.Uniform(0, 2 * TMath::Pi());
+      dr[i] = r.Uniform(0, 1) * 0.9 * xmax / Double_t(nsteps);
       Double_t rc = r.Rndm();
-      color[i] = kRed;
-      if (rc > 0.3) color[i] = kBlue;
-      if (rc > 0.7) color[i] = kYellow;
-      size[i] = r.Uniform(0.5,6);
+      if (rc > 0.7)
+         color[i] = kYellow;
+      else if (rc > 0.3)
+         color[i] = kBlue;
+      else
+         color[i] = kRed;
+
+      size[i] = r.Uniform(0.5, 6);
    }
-   for (s=0;s<nsteps;s++) { //fill the TGraphTime step by step
-      for (i=0;i<np;i++) {
-         Double_t newr = rr[i]+dr[i]*s;
-         Double_t newsize = 0.2+size[i]*TMath::Abs(TMath::Sin(newr+10));
-         Double_t newphi = phi[i] + 0.01*s;
-         Double_t xx = newr*TMath::Cos(newphi);
-         Double_t yy = newr*TMath::Sin(newphi);
-         TMarker *m = new TMarker(xx,yy,20);
+   for (Int_t s = 0; s < nsteps; s++) { // fill the TGraphTime step by step
+      for (Int_t i = 0; i < np; i++) {
+         Double_t newr = rr[i] + dr[i] * s;
+         Double_t newsize = 0.2 + size[i] * TMath::Abs(TMath::Sin(newr + 10));
+         Double_t newphi = phi[i] + 0.01 * s;
+         Double_t xx = newr * TMath::Cos(newphi);
+         Double_t yy = newr * TMath::Sin(newphi);
+         TMarker *m = new TMarker(xx, yy, 20);
          m->SetMarkerColor(color[i]);
          m->SetMarkerSize(newsize);
-         g->Add(m,s);
-         if (i==np-1) g->Add(new TArrow(xmin,ymax,xx,yy,0.02,"-|>"), s);
+         g->Add(m, s);
+         if (i == np - 1)
+            g->Add(new TArrow(xmin, ymax, xx, yy, 0.02, "-|>"), s);
       }
-      g->Add(new TPaveLabel(.90,.92,.98,.97,Form("%d",s+1),"brNDC"),s);
+      g->Add(new TPaveLabel(.90, .92, .98, .97, TString::Format("%d", s + 1), "brNDC"), s);
    }
+
    g->Draw();
 
+   // save object as animated gif
+   // g->SaveAnimatedGif("gtime.gif");
+
    //save object to a file
-   TFile f("gtime.root","recreate");
-   g->Write("g");
+   auto f = TFile::Open("gtime.root","recreate");
+   f->WriteObject(g, "g");
+   delete f;
+
    //to view this object in another session do
-   //  TFile f("gtime.root");
-   //  g.Draw();
+   //  TFile::Open("gtime.root");
+   //  g->Draw();
 }
 
 

--- a/tutorials/graphs/gtime2.C
+++ b/tutorials/graphs/gtime2.C
@@ -15,40 +15,44 @@
 #include "TPaveLabel.h"
 #include "TArrow.h"
 #include "TGraphTime.h"
+#include <vector>
 
-void gtime2(Int_t nsteps = 200, Int_t np=5000) {
+void gtime2(Int_t nsteps = 200, Int_t np = 5000)
+{
    if (np > 5000) np = 5000;
-   Int_t color[5000];
-   Double_t cosphi[5000], sinphi[5000], speed[5000];
+   std::vector<Int_t> color(np);
+   std::vector<Double_t> cosphi(np), sinphi(np), speed(np);
    TRandom3 r;
    Double_t xmin = 0, xmax = 10, ymin = -10, ymax = 10;
    TGraphTime *g = new TGraphTime(nsteps,xmin,ymin,xmax,ymax);
    g->SetTitle("TGraphTime demo 2;X;Y");
-   Int_t i,s;
-   Double_t phi,fact = xmax/Double_t(nsteps);
-   for (i=0;i<np;i++) { //calculate some object parameters
-      speed[i]  = r.Uniform(0.5,1);
-      phi       = r.Gaus(0,TMath::Pi()/6.);
-      cosphi[i] = fact*speed[i]*TMath::Cos(phi);
-      sinphi[i] = fact*speed[i]*TMath::Sin(phi);
+   Double_t fact = xmax/Double_t(nsteps);
+   for (Int_t i = 0; i < np; i++) { // calculate some object parameters
+      speed[i] = r.Uniform(0.5, 1);
+      Double_t phi = r.Gaus(0, TMath::Pi() / 6.);
+      cosphi[i] = fact * speed[i] * TMath::Cos(phi);
+      sinphi[i] = fact * speed[i] * TMath::Sin(phi);
       Double_t rc = r.Rndm();
       color[i] = kRed;
       if (rc > 0.3) color[i] = kBlue;
       if (rc > 0.7) color[i] = kYellow;
    }
-   for (s=0;s<nsteps;s++) { //fill the TGraphTime step by step
-      for (i=0;i<np;i++) {
+   for (Int_t s = 0; s < nsteps; s++) { // fill the TGraphTime step by step
+      for (Int_t i = 0; i < np; i++) {
          Double_t xx = s*cosphi[i];
          if (xx < xmin) continue;
          Double_t yy = s*sinphi[i];
          TMarker *m = new TMarker(xx,yy,25);
          m->SetMarkerColor(color[i]);
          m->SetMarkerSize(1.5 -s/(speed[i]*nsteps));
-         g->Add(m,s);
+         g->Add(m, s);
       }
-      g->Add(new TPaveLabel(.70,.92,.98,.99,Form("shower at %5.3f nsec",3.*s/nsteps),"brNDC"),s);
+      g->Add(new TPaveLabel(.70,.92,.98,.99,TString::Format("shower at %5.3f nsec",3.*s/nsteps),"brNDC"),s);
    }
+
    g->Draw();
+
+   // g->SaveAnimatedGif("gtime2.gif");
 }
 
 

--- a/tutorials/graphs/gtime2.C
+++ b/tutorials/graphs/gtime2.C
@@ -52,7 +52,11 @@ void gtime2(Int_t nsteps = 200, Int_t np = 5000)
 
    g->Draw();
 
+   // store object as animated gif
    // g->SaveAnimatedGif("gtime2.gif");
+
+   // start animation, can be stopped with g->Animate(kFALSE);
+   // g->Animate();
 }
 
 


### PR DESCRIPTION
1. Use new `TPad::Add()` and `TPad::Remove()` methods to manipulate primitives
2. Do not implement `TGraphTime::Paint()` method. It is illegal to add this object to list of primitives and painting is not allowed. 
3. Provide protected `TGraphTime::DrawStep()` method which used both in drawing and creation animated gif 
4. Remove unnecessary `gSystem->Sleep` and `gPad->Update` when creating animated gif, check if `gPad` is there, only plain ROOT canvas can be used here
5. Implement `TGraphTime::Animate()` to let run animation without blocking of main loop.
6. Adjust tutorials macros