### PR TITLE
[RF] Don't call `resetDataToken()` on RooRealVars in Evaluator d'tor

### DIFF
--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -332,7 +332,9 @@ void Evaluator::updateOutputSizes()
 Evaluator::~Evaluator()
 {
    for (auto &info : _nodes) {
-      info.absArg->resetDataToken();
+      if(!info.isVariable) {
+         info.absArg->resetDataToken();
+      }
    }
 }
 


### PR DESCRIPTION
It's not necessary because the data token is not set for `RooRealVar`s to begin with:
https://github.com/root-project/root/blob/master/roofit/roofitcore/src/RooFit/Evaluator.cxx#L185

And by not doing this unnecessary resetting, we avoid potential crashes in case the `RooRealVar`s live not as long as the evaluator.