### PR TITLE
[ntuple] Change `VisitIntField` to `VisitInt32Field`

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -152,7 +152,7 @@ class RFieldProvider : public RProvider {
       void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
       void VisitInt8Field(const RField<std::int8_t> &field) final { FillHistogram(field); }
       void VisitInt16Field(const RField<std::int16_t> &field) final { FillHistogram(field); }
-      void VisitIntField(const RField<int> &field) final { FillHistogram(field); }
+      void VisitInt32Field(const RField<std::int32_t> &field) final { FillHistogram(field); }
       void VisitInt64Field(const RField<std::int64_t> &field) final { FillHistogram(field); }
       void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
       void VisitUInt16Field(const RField<std::uint16_t> &field) final { FillHistogram(field); }

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -63,7 +63,7 @@ public:
    virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
    virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
    virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
-   virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
+   virtual void VisitInt32Field(const RField<std::int32_t> &field) { VisitField(field); }
    virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitNullableField(const RNullableField &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
@@ -209,7 +209,7 @@ public:
    void VisitCharField(const RField<char> &field) final;
    void VisitInt8Field(const RField<std::int8_t> &field) final;
    void VisitInt16Field(const RField<std::int16_t> &field) final;
-   void VisitIntField(const RField<int> &field) final;
+   void VisitInt32Field(const RField<std::int32_t> &field) final;
    void VisitInt64Field(const RField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;
    void VisitUInt8Field(const RField<std::uint8_t> &field) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1495,7 +1495,7 @@ void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTuple
 
 void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
-   visitor.VisitIntField(*this);
+   visitor.VisitInt32Field(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -236,11 +236,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RField<std::i
    fOutput << fValue.GetRef<std::int16_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitIntField(const RField<int> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt32Field(const RField<std::int32_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << fValue.GetRef<int>();
+   fOutput << fValue.GetRef<std::int32_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RField<std::int64_t> &field)


### PR DESCRIPTION
This change makes the visitor consistent with the other integer visitors, which all use a fixed-width representation.
