### PR TITLE
[ORC] Preserve order of constructors with same priority [v6.28]

### DIFF
--- a/interpreter/llvm/src/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/interpreter/llvm/src/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -481,8 +481,8 @@ GlobalCtorDtorScraper::operator()(ThreadSafeModule TSM,
     std::vector<std::pair<Function *, unsigned>> Inits;
     for (auto E : getConstructors(M))
       Inits.push_back(std::make_pair(E.Func, E.Priority));
-    llvm::sort(Inits, [](const std::pair<Function *, unsigned> &LHS,
-                         const std::pair<Function *, unsigned> &RHS) {
+    llvm::stable_sort(Inits, [](const std::pair<Function *, unsigned> &LHS,
+                                const std::pair<Function *, unsigned> &RHS) {
       return LHS.second < RHS.second;
     });
     auto *EntryBlock = BasicBlock::Create(Ctx, "entry", InitFunc);


### PR DESCRIPTION
Constructors with the same priority should keep their relative order that was specified. This is important for `clang-repl` with many `const` variables after commit https://github.com/llvm/llvm-project/commit/05137ecfca0bd2f7fa6cd30c771dfacbb8188785 ("[clang-repl] Emit const variables only once").

---

Fixes #15511

(version of commit a60f3538220e298f14c0ea5824d2fda91b71f39e for LLVM 13 in `v6-28-00-patches`, backport of https://github.com/root-project/root/pull/15854)