### PR TITLE
[v6-32][win32] Fix error with VS v17.10

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -193,7 +193,7 @@ if(MSVC)
       ??1LifetimeHandler@internal@runtime@cling@@QAE@XZ
       ?_Facet_Register@std@@YAXPAV_Facet_base@1@@Z
     )
-    if(MSVC_VERSION GREATER_EQUAL 1938)
+    if(MSVC_VERSION GREATER_EQUAL 1938 AND MSVC_VERSION LESS 1940)
       set(cling_exports ${cling_exports}
         ??$__std_find_trivial@$$CBDD@@YAPBDPBD0D@Z
         ??$__std_find_trivial@DD@@YAPADPAD0D@Z


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/15336
Fix the following compilation errors with Visual Studio v17.10 on x86
```
libCling.exp : error LNK2001: unresolved external symbol "char const * __cdecl __std_find_trivial<char const ,char>(char const *,char const *,char)" (??$__std_find_trivial@$$CBDD@@YAPBDPBD0D@Z) [C:\
root-dev\build\x86\release\core\metacling\src\Cling.vcxproj]
libCling.exp : error LNK2001: unresolved external symbol "char * __cdecl __std_find_trivial<char,char>(char *,char *,char)" (??$__std_find_trivial@DD@@YAPADPAD0D@Z) [C:\root-dev\build\x86\release\co
re\metacling\src\Cling.vcxproj]
libCling.exp : error LNK2001: unresolved external symbol "int * __cdecl __std_find_trivial<int,int>(int *,int *,int)" (??$__std_find_trivial@HH@@YAPAHPAH0H@Z) [C:\root-dev\build\x86\release\core\met
acling\src\Cling.vcxproj]
libCling.exp : error LNK2001: unresolved external symbol "unsigned int * __cdecl __std_find_trivial<unsigned int,int>(unsigned int *,unsigned int *,int)" (??$__std_find_trivial@IH@@YAPAIPAI0H@Z) [C:
\root-dev\build\x86\release\core\metacling\src\Cling.vcxproj]
C:\root-dev\build\x86\release\bin\libCling.dll : fatal error LNK1120: 4 unresolved externals [C:\root-dev\build\x86\release\core\metacling\src\Cling.vcxproj]
```
