### PR TITLE
[ci] Add alma9 clang build

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -83,9 +83,12 @@ def main():
         if args.architecture == 'x86':
             options = "-AWin32 " + options
 
-    # The hash of the build option string is used to find existing artifacts
-    # with matching build options on s3 storage.
-    options_hash = calc_options_hash(options)
+    # The hash of the name of the image (if any) and build option string is 
+    # used to find existing artifacts with matching build options on s3 storage.
+    options_for_hash = options
+    if args.image:
+        options_for_hash += args.image
+    options_hash = calc_options_hash(options_for_hash)
     obj_prefix = f'{args.platform}/{args.base_ref}/{args.buildtype}/{options_hash}'
 
     # Make testing of CI in forks not impact artifacts

--- a/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
@@ -1,0 +1,4 @@
+builtin_nlohmannjson=ON
+builtin_vdt=On
+tmva-sofie=On
+BLA_VENDOR=OpenBLAS

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -366,6 +366,10 @@ jobs:
             is_special: true
             property: march_native
             overrides: ["CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native"]
+          - image: alma9-clang
+            is_special: true
+            property: clang
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
 
     runs-on:
       - self-hosted


### PR DESCRIPTION
To correctly manage build artifacts, make the compiler name part of the string to be hashed.

