### PR TITLE
[webgui] let enable usage of currentdir [6.32]

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -152,6 +152,7 @@ private:
    unsigned fConnLimit{1};                          ///<! number of allowed active connections
    std::string fConnToken;                          ///<! value of "token" URL parameter which should be provided for connecting window
    bool fNativeOnlyConn{false};                     ///<! only native connection are allowed, created by Show() method
+   bool fUseCurrentDir{false};                      ///<! if window can access local files via currentdir/ path of http server
    unsigned fMaxQueueLength{10};                    ///<! maximal number of queue entries
    WebWindowConnectCallback_t fConnCallback;        ///<! callback for connect event
    WebWindowDataCallback_t fDataCallback;           ///<! main callback when data over channel 1 is arrived
@@ -317,6 +318,14 @@ public:
    /////////////////////////////////////////////////////////////////////////
    /// returns true if authentication string is required
    bool IsRequireAuthKey() const { return fRequireAuthKey; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// Configure if window can access local files via currentdir/ path of http server
+   void SetUseCurrentDir(bool on = true) { fUseCurrentDir = on; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// returns true if window can access local files via currentdir/ path of http server
+   bool IsUseCurrentDir() const { return fUseCurrentDir; }
 
    void SetClientVersion(const std::string &vers);
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -141,6 +141,8 @@ void RWebWindow::SetPanelName(const std::string &name)
 
    fPanelName = name;
    SetDefaultPage("file:rootui5sys/panel/panel.html");
+   if (fPanelName.find("localapp.") == 0)
+      SetUseCurrentDir(true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -763,7 +763,7 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
                "ROOT web-based widget started in the session where DISPLAY set to " << displ << "\n" <<
                "Means web browser will be displayed on remote X11 server which is usually very inefficient\n"
                "One can start ROOT session in server mode like \"root -b --web=server:8877\" and forward http port to display node\n"
-               "Or one can use rootssh script to configure pore forwarding and display web widgets automatically\n"
+               "Or one can use rootssh script to configure port forwarding and display web widgets automatically\n"
                "Find more info on https://root.cern/for_developers/root7/#rbrowser\n"
                "This message can be disabled by setting \"" << varname << ": no\" in .rootrc file\n";
          }
@@ -771,8 +771,13 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
    }
 #endif
 
+   auto server = GetServer();
+
+   if (win.IsUseCurrentDir())
+      server->AddLocation("currentdir/", ".");
+
    if (!normal_http)
-      args.SetHttpServer(GetServer());
+      args.SetHttpServer(server);
 
    auto handle = RWebDisplayHandle::Display(args);
 


### PR DESCRIPTION
Backport of #15867 

For security reasons this option is off by default. 

Only when desired `win.SetUseCurrentDir(true)` should be invoked. 
It happens automatically when "localapp." namespace configured as main ui5 panel for the window

