### PR TITLE
[ntuple] Fix clang compile warning due to typeid in RField

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2489,6 +2489,7 @@ std::size_t ROOT::Experimental::RVectorField::AppendImpl(const void *from)
    // TODO(jblomer): for the following error condition, we print very detailed information before aborting.
    // This is used to debug writing of CMS MiniAODs and can reverted back to an assert once the error is understood.
    if ((typedValue->size() % fItemSize) != 0) {
+      const auto &subfield0 = *fSubFields[0];
       std::string errMsg{"(typedValue->size() % fItemSize) != 0 in RVectorField::AppendImpl\n"};
       errMsg += "Field name: " + GetQualifiedFieldName() + "\n";
       errMsg += "Type name: " + GetTypeName() + "\n";
@@ -2496,13 +2497,13 @@ std::size_t ROOT::Experimental::RVectorField::AppendImpl(const void *from)
       errMsg += "fItemSize: " + std::to_string(fItemSize);
       errMsg += "   typedValue->size(): " + std::to_string(typedValue->size());
       errMsg += "   fNWritten: " + std::to_string(fNWritten) + "\n";
-      errMsg += "Item type: " + fSubFields[0]->GetTypeName() + "\n";
-      errMsg += "Item alias: " + fSubFields[0]->GetTypeAlias() + "\n";
-      errMsg += "Item field traits: " + std::to_string(fSubFields[0]->GetTraits()) + "\n";
-      errMsg += "Item field size: " + std::to_string(fSubFields[0]->GetValueSize()) + "\n";
-      errMsg += "Item field alignment: " + std::to_string(fSubFields[0]->GetAlignment()) + "\n";
-      errMsg += "Item field type: " + std::string(typeid(*fSubFields[0]).name());
-      errMsg += "   demangled: " + ROOT::Internal::GetDemangledTypeName(typeid(*fSubFields[0])) + "\n";
+      errMsg += "Item type: " + subfield0.GetTypeName() + "\n";
+      errMsg += "Item alias: " + subfield0.GetTypeAlias() + "\n";
+      errMsg += "Item field traits: " + std::to_string(subfield0.GetTraits()) + "\n";
+      errMsg += "Item field size: " + std::to_string(subfield0.GetValueSize()) + "\n";
+      errMsg += "Item field alignment: " + std::to_string(subfield0.GetAlignment()) + "\n";
+      errMsg += "Item field type: " + std::string(typeid(subfield0).name());
+      errMsg += "   demangled: " + ROOT::Internal::GetDemangledTypeName(typeid(subfield0)) + "\n";
       errMsg += "*from type: " + std::string(typeid(*typedValue).name());
       errMsg += "   demangled: " + ROOT::Internal::GetDemangledTypeName(typeid(*typedValue)) + "\n";
       ::Fatal("", kAssertMsg, errMsg.c_str(), __LINE__, __FILE__);


### PR DESCRIPTION
## Changes or fixes:
After b5d751c069df2725dbc0d96bb1a6a677addc3895, RField.cxx on clang yields the warning:
```
/home/jp/root/tree/ntuple/v7/src/RField.cxx:2504:58: error: expression with side effects will be evaluated despite being used as an operand to 'typeid' [-Werror,-Wpotentially-evaluated-expression]
      errMsg += "Item field type: " + std::string(typeid(*fSubFields[0]).name());
```

Fixing the warning is just a matter of splitting the ptr dereference from the `typeid` expression.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

