### PR TITLE
[skip-ci] mention how to change z axis title in tscatter

### DIFF
--- a/tutorials/graphs/scatter.C
+++ b/tutorials/graphs/scatter.C
@@ -32,4 +32,14 @@ void scatter()
    scatter->SetMarkerStyle(20);
    scatter->SetTitle("Scatter plot;X;Y");
    scatter->Draw("A");
+
+   // The next snippet is only needed if you want to change the colorbar title
+   canvas->Modified();
+   canvas->Update();
+   TPaletteAxis *palette = (TPaletteAxis*)scat->GetGraph()->GetListOfFunctions()->FindObject("palette");
+   palette->SetX1NDC(0.86);
+   palette->SetX2NDC(0.90);
+   palette->SetTitle("Palette Title");
+   canvas->Modified();
+   canvas->Update();
 }


### PR DESCRIPTION
this was done by couet, I just copy-pasted from https://root-forum.cern.ch/t/scatter-plot-with-colorbar/59562/14

There is one outstanding issue though:
- Save the object as .C and reload it, then the axis title is lost.

So the function SavePrimitive should be amended, too.

Also: 

`scat->GetHistogram()->SetMinimum(100);`

has no effect, it seems there is not an easy way to control the color range?