### PR TITLE
[ntuple] turn RSealedPage into class with getters/setters

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -74,12 +74,12 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
-   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.fSize; }
+   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.GetSize(); }
    void CommitSealedPageV(std::span<RSealedPageGroup> ranges) final
    {
       for (auto &range : ranges) {
          for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-            fNBytesCurrentCluster += sealedPageIt->fSize;
+            fNBytesCurrentCluster += sealedPageIt->GetSize();
          }
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -84,16 +84,27 @@ public:
    /// RSealedPage does _not_ own the buffer it is pointing to in order to not interfere with the memory management
    /// of concrete page sink and page source implementations.
    struct RSealedPage {
+   private:
       const void *fBuffer = nullptr;
       std::uint32_t fSize = 0;
       std::uint32_t fNElements = 0;
 
+   public:
       RSealedPage() = default;
       RSealedPage(const void *b, std::uint32_t s, std::uint32_t n) : fBuffer(b), fSize(s), fNElements(n) {}
       RSealedPage(const RSealedPage &other) = default;
       RSealedPage &operator=(const RSealedPage &other) = default;
       RSealedPage(RSealedPage &&other) = default;
       RSealedPage& operator =(RSealedPage &&other) = default;
+
+      const void *GetBuffer() const { return fBuffer; }
+      void SetBuffer(const void *buffer) { fBuffer = buffer; }
+
+      std::uint32_t GetSize() const { return fSize; }
+      void SetSize(std::uint32_t size) { fSize = size; }
+
+      std::uint32_t GetNElements() const { return fNElements; }
+      void SetNElements(std::uint32_t nElements) { fNElements = nElements; }
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -234,8 +234,8 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
                // The way LoadSealedPage works might require a double call
                // See the implementation. Here we do this in any case...
-               auto buffer = std::make_unique<unsigned char[]>(sealedPage.fSize);
-               sealedPage.fBuffer = buffer.get();
+               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+               sealedPage.SetBuffer(buffer.get());
                source->LoadSealedPage(columnId, clusterIndex, sealedPage);
 
                buffers.push_back(std::move(buffer));

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -87,15 +87,15 @@ ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage:
    std::uint64_t offsetData;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      offsetData = fWriter->WriteBlob(sealedPage.fBuffer, sealedPage.fSize, bytesPacked);
+      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetSize(), bytesPacked);
    }
 
    RNTupleLocator result;
    result.fPosition = offsetData;
-   result.fBytesOnStorage = sealedPage.fSize;
+   result.fBytesOnStorage = sealedPage.GetSize();
    fCounters->fNPageCommitted.Inc();
-   fCounters->fSzWritePayload.Add(sealedPage.fSize);
-   fNBytesCurrentCluster += sealedPage.fSize;
+   fCounters->fSzWritePayload.Add(sealedPage.GetSize());
+   fNBytesCurrentCluster += sealedPage.GetSize();
    return result;
 }
 
@@ -119,7 +119,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t
 {
    const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
       fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(physicalColumnId).GetModel().GetType());
-   const auto bytesPacked = (bitsOnStorage * sealedPage.fNElements + 7) / 8;
+   const auto bytesPacked = (bitsOnStorage * sealedPage.GetNElements() + 7) / 8;
 
    return WriteSealedPage(sealedPage, bytesPacked);
 }
@@ -137,8 +137,8 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
       const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
          fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(range.fPhysicalColumnId).GetModel().GetType());
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         size += sealedPageIt->fSize;
-         bytesPacked += (bitsOnStorage * sealedPageIt->fNElements + 7) / 8;
+         size += sealedPageIt->GetSize();
+         bytesPacked += (bitsOnStorage * sealedPageIt->GetNElements() + 7) / 8;
       }
    }
    if (size >= std::numeric_limits<std::int32_t>::max() || bytesPacked >= std::numeric_limits<std::int32_t>::max()) {
@@ -155,12 +155,12 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         fWriter->WriteIntoReservedBlob(sealedPageIt->fBuffer, sealedPageIt->fSize, offset);
+         fWriter->WriteIntoReservedBlob(sealedPageIt->GetBuffer(), sealedPageIt->GetSize(), offset);
          RNTupleLocator locator;
          locator.fPosition = offset;
-         locator.fBytesOnStorage = sealedPageIt->fSize;
+         locator.fBytesOnStorage = sealedPageIt->GetSize();
          locators.push_back(locator);
-         offset += sealedPageIt->fSize;
+         offset += sealedPageIt->GetSize();
       }
    }
 
@@ -361,15 +361,15 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
-   sealedPage.fSize = bytesOnStorage;
-   sealedPage.fNElements = pageInfo.fNElements;
-   if (!sealedPage.fBuffer)
+   sealedPage.SetSize(bytesOnStorage);
+   sealedPage.SetNElements(pageInfo.fNElements);
+   if (!sealedPage.GetBuffer())
       return;
    if (pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero) {
-      fReader.ReadBuffer(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage,
+      fReader.ReadBuffer(const_cast<void *>(sealedPage.GetBuffer()), bytesOnStorage,
                          pageInfo.fLocator.GetPosition<std::uint64_t>());
    } else {
-      memcpy(const_cast<void *>(sealedPage.fBuffer), RPage::GetPageZeroBuffer(), bytesOnStorage);
+      memcpy(const_cast<void *>(sealedPage.GetBuffer()), RPage::GetPageZeroBuffer(), bytesOnStorage);
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -118,8 +118,8 @@ TEST(RColumnElementEndian, ByteCopy)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -144,8 +144,8 @@ TEST(RColumnElementEndian, Cast)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -171,8 +171,8 @@ TEST(RColumnElementEndian, Split)
    page1.GrowUnchecked(2);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
 
    RPageSourceMock source1(sink1.GetPages(), splitElement);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
@@ -199,8 +199,8 @@ TEST(RColumnElementEndian, DeltaSplit)
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
-   EXPECT_EQ(
-      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x04\x04\x04\x02\x04\x04\x04\x01\x04\x04\x04\x00\x04\x04\x04", 16));
+   EXPECT_EQ(0, memcmp(sink1.GetPages()[0].GetBuffer(),
+                       "\x03\x04\x04\x04\x02\x04\x04\x04\x01\x04\x04\x04\x00\x04\x04\x04", 16));
 
    RPageSourceMock source1(sink1.GetPages(), element);
    auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -50,14 +50,14 @@ TEST(RPageStorage, ReadSealedPages)
    RClusterIndex index(source.GetSharedDescriptorGuard()->FindClusterId(columnId, 0), 0);
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
-   ASSERT_EQ(1U, sealedPage.fNElements);
-   ASSERT_EQ(4U, sealedPage.fSize);
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.fSize);
-   sealedPage.fBuffer = buffer.get();
+   ASSERT_EQ(1U, sealedPage.GetNElements());
+   ASSERT_EQ(4U, sealedPage.GetSize());
+   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+   sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
-   ASSERT_EQ(1U, sealedPage.fNElements);
-   ASSERT_EQ(4U, sealedPage.fSize);
-   EXPECT_EQ(42, ReadRawInt(sealedPage.fBuffer));
+   ASSERT_EQ(1U, sealedPage.GetNElements());
+   ASSERT_EQ(4U, sealedPage.GetSize());
+   EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 
    // Check second, big cluster
    auto clusterId = source.GetSharedDescriptorGuard()->FindClusterId(columnId, 1);
@@ -68,10 +68,10 @@ TEST(RPageStorage, ReadSealedPages)
    std::uint32_t firstElementInPage = 0;
    for (const auto &pi : pageRange.fPageInfos) {
       buffer = std::make_unique<unsigned char[]>(pi.fLocator.fBytesOnStorage);
-      sealedPage.fBuffer = buffer.get();
+      sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      ASSERT_GE(sealedPage.fSize, 4U);
-      EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.fBuffer));
+      ASSERT_GE(sealedPage.GetSize(), 4U);
+      EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
       firstElementInPage += pi.fNElements;
    }
 }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -306,51 +306,51 @@ TEST(Packing, OnDiskEncoding)
 
    source->LoadSealedPage(fnGetColumnId("int16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt16[] = {0x02, 0x05, 0x00, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt16, sizeof(expInt16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt16, sizeof(expInt16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("int32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt32[] = {0x06, 0x0d, 0x04, 0x0c, 0x02, 0x0a, 0x00, 0x08};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt32, sizeof(expInt32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt32, sizeof(expInt32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("int64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expInt64[] = {0x0e, 0x1d, 0x0c, 0x1c, 0x0a, 0x1a, 0x08, 0x18,
                                0x06, 0x16, 0x04, 0x14, 0x02, 0x12, 0x00, 0x10};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt64, sizeof(expInt64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expInt64, sizeof(expInt64)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt16[] = {0x01, 0x02, 0x00, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt16, sizeof(expUInt16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt16, sizeof(expUInt16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt32[] = {0x03, 0x07, 0x02, 0x06, 0x01, 0x05, 0x00, 0x04};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt32, sizeof(expUInt32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt32, sizeof(expUInt32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("uint64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expUInt64[] = {0x07, 0x0f, 0x06, 0x0e, 0x05, 0x0d, 0x04, 0x0c,
                                 0x03, 0x0b, 0x02, 0x0a, 0x01, 0x09, 0x00, 0x08};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expUInt64, sizeof(expUInt64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expUInt64, sizeof(expUInt64)), 0);
 
    source->LoadSealedPage(fnGetColumnId("float"), RClusterIndex(0, 0), sealedPage);
    unsigned char expFloat[] = {0x01, 0xff, 0x00, 0xff, 0x80, 0x7f, 0x3f, 0x3f};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expFloat, sizeof(expFloat)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expFloat, sizeof(expFloat)), 0);
 
    source->LoadSealedPage(fnGetColumnId("float16"), RClusterIndex(0, 0), sealedPage);
    unsigned char expFloat16[] = {0x00, 0x3c, 0x66, 0x2e};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expFloat16, sizeof(expFloat16)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expFloat16, sizeof(expFloat16)), 0);
 
    source->LoadSealedPage(fnGetColumnId("double"), RClusterIndex(0, 0), sealedPage);
    unsigned char expDouble[] = {0x01, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
                                 0x00, 0xff, 0x00, 0xff, 0xf0, 0xef, 0x3f, 0x7f};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expDouble, sizeof(expDouble)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expDouble, sizeof(expDouble)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index32"), RClusterIndex(0, 0), sealedPage);
    unsigned char expIndex32[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex32, sizeof(expIndex32)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expIndex32, sizeof(expIndex32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index64"), RClusterIndex(0, 0), sealedPage);
    unsigned char expIndex64[] = {0x00, 0x0D, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00,
                                  0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
+   EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(EColumnType::kIndex64, reader->GetModel().GetField("str").GetColumnRepresentative()[0]);


### PR DESCRIPTION
In preparation of adding page checksums. The `GetSize()` getter will later be split in `GetPayloadSize()` (page size without checksum) and `GetTotalPageSize()` (page size with checksum).