### PR TITLE
[ntuple] minor cleanups to some RNTuple classes

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -674,11 +674,11 @@ public:
    int GetTraits() const { return fTraits; }
    bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }
 
-   std::string GetFieldName() const { return fName; }
+   const std::string &GetFieldName() const { return fName; }
    /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
    std::string GetQualifiedFieldName() const;
-   std::string GetTypeName() const { return fType; }
-   std::string GetTypeAlias() const { return fTypeAlias; }
+   const std::string &GetTypeName() const { return fType; }
+   const std::string &GetTypeAlias() const { return fTypeAlias; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
@@ -687,7 +687,7 @@ public:
    std::vector<const RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }
    /// Get the field's description
-   std::string GetDescription() const { return fDescription; }
+   const std::string &GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
    EState GetState() const { return fState; }
 
@@ -758,7 +758,7 @@ public:
    {
    }
 
-   std::string GetError() const { return fError; }
+   const std::string &GetError() const { return fError; }
 
    size_t GetValueSize() const final { return 0; }
    size_t GetAlignment() const final { return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -112,10 +112,10 @@ public:
    DescriptorId_t GetId() const { return fFieldId; }
    std::uint32_t GetFieldVersion() const { return fFieldVersion; }
    std::uint32_t GetTypeVersion() const { return fTypeVersion; }
-   std::string GetFieldName() const { return fFieldName; }
-   std::string GetFieldDescription() const { return fFieldDescription; }
-   std::string GetTypeName() const { return fTypeName; }
-   std::string GetTypeAlias() const { return fTypeAlias; }
+   const std::string &GetFieldName() const { return fFieldName; }
+   const std::string &GetFieldDescription() const { return fFieldDescription; }
+   const std::string &GetTypeName() const { return fTypeName; }
+   const std::string &GetTypeAlias() const { return fTypeAlias; }
    std::uint64_t GetNRepetitions() const { return fNRepetitions; }
    ENTupleStructure GetStructure() const { return fStructure; }
    DescriptorId_t GetParentId() const { return fParentId; }
@@ -437,8 +437,8 @@ public:
    EExtraTypeInfoIds GetContentId() const { return fContentId; }
    std::uint32_t GetTypeVersionFrom() const { return fTypeVersionFrom; }
    std::uint32_t GetTypeVersionTo() const { return fTypeVersionTo; }
-   std::string GetTypeName() const { return fTypeName; }
-   std::string GetContent() const { return fContent; }
+   const std::string &GetTypeName() const { return fTypeName; }
+   const std::string &GetContent() const { return fContent; }
 };
 
 // clang-format off
@@ -862,8 +862,8 @@ public:
 
    RExtraTypeInfoDescriptorIterable GetExtraTypeInfoIterable() const { return RExtraTypeInfoDescriptorIterable(*this); }
 
-   std::string GetName() const { return fName; }
-   std::string GetDescription() const { return fDescription; }
+   const std::string &GetName() const { return fName; }
+   const std::string &GetDescription() const { return fDescription; }
 
    std::size_t GetNFields() const { return fFieldDescriptors.size(); }
    std::size_t GetNLogicalColumns() const { return fColumnDescriptors.size(); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
@@ -64,9 +64,9 @@ public:
    virtual ~RNTuplePerfCounter();
    void Enable() { fIsEnabled = true; }
    bool IsEnabled() const { return fIsEnabled; }
-   std::string GetName() const { return fName; }
-   std::string GetDescription() const { return fDescription; }
-   std::string GetUnit() const { return fUnit; }
+   const std::string &GetName() const { return fName; }
+   const std::string &GetDescription() const { return fDescription; }
+   const std::string &GetUnit() const { return fUnit; }
 
    virtual std::int64_t GetValueAsInt() const = 0;
    virtual std::string GetValueAsString() const = 0;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -335,7 +335,7 @@ public:
    const RFieldZero &GetFieldZero() const { return *fFieldZero; }
    const RFieldBase &GetField(std::string_view fieldName) const;
 
-   std::string GetDescription() const { return fDescription; }
+   const std::string &GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
 
    /// Estimate the memory usage for this model during writing

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -213,7 +213,7 @@ public:
    /// ~~~
    ///
    /// For use of ENTupleInfo::kMetrics, see #EnableMetrics.
-   void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout);
+   void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout) const;
 
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
    /// prints the output in JSON format.

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -33,13 +33,9 @@ struct ClusterInfo {
    std::uint32_t fBytesOnStorage = 0;
    std::uint32_t fBytesInMemory = 0;
 
-   bool operator ==(const ClusterInfo &other) const {
-      return fFirstEntry == other.fFirstEntry;
-   }
+   bool operator==(const ClusterInfo &other) const { return fFirstEntry == other.fFirstEntry; }
 
-   bool operator <(const ClusterInfo &other) const {
-      return fFirstEntry < other.fFirstEntry;
-   }
+   bool operator<(const ClusterInfo &other) const { return fFirstEntry < other.fFirstEntry; }
 };
 
 struct ColumnInfo {
@@ -55,15 +51,16 @@ struct ColumnInfo {
    std::string fFieldName;
    std::string fFieldDescription;
 
-   bool operator <(const ColumnInfo &other) const {
+   bool operator<(const ColumnInfo &other) const
+   {
       if (fFieldName == other.fFieldName)
          return fLocalOrder < other.fLocalOrder;
       return fFieldName < other.fFieldName;
    }
 };
 
-std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
-   const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
+std::string
+GetFieldName(ROOT::Experimental::DescriptorId_t fieldId, const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fieldId);
    if (fieldDesc.GetParentId() == ROOT::Experimental::kInvalidDescriptorId)
@@ -72,7 +69,7 @@ std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
 }
 
 std::string GetFieldDescription(ROOT::Experimental::DescriptorId_t fFieldId,
-   const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
+                                const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fFieldId);
    return fieldDesc.GetFieldDescription();
@@ -85,6 +82,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    std::vector<ColumnInfo> columns;
    std::vector<ClusterInfo> clusters;
    std::unordered_map<DescriptorId_t, unsigned int> cluster2Idx;
+   clusters.reserve(fClusterDescriptors.size());
    for (const auto &cluster : fClusterDescriptors) {
       ClusterInfo info;
       info.fFirstEntry = cluster.second.GetFirstEntryIndex();
@@ -138,44 +136,46 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    }
    auto headerSize = GetOnDiskHeaderSize();
    auto footerSize = GetOnDiskFooterSize();
-   output << "============================================================" << std::endl;
-   output << "NTUPLE:      " << GetName() << std::endl;
-   output << "Compression: " << compression << std::endl;
-   output << "------------------------------------------------------------" << std::endl;
-   output << "  # Entries:        " << GetNEntries() << std::endl;
-   output << "  # Fields:         " << GetNFields() << std::endl;
-   output << "  # Columns:        " << GetNPhysicalColumns() << std::endl;
-   output << "  # Alias Columns:  " << GetNLogicalColumns() - GetNPhysicalColumns() << std::endl;
-   output << "  # Pages:          " << nPages << std::endl;
-   output << "  # Clusters:       " << GetNClusters() << std::endl;
-   output << "  Size on storage:  " << bytesOnStorage << " B" << std::endl;
+   output << "============================================================\n";
+   output << "NTUPLE:      " << GetName() << "\n";
+   output << "Compression: " << compression << "\n";
+   output << "------------------------------------------------------------\n";
+   output << "  # Entries:        " << GetNEntries() << "\n";
+   output << "  # Fields:         " << GetNFields() << "\n";
+   output << "  # Columns:        " << GetNPhysicalColumns() << "\n";
+   output << "  # Alias Columns:  " << GetNLogicalColumns() - GetNPhysicalColumns() << "\n";
+   output << "  # Pages:          " << nPages << "\n";
+   output << "  # Clusters:       " << GetNClusters() << "\n";
+   output << "  Size on storage:  " << bytesOnStorage << " B"
+          << "\n";
    output << "  Compression rate: " << std::fixed << std::setprecision(2)
-                                    << float(bytesInMemory) / float(bytesOnStorage) << std::endl;
-   output << "  Header size:      " << headerSize << " B" << std::endl;
-   output << "  Footer size:      " << footerSize << " B" << std::endl;
+          << float(bytesInMemory) / float(bytesOnStorage) << "\n";
+   output << "  Header size:      " << headerSize << " B"
+          << "\n";
+   output << "  Footer size:      " << footerSize << " B"
+          << "\n";
    output << "  Meta-data / data: " << std::fixed << std::setprecision(3)
-                                    << float(headerSize + footerSize) / float(bytesOnStorage) << std::endl;
-   output << "------------------------------------------------------------" << std::endl;
-   output << "CLUSTER DETAILS" << std::endl;
+          << float(headerSize + footerSize) / float(bytesOnStorage) << "\n";
+   output << "------------------------------------------------------------\n";
+   output << "CLUSTER DETAILS\n";
    output << "------------------------------------------------------------" << std::endl;
 
    std::sort(clusters.begin(), clusters.end());
    for (unsigned int i = 0; i < clusters.size(); ++i) {
-      output << "  # " << std::setw(5) << i
-             << "   Entry range:     [" << clusters[i].fFirstEntry << ".."
-             << clusters[i].fFirstEntry + clusters[i].fNEntries - 1 << "]  --  " << clusters[i].fNEntries << std::endl;
+      output << "  # " << std::setw(5) << i << "   Entry range:     [" << clusters[i].fFirstEntry << ".."
+             << clusters[i].fFirstEntry + clusters[i].fNEntries - 1 << "]  --  " << clusters[i].fNEntries << "\n";
       output << "         "
-             << "   # Pages:         " << clusters[i].fNPages << std::endl;
+             << "   # Pages:         " << clusters[i].fNPages << "\n";
       output << "         "
-             << "   Size on storage: " << clusters[i].fBytesOnStorage << " B" << std::endl;
+             << "   Size on storage: " << clusters[i].fBytesOnStorage << " B\n";
       output << "         "
              << "   Compression:     " << std::fixed << std::setprecision(2)
              << float(clusters[i].fBytesInMemory) / float(float(clusters[i].fBytesOnStorage)) << std::endl;
    }
 
-   output << "------------------------------------------------------------" << std::endl;
-   output << "COLUMN DETAILS" << std::endl;
-   output << "------------------------------------------------------------" << std::endl;
+   output << "------------------------------------------------------------\n";
+   output << "COLUMN DETAILS\n";
+   output << "------------------------------------------------------------\n";
    for (auto &col : columns) {
       col.fFieldName = GetFieldName(col.fFieldId, *this).substr(1);
       col.fFieldDescription = GetFieldDescription(col.fFieldId, *this);
@@ -189,16 +189,16 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       std::string id = std::string("{id:") + std::to_string(col.fLogicalColumnId) + "}";
       if (col.fLogicalColumnId != col.fPhysicalColumnId)
          id += " --alias--> " + std::to_string(col.fPhysicalColumnId);
-      output << nameAndType << std::setw(60 - nameAndType.length()) << id << std::endl;
+      output << nameAndType << std::setw(60 - nameAndType.length()) << id << "\n";
       if (!col.fFieldDescription.empty())
-         output << "    Description:         " << col.fFieldDescription << std::endl;
-      output << "    # Elements:          " << col.fNElements << std::endl;
-      output << "    # Pages:             " << col.fNPages << std::endl;
-      output << "    Avg elements / page: " << avgElementsPerPage << std::endl;
-      output << "    Avg page size:       " << avgPageSize << " B" << std::endl;
-      output << "    Size on storage:     " << col.fBytesOnStorage << " B" << std::endl;
+         output << "    Description:         " << col.fFieldDescription << "\n";
+      output << "    # Elements:          " << col.fNElements << "\n";
+      output << "    # Pages:             " << col.fNPages << "\n";
+      output << "    Avg elements / page: " << avgElementsPerPage << "\n";
+      output << "    Avg page size:       " << avgPageSize << " B\n";
+      output << "    Size on storage:     " << col.fBytesOnStorage << " B\n";
       output << "    Compression:         " << std::fixed << std::setprecision(2)
-             << float(col.fElementSize * col.fNElements) / float(col.fBytesOnStorage) << std::endl;
+             << float(col.fElementSize * col.fNElements) / float(col.fBytesOnStorage) << "\n";
       output << "............................................................" << std::endl;
    }
 }

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -128,7 +128,7 @@ const ROOT::Experimental::RNTupleModel &ROOT::Experimental::RNTupleReader::GetMo
    return *fModel;
 }
 
-void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output)
+void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output) const
 {
    // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out
    // from the terminal.
@@ -155,12 +155,12 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       output << " NTUPLE ";
       for (int i = 0; i < (width / 2 - 4); ++i)
          output << frameSymbol;
-      output << std::endl;
+      output << "\n";
       // FitString defined in RFieldVisitor.cxx
       output << frameSymbol << " N-Tuple : " << RNTupleFormatter::FitString(name, width - 13) << frameSymbol
-             << std::endl; // prints line with name of ntuple
+             << "\n"; // prints line with name of ntuple
       output << frameSymbol << " Entries : " << RNTupleFormatter::FitString(std::to_string(GetNEntries()), width - 13)
-             << frameSymbol << std::endl; // prints line with number of entries
+             << frameSymbol << "\n"; // prints line with number of entries
 
       // Traverses through all fields to gather information needed for printing.
       RPrepareVisitor prepVisitor;
@@ -177,7 +177,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
 
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
-      output << std::endl;
+      output << "\n";
       fullModel->GetFieldZero().AcceptVisitor(printVisitor);
       for (int i = 0; i < width; ++i)
          output << frameSymbol;


### PR DESCRIPTION
- use "\n" instead of `std::endl` for all but last newline in PrintInfo
- avoid copying strings from getters when possible

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

