### PR TITLE
[PyROOT] Avoid linking TPython against libPython

### DIFF
--- a/bindings/tpython/CMakeLists.txt
+++ b/bindings/tpython/CMakeLists.txt
@@ -27,7 +27,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTPython
     # We link libTPython against Python libraries to compensate for the fact that libcppyy
     # is built with unresolved symbols. If we didn't do this, invoking TPython from C++
     # would not work.
-    Python3::Python
+    Python3::Module
 )
 
 # Disables warnings originating from deprecated register keyword in Python


### PR DESCRIPTION
I'm opening this PR to give it a go with our CI. This change is somewhat necessary on many levels (conda benefits from it, pip requires it). And it is also a good habit in general not to link against libPython.

EDIT: possibly superseeded by https://github.com/root-project/root/pull/16337