### PR TITLE
[ntuple] fix LoadSealedPage with DAOS/caging

### DIFF
--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -293,7 +293,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       auto elem = ROOT::Experimental::Internal::RColumnElementBase::Generate<std::uint32_t>(colType);
       auto page = pageSource->UnsealPage(sealedPage, *elem, colId);
       EXPECT_GT(page.GetNElements(), 0);
-      auto ptrData = static_cast<uint32_t *>(page.GetBuffer());
+      auto ptrData = static_cast<std::uint32_t *>(page.GetBuffer());
       for (std::uint32_t i = 0; i < page.GetNElements(); ++i) {
          EXPECT_EQ(i, *(ptrData + i));
       }


### PR DESCRIPTION
In preparation of adding page checksums, it makes sense to enable `LoadSealedPage()` support with DAOS and the caging option (caging: storage of multiple pages in a single object). Even though the implementation is not very performant, it will later allow to streamline the test for checksum verification.
