### PR TITLE
[DF] Make vector to RVec conversion optional in Snapshot() of RDF

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -345,7 +345,7 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
 std::string JitBuildAction(const ColumnNames_t &bl, std::shared_ptr<RDFDetail::RNodeBase> *prevNode,
                            const std::type_info &art, const std::type_info &at, void *rOnHeap, TTree *tree,
                            const unsigned int nSlots, const RColumnRegister &colRegister, RDataSource *ds,
-                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2rvec = true);
+                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2RVec = true);
 
 // Allocate a weak_ptr on the heap, return a pointer to it. The user is responsible for deleting this weak_ptr.
 // This function is meant to be used by RInterface's methods that book code for jitting.
@@ -377,7 +377,7 @@ ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColu
 
 std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RColumnRegister &colRegister,
                                               TTree *tree, RDataSource *ds, const std::string &context,
-                                              bool vector2rvec);
+                                              bool vector2RVec);
 
 std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, const ColumnNames_t &definedDSCols);
 

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -345,7 +345,7 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
 std::string JitBuildAction(const ColumnNames_t &bl, std::shared_ptr<RDFDetail::RNodeBase> *prevNode,
                            const std::type_info &art, const std::type_info &at, void *rOnHeap, TTree *tree,
                            const unsigned int nSlots, const RColumnRegister &colRegister, RDataSource *ds,
-                           std::weak_ptr<RJittedAction> *jittedActionOnHeap);
+                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2rvec = true);
 
 // Allocate a weak_ptr on the heap, return a pointer to it. The user is responsible for deleting this weak_ptr.
 // This function is meant to be used by RInterface's methods that book code for jitting.

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1352,7 +1352,7 @@ public:
 
       auto resPtr = CreateAction<RDFInternal::ActionTags::Snapshot, RDFDetail::RInferredType>(
          colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr, colListNoAliasesWithSizeBranches.size(),
-         options.fVector2rvec);
+         options.fVector2RVec);
 
       if (!options.fLazy)
          *resPtr;
@@ -1495,7 +1495,7 @@ public:
       const auto validColumnNames =
          GetValidatedColumnNames(columnListWithoutSizeColumns.size(), columnListWithoutSizeColumns);
       const auto colTypes = GetValidatedArgTypes(validColumnNames, fColRegister, fLoopManager->GetTree(), fDataSource,
-                                                 "Cache", /*vector2rvec=*/false);
+                                                 "Cache", /*vector2RVec=*/false);
       for (const auto &colType : colTypes)
          cacheCall << colType << ", ";
       if (!columnListWithoutSizeColumns.empty())

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1350,10 +1350,9 @@ public:
       auto newRDF = std::make_shared<RInterface<RLoopManager>>(ROOT::Detail::RDF::CreateLMFromTTree(
          fullTreeName, filename, colListNoAliasesWithSizeBranches, /*checkFile*/ false));
 
-
       auto resPtr = CreateAction<RDFInternal::ActionTags::Snapshot, RDFDetail::RInferredType>(
-         colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr,
-         colListNoAliasesWithSizeBranches.size(), options.fVector2rvec);
+         colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr, colListNoAliasesWithSizeBranches.size(),
+         options.fVector2rvec);
 
       if (!options.fLazy)
          *resPtr;

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1316,8 +1316,7 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  const ColumnNames_t &columnList,
-                                                 const RSnapshotOptions &options = RSnapshotOptions(),
-                                                 const bool vector2rvec = true)
+                                                 const RSnapshotOptions &options = RSnapshotOptions())
    {
       // like columnList but with `#var` columns removed
       auto colListNoPoundSizes = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
@@ -1351,9 +1350,10 @@ public:
       auto newRDF = std::make_shared<RInterface<RLoopManager>>(ROOT::Detail::RDF::CreateLMFromTTree(
          fullTreeName, filename, colListNoAliasesWithSizeBranches, /*checkFile*/ false));
 
+
       auto resPtr = CreateAction<RDFInternal::ActionTags::Snapshot, RDFDetail::RInferredType>(
          colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr,
-         colListNoAliasesWithSizeBranches.size(), vector2rvec);
+         colListNoAliasesWithSizeBranches.size(), options.fVector2rvec);
 
       if (!options.fLazy)
          *resPtr;
@@ -1375,8 +1375,7 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  std::string_view columnNameRegexp = "",
-                                                 const RSnapshotOptions &options = RSnapshotOptions(),
-                                                 const bool vector2rvec = true)
+                                                 const RSnapshotOptions &options = RSnapshotOptions())
    {
       const auto definedColumns = fColRegister.GenerateColumnNames();
       auto *tree = fLoopManager->GetTree();
@@ -1397,7 +1396,7 @@ public:
       RDFInternal::RemoveDuplicates(columnNames);
 
       const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Snapshot");
-      return Snapshot(treename, filename, selectedColumns, options, vector2rvec);
+      return Snapshot(treename, filename, selectedColumns, options);
    }
    // clang-format on
 
@@ -1416,11 +1415,10 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  std::initializer_list<std::string> columnList,
-                                                 const RSnapshotOptions &options = RSnapshotOptions(),
-                                                 const bool vector2rvec = true)
+                                                 const RSnapshotOptions &options = RSnapshotOptions())
    {
       ColumnNames_t selectedColumns(columnList);
-      return Snapshot(treename, filename, selectedColumns, options, vector2rvec);
+      return Snapshot(treename, filename, selectedColumns, options);
    }
    // clang-format on
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1316,7 +1316,8 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  const ColumnNames_t &columnList,
-                                                 const RSnapshotOptions &options = RSnapshotOptions())
+                                                 const RSnapshotOptions &options = RSnapshotOptions(),
+                                                 const bool vector2rvec = true)
    {
       // like columnList but with `#var` columns removed
       auto colListNoPoundSizes = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
@@ -1352,7 +1353,7 @@ public:
 
       auto resPtr = CreateAction<RDFInternal::ActionTags::Snapshot, RDFDetail::RInferredType>(
          colListNoAliasesWithSizeBranches, newRDF, snapHelperArgs, fProxiedPtr,
-         colListNoAliasesWithSizeBranches.size());
+         colListNoAliasesWithSizeBranches.size(), vector2rvec);
 
       if (!options.fLazy)
          *resPtr;
@@ -1374,7 +1375,8 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  std::string_view columnNameRegexp = "",
-                                                 const RSnapshotOptions &options = RSnapshotOptions())
+                                                 const RSnapshotOptions &options = RSnapshotOptions(),
+                                                 const bool vector2rvec = true)
    {
       const auto definedColumns = fColRegister.GenerateColumnNames();
       auto *tree = fLoopManager->GetTree();
@@ -1395,7 +1397,7 @@ public:
       RDFInternal::RemoveDuplicates(columnNames);
 
       const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Snapshot");
-      return Snapshot(treename, filename, selectedColumns, options);
+      return Snapshot(treename, filename, selectedColumns, options, vector2rvec);
    }
    // clang-format on
 
@@ -1414,10 +1416,11 @@ public:
    /// See above for a more complete description and example usages.
    RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
                                                  std::initializer_list<std::string> columnList,
-                                                 const RSnapshotOptions &options = RSnapshotOptions())
+                                                 const RSnapshotOptions &options = RSnapshotOptions(),
+                                                 const bool vector2rvec = true)
    {
       ColumnNames_t selectedColumns(columnList);
-      return Snapshot(treename, filename, selectedColumns, options);
+      return Snapshot(treename, filename, selectedColumns, options, vector2rvec);
    }
    // clang-format on
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -170,10 +170,10 @@ protected:
    template <typename ActionTag, typename... ColTypes, typename ActionResultType, typename RDFNode,
              typename HelperArgType = ActionResultType,
              std::enable_if_t<RDFInternal::RNeedJitting<ColTypes...>::value, int> = 0>
-   RResultPtr<ActionResultType> CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r,
-                                             const std::shared_ptr<HelperArgType> &helperArg,
-                                             const std::shared_ptr<RDFNode> &proxiedPtr, const int nColumns = -1,
-                                             const bool vector2rvec = true)
+   RResultPtr<ActionResultType>
+   CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r,
+                const std::shared_ptr<HelperArgType> &helperArg, const std::shared_ptr<RDFNode> &proxiedPtr,
+                const int nColumns = -1, const bool vector2rvec = true)
    {
       auto realNColumns = (nColumns > -1 ? nColumns : sizeof...(ColTypes));
 
@@ -189,10 +189,9 @@ protected:
                                                                              fColRegister, proxiedPtr->GetVariations());
       auto jittedActionOnHeap = RDFInternal::MakeWeakOnHeap(jittedAction);
 
-      auto toJit =
-         RDFInternal::JitBuildAction(validColumnNames, upcastNodeOnHeap, typeid(HelperArgType), typeid(ActionTag),
-                                     helperArgOnHeap, tree, nSlots, fColRegister, fDataSource, jittedActionOnHeap,
-                                     vector2rvec);
+      auto toJit = RDFInternal::JitBuildAction(validColumnNames, upcastNodeOnHeap, typeid(HelperArgType),
+                                               typeid(ActionTag), helperArgOnHeap, tree, nSlots, fColRegister,
+                                               fDataSource, jittedActionOnHeap, vector2rvec);
       fLoopManager->ToJitExec(toJit);
       return MakeResultPtr(r, *fLoopManager, std::move(jittedAction));
    }

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -172,7 +172,8 @@ protected:
              std::enable_if_t<RDFInternal::RNeedJitting<ColTypes...>::value, int> = 0>
    RResultPtr<ActionResultType> CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r,
                                              const std::shared_ptr<HelperArgType> &helperArg,
-                                             const std::shared_ptr<RDFNode> &proxiedPtr, const int nColumns = -1)
+                                             const std::shared_ptr<RDFNode> &proxiedPtr, const int nColumns = -1,
+                                             const bool vector2rvec = true)
    {
       auto realNColumns = (nColumns > -1 ? nColumns : sizeof...(ColTypes));
 
@@ -190,7 +191,8 @@ protected:
 
       auto toJit =
          RDFInternal::JitBuildAction(validColumnNames, upcastNodeOnHeap, typeid(HelperArgType), typeid(ActionTag),
-                                     helperArgOnHeap, tree, nSlots, fColRegister, fDataSource, jittedActionOnHeap);
+                                     helperArgOnHeap, tree, nSlots, fColRegister, fDataSource, jittedActionOnHeap,
+                                     vector2rvec);
       fLoopManager->ToJitExec(toJit);
       return MakeResultPtr(r, *fLoopManager, std::move(jittedAction));
    }

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -173,7 +173,7 @@ protected:
    RResultPtr<ActionResultType>
    CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r,
                 const std::shared_ptr<HelperArgType> &helperArg, const std::shared_ptr<RDFNode> &proxiedPtr,
-                const int nColumns = -1, const bool vector2rvec = true)
+                const int nColumns = -1, const bool vector2RVec = true)
    {
       auto realNColumns = (nColumns > -1 ? nColumns : sizeof...(ColTypes));
 
@@ -191,7 +191,7 @@ protected:
 
       auto toJit = RDFInternal::JitBuildAction(validColumnNames, upcastNodeOnHeap, typeid(HelperArgType),
                                                typeid(ActionTag), helperArgOnHeap, tree, nSlots, fColRegister,
-                                               fDataSource, jittedActionOnHeap, vector2rvec);
+                                               fDataSource, jittedActionOnHeap, vector2RVec);
       fLoopManager->ToJitExec(toJit);
       return MakeResultPtr(r, *fLoopManager, std::move(jittedAction));
    }

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -129,8 +129,8 @@ const std::type_info &TypeName2TypeID(const std::string &name);
 
 std::string TypeID2TypeName(const std::type_info &id);
 
-std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *, RDataSource *, RDefineBase *,
-                                      bool vector2rvec = true);
+std::string
+ColumnName2ColumnTypeName(const std::string &colName, TTree *, RDataSource *, RDefineBase *, bool vector2RVec = true);
 
 char TypeName2ROOTTypeName(const std::string &b);
 

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -44,7 +44,7 @@ struct RSnapshotOptions {
    int fSplitLevel = 99;                            ///< Split level of output tree
    bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
    bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
-   bool fVector2rvec = true; ///< If set to true will convert stl vectors to RVec
+   bool fVector2rvec = true;        ///< If set to true will convert stl vectors to RVec
 };
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -25,7 +25,7 @@ struct RSnapshotOptions {
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
    RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy,
-                    bool overwriteIfExists = false, bool vector2rvec = true)
+                    bool overwriteIfExists = false, bool vector2RVec = true)
       : fMode(mode),
         fCompressionAlgorithm(comprAlgo),
         fCompressionLevel{comprLevel},
@@ -33,7 +33,7 @@ struct RSnapshotOptions {
         fSplitLevel(splitLevel),
         fLazy(lazy),
         fOverwriteIfExists(overwriteIfExists),
-        fVector2rvec(vector2rvec)
+        fVector2RVec(vector2RVec)
    {
    }
    std::string fMode = "RECREATE"; ///< Mode of creation of output file
@@ -44,7 +44,7 @@ struct RSnapshotOptions {
    int fSplitLevel = 99;                            ///< Split level of output tree
    bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
    bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
-   bool fVector2rvec = true;        ///< If set to true will convert stl vectors to RVec
+   bool fVector2RVec = true;        ///< If set to true will convert std::vector columns to RVec when saving to disk
 };
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -25,14 +25,15 @@ struct RSnapshotOptions {
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
    RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy,
-                    bool overwriteIfExists = false)
+                    bool overwriteIfExists = false, bool vector2rvec = true)
       : fMode(mode),
         fCompressionAlgorithm(comprAlgo),
         fCompressionLevel{comprLevel},
         fAutoFlush(autoFlush),
         fSplitLevel(splitLevel),
         fLazy(lazy),
-        fOverwriteIfExists(overwriteIfExists)
+        fOverwriteIfExists(overwriteIfExists),
+        fVector2rvec(vector2rvec)
    {
    }
    std::string fMode = "RECREATE"; ///< Mode of creation of output file
@@ -43,6 +44,7 @@ struct RSnapshotOptions {
    int fSplitLevel = 99;                            ///< Split level of output tree
    bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
    bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
+   bool fVector2rvec = true; ///< If set to true will convert stl vectors to RVec
 };
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -662,7 +662,7 @@ BookFilterJit(std::shared_ptr<RDFDetail::RNodeBase> *prevNodeOnHeap, std::string
 
    const auto parsedExpr = ParseRDFExpression(expression, branches, colRegister, dsColumns);
    const auto exprVarTypes =
-      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Filter", /*vector2rvec=*/true);
+      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Filter", /*vector2RVec=*/true);
    const auto funcName = DeclareFunction(parsedExpr.fExpr, parsedExpr.fVarNames, exprVarTypes);
    const auto type = RetTypeOfFunc(funcName);
    if (type != "bool")
@@ -714,7 +714,7 @@ std::shared_ptr<RJittedDefine> BookDefineJit(std::string_view name, std::string_
 
    const auto parsedExpr = ParseRDFExpression(expression, branches, colRegister, dsColumns);
    const auto exprVarTypes =
-      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Define", /*vector2rvec=*/true);
+      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Define", /*vector2RVec=*/true);
    const auto funcName = DeclareFunction(parsedExpr.fExpr, parsedExpr.fVarNames, exprVarTypes);
    const auto type = RetTypeOfFunc(funcName);
 
@@ -789,7 +789,7 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
 
    const auto parsedExpr = ParseRDFExpression(expression, branches, colRegister, dsColumns);
    const auto exprVarTypes =
-      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Vary", /*vector2rvec=*/true);
+      GetValidatedArgTypes(parsedExpr.fUsedCols, colRegister, tree, ds, "Vary", /*vector2RVec=*/true);
    const auto funcName = DeclareFunction(parsedExpr.fExpr, parsedExpr.fVarNames, exprVarTypes);
    const auto type = RetTypeOfFunc(funcName);
 
@@ -849,7 +849,7 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
 std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail::RNodeBase> *prevNode,
                            const std::type_info &helperArgType, const std::type_info &at, void *helperArgOnHeap,
                            TTree *tree, const unsigned int nSlots, const RColumnRegister &colRegister, RDataSource *ds,
-                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2rvec)
+                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2RVec)
 {
    // retrieve type of action as a string
    auto actionTypeClass = TClass::GetClass(at);
@@ -873,7 +873,7 @@ std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail:
    // just-in-time create an RAction object and it will assign it to its corresponding RJittedAction.
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::RDF::CallBuildAction<" << actionTypeName;
-   const auto columnTypeNames = GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, vector2rvec);
+   const auto columnTypeNames = GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, vector2RVec);
    for (auto &colType : columnTypeNames)
       createAction_str << ", " << colType;
    // on Windows, to prefix the hexadecimal value of a pointer with '0x',
@@ -950,11 +950,11 @@ ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColu
 
 std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RColumnRegister &colRegister,
                                               TTree *tree, RDataSource *ds, const std::string &context,
-                                              bool vector2rvec)
+                                              bool vector2RVec)
 {
    auto toCheckedArgType = [&](const std::string &c) {
       RDFDetail::RDefineBase *define = colRegister.GetDefine(c);
-      const auto colType = ColumnName2ColumnTypeName(c, tree, ds, define, vector2rvec);
+      const auto colType = ColumnName2ColumnTypeName(c, tree, ds, define, vector2RVec);
       if (colType.rfind("CLING_UNKNOWN_TYPE", 0) == 0) { // the interpreter does not know this type
          const auto msg =
             "The type of custom column \"" + c + "\" (" + colType.substr(19) +

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -873,8 +873,7 @@ std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail:
    // just-in-time create an RAction object and it will assign it to its corresponding RJittedAction.
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::RDF::CallBuildAction<" << actionTypeName;
-   const auto columnTypeNames =
-      GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, vector2rvec);
+   const auto columnTypeNames = GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, vector2rvec);
    for (auto &colType : columnTypeNames)
       createAction_str << ", " << colType;
    // on Windows, to prefix the hexadecimal value of a pointer with '0x',

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -849,7 +849,7 @@ BookVariationJit(const std::vector<std::string> &colNames, std::string_view vari
 std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail::RNodeBase> *prevNode,
                            const std::type_info &helperArgType, const std::type_info &at, void *helperArgOnHeap,
                            TTree *tree, const unsigned int nSlots, const RColumnRegister &colRegister, RDataSource *ds,
-                           std::weak_ptr<RJittedAction> *jittedActionOnHeap)
+                           std::weak_ptr<RJittedAction> *jittedActionOnHeap, const bool vector2rvec)
 {
    // retrieve type of action as a string
    auto actionTypeClass = TClass::GetClass(at);
@@ -874,7 +874,7 @@ std::string JitBuildAction(const ColumnNames_t &cols, std::shared_ptr<RDFDetail:
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::RDF::CallBuildAction<" << actionTypeName;
    const auto columnTypeNames =
-      GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, /*vector2rvec=*/true);
+      GetValidatedArgTypes(cols, colRegister, tree, ds, actionTypeNameBase, vector2rvec);
    for (auto &colType : columnTypeNames)
       createAction_str << ", " << colType;
    // on Windows, to prefix the hexadecimal value of a pointer with '0x',

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -225,9 +225,9 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 /// Return a string containing the type of the given branch. Works both with real TTree branches and with temporary
 /// column created by Define. Throws if type name deduction fails.
 /// Note that for fixed- or variable-sized c-style arrays the returned type name will be RVec<T>.
-/// vector2rvec specifies whether typename 'std::vector<T>' should be converted to 'RVec<T>' or returned as is
+/// vector2RVec specifies whether typename 'std::vector<T>' should be converted to 'RVec<T>' or returned as is
 std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, RDataSource *ds, RDefineBase *define,
-                                      bool vector2rvec)
+                                      bool vector2RVec)
 {
    std::string colType;
 
@@ -238,7 +238,7 @@ std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, R
       colType = ds->GetTypeName(colName);
    } else if (tree) {
       colType = GetBranchOrLeafTypeName(*tree, colName);
-      if (vector2rvec && TClassEdit::IsSTLCont(colType) == ROOT::ESTLType::kSTLvector) {
+      if (vector2RVec && TClassEdit::IsSTLCont(colType) == ROOT::ESTLType::kSTLvector) {
          std::vector<std::string> split;
          int dummy;
          TClassEdit::GetSplit(colType.c_str(), split, dummy);

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -971,6 +971,83 @@ TEST(RDFSnapshotMore, OutOfOrderSizeBranch)
    gSystem->Unlink(outFile);
 }
 
+TEST(RDFSnapshotMore, PreserveStdVectorWithOptions)
+{
+   struct DatasetGuard {
+
+      const char *fFileName{"rdfsnapshotmore_preservestdvectorwithoptions.root"};
+      const char *fTreeName{"rdfsnapshotmore_preservestdvectorwithoptions"};
+      const char *fSnapFileDefault{"rdfsnapshotmore_preservestdvectorwithoptions_snap_default.root"};
+      const char *fSnapTreeDefault{"rdfsnapshotmore_preservestdvectorwithoptions_snap_default"};
+      const char *fSnapFileOpts{"rdfsnapshotmore_preservestdvectorwithoptions_snap_opts.root"};
+      const char *fSnapTreeOpts{"rdfsnapshotmore_preservestdvectorwithoptions_snap_opts"};
+
+      DatasetGuard()
+      {
+         std::unique_ptr<TFile> f{TFile::Open(fFileName, "RECREATE")};
+         auto t = std::make_unique<TTree>(fTreeName, fTreeName);
+         std::vector<int> a{11, 22, 33};
+         std::vector<float> b{44.f, 55.f, 66.f};
+         std::vector<double> c{77., 88., 99.};
+         t->Branch("a", &a);
+         t->Branch("b", &b);
+         t->Branch("c", &c);
+         t->Fill();
+         t->Write();
+      }
+
+      ~DatasetGuard()
+      {
+         std::remove(fFileName);
+         std::remove(fSnapFileDefault);
+         std::remove(fSnapFileOpts);
+      }
+   } dataset;
+
+   // Snapshot with default options: std::vector branches are converted to ROOT::RVec
+   {
+      ROOT::RDataFrame df{dataset.fTreeName, dataset.fFileName};
+      df.Snapshot(dataset.fSnapTreeDefault, dataset.fSnapFileDefault);
+   }
+
+   {
+      std::unique_ptr<TFile> f{TFile::Open(dataset.fSnapFileDefault)};
+      std::unique_ptr<TTree> t{f->Get<TTree>(dataset.fSnapTreeDefault)};
+      std::vector<std::string> expected_typenames_default{"ROOT::VecOps::RVec<int>", "ROOT::VecOps::RVec<float>",
+                                                          "ROOT::VecOps::RVec<double>"};
+      std::vector<std::string> typenames_default;
+      for (const auto *leaf : ROOT::Detail::TRangeStaticCast<TLeaf>(t->GetListOfLeaves())) {
+         typenames_default.push_back(leaf->GetTypeName());
+      }
+      EXPECT_EQ(expected_typenames_default.size(), typenames_default.size());
+      for (std::size_t i = 0; i < expected_typenames_default.size(); i++) {
+         EXPECT_EQ(expected_typenames_default[i], typenames_default[i]);
+      }
+   }
+
+   // Pass option to Snapshot to avoid the type conversion
+   {
+      ROOT::RDF::RSnapshotOptions opts;
+      opts.fVector2RVec = false;
+      ROOT::RDataFrame df{dataset.fTreeName, dataset.fFileName};
+      df.Snapshot(dataset.fSnapTreeOpts, dataset.fSnapFileOpts, df.GetColumnNames(), opts);
+   }
+
+   {
+      std::unique_ptr<TFile> f{TFile::Open(dataset.fSnapFileOpts)};
+      std::unique_ptr<TTree> t{f->Get<TTree>(dataset.fSnapTreeOpts)};
+      std::vector<std::string> expected_typenames_default{"vector<int>", "vector<float>", "vector<double>"};
+      std::vector<std::string> typenames_default;
+      for (const auto *leaf : ROOT::Detail::TRangeStaticCast<TLeaf>(t->GetListOfLeaves())) {
+         typenames_default.push_back(leaf->GetTypeName());
+      }
+      EXPECT_EQ(expected_typenames_default.size(), typenames_default.size());
+      for (std::size_t i = 0; i < expected_typenames_default.size(); i++) {
+         EXPECT_EQ(expected_typenames_default[i], typenames_default[i]);
+      }
+   }
+}
+
 /********* MULTI THREAD TESTS ***********/
 #ifdef R__USE_IMT
 TEST_F(RDFSnapshotMT, Snapshot_update_diff_treename)


### PR DESCRIPTION
This Pull request makes the conversion of stl vectors to RVec optional when using Snapshot() 

## Changes or fixes:
Propagating the relevant flag to the Snapshot() call

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #15503 

