### PR TITLE
[ntuple] don't bubble up exceptions from RNTuple::Merge

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -27,7 +27,8 @@
 #include <deque>
 
 Long64_t ROOT::Experimental::RNTuple::Merge(TCollection *inputs, TFileMergeInfo *mergeInfo)
-{
+// IMPORTANT: this function must not throw, as it is used in exception-unsafe code (TFileMerger).
+try {
    // Check the inputs
    if (!inputs || inputs->GetEntries() < 3 || !mergeInfo)
       return -1;
@@ -94,6 +95,9 @@ Long64_t ROOT::Experimental::RNTuple::Merge(TCollection *inputs, TFileMergeInfo 
    *this = *outFile->Get<RNTuple>(ntupleName.c_str());
 
    return 0;
+} catch (const RException &ex) {
+   Error("RNTuple::Merge", "Exception thrown while merging: %s", ex.what());
+   return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
the calling code in TFileMerger is not exception-safe and this ends up hiding the original exception under some bogus error


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


