### PR TITLE
Added RNTupleTTreeCheckerFiles + adapted main/CMakeLists & tree/ntupl…

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -39,6 +39,9 @@ ROOT_EXECUTABLE(rootnb.exe nbmain.cxx LIBRARIES Core)
 #---ReadSpeed-------------------------------------------------------------------------------------
 ROOT_EXECUTABLE(rootreadspeed src/readspeed.cxx LIBRARIES RIO Tree TreePlayer ReadSpeed)
 
+#---RNTupleTTreeChecker-------------------------------------------------------------------------------------
+ROOT_EXECUTABLE(rntuplevsttree src/rntuplevsttree.cxx LIBRARIES RIO Tree ROOTNTuple ROOTNTupleUtil)
+
 #---CreateHaddCommandLineOptions------------------------------------------------------------------
 generateHeader(hadd
   ${CMAKE_SOURCE_DIR}/main/src/hadd-argparse.py

--- a/main/src/rntuplevsttree.cxx
+++ b/main/src/rntuplevsttree.cxx
@@ -1,0 +1,30 @@
+/// \file rntuplevsttree.cxx
+/// \ingroup NTuple ROOT7
+/// \author Ida Caspary <ida.friederike.caspary@cern.ch>
+/// \date 2024-10-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RNTupleTTreeCheckerCLI.hxx"
+
+using namespace ROOT::Experimental::RNTupleTTreeCheckerCLI;
+
+int main(int argc, char **argv) {
+    auto config = ParseArgs(argc, argv);
+
+    if (!config.fShouldRun) {
+        return 1;
+    }
+
+    RunChecker(config);
+
+    return 0;
+}

--- a/tree/ntupleutil/CMakeLists.txt
+++ b/tree/ntupleutil/CMakeLists.txt
@@ -17,9 +17,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTupleUtil
 HEADERS
   ROOT/RNTupleImporter.hxx
   ROOT/RNTupleInspector.hxx
+        ROOT/RNTupleTTreeChecker.hxx
+        ROOT/RNTupleTTreeCheckerCLI.hxx
 SOURCES
   v7/src/RNTupleImporter.cxx
   v7/src/RNTupleInspector.cxx
+        v7/src/RNTupleTTreeChecker.cxx
+        v7/src/RNTupleTTreeCheckerCLI.cxx
 LINKDEF
   LinkDef.h
 DEPENDENCIES

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleTTreeChecker.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleTTreeChecker.hxx
@@ -1,0 +1,77 @@
+/// \file RNTupleTTreeChecker.hxx
+/// \ingroup NTuple ROOT7
+/// \author Ida Caspary <ida.friederike.caspary@cern.ch>
+/// \date 2024-10-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RNTupleTTreeChecker
+#define ROOT_RNTupleTTreeChecker
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+#include <ROOT/RError.hxx>
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <TTree.h>
+#include <TFile.h>
+#include <TLeaf.h>
+#include <TBranch.h>
+#include <TKey.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+namespace RNTupleTTreeCheckerCLI {
+    struct CheckerConfig;
+}
+
+class RNTupleTTreeChecker {
+public:
+    void Compare(const RNTupleTTreeCheckerCLI::CheckerConfig &config);
+private:
+    bool RNTupleExists(const std::string &filename, const std::string &rntupleName);
+    void CountEntries(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName);
+    void CountFields(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName);
+    void CompareFieldNames(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName);
+    void CompareFieldTypes(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName);
+    void PrintStyled(const std::string &text, const std::initializer_list<std::string> &styles, bool firstLineBreak = true, bool secondLineBreak = false);
+    void PrintStyled(const std::string &text, const std::initializer_list<std::string> &styles, int width, bool firstLineBreak = true, bool secondLineBreak = false);
+
+    static constexpr const char* GREEN = "\033[0;32m";
+    static constexpr const char* RED = "\033[0;31m";
+    static constexpr const char* YELLOW = "\033[0;33m";
+    static constexpr const char* BLUE = "\033[0;34m";
+    static constexpr const char* WHITE = "\033[0;37m";
+    static constexpr const char* BLACK = "\033[0;30m";
+
+    static constexpr const char* MEDIUM_BLUE = "\033[38;5;75m";
+    static constexpr const char* DARKER_BLUE = "\033[38;5;18m";
+
+    static constexpr const char* BG_WHITE = "\033[47m";
+    static constexpr const char* BG_RED = "\033[41m";
+    static constexpr const char* BG_GREEN = "\033[42m";
+
+    static constexpr const char* RESET = "\033[0m";
+    static constexpr const char* DEFAULT = "\033[39m";
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT_RNTupleTTreeChecker

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleTTreeCheckerCLI.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleTTreeCheckerCLI.hxx
@@ -1,0 +1,43 @@
+/// \file RNTupleTTreeCheckerCLI.hxx
+/// \ingroup NTuple ROOT7
+/// \author Ida Caspary <ida.friederike.caspary@cern.ch>
+/// \date 2024-10-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RNTupleTTreeCheckerCLI
+#define ROOT_RNTupleTTreeCheckerCLI
+
+#include "ROOT/RNTupleTTreeChecker.hxx"
+#include <vector>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+namespace RNTupleTTreeCheckerCLI {
+
+struct CheckerConfig {
+   std::string fTTreeFile;
+   std::string fRNTupleFile;
+   std::string fTTreeName;
+   std::string fRNTupleName;
+   bool fShouldRun = false;
+};
+
+CheckerConfig ParseArgs(const std::vector<std::string> &args);
+CheckerConfig ParseArgs(int argc, char **argv);
+void RunChecker(const CheckerConfig &config);
+
+} // namespace RNTupleTTreeCheckerCLI
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT_RNTupleTTreeCheckerCLI

--- a/tree/ntupleutil/v7/src/RNTupleTTreeChecker.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleTTreeChecker.cxx
@@ -1,0 +1,307 @@
+/// \file RNTupleTTreeChecker.cxx
+/// \ingroup NTuple ROOT7
+/// \author Ida Caspary <ida.friederike.caspary@cern.ch>
+/// \date 2024-10-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RNTupleTTreeChecker.hxx"
+#include "ROOT/RNTupleTTreeCheckerCLI.hxx"
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+#include <ROOT/RError.hxx>
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <iomanip>
+#include <TTree.h>
+#include <TFile.h>
+#include <TLeaf.h>
+#include <TBranch.h>
+#include <TKey.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace ROOT {
+namespace Experimental {
+
+void RNTupleTTreeChecker::PrintStyled(const std::string &text, const std::initializer_list<std::string> &styles, bool firstLineBreak, bool secondLineBreak) {
+    for (const auto &style: styles) {
+        std::cout << style;
+    }
+    std::cout << text << RESET;
+    if (firstLineBreak) {
+        std::cout << std::endl;
+    }
+    if (secondLineBreak) {
+        std::cout << std::endl;
+    }
+}
+
+void RNTupleTTreeChecker::PrintStyled(const std::string &text, const std::initializer_list<std::string> &styles, int width, bool firstLineBreak, bool secondLineBreak) {
+    for (const auto &style: styles) {
+        std::cout << style;
+    }
+    std::cout << std::setw(width) << std::left << text << RESET;
+    if (firstLineBreak) {
+        std::cout << std::endl;
+    }
+    if (secondLineBreak) {
+        std::cout << std::endl;
+    }
+}
+
+bool RNTupleTTreeChecker::RNTupleExists(const std::string &filename, const std::string &rntupleName) {
+    try {
+        const auto file = TFile::Open(filename.c_str());
+        if (!file || file->IsZombie()) {
+            PrintStyled("Cannot open file: " + filename, {RED});
+            return false;
+        }
+
+        auto keys = file->GetListOfKeys();
+        for (int i = 0; i < keys->GetEntries(); ++i) {
+            auto key = dynamic_cast<TKey *>(keys->At(i));
+            if (std::string(key->GetClassName()) == "ROOT::Experimental::RNTuple" &&
+                std::string(key->GetName()) == rntupleName) {
+                return true;
+            }
+        }
+
+        file->Close();
+    } catch (const std::exception &e) {
+        PrintStyled("Error checking RNTuple existence: " + std::string(e.what()), {RED});
+    }
+    return false;
+}
+
+void RNTupleTTreeChecker::CountEntries(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName) {
+    PrintStyled("\n*** Entry Count ***", {MEDIUM_BLUE});
+
+    const auto tfile = std::unique_ptr<TFile>(TFile::Open(ttreeFile.c_str()));
+    const auto ttree = dynamic_cast<TTree *>(tfile->Get(ttreeName.c_str()));
+    if (!ttree) {
+        PrintStyled("Cannot find TTree: " + ttreeName + " in file: " + ttreeFile, {RED});
+        return;
+    }
+
+    if (!RNTupleExists(rntupleFile, rntupleName)) {
+        PrintStyled("Cannot find RNTuple: " + rntupleName + " in file: " + rntupleFile, {RED});
+        return;
+    }
+
+    try {
+        auto rntpl = RNTupleReader::Open(rntupleName, rntupleFile);
+        if (!rntpl) {
+            throw std::runtime_error("can't find rntuple");
+        }
+
+        const bool compareCount = (static_cast<int>(ttree->GetEntries()) == static_cast<int>(rntpl->GetNEntries()));
+        if (compareCount) {
+            PrintStyled("Number of entries: ", {DEFAULT}, false);
+            PrintStyled(std::to_string(ttree->GetEntries()), {GREEN});
+        } else {
+            PrintStyled("Number of entries in TTree: ", {DEFAULT}, false);
+            PrintStyled(std::to_string(ttree->GetEntries()), {RED});
+            PrintStyled("Number of entries in RNTuple: ", {DEFAULT}, false);
+            PrintStyled(std::to_string(rntpl->GetNEntries()), {RED});
+        }
+
+        std::ostringstream oss;
+        oss << std::boolalpha << compareCount;
+        PrintStyled("TTree and RNTuple have the same entry count: ", {DEFAULT}, false);
+        if (compareCount) {
+            PrintStyled(oss.str(), {BLACK, BG_GREEN}, true, true);
+        } else {
+            PrintStyled(oss.str(), {BLACK, BG_RED}, true, true);
+        }
+    } catch (const RException &e) {
+        PrintStyled("Error opening RNTuple: " + std::string(e.what()), {RED});
+    }
+}
+
+void RNTupleTTreeChecker::CountFields(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName) {
+    PrintStyled("*** Field Count ***", {MEDIUM_BLUE});
+
+    const auto tfile = std::unique_ptr<TFile>(TFile::Open(ttreeFile.c_str()));
+    const auto ttree = dynamic_cast<TTree *>(tfile->Get(ttreeName.c_str()));
+    if (!ttree) {
+        PrintStyled("Cannot find TTree: " + ttreeName + " in file: " + ttreeFile, {RED});
+        return;
+    }
+
+    try {
+        const auto rfile = std::unique_ptr<TFile>(TFile::Open(rntupleFile.c_str()));
+        const auto rntpl = rfile->Get<RNTuple>(rntupleName.c_str());
+        if (!rntpl) {
+            throw std::runtime_error("can't find rntuple");
+        }
+
+        const auto reader = RNTupleReader::Open(rntpl);
+        if (!reader) {
+            PrintStyled("Failed to open RNTupleReader.", {RED});
+            return;
+        }
+
+        const auto ttreeBranches = ttree->GetListOfBranches();
+        const int ttreeFieldCount = ttreeBranches->GetEntries();
+
+        auto fieldIterable = reader->GetDescriptor().GetFieldIterable(reader->GetDescriptor().GetFieldZeroId());
+        const auto rntupleFieldCount = std::distance(fieldIterable.begin(), fieldIterable.end());
+
+        const bool compareCount = ttreeFieldCount == rntupleFieldCount;
+
+        if (compareCount) {
+            PrintStyled("Number of fields:  ", {DEFAULT}, false);
+            PrintStyled(std::to_string(ttreeFieldCount), {GREEN});
+        } else {
+            std::cout << "Number of fields in TTree: " << ttreeFieldCount << std::endl;
+            std::cout << "Number of fields in RNTuple: " << rntupleFieldCount << "\n" << std::endl;
+        }
+
+        std::ostringstream oss;
+        oss << std::boolalpha << compareCount;
+        PrintStyled("TTree and RNTuple have the same field count: ", {DEFAULT}, false);
+        if (compareCount) {
+            PrintStyled(oss.str(), {BLACK, BG_GREEN}, true, true);
+        } else {
+            PrintStyled(oss.str(), {BLACK, BG_RED}, true, true);
+        }
+    } catch (const RException &e) {
+        PrintStyled("Error opening RNTuple: " + std::string(e.what()), {RED});
+    }
+}
+
+void RNTupleTTreeChecker::CompareFieldNames(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName) {
+    PrintStyled("*** Field Names ***", {MEDIUM_BLUE});
+
+    const auto tfile = std::unique_ptr<TFile>(TFile::Open(ttreeFile.c_str()));
+    const auto ttree = dynamic_cast<TTree *>(tfile->Get(ttreeName.c_str()));
+
+    const auto rfile = std::unique_ptr<TFile>(TFile::Open(rntupleFile.c_str()));
+    const auto ntpl = rfile->Get<RNTuple>(rntupleName.c_str());
+
+    const auto reader = RNTupleReader::Open(ntpl);
+
+    const auto ttreeBranches = ttree->GetListOfBranches();
+    const int ttreeFieldCount = ttreeBranches->GetEntries();
+
+    int width = 13;
+
+    bool compareFields = true;
+    PrintStyled("\nTTree Field  |  RNTuple Field\n-----------------------------", {DEFAULT});
+
+    for (int i = 0; i < ttreeFieldCount; ++i) {
+        const auto branch = dynamic_cast<TBranch *>(ttreeBranches->At(i));
+        PrintStyled(std::string(branch->GetName()), {DEFAULT}, width, false);
+        PrintStyled(std::string("|  "), {DEFAULT}, false);
+
+        try {
+            auto rntuplefield = reader->GetDescriptor().GetFieldDescriptor(i).GetFieldName();
+
+            if (branch->GetName() == rntuplefield) {
+                PrintStyled(rntuplefield, {DEFAULT}, width);
+            } else {
+                PrintStyled(rntuplefield, {RED}, width);
+                compareFields = false;
+            }
+        } catch (const std::exception &e) {
+            PrintStyled("No matching field", {RED});
+            compareFields = false;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << std::boolalpha << compareFields;
+    PrintStyled("\nThe fields have the same names: ", {DEFAULT}, false);
+    if (compareFields) {
+        PrintStyled(oss.str(), {BLACK, BG_GREEN}, true, true);
+    } else {
+        PrintStyled(oss.str(), {BLACK, BG_RED}, true, true);
+    }
+}
+
+void RNTupleTTreeChecker::CompareFieldTypes(const std::string &ttreeFile, const std::string &rntupleFile, const std::string &ttreeName, const std::string &rntupleName) {
+    PrintStyled("*** Field Types ***", {MEDIUM_BLUE});
+
+    const auto tfile = std::unique_ptr<TFile>(TFile::Open(ttreeFile.c_str()));
+    const auto ttree = dynamic_cast<TTree *>(tfile->Get(ttreeName.c_str()));
+
+    const auto rfile = std::unique_ptr<TFile>(TFile::Open(rntupleFile.c_str()));
+    const auto ntpl = rfile->Get<RNTuple>(rntupleName.c_str());
+
+    const auto reader = RNTupleReader::Open(ntpl);
+
+    const auto ttreeBranches = ttree->GetListOfBranches();
+    const int ttreeFieldCount = ttreeBranches->GetEntries();
+
+    std::unordered_map<std::string, std::string> typeMap = {
+        {"Int_t", "int"},
+        {"std::int32_t", "int"},
+        {"Float_t", "float"},
+        {"float", "float"},
+        {"Double_t", "double"},
+        {"double", "double"},
+        {"Bool_t", "bool"},
+        {"bool", "bool"}
+    };
+
+    bool compareTypes = true;
+    int width = 13;
+    PrintStyled("\nType - TTree |  Type - Field    Field No\n-----------------------------", {DEFAULT});
+    for (int i = 0; i < ttreeFieldCount; ++i) {
+        const auto branch = dynamic_cast<TBranch *>(ttreeBranches->At(i));
+        auto ttreeFieldType = typeMap[std::string(branch->GetLeaf(branch->GetName())->GetTypeName())];
+        PrintStyled(ttreeFieldType, {DEFAULT}, width, false);
+        PrintStyled(std::string("|  "), {DEFAULT}, false);
+
+        try {
+            auto rntupleFieldType = typeMap[std::string(reader->GetDescriptor().GetFieldDescriptor(i).GetTypeName())];
+            PrintStyled(rntupleFieldType, {DEFAULT}, width, false);
+
+            PrintStyled("   " + std::to_string(i), {DEFAULT}, width, false);
+
+            if (ttreeFieldType != rntupleFieldType) {
+                compareTypes = false;
+                PrintStyled("   type mismatch   ", {WHITE, BG_RED}, false);
+            }
+            std::cout << std::endl;
+        } catch (const std::exception &e) {
+            PrintStyled("No matching field", {RED});
+            compareTypes = false;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << std::boolalpha << compareTypes;
+    PrintStyled("\nThe fields have the same types: ", {DEFAULT}, false);
+    if (compareTypes) {
+        PrintStyled(oss.str(), {BLACK, BG_GREEN}, true, true);
+    } else {
+        PrintStyled(oss.str(), {BLACK, BG_RED}, true, true);
+    }
+}
+
+void RNTupleTTreeChecker::Compare(const RNTupleTTreeCheckerCLI::CheckerConfig &config) {
+    PrintStyled("\nComparing TTree '" + config.fTTreeName + "' <> RNTuple '" + config.fRNTupleName + "'", {DARKER_BLUE, BG_WHITE});
+
+    CountEntries(config.fTTreeFile, config.fRNTupleFile, config.fTTreeName, config.fRNTupleName);
+    CountFields(config.fTTreeFile, config.fRNTupleFile, config.fTTreeName, config.fRNTupleName);
+    CompareFieldNames(config.fTTreeFile, config.fRNTupleFile, config.fTTreeName, config.fRNTupleName);
+    CompareFieldTypes(config.fTTreeFile, config.fRNTupleFile, config.fTTreeName, config.fRNTupleName);
+}
+
+} // namespace Experimental
+} // namespace ROOT

--- a/tree/ntupleutil/v7/src/RNTupleTTreeCheckerCLI.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleTTreeCheckerCLI.cxx
@@ -1,0 +1,112 @@
+/// \file RNTupleTTreeCheckerCLI.cxx
+/// \ingroup NTuple ROOT7
+/// \author Ida Caspary <ida.friederike.caspary@cern.ch>
+/// \date 2024-10-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RNTupleTTreeCheckerCLI.hxx"
+#include <iostream>
+
+namespace {
+const auto usageText = "Usage:\n"
+                       " rntuplettreechecker (--ttree|-t) <input_ttree_file>\n"
+                       "                     (--rntuple|-r) <input_rntuple_file>\n"
+                       "                     (--treename|-tn) <ttree_name>\n"
+                       "                     (--rntuplename|-rn) <rntuple_name>\n"
+                       " rntuplettreechecker [--help|-h]\n\n";
+}
+
+namespace ROOT {
+namespace Experimental {
+namespace RNTupleTTreeCheckerCLI {
+
+CheckerConfig ParseArgs(const std::vector<std::string> &args) {
+
+    const auto argsProvided = args.size() >= 2;
+    const auto helpUsed = argsProvided && (args[1] == "--help" || args[1] == "-h");
+
+    if (!argsProvided || helpUsed) {
+        std::cout << usageText;
+        if (!argsProvided)
+            std::cout << " Use --help or -h for usage help.";
+        std::cout << std::endl;
+        return {};
+    }
+
+    CheckerConfig config;
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        const auto &arg = args[i];
+
+        if (arg == "--ttree" || arg == "-t") {
+            if (++i < args.size()) config.fTTreeFile = args[i];
+        } else if (arg == "--rntuple" || arg == "-r") {
+            if (++i < args.size()) config.fRNTupleFile = args[i];
+        } else if (arg == "--treename" || arg == "-tn") {
+            if (++i < args.size()) config.fTTreeName = args[i];
+        } else if (arg == "--rntuplename" || arg == "-rn") {
+            if (++i < args.size()) config.fRNTupleName = args[i];
+        } else {
+            std::cerr << "Unknown argument '" << arg << "'\n" << usageText << "\n";
+            return {};
+        }
+    }
+
+    if (config.fTTreeFile.empty()) {
+        std::cerr << "Please provide the name of the TTree file to compare.\n\n" << usageText << "\n";
+        return {};
+    } else if (config.fRNTupleFile.empty()) {
+        std::cerr << "Please provide the name of the RNTuple file to compare.\n\n" << usageText << "\n";
+        return {};
+    } else if (config.fTTreeName.empty()) {
+        std::cerr << "Please provide the name of the TTree to compare.\n\n" << usageText << "\n";
+        return {};
+    } else if (config.fRNTupleName.empty()) {
+        std::cerr << "Please provide the name of the RNTuple to compare.\n\n" << usageText << "\n";
+        return {};
+    }
+
+    config.fShouldRun = true;
+    return config;
+}
+
+CheckerConfig ParseArgs(int argc, char **argv) {
+    std::vector<std::string> args;
+    args.reserve(argc);
+
+    for (int i = 0; i < argc; ++i) {
+        args.emplace_back(argv[i]);
+    }
+
+    return ParseArgs(args);
+}
+
+void RunChecker(const CheckerConfig &config) {
+    RNTupleTTreeChecker checker;
+    checker.Compare(config);
+}
+
+} // namespace RNTupleTTreeCheckerCLI
+} // namespace Experimental
+} // namespace ROOT
+
+int main(int argc, char **argv) {
+    auto config = ROOT::Experimental::RNTupleTTreeCheckerCLI::ParseArgs(argc, argv);
+
+    if (!config.fShouldRun) {
+        return 1;
+    }
+
+    ROOT::Experimental::RNTupleTTreeCheckerCLI::RunChecker(config);
+
+    return 0;
+}


### PR DESCRIPTION
…eutil/CMakeLists

# This Pull request:
Added RNTupleTTreeChecker and RNTupleTTreeCheckerCLI to ROOT

## Changes or fixes:
- Added RNTupleTTreeChecker class for comparing TTree and RNTuple structures.
- Added RNTupleTTreeCheckerCLI for command-line interface to interact with RNTupleTTreeChecker.
- Included necessary header and source files.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
Details:
ttree/ntupleutil/
- RNTupleTTreeChecker.cxx: Implementation of the RNTupleTTreeChecker class.
- RNTupleTTreeCheckerCLI.cxx: Implementation of the command line interface.
- inc/ROOT/RNTupleTTreeChecker.hxx: Header file for the RNTupleTTreeChecker class.
- inc/ROOT/RNTupleTTreeCheckerCLI.hxx: Header file for the RNTupleTTreeChecker CLI class.
- modified CMakeLists to include above files
main/
- src/rntuplevsttree.cxx: Main entry point for CLI.
- Modified CMakeLists to include rntuplevsttree.
