### PR TITLE
Propagate TGeoVolume extensions to TGeoAssemblyVolume

### DIFF
--- a/geom/geom/src/TGeoNode.cxx
+++ b/geom/geom/src/TGeoNode.cxx
@@ -499,11 +499,12 @@ void TGeoNode::SaveAttributes(std::ostream &out)
 
 void TGeoNode::SetUserExtension(TGeoExtension *ext)
 {
-   if (fUserExtension)
-      fUserExtension->Release();
+   TGeoExtension* tmp = fUserExtension;
    fUserExtension = nullptr;
    if (ext)
       fUserExtension = ext->Grab();
+   if (tmp)
+      tmp->Release();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -516,11 +517,12 @@ void TGeoNode::SetUserExtension(TGeoExtension *ext)
 
 void TGeoNode::SetFWExtension(TGeoExtension *ext)
 {
-   if (fFWExtension)
-      fFWExtension->Release();
+   TGeoExtension* tmp = fFWExtension;
    fFWExtension = nullptr;
    if (ext)
       fFWExtension = ext->Grab();
+   if (tmp)
+      tmp->Release();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -1479,11 +1479,12 @@ void TGeoVolume::SaveAs(const char *filename, Option_t *option) const
 
 void TGeoVolume::SetUserExtension(TGeoExtension *ext)
 {
-   if (fUserExtension)
-      fUserExtension->Release();
+   TGeoExtension* tmp = fUserExtension;
    fUserExtension = nullptr;
    if (ext)
       fUserExtension = ext->Grab();
+   if (tmp)
+      tmp->Release();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1496,11 +1497,12 @@ void TGeoVolume::SetUserExtension(TGeoExtension *ext)
 
 void TGeoVolume::SetFWExtension(TGeoExtension *ext)
 {
-   if (fFWExtension)
-      fFWExtension->Release();
+   TGeoExtension* tmp = fFWExtension;
    fFWExtension = nullptr;
    if (ext)
       fFWExtension = ext->Grab();
+   if (tmp)
+      tmp->Release();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -3028,6 +3028,9 @@ TGeoVolume *TGeoVolumeAssembly::CloneVolume() const
    vol->SetNumber(fNumber);
    vol->SetNtotal(fNtotal);
    vol->SetTitle(GetTitle());
+   // copy extensions
+   vol->SetUserExtension(fUserExtension);
+   vol->SetFWExtension(fFWExtension);
    return vol;
 }
 


### PR DESCRIPTION
# This Pull request:
Propagate user- and system-extensions in TGeoAssemblyVolumes to cloned entities.
This was missing in the sub-class of TGeoVolume and then tends to fail on
re-alignments using TGeoPhysicalNode.

## Changes or fixes:
Buggy volume clones if the volume has user extensions.

## Checklist:

- [x ] tested changes locally
- [ ] updated the docs (if necessary)

