### PR TITLE
[df] Correctly update sample info when dataset is in TFile subdirectory 

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -738,8 +738,15 @@ void RLoopManager::UpdateSampleInfo(unsigned int slot, TTreeReader &r) {
    if (range.second == -1) {
       range.second = tree->GetEntries(); // convert '-1', i.e. 'until the end', to the actual entry number
    }
-   const std::string &id = fname + '/' + treename;
-   fSampleInfos[slot] = fSampleMap.empty() ? RSampleInfo(id, range) : RSampleInfo(id, range, fSampleMap[id]);
+   // If the tree is stored in a subdirectory, treename will be the full path to it starting with the root directory '/'
+   const std::string &id = fname + (treename.rfind('/', 0) == 0 ? "" : "/") + treename;
+   if (fSampleMap.empty()) {
+      fSampleInfos[slot] = RSampleInfo(id, range);
+   } else {
+      if (fSampleMap.find(id) == fSampleMap.end())
+         throw std::runtime_error("Full sample identifier '" + id + "' cannot be found in the available samples.");
+      fSampleInfos[slot] = RSampleInfo(id, range, fSampleMap[id]);
+   }
 }
 
 /// Initialize all nodes of the functional graph before running the event loop.

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -708,6 +708,44 @@ TEST(RDatasetSpecTest, Clusters)
 }
 #endif
 
+TEST_P(RDatasetSpecTest, TreeInSubdir)
+{
+   class FileRAII {
+   private:
+      std::string fPath;
+
+   public:
+      explicit FileRAII(const std::string &path) : fPath(path) {}
+      FileRAII(const FileRAII &) = delete;
+      FileRAII &operator=(const FileRAII &) = delete;
+      ~FileRAII() { std::remove(fPath.c_str()); }
+      auto GetPath() const { return fPath.c_str(); }
+   };
+   FileRAII fraii("definepersample_treeinsubdir.root");
+   // Write TTree in TFile subdirectory
+   {
+      TFile f{fraii.GetPath(), "recreate"};
+      auto *outDir = f.mkdir("subdir");
+
+      outDir->cd();
+      int event{42};
+      TTree tree("T", "T");
+      tree.Branch("event", &event, "event/I");
+      tree.Fill();
+      tree.SetDirectory(outDir);
+      f.Write();
+   }
+
+   RDatasetSpec spec;
+   spec.AddSample({"mysample", {{"subdir/T", fraii.GetPath()}}});
+   ROOT::RDataFrame df{spec};
+   auto df_sample =
+      df.DefinePerSample("sample_id", [](unsigned int, const ROOT::RDF::RSampleInfo &id) { return id.AsString(); });
+   auto sample_ids = df_sample.Take<std::string>("sample_id");
+   EXPECT_EQ(sample_ids->size(), 1);
+   EXPECT_EQ(sample_ids->at(0), fraii.GetPath() + std::string("/subdir/T"));
+}
+
 // instantiate single-thread tests
 INSTANTIATE_TEST_SUITE_P(Seq, RDatasetSpecTest, ::testing::Values(false));
 


### PR DESCRIPTION
Fixes problem reported on the forum at https://root-forum.cern.ch/t/issue-with-root-rdf-experimental-fromspec-when-ttree-is-inside-a-sub-directory/59719