### PR TITLE
[ntuple] split loading and processing meta-data

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -84,6 +84,7 @@ private:
                         DescriptorId_t virtualParent, const std::string &virtualName);
 
 protected:
+   void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -179,6 +179,7 @@ private:
                                  ClusterSize_t::ValueType idxInCluster);
 
 protected:
+   void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final;
 
 public:

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -140,6 +140,21 @@ void ROOT::Experimental::Internal::RPageSource::SetEntryRange(const REntryRange 
    fEntryRange = range;
 }
 
+void ROOT::Experimental::Internal::RPageSource::LoadStructure()
+{
+   if (!fHasStructure)
+      LoadStructureImpl();
+   fHasStructure = true;
+}
+
+void ROOT::Experimental::Internal::RPageSource::Attach()
+{
+   LoadStructure();
+   if (!fIsAttached)
+      GetExclDescriptorGuard().MoveIn(AttachImpl());
+   fIsAttached = true;
+}
+
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Internal::RPageSource::GetNEntries()
 {
    return GetSharedDescriptorGuard()->GetNEntries();

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -54,6 +54,7 @@ public:
  */
 class RPageSourceMock : public RPageSource {
 protected:
+   void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
 
 public:

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -83,6 +83,7 @@ protected:
    const RColumnElementBase &fElement;
    const std::vector<RPageStorage::RSealedPage> &fPages;
 
+   void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
 
 public:


### PR DESCRIPTION
Adds `RPageSource::LoadStructure[Impl]()`. This allows to load header and footer without processing them. Decompression and deserialization will still happen in Attach(), which calls LoadStructure if it hasn't been called before.

This will facilitate asynchronous open of files for RDF MT scheduling.