### PR TITLE
[ci] Disable clad on mac-beta

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
@@ -22,6 +22,7 @@ builtin_xxhash=ON
 builtin_zeromq=ON
 builtin_zstd=ON
 ccache=ON
+clad=OFF
 cocoa=ON
 fortran=OFF
 mysql=OFF


### PR DESCRIPTION
Clad currently has problems with some new headers in `MacOSX15.0.sdk` and crashes / errors due to `__builtin_pow`. Disable it for now while a solution is worked on, so we can upgrade the nodes and keep the build green.