### PR TITLE
[ci] Enable libc++ for the clang build on Linux

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -369,7 +369,7 @@ jobs:
           - image: alma9-clang
             is_special: true
             property: clang
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++", "libcxx=ON"]
 
     runs-on:
       - self-hosted


### PR DESCRIPTION
Test https://its.cern.ch/jira/browse/ROOT-10021 in the new CI, to see the status of this issue
