### PR TITLE
[ntuple] Add page checksum creation and verification

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -686,8 +686,9 @@ Every inner item (that describes a page) has the following structure:
 ```
 
 Followed by a locator for the page.
-_C(hecksum)_: If set, an XxHash-3 64bit checksum of the uncompressed page data is stored just after the page.
-This bit should be interpreted as the sign bit of the size, i.e. negative values indicate pages with checksums.
+_C(hecksum)_: If set, an XxHash-3 64bit checksum of the compressed page data is stored just after the page.
+This bit should be interpreted as the sign bit of the number of elements, i.e. negative values indicate pages with checksums.
+Note that the page size stored in the locator does _not_ include the checksum.
 
 Depending on the number of pages per column per cluster, every page induces
 a total of 28-36 Bytes of data to be stored in the page list envelope.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -266,6 +266,8 @@ public:
          std::uint32_t fNElements = std::uint32_t(-1);
          /// The meaning of fLocator depends on the storage backend.
          RNTupleLocator fLocator;
+         /// If true, the 8 bytes following the serialized page are an xxhash of the on-disk page data
+         bool fHasChecksum = false;
 
          bool operator==(const RPageInfo &other) const {
             return fNElements == other.fNElements && fLocator == other.fLocator;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -64,6 +64,8 @@ protected:
    /// If set, 64bit index columns are replaced by 32bit index columns. This limits the cluster size to 512MB
    /// but it can result in smaller file sizes for data sets with many collections and lz4 or no compression.
    bool fHasSmallClusters = false;
+   /// If set, checksums will be calculated and written for every page.
+   bool fEnablePageChecksums = true;
 
 public:
    /// A maximum size of 512MB still allows for a vector of bool to be stored in a small cluster.  This is the
@@ -101,6 +103,9 @@ public:
 
    bool GetHasSmallClusters() const { return fHasSmallClusters; }
    void SetHasSmallClusters(bool val) { fHasSmallClusters = val; }
+
+   bool GetEnablePageChecksums() const { return fEnablePageChecksums; }
+   void SetEnablePageChecksums(bool val) { fEnablePageChecksums = val; }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -74,12 +74,15 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
-   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final { fNBytesCurrentCluster += page.GetSize(); }
+   void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final
+   {
+      fNBytesCurrentCluster += page.GetBufferSize();
+   }
    void CommitSealedPageV(std::span<RSealedPageGroup> ranges) final
    {
       for (auto &range : ranges) {
          for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-            fNBytesCurrentCluster += sealedPageIt->GetSize();
+            fNBytesCurrentCluster += sealedPageIt->GetBufferSize();
          }
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -124,6 +124,7 @@ public:
       void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
 
       void ChecksumIfEnabled();
+      RResult<void> VerifyChecksumIfEnabled() const;
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -217,6 +217,9 @@ protected:
       const RPage *fPage = nullptr;                 ///< Input page to be sealed
       const RColumnElementBase *fElement = nullptr; ///< Corresponds to the page's elements, for size calculation etc.
       int fCompressionSetting = 0;                  ///< Compression algorithm and level to apply
+      /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
+      /// to store the additional 8 bytes.
+      bool fWriteChecksum = true;
       /// If false, the output buffer must not point to the input page buffer, which would otherwise be an option
       /// if the page is mappable and should not be compressed
       bool fAllowAlias = false;
@@ -232,8 +235,8 @@ protected:
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
-   /// compressionSetting is 0 (uncompressed) and the page is mappable, the returned sealed page will
-   /// point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
+   /// compressionSetting is 0 (uncompressed) and the page is mappable and not checksummed, the returned sealed page
+   /// will point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
    /// of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
    /// Usage of this method requires construction of fCompressor.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -118,6 +118,9 @@ public:
 
       std::uint32_t GetNElements() const { return fNElements; }
       void SetNElements(std::uint32_t nElements) { fNElements = nElements; }
+
+      bool GetHasChecksum() const { return fHasChecksum; }
+      void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -121,6 +121,8 @@ public:
 
       bool GetHasChecksum() const { return fHasChecksum; }
       void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
+
+      void ChecksumIfEnabled();
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_RPageStorage
 #define ROOT7_RPageStorage
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RCluster.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
@@ -646,7 +647,8 @@ public:
    /// The optimization of directly mapping pages is left to the concrete page source implementations.
    /// Usage of this method requires construction of fDecompressor. Memory is allocated via
    /// `RPageAllocatorHeap`; use `RPageAllocatorHeap::DeletePage()` to deallocate returned pages.
-   RPage UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
+   RResult<RPage>
+   UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
 
    /// Populates all the pages of the given cluster ids and columns; it is possible that some columns do not
    /// contain any pages.  The page source may load more columns than the minimal necessary set from `columns`.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -62,7 +62,9 @@ private:
    std::uint64_t fNBytesCurrentCluster = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
-   RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage);
+   /// We pass bytesPacked so that TFile::ls() reports a reasonable value for the compression ratio of the corresponding
+   /// key. It is not strictly necessary to write and read the sealed page.
+   RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage, std::size_t bytesPacked);
 
 protected:
    using RPagePersistentSink::InitImpl;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -62,8 +62,7 @@ private:
    std::uint64_t fNBytesCurrentCluster = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
-   RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
-                                                std::size_t bytesPacked);
+   RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage);
 
 protected:
    using RPagePersistentSink::InitImpl;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -238,7 +238,7 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
                // The way LoadSealedPage works might require a double call
                // See the implementation. Here we do this in any case...
-               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
                sealedPage.SetBuffer(buffer.get());
                source->LoadSealedPage(columnId, clusterIndex, sealedPage);
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -146,7 +146,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
    // valid until the return value of DrainBufferedPages() goes out of scope in
    // CommitCluster().
    auto &zipItem = fBufferedColumns.at(colId).BufferPage(columnHandle);
-   zipItem.AllocateSealedPageBuf(page.GetNBytes());
+   zipItem.AllocateSealedPageBuf(page.GetNBytes() + GetWriteOptions().GetEnablePageChecksums() * kNBytesPageChecksum);
    R__ASSERT(zipItem.fBuf);
    auto &sealedPage = fBufferedColumns.at(colId).RegisterSealedPage();
 
@@ -156,6 +156,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
       config.fPage = &page;
       config.fElement = &element;
       config.fCompressionSetting = GetWriteOptions().GetCompression();
+      config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
       config.fAllowAlias = false;
       config.fBuffer = zipItem.fBuf.get();
       sealedPage = SealPage(config);
@@ -177,6 +178,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
       config.fPage = &zipItem.fPage;
       config.fElement = &element;
       config.fCompressionSetting = GetWriteOptions().GetCompression();
+      config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
       config.fAllowAlias = true;
       config.fBuffer = zipItem.fBuf.get();
       sealedPage = SealPage(config);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -50,6 +50,18 @@ void ROOT::Experimental::Internal::RPageStorage::RSealedPage::ChecksumIfEnabled(
    RNTupleSerializer::SerializeXxHash3(charBuf, GetDataSize(), xxhash3, checksumBuf);
 }
 
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Internal::RPageStorage::RSealedPage::VerifyChecksumIfEnabled() const
+{
+   if (!fHasChecksum)
+      return RResult<void>::Success();
+
+   auto success = RNTupleSerializer::VerifyXxHash3(reinterpret_cast<const unsigned char *>(fBuffer), GetDataSize());
+   if (!success)
+      return R__FAIL("page checksum verification failed, data corruption detected");
+   return RResult<void>::Success();
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::Internal::RPageSource::RActivePhysicalColumns::Insert(DescriptorId_t physicalColumnID)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -38,6 +38,17 @@ ROOT::Experimental::Internal::RPageStorage::RPageStorage(std::string_view name) 
 
 ROOT::Experimental::Internal::RPageStorage::~RPageStorage() {}
 
+void ROOT::Experimental::Internal::RPageStorage::RSealedPage::ChecksumIfEnabled()
+{
+   if (!fHasChecksum)
+      return;
+
+   auto charBuf = reinterpret_cast<const unsigned char *>(fBuffer);
+   auto checksumBuf = const_cast<unsigned char *>(charBuf) + GetDataSize();
+   std::uint64_t xxhash3;
+   RNTupleSerializer::SerializeXxHash3(charBuf, GetDataSize(), xxhash3, checksumBuf);
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::Internal::RPageSource::RActivePhysicalColumns::Insert(DescriptorId_t physicalColumnID)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -341,8 +341,8 @@ ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedP
    const auto bytesPacked = element.GetPackedSize(sealedPage.GetNElements());
    using Allocator_t = RPageAllocatorHeap;
    auto page = Allocator_t::NewPage(physicalColumnId, element.GetSize(), sealedPage.GetNElements());
-   if (sealedPage.GetSize() != bytesPacked) {
-      fDecompressor->Unzip(sealedPage.GetBuffer(), sealedPage.GetSize(), bytesPacked, page.GetBuffer());
+   if (sealedPage.GetDataSize() != bytesPacked) {
+      fDecompressor->Unzip(sealedPage.GetBuffer(), sealedPage.GetDataSize(), bytesPacked, page.GetBuffer());
    } else {
       // We cannot simply map the sealed page as we don't know its life time. Specialized page sources
       // may decide to implement to not use UnsealPage but to custom mapping / decompression code.

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -456,7 +456,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
 ROOT::Experimental::Internal::RPageStorage::RSealedPage
 ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element)
 {
-   const auto nBytes = page.GetNBytes() + GetWriteOptions().GetCompression() * kNBytesPageChecksum;
+   const auto nBytes = page.GetNBytes() + GetWriteOptions().GetEnablePageChecksums() * kNBytesPageChecksum;
    if (fSealPageBuffer.size() < nBytes)
       fSealPageBuffer.resize(nBytes);
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -429,7 +429,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
 
    if (!config.fElement->IsMappable()) {
       nBytesPacked = config.fElement->GetPackedSize(config.fPage->GetNElements());
-      pageBuf = new unsigned char[nBytesPacked + nBytesChecksum];
+      pageBuf = new unsigned char[nBytesPacked];
       isAdoptedBuffer = false;
       config.fElement->Pack(pageBuf, config.fPage->GetBuffer(), config.fPage->GetNElements());
    }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RPagePool.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 #include <ROOT/RPageStorageFile.hxx>
@@ -390,18 +391,20 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
 
    unsigned char *pageBuf = reinterpret_cast<unsigned char *>(config.fPage->GetBuffer());
    bool isAdoptedBuffer = true;
-   auto packedBytes = config.fPage->GetNBytes();
+   auto nBytesPacked = config.fPage->GetNBytes();
+   auto nBytesChecksum = config.fWriteChecksum * kNBytesPageChecksum;
 
    if (!config.fElement->IsMappable()) {
-      packedBytes = config.fElement->GetPackedSize(config.fPage->GetNElements());
-      pageBuf = new unsigned char[packedBytes];
+      nBytesPacked = config.fElement->GetPackedSize(config.fPage->GetNElements());
+      pageBuf = new unsigned char[nBytesPacked + nBytesChecksum];
       isAdoptedBuffer = false;
       config.fElement->Pack(pageBuf, config.fPage->GetBuffer(), config.fPage->GetNElements());
    }
-   auto zippedBytes = packedBytes;
+   auto nBytesZipped = nBytesPacked;
 
-   if ((config.fCompressionSetting != 0) || !config.fElement->IsMappable() || !config.fAllowAlias) {
-      zippedBytes = RNTupleCompressor::Zip(pageBuf, packedBytes, config.fCompressionSetting, config.fBuffer);
+   if ((config.fCompressionSetting != 0) || !config.fElement->IsMappable() || !config.fAllowAlias ||
+       config.fWriteChecksum) {
+      nBytesZipped = RNTupleCompressor::Zip(pageBuf, nBytesPacked, config.fCompressionSetting, config.fBuffer);
       if (!isAdoptedBuffer)
          delete[] pageBuf;
       pageBuf = reinterpret_cast<unsigned char *>(config.fBuffer);
@@ -410,19 +413,25 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
 
    R__ASSERT(isAdoptedBuffer);
 
-   return RSealedPage{pageBuf, static_cast<std::uint32_t>(zippedBytes), config.fPage->GetNElements()};
+   RSealedPage sealedPage{pageBuf, static_cast<std::uint32_t>(nBytesZipped + nBytesChecksum),
+                          config.fPage->GetNElements(), config.fWriteChecksum};
+   sealedPage.ChecksumIfEnabled();
+
+   return sealedPage;
 }
 
 ROOT::Experimental::Internal::RPageStorage::RSealedPage
 ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element)
 {
-   if (fSealPageBuffer.size() < page.GetNBytes())
-      fSealPageBuffer.resize(page.GetNBytes());
+   const auto nBytes = page.GetNBytes() + GetWriteOptions().GetCompression() * kNBytesPageChecksum;
+   if (fSealPageBuffer.size() < nBytes)
+      fSealPageBuffer.resize(nBytes);
 
    RSealPageConfig config;
    config.fPage = &page;
    config.fElement = &element;
    config.fCompressionSetting = GetWriteOptions().GetCompression();
+   config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
    config.fAllowAlias = true;
    config.fBuffer = fSealPageBuffer.data();
 
@@ -611,6 +620,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitPage(ColumnHandle_
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = page.GetNElements();
    pageInfo.fLocator = CommitPageImpl(columnHandle, page);
+   pageInfo.fHasChecksum = GetWriteOptions().GetEnablePageChecksums();
    fOpenPageRanges.at(columnHandle.fPhysicalId).fPageInfos.emplace_back(pageInfo);
 }
 
@@ -622,6 +632,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPage(Descrip
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = sealedPage.GetNElements();
    pageInfo.fLocator = CommitSealedPageImpl(physicalColumnId, sealedPage);
+   pageInfo.fHasChecksum = sealedPage.GetHasChecksum();
    fOpenPageRanges.at(physicalColumnId).fPageInfos.emplace_back(pageInfo);
 }
 
@@ -650,6 +661,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageV(
          RClusterDescriptor::RPageRange::RPageInfo pageInfo;
          pageInfo.fNElements = sealedPageIt->GetNElements();
          pageInfo.fLocator = locators[i++];
+         pageInfo.fHasChecksum = sealedPageIt->GetHasChecksum();
          fOpenPageRanges.at(range.fPhysicalColumnId).fPageInfos.emplace_back(pageInfo);
       }
    }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -33,6 +33,7 @@
 #include <Compression.h>
 #include <TError.h>
 
+#include <atomic>
 #include <utility>
 
 ROOT::Experimental::Internal::RPageStorage::RPageStorage(std::string_view name) : fMetrics(""), fNTupleName(name) {}
@@ -196,6 +197,8 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
 
    std::vector<std::unique_ptr<RColumnElementBase>> allElements;
 
+   std::atomic<bool> foundChecksumFailure{false};
+
    const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
    for (const auto columnId : columnsInCluster) {
       const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
@@ -208,12 +211,22 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
       for (const auto &pi : pageRange.fPageInfos) {
          ROnDiskPage::Key key(columnId, pageNo);
          auto onDiskPage = cluster->GetOnDiskPage(key);
-         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
-         RSealedPage sealedPage{onDiskPage->GetAddress(), pi.fLocator.fBytesOnStorage, pi.fNElements};
+         RSealedPage sealedPage;
+         sealedPage.SetNElements(pi.fNElements);
+         sealedPage.SetHasChecksum(pi.fHasChecksum);
+         sealedPage.SetBufferSize(pi.fLocator.fBytesOnStorage + pi.fHasChecksum * kNBytesPageChecksum);
+         sealedPage.SetBuffer(onDiskPage->GetAddress());
+         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
 
          auto taskFunc = [this, columnId, clusterId, firstInPage, sealedPage, element = allElements.back().get(),
+                          &foundChecksumFailure,
                           indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
-            auto newPage = UnsealPage(sealedPage, *element, columnId).Unwrap();
+            auto rv = UnsealPage(sealedPage, *element, columnId);
+            if (!rv) {
+               foundChecksumFailure = true;
+               return;
+            }
+            auto newPage = rv.Unwrap();
             fCounters->fSzUnzip.Add(element->GetSize() * sealedPage.GetNElements());
 
             newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
@@ -231,6 +244,10 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
    fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
 
    fTaskScheduler->Wait();
+
+   if (foundChecksumFailure) {
+      throw RException(R__FAIL("page checksum verification failed, data corruption detected"));
+   }
 }
 
 void ROOT::Experimental::Internal::RPageSource::PrepareLoadCluster(
@@ -361,6 +378,10 @@ ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedP
       page.GrowUnchecked(sealedPage.GetNElements());
       return page;
    }
+
+   auto rv = sealedPage.VerifyChecksumIfEnabled();
+   if (!rv)
+      return R__FORWARD_ERROR(rv);
 
    const auto bytesPacked = element.GetPackedSize(sealedPage.GetNElements());
    using Allocator_t = RPageAllocatorHeap;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -201,7 +201,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
 
          auto taskFunc = [this, columnId, clusterId, firstInPage, sealedPage, element = allElements.back().get(),
                           indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
-            auto newPage = UnsealPage(sealedPage, *element, columnId);
+            auto newPage = UnsealPage(sealedPage, *element, columnId).Unwrap();
             fCounters->fSzUnzip.Add(element->GetSize() * sealedPage.GetNElements());
 
             newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
@@ -338,7 +338,7 @@ void ROOT::Experimental::Internal::RPageSource::EnableDefaultMetrics(const std::
          })});
 }
 
-ROOT::Experimental::Internal::RPage
+ROOT::Experimental::RResult<ROOT::Experimental::Internal::RPage>
 ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element,
                                                       DescriptorId_t physicalColumnId)
 {

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -671,7 +671,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::PopulatePageFromCluster(ColumnHan
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId);
+      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -81,13 +81,12 @@ void ROOT::Experimental::Internal::RPageSinkFile::InitImpl(unsigned char *serial
 }
 
 inline ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
-                                                             std::size_t bytesPacked)
+ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage::RSealedPage &sealedPage)
 {
    std::uint64_t offsetData;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetBufferSize(), bytesPacked);
+      offsetData = fWriter->WriteBlob(sealedPage.GetBuffer(), sealedPage.GetBufferSize(), sealedPage.GetBufferSize());
    }
 
    RNTupleLocator result;
@@ -110,18 +109,14 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitPageImpl(ColumnHandle_t colum
    }
 
    fCounters->fSzZip.Add(page.GetNBytes());
-   return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
+   return WriteSealedPage(sealedPage);
 }
 
 ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t physicalColumnId,
+ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t /* physicalColumnId */,
                                                                   const RPageStorage::RSealedPage &sealedPage)
 {
-   const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
-      fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(physicalColumnId).GetModel().GetType());
-   const auto bytesPacked = (bitsOnStorage * sealedPage.GetNElements() + 7) / 8;
-
-   return WriteSealedPage(sealedPage, bytesPacked);
+   return WriteSealedPage(sealedPage);
 }
 
 std::vector<ROOT::Experimental::RNTupleLocator>

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -420,7 +420,7 @@ ROOT::Experimental::Internal::RPageSourceFile::PopulatePageFromCluster(ColumnHan
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId);
+      newPage = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element, columnId).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 ROOT_ADD_GTEST(ntuple_basics ntuple_basics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_bulk ntuple_bulk.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx ntuple_test.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_cluster ntuple_cluster.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_compat ntuple_compat.cxx RXTuple.cxx LIBRARIES ROOTNTuple xxHash::xxHash)
 ROOT_GENERATE_DICTIONARY(RXTupleDict ${CMAKE_CURRENT_SOURCE_DIR}/RXTuple.hxx

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -114,7 +114,7 @@ if(daos OR daos_mock)
     set(daos_test_pool ntuple-daos-test-pool)
   endif()
 
-  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
+  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx ntuple_test.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
   target_compile_definitions(ntuple_storage_daos PRIVATE R__DAOS_TEST_POOL="${daos_test_pool}")
 
   if(daos_mock)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -333,6 +333,7 @@ TEST(RNTuple, ClusterEntriesAuto)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       for (int i = 0; i < 100; i++) {
@@ -357,6 +358,7 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
 
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto entry = ntuple->CreateEntry();

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -1,0 +1,150 @@
+
+#include "ntuple_test.hxx"
+
+#include <cstring>
+
+TEST(RNTupleChecksum, VerifyOnRead)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
+
+   CreateCorruptedRNTuple(fileGuard.GetPath());
+
+   for (auto co : {RNTupleReadOptions::EClusterCache::kOn, RNTupleReadOptions::EClusterCache::kOff}) {
+      RNTupleReadOptions options;
+      options.SetClusterCache(co);
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath(), options);
+      EXPECT_EQ(1u, reader->GetNEntries());
+
+      auto viewPx = reader->GetView<float>("px");
+      auto viewPy = reader->GetView<float>("py");
+      EXPECT_THROW(viewPx(0), RException);
+      EXPECT_FLOAT_EQ(2.0, viewPy(0));
+   }
+}
+
+#ifdef R__USE_IMT
+TEST(RNTupleChecksum, VerifyOnReadImt)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_read.root");
+
+   CreateCorruptedRNTuple(fileGuard.GetPath());
+
+   IMTRAII _;
+
+   RNTupleReadOptions options;
+   options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath(), options);
+   EXPECT_EQ(1u, reader->GetNEntries());
+
+   auto viewPx = reader->GetView<float>("px");
+   auto viewPy = reader->GetView<float>("py");
+   try {
+      viewPy(0);
+      FAIL() << "now even reading py should fail because pages are unsealed in parallel";
+   } catch (const RException &e) {
+      EXPECT_THAT(e.what(), testing::HasSubstr("page checksum"));
+   }
+}
+#endif // R__USE_IMT
+
+TEST(RNTupleChecksum, VerifyOnLoad)
+{
+   FileRaii fileGuard("test_ntuple_checksum_verify_load.root");
+
+   CreateCorruptedRNTuple(fileGuard.GetPath());
+
+   RPageStorage::RSealedPage sealedPage;
+   DescriptorId_t pxColId;
+   DescriptorId_t pyColId;
+   DescriptorId_t clusterId;
+   auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+   pageSource->Attach();
+   {
+      auto descGuard = pageSource->GetSharedDescriptorGuard();
+      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+      clusterId = descGuard->FindClusterId(pxColId, 0);
+   }
+   RClusterIndex index{clusterId, 0};
+
+   constexpr std::size_t bufSize = 12;
+   pageSource->LoadSealedPage(pyColId, index, sealedPage);
+   EXPECT_EQ(bufSize, sealedPage.GetBufferSize());
+   unsigned char buffer[bufSize];
+   sealedPage.SetBuffer(buffer);
+   // no exception
+   pageSource->LoadSealedPage(pyColId, index, sealedPage);
+
+   EXPECT_THROW(pageSource->LoadSealedPage(pxColId, index, sealedPage), RException);
+}
+
+TEST(RNTupleChecksum, OmitPageChecksum)
+{
+   FileRaii fileGuard("test_ntuple_omit_page_checksum.root");
+
+   auto model = RNTupleModel::Create();
+   auto ptrPx = model->MakeField<float>("px", 1.0);
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+   options.SetEnablePageChecksums(false);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+   writer->Fill();
+   writer.reset();
+
+   auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+   pageSource->Attach();
+   auto descGuard = pageSource->GetSharedDescriptorGuard();
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+   const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
+   const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
+   EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
+   EXPECT_FALSE(pageInfo.fHasChecksum);
+
+   RPageStorage::RSealedPage sealedPage;
+   pageSource->LoadSealedPage(pxColId, RClusterIndex{clusterId, 0}, sealedPage);
+   EXPECT_FALSE(sealedPage.GetHasChecksum());
+   EXPECT_EQ(4u, sealedPage.GetBufferSize());
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+   auto viewPx = reader->GetView<float>("px");
+   EXPECT_FLOAT_EQ(1.0, viewPx(0));
+}
+
+TEST(RNTupleChecksum, Merge)
+{
+   FileRaii fileGuard1("test_ntuple_checksum_merge1.root");
+   FileRaii fileGuard2("test_ntuple_checksum_merge2.root");
+
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+
+   CreateCorruptedRNTuple(fileGuard1.GetPath());
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrPx = model->MakeField<float>("px", 3.0);
+      auto ptrPy = model->MakeField<float>("py", 4.0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      writer->Fill();
+   }
+
+   FileRaii fileGuard3("test_ntuple_checksum_merge_out.root");
+   std::vector<std::unique_ptr<RPageSource>> sources;
+   sources.push_back(RPageSource::Create("ntpl", fileGuard1.GetPath()));
+   sources.push_back(RPageSource::Create("ntpl", fileGuard2.GetPath()));
+   std::vector<RPageSource *> sourcePtrs;
+   for (const auto &s : sources) {
+      sourcePtrs.push_back(s.get());
+   }
+
+   auto destination = std::make_unique<RPageSinkFile>("ntpl", fileGuard3.GetPath(), options);
+   RNTupleMerger merger;
+   try {
+      merger.Merge(sourcePtrs, *destination);
+      FAIL() << "merging should fail due to checksum error";
+   } catch (const RException &e) {
+      EXPECT_THAT(e.what(), testing::HasSubstr("page checksum"));
+   }
+}

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -65,6 +65,7 @@ public:
    RPageSinkMock(const RColumnElementBase &elt)
       : RPageSink("test", ROOT::Experimental::RNTupleWriteOptions()), fElement(elt)
    {
+      fOptions->SetEnablePageChecksums(false);
       fCompressor = std::make_unique<ROOT::Experimental::Internal::RNTupleCompressor>();
    }
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage &page) final

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -95,7 +95,7 @@ public:
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
-      return RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId);
+      return RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId).Unwrap();
    }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPage(); }
    void ReleasePage(RPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -91,6 +91,7 @@ TEST(RNTuple, RandomAccess)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(nEvents * sizeof(std::int32_t) / 10);
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath(), options);
       for (unsigned int i = 0; i < nEvents; ++i)

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -51,12 +51,14 @@ TEST(RPageStorage, ReadSealedPages)
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetSize());
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+   ASSERT_EQ(4U, sealedPage.GetDataSize());
+   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
-   ASSERT_EQ(4U, sealedPage.GetSize());
+   ASSERT_EQ(4U, sealedPage.GetDataSize());
+   ASSERT_EQ(4U, sealedPage.GetBufferSize());
    EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 
    // Check second, big cluster
@@ -70,7 +72,8 @@ TEST(RPageStorage, ReadSealedPages)
       buffer = std::make_unique<unsigned char[]>(pi.fLocator.fBytesOnStorage);
       sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      ASSERT_GE(sealedPage.GetSize(), 4U);
+      ASSERT_GE(sealedPage.GetBufferSize(), 4U);
+      ASSERT_GE(sealedPage.GetDataSize(), 4U);
       EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
       firstElementInPage += pi.fNElements;
    }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -52,13 +52,13 @@ TEST(RPageStorage, ReadSealedPages)
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
    ASSERT_EQ(4U, sealedPage.GetDataSize());
-   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(12U, sealedPage.GetBufferSize());
    auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
    ASSERT_EQ(4U, sealedPage.GetDataSize());
-   ASSERT_EQ(4U, sealedPage.GetBufferSize());
+   ASSERT_EQ(12U, sealedPage.GetBufferSize());
    EXPECT_EQ(42, ReadRawInt(sealedPage.GetBuffer()));
 
    // Check second, big cluster
@@ -69,10 +69,12 @@ TEST(RPageStorage, ReadSealedPages)
    EXPECT_GT(pageRange.fPageInfos.size(), 1U);
    std::uint32_t firstElementInPage = 0;
    for (const auto &pi : pageRange.fPageInfos) {
-      buffer = std::make_unique<unsigned char[]>(pi.fLocator.fBytesOnStorage);
+      sealedPage.SetBuffer(nullptr);
+      source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
+      buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
       sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      ASSERT_GE(sealedPage.GetBufferSize(), 4U);
+      ASSERT_GE(sealedPage.GetBufferSize(), 12U);
       ASSERT_GE(sealedPage.GetDataSize(), 4U);
       EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
       firstElementInPage += pi.fNElements;

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -313,7 +313,8 @@ TEST_F(RPageStorageDaos, Checksum)
 
       auto viewPx = reader->GetView<float>("px");
       auto viewPy = reader->GetView<float>("py");
-      EXPECT_THROW(viewPy(0), RException); // we run under IMT, even the valid column should fail
+      auto viewPz = reader->GetView<float>("pz");
+      EXPECT_THROW(viewPz(0), RException); // we run under IMT, even the valid column should fail
    }
 
    auto reader = RNTupleReader::Open("ntpl", daosUri);
@@ -321,16 +322,20 @@ TEST_F(RPageStorageDaos, Checksum)
 
    auto viewPx = reader->GetView<float>("px");
    auto viewPy = reader->GetView<float>("py");
+   auto viewPz = reader->GetView<float>("pz");
    EXPECT_THROW(viewPx(0), RException);
-   EXPECT_FLOAT_EQ(2.0, viewPy(0));
+   EXPECT_THROW(viewPy(0), RException);
+   EXPECT_FLOAT_EQ(3.0, viewPz(0));
 
    DescriptorId_t pxColId;
+   DescriptorId_t pyColId;
    DescriptorId_t clusterId;
    auto pageSource = RPageSource::Create("ntpl", daosUri);
    pageSource->Attach();
    {
       auto descGuard = pageSource->GetSharedDescriptorGuard();
       pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
       clusterId = descGuard->FindClusterId(pxColId, 0);
    }
    RClusterIndex index{clusterId, 0};
@@ -340,5 +345,6 @@ TEST_F(RPageStorageDaos, Checksum)
    unsigned char buffer[bufSize];
    sealedPage.SetBuffer(buffer);
    EXPECT_THROW(pageSource->LoadSealedPage(pxColId, index, sealedPage), RException);
+   EXPECT_THROW(pageSource->LoadSealedPage(pyColId, index, sealedPage), RException);
 }
 #endif

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -291,7 +291,7 @@ TEST_F(RPageStorageDaos, CagedPages)
 
       auto colType = desc->GetColumnDescriptor(colId).GetModel().GetType();
       auto elem = ROOT::Experimental::Internal::RColumnElementBase::Generate<std::uint32_t>(colType);
-      auto page = pageSource->UnsealPage(sealedPage, *elem, colId);
+      auto page = pageSource->UnsealPage(sealedPage, *elem, colId).Unwrap();
       EXPECT_GT(page.GetNElements(), 0);
       auto ptrData = static_cast<std::uint32_t *>(page.GetBuffer());
       for (std::uint32_t i = 0; i < page.GetNElements(); ++i) {

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -285,7 +285,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       RPageStorage::RSealedPage sealedPage;
       pageSource->LoadSealedPage(colId, RClusterIndex{clusterId, 0}, sealedPage);
       EXPECT_GT(sealedPage.GetNElements(), 0);
-      auto pageBuf = std::make_unique<unsigned char[]>(sealedPage.GetSize());
+      auto pageBuf = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
       sealedPage.SetBuffer(pageBuf.get());
       pageSource->LoadSealedPage(colId, RClusterIndex{clusterId, 0}, sealedPage);
 

--- a/tree/ntuple/v7/test/ntuple_test.cxx
+++ b/tree/ntuple/v7/test/ntuple_test.cxx
@@ -10,6 +10,7 @@ void CreateCorruptedRNTuple(const std::string &uri)
    auto model = RNTupleModel::Create();
    model->MakeField<float>("px", 1.0);
    model->MakeField<float>("py", 2.0);
+   model->MakeField<float>("pz", 3.0);
    model->Freeze();
    auto modelClone = model->Clone(); // required later to write the corrupted version
    auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);
@@ -22,31 +23,42 @@ void CreateCorruptedRNTuple(const std::string &uri)
    auto descGuard = pageSource->GetSharedDescriptorGuard();
    const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
    const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+   const auto pzColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("pz"), 0);
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    RClusterIndex index{clusterId, 0};
 
    constexpr std::size_t bufSize = sizeof(float) + RPageStorage::kNBytesPageChecksum;
    unsigned char pxBuffer[bufSize];
-   RPageStorage::RSealedPage pxSealedPage;
-   pxSealedPage.SetBufferSize(bufSize);
-   pxSealedPage.SetBuffer(pxBuffer);
-   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
-   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
    unsigned char pyBuffer[bufSize];
+   unsigned char pzBuffer[bufSize];
+   RPageStorage::RSealedPage pxSealedPage;
    RPageStorage::RSealedPage pySealedPage;
+   RPageStorage::RSealedPage pzSealedPage;
+   pxSealedPage.SetBufferSize(bufSize);
    pySealedPage.SetBufferSize(bufSize);
+   pzSealedPage.SetBufferSize(bufSize);
+   pxSealedPage.SetBuffer(pxBuffer);
    pySealedPage.SetBuffer(pyBuffer);
+   pzSealedPage.SetBuffer(pzBuffer);
+   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
    pageSource->LoadSealedPage(pyColId, index, pySealedPage);
+   pageSource->LoadSealedPage(pzColId, index, pzSealedPage);
+   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
    EXPECT_EQ(bufSize, pySealedPage.GetBufferSize());
+   EXPECT_EQ(bufSize, pzSealedPage.GetBufferSize());
 
    // Corrupt px sealed page's checksum
    memset(pxBuffer + sizeof(float), 0, RPageStorage::kNBytesPageChecksum);
 
-   // Rewrite RNTuple with valid py page and corrupted px page
+   // Corrupt py sealed page's data
+   memset(pyBuffer, 0, sizeof(float));
+
+   // Rewrite RNTuple with valid pz page and corrupted px, py page
    auto pageSink = ROOT::Experimental::Internal::RPagePersistentSink::Create("ntpl", uri, options);
    pageSink->Init(*modelClone);
    pageSink->CommitSealedPage(pxColId, pxSealedPage);
    pageSink->CommitSealedPage(pyColId, pySealedPage);
+   pageSink->CommitSealedPage(pzColId, pzSealedPage);
    pageSink->CommitCluster(1);
    pageSink->CommitClusterGroup();
    pageSink->CommitDataset();

--- a/tree/ntuple/v7/test/ntuple_test.cxx
+++ b/tree/ntuple/v7/test/ntuple_test.cxx
@@ -1,0 +1,54 @@
+#include "ntuple_test.hxx"
+
+#include <cstring> // for memset
+
+void CreateCorruptedRNTuple(const std::string &uri)
+{
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("px", 1.0);
+   model->MakeField<float>("py", 2.0);
+   model->Freeze();
+   auto modelClone = model->Clone(); // required later to write the corrupted version
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);
+   writer->Fill();
+   writer.reset();
+
+   // Load sealed pages to memory
+   auto pageSource = RPageSource::Create("ntpl", uri);
+   pageSource->Attach();
+   auto descGuard = pageSource->GetSharedDescriptorGuard();
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+   const auto clusterId = descGuard->FindClusterId(pxColId, 0);
+   RClusterIndex index{clusterId, 0};
+
+   constexpr std::size_t bufSize = sizeof(float) + RPageStorage::kNBytesPageChecksum;
+   unsigned char pxBuffer[bufSize];
+   RPageStorage::RSealedPage pxSealedPage;
+   pxSealedPage.SetBufferSize(bufSize);
+   pxSealedPage.SetBuffer(pxBuffer);
+   pageSource->LoadSealedPage(pxColId, index, pxSealedPage);
+   EXPECT_EQ(bufSize, pxSealedPage.GetBufferSize());
+   unsigned char pyBuffer[bufSize];
+   RPageStorage::RSealedPage pySealedPage;
+   pySealedPage.SetBufferSize(bufSize);
+   pySealedPage.SetBuffer(pyBuffer);
+   pageSource->LoadSealedPage(pyColId, index, pySealedPage);
+   EXPECT_EQ(bufSize, pySealedPage.GetBufferSize());
+
+   // Corrupt px sealed page's checksum
+   memset(pxBuffer + sizeof(float), 0, RPageStorage::kNBytesPageChecksum);
+
+   // Rewrite RNTuple with valid py page and corrupted px page
+   auto pageSink = ROOT::Experimental::Internal::RPagePersistentSink::Create("ntpl", uri, options);
+   pageSink->Init(*modelClone);
+   pageSink->CommitSealedPage(pxColId, pxSealedPage);
+   pageSink->CommitSealedPage(pyColId, pySealedPage);
+   pageSink->CommitCluster(1);
+   pageSink->CommitClusterGroup();
+   pageSink->CommitDataset();
+   modelClone.reset();
+}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -137,4 +137,11 @@ public:
    void PreserveFile() { fPreserveFile = true; }
 };
 
+#ifdef R__USE_IMT
+struct IMTRAII {
+   IMTRAII() { ROOT::EnableImplicitMT(); }
+   ~IMTRAII() { ROOT::DisableImplicitMT(); }
+};
+#endif
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -144,4 +144,8 @@ struct IMTRAII {
 };
 #endif
 
+/// Creates an uncompressed RNTuple called "ntpl" with two float fields, px and py, with a single entry.
+/// The page of px has a wrong checksum. The function is backend agnostic (file, DAOS, ...).
+void CreateCorruptedRNTuple(const std::string &uri);
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -144,8 +144,9 @@ struct IMTRAII {
 };
 #endif
 
-/// Creates an uncompressed RNTuple called "ntpl" with two float fields, px and py, with a single entry.
-/// The page of px has a wrong checksum. The function is backend agnostic (file, DAOS, ...).
+/// Creates an uncompressed RNTuple called "ntpl" with three float fields, px, py, pz, with a single entry.
+/// The page of px has a wrong checksum. The page of py has corrupted data. The page of pz is valid.
+/// The function is backend agnostic (file, DAOS, ...).
 void CreateCorruptedRNTuple(const std::string &uri);
 
 #endif


### PR DESCRIPTION
Implements writing page checksums and checksum verification on read.
Page checksums are written on `SealPage()`. They are verified on `LoadSealedPage()` and on `UnsealPage()`.

Note that the page size stored in locators does not change. Pages flagged as having a checksum are serialized with additional trailing 8 bytes.
