### PR TITLE
[tree] prevent nullptr access in ttreereader

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeReaderValueFast.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeReaderValueFast.hxx
@@ -66,6 +66,11 @@ class TTreeReaderValueFastBase {
              }
              fRemaining -= adjust;
           } else {
+             if (!fBranch) {
+                fReadStatus = ROOT::Internal::TTreeReaderValueBase::kReadError;
+                //printf("Failed to retrieve branch.\n");
+                return -1;
+             }
              fRemaining = fBranch->GetBulkRead().GetEntriesSerialized(eventNum, fBuffer);
              if (R__unlikely(fRemaining < 0)) {
                 fReadStatus = ROOT::Internal::TTreeReaderValueBase::kReadError;

--- a/tree/treeplayer/test/regressions.cxx
+++ b/tree/treeplayer/test/regressions.cxx
@@ -4,6 +4,8 @@
 #include "TTree.h"
 #include "TTreeReader.h"
 #include "TTreeReaderValue.h"
+#include "ROOT/TTreeReaderValueFast.hxx"
+#include "TNtuple.h"
 
 #include "gtest/gtest.h"
 
@@ -172,4 +174,21 @@ TEST(TTreeReaderRegressions, IndexedFriend)
    }
 
    gSystem->Unlink(fname);
+}
+
+// ROOT-8842
+TEST(TTreeReaderRegressions, ValueFastTuple)
+{
+    TNtuple tree("tuple", "ROOT-8842", "px:py:pz:energy");
+    for(auto i=0; i<1000000; ++i)
+        tree.Fill(i,i+1,i+2,i+3);
+    ROOT::Experimental::TTreeReaderFast reader(&tree);
+    ROOT::Experimental::TTreeReaderValueFast<float> px(reader, "px");
+    ROOT::Experimental::TTreeReaderValueFast<float> py(reader, "py");
+    ROOT::Experimental::TTreeReaderValueFast<float> pz(reader, "pz");
+    double total = 0.0;
+    // reader.SetEntry(0); If I uncomment this, the crash disappears
+    for (auto it = reader.begin();  it != reader.end();  ++it)
+        total += sqrt((*px)*(*px) + (*py)*(*py) + (*pz)*(*pz));
+    EXPECT_EQ(total, 8.6602627e+11);
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

nullptr access when branch is not found

Fixes first part of https://its.cern.ch/jira/browse/ROOT-8842 by @jpivarski

`GetNextRange(int)`

but it still crashes later at:

```
1 frombuf                                                      Bytes.h                  384 0x7f62c0ded275 
2 ROOT::Experimental::TTreeReaderValueFast<float>::Deserialize TTreeReaderValueFast.hxx 171 0x7f62b6563bd0 
3 ROOT::Experimental::TTreeReaderValueFast<float>::Get         TTreeReaderValueFast.hxx 162 0x7f62b6563b42 
4 ROOT::Experimental::TTreeReaderValueFast<float>::operator *  TTreeReaderValueFast.hxx 165 0x7f62b6563b60 
5 reader                                                       reader.C                 30  0x7f62b6563004 
6 ??                                                                                        0x7f62b7e280bc 
7 ??                                                                                        0x7ffda58c2b60 
8 ??                                                                                        0x7ffda58c2b28 
9 ??                                                                                                       
```

and this part, I do not know how to solve.

The crash happens every time at a different entry.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

