### PR TITLE
[thstack] fix GetMinimum/GetMaximum, improve "pads" drawing

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -548,7 +548,7 @@ Double_t THStack::GetMinimum(Option_t *option, Double_t minval)
 {
    TString opt = option;
    opt.ToLower();
-   Bool_t lerr = kFALSE;
+   Bool_t lerr = kFALSE, logy = gPad ? gPad->GetLogy() : kFALSE;
    if (opt.Contains("e")) lerr = kTRUE;
    Double_t them = 0, themin = std::numeric_limits<Double_t>::max(), c1, e1;
    if (!fHists) return 0;
@@ -564,7 +564,8 @@ Double_t THStack::GetMinimum(Option_t *option, Double_t minval)
       for (Int_t i=0;i<nhists;i++) {
          h = (TH1*)fHists->At(i);
          them = h->GetMinimum(minval);
-         if (them <= 0 && gPad && gPad->GetLogy()) them = h->GetMinimum(0);
+         if (them <= 0 && logy)
+            them = h->GetMinimum(0);
          if (them < themin) themin = them;
       }
    }
@@ -577,7 +578,8 @@ Double_t THStack::GetMinimum(Option_t *option, Double_t minval)
          for (Int_t j=first; j<=last;j++) {
              e1     = h->GetBinError(j);
              c1     = h->GetBinContent(j);
-             themin = TMath::Min(themin,c1-e1);
+             if (!logy || (c1 - e1 > 0))
+                themin = TMath::Min(themin, c1 - e1);
          }
       }
    }

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -9,6 +9,7 @@ ROOT_ADD_GTEST(testTH2PolyBinError test_TH2Poly_BinError.cxx LIBRARIES Hist Matr
 ROOT_ADD_GTEST(testTH2PolyAdd test_TH2Poly_Add.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTHn THn.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTH1 test_TH1.cxx LIBRARIES Hist)
+ROOT_ADD_GTEST(testTHStack test_THStack.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testProject3Dname test_Project3D_name.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTFormula test_TFormula.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTKDE test_tkde.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_THStack.cxx
+++ b/hist/hist/test/test_THStack.cxx
@@ -1,0 +1,53 @@
+#include "gtest/gtest.h"
+
+#include "TH1F.h"
+#include "THStack.h"
+
+// StatOverflows TH1
+TEST(THStack, GetMinimumMaximum)
+{
+   THStack hs("hs", "stack");
+   TH1F h1("h1", "h1", 5, 0., 5.);
+   TH1F h2("h2", "h2", 5, 0., 5.);
+   TH1F h3("h3", "h3", 5, 0., 5.);
+   for (int n = 1; n <= 5; ++n) {
+      Double_t cont = n < 4 ? n : 6 - n;
+      h1.SetBinContent(n, cont);
+      h2.SetBinContent(n, cont);
+      h3.SetBinContent(n, cont);
+   }
+
+   hs.Add(&h1);
+   hs.Add(&h2);
+   hs.Add(&h3);
+
+   // default with stack building
+   EXPECT_EQ(hs.GetMinimum(), 3.);
+   EXPECT_EQ(hs.GetMaximum(), 9.);
+
+   // without stack
+   EXPECT_EQ(hs.GetMinimum("nostack"), 1.);
+   EXPECT_EQ(hs.GetMaximum("nostack"), 3.);
+
+   // stack with errors
+   EXPECT_NEAR(hs.GetMinimum("e"), 1.267949, 1e-6);
+   EXPECT_NEAR(hs.GetMaximum("e"), 12., 1e-6);
+
+   // nostack with errors
+   EXPECT_NEAR(hs.GetMinimum("nostack e"), 0, 1e-6);
+   EXPECT_NEAR(hs.GetMaximum("nostack e"), 4.732051, 1e-6);
+
+
+   // significant error at maximum bin
+   h3.SetBinError(4, 16);
+   // important - mark hstack as modified
+   hs.Modified();
+
+   // stack with errors
+   EXPECT_NEAR(hs.GetMinimum("e"), -10.124515, 1e-6);
+   EXPECT_NEAR(hs.GetMaximum("e"), 22.124515, 1e-6);
+
+   // nostack with errors
+   EXPECT_NEAR(hs.GetMinimum("nostack e"), -14., 1e-6);
+   EXPECT_NEAR(hs.GetMaximum("nostack e"), 18., 1e-6);
+}

--- a/tutorials/hist/hstackpads.C
+++ b/tutorials/hist/hstackpads.C
@@ -1,0 +1,38 @@
+/// \file
+/// \ingroup tutorial_hist
+/// \notebook
+/// Drawing stack histograms on subpads.
+///
+/// In this example three histograms are displayed on separate pads.
+/// If canvas divided in advance - provided subpads will be used by the THStack.
+///
+/// \macro_image
+/// \macro_code
+///
+/// \author Sergey Linev
+
+void hstackpads()
+{
+   auto hs = new THStack("hs", "Stacked 1D histograms");
+
+   // Create three 1-d histograms  and add them in the stack
+   auto h1st = new TH1F("h1st", "test hstack 1", 100, -4, 4);
+   h1st->FillRandom("gaus", 20000);
+   hs->Add(h1st);
+
+   auto h2st = new TH1F("h2st", "test hstack 2", 100, -4, 4);
+   h2st->FillRandom("gaus", 15000);
+   hs->Add(h2st);
+
+   auto h3st = new TH1F("h3st", "test hstack 3", 100, -4, 4);
+   h3st->FillRandom("gaus", 10000);
+   hs->Add(h3st);
+
+   auto c1 = new TCanvas("c1", "THStack drawing on pads", 800, 800);
+
+   // prepare subpads for drawing of histograms
+   c1->Divide(1, 3);
+
+   // draw thstack on canvas with "pads" draw option
+   c1->Add(hs, "pads");
+}


### PR DESCRIPTION
1. Errors for stacked histogram were not taken into account. Therefore methods were returning wrong values
2. Protect GetMinimum method for case of log scale
3. Improve pads options:
3.1.   Always ensure that subpad is clear when drawing stack histograms
3.2.   Reuse existing subpads, no need to divide canvas again
3.3.  Use TPad::Add() method to add histograms to subpads

