### PR TITLE
[ntuple] Dynamically activate fields in `RNTupleProcessor`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -130,9 +130,7 @@ private:
    NTupleSize_t ConnectNTuple(const RNTupleSourceSpec &ntuple);
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Creates and connects concrete fields to the current page source, based on the proto-fields.
-   void ConnectFields();
-
+   /// \brief Creates and connects a concrete field to the current page source, based on its proto-field.
    void ConnectField(std::string_view fieldName);
 
    /////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -20,7 +20,7 @@
 ROOT::Experimental::NTupleSize_t
 ROOT::Experimental::Internal::RNTupleProcessor::ConnectNTuple(const RNTupleSourceSpec &ntuple)
 {
-   for (auto &fieldContext : fFieldContexts) {
+   for (auto &[fieldName, fieldContext] : fFieldContexts) {
       fieldContext.ResetConcreteField();
    }
    fPageSource = Internal::RPageSource::Create(ntuple.fName, ntuple.fLocation);
@@ -33,26 +33,49 @@ void ROOT::Experimental::Internal::RNTupleProcessor::ConnectFields()
 {
    auto desc = fPageSource->GetSharedDescriptorGuard();
 
-   for (auto &fieldContext : fFieldContexts) {
-      auto fieldId = desc->FindFieldId(fieldContext.GetProtoField().GetFieldName());
+   for (auto &[fieldName, fieldContext] : fFieldContexts) {
+      auto fieldId = desc->FindFieldId(fieldName);
       if (fieldId == kInvalidDescriptorId) {
-         throw RException(
-            R__FAIL("field \"" + fieldContext.GetProtoField().GetFieldName() + "\" not found in current RNTuple"));
+         throw RException(R__FAIL("field \"" + fieldName + "\" not found in current RNTuple"));
       }
 
-      fieldContext.SetConcreteField();
-      fieldContext.GetConcreteField().SetOnDiskId(desc->FindFieldId(fieldContext.GetProtoField().GetFieldName()));
-      Internal::CallConnectPageSourceOnField(fieldContext.GetConcreteField(), *fPageSource);
+      auto &concreteField = fieldContext.CreateConcreteField();
+      fieldContext.GetConcreteField().SetOnDiskId(desc->FindFieldId(fieldName));
+      Internal::CallConnectPageSourceOnField(concreteField, *fPageSource);
 
       if (fieldContext.fValuePtr) {
-         fEntry->UpdateValue(fieldContext.GetToken(),
-                             fieldContext.GetConcreteField().BindValue(fieldContext.fValuePtr));
+         fEntry->UpdateValue(fieldContext.GetToken(), concreteField.BindValue(fieldContext.fValuePtr));
       } else {
-         auto value = fieldContext.GetConcreteField().CreateValue();
+         auto value = concreteField.CreateValue();
          fieldContext.fValuePtr = value.GetPtr<void>();
          fEntry->UpdateValue(fieldContext.GetToken(), value);
       }
    }
+}
+
+void ROOT::Experimental::Internal::RNTupleProcessor::ActivateField(std::string_view fieldName)
+{
+   auto desc = fPageSource->GetSharedDescriptorGuard();
+   auto fieldId = desc->FindFieldId(fieldName);
+   auto &fieldDesc = desc->GetFieldDescriptor(fieldId);
+
+   auto fieldOrException = RFieldBase::Create(fieldDesc.GetFieldName(), fieldDesc.GetTypeName());
+   if (!fieldOrException) {
+      throw RException(R__FAIL("could not create field \"" + fieldDesc.GetFieldName() + "\" with type \"" +
+                               fieldDesc.GetTypeName() + "\""));
+   }
+   auto protoField = fieldOrException.Unwrap();
+   fEntry->AddValue(protoField->CreateValue());
+
+   RFieldContext fieldContext(std::move(protoField), fEntry->GetToken(fieldDesc.GetFieldName()));
+   fieldContext.fValuePtr = fEntry->GetPtr<void>(fieldContext.GetToken());
+
+   auto &concreteField = fieldContext.CreateConcreteField();
+   concreteField.SetOnDiskId(fieldId);
+   Internal::CallConnectPageSourceOnField(concreteField, *fPageSource);
+   fEntry->UpdateValue(fieldContext.GetToken(), concreteField.BindValue(fieldContext.fValuePtr));
+
+   fFieldContexts.emplace(fieldName, std::move(fieldContext));
 }
 
 ROOT::Experimental::Internal::RNTupleProcessor::RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples)
@@ -69,20 +92,13 @@ ROOT::Experimental::Internal::RNTupleProcessor::RNTupleProcessor(const std::vect
    }
 
    fEntry = std::unique_ptr<REntry>(new REntry());
+}
 
-   auto desc = fPageSource->GetSharedDescriptorGuard();
-
-   for (const auto &fieldDesc : desc->GetTopLevelFields()) {
-      auto fieldOrException = RFieldBase::Create(fieldDesc.GetFieldName(), fieldDesc.GetTypeName());
-      if (fieldOrException) {
-         auto field = fieldOrException.Unwrap();
-         fEntry->AddValue(field->CreateValue());
-         fFieldContexts.emplace_back(std::move(field), fEntry->GetToken(fieldDesc.GetFieldName()));
-      } else {
-         throw RException(R__FAIL("could not create field \"" + fieldDesc.GetFieldName() + "\" with type \"" +
-                                  fieldDesc.GetTypeName() + "\""));
-      }
-   }
-
-   ConnectFields();
+const std::vector<std::string> ROOT::Experimental::Internal::RNTupleProcessor::GetActiveFields() const
+{
+   std::vector<std::string> fieldNames;
+   fieldNames.reserve(fFieldContexts.size());
+   std::transform(fFieldContexts.cbegin(), fFieldContexts.cend(), std::back_inserter(fieldNames),
+                  [](auto &fldCtx) { return fldCtx.first; });
+   return fieldNames;
 }

--- a/tutorials/v7/ntuple/ntpl012_processor.C
+++ b/tutorials/v7/ntuple/ntpl012_processor.C
@@ -68,9 +68,10 @@ void Read(const std::vector<RNTupleSourceSpec> &ntuples)
    hPx.SetFillColor(48);
 
    RNTupleProcessor processor(ntuples);
-   auto ptrPx = processor.GetEntry().GetPtr<std::vector<float>>("vpx");
+   // Obtain a pointer to the field value before iteration start from the processor.
+   auto ptrPx = processor.GetPtr<std::vector<float>>("vpx");
 
-   for (const auto &entry : processor) {
+   for (auto &entry : processor) {
       // The RNTupleProcessor iterator provides some additional bookkeeping information. The local entry index pertains
       // only to the ntuple currently being processed, whereas the global entry index also considers the previously
       // processed ntuples.
@@ -79,7 +80,13 @@ void Read(const std::vector<RNTupleSourceSpec> &ntuples)
                    << " total entries processed so far)" << std::endl;
       }
 
-      // From the entry returned by the RNTupleProcessor iterator, we can get a pointer to the field we want to read.
+      // After processing has begun, pointers to field values not initialized previously can be obtained from the
+      // iterator.
+      if (*entry.GetPtr<std::uint64_t>("vn") == 7) {
+         continue;
+      }
+
+      // Read data from the pointer that was initialized before processing started.
       for (auto x : *ptrPx) {
          hPx.Fill(x);
       }


### PR DESCRIPTION
With this change, fields are only added to the `REntry` and read when they are referenced in the processor loop. This prevents unecessary reads of unused fields.

It also makes the REntry completely transparent from an interface perspective. Pointers to values can be obtained through the processor interface itself *before* the iteration starts, or alternatively via the iterator returned by the processor.

Important to note that during iteration, the pointer returned by `RNTupleProcessor::GetPtr` will **not** contain the value for the current entry. The reason for this is that from the `RNTupleProcessor` interface there is (with the current implementation) no way to know what the current entry index is. For now, `RNTupleProcessor::GetPtr` contains a warning and a recommendation to get the pointer through the iterator instead. Alternative solutions could be:
1. Remove `RNTupleProcessor::GetPtr` altogether and only allow access to the field value pointers through the iterator.
2. Dispatch the local entry index from `RState` back to the processor on every `Advance`, and (re)load the entry when `RNTupleProcessor::GetPtr` is called.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

