### PR TITLE
[tmva][sofie] Introduce not writable initialized tensors in RModel

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -76,6 +76,10 @@ public:
       AddInitializedTensor(tensor_name, type, shape, data);
    }
 
+   // set a flag to indicate tensor does not need to be written in a weight file
+   // (e.g. shape tensors used as input to define a shape (in Reshape))
+   void SetNotWritableInitializedTensor(const std::string & tensor_name);
+
    // Check if a tensor is initialized
    bool IsInitializedTensor(const std::string &name) const;
    bool IsDynamicTensor(const std::string &name) const;

--- a/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
@@ -57,6 +57,8 @@ public:
             std::runtime_error("TMVA::SOFIE - Tensor " + fNIndices + " is not initialized.");
       }
       int64_t* indicesData = static_cast<int64_t*>(model.GetInitializedTensorData(fNIndices).get());
+      //flag index tensor as not writable
+      model.SetNotWritableInitializedTensor(fNIndices);
       fShapeIndices = model.GetTensorShape(fNIndices);
       size_t q = fShapeIndices.size();
       // Axis in range [0, r) where r=rank(X)

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -162,6 +162,8 @@ public:
             std::vector<size_t> descShape(n);
             std::copy(input_shape, input_shape + n, descShape.begin());
             fShapeOutput = ShapeInference({fShapeInput, descShape})[0];
+            // set flag to not write tensor in weight file. Its data will be hard-coded in way model is constructed
+            model.SetNotWritableInitializedTensor(fNShape);
          } else {
             throw std::runtime_error("TMVA Reshape Op Shape Tensor " + fNShape + " is not found in model");
          }

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -94,6 +94,10 @@ public:
    std::shared_ptr<void> const &sharedptr() const { return fData; }
    // query if tensor comes from a Constant operator
    bool IsConstantTensor() const { return fConstant;}
+   // query if tensor needs to be written in a weight file
+   bool IsWeightTensor() const { return !fConstant && !fIsNotWritable;}
+
+   void SetNotWritable() { fIsNotWritable = true;}
 
    template <class T = void>
    T const *data() const
@@ -145,7 +149,8 @@ public:
    }
 
 private:
-   bool        fConstant = false;   ///< Flag specifying if tensor is a Constant one (coming from a Constant operator)
+   bool  fConstant = false;      ///< Flag specifying if tensor is a Constant one (coming from a Constant operator)
+   bool  fIsNotWritable = false; ///< Flag to indicate that tensor values do not need to be written as weight or generated code
    ETensorType fType;               ///< Encodes the type of the data
    std::vector<std::size_t> fShape; ///< The shape of the data in terms of elements in each dimension
    std::shared_ptr<void> fData;     ///<! Transient shared data


### PR DESCRIPTION
We need to add a new category of initialized tensors in RModel that are not written in the weight file. These are for example tensors defining the shape and use as input to some operator such as Reshape. Its data are used when parsing and hard-coded then in the model. There is no need to generate or getting t heir value when using the model for inference

This Pull request should fix a failure reported in master after merging the PR on constant operator ( #15837 )



