### PR TITLE
[RF][HS3] Correct cast for collection proxies in RooJSONFactoryWSTool

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1088,7 +1088,7 @@ void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::str
       if (k->second.empty())
          continue;
 
-      if (auto l = dynamic_cast<RooListProxy *>(p)) {
+      if (auto l = dynamic_cast<RooAbsCollection *>(p)) {
          fillSeq(elem[k->second], *l);
       }
       if (auto r = dynamic_cast<RooArgProxy *>(p)) {


### PR DESCRIPTION
When exporting collection proxies, the type was only checked against the RooArgList proxy, so RooArgSet proxies would not get correctly exported.

It is better to check for the more general `RooAbsCollection` base class.

This fixes the build failures on macos-beta.