### PR TITLE
[ntuple] Improve RDF MT scheduling

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -478,6 +478,9 @@ void RNTupleDS::StageNextSources()
 {
    const auto nFiles = fFileNames.empty() ? 1 : fFileNames.size();
    for (auto i = fNextFileIndex; (i < nFiles) && ((i - fNextFileIndex) < fNSlots); ++i) {
+      if (fStagingThreadShouldTerminate)
+         return;
+
       if (fStagingArea[i]) {
          // The first file is already open and was used to read the schema
          assert(i == 0);

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -574,7 +574,6 @@ void RNTupleDS::PrepareNextRanges()
             range.fSource = std::move(source);
          } else {
             range.fSource = source->Clone();
-            range.fSource->Attach();
          }
          range.fSource->SetEntryRange({start, end - start});
          range.fFirstEntry = start;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -480,7 +480,7 @@ void RNTupleDS::StageNextSources()
    for (auto i = fNextFileIndex; (i < nFiles) && ((i - fNextFileIndex) < fNSlots); ++i) {
       if (fStagingArea[i]) {
          // The first file is already open and was used to read the schema
-         assert(i == fNextFileIndex == 0);
+         assert(i == 0);
       } else {
          fStagingArea[i] = CreatePageSource(fNTupleName, fFileNames[i]);
          fStagingArea[i]->LoadStructure();

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -19,6 +19,22 @@ using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::Internal::RPageSource;
 
+namespace {
+
+class FileRAII {
+private:
+   std::string fPath;
+
+public:
+   explicit FileRAII(const std::string &path) : fPath(path) {}
+   FileRAII(const FileRAII &) = delete;
+   FileRAII &operator=(const FileRAII &) = delete;
+   ~FileRAII() { std::remove(fPath.c_str()); }
+   std::string GetPath() const { return fPath; }
+};
+
+} // namespace
+
 template <typename V1, typename V2>
 void EXPECT_VEC_EQ(const V1 &v1, const V2 &v2)
 {
@@ -172,18 +188,6 @@ static void ChainTest(const std::string &name, const std::string &fname)
    auto df1000 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(name, fileNames));
    EXPECT_DOUBLE_EQ(42000.0, df1000.Sum<float>("pt").GetValue());
 
-   class FileRAII {
-   private:
-      std::string fPath;
-
-   public:
-      explicit FileRAII(const std::string &path) : fPath(path) {}
-      FileRAII(const FileRAII &) = delete;
-      FileRAII &operator=(const FileRAII &) = delete;
-      ~FileRAII() { std::remove(fPath.c_str()); }
-      std::string GetPath() const { return fPath; }
-   };
-
    FileRAII guardFile1("RNTupleDS_test_chain_1.root");
    FileRAII guardFile2("RNTupleDS_test_chain_2.root");
    FileRAII guardFile3("RNTupleDS_test_chain_3.root");
@@ -253,6 +257,48 @@ TEST_F(RNTupleDSTest, ChainMT)
    IMTRAII _;
 
    ChainTest(fNtplName, fFileName);
+}
+
+TEST_F(RNTupleDSTest, ChainTailScheduling)
+{
+   IMTRAII _;
+
+   FileRAII guardFile1("RNTupleDS_test_chain_tail_scheduling_1.root");
+   FileRAII guardFile2("RNTupleDS_test_chain_tail_scheduling_2.root");
+   FileRAII guardFile3("RNTupleDS_test_chain_tail_scheduling_3.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrX = model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile1.GetPath());
+      for (unsigned i = 0; i < 2; ++i) {
+         *ptrX = i;
+         writer->Fill();
+         writer->CommitCluster();
+      }
+   }
+   {
+      auto model = RNTupleModel::Create();
+      model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile2.GetPath());
+      // Empty file
+   }
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrX = model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile3.GetPath());
+      for (unsigned i = 0; i < 11; ++i) {
+         *ptrX = i;
+         writer->Fill();
+         writer->CommitCluster();
+      }
+   }
+
+   auto df = ROOT::RDataFrame(std::make_unique<RNTupleDS>(
+      "chain", std::vector<std::string>{guardFile1.GetPath(), guardFile2.GetPath(), guardFile3.GetPath()}));
+   EXPECT_EQ(3, df.Describe().GetNFiles());
+   auto sumX = df.Aggregate([](int &acc, int x) { acc += x; }, [](int a, int b) { return a + b; }, "x");
+   EXPECT_EQ(56, sumX.GetValue());
 }
 #endif
 

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -86,11 +86,10 @@ private:
 protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final;
+   std::unique_ptr<RPageSource> CloneImpl() const final;
 
 public:
    RPageSourceFriends(std::string_view ntupleName, std::span<std::unique_ptr<RPageSource>> sources);
-
-   std::unique_ptr<RPageSource> Clone() const final;
    ~RPageSourceFriends() final;
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -571,6 +571,8 @@ protected:
    virtual void LoadStructureImpl() = 0;
    /// LoadStructureImpl() has been called before AttachImpl() is called
    virtual RNTupleDescriptor AttachImpl() = 0;
+   /// Returns a new, unattached page source for the same data set
+   virtual std::unique_ptr<RPageSource> CloneImpl() const = 0;
    // Only called if a task scheduler is set. No-op be default.
    virtual void UnzipClusterImpl(RCluster *cluster);
 
@@ -602,8 +604,10 @@ public:
    /// Guess the concrete derived page source from the file name (location)
    static std::unique_ptr<RPageSource> Create(std::string_view ntupleName, std::string_view location,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
-   /// Open the same storage multiple time, e.g. for reading in multiple threads
-   virtual std::unique_ptr<RPageSource> Clone() const = 0;
+   /// Open the same storage multiple time, e.g. for reading in multiple threads.
+   /// If the source is already attached, the clone will be attached, too. The clone will use, however,
+   /// it's own connection to the underlying storage (e.g., file descriptor, XRootD handle, etc.)
+   std::unique_ptr<RPageSource> Clone() const;
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleReadOptions &GetReadOptions() const { return fOptions; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -181,12 +181,11 @@ private:
 protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final;
+   /// The cloned page source creates a new connection to the pool/container.
+   std::unique_ptr<RPageSource> CloneImpl() const final;
 
 public:
    RPageSourceDaos(std::string_view ntupleName, std::string_view uri, const RNTupleReadOptions &options);
-   /// The cloned page source creates a new connection to the pool/container.
-   /// The meta-data (header and footer) is reread and parsed by the clone.
-   std::unique_ptr<RPageSource> Clone() const final;
    ~RPageSourceDaos() override;
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -159,6 +159,8 @@ private:
 protected:
    void LoadStructureImpl() final;
    RNTupleDescriptor AttachImpl() final;
+   /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
+   std::unique_ptr<RPageSource> CloneImpl() const final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);
@@ -168,9 +170,6 @@ public:
    /// Requires the RNTuple object to be streamed from a file.
    static std::unique_ptr<RPageSourceFile>
    CreateFromAnchor(const RNTuple &anchor, const RNTupleReadOptions &options = RNTupleReadOptions());
-   /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
-   /// The meta-data (header and footer) is reread and parsed by the clone.
-   std::unique_ptr<RPageSource> Clone() const final;
 
    RPageSourceFile(const RPageSourceFile&) = delete;
    RPageSourceFile& operator=(const RPageSourceFile&) = delete;

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -117,13 +117,15 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RPageSource>
-ROOT::Experimental::Internal::RPageSourceFriends::Clone() const
+ROOT::Experimental::Internal::RPageSourceFriends::CloneImpl() const
 {
    std::vector<std::unique_ptr<RPageSource>> cloneSources;
    cloneSources.reserve(fSources.size());
    for (const auto &f : fSources)
       cloneSources.emplace_back(f->Clone());
-   return std::make_unique<RPageSourceFriends>(fNTupleName, cloneSources);
+   auto clone = std::make_unique<RPageSourceFriends>(fNTupleName, cloneSources);
+   clone->fIdBiMap = fIdBiMap;
+   return clone;
 }
 
 ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -180,6 +180,17 @@ void ROOT::Experimental::Internal::RPageSource::Attach()
    fIsAttached = true;
 }
 
+std::unique_ptr<ROOT::Experimental::Internal::RPageSource> ROOT::Experimental::Internal::RPageSource::Clone() const
+{
+   auto clone = CloneImpl();
+   if (fIsAttached) {
+      clone->GetExclDescriptorGuard().MoveIn(std::move(*GetSharedDescriptorGuard()->Clone()));
+      clone->fHasStructure = true;
+      clone->fIsAttached = true;
+   }
+   return clone;
+}
+
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Internal::RPageSource::GetNEntries()
 {
    return GetSharedDescriptorGuard()->GetNEntries();

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -744,7 +744,8 @@ void ROOT::Experimental::Internal::RPageSourceDaos::ReleasePage(RPage &page)
    fPagePool->ReturnPage(page);
 }
 
-std::unique_ptr<ROOT::Experimental::Internal::RPageSource> ROOT::Experimental::Internal::RPageSourceDaos::Clone() const
+std::unique_ptr<ROOT::Experimental::Internal::RPageSource>
+ROOT::Experimental::Internal::RPageSourceDaos::CloneImpl() const
 {
    auto clone = new RPageSourceDaos(fNTupleName, fURI, fOptions);
    return std::unique_ptr<RPageSourceDaos>(clone);

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -499,7 +499,8 @@ void ROOT::Experimental::Internal::RPageSourceFile::ReleasePage(RPage &page)
    fPagePool->ReturnPage(page);
 }
 
-std::unique_ptr<ROOT::Experimental::Internal::RPageSource> ROOT::Experimental::Internal::RPageSourceFile::Clone() const
+std::unique_ptr<ROOT::Experimental::Internal::RPageSource>
+ROOT::Experimental::Internal::RPageSourceFile::CloneImpl() const
 {
    auto clone = new RPageSourceFile(fNTupleName, fOptions);
    clone->fFile = fFile->Clone();

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -56,6 +56,7 @@ class RPageSourceMock : public RPageSource {
 protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
+   std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
 
 public:
    /// Records the cluster IDs requests by LoadClusters() calls
@@ -81,7 +82,6 @@ public:
       auto descriptorGuard = GetExclDescriptorGuard();
       descriptorGuard.MoveIn(descBuilder.MoveDescriptor());
    }
-   std::unique_ptr<RPageSource> Clone() const final { return nullptr; }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::NTupleSize_t) final { return RPage(); }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPage(); }
    void ReleasePage(RPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -86,13 +86,13 @@ protected:
 
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
+   std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
 
 public:
    RPageSourceMock(const std::vector<RPageStorage::RSealedPage> &pages, const RColumnElementBase &elt)
       : RPageSource("test", ROOT::Experimental::RNTupleReadOptions()), fElement(elt), fPages(pages)
    {
    }
-   std::unique_ptr<RPageSource> Clone() const final { return nullptr; }
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {


### PR DESCRIPTION
Implement two improvements to the RNTuple RDF scheduler for the multi-threaded case:

1. Files of a chain are opened in batches the background: while a batch of files (batch size == number of slots) is processed, the next batch is opened.
2. For the tail scheduling (multiple slots sharing the same files), the clones of the page source pointing to the same file do not need to re-read meta-data (anchor, header, footer) again.

The patch results in a speed improvement of about 10% for AGC, EOS cached, 32 cores.

