### PR TITLE
[ntuple] Reader: add option to enable metrics on construction

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
@@ -58,7 +58,7 @@ public:
    EImplicitMT GetUseImplicitMT() const { return fUseImplicitMT; }
    void SetUseImplicitMT(EImplicitMT val) { fUseImplicitMT = val; }
 
-   bool AreMetricsEnabled() const { return fEnableMetrics; }
+   bool HasMetricsEnabled() const { return fEnableMetrics; }
    void SetMetricsEnabled(bool enable) { fEnableMetrics = enable; }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
@@ -44,14 +44,22 @@ private:
    EClusterCache fClusterCache = EClusterCache::kDefault;
    unsigned int fClusterBunchSize = 1;
    EImplicitMT fUseImplicitMT = EImplicitMT::kDefault;
+   /// If true, the RNTupleReader will track metrics straight from its construction, as
+   /// if calling `RNTupleReader::EnableMetrics()` before having created the object.
+   bool fEnableMetrics = false;
 
 public:
    EClusterCache GetClusterCache() const { return fClusterCache; }
    void SetClusterCache(EClusterCache val) { fClusterCache = val; }
+
    unsigned int GetClusterBunchSize() const { return fClusterBunchSize; }
    void SetClusterBunchSize(unsigned int val) { fClusterBunchSize = val; }
+
    EImplicitMT GetUseImplicitMT() const { return fUseImplicitMT; }
    void SetUseImplicitMT(EImplicitMT val) { fUseImplicitMT = val; }
+
+   bool AreMetricsEnabled() const { return fEnableMetrics; }
+   void SetMetricsEnabled(bool enable) { fEnableMetrics = enable; }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -89,13 +89,14 @@ private:
    std::unique_ptr<RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
 
-   RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Internal::RPageSource> source);
+   RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Internal::RPageSource> source,
+                 const RNTupleReadOptions &options);
    /// The model is generated from the ntuple metadata on storage.
-   explicit RNTupleReader(std::unique_ptr<Internal::RPageSource> source);
+   explicit RNTupleReader(std::unique_ptr<Internal::RPageSource> source, const RNTupleReadOptions &options);
 
    void ConnectModel(RNTupleModel &model);
    RNTupleReader *GetDisplayReader();
-   void InitPageSource();
+   void InitPageSource(bool enableMetrics);
 
    DescriptorId_t RetrieveFieldId(std::string_view fieldName) const;
 
@@ -171,10 +172,13 @@ public:
    /// Open RNTuples as one virtual, horizontally combined ntuple.  The underlying RNTuples must
    /// have an identical number of entries.  Fields in the combined RNTuple are named with the ntuple name
    /// as a prefix, e.g. myNTuple1.px and myNTuple2.pt (see tutorial ntpl006_friends)
-   static std::unique_ptr<RNTupleReader> OpenFriends(std::span<ROpenSpec> ntuples);
+   static std::unique_ptr<RNTupleReader>
+   OpenFriends(std::span<ROpenSpec> ntuples, const RNTupleReadOptions &options = RNTupleReadOptions());
    std::unique_ptr<RNTupleReader> Clone()
    {
-      return std::unique_ptr<RNTupleReader>(new RNTupleReader(fSource->Clone()));
+      auto options = RNTupleReadOptions{};
+      options.SetMetricsEnabled(fMetrics.IsEnabled());
+      return std::unique_ptr<RNTupleReader>(new RNTupleReader(fSource->Clone(), options));
    }
    ~RNTupleReader();
 

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -68,7 +68,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
       throw RException(R__FAIL("model has projected fields, which is incompatible with providing a read model"));
    }
    fModel->Freeze();
-   InitPageSource(options.AreMetricsEnabled());
+   InitPageSource(options.HasMetricsEnabled());
    ConnectModel(*fModel);
 }
 
@@ -76,7 +76,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
                                                  const RNTupleReadOptions &options)
    : fSource(std::move(source)), fModel(nullptr), fMetrics("RNTupleReader")
 {
-   InitPageSource(options.AreMetricsEnabled());
+   InitPageSource(options.HasMetricsEnabled());
 }
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader() = default;

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -43,7 +43,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
    }
 }
 
-void ROOT::Experimental::RNTupleReader::InitPageSource()
+void ROOT::Experimental::RNTupleReader::InitPageSource(bool enableMetrics)
 {
 #ifdef R__USE_IMT
    if (IsImplicitMTEnabled() &&
@@ -52,12 +52,15 @@ void ROOT::Experimental::RNTupleReader::InitPageSource()
       fSource->SetTaskScheduler(fUnzipTasks.get());
    }
 #endif
-   fSource->Attach();
    fMetrics.ObserveMetrics(fSource->GetMetrics());
+   if (enableMetrics)
+      EnableMetrics();
+   fSource->Attach();
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
-                                                 std::unique_ptr<ROOT::Experimental::Internal::RPageSource> source)
+                                                 std::unique_ptr<ROOT::Experimental::Internal::RPageSource> source,
+                                                 const RNTupleReadOptions &options)
    : fSource(std::move(source)), fModel(std::move(model)), fMetrics("RNTupleReader")
 {
    // TODO(jblomer): properly support projected fields
@@ -65,14 +68,15 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
       throw RException(R__FAIL("model has projected fields, which is incompatible with providing a read model"));
    }
    fModel->Freeze();
-   InitPageSource();
+   InitPageSource(options.AreMetricsEnabled());
    ConnectModel(*fModel);
 }
 
-ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Internal::RPageSource> source)
+ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Internal::RPageSource> source,
+                                                 const RNTupleReadOptions &options)
    : fSource(std::move(source)), fModel(nullptr), fMetrics("RNTupleReader")
 {
-   InitPageSource();
+   InitPageSource(options.AreMetricsEnabled());
 }
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader() = default;
@@ -82,7 +86,7 @@ ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, std
                                         std::string_view storage, const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(std::move(model), Internal::RPageSource::Create(ntupleName, storage, options)));
+      new RNTupleReader(std::move(model), Internal::RPageSource::Create(ntupleName, storage, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
@@ -90,14 +94,14 @@ ROOT::Experimental::RNTupleReader::Open(std::string_view ntupleName, std::string
                                         const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(Internal::RPageSource::Create(ntupleName, storage, options)));
+      new RNTupleReader(Internal::RPageSource::Create(ntupleName, storage, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
 ROOT::Experimental::RNTupleReader::Open(ROOT::Experimental::RNTuple *ntuple, const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options)));
+      new RNTupleReader(Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
@@ -105,18 +109,19 @@ ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, ROO
                                         const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(std::move(model), Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options)));
+      new RNTupleReader(std::move(model), Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples)
+ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples, const RNTupleReadOptions &options)
 {
    std::vector<std::unique_ptr<Internal::RPageSource>> sources;
+   sources.reserve(ntuples.size());
    for (const auto &n : ntuples) {
       sources.emplace_back(Internal::RPageSource::Create(n.fNTupleName, n.fStorage, n.fOptions));
    }
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(std::make_unique<Internal::RPageSourceFriends>("_friends", sources)));
+      new RNTupleReader(std::make_unique<Internal::RPageSourceFriends>("_friends", sources), options));
 }
 
 const ROOT::Experimental::RNTupleModel &ROOT::Experimental::RNTupleReader::GetModel()


### PR DESCRIPTION
# This Pull request:
adds the possibility of requesting metrics in `RNTupleReadOptions`. 
Since one normally has to call `EnableMetrics()` on the RNTupleReader to start collecting metrics, it is currently not possible to query the metrics gathered during construction of the reader itself. With this new option you can request metrics to be enabled at construction time.

As a somewhat arbitrary choice, an RNTupleReader created via `Clone()` will inherit this option from the one it is cloned from.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

