### PR TITLE
[ntuple] use RClusterPool in RNTupleMerger

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -597,6 +597,7 @@ public:
 
       RIterator begin() { return RIterator(fNTuple, fColumns, 0); }
       RIterator end() { return RIterator(fNTuple, fColumns, fColumns.size()); }
+      size_t    count() { return fColumns.size(); }
    };
 
    // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -597,7 +597,7 @@ public:
 
       RIterator begin() { return RIterator(fNTuple, fColumns, 0); }
       RIterator end() { return RIterator(fNTuple, fColumns, fColumns.size()); }
-      size_t    count() { return fColumns.size(); }
+      size_t count() { return fColumns.size(); }
    };
 
    // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -63,11 +63,13 @@ private:
    void ValidateColumns(std::vector<RColumnInfo> &columns);
 
    /// Recursively add columns from a given field
-   void AddColumnsFromField(std::vector<RColumnInfo> &columns, const RNTupleDescriptor &desc,
-                            const RFieldDescriptor &fieldDesc, const std::string &prefix = "");
+   void AddColumnsFromField(std::vector<RColumnInfo> &columns, RCluster::ColumnSet_t &columnsSet,
+                            const RNTupleDescriptor &desc, const RFieldDescriptor &fieldDesc,
+                            const std::string &prefix = "");
 
    /// Recursively collect all the columns for all the fields rooted at field zero
-   std::vector<RColumnInfo> CollectColumns(const RNTupleDescriptor &descriptor);
+   void CollectColumns(const RNTupleDescriptor &descriptor, std::vector<RColumnInfo> &columns,
+                       RCluster::ColumnSet_t &columnSet);
 
    // Internal map that holds column name, type, and type id : output ID information
    std::unordered_map<std::string, DescriptorId_t> fOutputIdMap;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -63,13 +63,11 @@ private:
    void ValidateColumns(std::vector<RColumnInfo> &columns);
 
    /// Recursively add columns from a given field
-   void AddColumnsFromField(std::vector<RColumnInfo> &columns, RCluster::ColumnSet_t &columnsSet,
-                            const RNTupleDescriptor &desc, const RFieldDescriptor &fieldDesc,
-                            const std::string &prefix = "");
+   void AddColumnsFromField(std::vector<RColumnInfo> &columns, const RNTupleDescriptor &desc,
+                            const RFieldDescriptor &fieldDesc, const std::string &prefix = "");
 
    /// Recursively collect all the columns for all the fields rooted at field zero
-   void CollectColumns(const RNTupleDescriptor &descriptor, std::vector<RColumnInfo> &columns,
-                       RCluster::ColumnSet_t &columnSet);
+   void CollectColumns(const RNTupleDescriptor &descriptor, std::vector<RColumnInfo> &columns);
 
    // Internal map that holds column name, type, and type id : output ID information
    std::unordered_map<std::string, DescriptorId_t> fOutputIdMap;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -250,6 +250,7 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
                sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage +
                                         pageInfo.fHasChecksum * RPageStorage::kNBytesPageChecksum);
                sealedPage.SetBuffer(onDiskPage->GetAddress());
+               sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
                R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
 
                sealedPages.push_back(std::move(sealedPage));

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPageStorageFile.hxx>
+#include <ROOT/RClusterPool.hxx>
 #include <TError.h>
 #include <TFile.h>
 #include <TKey.h>
@@ -130,12 +131,12 @@ void ROOT::Experimental::Internal::RNTupleMerger::ValidateColumns(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::vector<ROOT::Experimental::Internal::RNTupleMerger::RColumnInfo>
-ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescriptor &descriptor)
+void ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescriptor &descriptor,
+                                                                 std::vector<RColumnInfo> &columns,
+                                                                 RCluster::ColumnSet_t &columnSet)
 {
-   std::vector<RColumnInfo> columns;
    // Here we recursively find the columns and fill the RColumnInfo vector
-   AddColumnsFromField(columns, descriptor, descriptor.GetFieldZero());
+   AddColumnsFromField(columns, columnSet, descriptor, descriptor.GetFieldZero());
    // Then we either build the internal map (first source) or validate the columns against it (remaning sources)
    // In either case, we also assign the output ids here
    if (fOutputIdMap.empty()) {
@@ -143,30 +144,38 @@ ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescrip
    } else {
       ValidateColumns(columns);
    }
-   return columns;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::AddColumnsFromField(
-   std::vector<ROOT::Experimental::Internal::RNTupleMerger::RColumnInfo> &columns, const RNTupleDescriptor &desc,
-   const RFieldDescriptor &fieldDesc, const std::string &prefix)
+void ROOT::Experimental::Internal::RNTupleMerger::AddColumnsFromField(std::vector<RColumnInfo> &columns,
+                                                                      RCluster::ColumnSet_t &columnSet,
+                                                                      const RNTupleDescriptor &desc,
+                                                                      const RFieldDescriptor &fieldDesc,
+                                                                      const std::string &prefix)
 {
    for (const auto &field : desc.GetFieldIterable(fieldDesc)) {
       std::string name = prefix + field.GetFieldName() + ".";
       const std::string typeAndVersion = field.GetTypeName() + "." + std::to_string(field.GetTypeVersion());
-      for (const auto &column : desc.GetColumnIterable(field)) {
+      auto columnIter = desc.GetColumnIterable(field);
+      columns.reserve(columns.size() + columnIter.count());
+      columnSet.reserve(columns.size() + columnIter.count());
+      for (const auto &column : columnIter) {
          columns.emplace_back(name + std::to_string(column.GetIndex()), typeAndVersion, column.GetPhysicalId(),
                               kInvalidDescriptorId);
+         columnSet.emplace(column.GetPhysicalId());
       }
-      AddColumnsFromField(columns, desc, field, name);
+      AddColumnsFromField(columns, columnSet, desc, field, name);
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination)
 {
+   std::vector<RColumnInfo> columns;
+   RCluster::ColumnSet_t columnSet;
+
    if (destination.IsInitialized()) {
-      CollectColumns(destination.GetDescriptor());
+      CollectColumns(destination.GetDescriptor(), columns, columnSet);
    }
 
    std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple
@@ -175,12 +184,15 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
    for (const auto &source : sources) {
       source->Attach();
 
+      RClusterPool clusterPool{*source};
+
       // Get a handle on the descriptor (metadata)
       auto descriptor = source->GetSharedDescriptorGuard();
 
       // Collect all the columns
       // The column name : output column id map is only built once
-      auto columns = CollectColumns(descriptor.GetRef());
+      columns.clear(), columnSet.clear();
+      CollectColumns(descriptor.GetRef(), columns, columnSet);
 
       // Create sink from the input model if not initialized
       if (!destination.IsInitialized()) {
@@ -203,9 +215,10 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
       auto clusterId = descriptor->FindClusterId(0, 0);
 
       while (clusterId != ROOT::Experimental::kInvalidDescriptorId) {
-         auto &cluster = descriptor->GetClusterDescriptor(clusterId);
+         auto *clusterP = clusterPool.GetCluster(clusterId, columnSet);
+         assert(clusterP);
+         const auto &cluster = descriptor->GetClusterDescriptor(clusterId);
 
-         std::vector<std::unique_ptr<unsigned char[]>> buffers;
          // We use a std::deque so that references to the contained SealedPageSequence_t, and its iterators, are never
          // invalidated.
          std::deque<RPageStorage::SealedPageSequence_t> sealedPagesV;
@@ -222,31 +235,26 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
 
             // Now get the pages for this column in this cluster
             const auto &pages = cluster.GetPageRange(columnId);
-            size_t idx{0};
 
             RPageStorage::SealedPageSequence_t sealedPages;
 
+            std::uint64_t pageNo = 0;
+            sealedPageGroups.reserve(sealedPageGroups.size() + pages.fPageInfos.size());
             // Loop over the pages
             for (const auto &pageInfo : pages.fPageInfos) {
+               ROnDiskPage::Key key{columnId, pageNo};
+               auto onDiskPage = clusterP->GetOnDiskPage(key);
+               RPageStorage::RSealedPage sealedPage;
+               sealedPage.SetNElements(pageInfo.fNElements);
+               sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
+               sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage +
+                                        pageInfo.fHasChecksum * RPageStorage::kNBytesPageChecksum);
+               sealedPage.SetBuffer(onDiskPage->GetAddress());
+               R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
 
-               // Each page contains N elements that we are going to read together
-               // LoadSealedPage reads packed/compressed bytes of a page into
-               // a memory buffer provided by a sealed page
-               RClusterIndex clusterIndex(clusterId, idx);
-               Internal::RPageStorage::RSealedPage sealedPage;
-               source->LoadSealedPage(columnId, clusterIndex, sealedPage);
-
-               // The way LoadSealedPage works might require a double call
-               // See the implementation. Here we do this in any case...
-               auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
-               sealedPage.SetBuffer(buffer.get());
-               source->LoadSealedPage(columnId, clusterIndex, sealedPage);
-
-               buffers.push_back(std::move(buffer));
                sealedPages.push_back(std::move(sealedPage));
 
-               // Move on to the next index
-               idx += pageInfo.fNElements;
+               ++pageNo;
 
             } // end of loop over pages
 


### PR DESCRIPTION
# This Pull request:
adds the use of `RClusterPool` to preload clusters during merging of RNTuples.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

