### PR TITLE
[ntuple] Deduplicate identical pages in a cluster

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -687,6 +687,9 @@ Every inner item (that describes a page) has the following structure:
 ```
 
 Followed by a locator for the page.
+Note that locators for byte ranges in a file do not need to reference pairwise distinct byte ranges.
+For instance, identical pages can point to the same page range.
+
 _C(hecksum)_: If set, an XxHash-3 64bit checksum of the compressed page data is stored just after the page.
 This bit should be interpreted as the sign bit of the number of elements, i.e. negative values indicate pages with checksums.
 Note that the page size stored in the locator does _not_ include the checksum.

--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -86,3 +86,13 @@ The following alternative strategies were discussed:
     One might reduce the additional state and complexity by only applying the fine-grained estimator for collections.
     Such an estimator would react better to a sudden change in the amount of data written for collections / columns
     that have substentially different compression ratios.
+
+Page Checksums
+--------------
+
+By default, RNTuple appends xxhash-3 64bit checksums to every compressed page.
+Typically, checksums increase the data size in the region of a per mille.
+As a side effect, page checksums allow for efficient "same page merging":
+identical pages in the same cluster will be written only once.
+On typical datasets, same page merging saves a few percent.
+Conversely, turning off page checksums also disables the same page merging optimization.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -125,6 +125,7 @@ public:
    void SetHasSmallClusters(bool val) { fHasSmallClusters = val; }
 
    bool GetEnablePageChecksums() const { return fEnablePageChecksums; }
+   /// Note that turning off page checksums will also turn off the same page merging optimization (see tuning.md)
    void SetEnablePageChecksums(bool val) { fEnablePageChecksums = val; }
 
    std::uint64_t GetMaxKeySize() const { return fMaxKeySize; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -125,6 +125,8 @@ public:
 
       void ChecksumIfEnabled();
       RResult<void> VerifyChecksumIfEnabled() const;
+      /// Returns a failure if the sealed page has no checksum
+      RResult<std::uint64_t> GetChecksum() const;
    };
 
    using SealedPageSequence_t = std::deque<RSealedPage>;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -376,6 +376,12 @@ private:
    RNTupleSerializer::StreamerInfoMap_t fStreamerInfos;
 
 protected:
+   /// Set of optional features supported by the persistent sink
+   struct RFeatures {
+      bool fCanMergePages = false;
+   };
+
+   RFeatures fFeatures;
    Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
    /// Default I/O performance counters that get registered in fMetrics

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -405,9 +405,12 @@ protected:
    /// committed for each column.  The returned vector contains, in order, the RNTupleLocator for each
    /// page on each range in `ranges`, i.e. the first N entries refer to the N pages in `ranges[0]`,
    /// followed by M entries that refer to the M pages in `ranges[1]`, etc.
+   /// The mask allows to skip writing out certain pages. The vector has the size of all the pages.
+   /// For every `false` value in the mask, the corresponding locator is skipped (missing) in the output vector.
    /// The default is to call `CommitSealedPageImpl` for each page; derived classes may provide an
    /// optimized implementation though.
-   virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges);
+   virtual std::vector<RNTupleLocator>
+   CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask);
    /// Returns the number of bytes written to storage (excluding metadata)
    virtual std::uint64_t CommitClusterImpl() = 0;
    /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -126,7 +126,8 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
-   std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
+   std::vector<RNTupleLocator>
+   CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask) final;
    std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    using RPagePersistentSink::CommitDatasetImpl;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -61,17 +61,12 @@ private:
    // A set of pages to be committed together in a vector write.
    // Currently we assume they're all sequential (although they may span multiple ranges).
    struct CommitBatch {
-      using Iter_t =
-         std::pair<std::span<RPageStorage::RSealedPageGroup>::iterator, SealedPageSequence_t::const_iterator>;
-
+      /// The list of pages to commit
+      std::vector<const RSealedPage *> fSealedPages;
       /// Total size in bytes of the batch
       size_t fSize;
       /// Total uncompressed size of the elements in the page batch
       size_t fBytesPacked;
-      /// Pair { group_iter, page_iter } marking the begin of the sequential multi-range of pages
-      Iter_t fBegin;
-      /// Pair { group_iter, page_iter } marking the end of the sequential multi-range of pages (exclusive)
-      Iter_t fEnd;
    };
 
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
@@ -97,7 +92,8 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
-   std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
+   std::vector<RNTupleLocator>
+   CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask) final;
    std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    using RPagePersistentSink::CommitDatasetImpl;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -710,20 +710,40 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPage(Descrip
 
 std::vector<ROOT::Experimental::RNTupleLocator>
 ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageVImpl(
-   std::span<RPageStorage::RSealedPageGroup> ranges)
+   std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask)
 {
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
+   locators.reserve(mask.size());
+   std::size_t i = 0;
    for (auto &range : ranges) {
-      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt)
-         locators.push_back(CommitSealedPageImpl(range.fPhysicalColumnId, *sealedPageIt));
+      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
+         if (mask[i++])
+            locators.push_back(CommitSealedPageImpl(range.fPhysicalColumnId, *sealedPageIt));
+      }
    }
+   locators.shrink_to_fit();
    return locators;
 }
 
 void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageV(
    std::span<RPageStorage::RSealedPageGroup> ranges)
 {
-   auto locators = CommitSealedPageVImpl(ranges);
+   std::vector<bool> mask;
+   for (auto &range : ranges) {
+      const auto rangeSize = std::distance(range.fFirst, range.fLast);
+      mask.reserve(mask.size() + rangeSize);
+      locatorIndexes.reserve(locatorIndexes.size() + rangeSize);
+
+      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
+         // TODO(jblomer): filter duplicate pages
+         mask.emplace_back(true);
+      }
+
+      mask.shrink_to_fit();
+      locatorIndexes.shrink_to_fit();
+   }
+
+   auto locators = CommitSealedPageVImpl(ranges, mask);
    unsigned i = 0;
 
    for (auto &range : ranges) {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -32,6 +32,7 @@
 #include <TError.h>
 
 #include <atomic>
+#include <unordered_map>
 #include <utility>
 #include <memory>
 #include <string_view>
@@ -740,15 +741,49 @@ ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageVImpl(
 void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageV(
    std::span<RPageStorage::RSealedPageGroup> ranges)
 {
+   /// Used in the `originalPages` map
+   struct RSealedPageLink {
+      const RSealedPage *fSealedPage = nullptr; ///< Points to the first occurrence of a page with a specific checksum
+      std::size_t fLocatorIdx = 0;              ///< The index in the locator vector returned by CommitSealedPageVImpl()
+   };
+
    std::vector<bool> mask;
+   // For every sealed page, stores the corresponding index in the locator vector returned by CommitSealedPageVImpl()
+   std::vector<std::size_t> locatorIndexes;
+   // Maps page checksums to the first sealed page with that checksum
+   std::unordered_map<std::uint64_t, RSealedPageLink> originalPages;
+   std::size_t iLocator = 0;
    for (auto &range : ranges) {
       const auto rangeSize = std::distance(range.fFirst, range.fLast);
       mask.reserve(mask.size() + rangeSize);
       locatorIndexes.reserve(locatorIndexes.size() + rangeSize);
 
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         // TODO(jblomer): filter duplicate pages
-         mask.emplace_back(true);
+         if (!fFeatures.fCanMergePages || !sealedPageIt->GetHasChecksum()) {
+            mask.emplace_back(true);
+            locatorIndexes.emplace_back(iLocator++);
+            continue;
+         }
+
+         const auto chk = sealedPageIt->GetChecksum().Unwrap();
+         auto itr = originalPages.find(chk);
+         if (itr == originalPages.end()) {
+            originalPages.insert({chk, {&(*sealedPageIt), iLocator}});
+            mask.emplace_back(true);
+            locatorIndexes.emplace_back(iLocator++);
+            continue;
+         }
+
+         const auto *p = itr->second.fSealedPage;
+         if (sealedPageIt->GetDataSize() != p->GetDataSize() ||
+             memcmp(sealedPageIt->GetBuffer(), p->GetBuffer(), p->GetDataSize())) {
+            mask.emplace_back(true);
+            locatorIndexes.emplace_back(iLocator++);
+            continue;
+         }
+
+         mask.emplace_back(false);
+         locatorIndexes.emplace_back(itr->second.fLocatorIdx);
       }
 
       mask.shrink_to_fit();
@@ -764,7 +799,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitSealedPageV(
 
          RClusterDescriptor::RPageRange::RPageInfo pageInfo;
          pageInfo.fNElements = sealedPageIt->GetNElements();
-         pageInfo.fLocator = locators[i++];
+         pageInfo.fLocator = locators[locatorIndexes[i++]];
          pageInfo.fHasChecksum = sealedPageIt->GetHasChecksum();
          fOpenPageRanges.at(range.fPhysicalColumnId).fPageInfos.emplace_back(pageInfo);
       }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -64,6 +64,18 @@ ROOT::Experimental::Internal::RPageStorage::RSealedPage::VerifyChecksumIfEnabled
    return RResult<void>::Success();
 }
 
+ROOT::Experimental::RResult<std::uint64_t> ROOT::Experimental::Internal::RPageStorage::RSealedPage::GetChecksum() const
+{
+   if (!fHasChecksum)
+      return R__FAIL("invalid attempt to extract non-existing page checksum");
+
+   assert(fBufferSize >= kNBytesPageChecksum);
+   std::uint64_t checksum;
+   RNTupleSerializer::DeserializeUInt64(
+      reinterpret_cast<const unsigned char *>(fBuffer) + fBufferSize - kNBytesPageChecksum, checksum);
+   return checksum;
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::Internal::RPageSource::RActivePhysicalColumns::Insert(DescriptorId_t physicalColumnID)

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -55,6 +55,7 @@ ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntup
    });
    fCompressor = std::make_unique<RNTupleCompressor>();
    EnableDefaultMetrics("RPageSinkFile");
+   fFeatures.fCanMergePages = true;
 }
 
 ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, std::string_view path,

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -439,6 +439,7 @@ TEST(RPageSinkBuf, Basics)
    FileRaii fileGuard("test_ntuple_sinkbuf_basics.root");
    {
       RNTupleWriteOptions options;
+      options.SetEnablePageChecksums(false); // disable same page merging
       options.SetUseBufferedWrite(true);
       TestModel bufModel;
       // PageSinkBuf wraps a concrete page source
@@ -1089,5 +1090,37 @@ TEST(RPageStorageFile, MultiKeyBlob_Footer)
          EXPECT_DOUBLE_EQ(valC, expectC);
          EXPECT_DOUBLE_EQ(valU, expectU);
       }
+   }
+}
+
+TEST(RPageSink, SamePageMerging)
+{
+   FileRaii fileGuard("test_same_page_merging.root");
+
+   for (auto enable : {true, false}) {
+      auto model = RNTupleModel::Create();
+      model->MakeField<float>("px", 1.0);
+      model->MakeField<float>("py", 1.0);
+      RNTupleWriteOptions options;
+      options.SetEnablePageChecksums(enable);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+      writer->Fill();
+      writer.reset();
+
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      EXPECT_EQ(1u, reader->GetNEntries());
+
+      const auto &desc = reader->GetDescriptor();
+      const auto pxColId = desc.FindPhysicalColumnId(desc.FindFieldId("px"), 0);
+      const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0);
+      const auto clusterId = desc.FindClusterId(pxColId, 0);
+      const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
+      EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).fLocator.fPosition ==
+                           clusterDesc.GetPageRange(pyColId).Find(0).fLocator.fPosition);
+
+      auto viewPx = reader->GetView<float>("px");
+      auto viewPy = reader->GetView<float>("py");
+      EXPECT_FLOAT_EQ(1.0, viewPx(0));
+      EXPECT_FLOAT_EQ(1.0, viewPy(0));
    }
 }


### PR DESCRIPTION
For the file backend only, map identical pages within a cluster to the same locator. That effectively de-duplicates identical pages on disk (not in memory though). 

As a result, reading code has to be able to deal with pages that don't necessarily reference pair-wise distinct byte ranges. This is difficult to combine with the DAOS caging feature. Same page merging needs explicit support from the backend and is turned off for the DAOS backend.

For the nanoAOD and ATLAS OpenData samples, same page merging reduces the file size by about 3.5%.

