### PR TITLE
[ntuple] Fix `ConstructValue` for `uint16_t` fields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2197,7 +2197,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   void ConstructValue(void *where) const final { new (where) int16_t(0); }
+   void ConstructValue(void *where) const final { new (where) uint16_t(0); }
 
 public:
    static std::string TypeName() { return "std::uint16_t"; }


### PR DESCRIPTION
Instead of (incorrectly) constructing a signed 16-bit int, now an unsigned 16-bit int is constructed.
