### PR TITLE
v6-08: fBits read: preserve kIsOnHeap, always set kNotDeleted.

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -842,8 +842,9 @@ void TObject::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.SkipVersion(); // Version_t R__v = R__b.ReadVersion(); if (R__v) { }
       R__b >> fUniqueID;
+      const UInt_t isonheap = fBits & kIsOnHeap; // Record how this instance was actually allocated.
       R__b >> fBits;
-      fBits |= kIsOnHeap;  // by definition de-serialized object is on heap
+      fBits |= isonheap | kNotDeleted;  // by definition de-serialized object are not yet deleted.
       if (TestBit(kIsReferenced)) {
          //if the object is referenced, we must read its old address
          //and store it in the ProcessID map in gROOT

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -209,7 +209,9 @@ namespace TStreamerInfoActions
       UInt_t *x = (UInt_t*)( ((char*)addr) + config->fOffset );
       // Idea: Implement buf.ReadBasic/Primitive to avoid the return value
       // Idea: This code really belongs inside TBuffer[File]
+      const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
       buf >> *x;
+      *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
 
       if ((*x & kIsReferenced) != 0) {
          HandleReferencedTObject(buf,addr,config);

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -607,6 +607,7 @@ Int_t TStreamerInfo::ReadBufferConv(TBuffer &b, const T &arr,  const TCompInfo *
          DOLOOP {
             UInt_t u;
             b >> u;
+            u |= kNotDeleted;  // by definition de-serialized object are not yet deleted.
             if ((u & kIsReferenced) != 0) {
                UShort_t pidf;
                b >> pidf;
@@ -1021,7 +1022,10 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
          // special case for TObject::fBits in case of a referenced object
          case TStreamerInfo::kBits: {
             DOLOOP {
-               UInt_t *x=(UInt_t*)(arr[k]+ioffset); b >> *x;
+               UInt_t *x=(UInt_t*)(arr[k]+ioffset);
+               const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
+               b >> *x;
+               *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
                if ((*x & kIsReferenced) != 0) {
                   UShort_t pidf;
                   b >> pidf;


### PR DESCRIPTION
Rather than reading from the file the value of kIsOnHeap, preserve the value that was calculated at object creation time (i.e. in the current execution).  For example, for an embedded object (inside an object created on the heap or stack), the bit always need to be off (i.e. it can never be explicitly deleted)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

