### PR TITLE
Update build guide for cling

### DIFF
--- a/interpreter/cling/README.md
+++ b/interpreter/cling/README.md
@@ -39,29 +39,31 @@ Our nightly binary snapshots can be found
 
 ### Building from Source
 
-```sh
+```bash
 git clone https://github.com/root-project/llvm-project.git
 cd llvm-project
 git checkout cling-latest
-cd ../
+cd ..
 git clone https://github.com/root-project/cling.git
 mkdir cling-build && cd cling-build
 cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ../llvm-project/llvm
+cmake --build . --target cling
 ```
 
 Usage
 -----
-```c++
-./cling '#include <stdio.h>' 'printf("Hello World!\n")'
+Assuming we're in the build folder:
+```bash
+./bin/cling '#include <stdio.h>' 'printf("Hello World!\n")'
 ```
 
 To get started run:
 ```bash
-./cling --help
+./bin/cling --help
 ```
-or type
-```
-./cling
+or
+```bash
+./bin/cling
 [cling]$ .help
 ```
 

--- a/interpreter/cling/README.md
+++ b/interpreter/cling/README.md
@@ -33,8 +33,7 @@ See our [release notes](docs/ReleaseNotes.md) to find what's new.
 
 
 ### Binaries
-Our nightly binary snapshots can be found
-[here](https://root.cern.ch/download/cling/).
+Our nightly binary snapshots are currently unavailable.
 
 
 ### Building from Source
@@ -49,6 +48,8 @@ mkdir cling-build && cd cling-build
 cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ../llvm-project/llvm
 cmake --build . --target cling
 ```
+
+See also the instructions [on the webpage](https://root.cern/cling/cling_build_instructions/).
 
 Usage
 -----

--- a/interpreter/cling/README.md
+++ b/interpreter/cling/README.md
@@ -44,9 +44,9 @@ git clone https://github.com/root-project/llvm-project.git
 cd llvm-project
 git checkout cling-latest
 cd ../
-git clone <cling>
+git clone https://github.com/root-project/cling.git
 mkdir cling-build && cd cling-build
-cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;nvptx" ../llvm-project/llvm
+cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ../llvm-project/llvm
 ```
 
 Usage

--- a/interpreter/cling/README.md
+++ b/interpreter/cling/README.md
@@ -7,7 +7,7 @@ The main repository is at [https://github.com/root-project/cling](https://github
 Overview
 --------
 Cling is an interactive C++ interpreter, built on top of Clang and LLVM compiler
-infrastructure. Cling realizes the [read-eval-print loop
+infrastructure. Cling implements the [read-eval-print loop
 (REPL)](http://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
 concept, in order to leverage rapid application development. Implemented as a
 small extension to LLVM and Clang, the interpreter reuses their strengths such


### PR DESCRIPTION
##### Edit:
I noticed an issue at https://github.com/root-project/cling/issues/515#issue-2092431022 created six months ago that describes the same problem. Sadly this issue has persisted for such a long time not fixed. 😣

##### Original PR description:
I'm not certain if it's just me, but after spending an entire day to building Cling, CMake consistently reported that the target `nvptx` was not found. This is quite perplexing, especially for someone with limited experience with CMake like myself. After searching the LLVM repository, I discovered that the target name should be capitalized as `NVPTX`. If this is not just me, then there appears to be a discrepancy in the build guide.

## Changes:
Simply changed `nvptx` to `NVPTX`. Additionally, CMake requires the explicit passing of `-DCMAKE_BUILD_TYPE`, which I have included as well.

Fixes https://github.com/root-project/cling/issues/515

## Checklist:

- [x] tested changes locally
- [x] updated the documentation as necessary