### PR TITLE
TCling: Remove error if symbols cannot be autoloaded

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -182,7 +182,6 @@ public:
       // provides the symbol and create one MaterializationUnit per library to
       // actually load it if needed.
       std::unordered_map<std::string, llvm::orc::SymbolNameVector> found;
-      llvm::orc::SymbolNameSet missing;
 
       // TODO: Do we need to take gInterpreterMutex?
       // R__LOCKGUARD(gInterpreterMutex);
@@ -204,9 +203,7 @@ public:
          // is made available as argument to `CreateInterpreter`.
          assert(libName.find("/libCling.") == std::string::npos && "Must not autoload libCling!");
 
-         if (libName.empty())
-            missing.insert(name);
-         else
+         if (!libName.empty())
             found[libName].push_back(name);
       }
 
@@ -215,10 +212,6 @@ public:
          if (auto Err = JD.define(MU))
             return Err;
       }
-
-      if (!missing.empty())
-         return llvm::make_error<llvm::orc::SymbolsNotFound>(
-            JD.getExecutionSession().getSymbolStringPool(), std::move(missing));
 
       return llvm::Error::success();
    }


### PR DESCRIPTION
I implemented `AutoloadLibraryGenerator` in commit 9b2041e300 during the upgrade to LLVM 13 and wasn't sure if it should return an error if some symbols cannot be found. In practice, it didn't make a big difference because it was the last generator of the only `JITDylib`. This will change with LLVM 18 where we have at least one additional `JITDylib` for platform symbols (like `__cxa_atexit`) and search must continue, so remove the error.

In contrast, `AutoloadLibraryMU`s continue to fail the materialization if they promised to find a symbol but there is an error.