### PR TITLE
[ntuple] RPageStorageFile: commit vectorized pages in chunks

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -60,13 +60,18 @@ class RPageSinkFile : public RPagePersistentSink {
 private:
    // A set of pages to be committed together in a vector write.
    // Currently we assume they're all sequential (although they may span multiple ranges).
-   struct CommittedBatch {
-      using Iter = std::pair<std::span<RPageStorage::RSealedPageGroup>::iterator, SealedPageSequence_t::const_iterator>;
+   struct CommitBatch {
+      using Iter_t =
+         std::pair<std::span<RPageStorage::RSealedPageGroup>::iterator, SealedPageSequence_t::const_iterator>;
 
+      /// Total size in bytes of the batch
       size_t fSize;
+      /// Total uncompressed size of the elements in the page batch
       size_t fBytesPacked;
-      Iter fBegin;
-      Iter fEnd;
+      /// Pair { group_iter, page_iter } marking the begin of the sequential multi-range of pages
+      Iter_t fBegin;
+      /// Pair { group_iter, page_iter } marking the end of the sequential multi-range of pages (exclusive)
+      Iter_t fEnd;
    };
 
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
@@ -84,7 +89,7 @@ private:
    /// contained in `batch`. The locators for the written pages are appended to `locators`.
    /// This procedure also updates some internal metrics of the page sink, hence it's not const.
    /// `batch` gets reset to size 0 after the writing is done (but its begin and end are not updated).
-   void CommitBatchOfPages(CommittedBatch &batch, std::vector<RNTupleLocator> &locators);
+   void CommitBatchOfPages(CommitBatch &batch, std::vector<RNTupleLocator> &locators);
 
 protected:
    using RPagePersistentSink::InitImpl;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -58,6 +58,17 @@ The written file can be either in ROOT format or in RNTuple bare format.
 // clang-format on
 class RPageSinkFile : public RPagePersistentSink {
 private:
+   // A set of pages to be committed together in a vector write.
+   // Currently we assume they're all sequential (although they may span multiple ranges).
+   struct CommittedBatch {
+      using Iter = std::pair<std::span<RPageStorage::RSealedPageGroup>::iterator, SealedPageSequence_t::const_iterator>;
+
+      size_t fSize;
+      size_t fBytesPacked;
+      Iter fBegin;
+      Iter fEnd;
+   };
+
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 
    std::unique_ptr<RNTupleFileWriter> fWriter;
@@ -68,6 +79,8 @@ private:
    /// We pass bytesPacked so that TFile::ls() reports a reasonable value for the compression ratio of the corresponding
    /// key. It is not strictly necessary to write and read the sealed page.
    RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage, std::size_t bytesPacked);
+
+   void CommitBatchOfPages(CommittedBatch &batch, std::vector<RNTupleLocator> &locators);
 
 protected:
    using RPagePersistentSink::InitImpl;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -80,6 +80,10 @@ private:
    /// key. It is not strictly necessary to write and read the sealed page.
    RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage, std::size_t bytesPacked);
 
+   /// Subroutine of CommitSealedPageVImpl, used to perform a vector write of the (multi-)range of pages
+   /// contained in `batch`. The locators for the written pages are appended to `locators`.
+   /// This procedure also updates some internal metrics of the page sink, hence it's not const.
+   /// `batch` gets reset to size 0 after the writing is done (but its begin and end are not updated).
    void CommitBatchOfPages(CommittedBatch &batch, std::vector<RNTupleLocator> &locators);
 
 protected:

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -125,7 +125,6 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t
    return WriteSealedPage(sealedPage, bytesPacked);
 }
 
-
 void ROOT::Experimental::Internal::RPageSinkFile::CommitBatchOfPages(CommittedBatch &batch,
                                                                      std::vector<RNTupleLocator> &locators)
 {
@@ -166,7 +165,6 @@ std::vector<ROOT::Experimental::RNTupleLocator>
 ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges)
 {
    const std::uint64_t maxKeySize = fOptions->GetMaxKeySize();
-   // const std::uint64_t maxKeySize = 0;
 
    CommittedBatch batch{};
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
@@ -588,15 +586,15 @@ ROOT::Experimental::Internal::RPageSourceFile::PrepareSingleCluster(
    std::vector<ROnDiskPageLocator> onDiskPages;
    auto activeSize = 0;
    auto pageZeroMap = std::make_unique<ROnDiskPageMap>();
-   PrepareLoadCluster(clusterKey, *pageZeroMap,
-                      [&](DescriptorId_t physicalColumnId, NTupleSize_t pageNo,
-                          const RClusterDescriptor::RPageRange::RPageInfo &pageInfo) {
-                         const auto &pageLocator = pageInfo.fLocator;
-                         const auto nBytes = pageLocator.fBytesOnStorage + pageInfo.fHasChecksum * kNBytesPageChecksum;
-                         activeSize += nBytes;
-                         onDiskPages.push_back(
-                            {physicalColumnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), nBytes, 0});
-                      });
+   PrepareLoadCluster(
+      clusterKey, *pageZeroMap,
+      [&](DescriptorId_t physicalColumnId, NTupleSize_t pageNo,
+          const RClusterDescriptor::RPageRange::RPageInfo &pageInfo) {
+         const auto &pageLocator = pageInfo.fLocator;
+         const auto nBytes = pageLocator.fBytesOnStorage + pageInfo.fHasChecksum * kNBytesPageChecksum;
+         activeSize += nBytes;
+         onDiskPages.push_back({physicalColumnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), nBytes, 0});
+      });
 
    // Linearize the page requests by file offset
    std::sort(onDiskPages.begin(), onDiskPages.end(),


### PR DESCRIPTION
In RPageStorageFile we're currently either writing all pages in a single vector write or, if their total size exceeds `maxKeySize`, we commit one at a time.
With this change we try to commit as many consecutive pages as possible and split the vector write as soon as the next page would exceed `maxKeySize`. If a single page is bigger than `maxKeySize` we take care to write it in the non-vectorized fashion, since splitting a key is only supported through `WriteBlob()`.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

