### PR TITLE
[webgui] always compile RBrowser (no root7), add `SetUseConnectionKey()` method

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -29,9 +29,10 @@ if(webgui)
 
    add_subdirectory(webgui6)
 
+   add_subdirectory(browsable)
+   add_subdirectory(browserv7)
+
    if(root7)
-      add_subdirectory(browsable)
-      add_subdirectory(browserv7)
       add_subdirectory(canvaspainter)
       add_subdirectory(fitpanelv7)
    endif()

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -101,7 +101,8 @@ public:
    static void SetLoopbackMode(bool on = true);
    static bool IsLoopbackMode();
 
-   static void SetUseSessionKey(bool on = false);
+   static void SetUseSessionKey(bool on = true);
+   static void SetUseConnectionKey(bool on = true);
 };
 
 } // namespace ROOT

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -624,7 +624,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 
    auto token = win.GetConnToken();
    if (!token.empty()) {
-      if (!qmark) addr.append("?");
+      addr.append(qmark ? "&" : "?");
       addr.append("token=");
       addr.append(token);
    }

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -149,13 +149,24 @@ bool RWebWindowsManager::IsLoopbackMode()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-/// Enable or disable usage of session key
-/// If enabled, each packet send to or from server is signed with special hashsum
-/// This protects http server from different attacks to get access to server functionality
+/// Enable or disable usage of session key (default on)
+/// If enabled, secrete session key used to calculate hash sum of each packet send to or from server
+/// This protects ROOT http server from anauthorized usage
 
 void RWebWindowsManager::SetUseSessionKey(bool on)
 {
    gWebWinUseSessionKey = on;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Enable or disable usage of connection key (default on)
+/// If enabled, each connection (and reconnection) to widget requires unique key
+/// Connection key used together with session key to calculate hash sum of each packet send to or from server
+/// This protects ROOT http server from anauthorized usage
+
+void RWebWindowsManager::SetUseConnectionKey(bool on)
+{
+   gEnv->SetValue("WebGui.OnetimeKey", on ? "yes" : "no");
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -654,7 +665,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 /// Following parameters can be configured in rootrc file:
 ///
 ///      WebGui.Display: kind of display like chrome or firefox or browser, can be overwritten by --web=value command line argument
-///      WebGui.OnetimeKey: if configured requires unique key every time window is connected (default no)
+///      WebGui.OnetimeKey: if configured requires unique key every time window is connected (default yes)
 ///      WebGui.Chrome: full path to Google Chrome executable
 ///      WebGui.ChromeBatch: command to start chrome in batch, used for image production, like "$prog --headless --disable-gpu $geometry $url"
 ///      WebGui.ChromeHeadless: command to start chrome in headless mode, like "fork: --headless --disable-gpu $geometry $url"
@@ -717,7 +728,7 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
    std::string key;
 
    std::string url = GetUrl(win, normal_http, &key);
-   // empty url indicates failure, which already pinted by GetUrl method
+   // empty url indicates failure, which already printed by GetUrl method
    if (url.empty())
       return 0;
 


### PR DESCRIPTION
`RBrowser` is no longer experimental and can be compiled once `webgui` is enabled.
It also required to implement file dialogs in other widgets (like TWebCanvas) therefore need to be compiled together.

Add `ROOT::RWebWindowsManager::SetUseConnectionKey` method to let change security settings via method call.
Before only rootrc file can be used.

Small fix in URL generation when token is used.