### PR TITLE
[math] remove unused param from SimplexSeedGenerator::operator()

### DIFF
--- a/math/minuit2/src/SimplexSeedGenerator.cxx
+++ b/math/minuit2/src/SimplexSeedGenerator.cxx
@@ -20,7 +20,7 @@ namespace ROOT {
 namespace Minuit2 {
 
 MinimumSeed SimplexSeedGenerator::
-operator()(const MnFcn &fcn, const GradientCalculator &, const MnUserParameterState &st, const MnStrategy &stra) const
+operator()(const MnFcn &fcn, const GradientCalculator &, const MnUserParameterState &st, const MnStrategy &) const
 {
    // create starting state for Simplex, which corresponds to the initial parameter values
    // using the simple Initial gradient calculator (does not use any FCN function calls)


### PR DESCRIPTION
# This Pull request:
fixes a warning due to an unused param in SimplexSeedGenerator (becomes a compile error with dev=ON)

