### PR TITLE
[ntuple] Make RNTupleDecompressor::Unzip overload static

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -54,13 +54,14 @@ public:
 
    RNTupleCompressor() : fZipBuffer(std::make_unique<Buffer_t>()) {}
    RNTupleCompressor(const RNTupleCompressor &other) = delete;
-   RNTupleCompressor &operator =(const RNTupleCompressor &other) = delete;
+   RNTupleCompressor &operator=(const RNTupleCompressor &other) = delete;
    RNTupleCompressor(RNTupleCompressor &&other) = default;
-   RNTupleCompressor &operator =(RNTupleCompressor &&other) = default;
+   RNTupleCompressor &operator=(RNTupleCompressor &&other) = default;
 
    /// Returns the size of the compressed data. Data is compressed in 16MB (kMAXZIPBUF) blocks and written
    /// piecewise using the provided writer
-   size_t Zip(const void *from, size_t nbytes, int compression, Writer_t fnWriter) {
+   size_t Zip(const void *from, size_t nbytes, int compression, Writer_t fnWriter)
+   {
       R__ASSERT(from != nullptr);
 
       auto cxLevel = compression % 100;
@@ -99,7 +100,8 @@ public:
 
    /// Returns the size of the compressed data block. The data is written into the zip buffer.
    /// This works only for small input buffer up to 16MB (kMAXZIPBUF)
-   size_t Zip(const void *from, size_t nbytes, int compression) {
+   size_t Zip(const void *from, size_t nbytes, int compression)
+   {
       R__ASSERT(from != nullptr);
       R__ASSERT(nbytes <= kMAXZIPBUF);
 
@@ -125,7 +127,8 @@ public:
    }
 
    /// Returns the size of the compressed data, written into the provided output buffer.
-   static std::size_t Zip(const void *from, std::size_t nbytes, int compression, void *to) {
+   static std::size_t Zip(const void *from, std::size_t nbytes, int compression, void *to)
+   {
       R__ASSERT(from != nullptr);
       R__ASSERT(to != nullptr);
       auto cxLevel = compression % 100;
@@ -165,7 +168,6 @@ public:
    void *GetZipBuffer() { return fZipBuffer->data(); }
 };
 
-
 // clang-format off
 /**
 \class ROOT::Experimental::Internal::RNTupleDecompressor
@@ -181,15 +183,16 @@ private:
 public:
    RNTupleDecompressor() : fUnzipBuffer(std::make_unique<Buffer_t>()) {}
    RNTupleDecompressor(const RNTupleDecompressor &other) = delete;
-   RNTupleDecompressor &operator =(const RNTupleDecompressor &other) = delete;
+   RNTupleDecompressor &operator=(const RNTupleDecompressor &other) = delete;
    RNTupleDecompressor(RNTupleDecompressor &&other) = default;
-   RNTupleDecompressor &operator =(RNTupleDecompressor &&other) = default;
+   RNTupleDecompressor &operator=(RNTupleDecompressor &&other) = default;
 
    /**
     * The nbytes parameter provides the size ls of the from buffer. The dataLen gives the size of the uncompressed data.
     * The block is uncompressed iff nbytes == dataLen.
     */
-   void Unzip(const void *from, size_t nbytes, size_t dataLen, void *to) {
+   static void Unzip(const void *from, size_t nbytes, size_t dataLen, void *to)
+   {
       if (dataLen == nbytes) {
          memcpy(to, from, nbytes);
          return;
@@ -223,7 +226,8 @@ public:
    /**
     * In-place decompression via unzip buffer
     */
-   void Unzip(void *fromto, size_t nbytes, size_t dataLen) {
+   void Unzip(void *fromto, size_t nbytes, size_t dataLen)
+   {
       R__ASSERT(dataLen <= kMAXZIPBUF);
       Unzip(fromto, nbytes, dataLen, fUnzipBuffer->data());
       memcpy(fromto, fUnzipBuffer->data(), dataLen);

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -9,7 +9,7 @@ TEST(RNTupleZip, Basics)
    auto szZipped = compressor.Zip(data.data(), data.length(), 101);
    EXPECT_LT(szZipped, data.length());
    auto unzipBuffer = std::unique_ptr<char[]>(new char[data.length()]);
-   decompressor.Unzip(compressor.GetZipBuffer(), szZipped, data.length(), unzipBuffer.get());
+   RNTupleDecompressor::Unzip(compressor.GetZipBuffer(), szZipped, data.length(), unzipBuffer.get());
    EXPECT_EQ(data, std::string_view(unzipBuffer.get(), data.length()));
 
    // inplace decompression
@@ -81,7 +81,7 @@ TEST(RNTupleZip, Large)
       });
    EXPECT_LT(szZip, N);
    EXPECT_EQ(2, nWrites);
-   decompressor.Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
+   RNTupleDecompressor::Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
    EXPECT_EQ(data, std::string_view(unzipBuffer.get(), N));
 }
 
@@ -101,6 +101,6 @@ TEST(RNTupleZip, LargeWithOutputBuffer)
 
    szZip = compressor.Zip(data.data(), data.length(), 101, zipBuffer.get());
    EXPECT_LT(szZip, N);
-   decompressor.Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
+   RNTupleDecompressor::Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
    EXPECT_EQ(data, std::string_view(unzipBuffer.get(), N));
 }


### PR DESCRIPTION
Avoids some memory allocations when the internal unzip buffer is never used throughout the decompressor's lifetime (since RNTupleDecompressor allocates a Buffer_t when default constructed).
With this change, RPageStorageDaos doesn't need to allocate a decompressor anymore.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

