### PR TITLE
[ntuple] Add `RNTupleModel` argument to `RNTupleProcessor` constructor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -309,6 +309,7 @@ public:
    void Freeze();
    void Unfreeze();
    bool IsFrozen() const { return fIsFrozen; }
+   bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }
 
    /// Ingests a model for a sub collection and attaches it to the current model

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -150,12 +150,12 @@ public:
    public:
       // clang-format off
       /**
-      \class ROOT::Experimental::RNTupleProcessor::RIterator::RState
+      \class ROOT::Experimental::RNTupleProcessor::RIterator::RProcessorState
       \ingroup NTuple
       \brief View on the RNTupleProcessor iterator state.
       */
       // clang-format on
-      class RState {
+      class RProcessorState {
          friend class RIterator;
 
       private:
@@ -166,8 +166,8 @@ public:
          std::size_t fNTupleIndex;
 
       public:
-         RState(const REntry &entry, NTupleSize_t globalEntryIndex, NTupleSize_t localEntryIndex,
-                std::size_t ntupleIndex)
+         RProcessorState(const REntry &entry, NTupleSize_t globalEntryIndex, NTupleSize_t localEntryIndex,
+                         std::size_t ntupleIndex)
             : fEntry(entry),
               fGlobalEntryIndex(globalEntryIndex),
               fLocalEntryIndex(localEntryIndex),
@@ -184,15 +184,15 @@ public:
 
    private:
       RNTupleProcessor &fProcessor;
-      RState fState;
+      RProcessorState fState;
 
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
-      using value_type = RState;
+      using value_type = RProcessorState;
       using difference_type = std::ptrdiff_t;
-      using pointer = RState *;
-      using reference = const RState &;
+      using pointer = RProcessorState *;
+      using reference = const RProcessorState &;
 
       RIterator(RNTupleProcessor &processor, std::size_t ntupleIndex, NTupleSize_t globalEntryIndex)
          : fProcessor(processor), fState(processor.GetEntry(), globalEntryIndex, 0, ntupleIndex)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -222,7 +222,7 @@ void ROOT::Experimental::RNTupleModel::EnsureNotFrozen() const
 
 void ROOT::Experimental::RNTupleModel::EnsureNotBare() const
 {
-   if (!fDefaultEntry)
+   if (IsBare())
       throw RException(R__FAIL("invalid attempt to use default entry of bare model"));
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -637,6 +637,7 @@ TEST(RNTuple, BareEntry)
 {
    auto m = RNTupleModel::CreateBare();
    auto f = m->MakeField<float>("pt");
+   EXPECT_TRUE(m->IsBare());
    EXPECT_FALSE(f);
 
    FileRaii fileGuard("test_ntuple_bare_entry.root");
@@ -830,6 +831,7 @@ TEST(RNTuple, RValue)
 TEST(REntry, Basics)
 {
    auto model = RNTupleModel::Create();
+   EXPECT_FALSE(model->IsBare());
    model->MakeField<float>("pt");
    model->Freeze();
 


### PR DESCRIPTION
This PR adds the possibility to specify which fields should be read by the `RNTupleProcessor` by passing an `RNTupleModel` to its constructor. The processor will create and own an `REntry` based on this, but it will use the pointers from the model's default entry to hold the field values during iteration. This way, the pointers returned by `RNTupleModel::MakeField` can be used in the processor iteration to access the values being read.

Passing a model is optional; if not provided, one will be created from the descriptor of the first specified RNTuple.

A follow-up PR will add the possibility to change the model after the processor has been created (useful when the set of fields to read cannot be decided at compile-time).


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)