### PR TITLE
TUri fixes

### DIFF
--- a/core/base/src/TUri.cxx
+++ b/core/base/src/TUri.cxx
@@ -270,7 +270,7 @@ Bool_t TUri::SetScheme(const TString &scheme)
 Bool_t TUri::IsScheme(const TString &string)
 {
    return TPRegexp(
-             "^[[:alpha:]][[:alpha:][:digit:]+-.]*$"
+             "^[[:alpha:]][[:alpha:][:digit:]+\\-.]*$"
           ).Match(string);
 }
 

--- a/core/base/src/TUri.cxx
+++ b/core/base/src/TUri.cxx
@@ -27,10 +27,10 @@ a validating parser.
 
 //RFC3986:
 // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
-const char* const kURI_pchar        = "(?:[[:alpha:][:digit:]-._~!$&'()*+,;=:@]|%[0-9A-Fa-f][0-9A-Fa-f])";
+const char* const kURI_pchar        = "(?:[[:alpha:][:digit:]\\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f][0-9A-Fa-f])";
 
 //unreserved characters, see chapter 2.3
-const char* const kURI_unreserved   = "[[:alpha:][:digit:]-._~]";
+const char* const kURI_unreserved   = "[[:alpha:][:digit:]\\-._~]";
 
 // reserved characters, see chapter
 // reserved      = gen-delims / sub-delims
@@ -900,7 +900,7 @@ Bool_t TUri::IsPathAbsolute(const TString &string)
 Bool_t TUri::IsPathNoscheme(const TString &string)
 {
    return (TPRegexp(
-              TString("^(([[:alpha:][:digit:]-._~!$&'()*+,;=@]|%[0-9A-Fa-f][0-9A-Fa-f])+)(/") + TString(kURI_pchar) + "*)*$"
+              TString("^(([[:alpha:][:digit:]\\-._~!$&'()*+,;=@]|%[0-9A-Fa-f][0-9A-Fa-f])+)(/") + TString(kURI_pchar) + "*)*$"
            ).Match(string) > 0);
 }
 
@@ -950,7 +950,7 @@ Bool_t TUri::IsPort(const TString &string)
 Bool_t TUri::IsRegName(const TString &string)
 {
    return (TPRegexp(
-              "^([[:alpha:][:digit:]-._~!$&'()*+,;=]|%[0-9A-Fa-f][0-9A-Fa-f])*$").Match(string) > 0);
+              "^([[:alpha:][:digit:]\\-._~!$&'()*+,;=]|%[0-9A-Fa-f][0-9A-Fa-f])*$").Match(string) > 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

    [core] Make TUri class PCRE2 compatible
    
    PCRE2 has a stricter regular expression syntax parsing than PCRE.
    Some non-conforming regular expressions that were accepted by PCRE are
    correcrly rejected by PCRE2.
    
    Some of the regular expressions used by the TUri class do not follow
    the syntax rules and were relying on them being acceped by PCRE
    anyway. This commit corrects the syntax of these expressions so that
    they are now accepted by PCRE2. The corrected expressions still work
    correctly with the old PCRE.


    [core] Correct the regular expression for the scheme part in TUri class
    
    RFC 3986 (https://datatracker.ietf.org/doc/html/rfc3986) defines the
    scheme part of a URI as:
    
        scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
    
    The regular expression for finding the scheme part in the TUri class
    was defined as
    
        ^[[:alpha:]][[:alpha:][:digit:]+-.]*$
    
    This does not match the definition in the RFC, since +-. in regular
    expression syntax is the range of ascii codes from '+' to '.', which
    means '+', ',', '-' and '.'. I.e. the ',' is included in the regular
    expression in error. This commit adds a backslash escape to the '-' so
    that it is interpreted as a literal '-' sign instead of indicating a
    range in the regular expression.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #15986
