### PR TITLE
[webgui] disable web batch mode for `--web=server:port` 

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -125,8 +125,8 @@ protected:
    TInterpreter    *fInterpreter;           ///< Command interpreter
    Bool_t          fBatch;                  ///< True if session without graphics
    TString         fWebDisplay;             ///< If not empty it defines where web graphics should be rendered (cef, qt5, browser...)
-   Bool_t          fIsWebDisplay;           ///< True if session with graphics on web
-   Bool_t          fIsWebDisplayBatch;      ///< True if session with graphics on web and batch mode
+   Bool_t          fIsWebDisplay;           ///< True if session uses web widgets
+   Bool_t          fIsWebDisplayBatch;      ///< True if web widgets are not displayed
    Bool_t          fEditHistograms;         ///< True if histograms can be edited with the mouse
    Bool_t          fFromPopUp;              ///< True if command executed from a popup menu
    Bool_t          fMustClean;              ///< True if object destructor scans canvases
@@ -315,8 +315,7 @@ public:
    void              ResetClassSaved();
    void              SaveContext();
    void              SetApplication(TApplication *app) { fApplication = app; }
-   /// Set the "Batch mode".  If the argument evaluates to `true`, the session does not use interactive graphics.
-   void              SetBatch(Bool_t batch = kTRUE) { fIsWebDisplayBatch = fBatch = batch; }
+   void              SetBatch(Bool_t batch = kTRUE);
    void              SetWebDisplay(const char *webdisplay = "");
    void              SetCutClassName(const char *name = "TCutG");
    void              SetDefCanvasName(const char *name = "c1") { fDefCanvasName = name; }

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2796,9 +2796,9 @@ void TROOT::SetMacroPath(const char *newpath)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set batch mode for the ROOT
+/// Set batch mode for ROOT
 /// If the argument evaluates to `true`, the session does not use interactive graphics.
-/// If web graphics runs in server mode, web widgets still be available via URL
+/// If web graphics runs in server mode, the web widgets are still available via URL
 
 void TROOT::SetBatch(Bool_t batch)
 {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2796,6 +2796,18 @@ void TROOT::SetMacroPath(const char *newpath)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set batch mode for the ROOT
+/// If the argument evaluates to `true`, the session does not use interactive graphics.
+/// If web graphics runs in server mode, web widgets still be available via URL
+
+void TROOT::SetBatch(Bool_t batch)
+{
+   fIsWebDisplayBatch = fBatch = batch;
+   if (fIsWebDisplayBatch && (fWebDisplay == "server"))
+      fIsWebDisplayBatch = kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// \brief Specify where web graphics shall be rendered
 ///
 /// The input parameter `webdisplay` defines where web graphics is rendered.
@@ -2825,6 +2837,8 @@ void TROOT::SetWebDisplay(const char *webdisplay)
    static TString brName = gEnv->GetValue("Browser.Name", "");
    static TString trName = gEnv->GetValue("TreeViewer.Name", "");
 
+   fIsWebDisplayBatch = fBatch;
+
    if (!strcmp(wd, "off")) {
       fIsWebDisplay = kFALSE;
       fWebDisplay = "off";
@@ -2834,6 +2848,7 @@ void TROOT::SetWebDisplay(const char *webdisplay)
       // handle server mode
       if (!strncmp(wd, "server", 6)) {
          fWebDisplay = "server";
+         fIsWebDisplayBatch = kFALSE;
          if (wd[6] == ':') {
             if ((wd[7] >= '0') && (wd[7] <= '9')) {
                auto port = TString(wd+7).Atoi();


### PR DESCRIPTION
When one runs with `root -b --web=server:port`,
http server will be started and widget URL will be printed. 
Before this commit -b flag fully suppress http server creation.

Partially resolves: https://root-forum.cern.ch/t/60086/

