### PR TITLE
[ntuple] set id for unsplit field in RFieldDescriptor::CreateField()

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -65,7 +65,9 @@ std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplDesc) const
 {
    if (GetStructure() == ENTupleStructure::kUnsplit) {
-      return std::make_unique<RUnsplitField>(GetFieldName(), GetTypeName());
+      auto unsplitField = std::make_unique<RUnsplitField>(GetFieldName(), GetTypeName());
+      unsplitField->SetOnDiskId(fFieldId);
+      return unsplitField;
    }
 
    if (GetTypeName().empty()) {


### PR DESCRIPTION
This is a minor fix/improvement. The RNTupleReader will figure out the field ID if not set by RFieldDescriptor::CreateField() but this requires another descriptor lookup.


