### PR TITLE
[cling] Fix failing python enum tests in cppyy

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.h
@@ -19,10 +19,12 @@ public:
 
     std::string GetName();
     void* GetAddress(CPPInstance* pyobj /* owner */);
+    intptr_t GetOffset();
 
 public:                 // public, as the python C-API works with C structs
     PyObject_HEAD
     intptr_t           fOffset;
+    Cppyy::TCppIndex_t fIdata;
     long               fFlags;
     Converter*         fConverter;
     Cppyy::TCppScope_t fEnclosingScope;
@@ -61,16 +63,6 @@ inline CPPDataMember* CPPDataMember_New(
     CPPDataMember* pyprop =
         (CPPDataMember*)CPPDataMember_Type.tp_new(&CPPDataMember_Type, nullptr, nullptr);
     pyprop->Set(scope, idata);
-    return pyprop;
-}
-
-inline CPPDataMember* CPPDataMember_NewConstant(
-    Cppyy::TCppScope_t scope, const std::string& name, void* address)
-{
-// Create an initialize a new property descriptor, given the C++ datum.
-    CPPDataMember* pyprop =
-        (CPPDataMember*)CPPDataMember_Type.tp_new(&CPPDataMember_Type, nullptr, nullptr);
-    pyprop->Set(scope, name, address);
     return pyprop;
 }
 


### PR DESCRIPTION
# This Pull request:
Just a draft PR to test for performance issues/failing tests. 

This fixes the failing python enum tests like:
- `roottest-python-cpp-cpp`
- `roottest-python-cmdLineUtils-ROOT_8197`


A memory leak was fixed in LLVM commit [142f270](https://github.com/devajithvs/llvm-project-root/commit/142f270c279f2576e4618fc0d1121181c7531fdf), which caused our tests to fail as they relied on the previous behavior.

If there are no serious performance issues/failure, we can clean up and try to upstream this patch to cppyy.

Currently a temporary fix https://github.com/devajithvs/root/commit/de5d1413e07170e396ac51d982c0844e4f548f4b is used to fix the failing tests for LLVM18

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

