### PR TITLE
[RF] Some improvements in RooFits memory management

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -130,6 +130,7 @@ public:
   bool addOwned(std::unique_ptr<RooAbsArg> var, bool silent=false);
   virtual RooAbsArg *addClone(const RooAbsArg& var, bool silent=false) ;
   virtual bool replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
+  bool replace(RooAbsArg* var1, std::unique_ptr<RooAbsArg> var2) ;
   virtual bool remove(const RooAbsArg& var, bool silent=false, bool matchByNameOnly=false) ;
   virtual void removeAll() ;
 
@@ -438,6 +439,8 @@ private:
 #else
 #error "Please remove this unneeded code."
 #endif
+
+  bool replaceImpl(const RooAbsArg& var1, const RooAbsArg& var2);
 
   using HashAssistedFind = RooFit::Detail::HashAssistedFind;
   mutable std::unique_ptr<HashAssistedFind> _hashAssistedFind; ///<!

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -389,8 +389,10 @@ bool RooAbsCollection::addOwned(RooAbsArg& var, bool silent)
 bool RooAbsCollection::addOwned(std::unique_ptr<RooAbsArg> var, bool silent) {
   bool result = addOwned(*var.release(), silent);
   if(!result) {
-    throw std::runtime_error(std::string("RooAbsCollection::addOwned could not add the argument to the")
-                             + " collection! The ownership would not be well defined if we ignore this.");
+    auto errMsg = std::string("RooAbsCollection::addOwned could not add the argument to the")
+                             + " collection! The ownership would not be well defined if we ignore this.";
+    coutE(ObjectHandling) << errMsg << std::endl;
+    throw std::runtime_error(errMsg);
   }
   return result;
 }
@@ -492,15 +494,17 @@ bool RooAbsCollection::addOwned(const RooAbsCollection& list, bool silent)
 bool RooAbsCollection::addOwned(RooAbsCollection&& list, bool silent)
 {
   if(list.isOwning()) {
-    list.releaseOwnership();
+    list._ownCont = false;
   }
   if(list.empty()) return false;
 
   bool result = addOwned(list, silent);
 
   if(!result) {
-    throw std::runtime_error(std::string("RooAbsCollection::addOwned could not add the argument to the")
-                             + " collection! The ownership would not be well defined if we ignore this.");
+    auto errMsg = std::string("RooAbsCollection::addOwned could not add the argument to the")
+                             + " collection! The ownership would not be well defined if we ignore this.";
+    coutE(ObjectHandling) << errMsg << std::endl;
+    throw std::runtime_error(errMsg);
   }
 
   // So far, comps has only released the ownership, but it is still valid.
@@ -553,24 +557,8 @@ bool RooAbsCollection::replace(const RooAbsCollection &other)
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Replace var1 with var2 and return true for success. Fails if
-/// this list is a copy of another, if var1 is not already in this set,
-/// or if var2 is already in this set. var1 and var2 do not need to have
-/// the same name.
-
-bool RooAbsCollection::replace(const RooAbsArg& var1, const RooAbsArg& var2)
+bool RooAbsCollection::replaceImpl(const RooAbsArg& var1, const RooAbsArg& var2)
 {
-  // check that this isn't a copy of a list
-  if(_ownCont) {
-    std::stringstream errMsg;
-    errMsg << "RooAbsCollection: cannot replace variables in a copied list";
-    coutE(ObjectHandling) << errMsg.str() << std::endl;
-    // better than returning "false" and leaving the collection in a broken state:
-    throw std::invalid_argument(errMsg.str());
-  }
-
   // is var1 already in this list?
   const char *name= var1.GetName();
   auto var1It = std::find(_list.begin(), _list.end(), &var1);
@@ -598,13 +586,58 @@ bool RooAbsCollection::replace(const RooAbsArg& var1, const RooAbsArg& var2)
   }
   *var1It = const_cast<RooAbsArg*>(&var2); //FIXME try to get rid of const_cast
 
-  if (_allRRV && dynamic_cast<const RooRealVar*>(&var2)==nullptr) {
+  if (_allRRV && dynamic_cast<const RooRealVar*>(&var2) == nullptr) {
     _allRRV=false ;
   }
 
   return true;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Replace var1 with var2 and return true for success. Fails if
+/// this list is a copy of another, if var1 is not already in this set,
+/// or if var2 is already in this set. var1 and var2 do not need to have
+/// the same name.
+
+bool RooAbsCollection::replace(const RooAbsArg &var1, const RooAbsArg &var2)
+{
+   // check that this isn't a copy of a list
+   if (_ownCont) {
+      std::string errMsg = "RooAbsCollection: cannot replace variables in a copied list";
+      coutE(ObjectHandling) << errMsg << std::endl;
+      throw std::runtime_error(errMsg);
+   }
+
+   return replaceImpl(var1, var2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Replace var1 with var2 and return true for success. Fails if
+/// this list is a copy of another, if var1 is not already in this set,
+/// or if var2 is already in this set. var1 and var2 do not need to have
+/// the same name.
+
+bool RooAbsCollection::replace(RooAbsArg *var1, std::unique_ptr<RooAbsArg> var2)
+{
+   // To accept an owning var2, the collection must be owning.
+   if (!_ownCont) {
+      std::string errMsg =
+         "RooAbsCollection::replace(RooAbsArg *, std::unique_ptr<RooAbsArg>) can't be used on a non-owning collection!";
+      coutE(ObjectHandling) << errMsg << std::endl;
+      throw std::runtime_error(errMsg);
+   }
+
+   bool success = replaceImpl(*var1, *var2.release());
+   if (!success) {
+      auto errMsg = std::string("RooAbsCollection::replace(RooAbsArg *, std::unique_ptr<RooAbsArg>) did not succeed!") +
+                    "The ownership would not be well defined if we ignore this.";
+      coutE(ObjectHandling) << errMsg << std::endl;
+      throw std::runtime_error(errMsg);
+   }
+   delete var1;
+   return success;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2265,11 +2265,8 @@ bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool
   for(std::unique_ptr<RooArgSet> const& normSet : _pdfNSetList) {
     for(RooAbsArg * arg : *normSet) {
       if(RooAbsArg * newArg = arg->findNewServer(newServerList, nameChange)) {
-        // Need to do some tricks here because it's not possible to replace in
-        // an owning RooAbsCollection.
-        normSet->releaseOwnership();
-        normSet->replace(*std::unique_ptr<RooAbsArg>{arg}, *newArg->cloneTree());
-        normSet->takeOwnership();
+        // Since normSet is owning, the original arg is now deleted.
+        normSet->replace(arg, std::unique_ptr<RooAbsArg>{newArg->cloneTree()});
       }
     }
   }

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -640,9 +640,9 @@ TEST_P(LikelihoodGradientJobErrorTest, ErrorHandling)
    RooAbsPdf *pdf = w.pdf("model");
    std::unique_ptr<RooAbsData> data;
    if (binned) {
-      data.reset(pdf->generateBinned(*w.var("m"), 10000));
+      data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("m"), 10000)};
    } else {
-      data.reset(pdf->generate(*w.var("m"), 10000));
+      data = std::unique_ptr<RooDataSet>{pdf->generate(*w.var("m"), 10000)};
    }
    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::EvalBackend::Legacy())};
 
@@ -710,9 +710,9 @@ TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
    RooGenericPdf pdf("pdf", "a1 + x", RooArgSet(x, a1));
    std::unique_ptr<RooAbsData> data;
    if (binned) {
-      data.reset(pdf.generateBinned(x, 1000));
+      data = std::unique_ptr<RooDataHist>{pdf.generateBinned(x, 1000)};
    } else {
-      data.reset(pdf.generate(x, 1000));
+      data = std::unique_ptr<RooDataSet>{pdf.generate(x, 1000)};
    }
    std::unique_ptr<RooAbsReal> nll(pdf.createNLL(*data, RooFit::EvalBackend::Legacy()));
 

--- a/tutorials/roofit/rf508_listsetmanip.py
+++ b/tutorials/roofit/rf508_listsetmanip.py
@@ -80,27 +80,13 @@ subset3 = s1.selectCommon(s2)
 # Owning RooArgSets
 # ---------------------------------
 
-# Create a RooArgSet that owns its components
-# A set either owns all of its components or none,
-# so once addOwned() is used, add() can no longer be
-# used and will result in an error message
-
-ac = a.clone("a")
-bc = b.clone("b")
-cc = c.clone("c")
-
+# You can create a RooArgSet that owns copies of the objects instead of
+# referencing the originals. A set either owns all of its components or none,
+# so once addClone() is used, add() can no longer be used and will result in an
+# error message
 s3 = ROOT.RooArgSet()
-# s3.addOwned(ROOT.RooArgSet(ac, bc, cc))
-s3.addOwned(ac)
-s3.addOwned(bc)
-s3.addOwned(cc)
-
-# Another possibility is to add an owned clone
-# of an object instead of the original
-# s3.addClone(ROOT.RooArgSet(d, e, g))
-s3.addClone(d)
-s3.addClone(e)
-s3.addClone(g)
+for arg in [a, b, c, d, e, g]:
+   s3.addClone(arg)
 
 # A clone of a owning set is non-owning and its
 # contents is owned by the originating owning set
@@ -118,7 +104,7 @@ sclone2 = s3.snapshot()
 # dependencies, together form a self-consistent
 # set that is free of external dependencies
 
-sclone3 = s3.snapshot(ROOT.kTRUE)
+sclone3 = s3.snapshot(True)
 
 # Set printing
 # ------------------------


### PR DESCRIPTION
  * Make ROOT compile again also with -DROOFIT_MEMORY_SAFE_INTERFACES
  * Don't showcase `RooAbsCollection::addOwned()` in PyROOT
  * Add overload of `RooAbsCollection::replace` for owning collections

More detail in the commit descriptions.