### PR TITLE
[skip-ci][ntuple] Remove `Unwrap` from inspector doc

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -64,7 +64,7 @@ using ROOT::Experimental::RNTupleInspector;
 
 auto file = TFile::Open("data.rntuple");
 auto rntuple = file->Get<RNTuple>("NTupleName");
-auto inspector = RNTupleInspector::Create(rntuple).Unwrap();
+auto inspector = RNTupleInspector::Create(rntuple);
 
 std::cout << "The compression factor is " << inspector->GetCompressionFactor()
           << " using compression settings " << inspector->GetCompressionSettings()


### PR DESCRIPTION
The call to `Unwrap` in the `RNTupleInspector` documentation is a remnant from when `Create` still returned an `RResult` pointer. This is not the case anymore, so the code example should reflect that.