### PR TITLE
[webgui] Improve web page reload

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -69,6 +69,7 @@ private:
    struct WebConn {
       unsigned fConnId{0};                 ///<! connection id (unique inside the window)
       bool fHeadlessMode{false};           ///<! indicate if connection represent batch job
+      bool fWasFirst{false};               ///<! indicate if this was first connection, will be reinjected also on first place
       std::string fKey;                    ///<! key value supplied to the window (when exists)
       int fKeyUsed{0};                     ///<! key value used to verify connection
       std::string fNewKey;                 ///<! new key if connection request reload

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -611,9 +611,9 @@ void RWebWindow::RemoveKey(const std::string &key)
 
 std::string RWebWindow::GenerateKey() const
 {
-   auto key = RWebWindowsManager::GenerateKey(32);
+   auto key = RWebWindowsManager::GenerateKey(IsRequireAuthKey() ? 32 : 4);
 
-   R__ASSERT((!HasKey(key) && (key != fMgr->fSessionKey)) && "Fail to generate window connection key");
+   R__ASSERT((!IsRequireAuthKey() || (!HasKey(key) && (key != fMgr->fSessionKey))) && "Fail to generate window connection key");
 
    return key;
 }

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1033,6 +1033,11 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
             ProvideQueueEntry(conn->fConnId, kind_Connect, ""s);
             conn->fReady = 10;
          }
+         if (!fMaster) {
+            conn->fNewKey = GenerateKey();
+            if(!conn->fNewKey.empty())
+               SubmitData(conn->fConnId, true, "NEW_KEY="s + conn->fNewKey, -1);
+         }
       } else if (cdata.compare(0, 8, "CLOSECH=") == 0) {
          int channel = std::stoi(cdata.substr(8));
          auto iter = conn->fEmbed.find(channel);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1155,7 +1155,10 @@ void TWebCanvas::ShowWebWindow(const ROOT::RWebDisplayArgs &args)
       fWindow->SetCallBacks(
          // connection
          [this](unsigned connid) {
-            fWebConn.emplace_back(connid);
+            if (fWindow->GetConnectionId(0) == connid)
+               fWebConn.emplace(fWebConn.begin() + 1, connid);
+            else
+               fWebConn.emplace_back(connid);
             CheckDataToSend(connid);
          },
          // data

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '26/06/2024',
+version_date = '9/07/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -1987,9 +1987,10 @@ class THistPainter extends ObjectPainter {
             zmin = zmax - 1;
       }
 
-      if (fp && (fp.zoom_zmin !== fp.zoom_zmax)) {
-         zmin = fp.zoom_zmin;
-         zmax = fp.zoom_zmax;
+      if (fp?.zoomChangedInteractive('z')) {
+         const mod = (fp.zoom_zmin !== fp.zoom_zmax);
+         zmin = mod ? fp.zoom_zmin : gzmin;
+         zmax = mod ? fp.zoom_zmax : gzmax;
       }
 
       if (histo.fContour?.length > 1) {
@@ -2009,7 +2010,7 @@ class THistPainter extends ObjectPainter {
             fp.zoom_zmin = cntr.colzmin;
             fp.zoom_zmax = cntr.colzmax;
          } else
-            fp.zoom_zmin = fp.zoom_zmax = undefined;
+            fp.zoom_zmin = fp.zoom_zmax = 0;
       }
 
       return cntr;

--- a/js/modules/webwindow.mjs
+++ b/js/modules/webwindow.mjs
@@ -567,14 +567,16 @@ class WebWindowHandle {
      * @private */
    connect(href) {
       this.close();
-      if (!href && this.href) href = this.href;
+      if (!href && this.href)
+         href = this.href;
 
       let ntry = 0;
 
       const retry_open = first_time => {
          if (this.state !== 0) return;
 
-         if (!first_time) console.log(`try connect window again ${new Date().toString()}`);
+         if (!first_time)
+            console.log(`try connect window again ${new Date().toString()}`);
 
          if (this._websocket) {
             this._websocket.close();
@@ -583,8 +585,10 @@ class WebWindowHandle {
 
          if (!href) {
             href = window.location.href;
-            if (href && href.indexOf('#') > 0) href = href.slice(0, href.indexOf('#'));
-            if (href && href.lastIndexOf('/') > 0) href = href.slice(0, href.lastIndexOf('/') + 1);
+            if (href && href.indexOf('#') > 0)
+               href = href.slice(0, href.indexOf('#'));
+            if (href && href.lastIndexOf('/') > 0)
+               href = href.slice(0, href.lastIndexOf('/') + 1);
          }
          this.href = href;
          ntry++;
@@ -601,8 +605,8 @@ class WebWindowHandle {
             console.log(`configure protocol log ${path}`);
          } else if ((this.kind === 'websocket') && first_time) {
             path = path.replace('http://', 'ws://').replace('https://', 'wss://') + 'root.websocket';
-            path += '?' + this.getConnArgs(ntry);
             console.log(`configure websocket ${path}`);
+            path += '?' + this.getConnArgs(ntry);
             this._websocket = new WebSocket(path);
          } else {
             path += 'root.longpoll';
@@ -683,7 +687,7 @@ class WebWindowHandle {
             if (this.key && sessionKey) {
                const client_hash = HMAC(this.key, msg.slice(i0+1));
                if (server_hash !== client_hash)
-                  return console.log(`Failure checking server md5 sum ${server_hash}`);
+                  return console.log(`Failure checking server HMAC sum ${server_hash}`);
             }
 
             if (seq_id <= this.recv_seq)
@@ -696,21 +700,15 @@ class WebWindowHandle {
             msg = msg.slice(i4 + 1);
 
             if (chid === 0) {
-               console.log(`GET chid=0 message ${msg}`);
+               // console.log(`GET chid=0 message ${msg}`);
                if (msg === 'CLOSE') {
                   this.close(true); // force closing of socket
                   this.invokeReceiver(true, 'onWebsocketClosed');
                } else if (msg.indexOf('NEW_KEY=') === 0) {
-                  const newkey = msg.slice(8);
-                  this.close(true);
-                  let href = (typeof document !== 'undefined') ? document.URL : null;
-                  if (isStr(href) && (typeof window !== 'undefined') && window?.history) {
-                     const p = href.indexOf('?key=');
-                     if (p > 0) href = href.slice(0, p);
-                     window.history.replaceState(window.history.state, undefined, `${href}?key=${newkey}`);
-                  } else if (typeof sessionStorage !== 'undefined')
-                     sessionStorage.setItem('RWebWindow_Key', newkey);
-                  location.reload(true);
+                  this.new_key = msg.slice(8);
+                  this.storeKeyInUrl();
+                  if (this._ask_reload)
+                     this.askReload(true);
                }
             } else if (msg.slice(0, 10) === '$$binary$$') {
                this.next_binary = chid;
@@ -749,13 +747,20 @@ class WebWindowHandle {
       retry_open(true); // call for the first time
    }
 
-   /** @summary Send newkey request to application
-     * @desc If server creates newkey and response - webpage will be reaload
-     * After key generation done, connection will not be working any longer
-     * WARNING - only call when you know that you are doing
+   /** @summary Ask to reload web widget
+     * @desc If new key already exists - reload immediately
+     * Otherwise request server to generate new key - and then reload page
+     * WARNING - call only when knowing that you are doing
      * @private */
-   askReload() {
-      this.send('GENERATE_KEY', 0);
+   askReload(force) {
+      if (this.new_key || force) {
+         this.close(true);
+         if (typeof location !== 'undefined')
+            location.reload(true);
+      } else {
+         this._ask_reload = true;
+         this.send('GENERATE_KEY', 0);
+      }
    }
 
    /** @summary Instal Ctrl-R handler to realod web window
@@ -763,7 +768,12 @@ class WebWindowHandle {
      * WARNING - only call when you know that you are doing
      * @private */
    addReloadKeyHandler() {
-      if (this.kind === 'file') return;
+      if ((this.kind === 'file') || this._handling_reload)
+         return;
+
+      // this websocket will handle reload
+      // embed widgets should not call this method
+      this._handling_reload = true;
 
       window.addEventListener('keydown', evnt => {
          if (((evnt.key === 'R') || (evnt.key === 'r')) && evnt.ctrlKey) {
@@ -774,6 +784,35 @@ class WebWindowHandle {
           }
       });
    }
+
+   /** @summary Replace widget URL before reload or close of the page
+     * @private */
+   storeKeyInUrl() {
+      if (!this._handling_reload)
+         return;
+
+      let href = (typeof document !== 'undefined') ? document.URL : null;
+      if (isStr(href) && (typeof window !== 'undefined') && window?.history) {
+         let prefix = '&key=', p = href.indexOf(prefix);
+         if (p < 0) {
+            prefix = '?key=';
+            p = href.indexOf(prefix);
+         }
+         if (p > 0)
+            href = href.slice(0, p);
+         if (this.new_key)
+            href += prefix + this.new_key;
+         if (sessionKey)
+            href += `#${sessionKey}`;
+         window.history.replaceState(window.history.state, undefined, href);
+      }
+      if (typeof sessionStorage !== 'undefined') {
+         sessionStorage.setItem('RWebWindow_SessionKey', sessionKey);
+         sessionStorage.setItem('RWebWindow_Key', this.new_key);
+      }
+   }
+
+
 
 } // class WebWindowHandle
 
@@ -812,18 +851,11 @@ async function connectWebWindow(arg) {
       if (typeof sessionStorage !== 'undefined') {
          new_key = sessionStorage.getItem('RWebWindow_Key');
          sessionStorage.removeItem('RWebWindow_Key');
-         if (new_key) console.log(`Use key ${new_key} from session storage`);
 
          if (sessionKey)
             sessionStorage.setItem('RWebWindow_SessionKey', sessionKey);
          else
             sessionKey = sessionStorage.getItem('RWebWindow_SessionKey') || '';
-      }
-
-      // hide key and any following parameters from URL, chrome do not allows to close browser with changed URL
-      if (d_key && !d.has('headless') && isStr(href) && (typeof window !== 'undefined') && window?.history) {
-         const p = href.indexOf('?key=');
-         if (p > 0) window.history.replaceState(window.history.state, undefined, href.slice(0, p));
       }
 
       // special holder script, prevents headless chrome browser from too early exit
@@ -875,11 +907,10 @@ async function connectWebWindow(arg) {
          handle.token = d_token;
       }
 
-      if (window) {
+      if (typeof window !== 'undefined') {
          window.onbeforeunload = () => handle.close(true);
          if (browser.qt5) window.onqt5unload = window.onbeforeunload;
       }
-
 
       if (arg.receiver) {
          // when receiver exists, it handles itself callbacks

--- a/ui5/canv/canvas.html
+++ b/ui5/canv/canvas.html
@@ -32,32 +32,27 @@
 
       assignPadPainterDraw(RPadPainter);
 
-      let url = decodeUrl(),
-          is_batch = url.has("batch_mode"),
-          is_ui5 = !url.has("noopenui") && !is_batch;
+      const url = decodeUrl(),
+            is_batch = url.has('batch_mode'),
+            ui5 = !url.has('noopenui') && !is_batch;
 
       if (is_batch)
          setBatchMode(true);
 
       connectWebWindow({
-         ui5: is_ui5
+         ui5
       }).then(handle => {
          let painter = new RCanvasPainter(null, null);
          painter.online_canvas = true;
-         painter.use_openui = is_ui5;
+         painter.use_openui = ui5;
          painter.batch_mode = is_batch;
 
-         if (window) {
-            window.onbeforeunload = () => painter.closeWebsocket(true);
-            if (browser.qt5) window.onqt5unload = window.onbeforeunload;
-         }
-
-         if (is_ui5) {
+         if (ui5) {
             painter._window_handle = handle;
 
-            sap.ui.require(["sap/ui/core/ComponentContainer"], ComponentContainer => {
+            sap.ui.require(['sap/ui/core/ComponentContainer'], ComponentContainer => {
                new ComponentContainer({
-                  name: "rootui5.canv",
+                  name: 'rootui5.canv',
                   manifest: true,
                   async: true,
                   settings: {
@@ -65,12 +60,13 @@
                         canvas_painter: painter
                      }
                   },
-                  height: "100%"
-               }).placeAt("CanvasDiv")
+                  height: '100%'
+               }).placeAt('CanvasDiv')
             });
          } else {
-            painter.setDom("CanvasDiv"); // just assign id, nothing else is happens
+            painter.setDom('CanvasDiv'); // just assign id, nothing else is happens
             painter.useWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
+            handle.addReloadKeyHandler(); // in ui5 assigned at the end
          }
       });
 

--- a/ui5/canv/canvas6.html
+++ b/ui5/canv/canvas6.html
@@ -32,33 +32,28 @@
 
       assignPadPainterDraw(TPadPainter);
 
-      let url = decodeUrl(),
-          is_batch = url.has("batch_mode"),
-          is_ui5 = !url.has("noopenui") && !is_batch;
+      const url = decodeUrl(),
+            is_batch = url.has('batch_mode'),
+            ui5 = !url.has('noopenui') && !is_batch;
 
       if (is_batch)
          setBatchMode(true);
 
       connectWebWindow({
-         ui5: is_ui5
+         ui5
       }).then(handle => {
          let painter = new TCanvasPainter(null, null);
 
          painter.online_canvas = true;
-         painter.use_openui = is_ui5;
+         painter.use_openui = ui5;
          painter.batch_mode = is_batch;
 
-         if (window) {
-            window.onbeforeunload = () => painter.closeWebsocket(true);
-            if (browser.qt5) window.onqt5unload = window.onbeforeunload;
-         }
-
-         if (is_ui5) {
+         if (ui5) {
             painter._window_handle = handle;
 
-            sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
+            sap.ui.require(['sap/ui/core/ComponentContainer'], function(ComponentContainer) {
                new ComponentContainer({
-                  name: "rootui5.canv",
+                  name: 'rootui5.canv',
                   manifest: true,
                   async: true,
                   settings: {
@@ -66,13 +61,14 @@
                         canvas_painter: painter
                      }
                   },
-                  height: "100%"
-               }).placeAt("CanvasDiv")
+                  height: '100%'
+               }).placeAt('CanvasDiv')
             });
 
          } else {
-            painter.setDom("CanvasDiv"); // just assign id, nothing else happens
+            painter.setDom('CanvasDiv'); // just assign id, nothing else happens
             painter.useWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
+            handle.addReloadKeyHandler(); // in ui5 assigned at the end
          }
       });
 


### PR DESCRIPTION
Up to now only Ctrl-R handler was able to correctly reload ROOT web window,

Now new connection key generated immediately after connection established and provided to the client.
Client insert new key in widget URL. Therefore direct page reload with browser buttons will work as well.
And reload can be started immediately - no need to wait on response from server.

Partially address https://root-forum.cern.ch/t/web-gui-in-root-6-32-00-how-to-handle-multiple-windows/60086/

Provide special handling for Qt5/Qt6/CEF displays - there disconnect event missing by reload 
and therefore newkey is not activated. 

In web canvas preserve reconnected client on first place if it was before. 
This ensure that only that client can modify canvas - all others are just "observers"