### PR TITLE
[ntuple] Add support for reconstructing projected fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -368,29 +368,29 @@ Every field record frame of the list of fields has the following contents
 
 The field version and type version are used for schema evolution.
 
-The structural role of the field can have on of the following values
+The structural role of the field can have one of the following values:
 
 | Value    | Structural role                                                          |
 |----------|--------------------------------------------------------------------------|
 | 0x00     | Leaf field in the schema tree                                            |
-| 0x01     | The field is the mother of a collection (e.g., a vector)                 |
-| 0x02     | The field is the mother of a record (e.g., a struct)                     |
-| 0x03     | The field is the mother of a variant                                     |
+| 0x01     | The field is the parent of a collection (e.g., a vector)                 |
+| 0x02     | The field is the parent of a record (e.g., a struct)                     |
+| 0x03     | The field is the parent of a variant                                     |
 | 0x04     | The field represents an unsplit object serialized with the ROOT streamer |
 
-The flags field can have one of the following bits set
+The flags field can have one of the following bits set:
 
 | Bit      | Meaning                                                                    |
 |----------|----------------------------------------------------------------------------|
 | 0x01     | Repetitive field, i.e. for every entry $n$ copies of the field are stored  |
 | 0x02     | Projected field                                                            |
 
-If `flag=0x01` (_repetitive field_) is set, the field represents a fixed-size array.
+If `flag==0x01` (_repetitive field_) is set, the field represents a fixed-size array.
 Typically, another (sub) field with `Parent Field ID` equal to the ID of this field
 is expected to be found, representing the array content
 (see Section "Mapping of C++ Types to Fields and Columns").
 
-If `flag=0x02` (_projected field_) is set,
+If `flag==0x02` (_projected field_) is set,
 the field has been created as a virtual field from another, non-projected source field.
 If a projected field has attached columns,
 these columns are alias columns to physical columns attached to the source field.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -813,6 +813,14 @@ public:
       RIterator end() { return RIterator(fNTuple, fNTuple.GetNExtraTypeInfos()); }
    };
 
+   /// Modifiers passed to `CreateModel`
+   struct RCreateModelOptions {
+      RCreateModelOptions() {} // Work around compiler bug, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+      /// If set to true, projected fields will be reconstructed as such. This will prevent the model to be used
+      /// with an RNTupleReader, but it is useful, e.g., to accurately merge data.
+      bool fReconstructProjections = false;
+   };
+
    RNTupleDescriptor() = default;
    RNTupleDescriptor(const RNTupleDescriptor &other) = delete;
    RNTupleDescriptor &operator=(const RNTupleDescriptor &other) = delete;
@@ -928,7 +936,7 @@ public:
    void IncGeneration() { fGeneration++; }
 
    /// Re-create the C++ model from the stored meta-data
-   std::unique_ptr<RNTupleModel> CreateModel() const;
+   std::unique_ptr<RNTupleModel> CreateModel(const RCreateModelOptions &options = RCreateModelOptions()) const;
    void PrintInfo(std::ostream &output) const;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -88,6 +88,8 @@ private:
    ENTupleStructure fStructure = ENTupleStructure::kInvalid;
    /// Establishes sub field relationships, such as classes and collections
    DescriptorId_t fParentId = kInvalidDescriptorId;
+   /// For projected fields, the source field ID
+   DescriptorId_t fProjectionSourceId = kInvalidDescriptorId;
    /// The pointers in the other direction from parent to children. They are serialized, too, to keep the
    /// order of sub fields.
    std::vector<DescriptorId_t> fLinkIds;
@@ -118,8 +120,10 @@ public:
    std::uint64_t GetNRepetitions() const { return fNRepetitions; }
    ENTupleStructure GetStructure() const { return fStructure; }
    DescriptorId_t GetParentId() const { return fParentId; }
+   DescriptorId_t GetProjectionSourceId() const { return fProjectionSourceId; }
    const std::vector<DescriptorId_t> &GetLinkIds() const { return fLinkIds; }
    const std::vector<DescriptorId_t> &GetLogicalColumnIds() const { return fLogicalColumnIds; }
+   bool IsProjectedField() const { return fProjectionSourceId != kInvalidDescriptorId; }
 };
 
 // clang-format off
@@ -1037,6 +1041,11 @@ public:
       fField.fParentId = id;
       return *this;
    }
+   RFieldDescriptorBuilder &ProjectionSourceId(DescriptorId_t id)
+   {
+      fField.fProjectionSourceId = id;
+      return *this;
+   }
    RFieldDescriptorBuilder &FieldName(const std::string &fieldName)
    {
       fField.fFieldName = fieldName;
@@ -1274,6 +1283,7 @@ public:
 
    void AddField(const RFieldDescriptor &fieldDesc);
    RResult<void> AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
+   RResult<void> AddFieldProjection(DescriptorId_t sourceId, DescriptorId_t targetId);
 
    // The field that the column belongs to has to be already available. For fields with multiple columns,
    // the columns need to be added in order of the column index

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -93,6 +93,11 @@ class RNTupleModel {
    Internal::MergeModels(const RNTupleModel &left, const RNTupleModel &right, std::string_view rightFieldPrefix);
 
 public:
+   /// User provided function that describes the mapping of existing source fields to projected fields in terms
+   /// of fully qualified field names. The mapping function is called with the qualified field names of the provided
+   /// field and the subfields.  It should return the qualified field names used as a mapping source.
+   using FieldMappingFunc_t = std::function<std::string(const std::string &)>;
+
    /// A wrapper over a field name and an optional description; used in `AddField()` and `RUpdater::AddField()`
    struct NameWithDescription_t {
       NameWithDescription_t(const char *name) : fName(name) {}
@@ -185,8 +190,7 @@ public:
 
       void AddField(std::unique_ptr<RFieldBase> field);
 
-      RResult<void>
-      AddProjectedField(std::unique_ptr<RFieldBase> field, std::function<std::string(const std::string &)> mapping);
+      RResult<void> AddProjectedField(std::unique_ptr<RFieldBase> field, FieldMappingFunc_t mapping);
    };
 
 private:
@@ -299,11 +303,8 @@ public:
    /// Throws an exception if the field is null.
    void AddField(std::unique_ptr<RFieldBase> field);
 
-   /// Adds a top-level field based on existing fields. The mapping function is called with the qualified field names
-   /// of the provided field and the subfields.  It should return the qualified field names used as a mapping source.
-   /// Projected fields can only be used for models used to write data.
-   RResult<void>
-   AddProjectedField(std::unique_ptr<RFieldBase> field, std::function<std::string(const std::string &)> mapping);
+   /// Adds a top-level field based on existing fields.
+   RResult<void> AddProjectedField(std::unique_ptr<RFieldBase> field, FieldMappingFunc_t mapping);
    const RProjectedFields &GetProjectedFields() const { return *fProjectedFields; }
 
    void Freeze();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -65,6 +65,7 @@ public:
    static constexpr std::uint16_t kEnvelopeTypePageList = 0x03;
 
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
+   static constexpr std::uint16_t kFlagProjectedField = 0x02;
 
    static constexpr std::uint32_t kFlagSortAscColumn     = 0x01;
    static constexpr std::uint32_t kFlagSortDesColumn     = 0x02;

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -194,7 +194,7 @@ void ROOT::Experimental::RNTupleModel::RUpdater::AddField(std::unique_ptr<RField
 
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleModel::RUpdater::AddProjectedField(std::unique_ptr<RFieldBase> field,
-                                                              std::function<std::string(const std::string &)> mapping)
+                                                              FieldMappingFunc_t mapping)
 {
    auto fieldp = field.get();
    auto result = fOpenChangeset.fModel.AddProjectedField(std::move(field), mapping);
@@ -309,8 +309,7 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<RFieldBase> fiel
 }
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<RFieldBase> field,
-                                                    std::function<std::string(const std::string &)> mapping)
+ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<RFieldBase> field, FieldMappingFunc_t mapping)
 {
    EnsureNotFrozen();
    if (!field)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -565,10 +565,11 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
    };
    auto addProjectedField = [&](RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();
+      auto sourceFieldId = changeset.fModel.GetProjectedFields().GetSourceField(&f)->GetOnDiskId();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
+      fDescriptorBuilder.AddFieldProjection(sourceFieldId, fieldId);
       f.SetOnDiskId(fieldId);
-      auto sourceFieldId = changeset.fModel.GetProjectedFields().GetSourceField(&f)->GetOnDiskId();
       for (const auto &source : descriptor.GetColumnIterable(sourceFieldId)) {
          auto targetId = descriptor.GetNLogicalColumns();
          RColumnDescriptorBuilder columnBuilder;

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -67,6 +67,67 @@ TEST(RNTupleDescriptorBuilder, CatchBadLinks)
    }
 }
 
+TEST(RNTupleDescriptorBuilder, CatchBadProjections)
+{
+   RNTupleDescriptorBuilder descBuilder;
+   descBuilder.AddField(
+      RFieldDescriptorBuilder().FieldId(0).Structure(ENTupleStructure::kRecord).MakeDescriptor().Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(1)
+                           .FieldName("field")
+                           .TypeName("int32_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(2)
+                           .FieldName("projField")
+                           .TypeName("int32_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(3)
+                           .FieldName("projField")
+                           .TypeName("int32_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+
+   try {
+      descBuilder.AddFieldProjection(1, 4);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("doesn't exist"));
+   }
+   try {
+      descBuilder.AddFieldProjection(4, 2);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("doesn't exist"));
+   }
+   try {
+      descBuilder.AddFieldProjection(1, 0);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("cannot make FieldZero a projected field"));
+   }
+   try {
+      descBuilder.AddFieldProjection(2, 2);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("projection of itself"));
+   }
+
+   descBuilder.AddFieldProjection(1, 2);
+   try {
+      descBuilder.AddFieldProjection(2, 1);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("projection of an already projected field"));
+   }
+   try {
+      descBuilder.AddFieldProjection(3, 2);
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("has already a projection source"));
+   }
+}
+
 TEST(RNTupleDescriptorBuilder, CatchBadColumnDescriptors)
 {
    RNTupleDescriptorBuilder descBuilder;

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -42,6 +42,21 @@ TEST(RNTupleProjection, Basics)
    EXPECT_FLOAT_EQ(1.0, viewAliasVec(0).at(0));
    EXPECT_FLOAT_EQ(2.0, viewAliasVec(0).at(1));
    EXPECT_EQ(2U, viewVecSize(0));
+
+   RNTupleDescriptor::RCreateModelOptions options;
+   options.fReconstructProjections = true;
+   auto reconstructedModel = reader->GetDescriptor().CreateModel(options);
+   auto itrFields = reconstructedModel->GetFieldZero().cbegin();
+   EXPECT_EQ("met", itrFields->GetQualifiedFieldName());
+   EXPECT_EQ("vec", (++itrFields)->GetQualifiedFieldName());
+   EXPECT_EQ("vec._0", (++itrFields)->GetQualifiedFieldName());
+   EXPECT_EQ(reconstructedModel->GetFieldZero().cend(), ++itrFields);
+   auto itrProjectedFields = reconstructedModel->GetProjectedFields().GetFieldZero()->cbegin();
+   EXPECT_EQ("missingE", itrProjectedFields->GetQualifiedFieldName());
+   EXPECT_EQ("aliasVec", (++itrProjectedFields)->GetQualifiedFieldName());
+   EXPECT_EQ("aliasVec._0", (++itrProjectedFields)->GetQualifiedFieldName());
+   EXPECT_EQ("vecSize", (++itrProjectedFields)->GetQualifiedFieldName());
+   EXPECT_EQ(reconstructedModel->GetProjectedFields().GetFieldZero()->cend(), ++itrProjectedFields);
 }
 
 TEST(RNTupleProjection, CatchInvalidMappings)

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -28,6 +28,12 @@ TEST(RNTupleProjection, Basics)
    }
 
    auto reader = RNTupleReader::Open("A", fileGuard.GetPath());
+   const auto &desc = reader->GetDescriptor();
+   const auto metFieldId = desc.FindFieldId("met");
+   const auto missingEFieldId = desc.FindFieldId("missingE");
+   EXPECT_FALSE(desc.GetFieldDescriptor(metFieldId).IsProjectedField());
+   EXPECT_TRUE(desc.GetFieldDescriptor(missingEFieldId).IsProjectedField());
+   EXPECT_EQ(metFieldId, desc.GetFieldDescriptor(missingEFieldId).GetProjectionSourceId());
    auto viewMissingE = reader->GetView<float>("missingE");
    auto viewAliasVec = reader->GetView<std::vector<float>>("aliasVec");
    auto viewVecSize = reader->GetView<ROOT::Experimental::RNTupleCardinality<std::uint64_t>>("vecSize");

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -572,6 +572,7 @@ TEST(RNTuple, SerializeHeader)
                        .FieldId(24)
                        .FieldName("ptAlias")
                        .Structure(ENTupleStructure::kLeaf)
+                       .ProjectionSourceId(42)
                        .MakeDescriptor()
                        .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
@@ -590,6 +591,7 @@ TEST(RNTuple, SerializeHeader)
    builder.AddFieldLink(0, 24);
    builder.AddFieldLink(0, 137);
    builder.AddFieldLink(137, 13);
+   builder.AddFieldProjection(42, 24);
    builder.AddColumn(RColumnDescriptorBuilder()
                         .LogicalColumnId(23)
                         .PhysicalColumnId(23)
@@ -642,6 +644,9 @@ TEST(RNTuple, SerializeHeader)
    EXPECT_TRUE(desc.GetColumnDescriptor(colId).IsAliasColumn());
    auto ptFieldId = desc.FindFieldId("pt");
    EXPECT_EQ(desc.FindLogicalColumnId(ptFieldId, 0), desc.GetColumnDescriptor(colId).GetPhysicalId());
+   EXPECT_TRUE(desc.GetFieldDescriptor(ptAliasFieldId).IsProjectedField());
+   EXPECT_EQ(ptFieldId, desc.GetFieldDescriptor(ptAliasFieldId).GetProjectionSourceId());
+   EXPECT_FALSE(desc.GetFieldDescriptor(ptFieldId).IsProjectedField());
    EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
    const auto &extraTypeInfoDesc = *desc.GetExtraTypeInfoIterable().begin();
    EXPECT_EQ(EExtraTypeInfoIds::kStreamerInfo, extraTypeInfoDesc.GetContentId());


### PR DESCRIPTION
Projected fields, so far, were read back as plain fields. This is useful for typical reading use cases. When we want to merge, e.g., it is more useful however to reconstruct the model exactly as it was written, including the projected fields.

For this to work, the field mappings need to be written to disk (forward incompatible change). While projected fields use alias columns, not all fields have an attached column. So from the column relationship it is in general not possible to reconstruct the field relationship described by projected fields.

Note that we still don't support models with projected fields in the RNTuple reader. The reason is the mismatch between RNTupleReader and RNTupleWriter: the RNTupleWriter effectively writes all the fields, projected or not. The RNTupleReader, however, would only read back non-projected fields.