### PR TITLE
[ntuple] fix RNTupleMerger using old API

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -246,7 +246,7 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
             }
 
             const auto &columnDesc = descriptor->GetColumnDescriptor(columnId);
-            const auto colElement = RColumnElementBase::Generate(columnDesc.GetModel().GetType());
+            const auto colElement = RColumnElementBase::Generate(columnDesc.GetType());
 
             // Now get the pages for this column in this cluster
             const auto &pages = clusterDesc.GetPageRange(columnId);


### PR DESCRIPTION
Fix merge issue for latest commit (using `columnDesc.GetModel()` which was recently removed)