### PR TITLE
[ntuple] fix wrong index being used in RNTupleMerger

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -312,9 +312,9 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
                         // only safe bet is to allocate a buffer big enough to hold as many bytes as the uncompressed
                         // data.
                         R__ASSERT(sealedPage.GetBufferSize() < uncompressedSize);
-                        sealedPageBuffers[pageBufferBaseIdx + pageIdx] =
-                           std::make_unique<unsigned char[]>(uncompressedSize);
-                        sealedPage.SetBuffer(sealedPageBuffers[pageIdx].get());
+                        auto &newBuf = sealedPageBuffers[pageBufferBaseIdx + pageIdx];
+                        newBuf = std::make_unique<unsigned char[]>(uncompressedSize);
+                        sealedPage.SetBuffer(newBuf.get());
                      } else {
                         // source column range is uncompressed. We can reuse the sealedPage's buffer since it's big
                         // enough.


### PR DESCRIPTION
# This Pull request:
fixes a copy-paste error resulting in the wrong index being used to assign the new buffer to the sealedPage in RNTupleMerger.
This could result not only in errors in the merged file, but also in memory corruption.
