### PR TITLE
[PyROOT] Don't link CPyCppyy against cppyy_backend

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -55,15 +55,18 @@ add_library(${libname} SHARED ${headers} ${sources})
 # Set the suffix to '.so' and the prefix to 'lib'
 set_target_properties(${libname} PROPERTIES  ${ROOT_LIBRARY_PROPERTIES})
 if(MSVC)
-  target_link_libraries(${libname} PUBLIC cppyy_backend Python3::Python)
+  target_link_libraries(${libname} PUBLIC Python3::Python)
   set_target_properties(${libname} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
   set_target_properties(${libname} PROPERTIES PREFIX "lib")
   set_target_properties(${libname} PROPERTIES SUFFIX ".pyd")
 elseif(APPLE)
-  target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-w -Wl,-undefined -Wl,dynamic_lookup cppyy_backend)
+  target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-w -Wl,-undefined -Wl,dynamic_lookup)
 else()
-  target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all cppyy_backend)
+  target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all)
 endif()
+
+# For the TString converter that is patched into CPyCppyy
+target_link_libraries(${libname} PRIVATE Core)
 
 if(NOT MSVC)
   target_compile_options(${libname} PRIVATE -Wno-strict-aliasing)

--- a/bindings/tpython/CMakeLists.txt
+++ b/bindings/tpython/CMakeLists.txt
@@ -24,6 +24,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTPython
     Core
   LIBRARIES
     cppyy
+    cppyy_backend
     # We link libTPython against Python libraries to compensate for the fact that libcppyy
     # is built with unresolved symbols. If we didn't do this, invoking TPython from C++
     # would not work.


### PR DESCRIPTION
This is also not done upstream:
https://github.com/wlav/CPyCppyy/blob/master/CMakeLists.txt

We only need to link against `Core` because of the TString converter.

I'm opening this PR now because we talked about this in the last cppyy meeting.

