### PR TITLE
[ntuple] fix change compression in RNTupleMerger, add tests

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -16,11 +16,11 @@
 #ifndef ROOT7_RNTupleMerger
 #define ROOT7_RNTupleMerger
 
-#include "Compression.h"
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPageStorage.hxx>
+#include <Compression.h>
 
 #include <memory>
 #include <string>

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPageStorageFile.hxx>
+#include <ROOT/RPageStorage.hxx>
 #include <ROOT/RClusterPool.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleZip.hxx>
@@ -29,7 +30,6 @@
 #include <TError.h>
 #include <TFile.h>
 #include <TKey.h>
-#include "ROOT/RPageStorage.hxx"
 
 #include <deque>
 

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -35,7 +35,7 @@ ROOT_GENERATE_DICTIONARY(RXTupleDict ${CMAKE_CURRENT_SOURCE_DIR}/RXTuple.hxx
 ROOT_ADD_GTEST(ntuple_descriptor ntuple_descriptor.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_endian ntuple_endian.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_friends ntuple_friends.cxx LIBRARIES ROOTNTuple CustomStruct)
-ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_model ntuple_model.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -2,6 +2,7 @@
 
 #include <TFileMerger.h>
 #include <ROOT/TBufferMerger.hxx>
+#include <zlib.h>
 
 namespace {
 
@@ -698,4 +699,157 @@ TEST(RNTupleMerger, MergeThroughTBufferMerger)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    EXPECT_EQ(reader->GetDescriptor().GetNClusters(), 10);
    EXPECT_EQ(reader->GetNEntries(), 10);
+}
+
+static bool VerifyValidZLIB(const void *buf, size_t bufsize, size_t tgtsize)
+{
+   // Mostly copy-pasted code from R__unzipZLIB
+   auto tgt = std::make_unique<Bytef[]>(tgtsize);
+   auto *src = reinterpret_cast<const uint8_t *>(buf);
+   const auto HDRSIZE = 9;
+   z_stream stream = {};
+   stream.next_in = (Bytef *)(&src[HDRSIZE]);
+   stream.avail_in = (uInt)bufsize - HDRSIZE;
+   stream.next_out = tgt.get();
+   stream.avail_out = (uInt)tgtsize;
+
+   auto is_valid_header_zlib = [](const uint8_t *s) { return s[0] == 'Z' && s[1] == 'L' && s[2] == Z_DEFLATED; };
+   if (!is_valid_header_zlib(src))
+      return false;
+
+   int err = inflateInit(&stream);
+   if (err != Z_OK)
+      return false;
+
+   while ((err = inflate(&stream, Z_FINISH)) != Z_STREAM_END) {
+      EXPECT_EQ(err, Z_OK);
+      if (err != Z_OK)
+         return false;
+   }
+
+   inflateEnd(&stream);
+
+   return true;
+}
+
+TEST(RNTupleMerger, ChangeCompression_Checksum)
+{
+   FileRaii fileGuard("test_ntuple_merge_changecomp_in.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      for (size_t i = 0; i < 1000; ++i) {
+         *fieldFoo = i * 123;
+         ntuple->Fill();
+      }
+   }
+
+   constexpr auto kNewComp = 101;
+   FileRaii fileGuardOut("test_ntuple_merge_changecomp_out.root");
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Create the output
+      auto writeOpts = RNTupleWriteOptions{};
+      writeOpts.SetEnablePageChecksums(true);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), writeOpts);
+
+      RNTupleMerger merger;
+      auto opts = RNTupleMergeOptions{};
+      opts.fCompressionSettings = kNewComp;
+      merger.Merge(sourcePtrs, *destination, opts);
+   }
+
+   // Check that compression is the right one
+   {
+      // TODO(gparolini): eventually we want to do the following check:
+      //   auto reader = RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+      //   auto compSettings = reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).fCompressionSettings;
+      //   EXPECT_EQ(compSettings, kNewComp);
+      // but right now we don't write the correct metadata when calling Merge() so we can't trust the advertised
+      // compression settings to reflect the actual algorithm being used for compression.
+      // Therefore, for now we do a more expensive check where we try to unzip the data using the expected
+      // algorithm and verify that it works.
+      auto source = RPageSource::Create("ntuple", fileGuardOut.GetPath());
+      source->Attach();
+      auto descriptor = source->GetSharedDescriptorGuard();
+      const auto &columnDesc = descriptor->GetColumnDescriptor(0);
+      const auto colElement = ROOT::Experimental::Internal::RColumnElementBase::Generate(columnDesc.GetType());
+      ROOT::Experimental::Internal::RPageStorage::RSealedPage sealedPage;
+      source->LoadSealedPage(0, {0, 0}, sealedPage);
+      auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+      sealedPage.SetBuffer(buffer.get());
+      source->LoadSealedPage(0, {0, 0}, sealedPage);
+
+      size_t tgtsize = sealedPage.GetNElements() * colElement->GetSize();
+      EXPECT_TRUE(VerifyValidZLIB(sealedPage.GetBuffer(), sealedPage.GetDataSize(), tgtsize));
+   }
+}
+
+TEST(RNTupleMerger, ChangeCompression_NoChecksum)
+{
+   FileRaii fileGuard("test_ntuple_merge_changecomp_in.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      for (size_t i = 0; i < 1000; ++i) {
+         *fieldFoo = i * 123;
+         ntuple->Fill();
+      }
+   }
+
+   constexpr auto kNewComp = 105;
+   FileRaii fileGuardOut("test_ntuple_merge_changecomp_out.root");
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Create the output
+      auto writeOpts = RNTupleWriteOptions{};
+      writeOpts.SetEnablePageChecksums(false);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), writeOpts);
+
+      RNTupleMerger merger;
+      auto opts = RNTupleMergeOptions{};
+      opts.fCompressionSettings = kNewComp;
+      merger.Merge(sourcePtrs, *destination, opts);
+   }
+
+   // Check that compression is the right one
+   {
+      // TODO(gparolini): eventually we want to do the following check:
+      //   auto reader = RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+      //   auto compSettings = reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).fCompressionSettings;
+      //   EXPECT_EQ(compSettings, kNewComp);
+      // but right now we don't write the correct metadata when calling Merge() so we can't trust the advertised
+      // compression settings to reflect the actual algorithm being used for compression.
+      // Therefore, for now we do a more expensive check where we try to unzip the data using the expected
+      // algorithm and verify that it works.
+      auto source = RPageSource::Create("ntuple", fileGuardOut.GetPath());
+      source->Attach();
+      auto descriptor = source->GetSharedDescriptorGuard();
+      const auto &columnDesc = descriptor->GetColumnDescriptor(0);
+      const auto colElement = ROOT::Experimental::Internal::RColumnElementBase::Generate(columnDesc.GetType());
+      ROOT::Experimental::Internal::RPageStorage::RSealedPage sealedPage;
+      source->LoadSealedPage(0, {0, 0}, sealedPage);
+      auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+      sealedPage.SetBuffer(buffer.get());
+      source->LoadSealedPage(0, {0, 0}, sealedPage);
+
+      size_t tgtsize = sealedPage.GetNElements() * colElement->GetSize();
+      EXPECT_TRUE(VerifyValidZLIB(sealedPage.GetBuffer(), sealedPage.GetDataSize(), tgtsize));
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -89,6 +89,7 @@ using RNTupleWriteOptions = ROOT::Experimental::RNTupleWriteOptions;
 using RNTupleWriteOptionsDaos = ROOT::Experimental::RNTupleWriteOptionsDaos;
 using RNTupleMetrics = ROOT::Experimental::Detail::RNTupleMetrics;
 using RNTupleMerger = ROOT::Experimental::Internal::RNTupleMerger;
+using RNTupleMergeOptions = ROOT::Experimental::Internal::RNTupleMergeOptions;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTuplePlainCounter = ROOT::Experimental::Detail::RNTuplePlainCounter;
 using RNTuplePlainTimer = ROOT::Experimental::Detail::RNTuplePlainTimer;


### PR DESCRIPTION
# This Pull request:
- makes it so that RNTupleMerger reads the outFile's compression settings and changes the destination RNTuple's compression accordingly. Effectively, this allows users to select the out RNTuple compression with the `-f[0-9]` flag of `hadd`.
- fixes a couple of bugs in the compression changing code
- adds some tests for it
- related PR in [roottest](https://github.com/root-project/roottest/pull/1143)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

