### PR TITLE
Two updates to clingwrapper for memory management

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -710,10 +710,11 @@ void Cppyy::Destruct(TCppType_t type, TCppObject_t instance)
         else {
             auto ib = sHasOperatorDelete.find(type);
             if (ib == sHasOperatorDelete.end()) {
-                sHasOperatorDelete[type] = (bool)cr->GetListOfAllPublicMethods()->FindObject("operator delete");
-                ib = sHasOperatorDelete.find(type);
+               TFunction *f = (TFunction *)cr->GetMethodAllAny("operator delete");
+               sHasOperatorDelete[type] = (bool)(f && (f->Property() & kIsPublic));
+               ib = sHasOperatorDelete.find(type);
             }
-            ib->second ? cr->Destructor((void*)instance) : free((void*)instance);
+            ib->second ? cr->Destructor((void *)instance) : ::operator delete((void *)instance);
         }
     }
 }

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -682,7 +682,7 @@ bool Cppyy::IsComplete(const std::string& type_name)
 Cppyy::TCppObject_t Cppyy::Allocate(TCppType_t type)
 {
     TClassRef& cr = type_from_handle(type);
-    return (TCppObject_t)malloc(gInterpreter->ClassInfo_Size(cr->GetClassInfo()));
+    return (TCppObject_t)::operator new(gInterpreter->ClassInfo_Size(cr->GetClassInfo()));
 }
 
 void Cppyy::Deallocate(TCppType_t /* type */, TCppObject_t instance)


### PR DESCRIPTION
The first commit is to directly fix the following scenario. Consider

```python
# simple_class.py
import ROOT
ROOT.gInterpreter.Declare("class foo{};")
ROOT.foo()
```

Then
```
$: valgrind python simple_class.py
```

Will report
```
==2728568== Mismatched free() / delete / delete []
==2728568==    at 0x4845B2C: free (vg_replace_malloc.c:985)
==2728568==    by 0x1380385C: Cppyy::Destruct(unsigned long, void*) (clingwrapper.cxx:716)
==2728568==    by 0x317B3E14: CPyCppyy::op_dealloc_nofree(CPyCppyy::CPPInstance*) (CPPInstance.cxx:222)
==2728568==    by 0x317B4563: CPyCppyy::op_dealloc(CPyCppyy::CPPInstance*) (CPPInstance.cxx:418)
==2728568==    by 0x4AA0834: subtype_dealloc (typeobject.c:2051)
==2728568==    by 0x498B90B: _PyEval_EvalFrameDefault.cold (generated_cases.c.h:256)
==2728568==    by 0x4AE8B35: PyEval_EvalCode (ceval.c:578)
==2728568==    by 0x4B0EDB9: run_eval_code_obj (pythonrun.c:1722)
==2728568==    by 0x4B0947D: run_mod (pythonrun.c:1743)
==2728568==    by 0x4B2D492: pyrun_file (pythonrun.c:1643)
==2728568==    by 0x4B2C689: _PyRun_SimpleFileObject (pythonrun.c:433)
==2728568==    by 0x4B2C3BE: _PyRun_AnyFileObject (pythonrun.c:78)
==2728568==    by 0x4B1B291: UnknownInlinedFun (main.c:360)
==2728568==    by 0x4B1B291: UnknownInlinedFun (main.c:379)
==2728568==    by 0x4B1B291: UnknownInlinedFun (main.c:629)
==2728568==    by 0x4B1B291: Py_RunMain (main.c:709)
==2728568==    by 0x4AD100B: Py_BytesMain (main.c:763)
==2728568==    by 0x4EE3149: (below main) (libc_start_call_main.h:58)
==2728568==  Address 0x1d0d4290 is 0 bytes inside a block of size 1 alloc'd
==2728568==    at 0x4842F95: operator new(unsigned long) (vg_replace_malloc.c:483)
==2728568==    by 0x3735A021: ???
==2728568==    by 0x13803C9D: WrapperCall(long, unsigned long, void*, void*, void*) (clingwrapper.cxx:802)
==2728568==    by 0x138042CD: Cppyy::CallConstructor(long, unsigned long, unsigned long, void*) (clingwrapper.cxx:895)
==2728568==    by 0x317DEB68: GILCallConstructor(long, unsigned long, CPyCppyy::CallContext*) (Executors.cxx:99)
==2728568==    by 0x317E2622: CPyCppyy::(anonymous namespace)::ConstructorExecutor::Execute(long, void*, CPyCppyy::CallContext*) (Executors.cxx:767)
==2728568==    by 0x317BBCB5: CPyCppyy::CPPMethod::ExecuteFast(void*, long, CPyCppyy::CallContext*) (CPPMethod.cxx:123)
==2728568==    by 0x317BC401: CPyCppyy::CPPMethod::ExecuteProtected(void*, long, CPyCppyy::CallContext*) (CPPMethod.cxx:203)
==2728568==    by 0x317BB389: CPyCppyy::CPPMethod::Execute(void*, long, CPyCppyy::CallContext*) (CPPMethod.cxx:956)
==2728568==    by 0x317A99C7: CPyCppyy::CPPConstructor::Call(CPyCppyy::CPPInstance*&, _object* const*, unsigned long, _object*, CPyCppyy::CallContext*) (CPPConstructor.cxx:133)
```

See also the before/after valgrind log for the first commit

* [simple_class_before.log](https://github.com/user-attachments/files/16178619/simple_class_before.log)
* [simple_class_after.log](https://github.com/user-attachments/files/16178617/simple_class_after.log)

While backporting the changes in the first commit I noticed the changes of the second commit and since they are thematically related and very close to the same function I thought to backport those as well.

