### PR TITLE
[pyroot] Whitelist libtbbmalloc in library import test

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -40,6 +40,7 @@ class ImportLoadLibs(unittest.TestCase):
             'libssl',
             'libcrypt.*', # by libssl
             'libtbb',
+            'libtbbmalloc',
             'liburing', # by libRIO if uring option is enabled
             # On centos7 libssl links against kerberos pulling in all dependencies below, removed with libssl1.1.0
             'libgssapi_krb5',


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Whitelist libtbbmalloc in library import test
```
   6/1344 Test   #12: pyunittests-pyroot-import-load-libs .......................................***Failed    1.35 sec
test_import (import_load_libs.ImportLoadLibs.test_import)
Test libraries loaded after importing ROOT ... ERROR
======================================================================
ERROR: test_import (import_load_libs.ImportLoadLibs.test_import)
Test libraries loaded after importing ROOT
----------------------------------------------------------------------
Exception: Found not whitelisted libraries after importing ROOT:
 - libtbbmalloc
If the test fails with a library that is loaded on purpose, please add it to the whitelist.
----------------------------------------------------------------------
Ran 1 test in 1.186s
FAILED (errors=1)
```
This failure is seen in Fedora 41 after tbb was updated from version 2021.11.0 to version 2021.13.0 in  the distribution.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
