### PR TITLE
[ntuple] add field modifier to importer

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -331,8 +331,8 @@ public:
    REntry &GetDefaultEntry();
    const REntry &GetDefaultEntry() const;
 
-   /// Non-const access to the root field is used to commit clusters during writing
-   /// and to set the on-disk field IDs when connecting a model to a page source or sink.
+   /// Non-const access to the root field is used to commit clusters during writing,
+   /// and to make adjustments to the fields between freezing and connecting to a page sink.
    RFieldZero &GetFieldZero();
    const RFieldZero &GetFieldZero() const { return *fFieldZero; }
    const RFieldBase &GetField(std::string_view fieldName) const;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -114,6 +114,14 @@ public:
       virtual void Finish(std::uint64_t nbytesWritten, std::uint64_t neventsWritten) = 0;
    };
 
+   /// Used to make adjustments to the fields of the output model
+   class RFieldModifier {
+   public:
+      virtual ~RFieldModifier() = default;
+      /// Will be called for every field of the frozen model before it is attached to the page sink
+      virtual void EditField(RFieldBase &field) = 0;
+   };
+
 private:
    struct RImportBranch {
       RImportBranch() = default;
@@ -228,6 +236,7 @@ private:
    /// No standard output, conversely if set to false, schema information and progress is printed.
    bool fIsQuiet = false;
    std::unique_ptr<RProgressCallback> fProgressCallback;
+   std::unique_ptr<RFieldModifier> fFieldModifier;
 
    std::unique_ptr<RNTupleModel> fModel;
    std::unique_ptr<REntry> fEntry;
@@ -271,6 +280,9 @@ public:
 
    /// Whether or not information and progress is printed to stdout.
    void SetIsQuiet(bool value) { fIsQuiet = value; }
+
+   /// Add custom method to adjust column representations
+   void SetFieldModifier(std::unique_ptr<RFieldModifier> modifier) { fFieldModifier = std::move(modifier); }
 
    /// Import works in two steps:
    /// 1. PrepareSchema() calls SetBranchAddress() on all the TTree branches and creates the corresponding RNTuple

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -355,6 +355,12 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    }
 
    fModel->Freeze();
+   if (fFieldModifier) {
+      for (auto &field : fModel->GetFieldZero()) {
+         fFieldModifier->EditField(field);
+      }
+   }
+
    fEntry = fModel->CreateBareEntry();
    for (const auto &f : fImportFields) {
       if (f.fIsInUntypedCollection)

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -357,7 +357,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    fModel->Freeze();
    if (fFieldModifier) {
       for (auto &field : fModel->GetFieldZero()) {
-         fFieldModifier->EditField(field);
+         fFieldModifier(field);
       }
    }
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -237,19 +237,15 @@ TEST(RNTupleImporter, FieldModifier)
       tree->Write();
    }
 
-   class RLowPrecisionFloatModifier : public RNTupleImporter::RFieldModifier {
-   public:
-      void EditField(RFieldBase &field) final
-      {
-         if (field.GetFieldName() == "a")
-            return field.SetColumnRepresentative({EColumnType::kReal16});
-      }
+   auto fnLowPrecisionFloatModifier = [](RFieldBase &field) {
+      if (field.GetFieldName() == "a")
+         field.SetColumnRepresentative({EColumnType::kReal16});
    };
 
    auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
-   importer->SetFieldModifier(std::make_unique<RLowPrecisionFloatModifier>());
+   importer->SetFieldModifier(fnLowPrecisionFloatModifier);
    importer->Import();
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());


### PR DESCRIPTION
This provides a mechanism to adjust the column representation (and other things, such as the field description) in the model created by the RNTupleImporter. We can use it, e.g., to import the AGC with half-precision floats.