### PR TITLE
[ntuple] replace RClusterDescriptor::GetColumnIds with GetColumnRanges

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -338,10 +338,10 @@ public:
       public:
          using iterator_category = std::forward_iterator_tag;
          using iterator = RIterator;
-         using value_type = std::pair<const DescriptorId_t, RColumnRange>;
+         using value_type = RColumnRange;
          using difference_type = std::ptrdiff_t;
-         using pointer = const std::pair<const DescriptorId_t, RColumnRange> *;
-         using reference = const std::pair<const DescriptorId_t, RColumnRange> &;
+         using pointer = const RColumnRange *;
+         using reference = const RColumnRange &;
 
          RIterator(Iter_t iter) : fIter(iter) {}
          iterator operator++()
@@ -349,8 +349,8 @@ public:
             ++fIter;
             return *this;
          }
-         reference operator*() { return *fIter; }
-         pointer operator->() { return fIter.operator->(); }
+         reference operator*() { return fIter->second; }
+         pointer operator->() { return &fIter->second; }
          bool operator!=(const iterator &rh) const { return fIter != rh.fIter; }
          bool operator==(const iterator &rh) const { return fIter == rh.fIter; }
       };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -343,7 +343,7 @@ public:
    {
       return fColumnRanges.find(physicalId) != fColumnRanges.end();
    }
-   std::unordered_set<DescriptorId_t> GetColumnIds() const;
+   const std::unordered_map<DescriptorId_t, RColumnRange> &GetColumnRanges() const { return fColumnRanges; }
    std::uint64_t GetBytesOnStorage() const;
 };
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -187,15 +187,6 @@ bool ROOT::Experimental::RClusterDescriptor::operator==(const RClusterDescriptor
           fNEntries == other.fNEntries && fColumnRanges == other.fColumnRanges && fPageRanges == other.fPageRanges;
 }
 
-
-std::unordered_set<ROOT::Experimental::DescriptorId_t> ROOT::Experimental::RClusterDescriptor::GetColumnIds() const
-{
-   std::unordered_set<DescriptorId_t> result;
-   for (const auto &x : fColumnRanges)
-      result.emplace(x.first);
-   return result;
-}
-
 std::uint64_t ROOT::Experimental::RClusterDescriptor::GetBytesOnStorage() const
 {
    std::uint64_t nbytes = 0;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1390,8 +1390,8 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
       const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(clusterId));
       // Get an ordered set of physical column ids
       std::set<DescriptorId_t> onDiskColumnIds;
-      for (const auto &column : clusterDesc.GetColumnRangeIterable())
-         onDiskColumnIds.insert(context.GetOnDiskColumnId(column.first));
+      for (const auto &columnRange : clusterDesc.GetColumnRangeIterable())
+         onDiskColumnIds.insert(context.GetOnDiskColumnId(columnRange.fPhysicalColumnId));
 
       auto outerFrame = pos;
       pos += SerializeListFramePreamble(onDiskColumnIds.size(), *where);

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1390,7 +1390,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
       const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(clusterId));
       // Get an ordered set of physical column ids
       std::set<DescriptorId_t> onDiskColumnIds;
-      for (const auto &column : clusterDesc.GetColumnRanges())
+      for (const auto &column : clusterDesc.GetColumnRangeIterable())
          onDiskColumnIds.insert(context.GetOnDiskColumnId(column.first));
 
       auto outerFrame = pos;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1390,8 +1390,8 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
       const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(clusterId));
       // Get an ordered set of physical column ids
       std::set<DescriptorId_t> onDiskColumnIds;
-      for (auto column : clusterDesc.GetColumnIds())
-         onDiskColumnIds.insert(context.GetOnDiskColumnId(column));
+      for (const auto &column : clusterDesc.GetColumnRanges())
+         onDiskColumnIds.insert(context.GetOnDiskColumnId(column.first));
 
       auto outerFrame = pos;
       pos += SerializeListFramePreamble(onDiskColumnIds.size(), *where);

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -101,7 +101,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
       for (const auto &c : descriptorGuard->GetClusterIterable()) {
          RClusterDescriptorBuilder clusterBuilder;
          clusterBuilder.ClusterId(fNextId).FirstEntryIndex(c.GetFirstEntryIndex()).NEntries(c.GetNEntries());
-         for (const auto &[originColumnId, originColumnRange] : c.GetColumnRanges()) {
+         for (const auto &[originColumnId, originColumnRange] : c.GetColumnRangeIterable()) {
             DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
 
             auto pageRange = c.GetPageRange(originColumnId).Clone();

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -49,7 +49,7 @@ void ROOT::Experimental::Internal::RPageSourceFriends::AddVirtualField(const RNT
    for (const auto &f : originDesc.GetFieldIterable(originField))
       AddVirtualField(originDesc, originIdx, f, virtualFieldId, f.GetFieldName());
 
-   for (const auto &c: originDesc.GetColumnIterable(originField)) {
+   for (const auto &c : originDesc.GetColumnIterable(originField)) {
       auto physicalId = c.IsAliasColumn() ? fIdBiMap.GetVirtualId({originIdx, c.GetPhysicalId()}) : fNextId;
       RColumnDescriptorBuilder columnBuilder;
       columnBuilder.LogicalColumnId(fNextId)
@@ -101,10 +101,10 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
       for (const auto &c : descriptorGuard->GetClusterIterable()) {
          RClusterDescriptorBuilder clusterBuilder;
          clusterBuilder.ClusterId(fNextId).FirstEntryIndex(c.GetFirstEntryIndex()).NEntries(c.GetNEntries());
-         for (const auto &[originColumnId, originColumnRange] : c.GetColumnRangeIterable()) {
-            DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
+         for (const auto &originColumnRange : c.GetColumnRangeIterable()) {
+            DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnRange.fPhysicalColumnId});
 
-            auto pageRange = c.GetPageRange(originColumnId).Clone();
+            auto pageRange = c.GetPageRange(originColumnRange.fPhysicalColumnId).Clone();
             pageRange.fPhysicalColumnId = virtualColumnId;
 
             auto firstElementIndex = originColumnRange.fFirstElementIndex;
@@ -170,9 +170,7 @@ ROOT::Experimental::Internal::RPageSourceFriends::PopulatePage(ColumnHandle_t co
 {
    auto virtualColumnId = columnHandle.fPhysicalId;
    auto originColumnId = fIdBiMap.GetOriginId(virtualColumnId);
-   RClusterIndex originClusterIndex(
-      fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId,
-      clusterIndex.GetIndex());
+   RClusterIndex originClusterIndex(fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId, clusterIndex.GetIndex());
    columnHandle.fPhysicalId = originColumnId.fId;
 
    auto page = fSources[originColumnId.fSourceIdx]->PopulatePage(columnHandle, originClusterIndex);
@@ -186,9 +184,7 @@ void ROOT::Experimental::Internal::RPageSourceFriends::LoadSealedPage(Descriptor
                                                                       RSealedPage &sealedPage)
 {
    auto originColumnId = fIdBiMap.GetOriginId(physicalColumnId);
-   RClusterIndex originClusterIndex(
-      fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId,
-      clusterIndex.GetIndex());
+   RClusterIndex originClusterIndex(fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId, clusterIndex.GetIndex());
 
    fSources[originColumnId.fSourceIdx]->LoadSealedPage(physicalColumnId, originClusterIndex, sealedPage);
 }

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -101,14 +101,14 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
       for (const auto &c : descriptorGuard->GetClusterIterable()) {
          RClusterDescriptorBuilder clusterBuilder;
          clusterBuilder.ClusterId(fNextId).FirstEntryIndex(c.GetFirstEntryIndex()).NEntries(c.GetNEntries());
-         for (auto originColumnId : c.GetColumnIds()) {
+         for (const auto &[originColumnId, originColumnRange] : c.GetColumnRanges()) {
             DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
 
             auto pageRange = c.GetPageRange(originColumnId).Clone();
             pageRange.fPhysicalColumnId = virtualColumnId;
 
-            auto firstElementIndex = c.GetColumnRange(originColumnId).fFirstElementIndex;
-            auto compressionSettings = c.GetColumnRange(originColumnId).fCompressionSettings;
+            auto firstElementIndex = originColumnRange.fFirstElementIndex;
+            auto compressionSettings = originColumnRange.fCompressionSettings;
 
             clusterBuilder.CommitColumnRange(virtualColumnId, firstElementIndex, compressionSettings, pageRange);
          }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -755,7 +755,7 @@ TEST(RNTuple, SerializeFooter)
    const auto &clusterDesc = desc.GetClusterDescriptor(0);
    EXPECT_EQ(0, clusterDesc.GetFirstEntryIndex());
    EXPECT_EQ(100, clusterDesc.GetNEntries());
-   auto columnIds = clusterDesc.GetColumnIds();
+   const auto &columnIds = clusterDesc.GetColumnRanges();
    EXPECT_EQ(1u, columnIds.size());
    EXPECT_EQ(1u, columnIds.count(0));
    columnRange = clusterDesc.GetColumnRange(0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -755,9 +755,9 @@ TEST(RNTuple, SerializeFooter)
    const auto &clusterDesc = desc.GetClusterDescriptor(0);
    EXPECT_EQ(0, clusterDesc.GetFirstEntryIndex());
    EXPECT_EQ(100, clusterDesc.GetNEntries());
-   const auto &columnIds = clusterDesc.GetColumnRanges();
-   EXPECT_EQ(1u, columnIds.size());
-   EXPECT_EQ(1u, columnIds.count(0));
+   auto columnIds = clusterDesc.GetColumnRangeIterable();
+   EXPECT_EQ(1u, columnIds.count());
+   EXPECT_EQ(0, columnIds.begin()->first);
    columnRange = clusterDesc.GetColumnRange(0);
    EXPECT_EQ(100u, columnRange.fNElements);
    EXPECT_EQ(0u, columnRange.fFirstElementIndex);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -757,7 +757,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(100, clusterDesc.GetNEntries());
    auto columnIds = clusterDesc.GetColumnRangeIterable();
    EXPECT_EQ(1u, columnIds.count());
-   EXPECT_EQ(0, columnIds.begin()->first);
+   EXPECT_EQ(0, columnIds.begin()->fPhysicalColumnId);
    columnRange = clusterDesc.GetColumnRange(0);
    EXPECT_EQ(100u, columnRange.fNElements);
    EXPECT_EQ(0u, columnRange.fFirstElementIndex);


### PR DESCRIPTION
The current API forces the user to copy the entire fColumnRanges map and do a map lookup if they want to iterate the column ranges. With this change, one can simply access the underlying map directly, avoiding extra work in most cases.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

