### PR TITLE
Revert "[ntuple] add debug output to RVectorField"

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2485,28 +2485,7 @@ ROOT::Experimental::RVectorField::CloneImpl(std::string_view newName) const
 std::size_t ROOT::Experimental::RVectorField::AppendImpl(const void *from)
 {
    auto typedValue = static_cast<const std::vector<char> *>(from);
-   // TODO(jblomer): for the following error condition, we print very detailed information before aborting.
-   // This is used to debug writing of CMS MiniAODs and can reverted back to an assert once the error is understood.
-   if ((typedValue->size() % fItemSize) != 0) {
-      const auto &subfield0 = *fSubFields[0];
-      std::string errMsg{"(typedValue->size() % fItemSize) != 0 in RVectorField::AppendImpl\n"};
-      errMsg += "Field name: " + GetQualifiedFieldName() + "\n";
-      errMsg += "Type name: " + GetTypeName() + "\n";
-      errMsg += "Type alias: " + GetTypeAlias() + "\n";
-      errMsg += "fItemSize: " + std::to_string(fItemSize);
-      errMsg += "   typedValue->size(): " + std::to_string(typedValue->size());
-      errMsg += "   fNWritten: " + std::to_string(fNWritten) + "\n";
-      errMsg += "Item type: " + subfield0.GetTypeName() + "\n";
-      errMsg += "Item alias: " + subfield0.GetTypeAlias() + "\n";
-      errMsg += "Item field traits: " + std::to_string(subfield0.GetTraits()) + "\n";
-      errMsg += "Item field size: " + std::to_string(subfield0.GetValueSize()) + "\n";
-      errMsg += "Item field alignment: " + std::to_string(subfield0.GetAlignment()) + "\n";
-      errMsg += "Item field type: " + std::string(typeid(subfield0).name());
-      errMsg += "   demangled: " + ROOT::Internal::GetDemangledTypeName(typeid(subfield0)) + "\n";
-      errMsg += "*from type: " + std::string(typeid(*typedValue).name());
-      errMsg += "   demangled: " + ROOT::Internal::GetDemangledTypeName(typeid(*typedValue)) + "\n";
-      ::Fatal("", kAssertMsg, errMsg.c_str(), __LINE__, __FILE__);
-   }
+   R__ASSERT((typedValue->size() % fItemSize) == 0);
    std::size_t nbytes = 0;
    auto count = typedValue->size() / fItemSize;
 


### PR DESCRIPTION
This reverts commit b5d751c069df2725dbc0d96bb1a6a677addc3895.

The problem that lead to adding additional debug output is understood and turned out to be a CMSSW memory issue.
