### PR TITLE
[ntuple] Map integral types to fixed width equivalents

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -28,8 +28,11 @@ using namespace ROOT::Browsable;
 
 using namespace std::string_literals;
 
+// FIXME: this exposes RField and RIntegralField into the global namespace
 template<typename T>
 using RField = ROOT::Experimental::RField<T>;
+template<typename T>
+using RIntegralField = ROOT::Experimental::RIntegralField<T>;
 
 // ==============================================================================================
 
@@ -80,7 +83,7 @@ class RFieldProvider : public RProvider {
       }
 
       template<typename T>
-      void FillHistogram(const RField<T> &field)
+      void FillHistogramImpl(const ROOT::Experimental::RFieldBase &field, ROOT::Experimental::RNTupleView<T, false> &view)
       {
          std::string title = "Drawing of RField "s + field.GetFieldName();
 
@@ -91,7 +94,6 @@ class RFieldProvider : public RProvider {
          int cnt = 0;
          if (bufsize > 10) bufsize-=3; else bufsize = -1;
 
-         auto view = fNtplReader->GetView<T>(field.GetOnDiskId());
          for (auto i : view.GetFieldRange()) {
             fHist->Fill(view(i));
             if (++cnt == bufsize) {
@@ -103,6 +105,20 @@ class RFieldProvider : public RProvider {
             TestHistBuffer();
 
          fHist->BufferEmpty();
+      }
+
+      template<typename T>
+      void FillHistogram(const RIntegralField<T> &field)
+      {
+         auto view = fNtplReader->GetView<T>(field.GetOnDiskId());
+         FillHistogramImpl(field, view);
+      }
+
+      template<typename T>
+      void FillHistogram(const RField<T> &field)
+      {
+         auto view = fNtplReader->GetView<T>(field.GetOnDiskId());
+         FillHistogramImpl(field, view);
       }
 
       void FillStringHistogram(const RField<std::string> &field)
@@ -150,15 +166,15 @@ class RFieldProvider : public RProvider {
       void VisitFloatField(const RField<float> &field) final { FillHistogram(field); }
       void VisitDoubleField(const RField<double> &field) final { FillHistogram(field); }
       void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
-      void VisitInt8Field(const RField<std::int8_t> &field) final { FillHistogram(field); }
-      void VisitInt16Field(const RField<std::int16_t> &field) final { FillHistogram(field); }
-      void VisitInt32Field(const RField<std::int32_t> &field) final { FillHistogram(field); }
-      void VisitInt64Field(const RField<std::int64_t> &field) final { FillHistogram(field); }
+      void VisitInt8Field(const RIntegralField<std::int8_t> &field) final { FillHistogram(field); }
+      void VisitInt16Field(const RIntegralField<std::int16_t> &field) final { FillHistogram(field); }
+      void VisitInt32Field(const RIntegralField<std::int32_t> &field) final { FillHistogram(field); }
+      void VisitInt64Field(const RIntegralField<std::int64_t> &field) final { FillHistogram(field); }
       void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
-      void VisitUInt16Field(const RField<std::uint16_t> &field) final { FillHistogram(field); }
-      void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
-      void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
-      void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
+      void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) final { FillHistogram(field); }
+      void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) final { FillHistogram(field); }
+      void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) final { FillHistogram(field); }
+      void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) final { FillHistogram(field); }
       void VisitCardinalityField(const ROOT::Experimental::RCardinalityField &field) final
       {
          if (const auto f32 = field.As32Bit()) {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2574,12 +2574,24 @@ class RField<T, typename std::enable_if<std::is_integral_v<T>>::type> final
    using MappedType = typename Internal::RIntegralTypeMap<T>::type;
    static_assert(sizeof(T) == sizeof(MappedType), "invalid size of mapped type");
    static_assert(std::is_signed_v<T> == std::is_signed_v<MappedType>, "invalid signedness of mapped type");
+   using BaseType = RIntegralField<MappedType>;
 
 public:
    RField(std::string_view name) : RIntegralField<MappedType>(name) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() override = default;
+
+   T *Map(NTupleSize_t globalIndex) { return reinterpret_cast<T *>(this->BaseType::Map(globalIndex)); }
+   T *Map(RClusterIndex clusterIndex) { return reinterpret_cast<T *>(this->BaseType::Map(clusterIndex)); }
+   T *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems)
+   {
+      return reinterpret_cast<T *>(this->BaseType::MapV(globalIndex, nItems));
+   }
+   T *MapV(RClusterIndex clusterIndex, NTupleSize_t &nItems)
+   {
+      return reinterpret_cast<T *>(this->BaseType::MapV(clusterIndex, nItems));
+   }
 };
 
 template <>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2177,12 +2177,18 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+template <typename T>
+class RIntegralField {
+   // Instantiating this base template definition should never happen and is an error!
+   RIntegralField() = delete;
+};
+
 template <>
-class RField<std::int8_t> final : public RFieldBase {
+class RIntegralField<std::int8_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2192,13 +2198,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::int8_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::int8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int8_t>(globalIndex);
@@ -2218,11 +2225,11 @@ public:
 };
 
 template <>
-class RField<std::uint8_t> final : public RFieldBase {
+class RIntegralField<std::uint8_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2232,13 +2239,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::uint8_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::uint8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint8_t>(globalIndex);
@@ -2258,11 +2266,11 @@ public:
 };
 
 template <>
-class RField<std::int16_t> final : public RFieldBase {
+class RIntegralField<std::int16_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2272,13 +2280,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::int16_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::int16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int16_t>(globalIndex);
@@ -2298,11 +2307,11 @@ public:
 };
 
 template <>
-class RField<std::uint16_t> final : public RFieldBase {
+class RIntegralField<std::uint16_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2312,13 +2321,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::uint16_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::uint16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint16_t>(globalIndex);
@@ -2338,11 +2348,11 @@ public:
 };
 
 template <>
-class RField<std::int32_t> final : public RFieldBase {
+class RIntegralField<std::int32_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2352,13 +2362,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::int32_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::int32_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int32_t>(globalIndex);
@@ -2378,11 +2389,11 @@ public:
 };
 
 template <>
-class RField<std::uint32_t> final : public RFieldBase {
+class RIntegralField<std::uint32_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2392,13 +2403,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::uint32_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::uint32_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint32_t>(globalIndex);
@@ -2420,11 +2432,11 @@ public:
 };
 
 template <>
-class RField<std::uint64_t> final : public RFieldBase {
+class RIntegralField<std::uint64_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2434,13 +2446,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::uint64_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::uint64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint64_t>(globalIndex);
@@ -2460,11 +2473,11 @@ public:
 };
 
 template <>
-class RField<std::int64_t> final : public RFieldBase {
+class RIntegralField<std::int64_t> : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RIntegralField>(newName);
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2474,13 +2487,14 @@ protected:
 
 public:
    static std::string TypeName() { return "std::int64_t"; }
-   explicit RField(std::string_view name) : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   explicit RIntegralField(std::string_view name)
+      : RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
       fTraits |= kTraitTrivialType;
    }
-   RField(RField&& other) = default;
-   RField& operator =(RField&& other) = default;
-   ~RField() override = default;
+   RIntegralField(RIntegralField &&other) = default;
+   RIntegralField &operator=(RIntegralField &&other) = default;
+   ~RIntegralField() override = default;
 
    std::int64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int64_t>(globalIndex);
@@ -2497,6 +2511,15 @@ public:
    size_t GetValueSize() const final { return sizeof(std::int64_t); }
    size_t GetAlignment() const final { return alignof(std::int64_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <typename T>
+class RField<T, typename std::enable_if<std::is_integral_v<T>>::type> final : public RIntegralField<T> {
+public:
+   RField(std::string_view name) : RIntegralField<T>(name) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
 };
 
 template <>

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -61,16 +61,18 @@ public:
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
    virtual void VisitByteField(const RField<std::byte> &field) { VisitField(field); }
    virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
-   virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
-   virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
-   virtual void VisitInt32Field(const RField<std::int32_t> &field) { VisitField(field); }
-   virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
+   // We have to accept RIntegralField here because there can be multiple basic types that map to the same fixed-width
+   // integer type; for example on 64-bit Unix systems, both long and long long map to std::int64_t.
+   virtual void VisitInt8Field(const RIntegralField<std::int8_t> &field) { VisitField(field); }
+   virtual void VisitInt16Field(const RIntegralField<std::int16_t> &field) { VisitField(field); }
+   virtual void VisitInt32Field(const RIntegralField<std::int32_t> &field) { VisitField(field); }
+   virtual void VisitInt64Field(const RIntegralField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitNullableField(const RNullableField &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
-   virtual void VisitUInt16Field(const RField<std::uint16_t> &field) { VisitField(field); }
-   virtual void VisitUInt32Field(const RField<std::uint32_t> &field) { VisitField(field); }
-   virtual void VisitUInt64Field(const RField<std::uint64_t> &field) { VisitField(field); }
-   virtual void VisitUInt8Field(const RField<std::uint8_t> &field) { VisitField(field); }
+   virtual void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) { VisitField(field); }
+   virtual void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) { VisitField(field); }
+   virtual void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) { VisitField(field); }
+   virtual void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) { VisitField(field); }
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
@@ -207,15 +209,15 @@ public:
    void VisitFloatField(const RField<float> &field) final;
    void VisitByteField(const RField<std::byte> &field) final;
    void VisitCharField(const RField<char> &field) final;
-   void VisitInt8Field(const RField<std::int8_t> &field) final;
-   void VisitInt16Field(const RField<std::int16_t> &field) final;
-   void VisitInt32Field(const RField<std::int32_t> &field) final;
-   void VisitInt64Field(const RField<std::int64_t> &field) final;
+   void VisitInt8Field(const RIntegralField<std::int8_t> &field) final;
+   void VisitInt16Field(const RIntegralField<std::int16_t> &field) final;
+   void VisitInt32Field(const RIntegralField<std::int32_t> &field) final;
+   void VisitInt64Field(const RIntegralField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;
-   void VisitUInt8Field(const RField<std::uint8_t> &field) final;
-   void VisitUInt16Field(const RField<std::uint16_t> &field) final;
-   void VisitUInt32Field(const RField<std::uint32_t> &field) final;
-   void VisitUInt64Field(const RField<std::uint64_t> &field) final;
+   void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) final;
+   void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) final;
+   void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) final;
+   void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) final;
 
    void VisitCardinalityField(const RCardinalityField &field) final;
    void VisitArrayField(const RArrayField &field) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -67,7 +67,6 @@ const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
    {"byte",          "std::byte"},
    {"Char_t",        "char"},
    {"int8_t",        "std::int8_t"},
-   {"signed char",   "char"},
    {"UChar_t",       "std::uint8_t"},
    {"unsigned char", "std::uint8_t"},
    {"uint8_t",       "std::uint8_t"},

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1288,24 +1288,24 @@ void ROOT::Experimental::RField<std::byte>::AcceptVisitor(Detail::RFieldVisitor 
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::int8_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kInt8}}, {{EColumnType::kUInt8}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt8Field(*this);
 }
@@ -1313,24 +1313,24 @@ void ROOT::Experimental::RField<std::int8_t>::AcceptVisitor(Detail::RFieldVisito
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::uint8_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kUInt8}}, {{EColumnType::kInt8}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt8Field(*this);
 }
@@ -1429,25 +1429,25 @@ void ROOT::Experimental::RField<double>::SetDouble32()
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitInt16}, {EColumnType::kInt16}},
                                                  {{EColumnType::kSplitUInt16}, {EColumnType::kUInt16}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt16Field(*this);
 }
@@ -1455,25 +1455,25 @@ void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisit
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitUInt16}, {EColumnType::kUInt16}},
                                                  {{EColumnType::kSplitInt16}, {EColumnType::kInt16}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt16Field(*this);
 }
@@ -1481,25 +1481,25 @@ void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisi
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitInt32}, {EColumnType::kInt32}},
                                                  {{EColumnType::kSplitUInt32}, {EColumnType::kUInt32}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt32Field(*this);
 }
@@ -1507,25 +1507,25 @@ void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisit
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitUInt32}, {EColumnType::kUInt32}},
                                                  {{EColumnType::kSplitInt32}, {EColumnType::kInt32}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt32Field(*this);
 }
@@ -1533,25 +1533,25 @@ void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisi
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitUInt64}, {EColumnType::kUInt64}},
                                                  {{EColumnType::kSplitInt64}, {EColumnType::kInt64}});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt64Field(*this);
 }
@@ -1559,7 +1559,7 @@ void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisi
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
+ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitInt64}, {EColumnType::kInt64}},
                                                  {{EColumnType::kSplitUInt64},
@@ -1571,18 +1571,18 @@ ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(onDiskTypes[0], 0));
 }
 
-void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RIntegralField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt64Field(*this);
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -59,43 +59,37 @@
 namespace {
 
 const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
-   {"Bool_t",   "bool"},
-   {"Float_t",  "float"},
+   {"Bool_t", "bool"},
+   {"Float_t", "float"},
    {"Double_t", "double"},
-   {"string",   "std::string"},
+   {"string", "std::string"},
 
-   {"byte",          "std::byte"},
-   {"Char_t",        "char"},
-   {"int8_t",        "std::int8_t"},
-   {"UChar_t",       "std::uint8_t"},
-   {"unsigned char", "std::uint8_t"},
-   {"uint8_t",       "std::uint8_t"},
+   {"byte", "std::byte"},
+   {"Char_t", "char"},
+   {"int8_t", "std::int8_t"},
+   {"UChar_t", "unsigned char"},
+   {"uint8_t", "std::uint8_t"},
 
-   {"Short_t",        "std::int16_t"},
-   {"int16_t",        "std::int16_t"},
-   {"short",          "std::int16_t"},
-   {"UShort_t",       "std::uint16_t"},
-   {"unsigned short", "std::uint16_t"},
-   {"uint16_t",       "std::uint16_t"},
+   {"Short_t", "short"},
+   {"int16_t", "std::int16_t"},
+   {"UShort_t", "unsigned short"},
+   {"uint16_t", "std::uint16_t"},
 
-   {"Int_t",        "std::int32_t"},
-   {"int32_t",      "std::int32_t"},
-   {"int",          "std::int32_t"},
-   {"UInt_t",       "std::uint32_t"},
-   {"unsigned",     "std::uint32_t"},
-   {"unsigned int", "std::uint32_t"},
-   {"uint32_t",     "std::uint32_t"},
+   {"Int_t", "int"},
+   {"int32_t", "std::int32_t"},
+   {"UInt_t", "unsigned int"},
+   {"unsigned", "unsigned int"},
+   {"uint32_t", "std::uint32_t"},
 
-   // FIXME: Long_t and ULong_t are 32-bit on 64-bit Windows.
-   {"Long_t",        "std::int64_t"},
-   {"Long64_t",      "std::int64_t"},
-   {"int64_t",       "std::int64_t"},
-   {"long",          "std::int64_t"},
-   {"ULong_t",       "std::uint64_t"},
-   {"ULong64_t",     "std::uint64_t"},
-   {"unsigned long", "std::uint64_t"},
-   {"uint64_t",      "std::uint64_t"}
-};
+   // Long_t and ULong_t follow the platform's size of long and unsigned long: They are 64 bit on 64-bit Linux and
+   // macOS, but 32 bit on 32-bit platforms and Windows (regardless of pointer size).
+   {"Long_t", "long"},
+   {"ULong_t", "unsigned long"},
+
+   {"Long64_t", "long long"},
+   {"int64_t", "std::int64_t"},
+   {"ULong64_t", "unsigned long long"},
+   {"uint64_t", "std::uint64_t"}};
 
 /// Used in CreateField() in order to get the comma-separated list of template types
 /// E.g., gets {"int", "std::variant<double,int>"} from "int,std::variant<double,int>"
@@ -167,10 +161,9 @@ std::string GetCanonicalTypeName(const std::string &typeName)
 }
 
 /// Applies type name normalization rules that lead to the final name used to create a RField, e.g. transforms
-/// `unsigned int` to `std::uint32_t` or `const vector<T>` to `std::vector<T>`.  Specifically, `const` / `volatile`
-/// qualifiers are removed, integral types such as `unsigned int` or `long` are translated to fixed-length integer types
-/// (e.g. `std::uint32_t`), and `std::` is added to fully qualify known types in the `std` namespace.  The same happens
-/// to `ROOT::RVec` which is normalized to `ROOT::VecOps::RVec`.
+/// `const vector<T>` to `std::vector<T>`.  Specifically, `const` / `volatile` qualifiers are removed and `std::` is
+/// added to fully qualify known types in the `std` namespace.  The same happens to `ROOT::RVec` which is normalized to
+/// `ROOT::VecOps::RVec`.
 std::string GetNormalizedTypeName(const std::string &typeName)
 {
    std::string normalizedType{TClassEdit::CleanType(typeName.c_str(), /*mode=*/2)};
@@ -656,6 +649,24 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       result = std::make_unique<RField<bool>>(fieldName);
    } else if (canonicalType == "char") {
       result = std::make_unique<RField<char>>(fieldName);
+   } else if (canonicalType == "unsigned char") {
+      result = std::make_unique<RField<unsigned char>>(fieldName);
+   } else if (canonicalType == "short") {
+      result = std::make_unique<RField<short>>(fieldName);
+   } else if (canonicalType == "unsigned short") {
+      result = std::make_unique<RField<unsigned short>>(fieldName);
+   } else if (canonicalType == "int") {
+      result = std::make_unique<RField<int>>(fieldName);
+   } else if (canonicalType == "unsigned int") {
+      result = std::make_unique<RField<unsigned int>>(fieldName);
+   } else if (canonicalType == "long") {
+      result = std::make_unique<RField<long>>(fieldName);
+   } else if (canonicalType == "unsigned long") {
+      result = std::make_unique<RField<unsigned long>>(fieldName);
+   } else if (canonicalType == "long long") {
+      result = std::make_unique<RField<long long>>(fieldName);
+   } else if (canonicalType == "unsigned long long") {
+      result = std::make_unique<RField<unsigned long long>>(fieldName);
    } else if (canonicalType == "std::byte") {
       result = std::make_unique<RField<std::byte>>(fieldName);
    } else if (canonicalType == "std::int8_t") {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -222,28 +222,28 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const RField<char> &
    fOutput << fValue.GetRef<char>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RField<std::int8_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RIntegralField<std::int8_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int8_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RField<std::int16_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RIntegralField<std::int16_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int16_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt32Field(const RField<std::int32_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt32Field(const RIntegralField<std::int32_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int32_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RField<std::int64_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RIntegralField<std::int64_t> &field)
 {
    PrintIndent();
    PrintName(field);
@@ -258,29 +258,28 @@ void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::
    fOutput << "\"" << fValue.GetRef<std::string>() << "\"";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RField<std::uint8_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RIntegralField<std::uint8_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << static_cast<int>(fValue.GetRef<std::uint8_t>());
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const RField<std::uint16_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const RIntegralField<std::uint16_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::uint16_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const RField<std::uint32_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const RIntegralField<std::uint32_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::uint32_t>();
 }
 
-
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RField<std::uint64_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RIntegralField<std::uint64_t> &field)
 {
    PrintIndent();
    PrintName(field);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -676,8 +676,26 @@ TEST(RNTuple, StdUnorderedMap)
 
 TEST(RNTuple, Int64)
 {
-   auto field = RFieldBase::Create("test", "std::int64_t").Unwrap();
-   auto otherField = RFieldBase::Create("test", "std::uint64_t").Unwrap();
+   {
+      RField<std::int64_t> typedField("test");
+      EXPECT_EQ("std::int64_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::int64_t").Unwrap();
+      EXPECT_EQ("std::int64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "int64_t").Unwrap();
+      EXPECT_EQ("std::int64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Long64_t").Unwrap();
+      EXPECT_EQ("std::int64_t", field->GetTypeName());
+   }
+   {
+      RField<std::uint64_t> typedField("test");
+      EXPECT_EQ("std::uint64_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::uint64_t").Unwrap();
+      EXPECT_EQ("std::uint64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "uint64_t").Unwrap();
+      EXPECT_EQ("std::uint64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "ULong64_t").Unwrap();
+      EXPECT_EQ("std::uint64_t", field->GetTypeName());
+   }
 
    FileRaii fileGuard("test_ntuple_int64.root");
 
@@ -732,8 +750,26 @@ TEST(RNTuple, Int64)
 
 TEST(RNTuple, Int32)
 {
-   auto field = RFieldBase::Create("test", "std::int32_t").Unwrap();
-   auto otherField = RFieldBase::Create("test", "std::uint32_t").Unwrap();
+   {
+      RField<std::int32_t> typedField("test");
+      EXPECT_EQ("std::int32_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::int32_t").Unwrap();
+      EXPECT_EQ("std::int32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "int32_t").Unwrap();
+      EXPECT_EQ("std::int32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Int_t").Unwrap();
+      EXPECT_EQ("std::int32_t", field->GetTypeName());
+   }
+   {
+      RField<std::uint32_t> typedField("test");
+      EXPECT_EQ("std::uint32_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::uint32_t").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "uint32_t").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "UInt_t").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+   }
 
    FileRaii fileGuard("test_ntuple_int32.root");
 
@@ -788,10 +824,26 @@ TEST(RNTuple, Int32)
 
 TEST(RNTuple, Int16)
 {
-   auto field = RFieldBase::Create("test", "std::int16_t").Unwrap();
-   auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
-   ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetTypeName());
-   ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetTypeName());
+   {
+      RField<std::int16_t> typedField("test");
+      EXPECT_EQ("std::int16_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::int16_t").Unwrap();
+      EXPECT_EQ("std::int16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "int16_t").Unwrap();
+      EXPECT_EQ("std::int16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Short_t").Unwrap();
+      EXPECT_EQ("std::int16_t", field->GetTypeName());
+   }
+   {
+      RField<std::uint16_t> typedField("test");
+      EXPECT_EQ("std::uint16_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::uint16_t").Unwrap();
+      EXPECT_EQ("std::uint16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "uint16_t").Unwrap();
+      EXPECT_EQ("std::uint16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "UShort_t").Unwrap();
+      EXPECT_EQ("std::uint16_t", field->GetTypeName());
+   }
 
    FileRaii fileGuard("test_ntuple_int16.root");
 
@@ -846,21 +898,26 @@ TEST(RNTuple, Int16)
 
 TEST(RNTuple, Char)
 {
-   auto charField = RField<char>("myChar");
-   auto otherField = RFieldBase::Create("test", "char").Unwrap();
-   ASSERT_EQ("char", otherField->GetTypeName());
-
-   auto charTField = RField<Char_t>("myChar");
-   ASSERT_EQ("char", charTField.GetTypeName());
+   RField<char> typedField("test");
+   EXPECT_EQ("char", typedField.GetTypeName());
+   auto field = RFieldBase::Create("test", "char").Unwrap();
+   EXPECT_EQ("char", field->GetTypeName());
+   field = RFieldBase::Create("test", "Char_t").Unwrap();
+   EXPECT_EQ("char", field->GetTypeName());
 }
 
 TEST(RNTuple, Byte)
 {
-   FileRaii fileGuard("ntuple_test_byte.root");
+   {
+      RField<std::byte> typedField("test");
+      EXPECT_EQ("std::byte", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::byte").Unwrap();
+      EXPECT_EQ("std::byte", field->GetTypeName());
+      field = RFieldBase::Create("test", "byte").Unwrap();
+      EXPECT_EQ("std::byte", field->GetTypeName());
+   }
 
-   auto byteField = RField<std::byte>("myByte");
-   auto otherField = RFieldBase::Create("test", "std::byte").Unwrap();
-   ASSERT_EQ("std::byte", otherField->GetTypeName());
+   FileRaii fileGuard("ntuple_test_byte.root");
 
    {
       auto model = RNTupleModel::Create();
@@ -877,8 +934,24 @@ TEST(RNTuple, Byte)
 
 TEST(RNTuple, Int8_t)
 {
-   auto field = RField<std::int8_t>("myInt8");
-   auto otherField = RFieldBase::Create("test", "std::int8_t").Unwrap();
+   {
+      RField<std::int8_t> typedField("test");
+      EXPECT_EQ("std::int8_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::int8_t").Unwrap();
+      EXPECT_EQ("std::int8_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "int8_t").Unwrap();
+      EXPECT_EQ("std::int8_t", field->GetTypeName());
+   }
+   {
+      RField<std::uint8_t> typedField("test");
+      EXPECT_EQ("std::uint8_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::uint8_t").Unwrap();
+      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "uint8_t").Unwrap();
+      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "UChar_t").Unwrap();
+      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+   }
 }
 
 TEST(RNTuple, Double)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -683,8 +683,6 @@ TEST(RNTuple, Int64)
       EXPECT_EQ("std::int64_t", field->GetTypeName());
       field = RFieldBase::Create("test", "int64_t").Unwrap();
       EXPECT_EQ("std::int64_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "Long64_t").Unwrap();
-      EXPECT_EQ("std::int64_t", field->GetTypeName());
    }
    {
       RField<std::uint64_t> typedField("test");
@@ -692,8 +690,6 @@ TEST(RNTuple, Int64)
       auto field = RFieldBase::Create("test", "std::uint64_t").Unwrap();
       EXPECT_EQ("std::uint64_t", field->GetTypeName());
       field = RFieldBase::Create("test", "uint64_t").Unwrap();
-      EXPECT_EQ("std::uint64_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "ULong64_t").Unwrap();
       EXPECT_EQ("std::uint64_t", field->GetTypeName());
    }
 
@@ -757,8 +753,6 @@ TEST(RNTuple, Int32)
       EXPECT_EQ("std::int32_t", field->GetTypeName());
       field = RFieldBase::Create("test", "int32_t").Unwrap();
       EXPECT_EQ("std::int32_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "Int_t").Unwrap();
-      EXPECT_EQ("std::int32_t", field->GetTypeName());
    }
    {
       RField<std::uint32_t> typedField("test");
@@ -766,8 +760,6 @@ TEST(RNTuple, Int32)
       auto field = RFieldBase::Create("test", "std::uint32_t").Unwrap();
       EXPECT_EQ("std::uint32_t", field->GetTypeName());
       field = RFieldBase::Create("test", "uint32_t").Unwrap();
-      EXPECT_EQ("std::uint32_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "UInt_t").Unwrap();
       EXPECT_EQ("std::uint32_t", field->GetTypeName());
    }
 
@@ -831,8 +823,6 @@ TEST(RNTuple, Int16)
       EXPECT_EQ("std::int16_t", field->GetTypeName());
       field = RFieldBase::Create("test", "int16_t").Unwrap();
       EXPECT_EQ("std::int16_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "Short_t").Unwrap();
-      EXPECT_EQ("std::int16_t", field->GetTypeName());
    }
    {
       RField<std::uint16_t> typedField("test");
@@ -840,8 +830,6 @@ TEST(RNTuple, Int16)
       auto field = RFieldBase::Create("test", "std::uint16_t").Unwrap();
       EXPECT_EQ("std::uint16_t", field->GetTypeName());
       field = RFieldBase::Create("test", "uint16_t").Unwrap();
-      EXPECT_EQ("std::uint16_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "UShort_t").Unwrap();
       EXPECT_EQ("std::uint16_t", field->GetTypeName());
    }
 
@@ -896,14 +884,24 @@ TEST(RNTuple, Int16)
              *reader->GetModel().GetDefaultEntry().GetPtr<std::uint16_t>("i4"));
 }
 
-TEST(RNTuple, Char)
+TEST(RNTuple, Int8_t)
 {
-   RField<char> typedField("test");
-   EXPECT_EQ("char", typedField.GetTypeName());
-   auto field = RFieldBase::Create("test", "char").Unwrap();
-   EXPECT_EQ("char", field->GetTypeName());
-   field = RFieldBase::Create("test", "Char_t").Unwrap();
-   EXPECT_EQ("char", field->GetTypeName());
+   {
+      RField<std::int8_t> typedField("test");
+      EXPECT_EQ("std::int8_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::int8_t").Unwrap();
+      EXPECT_EQ("std::int8_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "int8_t").Unwrap();
+      EXPECT_EQ("std::int8_t", field->GetTypeName());
+   }
+   {
+      RField<std::uint8_t> typedField("test");
+      EXPECT_EQ("std::uint8_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "std::uint8_t").Unwrap();
+      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "uint8_t").Unwrap();
+      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+   }
 }
 
 TEST(RNTuple, Byte)
@@ -932,25 +930,115 @@ TEST(RNTuple, Byte)
    EXPECT_EQ(std::byte{137}, *reader->GetModel().GetDefaultEntry().GetPtr<std::byte>("b"));
 }
 
-TEST(RNTuple, Int8_t)
+TEST(RNTuple, Char)
+{
+   RField<char> typedField("test");
+   EXPECT_EQ("char", typedField.GetTypeName());
+   auto field = RFieldBase::Create("test", "char").Unwrap();
+   EXPECT_EQ("char", field->GetTypeName());
+   field = RFieldBase::Create("test", "Char_t").Unwrap();
+   EXPECT_EQ("char", field->GetTypeName());
+}
+
+TEST(RNTuple, UnsignedChar)
+{
+   RField<unsigned char> typedField("test");
+   EXPECT_EQ("std::uint8_t", typedField.GetTypeName());
+   auto field = RFieldBase::Create("test", "unsigned char").Unwrap();
+   EXPECT_EQ("std::uint8_t", field->GetTypeName());
+   field = RFieldBase::Create("test", "UChar_t").Unwrap();
+   EXPECT_EQ("std::uint8_t", field->GetTypeName());
+}
+
+TEST(RNTuple, Short)
 {
    {
-      RField<std::int8_t> typedField("test");
-      EXPECT_EQ("std::int8_t", typedField.GetTypeName());
-      auto field = RFieldBase::Create("test", "std::int8_t").Unwrap();
-      EXPECT_EQ("std::int8_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "int8_t").Unwrap();
-      EXPECT_EQ("std::int8_t", field->GetTypeName());
+      RField<short> typedField("test");
+      EXPECT_EQ("std::int16_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "short").Unwrap();
+      EXPECT_EQ("std::int16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Short_t").Unwrap();
+      EXPECT_EQ("std::int16_t", field->GetTypeName());
    }
    {
-      RField<std::uint8_t> typedField("test");
-      EXPECT_EQ("std::uint8_t", typedField.GetTypeName());
-      auto field = RFieldBase::Create("test", "std::uint8_t").Unwrap();
-      EXPECT_EQ("std::uint8_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "uint8_t").Unwrap();
-      EXPECT_EQ("std::uint8_t", field->GetTypeName());
-      field = RFieldBase::Create("test", "UChar_t").Unwrap();
-      EXPECT_EQ("std::uint8_t", field->GetTypeName());
+      RField<unsigned short> typedField("test");
+      EXPECT_EQ("std::uint16_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "unsigned short").Unwrap();
+      EXPECT_EQ("std::uint16_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "UShort_t").Unwrap();
+      EXPECT_EQ("std::uint16_t", field->GetTypeName());
+   }
+}
+
+TEST(RNTuple, Int)
+{
+   {
+      RField<int> typedField("test");
+      EXPECT_EQ("std::int32_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "int").Unwrap();
+      EXPECT_EQ("std::int32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Int_t").Unwrap();
+      EXPECT_EQ("std::int32_t", field->GetTypeName());
+   }
+   {
+      RField<unsigned int> typedField("test");
+      EXPECT_EQ("std::uint32_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "unsigned int").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "unsigned").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "UInt_t").Unwrap();
+      EXPECT_EQ("std::uint32_t", field->GetTypeName());
+   }
+}
+
+TEST(RNTuple, Long)
+{
+   {
+      std::string expectedType = "std::int64_t";
+      if (sizeof(long) == 4) {
+         expectedType = "std::int32_t";
+      }
+
+      RField<long> typedField("test");
+      EXPECT_EQ(expectedType, typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "long").Unwrap();
+      EXPECT_EQ(expectedType, field->GetTypeName());
+      field = RFieldBase::Create("test", "Long_t").Unwrap();
+      EXPECT_EQ(expectedType, field->GetTypeName());
+   }
+   {
+      std::string expectedType = "std::uint64_t";
+      if (sizeof(long) == 4) {
+         expectedType = "std::uint32_t";
+      }
+
+      RField<unsigned long> typedField("test");
+      EXPECT_EQ(expectedType, typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "unsigned long").Unwrap();
+      EXPECT_EQ(expectedType, field->GetTypeName());
+      field = RFieldBase::Create("test", "ULong_t").Unwrap();
+      EXPECT_EQ(expectedType, field->GetTypeName());
+   }
+}
+
+TEST(RNTuple, LongLong)
+{
+   {
+      RField<long long> typedField("test");
+      EXPECT_EQ("std::int64_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "long long").Unwrap();
+      EXPECT_EQ("std::int64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "Long64_t").Unwrap();
+      EXPECT_EQ("std::int64_t", field->GetTypeName());
+   }
+   {
+      RField<unsigned long long> typedField("test");
+      EXPECT_EQ("std::uint64_t", typedField.GetTypeName());
+      auto field = RFieldBase::Create("test", "unsigned long long").Unwrap();
+      EXPECT_EQ("std::uint64_t", field->GetTypeName());
+      field = RFieldBase::Create("test", "ULong64_t").Unwrap();
+      EXPECT_EQ("std::uint64_t", field->GetTypeName());
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -362,3 +362,39 @@ TEST(RNTuple, BindEmplaceVoid)
    EXPECT_FLOAT_EQ(33.f, view.GetValue().GetRef<float>());
    EXPECT_FLOAT_EQ(22.f, value2); // The previous value was not modified
 }
+
+TEST(RNTuple, ViewStandardIntegerTypes)
+{
+   FileRaii fileGuard("test_ntuple_viewstandardintegertypes.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto c = model->MakeField<char>("c", 'a');
+      auto uc = model->MakeField<unsigned char>("uc", 1);
+      auto s = model->MakeField<short>("s", 2);
+      auto us = model->MakeField<unsigned short>("us", 3);
+      auto i = model->MakeField<int>("i", 4);
+      auto ui = model->MakeField<unsigned int>("ui", 5);
+      auto l = model->MakeField<long>("l", 6);
+      auto ul = model->MakeField<unsigned long>("ul", 7);
+      auto ll = model->MakeField<long long>("ll", 8);
+      auto ull = model->MakeField<unsigned long long>("ull", 9);
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   ASSERT_EQ(1, reader->GetNEntries());
+
+   EXPECT_EQ('a', reader->GetView<char>("c")(0));
+   EXPECT_EQ(1, reader->GetView<unsigned char>("uc")(0));
+   EXPECT_EQ(2, reader->GetView<short>("s")(0));
+   EXPECT_EQ(3, reader->GetView<unsigned short>("us")(0));
+   EXPECT_EQ(4, reader->GetView<int>("i")(0));
+   EXPECT_EQ(5, reader->GetView<unsigned int>("ui")(0));
+   EXPECT_EQ(6, reader->GetView<long>("l")(0));
+   EXPECT_EQ(7, reader->GetView<unsigned long>("ul")(0));
+   EXPECT_EQ(8, reader->GetView<long long>("ll")(0));
+   EXPECT_EQ(9, reader->GetView<unsigned long long>("ull")(0));
+}


### PR DESCRIPTION
This already used to work for some types, such as `int`, which happen to have the same underlying storage as a fixed width type. This change adds a general `RIntegralTypeMap` with specializations for standard integer types. As a result, RNTuple gains support for `(unsigned) long long` on Linux, which is now mapped to `[u]int64_t`.