### PR TITLE
[core] Simplify typedef of `[U]Long64_t`

### DIFF
--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -68,17 +68,12 @@ typedef int            Ssiz_t;      //String size (int)
 typedef float          Real_t;      //TVector and TMatrix element type (float)
 typedef long long          Long64_t; //Portable signed long integer 8 bytes
 typedef unsigned long long ULong64_t;//Portable unsigned long integer 8 bytes
-#if defined(R__WIN32)
 #ifdef _WIN64
 typedef long long      Longptr_t;   //Integer large enough to hold a pointer
 typedef unsigned long long ULongptr_t;  //Unsigned integer large enough to hold a pointer
 #else
 typedef long           Longptr_t;   //Integer large enough to hold a pointer
 typedef unsigned long  ULongptr_t;  //Unsigned integer large enough to hold a pointer
-#endif
-#else
-typedef long           Longptr_t;
-typedef unsigned long  ULongptr_t;
 #endif
 typedef double         Axis_t;      //Axis values type (double)
 typedef double         Stat_t;      //Statistics type (double)

--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -66,9 +66,9 @@ typedef short          Version_t;   //Class version identifier (short)
 typedef const char     Option_t;    //Option string (const char)
 typedef int            Ssiz_t;      //String size (int)
 typedef float          Real_t;      //TVector and TMatrix element type (float)
+typedef long long          Long64_t; //Portable signed long integer 8 bytes
+typedef unsigned long long ULong64_t;//Portable unsigned long integer 8 bytes
 #if defined(R__WIN32)
-typedef __int64          Long64_t;  //Portable signed long integer 8 bytes
-typedef unsigned __int64 ULong64_t; //Portable unsigned long integer 8 bytes
 #ifdef _WIN64
 typedef long long      Longptr_t;   //Integer large enough to hold a pointer
 typedef unsigned long long ULongptr_t;  //Unsigned integer large enough to hold a pointer
@@ -77,8 +77,6 @@ typedef long           Longptr_t;   //Integer large enough to hold a pointer
 typedef unsigned long  ULongptr_t;  //Unsigned integer large enough to hold a pointer
 #endif
 #else
-typedef long long          Long64_t; //Portable signed long integer 8 bytes
-typedef unsigned long long ULong64_t;//Portable unsigned long integer 8 bytes
 typedef long           Longptr_t;
 typedef unsigned long  ULongptr_t;
 #endif


### PR DESCRIPTION
C++ guarantees that `long long` has at least 64 bits, so we don't need the extra code for Windows.

FYI @jblomer @enirolf 