### PR TITLE
[math][roofit] Include missing header in two tests

### DIFF
--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <iomanip>
 
 int printLevel = 0;
 

--- a/roofit/roofitcore/test/testRooRombergIntegrator.cxx
+++ b/roofit/roofitcore/test/testRooRombergIntegrator.cxx
@@ -17,6 +17,7 @@
 
 #include <numeric>
 #include <algorithm>
+#include <iomanip>
 
 #include "../src/RooRombergIntegrator.h"
 


### PR DESCRIPTION
Found by the conda nightly 

```
2024-07-17T04:49:33.5552609Z /home/conda/feedstock_root/build_artifacts/root_base_1721190805440/work/root-source/math/mathcore/test/testGradient.cxx:467:36: error: 'setprecision' is not a member of 'std'
2024-07-17T04:49:33.5632853Z   467 |    std::cout << std::fixed << std::setprecision(4);
```