### PR TITLE
[webgui] support importmap in `THttpServer` [6.32]

### DIFF
--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -773,7 +773,8 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
       }
 
       std::string key, ntry;
-      key = url.GetValueFromOptions("key");
+      if (url.HasOption("key"))
+         key = url.GetValueFromOptions("key");
       if(url.HasOption("ntry"))
          ntry = url.GetValueFromOptions("ntry");
 

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -35,6 +35,9 @@ protected:
       return IsDisabled() ? kFALSE : fWindow.ProcessBatchHolder(arg);
    }
 
+   std::string GetCodeVersion() override { return fWindow.GetClientVersion(); }
+
+
    void VerifyDefaultPageContent(std::shared_ptr<THttpCallArg> &arg) override
    {
       auto token = fWindow.GetConnToken();
@@ -43,7 +46,7 @@ protected:
          url.SetOptions(arg->GetQuery());
          // refuse connection which does not provide proper token
          if (!url.HasOption("token") || (token != url.GetValueFromOptions("token"))) {
-            // refuce loading of default web page without token
+            // refuse loading of default web page without token
             arg->SetContent("refused");
             arg->Set404();
             return;
@@ -55,7 +58,7 @@ protected:
          url.SetOptions(arg->GetQuery());
          TString key = url.GetValueFromOptions("key");
          if (key.IsNull() || !fWindow.HasKey(key.Data(), true)) {
-            // refuce loading of default web page without valid key
+            // refuse loading of default web page without valid key
             arg->SetContent("refused");
             arg->Set404();
             return;

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -70,7 +70,7 @@ protected:
 
    std::string BuildWSEntryPage();
 
-   void ReplaceJSROOTLinks(std::shared_ptr<THttpCallArg> &arg);
+   void ReplaceJSROOTLinks(std::shared_ptr<THttpCallArg> &arg, const std::string &version = "");
 
    static Bool_t VerifyFilePath(const char *fname);
 

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -59,6 +59,9 @@ protected:
    /// By default no-cache header is provided
    virtual void VerifyDefaultPageContent(std::shared_ptr<THttpCallArg> &arg) { arg->AddNoCacheHeader(); }
 
+   /// Method generate extra suffix for all kinds of loaded code
+   virtual std::string GetCodeVersion() { return ""; }
+
 public:
    virtual ~THttpWSHandler();
 


### PR DESCRIPTION
Only backport functionality to insert `importmap` script into HTML files.
If no magic string appears in HTML code - old functionality will be used.

Let use newer JSROOT with older ROOT versions.
Also let use jsroot ES6 modules directly in HTML files.

