### PR TITLE
[skip-ci] Fix MSVC version for exporting symbols

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -132,7 +132,7 @@ if(MSVC)
       __std_terminate
       cling_runtime_internal_throwIfInvalidPointer
   )
-  if(MSVC_VERSION GREATER_EQUAL 1936)
+  if(MSVC_VERSION GREATER_EQUAL 1933)
     set(cling_exports ${cling_exports}
         __std_find_trivial_1
         __std_find_trivial_2


### PR DESCRIPTION
Fix an issue reported on the forum: https://root-forum.cern.ch/t/windows-stream-failed-to-materialize-symbols
