### PR TITLE
[ntuple] replace pointers with references in some factory API

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -162,13 +162,13 @@ public:
    static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
    static std::unique_ptr<RNTupleReader>
-   Open(RNTuple &ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
+   Open(const RNTuple &ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
    /// The caller imposes a model, which must be compatible with the model found in the data on storage.
    static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
-   static std::unique_ptr<RNTupleReader>
-   Open(std::unique_ptr<RNTupleModel> model, RNTuple &ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
+   static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, const RNTuple &ntuple,
+                                              const RNTupleReadOptions &options = RNTupleReadOptions());
    /// Open RNTuples as one virtual, horizontally combined ntuple.  The underlying RNTuples must
    /// have an identical number of entries.  Fields in the combined RNTuple are named with the ntuple name
    /// as a prefix, e.g. myNTuple1.px and myNTuple2.pt (see tutorial ntpl006_friends)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -162,13 +162,13 @@ public:
    static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
    static std::unique_ptr<RNTupleReader>
-   Open(RNTuple *ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
+   Open(RNTuple &ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
    /// The caller imposes a model, which must be compatible with the model found in the data on storage.
    static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
    static std::unique_ptr<RNTupleReader>
-   Open(std::unique_ptr<RNTupleModel> model, RNTuple *ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
+   Open(std::unique_ptr<RNTupleModel> model, RNTuple &ntuple, const RNTupleReadOptions &options = RNTupleReadOptions());
    /// Open RNTuples as one virtual, horizontally combined ntuple.  The underlying RNTuples must
    /// have an identical number of entries.  Fields in the combined RNTuple are named with the ntuple name
    /// as a prefix, e.g. myNTuple1.px and myNTuple2.pt (see tutorial ntpl006_friends)

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -98,18 +98,18 @@ ROOT::Experimental::RNTupleReader::Open(std::string_view ntupleName, std::string
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(ROOT::Experimental::RNTuple *ntuple, const RNTupleReadOptions &options)
+ROOT::Experimental::RNTupleReader::Open(ROOT::Experimental::RNTuple &ntuple, const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options), options));
+      new RNTupleReader(Internal::RPageSourceFile::CreateFromAnchor(ntuple, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, ROOT::Experimental::RNTuple *ntuple,
+ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, ROOT::Experimental::RNTuple &ntuple,
                                         const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
-      new RNTupleReader(std::move(model), Internal::RPageSourceFile::CreateFromAnchor(*ntuple, options), options));
+      new RNTupleReader(std::move(model), Internal::RPageSourceFile::CreateFromAnchor(ntuple, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -98,14 +98,14 @@ ROOT::Experimental::RNTupleReader::Open(std::string_view ntupleName, std::string
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(ROOT::Experimental::RNTuple &ntuple, const RNTupleReadOptions &options)
+ROOT::Experimental::RNTupleReader::Open(const ROOT::Experimental::RNTuple &ntuple, const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(
       new RNTupleReader(Internal::RPageSourceFile::CreateFromAnchor(ntuple, options), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, ROOT::Experimental::RNTuple &ntuple,
+ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, const ROOT::Experimental::RNTuple &ntuple,
                                         const RNTupleReadOptions &options)
 {
    return std::unique_ptr<RNTupleReader>(

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -214,7 +214,7 @@ TEST(RNTuple, FileAnchor)
    auto readerB = RNTupleReader::Open("B", fileGuard.GetPath());
 
    auto f = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
-   auto readerA = RNTupleReader::Open(f->Get<RNTuple>("A"));
+   auto readerA = RNTupleReader::Open(*f->Get<RNTuple>("A"));
 
    EXPECT_EQ(1U, readerA->GetNEntries());
    EXPECT_EQ(1U, readerB->GetNEntries());

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -167,7 +167,7 @@ TEST(RNTuple, LargeFile1)
    {
       auto f = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "READ"));
       EXPECT_TRUE(f);
-      auto reader = RNTupleReader::Open(f->Get<RNTuple>("myNTuple"));
+      auto reader = RNTupleReader::Open(*f->Get<RNTuple>("myNTuple"));
       auto rdEnergy  = reader->GetView<double>("energy");
 
       double chksumRead = 0.0;
@@ -257,11 +257,11 @@ TEST(RNTuple, LargeFile2)
       auto s2 = f->Get<std::string>("s2");
       EXPECT_EQ("two", *s2);
 
-      auto reader = RNTupleReader::Open(f->Get<RNTuple>("small"));
+      auto reader = RNTupleReader::Open(*f->Get<RNTuple>("small"));
       reader->LoadEntry(0);
       EXPECT_EQ(42.0f, *reader->GetModel().GetDefaultEntry().GetPtr<float>("pt"));
 
-      reader = RNTupleReader::Open(f->Get<RNTuple>("large"));
+      reader = RNTupleReader::Open(*f->Get<RNTuple>("large"));
       auto viewE = reader->GetView<double>("E");
       double chksumRead = 0.0;
       for (auto i : reader->GetEntryRange()) {

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -398,7 +398,7 @@ TEST(RNTuple, PageFillingString)
 TEST(RNTuple, OpenHTTP)
 {
    std::unique_ptr<TFile> file(TFile::Open("http://root.cern/files/tutorials/ntpl004_dimuon_v1rc2.root"));
-   auto reader = RNTupleReader::Open(file->Get<RNTuple>("Events"));
+   auto reader = RNTupleReader::Open(*file->Get<RNTuple>("Events"));
    reader->LoadEntry(0);
 }
 #endif
@@ -415,7 +415,7 @@ TEST(RNTuple, TMemFile)
       writer->Fill();
    }
 
-   auto reader = RNTupleReader::Open(file.Get<RNTuple>("ntpl"));
+   auto reader = RNTupleReader::Open(*file.Get<RNTuple>("ntpl"));
    auto pt = reader->GetModel().GetDefaultEntry().GetPtr<float>("pt");
    reader->LoadEntry(0);
    EXPECT_EQ(*pt, 42.0);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -187,7 +187,7 @@ public:
    /// \note When this factory method is called, all required static information is collected from the RNTuple's fields
    /// and underlying columns are collected at ones. This means that when any inconsistencies are encountered (e.g.
    /// inconsistent compression across clusters), it will throw an error here.
-   static std::unique_ptr<RNTupleInspector> Create(RNTuple *sourceNTuple);
+   static std::unique_ptr<RNTupleInspector> Create(RNTuple &sourceNTuple);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create a new RNTupleInspector.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -187,7 +187,7 @@ public:
    /// \note When this factory method is called, all required static information is collected from the RNTuple's fields
    /// and underlying columns are collected at ones. This means that when any inconsistencies are encountered (e.g.
    /// inconsistent compression across clusters), it will throw an error here.
-   static std::unique_ptr<RNTupleInspector> Create(RNTuple &sourceNTuple);
+   static std::unique_ptr<RNTupleInspector> Create(const RNTuple &sourceNTuple);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create a new RNTupleInspector.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -145,13 +145,9 @@ ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(DescriptorId_t fieldId
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleInspector>
-ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
+ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple &sourceNTuple)
 {
-   if (!sourceNTuple) {
-      throw RException(R__FAIL("provided RNTuple is null"));
-   }
-
-   auto pageSource = Internal::RPageSourceFile::CreateFromAnchor(*sourceNTuple);
+   auto pageSource = Internal::RPageSourceFile::CreateFromAnchor(sourceNTuple);
    return std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));
 }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -145,7 +145,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(DescriptorId_t fieldId
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleInspector>
-ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple &sourceNTuple)
+ROOT::Experimental::RNTupleInspector::Create(const ROOT::Experimental::RNTuple &sourceNTuple)
 {
    auto pageSource = Internal::RPageSourceFile::CreateFromAnchor(sourceNTuple);
    return std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -30,9 +30,6 @@ TEST(RNTupleInspector, CreateFromPointer)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(*ntuple);
    EXPECT_EQ(inspector->GetDescriptor()->GetName(), "ntuple");
-
-   auto nullNTuple = file->Get<RNTuple>("null");
-   EXPECT_THROW(RNTupleInspector::Create(*nullNTuple), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, CreateFromString)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -28,11 +28,11 @@ TEST(RNTupleInspector, CreateFromPointer)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create(*ntuple);
    EXPECT_EQ(inspector->GetDescriptor()->GetName(), "ntuple");
 
    auto nullNTuple = file->Get<RNTuple>("null");
-   EXPECT_THROW(RNTupleInspector::Create(nullNTuple), ROOT::Experimental::RException);
+   EXPECT_THROW(RNTupleInspector::Create(*nullNTuple), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, CreateFromString)

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -54,7 +54,7 @@ void ntpl008_import()
       return;
    }
    auto ntpl = file->Get<RNTuple>("Events");
-   auto reader = RNTupleReader::Open(ntpl);
+   auto reader = RNTupleReader::Open(*ntpl);
    reader->PrintInfo();
 
    ROOT::RDataFrame df("Events", kNTupleFileName);


### PR DESCRIPTION
- RNTupleInspector::Create
- RNTupleReader::Open (2 overloads)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


