### PR TITLE
[VecOps] Use the correct type for BINARY_FUNCTION

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1809,7 +1809,7 @@ using PromoteTypes = decltype(PromoteType<U>() + PromoteType<V>());
    RVec<PromoteTypes<T0, T1>> NAME(const RVec<T0> &v, const T1 &y)             \
    {                                                                           \
       RVec<PromoteTypes<T0, T1>> ret(v.size());                                \
-      auto f = [&y](const T1 &x) { return FUNC(x, y); };                       \
+      auto f = [&y](const T0 &x) { return FUNC(x, y); };                       \
       std::transform(v.begin(), v.end(), ret.begin(), f);                      \
       return ret;                                                              \
    }                                                                           \

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -455,6 +455,12 @@ TEST(VecOps, MathFuncs)
    CheckEqual(pow(v,1), v, " error checking math function pow");
    CheckEqual(pow(v,v), w, " error checking math function pow");
 
+   // #16031
+   RVec<double> vv{3.4};
+   RVec<double> vv_ref{11.56};
+   CheckEqual(pow(vv,2), vv_ref, " error checking math function pow");
+   CheckEqual(pow(vv,2.), vv_ref, " error checking math function pow");
+
    CheckEqual(sqrt(v), Map(v, [](double x) { return std::sqrt(x); }), " error checking math function sqrt");
    CheckEqual(log(v), Map(v, [](double x) { return std::log(x); }), " error checking math function log");
    CheckEqual(sin(v), Map(v, [](double x) { return std::sin(x); }), " error checking math function sin");


### PR DESCRIPTION
This PR fixes #16031 

