### PR TITLE
[ntuple] Multiple column representations: foundation

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -450,6 +450,8 @@ A field can have multiple alternative column representations.
 The representation index distinguishes the different representations.
 For any given cluster, only one of the representations is the primary representation.
 All the other, secondary representations are _suppressed_ in the cluster.
+All column representations of a cluster need to have the same number of columns,
+and the number of elements in each of the corresponding columns must be the same.
 The page list (see Section Page List Envelope) indicates suppressed columns through a negative element index.
 Columns need to be stored in order from smaller to larger representation indexes.
 The representation index is consecutive starting at zero.
@@ -773,9 +775,8 @@ Suppressed columns omit the compression settings in the inner list frame.
 
 Suppressed columns belong to a secondary column representation (see Section "Column Description")
 that is inactive in the current cluster.
-All secondary column representations have the same column cardinality than the primary column representation.
-That means that the number of columns and the absolute values of the element offsets
-of primary and secondary representations are identical.
+The number of columns
+and the absolute values of the element offsets of primary and secondary representations are identical.
 When reading a field of a certain entry, this assertion allows for searching the corresponding
 cluster and column element indexes using any of the column representations.
 It also means that readers need to get the element index offset and the number of elements of suppressed columns

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -769,7 +769,7 @@ the page list envelope can be extended by additional list and record frames.
 #### Suppressed Columns
 
 If the element offset in the inner list frame is negative (sign bit set), the column is suppressed.
-Writers should write the value `uint64_t(-1)`, readers should check for a negative value.
+Writers should write the lowest int64_t value, readers should check for a negative value.
 Suppressed columns always have an empty list of pages.
 Suppressed columns omit the compression settings in the inner list frame.
 

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -42,11 +42,11 @@ namespace Internal {
 class RColumn {
 private:
    EColumnType fType;
-   /**
-    * Columns belonging to the same field are distinguished by their order.  E.g. for an std::string field, there is
-    * the offset column with index 0 and the character value column with index 1.
-    */
+   /// Columns belonging to the same field are distinguished by their order.  E.g. for an std::string field, there is
+   /// the offset column with index 0 and the character value column with index 1.
    std::uint32_t fIndex;
+   /// Fields can have multiple column representations, distinguished by representation index
+   std::uint16_t fRepresentationIndex;
    RPageSink *fPageSink = nullptr;
    RPageSource *fPageSource = nullptr;
    RPageStorage::ColumnHandle_t fHandleSink;
@@ -335,6 +335,7 @@ public:
    RColumnElementBase *GetElement() const { return fElement.get(); }
    EColumnType GetType() const { return fType; }
    std::uint32_t GetIndex() const { return fIndex; }
+   std::uint16_t GetRepresentationIndex() const { return fRepresentationIndex; }
    ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
    NTupleSize_t GetFirstElementIndex() const { return fFirstElementIndex; }
    RPageSource *GetPageSource() const { return fPageSource; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -21,7 +21,8 @@
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RSpan.hxx>
-#include <string_view>
+
+#include <TError.h>
 
 #include <algorithm>
 #include <chrono>
@@ -35,6 +36,7 @@
 #include <vector>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -1053,6 +1055,7 @@ public:
    }
    RColumnDescriptorBuilder &SetSuppressedDeferred()
    {
+      R__ASSERT(fColumn.fFirstElementIndex != 0);
       if (fColumn.fFirstElementIndex > 0)
          fColumn.fFirstElementIndex = -fColumn.fFirstElementIndex;
       return *this;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -603,7 +603,7 @@ public:
    private:
       /// The associated NTuple for this range.
       const RNTupleDescriptor &fNTuple;
-      /// The descriptor ids of the columns ordered by index id
+      /// The descriptor ids of the columns ordered by field, representation, and column index
       std::vector<DescriptorId_t> fColumns = {};
 
    public:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1338,7 +1338,8 @@ private:
 public:
    /// Checks whether invariants hold:
    /// * NTuple name is valid
-   /// * Fields have valid parent and child ids
+   /// * Fields have valid parents
+   /// * Number of columns is constant across column representations
    RResult<void> EnsureValidDescriptor() const;
    const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
    RNTupleDescriptor MoveDescriptor();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -94,7 +94,11 @@ private:
    /// The pointers in the other direction from parent to children. They are serialized, too, to keep the
    /// order of sub fields.
    std::vector<DescriptorId_t> fLinkIds;
-   /// The ordered list of columns attached to this field
+   /// The number of columns in the column representations of the field. The column cardinality helps to navigate the
+   /// list of logical column ids. For example, the second column of the third column representation is
+   /// fLogicalColumnIds[2 * fColumnCardinality + 1]
+   std::uint32_t fColumnCardinality = 0;
+   /// The ordered list of columns attached to this field: first by representation index then by column index.
    std::vector<DescriptorId_t> fLogicalColumnIds;
    /// For custom classes, we store the ROOT TClass reported checksum to facilitate the use of I/O rules that
    /// identify types by their checksum
@@ -127,6 +131,7 @@ public:
    DescriptorId_t GetProjectionSourceId() const { return fProjectionSourceId; }
    const std::vector<DescriptorId_t> &GetLinkIds() const { return fLinkIds; }
    const std::vector<DescriptorId_t> &GetLogicalColumnIds() const { return fLogicalColumnIds; }
+   std::uint32_t GetColumnCardinality() const { return fColumnCardinality; }
    std::optional<std::uint32_t> GetTypeChecksum() const { return fTypeChecksum; }
    bool IsProjectedField() const { return fProjectionSourceId != kInvalidDescriptorId; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -963,8 +963,10 @@ public:
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    /// Searches for a top-level field
    DescriptorId_t FindFieldId(std::string_view fieldName) const;
-   DescriptorId_t FindLogicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
-   DescriptorId_t FindPhysicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
+   DescriptorId_t
+   FindLogicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex, std::uint16_t representationIndex) const;
+   DescriptorId_t
+   FindPhysicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex, std::uint16_t representationIndex) const;
    DescriptorId_t FindClusterId(DescriptorId_t physicalColumnId, NTupleSize_t index) const;
    DescriptorId_t FindNextClusterId(DescriptorId_t clusterId) const;
    DescriptorId_t FindPrevClusterId(DescriptorId_t clusterId) const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1334,8 +1334,6 @@ class RNTupleDescriptorBuilder {
 private:
    RNTupleDescriptor fDescriptor;
    RResult<void> EnsureFieldExists(DescriptorId_t fieldId) const;
-   // Called by AddColumn() to populate the fLogicalFieldIds member of the field descriptor
-   RResult<void> AttachColumn(DescriptorId_t fieldId, const RColumnDescriptor &columnDesc);
 
 public:
    /// Checks whether invariants hold:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -68,7 +68,7 @@ public:
    static constexpr std::uint16_t kFlagProjectedField = 0x02;
    static constexpr std::uint16_t kFlagHasTypeChecksum = 0x04;
 
-   static constexpr std::uint32_t kFlagDeferredColumn = 0x08;
+   static constexpr std::uint16_t kFlagDeferredColumn = 0x08;
 
    static constexpr DescriptorId_t kZeroFieldId = std::uint64_t(-2);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -24,6 +24,7 @@
 #include <Rtypes.h>
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <string>
 #include <unordered_map>
@@ -71,6 +72,8 @@ public:
    static constexpr std::uint16_t kFlagDeferredColumn = 0x08;
 
    static constexpr DescriptorId_t kZeroFieldId = std::uint64_t(-2);
+
+   static constexpr int64_t kSuppressedColumnMarker = std::numeric_limits<std::int64_t>::min();
 
    // In the page sink and the unsplit field, the seen streamer infos are stored in a map
    // with the unique streamer info number being the key.

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -19,7 +19,10 @@
 
 #include <TError.h>
 
-ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t index) : fType(type), fIndex(index) {}
+ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t index)
+   : fType(type), fIndex(index), fRepresentationIndex(0 /* TODO(jblomer) */)
+{
+}
 
 ROOT::Experimental::Internal::RColumn::~RColumn()
 {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -159,6 +159,7 @@ ROOT::Experimental::RClusterDescriptor::RPageRange::ExtendToFitColumnRange(const
                                                                            std::size_t pageSize)
 {
    R__ASSERT(fPhysicalColumnId == columnRange.fPhysicalColumnId);
+   R__ASSERT(!columnRange.fIsSuppressed);
 
    const auto nElements = std::accumulate(fPageInfos.begin(), fPageInfos.end(), 0U,
                                           [](std::size_t n, const auto &PI) { return n + PI.fNElements; });
@@ -572,6 +573,27 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RClusterDescript
    }
    fCluster.fPageRanges[physicalId] = pageRange.Clone();
    fCluster.fColumnRanges[physicalId] = columnRange;
+   return RResult<void>::Success();
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRange(DescriptorId_t physicalId)
+{
+   if (fCluster.fPageRanges.count(physicalId) > 0)
+      return R__FAIL("column ID conflict");
+
+   RClusterDescriptor::RColumnRange columnRange;
+   columnRange.fPhysicalColumnId = physicalId;
+   columnRange.fCompressionSettings = kUnknownCompressionSettings;
+   columnRange.fIsSuppressed = true;
+   fCluster.fColumnRanges[physicalId] = columnRange;
+   return RResult<void>::Success();
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Internal::RClusterDescriptorBuilder::CommitSuppressedColumnRanges(const RNTupleDescriptor &)
+{
+   // TODO(jblomer): implement
    return RResult<void>::Success();
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -110,7 +110,8 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
 bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &other) const
 {
    return fLogicalColumnId == other.fLogicalColumnId && fPhysicalColumnId == other.fPhysicalColumnId &&
-          fType == other.fType && fFieldId == other.fFieldId && fIndex == other.fIndex;
+          fType == other.fType && fFieldId == other.fFieldId && fIndex == other.fIndex &&
+          fRepresentationIndex == other.fRepresentationIndex;
 }
 
 
@@ -124,6 +125,7 @@ ROOT::Experimental::RColumnDescriptor::Clone() const
    clone.fFieldId = fFieldId;
    clone.fIndex = fIndex;
    clone.fFirstElementIndex = fFirstElementIndex;
+   clone.fRepresentationIndex = fRepresentationIndex;
    return clone;
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -379,10 +379,9 @@ ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
-   const RNTupleDescriptor &ntuple, const RFieldDescriptor &fieldDesc)
-   : fNTuple(ntuple)
+   const RNTupleDescriptor &ntuple, const RFieldDescriptor &field)
+   : fNTuple(ntuple), fColumns(field.GetLogicalColumnIds())
 {
-   fColumns = fieldDesc.GetLogicalColumnIds();
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
@@ -395,8 +394,7 @@ ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescrip
       auto currFieldId = fieldIdQueue.front();
       fieldIdQueue.pop_front();
 
-      const auto &field = ntuple.GetFieldDescriptor(currFieldId);
-      const auto &columns = field.GetLogicalColumnIds();
+      const auto &columns = ntuple.GetFieldDescriptor(currFieldId).GetLogicalColumnIds();
       fColumns.insert(fColumns.end(), columns.begin(), columns.end());
 
       for (const auto &field : ntuple.GetFieldIterable(currFieldId)) {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -59,6 +59,7 @@ ROOT::Experimental::RFieldDescriptor::Clone() const
    clone.fParentId = fParentId;
    clone.fProjectionSourceId = fProjectionSourceId;
    clone.fLinkIds = fLinkIds;
+   clone.fColumnCardinality = fColumnCardinality;
    clone.fLogicalColumnIds = fLogicalColumnIds;
    clone.fTypeChecksum = fTypeChecksum;
    return clone;
@@ -914,6 +915,8 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AttachColumn(DescriptorI
       logicalColumnIds.emplace_back(kInvalidDescriptorId);
    }
    logicalColumnIds.at(columnDesc.GetIndex()) = columnDesc.GetLogicalId();
+   itrFieldDesc->second.fColumnCardinality =
+      std::max(itrFieldDesc->second.fColumnCardinality, columnDesc.GetIndex() + 1);
 
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -564,7 +564,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RClusterDescript
 {
    if (physicalId != pageRange.fPhysicalColumnId)
       return R__FAIL("column ID mismatch");
-   if (fCluster.fPageRanges.count(physicalId) > 0)
+   if (fCluster.fColumnRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
    RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, ClusterSize_t{0}};
    columnRange.fCompressionSettings = compressionSettings;
@@ -579,7 +579,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RClusterDescript
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRange(DescriptorId_t physicalId)
 {
-   if (fCluster.fPageRanges.count(physicalId) > 0)
+   if (fCluster.fColumnRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
 
    RClusterDescriptor::RColumnRange columnRange;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -791,7 +791,8 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleDescripto
       // Check that the last column representation is complete, i.e. has all columns.
       const auto &logicalColumnIds = fieldDesc.GetLogicalColumnIds();
       const auto nColumns = logicalColumnIds.size();
-      if (nColumns <= columnCardinality)
+      // If we have only a single column representation, the following condition is true by construction
+      if ((nColumns + 1) == columnCardinality)
          continue;
 
       const auto &lastColumn = fDescriptor.GetColumnDescriptor(logicalColumnIds.back());

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -56,7 +56,8 @@ void ROOT::Experimental::Internal::RPageSourceFriends::AddVirtualField(const RNT
          .PhysicalColumnId(physicalId)
          .FieldId(virtualFieldId)
          .Type(c.GetType())
-         .Index(c.GetIndex());
+         .Index(c.GetIndex())
+         .RepresentationIndex(c.GetRepresentationIndex());
       fBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap()).ThrowOnError();
       fIdBiMap.Insert({originIdx, c.GetLogicalId()}, fNextId);
       fNextId++;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -160,7 +160,8 @@ ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Internal::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
    R__ASSERT(fieldId != kInvalidDescriptorId);
-   auto physicalId = GetSharedDescriptorGuard()->FindPhysicalColumnId(fieldId, column.GetIndex());
+   auto physicalId =
+      GetSharedDescriptorGuard()->FindPhysicalColumnId(fieldId, column.GetIndex(), column.GetRepresentationIndex());
    R__ASSERT(physicalId != kInvalidDescriptorId);
    fActivePhysicalColumns.Insert(physicalId);
    return ColumnHandle_t{physicalId, &column};

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -560,6 +560,7 @@ ROOT::Experimental::Internal::RPagePersistentSink::AddColumn(DescriptorId_t fiel
       .FieldId(fieldId)
       .Type(column.GetType())
       .Index(column.GetIndex())
+      .RepresentationIndex(column.GetRepresentationIndex())
       .FirstElementIndex(column.GetFirstElementIndex());
    fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
    return ColumnHandle_t{columnId, &column};
@@ -590,7 +591,8 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
             .PhysicalColumnId(source.GetLogicalId())
             .FieldId(fieldId)
             .Type(source.GetType())
-            .Index(source.GetIndex());
+            .Index(source.GetIndex())
+            .RepresentationIndex(source.GetRepresentationIndex());
          fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
       }
    };

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -65,9 +65,9 @@ TEST(RNTupleChecksum, VerifyOnLoad)
    pageSource->Attach();
    {
       auto descGuard = pageSource->GetSharedDescriptorGuard();
-      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
-      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
-      pzColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("pz"), 0);
+      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0, 0);
+      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0, 0);
+      pzColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("pz"), 0, 0);
       clusterId = descGuard->FindClusterId(pxColId, 0);
    }
    RClusterIndex index{clusterId, 0};
@@ -100,7 +100,7 @@ TEST(RNTupleChecksum, OmitPageChecksum)
    auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
    pageSource->Attach();
    auto descGuard = pageSource->GetSharedDescriptorGuard();
-   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0, 0);
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
    const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -337,7 +337,7 @@ TEST(PageStorageFile, LoadClusters)
       auto descriptorGuard = source.GetSharedDescriptorGuard();
       ptId = descriptorGuard->FindFieldId("pt");
       EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, ptId);
-      colId = descriptorGuard->FindPhysicalColumnId(ptId, 0);
+      colId = descriptorGuard->FindPhysicalColumnId(ptId, 0, 0);
       EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, colId);
    }
 

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -51,6 +51,7 @@ public:
    RPageSourceMock() : RPageSource("test", ROOT::Experimental::RNTupleReadOptions())
    {
       ROOT::Experimental::Internal::RNTupleDescriptorBuilder descBuilder;
+      descBuilder.SetNTuple("ntpl", "");
       for (unsigned i = 0; i <= 5; ++i) {
          descBuilder.AddCluster(ROOT::Experimental::Internal::RClusterDescriptorBuilder()
                                    .ClusterId(i)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -210,6 +210,7 @@ TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
 TEST(RFieldDescriptorBuilder, HeaderExtension)
 {
    RNTupleDescriptorBuilder descBuilder;
+   descBuilder.SetNTuple("ntpl", "");
    descBuilder.AddField(
       RFieldDescriptorBuilder().FieldId(0).Structure(ENTupleStructure::kRecord).MakeDescriptor().Unwrap());
    descBuilder.AddField(RFieldDescriptorBuilder()

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -297,7 +297,7 @@ TEST(RNTuple, LargePages)
 
       auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
       const auto &desc = reader->GetDescriptor();
-      const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0);
+      const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(desc.FindClusterId(rndColId, 0));
       EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.fBytesOnStorage, kMAXZIPBUF);
 
@@ -327,7 +327,7 @@ TEST(RNTuple, SmallClusters)
    {
       auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
       auto desc = reader->GetDescriptor();
-      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0);
+      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0, 0);
       EXPECT_EQ(EColumnType::kSplitIndex64, desc->GetColumnDescriptor(colId).GetModel().GetType());
       reader->LoadEntry(0);
       auto entry = reader->GetModel()->GetDefaultEntry();
@@ -347,7 +347,7 @@ TEST(RNTuple, SmallClusters)
    {
       auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
       auto desc = reader->GetDescriptor();
-      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0);
+      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0, 0);
       EXPECT_EQ(EColumnType::kSplitIndex32, desc->GetColumnDescriptor(colId).GetModel().GetType());
       reader->LoadEntry(0);
       auto entry = reader->GetModel()->GetDefaultEntry();

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -144,7 +144,7 @@ TEST(RNTuple, DISABLED_Limits_ManyPages)
    const auto &descriptor = reader->GetDescriptor();
    const auto &model = reader->GetModel();
    auto fieldId = descriptor.FindFieldId("id");
-   auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0);
+   auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0, 0);
 
    EXPECT_EQ(reader->GetNEntries(), NumEntries);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
@@ -185,7 +185,7 @@ TEST(RNTuple, DISABLED_Limits_ManyPagesOneEntry)
    const auto &model = reader->GetModel();
    auto fieldId = descriptor.FindFieldId("ids");
    auto subFieldId = descriptor.FindFieldId("_0", fieldId);
-   auto columnId = descriptor.FindPhysicalColumnId(subFieldId, 0);
+   auto columnId = descriptor.FindPhysicalColumnId(subFieldId, 0, 0);
 
    EXPECT_EQ(reader->GetNEntries(), 1);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
@@ -227,7 +227,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
    const auto &descriptor = reader->GetDescriptor();
    const auto &model = reader->GetModel();
    auto fieldId = descriptor.FindFieldId("id");
-   auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0);
+   auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0, 0);
 
    EXPECT_EQ(reader->GetNEntries(), NumElements);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
@@ -269,7 +269,7 @@ TEST(RNTuple, DISABLED_Limits_LargePageOneEntry)
    const auto &model = reader->GetModel();
    auto fieldId = descriptor.FindFieldId("ids");
    auto subFieldId = descriptor.FindFieldId("_0", fieldId);
-   auto columnId = descriptor.FindPhysicalColumnId(subFieldId, 0);
+   auto columnId = descriptor.FindPhysicalColumnId(subFieldId, 0, 0);
 
    EXPECT_EQ(reader->GetNEntries(), 1);
    EXPECT_EQ(descriptor.GetNClusters(), 1);

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -45,8 +45,8 @@ TEST(RPageStorage, ReadSealedPages)
 
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
-   auto columnId =
-      source.GetSharedDescriptorGuard()->FindPhysicalColumnId(source.GetSharedDescriptorGuard()->FindFieldId("pt"), 0);
+   const auto fieldId = source.GetSharedDescriptorGuard()->FindFieldId("pt");
+   auto columnId = source.GetSharedDescriptorGuard()->FindPhysicalColumnId(fieldId, 0, 0);
 
    // Check first cluster consisting of a single entry
    RClusterIndex index(source.GetSharedDescriptorGuard()->FindClusterId(columnId, 0), 0);

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -301,7 +301,7 @@ TEST(Packing, OnDiskEncoding)
 
    auto fnGetColumnId = [&source](const std::string &fieldName) {
       auto descGuard = source->GetSharedDescriptorGuard();
-      return descGuard->FindPhysicalColumnId(descGuard->FindFieldId(fieldName), 0);
+      return descGuard->FindPhysicalColumnId(descGuard->FindFieldId(fieldName), 0, 0);
    };
 
    source->LoadSealedPage(fnGetColumnId("int16"), RClusterIndex(0, 0), sealedPage);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -640,10 +640,10 @@ TEST(RNTuple, SerializeHeader)
 
    desc = builder.MoveDescriptor();
    auto ptAliasFieldId = desc.FindFieldId("ptAlias");
-   auto colId = desc.FindLogicalColumnId(ptAliasFieldId, 0);
+   auto colId = desc.FindLogicalColumnId(ptAliasFieldId, 0, 0);
    EXPECT_TRUE(desc.GetColumnDescriptor(colId).IsAliasColumn());
    auto ptFieldId = desc.FindFieldId("pt");
-   EXPECT_EQ(desc.FindLogicalColumnId(ptFieldId, 0), desc.GetColumnDescriptor(colId).GetPhysicalId());
+   EXPECT_EQ(desc.FindLogicalColumnId(ptFieldId, 0, 0), desc.GetColumnDescriptor(colId).GetPhysicalId());
    EXPECT_TRUE(desc.GetFieldDescriptor(ptAliasFieldId).IsProjectedField());
    EXPECT_EQ(ptFieldId, desc.GetFieldDescriptor(ptAliasFieldId).GetProjectionSourceId());
    EXPECT_FALSE(desc.GetFieldDescriptor(ptFieldId).IsProjectedField());

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -1111,8 +1111,8 @@ TEST(RPageSink, SamePageMerging)
       EXPECT_EQ(1u, reader->GetNEntries());
 
       const auto &desc = reader->GetDescriptor();
-      const auto pxColId = desc.FindPhysicalColumnId(desc.FindFieldId("px"), 0);
-      const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0);
+      const auto pxColId = desc.FindPhysicalColumnId(desc.FindFieldId("px"), 0, 0);
+      const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
       const auto clusterId = desc.FindClusterId(pxColId, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
       EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).fLocator.fPosition ==

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -233,8 +233,8 @@ TEST_F(RPageStorageDaos, DisabledSamePageMerging)
    EXPECT_EQ(1u, reader->GetNEntries());
 
    const auto &desc = reader->GetDescriptor();
-   const auto pxColId = desc.FindPhysicalColumnId(desc.FindFieldId("px"), 0);
-   const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0);
+   const auto pxColId = desc.FindPhysicalColumnId(desc.FindFieldId("px"), 0, 0);
+   const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
    const auto clusterId = desc.FindClusterId(pxColId, 0);
    const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
    EXPECT_FALSE(clusterDesc.GetPageRange(pxColId).Find(0).fLocator.fPosition ==
@@ -308,7 +308,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       auto pageSource = RPageSource::Create(ntupleName, daosUri, options);
       pageSource->Attach();
       const auto &desc = pageSource->GetSharedDescriptorGuard()->Clone();
-      const auto colId = desc->FindPhysicalColumnId(desc->FindFieldId("cnt"), 0);
+      const auto colId = desc->FindPhysicalColumnId(desc->FindFieldId("cnt"), 0, 0);
       const auto clusterId = desc->FindClusterId(colId, 0);
 
       RPageStorage::RSealedPage sealedPage;
@@ -363,8 +363,8 @@ TEST_F(RPageStorageDaos, Checksum)
    pageSource->Attach();
    {
       auto descGuard = pageSource->GetSharedDescriptorGuard();
-      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
-      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
+      pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0, 0);
+      pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0, 0);
       clusterId = descGuard->FindClusterId(pxColId, 0);
    }
    RClusterIndex index{clusterId, 0};

--- a/tree/ntuple/v7/test/ntuple_test.cxx
+++ b/tree/ntuple/v7/test/ntuple_test.cxx
@@ -21,9 +21,9 @@ void CreateCorruptedRNTuple(const std::string &uri)
    auto pageSource = RPageSource::Create("ntpl", uri);
    pageSource->Attach();
    auto descGuard = pageSource->GetSharedDescriptorGuard();
-   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0);
-   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0);
-   const auto pzColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("pz"), 0);
+   const auto pxColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("px"), 0, 0);
+   const auto pyColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("py"), 0, 0);
+   const auto pzColId = descGuard->FindPhysicalColumnId(descGuard->FindFieldId("pz"), 0, 0);
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    RClusterIndex index{clusterId, 0};
 

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -58,6 +58,7 @@ using ROOT::Experimental::EExtraTypeInfoIds;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RClusterIndex = ROOT::Experimental::RClusterIndex;
+using RClusterDescriptor = ROOT::Experimental::RClusterDescriptor;
 using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescriptorBuilder;
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
 using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;


### PR DESCRIPTION
Provides the foundations for multiple, alternative column representations of a single field. Extends the binary format to store multiple sets of columns per field and handles (de-)serialization and the descriptor representation (backwards compatible).

A follow-up PR will use this capability from the RField/RColumn classes.

