### PR TITLE
[ntuple] Store streamer checksum if available

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.5.0
+# RNTuple Reference Specifications 0.2.6.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 
@@ -384,6 +384,7 @@ The flags field can have one of the following bits set:
 |----------|----------------------------------------------------------------------------|
 | 0x01     | Repetitive field, i.e. for every entry $n$ copies of the field are stored  |
 | 0x02     | Projected field                                                            |
+| 0x04     | Has ROOT streamer checksum                                                 |
 
 If `flag==0x01` (_repetitive field_) is set, the field represents a fixed-size array.
 Typically, another (sub) field with `Parent Field ID` equal to the ID of this field
@@ -394,6 +395,9 @@ If `flag==0x02` (_projected field_) is set,
 the field has been created as a virtual field from another, non-projected source field.
 If a projected field has attached columns,
 these columns are alias columns to physical columns attached to the source field.
+
+If `flag==0x04` (ROOT streamer checksum) is set, the field metadata contain the checksum of the ROOT streamer.
+This checksum is only used for I/O rules in order to find types that are identified by checksum.
 
 Depending on the flags, the following optional values follow:
 
@@ -406,6 +410,8 @@ Depending on the flags, the following optional values follow:
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 +             Source Field ID (if flag 0x02 is set)             +
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
++          ROOT Streamer Checksum (if flag 0x04 is set)         +
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -148,6 +148,8 @@ public:
    /// A field of a fundamental type that can be directly mapped via `RField<T>::Map()`, i.e. maps as-is to a single
    /// column
    static constexpr int kTraitMappable = 0x04;
+   /// The streamer checksum is set and valid
+   static constexpr int kTraitStreamerChecksum = 0x08;
    /// Shorthand for types that are both trivially constructible and destructible
    static constexpr int kTraitTrivialType = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
 
@@ -707,6 +709,8 @@ public:
    virtual std::uint32_t GetFieldVersion() const { return 0; }
    /// Indicates an evolution of the C++ type itself
    virtual std::uint32_t GetTypeVersion() const { return 0; }
+   /// Return the current streamer checksum of this class. Only valid if kTraitStreamerChecksum is set.
+   virtual std::uint32_t GetStreamerChecksum() const { return 0; }
    /// Return the C++ type version stored in the field descriptor; only valid after a call to `ConnectPageSource()`
    std::uint32_t GetOnDiskTypeVersion() const { return fOnDiskTypeVersion; }
 
@@ -820,6 +824,7 @@ public:
    size_t GetValueSize() const override;
    size_t GetAlignment() const final { return fMaxAlignment; }
    std::uint32_t GetTypeVersion() const final;
+   std::uint32_t GetStreamerChecksum() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
 };
 
@@ -872,6 +877,7 @@ public:
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
    std::uint32_t GetTypeVersion() const final;
+   std::uint32_t GetStreamerChecksum() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
@@ -2554,6 +2560,7 @@ public:
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
    std::uint32_t GetTypeVersion() const final;
+   std::uint32_t GetStreamerChecksum() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -412,6 +412,9 @@ protected:
    std::vector<ReadCallback_t> fReadCallbacks;
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
+   /// Streamer checksum cached from the descriptor after a call to `ConnectPageSource()`. Only set
+   /// for classes with dictionaries.
+   std::uint32_t fOnDiskStreamerChecksum = 0;
    /// Points into the static vector GetColumnRepresentations().GetSerializationTypes() when SetColumnRepresentative
    /// is called.  Otherwise GetColumnRepresentative returns the default representation.
    const ColumnRepresentation_t *fColumnRepresentative = nullptr;
@@ -713,6 +716,9 @@ public:
    virtual std::uint32_t GetStreamerChecksum() const { return 0; }
    /// Return the C++ type version stored in the field descriptor; only valid after a call to `ConnectPageSource()`
    std::uint32_t GetOnDiskTypeVersion() const { return fOnDiskTypeVersion; }
+   /// Return streamer checksum stored in the field descriptor; only valid after a call to `ConnectPageSource()`,
+   /// if the field stored a streamer checksum
+   std::uint32_t GetOnDiskStreamerChecksum() const { return fOnDiskStreamerChecksum; }
 
    RSchemaIterator begin()
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -29,6 +29,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <vector>
 #include <set>
@@ -95,6 +96,9 @@ private:
    std::vector<DescriptorId_t> fLinkIds;
    /// The ordered list of columns attached to this field
    std::vector<DescriptorId_t> fLogicalColumnIds;
+   /// For custom classes, we store the ROOT streamer checksum to facilitate the use of I/O rules that
+   /// identify types by their streamer checksum
+   std::optional<std::uint32_t> fStreamerChecksum;
 
 public:
    RFieldDescriptor() = default;
@@ -123,6 +127,7 @@ public:
    DescriptorId_t GetProjectionSourceId() const { return fProjectionSourceId; }
    const std::vector<DescriptorId_t> &GetLinkIds() const { return fLinkIds; }
    const std::vector<DescriptorId_t> &GetLogicalColumnIds() const { return fLogicalColumnIds; }
+   const std::optional<std::uint32_t> &GetStreamerChecksum() const { return fStreamerChecksum; }
    bool IsProjectedField() const { return fProjectionSourceId != kInvalidDescriptorId; }
 };
 
@@ -1121,6 +1126,11 @@ public:
    RFieldDescriptorBuilder &Structure(const ENTupleStructure &structure)
    {
       fField.fStructure = structure;
+      return *this;
+   }
+   RFieldDescriptorBuilder &StreamerChecksum(const std::optional<std::uint32_t> streamerChecksum)
+   {
+      fField.fStreamerChecksum = streamerChecksum;
       return *this;
    }
    DescriptorId_t GetParentId() const { return fField.fParentId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -127,7 +127,7 @@ public:
    DescriptorId_t GetProjectionSourceId() const { return fProjectionSourceId; }
    const std::vector<DescriptorId_t> &GetLinkIds() const { return fLinkIds; }
    const std::vector<DescriptorId_t> &GetLogicalColumnIds() const { return fLogicalColumnIds; }
-   const std::optional<std::uint32_t> &GetStreamerChecksum() const { return fStreamerChecksum; }
+   std::optional<std::uint32_t> GetStreamerChecksum() const { return fStreamerChecksum; }
    bool IsProjectedField() const { return fProjectionSourceId != kInvalidDescriptorId; }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -66,6 +66,7 @@ public:
 
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
    static constexpr std::uint16_t kFlagProjectedField = 0x02;
+   static constexpr std::uint16_t kFlagHasStreamerChecksum = 0x04;
 
    static constexpr std::uint32_t kFlagDeferredColumn = 0x08;
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1140,7 +1140,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
          const auto &fieldDesc = desc.GetFieldDescriptor(fOnDiskId);
          fOnDiskTypeVersion = fieldDesc.GetTypeVersion();
          if (fieldDesc.GetStreamerChecksum().has_value())
-            fOnDiskStreamerChecksum = fieldDesc.GetStreamerChecksum().value();
+            fOnDiskStreamerChecksum = *fieldDesc.GetStreamerChecksum();
       }
    }
    if (!fColumns.empty())

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1807,7 +1807,8 @@ void ROOT::Experimental::RClassField::OnConnectPageSource()
       return false;
    };
 
-   auto rules = ruleset->FindRules(fClass->GetName(), static_cast<Int_t>(GetOnDiskTypeVersion()));
+   auto rules = ruleset->FindRules(fClass->GetName(), static_cast<Int_t>(GetOnDiskTypeVersion()),
+                                   static_cast<UInt_t>(GetOnDiskStreamerChecksum()));
    rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
    AddReadCallbacksFromIORules(rules, fClass);
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1136,8 +1136,12 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
             fColumnRepresentative = &t;
       }
       R__ASSERT(fColumnRepresentative);
-      if (fOnDiskId != kInvalidDescriptorId)
-         fOnDiskTypeVersion = desc.GetFieldDescriptor(fOnDiskId).GetTypeVersion();
+      if (fOnDiskId != kInvalidDescriptorId) {
+         const auto &fieldDesc = desc.GetFieldDescriptor(fOnDiskId);
+         fOnDiskTypeVersion = fieldDesc.GetTypeVersion();
+         if (fieldDesc.GetStreamerChecksum().has_value())
+            fOnDiskStreamerChecksum = fieldDesc.GetStreamerChecksum().value();
+      }
    }
    if (!fColumns.empty())
       fPrincipalColumn = fColumns[0].get();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1721,6 +1721,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       Attach(std::move(subField),
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }
+   fTraits |= kTraitStreamerChecksum;
 }
 
 void ROOT::Experimental::RClassField::Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo info)
@@ -1842,6 +1843,11 @@ std::uint32_t ROOT::Experimental::RClassField::GetTypeVersion() const
    return fClass->GetClassVersion();
 }
 
+std::uint32_t ROOT::Experimental::RClassField::GetStreamerChecksum() const
+{
+   return fClass->GetCheckSum();
+}
+
 void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClassField(*this);
@@ -1862,6 +1868,7 @@ ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
 {
    assert(TObject::Class()->GetClassVersion() == 1);
 
+   fTraits |= kTraitStreamerChecksum;
    Attach(std::make_unique<RField<UInt_t>>("fUniqueID"));
    Attach(std::make_unique<RField<UInt_t>>("fBits"));
 }
@@ -1923,6 +1930,11 @@ std::uint32_t ROOT::Experimental::RField<TObject>::GetTypeVersion() const
    return TObject::Class()->GetClassVersion();
 }
 
+std::uint32_t ROOT::Experimental::RField<TObject>::GetStreamerChecksum() const
+{
+   return TObject::Class()->GetCheckSum();
+}
+
 void ROOT::Experimental::RField<TObject>::ConstructValue(void *where) const
 {
    new (where) TObject();
@@ -1973,6 +1985,7 @@ ROOT::Experimental::RUnsplitField::RUnsplitField(std::string_view fieldName, std
       throw RException(R__FAIL("RUnsplitField: no I/O support for type " + std::string(className)));
    }
 
+   fTraits |= kTraitStreamerChecksum;
    if (!(fClass->ClassProperty() & kClassHasExplicitCtor))
       fTraits |= kTraitTriviallyConstructible;
    if (!(fClass->ClassProperty() & kClassHasExplicitDtor))
@@ -2068,6 +2081,11 @@ std::size_t ROOT::Experimental::RUnsplitField::GetValueSize() const
 std::uint32_t ROOT::Experimental::RUnsplitField::GetTypeVersion() const
 {
    return fClass->GetClassVersion();
+}
+
+std::uint32_t ROOT::Experimental::RUnsplitField::GetStreamerChecksum() const
+{
+   return fClass->GetCheckSum();
 }
 
 void ROOT::Experimental::RUnsplitField::AcceptVisitor(Detail::RFieldVisitor &visitor) const

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -40,7 +40,7 @@ bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &ot
           fTypeName == other.fTypeName && fTypeAlias == other.fTypeAlias && fNRepetitions == other.fNRepetitions &&
           fStructure == other.fStructure && fParentId == other.fParentId &&
           fProjectionSourceId == other.fProjectionSourceId && fLinkIds == other.fLinkIds &&
-          fLogicalColumnIds == other.fLogicalColumnIds;
+          fLogicalColumnIds == other.fLogicalColumnIds && other.fStreamerChecksum == other.fStreamerChecksum;
 }
 
 ROOT::Experimental::RFieldDescriptor
@@ -60,6 +60,7 @@ ROOT::Experimental::RFieldDescriptor::Clone() const
    clone.fProjectionSourceId = fProjectionSourceId;
    clone.fLinkIds = fLinkIds;
    clone.fLogicalColumnIds = fLogicalColumnIds;
+   clone.fStreamerChecksum = fStreamerChecksum;
    return clone;
 }
 
@@ -784,6 +785,8 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::FromField(const RFieldBas
       .TypeAlias(field.GetTypeAlias())
       .Structure(field.GetStructure())
       .NRepetitions(field.GetNRepetitions());
+   if (field.GetTraits() & RFieldBase::kTraitStreamerChecksum)
+      fieldDesc.StreamerChecksum(field.GetStreamerChecksum());
    return fieldDesc;
 }
 

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -204,6 +204,8 @@ struct StructWithTransientString {
 struct StructWithIORules : StructWithIORulesBase {
    StructWithTransientString s;
    float c = 0.0f; //! transient member
+   float checksumA = 0.0f;   //! transient member, edited by checksum based rule
+   float checksumB = 137.0f; //! transient member, skipped by checksum based rule due to checksum mismatch
 
    StructWithIORules() = default;
    StructWithIORules(float _a, char _c[4]) : StructWithIORulesBase{_a, 0.0f}, s{{_c[0], _c[1], _c[2], _c[3]}, {}} {}

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -67,6 +67,13 @@
 #pragma read sourceClass = "StructWithIORules" source = "float a;float b" version = "[1-]" targetClass = \
    "StructWithIORules" target = "c" code = "{ c = onfile.a + onfile.b; }"
 
+// This rule uses a checksum to identify the source class
+#pragma read sourceClass = "StructWithIORules" source = "float checksumA" checksum = "[3494027874]" targetClass = \
+   "StructWithIORules" target = "checksumA" code = "{ checksumA = 42.0; }"
+// This rule will be ignored due to a checksum mismatch
+#pragma read sourceClass = "StructWithIORules" source = "float checksumB" checksum = "[1]" targetClass = \
+   "StructWithIORules" target = "checksumB" code = "{ checksumB = 0.0; }"
+
 #pragma link C++ class Cyclic + ;
 #pragma link C++ class CyclicCollectionProxy + ;
 #pragma link C++ class Unsupported + ;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1929,6 +1929,8 @@ TEST(RNTuple, TClassReadRules)
    }
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
+   EXPECT_EQ(TClass::GetClass("StructWithIORules")->GetCheckSum(),
+             ntuple->GetModel().GetField("klass").GetOnDiskStreamerChecksum());
    EXPECT_EQ(20U, ntuple->GetNEntries());
    auto viewKlass = ntuple->GetView<StructWithIORules>("klass");
    for (auto i : ntuple->GetEntryRange()) {
@@ -1940,6 +1942,11 @@ TEST(RNTuple, TClassReadRules)
       EXPECT_EQ(fi + 1.0f, viewKlass(i).b);
       EXPECT_EQ(viewKlass(i).a + viewKlass(i).b, viewKlass(i).c);
       EXPECT_EQ("ROOT", viewKlass(i).s.str);
+
+      // The following member is set by a checksum based rule
+      EXPECT_FLOAT_EQ(42.0, viewKlass(i).checksumA);
+      // The following member is not touched by a rule due to a checksum mismatch
+      EXPECT_FLOAT_EQ(137.0, viewKlass(i).checksumB);
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1899,12 +1899,13 @@ TEST(RNTuple, Traits)
    auto f9 = RField<std::array<std::string, 3>>("f");
    EXPECT_EQ(0, f9.GetTraits());
 
-   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<TrivialTraits>("f").GetTraits());
-   EXPECT_EQ(0, RField<TransientTraits>("f").GetTraits());
-   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, RField<VariantTraits>("f").GetTraits());
-   EXPECT_EQ(0, RField<StringTraits>("f").GetTraits());
-   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, RField<ConstructorTraits>("f").GetTraits());
-   EXPECT_EQ(RFieldBase::kTraitTriviallyConstructible, RField<DestructorTraits>("f").GetTraits());
+   int baseTraits = RFieldBase::kTraitStreamerChecksum;
+   EXPECT_EQ(baseTraits | RFieldBase::kTraitTrivialType, RField<TrivialTraits>("f").GetTraits());
+   EXPECT_EQ(baseTraits, RField<TransientTraits>("f").GetTraits());
+   EXPECT_EQ(baseTraits | RFieldBase::kTraitTriviallyDestructible, RField<VariantTraits>("f").GetTraits());
+   EXPECT_EQ(baseTraits, RField<StringTraits>("f").GetTraits());
+   EXPECT_EQ(baseTraits | RFieldBase::kTraitTriviallyDestructible, RField<ConstructorTraits>("f").GetTraits());
+   EXPECT_EQ(baseTraits | RFieldBase::kTraitTriviallyConstructible, RField<DestructorTraits>("f").GetTraits());
 }
 
 TEST(RNTuple, TClassReadRules)

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -209,3 +209,22 @@ TEST(RTNuple, TObjectDerived)
    EXPECT_FLOAT_EQ(1.0, ptrMultiple->x);
    EXPECT_EQ(137u, ptrMultiple->GetUniqueID());
 }
+
+TEST(RNTuple, TClassStreamerChecksum)
+{
+   auto f0 = RFieldBase::Create("f0", "std::vector<int>").Unwrap();
+   EXPECT_FALSE(f0->GetTraits() & RFieldBase::kTraitStreamerChecksum);
+   EXPECT_EQ(0u, f0->GetStreamerChecksum());
+
+   auto f1 = RFieldBase::Create("f1", "CustomStruct").Unwrap();
+   EXPECT_TRUE(f1->GetTraits() & RFieldBase::kTraitStreamerChecksum);
+   EXPECT_EQ(TClass::GetClass("CustomStruct")->GetCheckSum(), f1->GetStreamerChecksum());
+
+   auto f2 = std::make_unique<ROOT::Experimental::RUnsplitField>("f2", "TRotation");
+   EXPECT_TRUE(f2->GetTraits() & RFieldBase::kTraitStreamerChecksum);
+   EXPECT_EQ(TClass::GetClass("TRotation")->GetCheckSum(), f2->GetStreamerChecksum());
+
+   auto f3 = RFieldBase::Create("f1", "TObject").Unwrap();
+   EXPECT_TRUE(f3->GetTraits() & RFieldBase::kTraitStreamerChecksum);
+   EXPECT_EQ(TClass::GetClass("TObject")->GetCheckSum(), f3->GetStreamerChecksum());
+}


### PR DESCRIPTION
For custom classes with dictionaries, store the streamer checksum in the field metadata. The checksum is used to apply read rules that use checksums to identify the source class.
