### PR TITLE
[tree] TChain: disable creating TTreeCache when querying branch list

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -51,6 +51,11 @@ private:
    void
    ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query, TString &suffix) const;
 
+   struct TLoadTreeOptions {
+      bool fDisableCache = false;
+   };
+   Long64_t LoadTreeWithOptions(Long64_t entry, const TLoadTreeOptions &options);
+
 protected:
    void InvalidateCurrentTree();
    void ReleaseChainProof();


### PR DESCRIPTION
While profiling the AGC running on local dask, we found that TChain::GetListOfBranches() allocated a large amount of memory. The reason is that when the function is called, TChain does a LoadTree(0), which results in the tree allocating a new TTreeCache. This piles up during the execution of the python tasks and results in a large memory overhead.
Since we don't really need the cache when only querying the branch list, this commit introduces a new private LoadTreeWithOptions() function that allows the TChain to internally disable the tree's cache (setting the cache size to 0) before performing the LoadTree. The original cache size is then restored.
This saves about 350 MB of memory during the AGC execution for no visible downside.

