### PR TITLE
[CMake] Always use `lib` as library directory in builtin CFITSIO prefix

### DIFF
--- a/builtins/cfitsio/CMakeLists.txt
+++ b/builtins/cfitsio/CMakeLists.txt
@@ -30,6 +30,7 @@ ExternalProject_Add(
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
              -DCMAKE_C_FLAGS=${CFITSIO_C_FLAGS}
              -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+             -DCMAKE_INSTALL_LIBDIR=<INSTALL_DIR>/lib
              -DBUILD_SHARED_LIBS=OFF
              -DUSE_CURL=OFF
              -DZLIB_FOUND=TRUE


### PR DESCRIPTION
Like this, we make sure the static library is where we expect it to be: `CFITSIO-prefix/lib/libcfitsio.a`, and not for example in the `lib64` directory.

This is already done for other builtins, like `xrootd` and `zeromq`.

Inspired by this forum post:
https://root-forum.cern.ch/t/6-32-02-will-not-build-from-source-with-option-dbuiltin-cfitsio/60270