### PR TITLE
[ntuple] Remove incorrect std::vector::reserve

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -274,8 +274,6 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
             if (colRangeCompressionSettings != 0)
                sealedPageBuffers.resize(sealedPageBuffers.size() + pages.fPageInfos.size());
 
-            sealedPageGroups.reserve(sealedPageGroups.size() + pages.fPageInfos.size());
-
             std::uint64_t pageIdx = 0;
 
             // Loop over the pages


### PR DESCRIPTION
This was added in commit d950e9903a ("[ntuple] use RClusterPool in RNTupleMerger") with no explicit mention, and I believe it's wrong because every column yields exactly one page group that contains all pages for that column.