### PR TITLE
[gui] fix compile error in RWebWindowsManager.cxx

### DIFF
--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -31,6 +31,7 @@
 #include "TExec.h"
 #include "TSocket.h"
 #include "TThread.h"
+#include "TObjArray.h"
 
 #include <thread>
 #include <chrono>


### PR DESCRIPTION
Fix compile error (happening with `DEV=on` due to missing include):

```
/home/jp/root/gui/webdisplay/src/RWebWindowsManager.cxx:215:13: error: no matching constructor for initialization of 'TIter'
      TIter next(arr);
            ^    ~~~
/home/jp/root/core/cont/inc/TCollection.h:244:4: note: candidate constructor not viable: cannot convert argument of incomplete type 'TObjArray *' to 'const TCollection *' for 1st argument
   TIter(const TCollection *col, Bool_t dir = kIterForward)
   ^
/home/jp/root/core/cont/inc/TCollection.h:246:4: note: candidate constructor not viable: cannot convert argument of incomplete type 'TObjArray *' to 'TIterator *' for 1st argument
   TIter(TIterator *it) : fIterator(it) { }
   ^
/home/jp/root/core/cont/inc/TCollection.h:247:4: note: candidate constructor not viable: cannot convert argument of incomplete type 'TObjArray *' to 'const TIter' for 1st argument
   TIter(const TIter &iter);
   ^
/home/jp/root/core/cont/inc/TCollection.h:241:4: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
   TIter() : fIterator(nullptr) { }
   ^
/home/jp/root/gui/webdisplay/src/RWebWindowsManager.cxx:229:7: error: deleting pointer to incomplete type 'TObjArray' may cause undefined behavior [-Werror,-Wdelete-incomplete]
      delete arr;
      ^      ~~~
/home/jp/root/core/base/inc/TObject.h:32:7: note: forward declaration of 'TObjArray'
class TObjArray;
      ^
```
