### PR TITLE
Update ROOT's R interface for Rcpp 1.0.13

### DIFF
--- a/bindings/r/inc/TRInternalFunction.h
+++ b/bindings/r/inc/TRInternalFunction.h
@@ -31,7 +31,15 @@ public:
 
       RCPP_GENERATE_CTOR_ASSIGN(TRInternalFunction_Impl)
 
+#if RCPP_VERSION >= Rcpp_Version(1,0,13)
+      template <typename OUT, typename... T>
+      TRInternalFunction_Impl(OUT(*fun)(T...))
+      {
+         set(Rcpp::XPtr< Rcpp::CppFunctionN<OUT, T...> >(new Rcpp::CppFunctionN<OUT, T...>(fun), false));
+      }
+#else
 #include <TRInternalFunction__ctors.h>
+#endif
       void update(SEXP) {}
 private:
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

From the Rcpp changelog:

* inst/include/Rcpp/: Added variadic templates to be used instead of
   the generated code in `Rcpp/generated` and `Rcpp/module` when
   compiling with C++11 or later.

This PR adapts ROOT's R interface code to this change,

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
