### PR TITLE
Add late model extension to RNTupleMerger

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -622,13 +622,6 @@ public:
    std::uint64_t GetOnDiskFooterSize() const { return fOnDiskFooterSize; }
 
    const RFieldDescriptor &GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
-   const RFieldDescriptor *FindFieldDescriptor(const std::string &fieldName) const
-   {
-      for (const auto &[_, desc] : fFieldDescriptors)
-         if (desc.GetFieldName() == fieldName)
-            return &desc;
-      return nullptr;
-   }
    const RColumnDescriptor &GetColumnDescriptor(DescriptorId_t columnId) const
    {
       return fColumnDescriptors.at(columnId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -622,6 +622,13 @@ public:
    std::uint64_t GetOnDiskFooterSize() const { return fOnDiskFooterSize; }
 
    const RFieldDescriptor &GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
+   const RFieldDescriptor *FindFieldDescriptor(const std::string &fieldName) const
+   {
+      for (const auto &[_, desc] : fFieldDescriptors)
+         if (desc.GetFieldName() == fieldName)
+            return &desc;
+      return nullptr;
+   }
    const RColumnDescriptor &GetColumnDescriptor(DescriptorId_t columnId) const
    {
       return fColumnDescriptors.at(columnId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -27,17 +27,24 @@
 #include <vector>
 #include <unordered_map>
 
-namespace ROOT {
-namespace Experimental {
-namespace Internal {
+namespace ROOT::Experimental::Internal {
 
-enum class RNTupleMergingMode {
+enum class ENTupleMergingMode {
    /// The merger will discard all columns that aren't present in the prototype model (i.e. the model of the first
    /// source)
    kFilter,
+   /// The merger will refuse to merge any 2 RNTuples whose schema doesn't match exactly
+   kStrict,
    /// The merger will update the output model to include all columns from all sources. Entries corresponding to columns
    /// that are not present in a source will be set to the default value of the type.
    kUnion
+};
+
+enum class ENTupleMergeErrBehavior {
+   /// The merger will abort merging as soon as an error is encountered
+   kAbort,
+   /// Upon errors, the merger will skip the current source and continue
+   kSkip
 };
 
 struct RNTupleMergeOptions {
@@ -45,8 +52,10 @@ struct RNTupleMergeOptions {
    /// compression of any of its sources (fast merging). Otherwise, all sources will be converted to the specified
    /// compression algorithm and level.
    int fCompressionSettings = kUnknownCompressionSettings;
-   /// Determines how the merging treats sources with different models (\see RNTupleMergingMode).
-   RNTupleMergingMode fMergingMode = RNTupleMergingMode::kFilter;
+   /// Determines how the merging treats sources with different models (\see ENTupleMergingMode).
+   ENTupleMergingMode fMergingMode = ENTupleMergingMode::kFilter;
+   /// Determines how the Merge function behaves upon merging errors
+   ENTupleMergeErrBehavior fErrBehavior = ENTupleMergeErrBehavior::kAbort;
 };
 
 // clang-format off
@@ -57,62 +66,16 @@ struct RNTupleMergeOptions {
  *        This can also be used to change the compression of a single RNTuple by just passing a single source.
  */
 // clang-format on
-class RNTupleMerger {
-private:
-   // Internal map that holds column name, type, and type id : output ID information
-   std::unordered_map<std::string, DescriptorId_t> fOutputIdMap;
-
-   // Struct to hold column information
-   struct RColumnInfo {
-      /// The qualified field name to which the column belongs, followed by the column index, type and version
-      std::string fColumnNameTypeAndVersion;
-      DescriptorId_t fColumnInputId;
-      DescriptorId_t fColumnOutputId;
-
-      RColumnInfo(const std::string &name, const std::string &typeAndVersion, const DescriptorId_t &inputId,
-                  const DescriptorId_t &outputId)
-         : fColumnNameTypeAndVersion(name + "." + typeAndVersion), fColumnInputId(inputId), fColumnOutputId(outputId)
-      {
-      }
-   };
-
-   /// Validate the columns against the internal map that is built from the first source
-   /// This is where we assign the output ids for the remaining sources
-   void ValidateColumns(std::vector<RColumnInfo> &columns) const;
-
-   /// Recursively add columns from a given field.
-   /// The columns are added in such a way that all already-seen columns (i.e. the ones whose name and version
-   /// were already in `fOutputIdMap`) are at the end of `columns` and all new ones are at the start of it.
-   /// Old and new columns preserve their relative order, so this input:
-   ///
-   ///    [old0, old1, new0, old2, new1, new2]
-   ///
-   /// will be mapped to this output:
-   ///
-   ///    [new0, new1, new2, old0, old1, old2]
-   ///
-   /// Returns the number of new columns.
-   size_t AddColumnsFromField(std::vector<RColumnInfo> &columns, const RNTupleDescriptor &desc,
-                              const RFieldDescriptor &fieldDesc, const std::string &prefix = "") const;
-
-   /// Recursively collect all the columns for all the fields rooted at field zero
-   /// Returns the number of new columns added.
-   size_t CollectColumns(const RNTupleDescriptor &descriptor, RNTupleMergingMode mergingMode,
-                         std::vector<RColumnInfo> &columns);
-
-   /// Adds the new columns `newCols` to the destination's model `model`.
-   void ExtendOutputModel(RNTupleModel &model, std::span<RColumnInfo> newCols, int nDstEntries,
-                          const RNTupleDescriptor &descriptor, RPageSink &destination) const;
-
+class RNTupleMerger final {
 public:
+   struct RChangeCompressionFunc;
+
    /// Merge a given set of sources into the destination
-   void Merge(std::span<RPageSource *> sources, RPageSink &destination,
-              const RNTupleMergeOptions &options = RNTupleMergeOptions());
+   RResult<void> Merge(std::span<RPageSource *> sources, RPageSink &destination,
+                       const RNTupleMergeOptions &options = RNTupleMergeOptions()) const;
 
 }; // end of class RNTupleMerger
 
-} // namespace Internal
-} // namespace Experimental
-} // namespace ROOT
+} // namespace ROOT::Experimental::Internal
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -31,11 +31,22 @@ namespace ROOT {
 namespace Experimental {
 namespace Internal {
 
+enum class RNTupleMergingMode {
+   /// The merger will discard all columns that aren't present in the prototype model (i.e. the model of the first
+   /// source)
+   kFilter,
+   /// The merger will update the output model to include all columns from all sources. Entries corresponding to columns
+   /// that are not present in a source will be set to the default value of the type.
+   kUnion
+};
+
 struct RNTupleMergeOptions {
    /// If `fCompressionSettings == kUnknownCompressionSettings` (the default), the merger will not change the
    /// compression of any of its sources (fast merging). Otherwise, all sources will be converted to the specified
    /// compression algorithm and level.
    int fCompressionSettings = kUnknownCompressionSettings;
+   /// Determines how the merging treats sources with different models (\see RNTupleMergingMode).
+   RNTupleMergingMode fMergingMode = RNTupleMergingMode::kFilter;
 };
 
 // clang-format off
@@ -47,39 +58,51 @@ struct RNTupleMergeOptions {
  */
 // clang-format on
 class RNTupleMerger {
-
 private:
+   // Internal map that holds column name, type, and type id : output ID information
+   std::unordered_map<std::string, DescriptorId_t> fOutputIdMap;
+
    // Struct to hold column information
    struct RColumnInfo {
-      std::string fColumnName; ///< The qualified field name to which the column belongs, followed by the column index
-      std::string fColumnTypeAndVersion; ///< "<type>.<version>" of the field to which the column belongs
+      /// The qualified field name to which the column belongs, followed by the column index, type and version
+      std::string fColumnNameTypeAndVersion;
       DescriptorId_t fColumnInputId;
       DescriptorId_t fColumnOutputId;
 
       RColumnInfo(const std::string &name, const std::string &typeAndVersion, const DescriptorId_t &inputId,
                   const DescriptorId_t &outputId)
-         : fColumnName(name), fColumnTypeAndVersion(typeAndVersion), fColumnInputId(inputId), fColumnOutputId(outputId)
+         : fColumnNameTypeAndVersion(name + "." + typeAndVersion), fColumnInputId(inputId), fColumnOutputId(outputId)
       {
       }
    };
 
-   /// Build the internal column id map from the first source
-   /// This is where we assign the output ids for the first source
-   void BuildColumnIdMap(std::vector<RColumnInfo> &columns);
-
    /// Validate the columns against the internal map that is built from the first source
    /// This is where we assign the output ids for the remaining sources
-   void ValidateColumns(std::vector<RColumnInfo> &columns);
+   void ValidateColumns(std::vector<RColumnInfo> &columns) const;
 
-   /// Recursively add columns from a given field
-   void AddColumnsFromField(std::vector<RColumnInfo> &columns, const RNTupleDescriptor &desc,
-                            const RFieldDescriptor &fieldDesc, const std::string &prefix = "");
+   /// Recursively add columns from a given field.
+   /// The columns are added in such a way that all already-seen columns (i.e. the ones whose name and version
+   /// were already in `fOutputIdMap`) are at the end of `columns` and all new ones are at the start of it.
+   /// Old and new columns preserve their relative order, so this input:
+   ///
+   ///    [old0, old1, new0, old2, new1, new2]
+   ///
+   /// will be mapped to this output:
+   ///
+   ///    [new0, new1, new2, old0, old1, old2]
+   ///
+   /// Returns the number of new columns.
+   size_t AddColumnsFromField(std::vector<RColumnInfo> &columns, const RNTupleDescriptor &desc,
+                              const RFieldDescriptor &fieldDesc, const std::string &prefix = "") const;
 
    /// Recursively collect all the columns for all the fields rooted at field zero
-   void CollectColumns(const RNTupleDescriptor &descriptor, std::vector<RColumnInfo> &columns);
+   /// Returns the number of new columns added.
+   size_t CollectColumns(const RNTupleDescriptor &descriptor, RNTupleMergingMode mergingMode,
+                         std::vector<RColumnInfo> &columns);
 
-   // Internal map that holds column name, type, and type id : output ID information
-   std::unordered_map<std::string, DescriptorId_t> fOutputIdMap;
+   /// Adds the new columns `newCols` to the destination's model `model`.
+   void ExtendOutputModel(RNTupleModel &model, std::span<RColumnInfo> newCols, int nDstEntries,
+                          const RNTupleDescriptor &descriptor, RPageSink &destination) const;
 
 public:
    /// Merge a given set of sources into the destination

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -89,7 +89,7 @@ class RNTupleMerger final {
 
 public:
    RNTupleMerger();
-   
+
    /// Merge a given set of sources into the destination.
    RResult<void> Merge(std::span<RPageSource *> sources, RPageSink &destination,
                        const RNTupleMergeOptions &mergeOpts = RNTupleMergeOptions());

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -64,6 +64,8 @@ struct RNTupleMergeOptions {
    ENTupleMergingMode fMergingMode = ENTupleMergingMode::kFilter;
    /// Determines how the Merge function behaves upon merging errors
    ENTupleMergeErrBehavior fErrBehavior = ENTupleMergeErrBehavior::kAbort;
+   /// If true, the merger will emit further diagnostics and information.
+   bool fExtraVerbose = false;
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -50,7 +50,6 @@ namespace Internal {
 class RColumn;
 class RColumnElementBase;
 class RNTupleCompressor;
-class RNTupleMerger;
 struct RNTupleModelChangeset;
 class RPageAllocator;
 
@@ -259,23 +258,6 @@ public:
    using Callback_t = std::function<void(RPageSink &)>;
 
 protected:
-   friend class Internal::RNTupleMerger;
-
-   /// Parameters for the SealPage() method
-   struct RSealPageConfig {
-      const RPage *fPage = nullptr;                 ///< Input page to be sealed
-      const RColumnElementBase *fElement = nullptr; ///< Corresponds to the page's elements, for size calculation etc.
-      int fCompressionSetting = 0;                  ///< Compression algorithm and level to apply
-      /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
-      /// to store the additional 8 bytes.
-      bool fWriteChecksum = true;
-      /// If false, the output buffer must not point to the input page buffer, which would otherwise be an option
-      /// if the page is mappable and should not be compressed
-      bool fAllowAlias = false;
-      /// Location for sealed output. The memory buffer has to be large enough.
-      void *fBuffer = nullptr;
-   };
-
    std::unique_ptr<RNTupleWriteOptions> fOptions;
 
    /// Helper to zip pages and header/footer; includes a 16MB (kMAXZIPBUF) zip buffer.
@@ -289,9 +271,6 @@ protected:
    /// of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
    /// Usage of this method requires construction of fCompressor.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
-
-   /// Seal a page using the provided info.
-   static RSealedPage SealPage(const RSealPageConfig &config);
 
 private:
    /// Flag if sink was initialized
@@ -338,6 +317,24 @@ protected:
    virtual void CommitDatasetImpl() = 0;
 
 public:
+   /// Parameters for the SealPage() method
+   struct RSealPageConfig {
+      const RPage *fPage = nullptr;                 ///< Input page to be sealed
+      const RColumnElementBase *fElement = nullptr; ///< Corresponds to the page's elements, for size calculation etc.
+      int fCompressionSetting = 0;                  ///< Compression algorithm and level to apply
+      /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
+      /// to store the additional 8 bytes.
+      bool fWriteChecksum = true;
+      /// If false, the output buffer must not point to the input page buffer, which would otherwise be an option
+      /// if the page is mappable and should not be compressed
+      bool fAllowAlias = false;
+      /// Location for sealed output. The memory buffer has to be large enough.
+      void *fBuffer = nullptr;
+   };
+
+   /// Seal a page using the provided info.
+   static RSealedPage SealPage(const RSealPageConfig &config);
+
    /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
    /// added after the initial call to `RPageSink::Init(RNTupleModel &)`.
    /// `firstEntry` specifies the global index for the first stored element in the added columns.
@@ -681,6 +678,13 @@ public:
    /// it's own connection to the underlying storage (e.g., file descriptor, XRootD handle, etc.)
    std::unique_ptr<RPageSource> Clone() const;
 
+   /// Helper for unstreaming a page. This is commonly used in derived, concrete page sources.  The implementation
+   /// currently always makes a memory copy, even if the sealed page is uncompressed and in the final memory layout.
+   /// The optimization of directly mapping pages is left to the concrete page source implementations.
+   RResult<RPage>
+   static UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId,
+                     RPageAllocator &pageAlloc);
+
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleReadOptions &GetReadOptions() const { return fOptions; }
 
@@ -728,12 +732,6 @@ public:
    virtual void
    LoadSealedPage(DescriptorId_t physicalColumnId, RClusterIndex clusterIndex, RSealedPage &sealedPage) = 0;
 
-   /// Helper for unstreaming a page. This is commonly used in derived, concrete page sources.  The implementation
-   /// currently always makes a memory copy, even if the sealed page is uncompressed and in the final memory layout.
-   /// The optimization of directly mapping pages is left to the concrete page source implementations.
-   RResult<RPage>
-   UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
-
    /// Populates all the pages of the given cluster ids and columns; it is possible that some columns do not
    /// contain any pages.  The page source may load more columns than the minimal necessary set from `columns`.
    /// To indicate which columns have been loaded, `LoadClusters()`` must mark them with `SetColumnAvailable()`.
@@ -749,6 +747,11 @@ public:
    /// actual implementation will only run if a task scheduler is set. In practice, a task scheduler is set
    /// if implicit multi-threading is turned on.
    void UnzipCluster(RCluster *cluster);
+
+   // TODO(gparolini): for symmetry with SealPage(), we should either make this private or SealPage() public.
+   RResult<RPage>
+   UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
+
 }; // class RPageSource
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -50,6 +50,7 @@ namespace Internal {
 class RColumn;
 class RColumnElementBase;
 class RNTupleCompressor;
+class RNTupleMerger;
 struct RNTupleModelChangeset;
 class RPageAllocator;
 
@@ -258,6 +259,8 @@ public:
    using Callback_t = std::function<void(RPageSink &)>;
 
 protected:
+   friend class Internal::RNTupleMerger;
+
    /// Parameters for the SealPage() method
    struct RSealPageConfig {
       const RPage *fPage = nullptr;                 ///< Input page to be sealed

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -681,9 +681,8 @@ public:
    /// Helper for unstreaming a page. This is commonly used in derived, concrete page sources.  The implementation
    /// currently always makes a memory copy, even if the sealed page is uncompressed and in the final memory layout.
    /// The optimization of directly mapping pages is left to the concrete page source implementations.
-   RResult<RPage>
-   static UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId,
-                     RPageAllocator &pageAlloc);
+   RResult<RPage> static UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element,
+                                    DescriptorId_t physicalColumnId, RPageAllocator &pageAlloc);
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleReadOptions &GetReadOptions() const { return fOptions; }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -37,8 +37,10 @@ Long64_t ROOT::Experimental::RNTuple::Merge(TCollection *inputs, TFileMergeInfo 
 // IMPORTANT: this function must not throw, as it is used in exception-unsafe code (TFileMerger).
 try {
    // Check the inputs
-   if (!inputs || inputs->GetEntries() < 3 || !mergeInfo)
+   if (!inputs || inputs->GetEntries() < 3 || !mergeInfo) {
+      Error("RNTuple::Merge", "Invalid inputs.");
       return -1;
+   }
 
    // Parse the input parameters
    TIter itr(inputs);
@@ -47,9 +49,12 @@ try {
    std::string ntupleName = std::string(itr()->GetName());
 
    // Second entry is the output file
-   TFile *outFile = dynamic_cast<TFile *>(itr());
-   if (!outFile)
+   TObject *secondArg = itr();
+   TFile *outFile = dynamic_cast<TFile *>(secondArg);
+   if (!outFile) {
+      Error("RNTuple::Merge", "Second input parameter should be a TFile, but it's a %s.", secondArg->ClassName());
       return -1;
+   }
 
    // Check if the output file already has a key with that name
    TKey *outKey = outFile->FindKey(ntupleName.c_str());
@@ -89,8 +94,11 @@ try {
    while (const auto &pitr = itr()) {
       TFile *inFile = dynamic_cast<TFile *>(pitr);
       RNTuple *anchor = inFile ? inFile->Get<RNTuple>(ntupleName.c_str()) : nullptr;
-      if (!anchor)
+      if (!anchor) {
+         Error("RNTuple::Merge", "Failed to retrieve RNTuple anchor named '%s' from file '%s'", ntupleName.c_str(),
+               inFile->GetName());
          return -1;
+      }
       sources.push_back(Internal::RPageSourceFile::CreateFromAnchor(*anchor));
    }
 
@@ -117,18 +125,7 @@ try {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::BuildColumnIdMap(
-   std::vector<ROOT::Experimental::Internal::RNTupleMerger::RColumnInfo> &columns)
-{
-   for (auto &column : columns) {
-      column.fColumnOutputId = fOutputIdMap.size();
-      fOutputIdMap[column.fColumnName + "." + column.fColumnTypeAndVersion] = column.fColumnOutputId;
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::ValidateColumns(
-   std::vector<ROOT::Experimental::Internal::RNTupleMerger::RColumnInfo> &columns)
+void ROOT::Experimental::Internal::RNTupleMerger::ValidateColumns(std::vector<RColumnInfo> &columns) const
 {
    // First ensure that we have the same number of columns
    if (fOutputIdMap.size() != columns.size()) {
@@ -137,57 +134,130 @@ void ROOT::Experimental::Internal::RNTupleMerger::ValidateColumns(
    // Then ensure that we have the same names of columns and assign the ids
    for (auto &column : columns) {
       try {
-         column.fColumnOutputId = fOutputIdMap.at(column.fColumnName + "." + column.fColumnTypeAndVersion);
+         column.fColumnOutputId = fOutputIdMap.at(column.fColumnNameTypeAndVersion);
       } catch (const std::out_of_range &) {
-         throw RException(R__FAIL("Column NOT found in the first source w/ name " + column.fColumnName +
-                                  " type and version " + column.fColumnTypeAndVersion));
+         throw RException(R__FAIL("Column NOT found in the first source w/ name " + column.fColumnNameTypeAndVersion));
       }
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescriptor &descriptor,
-                                                                 std::vector<RColumnInfo> &columns)
+size_t ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescriptor &descriptor,
+                                                                   RNTupleMergingMode mergingMode,
+                                                                   std::vector<RColumnInfo> &columns)
 {
    // Here we recursively find the columns and fill the RColumnInfo vector
-   AddColumnsFromField(columns, descriptor, descriptor.GetFieldZero());
+   columns.clear();
+   const auto nNewCols = AddColumnsFromField(columns, descriptor, descriptor.GetFieldZero());
+
    // Then we either build the internal map (first source) or validate the columns against it (remaning sources)
    // In either case, we also assign the output ids here
-   if (fOutputIdMap.empty()) {
-      BuildColumnIdMap(columns);
+
+   if (mergingMode == RNTupleMergingMode::kUnion) {
+      // Assign new ids to new columns
+      for (size_t i = 0; i < nNewCols; ++i) {
+         auto &column = columns[i];
+         column.fColumnOutputId = fOutputIdMap.size();
+         assert(fOutputIdMap.find(column.fColumnNameTypeAndVersion) == fOutputIdMap.end());
+         fOutputIdMap[column.fColumnNameTypeAndVersion] = column.fColumnOutputId;
+      }
+      // Assign existing ids to old columns
+      for (size_t i = nNewCols; i < columns.size(); ++i) {
+         auto &column = columns[i];
+         auto id = fOutputIdMap.find(column.fColumnNameTypeAndVersion);
+         assert(id != fOutputIdMap.end());
+         column.fColumnOutputId = id->second;
+      }
    } else {
-      ValidateColumns(columns);
+      if (fOutputIdMap.empty()) {
+         for (auto &column : columns) {
+            column.fColumnOutputId = fOutputIdMap.size();
+            fOutputIdMap[column.fColumnNameTypeAndVersion] = column.fColumnOutputId;
+         }
+      } else {
+         ValidateColumns(columns);
+      }
    }
+
+   return nNewCols;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::AddColumnsFromField(std::vector<RColumnInfo> &columns,
-                                                                      const RNTupleDescriptor &desc,
-                                                                      const RFieldDescriptor &fieldDesc,
-                                                                      const std::string &prefix)
+size_t ROOT::Experimental::Internal::RNTupleMerger::AddColumnsFromField(std::vector<RColumnInfo> &columns,
+                                                                        const RNTupleDescriptor &desc,
+                                                                        const RFieldDescriptor &fieldDesc,
+                                                                        const std::string &prefix) const
 {
+   size_t nNewCols = 0;
    for (const auto &field : desc.GetFieldIterable(fieldDesc)) {
       std::string name = prefix + field.GetFieldName() + ".";
       const std::string typeAndVersion = field.GetTypeName() + "." + std::to_string(field.GetTypeVersion());
       auto columnIter = desc.GetColumnIterable(field);
       columns.reserve(columns.size() + columnIter.count());
       for (const auto &column : columnIter) {
-         columns.emplace_back(name + std::to_string(column.GetIndex()), typeAndVersion, column.GetPhysicalId(),
-                              kInvalidDescriptorId);
+         RColumnInfo info{name + std::to_string(column.GetIndex()), typeAndVersion, column.GetPhysicalId(),
+                          kInvalidDescriptorId};
+
+         // Output columns like this:
+         //    [new_columns|old_columns]
+         // where both old and new columns preserve the original order.
+         if (fOutputIdMap.find(info.fColumnNameTypeAndVersion) != fOutputIdMap.end()) {
+            columns.emplace_back(info);
+         } else {
+            columns.insert(columns.begin() + nNewCols, info);
+            ++nNewCols;
+         }
       }
-      AddColumnsFromField(columns, desc, field, name);
+      nNewCols += AddColumnsFromField(columns, desc, field, name);
    }
+
+   return nNewCols;
+}
+
+void ROOT::Experimental::Internal::RNTupleMerger::ExtendOutputModel(RNTupleModel &model, std::span<RColumnInfo> newCols,
+                                                                    int nDstEntries,
+                                                                    const RNTupleDescriptor &descriptor,
+                                                                    RPageSink &destination) const
+{
+   assert(newCols.size() > 0); // no point in calling this with 0 new cols
+
+   model.Unfreeze();
+   Internal::RNTupleModelChangeset changeset{model};
+
+   std::string msg = "[ INFO ] destination doesn't contain column";
+   if (newCols.size() > 1)
+      msg += 's';
+   msg += ' ';
+   msg = std::accumulate(newCols.begin(), newCols.end(), msg, [](const std::string &acc, const RColumnInfo &col) {
+      return acc + ", " + col.fColumnNameTypeAndVersion;
+   });
+   std::cerr << msg << ": adding it to the destination model.\n";
+
+   changeset.fAddedFields.reserve(newCols.size());
+   for (const auto &column : newCols) {
+      const auto columnId = column.fColumnInputId;
+      const auto &columnDesc = descriptor.GetColumnDescriptor(columnId);
+      const auto &fieldId = columnDesc.GetFieldId();
+      const auto &fieldDesc = descriptor.GetFieldDescriptor(fieldId);
+      auto field = fieldDesc.CreateField(descriptor);
+      // TODO(gparolini): handle projected fields
+      changeset.fAddedFields.emplace_back(field.get());
+      changeset.fModel.AddField(std::move(field));
+   }
+   model.Freeze();
+   destination.UpdateSchema(changeset, nDstEntries);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination,
                                                         const RNTupleMergeOptions &options)
 {
-   std::vector<RColumnInfo> columns;
+   std::vector<RColumnInfo> srcColumns;
    RCluster::ColumnSet_t columnSet;
 
    if (destination.IsInitialized()) {
-      CollectColumns(destination.GetDescriptor(), columns);
+      auto nNewCols = CollectColumns(destination.GetDescriptor(), options.fMergingMode, srcColumns);
+      assert(nNewCols == srcColumns.size());
    }
 
    std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple
@@ -196,6 +266,8 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
    if (ROOT::IsImplicitMTEnabled())
       taskGroup = TTaskGroup();
 #endif
+
+   auto nDstEntries = 0;
 
    // Append the sources to the destination one-by-one
    for (const auto &source : sources) {
@@ -206,12 +278,19 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
       // Get a handle on the descriptor (metadata)
       auto descriptor = source->GetSharedDescriptorGuard();
 
-      // Collect all the columns
-      // The column name : output column id map is only built once
-      columns.clear(), columnSet.clear();
-      CollectColumns(descriptor.GetRef(), columns);
-      columnSet.reserve(columns.size());
-      for (const auto &column : columns)
+      // Collect all the srcColumns
+      size_t nNewCols = CollectColumns(descriptor.GetRef(), options.fMergingMode, srcColumns);
+
+      // If this source contains columns that weren't known so far, perform late model extension
+      // of the destination model.
+      if (options.fMergingMode == RNTupleMergingMode::kUnion && model && nNewCols > 0) {
+         std::span<RColumnInfo> newCols{srcColumns.data(), nNewCols};
+         ExtendOutputModel(*model, srcColumns, nDstEntries, descriptor.GetRef(), destination);
+      }
+
+      columnSet.clear();
+      columnSet.reserve(srcColumns.size());
+      for (const auto &column : srcColumns)
          columnSet.emplace(column.fColumnInputId);
 
       // Create sink from the input model if not initialized
@@ -245,16 +324,19 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
          std::vector<RPageStorage::RSealedPageGroup> sealedPageGroups;
          std::vector<std::unique_ptr<unsigned char[]>> sealedPageBuffers;
 
-         for (const auto &column : columns) {
+         for (const auto &column : srcColumns) {
+
+            assert(column.fColumnOutputId != (DescriptorId_t)-1);
+
+            const auto columnId = column.fColumnInputId;
+            const auto &columnDesc = descriptor->GetColumnDescriptor(columnId);
 
             // See if this cluster contains this column
-            // if not, there is nothing to read/do...
-            auto columnId = column.fColumnInputId;
+            // if not, there is nothing to read/do..
             if (!clusterDesc.ContainsColumn(columnId)) {
                continue;
             }
 
-            const auto &columnDesc = descriptor->GetColumnDescriptor(columnId);
             const auto colElement = RColumnElementBase::Generate(columnDesc.GetType());
 
             // Now get the pages for this column in this cluster
@@ -358,13 +440,14 @@ void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *>
             sealedPageGroups.emplace_back(column.fColumnOutputId, sealedPagesV.back().cbegin(),
                                           sealedPagesV.back().cend());
 
-         } // end of loop over columns
+         } // end of loop over srcColumns
 
          // Now commit all pages to the output
          destination.CommitSealedPageV(sealedPageGroups);
 
          // Commit the clusters
          destination.CommitCluster(clusterDesc.GetNEntries());
+         nDstEntries += clusterDesc.GetNEntries();
 
          // Go to the next cluster
          clusterId = descriptor->FindNextClusterId(clusterId);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -401,7 +401,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
       const bool needsCompressionChange = mergeData.fMergeOpts.fCompressionSettings != kUnknownCompressionSettings &&
                                           colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings;
 
-      if (needsCompressionChange)
+      if (needsCompressionChange && mergeData.fMergeOpts.fExtraVerbose)
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
               colRangeCompressionSettings, mergeData.fMergeOpts.fCompressionSettings);
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -1,9 +1,9 @@
 /// \file RNTupleMerger.cxx
 /// \ingroup NTuple ROOT7
-/// \author Jakob Blomer <jblomer@cern.ch>, Max Orok <maxwellorok@gmail.com>, Alaettin Serhan Mete <amete@anl.gov>
-/// \date 2020-07-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
+/// \author Jakob Blomer <jblomer@cern.ch>, Max Orok <maxwellorok@gmail.com>, Alaettin Serhan Mete <amete@anl.gov>,
+/// Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2020-07-08 \warning This is part of the ROOT 7 prototype! It will
+/// change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
@@ -25,6 +25,7 @@
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/TTaskGroup.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <TROOT.h>
 #include <TFileMergeInfo.h>
 #include <TError.h>
@@ -32,8 +33,16 @@
 #include <TKey.h>
 
 #include <deque>
+#include <algorithm>
+#include <optional>
+#include <unordered_map>
+#include <vector>
 
-Long64_t ROOT::Experimental::RNTuple::Merge(TCollection *inputs, TFileMergeInfo *mergeInfo)
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::Internal;
+
+// Entry point for TFileMerger. Internally calls RNTupleMerger::Merge().
+Long64_t RNTuple::Merge(TCollection *inputs, TFileMergeInfo *mergeInfo)
 // IMPORTANT: this function must not throw, as it is used in exception-unsafe code (TFileMerger).
 try {
    // Check the inputs
@@ -69,7 +78,7 @@ try {
       // pointer we just got.
    }
 
-   // The "fast" options is present if and only if we don't want to change compression.
+   // The "fast" option is present if and only if we don't want to change compression.
    const int compression =
       mergeInfo->fOptions.Contains("fast") ? kUnknownCompressionSettings : outFile->GetCompressionSettings();
 
@@ -77,19 +86,19 @@ try {
    writeOpts.SetUseBufferedWrite(false);
    if (compression != kUnknownCompressionSettings)
       writeOpts.SetCompression(compression);
-   auto destination = std::make_unique<Internal::RPageSinkFile>(ntupleName, *outFile, writeOpts);
+   auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
 
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
-      auto source = Internal::RPageSourceFile::CreateFromAnchor(*outNTuple);
+      auto source = RPageSourceFile::CreateFromAnchor(*outNTuple);
       source->Attach();
       auto desc = source->GetSharedDescriptorGuard();
       destination->InitFromDescriptor(desc.GetRef());
    }
 
    // The remaining entries are the input files
-   std::vector<std::unique_ptr<Internal::RPageSourceFile>> sources;
-   std::vector<Internal::RPageSource *> sourcePtrs;
+   std::vector<std::unique_ptr<RPageSourceFile>> sources;
+   std::vector<RPageSource *> sourcePtrs;
 
    while (const auto &pitr = itr()) {
       TFile *inFile = dynamic_cast<TFile *>(pitr);
@@ -99,7 +108,7 @@ try {
                inFile->GetName());
          return -1;
       }
-      sources.push_back(Internal::RPageSourceFile::CreateFromAnchor(*anchor));
+      sources.push_back(RPageSourceFile::CreateFromAnchor(*anchor));
    }
 
    // Interface conversion
@@ -109,10 +118,10 @@ try {
    }
 
    // Now merge
-   Internal::RNTupleMerger merger;
-   Internal::RNTupleMergeOptions options;
+   RNTupleMerger merger;
+   RNTupleMergeOptions options;
    options.fCompressionSettings = compression;
-   merger.Merge(sourcePtrs, *destination, options);
+   merger.Merge(sourcePtrs, *destination, options).ThrowOnError();
 
    // Provide the caller with a merged anchor object (even though we've already
    // written it).
@@ -124,341 +133,558 @@ try {
    return -1;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::ValidateColumns(std::vector<RColumnInfo> &columns) const
-{
-   // First ensure that we have the same number of columns
-   if (fOutputIdMap.size() != columns.size()) {
-      throw RException(R__FAIL("Columns between sources do NOT match"));
+struct RNTupleMerger::RChangeCompressionFunc {
+   size_t pageIdx;
+   size_t pageBufferBaseIdx;
+   size_t checksumSize;
+   int colRangeCompressionSettings;
+   DescriptorId_t outputColumnId;
+
+   const RColumnElementBase &srcColElement;
+   const RColumnElementBase &dstColElement;
+   const RClusterDescriptor::RPageRange::RPageInfo &pageInfo;
+   const RNTupleMergeOptions &options;
+
+   RPageStorage::RSealedPage &sealedPage;
+   std::vector<std::unique_ptr<unsigned char[]>> &sealedPageBuffers;
+   RPageSource &source;
+
+   void operator()() const
+   {
+      const auto uncompressedSize = srcColElement.GetSize() * sealedPage.GetNElements();
+      auto &buffer = sealedPageBuffers[pageBufferBaseIdx + pageIdx];
+      buffer = std::make_unique<unsigned char[]>(uncompressedSize + checksumSize);
+
+      auto page = source.UnsealPage(sealedPage, srcColElement, outputColumnId).Unwrap();
+      RPageSink::RSealPageConfig sealConf;
+      sealConf.fElement = &dstColElement;
+      sealConf.fPage = &page;
+      sealConf.fBuffer = buffer.get();
+      sealConf.fCompressionSetting = options.fCompressionSettings;
+      auto resealedPage = RPageSink::SealPage(sealConf);
+      sealedPage = resealedPage;
    }
-   // Then ensure that we have the same names of columns and assign the ids
-   for (auto &column : columns) {
-      try {
-         column.fColumnOutputId = fOutputIdMap.at(column.fColumnNameTypeAndVersion);
-      } catch (const std::out_of_range &) {
-         throw RException(R__FAIL("Column NOT found in the first source w/ name " + column.fColumnNameTypeAndVersion));
-      }
-   }
-}
+};
 
-////////////////////////////////////////////////////////////////////////////////
-size_t ROOT::Experimental::Internal::RNTupleMerger::CollectColumns(const RNTupleDescriptor &descriptor,
-                                                                   RNTupleMergingMode mergingMode,
-                                                                   std::vector<RColumnInfo> &columns)
+namespace {
+struct RDescriptorsComparison {
+   std::vector<const RFieldDescriptor *> fExtraDstFields, fExtraSrcFields, fCommonFields;
+};
+
+struct RColumnOutInfo {
+   DescriptorId_t fColumnId;
+   EColumnType fColumnType;
+};
+
+// { fully.qualified.fieldName.colInputId => colOutputId }
+using ColumnIdMap_t = std::unordered_map<std::string, RColumnOutInfo>;
+
+struct RColumnInfo {
+   std::string fColumnName;
+   DescriptorId_t fInputId;
+   DescriptorId_t fOutputId;
+   EColumnType fColumnType;
+   const RFieldDescriptor *fParentField;
+};
+
+struct RColumnInfoGroup {
+   std::vector<RColumnInfo> fExtraDstColumns;
+   std::vector<RColumnInfo> fCommonColumns;
+};
+} // namespace
+
+/// Compares the top level fields of `dst` and `src` and determines whether they can be merged or not.
+/// In addition, returns the differences between `dst` and `src`'s structures
+static RResult<RDescriptorsComparison>
+CompareDescriptorStructure(const RNTupleDescriptor &dst, const RNTupleDescriptor &src)
 {
-   // Here we recursively find the columns and fill the RColumnInfo vector
-   columns.clear();
-   const auto nNewCols = AddColumnsFromField(columns, descriptor, descriptor.GetFieldZero());
+   // Cases:
+   // 1. dst == src
+   // 2. dst has fields that src hasn't
+   // 3. src has fields that dst hasn't
+   // 4. dst and src have fields that differ (compatible or incompatible)
 
-   // Then we either build the internal map (first source) or validate the columns against it (remaning sources)
-   // In either case, we also assign the output ids here
+   std::vector<std::string> errors;
+   RDescriptorsComparison res;
 
-   if (mergingMode == RNTupleMergingMode::kUnion) {
-      // Assign new ids to new columns
-      for (size_t i = 0; i < nNewCols; ++i) {
-         auto &column = columns[i];
-         column.fColumnOutputId = fOutputIdMap.size();
-         assert(fOutputIdMap.find(column.fColumnNameTypeAndVersion) == fOutputIdMap.end());
-         fOutputIdMap[column.fColumnNameTypeAndVersion] = column.fColumnOutputId;
-      }
-      // Assign existing ids to old columns
-      for (size_t i = nNewCols; i < columns.size(); ++i) {
-         auto &column = columns[i];
-         auto id = fOutputIdMap.find(column.fColumnNameTypeAndVersion);
-         assert(id != fOutputIdMap.end());
-         column.fColumnOutputId = id->second;
-      }
-   } else {
-      if (fOutputIdMap.empty()) {
-         for (auto &column : columns) {
-            column.fColumnOutputId = fOutputIdMap.size();
-            fOutputIdMap[column.fColumnNameTypeAndVersion] = column.fColumnOutputId;
+   struct RCommonField {
+      const RFieldDescriptor *fDst;
+      const RFieldDescriptor *fSrc;
+   };
+   std::vector<RCommonField> commonFields;
+
+   for (const auto &dstField : dst.GetTopLevelFields()) {
+      if (const auto *srcField = src.FindFieldDescriptor(dstField.GetFieldName()))
+         commonFields.push_back({&dstField, srcField});
+      else
+         res.fExtraDstFields.emplace_back(&dstField);
+   }
+   for (const auto &srcField : src.GetTopLevelFields()) {
+      if (!dst.FindFieldDescriptor(srcField.GetFieldName()))
+         res.fExtraSrcFields.push_back(&srcField);
+   }
+
+   // Check compatibility of common fields
+   for (const auto &field : commonFields) {
+      const auto &srcFdName = field.fSrc->GetFieldName();
+
+      // Require that fields are both projected or both not projected
+      bool projCompatible = field.fSrc->IsProjectedField() == field.fDst->IsProjectedField();
+      if (!projCompatible) {
+         std::stringstream ss;
+         ss << "Field `" << srcFdName << "` is incompatible with previously-seen field with that name because the "
+            << (field.fSrc->IsProjectedField() ? "new" : "old") << " one is projected and the other isn't";
+         errors.push_back(ss.str());
+      } else if (field.fSrc->IsProjectedField()) {
+         // if both fields are projected, verify that they point to the same real field
+         const auto srcId = field.fSrc->GetProjectionSourceId();
+         const auto dstId = field.fDst->GetProjectionSourceId();
+         if (srcId != dstId) {
+            std::stringstream ss;
+            ss << "Field `" << srcFdName
+               << "` is projected to a different field than a previously-seen field with the same name (old: " << dstId
+               << ", new: " << srcId << ")";
+            errors.push_back(ss.str());
          }
-      } else {
-         ValidateColumns(columns);
+      }
+
+      // Require that fields types match
+      const auto &srcTyName = field.fSrc->GetTypeName();
+      const auto &dstTyName = field.fDst->GetTypeName();
+      if (srcTyName != dstTyName) {
+         std::stringstream ss;
+         ss << "Field `" << srcFdName
+            << "` has a type incompatible with a previously-seen field with the same name: (old: " << dstTyName
+            << ", new: " << srcTyName << ")";
+         errors.push_back(ss.str());
+      }
+
+      const auto srcTyChk = field.fSrc->GetTypeChecksum();
+      const auto dstTyChk = field.fDst->GetTypeChecksum();
+      if (srcTyChk && dstTyChk && *srcTyChk != *dstTyChk) {
+         std::stringstream ss;
+         ss << "Field `" << field.fSrc->GetFieldName()
+            << "` has a different type checksum than previously-seen field with the same name";
+         errors.push_back(ss.str());
+      }
+
+      const auto srcTyVer = field.fSrc->GetTypeVersion();
+      const auto dstTyVer = field.fDst->GetTypeVersion();
+      if (srcTyVer != dstTyVer) {
+         std::stringstream ss;
+         ss << "Field `" << field.fSrc->GetFieldName()
+            << "` has a different type version than previously-seen field with the same name (old: " << dstTyVer
+            << ", new: " << srcTyVer << ")";
+         errors.push_back(ss.str());
       }
    }
 
-   return nNewCols;
-}
+   std::string errMsg;
+   for (const auto &err : errors)
+      errMsg += std::string("\n  * ") + err;
 
-////////////////////////////////////////////////////////////////////////////////
-size_t ROOT::Experimental::Internal::RNTupleMerger::AddColumnsFromField(std::vector<RColumnInfo> &columns,
-                                                                        const RNTupleDescriptor &desc,
-                                                                        const RFieldDescriptor &fieldDesc,
-                                                                        const std::string &prefix) const
-{
-   size_t nNewCols = 0;
-   for (const auto &field : desc.GetFieldIterable(fieldDesc)) {
-      std::string name = prefix + field.GetFieldName() + ".";
-      const std::string typeAndVersion = field.GetTypeName() + "." + std::to_string(field.GetTypeVersion());
-      auto columnIter = desc.GetColumnIterable(field);
-      columns.reserve(columns.size() + columnIter.count());
-      for (const auto &column : columnIter) {
-         RColumnInfo info{name + std::to_string(column.GetIndex()), typeAndVersion, column.GetPhysicalId(),
-                          kInvalidDescriptorId};
+   if (errMsg.length())
+      return R__FAIL(errMsg);
 
-         // Output columns like this:
-         //    [new_columns|old_columns]
-         // where both old and new columns preserve the original order.
-         if (fOutputIdMap.find(info.fColumnNameTypeAndVersion) != fOutputIdMap.end()) {
-            columns.emplace_back(info);
-         } else {
-            columns.insert(columns.begin() + nNewCols, info);
-            ++nNewCols;
-         }
-      }
-      nNewCols += AddColumnsFromField(columns, desc, field, name);
+   res.fCommonFields.reserve(commonFields.size());
+   for (const auto &[_, srcField] : commonFields) {
+      res.fCommonFields.emplace_back(srcField);
    }
 
-   return nNewCols;
+   return RResult(res);
 }
 
-void ROOT::Experimental::Internal::RNTupleMerger::ExtendOutputModel(RNTupleModel &model, std::span<RColumnInfo> newCols,
-                                                                    int nDstEntries,
-                                                                    const RNTupleDescriptor &descriptor,
-                                                                    RPageSink &destination) const
+// Applies late model extension to `destination`, adding all `newFields` to it.
+static void ExtendDestinationModel(std::span<const RFieldDescriptor *> newFields, RPageSink &destination,
+                                   RNTupleModel &dstModel, NTupleSize_t nDstEntries)
 {
-   assert(newCols.size() > 0); // no point in calling this with 0 new cols
+   assert(newFields.size() > 0); // no point in calling this with 0 new cols
 
-   model.Unfreeze();
-   Internal::RNTupleModelChangeset changeset{model};
+   dstModel.Unfreeze();
+   RNTupleModelChangeset changeset{dstModel};
 
-   std::string msg = "[ INFO ] destination doesn't contain column";
-   if (newCols.size() > 1)
+   std::string msg = "destination doesn't contain field";
+   if (newFields.size() > 1)
       msg += 's';
    msg += ' ';
-   msg = std::accumulate(newCols.begin(), newCols.end(), msg, [](const std::string &acc, const RColumnInfo &col) {
-      return acc + ", " + col.fColumnNameTypeAndVersion;
+   msg += std::accumulate(newFields.begin(), newFields.end(), std::string{}, [](const auto &acc, const auto *field) {
+      return acc + (acc.length() ? ", " : "") + '`' + field->GetFieldName() + '`';
    });
-   std::cerr << msg << ": adding it to the destination model.\n";
+   Info("RNTuple::Merge", "%s: adding %s to the destination model (entry #%lu).", msg.c_str(),
+        (newFields.size() > 1 ? "them" : "it"), nDstEntries);
 
-   changeset.fAddedFields.reserve(newCols.size());
-   for (const auto &column : newCols) {
-      const auto columnId = column.fColumnInputId;
-      const auto &columnDesc = descriptor.GetColumnDescriptor(columnId);
-      const auto &fieldId = columnDesc.GetFieldId();
-      const auto &fieldDesc = descriptor.GetFieldDescriptor(fieldId);
-      auto field = fieldDesc.CreateField(descriptor);
-      // TODO(gparolini): handle projected fields
-      changeset.fAddedFields.emplace_back(field.get());
+   changeset.fAddedFields.reserve(newFields.size());
+   for (const auto *fieldDesc : newFields) {
+      auto field = fieldDesc->CreateField(destination.GetDescriptor());
+      if (fieldDesc->IsProjectedField())
+         changeset.fAddedProjectedFields.emplace_back(field.get());
+      else
+         changeset.fAddedFields.emplace_back(field.get());
       changeset.fModel.AddField(std::move(field));
    }
-   model.Freeze();
+   dstModel.Freeze();
    destination.UpdateSchema(changeset, nDstEntries);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-void ROOT::Experimental::Internal::RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination,
-                                                        const RNTupleMergeOptions &options)
+// Merges all columns appearing both in the source and destination RNTuples, just copying them if their
+// compression matches ("fast merge") or by unsealing and resealing them with the proper compression.
+static void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
+                               std::span<RColumnInfo> commonColumns, RCluster::ColumnSet_t commonColumnSet,
+                               std::optional<TTaskGroup> &taskGroup,
+                               std::deque<RPageStorage::SealedPageSequence_t> &sealedPagesV,
+                               std::vector<RPageStorage::RSealedPageGroup> &sealedPageGroups,
+                               std::vector<std::unique_ptr<unsigned char[]>> &sealedPageBuffers, RPageSource &source,
+                               const RNTupleDescriptor &srcDescriptor, const RNTupleMergeOptions &options)
 {
-   std::vector<RColumnInfo> srcColumns;
-   RCluster::ColumnSet_t columnSet;
+   assert(commonColumns.size() == commonColumnSet.size());
+   if (commonColumns.empty())
+      return;
 
-   if (destination.IsInitialized()) {
-      auto nNewCols = CollectColumns(destination.GetDescriptor(), options.fMergingMode, srcColumns);
-      assert(nNewCols == srcColumns.size());
+   const RCluster *cluster = clusterPool.GetCluster(clusterId, commonColumnSet);
+   if (!cluster)
+      return;
+
+   const auto &clusterDesc = srcDescriptor.GetClusterDescriptor(clusterId);
+
+   for (const auto &column : commonColumns) {
+      const auto &columnId = column.fInputId;
+      R__ASSERT(clusterDesc.ContainsColumn(columnId));
+
+      const auto &columnDesc = srcDescriptor.GetColumnDescriptor(columnId);
+      const auto srcColElement = RColumnElementBase::Generate(columnDesc.GetType());
+      const auto dstColElement = RColumnElementBase::Generate(column.fColumnType);
+
+      // Now get the pages for this column in this cluster
+      const auto &pages = clusterDesc.GetPageRange(columnId);
+
+      RPageStorage::SealedPageSequence_t sealedPages;
+      sealedPages.resize(pages.fPageInfos.size());
+
+      // Each column range potentially has a distinct compression settings
+      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings;
+      const bool needsCompressionChange = options.fCompressionSettings != kUnknownCompressionSettings &&
+                                          colRangeCompressionSettings != options.fCompressionSettings;
+
+      if (needsCompressionChange)
+         Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
+              colRangeCompressionSettings, options.fCompressionSettings);
+
+      // If the column range is already uncompressed we don't need to allocate any new buffer, so we don't
+      // bother reserving memory for them.
+      size_t pageBufferBaseIdx = sealedPageBuffers.size();
+      if (colRangeCompressionSettings != 0)
+         sealedPageBuffers.resize(sealedPageBuffers.size() + pages.fPageInfos.size());
+
+      // Loop over the pages
+      std::uint64_t pageIdx = 0;
+      for (const auto &pageInfo : pages.fPageInfos) {
+         assert(pageIdx < sealedPages.size());
+         assert(sealedPageBuffers.size() == 0 || pageIdx < sealedPageBuffers.size());
+
+         ROnDiskPage::Key key{columnId, pageIdx};
+         auto onDiskPage = cluster->GetOnDiskPage(key);
+
+         const auto checksumSize = pageInfo.fHasChecksum * RPageStorage::kNBytesPageChecksum;
+         RPageStorage::RSealedPage &sealedPage = sealedPages[pageIdx];
+         sealedPage.SetNElements(pageInfo.fNElements);
+         sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
+         sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage + checksumSize);
+         sealedPage.SetBuffer(onDiskPage->GetAddress());
+         // TODO(gparolini): more graceful error handling (skip the page?)
+         sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
+         R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
+
+         if (needsCompressionChange) {
+            RNTupleMerger::RChangeCompressionFunc compressTask{
+               pageIdx,          pageBufferBaseIdx, checksumSize,      colRangeCompressionSettings,
+               column.fOutputId, *srcColElement,    *dstColElement,    pageInfo,
+               options,          sealedPage,        sealedPageBuffers, source};
+
+            if (taskGroup)
+               taskGroup->Run(compressTask);
+            else
+               compressTask();
+         }
+
+         ++pageIdx;
+
+      } // end of loop over pages
+
+      if (taskGroup)
+         taskGroup->Wait();
+
+      sealedPagesV.push_back(std::move(sealedPages));
+      sealedPageGroups.emplace_back(column.fOutputId, sealedPagesV.back().cbegin(), sealedPagesV.back().cend());
+   } // end loop over common columns
+}
+
+// Generates default values for columns that are not present in the current source RNTuple
+// but are present in the destination's schema.
+static void GenerateExtraDstColumns(size_t nClusterEntries, std::span<RColumnInfo> extraDstColumns,
+                                    std::deque<RPageStorage::SealedPageSequence_t> &sealedPagesV,
+                                    std::vector<RPageStorage::RSealedPageGroup> &sealedPageGroups,
+                                    std::vector<std::unique_ptr<unsigned char[]>> &sealedPageBuffers,
+                                    const RNTupleDescriptor &srcDescriptor, const RNTupleDescriptor &dstDescriptor)
+{
+   for (const auto &column : extraDstColumns) {
+      const auto &columnId = column.fInputId;
+      const auto &columnDesc = dstDescriptor.GetColumnDescriptor(columnId);
+
+      // Check if this column is a child of a Collection or a Variant. If so, it has no data
+      // and can be skipped.
+      const RFieldDescriptor *field = column.fParentField;
+      bool skipColumn = false;
+      for (auto parentId = field->GetParentId(); parentId != kInvalidDescriptorId;) {
+         const RFieldDescriptor &parent = srcDescriptor.GetFieldDescriptor(parentId);
+         if (parent.GetStructure() == ENTupleStructure::kCollection ||
+             parent.GetStructure() == ENTupleStructure::kVariant) {
+            skipColumn = true;
+            break;
+         }
+         parentId = parent.GetParentId();
+      }
+      if (skipColumn)
+         continue;
+
+      const auto structure = field->GetStructure();
+
+      // TODO: what about the other types?
+      R__ASSERT(structure == ENTupleStructure::kCollection || structure == ENTupleStructure::kVariant ||
+                structure == ENTupleStructure::kLeaf);
+
+      const auto colElement = RColumnElementBase::Generate(columnDesc.GetType());
+      const auto nRepetitions =
+         (structure == ENTupleStructure::kCollection || field->GetNRepetitions() > 0) ? field->GetNRepetitions() : 1;
+      const auto nElements = nClusterEntries * nRepetitions;
+      const auto bytesOnStorage = colElement->GetPackedSize(nElements);
+      constexpr auto kPageSizeLimit = 64 * 1024; // TODO: make this an option
+      // TODO: consider coalescing the last page if its size is less than some threshold
+      const size_t nPages = bytesOnStorage / kPageSizeLimit + !!(bytesOnStorage % kPageSizeLimit);
+      for (size_t i = 0; i < nPages; ++i) {
+         const auto pageSize = (i < nPages - 1) ? kPageSizeLimit : bytesOnStorage - kPageSizeLimit * (nPages - 1);
+         auto &buffer = sealedPageBuffers.emplace_back(new unsigned char[pageSize]);
+
+         RPageStorage::RSealedPage sealedPage;
+         sealedPage.SetHasChecksum(false); // XXX: probably need an option to choose this
+         sealedPage.SetNElements(nElements);
+         sealedPage.SetBufferSize(pageSize);
+         sealedPage.SetBuffer(buffer.get());
+
+         memset(buffer.get(), 0, pageSize);
+
+         sealedPagesV.push_back({sealedPage});
+      }
+
+      sealedPageGroups.emplace_back(column.fOutputId, sealedPagesV.back().cbegin(), sealedPagesV.back().cend());
+   }
+}
+
+// Iterates over all clusters of `source` and merges their pages into `destination`.
+// It is assumed that all columns in `commonColumns` are present (and compatible) in both the source and
+// the destination's schemas.
+// The pages may be "fast-merged" (i.e. simply copied with no decompression/recompression) if the target
+// compression is unspecified or matches the original compression settings.
+static void MergeSourceClusters(RPageSink &destination, RPageSource &source, NTupleSize_t &nDstEntries,
+                                const RNTupleDescriptor &srcDescriptor, std::span<RColumnInfo> commonColumns,
+                                std::span<RColumnInfo> extraDstColumns, std::optional<TTaskGroup> &taskGroup,
+                                const RNTupleMergeOptions &options)
+{
+   RClusterPool clusterPool{source};
+
+   // Convert columns to a ColumnSet for the ClusterPool query
+   RCluster::ColumnSet_t commonColumnSet;
+   commonColumnSet.reserve(commonColumns.size());
+   for (const auto &column : commonColumns)
+      commonColumnSet.emplace(column.fInputId);
+
+   RCluster::ColumnSet_t extraDstColumnSet;
+   extraDstColumnSet.reserve(extraDstColumns.size());
+   for (const auto &column : extraDstColumns)
+      extraDstColumnSet.emplace(column.fInputId);
+
+   // Loop over all clusters in this file.
+   // descriptor->GetClusterIterable() doesn't guarantee any specific order, so we explicitly
+   // request the first cluster.
+   DescriptorId_t clusterId = srcDescriptor.FindClusterId(0, 0);
+   while (clusterId != kInvalidDescriptorId) {
+      const auto &clusterDesc = srcDescriptor.GetClusterDescriptor(clusterId);
+      const auto nClusterEntries = clusterDesc.GetNEntries();
+      if (nClusterEntries == 0)
+         continue;
+
+      // We use a std::deque so that references to the contained SealedPageSequence_t, and its iterators, are
+      // never invalidated.
+      std::deque<RPageStorage::SealedPageSequence_t> sealedPagesV;
+      std::vector<RPageStorage::RSealedPageGroup> sealedPageGroups;
+      std::vector<std::unique_ptr<unsigned char[]>> sealedPageBuffers;
+
+      if (!commonColumnSet.empty()) {
+         MergeCommonColumns(clusterPool, clusterId, commonColumns, commonColumnSet, taskGroup, sealedPagesV,
+                            sealedPageGroups, sealedPageBuffers, source, srcDescriptor, options);
+      }
+
+      if (!extraDstColumnSet.empty()) {
+         GenerateExtraDstColumns(nClusterEntries, extraDstColumns, sealedPagesV, sealedPageGroups, sealedPageBuffers,
+                                 srcDescriptor, destination.GetDescriptor());
+      }
+
+      // Commit the pages and the clusters
+      destination.CommitSealedPageV(sealedPageGroups);
+      destination.CommitCluster(nClusterEntries);
+      nDstEntries += nClusterEntries;
+
+      // Go to the next cluster
+      clusterId = srcDescriptor.FindNextClusterId(clusterId);
    }
 
+   // TODO(gparolini): when we get serious about huge file support (>~ 100GB) we might want to check here
+   // the size of the running page list and commit a cluster group when it exceeds some threshold,
+   // which would prevent the page list from getting too large.
+   // However, as of today, we aren't really handling such huge files, and even relatively big ones
+   // such as the CMS dataset have a page list size of about only 2 MB.
+   // So currently we simply merge all cluster groups into one.
+}
+
+// Given a field, fill `columns` and `colIdMap` with information about all columns belonging to it and its subfields.
+// `colIdMap` is used to map matching columns from different sources to the same output column in the destination.
+// We match columns by their "fully qualified name", which is the concatenation of their ancestor fields' names
+// and the column index.
+// By this point, since we called `CompareDescriptorStructures()` earlier, we should be guaranteed that two matching
+// columns will have at least compatible representations.
+static void AddColumnsFromField(std::vector<RColumnInfo> &columns, ColumnIdMap_t &colIdMap,
+                                const RNTupleDescriptor &srcDesc, const RNTupleDescriptor &dstDesc,
+                                const RFieldDescriptor &fieldDesc, const std::string &prefix = "")
+{
+   std::string name = prefix + '.' + fieldDesc.GetFieldName();
+
+   const auto &columnIds = fieldDesc.GetLogicalColumnIds();
+   columns.reserve(columns.size() + columnIds.size());
+   for (const auto &columnId : columnIds) {
+      const auto &srcColumn = srcDesc.GetColumnDescriptor(columnId);
+      RColumnInfo info;
+      info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex());
+      info.fInputId = columnId;
+      info.fParentField = &fieldDesc;
+
+      if (auto it = colIdMap.find(info.fColumnName); it != colIdMap.end()) {
+         info.fOutputId = it->second.fColumnId;
+         info.fColumnType = it->second.fColumnType;
+      } else {
+         info.fOutputId = colIdMap.size();
+         // NOTE(gparolini): map the type of src column to the type of dst column.
+         // This mapping is only relevant for common columns and it's done to ensure we keep a consistent
+         // on-disk representation of the same column.
+         // This is also important to do for first source when it is used to generate the destination sink,
+         // because even in that case their column representations may differ.
+         // e.g. if the destination has a different compression than the source, an integer column might be
+         // zigzag-encoded in the source but not in the destination.
+         const auto &dstColumn = (&dstDesc == &srcDesc) ? srcColumn : dstDesc.GetColumnDescriptor(columnId);
+         info.fColumnType = dstColumn.GetType();
+         colIdMap[info.fColumnName] = {info.fOutputId, info.fColumnType};
+      }
+      columns.emplace_back(info);
+   }
+
+   for (const auto &field : srcDesc.GetFieldIterable(fieldDesc))
+      AddColumnsFromField(columns, colIdMap, srcDesc, dstDesc, field, name);
+}
+
+// Converts the fields comparison data to the corresponding column information.
+// While doing so, it collects such information in `colIdMap`, which is used by later calls to this function
+// to map already-seen column names to their chosen outputId, type and so on.
+static RColumnInfoGroup GatherColumnInfos(const RDescriptorsComparison &descCmp, const RNTupleDescriptor &dstDesc,
+                                          const RNTupleDescriptor &srcDesc, ColumnIdMap_t &colIdMap)
+{
+   RColumnInfoGroup res;
+   for (const RFieldDescriptor *field : descCmp.fExtraDstFields) {
+      AddColumnsFromField(res.fExtraDstColumns, colIdMap, dstDesc, dstDesc, *field);
+   }
+   for (const auto *field : descCmp.fCommonFields) {
+      AddColumnsFromField(res.fCommonColumns, colIdMap, srcDesc, dstDesc, *field);
+   }
+   return res;
+}
+
+RResult<void>
+RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination, const RNTupleMergeOptions &options) const
+{
+   auto &dstDescriptor = destination.GetDescriptor();
+
    std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple
+   NTupleSize_t nDstEntries = 0;
+   std::vector<RColumnInfo> columns;
+   ColumnIdMap_t columnIdMap;
    std::optional<TTaskGroup> taskGroup;
 #ifdef R__USE_IMT
    if (ROOT::IsImplicitMTEnabled())
       taskGroup = TTaskGroup();
 #endif
 
-   auto nDstEntries = 0;
+#define SKIP_OR_ABORT(errMsg)                                                        \
+   do {                                                                              \
+      if (options.fErrBehavior == ENTupleMergeErrBehavior::kSkip) {                  \
+         Warning("RNTuple::Merge", "Skipping RNTuple due to: %s", (errMsg).c_str()); \
+         continue;                                                                   \
+      } else {                                                                       \
+         return R__FAIL(errMsg);                                                     \
+      }                                                                              \
+   } while (0)
 
-   // Append the sources to the destination one-by-one
-   for (const auto &source : sources) {
+   // Merge main loop
+   for (RPageSource *source : sources) {
       source->Attach();
-
-      RClusterPool clusterPool{*source};
-
-      // Get a handle on the descriptor (metadata)
-      auto descriptor = source->GetSharedDescriptorGuard();
-
-      // Collect all the srcColumns
-      size_t nNewCols = CollectColumns(descriptor.GetRef(), options.fMergingMode, srcColumns);
-
-      // If this source contains columns that weren't known so far, perform late model extension
-      // of the destination model.
-      if (options.fMergingMode == RNTupleMergingMode::kUnion && model && nNewCols > 0) {
-         std::span<RColumnInfo> newCols{srcColumns.data(), nNewCols};
-         ExtendOutputModel(*model, srcColumns, nDstEntries, descriptor.GetRef(), destination);
-      }
-
-      columnSet.clear();
-      columnSet.reserve(srcColumns.size());
-      for (const auto &column : srcColumns)
-         columnSet.emplace(column.fColumnInputId);
+      auto srcDescriptor = source->GetSharedDescriptorGuard();
 
       // Create sink from the input model if not initialized
       if (!destination.IsInitialized()) {
-         model = descriptor->CreateModel();
-         destination.Init(*model.get());
+         model = srcDescriptor->CreateModel();
+         destination.Init(*model);
       }
 
-      for (const auto &extraTypeInfoDesc : descriptor->GetExtraTypeInfoIterable()) {
+      for (const auto &extraTypeInfoDesc : srcDescriptor->GetExtraTypeInfoIterable())
          destination.UpdateExtraTypeInfo(extraTypeInfoDesc);
+
+      auto descCmpRes = CompareDescriptorStructure(dstDescriptor, srcDescriptor.GetRef());
+      if (!descCmpRes) {
+         SKIP_OR_ABORT(
+            std::string("Source RNTuple will be skipped due to incompatible schema with the destination:\n") +
+            descCmpRes.GetError()->GetReport());
+      }
+      auto descCmp = descCmpRes.Unwrap();
+
+      if (options.fMergingMode == ENTupleMergingMode::kFilter && !descCmp.fExtraDstFields.empty()) {
+         std::string msg = "Source RNTuple is missing the following fields:";
+         for (const auto *field : descCmp.fExtraDstFields) {
+            msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
+         }
+         SKIP_OR_ABORT(msg);
       }
 
-      // Make sure the source contains events to be merged
-      if (source->GetNEntries() == 0) {
-         continue;
-      }
-
-      // Now loop over all clusters in this file
-      // descriptor->GetClusterIterable() doesn't guarantee any specific order...
-      // Find the first cluster id and iterate from there...
-      auto clusterId = descriptor->FindClusterId(0, 0);
-
-      while (clusterId != ROOT::Experimental::kInvalidDescriptorId) {
-         auto *cluster = clusterPool.GetCluster(clusterId, columnSet);
-         assert(cluster);
-         const auto &clusterDesc = descriptor->GetClusterDescriptor(clusterId);
-
-         // We use a std::deque so that references to the contained SealedPageSequence_t, and its iterators, are never
-         // invalidated.
-         std::deque<RPageStorage::SealedPageSequence_t> sealedPagesV;
-         std::vector<RPageStorage::RSealedPageGroup> sealedPageGroups;
-         std::vector<std::unique_ptr<unsigned char[]>> sealedPageBuffers;
-
-         for (const auto &column : srcColumns) {
-
-            assert(column.fColumnOutputId != (DescriptorId_t)-1);
-
-            const auto columnId = column.fColumnInputId;
-            const auto &columnDesc = descriptor->GetColumnDescriptor(columnId);
-
-            // See if this cluster contains this column
-            // if not, there is nothing to read/do..
-            if (!clusterDesc.ContainsColumn(columnId)) {
-               continue;
+      // handle extra src fields
+      if (descCmp.fExtraSrcFields.size()) {
+         if (options.fMergingMode == ENTupleMergingMode::kUnion) {
+            // late model extension for all fExtraSrcFields in Union mode
+            ExtendDestinationModel(descCmp.fExtraSrcFields, destination, *model, nDstEntries);
+            descCmp.fCommonFields.insert(descCmp.fCommonFields.end(), descCmp.fExtraSrcFields.begin(),
+                                         descCmp.fExtraSrcFields.end());
+         } else if (options.fMergingMode == ENTupleMergingMode::kStrict) {
+            std::string msg = "Source RNTuple has extra fields that the destination RNTuple doesn't have:";
+            for (const auto *field : descCmp.fExtraSrcFields) {
+               msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }
+            SKIP_OR_ABORT(msg);
+         }
+      }
 
-            const auto colElement = RColumnElementBase::Generate(columnDesc.GetType());
-
-            // Now get the pages for this column in this cluster
-            const auto &pages = clusterDesc.GetPageRange(columnId);
-
-            RPageStorage::SealedPageSequence_t sealedPages;
-            sealedPages.resize(pages.fPageInfos.size());
-
-            // Each column range potentially has a distinct compression settings
-            const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings;
-            const bool needsCompressionChange = options.fCompressionSettings != kUnknownCompressionSettings &&
-                                                colRangeCompressionSettings != options.fCompressionSettings;
-
-            // If the column range is already uncompressed we don't need to allocate any new buffer, so we don't
-            // bother reserving memory for them.
-            size_t pageBufferBaseIdx = sealedPageBuffers.size();
-            if (colRangeCompressionSettings != 0)
-               sealedPageBuffers.resize(sealedPageBuffers.size() + pages.fPageInfos.size());
-
-            std::uint64_t pageIdx = 0;
-
-            // Loop over the pages
-            for (const auto &pageInfo : pages.fPageInfos) {
-               assert(pageIdx < sealedPages.size());
-               assert(sealedPageBuffers.size() == 0 || pageIdx < sealedPageBuffers.size());
-
-               ROnDiskPage::Key key{columnId, pageIdx};
-               auto onDiskPage = cluster->GetOnDiskPage(key);
-
-               const auto checksumSize = pageInfo.fHasChecksum * RPageStorage::kNBytesPageChecksum;
-               RPageStorage::RSealedPage &sealedPage = sealedPages[pageIdx];
-               sealedPage.SetNElements(pageInfo.fNElements);
-               sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
-               sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage + checksumSize);
-               sealedPage.SetBuffer(onDiskPage->GetAddress());
-               sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
-               R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
-
-               // Change compression if needed
-               if (needsCompressionChange) {
-                  auto taskFunc = [ // values in
-                                     pageIdx, colRangeCompressionSettings, pageBufferBaseIdx, checksumSize,
-                                     // const refs in
-                                     &colElement, &pageInfo, &options,
-                                     // refs in-out
-                                     &sealedPage, &sealedPageBuffers]() {
-                     // Step 1: prepare the source data.
-                     // Unzip the source buffer into the zip staging buffer. This is a memcpy if the source was
-                     // already uncompressed.
-                     // Note that the checksum, if present, is not zipped, so we only need to unzip
-                     // `sealedPage.GetDataSize()` bytes.
-                     const auto uncompressedSize = colElement->GetSize() * sealedPage.GetNElements();
-                     auto zipBuffer = std::make_unique<unsigned char[]>(uncompressedSize);
-                     RNTupleDecompressor::Unzip(sealedPage.GetBuffer(), sealedPage.GetDataSize(), uncompressedSize,
-                                                zipBuffer.get());
-
-                     // Step 2: prepare the destination buffer.
-                     if (uncompressedSize != sealedPage.GetDataSize()) {
-                        // source page is compressed
-                        R__ASSERT(colRangeCompressionSettings != 0);
-
-                        // We need to reallocate sealedPage's buffer because we are going to recompress the data
-                        // with a different algorithm/level. Since we don't know a priori how big that'll be, the
-                        // only safe bet is to allocate a buffer big enough to hold as many bytes as the uncompressed
-                        // data.
-                        R__ASSERT(sealedPage.GetDataSize() < uncompressedSize);
-                        auto &newBuf = sealedPageBuffers[pageBufferBaseIdx + pageIdx];
-                        newBuf = std::make_unique<unsigned char[]>(uncompressedSize + checksumSize);
-                        sealedPage.SetBuffer(newBuf.get());
-                     } else {
-                        // source page is uncompressed. We can reuse the sealedPage's buffer since it's big
-                        // enough.
-                        // Note that this does not necessarily mean that the column range's compressionSettings are 0,
-                        // as a page might have been stored uncompressed because it was not compressible with its
-                        // advertised compression settings.
-                     }
-
-                     const auto newNBytes =
-                        RNTupleCompressor::Zip(zipBuffer.get(), uncompressedSize, options.fCompressionSettings,
-                                               const_cast<void *>(sealedPage.GetBuffer()));
-                     sealedPage.SetBufferSize(newNBytes + checksumSize);
-                     if (pageInfo.fHasChecksum) {
-                        // Calculate new checksum (this must happen after setting the new buffer size!)
-                        sealedPage.ChecksumIfEnabled();
-                     }
-                  };
-
-                  if (taskGroup)
-                     taskGroup->Run(taskFunc);
-                  else
-                     taskFunc();
-               }
-
-               ++pageIdx;
-
-            } // end of loop over pages
-
-            if (taskGroup)
-               taskGroup->Wait();
-            sealedPagesV.push_back(std::move(sealedPages));
-            sealedPageGroups.emplace_back(column.fColumnOutputId, sealedPagesV.back().cbegin(),
-                                          sealedPagesV.back().cend());
-
-         } // end of loop over srcColumns
-
-         // Now commit all pages to the output
-         destination.CommitSealedPageV(sealedPageGroups);
-
-         // Commit the clusters
-         destination.CommitCluster(clusterDesc.GetNEntries());
-         nDstEntries += clusterDesc.GetNEntries();
-
-         // Go to the next cluster
-         clusterId = descriptor->FindNextClusterId(clusterId);
-
-      } // end of loop over clusters
-
-      // Commit all clusters for this input
-      destination.CommitClusterGroup();
-
-   } // end of loop over sources
+      // handle extra dst fields & common fields
+      auto columnInfos = GatherColumnInfos(descCmp, dstDescriptor, srcDescriptor.GetRef(), columnIdMap);
+      MergeSourceClusters(destination, *source, nDstEntries, srcDescriptor.GetRef(), columnInfos.fCommonColumns,
+                          columnInfos.fExtraDstColumns, taskGroup, options);
+   } // end loop over sources
 
    // Commit the output
+   destination.CommitClusterGroup();
    destination.CommitDataset();
+
+   return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -146,7 +146,7 @@ TEST(RNTupleMerger, MergeSymmetric)
       }
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
-         opts.fMergingMode = ENTupleMergingMode::kFilter;
+         opts.fMergingMode = ENTupleMergingMode::kStrict;
          auto res = merger.Merge(sourcePtrs, *destination, opts);
          EXPECT_TRUE(bool(res));
       }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -116,6 +116,7 @@ TEST(RNTupleMerger, MergeSymmetric)
 
    // Now merge the inputs
    FileRaii fileGuard3("test_ntuple_merge_out.root");
+   fileGuard3.PreserveFile();
    {
       // Gather the input sources
       std::vector<std::unique_ptr<RPageSource>> sources;
@@ -328,11 +329,14 @@ TEST(RNTupleMerger, MergeVector)
    // Write two test ntuples to be merged
    // These files are practically identical except that filed indices are interchanged
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
+   fileGuard1.PreserveFile();
    {
       auto model = RNTupleModel::Create();
       auto fieldFoo = model->MakeField<std::vector<int>>("foo");
       auto fieldBar = model->MakeField<std::vector<int>>("bar");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath(), opts);
       for (size_t i = 0; i < 10; ++i) {
          fieldFoo->clear();
          fieldBar->clear();
@@ -344,11 +348,14 @@ TEST(RNTupleMerger, MergeVector)
    }
 
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
+   fileGuard2.PreserveFile();
    {
       auto model = RNTupleModel::Create();
       auto fieldBar = model->MakeField<std::vector<int>>("bar");
       auto fieldFoo = model->MakeField<std::vector<int>>("foo");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath(), opts);
       for (size_t i = 0; i < 10; ++i) {
          fieldFoo->clear();
          fieldBar->clear();
@@ -361,6 +368,7 @@ TEST(RNTupleMerger, MergeVector)
 
    // Now merge the inputs
    FileRaii fileGuard3("test_ntuple_merge_out.root");
+   fileGuard3.PreserveFile();
    {
       // Gather the input sources
       std::vector<std::unique_ptr<RPageSource>> sources;
@@ -372,7 +380,9 @@ TEST(RNTupleMerger, MergeVector)
       }
 
       // Create the output
-      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), opts);
 
       // Now Merge the inputs
       RNTupleMerger merger;

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -95,6 +95,7 @@ using RNTupleWriteOptionsDaos = ROOT::Experimental::RNTupleWriteOptionsDaos;
 using RNTupleMetrics = ROOT::Experimental::Detail::RNTupleMetrics;
 using RNTupleMerger = ROOT::Experimental::Internal::RNTupleMerger;
 using RNTupleMergeOptions = ROOT::Experimental::Internal::RNTupleMergeOptions;
+using ENTupleMergingMode = ROOT::Experimental::Internal::ENTupleMergingMode;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTuplePlainCounter = ROOT::Experimental::Detail::RNTuplePlainCounter;
 using RNTuplePlainTimer = ROOT::Experimental::Detail::RNTuplePlainTimer;


### PR DESCRIPTION
# This Pull request:
refactors RNTupleMerger to properly support late model extension.
The "Union"  merging mode is added, allowing the merger to late-model-extend the destination to include all the fields of the input ntuples (instead of ignoring unknown fields / complaining when models don't match).
Likewise, the "Strict" merging mode is added that checks that all inputs have the exact same structure.
By default, the old behavior (named "Filter") is used.

To better compare the RNTuples structures, the merging logic is now more properly considering the fields of each input, rather than just the columns as it was previously. This also allows for more descriptive messages to the user if some mismatch is found.

NOTE: the `RNTupleMerger::Merge` function now returns a RResult instead of throwing exceptions on error.

## TODO
- the new merging modes should be exposed to hadd

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
