### PR TITLE
[hadd] properly change compression when levels are the same

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -175,7 +175,8 @@ Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
          Error("AddFile", "cannot open file %s", url);
       return kFALSE;
    } else {
-      if (fOutputFile && fOutputFile->GetCompressionLevel() != newfile->GetCompressionLevel()) fCompressionChange = kTRUE;
+      if (fOutputFile && fOutputFile->GetCompressionSettings() != newfile->GetCompressionSettings())
+         fCompressionChange = kTRUE;
 
       newfile->SetBit(kCanDelete);
       fFileList.Add(newfile);

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -483,7 +483,7 @@ int main( int argc, char **argv )
       } else {
          if (!keepCompressionAsIs && merger.HasCompressionChange()) {
             // Don't warn if the user any request re-optimization.
-            std::cout << "hadd Sources and Target have different compression levels" << std::endl;
+            std::cout << "hadd Sources and Target have different compression settings\n";
             std::cout << "hadd merging will be slower" << std::endl;
          }
       }

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -482,7 +482,7 @@ int main( int argc, char **argv )
          merger.SetFastMethod(kFALSE);
       } else {
          if (!keepCompressionAsIs && merger.HasCompressionChange()) {
-            // Don't warn if the user any request re-optimization.
+            // Don't warn if the user explicitly requested re-optimization.
             std::cout << "hadd Sources and Target have different compression settings\n";
             std::cout << "hadd merging will be slower" << std::endl;
          }


### PR DESCRIPTION
Currently hadd is only checking the compression levels to determine whether fast merging should be used or not. This is wrong, as it will incorrectly skip compression change when a file is changed from e.g. 101 to 201. With this commit, hadd (actually, TFileMerger) will check for equality of compression settings instead.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #11245 

