### PR TITLE
Update bindings/jupyroot/README.md

### DIFF
--- a/bindings/jupyroot/README.md
+++ b/bindings/jupyroot/README.md
@@ -3,26 +3,20 @@ A software layer to integrate Jupyter notebooks and ROOT.
 
 ## Installation
 1. [Install ROOT6](https://root.cern.ch/building-root) (> 6.05)
-2. Install dependencies: pip install jupyter metakernel
+2. Install dependencies: `pip install jupyter metakernel`
 
 ## Start using ROOTbooks
 Set up the ROOT environment (`. $ROOTSYS/bin/thisroot.[c]sh`) and type in your
 shell:
-```
+```shell
 root --notebook
 ```
 This will start a ROOT-flavoured notebook server in your computer.
 
 Alternatively, if you would like to use the Jupyter command directly, you
-can do on Linux:
-```
-cp -r $ROOTSYS/etc/notebook/kernels/root ~/.local/share/jupyter/kernels
-jupyter notebook
-```
-and on OSx:
-```
-cp -r $ROOTSYS/etc/notebook/kernels/root /Users/$USER/Library/Jupyter/kernels/
-jupyter notebook
+can do:
+```shell
+jupyter kernelspec install $ROOTSYS/etc/root/notebook/kernels/root --user
 ```
 
 Once the server is up, you can use ROOT with two kernels:


### PR DESCRIPTION

# This Pull request:

## Changes or fixes:
README fixes.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes kernel installation description to use `jupyter kernelspec install` instead of `cp` because `cp -r` didn't work for me and it is appropriate for kernel to be installed using `jupyter kernelspec install` command. 
