### PR TITLE
[df] Cleanup execution artifacts from worker caches in Dask

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -314,3 +314,10 @@ class BaseBackend(ABC):
         Distributed backends have to take care of creating an RDataFrame object
         that can run distributedly.
         """
+
+    def cleanup_cache(self, _: ExecutionIdentifier) -> None:
+        """
+        Remove the artifacts of the computation graph identified by the input
+        argument.
+        """
+        pass

--- a/bindings/experimental/distrdf/python/DistRDF/ComputationGraphGenerator.py
+++ b/bindings/experimental/distrdf/python/DistRDF/ComputationGraphGenerator.py
@@ -217,23 +217,20 @@ def trigger_computation_graph(
     """
     if exec_id not in _ACTIONS_REGISTER or exec_id.rdf_uuid == "RNTuple":
         # Fill the cache with the future results
-        actions = generate_computation_graph(graph, starting_node, range_id)
-        _ACTIONS_REGISTER[exec_id] = actions
+        _ACTIONS_REGISTER[exec_id] = generate_computation_graph(graph, starting_node, range_id)
     else:
         # Create clones according to different types of actions
-        actions = [
+        _ACTIONS_REGISTER[exec_id] = [
             Utils.clone_action(action, range_id)
             for action in _ACTIONS_REGISTER[exec_id]
         ]
 
-    # Trigger computation graph with the GIL released
-    rnode = ROOT.RDF.AsRNode(starting_node)
     ROOT.Internal.RDF.TriggerRun.__release_gil__ = True
-    ROOT.Internal.RDF.TriggerRun(rnode)
+    ROOT.Internal.RDF.TriggerRun(ROOT.RDF.AsRNode(starting_node))
 
     # Return a list of objects that can be later merged. In most cases this
     # is still made of RResultPtrs that will then be used as input arguments
     # to `ROOT::RDF::Detail::GetMergeableValue`. For `AsNumpy`, it returns
     # an instance of `AsNumpyResult`. For `Snapshot`, it returns a
     # `SnapshotResult`
-    return actions
+    return _ACTIONS_REGISTER[exec_id]

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -386,15 +386,13 @@ class EmptySourceHeadNode(HeadNode):
             Builds an RDataFrame instance for a distributed mapper.
             """
             if current_range.exec_id not in _graph_cache._RDF_REGISTER:
-                rdf_toprocess = ROOT.RDataFrame(nentries)
-                _graph_cache._RDF_REGISTER[current_range.exec_id] = rdf_toprocess
-            else:
-                rdf_toprocess = _graph_cache._RDF_REGISTER[current_range.exec_id]
+                _graph_cache._RDF_REGISTER[current_range.exec_id] = ROOT.RDataFrame(nentries)
 
             ROOT.Internal.RDF.ChangeEmptyEntryRange(
-                ROOT.RDF.AsRNode(rdf_toprocess), (current_range.start, current_range.end))
+                ROOT.RDF.AsRNode(_graph_cache._RDF_REGISTER[current_range.exec_id]),
+                (current_range.start, current_range.end))
 
-            return TaskObjects(rdf_toprocess, None)
+            return TaskObjects(_graph_cache._RDF_REGISTER[current_range.exec_id], None)
 
         return build_rdf_from_range
 
@@ -581,16 +579,15 @@ class TreeHeadNode(HeadNode):
             attach_friend_info_if_present(clustered_range, ds)
 
             if current_range.exec_id not in _graph_cache._RDF_REGISTER:
-                rdf_toprocess = ROOT.RDataFrame(ds)
                 # Fill the cache with the new RDataFrame
-                _graph_cache._RDF_REGISTER[current_range.exec_id] = rdf_toprocess
+                _graph_cache._RDF_REGISTER[current_range.exec_id] = ROOT.RDataFrame(ds)
             else:
-                # Retrieve an already present RDataFrame from the cache
-                rdf_toprocess = _graph_cache._RDF_REGISTER[current_range.exec_id]
                 # Update it to the range of entries for this task
-                ROOT.Internal.RDF.ChangeSpec(ROOT.RDF.AsRNode(rdf_toprocess), ROOT.std.move(ds))
+                ROOT.Internal.RDF.ChangeSpec(
+                    ROOT.RDF.AsRNode(_graph_cache._RDF_REGISTER[current_range.exec_id]),
+                    ROOT.std.move(ds))
 
-            return TaskObjects(rdf_toprocess, entries_in_trees)
+            return TaskObjects(_graph_cache._RDF_REGISTER[current_range.exec_id], entries_in_trees)
 
         return build_rdf_from_range
 
@@ -770,17 +767,15 @@ class RDatasetSpecHeadNode(HeadNode):
             attach_friend_info_if_present(clustered_range, ds)
 
             if current_range.exec_id not in _graph_cache._RDF_REGISTER:
-                rdf_toprocess = ROOT.RDataFrame(ds)
                 # Fill the cache with the new RDataFrame
-                _graph_cache._RDF_REGISTER[current_range.exec_id] = rdf_toprocess
+                _graph_cache._RDF_REGISTER[current_range.exec_id] = ROOT.RDataFrame(ds)
             else:
-                # Retrieve an already present RDataFrame from the cache
-                rdf_toprocess = _graph_cache._RDF_REGISTER[current_range.exec_id]
                 # Update it to the range of entries for this task
                 ROOT.Internal.RDF.ChangeSpec(
-                    ROOT.RDF.AsRNode(rdf_toprocess), ROOT.std.move(ds))
+                    ROOT.RDF.AsRNode( _graph_cache._RDF_REGISTER[current_range.exec_id]),
+                    ROOT.std.move(ds))
 
-            return TaskObjects(rdf_toprocess, entries_in_trees)
+            return TaskObjects(_graph_cache._RDF_REGISTER[current_range.exec_id], entries_in_trees)
 
         return build_rdf_from_range
 
@@ -873,8 +868,7 @@ class RNTupleHeadNode(HeadNode):
             if not filenames:
                 return TaskObjects(None, None)
 
-            rdf_toprocess = ROOT.RDF.Experimental.FromRNTuple(ntuplename, filenames)
-            return TaskObjects(rdf_toprocess, None)
+            return TaskObjects(ROOT.RDF.Experimental.FromRNTuple(ntuplename, filenames), None)
 
         return build_rdf_from_range
 

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -182,6 +182,28 @@ class HeadNode(Node, ABC):
     def _handle_returned_values(self, values: TaskResult) -> Iterable:
         pass
 
+    def _execute_and_retrieve_results(self, mapper, local_nodes) -> TaskResult:
+        if self.drawables_dict is not None:
+            # Prepare a dictionary with additional information for live visualization
+            drawables_info_dict = {
+                # Key: node_id
+                node.node_id: (
+                    # Tuple containing:
+                    # 1. Callback functions passed by the user
+                    self.drawables_dict[node.node_id],
+                    # 2. Index of the node in the local_nodes list
+                    i,
+                    # 3. Name of the operation associated with the node
+                    node.operation.name
+                )
+                for i, node in enumerate(local_nodes)
+                # Filter: Only include nodes requested by the user
+                if node.node_id in self.drawables_dict
+            }
+            return self.backend.ProcessAndMergeLive(self._build_ranges(), mapper, distrdf_reducer, drawables_info_dict)
+        else:
+            return self.backend.ProcessAndMerge(self._build_ranges(), mapper, distrdf_reducer)
+
     def execute_graph(self) -> None:
         """
         Executes an RDataFrame computation graph on a distributed backend.
@@ -225,26 +247,11 @@ class HeadNode(Node, ABC):
 
         # Execute graph distributedly and return the aggregated results from all tasks
         # using the appropriate backend method based on whether or not live visualization is enabled
-        if self.drawables_dict is not None:
-            # Prepare a dictionary with additional information for live visualization
-            drawables_info_dict = {
-                # Key: node_id
-                node.node_id: (
-                    # Tuple containing:
-                    # 1. Callback functions passed by the user
-                    self.drawables_dict[node.node_id],
-                    # 2. Index of the node in the local_nodes list
-                    i,
-                    # 3. Name of the operation associated with the node
-                    node.operation.name
-                )
-                for i, node in enumerate(local_nodes)
-                # Filter: Only include nodes requested by the user
-                if node.node_id in self.drawables_dict
-            }
-            returned_values = self.backend.ProcessAndMergeLive(self._build_ranges(), mapper, distrdf_reducer, drawables_info_dict)
-        else:
-            returned_values = self.backend.ProcessAndMerge(self._build_ranges(), mapper, distrdf_reducer)
+        try:
+            returned_values = self._execute_and_retrieve_results(mapper, local_nodes)
+        finally:
+            # Cleanup the current execution artifacts from the caches on the workers
+            self.backend.cleanup_cache(self.exec_id)
 
         # Perform any extra checks that may be needed according to the
         # type of the head node


### PR DESCRIPTION
Every worker stores the RDataFrame created and the computation graph jitted during the first task in a process-wide dictionary serving as a cache. This is required in order to avoid having to re-jit the computation graph at each task.

This commit introduces a post-execution cleanup job for the Dask workers so that when a distributed execution ends, the workers are instructed to remove the artifacts generated by the execution from the caches.

In particular, if the RDataFrame execution was processing a TTree-based dataset, removing the artifact from the cache also notably deallocates the corresponding TTreeCache, one per RDataFrame in-flight in the process.

Here are some memory usage flamegraphs obtained with memray running the AGC analysis script

https://cernbox.cern.ch/s/YPEmBfULdvy8CbN

You will find the following:
* report_1sample_1file_2task_master.html : 1 RDataFrame, 1 file, 2 partitions. Total memory seen 293 MB
* report_1sample_1file_2task_cleancache.html : 1 RDataFrame, 1 file, 2 partitions. Total memory seen 238 MB
* report_5sample_1file_2task_master.html: 5 RDataFrames, 1 file each, 2 partitions each. Total memory seen 521 MB
* report_5sample_1file_2task_cleancache.html: 5 RDataFrames, 1 file each, 2 partitions each. Total memory seen 249 MB

One can search for the `TTreeCache` symbol and notice that e.g. between the second and the first flamegraphs the difference is ~40MB which is the size of the TTreeCache. Similarly between the 4th and 3rd there is approximately a difference of ~5 TTreeCache sizes.
