### PR TITLE
[ntuple] change RColumnDescriptorIterable to accept a fieldID

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -639,7 +639,7 @@ public:
          bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
       };
 
-      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const RFieldDescriptor &field);
+      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const DescriptorId_t fieldId);
       RColumnDescriptorIterable(const RNTupleDescriptor &ntuple);
 
       RIterator begin() { return RIterator(fNTuple, fColumns, 0); }
@@ -922,11 +922,11 @@ public:
    RColumnDescriptorIterable GetColumnIterable() const { return RColumnDescriptorIterable(*this); }
    RColumnDescriptorIterable GetColumnIterable(const RFieldDescriptor &fieldDesc) const
    {
-      return RColumnDescriptorIterable(*this, fieldDesc);
+      return RColumnDescriptorIterable(*this, fieldDesc.GetId());
    }
    RColumnDescriptorIterable GetColumnIterable(DescriptorId_t fieldId) const
    {
-      return RColumnDescriptorIterable(*this, GetFieldDescriptor(fieldId));
+      return RColumnDescriptorIterable(*this, fieldId);
    }
 
    RClusterGroupDescriptorIterable GetClusterGroupIterable() const { return RClusterGroupDescriptorIterable(*this); }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -388,10 +388,10 @@ void ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::CollectCo
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
-   const RNTupleDescriptor &ntuple, const RFieldDescriptor &field)
+   const RNTupleDescriptor &ntuple, const DescriptorId_t fieldId)
    : fNTuple(ntuple)
 {
-   CollectColumnIds(field.GetId());
+   CollectColumnIds(fieldId);
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(


### PR DESCRIPTION
Currently RColumnDescriptorIterable's ctor wants a RFieldDescriptor even though it only uses the field's id internally. One of the overloads of GetColumnIterable accepts a fieldId but it is forced to retrieve back the field descriptor before constructing an Iterable object, only for the object itself to extract back the id, wasting work.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


