### PR TITLE
[RF] Implement RooArgSet::selectCommon() and selectByName()

### DIFF
--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -105,7 +105,7 @@ RooFit::OwningPtr<RooArgSet> RooAbsSelfCached<Base_t>::actualObservables(const R
    }
 
    // Return servers that are in common with given normalization set
-   return RooFit::OwningPtr<RooArgSet>{static_cast<RooArgSet *>(serverSet.selectCommon(nset))};
+   return RooFit::OwningPtr<RooArgSet>{serverSet.selectCommon(nset)};
 }
 
 template <>

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -174,14 +174,22 @@ public:
 
   bool isInRange(const char* rangeSpec) ;
 
-  /// Use RooAbsCollection::snapshot(), but return as RooArgSet.
-  RooArgSet * snapshot(bool deepCopy = true) const {
-    return static_cast<RooArgSet*>(RooAbsCollection::snapshot(deepCopy));
+  using RooAbsCollection::selectCommon;
+  using RooAbsCollection::snapshot;
+
+  /// Use RooAbsCollection::selectByName(), but return as RooArgSet.
+  inline RooArgSet* selectByName(const char* nameList, bool verbose=false) const {
+    return static_cast<RooArgSet*>(RooAbsCollection::selectByName(nameList, verbose));
   }
 
-  /// \copydoc RooAbsCollection::snapshot()
-  bool snapshot(RooAbsCollection& output, bool deepCopy=true) const {
-    return RooAbsCollection::snapshot(output, deepCopy);
+  /// Use RooAbsCollection::selecCommon(), but return as RooArgSet.
+  inline RooArgSet* selectCommon(const RooAbsCollection& refColl) const {
+    return static_cast<RooArgSet*>(RooAbsCollection::selectCommon(refColl));
+  }
+
+  /// Use RooAbsCollection::snapshot(), but return as RooArgSet.
+  inline RooArgSet * snapshot(bool deepCopy = true) const {
+    return static_cast<RooArgSet*>(RooAbsCollection::snapshot(deepCopy));
   }
 
 protected:

--- a/roofit/roofitcore/inc/RooSimGenContext.h
+++ b/roofit/roofitcore/inc/RooSimGenContext.h
@@ -47,16 +47,16 @@ protected:
   RooSimGenContext(const RooSimGenContext& other) ;
 
   RooAbsCategoryLValue* _idxCat{nullptr};    ///< Clone of index category
-  RooArgSet*            _idxCatSet{nullptr}; ///< Owner of index category components
+  std::unique_ptr<RooArgSet> _idxCatSet;     ///< Owner of index category components
   const RooDataSet *_prototype{nullptr};     ///< Prototype data set
   const RooSimultaneous *_pdf{nullptr};      ///< Original PDF
-  std::vector<RooAbsGenContext*> _gcList ;   ///< List of component generator contexts
+  std::vector<std::unique_ptr<RooAbsGenContext>> _gcList; ///< List of component generator contexts
   std::vector<int>               _gcIndex ;  ///< Index value corresponding to component
-  bool _haveIdxProto{false};               ///< Flag set if generation of index is requested
+  bool _haveIdxProto{false};                 ///< Flag set if generation of index is requested
   TString _idxCatName{};                     ///< Name of index category
   Int_t _numPdf{0};                          ///< Number of generated PDFs
-  double* _fracThresh{nullptr};            ///<[_numPdf] Fraction threshold array
-  RooDataSet* _protoData{nullptr};           ///<! Prototype dataset
+  std::vector<double> _fracThresh;           ///<[_numPdf] Fraction threshold array
+  std::unique_ptr<RooDataSet> _protoData;    ///<! Prototype dataset
 
   RooArgSet _allVarsPdf{};        ///< All pdf variables
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -155,7 +155,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
 
   // Mark all projected dependents as such
   if (!projDeps.empty()) {
-    std::unique_ptr<RooArgSet> projDataDeps{static_cast<RooArgSet*>(_funcObsSet->selectCommon(projDeps))};
+    std::unique_ptr<RooArgSet> projDataDeps{_funcObsSet->selectCommon(projDeps)};
     projDataDeps->setAttribAll("projectedDependent") ;
   }
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2174,9 +2174,9 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
     // Obtain direct selection
     std::unique_ptr<RooArgSet> dirSelNodes;
     if (compSet) {
-      dirSelNodes.reset(static_cast<RooArgSet*>(branchNodeSet.selectCommon(*compSet)));
+      dirSelNodes = std::unique_ptr<RooArgSet>{branchNodeSet.selectCommon(*compSet)};
     } else {
-      dirSelNodes.reset(static_cast<RooArgSet*>(branchNodeSet.selectByName(compSpec)));
+      dirSelNodes = std::unique_ptr<RooArgSet>{branchNodeSet.selectByName(compSpec)};
     }
     if (!dirSelNodes->empty()) {
       coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") directly selected PDF components: " << *dirSelNodes << endl ;
@@ -2321,7 +2321,7 @@ RooPlot* RooAbsPdf::paramOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
   // Decode command line arguments
   std::unique_ptr<RooArgSet> params{getParameters(frame->getNormVars())} ;
   if(RooArgSet* requestedParams = pc.getSet("params")) {
-    params = std::unique_ptr<RooArgSet>{static_cast<RooArgSet*>(params->selectCommon(*requestedParams))};
+    params = std::unique_ptr<RooArgSet>{params->selectCommon(*requestedParams)};
   }
   paramOn(frame,*params,showc,label,xmin,xmax,ymax,formatCmd);
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -909,7 +909,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
   // are still in the cloneList and so will be cleaned up eventually.
   //cout << "redirection leafNodes : " ; leafNodes.Print("1") ;
 
-  std::unique_ptr<RooArgSet> plotLeafNodes{static_cast<RooArgSet*>(leafNodes.selectCommon(dependentVars))};
+  std::unique_ptr<RooArgSet> plotLeafNodes{leafNodes.selectCommon(dependentVars)};
   theClone->recursiveRedirectServers(*plotLeafNodes,false,false,false);
 
   // Create the set of normalization variables to use in the projection integrand
@@ -1419,9 +1419,9 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
 
     std::unique_ptr<RooArgSet> dirSelNodes;
     if (compSet) {
-      dirSelNodes.reset(static_cast<RooArgSet*>(branchNodeSet.selectCommon(*compSet)));
+      dirSelNodes = std::unique_ptr<RooArgSet>{branchNodeSet.selectCommon(*compSet)};
     } else {
-      dirSelNodes.reset(static_cast<RooArgSet*>(branchNodeSet.selectByName(compSpec)));
+      dirSelNodes = std::unique_ptr<RooArgSet>{branchNodeSet.selectByName(compSpec)};
     }
     if (!dirSelNodes->empty()) {
       coutI(Plotting) << "RooAbsPdf::createHistogram(" << GetName() << ") directly selected PDF components: " << *dirSelNodes << std::endl ;
@@ -1940,7 +1940,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
   if (o.projData) {
     cxcoutD(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") have ProjData with observables = " << *o.projData->get() << std::endl ;
     if (o.projDataSet) {
-      std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet*>(o.projData->get()->selectCommon(*o.projDataSet))};
+      std::unique_ptr<RooArgSet> tmp{o.projData->get()->selectCommon(*o.projDataSet)};
       projDataVars.add(*tmp) ;
       cxcoutD(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") have ProjDataSet = " << *o.projDataSet << " will only use this subset of projData" << std::endl ;
     } else {
@@ -1970,7 +1970,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       sliceSetTmp.remove(*frame->getPlotVar(),true,true) ;
 
       if (o.projData) {
-        std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet*>(projDataVars.selectCommon(*o.projSet))};
+        std::unique_ptr<RooArgSet> tmp{projDataVars.selectCommon(*o.projSet)};
         sliceSetTmp.remove(*tmp,true,true) ;
       }
 
@@ -1990,7 +1990,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
   RooArgSet* projDataNeededVars = nullptr ;
   // Take out data-projected dependents from projectedVars
   if (o.projData) {
-    projDataNeededVars = static_cast<RooArgSet*>(projectedVars.selectCommon(projDataVars)) ;
+    projDataNeededVars = projectedVars.selectCommon(projDataVars);
     projectedVars.remove(projDataVars,true,true) ;
   }
 
@@ -2060,7 +2060,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     if (projDataNeededVars->size() < o.projData->get()->size()) {
 
       // Determine if there are any slice variables in the projection set
-        std::unique_ptr<RooArgSet> sliceDataSet{static_cast<RooArgSet*>(sliceSet.selectCommon(*o.projData->get()))};
+        std::unique_ptr<RooArgSet> sliceDataSet{sliceSet.selectCommon(*o.projData->get())};
       TString cutString ;
       if (!sliceDataSet->empty()) {
    bool first(true) ;
@@ -2304,7 +2304,7 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
   RooArgSet projDataVars ;
   if (o.projData) {
     if (o.projDataSet) {
-      std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet*>(o.projData->get()->selectCommon(*o.projDataSet))};
+      std::unique_ptr<RooArgSet> tmp{o.projData->get()->selectCommon(*o.projDataSet)};
       projDataVars.add(*tmp) ;
     } else {
       projDataVars.add(*o.projData->get()) ;
@@ -2339,7 +2339,7 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
       sliceSetTmp.remove(*frame->getPlotVar(),true,true) ;
 
       if (o.projData) {
-        std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet*>(projDataVars.selectCommon(*o.projSet))};
+        std::unique_ptr<RooArgSet> tmp{projDataVars.selectCommon(*o.projSet)};
         sliceSetTmp.remove(*tmp,true,true) ;
       }
 
@@ -2357,7 +2357,7 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
   // Take out data-projected dependens from projectedVars
   RooArgSet* projDataNeededVars = nullptr ;
   if (o.projData) {
-    projDataNeededVars = static_cast<RooArgSet*>(projectedVars.selectCommon(projDataVars)) ;
+    projDataNeededVars = projectedVars.selectCommon(projDataVars);
     projectedVars.remove(projDataVars,true,true) ;
   }
 

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -395,9 +395,9 @@ void RooCompositeDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarS
 void RooCompositeDataStore::setArgStatus(const RooArgSet& set, bool active)
 {
   for (auto const& item : _dataMap) {
-    RooArgSet* subset = static_cast<RooArgSet*>(set.selectCommon(*item.second->get())) ;
-    item.second->setArgStatus(*subset,active) ;
-    delete subset ;
+    RooArgSet subset;
+    set.selectCommon(*item.second->get(), subset);
+    item.second->setArgStatus(subset,active) ;
   }
   return ;
 }

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -233,10 +233,10 @@ void RooConvGenContext::attach(const RooArgSet& args)
   auto* cvPdf   = static_cast<RooRealVar*>(_pdfVars->find(_convVarName));
 
   // Replace all servers in _pdfVars and _modelVars with those in theEvent, except for the convolution variable
-  std::unique_ptr<RooArgSet> pdfCommon{static_cast<RooArgSet*>(args.selectCommon(*_pdfVars))};
+  std::unique_ptr<RooArgSet> pdfCommon{args.selectCommon(*_pdfVars)};
   pdfCommon->remove(*cvPdf,true,true) ;
 
-  std::unique_ptr<RooArgSet> modelCommon{static_cast<RooArgSet*>(args.selectCommon(*_modelVars))};
+  std::unique_ptr<RooArgSet> modelCommon{args.selectCommon(*_modelVars)};
   modelCommon->remove(*cvModel,true,true) ;
 
   _pdfGen->attach(*pdfCommon) ;
@@ -256,11 +256,11 @@ void RooConvGenContext::initGenerator(const RooArgSet &theEvent)
   _cvOut   = static_cast<RooRealVar*>(theEvent.find(_convVarName)) ;
 
   // Replace all servers in _pdfVars and _modelVars with those in theEvent, except for the convolution variable
-  std::unique_ptr<RooArgSet> pdfCommon{static_cast<RooArgSet*>(theEvent.selectCommon(*_pdfVars))};
+  std::unique_ptr<RooArgSet> pdfCommon{theEvent.selectCommon(*_pdfVars)};
   pdfCommon->remove(*_cvPdf,true,true) ;
   _pdfVars->replace(*pdfCommon) ;
 
-  std::unique_ptr<RooArgSet> modelCommon{static_cast<RooArgSet*>(theEvent.selectCommon(*_modelVars))};
+  std::unique_ptr<RooArgSet> modelCommon{theEvent.selectCommon(*_modelVars)};
   modelCommon->remove(*_cvModel,true,true) ;
   _modelVars->replace(*modelCommon) ;
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -494,14 +494,14 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
 
     // process StoreError requests
     if (errorSet) {
-      std::unique_ptr<RooArgSet> intErrorSet{static_cast<RooArgSet*>(_vars.selectCommon(*errorSet))};
+      std::unique_ptr<RooArgSet> intErrorSet{_vars.selectCommon(*errorSet)};
       intErrorSet->setAttribAll("StoreError") ;
       for(RooAbsArg* arg : *intErrorSet) {
         arg->attachToStore(*_dstore) ;
       }
     }
     if (asymErrorSet) {
-      std::unique_ptr<RooArgSet> intAsymErrorSet{static_cast<RooArgSet*>(_vars.selectCommon(*asymErrorSet))};
+      std::unique_ptr<RooArgSet> intAsymErrorSet{_vars.selectCommon(*asymErrorSet)};
       intAsymErrorSet->setAttribAll("StoreAsymError") ;
       for(RooAbsArg* arg : *intAsymErrorSet) {
         arg->attachToStore(*_dstore) ;

--- a/roofit/roofitcore/src/RooErrorVar.cxx
+++ b/roofit/roofitcore/src/RooErrorVar.cxx
@@ -171,10 +171,8 @@ void RooErrorVar::setBinning(const RooAbsBinning& binning, const char* name)
   } else {
 
     // Remove any old binning with this name
-    RooAbsBinning* oldBinning = static_cast<RooAbsBinning*>(_altBinning.FindObject(name)) ;
-    if (oldBinning) {
-      _altBinning.Remove(oldBinning) ;
-      delete oldBinning ;
+    if (std::unique_ptr<RooAbsBinning> oldBinning{static_cast<RooAbsBinning*>(_altBinning.FindObject(name))}) {
+      _altBinning.Remove(oldBinning.get()) ;
     }
 
     // Insert new binning in list of alternative binnings

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1321,7 +1321,7 @@ void RooProdPdf::groupProductTerms(std::list<std::vector<RooArgSet*>>& groupedTe
   }
 
   outerIntDeps.removeAll() ;
-  outerIntDeps.add(*std::unique_ptr<RooArgSet>{static_cast<RooArgSet*>(allIntDeps.selectCommon(allImpDeps))});
+  outerIntDeps.add(*std::unique_ptr<RooArgSet>{allIntDeps.selectCommon(allImpDeps)});
 
   // Now iteratively merge groups that should be (partially) integrated together
   for(RooAbsArg * outerIntDep : outerIntDeps) {

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -847,7 +847,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 //       cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a normalization set specification CATNormSet = " << catNset << endl ;
 
       RooArgSet anset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catNset);
-      normSet = static_cast<RooArgSet*>(anset.selectCommon(*argObs)) ;
+      normSet = anset.selectCommon(*argObs);
 
     }
     const char* catCset = arg->getStringAttribute("CATCondSet") ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -212,8 +212,7 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
   // Copy named sets
   for (map<string,RooArgSet>::const_iterator iter3 = other._namedSets.begin() ; iter3 != other._namedSets.end() ; ++iter3) {
     // Make RooArgSet with equivalent content of this workspace
-    std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet*>(_allOwnedNodes.selectCommon(iter3->second))};
-    _namedSets[iter3->first].add(*tmp) ;
+    _namedSets[iter3->first].add(*std::unique_ptr<RooArgSet>{_allOwnedNodes.selectCommon(iter3->second)});
   }
 
   // Copy generic objects

--- a/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
+++ b/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
@@ -74,9 +74,8 @@ void ConstantTermsOptimizer::enableConstantTermsOptimization(RooAbsReal *functio
          arg->setCacheAndTrackHints(trackNodes);
       }
       // Do not set CacheAndTrack on constant expressions
-      auto constNodes = static_cast<RooArgSet *>(trackNodes.selectByAttrib("Constant", true));
+      std::unique_ptr<RooArgSet> constNodes{static_cast<RooArgSet *>(trackNodes.selectByAttrib("Constant", true))};
       trackNodes.remove(*constNodes);
-      delete constNodes;
 
       // Set CacheAndTrack flag on all remaining nodes
       trackNodes.setAttribAll("CacheAndTrack", true);

--- a/roofit/roofitcore/test/testProxiesAndCategories.cxx
+++ b/roofit/roofitcore/test/testProxiesAndCategories.cxx
@@ -81,30 +81,25 @@ public:
     TFile file(GetParam(), "READ");
     ASSERT_TRUE(file.IsOpen());
 
-    file.GetObject("catOrig", cat);
+    cat = std::unique_ptr<RooCategory>{file.Get<RooCategory>("catOrig")};
     ASSERT_NE(cat, nullptr);
 
-    file.GetObject("data", data);
+    data = std::unique_ptr<RooDataSet>{file.Get<RooDataSet>("data")};
     ASSERT_NE(data, nullptr);
 
     catFromDataset = dynamic_cast<RooCategory*>(data->get(0)->find("cat"));
     ASSERT_NE(catFromDataset, nullptr);
   }
 
-  void TearDown() override {
-    delete cat;
-    delete data;
-  }
-
 protected:
   enum State_t {one = 0, two = 1, three = 2, four = 3};
-  RooCategory* cat{nullptr};
-  RooDataSet* data{nullptr};
+  std::unique_ptr<RooCategory> cat;
+  std::unique_ptr<RooDataSet> data;
   RooCategory* catFromDataset{nullptr};
 };
 
 TEST_P(RooCategoryIO, ReadWithRanges) {
-  for (RooCategory* theCat : {cat, catFromDataset}) {
+  for (RooCategory* theCat : {cat.get(), catFromDataset}) {
     ASSERT_TRUE(theCat->hasRange("odds"));
     ASSERT_TRUE(theCat->hasRange("evens"));
 


### PR DESCRIPTION
The difference is only that the return type is casted to the actual
`RooArgSet` type. We avoid a few static casts all over the place like
this.

A second commit in this PR applies some general improvements in memory management.

