### PR TITLE
[RF] Forbid RooArgList::useHashMapForFind(true)

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -95,6 +95,10 @@ The following people have contributed to this new version:
 
 ## RooFit Libraries
 
+### Miscellaneous
+
+* Setting `useHashMapForFind(true)` is not supported for RooArgLists anymore, since hash-assisted finding by name hash can be ambiguous: a RooArgList is allowed to have different elements with the same name. If you want to do fast lookups by name, convert your RooArgList to a RooArgSet.
+
 ## Graphics Backends
 
 ## 2D Graphics Libraries

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1601,9 +1601,26 @@ void RooAbsCollection::insert(RooAbsArg* item) {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \param[in] flag Switch hash map on or off.
-void RooAbsCollection::useHashMapForFind(bool flag) const {
-  if (flag && !_hashAssistedFind) _hashAssistedFind = std::make_unique<HashAssistedFind>(_list.begin(), _list.end());
-  if (!flag) _hashAssistedFind = nullptr;
+void RooAbsCollection::useHashMapForFind(bool flag) const
+{
+// Use a ROOT version macro for behavior-changing code in ROOT 6.33, so se can
+// keep the same RooFit code base in master and in the 6.32 patch release
+// branch for now.
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 00)
+   if (flag && !dynamic_cast<RooArgSet const *>(this)) {
+      // RooArgLists can have duplicate object, so we can't do hash-assisted lookups.
+      std::stringstream msg;
+      msg << "RooAbsCollection::useHashMapForFind() ERROR: this collection is not a RooArgSet but a RooArgList, so "
+             "hash-assisted finding can't be enabled!"
+          << std::endl;
+      oocoutE(nullptr, ObjectHandling) << msg.str() << std::endl;
+      throw std::runtime_error(msg.str());
+   }
+#endif
+   if (flag && !_hashAssistedFind)
+      _hashAssistedFind = std::make_unique<HashAssistedFind>(_list.begin(), _list.end());
+   if (!flag)
+      _hashAssistedFind = nullptr;
 }
 
 

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -133,12 +133,7 @@ TEST(RooArgSet, HashAssistedFind) {
   EXPECT_EQ(set.size(), 5);
 
   // Renaming would invalidate the old hash map. Test that it gets regenerated correctly:
-  list.useHashMapForFind(true);
-
   list[0].SetName("a'");
   EXPECT_EQ(set.find("a"), nullptr);
   EXPECT_EQ(set.find("a'"), & list[0]);
-
-  EXPECT_EQ(list.find("a"), nullptr);
-  EXPECT_EQ(list.find("a'"), & list[0]);
 }


### PR DESCRIPTION
# This Pull request:

Setting `useHashMapForFind(true)` is not supported for RooArgLists
anymore, since hash-assisted finding by name hash can be ambiguous: a
RooArgList is allowed to have different elements with the same name.

If one wants to use name-lookups on a RooArgList, one can just convert
it to a RooArgSet, which is cheap anyway (copy of a vector of pointers).

Also inside RooFit itself, `useHashMapForFind` is only used for
RooArgSets, most notably the RooArgSet that contains all the components
of a RooWorkspace.

Closes https://github.com/root-project/root/pull/9425.