### PR TITLE
[ntuple] remove CollectColumnIds from ColumnIterable

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -637,7 +637,7 @@ public:
          bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
       };
 
-      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const DescriptorId_t fieldId);
+      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const RFieldDescriptor &fieldDesc);
       RColumnDescriptorIterable(const RNTupleDescriptor &ntuple);
 
       RIterator begin() { return RIterator(fNTuple, fColumns, 0); }
@@ -920,11 +920,11 @@ public:
    RColumnDescriptorIterable GetColumnIterable() const { return RColumnDescriptorIterable(*this); }
    RColumnDescriptorIterable GetColumnIterable(const RFieldDescriptor &fieldDesc) const
    {
-      return RColumnDescriptorIterable(*this, fieldDesc.GetId());
+      return RColumnDescriptorIterable(*this, fieldDesc);
    }
    RColumnDescriptorIterable GetColumnIterable(DescriptorId_t fieldId) const
    {
-      return RColumnDescriptorIterable(*this, fieldId);
+      return RColumnDescriptorIterable(*this, GetFieldDescriptor(fieldId));
    }
 
    RClusterGroupDescriptorIterable GetClusterGroupIterable() const { return RClusterGroupDescriptorIterable(*this); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -606,8 +606,6 @@ public:
       /// The descriptor ids of the columns ordered by index id
       std::vector<DescriptorId_t> fColumns = {};
 
-      void CollectColumnIds(DescriptorId_t fieldId);
-
    public:
       class RIterator {
       private:

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -379,10 +379,9 @@ ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
-   const RNTupleDescriptor &ntuple, const DescriptorId_t fieldId)
+   const RNTupleDescriptor &ntuple, const RFieldDescriptor &fieldDesc)
    : fNTuple(ntuple)
 {
-   const auto &fieldDesc = ntuple.GetFieldDescriptor(fieldId);
    fColumns = fieldDesc.GetLogicalColumnIds();
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -378,20 +378,12 @@ ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const
    return fields;
 }
 
-void ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::CollectColumnIds(DescriptorId_t fieldId) {
-   for (unsigned int i = 0; true; ++i) {
-      auto logicalId = fNTuple.FindLogicalColumnId(fieldId, i);
-      if (logicalId == kInvalidDescriptorId)
-         break;
-      fColumns.emplace_back(logicalId);
-   }
-}
-
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
    const RNTupleDescriptor &ntuple, const DescriptorId_t fieldId)
    : fNTuple(ntuple)
 {
-   CollectColumnIds(fieldId);
+   const auto &fieldDesc = ntuple.GetFieldDescriptor(fieldId);
+   fColumns = fieldDesc.GetLogicalColumnIds();
 }
 
 ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
@@ -404,7 +396,9 @@ ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescrip
       auto currFieldId = fieldIdQueue.front();
       fieldIdQueue.pop_front();
 
-      CollectColumnIds(currFieldId);
+      const auto &field = ntuple.GetFieldDescriptor(currFieldId);
+      const auto &columns = field.GetLogicalColumnIds();
+      fColumns.insert(fColumns.end(), columns.begin(), columns.end());
 
       for (const auto &field : ntuple.GetFieldIterable(currFieldId)) {
          auto fieldId = field.GetId();


### PR DESCRIPTION
It's not needed anymore since we can now just take the column ids from the field descriptor.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

