### PR TITLE
[ntuple] Account for buffer model in memory estimation

### DIFF
--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -479,10 +479,12 @@ std::size_t ROOT::Experimental::RNTupleModel::EstimateWriteMemoryUsage(const RNT
    for (auto &&field : *fFieldZero) {
       nColumns += field.GetColumnRepresentative().size();
    }
-   bytes += nColumns * pageBufferPerColumn;
+   const std::size_t pageBuffersPerModel = nColumns * pageBufferPerColumn;
+   bytes += pageBuffersPerModel;
 
-   // If using buffered writing with RPageSinkBuf, we keep at least the compressed pages in memory.
+   // If using buffered writing with RPageSinkBuf, we create a clone of the model and keep at least the compressed pages in memory.
    if (options.GetUseBufferedWrite()) {
+      bytes += pageBuffersPerModel;
       // Use the target cluster size as an estimate for all compressed pages combined.
       bytes += options.GetApproxZippedClusterSize();
       int compression = options.GetCompression();

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -61,12 +61,12 @@ TEST(RNTupleModel, EstimateWriteMemoryUsage)
    options.SetApproxZippedClusterSize(ClusterSize);
 
    // Tail page optimization and buffered writing on, IMT not disabled.
-   static constexpr std::size_t Expected1 = NumColumns * 3 * PageSize + 3 * ClusterSize;
+   static constexpr std::size_t Expected1 = NumColumns * 3 * PageSize * 2 + 3 * ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected1);
 
    // Disable IMT.
    options.SetUseImplicitMT(RNTupleWriteOptions::EImplicitMT::kOff);
-   static constexpr std::size_t Expected2 = NumColumns * 3 * PageSize + ClusterSize;
+   static constexpr std::size_t Expected2 = NumColumns * 3 * PageSize * 2 + ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected2);
 
    // Disable buffered writing.
@@ -81,6 +81,6 @@ TEST(RNTupleModel, EstimateWriteMemoryUsage)
 
    // Enable buffered writing again.
    options.SetUseBufferedWrite(true);
-   static constexpr std::size_t Expected5 = NumColumns * PageSize + ClusterSize;
+   static constexpr std::size_t Expected5 = NumColumns * PageSize * 2 + ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected5);
 }

--- a/tree/ntuple/v7/test/ntuple_model.py
+++ b/tree/ntuple/v7/test/ntuple_model.py
@@ -34,7 +34,7 @@ class NTupleModel(unittest.TestCase):
         options.SetApproxUnzippedPageSize(PageSize)
         options.SetApproxZippedClusterSize(ClusterSize)
 
-        Expected = 4 * 3 * PageSize + 3 * ClusterSize
+        Expected = 4 * 3 * PageSize * 2 + 3 * ClusterSize
         self.assertEqual(model.EstimateWriteMemoryUsage(options), Expected)
 
 


### PR DESCRIPTION
`RPageSinkBuf` internally clones the model, which also allocates the column page buffers.