### PR TITLE
[skip-ci] correct a few  website links in doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See more screenshots on our [gallery](https://root.cern/gallery).
 See https://root.cern/install for installation instructions.
 For instructions on how to build ROOT from these source files, see https://root.cern/install/build_from_source.
 
-Our ["Getting started with ROOT"](https://root.cern/get_started) page is then the perfect place to get familiar with ROOT.
+Our ["Getting started with ROOT"](https://root.cern/learn) page is then the perfect place to get familiar with ROOT.
 
 ## Help and Support
 - [Forum](https://root.cern/forum/)

--- a/roofit/doc/index.md
+++ b/roofit/doc/index.md
@@ -2,7 +2,7 @@
 \brief RooFit is a package for building likelihood models and fitting these to data.
 
 For an introduction check the \ref tutorial_roofit, [user's guides](https://root.cern.ch/root-user-guides-and-manuals),
-[courses](https://root.cern.ch/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
+[courses](https://root.cern.ch/learn/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
 
 For developers, there is also the \ref roofit_dev_docs, which serves as a reference on how to extend %RooFit with custom classes or for contributing to %RooFit itself.
 

--- a/roofit/roofit/doc/index.md
+++ b/roofit/roofit/doc/index.md
@@ -3,6 +3,6 @@
 \ingroup Roofitmain
 
 For an introduction check the [user's guides](https://root.cern.ch/root-user-guides-and-manuals),
-[courses](https://root.cern.ch/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
+[courses](https://root.cern.ch/learn/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
 
 For tutorials see \ref tutorial_roofit.

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -52,7 +52,7 @@ The namespace RooFit contains mostly switches that change the behaviour of funct
 
 These switches are documented with the relevant functions, e.g. RooAbsPdf::fitTo().
 For an introduction to RooFit (not the namespace), check the [user's guides](https://root.cern/root-user-guides-and-manuals),
-[courses](https://root.cern/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
+[courses](https://root.cern/learn/courses) or [the RooFit chapter of the Manual](https://root.cern/manual/roofit/).
 */
 namespace RooFit {
 

--- a/roofit/roostats/doc/index.md
+++ b/roofit/roostats/doc/index.md
@@ -3,6 +3,6 @@
 \ingroup Roofitmain
 
 RooStats is a package containing statistical tools built on top of RooFit.
-See the RooStats [Twiki Page](https://twiki.cern.ch/twiki/bin/view/RooStats/WebHome) or the [courses](https://root.cern/courses) for more information.
+See the RooStats [Twiki Page](https://twiki.cern.ch/twiki/bin/view/RooStats/WebHome) or the [courses](https://root.cern/learn/courses) for more information.
 
 For tutorials see \ref tutorial_roostats. 


### PR DESCRIPTION
Since we re-organized a few things on the website, the links in doxygen need to be updated accordingly. 

