### PR TITLE
[ntuple] Streamline RField<>::GenerateColumns()

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -86,7 +86,7 @@ public:
    }
    // Field is only used for reading
    void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<0, ClusterSize_t>(desc); }
+   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<ClusterSize_t>(desc); }
 
    size_t GetValueSize() const final { return sizeof(std::size_t); }
    size_t GetAlignment() const final { return alignof(std::size_t); }

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -85,8 +85,8 @@ public:
       return representations;
    }
    // Field is only used for reading
-   void GenerateColumnsImpl() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final
+   void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
+   void GenerateColumns(const RNTupleDescriptor &desc) final
    {
       auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
       fColumns.emplace_back(ROOT::Experimental::Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -128,8 +128,8 @@ private:
    {
       return std::make_unique<RArraySizeField>(fArrayLength);
    }
-   void GenerateColumnsImpl() final { assert(false && "RArraySizeField fields must only be used for reading"); }
-   void GenerateColumnsImpl(const ROOT::Experimental::RNTupleDescriptor &) final {}
+   void GenerateColumns() final { assert(false && "RArraySizeField fields must only be used for reading"); }
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final {}
    void ReadGlobalImpl(NTupleSize_t /*globalIndex*/, void *to) final { *static_cast<std::size_t *>(to) = fArrayLength; }
    void ReadInClusterImpl(RClusterIndex /*clusterIndex*/, void *to) final
    {

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -86,11 +86,7 @@ public:
    }
    // Field is only used for reading
    void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final
-   {
-      auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-      fColumns.emplace_back(ROOT::Experimental::Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
-   }
+   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<0, ClusterSize_t>(desc); }
 
    size_t GetValueSize() const final { return sizeof(std::size_t); }
    size_t GetAlignment() const final { return alignof(std::size_t); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -432,17 +432,17 @@ protected:
    }
 
    /// For writing, use the currently set column representative
-   template <int ColumnIndexT, typename HeadT, typename... TailTs>
+   template <typename... ColumnCppTs>
    void GenerateColumnsImpl()
    {
-      GenerateColumnsImpl<0, HeadT, TailTs...>(GetColumnRepresentative());
+      GenerateColumnsImpl<0, ColumnCppTs...>(GetColumnRepresentative());
    }
 
    /// For reading, use the on-disk column list
-   template <int ColumnIndexT, typename HeadT, typename... TailTs>
+   template <typename... ColumnCppTs>
    void GenerateColumnsImpl(const RNTupleDescriptor &desc)
    {
-      GenerateColumnsImpl<0, HeadT, TailTs...>(EnsureCompatibleColumnTypes(desc));
+      GenerateColumnsImpl<0, ColumnCppTs...>(EnsureCompatibleColumnTypes(desc));
    }
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
@@ -1875,8 +1875,8 @@ public:
 template <typename T>
 class RSimpleField : public RFieldBase {
 protected:
-   void GenerateColumns() final { GenerateColumnsImpl<0, T>(); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<0, T>(desc); }
+   void GenerateColumns() final { GenerateColumnsImpl<T>(); }
+   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<T>(desc); }
 
    void ConstructValue(void *where) const final { new (where) T{0}; }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -424,11 +424,11 @@ protected:
    virtual const RColumnRepresentations &GetColumnRepresentations() const;
    /// Implementations in derived classes should create the backing columns corresponsing to the field type for
    /// writing. The default implementation does not attach any columns to the field.
-   virtual void GenerateColumnsImpl() {}
+   virtual void GenerateColumns() {}
    /// Implementations in derived classes should create the backing columns corresponsing to the field type for reading.
    /// The default implementation does not attach any columns to the field. The method should check, using the page
    /// source and fOnDiskId, if the column types match and throw if they don't.
-   virtual void GenerateColumnsImpl(const RNTupleDescriptor & /*desc*/) {}
+   virtual void GenerateColumns(const RNTupleDescriptor & /*desc*/) {}
    /// Returns the on-disk column types found in the provided descriptor for fOnDiskId. Throws an exception if the types
    /// don't match any of the deserialization types from GetColumnRepresentations().
    const ColumnRepresentation_t &EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
@@ -859,8 +859,8 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RUnsplitDeleter>(fClass); }
@@ -1033,8 +1033,8 @@ protected:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const override;
    std::unique_ptr<RDeleter> GetDeleter() const override;
@@ -1154,8 +1154,8 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const override { new (where) std::vector<char>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -1212,8 +1212,8 @@ protected:
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const override;
    std::unique_ptr<RDeleter> GetDeleter() const override;
@@ -1306,8 +1306,8 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void GenerateColumnsImpl() final { R__ASSERT(false && "RArrayAsRVec fields must only be used for reading"); }
-   using RFieldBase::GenerateColumnsImpl;
+   void GenerateColumns() final { R__ASSERT(false && "RArrayAsRVec fields must only be used for reading"); }
+   using RFieldBase::GenerateColumns;
 
    void ConstructValue(void *where) const final;
    /// Returns an RRVecField::RRVecDeleter
@@ -1353,8 +1353,8 @@ protected:
       return std::make_unique<RBitsetField>(newName, fN);
    }
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
    void ConstructValue(void *where) const final { memset(where, 0, GetValueSize()); }
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -1417,8 +1417,8 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const override;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -1491,8 +1491,8 @@ class RNullableField : public RFieldBase {
 
 protected:
    const RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &) final;
 
    std::size_t AppendNull();
    std::size_t AppendValue(const void *from);
@@ -1735,8 +1735,8 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
    void ConstructValue(void *) const final {}
 
    std::size_t AppendImpl(const void *from) final;
@@ -1832,8 +1832,8 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    // Field is only used for reading
-   void GenerateColumnsImpl() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
+   void GenerateColumns() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
+   void GenerateColumns(const RNTupleDescriptor &) final;
 
 public:
    RCardinalityField(RCardinalityField &&other) = default;
@@ -1893,8 +1893,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t"; }
@@ -1987,8 +1987,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "bool"; }
@@ -2009,8 +2009,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "float"; }
@@ -2033,8 +2033,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "double"; }
@@ -2058,8 +2058,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::byte"; }
@@ -2080,8 +2080,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "char"; }
@@ -2103,8 +2103,8 @@ template <>
 class RIntegralField<std::int8_t> : public RSimpleField<std::int8_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::int8_t"; }
@@ -2120,8 +2120,8 @@ template <>
 class RIntegralField<std::uint8_t> : public RSimpleField<std::uint8_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::uint8_t"; }
@@ -2137,8 +2137,8 @@ template <>
 class RIntegralField<std::int16_t> : public RSimpleField<std::int16_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::int16_t"; }
@@ -2154,8 +2154,8 @@ template <>
 class RIntegralField<std::uint16_t> : public RSimpleField<std::uint16_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::uint16_t"; }
@@ -2171,8 +2171,8 @@ template <>
 class RIntegralField<std::int32_t> : public RSimpleField<std::int32_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::int32_t"; }
@@ -2188,8 +2188,8 @@ template <>
 class RIntegralField<std::uint32_t> : public RSimpleField<std::uint32_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::uint32_t"; }
@@ -2205,8 +2205,8 @@ template <>
 class RIntegralField<std::uint64_t> : public RSimpleField<std::uint64_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::uint64_t"; }
@@ -2222,8 +2222,8 @@ template <>
 class RIntegralField<std::int64_t> : public RSimpleField<std::int64_t> {
 protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "std::int64_t"; }
@@ -2333,8 +2333,8 @@ private:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::string(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::string>>(); }
@@ -2580,8 +2580,8 @@ protected:
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::vector<bool>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::vector<bool>>>(); }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1214,7 +1214,7 @@ ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCardinalityField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RCardinalityField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1458,12 +1458,12 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t, char>();
+   GenerateColumnsImpl<ClusterSize_t, char>();
 }
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t, char>(desc);
+   GenerateColumnsImpl<ClusterSize_t, char>(desc);
 }
 
 std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const void *from)
@@ -1892,12 +1892,12 @@ ROOT::Experimental::RUnsplitField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RUnsplitField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t, std::byte>();
+   GenerateColumnsImpl<ClusterSize_t, std::byte>();
 }
 
 void ROOT::Experimental::RUnsplitField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t, std::byte>(desc);
+   GenerateColumnsImpl<ClusterSize_t, std::byte>(desc);
 }
 
 void ROOT::Experimental::RUnsplitField::ConstructValue(void *where) const
@@ -2152,12 +2152,12 @@ ROOT::Experimental::RProxiedCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t>();
+   GenerateColumnsImpl<ClusterSize_t>();
 }
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RProxiedCollectionField::ConstructValue(void *where) const
@@ -2422,12 +2422,12 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVectorField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t>();
+   GenerateColumnsImpl<ClusterSize_t>();
 }
 
 void ROOT::Experimental::RVectorField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RVectorField::RVectorDeleter::operator()(void *objPtr, bool dtorOnly)
@@ -2663,12 +2663,12 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RRVecField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t>();
+   GenerateColumnsImpl<ClusterSize_t>();
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RRVecField::ConstructValue(void *where) const
@@ -2779,12 +2779,12 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t>();
+   GenerateColumnsImpl<ClusterSize_t>();
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>
@@ -3070,12 +3070,12 @@ ROOT::Experimental::RBitsetField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RBitsetField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, bool>();
+   GenerateColumnsImpl<bool>();
 }
 
 void ROOT::Experimental::RBitsetField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, bool>(desc);
+   GenerateColumnsImpl<bool>(desc);
 }
 
 std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const void *from)
@@ -3223,12 +3223,12 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVariantField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, RColumnSwitch>();
+   GenerateColumnsImpl<RColumnSwitch>();
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, RColumnSwitch>(desc);
+   GenerateColumnsImpl<RColumnSwitch>(desc);
 }
 
 void ROOT::Experimental::RVariantField::ConstructValue(void *where) const
@@ -3780,12 +3780,12 @@ ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCollectionField::GenerateColumns()
 {
-   GenerateColumnsImpl<0, ClusterSize_t>();
+   GenerateColumnsImpl<ClusterSize_t>();
 }
 
 void ROOT::Experimental::RCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<0, ClusterSize_t>(desc);
+   GenerateColumnsImpl<ClusterSize_t>(desc);
 }
 
 std::unique_ptr<ROOT::Experimental::RFieldBase>

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1097,7 +1097,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSink(Internal::RPageSink &pageSi
 
    AutoAdjustColumnTypes(pageSink.GetWriteOptions());
 
-   GenerateColumnsImpl();
+   GenerateColumns();
    if (!fColumns.empty())
       fPrincipalColumn = fColumns[0].get();
    for (auto &column : fColumns) {
@@ -1135,7 +1135,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
    {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();
-      GenerateColumnsImpl(desc);
+      GenerateColumns(desc);
       ColumnRepresentation_t onDiskColumnTypes;
       onDiskColumnTypes.reserve(fColumns.size());
       for (const auto &c : fColumns) {
@@ -1196,12 +1196,12 @@ ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresen
    return representations;
 }
 
-void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -1223,7 +1223,7 @@ ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RCardinalityField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RCardinalityField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -1255,12 +1255,12 @@ ROOT::Experimental::RField<char>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<char>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<char>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<char>(onDiskTypes[0], 0));
@@ -1280,12 +1280,12 @@ ROOT::Experimental::RField<std::byte>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<std::byte>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<std::byte>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::byte>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<std::byte>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<char>(onDiskTypes[0], 0));
@@ -1305,12 +1305,12 @@ ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() cons
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(onDiskTypes[0], 0));
@@ -1330,12 +1330,12 @@ ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(onDiskTypes[0], 0));
@@ -1355,12 +1355,12 @@ ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<bool>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<bool>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<bool>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<bool>(onDiskTypes[0], 0));
@@ -1381,12 +1381,12 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<float>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<float>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<float>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<float>(onDiskTypes[0], 0));
@@ -1416,12 +1416,12 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<double>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<double>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<double>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<double>(onDiskTypes[0], 0));
@@ -1447,12 +1447,12 @@ ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(onDiskTypes[0], 0));
@@ -1473,12 +1473,12 @@ ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(onDiskTypes[0], 0));
@@ -1499,12 +1499,12 @@ ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(onDiskTypes[0], 0));
@@ -1525,12 +1525,12 @@ ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(onDiskTypes[0], 0));
@@ -1551,12 +1551,12 @@ ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(onDiskTypes[0], 0));
@@ -1582,12 +1582,12 @@ ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumnsImpl()
+void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(onDiskTypes[0], 0));
@@ -1611,13 +1611,13 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<std::string>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
    fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[1], 1));
 }
 
-void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<std::string>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -2048,13 +2048,13 @@ ROOT::Experimental::RUnsplitField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RUnsplitField::GenerateColumnsImpl()
+void ROOT::Experimental::RUnsplitField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
    fColumns.emplace_back(Internal::RColumn::Create<std::byte>(GetColumnRepresentative()[1], 1));
 }
 
-void ROOT::Experimental::RUnsplitField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RUnsplitField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -2311,12 +2311,12 @@ ROOT::Experimental::RProxiedCollectionField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RProxiedCollectionField::GenerateColumnsImpl()
+void ROOT::Experimental::RProxiedCollectionField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RProxiedCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RProxiedCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -2582,12 +2582,12 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
+void ROOT::Experimental::RVectorField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RVectorField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -2824,12 +2824,12 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RRVecField::GenerateColumnsImpl()
+void ROOT::Experimental::RRVecField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RRVecField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RRVecField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -2941,12 +2941,12 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
+void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
@@ -3233,12 +3233,12 @@ ROOT::Experimental::RBitsetField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RBitsetField::GenerateColumnsImpl()
+void ROOT::Experimental::RBitsetField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<bool>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RBitsetField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RBitsetField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<bool>(onDiskTypes[0], 0));
@@ -3387,12 +3387,12 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
+void ROOT::Experimental::RVariantField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<RColumnSwitch>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RVariantField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<RColumnSwitch>(onDiskTypes[0], 0));
@@ -3540,7 +3540,7 @@ ROOT::Experimental::RNullableField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RNullableField::GenerateColumnsImpl()
+void ROOT::Experimental::RNullableField::GenerateColumns()
 {
    if (HasDefaultColumnRepresentative()) {
       if (fSubFields[0]->GetValueSize() < 4) {
@@ -3555,7 +3555,7 @@ void ROOT::Experimental::RNullableField::GenerateColumnsImpl()
    }
 }
 
-void ROOT::Experimental::RNullableField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RNullableField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    if (onDiskTypes[0] == EColumnType::kBit) {
@@ -3945,12 +3945,12 @@ ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
+void ROOT::Experimental::RCollectionField::GenerateColumns()
 {
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
 }
 
-void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1196,17 +1196,6 @@ ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresen
    return representations;
 }
 
-void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClusterSizeField(*this);
@@ -1225,8 +1214,7 @@ ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCardinalityField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RCardinalityField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1255,17 +1243,6 @@ ROOT::Experimental::RField<char>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<char>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<char>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<char>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitCharField(*this);
@@ -1278,17 +1255,6 @@ ROOT::Experimental::RField<std::byte>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kByte}}, {});
    return representations;
-}
-
-void ROOT::Experimental::RField<std::byte>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<std::byte>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<char>(onDiskTypes[0], 0));
 }
 
 void ROOT::Experimental::RField<std::byte>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1305,17 +1271,6 @@ ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() cons
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::int8_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::int8_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RIntegralField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt8Field(*this);
@@ -1328,17 +1283,6 @@ ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() con
 {
    static RColumnRepresentations representations({{EColumnType::kUInt8}}, {{EColumnType::kInt8}});
    return representations;
-}
-
-void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::uint8_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint8_t>(onDiskTypes[0], 0));
 }
 
 void ROOT::Experimental::RIntegralField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1355,17 +1299,6 @@ ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<bool>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<bool>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<bool>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<bool>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitBoolField(*this);
@@ -1379,17 +1312,6 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
    static RColumnRepresentations representations(
       {{EColumnType::kSplitReal32}, {EColumnType::kReal32}, {EColumnType::kReal16}}, {});
    return representations;
-}
-
-void ROOT::Experimental::RField<float>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<float>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<float>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<float>(onDiskTypes[0], 0));
 }
 
 void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1416,17 +1338,6 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<double>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<double>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RField<double>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<double>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitDoubleField(*this);
@@ -1447,17 +1358,6 @@ ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::int16_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::int16_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RIntegralField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt16Field(*this);
@@ -1471,17 +1371,6 @@ ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() co
    static RColumnRepresentations representations({{EColumnType::kSplitUInt16}, {EColumnType::kUInt16}},
                                                  {{EColumnType::kSplitInt16}, {EColumnType::kInt16}});
    return representations;
-}
-
-void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::uint16_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint16_t>(onDiskTypes[0], 0));
 }
 
 void ROOT::Experimental::RIntegralField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1499,17 +1388,6 @@ ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::int32_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::int32_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RIntegralField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt32Field(*this);
@@ -1525,17 +1403,6 @@ ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::uint32_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint32_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RIntegralField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt32Field(*this);
@@ -1549,17 +1416,6 @@ ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() co
    static RColumnRepresentations representations({{EColumnType::kSplitUInt64}, {EColumnType::kUInt64}},
                                                  {{EColumnType::kSplitInt64}, {EColumnType::kInt64}});
    return representations;
-}
-
-void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::uint64_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::uint64_t>(onDiskTypes[0], 0));
 }
 
 void ROOT::Experimental::RIntegralField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -1582,17 +1438,6 @@ ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumns()
-{
-   fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(GetColumnRepresentative()[0], 0));
-}
-
-void ROOT::Experimental::RIntegralField<std::int64_t>::GenerateColumns(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<std::int64_t>(onDiskTypes[0], 0));
-}
-
 void ROOT::Experimental::RIntegralField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt64Field(*this);
@@ -1613,15 +1458,12 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
-   fColumns.emplace_back(Internal::RColumn::Create<char>(GetColumnRepresentative()[1], 1));
+   GenerateColumnsImpl<0, ClusterSize_t, char>();
 }
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
-   fColumns.emplace_back(Internal::RColumn::Create<char>(onDiskTypes[1], 1));
+   GenerateColumnsImpl<0, ClusterSize_t, char>(desc);
 }
 
 std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const void *from)
@@ -2050,15 +1892,12 @@ ROOT::Experimental::RUnsplitField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RUnsplitField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
-   fColumns.emplace_back(Internal::RColumn::Create<std::byte>(GetColumnRepresentative()[1], 1));
+   GenerateColumnsImpl<0, ClusterSize_t, std::byte>();
 }
 
 void ROOT::Experimental::RUnsplitField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
-   fColumns.emplace_back(Internal::RColumn::Create<std::byte>(onDiskTypes[1], 1));
+   GenerateColumnsImpl<0, ClusterSize_t, std::byte>(desc);
 }
 
 void ROOT::Experimental::RUnsplitField::ConstructValue(void *where) const
@@ -2313,13 +2152,12 @@ ROOT::Experimental::RProxiedCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>();
 }
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RProxiedCollectionField::ConstructValue(void *where) const
@@ -2584,13 +2422,12 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVectorField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>();
 }
 
 void ROOT::Experimental::RVectorField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RVectorField::RVectorDeleter::operator()(void *objPtr, bool dtorOnly)
@@ -2826,13 +2663,12 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RRVecField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>();
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 void ROOT::Experimental::RRVecField::ConstructValue(void *where) const
@@ -2943,13 +2779,12 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>();
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>
@@ -3235,13 +3070,12 @@ ROOT::Experimental::RBitsetField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RBitsetField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<bool>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, bool>();
 }
 
 void ROOT::Experimental::RBitsetField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<bool>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, bool>(desc);
 }
 
 std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const void *from)
@@ -3389,13 +3223,12 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVariantField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<RColumnSwitch>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, RColumnSwitch>();
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<RColumnSwitch>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, RColumnSwitch>(desc);
 }
 
 void ROOT::Experimental::RVariantField::ConstructValue(void *where) const
@@ -3947,13 +3780,12 @@ ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCollectionField::GenerateColumns()
 {
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentative()[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>();
 }
 
 void ROOT::Experimental::RCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+   GenerateColumnsImpl<0, ClusterSize_t>(desc);
 }
 
 std::unique_ptr<ROOT::Experimental::RFieldBase>


### PR DESCRIPTION
For all fields but the nullable field, all the column representations of a given field have the same in-memory type. This is used to create a central helper in `RFieldBase` that implements the column creation logic, given the list of in-memory types.