### PR TITLE
[RF] Add an option to disable per-region WS creation in HistFactory

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -47,6 +47,7 @@ namespace RooStats{
 
       struct Configuration {
         bool binnedFitOptimization = true;
+        bool createPerRegionWorkspaces = true;
       };
 
       HistoToWorkspaceFactoryFast() {}

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -171,10 +171,10 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
       channel_names.push_back(ch_name);
       std::unique_ptr<RooWorkspace> ws_single{factory.MakeSingleChannelModel( measurement, channel )};
 
-      {
+      if (cfg.createPerRegionWorkspaces) {
         // Make the output
-        std::string ChannelFileName = measurement.GetOutputFilePrefix() + "_"
-    + ch_name + "_" + rowTitle + "_model.root";
+        std::string ChannelFileName = measurement.GetOutputFilePrefix() + "_" 
+          + ch_name + "_" + rowTitle + "_model.root";
         cxcoutIHF << "Opening File to hold channel: " << ChannelFileName << std::endl;
         std::unique_ptr<TFile> chanFile{TFile::Open( ChannelFileName.c_str(), "RECREATE" )};
         chanFile->WriteTObject(ws_single.get());


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Updates the HistoToWorkspaceFactoryFast code to add an option to disable the per-region WS production. This might be relevant in cases where the WS creation takes a long time as the per-region WS might not be needed in many cases

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


