### PR TITLE
[dictgen] Introduce --print-rootcling-invocation for genreflex

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -72,6 +72,10 @@ The following people have contributed to this new version:
 
 ## Core Libraries
 
+* The `rootcling` invocation corresponding to a `genreflex` invocation can be obtained with the new `genreflex`
+  command line argument `--print-rootcling-invocation`. This can be useful when migrating from genreflex to
+  rootcling.
+* The `rootcling` utility now fully supports selection xml files and not only LinkDef files.
 
 ## I/O Libraries
 


### PR DESCRIPTION
to easily get the rootcling invocation that corresponds to the current genreflex invocation, to ease the migration from genrelfex to rootcling.
Update the genreflex usage as well, stating that the tool does not support C++ modules generation.
Memorialise the change to the Release Notes, too.

Fixes #13481