### PR TITLE
[ntuple] fix column representation of nullable field

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1535,10 +1535,8 @@ public:
    RNullableField &operator=(RNullableField &&other) = default;
    ~RNullableField() override = default;
 
-   bool IsDense() const { return GetColumnRepresentative()[0] ==  EColumnType::kBit; }
-   bool IsSparse() const { return !IsDense(); }
    void SetDense() { SetColumnRepresentative({EColumnType::kBit}); }
-   void SetSparse() { SetColumnRepresentative({EColumnType::kSplitIndex32}); }
+   void SetSparse() { SetColumnRepresentative({EColumnType::kSplitIndex64}); }
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3375,12 +3375,7 @@ ROOT::Experimental::RNullableField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RNullableField::GenerateColumns()
 {
-   if (HasDefaultColumnRepresentative()) {
-      if (fSubFields[0]->GetValueSize() < 4) {
-         SetColumnRepresentative({EColumnType::kBit});
-      }
-   }
-   if (IsDense()) {
+   if (GetColumnRepresentative()[0] == EColumnType::kBit) {
       fDefaultItemValue = std::make_unique<RValue>(fSubFields[0]->CreateValue());
       fColumns.emplace_back(Internal::RColumn::Create<bool>(EColumnType::kBit, 0));
    } else {
@@ -3400,7 +3395,7 @@ void ROOT::Experimental::RNullableField::GenerateColumns(const RNTupleDescriptor
 
 std::size_t ROOT::Experimental::RNullableField::AppendNull()
 {
-   if (IsDense()) {
+   if (fPrincipalColumn->GetType() == EColumnType::kBit) {
       bool mask = false;
       fPrincipalColumn->Append(&mask);
       return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->GetPtr<void>().get());
@@ -3413,7 +3408,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
 std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
 {
    auto nbytesItem = CallAppendOn(*fSubFields[0], from);
-   if (IsDense()) {
+   if (fPrincipalColumn->GetType() == EColumnType::kBit) {
       bool mask = true;
       fPrincipalColumn->Append(&mask);
       return 1 + nbytesItem;
@@ -3427,7 +3422,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
 ROOT::Experimental::RClusterIndex ROOT::Experimental::RNullableField::GetItemIndex(NTupleSize_t globalIndex)
 {
    RClusterIndex nullIndex;
-   if (IsDense()) {
+   if (fPrincipalColumn->GetType() == EColumnType::kBit) {
       const bool isValidItem = *fPrincipalColumn->Map<bool>(globalIndex);
       return isValidItem ? fPrincipalColumn->GetClusterIndex(globalIndex) : nullIndex;
    } else {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1205,8 +1205,6 @@ static void AddUniquePtrField(RNTupleModel &model, const std::string &fieldName)
 
 TYPED_TEST(UniquePtr, Basics)
 {
-   using RUniquePtrField = ROOT::Experimental::RUniquePtrField;
-
    FileRaii fileGuard("test_ntuple_unique_ptr.root");
 
    {
@@ -1228,23 +1226,13 @@ TYPED_TEST(UniquePtr, Basics)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
 
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDefault>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsDense());
+         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldSparse>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PIOConstructor")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PPString")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsSparse());
+         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDense>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PCustomStruct")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PIOConstructor")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PPString")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel().GetField("PArray")).IsDense());
+         EXPECT_EQ(EColumnType::kBit, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
       }
 
       auto pBool = writer->GetModel().GetDefaultEntry().GetPtr<std::unique_ptr<bool>>("PBool");


### PR DESCRIPTION
Makes the following changes:
  - The default representation is now always a vector of 0/1 elements. There are very few cases where the bitmask plus default constructed NULL values are better. Users now need to explicitly request that representation.

  - Remove IsDense(), IsSparse(), which will be hard to maintain once the representation can change from cluster to cluster

  - Use kSplitIndex64 (instead of 32bit) as a default column type for the vector representation

Fixes #12842 