### PR TITLE
[ntuple] ensure empty page ranges for suppressed columns

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -681,9 +681,8 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges
                      const auto element = Internal::RColumnElementBase::Generate<void>(c.GetType());
                      pageRange.ExtendToFitColumnRange(columnRange, *element, Internal::RPage::kPageZeroSize);
                   }
-               } else {
-                  auto &pageRange = fCluster.fPageRanges[physicalId];
-                  pageRange.fPhysicalColumnId = physicalId;
+               } else if (!columnRange.fIsSuppressed) {
+                  fCluster.fPageRanges[physicalId].fPhysicalColumnId = physicalId;
                }
             }
          },

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -1095,6 +1095,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    EXPECT_TRUE(clusterDesc0.ContainsColumn(columnIds[1]));
    EXPECT_TRUE(clusterDesc0.ContainsColumn(columnIds[2]));
    EXPECT_TRUE(clusterDesc0.ContainsColumn(columnIds[3]));
+   EXPECT_THROW(clusterDesc0.GetPageRange(0), std::out_of_range);
+   EXPECT_THROW(clusterDesc0.GetPageRange(1), std::out_of_range);
    const auto columnRange0_0 = clusterDesc0.GetColumnRange(columnIds[0]);
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
    const auto columnRange0_2 = clusterDesc0.GetColumnRange(columnIds[2]);
@@ -1115,6 +1117,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    EXPECT_TRUE(clusterDesc1.ContainsColumn(columnIds[1]));
    EXPECT_TRUE(clusterDesc1.ContainsColumn(columnIds[2]));
    EXPECT_TRUE(clusterDesc1.ContainsColumn(columnIds[3]));
+   EXPECT_THROW(clusterDesc1.GetPageRange(2), std::out_of_range);
+   EXPECT_THROW(clusterDesc1.GetPageRange(3), std::out_of_range);
    const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
    const auto columnRange1_2 = clusterDesc1.GetColumnRange(columnIds[2]);


### PR DESCRIPTION
The cluster descriptor should contain no page range for suppressed columns. This fix prevents the accidental creation of an empty page range during deserialization of the page list.
