### PR TITLE
[CPyCppyy] Auto-cast elements of std::vector<T*>, with T a class type

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -420,7 +420,10 @@ static PyObject* vectoriter_iternext(vectoriterobject* vi) {
     // that objects in vectors are simple and thus do not need to maintain object identity
     // (or at least not during the loop anyway). This gains 2x in performance.
         Cppyy::TCppObject_t cppobj = (Cppyy::TCppObject_t)((ptrdiff_t)vi->vi_data + vi->vi_stride * vi->ii_pos);
-        result = CPyCppyy::BindCppObjectNoCast(cppobj, vi->vi_klass, CPyCppyy::CPPInstance::kNoMemReg);
+        if (vi->vi_flags & vectoriterobject::kIsPolymorphic)
+            result = CPyCppyy::BindCppObject(*(void**)cppobj, vi->vi_klass, CPyCppyy::CPPInstance::kNoMemReg);
+        else
+            result = CPyCppyy::BindCppObjectNoCast(cppobj, vi->vi_klass, CPyCppyy::CPPInstance::kNoMemReg);
         if ((vi->vi_flags & vectoriterobject::kNeedLifeLine) && result)
             PyObject_SetAttr(result, PyStrings::gLifeLine, vi->ii_container);
     } else {

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.h
@@ -102,6 +102,7 @@ struct vectoriterobject : public indexiterobject {
     enum EFlags {
         kDefault        = 0x0000,
         kNeedLifeLine   = 0x0001,
+        kIsPolymorphic  = 0x0002,
     };
 };
 


### PR DESCRIPTION
Applying the following commit from CPyCppyy upstream: https://github.com/wlav/CPyCppyy/commit/9a792b231c73452d08686ea83c6588f5e98ca9a7

Closes #1523.

