### PR TITLE
[gpad] update list of free colors when streaming canvas from file

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2251,7 +2251,19 @@ void TCanvas::Streamer(TBuffer &b)
                   delete colcur;
                }
                colors->Remove(colold);
-               if (root_colors) root_colors->AddAtAndExpand(colold, cn);
+               if (root_colors) {
+                  if (colcur) {
+                     root_colors->AddAtAndExpand(colold, cn);
+                  }
+                  else {
+                     // Copy to current session
+                     // do not use copy constructor which does not update highest color index
+                     TColor* const colnew = new TColor(cn, colold->GetRed(), colold->GetGreen(), colold->GetBlue(), colold->GetName(), colold->GetAlpha());
+                     delete colold;
+                     // No need to delete colnew, as the constructor adds it to global list of colors
+                     assert(root_colors->At(cn) == colnew);
+                  }
+               }
             }
          }
          //restore the palette if needed


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/16051

What I did was to copy using the full constructor which updates the list.

Another solution could to be change the Streamer so that it interacts with the list of colors directly, but don't know how to.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

