### PR TITLE
Fix buffer overflow in cint's G__defineMacro

### DIFF
--- a/cint/cint/src/init.cxx
+++ b/cint/cint/src/init.cxx
@@ -2051,7 +2051,7 @@ static void G__defineMacro(const char* name, long value, const char* cintname = 
          --end;
       }
 
-      snprintf(end + 1, G__ONELINE - (end-temp), "=%ld", value);
+      snprintf(end + 1, G__ONELINE - (end+1-temp), "=%ld", value);
       while (cap && end != start) {
          // capitalize the CINT macro name
          *end = (char)toupper(*end);


### PR DESCRIPTION
Fixes a "buffer overflow" in `G__defineMacro` of `cint`, where `snprintf` is given buffer length that is 1 byte longer that the actual buffer.

It is seems like this never caused any actual buffer overflows - at least while building ROOT, where `cint` or rather `rootcint_tmp` is already used. However, this causes issues in certain scenarios, where GCC's (?) fortify mechanism causes `cint` (or rather `rootcint_tmp`) to abort during `G__DEFINE_MACRO(__linux__);`.

Notes on my encounter with this issue:
- using GCC 13.2.0 on Ubuntu 24.04
- does not occur in `Debug` build mode, but was debuggable when using `RelWithDebInfo`
- the ROOT version is some legacy patched tarball apparently based on v5.34.00

I did not reproduce this issue using this branch, nor do I plan to, since I encountered other issues earlier during such a build attempt. Consequently, I also didn't run any tests.
If this makes this PR ineligible to merge, I'm fine with having it closed. This way, at least the potential error scenario and a solution are effectively "documented".