### PR TITLE
[ntuple] Multiple column representations: high-level support

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -75,11 +75,11 @@ private:
    NTupleSize_t fFirstElementIndex = 0;
    /// Used to pack and unpack pages on writing/reading
    std::unique_ptr<RColumnElementBase> fElement;
-   /// The column team is a set of columns that serve the same column index for different representation IDs
-   /// Initially, the team has only one member, the very column it belongs to. Through MergeTeams(), two column
+   /// The column team is a set of columns that serve the same column index for different representation IDs.
+   /// Initially, the team has only one member, the very column it belongs to. Through MergeTeams(), two columns
    /// can join forces. The team is used to react on suppressed columns: if the current team member has a suppressed
    /// column for a MapPage() call, it get the page from the active column in the corresponding cluster.
-   std::shared_ptr<std::vector<RColumn *>> fTeam;
+   std::vector<RColumn *> fTeam;
    /// Points into fTeam to the column that successfully returned the last page.
    std::size_t fLastGoodTeamIdx = 0;
 
@@ -116,8 +116,6 @@ private:
       // fNElements in SwapWritePagesIfFull() when the pages swap
       fWritePage[otherIdx].Reset(0);
    }
-
-   void TeamUp(const RColumn &other) { fTeam = other.fTeam; }
 
 public:
    template <typename CppT>

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -330,6 +330,7 @@ public:
    }
 
    void Flush();
+   void CommitSuppressed();
    void MapPage(const NTupleSize_t index);
    void MapPage(RClusterIndex clusterIndex);
    NTupleSize_t GetNElements() const { return fNElements; }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -76,7 +76,7 @@ private:
    /// Used to pack and unpack pages on writing/reading
    std::unique_ptr<RColumnElementBase> fElement;
 
-   RColumn(EColumnType type, std::uint32_t index);
+   RColumn(EColumnType type, std::uint32_t columnIndex, std::uint16_t representationIndex);
 
    /// Used in Append() and AppendV() to handle the case when the main page reached the target size.
    /// If tail page optimization is enabled, switch the pages; the other page has been flushed when
@@ -112,9 +112,9 @@ private:
 
 public:
    template <typename CppT>
-   static std::unique_ptr<RColumn> Create(EColumnType type, std::uint32_t index)
+   static std::unique_ptr<RColumn> Create(EColumnType type, std::uint32_t columnIdx, std::uint16_t representationIdx)
    {
-      auto column = std::unique_ptr<RColumn>(new RColumn(type, index));
+      auto column = std::unique_ptr<RColumn>(new RColumn(type, columnIdx, representationIdx));
       column->fElement = RColumnElementBase::Generate<CppT>(type);
       return column;
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -340,9 +340,17 @@ public:
 
    void Flush();
    void CommitSuppressed();
-   void MapPage(const NTupleSize_t index);
-   void MapPage(RClusterIndex clusterIndex);
+
+   void MapPage(NTupleSize_t globalIndex) { R__ASSERT(TryMapPage(globalIndex)); }
+   void MapPage(RClusterIndex clusterIndex) { R__ASSERT(TryMapPage(clusterIndex)); }
+   bool TryMapPage(NTupleSize_t globalIndex);
+   bool TryMapPage(RClusterIndex clusterIndex);
+
+   bool ReadPageContains(NTupleSize_t globalIndex) const { return fReadPage.Contains(globalIndex); }
+   bool ReadPageContains(RClusterIndex clusterIndex) const { return fReadPage.Contains(clusterIndex); }
+
    void MergeTeams(RColumn &other);
+
    NTupleSize_t GetNElements() const { return fNElements; }
    RColumnElementBase *GetElement() const { return fElement.get(); }
    EColumnType GetType() const { return fType; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -172,20 +172,22 @@ public:
    /// i.e. for the example above, the unpacking of 32bit ints to 64bit pages must be implemented in RColumnElement.hxx
    class RColumnRepresentations {
    public:
-      using TypesList_t = std::vector<ColumnRepresentation_t>;
+      /// A list of column representations
+      using Selection_t = std::vector<ColumnRepresentation_t>;
+
       RColumnRepresentations();
-      RColumnRepresentations(const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes);
+      RColumnRepresentations(const Selection_t &serializationTypes, const Selection_t &deserializationExtraTypes);
 
       /// The first column list from fSerializationTypes is the default for writing.
       const ColumnRepresentation_t &GetSerializationDefault() const { return fSerializationTypes[0]; }
-      const TypesList_t &GetSerializationTypes() const { return fSerializationTypes; }
-      const TypesList_t &GetDeserializationTypes() const { return fDeserializationTypes; }
+      const Selection_t &GetSerializationTypes() const { return fSerializationTypes; }
+      const Selection_t &GetDeserializationTypes() const { return fDeserializationTypes; }
 
    private:
-      TypesList_t fSerializationTypes;
+      Selection_t fSerializationTypes;
       /// The union of the serialization types and the deserialization extra types.  Duplicates the serialization types
       /// list but the benenfit is that GetDeserializationTypes does not need to compile the list.
-      TypesList_t fDeserializationTypes;
+      Selection_t fDeserializationTypes;
    }; // class RColumnRepresentations
 
    /// Points to an object with RNTuple I/O support and keeps a pointer to the corresponding field.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -463,6 +463,11 @@ protected:
             break;
          GenerateColumnsImpl<0, ColumnCppTs...>(onDiskTypes, representationIndex);
          fColumnRepresentatives.emplace_back(onDiskTypes);
+         if (representationIndex > 0) {
+            for (std::size_t i = 0; i < sizeof...(ColumnCppTs); ++i) {
+               fColumns[i]->MergeTeams(*fColumns[representationIndex * sizeof...(ColumnCppTs) + i].get());
+            }
+         }
          representationIndex++;
       } while (true);
    }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -733,7 +733,7 @@ public:
    /// Fixes a column representative. This can only be done _before_ connecting the field to a page sink.
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
    /// an exception is thrown
-   void SetColumnRepresentative(const ColumnRepresentation_t &representative);
+   void SetColumnRepresentatives(const RColumnRepresentations::Selection_t &representatives);
    /// Whether or not an explicit column representative was set
    bool HasDefaultColumnRepresentative() const { return fColumnRepresentatives.empty(); }
 
@@ -1538,8 +1538,8 @@ public:
    RNullableField &operator=(RNullableField &&other) = default;
    ~RNullableField() override = default;
 
-   void SetDense() { SetColumnRepresentative({EColumnType::kBit}); }
-   void SetSparse() { SetColumnRepresentative({EColumnType::kSplitIndex64}); }
+   void SetDense() { SetColumnRepresentatives({{EColumnType::kBit}}); }
+   void SetSparse() { SetColumnRepresentatives({{EColumnType::kSplitIndex64}}); }
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1556,6 +1556,10 @@ protected:
    std::size_t AppendValue(const void *from);
    void CommitClusterImpl() final { fNWritten = 0; }
 
+   // The default implementation that translates the request into a call to ReadGlobalImpl() cannot be used
+   // because we don't team up the columns of the different column representations for this field.
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
+
    /// Given the index of the nullable field, returns the corresponding global index of the subfield or,
    /// if it is null, returns kInvalidClusterIndex
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -415,9 +415,10 @@ protected:
    /// TClass checksum cached from the descriptor after a call to `ConnectPageSource()`. Only set
    /// for classes with dictionaries.
    std::uint32_t fOnDiskTypeChecksum = 0;
-   /// Points into the static vector GetColumnRepresentations().GetSerializationTypes() when SetColumnRepresentative
-   /// is called.  Otherwise GetColumnRepresentative returns the default representation.
-   const ColumnRepresentation_t *fColumnRepresentative = nullptr;
+   /// Pointers into the static vector GetColumnRepresentations().GetSerializationTypes() when
+   /// SetColumnRepresentative(s) is called.  Otherwise (if empty) GetColumnRepresentative() returns the
+   /// default representation.
+   std::vector<std::reference_wrapper<const ColumnRepresentation_t>> fColumnRepresentatives;
 
    /// Helpers for generating columns. We use the fact that most fields have the same C++/memory types
    /// for all their column representations.
@@ -732,7 +733,7 @@ public:
    /// an exception is thrown
    void SetColumnRepresentative(const ColumnRepresentation_t &representative);
    /// Whether or not an explicit column representative was set
-   bool HasDefaultColumnRepresentative() const { return fColumnRepresentative == nullptr; }
+   bool HasDefaultColumnRepresentative() const { return fColumnRepresentatives.empty(); }
 
    /// Indicates an evolution of the mapping scheme from C++ type to columns
    virtual std::uint32_t GetFieldVersion() const { return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1255,6 +1255,11 @@ public:
    /// should happen before calling this function.
    RClusterDescriptorBuilder &AddExtendedColumnRanges(const RNTupleDescriptor &desc);
 
+   const RClusterDescriptor::RColumnRange &GetColumnRange(DescriptorId_t physicalId)
+   {
+      return fCluster.GetColumnRange(physicalId);
+   }
+
    /// Move out the full cluster descriptor including page locations
    RResult<RClusterDescriptor> MoveDescriptor();
 };

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -139,6 +139,7 @@ public:
    /// Return a pointer to the page zero buffer used if there is no on-disk data for a particular deferred column
    static const void *GetPageZeroBuffer();
 
+   bool IsValid() const { return fColumnId != kInvalidColumnId; }
    bool IsNull() const { return fBuffer == nullptr; }
    bool IsPageZero() const { return fBuffer == GetPageZeroBuffer(); }
    bool IsEmpty() const { return fNElements == 0; }

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -73,6 +73,7 @@ public:
    }
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
 
+   void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitPage(ColumnHandle_t, const RPage &page) final { fNBytesCurrentCluster += page.GetNBytes(); }
    void CommitSealedPage(DescriptorId_t, const RSealedPage &page) final
    {

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -126,6 +126,8 @@ private:
    std::unique_ptr<RNTupleModel> fInnerModel;
    /// Vector of buffered column pages. Indexed by column id.
    std::vector<RColumnBuf> fBufferedColumns;
+   /// Columns committed as suppressed are stored and passed to the inner sink at cluster commit
+   std::vector<ColumnHandle_t> fSuppressedColumns;
    DescriptorId_t fNFields = 0;
    DescriptorId_t fNColumns = 0;
 
@@ -147,6 +149,7 @@ public:
    void UpdateSchema(const RNTupleModelChangeset &changeset, NTupleSize_t firstEntry) final;
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
+   void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -76,6 +76,7 @@ private:
    Detail::RNTupleMetrics fMetrics;
    std::vector<std::unique_ptr<RPageSource>> fSources;
    RIdBiMap fIdBiMap;
+   RIdBiMap fColumnMap;
 
    RNTupleDescriptorBuilder fBuilder;
    DescriptorId_t fNextId = 1;  ///< 0 is reserved for the friend zero field

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -76,6 +76,10 @@ private:
    Detail::RNTupleMetrics fMetrics;
    std::vector<std::unique_ptr<RPageSource>> fSources;
    RIdBiMap fIdBiMap;
+   /// TODO(jblomer): Not only the columns, but actually all the different objects of the descriptor would need
+   /// their own maps to avoid descriptor ID clashes. The need for the distinct column map was triggered by adding
+   /// support for multi-column representations. A follow-up patch should either fix the friend page source properly
+   /// or remove it in favor of the RNTupleProcessor.
    RIdBiMap fColumnMap;
 
    RNTupleDescriptorBuilder fBuilder;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -667,9 +667,10 @@ public:
    REntryRange GetEntryRange() const { return fEntryRange; }
 
    /// Allocates and fills a page that contains the index-th element. The default implementation searches
-   /// the page and calls PopulatePageImpl().
+   /// the page and calls PopulatePageImpl(). Returns a default-constructed RPage for suppressed columns.
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex);
    /// Another version of `PopulatePage` that allows to specify cluster-relative indexes.
+   /// Returns a default-constructed RPage for suppressed columns.
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, RClusterIndex clusterIndex);
 
    /// Read the packed and compressed bytes of a page into the memory buffer provided by `sealedPage`. The sealed page

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -300,6 +300,9 @@ public:
    /// registered by specific fields (e.g., unsplit field) and during merging.
    virtual void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) = 0;
 
+   /// Commits a suppressed column for the current cluster. Can be called anytime before CommitCluster().
+   /// For any given column and cluster, there must be no calls to both CommitSuppressedColumn() and page commits.
+   virtual void CommitSuppressedColumn(ColumnHandle_t columnHandle) = 0;
    /// Write a page to the storage. The column must have been added before.
    virtual void CommitPage(ColumnHandle_t columnHandle, const RPage &page) = 0;
    /// Write a preprocessed page to storage. The column must have been added before.
@@ -452,6 +455,7 @@ public:
    /// Initialize sink based on an existing descriptor and fill into the descriptor builder.
    void InitFromDescriptor(const RNTupleDescriptor &descriptor);
 
+   void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -121,7 +121,8 @@ bool ROOT::Experimental::Internal::RColumn::TryMapPage(NTupleSize_t globalIndex)
       fReadPage = fPageSource->PopulatePage(fTeam->at(fLastGoodTeamIdx)->GetHandleSource(), globalIndex);
       if (fReadPage.IsValid())
          break;
-      fLastGoodTeamIdx = (fLastGoodTeamIdx + iTeam++) % nTeam;
+      fLastGoodTeamIdx = (fLastGoodTeamIdx + 1) % nTeam;
+      iTeam++;
    } while (iTeam <= nTeam);
 
    return fReadPage.Contains(globalIndex);
@@ -140,7 +141,8 @@ bool ROOT::Experimental::Internal::RColumn::TryMapPage(RClusterIndex clusterInde
       fReadPage = fPageSource->PopulatePage(fTeam->at(fLastGoodTeamIdx)->GetHandleSource(), clusterIndex);
       if (fReadPage.IsValid())
          break;
-      fLastGoodTeamIdx = (fLastGoodTeamIdx + iTeam++) % nTeam;
+      fLastGoodTeamIdx = (fLastGoodTeamIdx + 1) % nTeam;
+      iTeam++;
    } while (iTeam <= nTeam);
 
    return fReadPage.Contains(clusterIndex);

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -21,8 +21,9 @@
 
 #include <cassert>
 
-ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t index)
-   : fType(type), fIndex(index), fRepresentationIndex(0 /* TODO(jblomer) */)
+ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t columnIndex,
+                                               std::uint16_t representationIndex)
+   : fType(type), fIndex(columnIndex), fRepresentationIndex(representationIndex)
 {
    // TODO(jblomer): fix for column types with configurable bit length once available
    const auto [minBits, maxBits] = RColumnElementBase::GetValidBitRange(type);

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -99,6 +99,11 @@ void ROOT::Experimental::Internal::RColumn::Flush()
    fWritePage[fWritePageIdx].Reset(fNElements);
 }
 
+void ROOT::Experimental::Internal::RColumn::CommitSuppressed()
+{
+   fPageSink->CommitSuppressedColumn(fHandleSink);
+}
+
 void ROOT::Experimental::Internal::RColumn::MapPage(const NTupleSize_t index)
 {
    fPageSource->ReleasePage(fReadPage);

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -108,7 +108,7 @@ void ROOT::Experimental::Internal::RColumn::CommitSuppressed()
    fPageSink->CommitSuppressedColumn(fHandleSink);
 }
 
-void ROOT::Experimental::Internal::RColumn::MapPage(const NTupleSize_t index)
+bool ROOT::Experimental::Internal::RColumn::TryMapPage(NTupleSize_t globalIndex)
 {
    fPageSource->ReleasePage(fReadPage);
    // Set fReadPage to an empty page before populating it to prevent double destruction of the previously page in case
@@ -118,16 +118,16 @@ void ROOT::Experimental::Internal::RColumn::MapPage(const NTupleSize_t index)
    const auto nTeam = fTeam->size();
    std::size_t iTeam = 1;
    do {
-      fReadPage = fPageSource->PopulatePage(fTeam->at(fLastGoodTeamIdx)->GetHandleSource(), index);
+      fReadPage = fPageSource->PopulatePage(fTeam->at(fLastGoodTeamIdx)->GetHandleSource(), globalIndex);
       if (fReadPage.IsValid())
          break;
       fLastGoodTeamIdx = (fLastGoodTeamIdx + iTeam++) % nTeam;
    } while (iTeam <= nTeam);
 
-   R__ASSERT(fReadPage.Contains(index));
+   return fReadPage.Contains(globalIndex);
 }
 
-void ROOT::Experimental::Internal::RColumn::MapPage(RClusterIndex clusterIndex)
+bool ROOT::Experimental::Internal::RColumn::TryMapPage(RClusterIndex clusterIndex)
 {
    fPageSource->ReleasePage(fReadPage);
    // Set fReadPage to an empty page before populating it to prevent double destruction of the previously page in case
@@ -143,7 +143,7 @@ void ROOT::Experimental::Internal::RColumn::MapPage(RClusterIndex clusterIndex)
       fLastGoodTeamIdx = (fLastGoodTeamIdx + iTeam++) % nTeam;
    } while (iTeam <= nTeam);
 
-   R__ASSERT(fReadPage.Contains(clusterIndex));
+   return fReadPage.Contains(clusterIndex);
 }
 
 void ROOT::Experimental::Internal::RColumn::MergeTeams(RColumn &other)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3393,9 +3393,9 @@ void ROOT::Experimental::RNullableField::GenerateColumns()
    // TODO(jblomer): handle all column representatives
    if (GetColumnRepresentatives()[0][0] == EColumnType::kBit) {
       fDefaultItemValue = std::make_unique<RValue>(fSubFields[0]->CreateValue());
-      fColumns.emplace_back(Internal::RColumn::Create<bool>(EColumnType::kBit, 0));
+      fColumns.emplace_back(Internal::RColumn::Create<bool>(EColumnType::kBit, 0, 0));
    } else {
-      fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentatives()[0][0], 0));
+      fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(GetColumnRepresentatives()[0][0], 0, 0));
    }
 }
 
@@ -3403,9 +3403,9 @@ void ROOT::Experimental::RNullableField::GenerateColumns(const RNTupleDescriptor
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    if (onDiskTypes[0] == EColumnType::kBit) {
-      fColumns.emplace_back(Internal::RColumn::Create<bool>(EColumnType::kBit, 0));
+      fColumns.emplace_back(Internal::RColumn::Create<bool>(EColumnType::kBit, 0, 0));
    } else {
-      fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0));
+      fColumns.emplace_back(Internal::RColumn::Create<ClusterSize_t>(onDiskTypes[0], 0, 0));
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1027,6 +1027,7 @@ void ROOT::Experimental::RFieldBase::SetColumnRepresentatives(
       throw RException(R__FAIL("cannot set column representative once field is connected"));
    const auto &validTypes = GetColumnRepresentations().GetSerializationTypes();
    fColumnRepresentatives.clear();
+   fColumnRepresentatives.reserve(representatives.size());
    for (const auto &r : representatives) {
       auto itRepresentative = std::find(validTypes.begin(), validTypes.end(), r);
       if (itRepresentative == std::end(validTypes))

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1006,15 +1006,19 @@ ROOT::Experimental::RFieldBase::GetColumnRepresentative() const
    return GetColumnRepresentations().GetSerializationDefault();
 }
 
-void ROOT::Experimental::RFieldBase::SetColumnRepresentative(const ColumnRepresentation_t &representative)
+void ROOT::Experimental::RFieldBase::SetColumnRepresentatives(
+   const RColumnRepresentations::Selection_t &representatives)
 {
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("cannot set column representative once field is connected"));
    const auto &validTypes = GetColumnRepresentations().GetSerializationTypes();
-   auto itRepresentative = std::find(validTypes.begin(), validTypes.end(), representative);
-   if (itRepresentative == std::end(validTypes))
-      throw RException(R__FAIL("invalid column representative"));
-   fColumnRepresentatives = {*itRepresentative};
+   fColumnRepresentatives.clear();
+   for (const auto &r : representatives) {
+      auto itRepresentative = std::find(validTypes.begin(), validTypes.end(), r);
+      if (itRepresentative == std::end(validTypes))
+         throw RException(R__FAIL("invalid column representative"));
+      fColumnRepresentatives.emplace_back(*itRepresentative);
+   }
 }
 
 const ROOT::Experimental::RFieldBase::ColumnRepresentation_t &
@@ -1071,7 +1075,7 @@ void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const RNTupleWriteOpt
          default: break;
          }
       }
-      SetColumnRepresentative(rep);
+      SetColumnRepresentatives({rep});
    }
 
    if (options.GetHasSmallClusters()) {
@@ -1083,11 +1087,11 @@ void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const RNTupleWriteOpt
          default: break;
          }
       }
-      SetColumnRepresentative(rep);
+      SetColumnRepresentatives({rep});
    }
 
    if (fTypeAlias == "Double32_t")
-      SetColumnRepresentative({EColumnType::kSplitReal32});
+      SetColumnRepresentatives({{EColumnType::kSplitReal32}});
 }
 
 void ROOT::Experimental::RFieldBase::ConnectPageSink(Internal::RPageSink &pageSink, NTupleSize_t firstEntry)
@@ -1325,7 +1329,7 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
 
 void ROOT::Experimental::RField<float>::SetHalfPrecision()
 {
-   SetColumnRepresentative({EColumnType::kReal16});
+   SetColumnRepresentatives({{EColumnType::kReal16}});
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -427,7 +427,7 @@ ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations()
 }
 
 ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
-   const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes)
+   const Selection_t &serializationTypes, const Selection_t &deserializationExtraTypes)
    : fSerializationTypes(serializationTypes), fDeserializationTypes(serializationTypes)
 {
    fDeserializationTypes.insert(fDeserializationTypes.end(),

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -978,8 +978,15 @@ std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBa
 
 void ROOT::Experimental::RFieldBase::CommitCluster()
 {
-   for (auto& column : fColumns) {
-      column->Flush();
+   if (!fColumns.empty()) {
+      const auto activeRepresentationIndex = fColumns[0]->GetRepresentationIndex();
+      for (auto &column : fColumns) {
+         if (column->GetRepresentationIndex() == activeRepresentationIndex) {
+            column->Flush();
+         } else {
+            column->CommitSuppressed();
+         }
+      }
    }
    CommitClusterImpl();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -54,11 +54,9 @@ struct ColumnInfo {
    bool operator<(const ColumnInfo &other) const
    {
       if (fFieldName == other.fFieldName) {
-         if (fRepresentationIndex < other.fRepresentationIndex)
-            return true;
-         else if (fRepresentationIndex > other.fRepresentationIndex)
-            return false;
-         return fColumnIndex < other.fColumnIndex;
+         if (fRepresentationIndex == other.fRepresentationIndex)
+            return fColumnIndex < other.fColumnIndex;
+         return fRepresentationIndex < other.fRepresentationIndex;
       }
       return fFieldName < other.fFieldName;
    }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -477,7 +477,9 @@ std::size_t ROOT::Experimental::RNTupleModel::EstimateWriteMemoryUsage(const RNT
 
    std::size_t nColumns = 0;
    for (auto &&field : *fFieldZero) {
-      nColumns += field.GetColumnRepresentative().size();
+      for (const auto &r : field.GetColumnRepresentatives()) {
+         nColumns += r.size();
+      }
    }
    const std::size_t pageBuffersPerModel = nColumns * pageBufferPerColumn;
    bytes += pageBuffersPerModel;

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -82,6 +82,7 @@ public:
       throw RException(R__FAIL("UpdateExtraTypeInfo not supported via RPageSynchronizingSink"));
    }
 
+   void CommitSuppressedColumn(ColumnHandle_t handle) final { fInnerSink->CommitSuppressedColumn(handle); }
    void CommitPage(ColumnHandle_t, const RPage &) final
    {
       throw RException(R__FAIL("should never commit single pages via RPageSynchronizingSink"));

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -160,6 +160,9 @@ ROOT::Experimental::Internal::RPageSourceFriends::PopulatePage(ColumnHandle_t co
    columnHandle.fPhysicalId = originColumnId.fId;
 
    auto page = fSources[originColumnId.fSourceIdx]->PopulatePage(columnHandle, globalIndex);
+   // Suppressed column
+   if (!page.IsValid())
+      return RPage();
 
    auto virtualClusterId = fIdBiMap.GetVirtualId({originColumnId.fSourceIdx, page.GetClusterInfo().GetId()});
    page.ChangeIds(virtualColumnId, virtualClusterId);
@@ -176,6 +179,9 @@ ROOT::Experimental::Internal::RPageSourceFriends::PopulatePage(ColumnHandle_t co
    columnHandle.fPhysicalId = originColumnId.fId;
 
    auto page = fSources[originColumnId.fSourceIdx]->PopulatePage(columnHandle, originClusterIndex);
+   // Suppressed column
+   if (!page.IsValid())
+      return RPage();
 
    page.ChangeIds(virtualColumnId, clusterIndex.GetClusterId());
    return page;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -616,6 +616,10 @@ ROOT::Experimental::Internal::RPagePersistentSink::AddColumn(DescriptorId_t fiel
       .Index(column.GetIndex())
       .RepresentationIndex(column.GetRepresentationIndex())
       .FirstElementIndex(column.GetFirstElementIndex());
+   // For late model extension, we assume that the primary column representation is the active one for the
+   // deferred range. All other representations are suppressed.
+   if (column.GetFirstElementIndex() > 0 && column.GetRepresentationIndex() > 0)
+      columnBuilder.SetSuppressedDeferred();
    fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
    return ColumnHandle_t{columnId, &column};
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -332,7 +332,11 @@ ROOT::Experimental::Internal::RPageSource::PopulatePage(ColumnHandle_t columnHan
          throw RException(R__FAIL("entry with index " + std::to_string(globalIndex) + " out of bounds"));
 
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterInfo.fClusterId);
-      clusterInfo.fColumnOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
+      const auto &columnRange = clusterDescriptor.GetColumnRange(columnId);
+      if (columnRange.fIsSuppressed)
+         return RPage();
+
+      clusterInfo.fColumnOffset = columnRange.fFirstElementIndex;
       R__ASSERT(clusterInfo.fColumnOffset <= globalIndex);
       idxInCluster = globalIndex - clusterInfo.fColumnOffset;
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
@@ -358,8 +362,12 @@ ROOT::Experimental::Internal::RPageSource::PopulatePage(ColumnHandle_t columnHan
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
+      const auto &columnRange = clusterDescriptor.GetColumnRange(columnId);
+      if (columnRange.fIsSuppressed)
+         return RPage();
+
       clusterInfo.fClusterId = clusterId;
-      clusterInfo.fColumnOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
+      clusterInfo.fColumnOffset = columnRange.fFirstElementIndex;
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -299,6 +299,9 @@ void ROOT::Experimental::Internal::RPageSource::PrepareLoadCluster(
    const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);
 
    for (auto physicalColumnId : clusterKey.fPhysicalColumnSet) {
+      if (clusterDesc.GetColumnRange(physicalColumnId).fIsSuppressed)
+         continue;
+
       const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
       NTupleSize_t pageNo = 0;
       for (const auto &pageInfo : pageRange.fPageInfos) {

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -38,6 +38,7 @@ ROOT_ADD_GTEST(ntuple_friends ntuple_friends.cxx LIBRARIES ROOTNTuple CustomStru
 ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_model ntuple_model.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_multi_column ntuple_multi_column.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -347,7 +347,7 @@ TEST(PageStorageFile, LoadClusters)
    EXPECT_EQ(0U, cluster->GetId());
    EXPECT_EQ(0U, cluster->GetNOnDiskPages());
 
-   auto column = ROOT::Experimental::Internal::RColumn::Create<float>(ROOT::Experimental::EColumnType::kReal32, 0);
+   auto column = ROOT::Experimental::Internal::RColumn::Create<float>(ROOT::Experimental::EColumnType::kReal32, 0, 0);
    column->ConnectPageSource(ptId, source);
    clusterKeys[0].fClusterId = 1;
    clusterKeys[0].fPhysicalColumnSet.insert(colId);

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -51,6 +51,7 @@ protected:
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
    void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
+   void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}
    std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -1,0 +1,378 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTuple, MultiColumnRepresentationSimple)
+{
+   using ROOT::Experimental::kUnknownCompressionSettings;
+   FileRaii fileGuard("test_ntuple_multi_column_representation_simple.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldPx = RFieldBase::Create("px", "float").Unwrap();
+      fldPx->SetColumnRepresentatives({{EColumnType::kReal32}, {EColumnType::kReal16}});
+      model->AddField(std::move(fldPx));
+      auto ptrPx = model->GetDefaultEntry().GetPtr<float>("px");
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+      *ptrPx = 1.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
+      *ptrPx = 2.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
+      *ptrPx = 3.0;
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(3u, reader->GetModel().GetField("px").GetNElements());
+
+   const auto &desc = reader->GetDescriptor();
+   EXPECT_EQ(3u, desc.GetNClusters());
+
+   const auto &fieldDesc = desc.GetFieldDescriptor(desc.FindFieldId("px"));
+   EXPECT_EQ(1u, fieldDesc.GetColumnCardinality());
+   EXPECT_EQ(2u, fieldDesc.GetLogicalColumnIds().size());
+
+   const auto &colDesc32 = desc.GetColumnDescriptor(fieldDesc.GetLogicalColumnIds()[0]);
+   const auto &colDesc16 = desc.GetColumnDescriptor(fieldDesc.GetLogicalColumnIds()[1]);
+
+   EXPECT_EQ(EColumnType::kReal32, colDesc32.GetType());
+   EXPECT_EQ(0u, colDesc32.GetRepresentationIndex());
+   EXPECT_EQ(EColumnType::kReal16, colDesc16.GetType());
+   EXPECT_EQ(1u, colDesc16.GetRepresentationIndex());
+
+   const auto &clusterDesc0 = desc.GetClusterDescriptor(0);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+
+   const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+
+   const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+
+   auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(1.0, *ptrPx);
+   reader->LoadEntry(1);
+   EXPECT_FLOAT_EQ(2.0, *ptrPx);
+   reader->LoadEntry(2);
+   EXPECT_FLOAT_EQ(3.0, *ptrPx);
+
+   auto viewPx = reader->GetView<float>("px");
+   EXPECT_FLOAT_EQ(1.0, viewPx(0));
+   EXPECT_FLOAT_EQ(2.0, viewPx(1));
+   EXPECT_FLOAT_EQ(3.0, viewPx(2));
+
+   std::ostringstream osDetails;
+   reader->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, osDetails);
+   const std::string reference = std::string("") + "============================================================\n"
+                                                   "NTUPLE:      ntpl\n"
+                                                   "Compression: 0\n"
+                                                   "------------------------------------------------------------\n"
+                                                   "  # Entries:        3\n"
+                                                   "  # Fields:         2\n"
+                                                   "  # Columns:        2\n"
+                                                   "  # Alias Columns:  0\n"
+                                                   "  # Pages:          3\n"
+                                                   "  # Clusters:       3\n"
+                                                   "  Size on storage:  .* B\n"
+                                                   "  Compression rate: .*\n"
+                                                   "  Header size:      .* B\n"
+                                                   "  Footer size:      .* B\n"
+                                                   "  Meta-data / data: .*\n"
+                                                   "------------------------------------------------------------\n"
+                                                   "CLUSTER DETAILS\n"
+                                                   "------------------------------------------------------------\n"
+                                                   "  #     0   Entry range:     .0..0.  --  1\n"
+                                                   "            # Pages:         1\n"
+                                                   "            Size on storage: 4 B\n"
+                                                   "            Compression:     1.00\n"
+                                                   "  #     1   Entry range:     .1..1.  --  1\n"
+                                                   "            # Pages:         1\n"
+                                                   "            Size on storage: 2 B\n"
+                                                   "            Compression:     2.00\n"
+                                                   "  #     2   Entry range:     .2..2.  --  1\n"
+                                                   "            # Pages:         1\n"
+                                                   "            Size on storage: 4 B\n"
+                                                   "            Compression:     1.00\n"
+                                                   "------------------------------------------------------------\n"
+                                                   "COLUMN DETAILS\n"
+                                                   "------------------------------------------------------------\n"
+                                                   "  px .#0.  --  Real32                                 .id:0.\n"
+                                                   "    # Elements:          2\n"
+                                                   "    # Pages:             2\n"
+                                                   "    Avg elements / page: 1\n"
+                                                   "    Avg page size:       4 B\n"
+                                                   "    Size on storage:     8 B\n"
+                                                   "    Compression:         1.00\n"
+                                                   "............................................................\n"
+                                                   "  px .#0 / R.1.  --  Real16                           .id:1.\n"
+                                                   "    # Elements:          1\n"
+                                                   "    # Pages:             1\n"
+                                                   "    Avg elements / page: 1\n"
+                                                   "    Avg page size:       2 B\n"
+                                                   "    Size on storage:     2 B\n"
+                                                   "    Compression:         2.00\n"
+                                                   "............................................................\n";
+   EXPECT_THAT(osDetails.str(), testing::MatchesRegex(reference));
+}
+
+TEST(RNTuple, MultiColumnRepresentationString)
+{
+   using ROOT::Experimental::kUnknownCompressionSettings;
+   FileRaii fileGuard("test_ntuple_multi_column_representation_string.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldStr = RFieldBase::Create("str", "std::string").Unwrap();
+      fldStr->SetColumnRepresentatives(
+         {{EColumnType::kIndex32, EColumnType::kChar}, {EColumnType::kSplitIndex64, EColumnType::kChar}});
+      model->AddField(std::move(fldStr));
+      auto ptrStr = model->GetDefaultEntry().GetPtr<std::string>("str");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      *ptrStr = "abc";
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
+      ptrStr->clear();
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
+      *ptrStr = "x";
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(4u, reader->GetNEntries());
+   auto ptrStr = reader->GetModel().GetDefaultEntry().GetPtr<std::string>("str");
+   reader->LoadEntry(0);
+   EXPECT_EQ("abc", *ptrStr);
+   reader->LoadEntry(1);
+   EXPECT_TRUE(ptrStr->empty());
+   reader->LoadEntry(2);
+   EXPECT_TRUE(ptrStr->empty());
+   reader->LoadEntry(3);
+   EXPECT_EQ("x", *ptrStr);
+}
+
+TEST(RNTuple, MultiColumnRepresentationVector)
+{
+   using ROOT::Experimental::kUnknownCompressionSettings;
+   FileRaii fileGuard("test_ntuple_multi_column_representation_vector.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldVec = RFieldBase::Create("vec", "std::vector<float>").Unwrap();
+      fldVec->SetColumnRepresentatives({{EColumnType::kIndex32}, {EColumnType::kSplitIndex64}});
+      model->AddField(std::move(fldVec));
+      auto ptrVec = model->GetDefaultEntry().GetPtr<std::vector<float>>("vec");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
+      ptrVec->push_back(1.0);
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
+      ptrVec->clear();
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
+      ptrVec->push_back(2.0);
+      ptrVec->push_back(3.0);
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(4u, reader->GetNEntries());
+   auto ptrVec = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<float>>("vec");
+   reader->LoadEntry(0);
+   EXPECT_TRUE(ptrVec->empty());
+   reader->LoadEntry(1);
+   EXPECT_EQ(1u, ptrVec->size());
+   EXPECT_FLOAT_EQ(1.0, ptrVec->at(0));
+   reader->LoadEntry(2);
+   EXPECT_TRUE(ptrVec->empty());
+   reader->LoadEntry(3);
+   EXPECT_EQ(2u, ptrVec->size());
+   EXPECT_FLOAT_EQ(2.0, ptrVec->at(0));
+   EXPECT_FLOAT_EQ(3.0, ptrVec->at(1));
+}
+
+TEST(RNTuple, MultiColumnRepresentationNullable)
+{
+   FileRaii fileGuard("test_ntuple_multi_column_representation_nullable.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldScalar = RFieldBase::Create("scalar", "std::optional<float>").Unwrap();
+      auto fldVector = RFieldBase::Create("vector", "std::vector<std::optional<float>>").Unwrap();
+      fldScalar->SetColumnRepresentatives({{EColumnType::kBit}, {EColumnType::kSplitIndex64}});
+      fldVector->GetSubFields()[0]->SetColumnRepresentatives({{EColumnType::kSplitIndex64}, {EColumnType::kBit}});
+      model->AddField(std::move(fldScalar));
+      model->AddField(std::move(fldVector));
+      auto ptrScalar = model->GetDefaultEntry().GetPtr<std::optional<float>>("scalar");
+      auto ptrVector = model->GetDefaultEntry().GetPtr<std::vector<std::optional<float>>>("vector");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      *ptrScalar = 1.0;
+      ptrVector->push_back(13.0);
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("scalar")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vector._0")), 1);
+      ptrScalar->reset();
+      ptrVector->clear();
+      ptrVector->push_back(std::optional<float>());
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("scalar")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vector._0")), 1);
+      *ptrScalar = 3.0;
+      ptrVector->clear();
+      ptrVector->push_back(15.0);
+      ptrVector->push_back(17.0);
+      writer->Fill();
+      writer->CommitCluster();
+      ptrScalar->reset();
+      ptrVector->clear();
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(4u, reader->GetNEntries());
+   auto ptrScalar = reader->GetModel().GetDefaultEntry().GetPtr<std::optional<float>>("scalar");
+   auto ptrVector = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<std::optional<float>>>("vector");
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(1.0, ptrScalar->value());
+   EXPECT_FLOAT_EQ(1u, ptrVector->size());
+   EXPECT_FLOAT_EQ(13.0, ptrVector->at(0).value());
+   reader->LoadEntry(1);
+   EXPECT_FALSE(ptrScalar->has_value());
+   EXPECT_FLOAT_EQ(1u, ptrVector->size());
+   EXPECT_FALSE(ptrVector->at(0).has_value());
+   reader->LoadEntry(2);
+   EXPECT_FLOAT_EQ(3.0, ptrScalar->value());
+   EXPECT_FLOAT_EQ(2u, ptrVector->size());
+   EXPECT_FLOAT_EQ(15.0, ptrVector->at(0).value());
+   EXPECT_FLOAT_EQ(17.0, ptrVector->at(1).value());
+   reader->LoadEntry(3);
+   EXPECT_FALSE(ptrScalar->has_value());
+   EXPECT_TRUE(ptrVector->empty());
+}
+
+TEST(RNTuple, MultiColumnRepresentationBulk)
+{
+   FileRaii fileGuard("test_ntuple_multi_column_representation_bulk.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldPx = RFieldBase::Create("px", "float").Unwrap();
+      fldPx->SetColumnRepresentatives({{EColumnType::kReal32}, {EColumnType::kReal16}});
+      model->AddField(std::move(fldPx));
+      auto ptrPx = model->GetDefaultEntry().GetPtr<float>("px");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      *ptrPx = 1.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
+      *ptrPx = 2.0;
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   RFieldBase::RBulk bulk = reader->GetModel().CreateBulk("px");
+
+   auto mask = std::make_unique<bool[]>(1);
+   mask[0] = true;
+   auto arr = static_cast<float *>(bulk.ReadBulk(RClusterIndex(0, 0), mask.get(), 1));
+   EXPECT_FLOAT_EQ(1.0, arr[0]);
+
+   arr = static_cast<float *>(bulk.ReadBulk(RClusterIndex(1, 0), mask.get(), 1));
+   EXPECT_FLOAT_EQ(2.0, arr[0]);
+}
+
+TEST(RNTuple, MultiColumnRepresentationFriends)
+{
+   FileRaii fileGuard1("test_ntuple_multi_column_representation_friend1.root");
+   FileRaii fileGuard2("test_ntuple_multi_column_representation_friend2.root");
+
+   auto model1 = RNTupleModel::Create();
+   auto fldPt = RFieldBase::Create("pt", "float").Unwrap();
+   fldPt->SetColumnRepresentatives({{EColumnType::kReal32}, {EColumnType::kReal16}});
+   model1->AddField(std::move(fldPt));
+   auto ptrPt = model1->GetDefaultEntry().GetPtr<float>("pt");
+
+   auto model2 = RNTupleModel::Create();
+   auto fldEta = RFieldBase::Create("eta", "float").Unwrap();
+   fldEta->SetColumnRepresentatives({{EColumnType::kReal16}, {EColumnType::kReal32}});
+   model2->AddField(std::move(fldEta));
+   auto ptrEta = model2->GetDefaultEntry().GetPtr<float>("eta");
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model1), "ntpl1", fileGuard1.GetPath());
+      *ptrPt = 1.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("pt")), 1);
+      *ptrPt = 2.0;
+      writer->Fill();
+   }
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model2), "ntpl2", fileGuard2.GetPath());
+      *ptrEta = 3.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("eta")), 1);
+      *ptrEta = 4.0;
+      writer->Fill();
+   }
+
+   std::vector<RNTupleReader::ROpenSpec> friends{{"ntpl1", fileGuard1.GetPath()}, {"ntpl2", fileGuard2.GetPath()}};
+   auto reader = RNTupleReader::OpenFriends(friends);
+   EXPECT_EQ(2u, reader->GetNEntries());
+   auto viewPt = reader->GetView<float>("ntpl1.pt");
+   EXPECT_FLOAT_EQ(1.0, viewPt(0));
+   EXPECT_FLOAT_EQ(2.0, viewPt(1));
+   auto viewEta = reader->GetView<float>("ntpl2.eta");
+   EXPECT_FLOAT_EQ(3.0, viewEta(0));
+   EXPECT_FLOAT_EQ(4.0, viewEta(1));
+}

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -17,13 +17,13 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
       *ptrPx = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
       *ptrPx = 2.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
-         const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 0);
       *ptrPx = 3.0;
       writer->Fill();
    }
@@ -156,16 +156,16 @@ TEST(RNTuple, MultiColumnRepresentationString)
       *ptrStr = "abc";
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
       ptrStr->clear();
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
-         const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("str")), 1);
       *ptrStr = "x";
       writer->Fill();
@@ -198,17 +198,17 @@ TEST(RNTuple, MultiColumnRepresentationVector)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
       ptrVec->push_back(1.0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
-         const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 0);
       ptrVec->clear();
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("vec")), 1);
       ptrVec->push_back(2.0);
       ptrVec->push_back(3.0);
@@ -250,19 +250,19 @@ TEST(RNTuple, MultiColumnRepresentationNullable)
       ptrVector->push_back(13.0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("scalar")), 1);
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("vector._0")), 1);
       ptrScalar->reset();
       ptrVector->clear();
       ptrVector->push_back(std::optional<float>());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
-         const_cast<RFieldBase &>(writer->GetModel().GetField("scalar")), 1);
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
-         const_cast<RFieldBase &>(writer->GetModel().GetField("vector._0")), 1);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("scalar")), 0);
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetField("vector._0")), 0);
       *ptrScalar = 3.0;
       ptrVector->clear();
       ptrVector->push_back(15.0);
@@ -310,7 +310,7 @@ TEST(RNTuple, MultiColumnRepresentationBulk)
       *ptrPx = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
       *ptrPx = 2.0;
       writer->Fill();
@@ -350,7 +350,7 @@ TEST(RNTuple, MultiColumnRepresentationFriends)
       *ptrPt = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("pt")), 1);
       *ptrPt = 2.0;
       writer->Fill();
@@ -360,7 +360,7 @@ TEST(RNTuple, MultiColumnRepresentationFriends)
       *ptrEta = 3.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("eta")), 1);
       *ptrEta = 4.0;
       writer->Fill();

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -229,7 +229,7 @@ template <typename PodT, ROOT::Experimental::EColumnType ColumnT>
 static void AddField(RNTupleModel &model, const std::string &fieldName)
 {
    auto fld = std::make_unique<RField<PodT>>(fieldName);
-   fld->SetColumnRepresentative({ColumnT});
+   fld->SetColumnRepresentatives({{ColumnT}});
    model.AddField(std::move(fld));
 }
 

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -353,7 +353,7 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(EColumnType::kIndex64, reader->GetModel().GetField("str").GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kIndex64, reader->GetModel().GetField("str").GetColumnRepresentatives()[0][0]);
    EXPECT_EQ(2u, reader->GetNEntries());
    auto viewStr = reader->GetView<std::string>("str");
    EXPECT_EQ(std::string("abc"), viewStr(0));

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -41,6 +41,7 @@ protected:
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
    void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
+   void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final
    {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -2112,13 +2112,13 @@ TEST(RNTuple, RColumnRepresentations)
    using RColumnRepresentations = ROOT::Experimental::RFieldBase::RColumnRepresentations;
    RColumnRepresentations colReps1;
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t(), colReps1.GetSerializationDefault());
-   EXPECT_EQ(RColumnRepresentations::TypesList_t{RFieldBase::ColumnRepresentation_t()},
+   EXPECT_EQ(RColumnRepresentations::Selection_t{RFieldBase::ColumnRepresentation_t()},
              colReps1.GetDeserializationTypes());
 
    RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kSplitReal64}},
                                    {{EColumnType::kReal32}, {EColumnType::kReal16}});
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t({EColumnType::kReal64}), colReps2.GetSerializationDefault());
-   EXPECT_EQ(RColumnRepresentations::TypesList_t(
+   EXPECT_EQ(RColumnRepresentations::Selection_t(
                 {{EColumnType::kReal64}, {EColumnType::kSplitReal64}, {EColumnType::kReal32}, {EColumnType::kReal16}}),
              colReps2.GetDeserializationTypes());
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1740,7 +1740,7 @@ TEST(RNTuple, TClass)
          auto viewKlass = ntuple->GetView<DerivedA>("klass");
          FAIL() << "GetView<a_base_class_of_T> should throw";
       } catch (const RException& err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk column information for field `klass.:_0.a`"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk field information for `klass.:_0.a`"));
       }
    }
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -698,19 +698,19 @@ TEST(RNTuple, Int64)
    auto model = RNTupleModel::Create();
 
    auto f1 = std::make_unique<RField<std::int64_t>>("i1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt64});
+   f1->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt64}});
    model->AddField(std::move(f1));
 
    auto f2 = std::make_unique<RField<std::int64_t>>("i2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt64});
+   f2->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitInt64}});
    model->AddField(std::move(f2));
 
    auto f3 = std::make_unique<RField<std::uint64_t>>("i3");
-   f3->SetColumnRepresentative({ROOT::Experimental::EColumnType::kUInt64});
+   f3->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt64}});
    model->AddField(std::move(f3));
 
    auto f4 = std::make_unique<RField<std::uint64_t>>("i4");
-   f4->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitUInt64});
+   f4->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitUInt64}});
    model->AddField(std::move(f4));
 
    {
@@ -768,19 +768,19 @@ TEST(RNTuple, Int32)
    auto model = RNTupleModel::Create();
 
    auto f1 = std::make_unique<RField<std::int32_t>>("i1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt32});
+   f1->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt32}});
    model->AddField(std::move(f1));
 
    auto f2 = std::make_unique<RField<std::int32_t>>("i2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt32});
+   f2->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitInt32}});
    model->AddField(std::move(f2));
 
    auto f3 = std::make_unique<RField<std::uint32_t>>("i3");
-   f3->SetColumnRepresentative({ROOT::Experimental::EColumnType::kUInt32});
+   f3->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt32}});
    model->AddField(std::move(f3));
 
    auto f4 = std::make_unique<RField<std::uint32_t>>("i4");
-   f4->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitUInt32});
+   f4->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitUInt32}});
    model->AddField(std::move(f4));
 
    {
@@ -838,19 +838,19 @@ TEST(RNTuple, Int16)
    auto model = RNTupleModel::Create();
 
    auto f1 = std::make_unique<RField<std::int16_t>>("i1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt16});
+   f1->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt16}});
    model->AddField(std::move(f1));
 
    auto f2 = std::make_unique<RField<std::int16_t>>("i2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt16});
+   f2->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitInt16}});
    model->AddField(std::move(f2));
 
    auto f3 = std::make_unique<RField<std::uint16_t>>("i3");
-   f3->SetColumnRepresentative({ROOT::Experimental::EColumnType::kUInt16});
+   f3->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt16}});
    model->AddField(std::move(f3));
 
    auto f4 = std::make_unique<RField<std::uint16_t>>("i4");
-   f4->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitUInt16});
+   f4->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitUInt16}});
    model->AddField(std::move(f4));
 
    {
@@ -1057,11 +1057,11 @@ TEST(RNTuple, Double)
    auto model = RNTupleModel::Create();
 
    auto f1 = std::make_unique<RField<double>>("d1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kReal64});
+   f1->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kReal64}});
    model->AddField(std::move(f1));
 
    auto f2 = std::make_unique<RField<double>>("d2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitReal64});
+   f2->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitReal64}});
    model->AddField(std::move(f2));
 
    {
@@ -1090,11 +1090,11 @@ TEST(RNTuple, Float)
    auto model = RNTupleModel::Create();
 
    auto f1 = std::make_unique<RField<float>>("f1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kReal32});
+   f1->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kReal32}});
    model->AddField(std::move(f1));
 
    auto f2 = std::make_unique<RField<float>>("f2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitReal32});
+   f2->SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kSplitReal32}});
    model->AddField(std::move(f2));
 
    {
@@ -1482,13 +1482,13 @@ TEST(RNTuple, Casting)
    FileRaii fileGuard("test_ntuple_casting.root");
 
    auto fldI1 = RFieldBase::Create("i1", "std::int32_t").Unwrap();
-   fldI1->SetColumnRepresentative({EColumnType::kInt32});
+   fldI1->SetColumnRepresentatives({{EColumnType::kInt32}});
    auto fldI2 = RFieldBase::Create("i2", "std::int32_t").Unwrap();
-   fldI2->SetColumnRepresentative({EColumnType::kSplitInt32});
+   fldI2->SetColumnRepresentatives({{EColumnType::kSplitInt32}});
    auto fldF = ROOT::Experimental::RFieldBase::Create("F", "float").Unwrap();
-   fldF->SetColumnRepresentative({EColumnType::kReal32});
+   fldF->SetColumnRepresentatives({{EColumnType::kReal32}});
    try {
-      fldF->SetColumnRepresentative({EColumnType::kBit});
+      fldF->SetColumnRepresentatives({{EColumnType::kBit}});
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid column representative"));
    }
@@ -1507,7 +1507,7 @@ TEST(RNTuple, Casting)
    try {
       auto model = RNTupleModel::Create();
       auto f = ROOT::Experimental::RFieldBase::Create("i1", "std::int32_t").Unwrap();
-      f->SetColumnRepresentative({EColumnType::kInt32});
+      f->SetColumnRepresentatives({{EColumnType::kInt32}});
       model->AddField(std::move(f));
       auto reader = RNTupleReader::Open(std::move(model), "ntuple", fileGuard.GetPath());
       FAIL() << "should not be able fix column representation when model is connected to a page source";
@@ -1592,7 +1592,7 @@ TEST(RNTuple, Double32)
    FileRaii fileGuard("test_ntuple_double32.root");
 
    auto fldD1 = RFieldBase::Create("d1", "double").Unwrap();
-   fldD1->SetColumnRepresentative({EColumnType::kReal32});
+   fldD1->SetColumnRepresentatives({{EColumnType::kReal32}});
    auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
    EXPECT_EQ("Double32_t", fldD2->GetTypeAlias());
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1234,13 +1234,13 @@ TYPED_TEST(UniquePtr, Basics)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
 
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDefault>) {
-         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
+         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentatives()[0][0]);
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldSparse>) {
-         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
+         EXPECT_EQ(EColumnType::kSplitIndex64, writer->GetModel().GetField("PBool").GetColumnRepresentatives()[0][0]);
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDense>) {
-         EXPECT_EQ(EColumnType::kBit, writer->GetModel().GetField("PBool").GetColumnRepresentative()[0]);
+         EXPECT_EQ(EColumnType::kBit, writer->GetModel().GetField("PBool").GetColumnRepresentatives()[0][0]);
       }
 
       auto pBool = writer->GetModel().GetDefaultEntry().GetPtr<std::unique_ptr<bool>>("PBool");
@@ -1542,12 +1542,12 @@ TEST(RNTuple, HalfPrecisionFloat)
    // TODO: Add std::float16 tests once available (from C++23)
    auto f1Fld = RFieldBase::Create("f1", "float").Unwrap();
    dynamic_cast<RField<float> *>(f1Fld.get())->SetHalfPrecision();
-   EXPECT_EQ(EColumnType::kReal16, f1Fld->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kReal16, f1Fld->GetColumnRepresentatives()[0][0]);
    EXPECT_EQ("float", f1Fld->GetTypeName());
 
    auto fVecFld = RFieldBase::Create("fVec", "std::vector<float>").Unwrap();
    dynamic_cast<RField<float> *>(fVecFld->GetSubFields()[0])->SetHalfPrecision();
-   EXPECT_EQ(EColumnType::kReal16, fVecFld->GetSubFields()[0]->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kReal16, fVecFld->GetSubFields()[0]->GetColumnRepresentatives()[0][0]);
 
    auto model = RNTupleModel::Create();
    model->AddField(std::move(f1Fld));
@@ -1625,9 +1625,9 @@ TEST(RNTuple, Double32)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(EColumnType::kReal32, reader->GetModel().GetField("d1").GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kReal32, reader->GetModel().GetField("d1").GetColumnRepresentatives()[0][0]);
    EXPECT_EQ("", reader->GetModel().GetField("d1").GetTypeAlias());
-   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel().GetField("d2").GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel().GetField("d2").GetColumnRepresentatives()[0][0]);
    EXPECT_EQ("Double32_t", reader->GetModel().GetField("d2").GetTypeAlias());
    auto d1 = reader->GetModel().GetDefaultEntry().GetPtr<double>("d1");
    auto d2 = reader->GetModel().GetDefaultEntry().GetPtr<double>("d2");

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -64,6 +64,9 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          }
 
          auto columnRange = clusterDescriptor.GetColumnRange(colId);
+         if (columnRange.fIsSuppressed)
+            continue;
+
          nElems += columnRange.fNElements;
 
          if (fCompressionSettings == -1) {

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -239,7 +239,7 @@ TEST(RNTupleImporter, FieldModifier)
 
    auto fnLowPrecisionFloatModifier = [](RFieldBase &field) {
       if (field.GetFieldName() == "a")
-         field.SetColumnRepresentative({EColumnType::kReal16});
+         field.SetColumnRepresentatives({{EColumnType::kReal16}});
    };
 
    auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -254,9 +254,9 @@ TEST(RNTupleImporter, FieldModifier)
    EXPECT_FLOAT_EQ(2.0, *reader->GetModel().GetDefaultEntry().GetPtr<float>("b"));
 
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t{EColumnType::kReal16},
-             reader->GetModel().GetField("a").GetColumnRepresentative());
+             reader->GetModel().GetField("a").GetColumnRepresentatives()[0]);
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t{EColumnType::kSplitReal32},
-             reader->GetModel().GetField("b").GetColumnRepresentative());
+             reader->GetModel().GetField("b").GetColumnRepresentatives()[0]);
 }
 
 TEST(RNTupleImporter, CString)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -297,11 +297,11 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       auto model = RNTupleModel::Create();
 
       auto int32fld = std::make_unique<RField<std::int32_t>>("int32");
-      int32fld->SetColumnRepresentative({EColumnType::kInt32});
+      int32fld->SetColumnRepresentatives({{EColumnType::kInt32}});
       model->AddField(std::move(int32fld));
 
       auto splitReal64fld = std::make_unique<RField<double>>("splitReal64");
-      splitReal64fld->SetColumnRepresentative({EColumnType::kSplitReal64});
+      splitReal64fld->SetColumnRepresentatives({{EColumnType::kSplitReal64}});
       model->AddField(std::move(splitReal64fld));
 
       auto writeOptions = RNTupleWriteOptions();

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -772,7 +772,7 @@ TEST(RNTupleInspector, MultiColumnRepresentations)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SwapPrimayColumnRepresentation(
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetField("px")), 1);
       writer->Fill();
    }


### PR DESCRIPTION
Completes the support for fields with multiple column representations. For the moment, only the unit tests can change the column representation between clusters on writing. Eventually, we may add a proper interface. Merging will also lead to this situation.

In all cases but the nullable field, we can exploit the fact that the number of columns of multiple representations is the same and the corresponding columns have the same number of elements and cluster boundaries. Therefore, when reading we team up the corresponding columns of multiple representations. When we map another page, the column teams can then figure out amongst each other the column that is not suppressed for the given page / element index and forward the call.

Follow-up of #16054 

