### PR TITLE
[ntuple] Add option to enable Direct I/O

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -37,6 +37,8 @@ class RRawFile;
 
 namespace Experimental {
 
+class RNTupleWriteOptions;
+
 namespace Internal {
 /// Holds status information of an open ROOT file during writing
 struct RTFileControlBlock;
@@ -194,8 +196,8 @@ public:
    /// Create or truncate the local file given by path with the new empty RNTuple identified by ntupleName.
    /// Uses a C stream for writing
    static std::unique_ptr<RNTupleFileWriter> Recreate(std::string_view ntupleName, std::string_view path,
-                                                      int defaultCompression, EContainerFormat containerFormat,
-                                                      std::uint64_t maxKeySize);
+                                                      EContainerFormat containerFormat,
+                                                      const RNTupleWriteOptions &options);
    /// Add a new RNTuple identified by ntupleName to the existing TFile.
    static std::unique_ptr<RNTupleFileWriter> Append(std::string_view ntupleName, TFile &file, std::uint64_t maxKeySize);
 

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -130,6 +130,8 @@ private:
 
       /// For the simplest cases, a C file stream can be used for writing
       FILE *fFile = nullptr;
+      /// Whether the C file stream has been opened with Direct I/O, introducing alignment requirements.
+      bool fDirectIO = false;
       /// Keeps track of the seek offset
       std::uint64_t fFilePos = 0;
       /// Keeps track of the next key offset

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -76,6 +76,9 @@ protected:
    /// Whether to use buffered writing (with RPageSinkBuf). This buffers compressed pages in memory, reorders them
    /// to keep pages of the same column adjacent, and coalesces the writes when committing a cluster.
    bool fUseBufferedWrite = true;
+   /// Whether to use Direct I/O for writing. Note that this introduces alignment requirements that may very between
+   /// filesystems and platforms.
+   bool fUseDirectIO = false;
    /// Whether to use implicit multi-threading to compress pages. Only has an effect if buffered writing is turned on.
    EImplicitMT fUseImplicitMT = EImplicitMT::kDefault;
    /// If set, 64bit index columns are replaced by 32bit index columns. This limits the cluster size to 512MB
@@ -117,6 +120,9 @@ public:
 
    bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
    void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }
+
+   bool GetUseDirectIO() const { return fUseDirectIO; }
+   void SetUseDirectIO(bool val) { fUseDirectIO = val; }
 
    EImplicitMT GetUseImplicitMT() const { return fUseImplicitMT; }
    void SetUseImplicitMT(EImplicitMT val) { fUseImplicitMT = val; }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -22,6 +22,7 @@
 #include <ROOT/RRawFile.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
 
 #include <Byteswap.h>
 #include <TError.h>
@@ -1494,8 +1495,8 @@ ROOT::Experimental::Internal::RNTupleFileWriter::~RNTupleFileWriter() {}
 
 std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
 ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupleName, std::string_view path,
-                                                          int defaultCompression, EContainerFormat containerFormat,
-                                                          std::uint64_t maxKeySize)
+                                                          EContainerFormat containerFormat,
+                                                          const RNTupleWriteOptions &options)
 {
    std::string fileName(path);
    size_t idxDirSep = fileName.find_last_of("\\/");
@@ -1511,10 +1512,11 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupl
    // RNTupleFileWriter::RFileSimple does its own buffering, turn off additional buffering from C stdio.
    std::setvbuf(fileStream, nullptr, _IONBF, 0);
 
-   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
+   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, options.GetMaxKeySize()));
    writer->fFileSimple.fFile = fileStream;
    writer->fFileName = fileName;
 
+   int defaultCompression = options.GetCompression();
    switch (containerFormat) {
    case EContainerFormat::kTFile: writer->WriteTFileSkeleton(defaultCompression); break;
    case EContainerFormat::kBare:

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1305,17 +1305,24 @@ ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::~RFileSimple()
       fclose(fFile);
 }
 
+namespace {
+int FSeek64(FILE *stream, std::int64_t offset, int origin)
+{
+#ifdef R__SEEK64
+   return fseeko64(stream, offset, origin);
+#else
+   return fseek(stream, offset, origin);
+#endif
+}
+} // namespace
+
 void ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Write(const void *buffer, size_t nbytes,
                                                                          std::int64_t offset)
 {
    R__ASSERT(fFile);
    size_t retval;
    if ((offset >= 0) && (static_cast<std::uint64_t>(offset) != fFilePos)) {
-#ifdef R__SEEK64
-      retval = fseeko64(fFile, offset, SEEK_SET);
-#else
-      retval = fseek(fFile, offset, SEEK_SET);
-#endif
+      retval = FSeek64(fFile, offset, SEEK_SET);
       if (retval)
          throw RException(R__FAIL(std::string("Seek failed: ") + strerror(errno)));
       fFilePos = offset;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1373,7 +1373,9 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Flush()
          throw RException(R__FAIL(std::string("write failed: ") + strerror(errno)));
    }
 
-   fflush(fFile);
+   retval = fflush(fFile);
+   if (retval)
+      throw RException(R__FAIL(std::string("Flush failed: ") + strerror(errno)));
 }
 
 void ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Write(const void *buffer, size_t nbytes,

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1508,6 +1508,8 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupl
    FILE *fileStream = fopen(std::string(path.data(), path.size()).c_str(), "wb");
 #endif
    R__ASSERT(fileStream);
+   // RNTupleFileWriter::RFileSimple does its own buffering, turn off additional buffering from C stdio.
+   std::setvbuf(fileStream, nullptr, _IONBF, 0);
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
    writer->fFileSimple.fFile = fileStream;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -62,8 +62,7 @@ ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntup
                                                            const RNTupleWriteOptions &options)
    : RPageSinkFile(ntupleName, options)
 {
-   fWriter = RNTupleFileWriter::Recreate(ntupleName, path, options.GetCompression(),
-                                         RNTupleFileWriter::EContainerFormat::kTFile, options.GetMaxKeySize());
+   fWriter = RNTupleFileWriter::Recreate(ntupleName, path, RNTupleFileWriter::EContainerFormat::kTFile, options);
 }
 
 ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, TFile &file,

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -38,8 +38,8 @@ TEST(RNTupleCompat, FeatureFlag)
       RFieldDescriptorBuilder::FromField(ROOT::Experimental::RFieldZero()).FieldId(0).MakeDescriptor().Unwrap());
    ASSERT_TRUE(static_cast<bool>(descBuilder.EnsureValidDescriptor()));
 
-   auto writer = RNTupleFileWriter::Recreate("ntpl", fileGuard.GetPath(), 0, EContainerFormat::kTFile,
-                                             RNTupleWriteOptions::kDefaultMaxKeySize);
+   RNTupleWriteOptions options;
+   auto writer = RNTupleFileWriter::Recreate("ntpl", fileGuard.GetPath(), EContainerFormat::kTFile, options);
    RNTupleSerializer serializer;
 
    auto ctx = serializer.SerializeHeader(nullptr, descBuilder.GetDescriptor());

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -121,6 +121,8 @@ TEST(MiniFile, SimpleKeys)
    FileRaii fileGuard("test_ntuple_minifile_simple_keys.root");
 
    RNTupleWriteOptions options;
+   // We check the file size at the end, so Direct I/O alignment requirements must not introduce padding.
+   options.SetUseDirectIO(false);
    auto writer = RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), EContainerFormat::kTFile, options);
 
    char blob1 = '1';


### PR DESCRIPTION
Direct I/O bypasses the OS page cache and allows to reach much higher bandwidths. However, it introduces strict alignment requirements to the offset and size of all write requests, as well as the userspace pointer.