### PR TITLE
[cling] Forcefully clean up `TemplateIdAnnotation`s

### DIFF
--- a/interpreter/cling/lib/Utils/ParserStateRAII.cpp
+++ b/interpreter/cling/lib/Utils/ParserStateRAII.cpp
@@ -50,10 +50,13 @@ cling::ParserStateRAII::~ParserStateRAII() {
   // Note: Consuming the EOF token will pop the include stack.
   //
   {
-    // Cleanup the TemplateIds before swapping the previous set back.
-    Parser::DestroyTemplateIdAnnotationsRAIIObj CleanupTemplateIds(*P);
+    // Forcefully clean up the TemplateIds, ignoring additional checks in
+    // MaybeDestroyTemplateIds called from DestroyTemplateIdAnnotationsRAIIObj,
+    // before swapping the previous set back.
+    P->DestroyTemplateIds();
   }
   P->TemplateIds.swap(OldTemplateIds);
+  assert(OldTemplateIds.empty());
   if (SkipToEOF)
     P->SkipUntil(tok::eof);
   else


### PR DESCRIPTION
Upstream Clang keeps `TemplateIdAnnotation`s around "if they might still be in the token stream." See upstream commit for more details: https://github.com/llvm/llvm-project/commit/6163aa96799cbad7f2f58e02c5bebee9647056a5 (included in Clang 11, in ROOT since the upgrade to LLVM 13)

This reasoning doesn't apply when we fully reset the `Parser` state in `ParserStateRAII`'s destructor, and we expect the swapped out vector of `TemplateIdAnnotation`s to be empty in order to not leak.

Fixes #16121