### PR TITLE
[RF] Avoid using `std::map` in RooFit pythonizations

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roocategory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roocategory.py
@@ -11,7 +11,7 @@
 ################################################################################
 
 
-from ._utils import _dict_to_std_map, cpp_signature
+from ._utils import cpp_signature
 
 
 class RooCategory(object):
@@ -33,9 +33,11 @@ class RooCategory(object):
         r"""The RooCategory constructor is pythonized for converting python dict to std::map.
         The instances in the dict must correspond to the template argument in std::map of the constructor.
         """
-        # Redefinition of `RooCategory` constructor for converting python dict to std::map.
-        if len(args) > 2 and isinstance(args[2], dict):
-            args = list(args)
-            args[2] = _dict_to_std_map(args[2], {"std::string": "int"})
+        # Redefinition of `RooCategory` constructor for taking input from a dictionary.
+        if len(args) == 3 and len(kwargs) == 0 and isinstance(args[2], dict):
+            self._init(args[0], args[1])
+            for label, index in args[2].items():
+                self.defineType(label, index)
+            return
 
         self._init(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
@@ -11,7 +11,7 @@
 ################################################################################
 
 
-from ._utils import _kwargs_to_roocmdargs, _dict_to_std_map, cpp_signature
+from ._utils import _kwargs_to_roocmdargs, _dict_to_flat_map, cpp_signature
 
 
 class RooDataHist(object):
@@ -40,7 +40,7 @@ class RooDataHist(object):
         # Redefinition of `RooDataHist` constructor for keyword arguments and converting python dict to std::map.
         if len(args) > 4 and isinstance(args[4], dict):
             args = list(args)
-            args[4] = _dict_to_std_map(args[4], {"std::string": ["RooDataHist*", "TH1*"]})
+            args[4] = _dict_to_flat_map(args[4], {"std::string": ["RooDataHist*", "TH1*"]})
 
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         self._init(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -37,7 +37,7 @@ ROOT.RooMCStudy(model, ROOT.RooArgSet(x), FitOptions=dict(Save=True, PrintEvalEr
 */
 """
 
-from ._utils import _kwargs_to_roocmdargs, _string_to_root_attribute, _dict_to_std_map, cpp_signature
+from ._utils import _kwargs_to_roocmdargs, _string_to_root_attribute, _dict_to_flat_map, cpp_signature
 
 
 # Color and Style dictionary to define matplotlib conventions
@@ -163,9 +163,7 @@ def Slice(*args, **kwargs):
     from cppyy.gbl import RooFit
 
     if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], dict):
-        args = list(args)
-        args[0] = _dict_to_std_map(args[0], {"RooCategory*": "std::string"})
-        return RooFit._Slice(args[0])
+        return RooFit.Detail.SliceFlatMap(_dict_to_flat_map(args[0], {"RooCategory*": "std::string"}))
 
     return RooFit._Slice(*args, **kwargs)
 
@@ -186,9 +184,7 @@ def Import(*args, **kwargs):
     from cppyy.gbl import RooFit
 
     if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], dict):
-        args = list(args)
-        args[0] = _dict_to_std_map(args[0], {"std::string": ["TH1*", "RooDataHist*", "RooDataSet*"]})
-        return RooFit._Import(args[0])
+        return RooFit.Detail.ImportFlatMap(_dict_to_flat_map(args[0], {"std::string": ["TH1*", "RooDataHist*", "RooDataSet*"]}))
 
     return RooFit._Import(*args, **kwargs)
 
@@ -203,9 +199,7 @@ def Link(*args, **kwargs):
     from cppyy.gbl import RooFit
 
     if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], dict):
-        args = list(args)
-        args[0] = _dict_to_std_map(args[0], {"std::string": "RooAbsData*"})
-        return RooFit._Link(args[0])
+        return RooFit.Detail.LinkFlatMap(_dict_to_flat_map(args[0], {"std::string": "RooAbsData*"}))
 
     return RooFit._Link(*args, **kwargs)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
@@ -11,7 +11,7 @@
 ################################################################################
 
 
-from ._utils import _kwargs_to_roocmdargs, cpp_signature, _dict_to_std_map
+from ._utils import _kwargs_to_roocmdargs, cpp_signature, _dict_to_flat_map
 
 
 class RooSimultaneous(object):
@@ -37,7 +37,7 @@ class RooSimultaneous(object):
         """
         if len(args) >= 3 and isinstance(args[2], dict):
             args = list(args)
-            args[2] = _dict_to_std_map(args[2], {"std::string": "RooAbsPdf*"})
+            args[2] = _dict_to_flat_map(args[2], {"std::string": "RooAbsPdf*"})
         self._init(*args)
 
     @cpp_signature(

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_utils.py
@@ -85,7 +85,7 @@ def _string_to_root_attribute(value, lookup_map):
         return value
 
 
-def _dict_to_std_map(arg_dict, allowed_val_dict):
+def _dict_to_flat_map(arg_dict, allowed_val_dict):
     """
     Helper function to convert python dict to std::map.
 
@@ -157,15 +157,16 @@ def _dict_to_std_map(arg_dict, allowed_val_dict):
 
         return key_type + "," + value_type
 
-    # The std::map created by this function usually contains non-owning pointers as values.
+    # The map created by this function usually contains non-owning pointers as values.
     # This is not considered by Pythons reference counter. To ensure that the pointed-to objects
-    # live at least as long as the std::map, a python list containing references to these objects
-    # is added as an attribute to the std::map.
-    arg_map = ROOT.std.map[get_template_args(arg_dict)]()
+    # live at least as long as the map, a python list containing references to these objects
+    # is added as an attribute to the map.
+    arg_map = ROOT.RooFit.Detail.FlatMap[get_template_args(arg_dict)]()
     arg_map.keepalive = list()
-    for key, value in arg_dict.items():
-        arg_map.keepalive.append(value)
-        arg_map[key] = value
+    for key, val in arg_dict.items():
+        arg_map.keepalive.append(val)
+        arg_map.keys.push_back(key)
+        arg_map.vals.push_back(val)
 
     return arg_map
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -16,19 +16,20 @@
 #ifndef ROO_DATA_HIST
 #define ROO_DATA_HIST
 
-#include "RooAbsData.h"
-#include "RooDirItem.h"
-#include "RooArgSet.h"
+#include <RooAbsData.h>
+#include <RooArgSet.h>
+#include <RooDirItem.h>
+#include <RooGlobalFunc.h>
 
-#include <string_view>
-#include "Rtypes.h"
+#include <Rtypes.h>
 
-#include <map>
-#include <vector>
-#include <string>
 #include <functional>
+#include <map>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <unordered_map>
+#include <vector>
 
 class TAxis ;
 class RooAbsArg;
@@ -46,9 +47,14 @@ public:
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const TH1* hist, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, double wgt=1.0) ;
-  //RooDataHist(const char *name, const char *title, const RooArgList& vars, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
         const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
+
+  /// For internal use in RooFit.
+  template<class Val_t>
+  inline RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, RooFit::Detail::FlatMap<std::string,Val_t> const& histMap, double initWgt=1.0)
+    : RooDataHist(name, title, vars, indexCat, RooFit::Detail::flatMapToStdMap(histMap), initWgt) {}
+
   RooDataHist& operator=(const RooDataHist&) = delete;
 
   RooDataHist(const RooDataHist& other, const char* newname = nullptr) ;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -468,6 +468,31 @@ inline std::unique_ptr<RooLinkedList> createCmdList(RooLinkedList const *cmdList
    return cmdListCopy;
 }
 
+// RooFit-internal helper struct to build a map object that only uses
+// std::vector, which can be implicitly converted to std::map in C++. Used to
+// avoid std::map in pythonizations.
+template <class Key_t, class Val_t>
+struct FlatMap {
+   std::vector<Key_t> keys;
+   std::vector<Val_t> vals;
+};
+
+template <class Key_t, class Val_t>
+auto flatMapToStdMap(FlatMap<Key_t, Val_t> const& flatMap) {
+   std::map<Key_t, Val_t> out;
+   for (std::size_t i = 0; i < flatMap.keys.size(); ++i) {
+      out[flatMap.keys[i]] = flatMap.vals[i];
+   }
+   return out;
+}
+
+// Internal variant of Slice(), Import(), and Link(), that take flat maps instad of std::map.
+RooCmdArg SliceFlatMap(FlatMap<RooCategory *, std::string> const &args);
+RooCmdArg ImportFlatMap(FlatMap<std::string, RooDataHist *> const &args);
+RooCmdArg ImportFlatMap(FlatMap<std::string, TH1 *> const &args);
+RooCmdArg ImportFlatMap(FlatMap<std::string, RooDataSet *> const &args);
+RooCmdArg LinkFlatMap(FlatMap<std::string, RooAbsData *> const &args);
+
 } // namespace Detail
 
 } // namespace RooFit

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -16,16 +16,18 @@
 #ifndef ROO_SIMULTANEOUS
 #define ROO_SIMULTANEOUS
 
-//#include "THashList.h"
-#include "TList.h"
-#include "RooAbsPdf.h"
-#include "RooCategoryProxy.h"
-#include "RooRealProxy.h"
-#include "RooSetProxy.h"
-#include "RooAICRegistry.h"
-#include "RooObjCacheManager.h"
-#include "RooAbsCacheElement.h"
-#include "RooArgList.h"
+#include <RooAICRegistry.h>
+#include <RooAbsCacheElement.h>
+#include <RooAbsPdf.h>
+#include <RooArgList.h>
+#include <RooCategoryProxy.h>
+#include <RooGlobalFunc.h>
+#include <RooObjCacheManager.h>
+#include <RooRealProxy.h>
+#include <RooSetProxy.h>
+
+#include <TList.h>
+
 #include <map>
 #include <string>
 
@@ -56,6 +58,7 @@ public:
   inline RooSimultaneous() : _partIntMgr(this,10) {}
   RooSimultaneous(const char *name, const char *title, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const char *name, const char *title, std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;
+  RooSimultaneous(const char *name, const char *title, RooFit::Detail::FlatMap<std::string,RooAbsPdf*> const &pdfMap, RooAbsCategoryLValue& inIndexCat);
   RooSimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const RooSimultaneous& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooSimultaneous(*this,newname) ; }

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -16,20 +16,21 @@
 
 // Global helper functions
 
-#include "RooGlobalFunc.h"
+#include <RooGlobalFunc.h>
 
-#include "RooCategory.h"
-#include "RooRealConstant.h"
-#include "RooDataSet.h"
-#include "RooDataHist.h"
-#include "RooNumIntConfig.h"
-#include "RooRealVar.h"
-#include "RooFitResult.h"
-#include "RooAbsPdf.h"
-#include "RooFormulaVar.h"
-#include "RooHelpers.h"
-#include "RooMsgService.h"
-#include "TH1.h"
+#include <RooAbsPdf.h>
+#include <RooCategory.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
+#include <RooFormulaVar.h>
+#include <RooHelpers.h>
+#include <RooMsgService.h>
+#include <RooNumIntConfig.h>
+#include <RooRealConstant.h>
+#include <RooRealVar.h>
+
+#include <TH1.h>
 
 #include <algorithm>
 
@@ -41,28 +42,39 @@ namespace RooFit {
 namespace {
 
 template <class T>
-RooCmdArg processImportItem(std::pair<std::string const, T *> const &item)
+RooCmdArg processImportItem(std::string const &key, T *val)
 {
-   return Import(item.first.c_str(), *item.second);
+   return Import(key.c_str(), *val);
 }
 
 template <class T>
-RooCmdArg processLinkItem(std::pair<std::string const, T *> const &item)
+RooCmdArg processLinkItem(std::string const &key, T *val)
 {
-   return Link(item.first.c_str(), *item.second);
+   return Link(key.c_str(), *val);
 }
 
-RooCmdArg processSliceItem(std::pair<RooCategory *const, std::string> const &item)
+RooCmdArg processSliceItem(RooCategory *key, std::string const &val)
 {
-   return Slice(*item.first, item.second.c_str());
+   return Slice(*key, val.c_str());
 }
 
-template <class Map_t, class Func_t>
-RooCmdArg processMap(const char *name, Func_t func, Map_t const &map)
+template <class Key_t, class Val_t, class Func_t>
+RooCmdArg processMap(const char *name, Func_t func, std::map<Key_t, Val_t> const &map)
 {
    RooCmdArg container(name, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
    for (auto const &item : map) {
-      container.addArg(func(item));
+      container.addArg(func(item.first, item.second));
+   }
+   container.setProcessRecArgs(true, false);
+   return container;
+}
+
+template <class Key_t, class Val_t, class Func_t>
+RooCmdArg processFlatMap(const char *name, Func_t func, Detail::FlatMap<Key_t, Val_t> const &map)
+{
+   RooCmdArg container(name, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
+   for (std::size_t i = 0; i < map.keys.size(); ++i) {
+      container.addArg(func(map.keys[i], map.vals[i]));
    }
    container.setProcessRecArgs(true, false);
    return container;
@@ -1050,7 +1062,32 @@ RooConstVar &RooConst(double val)
    return RooRealConstant::value(val);
 }
 
-} // End namespace RooFit
+namespace Detail {
+
+RooCmdArg SliceFlatMap(FlatMap<RooCategory *, std::string> const &args)
+{
+   return processFlatMap("SliceCatMany", processSliceItem, args);
+}
+RooCmdArg ImportFlatMap(FlatMap<std::string, RooDataHist *> const &args)
+{
+   return processFlatMap("ImportDataSliceMany", processImportItem<RooDataHist>, args);
+}
+RooCmdArg ImportFlatMap(FlatMap<std::string, TH1 *> const &args)
+{
+   return processFlatMap("ImportDataSliceMany", processImportItem<TH1>, args);
+}
+RooCmdArg ImportFlatMap(FlatMap<std::string, RooDataSet *> const &args)
+{
+   return processFlatMap("ImportDataSliceMany", processImportItem<RooDataSet>, args);
+}
+RooCmdArg LinkFlatMap(FlatMap<std::string, RooAbsData *> const &args)
+{
+   return processFlatMap("LinkDataSliceMany", processLinkItem<RooAbsData>, args);
+}
+
+}
+
+} // namespace RooFit
 
 namespace RooFitShortHand {
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -151,6 +151,14 @@ RooSimultaneous::RooSimultaneous(const char *name, const char *title, std::map<s
 {
 }
 
+/// For internal use in RooFit.
+RooSimultaneous::RooSimultaneous(const char *name, const char *title,
+                                 RooFit::Detail::FlatMap<std::string, RooAbsPdf *> const &pdfMap,
+                                 RooAbsCategoryLValue &inIndexCat)
+   : RooSimultaneous(name, title, RooFit::Detail::flatMapToStdMap(pdfMap), inIndexCat)
+{
+}
+
 RooSimultaneous::RooSimultaneous(const char *name, const char *title, RooSimultaneous::InitializationOutput &&initInfo)
    : RooAbsPdf(name, title),
      _plotCoefNormSet("!plotCoefNormSet", "plotCoefNormSet", this, false, false),

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -128,12 +128,6 @@ if(NOT ROOT_roofit_FOUND)
                   roostats/*.C roostats/*.py
                   histfactory/*.C histfactory/*.py)
 else()
-  if(DEFINED ENV{JENKINS_HOME})
-    if(MSVC AND NOT win_broken_tests)
-      message(STATUS "Running in Jenkins: Disabling rf401_importttreethx.py rf708_bphysics.py and rf501_simultaneouspdf.py")
-      set(roofit_veto roofit/rf401_importttreethx.py roofit/rf708_bphysics.py roofit/rf501_simultaneouspdf.py)
-    endif()
-  endif()
   if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4 AND NOT llvm13_broken_tests)
     # The following tutorials are failing with this error:
     # IncrementalExecutor::executeFunction: symbol '__std_find_trivial_4@12' unresolved while linking [cling interface function]!


### PR DESCRIPTION
Introduce an internal elper class to build a map object that only uses `std::vector`, which can be implicitly converted to `std::map` in C++.

This avoids using `std::map` in pythonizations, which can cause assertion failures in Windows debug builds.