### PR TITLE
[RooFit] : fix 6thorder+exponential interpolation if nominal is not equal to 1

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -278,9 +278,12 @@ inline double flexibleInterpSingle(unsigned int code, double low, double high, d
          // interpolate 6th degree exp
          double x0 = boundary;
 
+         high /= nominal;
+         low /= nominal;
+
          // GHL: Swagato's suggestions
-         double powUp = std::pow(high / nominal, x0);
-         double powDown = std::pow(low / nominal, x0);
+         double powUp = std::pow(high, x0);
+         double powDown = std::pow(low, x0);
          double logHi = std::log(high);
          double logLo = std::log(low);
          double powUpLog = high <= 0.0 ? 0.0 : powUp * logHi;


### PR DESCRIPTION
I discovered that the current 6th-order polynominal + exponential interpolation (interpCode 5 in PiecewiseInterpolation class, 4 in FlexibleInterpVar class) does something quite bizarre if the nominal value is not equal to 1. See:

```
  RooRealVar alpha("alpha","alpha",-5,5);
  RooRealVar nom("nom","nom",10);
  RooRealVar up("up","up",11);
  RooRealVar down("down","down",9);

  PiecewiseInterpolation pi("pi","pi",nom,{down},{up},{alpha});
  pi.setAllInterpCodes(5);
  TGraph gr;
  alpha = -3;
  while (alpha.getVal()<3) {
    gr.AddPoint(alpha.getVal(),pi.getVal());
    alpha.setVal(alpha.getVal()+0.1);
  }
  gr.Draw("ALP");
```
![Screenshot 2024-08-05 at 16 15 06](https://github.com/user-attachments/assets/c1a55272-89c6-4794-8767-ae2a168734a7)

This strange behaviour can be fixed with the proposed modification, which doesn't affect the behaviour of the usual FlexibleInterpVar where nominal = 1. (i.e. it is used as a scale factor). 

This should also go into 6.32 patches.