### PR TITLE
[PyROOT] Call typed overload of `SetBranchAddress` for array types

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -131,6 +131,25 @@ The following people have contributed to this new version:
 ## PROOF Libraries
 
 
+## PyROOT
+
+### Typesafe `TTree::SetBranchAddress()` for array inputs
+
+If you call `TTree::SetBranchAddress` with NumPy array or `array.array` inputs, ROOT will now check if the array type matches with the column type.
+If it doesn't, `SetBranchAddress()` will return a negative status code and print an error.
+Take for example this code snippet:
+```python
+arr = array.array(typecode, "d")
+status = t.SetBranchAddress("name", arr)
+print("Status = %s" % (status, ))
+```
+If the branch type is also `double` (like the type of the array indicated by `"d"`), the call to `SetBranchAddress()` would succeed with status code zero.
+If the type doesn't match, you now get a clear error instead of garbage values.
+```txt
+Error in <TTree::SetBranchAddress>: The pointer type given "Double_t" (8) does not correspond to the type needed "Float_t" (5) by the branch: a
+Status = -2
+```
+
 ## Language Bindings
 
 

--- a/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
+++ b/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
@@ -72,22 +72,38 @@ class TTreeSetBranchAddress(unittest.TestCase):
 
         for ds in t, c:
             a = array("d", self.arraysize * [0.0])
-            ds.SetBranchAddress("arrayb", a)
+
+            status = ds.SetBranchAddress("arrayb", a)
+            self.assertEqual(status, 0)  # should return status 0 for success
+
             ds.GetEntry(0)
 
             for j in range(self.arraysize):
                 self.assertEqual(a[j], j)
+
+            # check if type mismatch is correctly detected
+            a_wrong_type = array("f", self.arraysize * [0.0])
+            status = ds.SetBranchAddress("arrayb", a_wrong_type)
+            self.assertEqual(status, -2)  # should return error code because of type mismatch
 
     def test_numpy_array_branch(self):
         f, t, c = self.get_tree_and_chain()
 
         for ds in t, c:
             a = np.array(self.arraysize * [0.0])  # dtype='float64'
-            ds.SetBranchAddress("arrayb", a)
+
+            status = ds.SetBranchAddress("arrayb", a)
+            self.assertEqual(status, 0)  # should return status 0 for success
+
             ds.GetEntry(0)
 
             for j in range(self.arraysize):
                 self.assertEqual(a[j], j)
+
+            # check if type mismatch is correctly detected
+            a_wrong_type = np.zeros(self.arraysize, dtype=np.float32)
+            status = ds.SetBranchAddress("arrayb", a_wrong_type)
+            self.assertEqual(status, -2)  # should return error code because of type mismatch
 
     def test_struct_branch_leaflist(self):
         f, t, c = self.get_tree_and_chain()

--- a/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
+++ b/bindings/pyroot/pythonizations/test/ttree_setbranchaddress.py
@@ -16,28 +16,19 @@ class TTreeSetBranchAddress(unittest.TestCase):
     and TNtupleD are also tested here.
     """
 
-    filename  = 'treesetbranchaddress.root'
-    treename  = 'mytree'
-    tuplename = 'mytuple'
-    nentries  = 2
+    filename = "treesetbranchaddress.root"
+    treename = "mytree"
+    tuplename = "mytuple"
+    nentries = 2
     arraysize = 10
-    more      = 10
+    more = 10
 
     # Setup
     @classmethod
     def setUpClass(cls):
         ROOT.gInterpreter.Declare('#include "TreeHelper.h"')
-        ROOT.CreateTTree(cls.filename,
-                         cls.treename,
-                         cls.nentries,
-                         cls.arraysize,
-                         cls.more,
-                         'RECREATE')
-        ROOT.CreateTNtuple(cls.filename,
-                           cls.tuplename,
-                           cls.nentries,
-                           cls.more,
-                           'UPDATE')
+        ROOT.CreateTTree(cls.filename, cls.treename, cls.nentries, cls.arraysize, cls.more, "RECREATE")
+        ROOT.CreateTNtuple(cls.filename, cls.tuplename, cls.nentries, cls.more, "UPDATE")
 
     # Helpers
     def get_tree_and_chain(self):
@@ -50,7 +41,7 @@ class TTreeSetBranchAddress(unittest.TestCase):
         c.Add(self.filename)
         c.Add(self.filename)
 
-        return f,t,c
+        return f, t, c
 
     def get_ntuples(self):
         f = ROOT.TFile(self.filename)
@@ -58,52 +49,52 @@ class TTreeSetBranchAddress(unittest.TestCase):
         nt = f.Get(self.tuplename)
         ROOT.SetOwnership(nt, False)
 
-        ntd = f.Get(self.tuplename + 'D')
+        ntd = f.Get(self.tuplename + "D")
         ROOT.SetOwnership(ntd, False)
 
-        return f,nt,ntd
+        return f, nt, ntd
 
     # Tests
     # Basic type, array and struct leaf list do not actually need the pythonization,
     # but testing anyway for the sake of completeness
     def test_basic_type_branch(self):
-        f,t,c = self.get_tree_and_chain()
-        
-        for ds in t,c:
-            n = array('f', [ 0. ])
-            ds.SetBranchAddress('floatb', n)
+        f, t, c = self.get_tree_and_chain()
+
+        for ds in t, c:
+            n = array("f", [0.0])
+            ds.SetBranchAddress("floatb", n)
             ds.GetEntry(0)
 
             self.assertEqual(n[0], self.more)
 
     def test_array_branch(self):
-        f,t,c, = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
-            a = array('d', self.arraysize*[ 0. ])
-            ds.SetBranchAddress('arrayb', a)
+        for ds in t, c:
+            a = array("d", self.arraysize * [0.0])
+            ds.SetBranchAddress("arrayb", a)
             ds.GetEntry(0)
 
             for j in range(self.arraysize):
                 self.assertEqual(a[j], j)
 
     def test_numpy_array_branch(self):
-        f,t,c = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
-            a = np.array(self.arraysize*[ 0. ]) # dtype='float64'
-            ds.SetBranchAddress('arrayb', a)
+        for ds in t, c:
+            a = np.array(self.arraysize * [0.0])  # dtype='float64'
+            ds.SetBranchAddress("arrayb", a)
             ds.GetEntry(0)
 
             for j in range(self.arraysize):
                 self.assertEqual(a[j], j)
 
     def test_struct_branch_leaflist(self):
-        f,t,c = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
+        for ds in t, c:
             ms = ROOT.MyStruct()
-            ds.SetBranchAddress('structleaflistb', ms)
+            ds.SetBranchAddress("structleaflistb", ms)
             ds.GetEntry(0)
 
             self.assertEqual(ms.myint1, self.more)
@@ -111,72 +102,72 @@ class TTreeSetBranchAddress(unittest.TestCase):
 
     # Vector and struct do benefit from the pythonization
     def test_vector_branch(self):
-        f,t,c = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
-            v = ROOT.std.vector('double')()
-            ds.SetBranchAddress('vectorb', v)
+        for ds in t, c:
+            v = ROOT.std.vector("double")()
+            ds.SetBranchAddress("vectorb", v)
             ds.GetEntry(0)
 
             for j in range(self.arraysize):
                 self.assertEqual(v[j], j)
 
     def test_struct_branch(self):
-        f,t,c = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
+        for ds in t, c:
             ms = ROOT.MyStruct()
-            ds.SetBranchAddress('structb', ms)
+            ds.SetBranchAddress("structb", ms)
             ds.GetEntry(0)
 
             self.assertEqual(ms.myint1, self.more)
             self.assertEqual(ms.myint2, 0)
 
     def test_fallback_case(self):
-        f,t,c = self.get_tree_and_chain()
-        
-        for ds in t,c:
-            n = array('f', [ 0. ])
-            b = ds.GetBranch('floatb')
+        f, t, c = self.get_tree_and_chain()
+
+        for ds in t, c:
+            n = array("f", [0.0])
+            b = ds.GetBranch("floatb")
             # Test an overload that uses the original SetBranchAddress proxy
-            ds.SetBranchAddress('floatb', n, b)
+            ds.SetBranchAddress("floatb", n, b)
             ds.GetEntry(0)
 
             self.assertEqual(n[0], self.more)
 
     def test_ntuples(self):
-        f,nt,ntd = self.get_ntuples()
+        f, nt, ntd = self.get_ntuples()
 
-        colnames = ['x','y','z']
-        cols  = [ array('f', [ 0. ]) for _ in colnames ]
-        colsd = [ array('d', [ 0. ]) for _ in colnames ]
+        colnames = ["x", "y", "z"]
+        cols = [array("f", [0.0]) for _ in colnames]
+        colsd = [array("d", [0.0]) for _ in colnames]
         ncols = len(cols)
 
-        for ds,cs in [(nt,cols),(ntd,colsd)]:
+        for ds, cs in [(nt, cols), (ntd, colsd)]:
             for i in range(ncols):
                 ds.SetBranchAddress(colnames[i], cs[i])
 
             ds.GetEntry(0)
-        
+
             for i in range(ncols):
-                self.assertEqual(cs[i][0], i*self.more)
+                self.assertEqual(cs[i][0], i * self.more)
 
     def test_class_with_array_member(self):
         # 6468
-        f,t,c = self.get_tree_and_chain()
+        f, t, c = self.get_tree_and_chain()
 
-        for ds in t,c:
+        for ds in t, c:
             mc = ROOT.MyClass()
-            ds.SetBranchAddress('clarrmember', mc)
+            ds.SetBranchAddress("clarrmember", mc)
 
             ds.GetEntry(0)
-            self.assertEqual(mc.foo[0], 0.)
-            self.assertEqual(mc.foo[1], 1.)
+            self.assertEqual(mc.foo[0], 0.0)
+            self.assertEqual(mc.foo[1], 1.0)
 
             ds.GetEntry(1)
-            self.assertEqual(mc.foo[0], 1.)
-            self.assertEqual(mc.foo[1], 2.)
+            self.assertEqual(mc.foo[0], 1.0)
+            self.assertEqual(mc.foo[1], 2.0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Call typed overload of `SetBranchAddress` for array types like `np.ndarray` or `array.array`. The correct C++ template parameter is inferred from the array interface type information.

This is an improvement for two reasons:

  1. We don't need to cast the arrays to a `void *` to avoid template resolution problems anymore.

  2. More importantly: ROOT will do a runtime check for type compatibility, which was requested in the JIRA ticked linked below.

To see the benefit of the added type check, take for example this code, where the branch address is set to an array address with a mismatched type:

```python
import array
import ROOT

def create():
    f = ROOT.TFile("dummy.root", 'RECREATE')
    t = ROOT.TTree("tree", 'A tree')
    a = array.array('f', [42])
    br = t.Branch('a', a, 'a/F')

    for x in (21, 42, 1337):
        a[0] = x
        t.Fill()

    t.Write()
    f.Close()

def test(typecode='f'):
    f = ROOT.TFile("dummy.root", 'READ')
    t = f.Get('tree')
    a = array.array(typecode, [0])
    status = t.SetBranchAddress('a', a)
    print("Status = %s" % (status, ))

    for i in range(t.GetEntries()):
        t.GetEntry(i)
        print("a = %s" % (a[0], ))

create()
test("f")
test("d")
```

Before this commit, the output would be like this:
```txt
Status = 4
a = 21.0
a = 42.0
a = 1337.0
Status = 4
a = 5.442276803e-315
a = 5.483722033e-315
a = 5.690664868e-315
```

With this commit, you get a clear error:
```txt
Status = 0
a = 21.0
a = 42.0
a = 1337.0
Error in <TTree::SetBranchAddress>: The pointer type given "Double_t" (8) does not correspond to the type needed "Float_t" (5) by the branch: a
Status = -2
a = 0.0
a = 0.0
a = 0.0
```

Closes the following JIRA ticket:
https://its.cern.ch/jira/browse/ROOT-8213