### PR TITLE
[PyROOT] Deprecate `TPython::Eval()`

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -159,7 +159,7 @@ Status = -2
 ### Deprecation of `TPython::Eval()`
 
 The `TPython::Eval()` method is deprecated and scheduled for removal in ROOT 6.36.
-Its implementation was fragile, and the same functionality can be achieved with `TPython::Exec()`, using a C++ variable that is known to the ROOT interpreter for crossing over from Python to C++. You can use the static `TPython::Result()` value for that.
+Its implementation was fragile, and the same functionality can be achieved with `TPython::Exec()`, using a C++ variable that is known to the ROOT interpreter for crossing over from Python to C++.
 
 Example:
 ```c++
@@ -167,10 +167,12 @@ Example:
 std::string stringVal = static_cast<const char*>(TPython::Eval("'done'"));
 std::cout << stringVal << std::endl;
 
-// Now, with TPython::Exec()
-TPython::Exec("ROOT.TPython.Result().stringVal = 'done'");
-std::cout << TPython::Result().stringVal << std::endl;
->>>>>>> 998259061f8 ([PyROOT] Deprecate `TPython::Eval()`)
+// Now, with TPython::Exec(). The TPyBuffer() instance wil be synchronized with
+// the optional second result parameter for TPython::Exec().
+
+TPyResult res;
+TPython::Exec("ROOT.TPyBuffer().Set('done')", &res);
+std::cout << res.Get<std::string>() << std::endl;
 ```
 
 ## Language Bindings

--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -167,12 +167,12 @@ Example:
 std::string stringVal = static_cast<const char*>(TPython::Eval("'done'"));
 std::cout << stringVal << std::endl;
 
-// Now, with TPython::Exec(). The TPyBuffer() instance wil be synchronized with
-// the optional second result parameter for TPython::Exec().
+// Now, with TPython::Exec(). You can set `_anyresult` to whatever std::any you want.
+// It will be swapped into the return variabe in the end.
 
-TPyResult res;
-TPython::Exec("ROOT.TPyBuffer().Set('done')", &res);
-std::cout << res.Get<std::string>() << std::endl;
+std::any result;
+TPython::Exec("_anyresult = ROOT.std.make_any['std::string']('done')", &result);
+std::cout << std::any_cast<std::string>(result) << std::endl;
 ```
 
 ## Language Bindings

--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -155,6 +155,22 @@ If the type doesn't match, you now get a clear error instead of garbage values.
 ```txt
 Error in <TTree::SetBranchAddress>: The pointer type given "Double_t" (8) does not correspond to the type needed "Float_t" (5) by the branch: a
 Status = -2
+
+### Deprecation of `TPython::Eval()`
+
+The `TPython::Eval()` method is deprecated and scheduled for removal in ROOT 6.36.
+Its implementation was fragile, and the same functionality can be achieved with `TPython::Exec()`, using a C++ variable that is known to the ROOT interpreter for crossing over from Python to C++. You can use the static `TPython::Result()` value for that.
+
+Example:
+```c++
+// Before, with TPython::Eval()
+std::string stringVal = static_cast<const char*>(TPython::Eval("'done'"));
+std::cout << stringVal << std::endl;
+
+// Now, with TPython::Exec()
+TPython::Exec("ROOT.TPython.Result().stringVal = 'done'");
+std::cout << TPython::Result().stringVal << std::endl;
+>>>>>>> 998259061f8 ([PyROOT] Deprecate `TPython::Eval()`)
 ```
 
 ## Language Bindings

--- a/bindings/tpython/inc/TPython.h
+++ b/bindings/tpython/inc/TPython.h
@@ -28,6 +28,46 @@
 
 #include "ROOT/RConfig.hxx" // R__DEPRECATED
 
+#include <type_traits>
+
+class TPyResult {
+
+public:
+   template<class T>
+   T Get() const {
+      static_assert(std::is_pointer<T>::value, "Expected a pointer");
+      return static_cast<T>(fVoidPtr);
+   }
+
+   void Set(std::string val) { fString = std::move(val); }
+   void Set(Double_t val) { fDouble = val; }
+   void Set(Long_t val) { fLong = val; }
+   void Set(ULong_t val) { fUnsignedLong = val; }
+   void Set(Char_t val) { fChar = val; }
+   void Set(void *val) { fVoidPtr = val; }
+
+private:
+   std::string fString;
+   Double_t fDouble;
+   Long_t fLong;
+   ULong_t fUnsignedLong;
+   Char_t fChar;
+   void *fVoidPtr = nullptr;
+};
+
+template<> inline std::string TPyResult::Get<std::string>() const { return fString; }
+template<> inline Double_t TPyResult::Get<Double_t>() const { return fDouble; }
+template<> inline Long_t TPyResult::Get<Long_t>() const { return fLong; }
+template<> inline ULong_t TPyResult::Get<ULong_t>() const { return fUnsignedLong; }
+template<> inline Char_t TPyResult::Get<Char_t>() const { return fChar; }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get result buffer for the communication between the Python and C++
+/// interpreters. Meant to be used in the Python code passed to
+/// TPython::Exec().
+
+TPyResult &TPyBuffer();
+
 class TPython {
 
 private:
@@ -44,7 +84,7 @@ public:
    static void ExecScript(const char *name, int argc = 0, const char **argv = nullptr);
 
    // execute a python statement (e.g. "import ROOT" )
-   static Bool_t Exec(const char *cmd);
+   static Bool_t Exec(const char *cmd, TPyResult *result = nullptr);
 
    // evaluate a python expression (e.g. "1+1")
    static const TPyReturn Eval(const char *expr) R__DEPRECATED(6,36, "Use TPython::Exec() In combination with TPython::Result() instead.");
@@ -69,18 +109,8 @@ public:
    // void* to CPPInstance conversion, returns a new reference
    static PyObject *CPPInstance_FromVoidPtr(void *addr, const char *classname, Bool_t python_owns = kFALSE);
 
-   struct TPyResult {
-      std::string stringVal;
-      Double_t doubleVal;
-      Long_t longVal;
-      ULong_t unsignedLongVal;
-      Char_t charVal;
-      void *voidPtrVal = nullptr;
-   };
-
-   static TPyResult &Result();
-
    virtual ~TPython() {}
+
    ClassDef(TPython, 0) // Access to the python interpreter
 };
 

--- a/bindings/tpython/inc/TPython.h
+++ b/bindings/tpython/inc/TPython.h
@@ -26,6 +26,8 @@
 // ROOT
 #include "TObject.h"
 
+#include "ROOT/RConfig.hxx" // R__DEPRECATED
+
 class TPython {
 
 private:
@@ -45,7 +47,7 @@ public:
    static Bool_t Exec(const char *cmd);
 
    // evaluate a python expression (e.g. "1+1")
-   static const TPyReturn Eval(const char *expr);
+   static const TPyReturn Eval(const char *expr) R__DEPRECATED(6,36, "Use TPython::Exec() In combination with TPython::Result() instead.");
 
    // bind a ROOT object with, at the python side, the name "label"
    static Bool_t Bind(TObject *object, const char *label);
@@ -66,6 +68,17 @@ public:
 
    // void* to CPPInstance conversion, returns a new reference
    static PyObject *CPPInstance_FromVoidPtr(void *addr, const char *classname, Bool_t python_owns = kFALSE);
+
+   struct TPyResult {
+      std::string stringVal;
+      Double_t doubleVal;
+      Long_t longVal;
+      ULong_t unsignedLongVal;
+      Char_t charVal;
+      void *voidPtrVal = nullptr;
+   };
+
+   static TPyResult &Result();
 
    virtual ~TPython() {}
    ClassDef(TPython, 0) // Access to the python interpreter

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -43,16 +43,18 @@
 ///  root [0] TPython::Exec( "print(\'Hello World!\')" );
 ///  Hello World!
 ///
-///  // Create a TBrowser on the python side, and transfer it back and forth.
+///  // Create a TNamed on the python side, and transfer it back and forth.
 ///  // Note the required explicit (void*) cast!
-///  root [1] TBrowser* b = (void*)TPython::Eval( "ROOT.TBrowser()" );
-///  root [2] TPython::Bind( b, "b" );
-///  root [3] b == (void*) TPython::Eval( "b" )
+///  root [1] TPython::Exec("ROOT.TPython.Result().voidPtrVal = ROOT.TNamed(\"hello\", \"\")");
+///  root [2] auto *n = static_cast<TNamed *>(TPython::Result().voidPtrVal);
+///  root [3] TPython::Bind(n, "n");
+///  root [4] TPython::Exec("ROOT.TPython.Result().voidPtrVal = n");
+///  root [5] (n == TPython::Result().voidPtrVal)
 ///  (int)1
 ///
-///  // Builtin variables can cross-over by using implicit casts.
-///  root [4] int i = TPython::Eval( "1 + 1" );
-///  root [5] i
+///  // Variables can cross-over by using TPython::Result().
+///  root [6] TPython::Exec("ROOT.TPython.Result().longVal = 1 + 1");
+///  root [7] TPython::Result().longVal
 ///  (int)2
 /// ~~~
 ///
@@ -402,6 +404,8 @@ Bool_t TPython::Exec(const char *cmd)
 /// Caution: do not hold on to the return value: either store it in a builtin
 /// type (implicit casting will work), or in a pointer to a ROOT object (explicit
 /// casting to a void* is required).
+///
+/// \deprecated Use TPython::Exec() In combination with TPython::Result() instead.
 
 const TPyReturn TPython::Eval(const char *expr)
 {
@@ -569,4 +573,13 @@ PyObject *TPython::CPPInstance_FromVoidPtr(void *addr, const char *classname, Bo
    // perform cast (the call will check TClass and addr, and set python errors)
    // give ownership, for ref-counting, to the python side, if so requested
    return CPyCppyy::Instance_FromVoidPtr(addr, classname, python_owns);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Result buffer for the communication between the Python and C++
+/// interpreters.
+
+TPython::TPyResult &TPython::Result() {
+   static TPyResult result;
+   return result;
 }


### PR DESCRIPTION
The implementation of `TPython::Eval()` is fragile, and the funcitonality it provides is redundant. One can always communicate between Python and C++ using variables known to the ROOT interpreter.

To make the output-variable-pattern easy to use in `TPython::Exec()`, a new output parameter of type `std::any` is introduced.

Closes #12182.