### PR TITLE
[DF] Remove extern template function declarations

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1040,13 +1040,6 @@ public:
    }
 };
 
-// TODO
-// extern template void MinHelper::Exec(unsigned int, const std::vector<float> &);
-// extern template void MinHelper::Exec(unsigned int, const std::vector<double> &);
-// extern template void MinHelper::Exec(unsigned int, const std::vector<char> &);
-// extern template void MinHelper::Exec(unsigned int, const std::vector<int> &);
-// extern template void MinHelper::Exec(unsigned int, const std::vector<unsigned int> &);
-
 template <typename ResultType>
 class R__CLING_PTRCHECK(off) MaxHelper : public RActionImpl<MaxHelper<ResultType>> {
    std::shared_ptr<ResultType> fResultMax;
@@ -1096,13 +1089,6 @@ public:
       return MaxHelper(result, fMaxs.size());
    }
 };
-
-// TODO
-// extern template void MaxHelper::Exec(unsigned int, const std::vector<float> &);
-// extern template void MaxHelper::Exec(unsigned int, const std::vector<double> &);
-// extern template void MaxHelper::Exec(unsigned int, const std::vector<char> &);
-// extern template void MaxHelper::Exec(unsigned int, const std::vector<int> &);
-// extern template void MaxHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 template <typename ResultType>
 class R__CLING_PTRCHECK(off) SumHelper : public RActionImpl<SumHelper<ResultType>> {
@@ -1238,12 +1224,6 @@ public:
    }
 };
 
-extern template void MeanHelper::Exec(unsigned int, const std::vector<float> &);
-extern template void MeanHelper::Exec(unsigned int, const std::vector<double> &);
-extern template void MeanHelper::Exec(unsigned int, const std::vector<char> &);
-extern template void MeanHelper::Exec(unsigned int, const std::vector<int> &);
-extern template void MeanHelper::Exec(unsigned int, const std::vector<unsigned int> &);
-
 class R__CLING_PTRCHECK(off) StdDevHelper : public RActionImpl<StdDevHelper> {
    // Number of subsets of data
    unsigned int fNSlots;
@@ -1291,12 +1271,6 @@ public:
       return StdDevHelper(result, fCounts.size());
    }
 };
-
-extern template void StdDevHelper::Exec(unsigned int, const std::vector<float> &);
-extern template void StdDevHelper::Exec(unsigned int, const std::vector<double> &);
-extern template void StdDevHelper::Exec(unsigned int, const std::vector<char> &);
-extern template void StdDevHelper::Exec(unsigned int, const std::vector<int> &);
-extern template void StdDevHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 template <typename PrevNodeType>
 class R__CLING_PTRCHECK(off) DisplayHelper : public RActionImpl<DisplayHelper<PrevNodeType>> {

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -147,12 +147,6 @@ double &MeanHelper::PartialUpdate(unsigned int slot)
    return fPartialMeans[slot];
 }
 
-template void MeanHelper::Exec(unsigned int, const std::vector<float> &);
-template void MeanHelper::Exec(unsigned int, const std::vector<double> &);
-template void MeanHelper::Exec(unsigned int, const std::vector<char> &);
-template void MeanHelper::Exec(unsigned int, const std::vector<int> &);
-template void MeanHelper::Exec(unsigned int, const std::vector<unsigned int> &);
-
 StdDevHelper::StdDevHelper(const std::shared_ptr<double> &meanVPtr, const unsigned int nSlots)
    : fNSlots(nSlots), fResultStdDev(meanVPtr), fCounts(nSlots, 0), fMeans(nSlots, 0), fDistancesfromMean(nSlots, 0)
 {
@@ -203,12 +197,6 @@ void StdDevHelper::Finalize()
    variance = variance / (totalElements - 1);
    *fResultStdDev = std::sqrt(variance);
 }
-
-template void StdDevHelper::Exec(unsigned int, const std::vector<float> &);
-template void StdDevHelper::Exec(unsigned int, const std::vector<double> &);
-template void StdDevHelper::Exec(unsigned int, const std::vector<char> &);
-template void StdDevHelper::Exec(unsigned int, const std::vector<int> &);
-template void StdDevHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 // External templates are disabled for gcc5 since this version wrongly omits the C++11 ABI attribute
 #if __GNUC__ > 5


### PR DESCRIPTION
Clang 18 changed the name mangling of function templates, see https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html#c-specific-potentially-breaking-changes

The first mentioned case is "When a template parameter in a function template depends on a previous template parameter", for example:
```
struct A {
    template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
    void Member(T p) {}
};

template void A::Member(int);
```

With Clang < 18 and current versions of GCC, this will mangle to `_ZN1A6MemberIiLi0EEEvT_`, but Clang 18 and later will mangle it to `_ZN1A6MemberIiTnNSt9enable_ifIXsr3stdE13is_integral_vIT_EEiE4typeELi0EEEvS2_` (unless reverted for compatibility with `-fclang-abi-compat=17`).

For ROOT's use of Cling, this poses a bidirectional problem:
 * If building current master with Clang 18, the compiler will, by default, mangle according to the new rules. At runtime, Cling based on LLVM/Clang 16 will generate the old name, but that symbol cannot be found in the shared library.
 * Conversely, in the current attempt to upgrade to LLVM/Clang 18, the opposite situation will happen when building with an "older" compiler so the shared library has the old name.

In both cases, a failure of `tutorial-tmva-tmva103_Application` can be observed, when Cling cannot find the symbol.

Unfortunately, it is not easily possible to detect which symbol names are in the shared library because it depends on the host compiler and configuration. Furthermore, with the current LLVM/Clang 16, we do not have access to the new mangling. Finally, it is unclear if generating the template instantiations in question actually takes up significant time during compilation.

As such, the best approach in the current situation is to remove the `extern template` declarations and let the compiler / Cling re-generate them as needed.

FYI @devajithvs 