### PR TITLE
[core] No longer inline override `TViewPub` classes from `TList`

### DIFF
--- a/core/meta/src/TViewPubDataMembers.h
+++ b/core/meta/src/TViewPubDataMembers.h
@@ -75,9 +75,6 @@ protected:
    void       RecursiveRemove(TObject *obj) override;
    TObject   *Remove(TObject *obj) override;
    TObject   *Remove(TObjLink *lnk) override;
-
-public:
-   ClassDefInlineOverride(TViewPubDataMembers, 0)
 };
 
 // Preventing warnings with -Weffc++ in GCC since it is a false positive for the TListIter destructor.
@@ -90,7 +87,7 @@ public:
 //                                                                      //
 // TViewPubDataMembersIter                                              //
 //                                                                      //
-// Iterator of view of linked list.      `                              //
+// Iterator of view of linked list.                                     //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 class TViewPubDataMembersIter : public TIterator {

--- a/core/meta/src/TViewPubFunctions.h
+++ b/core/meta/src/TViewPubFunctions.h
@@ -75,9 +75,6 @@ protected:
    void       RecursiveRemove(TObject *obj) override;
    TObject   *Remove(TObject *obj) override;
    TObject   *Remove(TObjLink *lnk) override;
-
-public:
-   ClassDefInlineOverride(TViewPubFunctions, 0) // Doubly linked list with hashtable for lookup
 };
 
 // Preventing warnings with -Weffc++ in GCC since it is a false positive for the TListIter destructor.
@@ -90,7 +87,7 @@ public:
 //                                                                      //
 // TViewPubFunctionsIter                                                //
 //                                                                      //
-// Iterator of view of linked list.      `1234                               //
+// Iterator of view of linked list.                                     //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 class TViewPubFunctionsIter : public TIterator {


### PR DESCRIPTION
This PR fixes 
- #15919
## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

clingwrapper tries to lookup the `ClassInfo` of `TViewPubFunctions` in meta which is not public. The return type of `GetListOfAllPublicMethods` should be a `TList` but the public `ClassDefInlineOverride` here:

https://github.com/root-project/root/blob/a038a2f345f41392ce86e07b0683d1740dc9b07c/core/meta/src/TViewPubFunctions.h#L78-L82

and this usage:

https://github.com/root-project/root/blob/a038a2f345f41392ce86e07b0683d1740dc9b07c/core/meta/src/TClass.cxx#L3845-L3849

exposes the type as `TViewPubFunctions`.

This causes the observed offset calculation between `TList` and `TViewPubFunctions` in `Cppyy::GetBaseOffset`:
https://github.com/root-project/root/blob/a038a2f345f41392ce86e07b0683d1740dc9b07c/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx#L1443-L1457

which then fails, producing the warning.

Running a check on the type:

```python
import ROOT; print("Type:", ROOT.TObject.Class().GetListOfAllPublicMethods().IsA().GetName())"
```

Gives:
```
Warning: failed offset calculation between TList and TViewPubFunctions
Type: TViewPubFunctions
```

No longer performing this override in `TViewPubFunction.h` fixes the type back to `TList` and the call to `GetBaseOffset` no longer happens:

```python
print("Type:", ROOT.TObject.Class().GetListOfAllPublicMethods().IsA().GetName())
```
and the warning disappears:

```
Type: TList
```

This fix also required an update in the reference file in roottest : https://github.com/root-project/roottest/pull/1159
