### PR TITLE
[PyROOT] Add Sequence_Check to the public API

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/API.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/API.h
@@ -189,6 +189,9 @@ CPYCPPYY_EXTERN bool Scope_CheckExact(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_CheckExact(PyObject* pyobject);
 
+// type verifier for sequences
+CPYCPPYY_EXTERN bool Sequence_Check(PyObject* pyobject);
+
 // helper to verify expected safety of moving an instance into C++
 CPYCPPYY_EXTERN bool Instance_IsLively(PyObject* pyobject);
 


### PR DESCRIPTION
This PR fixes https://github.com/root-project/root/issues/15161

Applying the following commit from CPyCppyy upstream:
https://github.com/wlav/CPyCppyy/commit/9a792b231c73452d08686ea83c6588f5e98ca9a7

Adds a Sequence_Check which does not pass objects not supporting indexing.