### PR TITLE
[v632][PyROOT] add Sequence_Check to the public API

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/API.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/API.h
@@ -189,6 +189,9 @@ CPYCPPYY_EXTERN bool Scope_CheckExact(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_CheckExact(PyObject* pyobject);
 
+// type verifier for sequences
+CPYCPPYY_EXTERN bool Sequence_Check(PyObject* pyobject);
+
 // helper to verify expected safety of moving an instance into C++
 CPYCPPYY_EXTERN bool Instance_IsLively(PyObject* pyobject);
 


### PR DESCRIPTION
Backporting fix from https://github.com/root-project/root/pull/16180

Applies the following commit from CPyCppyy upstream: wlav/CPyCppyy@a02ceeb
Closes #15161.


