### PR TITLE
[hist] Fix I/O of TFormula nd TFitResultPtr

### DIFF
--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -24,7 +24,7 @@
 #pragma link C++ class ROOT::v5::TFormulaPrimitive+;
 #pragma link C++ class TFractionFitter+;
 #pragma link C++ class TFitResult+;
-#pragma link C++ class TFitResultPtr+;
+#pragma link C++ class TFitResultPtr-;
 #pragma link C++ class TF1NormSum+;
 #pragma link C++ class TF1Convolution+;
 #pragma link C++ class TF1-;

--- a/hist/hist/inc/TFitResultPtr.h
+++ b/hist/hist/inc/TFitResultPtr.h
@@ -56,8 +56,9 @@ private:
 
    int fStatus;                            ///< fit status code
    std::shared_ptr<TFitResult>  fPointer;  ///<! Smart Pointer to TFitResult class
+   TFitResult * fSavedPointer = nullptr;   /// Persistent pointer to TFitResult class
 
-   ClassDef(TFitResultPtr,2)  //indirection to TFitResult
+   ClassDef(TFitResultPtr,3)  //indirection to TFitResult
 };
 
 namespace cling {

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -148,7 +148,7 @@ protected:
    TString                             fFormula;            ///<   String representing the formula expression
    Int_t                               fNdim;               ///<   Dimension - needed for lambda expressions
    Int_t                               fNpar;               ///<!  Number of parameter (transient since we save the vector)
-   Int_t                               fNumber;             ///<!
+   Int_t                               fNumber;             ///<   Number used to identify pre-defined functions (gaus, expo,..)
    std::vector<TObject*>               fLinearParts;        ///<   Vector of linear functions
    Bool_t                              fVectorized = false; ///<   Whether we should use vectorized or regular variables
    // (we default to false since a lot of functions still cannot be expressed in vectorized form)
@@ -286,7 +286,7 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDefOverride(TFormula,13)
+   ClassDefOverride(TFormula,14)
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -321,7 +321,7 @@ void TFormula::SetParNames(Args &&...args)
 /// and evaluate formula.
 
 template <typename... Args>
-Double_t TFormula::Eval(Args... args) const 
+Double_t TFormula::Eval(Args... args) const
 {
    if (sizeof...(args) > 4) {
       Error("Eval", "Eval() only support setting up to 4 variables");

--- a/hist/hist/src/TFitResultPtr.cxx
+++ b/hist/hist/src/TFitResultPtr.cxx
@@ -12,6 +12,7 @@
 #include "TFitResultPtr.h"
 #include "TFitResult.h"
 #include "TError.h"
+#include "TBuffer.h"
 
 /** \class TFitResultPtr
 Provides an indirection to the TFitResult class and with a semantics
@@ -95,7 +96,7 @@ TFitResultPtr & TFitResultPtr::operator=(const TFitResultPtr& rhs)
 {
    if ( &rhs == this) return *this; // self assignment
    fStatus = rhs.fStatus;
-   fPointer = rhs.fPointer; 
+   fPointer = rhs.fPointer;
    // if ( fPointer ) delete fPointer;
    // fPointer = 0;
    // if (rhs.fPointer != 0)  fPointer = new TFitResult(*rhs);
@@ -109,4 +110,24 @@ std::string cling::printValue(const TFitResultPtr* val) {
    if (TFitResult* fr = val->Get())
       return printValue(fr);
    return "<nullptr TFitResult>";
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Streaming of TFitResultPtr as a TFitResult
+void TFitResultPtr::Streamer(TBuffer &b) {
+   if (b.IsReading()) {
+      UInt_t R__s, R__c;
+      Version_t v = b.ReadVersion(&R__s, &R__c);
+      b.ReadClassBuffer(TFitResultPtr::Class(), this, v, R__s, R__c);
+      if (v < 3)
+         Error("TFitResultPtr","Reading old versions of TFitResultPtr is not supported - use TFitResult for saving fit results in a file");
+      else {
+         fPointer = std::shared_ptr<TFitResult>(fSavedPointer);
+         fSavedPointer = nullptr;
+      }
+   }  else {
+      // case of writing
+      fSavedPointer = fPointer.get();
+      b.WriteClassBuffer(TFitResultPtr::Class(), this);
+   }
 }


### PR DESCRIPTION
Fix the I/O of predefined functions (gaus, expo, etc..) where the data member fNumber was not saved in the file and could not be recomputed afterwards. 

Fix also the I/O of the TFitResultPtr class 

This PR fixes #16184

