### PR TITLE
[cling] Globally enable incremental extensions

### DIFF
--- a/interpreter/cling/include/cling/Utils/ParserStateRAII.h
+++ b/interpreter/cling/include/cling/Utils/ParserStateRAII.h
@@ -30,7 +30,6 @@ namespace cling {
     clang::Parser* P;
     clang::Preprocessor& PP;
     decltype(clang::Parser::TemplateIds) OldTemplateIds;
-    bool ResetIncrementalProcessing;
     bool PPDiagHadErrors;
     bool SemaDiagHadErrors;
     bool OldSuppressAllDiagnostics;

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -396,6 +396,8 @@ namespace {
 //    Opts.StackProtector = 0;
 #endif // _MSC_VER
 
+    Opts.IncrementalExtensions = 1;
+
     Opts.Exceptions = 1;
     if (Opts.CPlusPlus) {
       Opts.CXXExceptions = 1;

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -870,7 +870,6 @@ namespace cling {
              nullptr, SourceLocation());
     }
     assert(PP.isIncrementalProcessingEnabled() && "Not in incremental mode!?");
-    PP.enableIncrementalProcessing();
 
     smallstream source_name;
     // FIXME: Pre-increment to avoid failing tests.

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -266,9 +266,6 @@ namespace cling {
 
     Sema& SemaRef = getSema();
     Preprocessor& PP = SemaRef.getPreprocessor();
-    // Enable incremental processing, which prevents the preprocessor destroying
-    // the lexer on EOF token.
-    PP.enableIncrementalProcessing();
 
     m_LookupHelper.reset(new LookupHelper(new Parser(PP, SemaRef,
                                                      /*SkipFunctionBodies*/false,

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -89,15 +89,6 @@ namespace cling {
     //  Tell the parser to not attempt spelling correction.
     //
     const_cast<LangOptions&>(PP.getLangOpts()).SpellChecking = 0;
-    //
-    //  Turn on ignoring of the main file eof token.
-    //
-    //  Note: We need this because token readahead in the following
-    //        routine calls ends up parsing it multiple times.
-    //
-    if (!PP.isIncrementalProcessingEnabled()) {
-      PP.enableIncrementalProcessing();
-    }
     assert(!code.empty() &&
            "prepareForParsing should only be called when need");
 

--- a/interpreter/cling/lib/Utils/ParserStateRAII.cpp
+++ b/interpreter/cling/lib/Utils/ParserStateRAII.cpp
@@ -16,8 +16,6 @@ using namespace clang;
 
 cling::ParserStateRAII::ParserStateRAII(Parser& p, bool skipToEOF)
   : P(&p), PP(p.getPreprocessor()),
-    ResetIncrementalProcessing(p.getPreprocessor()
-                               .isIncrementalProcessingEnabled()),
     PPDiagHadErrors(PP.getDiagnostics().hasErrorOccurred()),
     SemaDiagHadErrors(P->getActions().getDiagnostics().hasErrorOccurred()),
     OldSuppressAllDiagnostics(P->getActions().getDiagnostics()
@@ -61,7 +59,6 @@ cling::ParserStateRAII::~ParserStateRAII() {
     P->SkipUntil(tok::eof);
   else
     P->Tok = OldTok;
-  PP.enableIncrementalProcessing(ResetIncrementalProcessing);
   if (!SemaDiagHadErrors) {
     // Doesn't reset the diagnostic mappings
     P->getActions().getDiagnostics().Reset(/*soft=*/true);


### PR DESCRIPTION
We are relying on this since a while, for example for reemission of template symbols. At the moment, we get the incremental extensions because `Preprocessor::enableIncrementalProcessing()` turns them on internally, but this will change with LLVM 18 where this method only controls incremental processing of a single `Preprocessor` object.

---

This should mean no change in `master` with LLVM 16, but given that we already rely on this we should enable the incremental extensions properly outside of the upgrade to LLVM 18.