### PR TITLE
[ntuple] Add support for truncated single-precision float columns

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -840,6 +840,7 @@ Such cases are marked as `R` in the table.
 | Real16        |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | (Split)Real32 |      |           |      |        |         |         |          |         |          |         |          |   W*  |   W    |
 | (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |       |   W*   |
+| Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W*  |        |
 
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.
 The default column for serialization is denoted with an asterix.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -528,8 +528,7 @@ Zigzag + split
 not cluster-wise.
 
 The "Real32Trunc" type column is a variable-sized floating point column with lower precision than `Real32` and `SplitReal32`.
-It is a IEEE-754 single precision float with some of the mantissa's least significant bits truncated. The amount of truncated bits
-is fixed per-cluster.
+It is a IEEE-754 single precision float with some of the mantissa's least significant bits truncated.
 
 Future versions of the file format may introduce additional column types
 without changing the minimum version of the header.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.8.0
+# RNTuple Reference Specifications 0.2.9.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -508,6 +508,7 @@ The column type and bits on storage integers can have one of the following value
 | 0x14 |   32 | SplitUInt32  | Like UInt32 but in split encoding                                             |
 | 0x1C |   16 | SplitInt16   | Like Int16 but in split + zigzag encoding                                     |
 | 0x15 |   16 | SplitUInt16  | Like UInt16 but in split encoding                                             |
+| 0x1D |10-31 | Real32Trunc  | IEEE-754 single precision float with truncated mantissa                       |
 
 The "split encoding" columns apply a byte transformation encoding to all pages of that column
 and in addition, depending on the column type, delta or zigzag encoding:
@@ -525,6 +526,10 @@ Zigzag + split
 
 **Note**: these encodings always happen within each page, thus decoding should be done page-wise,
 not cluster-wise.
+
+The "Real32Trunc" type column is a variable-sized floating point column with lower precision than `Real32` and `SplitReal32`.
+It is a IEEE-754 single precision float with some of the mantissa's least significant bits truncated. The amount of truncated bits
+is fixed per-cluster.
 
 Future versions of the file format may introduce additional column types
 without changing the minimum version of the header.

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -364,6 +364,12 @@ public:
    RPageSink *GetPageSink() const { return fPageSink; }
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
    RPageStorage::ColumnHandle_t GetHandleSink() const { return fHandleSink; }
+
+   void SetBitsOnStorage(std::size_t bits)
+   {
+      fElement->SetBitsOnStorage(bits);
+      fBitsOnStorage = bits;
+   }
 }; // class RColumn
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -28,9 +28,7 @@
 #include <memory>
 #include <utility>
 
-namespace ROOT {
-namespace Experimental {
-namespace Internal {
+namespace ROOT::Experimental::Internal {
 
 // clang-format off
 /**
@@ -42,7 +40,6 @@ namespace Internal {
 class RColumn {
 private:
    EColumnType fType;
-   std::uint16_t fBitsOnStorage = 0;
    /// Columns belonging to the same field are distinguished by their order.  E.g. for an std::string field, there is
    /// the offset column with index 0 and the character value column with index 1.
    std::uint32_t fIndex;
@@ -355,7 +352,11 @@ public:
    NTupleSize_t GetNElements() const { return fNElements; }
    RColumnElementBase *GetElement() const { return fElement.get(); }
    EColumnType GetType() const { return fType; }
-   std::uint16_t GetBitsOnStorage() const { return fBitsOnStorage; }
+   std::uint16_t GetBitsOnStorage() const
+   {
+      assert(fElement);
+      return fElement->GetBitsOnStorage();
+   }
    std::uint32_t GetIndex() const { return fIndex; }
    std::uint16_t GetRepresentationIndex() const { return fRepresentationIndex; }
    ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
@@ -365,15 +366,9 @@ public:
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
    RPageStorage::ColumnHandle_t GetHandleSink() const { return fHandleSink; }
 
-   void SetBitsOnStorage(std::size_t bits)
-   {
-      fElement->SetBitsOnStorage(bits);
-      fBitsOnStorage = bits;
-   }
+   void SetBitsOnStorage(std::size_t bits) { fElement->SetBitsOnStorage(bits); }
 }; // class RColumn
 
-} // namespace Internal
-} // namespace Experimental
-} // namespace ROOT
+} // namespace ROOT::Experimental::Internal
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -83,6 +83,11 @@ public:
       return false;
    }
 
+   virtual void SetBitsOnStorage(std::size_t)
+   {
+      throw RException(R__FAIL(std::string("internal error: cannot change bit width of this column type")));
+   }
+
    /// If the on-storage layout and the in-memory layout differ, packing creates an on-disk page from an in-memory page
    virtual void Pack(void *destination, const void *source, std::size_t count) const
    {

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -83,9 +83,10 @@ public:
       return false;
    }
 
-   virtual void SetBitsOnStorage(std::size_t)
+   virtual void SetBitsOnStorage(std::size_t bitsOnStorage)
    {
-      throw RException(R__FAIL(std::string("internal error: cannot change bit width of this column type")));
+      if (bitsOnStorage != fBitsOnStorage)
+         throw RException(R__FAIL(std::string("internal error: cannot change bit width of this column type")));
    }
 
    /// If the on-storage layout and the in-memory layout differ, packing creates an on-disk page from an in-memory page

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -330,8 +330,8 @@ public:
 template <typename T>
 class RSimpleField : public RFieldBase {
 protected:
-   void GenerateColumns() final { GenerateColumnsImpl<T>(); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<T>(desc); }
+   void GenerateColumns() override { GenerateColumnsImpl<T>(); }
+   void GenerateColumns(const RNTupleDescriptor &desc) override { GenerateColumnsImpl<T>(desc); }
 
    void ConstructValue(void *where) const final { new (where) T{0}; }
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -351,7 +351,7 @@ extern template class RSimpleField<float>;
 template <>
 class RField<float> final : public RSimpleField<float> {
    std::size_t fBitWidth = sizeof(float) * 8;
-   
+
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -375,6 +375,9 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
    void SetHalfPrecision();
+   /// Set the precision of this field to `nBits`. The remaining (32 - `nBits`) bits will be truncated
+   /// from the number's mantissa. `nBits` must be $10 <= nBits <= 31$ (this means that at least 1 bit
+   /// of mantissa is always preserved). Note that this effectively rounds the number towards 0.
    void SetTruncated(std::size_t nBits);
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -350,13 +350,20 @@ extern template class RSimpleField<float>;
 
 template <>
 class RField<float> final : public RSimpleField<float> {
+   std::size_t fBitWidth = sizeof(float) * 8;
+   
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      auto cloned = std::make_unique<RField<float>>(newName);
+      cloned->fBitWidth = fBitWidth;
+      return cloned;
    }
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
+
+   void GenerateColumns() final;
+   void GenerateColumns(const RNTupleDescriptor &desc) final;
 
 public:
    static std::string TypeName() { return "float"; }
@@ -368,6 +375,7 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
    void SetHalfPrecision();
+   void SetTruncated(std::size_t nBits);
 };
 
 extern template class RSimpleField<double>;

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -405,14 +405,14 @@ protected:
    void GenerateColumnsImpl(const ColumnRepresentation_t &representation, std::uint16_t representationIndex)
    {
       assert(ColumnIndexT < representation.size());
-      fAvailableColumns.emplace_back(
+      auto &column = fAvailableColumns.emplace_back(
          Internal::RColumn::Create<HeadT>(representation[ColumnIndexT], ColumnIndexT, representationIndex));
 
       // Initially, the first two columns become the active column representation
       if (representationIndex == 0 && !fPrincipalColumn) {
-         fPrincipalColumn = fAvailableColumns.back().get();
+         fPrincipalColumn = column.get();
       } else if (representationIndex == 0 && !fAuxiliaryColumn) {
-         fAuxiliaryColumn = fAvailableColumns.back().get();
+         fAuxiliaryColumn = column.get();
       } else {
          // We currently have no fields with more than 2 columns in its column representation
          R__ASSERT(representationIndex > 0);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -30,6 +30,10 @@ class RLogChannel;
 /// Log channel for RNTuple diagnostics.
 RLogChannel &NTupleLog();
 
+inline constexpr auto kReal32TruncBitsMin = 10;
+inline constexpr auto kReal32TruncBitsMax = 31;
+inline constexpr auto kReal32TruncBitsRangeLen = kReal32TruncBitsMax - kReal32TruncBitsMin;
+
 // clang-format off
 /**
 \class ROOT::Experimental::EColumnType
@@ -78,6 +82,11 @@ enum class EColumnType {
    kSplitUInt32,
    kSplitInt16,
    kSplitUInt16,
+   kReal32TruncBegin,
+   // ---
+   // Values reserved for all Real32Trunc bit widths
+   // ---
+   kReal32TruncEnd = kReal32TruncBegin + kReal32TruncBitsRangeLen,
    kMax,
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -30,10 +30,6 @@ class RLogChannel;
 /// Log channel for RNTuple diagnostics.
 RLogChannel &NTupleLog();
 
-inline constexpr auto kReal32TruncBitsMin = 10;
-inline constexpr auto kReal32TruncBitsMax = 31;
-inline constexpr auto kReal32TruncBitsRangeLen = kReal32TruncBitsMax - kReal32TruncBitsMin;
-
 // clang-format off
 /**
 \class ROOT::Experimental::EColumnType

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -82,11 +82,7 @@ enum class EColumnType {
    kSplitUInt32,
    kSplitInt16,
    kSplitUInt16,
-   kReal32TruncBegin,
-   // ---
-   // Values reserved for all Real32Trunc bit widths
-   // ---
-   kReal32TruncEnd = kReal32TruncBegin + kReal32TruncBitsRangeLen,
+   kReal32Trunc,
    kMax,
 };
 

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -27,11 +27,9 @@ ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t c
                                                std::uint16_t representationIndex)
    : fType(type), fIndex(columnIndex), fRepresentationIndex(representationIndex), fTeam({this})
 {
-   // TODO(jblomer): fix for column types with configurable bit length once available
    const auto [minBits, maxBits] = RColumnElementBase::GetValidBitRange(type);
-   // assert(minBits == maxBits);
-   (void)maxBits;
-   fBitsOnStorage = minBits;
+   (void)minBits;
+   fBitsOnStorage = maxBits;
 }
 
 ROOT::Experimental::Internal::RColumn::~RColumn()

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -29,7 +29,8 @@ ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t c
 {
    // TODO(jblomer): fix for column types with configurable bit length once available
    const auto [minBits, maxBits] = RColumnElementBase::GetValidBitRange(type);
-   assert(minBits == maxBits);
+   // assert(minBits == maxBits);
+   (void)maxBits;
    fBitsOnStorage = minBits;
 }
 

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -27,9 +27,6 @@ ROOT::Experimental::Internal::RColumn::RColumn(EColumnType type, std::uint32_t c
                                                std::uint16_t representationIndex)
    : fType(type), fIndex(columnIndex), fRepresentationIndex(representationIndex), fTeam({this})
 {
-   const auto [minBits, maxBits] = RColumnElementBase::GetValidBitRange(type);
-   (void)minBits;
-   fBitsOnStorage = maxBits;
 }
 
 ROOT::Experimental::Internal::RColumn::~RColumn()

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -230,7 +230,7 @@ void ROOT::Experimental::Internal::FloatPacking::UnpackFloats(float *dst, const 
    const Word_t *srcArray = reinterpret_cast<const Word_t *>(src);
    const auto nWordsToLoad = (count * nFloatBits + kBitsPerWord - 1) / kBitsPerWord;
 
-   // bit offset inside the loaded word of the next packed float
+   // bit offset of the next packed float inside the currently loaded word
    int offInWord = 0;
    std::size_t dstIdx = 0;
    std::uint32_t prevWordAccum = 0;
@@ -274,9 +274,6 @@ void ROOT::Experimental::Internal::FloatPacking::UnpackFloats(float *dst, const 
          memcpy(&dst[dstIdx], &packedFloat, sizeof(float));
          ByteSwapIfNecessary(dst[dstIdx]);
          ++dstIdx;
-
-         // advance to next float. This may be either fully contained in this word (easy case)
-         // or it may be split between this and the next word.
          offInWord += nFloatBits;
       }
    }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -165,11 +165,6 @@ ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, ECol
    return nullptr;
 }
 
-std::size_t ROOT::Experimental::Internal::FloatPacking::MinBufSize(std::size_t count, std::size_t nFloatBits)
-{
-   return (count != 0) * std::max<std::size_t>(sizeof(Word_t), (count * nFloatBits + kBitsPerWord - 1) / kBitsPerWord);
-}
-
 void ROOT::Experimental::Internal::FloatPacking::PackFloats(void *dst, const float *src, std::size_t count,
                                                             std::size_t nFloatBits)
 {

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -133,7 +133,7 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>();
    case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
-   case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kReal32Trunc>>();
+   case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<float, EColumnType::kReal32Trunc>>();
    default: assert(false);
    }
    // never here

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -56,6 +56,7 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    case EColumnType::kSplitUInt32: return std::make_pair(32, 32);
    case EColumnType::kSplitInt16: return std::make_pair(16, 16);
    case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
+   case EColumnType::kReal32Trunc: return std::make_pair(kReal32TruncBitsMin, kReal32TruncBitsMax);
    default: assert(false);
    }
    // never here
@@ -92,6 +93,7 @@ std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColum
    case EColumnType::kSplitUInt32: return "SplitUInt32";
    case EColumnType::kSplitInt16: return "SplitInt16";
    case EColumnType::kSplitUInt16: return "SplitUInt16";
+   case EColumnType::kReal32Trunc: return "Real32Trunc";
    default: return "UNKNOWN";
    }
 }
@@ -131,6 +133,7 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>();
    case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
+   case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kReal32Trunc>>();
    default: assert(false);
    }
    // never here

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -278,6 +278,7 @@ std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType ty
    case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitUInt32>>();
    case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt16>>();
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitUInt16>>();
+   case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Trunc>>();
    default: R__ASSERT(false);
    }
    // never here
@@ -667,19 +668,21 @@ public:
 };
 
 template <>
-class RColumnElement<float, EColumnType::kReal32TruncBegin> : public RColumnElementBase {
-   static constexpr std::size_t kWordSize = sizeof(std::uint32_t);
-   static constexpr std::size_t kBitsPerWord = kWordSize * 8;
-
+class RColumnElement<float, EColumnType::kReal32Trunc> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = false;
    static constexpr std::size_t kSize = sizeof(float);
 
-   RColumnElement(std::size_t nFloatBits) : RColumnElementBase(kSize, nFloatBits)
+   RColumnElement() : RColumnElementBase(kSize, ROOT::Experimental::kReal32TruncBitsMax) {}
+
+   void SetBitsOnStorage(std::size_t bitsOnStorage) final
    {
       namespace REx = ROOT::Experimental;
-      R__ASSERT(nFloatBits >= REx::kReal32TruncBitsMin && nFloatBits <= REx::kReal32TruncBitsMax);
+      R__ASSERT(bitsOnStorage >= REx::kReal32TruncBitsMin && bitsOnStorage <= REx::kReal32TruncBitsMax);
+      fBitsOnStorage = bitsOnStorage;
    }
+
+   bool IsMappable() const final { return kIsMappable; }
 
    void Pack(void *dst, const void *src, std::size_t count) const final
    {

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -716,6 +716,8 @@ public:
       R__ASSERT(GetPackedSize(count) == MinBufSize(count, fBitsOnStorage));
 
 #if R__LITTLE_ENDIAN == 0
+      // TODO(gparolini): to avoid this extra allocation we might want to perform byte swapping
+      // directly in the Pack/UnpackBits functions.
       auto bswapped = std::make_unique<float[]>(count);
       CopyBswap<sizeof(float)>(bswapped.get(), src, count);
       const auto *srcLe = bswapped.get();

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -23,7 +23,16 @@
 #endif
 #endif /* R__LITTLE_ENDIAN */
 
-namespace ROOT::Experimental::Internal {
+namespace ROOT::Experimental::Internal::FloatPacking {
+
+using Word_t = std::uintmax_t;
+inline constexpr std::size_t kBitsPerWord = sizeof(Word_t) * 8;
+
+/// Returns the minimum safe size of a buffer that is intended to be used as a destination for PackFloats
+/// or a source for UnpackFloats.
+/// Passing a buffer that's less than this size will cause invalid memory reads and writes.
+std::size_t MinBufSize(std::size_t count, std::size_t nFloatBits);
+
 /// Tightly packs `count` floats contained in `src` into `dst` using `nFloatBits` per float.
 /// `nFloatBits` must be >= kReal32TruncBitsMin and <= kReal32TruncBitsMax.
 /// The extra bits are dropped from the mantissa. The sign and exponent bits are always preserved.
@@ -36,7 +45,7 @@ void PackFloats(void *dst, const float *src, std::size_t count, std::size_t nFlo
 /// IMPORTANT: the size of `src` must be rounded up from `count * nFloatBits`
 /// to the next multiple of 4 (i.e. the word size).
 void UnpackFloats(float *dst, const void *src, std::size_t count, std::size_t nFloatBits);
-} // namespace ROOT::Experimental::Internal
+} // namespace ROOT::Experimental::Internal::FloatPacking
 
 namespace {
 
@@ -686,12 +695,14 @@ public:
 
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
-      ROOT::Experimental::Internal::PackFloats(dst, reinterpret_cast<const float *>(src), count, fBitsOnStorage);
+      ROOT::Experimental::Internal::FloatPacking::PackFloats(dst, reinterpret_cast<const float *>(src), count,
+                                                             fBitsOnStorage);
    }
 
    void Unpack(void *dst, const void *src, std::size_t count) const final
    {
-      ROOT::Experimental::Internal::UnpackFloats(reinterpret_cast<float *>(dst), src, count, fBitsOnStorage);
+      ROOT::Experimental::Internal::FloatPacking::UnpackFloats(reinterpret_cast<float *>(dst), src, count,
+                                                               fBitsOnStorage);
    }
 };
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -31,7 +31,11 @@ inline constexpr std::size_t kBitsPerWord = sizeof(Word_t) * 8;
 /// Returns the minimum safe size of a buffer that is intended to be used as a destination for PackFloats
 /// or a source for UnpackFloats.
 /// Passing a buffer that's less than this size will cause invalid memory reads and writes.
-std::size_t MinBufSize(std::size_t count, std::size_t nFloatBits);
+constexpr std::size_t MinBufSize(std::size_t count, std::size_t nFloatBits)
+{
+   return (count != 0) * sizeof(Word_t) *
+          std::max<std::size_t>(1, (count * nFloatBits + kBitsPerWord - 1) / kBitsPerWord);
+}
 
 /// Tightly packs `count` floats contained in `src` into `dst` using `nFloatBits` per float.
 /// `nFloatBits` must be >= kReal32TruncBitsMin and <= kReal32TruncBitsMax.

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -708,15 +708,15 @@ public:
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
       using namespace ROOT::Experimental::Internal::BitPacking;
-      
+
       R__ASSERT(GetPackedSize(count) == MinBufSize(count, fBitsOnStorage));
 
 #if R__LITTLE_ENDIAN == 0
       auto bswapped = std::make_unique<float[]>(count);
       CopyBswap<sizeof(float)>(bswapped.get(), src, count);
-      auto *srcLe = bswapped.get();
+      const auto *srcLe = bswapped.get();
 #else
-      auto *srcLe = src;
+      const auto *srcLe = reinterpret_cast<const float *>(src);
 #endif
       PackBits(dst, srcLe, count, sizeof(float), fBitsOnStorage);
    }
@@ -841,8 +841,8 @@ DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSpl
 DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSplitIndex32, 32,
                             RColumnElementDeltaSplitLE, <std::uint64_t, std::uint32_t>);
 
-void RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(void *dst, const void *src,
-                                                                       std::size_t count) const
+inline void
+RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(void *dst, const void *src, std::size_t count) const
 {
    const bool *boolArray = reinterpret_cast<const bool *>(src);
    char *charArray = reinterpret_cast<char *>(dst);
@@ -861,8 +861,8 @@ void RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(void *dst
    }
 }
 
-void RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Unpack(void *dst, const void *src,
-                                                                         std::size_t count) const
+inline void
+RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Unpack(void *dst, const void *src, std::size_t count) const
 {
    bool *boolArray = reinterpret_cast<bool *>(dst);
    const char *charArray = reinterpret_cast<const char *>(src);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1443,10 +1443,10 @@ void ROOT::Experimental::RField<float>::SetHalfPrecision()
 
 void ROOT::Experimental::RField<float>::SetTruncated(std::size_t nBits)
 {
-   if (nBits < kReal32TruncBitsMin || nBits > kReal32TruncBitsMax) {
+   const auto &[minBits, maxBits] = Internal::RColumnElementBase::GetValidBitRange(EColumnType::kReal32Trunc);
+   if (nBits < minBits || nBits > maxBits) {
       throw RException(R__FAIL("SetTruncated() argument nBits = " + std::to_string(nBits) + " is out of valid range [" +
-                               std::to_string(kReal32TruncBitsMin) + ", " + std::to_string(kReal32TruncBitsMax) +
-                               "])"));
+                               std::to_string(minBits) + ", " + std::to_string(maxBits) + "])"));
    }
    SetColumnRepresentatives({{EColumnType::kReal32Trunc}});
    fBitWidth = nBits;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1400,7 +1400,7 @@ void ROOT::Experimental::RField<float>::GenerateColumns()
    for (std::uint16_t i = 0; i < n; ++i) {
       auto &column = fAvailableColumns.emplace_back(Internal::RColumn::Create<float>(r[i][0], 0, i));
       if (r[i][0] == EColumnType::kReal32Trunc) {
-         column->GetElement()->SetBitsOnStorage(fBitWidth);
+         column->SetBitsOnStorage(fBitWidth);
       }
    }
    fPrincipalColumn = fAvailableColumns[0].get();
@@ -1414,12 +1414,12 @@ void ROOT::Experimental::RField<float>::GenerateColumns(const RNTupleDescriptor 
       if (onDiskTypes.empty())
          break;
 
-      auto &column = fAvailableColumns.emplace_back(
-            Internal::RColumn::Create<float>(onDiskTypes[0], 0, representationIndex));
+      auto &column =
+         fAvailableColumns.emplace_back(Internal::RColumn::Create<float>(onDiskTypes[0], 0, representationIndex));
       if (onDiskTypes[0] == EColumnType::kReal32Trunc) {
          const auto &fdesc = desc.GetFieldDescriptor(GetOnDiskId());
          const auto &coldesc = desc.GetColumnDescriptor(fdesc.GetLogicalColumnIds()[0]);
-         column->GetElement()->SetBitsOnStorage(coldesc.GetBitsOnStorage());
+         column->SetBitsOnStorage(coldesc.GetBitsOnStorage());
       }
       fColumnRepresentatives.emplace_back(onDiskTypes);
       if (representationIndex > 0) {

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -18,6 +18,7 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
+#include <ROOT/RNTupleUtil.hxx>
 
 #include <RVersion.h>
 #include <TBufferFile.h>
@@ -25,7 +26,6 @@
 #include <TList.h>
 #include <TStreamerInfo.h>
 #include <TVirtualStreamerInfo.h>
-#include "ROOT/RNTupleUtil.hxx"
 #include <xxhash.h>
 
 #include <cassert>

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -25,6 +25,7 @@
 #include <TList.h>
 #include <TStreamerInfo.h>
 #include <TVirtualStreamerInfo.h>
+#include "ROOT/RNTupleUtil.hxx"
 #include <xxhash.h>
 
 #include <cassert>
@@ -655,6 +656,7 @@ std::uint32_t
 ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnType(ROOT::Experimental::EColumnType type, void *buffer)
 {
    using EColumnType = ROOT::Experimental::EColumnType;
+
    switch (type) {
    case EColumnType::kIndex64: return SerializeUInt16(0x01, buffer);
    case EColumnType::kIndex32: return SerializeUInt16(0x02, buffer);
@@ -683,6 +685,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnType(ROOT::Exper
    case EColumnType::kSplitUInt32: return SerializeUInt16(0x14, buffer);
    case EColumnType::kSplitInt16: return SerializeUInt16(0x1C, buffer);
    case EColumnType::kSplitUInt16: return SerializeUInt16(0x15, buffer);
+   case EColumnType::kReal32Trunc: return SerializeUInt16(0x1D, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
@@ -694,6 +697,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeColumnType(const voi
    using EColumnType = ROOT::Experimental::EColumnType;
    std::uint16_t onDiskType;
    auto result = DeserializeUInt16(buffer, onDiskType);
+
    switch (onDiskType) {
    case 0x01: type = EColumnType::kIndex64; break;
    case 0x02: type = EColumnType::kIndex32; break;
@@ -722,6 +726,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeColumnType(const voi
    case 0x14: type = EColumnType::kSplitUInt32; break;
    case 0x1C: type = EColumnType::kSplitInt16; break;
    case 0x15: type = EColumnType::kSplitUInt16; break;
+   case 0x1D: type = EColumnType::kReal32Trunc; break;
    default: return R__FAIL("unexpected on-disk column type");
    }
    return result;

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -407,6 +407,19 @@ TEST(Packing, Real32Trunc)
       element.Unpack(fout, out2, 5);
       for (int i = 0; i < 5; ++i)
          EXPECT_EQ(fout[i], 3.f);
+
+      // verify that Pack() doesn't write past the end of the valid buffer
+      unsigned char outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 4];
+      outExtra[BitPacking::MinBufSize(5, kBitsOnStorage)] = 44;
+      outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 1] = 11;
+      outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 2] = 22;
+      outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 3] = 33;
+      element.Pack(outExtra, f, 5);
+
+      EXPECT_EQ(outExtra[BitPacking::MinBufSize(5, kBitsOnStorage)], 44);
+      EXPECT_EQ(outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 1], 11);
+      EXPECT_EQ(outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 2], 22);
+      EXPECT_EQ(outExtra[BitPacking::MinBufSize(5, kBitsOnStorage) + 3], 33);
    }
 
    {
@@ -460,8 +473,7 @@ TEST(Packing, Real32Trunc)
       float f[N];
       for (int i = 0; i < N; ++i)
          f[i] = -2097176.7f;
-      auto out2 =
-         std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out2 = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out2.get(), f, N);
 
       float fout[N];
@@ -482,8 +494,7 @@ TEST(Packing, Real32Trunc)
       for (int i = 0; i < N; ++i)
          f[i] = 2.f + (0.000001f * i);
 
-      auto out =
-         std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out.get(), f, N);
 
       float fout[N];

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -464,8 +464,11 @@ TEST(Packing, Real32Trunc)
 
       float fout[N];
       element.Unpack(fout, out2, N);
-      for (int i = 0; i < N; ++i)
+      for (int i = 0; i < N; ++i) {
          EXPECT_EQ(fout[i], -2097176.5f); // dropped last bit of mantissa
+         if (fout[i] != -2097176.5f) // prevent spamming
+            break;
+      }
    }
 
    {
@@ -482,7 +485,10 @@ TEST(Packing, Real32Trunc)
 
       float fout[N];
       element.Unpack(fout, out, N);
-      for (int i = 0; i < N; ++i)
+      for (int i = 0; i < N; ++i) {
          EXPECT_EQ(fout[i], 2.f);
+         if (fout[i] != 2.f) // prevent spamming
+            break;
+      }
    }
 }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -509,8 +509,7 @@ TEST(Packing, Real32Trunc)
    // Exhaustively test, for all valid bit widths, packing and unpacking of 0 to N random floats.
    std::uniform_real_distribution<float> dist(-1000000, 1000000);
    const auto &[minBits, maxBits] = RColumnElementBase::GetValidBitRange(EColumnType::kReal32Trunc);
-   for (int bitWidth = minBits; bitWidth <= maxBits; ++bitWidth)
-   {
+   for (int bitWidth = minBits; bitWidth <= maxBits; ++bitWidth) {
       RColumnElement<float, EColumnType::kReal32Trunc> element;
       element.SetBitsOnStorage(bitWidth);
 

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -380,7 +380,7 @@ TEST(Packing, OnDiskEncoding)
 
 TEST(Packing, Real32Trunc)
 {
-   namespace FloatPacking = ROOT::Experimental::Internal::FloatPacking;
+   namespace BitPacking = ROOT::Experimental::Internal::BitPacking;
    {
       constexpr auto kBitsOnStorage = 10;
       RColumnElement<float, EColumnType::kReal32Trunc> element;
@@ -400,7 +400,7 @@ TEST(Packing, Real32Trunc)
       EXPECT_EQ(f2, 3.f);
 
       float f[5] = {3.5f, 3.5f, 3.5f, 3.5f, 3.5f};
-      unsigned char out2[FloatPacking::MinBufSize(5, kBitsOnStorage)];
+      unsigned char out2[BitPacking::MinBufSize(5, kBitsOnStorage)];
       element.Pack(out2, f, 5);
 
       float fout[5];
@@ -431,7 +431,7 @@ TEST(Packing, Real32Trunc)
       float f[5] = {4.408104e-39, 1.0285575e-38, -2.2040519e-38, 8.8162076e-38, 1.4105932e-36};
       // ... truncated to: 0b000'0000'0010, 0b000'0000'0110, 0b000'0000'1110, ...
       const float expf[5] = {2.938736e-39, 8.816207e-39, -2.0571151e-38, 8.2284604e-38, 1.3165537e-36};
-      unsigned char out2[FloatPacking::MinBufSize(5, kBitsOnStorage)];
+      unsigned char out2[BitPacking::MinBufSize(5, kBitsOnStorage)];
       element.Pack(out2, f, 5);
 
       float fout[5];
@@ -461,7 +461,7 @@ TEST(Packing, Real32Trunc)
       for (int i = 0; i < N; ++i)
          f[i] = -2097176.7f;
       auto out2 =
-         std::make_unique<unsigned char[]>(FloatPacking::MinBufSize(N, kBitsOnStorage));
+         std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out2.get(), f, N);
 
       float fout[N];
@@ -483,7 +483,7 @@ TEST(Packing, Real32Trunc)
          f[i] = 2.f + (0.000001f * i);
 
       auto out =
-         std::make_unique<unsigned char[]>(FloatPacking::MinBufSize(N, kBitsOnStorage));
+         std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out.get(), f, N);
 
       float fout[N];

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -380,6 +380,7 @@ TEST(Packing, OnDiskEncoding)
 
 TEST(Packing, Real32Trunc)
 {
+   namespace FloatPacking = ROOT::Experimental::Internal::FloatPacking;
    {
       constexpr auto kBitsOnStorage = 10;
       RColumnElement<float, EColumnType::kReal32Trunc> element;
@@ -388,7 +389,7 @@ TEST(Packing, Real32Trunc)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 3.5f;
-      unsigned char out[std::max<size_t>(4, (kBitsOnStorage + 31) / 32)];
+      unsigned char out[8];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -399,7 +400,7 @@ TEST(Packing, Real32Trunc)
       EXPECT_EQ(f2, 3.f);
 
       float f[5] = {3.5f, 3.5f, 3.5f, 3.5f, 3.5f};
-      unsigned char out2[20];
+      unsigned char out2[FloatPacking::MinBufSize(5, kBitsOnStorage)];
       element.Pack(out2, f, 5);
 
       float fout[5];
@@ -416,7 +417,7 @@ TEST(Packing, Real32Trunc)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 992.f;
-      unsigned char out[std::max<size_t>(4, (kBitsOnStorage + 31) / 32)];
+      unsigned char out[8];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -430,7 +431,7 @@ TEST(Packing, Real32Trunc)
       float f[5] = {4.408104e-39, 1.0285575e-38, -2.2040519e-38, 8.8162076e-38, 1.4105932e-36};
       // ... truncated to: 0b000'0000'0010, 0b000'0000'0110, 0b000'0000'1110, ...
       const float expf[5] = {2.938736e-39, 8.816207e-39, -2.0571151e-38, 8.2284604e-38, 1.3165537e-36};
-      unsigned char out2[20];
+      unsigned char out2[FloatPacking::MinBufSize(5, kBitsOnStorage)];
       element.Pack(out2, f, 5);
 
       float fout[5];
@@ -447,7 +448,7 @@ TEST(Packing, Real32Trunc)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 2.126f;
-      unsigned char out[std::max<size_t>(4, (kBitsOnStorage + 31) / 32)];
+      unsigned char out[8];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -459,11 +460,12 @@ TEST(Packing, Real32Trunc)
       float f[N];
       for (int i = 0; i < N; ++i)
          f[i] = -2097176.7f;
-      unsigned char out2[(N * 30 + 7) / 8];
-      element.Pack(out2, f, N);
+      auto out2 =
+         std::make_unique<unsigned char[]>(FloatPacking::MinBufSize(N, kBitsOnStorage));
+      element.Pack(out2.get(), f, N);
 
       float fout[N];
-      element.Unpack(fout, out2, N);
+      element.Unpack(fout, out2.get(), N);
       for (int i = 0; i < N; ++i) {
          EXPECT_EQ(fout[i], -2097176.5f); // dropped last bit of mantissa
          if (fout[i] != -2097176.5f)      // prevent spamming
@@ -480,11 +482,12 @@ TEST(Packing, Real32Trunc)
       for (int i = 0; i < N; ++i)
          f[i] = 2.f + (0.000001f * i);
 
-      unsigned char out[(N * kBitsOnStorage + 31) / 32];
-      element.Pack(out, f, N);
+      auto out =
+         std::make_unique<unsigned char[]>(FloatPacking::MinBufSize(N, kBitsOnStorage));
+      element.Pack(out.get(), f, N);
 
       float fout[N];
-      element.Unpack(fout, out, N);
+      element.Unpack(fout, out.get(), N);
       for (int i = 0; i < N; ++i) {
          EXPECT_EQ(fout[i], 2.f);
          if (fout[i] != 2.f) // prevent spamming


### PR DESCRIPTION
# This Pull request:
adds a new ColumnType `Real32Trunc`, that stores a real value as a tightly-packed, IEEE-754 single precision float using less than 32 bits. The missing bits are simply truncated from the mantissa, causing the value to be rounded towards zero.
The valid range of bit widths is `[10, 31]` inclusive.

This is the first ColumnType with a variable bit width, therefore it requires some extra handling on the RColumnElement and RField side, but it uses a single type id on disk (`0x1D`) and a single enum value `EColumnType::kReal32Trunc`.

The way to use it is by calling the new `SetTruncated(nBits)` method on `RField<float>`.


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


