### PR TITLE
Update TProfile2D.cxx - copy all attributes of axis to projection histograms

### DIFF
--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -1311,6 +1311,8 @@ TH2D *TProfile2D::ProjectionXY(const char *name, Option_t *option) const
    } else {
       h1 = new TH2D(pname,GetTitle(),nx,xbins->GetArray(),ny,ybins->GetArray() );
    }
+   fXaxis.Copy(*h1->GetXaxis());
+   fYaxis.Copy(*h1->GetYaxis());
    Bool_t computeErrors = kFALSE;
    Bool_t cequalErrors  = kFALSE;
    Bool_t binEntries    = kFALSE;

--- a/hist/hist/test/test_projections.cxx
+++ b/hist/hist/test/test_projections.cxx
@@ -78,7 +78,7 @@ TEST(Projections, Issue_6658_Profile2D)
    auto xaxis_2d_nbins = xaxis_2d->GetNbins();
    auto *labels_2d = xaxis_2d->GetLabels();
 
-   auto *hist_pxy = prof2d.ProjectionXY("x");
+   auto *hist_pxy = prof2d.ProjectionXY("xy");
    auto *xaxis_pxy = hist_pxy->GetXaxis();
    auto xaxis_pxy_nbins = xaxis_pxy->GetNbins();
    auto *labels_pxy = xaxis_pxy->GetLabels();

--- a/hist/hist/test/test_projections.cxx
+++ b/hist/hist/test/test_projections.cxx
@@ -81,7 +81,7 @@ TEST(Projections, Issue_6658_Profile2D)
    auto *hist_pxy = prof2d.ProjectionXY("x");
    auto *xaxis_pxy = hist_pxy->GetXaxis();
    auto xaxis_pxy_nbins = xaxis_pxy->GetNbins();
-   auto *labels_pxy = xaxis_pyx->GetLabels();
+   auto *labels_pxy = xaxis_pxy->GetLabels();
    EXPECT_EQ(xaxis_2d_nbins, xaxis_pxy_nbins);
    expect_list_eq_names(*labels_2d, *labels_pxy);
 }

--- a/hist/hist/test/test_projections.cxx
+++ b/hist/hist/test/test_projections.cxx
@@ -67,3 +67,21 @@ TEST(Projections, Issue_6658_3D)
    EXPECT_EQ(xaxis_3d_nbins, prof2_px_nbins);
    expect_list_eq_names(*labels_3d, *labels_prof2_px);
 }
+
+// Test projection from Profile2D hist for labels/nbins
+TEST(Projections, Issue_6658_Profile2D)
+{
+   TProfile2D prof2d("prof2d", "", 2, 0, 2, 2, 0, 3);
+   auto *xaxis_2d = prof2d.GetXaxis();
+   xaxis_2d->SetBinLabel(1, "A");
+   xaxis_2d->SetBinLabel(2, "B");
+   auto xaxis_2d_nbins = xaxis_2d->GetNbins();
+   auto *labels_2d = xaxis_2d->GetLabels();
+
+   auto *hist_pxy = prof2d.ProjectionXY("x");
+   auto *xaxis_pxy = hist_pxy->GetXaxis();
+   auto xaxis_pxy_nbins = xaxis_pxy->GetNbins();
+   auto *labels_pxy = xaxis_pyx->GetLabels();
+   EXPECT_EQ(xaxis_2d_nbins, xaxis_pxy_nbins);
+   expect_list_eq_names(*labels_2d, *labels_pxy);
+}


### PR DESCRIPTION
these two lines will ensure any bin labels are propagated to projection histograms

