### PR TITLE
Update IncrementalCUDADeviceCompiler.cpp - change string comparison to exact match for "-include"

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -72,7 +72,7 @@ namespace cling {
     // add included files to the cling ptx
     for (const char* c : invocationOptions.CompilerOpts.Remaining) {
       std::string s(c);
-      if (s.find("-include") == 0)
+      if (s == "-include")
         argv.push_back(s);
     }
 


### PR DESCRIPTION
Modified the loop to use exact string comparison `(s == "-include")` instead of checking if the string starts with "-include" `(s.find("-include") == 0)` to ensure only exact matches are considered.

### Explanation

- `(s.find("-include")`: Adds `s` to `argv` if `s` starts with `"-include"`.
- `(s == "-include")`: Adds `s` to `argv` only if `s` is exactly `"-include"`.

The first snippet is more inclusive, as it will match any string that begins with `"-include"`, such as `"-include-pch"` or something else starting with `"-include"`, while the second snippet will only match the exact string `"-include"`.