### PR TITLE
[TTreeReader] Properly cleanup non-owned chains

### DIFF
--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -284,7 +284,8 @@ private:
    enum EStatusBits {
       kBitIsChain = BIT(14), ///< our tree is a chain
       kBitHaveWarnedAboutEntryListAttachedToTTree = BIT(15), ///< the tree had a TEntryList and we have warned about that
-      kBitSetEntryBaseCallingLoadTree = BIT(16) ///< SetEntryBase is in the process of calling TChain/TTree::%LoadTree.
+      kBitSetEntryBaseCallingLoadTree = BIT(16), ///< SetEntryBase is in the process of calling TChain/TTree::%LoadTree.
+      kBitIsExternalTree = BIT(17)  ///< we do not own the tree
    };
 
    TTree* fTree = nullptr; ///< tree that's read


### PR DESCRIPTION
therewith avoiding memory hogging because of the attached TTreeChaches.

This code has been written by David Smith and minimally edited for its integration in root.
See sister PR in roottest: https://github.com/root-project/roottest/pull/1161

This PR fixes [ROOT-6286](https://its.cern.ch/jira/browse/ROOT-6286)

