### PR TITLE
[v632] [PyROOT] Perform function-style casts when returning multi-keyword types

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -45,7 +45,7 @@ static inline void InjectMethod(Cppyy::TCppMethod_t method, const std::string& m
             "      return";
     if (retType != "void") {
         if (retType.back() != '*')
-            code << " " << CPyCppyy::TypeManip::remove_const(retType) << "{}";
+            code << " (" << CPyCppyy::TypeManip::remove_const(retType) << "){}";
         else
             code << " nullptr";
     }


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/15315

 - [X] tested changes locally

This enables the failing example in the manual with `ROOT.Math.IMultiGenFunction` that failed due to an invalid zero initialization of an `unsigned int`
