### PR TITLE
[PyROOT] Avoid using deprecated `numpy._float`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_conversion_maps.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_conversion_maps.py
@@ -60,7 +60,6 @@ NUMPY_TO_TREE = {
     numpy.int16 : 'Int_t',
     numpy.int32: 'Int_t',
     numpy.int64 : 'Long_t',
-    numpy.float_ : 'Float_t',
     numpy.float32 : 'Float_t',
     numpy.float64 : 'Double_t',
 }


### PR DESCRIPTION
The `np.float_` was removed in the NumPy 2.0 release. One should use `np.float64` instead, which is already in the same dictionary.