### PR TITLE
[RF] Remove `RooAbsReal::plotSliceOn()`

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -69,6 +69,7 @@ The following people have contributed to this new version:
 
 ## Deprecation and Removal
 
+* The `RooAbsReal::plotSliceOn()` function that was deprecated since at least ROOT 6 was removed. Use `plotOn(frame,Slice(...))` instead.
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -275,10 +275,6 @@ public:
 
   enum ScaleType { Raw, Relative, NumEvent, RelativeExpected } ;
 
-  // Forwarder function for backward compatibility
-  virtual RooPlot *plotSliceOn(RooPlot *frame, const RooArgSet& sliceSet, Option_t* drawOptions="L",
-                double scaleFactor=1.0, ScaleType stype=Relative, const RooAbsData* projData=nullptr) const;
-
   // Fill an existing histogram
   TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars,
            double scaleFactor= 1, const RooArgSet *projectedVars= nullptr, bool scaling=true,

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1924,8 +1924,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
 /// possible, which can be selection with 'stype' (see RooAbsPdf::plotOn() for details).
 ///
 /// The default projection behaviour can be overridden by supplying an optional set of dependents
-/// to project. For most cases, plotSliceOn() and plotProjOn() provide a more intuitive interface
-/// to modify the default projection behaviour.
+/// to project via RooFit command arguments.
 //_____________________________________________________________________________
 // coverity[PASS_BY_VALUE]
 RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
@@ -2243,40 +2242,6 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
   plotVar->setVal(oldPlotVarVal); // reset the plot variable value to not disturb the original state
   return frame;
 }
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// \deprecated OBSOLETE -- RETAINED FOR BACKWARD COMPATIBILITY. Use plotOn() with Slice() instead
-
-RooPlot* RooAbsReal::plotSliceOn(RooPlot *frame, const RooArgSet& sliceSet, Option_t* drawOptions,
-             double scaleFactor, ScaleType stype, const RooAbsData* projData) const
-{
-  RooArgSet projectedVars ;
-  makeProjectionSet(frame->getPlotVar(),frame->getNormVars(),projectedVars,true) ;
-
-  // Take out the sliced variables
-  for(RooAbsArg * sliceArg : sliceSet) {
-    RooAbsArg* arg = projectedVars.find(sliceArg->GetName()) ;
-    if (arg) {
-      projectedVars.remove(*arg) ;
-    } else {
-      coutI(Plotting) << "RooAbsReal::plotSliceOn(" << GetName() << ") slice variable "
-            << sliceArg->GetName() << " was not projected anyway" << std::endl ;
-    }
-  }
-
-  PlotOpt o ;
-  o.drawOptions = drawOptions ;
-  o.scaleFactor = scaleFactor ;
-  o.stype = stype ;
-  o.projData = projData ;
-  o.projSet = &projectedVars ;
-  return plotOn(frame,o) ;
-}
-
-
 
 
 //_____________________________________________________________________________


### PR DESCRIPTION
The `RooAbsReal::plotSliceOn()` function that was deprecated since at least ROOT 6 was removed. Use `plotOn(frame,Slice(...))` instead.