### PR TITLE
[core] Return 2 if root macro.C and macro.C does not exist as it is done for the Python interpreter

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -541,8 +541,12 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                   fFiles->Add(new TNamed("NOT FOUND!", argv[i]));
                   // only warn if we're plain root,
                   // other progs might have their own params
-                  if (!strcmp(gROOT->GetName(), "Rint"))
-                     Warning("GetOptions", "macro %s not found", fname.Data());
+                  if (!strcmp(gROOT->GetName(), "Rint")) {
+                     Error("GetOptions", "macro %s not found", fname.Data());
+                     // Return 2 as the Python interpreter does in case the macro
+                     // is not found.
+                     Terminate(2);
+                  }
                }
             }
          }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Currently this is the behaviour
```
~> root -b -q -l NotExistingFile.C
Warning in <TApplication::GetOptions>: macro pippo.C not found
root: unrecognized option 'pippo.C'
Try 'root --help' for more information.
~> echo $?
0
```
the root executable simply warns about the file not existing but returns 0, as everything went well. This has several downsides, including not protecting us from our typos when adding tests to the suite (see original JIRA issue)

## Checklist:

- [v] tested changes locally
- [v] updated the docs (if necessary)

This PR fixes [ROOT-9365](https://its.cern.ch/jira/browse/ROOT-9395)
