### PR TITLE
[Core] ACLiC: set default verbosity level for rootcling

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3527,7 +3527,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    // ======= Generate the rootcling command line
    TString rcling = "rootcling";
    PrependPathName(TROOT::GetBinDir(), rcling);
-   rcling += " -v0 \"--lib-list-prefix=";
+   rcling += " \"--lib-list-prefix=";
    rcling += mapfile;
    rcling += "\" -f \"";
    rcling.Append(dict).Append("\" ");

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -785,17 +785,10 @@ int TCling_GenerateDictionary(const std::vector<std::string> &classes,
          }
          fileContent += "#pragma link C++ class ";
          fileContent +=    *it + "+;\n" ;
-         fileContent += "#pragma link C++ class ";
-         if (iSTLType != sSTLTypes.end()) {
-            // STL class; we cannot (and don't need to) store iterators;
-            // their shadow and the compiler's version don't agree. So
-            // don't ask for the '+'
-            fileContent +=    *it + "::*;\n" ;
-         }
-         else {
+         if (iSTLType == sSTLTypes.end()) {
             // Not an STL class; we need to allow the I/O of contained
             // classes (now that we have a dictionary for them).
-            fileContent +=    *it + "::*+;\n" ;
+            fileContent += "#pragma link C++ class " + *it + "::*+;\n" ;
          }
       }
       fileContent += "#endif\n";


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Sets the verbosity level of rootcling in ACLiC to the default, therewith printing also warnings and not only fatal errors.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes [ROOT-10975](https://its.cern.ch/jira/browse/ROOT-10975)

Linked roottest PR https://github.com/root-project/roottest/pull/1168 and  https://github.com/root-project/roottest/pull/1169, that fixes a test which becomes broken once the verbosity is increased because some unused rules start to generate warnings. The rules are unused simply because the name of some template instantiations are not spelled correctly.

