### PR TITLE
[ci] Revert Numba restrictions and lock NumPy version for upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ torch
 xgboost
 
 # PyROOT: ROOT.Numba.Declare decorator
-numba>=0.47.0,<0.60.0 ; python_version < "3.11" # See https://github.com/numba/numba/issues/8304
-numba>=0.57.0,<0.60.0 ; python_version >= "3.11" and python_version < "3.12"
-numba>=0.59.0,<0.60.0 ; python_version >= "3.12"
+numba>=0.47.0 ; python_version < "3.11" # See https://github.com/numba/numba/issues/8304
+numba>=0.57.0 ; python_version >= "3.11" and python_version < "3.12"
+numba>=0.59.0 ; python_version >= "3.12"
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ROOT requirements for third-party Python packages
 
 # PyROOT: Interoperability with numpy arrays
-numpy>=1.4.1
+numpy>=1.4.1, <=1.26.4
 
 # TMVA: SOFIE
 graph_nets


### PR DESCRIPTION
This reverts commit d6b623fff5a6d47ae66ec6db09dad26e987deb4e to no longer restrict numba versions to <0.6 which also unlocks support for numpy 2.0. The corresponding PR in rootest (https://github.com/root-project/roottest/pull/1162) updates the error style in the numba test to be backwards compatible.

The numpy version is temporarily locked to below 2.0 to prevent both upgrades at the same time.

- [X] tested changes locally

Fixes https://github.com/root-project/root/issues/16201