### PR TITLE
[ci] Updated requirements to unlock numpy2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # ROOT requirements for third-party Python packages
 
 # PyROOT: Interoperability with numpy arrays
-numpy>=1.4.1, <=1.26.4
+numpy
+pandas
 
 # TMVA: SOFIE
 graph_nets
@@ -15,9 +16,7 @@ torch
 xgboost
 
 # PyROOT: ROOT.Numba.Declare decorator
-numba>=0.47.0 ; python_version < "3.11" # See https://github.com/numba/numba/issues/8304
-numba>=0.57.0 ; python_version >= "3.11" and python_version < "3.12"
-numba>=0.59.0 ; python_version >= "3.12"
+numba
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel
@@ -26,8 +25,8 @@ metakernel>=0.20.0
 
 # Distributed RDataFrame
 pyspark>=2.4 # Spark backend
-dask>=2022.08.1 ; python_version >= "3.8" # Dask backend
-distributed>=2022.08.1 ; python_version >= "3.8" # Dask backend
+dask>=2022.08.1 # Dask backend
+distributed>=2022.08.1 # Dask backend
 
 # JsMVA: Jupyter notebook magic for TMVA
 ipywidgets


### PR DESCRIPTION
No longer set min numpy to 1.4 as this version is outdated. Unlocks numpy2.0 support.

This also cleans up the requirements.txt file in terms of some version conditions(dask, distributed) that are no longer needed(as the min supported python version is 3.8)

Also adds pandas and sets numba to latest.

