### PR TITLE
[ci] Temporarily disable the mac-beta builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -101,9 +101,10 @@ jobs:
           - platform: mac14
             arch: ARM64
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
-          - platform: mac-beta
-            arch: ARM64
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
+          # Disable mac-beta builds until the issue with the new modules map is fixed 
+          # - platform: mac-beta
+          #   arch: ARM64
+          #   overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
 
     runs-on: # Using '[self-hosted, ..., ...]' does not work for some reason :)
       - self-hosted


### PR DESCRIPTION
until the issue with module maps #16219 is fixed.

