### PR TITLE
[ntuple] Convert count leaf names for `SetConvertDotsInBranchNames`

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -323,7 +323,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    for (auto &p : fLeafCountCollections) {
       // We want to capture this variable, which is not possible with a
       // structured binding in C++17. Explicitly defining a variable works.
-      auto &countLeafName = p.first;
+      auto countLeafName = p.first;
       auto &c = p.second;
       c.fCollectionModel->Freeze();
       c.fCollectionEntry = c.fCollectionModel->CreateBareEntry();
@@ -347,6 +347,12 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
                return c.fFieldName + "." + name;
          });
       }
+
+      if (fConvertDotsInBranchNames) {
+         // Replace any occurrenceof a dot ('.') in the count leaf name with an underscore.
+         std::replace(countLeafName.begin(), countLeafName.end(), '.', '_');
+      }
+
       // Add projected fields for count leaf
       auto projectedField =
          RFieldBase::Create(countLeafName, "ROOT::Experimental::RNTupleCardinality<std::uint32_t>").Unwrap();

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -202,7 +202,11 @@ TEST(RNTupleImporter, ConvertDotsInBranchNames)
       std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
       auto tree = std::make_unique<TTree>("tree", "");
       Int_t a = 42;
+      Int_t muons_length = 1;
+      float muon_pt[1] = {3.14};
       tree->Branch("a.a", &a);
+      tree->Branch("muon.length", &muons_length);
+      tree->Branch("muon.pt", muon_pt, "muon.pt[muon.length]");
       tree->Fill();
       tree->Write();
    }
@@ -218,6 +222,11 @@ TEST(RNTupleImporter, ConvertDotsInBranchNames)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    reader->LoadEntry(0);
    EXPECT_EQ(42, *reader->GetModel().GetDefaultEntry().GetPtr<std::int32_t>("a_a"));
+
+   auto viewMuon = reader->GetCollectionView("_collection0");
+   auto viewMuonPt = viewMuon.GetView<float>("muon_pt");
+   EXPECT_EQ(1, viewMuon(0));
+   EXPECT_FLOAT_EQ(3.14, viewMuonPt(0));
 }
 
 TEST(RNTupleImporter, FieldModifier)


### PR DESCRIPTION
When `SetConvertDotsInBranchNames`, dot characters in field names are converted into underscores. This flag previously did not take into account count leafs, which in the RNTuple are represented as a projected fields. With this commit, the conversion is also done for these kinds of fields.