### PR TITLE
[net][graf3d] fix some warnings (vsprintf -> vsnprintf)

### DIFF
--- a/graf3d/gl/src/gl2ps.cxx
+++ b/graf3d/gl/src/gl2ps.cxx
@@ -445,7 +445,7 @@ static int gl2psPrintf(const char* fmt, ...)
   static char buf[1000];
   if(gl2ps->options & GL2PS_COMPRESS){
     va_start(args, fmt);
-    ret = vsprintf(buf, fmt, args);
+    ret = vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
     oldsize = gl2ps->compress->srcLen;
     gl2ps->compress->start = (Bytef*)gl2psReallocCompress(oldsize + ret);

--- a/net/rpdutils/src/DaemonUtils.cxx
+++ b/net/rpdutils/src/DaemonUtils.cxx
@@ -553,7 +553,7 @@ namespace ROOT {
       char    buf[1024];
       va_list ap;
       va_start(ap,va_(fmt));
-      vsprintf(buf, fmt, ap);
+      vsnprintf(buf, sizeof(buf), fmt, ap);
       va_end(ap);
       printf("%s\n", buf);
       fflush(stdout);
@@ -567,7 +567,7 @@ namespace ROOT {
       char    buf[1024];
       va_list ap;
       va_start(ap,va_(fmt));
-      vsprintf(buf, fmt, ap);
+      vsnprintf(buf, sizeof(buf), fmt, ap);
       va_end(ap);
       printf("%s\n", buf);
       fflush(stdout);


### PR DESCRIPTION
# This Pull request:
changes a couple of usages of `vsprintf` to `vsnprintf` to fix some compiler warnings




