### PR TITLE
[ntuple] clang-format pass

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -61,9 +61,9 @@ private:
    RPage fWritePage[2];
    /// Index of the current write page
    int fWritePageIdx = 0;
-   /// For writing, the targeted number of elements, given by `fApproxNElementsPerPage` (in the write options) and the element size.
-   /// We ensure this value to be >= 2 in Connect() so that we have meaningful
-   /// "page full" and "page half full" events when writing the page.
+   /// For writing, the targeted number of elements, given by `fApproxNElementsPerPage` (in the write options) and the
+   /// element size. We ensure this value to be >= 2 in Connect() so that we have meaningful "page full" and "page half
+   /// full" events when writing the page.
    std::uint32_t fApproxNElementsPerPage = 0;
    /// The number of elements written resp. available in the column
    NTupleSize_t fNElements = 0;
@@ -107,7 +107,8 @@ private:
    }
 
    /// When the main write page surpasses the 50% fill level, the (full) shadow write page gets flushed
-   void FlushShadowWritePage() {
+   void FlushShadowWritePage()
+   {
       auto otherIdx = 1 - fWritePageIdx;
       if (fWritePage[otherIdx].IsEmpty())
          return;
@@ -126,8 +127,8 @@ public:
       return column;
    }
 
-   RColumn(const RColumn&) = delete;
-   RColumn &operator =(const RColumn&) = delete;
+   RColumn(const RColumn &) = delete;
+   RColumn &operator=(const RColumn &) = delete;
    ~RColumn();
 
    /// Connect the column to a page sink.  `firstElementIndex` can be used to specify the first column element index
@@ -168,8 +169,7 @@ public:
       // This check should be done before calling `RPage::GrowUnchecked()` as the latter affects the return value of
       // `RPage::GetNElements()`.
       if ((fWritePage[fWritePageIdx].GetNElements() < fApproxNElementsPerPage / 2) &&
-          (fWritePage[fWritePageIdx].GetNElements() + count >= fApproxNElementsPerPage / 2))
-      {
+          (fWritePage[fWritePageIdx].GetNElements() + count >= fApproxNElementsPerPage / 2)) {
          FlushShadowWritePage();
       }
 
@@ -243,7 +243,8 @@ public:
    }
 
    template <typename CppT>
-   CppT *Map(const NTupleSize_t globalIndex) {
+   CppT *Map(const NTupleSize_t globalIndex)
+   {
       NTupleSize_t nItems;
       return MapV<CppT>(globalIndex, nItems);
    }
@@ -256,15 +257,15 @@ public:
    }
 
    template <typename CppT>
-   CppT *MapV(const NTupleSize_t globalIndex, NTupleSize_t &nItems) {
+   CppT *MapV(const NTupleSize_t globalIndex, NTupleSize_t &nItems)
+   {
       if (R__unlikely(!fReadPage.Contains(globalIndex))) {
          MapPage(globalIndex);
       }
       // +1 to go from 0-based indexing to 1-based number of items
       nItems = fReadPage.GetGlobalRangeLast() - globalIndex + 1;
-      return reinterpret_cast<CppT*>(
-         static_cast<unsigned char *>(fReadPage.GetBuffer()) +
-         (globalIndex - fReadPage.GetGlobalRangeFirst()) * RColumnElement<CppT>::kSize);
+      return reinterpret_cast<CppT *>(static_cast<unsigned char *>(fReadPage.GetBuffer()) +
+                                      (globalIndex - fReadPage.GetGlobalRangeFirst()) * RColumnElement<CppT>::kSize);
    }
 
    template <typename CppT>
@@ -275,9 +276,9 @@ public:
       }
       // +1 to go from 0-based indexing to 1-based number of items
       nItems = fReadPage.GetClusterRangeLast() - clusterIndex.GetIndex() + 1;
-      return reinterpret_cast<CppT*>(
-         static_cast<unsigned char *>(fReadPage.GetBuffer()) +
-         (clusterIndex.GetIndex() - fReadPage.GetClusterRangeFirst()) * RColumnElement<CppT>::kSize);
+      return reinterpret_cast<CppT *>(static_cast<unsigned char *>(fReadPage.GetBuffer()) +
+                                      (clusterIndex.GetIndex() - fReadPage.GetClusterRangeFirst()) *
+                                         RColumnElement<CppT>::kSize);
    }
 
    NTupleSize_t GetGlobalIndex(RClusterIndex clusterIndex)
@@ -288,7 +289,8 @@ public:
       return fReadPage.GetClusterInfo().GetIndexOffset() + clusterIndex.GetIndex();
    }
 
-   RClusterIndex GetClusterIndex(NTupleSize_t globalIndex) {
+   RClusterIndex GetClusterIndex(NTupleSize_t globalIndex)
+   {
       if (!fReadPage.Contains(globalIndex)) {
          MapPage(globalIndex);
       }
@@ -330,7 +332,8 @@ public:
    }
 
    /// Get the currently active cluster id
-   void GetSwitchInfo(NTupleSize_t globalIndex, RClusterIndex *varIndex, std::uint32_t *tag) {
+   void GetSwitchInfo(NTupleSize_t globalIndex, RClusterIndex *varIndex, std::uint32_t *tag)
+   {
       auto varSwitch = Map<RColumnSwitch>(globalIndex);
       *varIndex = RClusterIndex(fReadPage.GetClusterInfo().GetId(), varSwitch->GetIndex());
       *tag = varSwitch->GetTag();

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -67,37 +67,37 @@ std::pair<std::uint16_t, std::uint16_t>
 ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kIndex64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kIndex32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kSwitch: return std::make_pair<std::uint16_t, std::uint16_t>(96, 96);
-   case EColumnType::kByte: return std::make_pair<std::uint16_t, std::uint16_t>(8, 8);
-   case EColumnType::kChar: return std::make_pair<std::uint16_t, std::uint16_t>(8, 8);
-   case EColumnType::kBit: return std::make_pair<std::uint16_t, std::uint16_t>(1, 1);
-   case EColumnType::kReal64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kReal32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kReal16: return std::make_pair<std::uint16_t, std::uint16_t>(16, 16);
-   case EColumnType::kInt64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kUInt64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kInt32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kUInt32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kInt16: return std::make_pair<std::uint16_t, std::uint16_t>(16, 16);
-   case EColumnType::kUInt16: return std::make_pair<std::uint16_t, std::uint16_t>(16, 16);
-   case EColumnType::kInt8: return std::make_pair<std::uint16_t, std::uint16_t>(8, 8);
-   case EColumnType::kUInt8: return std::make_pair<std::uint16_t, std::uint16_t>(8, 8);
-   case EColumnType::kSplitIndex64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kSplitIndex32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kSplitReal64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kSplitReal32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kSplitInt64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kSplitUInt64: return std::make_pair<std::uint16_t, std::uint16_t>(64, 64);
-   case EColumnType::kSplitInt32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kSplitUInt32: return std::make_pair<std::uint16_t, std::uint16_t>(32, 32);
-   case EColumnType::kSplitInt16: return std::make_pair<std::uint16_t, std::uint16_t>(16, 16);
-   case EColumnType::kSplitUInt16: return std::make_pair<std::uint16_t, std::uint16_t>(16, 16);
+   case EColumnType::kIndex64: return std::make_pair(64, 64);
+   case EColumnType::kIndex32: return std::make_pair(32, 32);
+   case EColumnType::kSwitch: return std::make_pair(96, 96);
+   case EColumnType::kByte: return std::make_pair(8, 8);
+   case EColumnType::kChar: return std::make_pair(8, 8);
+   case EColumnType::kBit: return std::make_pair(1, 1);
+   case EColumnType::kReal64: return std::make_pair(64, 64);
+   case EColumnType::kReal32: return std::make_pair(32, 32);
+   case EColumnType::kReal16: return std::make_pair(16, 16);
+   case EColumnType::kInt64: return std::make_pair(64, 64);
+   case EColumnType::kUInt64: return std::make_pair(64, 64);
+   case EColumnType::kInt32: return std::make_pair(32, 32);
+   case EColumnType::kUInt32: return std::make_pair(32, 32);
+   case EColumnType::kInt16: return std::make_pair(16, 16);
+   case EColumnType::kUInt16: return std::make_pair(16, 16);
+   case EColumnType::kInt8: return std::make_pair(8, 8);
+   case EColumnType::kUInt8: return std::make_pair(8, 8);
+   case EColumnType::kSplitIndex64: return std::make_pair(64, 64);
+   case EColumnType::kSplitIndex32: return std::make_pair(32, 32);
+   case EColumnType::kSplitReal64: return std::make_pair(64, 64);
+   case EColumnType::kSplitReal32: return std::make_pair(32, 32);
+   case EColumnType::kSplitInt64: return std::make_pair(64, 64);
+   case EColumnType::kSplitUInt64: return std::make_pair(64, 64);
+   case EColumnType::kSplitInt32: return std::make_pair(32, 32);
+   case EColumnType::kSplitUInt32: return std::make_pair(32, 32);
+   case EColumnType::kSplitInt16: return std::make_pair(16, 16);
+   case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
    default: assert(false);
    }
    // never here
-   return std::make_pair<std::uint16_t, std::uint16_t>(0, 0);
+   return std::make_pair(0, 0);
 }
 
 std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColumnType type)

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -7,18 +7,18 @@
 #include <type_traits>
 #include <utility>
 
-template <typename PodT, typename NarrowT, ROOT::Experimental::EColumnType ColumnT>
+template <typename PodT, typename NarrowT, EColumnType ColumnT>
 struct Helper {
    using Pod_t = PodT;
    using Narrow_t = NarrowT;
-   static constexpr ROOT::Experimental::EColumnType kColumnType = ColumnT;
+   static constexpr EColumnType kColumnType = ColumnT;
 };
 
-template <typename NarrowT, ROOT::Experimental::EColumnType ColumnT>
-struct Helper<ROOT::Experimental::ClusterSize_t, NarrowT, ColumnT> {
+template <typename NarrowT, EColumnType ColumnT>
+struct Helper<ClusterSize_t, NarrowT, ColumnT> {
    using Pod_t = std::uint64_t;
    using Narrow_t = NarrowT;
-   static constexpr ROOT::Experimental::EColumnType kColumnType = ColumnT;
+   static constexpr EColumnType kColumnType = ColumnT;
 };
 
 template <typename HelperT>
@@ -39,27 +39,25 @@ public:
    using Helper_t = HelperT;
 };
 
-using PackingRealTypes = ::testing::Types<Helper<double, double, ROOT::Experimental::EColumnType::kSplitReal64>,
-                                          Helper<float, float, ROOT::Experimental::EColumnType::kSplitReal32>>;
+using PackingRealTypes =
+   ::testing::Types<Helper<double, double, EColumnType::kSplitReal64>, Helper<float, float, EColumnType::kSplitReal32>>;
 TYPED_TEST_SUITE(PackingReal, PackingRealTypes);
 
-using PackingIntTypes =
-   ::testing::Types<Helper<std::int64_t, std::int64_t, ROOT::Experimental::EColumnType::kSplitInt64>,
-                    Helper<std::uint64_t, std::uint64_t, ROOT::Experimental::EColumnType::kSplitUInt64>,
-                    Helper<std::int32_t, std::int32_t, ROOT::Experimental::EColumnType::kSplitInt32>,
-                    Helper<std::uint32_t, std::uint32_t, ROOT::Experimental::EColumnType::kSplitUInt32>,
-                    Helper<std::int16_t, std::int16_t, ROOT::Experimental::EColumnType::kSplitInt16>,
-                    Helper<std::uint16_t, std::uint16_t, ROOT::Experimental::EColumnType::kSplitUInt16>>;
+using PackingIntTypes = ::testing::Types<Helper<std::int64_t, std::int64_t, EColumnType::kSplitInt64>,
+                                         Helper<std::uint64_t, std::uint64_t, EColumnType::kSplitUInt64>,
+                                         Helper<std::int32_t, std::int32_t, EColumnType::kSplitInt32>,
+                                         Helper<std::uint32_t, std::uint32_t, EColumnType::kSplitUInt32>,
+                                         Helper<std::int16_t, std::int16_t, EColumnType::kSplitInt16>,
+                                         Helper<std::uint16_t, std::uint16_t, EColumnType::kSplitUInt16>>;
 TYPED_TEST_SUITE(PackingInt, PackingIntTypes);
 
-using PackingIndexTypes = ::testing::Types<
-   Helper<ROOT::Experimental::ClusterSize_t, std::uint32_t, ROOT::Experimental::EColumnType::kSplitIndex32>,
-   Helper<ROOT::Experimental::ClusterSize_t, std::uint64_t, ROOT::Experimental::EColumnType::kSplitIndex64>>;
+using PackingIndexTypes = ::testing::Types<Helper<ClusterSize_t, std::uint32_t, EColumnType::kSplitIndex32>,
+                                           Helper<ClusterSize_t, std::uint64_t, EColumnType::kSplitIndex64>>;
 TYPED_TEST_SUITE(PackingIndex, PackingIndexTypes);
 
 TEST(Packing, Bitfield)
 {
-   ROOT::Experimental::Internal::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit> element;
+   RColumnElement<bool, EColumnType::kBit> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -92,8 +90,8 @@ TEST(Packing, Bitfield)
 
 TEST(Packing, HalfPrecisionFloat)
 {
-   ROOT::Experimental::Internal::RColumnElement<float, ROOT::Experimental::EColumnType::kReal16> element32_16;
-   ROOT::Experimental::Internal::RColumnElement<double, ROOT::Experimental::EColumnType::kReal16> element64_16;
+   RColumnElement<float, EColumnType::kReal16> element32_16;
+   RColumnElement<double, EColumnType::kReal16> element64_16;
    element32_16.Pack(nullptr, nullptr, 0);
    element32_16.Unpack(nullptr, nullptr, 0);
    element64_16.Pack(nullptr, nullptr, 0);
@@ -142,16 +140,14 @@ TEST(Packing, HalfPrecisionFloat)
 
 TEST(Packing, RColumnSwitch)
 {
-   ROOT::Experimental::Internal::RColumnElement<ROOT::Experimental::RColumnSwitch,
-                                                ROOT::Experimental::EColumnType::kSwitch>
-      element;
+   RColumnElement<RColumnSwitch, EColumnType::kSwitch> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
-   ROOT::Experimental::RColumnSwitch s1(ClusterSize_t{0xaa}, 0x55);
+   RColumnSwitch s1(ClusterSize_t{0xaa}, 0x55);
    unsigned char out[12];
    element.Pack(out, &s1, 1);
-   ROOT::Experimental::RColumnSwitch s2;
+   RColumnSwitch s2;
    element.Unpack(&s2, out, 1);
    EXPECT_EQ(0xaa, s2.GetIndex());
    EXPECT_EQ(0x55, s2.GetTag());
@@ -162,7 +158,7 @@ TYPED_TEST(PackingReal, SplitReal)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Internal::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
+   RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -187,13 +183,18 @@ TYPED_TEST(PackingInt, SplitInt)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Internal::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
+   RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
-   std::array<Pod_t, 9> mem{0, std::is_signed_v<Pod_t> ? -42 : 1, 42, std::numeric_limits<Narrow_t>::min(),
-                            std::numeric_limits<Narrow_t>::min() + 1, std::numeric_limits<Narrow_t>::min() + 2,
-                            std::numeric_limits<Narrow_t>::max(), std::numeric_limits<Narrow_t>::max() - 1,
+   std::array<Pod_t, 9> mem{0,
+                            std::is_signed_v<Pod_t> ? -42 : 1,
+                            42,
+                            std::numeric_limits<Narrow_t>::min(),
+                            std::numeric_limits<Narrow_t>::min() + 1,
+                            std::numeric_limits<Narrow_t>::min() + 2,
+                            std::numeric_limits<Narrow_t>::max(),
+                            std::numeric_limits<Narrow_t>::max() - 1,
                             std::numeric_limits<Narrow_t>::max() - 2};
    std::array<Pod_t, 9> packed;
    std::array<Pod_t, 9> cmp;
@@ -209,7 +210,7 @@ TYPED_TEST(PackingIndex, SplitIndex)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Internal::RColumnElement<ClusterSize_t, TestFixture::Helper_t::kColumnType> element;
+   RColumnElement<ClusterSize_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -225,7 +226,7 @@ TYPED_TEST(PackingIndex, SplitIndex)
 
 namespace {
 
-template <typename PodT, ROOT::Experimental::EColumnType ColumnT>
+template <typename PodT, EColumnType ColumnT>
 static void AddField(RNTupleModel &model, const std::string &fieldName)
 {
    auto fld = std::make_unique<RField<PodT>>(fieldName);
@@ -243,17 +244,17 @@ TEST(Packing, OnDiskEncoding)
 
    auto model = RNTupleModel::Create();
 
-   AddField<std::int16_t, ROOT::Experimental::EColumnType::kSplitInt16>(*model, "int16");
-   AddField<std::int32_t, ROOT::Experimental::EColumnType::kSplitInt32>(*model, "int32");
-   AddField<std::int64_t, ROOT::Experimental::EColumnType::kSplitInt64>(*model, "int64");
-   AddField<std::uint16_t, ROOT::Experimental::EColumnType::kSplitUInt16>(*model, "uint16");
-   AddField<std::uint32_t, ROOT::Experimental::EColumnType::kSplitUInt32>(*model, "uint32");
-   AddField<std::uint64_t, ROOT::Experimental::EColumnType::kSplitUInt64>(*model, "uint64");
-   AddField<float, ROOT::Experimental::EColumnType::kSplitReal32>(*model, "float");
-   AddField<float, ROOT::Experimental::EColumnType::kReal16>(*model, "float16");
-   AddField<double, ROOT::Experimental::EColumnType::kSplitReal64>(*model, "double");
-   AddField<ClusterSize_t, ROOT::Experimental::EColumnType::kSplitIndex32>(*model, "index32");
-   AddField<ClusterSize_t, ROOT::Experimental::EColumnType::kSplitIndex64>(*model, "index64");
+   AddField<std::int16_t, EColumnType::kSplitInt16>(*model, "int16");
+   AddField<std::int32_t, EColumnType::kSplitInt32>(*model, "int32");
+   AddField<std::int64_t, EColumnType::kSplitInt64>(*model, "int64");
+   AddField<std::uint16_t, EColumnType::kSplitUInt16>(*model, "uint16");
+   AddField<std::uint32_t, EColumnType::kSplitUInt32>(*model, "uint32");
+   AddField<std::uint64_t, EColumnType::kSplitUInt64>(*model, "uint64");
+   AddField<float, EColumnType::kSplitReal32>(*model, "float");
+   AddField<float, EColumnType::kReal16>(*model, "float16");
+   AddField<double, EColumnType::kSplitReal64>(*model, "double");
+   AddField<ClusterSize_t, EColumnType::kSplitIndex32>(*model, "index32");
+   AddField<ClusterSize_t, EColumnType::kSplitIndex64>(*model, "index64");
    auto fldStr = std::make_unique<RField<std::string>>("str");
    model->AddField(std::move(fldStr));
    {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -1,6 +1,7 @@
 #ifndef ROOT7_RNTuple_Test
 #define ROOT7_RNTuple_Test
 
+#include <ROOT/RColumnElement.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldVisitor.hxx>
@@ -15,6 +16,7 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleParallelWriter.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
+#include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriteOptionsDaos.hxx>
 #include <ROOT/RNTupleWriter.hxx>
@@ -62,6 +64,9 @@ using RClusterDescriptor = ROOT::Experimental::RClusterDescriptor;
 using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescriptorBuilder;
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
 using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;
+template <typename T, EColumnType C>
+using RColumnElement = ROOT::Experimental::Internal::RColumnElement<T, C>;
+using RColumnSwitch = ROOT::Experimental::RColumnSwitch;
 using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
 using RException = ROOT::Experimental::RException;


### PR DESCRIPTION
clang-format some files + add some typedefs to `ntuple_test.hxx` to reduce namespace noise in the tests