### PR TITLE
[geom] TGeoTessellated: fix facet surface calculation

### DIFF
--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -304,7 +304,7 @@ bool TGeoTessellated::FacetCheck(int ifacet) const
    double surfaceArea = 0.;
    for (int i = 1; i < nvert - 1; ++i) {
       Vertex_t e1 = fVertices[facet[i]] - fVertices[facet[0]];
-      Vertex_t e2 = GetVertex(i + 1) - GetVertex(0);
+      Vertex_t e2 = fVertices[facet[i + 1]] - fVertices[facet[0]];
       surfaceArea += 0.5 * Vertex_t::Cross(e1, e2).Mag();
    }
    if (surfaceArea < kTolerance) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Fixes an issue in the facet surface area calculation which was mixing vertex indexing at the facet level and at the shape level, resulting in spurious surface area warnings.

`surfaceArea += 0.5 * Vertex_t::Cross(e1, e2).Mag()` works when `e1` and `e2` are chords within the same facet. That is only guaranteed when using the direction provided by `facet = fFacets[ifacet]` and `fVertices[facet[i + 1]]`, not by using `GetVertex(i+1)` directly.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

