### PR TITLE
[cling] Fix `DelegateGenerator` on macOS

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -586,7 +586,7 @@ IncrementalJIT::IncrementalJIT(
 
 std::unique_ptr<llvm::orc::DefinitionGenerator> IncrementalJIT::getGenerator() {
   return std::make_unique<DelegateGenerator>(
-      [&](StringRef UnmangledName) { return Jit->lookup(UnmangledName); });
+      [&](StringRef Name) { return Jit->lookupLinkerMangled(Name); });
 }
 
 void IncrementalJIT::addModule(Transaction& T) {


### PR DESCRIPTION
Commit 785c9df34d ("Restore symbol lookup in child interpreters") added a `DefinitionGenerator` to allow symbol lookup in the parent `IncrementalJIT` after the upgrade to LLVM 13. It appears that instead of the unmangled name, we need to lookup already linker mangled names.

This fixes the tests `CodeUnloading/AtExit.C` and `MultipleInterpreters/MultipleInterpreters.C` on macOS, which adds an underscore during linker mangling. No change on Linux because there is no additional linker name mangling.