### PR TITLE
[PyROOT] Improve error handling for AsNumpy with unreadable objects

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
@@ -204,6 +204,9 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None, lazy=False):
             1D numpy arrays with content as values; if lazy, AsNumpyResult containing
             the result pointers obtained from the Take actions.
     """
+
+    import ROOT
+
     # Sanitize input arguments
     if isinstance(columns, str):
         raise TypeError("The columns argument requires a list of strings")
@@ -233,14 +236,19 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None, lazy=False):
         # bools in bytes - different from the std::vector<bool> returned by the
         # action, which might do some space optimization
         column_type = "unsigned char" if column_type == "bool" else column_type
+
+        # If the column type is a class, make sure cling knows about it
+        tclass = ROOT.TClass.GetClass(column_type)
+        if tclass and not tclass.GetClassInfo():
+            raise RuntimeError(
+                f'The column named "{column}" is of type "{column_type}", which is not known to the ROOT interpreter. Please load the corresponding header files or dictionaries.'
+            )
+
         result_ptrs[column] = df.Take[column_type](column)
 
     result = AsNumpyResult(result_ptrs, columns)
 
-    if lazy:
-        return result
-    else:
-        return result.GetValue()
+    return result if lazy else result.GetValue()
 
 
 class AsNumpyResult(object):
@@ -355,12 +363,9 @@ def _clone_asnumpyresult(res: AsNumpyResult) -> AsNumpyResult:
     result.
     """
     import ROOT
+
     return AsNumpyResult(
-        {
-            col: ROOT.Internal.RDF.CloneResultAndAction(ptr)
-            for (col, ptr) in res._result_ptrs.items()
-        },
-        res._columns
+        {col: ROOT.Internal.RDF.CloneResultAndAction(ptr) for (col, ptr) in res._result_ptrs.items()}, res._columns
     )
 
 


### PR DESCRIPTION
Improve the error message when you try to build NumPy arrays with types
that the interpreter doesn't know about.

Running the reproducer from the JIRA ticket, one now gets this output:
```txt
TClass::Init:0: RuntimeWarning: no dictionary for class Foo is available
{ "a", "b", "foo", "foo.a", "foo.b" }
Traceback (most recent call last):
  File "/home/rembserj/root-support/jira/ROOT-10930/reproducer.py", line 13, in <module>
    print(df.AsNumpy())
          ^^^^^^^^^^^^
  File "/home/rembserj/spaces/master/install/lib/root/ROOT/_pythonization/_rdataframe.py", line 243, in RDataFrameAsNumpy
    raise RuntimeError(
RuntimeError: The column named "foo" is of type "Foo", which is not known to the ROOT interpreter. Please load the corresponding header files or dictionaries.
```

This was the output before:
```txt
TClass::Init:0: RuntimeWarning: no dictionary for class Foo is available
{ "a", "b", "foo", "foo.a", "foo.b" }
Traceback (most recent call last):
  File "/home/rembserj/root-support/jira/ROOT-10930/reproducer.py", line 5, in <module>
    print(df.AsNumpy())
          ^^^^^^^^^^^^
  File "/home/rembserj/spaces/master/install/lib/root/ROOT/_pythonization/_rdataframe.py", line 236, in RDataFrameAsNumpy
    result_ptrs[column] = df.Take[column_type](column)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Could not find "Take<Foo>" (set cppyy.set_debug() for C++ errors):
  Failed to instantiate "Take<Foo>(std::string)"
```

Closes the following Jira issue:
https://its.cern.ch/jira/browse/ROOT-10930