### PR TITLE
[ntuple] Prevent automatic instantiation of `RSimpleField<T>`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -57,6 +57,8 @@ public:
 
 // bool and char are somewhat special, handle them first
 
+extern template class RSimpleField<bool>;
+
 template <>
 class RField<bool> final : public RSimpleField<bool> {
 protected:
@@ -76,6 +78,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
+
+extern template class RSimpleField<char>;
 
 template <>
 class RField<char> final : public RSimpleField<char> {
@@ -107,6 +111,8 @@ class RIntegralField {
    RIntegralField() = delete;
 };
 
+extern template class RSimpleField<std::int8_t>;
+
 template <>
 class RIntegralField<std::int8_t> : public RSimpleField<std::int8_t> {
 protected:
@@ -121,6 +127,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
+
+extern template class RSimpleField<std::uint8_t>;
 
 template <>
 class RIntegralField<std::uint8_t> : public RSimpleField<std::uint8_t> {
@@ -137,6 +145,8 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+extern template class RSimpleField<std::int16_t>;
+
 template <>
 class RIntegralField<std::int16_t> : public RSimpleField<std::int16_t> {
 protected:
@@ -151,6 +161,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
+
+extern template class RSimpleField<std::uint16_t>;
 
 template <>
 class RIntegralField<std::uint16_t> : public RSimpleField<std::uint16_t> {
@@ -167,6 +179,8 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+extern template class RSimpleField<std::int32_t>;
+
 template <>
 class RIntegralField<std::int32_t> : public RSimpleField<std::int32_t> {
 protected:
@@ -181,6 +195,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
+
+extern template class RSimpleField<std::uint32_t>;
 
 template <>
 class RIntegralField<std::uint32_t> : public RSimpleField<std::uint32_t> {
@@ -197,6 +213,8 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+extern template class RSimpleField<std::int64_t>;
+
 template <>
 class RIntegralField<std::int64_t> : public RSimpleField<std::int64_t> {
 protected:
@@ -211,6 +229,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
+
+extern template class RSimpleField<std::uint64_t>;
 
 template <>
 class RIntegralField<std::uint64_t> : public RSimpleField<std::uint64_t> {
@@ -326,6 +346,8 @@ public:
 /// Template specializations for floating-point types
 ////////////////////////////////////////////////////////////////////////////////
 
+extern template class RSimpleField<float>;
+
 template <>
 class RField<float> final : public RSimpleField<float> {
 protected:
@@ -347,6 +369,8 @@ public:
 
    void SetHalfPrecision();
 };
+
+extern template class RSimpleField<double>;
 
 template <>
 class RField<double> final : public RSimpleField<double> {
@@ -370,7 +394,6 @@ public:
    // Set the column representation to 32 bit floating point and the type alias to Double32_t
    void SetDouble32();
 };
-
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -133,6 +133,8 @@ public:
 /// Template specializations for C++ std::byte
 ////////////////////////////////////////////////////////////////////////////////
 
+extern template class RSimpleField<std::byte>;
+
 template <>
 class RField<std::byte> final : public RSimpleField<std::byte> {
 protected:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1262,6 +1262,8 @@ ROOT::Experimental::RCardinalityField::As64Bit() const
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<char>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<char>::GetColumnRepresentations() const
 {
@@ -1275,6 +1277,8 @@ void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visi
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<std::byte>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::byte>::GetColumnRepresentations() const
@@ -1290,6 +1294,8 @@ void ROOT::Experimental::RField<std::byte>::AcceptVisitor(Detail::RFieldVisitor 
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<int8_t>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() const
 {
@@ -1303,6 +1309,8 @@ void ROOT::Experimental::RIntegralField<std::int8_t>::AcceptVisitor(Detail::RFie
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<uint8_t>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() const
@@ -1318,6 +1326,8 @@ void ROOT::Experimental::RIntegralField<std::uint8_t>::AcceptVisitor(Detail::RFi
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<bool>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
 {
@@ -1331,6 +1341,8 @@ void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visi
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<float>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<float>::GetColumnRepresentations() const
@@ -1351,6 +1363,8 @@ void ROOT::Experimental::RField<float>::SetHalfPrecision()
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<double>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<double>::GetColumnRepresentations() const
@@ -1376,6 +1390,8 @@ void ROOT::Experimental::RField<double>::SetDouble32()
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<int16_t>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() const
 {
@@ -1390,6 +1406,8 @@ void ROOT::Experimental::RIntegralField<std::int16_t>::AcceptVisitor(Detail::RFi
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<uint16_t>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() const
@@ -1406,6 +1424,8 @@ void ROOT::Experimental::RIntegralField<std::uint16_t>::AcceptVisitor(Detail::RF
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<int32_t>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() const
 {
@@ -1420,6 +1440,8 @@ void ROOT::Experimental::RIntegralField<std::int32_t>::AcceptVisitor(Detail::RFi
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<uint32_t>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() const
@@ -1436,6 +1458,8 @@ void ROOT::Experimental::RIntegralField<std::uint32_t>::AcceptVisitor(Detail::RF
 
 //------------------------------------------------------------------------------
 
+template class ROOT::Experimental::RSimpleField<uint64_t>;
+
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() const
 {
@@ -1450,6 +1474,8 @@ void ROOT::Experimental::RIntegralField<std::uint64_t>::AcceptVisitor(Detail::RF
 }
 
 //------------------------------------------------------------------------------
+
+template class ROOT::Experimental::RSimpleField<int64_t>;
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() const


### PR DESCRIPTION
With the helpers for column creation introduced by #16116, memory consumption during compilation significantly increases (from ~200MB to ~600MB using clang) due to the fact that templated field types, and therefore all possible column representations are automatically instantiated. This commit prevents this automatic instantiation from happening by `extern`-alizing all `RSimpleField` template specializations and only instantiating them in `RField.cxx`, bringing down memory consumption to ~230MB.