### PR TITLE
[CMake] Only replace `find_package` if required

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -13,12 +13,6 @@ include(FindPackageHandleStandardArgs)
 set(lcgpackages http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
 string(REPLACE "-Werror " "" ROOT_EXTERNAL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 
-macro(find_package)
-  if(NOT "${ARGV0}" IN_LIST ROOT_BUILTINS)
-    _find_package(${ARGV})
-  endif()
-endmacro()
-
 #---On MacOSX, try to find frameworks after standard libraries or headers------------
 set(CMAKE_FIND_FRAMEWORK LAST)
 
@@ -1992,4 +1986,18 @@ endif()
 # Needed to run tests of the distributed RDataFrame module that use dask.
 if(test_distrdf_dask)
   find_package(Dask 2022.08.1 REQUIRED)
+endif()
+
+#------------------------------------------------------------------------------------
+# Modify find_package to ignore any ROOT builtins, such that the builtin LLVM
+# doesn't find and use system versions of the builtin dependencies. This is a
+# bit hacky, but fortunately this needs to be done only when builtins are used.
+#
+# See also discussion on GitHub: https://github.com/root-project/root/issues/8633
+if(ROOT_BUILTINS)
+  macro(find_package)
+    if(NOT "${ARGV0}" IN_LIST ROOT_BUILTINS)
+      _find_package(${ARGV})
+    endif()
+  endmacro()
 endif()


### PR DESCRIPTION
**This is a replay of #16274 with the "clear build" label for the CI, to see if we can reproduce the build error that were observed after merging said PR**

Our CMake code modifies `find_package` to ignore any ROOT builtins, such that the builtin LLVM doesn't find and use system versions of the builtin dependencies.

This is a bit hacky, but fortunately this needs to be done only when builtins are used.

Therefore, this commit suggests to only do this redefinition of `find_package` if any builtins are used.

This closes #8633, where it was requested to avoid this hack for the sake of being compatible with the `vcpkg` package manager.

Although the hack is not completely removed, it is removed for the case where not builtins are used, which is probably what is done when using a C++ package manager to manage dependencies.