### PR TITLE
[ntuple] Remove outdated test dependency on RDF

### DIFF
--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -6,10 +6,6 @@
 
 # @author Jakob Blomer CERN
 
-if(NOT dataframe)
-  return()
-endif()
-
 ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               NO_INSTALL_HEADERS
                               HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/CustomStruct.hxx


### PR DESCRIPTION
The RDF dependencies were cleaned up in commit 8d7fa5f87c and commit f215692b3d removed the RDF unit test.