### PR TITLE
[core] remove deprecated ATOMIC_VAR_INIT from TUrl.cxx

### DIFF
--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -573,7 +573,7 @@ void TUrl::Print(Option_t *) const
 
 TObjArray *TUrl::GetSpecialProtocols()
 {
-   static std::atomic_bool usedEnv = ATOMIC_VAR_INIT(false);
+   static std::atomic_bool usedEnv { false };
 
    if (!gEnv) {
       R__LOCKGUARD(gROOTMutex);


### PR DESCRIPTION
`ATOMIC_VAR_INIT` is not useful anymore and deprecated in c++20.
