### PR TITLE
[ntuple] Move RColumnElement concrete definitions out of the header file

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -18,7 +18,7 @@ HEADERS
   ROOT/RCluster.hxx
   ROOT/RClusterPool.hxx
   ROOT/RColumn.hxx
-  ROOT/RColumnElement.hxx
+  ROOT/RColumnElementBase.hxx
   ROOT/REntry.hxx
   ROOT/RField.hxx
   ROOT/RFieldBase.hxx

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -17,7 +17,7 @@
 #define ROOT7_RColumn
 
 #include <ROOT/RConfig.hxx> // for R__likely
-#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPage.hxx>
 #include <ROOT/RPageStorage.hxx>

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -265,8 +265,7 @@ public:
       // +1 to go from 0-based indexing to 1-based number of items
       nItems = fReadPageRef.Get().GetGlobalRangeLast() - globalIndex + 1;
       return reinterpret_cast<CppT *>(static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) +
-                                      (globalIndex - fReadPageRef.Get().GetGlobalRangeFirst()) *
-                                         RColumnElement<CppT>::kSize);
+                                      (globalIndex - fReadPageRef.Get().GetGlobalRangeFirst()) * sizeof(CppT));
    }
 
    template <typename CppT>
@@ -279,7 +278,7 @@ public:
       nItems = fReadPageRef.Get().GetClusterRangeLast() - clusterIndex.GetIndex() + 1;
       return reinterpret_cast<CppT *>(static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) +
                                       (clusterIndex.GetIndex() - fReadPageRef.Get().GetClusterRangeFirst()) *
-                                         RColumnElement<CppT>::kSize);
+                                         sizeof(CppT));
    }
 
    NTupleSize_t GetGlobalIndex(RClusterIndex clusterIndex)

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -114,7 +114,6 @@ enum class EColumnCppType {
    kInt32,
    kInt64,
    kFloat,
-   kDouble32,
    kDouble,
    kClusterSize,
    kColumnSwitch,
@@ -151,14 +150,10 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
       return GenerateColumnElement(EColumnCppType::kFloat, type);
    else if constexpr (std::is_same_v<CppT, double>)
       return GenerateColumnElement(EColumnCppType::kDouble, type);
-   else if constexpr (std::is_same_v<CppT, Double32_t>)
-      return GenerateColumnElement(EColumnCppType::kDouble32, type);
    else if constexpr (std::is_same_v<CppT, ClusterSize_t>)
       return GenerateColumnElement(EColumnCppType::kClusterSize, type);
    else if constexpr (std::is_same_v<CppT, RColumnSwitch>)
       return GenerateColumnElement(EColumnCppType::kColumnSwitch, type);
-   else if constexpr (std::is_same_v<CppT, void>)
-      return Generate<void>(type);
    else
       static_assert(!sizeof(CppT), "Unsupported Cpp type");
 }

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -1,0 +1,171 @@
+/// \file ROOT/RColumnElementBase.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2018-10-09
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RColumnElementBase
+#define ROOT7_RColumnElementBase
+
+#include "RtypesCore.h"
+#include <ROOT/RError.hxx>
+#include <ROOT/RFloat16.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <Byteswap.h>
+#include <TError.h>
+
+#include <cstring> // for memcpy
+#include <cstddef> // for std::byte
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+
+namespace ROOT::Experimental::Internal {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Internal::RColumnElementBase
+\ingroup NTuple
+\brief A column element encapsulates the translation between basic C++ types and their column representation.
+
+Usually the on-disk element should map bitwise to the in-memory element. Sometimes that's not the case
+though, for instance on big endian platforms or for bools.
+
+There is a template specialization for every valid pair of C++ type and column representation.
+These specialized child classes are responsible for overriding `Pack()` / `Unpack()` for packing / unpacking elements
+as appropriate.
+*/
+// clang-format on
+class RColumnElementBase {
+protected:
+   /// Size of the C++ value that corresponds to the on-disk element
+   std::size_t fSize;
+   std::size_t fBitsOnStorage;
+
+   explicit RColumnElementBase(std::size_t size, std::size_t bitsOnStorage = 0)
+      : fSize(size), fBitsOnStorage(bitsOnStorage ? bitsOnStorage : 8 * size)
+   {
+   }
+
+public:
+   RColumnElementBase(const RColumnElementBase &other) = default;
+   RColumnElementBase(RColumnElementBase &&other) = default;
+   RColumnElementBase &operator=(const RColumnElementBase &other) = delete;
+   RColumnElementBase &operator=(RColumnElementBase &&other) = default;
+   virtual ~RColumnElementBase() = default;
+
+   /// If CppT == void, use the default C++ type for the given column type
+   template <typename CppT = void>
+   static std::unique_ptr<RColumnElementBase> Generate(EColumnType type);
+   static std::string GetTypeName(EColumnType type);
+   /// Most types have a fixed on-disk bit width. Some low-precision column types
+   /// have a range of possible bit widths. Return the minimum and maximum allowed
+   /// bit size per type.
+   static std::pair<std::uint16_t, std::uint16_t> GetValidBitRange(EColumnType type);
+
+   /// Derived, typed classes tell whether the on-storage layout is bitwise identical to the memory layout
+   virtual bool IsMappable() const
+   {
+      R__ASSERT(false);
+      return false;
+   }
+
+   /// If the on-storage layout and the in-memory layout differ, packing creates an on-disk page from an in-memory page
+   virtual void Pack(void *destination, const void *source, std::size_t count) const
+   {
+      std::memcpy(destination, source, count);
+   }
+
+   /// If the on-storage layout and the in-memory layout differ, unpacking creates a memory page from an on-storage page
+   virtual void Unpack(void *destination, const void *source, std::size_t count) const
+   {
+      std::memcpy(destination, source, count);
+   }
+
+   std::size_t GetSize() const { return fSize; }
+   std::size_t GetBitsOnStorage() const { return fBitsOnStorage; }
+   std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * fBitsOnStorage + 7) / 8; }
+}; // class RColumnElementBase
+
+// All supported C++ in-memory types
+enum class EColumnCppType {
+   kChar,
+   kBool,
+   kByte,
+   kUint8,
+   kUint16,
+   kUint32,
+   kUint64,
+   kInt8,
+   kInt16,
+   kInt32,
+   kInt64,
+   kFloat,
+   kDouble32,
+   kDouble,
+   kClusterSize,
+   kColumnSwitch,
+};
+
+std::unique_ptr<RColumnElementBase> GenerateColumnElement(EColumnCppType cppType, EColumnType colType);
+
+template <typename CppT>
+std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
+{
+   if constexpr (std::is_same_v<CppT, char>)
+      return GenerateColumnElement(EColumnCppType::kChar, type);
+   else if constexpr (std::is_same_v<CppT, bool>)
+      return GenerateColumnElement(EColumnCppType::kBool, type);
+   else if constexpr (std::is_same_v<CppT, std::byte>)
+      return GenerateColumnElement(EColumnCppType::kByte, type);
+   else if constexpr (std::is_same_v<CppT, std::uint8_t>)
+      return GenerateColumnElement(EColumnCppType::kUint8, type);
+   else if constexpr (std::is_same_v<CppT, std::uint16_t>)
+      return GenerateColumnElement(EColumnCppType::kUint16, type);
+   else if constexpr (std::is_same_v<CppT, std::uint32_t>)
+      return GenerateColumnElement(EColumnCppType::kUint32, type);
+   else if constexpr (std::is_same_v<CppT, std::uint64_t>)
+      return GenerateColumnElement(EColumnCppType::kUint64, type);
+   else if constexpr (std::is_same_v<CppT, std::int8_t>)
+      return GenerateColumnElement(EColumnCppType::kInt8, type);
+   else if constexpr (std::is_same_v<CppT, std::int16_t>)
+      return GenerateColumnElement(EColumnCppType::kInt16, type);
+   else if constexpr (std::is_same_v<CppT, std::int32_t>)
+      return GenerateColumnElement(EColumnCppType::kInt32, type);
+   else if constexpr (std::is_same_v<CppT, std::int64_t>)
+      return GenerateColumnElement(EColumnCppType::kInt64, type);
+   else if constexpr (std::is_same_v<CppT, float>)
+      return GenerateColumnElement(EColumnCppType::kFloat, type);
+   else if constexpr (std::is_same_v<CppT, double>)
+      return GenerateColumnElement(EColumnCppType::kDouble, type);
+   else if constexpr (std::is_same_v<CppT, Double32_t>)
+      return GenerateColumnElement(EColumnCppType::kDouble32, type);
+   else if constexpr (std::is_same_v<CppT, ClusterSize_t>)
+      return GenerateColumnElement(EColumnCppType::kClusterSize, type);
+   else if constexpr (std::is_same_v<CppT, RColumnSwitch>)
+      return GenerateColumnElement(EColumnCppType::kColumnSwitch, type);
+   else if constexpr (std::is_same_v<CppT, void>)
+      return Generate<void>(type);
+   else
+      static_assert(!sizeof(CppT), "Unsupported Cpp type");
+}
+
+template <>
+std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate<void>(EColumnType type);
+
+} // namespace ROOT::Experimental::Internal
+
+#endif

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -13,7 +13,10 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RColumnElement.hxx>
+#include "ROOT/RColumn.hxx"
+#include <ROOT/RColumnElementBase.hxx>
+
+#include "RColumnElement.hxx"
 
 #include <algorithm>
 #include <bitset>
@@ -21,47 +24,6 @@
 #include <cstdint>
 #include <memory>
 #include <utility>
-
-template <>
-std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
-ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType type)
-{
-   switch (type) {
-   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
-   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
-   case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
-   case EColumnType::kByte: return std::make_unique<RColumnElement<std::byte, EColumnType::kByte>>();
-   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>();
-   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>();
-   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>();
-   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>();
-   // TODO: Change to std::float16_t in-memory type once available (from C++23).
-   case EColumnType::kReal16: return std::make_unique<RColumnElement<float, EColumnType::kReal16>>();
-   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>();
-   case EColumnType::kUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kUInt64>>();
-   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>();
-   case EColumnType::kUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kUInt32>>();
-   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>();
-   case EColumnType::kUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kUInt16>>();
-   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>();
-   case EColumnType::kUInt8: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kUInt8>>();
-   case EColumnType::kSplitIndex64:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>();
-   case EColumnType::kSplitIndex32:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>();
-   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>();
-   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>();
-   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>();
-   case EColumnType::kSplitUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kSplitUInt64>>();
-   case EColumnType::kSplitInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>();
-   case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>();
-   case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
-   case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
-   default: assert(false);
-   }
-   // never here
-   return nullptr;
-}
 
 std::pair<std::uint16_t, std::uint16_t>
 ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType type)
@@ -134,36 +96,69 @@ std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColum
    }
 }
 
-void ROOT::Experimental::Internal::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(
-   void *dst, const void *src, std::size_t count) const
+template <>
+std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
+ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType type)
 {
-   const bool *boolArray = reinterpret_cast<const bool *>(src);
-   char *charArray = reinterpret_cast<char *>(dst);
-   std::bitset<8> bitSet;
-   std::size_t i = 0;
-   for (; i < count; ++i) {
-      bitSet.set(i % 8, boolArray[i]);
-      if (i % 8 == 7) {
-         char packed = bitSet.to_ulong();
-         charArray[i / 8] = packed;
-      }
+   switch (type) {
+   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
+   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
+   case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
+   case EColumnType::kByte: return std::make_unique<RColumnElement<std::byte, EColumnType::kByte>>();
+   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>();
+   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>();
+   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>();
+   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>();
+   // TODO: Change to std::float16_t in-memory type once available (from C++23).
+   case EColumnType::kReal16: return std::make_unique<RColumnElement<float, EColumnType::kReal16>>();
+   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>();
+   case EColumnType::kUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kUInt64>>();
+   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>();
+   case EColumnType::kUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kUInt32>>();
+   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>();
+   case EColumnType::kUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kUInt16>>();
+   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>();
+   case EColumnType::kUInt8: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kUInt8>>();
+   case EColumnType::kSplitIndex64:
+      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>();
+   case EColumnType::kSplitIndex32:
+      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>();
+   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>();
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>();
+   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>();
+   case EColumnType::kSplitUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kSplitUInt64>>();
+   case EColumnType::kSplitInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>();
+   case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>();
+   case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
+   case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
+   default: assert(false);
    }
-   if (i % 8 != 0) {
-      char packed = bitSet.to_ulong();
-      charArray[i / 8] = packed;
-   }
+   // never here
+   return nullptr;
 }
 
-void ROOT::Experimental::Internal::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Unpack(
-   void *dst, const void *src, std::size_t count) const
+std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
+ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, EColumnType type)
 {
-   bool *boolArray = reinterpret_cast<bool *>(dst);
-   const char *charArray = reinterpret_cast<const char *>(src);
-   std::bitset<8> bitSet;
-   for (std::size_t i = 0; i < count; i += 8) {
-      bitSet = charArray[i / 8];
-      for (std::size_t j = i; j < std::min(count, i + 8); ++j) {
-         boolArray[j] = bitSet[j % 8];
-      }
+   switch (cppType) {
+   case EColumnCppType::kChar: return GenerateColumnElementInternal<char>(type);
+   case EColumnCppType::kBool: return GenerateColumnElementInternal<bool>(type);
+   case EColumnCppType::kByte: return GenerateColumnElementInternal<std::byte>(type);
+   case EColumnCppType::kUint8: return GenerateColumnElementInternal<std::uint8_t>(type);
+   case EColumnCppType::kUint16: return GenerateColumnElementInternal<std::uint16_t>(type);
+   case EColumnCppType::kUint32: return GenerateColumnElementInternal<std::uint32_t>(type);
+   case EColumnCppType::kUint64: return GenerateColumnElementInternal<std::uint64_t>(type);
+   case EColumnCppType::kInt8: return GenerateColumnElementInternal<std::int8_t>(type);
+   case EColumnCppType::kInt16: return GenerateColumnElementInternal<std::int16_t>(type);
+   case EColumnCppType::kInt32: return GenerateColumnElementInternal<std::int32_t>(type);
+   case EColumnCppType::kInt64: return GenerateColumnElementInternal<std::int64_t>(type);
+   case EColumnCppType::kFloat: return GenerateColumnElementInternal<float>(type);
+   case EColumnCppType::kDouble32: return GenerateColumnElementInternal<Double32_t>(type);
+   case EColumnCppType::kDouble: return GenerateColumnElementInternal<double>(type);
+   case EColumnCppType::kClusterSize: return GenerateColumnElementInternal<ClusterSize_t>(type);
+   case EColumnCppType::kColumnSwitch: return GenerateColumnElementInternal<RColumnSwitch>(type);
+   default: R__ASSERT(!"Invalid column cpp type");
    }
+   // never here
+   return nullptr;
 }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -153,7 +153,6 @@ ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, ECol
    case EColumnCppType::kInt32: return GenerateColumnElementInternal<std::int32_t>(type);
    case EColumnCppType::kInt64: return GenerateColumnElementInternal<std::int64_t>(type);
    case EColumnCppType::kFloat: return GenerateColumnElementInternal<float>(type);
-   case EColumnCppType::kDouble32: return GenerateColumnElementInternal<Double32_t>(type);
    case EColumnCppType::kDouble: return GenerateColumnElementInternal<double>(type);
    case EColumnCppType::kClusterSize: return GenerateColumnElementInternal<ClusterSize_t>(type);
    case EColumnCppType::kColumnSwitch: return GenerateColumnElementInternal<RColumnSwitch>(type);

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -13,7 +13,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -14,7 +14,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleSerialize.hxx>

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -1,6 +1,7 @@
 // Override endianness detection in RColumnElement.hxx; assume big-endian machine
 // These tests are simulating a big endian machine; we will turn them off on an actual big endian node.
 #define R__LITTLE_ENDIAN 0
+#include "../src/RColumnElement.hxx"
 
 #include "gtest/gtest.h"
 
@@ -22,7 +23,6 @@
 using ROOT::Experimental::EColumnType;
 using ROOT::Experimental::NTupleSize_t;
 using ROOT::Experimental::RNTupleDescriptor;
-using ROOT::Experimental::RNTupleLocator;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::Internal::RCluster;
 using ROOT::Experimental::Internal::RColumnElementBase;
@@ -112,7 +112,7 @@ TEST(RColumnElementEndian, ByteCopy)
 #ifndef R__BYTESWAP
    GTEST_SKIP() << "Skipping test on big endian node";
 #else
-   ROOT::Experimental::Internal::RColumnElement<float, EColumnType::kReal32> element;
+   RColumnElement<float, EColumnType::kReal32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);
@@ -137,7 +137,7 @@ TEST(RColumnElementEndian, Cast)
 #ifndef R__BYTESWAP
    GTEST_SKIP() << "Skipping test on big endian node";
 #else
-   ROOT::Experimental::Internal::RColumnElement<std::int64_t, EColumnType::kInt32> element;
+   RColumnElement<std::int64_t, EColumnType::kInt32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);
@@ -165,7 +165,7 @@ TEST(RColumnElementEndian, Split)
 #ifndef R__BYTESWAP
    GTEST_SKIP() << "Skipping test on big endian node";
 #else
-   ROOT::Experimental::Internal::RColumnElement<double, EColumnType::kSplitReal64> splitElement;
+   RColumnElement<double, EColumnType::kSplitReal64> splitElement;
 
    RPageSinkMock sink1(splitElement);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -191,7 +191,7 @@ TEST(RColumnElementEndian, DeltaSplit)
 #else
    using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 
-   ROOT::Experimental::Internal::RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element;
+   RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -57,32 +57,32 @@ TYPED_TEST_SUITE(PackingIndex, PackingIndexTypes);
 
 TEST(Packing, Bitfield)
 {
-   RColumnElement<bool, EColumnType::kBit> element;
-   element.Pack(nullptr, nullptr, 0);
-   element.Unpack(nullptr, nullptr, 0);
+   auto element = RColumnElementBase::Generate<bool>(EColumnType::kBit);
+   element->Pack(nullptr, nullptr, 0);
+   element->Unpack(nullptr, nullptr, 0);
 
    bool b = true;
    char c = 0;
-   element.Pack(&c, &b, 1);
+   element->Pack(&c, &b, 1);
    EXPECT_EQ(1, c);
    bool e = false;
-   element.Unpack(&e, &c, 1);
+   element->Unpack(&e, &c, 1);
    EXPECT_TRUE(e);
 
    bool b8[] = {true, false, true, false, false, true, false, true};
    c = 0;
-   element.Pack(&c, &b8, 8);
+   element->Pack(&c, &b8, 8);
    bool e8[] = {false, false, false, false, false, false, false, false};
-   element.Unpack(&e8, &c, 8);
+   element->Unpack(&e8, &c, 8);
    for (unsigned i = 0; i < 8; ++i) {
       EXPECT_EQ(b8[i], e8[i]);
    }
 
    bool b9[] = {true, false, true, false, false, true, false, true, true};
    char c2[2];
-   element.Pack(&c2, &b9, 9);
+   element->Pack(&c2, &b9, 9);
    bool e9[] = {false, false, false, false, false, false, false, false, false};
-   element.Unpack(&e9, &c2, 9);
+   element->Unpack(&e9, &c2, 9);
    for (unsigned i = 0; i < 9; ++i) {
       EXPECT_EQ(b9[i], e9[i]);
    }
@@ -90,38 +90,38 @@ TEST(Packing, Bitfield)
 
 TEST(Packing, HalfPrecisionFloat)
 {
-   RColumnElement<float, EColumnType::kReal16> element32_16;
-   RColumnElement<double, EColumnType::kReal16> element64_16;
-   element32_16.Pack(nullptr, nullptr, 0);
-   element32_16.Unpack(nullptr, nullptr, 0);
-   element64_16.Pack(nullptr, nullptr, 0);
-   element64_16.Unpack(nullptr, nullptr, 0);
+   auto element32_16 = RColumnElementBase::Generate<float>(EColumnType::kReal16);
+   auto element64_16 = RColumnElementBase::Generate<double>(EColumnType::kReal16);
+   element32_16->Pack(nullptr, nullptr, 0);
+   element32_16->Unpack(nullptr, nullptr, 0);
+   element64_16->Pack(nullptr, nullptr, 0);
+   element64_16->Unpack(nullptr, nullptr, 0);
 
    float fin = 3.14;
    unsigned char buf[2] = {0, 0};
-   element32_16.Pack(buf, &fin, 1);
+   element32_16->Pack(buf, &fin, 1);
    // Expected bit representation: 0b01000010 01001000
    EXPECT_EQ(0x48, buf[0]);
    EXPECT_EQ(0x42, buf[1]);
    float fout = 0.;
-   element32_16.Unpack(&fout, buf, 1);
+   element32_16->Unpack(&fout, buf, 1);
    EXPECT_FLOAT_EQ(3.140625, fout);
 
    buf[0] = buf[1] = 0;
    double din = 3.14;
-   element64_16.Pack(buf, &din, 1);
+   element64_16->Pack(buf, &din, 1);
    // Expected bit representation: 0b01000010 01001000
    EXPECT_EQ(0x48, buf[0]);
    EXPECT_EQ(0x42, buf[1]);
    double dout = 0.;
-   element64_16.Unpack(&dout, buf, 1);
+   element64_16->Unpack(&dout, buf, 1);
    EXPECT_FLOAT_EQ(3.140625, dout);
 
    float fin4[] = {0.1, 0.2, 0.3, 0.4};
    std::uint64_t b4 = 0;
-   element32_16.Pack(&b4, &fin4, 4);
+   element32_16->Pack(&b4, &fin4, 4);
    float fout4[] = {0., 0., 0., 0.};
-   element32_16.Unpack(&fout4, &b4, 4);
+   element32_16->Unpack(&fout4, &b4, 4);
    EXPECT_FLOAT_EQ(0.099975586, fout4[0]);
    EXPECT_FLOAT_EQ(0.199951171, fout4[1]);
    EXPECT_FLOAT_EQ(0.300048828, fout4[2]);
@@ -129,9 +129,9 @@ TEST(Packing, HalfPrecisionFloat)
 
    double din4[] = {0.1, 0.2, 0.3, 0.4};
    b4 = 0;
-   element64_16.Pack(&b4, &din4, 4);
+   element64_16->Pack(&b4, &din4, 4);
    double dout4[] = {0., 0., 0., 0.};
-   element64_16.Unpack(&dout4, &b4, 4);
+   element64_16->Unpack(&dout4, &b4, 4);
    EXPECT_FLOAT_EQ(0.099975586, dout4[0]);
    EXPECT_FLOAT_EQ(0.199951171, dout4[1]);
    EXPECT_FLOAT_EQ(0.300048828, dout4[2]);
@@ -140,15 +140,15 @@ TEST(Packing, HalfPrecisionFloat)
 
 TEST(Packing, RColumnSwitch)
 {
-   RColumnElement<RColumnSwitch, EColumnType::kSwitch> element;
-   element.Pack(nullptr, nullptr, 0);
-   element.Unpack(nullptr, nullptr, 0);
+   auto element = RColumnElementBase::Generate<RColumnSwitch>(EColumnType::kSwitch);
+   element->Pack(nullptr, nullptr, 0);
+   element->Unpack(nullptr, nullptr, 0);
 
    RColumnSwitch s1(ClusterSize_t{0xaa}, 0x55);
    unsigned char out[12];
-   element.Pack(out, &s1, 1);
+   element->Pack(out, &s1, 1);
    RColumnSwitch s2;
-   element.Unpack(&s2, out, 1);
+   element->Unpack(&s2, out, 1);
    EXPECT_EQ(0xaa, s2.GetIndex());
    EXPECT_EQ(0x55, s2.GetTag());
 }
@@ -158,9 +158,9 @@ TYPED_TEST(PackingReal, SplitReal)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
-   element.Pack(nullptr, nullptr, 0);
-   element.Unpack(nullptr, nullptr, 0);
+   auto element = RColumnElementBase::Generate<Pod_t>(TestFixture::Helper_t::kColumnType);
+   element->Pack(nullptr, nullptr, 0);
+   element->Unpack(nullptr, nullptr, 0);
 
    std::array<Pod_t, 7> mem{0.0,
                             42.0,
@@ -172,8 +172,8 @@ TYPED_TEST(PackingReal, SplitReal)
    std::array<Pod_t, 7> packed;
    std::array<Pod_t, 7> cmp;
 
-   element.Pack(packed.data(), mem.data(), 7);
-   element.Unpack(cmp.data(), packed.data(), 7);
+   element->Pack(packed.data(), mem.data(), 7);
+   element->Unpack(cmp.data(), packed.data(), 7);
 
    EXPECT_EQ(mem, cmp);
 }
@@ -183,9 +183,9 @@ TYPED_TEST(PackingInt, SplitInt)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
-   element.Pack(nullptr, nullptr, 0);
-   element.Unpack(nullptr, nullptr, 0);
+   auto element = RColumnElementBase::Generate<Pod_t>(TestFixture::Helper_t::kColumnType);
+   element->Pack(nullptr, nullptr, 0);
+   element->Unpack(nullptr, nullptr, 0);
 
    std::array<Pod_t, 9> mem{0,
                             std::is_signed_v<Pod_t> ? -42 : 1,
@@ -199,8 +199,8 @@ TYPED_TEST(PackingInt, SplitInt)
    std::array<Pod_t, 9> packed;
    std::array<Pod_t, 9> cmp;
 
-   element.Pack(packed.data(), mem.data(), 9);
-   element.Unpack(cmp.data(), packed.data(), 9);
+   element->Pack(packed.data(), mem.data(), 9);
+   element->Unpack(cmp.data(), packed.data(), 9);
 
    EXPECT_EQ(mem, cmp);
 }
@@ -210,16 +210,16 @@ TYPED_TEST(PackingIndex, SplitIndex)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   RColumnElement<ClusterSize_t, TestFixture::Helper_t::kColumnType> element;
-   element.Pack(nullptr, nullptr, 0);
-   element.Unpack(nullptr, nullptr, 0);
+   auto element = RColumnElementBase::Generate<ClusterSize_t>(TestFixture::Helper_t::kColumnType);
+   element->Pack(nullptr, nullptr, 0);
+   element->Unpack(nullptr, nullptr, 0);
 
    std::array<Pod_t, 5> mem{0, 1, 1, 42, std::numeric_limits<Narrow_t>::max()};
    std::array<Pod_t, 5> packed;
    std::array<Pod_t, 5> cmp;
 
-   element.Pack(packed.data(), mem.data(), 5);
-   element.Unpack(cmp.data(), packed.data(), 5);
+   element->Pack(packed.data(), mem.data(), 5);
+   element->Unpack(cmp.data(), packed.data(), 5);
 
    EXPECT_EQ(mem, cmp);
 }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -1,7 +1,7 @@
 #ifndef ROOT7_RNTuple_Test
 #define ROOT7_RNTuple_Test
 
-#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldVisitor.hxx>

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -64,8 +64,7 @@ using RClusterDescriptor = ROOT::Experimental::RClusterDescriptor;
 using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescriptorBuilder;
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
 using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;
-template <typename T, EColumnType C>
-using RColumnElement = ROOT::Experimental::Internal::RColumnElement<T, C>;
+using RColumnElementBase = ROOT::Experimental::Internal::RColumnElementBase;
 using RColumnSwitch = ROOT::Experimental::RColumnSwitch;
 using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -13,7 +13,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnElementBase.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>


### PR DESCRIPTION
# This Pull request:
by @hahnjo suggestion, since we are exposing a type-erased virtual interface for `RColumnElement` through `RColumnElementBase`, we can hide all the concrete definitions into a cxx file.
This has the benefit of reducing the compile time of any translation unit that includes `RColumnElementBase.hxx` significantly, as the compiler won't have to instantiate all the combination matrix of `RColumnElement<CppT, ColumnType>` every time.
It also let us have better control on exactly which types of `RColumnElement` we allow to instantiate by explicitly listing them into a proxy enum.

## Changes or fixes:
- renamed `RColumnElement.hxx` to `RColumnElementBase.hxx`
- moved all concrete definitions from `RColumnElementBase.hxx` to `src/RColumnElement.hxx`. This is a private header file that is included by `RColumnElement.cxx` and by `ntuple_endian.cxx`. The reason to separate this from `RColumnElement.cxx` is that `ntuple_endian.cxx` needs to simulate a big-endian machine by defining `R__LITTLE_ENDIAN 0`, which changes the definitions of some `RColumnElement`s. To avoid including the whole `RColumnElement.cxx` in the test, we decided to split the definitions into a file that can be included independently by the test. It's not a perfect solution (the test executable ends up with mismatching instantiations of RColumnElement since it links to libROOTNTuple.so) but it's technically not worse than before. We still might want to think of alternative solutions.
- introduces an enum `EColumnCppType` that lists all the allowed c++ in-memory types for RColumnElement. This is used internally to map the templated `RColumnElementBase::Generate` to a non-templated function that can be implemented in the cxx file.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


