### PR TITLE
[ntuple] Adaptive page sizes

### DIFF
--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -48,7 +48,7 @@ Note that the total amount of memory consumed for writing is usually larger than
 For instance, if buffered writing is used (the default), additional memory is required.
 Use RNTupleModel::EstimateWriteMemoryUsage() for the total estimated memory use for writing.
 
-The default values are tuned for a total write memory of around 1 GB per writer resp. fill context.
+The default values are tuned for a total write memory of around 300 MB per writer resp. fill context.
 In order to decrease the memory consumption,
 users should decrease the target cluster size before tuning more intricate memory settings.
 

--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -27,35 +27,30 @@ See the notes below on a discussion of this approximation.
 Page Sizes
 ==========
 
-Pages contain consecutive elements of a certain columns.
+Pages contain consecutive elements of a certain column.
 They are the unit of compression and of addressability on storage.
-RNTuple uses a *target size* for the uncompressed data as a guideline for when to flush a page.
+RNTuple puts a configurable maximum uncompressed size for pages.
+This limit is by default set to 1 MiB.
+When the limit is reached, a page will be flushed to disk.
 
-The default page target size is 64KiB.
-The default can be changed by the `RNTupleWriteOptions`.
-In general, larger pages give better compression ratios; smaller pages reduce the memory footprint.
-When reading, every active column requires at least one page buffer.
-For the number of read requests, the page size does not matter
-because pages of the same column are written consecutively and therefore read in one go.
+In addition, RNTuple maintains a memory budget for the combined allocated size of the pages that are currently filled.
+By default, this limit is set to twice the compressed target cluster size when compression is used,
+and to the cluster target size for uncompressed data.
+Initially, and after flushing, all columns use small pages,
+just big enough to hold the configurable minimum number of elements (64 by default).
+Page sizes are doubled as more data is filled into them.
+When a page reaches the maximum page size (see above), it is flushed.
+When the overall page budget is reached,
+pages larger than the page at hand are flushed before the page at hand is flushed.
+For the parallel writer, every fill context maintains the page memory budget independently.
 
-Given the target size, writing works as follows:
-In the beginning, the first page is filled until the target size.
-Afterwards there is a mechanism to prevent undersized tail pages:
-writing uses two page buffers in turns and flushes the previous buffer filled to its target size only once the next buffer is at least at 50%.
-Then writing continues until the target size, at which point writing switches back to the other page.
-If the cluster gets flushed with an undersized tail page,
-the small page is appended to the previous page before flushing.
-Therefore, tail pages sizes are between `[0.5 * target size .. 1.5 * target size]`
-(unless the column doesn't have enough elements to fill 50% of the first page).
+Note that the total amount of memory consumed for writing is usually larger than the write page budget.
+For instance, if buffered writing is used (the default), additional memory is required.
+Use RNTupleModel::EstimateWriteMemoryUsage() for the total estimated memory use for writing.
 
-Concretely, writing will fill and flush two pages `A` and `B` as follows:
-1. Writing starts to fill page `A`.
-2. When page `A` reached its target size, writing switches to page `B` while the contents of page `A` are kept in memory.
-3. Once page `B` is at least at 50%, page `A` is flushed.
-4. When page `B` reaches its target size, writing switches to page `A`.
-5. Once page `A` is at least at 50%, page `B` is flushed.
-6. ... and so on, going back to 2.
-
+The default values are tuned for a total write memory of around 1 GB per writer resp. fill context.
+In order to decrease the memory consumption,
+users should decrease the target cluster size before tuning more intricate memory settings.
 
 Notes
 =====

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -134,6 +134,7 @@ public:
    void AppendV(const void *from, std::size_t count)
    {
       auto src = reinterpret_cast<const unsigned char *>(from);
+      // TODO(jblomer): A future optimization should grow the page in one go, up to the maximum unzipped page size
       while (count > 0) {
          std::size_t nElementsRemaining = fWritePage.GetMaxElements() - fWritePage.GetNElements();
          if (nElementsRemaining == 0) {

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -97,6 +97,8 @@ private:
             fWritePage = std::move(expandedPage);
          }
       }
+
+      assert(fWritePage.GetNElements() < fWritePage.GetMaxElements());
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -58,8 +58,8 @@ private:
    NTupleSize_t fNElements = 0;
    /// The currently mapped page for reading
    RPageRef fReadPageRef;
-   /// The column id is used to find matching pages with content when reading
-   ColumnId_t fColumnIdSource = kInvalidColumnId;
+   /// The column id in the column descriptor, once connected to a sink or source
+   DescriptorId_t fOnDiskId = kInvalidDescriptorId;
    /// Global index of the first element in this column; usually == 0, unless it is a deferred column
    NTupleSize_t fFirstElementIndex = 0;
    /// Used to pack and unpack pages on writing/reading
@@ -335,7 +335,7 @@ public:
    }
    std::uint32_t GetIndex() const { return fIndex; }
    std::uint16_t GetRepresentationIndex() const { return fRepresentationIndex; }
-   ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
+   DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    NTupleSize_t GetFirstElementIndex() const { return fFirstElementIndex; }
    RPageSource *GetPageSource() const { return fPageSource; }
    RPageSink *GetPageSink() const { return fPageSink; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -70,9 +70,6 @@ protected:
    /// fApproxUnzippedPageSize in size. If tail page optimization is enabled, the last page in a cluster is
    /// between fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 1.5 in size.
    std::size_t fApproxUnzippedPageSize = 64 * 1024;
-   /// Whether to optimize tail pages to avoid an undersized last page per cluster (see above). Increases the
-   /// required memory by a factor 3x.
-   bool fUseTailPageOptimization = true;
    /// Initially, columns start with a page large enough to hold the given number of elements. The initial
    /// page size is the given number of elements multiplied by the column's element size.
    /// If more elements are needed, pages are increased up until the byte limit given by fMaxUnzippedPageSize
@@ -126,9 +123,6 @@ public:
 
    std::size_t GetApproxUnzippedPageSize() const { return fApproxUnzippedPageSize; }
    void SetApproxUnzippedPageSize(std::size_t val);
-
-   bool GetUseTailPageOptimization() const { return fUseTailPageOptimization; }
-   void SetUseTailPageOptimization(bool val) { fUseTailPageOptimization = val; }
 
    std::size_t GetInitialNElementsPerPage() const { return fInitialNElementsPerPage; }
    void SetInitialNElementsPerPage(std::size_t val);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -78,7 +78,7 @@ protected:
    /// If set manually, the size needs to be large enough to hold all initial page buffers.
    /// The total amount of memory for writing is larger, e.g. for the additional compressed buffers etc.
    /// Use RNTupleModel::EstimateWriteMemoryUsage() for the total estimated memory use for writing.
-   /// The default values are tuned for a total write memory of around 1GB per fill context.
+   /// The default values are tuned for a total write memory of around 300 MB per fill context.
    std::size_t fPageBufferBudget = 0;
    /// Whether to use buffered writing (with RPageSinkBuf). This buffers compressed pages in memory, reorders them
    /// to keep pages of the same column adjacent, and coalesces the writes when committing a cluster.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -65,11 +65,6 @@ protected:
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
    /// on how large the I/O buffer can grow during writing.
    std::size_t fMaxUnzippedClusterSize = 512 * 1024 * 1024;
-   /// Should be just large enough so that the compression ratio does not benefit much more from larger pages.
-   /// Unless the cluster is too small to contain a sufficiently large page, pages are
-   /// fApproxUnzippedPageSize in size. If tail page optimization is enabled, the last page in a cluster is
-   /// between fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 1.5 in size.
-   std::size_t fApproxUnzippedPageSize = 64 * 1024;
    /// Initially, columns start with a page large enough to hold the given number of elements. The initial
    /// page size is the given number of elements multiplied by the column's element size.
    /// If more elements are needed, pages are increased up until the byte limit given by fMaxUnzippedPageSize
@@ -120,9 +115,6 @@ public:
 
    std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
    void SetMaxUnzippedClusterSize(std::size_t val);
-
-   std::size_t GetApproxUnzippedPageSize() const { return fApproxUnzippedPageSize; }
-   void SetApproxUnzippedPageSize(std::size_t val);
 
    std::size_t GetInitialNElementsPerPage() const { return fInitialNElementsPerPage; }
    void SetInitialNElementsPerPage(std::size_t val);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -73,6 +73,21 @@ protected:
    /// Whether to optimize tail pages to avoid an undersized last page per cluster (see above). Increases the
    /// required memory by a factor 3x.
    bool fUseTailPageOptimization = true;
+   /// Initially, columns start with a page large enough to hold the given number of elements. The initial
+   /// page size is the given number of elements multiplied by the column's element size.
+   /// If more elements are needed, pages are increased up until the byte limit given by fMaxUnzippedPageSize
+   /// or until the total page buffer limit is reached (as a sum of all page buffers).
+   /// The total write buffer limit needs to be large enough to hold the initial pages of all columns.
+   std::size_t fInitialNElementsPerPage = 64;
+   /// Pages can grow only to the given limit in bytes.
+   std::size_t fMaxUnzippedPageSize = 1024 * 1024;
+   /// The maximum size that the sum of all page buffers used for writing into a persistent sink are allowed to use.
+   /// If set to zero, RNTuple will auto-adjust the budget based on the value of fApproxZippedClusterSize.
+   /// If set manually, the size needs to be large enough to hold all initial page buffers.
+   /// The total amount of memory for writing is larger, e.g. for the additional compressed buffers etc.
+   /// Use RNTupleModel::EstimateWriteMemoryUsage() for the total estimated memory use for writing.
+   /// The default values are tuned for a total write memory of around 1GB per fill context.
+   std::size_t fPageBufferBudget = 0;
    /// Whether to use buffered writing (with RPageSinkBuf). This buffers compressed pages in memory, reorders them
    /// to keep pages of the same column adjacent, and coalesces the writes when committing a cluster.
    bool fUseBufferedWrite = true;
@@ -114,6 +129,15 @@ public:
 
    bool GetUseTailPageOptimization() const { return fUseTailPageOptimization; }
    void SetUseTailPageOptimization(bool val) { fUseTailPageOptimization = val; }
+
+   std::size_t GetInitialNElementsPerPage() const { return fInitialNElementsPerPage; }
+   void SetInitialNElementsPerPage(std::size_t val);
+
+   std::size_t GetMaxUnzippedPageSize() const { return fMaxUnzippedPageSize; }
+   void SetMaxUnzippedPageSize(std::size_t val);
+
+   std::size_t GetPageBufferBudget() const;
+   void SetPageBufferBudget(std::size_t val) { fPageBufferBudget = val; }
 
    bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
    void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
@@ -35,10 +35,9 @@ namespace Experimental {
 // clang-format on
 class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
    std::string fObjectClass{"SX"};
-   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 1MiB by default. Empirically, such a
-   /// cage size yields acceptable results in throughput and page granularity for most use cases. A `fMaxCageSize` of 0
-   /// disables the caging mechanism.
-   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fApproxUnzippedPageSize;
+   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 16MiB by default.
+   /// A `fMaxCageSize` of 0 disables the caging mechanism.
+   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fMaxUnzippedPageSize;
 
 public:
    ~RNTupleWriteOptionsDaos() override = default;

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -123,6 +123,10 @@ public:
    {
       return static_cast<std::size_t>(fElementSize) * static_cast<std::size_t>(fNElements);
    }
+   std::size_t GetCapacity() const
+   {
+      return static_cast<std::size_t>(fElementSize) * static_cast<std::size_t>(fMaxElements);
+   }
    std::uint32_t GetElementSize() const { return fElementSize; }
    std::uint32_t GetNElements() const { return fNElements; }
    std::uint32_t GetMaxElements() const { return fMaxElements; }

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -40,7 +40,7 @@ class RPageNullSink : public RPageSink {
 public:
    RPageNullSink(std::string_view ntupleName, const RNTupleWriteOptions &options) : RPageSink(ntupleName, options) {}
 
-   ColumnHandle_t AddColumn(DescriptorId_t, const RColumn &column) final { return {fNColumns++, &column}; }
+   ColumnHandle_t AddColumn(DescriptorId_t, RColumn &column) final { return {fNColumns++, &column}; }
 
    const RNTupleDescriptor &GetDescriptor() const final
    {

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -140,7 +140,7 @@ public:
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
    ~RPageSinkBuf() override;
 
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, RColumn &column) final;
 
    const RNTupleDescriptor &GetDescriptor() const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -104,7 +104,7 @@ public:
    RPageSourceFriends(std::string_view ntupleName, std::span<std::unique_ptr<RPageSource>> sources);
    ~RPageSourceFriends() final;
 
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, RColumn &column) final;
    void DropColumn(ColumnHandle_t columnHandle) final;
 
    RPageRef LoadPage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -169,7 +169,7 @@ public:
 
    struct RColumnHandle {
       DescriptorId_t fPhysicalId = kInvalidDescriptorId;
-      const RColumn *fColumn = nullptr;
+      RColumn *fColumn = nullptr;
 
       /// Returns true for a valid column handle; fColumn and fPhysicalId should always either both
       /// be valid or both be invalid.
@@ -180,7 +180,7 @@ public:
 
    /// Register a new column.  When reading, the column must exist in the ntuple on disk corresponding to the meta-data.
    /// When writing, every column can only be attached once.
-   virtual ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) = 0;
+   virtual ColumnHandle_t AddColumn(DescriptorId_t fieldId, RColumn &column) = 0;
    /// Unregisters a column.  A page source decreases the reference counter for the corresponding active column.
    /// For a page sink, dropping columns is currently a no-op.
    virtual void DropColumn(ColumnHandle_t columnHandle) = 0;
@@ -441,7 +441,7 @@ public:
    static std::unique_ptr<RPageSink> Create(std::string_view ntupleName, std::string_view location,
                                             const RNTupleWriteOptions &options = RNTupleWriteOptions());
 
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, RColumn &column) final;
 
    const RNTupleDescriptor &GetDescriptor() const final { return fDescriptorBuilder.GetDescriptor(); }
 
@@ -645,7 +645,7 @@ public:
       return RSharedDescriptorGuard(fDescriptor, fDescriptorLock);
    }
 
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) override;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, RColumn &column) override;
    void DropColumn(ColumnHandle_t columnHandle) override;
 
    /// Loads header and footer without decompressing or deserializing them. This can be used to asynchronously open

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -185,6 +185,7 @@ public:
    /// Unregisters a column.  A page source decreases the reference counter for the corresponding active column.
    /// For a page sink, dropping columns is currently a no-op.
    virtual void DropColumn(ColumnHandle_t columnHandle) = 0;
+   ColumnId_t GetColumnId(ColumnHandle_t columnHandle) const { return columnHandle.fPhysicalId; }
 
    /// Returns the default metrics object.  Subclasses might alternatively provide their own metrics object by
    /// overriding this.
@@ -709,7 +710,6 @@ public:
    void Attach();
    NTupleSize_t GetNEntries();
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
-   ColumnId_t GetColumnId(ColumnHandle_t columnHandle);
 
    /// Promise to only read from the given entry range. If set, prevents the cluster pool from reading-ahead beyond
    /// the given range. The range needs to be within `[0, GetNEntries())`.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -214,13 +214,7 @@ private:
       std::size_t fCurrentPageSize = 0;
       std::size_t fInitialPageSize = 0;
 
-      bool operator>(const RColumnInfo &other) const
-      {
-         // Make the sort order unique by adding the column pointer as a secondary key
-         if (fCurrentPageSize == other.fCurrentPageSize)
-            return fColumn > other.fColumn;
-         return fCurrentPageSize > other.fCurrentPageSize;
-      }
+      bool operator>(const RColumnInfo &other) const;
    };
 
    /// Sum of all the write page sizes (their capacity) of the columns in `fColumnsSortedByPageSize`

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -48,6 +48,7 @@ void ROOT::Experimental::Internal::RColumn::ConnectPageSink(DescriptorId_t field
    fPageSink = &pageSink;
    fFirstElementIndex = firstElementIndex;
    fHandleSink = fPageSink->AddColumn(fieldId, *this);
+   fOnDiskId = fPageSink->GetColumnId(fHandleSink);
    fWritePage = fPageSink->ReservePage(fHandleSink, fPageSink->GetWriteOptions().GetInitialNElementsPerPage());
    if (fWritePage.IsNull())
       throw RException(R__FAIL("page buffer memory budget too small"));
@@ -58,10 +59,10 @@ void ROOT::Experimental::Internal::RColumn::ConnectPageSource(DescriptorId_t fie
    fPageSource = &pageSource;
    fHandleSource = fPageSource->AddColumn(fieldId, *this);
    fNElements = fPageSource->GetNElements(fHandleSource);
-   fColumnIdSource = fPageSource->GetColumnId(fHandleSource);
+   fOnDiskId = fPageSource->GetColumnId(fHandleSource);
    {
       auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
-      fFirstElementIndex = descriptorGuard->GetColumnDescriptor(fColumnIdSource).GetFirstElementIndex();
+      fFirstElementIndex = descriptorGuard->GetColumnDescriptor(fOnDiskId).GetFirstElementIndex();
    }
 }
 

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -40,22 +40,15 @@ ROOT::Experimental::Internal::RColumn::~RColumn()
 void ROOT::Experimental::Internal::RColumn::ConnectPageSink(DescriptorId_t fieldId, RPageSink &pageSink,
                                                             NTupleSize_t firstElementIndex)
 {
-   fPageSink = &pageSink; // the page sink initializes fWritePage on AddColumn
+   if (pageSink.GetWriteOptions().GetInitialNElementsPerPage() * fElement->GetSize() >
+       pageSink.GetWriteOptions().GetMaxUnzippedPageSize()) {
+      throw RException(R__FAIL("initial number of elements per page too small"));
+   }
+
+   fPageSink = &pageSink;
    fFirstElementIndex = firstElementIndex;
    fHandleSink = fPageSink->AddColumn(fieldId, *this);
-   fApproxNElementsPerPage = fPageSink->GetWriteOptions().GetApproxUnzippedPageSize() / fElement->GetSize();
-   if (fApproxNElementsPerPage < 2)
-      throw RException(R__FAIL("page size too small for writing"));
-   // We now have 0 < fApproxNElementsPerPage / 2 < fApproxNElementsPerPage
-
-   if (pageSink.GetWriteOptions().GetUseTailPageOptimization()) {
-      // Allocate two pages that are larger by 50% to accomodate merging a small tail page.
-      fWritePage[0] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
-      fWritePage[1] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
-   } else {
-      // Allocate only a single page; small tail pages will not be merged.
-      fWritePage[0] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage);
-   }
+   fWritePage = fPageSink->ReservePage(fHandleSink, fPageSink->GetWriteOptions().GetInitialNElementsPerPage());
 }
 
 void ROOT::Experimental::Internal::RColumn::ConnectPageSource(DescriptorId_t fieldId, RPageSource &pageSource)
@@ -72,23 +65,12 @@ void ROOT::Experimental::Internal::RColumn::ConnectPageSource(DescriptorId_t fie
 
 void ROOT::Experimental::Internal::RColumn::Flush()
 {
-   auto otherIdx = 1 - fWritePageIdx;
-   if (fWritePage[fWritePageIdx].IsEmpty() && fWritePage[otherIdx].IsEmpty())
+   if (fWritePage.GetNElements() == 0)
       return;
 
-   if ((fWritePage[fWritePageIdx].GetNElements() < fApproxNElementsPerPage / 2) && !fWritePage[otherIdx].IsEmpty()) {
-      // Small tail page: merge with previously used page
-      auto &thisPage = fWritePage[fWritePageIdx];
-      R__ASSERT(fWritePage[otherIdx].GetMaxElements() >= fWritePage[otherIdx].GetNElements() + thisPage.GetNElements());
-      void *dst = fWritePage[otherIdx].GrowUnchecked(thisPage.GetNElements());
-      memcpy(dst, thisPage.GetBuffer(), thisPage.GetNBytes());
-      thisPage.Reset(0);
-      std::swap(fWritePageIdx, otherIdx);
-   }
-
-   R__ASSERT(fWritePage[otherIdx].IsEmpty());
-   fPageSink->CommitPage(fHandleSink, fWritePage[fWritePageIdx]);
-   fWritePage[fWritePageIdx].Reset(fNElements);
+   fPageSink->CommitPage(fHandleSink, fWritePage);
+   fWritePage = fPageSink->ReservePage(fHandleSink, fPageSink->GetWriteOptions().GetInitialNElementsPerPage());
+   fWritePage.Reset(fNElements);
 }
 
 void ROOT::Experimental::Internal::RColumn::CommitSuppressed()

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -49,6 +49,8 @@ void ROOT::Experimental::Internal::RColumn::ConnectPageSink(DescriptorId_t field
    fFirstElementIndex = firstElementIndex;
    fHandleSink = fPageSink->AddColumn(fieldId, *this);
    fWritePage = fPageSink->ReservePage(fHandleSink, fPageSink->GetWriteOptions().GetInitialNElementsPerPage());
+   if (fWritePage.IsNull())
+      throw RException(R__FAIL("page buffer memory budget too small"));
 }
 
 void ROOT::Experimental::Internal::RColumn::ConnectPageSource(DescriptorId_t fieldId, RPageSource &pageSource)
@@ -70,6 +72,7 @@ void ROOT::Experimental::Internal::RColumn::Flush()
 
    fPageSink->CommitPage(fHandleSink, fWritePage);
    fWritePage = fPageSink->ReservePage(fHandleSink, fPageSink->GetWriteOptions().GetInitialNElementsPerPage());
+   R__ASSERT(!fWritePage.IsNull());
    fWritePage.Reset(fNElements);
 }
 

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -42,7 +42,7 @@ void ROOT::Experimental::Internal::RColumn::ConnectPageSink(DescriptorId_t field
 {
    if (pageSink.GetWriteOptions().GetInitialNElementsPerPage() * fElement->GetSize() >
        pageSink.GetWriteOptions().GetMaxUnzippedPageSize()) {
-      throw RException(R__FAIL("initial number of elements per page too small"));
+      throw RException(R__FAIL("maximum page size to small for the initial number of elements per page"));
    }
 
    fPageSink = &pageSink;

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -21,6 +21,8 @@
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 
+#include <TError.h>
+
 namespace {
 
 using ROOT::Experimental::DescriptorId_t;
@@ -33,6 +35,7 @@ using ROOT::Experimental::Internal::RColumn;
 using ROOT::Experimental::Internal::RNTupleModelChangeset;
 using ROOT::Experimental::Internal::RPage;
 using ROOT::Experimental::Internal::RPageSink;
+using ROOT::Experimental::Internal::RWritePageMemoryManager;
 
 /// An internal RPageSink that enables multiple RNTupleFillContext to write into a single common RPageSink.
 ///

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -71,7 +71,7 @@ public:
 
    const RNTupleDescriptor &GetDescriptor() const final { return fInnerSink->GetDescriptor(); }
 
-   ColumnHandle_t AddColumn(DescriptorId_t, const RColumn &) final { return {}; }
+   ColumnHandle_t AddColumn(DescriptorId_t, RColumn &) final { return {}; }
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const RNTupleModelChangeset &, NTupleSize_t) final
    {

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -35,7 +35,6 @@ using ROOT::Experimental::Internal::RColumn;
 using ROOT::Experimental::Internal::RNTupleModelChangeset;
 using ROOT::Experimental::Internal::RPage;
 using ROOT::Experimental::Internal::RPageSink;
-using ROOT::Experimental::Internal::RWritePageMemoryManager;
 
 /// An internal RPageSink that enables multiple RNTupleFillContext to write into a single common RPageSink.
 ///

--- a/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
@@ -20,21 +20,25 @@
 
 namespace {
 
-void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClusterSize, std::size_t unzippedPageSize)
+void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClusterSize,
+                         std::size_t initialNElementsPerPage, std::size_t maxUnzippedPageSize)
 {
    using RException = ROOT::Experimental::RException;
    if (zippedClusterSize == 0) {
       throw RException(R__FAIL("invalid target cluster size: 0"));
    }
-   if (unzippedPageSize == 0) {
-      throw RException(R__FAIL("invalid target page size: 0"));
+   if (maxUnzippedPageSize == 0) {
+      throw RException(R__FAIL("invalid maximum page size: 0"));
+   }
+   if (initialNElementsPerPage == 0) {
+      throw RException(R__FAIL("invalid initial number of elements per page: 0"));
    }
    if (zippedClusterSize > unzippedClusterSize) {
       throw RException(R__FAIL("compressed target cluster size must not be larger than "
                                "maximum uncompressed cluster size"));
    }
-   if (unzippedPageSize > unzippedClusterSize) {
-      throw RException(R__FAIL("target page size must not be larger than "
+   if (maxUnzippedPageSize > unzippedClusterSize) {
+      throw RException(R__FAIL("maximum page size must not be larger than "
                                "maximum uncompressed cluster size"));
    }
 }
@@ -48,18 +52,38 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriteOptions> ROOT::Experimental::RNT
 
 void ROOT::Experimental::RNTupleWriteOptions::SetApproxZippedClusterSize(std::size_t val)
 {
-   EnsureValidTunables(val, fMaxUnzippedClusterSize, fApproxUnzippedPageSize);
+   EnsureValidTunables(val, fMaxUnzippedClusterSize, fInitialNElementsPerPage, fMaxUnzippedPageSize);
    fApproxZippedClusterSize = val;
 }
 
 void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedClusterSize(std::size_t val)
 {
-   EnsureValidTunables(fApproxZippedClusterSize, val, fApproxUnzippedPageSize);
+   EnsureValidTunables(fApproxZippedClusterSize, val, fInitialNElementsPerPage, fMaxUnzippedPageSize);
    fMaxUnzippedClusterSize = val;
 }
 
 void ROOT::Experimental::RNTupleWriteOptions::SetApproxUnzippedPageSize(std::size_t val)
 {
-   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, val);
+   // TODO(jblomer): remove option
    fApproxUnzippedPageSize = val;
+}
+
+void ROOT::Experimental::RNTupleWriteOptions::SetInitialNElementsPerPage(std::size_t val)
+{
+   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, val, fMaxUnzippedPageSize);
+   fInitialNElementsPerPage = val;
+}
+
+void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedPageSize(std::size_t val)
+{
+   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, fInitialNElementsPerPage, val);
+   fMaxUnzippedPageSize = val;
+}
+
+std::size_t ROOT::Experimental::RNTupleWriteOptions::GetPageBufferBudget() const
+{
+   if (fPageBufferBudget != 0)
+      return fPageBufferBudget;
+
+   return GetApproxZippedClusterSize() + (GetCompression() != 0) * GetApproxZippedClusterSize();
 }

--- a/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
@@ -62,12 +62,6 @@ void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedClusterSize(std::siz
    fMaxUnzippedClusterSize = val;
 }
 
-void ROOT::Experimental::RNTupleWriteOptions::SetApproxUnzippedPageSize(std::size_t val)
-{
-   // TODO(jblomer): remove option
-   fApproxUnzippedPageSize = val;
-}
-
 void ROOT::Experimental::RNTupleWriteOptions::SetInitialNElementsPerPage(std::size_t val)
 {
    EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, val, fMaxUnzippedPageSize);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -53,7 +53,7 @@ ROOT::Experimental::Internal::RPageSinkBuf::~RPageSinkBuf()
 }
 
 ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Internal::RPageSinkBuf::AddColumn(DescriptorId_t /*fieldId*/, const RColumn &column)
+ROOT::Experimental::Internal::RPageSinkBuf::AddColumn(DescriptorId_t /*fieldId*/, RColumn &column)
 {
    return ColumnHandle_t{fNColumns++, &column};
 }

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -144,7 +144,7 @@ ROOT::Experimental::Internal::RPageSourceFriends::CloneImpl() const
 }
 
 ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Internal::RPageSourceFriends::AddColumn(DescriptorId_t fieldId, const RColumn &column)
+ROOT::Experimental::Internal::RPageSourceFriends::AddColumn(DescriptorId_t fieldId, RColumn &column)
 {
    auto originFieldId = fIdBiMap.GetOriginId(fieldId);
    fSources[originFieldId.fSourceIdx]->AddColumn(originFieldId.fId, column);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -509,6 +509,14 @@ ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedP
 
 //------------------------------------------------------------------------------
 
+bool ROOT::Experimental::Internal::RWritePageMemoryManager::RColumnInfo::operator>(const RColumnInfo &other) const
+{
+   // Make the sort order unique by adding the physical on-disk column id as a secondary key
+   if (fCurrentPageSize == other.fCurrentPageSize)
+      return fColumn->GetOnDiskId() > other.fColumn->GetOnDiskId();
+   return fCurrentPageSize > other.fCurrentPageSize;
+}
+
 bool ROOT::Experimental::Internal::RWritePageMemoryManager::TryEvict(std::size_t targetAvailableSize,
                                                                      std::size_t pageSizeLimit)
 {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -221,12 +221,6 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::Internal::RPageSource::GetN
    return GetSharedDescriptorGuard()->GetNElements(columnHandle.fPhysicalId);
 }
 
-ROOT::Experimental::ColumnId_t ROOT::Experimental::Internal::RPageSource::GetColumnId(ColumnHandle_t columnHandle)
-{
-   // TODO(jblomer) distinguish trees
-   return columnHandle.fPhysicalId;
-}
-
 void ROOT::Experimental::Internal::RPageSource::UnzipCluster(RCluster *cluster)
 {
    if (fTaskScheduler)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -160,7 +160,7 @@ ROOT::Experimental::Internal::RPageSource::Create(std::string_view ntupleName, s
 }
 
 ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Internal::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
+ROOT::Experimental::Internal::RPageSource::AddColumn(DescriptorId_t fieldId, RColumn &column)
 {
    R__ASSERT(fieldId != kInvalidDescriptorId);
    auto physicalId =
@@ -623,7 +623,7 @@ ROOT::Experimental::Internal::RPagePersistentSink::RPagePersistentSink(std::stri
 ROOT::Experimental::Internal::RPagePersistentSink::~RPagePersistentSink() {}
 
 ROOT::Experimental::Internal::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Internal::RPagePersistentSink::AddColumn(DescriptorId_t fieldId, const RColumn &column)
+ROOT::Experimental::Internal::RPagePersistentSink::AddColumn(DescriptorId_t fieldId, RColumn &column)
 {
    auto columnId = fDescriptorBuilder.GetDescriptor().GetNPhysicalColumns();
    RColumnDescriptorBuilder columnBuilder;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -304,7 +304,7 @@ void ROOT::Experimental::Internal::RPageSinkDaos::InitImpl(unsigned char *serial
       throw ROOT::Experimental::RException(R__FAIL("Unknown object class " + fNTupleAnchor.fObjClass));
 
    size_t cageSz = opts ? opts->GetMaxCageSize() : RNTupleWriteOptionsDaos().GetMaxCageSize();
-   size_t pageSz = opts ? opts->GetApproxUnzippedPageSize() : RNTupleWriteOptionsDaos().GetApproxUnzippedPageSize();
+   size_t pageSz = opts ? opts->GetMaxUnzippedPageSize() : RNTupleWriteOptionsDaos().GetMaxUnzippedPageSize();
    fCageSizeLimit = std::max(cageSz, pageSz);
 
    auto args = ParseDaosURI(fURI);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -336,6 +336,7 @@ TEST(RNTuple, ClusterEntriesAuto)
       options.SetCompression(0);
       options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
+      options.SetPageBufferBudget(1000 * 1000);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       for (int i = 0; i < 100; i++) {
          ntuple->Fill();
@@ -361,6 +362,7 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
       options.SetCompression(0);
       options.SetEnablePageChecksums(false);
       options.SetApproxZippedClusterSize(5 * sizeof(float));
+      options.SetPageBufferBudget(1000 * 1000);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto entry = ntuple->CreateEntry();
       for (int i = 0; i < 100; i++) {
@@ -386,12 +388,11 @@ TEST(RNTuple, PageSize)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetApproxUnzippedPageSize(200);
-      auto ntuple = RNTupleWriter::Recreate(
-         std::move(model), "ntuple", fileGuard.GetPath(), opt
-      );
+      opt.SetInitialNElementsPerPage(10);
+      opt.SetMaxUnzippedPageSize(200);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opt);
       for (int i = 0; i < 1000; i++) {
-         ntuple->Fill();
+         writer->Fill();
       }
    }
 

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -38,7 +38,7 @@ protected:
    const RColumnElementBase &fElement;
    std::vector<RPageStorage::RSealedPage> fPages;
 
-   ColumnHandle_t AddColumn(ROOT::Experimental::DescriptorId_t, const ROOT::Experimental::Internal::RColumn &) final
+   ColumnHandle_t AddColumn(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::Internal::RColumn &) final
    {
       return {};
    }

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -285,7 +285,7 @@ TEST(RNTuple, LargePages)
          auto fldRnd = model->MakeField<std::uint32_t>("rnd");
          RNTupleWriteOptions options;
          // Larger than the 16MB compression block limit
-         options.SetApproxUnzippedPageSize(32 * 1024 * 1024);
+         options.SetMaxUnzippedPageSize(32 * 1024 * 1024);
          options.SetUseBufferedWrite(useBufferedWrite);
          auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
 

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -133,7 +133,8 @@ TEST(RNTuple, DISABLED_Limits_ManyPages)
       auto id = model->MakeField<int>("id");
       RNTupleWriteOptions options;
       // Two elements per page.
-      options.SetApproxUnzippedPageSize(8);
+      options.SetInitialNElementsPerPage(1);
+      options.SetMaxUnzippedPageSize(8);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
       for (int i = 0; i < NumEntries; i++) {
@@ -173,7 +174,8 @@ TEST(RNTuple, DISABLED_Limits_ManyPagesOneEntry)
       auto ids = model->MakeField<std::vector<int>>("ids");
       RNTupleWriteOptions options;
       // Four elements per page (must fit two 64-bit indices!)
-      options.SetApproxUnzippedPageSize(16);
+      options.SetInitialNElementsPerPage(1);
+      options.SetMaxUnzippedPageSize(16);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
       for (int i = 0; i < NumElements; i++) {
@@ -218,7 +220,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
       static constexpr std::size_t Size = NumElements * sizeof(std::uint64_t);
       options.SetMaxUnzippedClusterSize(Size);
       options.SetApproxZippedClusterSize(Size);
-      options.SetApproxUnzippedPageSize(Size);
+      options.SetMaxUnzippedPageSize(Size);
       options.SetUseBufferedWrite(false);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
@@ -264,7 +266,7 @@ TEST(RNTuple, DISABLED_Limits_LargePageOneEntry)
       static constexpr std::size_t Size = NumElements * sizeof(int);
       options.SetMaxUnzippedClusterSize(Size);
       options.SetApproxZippedClusterSize(Size);
-      options.SetApproxUnzippedPageSize(Size);
+      options.SetMaxUnzippedPageSize(Size);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
       for (int i = 0; i < NumElements; i++) {

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -34,6 +34,7 @@ TEST(RPageStorage, ReadSealedPages)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetMaxUnzippedPageSize(4096);
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
       writer->Fill();
       writer->CommitCluster();

--- a/tree/ntuple/v7/test/ntuple_model.py
+++ b/tree/ntuple/v7/test/ntuple_model.py
@@ -29,12 +29,14 @@ class NTupleModel(unittest.TestCase):
         model.MakeField["std::vector<std::vector<float>>"]("f")
 
         options = RNTupleWriteOptions()
-        PageSize = 1234
+        InitialNElementsPerPage = 1
+        MaxPageSize = 100
         ClusterSize = 6789
-        options.SetApproxUnzippedPageSize(PageSize)
+        options.SetInitialNElementsPerPage(InitialNElementsPerPage)
+        options.SetMaxUnzippedPageSize(MaxPageSize)
         options.SetApproxZippedClusterSize(ClusterSize)
 
-        Expected = 4 * 3 * PageSize * 2 + 3 * ClusterSize
+        Expected = 4 * MaxPageSize + (4 + 8 + 8 + 4) + 3 * ClusterSize
         self.assertEqual(model.EstimateWriteMemoryUsage(options), Expected)
 
 

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -30,7 +30,7 @@ public:
    } fCounters{};
 
 protected:
-   ColumnHandle_t AddColumn(ROOT::Experimental::DescriptorId_t, const ROOT::Experimental::Internal::RColumn &) final
+   ColumnHandle_t AddColumn(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::Internal::RColumn &) final
    {
       return {};
    }

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -62,7 +62,7 @@ TEST(RNTuple, BulkView)
    auto eltsPerPage = 10'000;
    {
       RNTupleWriteOptions opt;
-      opt.SetApproxUnzippedPageSize(eltsPerPage * sizeof(float));
+      opt.SetMaxUnzippedPageSize(eltsPerPage * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple",
          fileGuard.GetPath(), opt);
       for (int i = 0; i < 100'000; i++) {
@@ -101,7 +101,7 @@ TEST(RNTuple, BulkCollectionView)
    auto pageSize = 80 * 1024;
    {
       RNTupleWriteOptions opt;
-      opt.SetApproxUnzippedPageSize(pageSize);
+      opt.SetMaxUnzippedPageSize(pageSize);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple",
          fileGuard.GetPath(), opt);
       for (int i = 0; i < 100'000; i++) {

--- a/tree/ntuple/v7/test/rfield_string.cxx
+++ b/tree/ntuple/v7/test/rfield_string.cxx
@@ -4,7 +4,7 @@
 TEST(RNTuple, ReadString)
 {
    const std::string_view ntupleName = "rs";
-   constexpr int numEntries = 25000;
+   constexpr int numEntries = 250000;
    const std::string contentString = "foooooo";
 
    FileRaii fileGuard("test_ntuple_readstring.root");

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -534,7 +534,8 @@ TEST(RNTupleInspector, PageSizeDistribution)
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
-      writeOptions.SetApproxUnzippedPageSize(64);
+      writeOptions.SetInitialNElementsPerPage(1);
+      writeOptions.SetMaxUnzippedPageSize(64);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
       for (unsigned i = 0; i < 100; ++i) {


### PR DESCRIPTION
Moves from fixed page sizes on write to adaptive page sizes, following the original idea of @hahnjo 

The new mechanism is explained in the tuning.md document in the PR.

The PR also bumps the target compressed cluster size to 150MB. We may want to reduce that still. Evaluation of the new method is currently ongoing and the PR description will be amended with the results.

EDIT: [Comparison](https://docs.google.com/spreadsheets/d/1maJhgvgVU8RkX7QXd7B3QiTBfKuYbTbvgkoHzBUOurY/edit?usp=sharing) of current write performance vs adaptive page sizes with 50MB, 100MB, 150MB target cluster size. To me it seems that there is not a good argument to go to 150 MB clusters. There may be an argument for 100 MB clusters. For the moment, I'll remove the commit that changes the default settings from the PR.

An additional flavor, `adaptive / exp`, is included in the table to test the effect of flushing _foreign columns_. In the experimental mode, columns only flush themselves, which simplifies the `RWritePageMemoryManager` and avoids the upcall from the sink to the column. There is a small positive effect of foreign flushes on the file size in the nanoAOD sample. The effect is more visible for the number of pages. The memory consumption is slightly smaller without foreign column flushes.

I'll see if I can construct an example that shows better the advantage of foreign column flushes (or not).

As expected, the memory savings become visible for large EDMs (e.g., nanoAOD in this set of samples).



