### PR TITLE
[RF] RooDataHist arraySize getter

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -212,6 +212,7 @@ public:
 
   std::vector<std::unique_ptr<const RooAbsBinning>> const& getBinnings() const { return _lvbins; }
 
+  int arraySize()   const { return _arrSize; }  
   double const* weightArray()   const { return _wgt; }
   double const* wgtErrLoArray() const { return _errLo; }
   double const* wgtErrHiArray() const { return _errHi; }


### PR DESCRIPTION
# This Pull request:

Add a getter for the "arraySize" memeber function RooDataHist.
The weightArray getters are way more useful when actually being able to loop over the list.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

