### PR TITLE
[cling] Fix lifetime of `ClingMMapper` [v6.30]

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -33,6 +33,7 @@ class CompilerInstance;
 
 namespace cling {
 
+class ClingMMapper;
 class IncrementalExecutor;
 class Transaction;
 
@@ -59,6 +60,7 @@ public:
                  const clang::CompilerInstance &CI,
                  std::unique_ptr<llvm::orc::ExecutorProcessControl> EPC,
                  llvm::Error &Err, void *ExtraLibHandle, bool Verbose);
+  ~IncrementalJIT();
 
   /// Register a DefinitionGenerator to dynamically provide symbols for
   /// generated code that are not already available within the process.
@@ -102,6 +104,7 @@ public:
   llvm::TargetMachine &getTargetMachine() { return *m_TM; }
 
 private:
+  std::unique_ptr<ClingMMapper> m_MMapper;
   std::unique_ptr<llvm::orc::LLJIT> Jit;
   llvm::orc::SymbolMap m_InjectedSymbols;
   SharedAtomicFlag SkipHostProcessLookup;


### PR DESCRIPTION
The `ClingMMapper` must remain available until all `ClingMemoryManager`s are destructed, which is typically during shutdown of `IncrementalJIT`. This was not the case for the global object `MMapperInstance` that was introduced during the upgrade to LLVM 13 because `libCling` variables are destructed before running `TROOT` `atexit` handlers that shut down the JIT. In practice, it happened to work but this will change with the upgrade to LLVM 18 where we see crashes in some tests, potentially because of upstream commit https://github.com/llvm/llvm-project/commit/47f5c54f997a59bb2c65abe6b8b811f6e7553456

See also commits e0f6c04660 ("Prevent static destruction from ending DefaultMMapper too early") and 80c14bb948 ("Extend lifetime of SectionMemoryManager::DefaultMMapper, again") for the same problem that we previously patched in our copy of LLVM.

This differs from commit fd97311519a5d64f0110686db46e0d912503751c in master because LLVM doesn't support passing move-only lambdas.

---

This aims to backport https://github.com/root-project/root/pull/16314, but it's a bit more complicated with LLVM 13. We need to decide if we want this or just leave v6.30 and v6.28 alone.