### PR TITLE
[cmake] Introduce the needs_network flag for tests

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -63,6 +63,9 @@ function(ROOT_ADD_TUTORIAL macrofile rc)
                 PASSRC ${rc} FAILREGEX "Error in" "error:" "warning: Failed to call" LABELS tutorial)
 endfunction()
 
+#---Tutorials that need substantial network to work------------------
+set(need_network dataframe/df027_SQliteDependencyOverVersion.C)
+
 #---Tutorials disabled depending on the build components-------------
 
 if(NOT clad)
@@ -645,6 +648,9 @@ foreach(t ${tutorials})
     unset(createThreadPool)
   endif()
 
+  if(${t} IN_LIST need_network)
+    list(APPEND labels needs_network)
+  endif()
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
    if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)


### PR DESCRIPTION
and assign it to the dataframe/df027_SQliteDependencyOverVersion.C, as a start.

## Checklist:

- [v] tested changes locally
- [v] updated the docs (if necessary)

This PR fixes
- [ROOT-9705](https://its.cern.ch/jira/browse/ROOT-9705)
- [ROOT-10539](https://its.cern.ch/jira/browse/ROOT-10539)

