### PR TITLE
[ntuple] Add support for `std::(unordered)_multiset`

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -943,7 +943,7 @@ This is called sparse representation.
 The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
 In this second case, a default-constructed `T` (or, if applicable, a `T` constructed by the ROOT I/O constructor) is stored on disk for the non-existing instances.
 
-#### std::set\<T\>, std::unordered_set\<T\>, std::multiset\<T\>
+#### std::set\<T\>, std::unordered_set\<T\>, std::multiset\<T\>, std::unordered_multiset\<T\>
 
 While STL (unordered) (multi)sets by definition are associative containers (i.e., elements are referenced by their keys,
 which in the case for sets are equal to the values), on disk they are represented as indexed collections.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -943,9 +943,10 @@ This is called sparse representation.
 The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
 In this second case, a default-constructed `T` (or, if applicable, a `T` constructed by the ROOT I/O constructor) is stored on disk for the non-existing instances.
 
-#### std::set\<T\> and std::unordered_set\<T\>
+#### std::set\<T\>, std::unordered_set\<T\>, std::multiset\<T\>
 
-While STL (unordered) sets by definition are associative containers (i.e., elements are referenced by their keys, which in the case for sets are equal to the values), on disk they are represented as indexed collections.
+While STL (unordered) (multi)sets by definition are associative containers (i.e., elements are referenced by their keys,
+which in the case for sets are equal to the values), on disk they are represented as indexed collections.
 This means that they have the same on-disk representation as `std::vector<T>`, using two fields:
   - Collection parent field whose principal column is of type `(Split)Index[64|32]`.
   - Child field of type `T`, which must by a type with RNTuple I/O support.

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -356,7 +356,7 @@ public:
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Template specializations for C++ std::[unordered_]set
+/// Template specializations for C++ std::[unordered_][multi]set
 ////////////////////////////////////////////////////////////////////////////////
 
 /// The generic field for a std::set<Type> and std::unordered_set<Type>
@@ -403,6 +403,26 @@ protected:
 
 public:
    static std::string TypeName() { return "std::unordered_set<" + RField<ItemT>::TypeName() + ">"; }
+
+   explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
+};
+
+template <typename ItemT>
+class RField<std::multiset<ItemT>> : public RSetField {
+   using ContainerT = typename std::multiset<ItemT>;
+
+protected:
+   void ConstructValue(void *where) const final { new (where) ContainerT(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
+
+public:
+   static std::string TypeName() { return "std::multiset<" + RField<ItemT>::TypeName() + ">"; }
 
    explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -433,6 +433,26 @@ public:
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
+template <typename ItemT>
+class RField<std::unordered_multiset<ItemT>> : public RSetField {
+   using ContainerT = typename std::unordered_multiset<ItemT>;
+
+protected:
+   void ConstructValue(void *where) const final { new (where) ContainerT(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
+
+public:
+   static std::string TypeName() { return "std::unordered_multiset<" + RField<ItemT>::TypeName() + ">"; }
+
+   explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
+};
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -186,6 +186,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 14) == "unordered_set<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 9) == "multiset<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 4) == "map<")
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 14) == "unordered_map<")
@@ -766,6 +768,12 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       auto normalizedInnerTypeName = itemField->GetTypeName();
       result = std::make_unique<RSetField>(fieldName, "std::unordered_set<" + normalizedInnerTypeName + ">",
                                            std::move(itemField));
+   } else if (canonicalType.substr(0, 14) == "std::multiset<") {
+      std::string itemTypeName = canonicalType.substr(14, canonicalType.length() - 15);
+      auto itemField = Create("_0", itemTypeName).Unwrap();
+      auto normalizedInnerTypeName = itemField->GetTypeName();
+      result =
+         std::make_unique<RSetField>(fieldName, "std::multiset<" + normalizedInnerTypeName + ">", std::move(itemField));
    } else if (canonicalType.substr(0, 9) == "std::map<") {
       auto innerTypes = TokenizeTypeList(canonicalType.substr(9, canonicalType.length() - 10));
       if (innerTypes.size() != 2) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -188,6 +188,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 9) == "multiset<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 19) == "unordered_multiset<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 4) == "map<")
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 14) == "unordered_map<")
@@ -774,6 +776,12 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       auto normalizedInnerTypeName = itemField->GetTypeName();
       result =
          std::make_unique<RSetField>(fieldName, "std::multiset<" + normalizedInnerTypeName + ">", std::move(itemField));
+   } else if (canonicalType.substr(0, 24) == "std::unordered_multiset<") {
+      std::string itemTypeName = canonicalType.substr(24, canonicalType.length() - 25);
+      auto itemField = Create("_0", itemTypeName).Unwrap();
+      auto normalizedInnerTypeName = itemField->GetTypeName();
+      result = std::make_unique<RSetField>(fieldName, "std::unordered_multiset<" + normalizedInnerTypeName + ">",
+                                           std::move(itemField));
    } else if (canonicalType.substr(0, 9) == "std::map<") {
       auto innerTypes = TokenizeTypeList(canonicalType.substr(9, canonicalType.length() - 10));
       if (innerTypes.size() != 2) {

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -14,6 +14,10 @@
 #pragma link C++ class std::unordered_set<CustomStruct>+;
 #pragma link C++ class std::unordered_set<std::vector<bool>>+;
 
+#pragma link C++ class std::multiset<std::int64_t>+;
+#pragma link C++ class std::multiset<float>+;
+#pragma link C++ class std::multiset<CustomStruct>+;
+
 #pragma link C++ class std::map<char, long>+;
 #pragma link C++ class std::map<char, std::int64_t>+;
 #pragma link C++ class std::map<int, std::string>+;

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -18,6 +18,10 @@
 #pragma link C++ class std::multiset<float>+;
 #pragma link C++ class std::multiset<CustomStruct>+;
 
+#pragma link C++ class std::unordered_multiset<std::int64_t>+;
+#pragma link C++ class std::unordered_multiset<float>+;
+#pragma link C++ class std::unordered_multiset<CustomStruct>+;
+
 #pragma link C++ class std::map<char, long>+;
 #pragma link C++ class std::map<char, std::int64_t>+;
 #pragma link C++ class std::map<int, std::string>+;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -542,6 +542,53 @@ TEST(RNTuple, StdMultiSet)
    }
 }
 
+TEST(RNTuple, StdUnorderedMultiSet)
+{
+   auto field = RField<std::unordered_multiset<int64_t>>("setField");
+   EXPECT_STREQ("std::unordered_multiset<std::int64_t>", field.GetTypeName().c_str());
+   auto otherField = RFieldBase::Create("test", "std::unordered_multiset<int64_t>").Unwrap();
+   EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
+   EXPECT_EQ((sizeof(std::unordered_multiset<int64_t>)), field.GetValueSize());
+   EXPECT_EQ((sizeof(std::unordered_multiset<int64_t>)), otherField->GetValueSize());
+   EXPECT_EQ((alignof(std::unordered_multiset<int64_t>)), field.GetAlignment());
+   // For type-erased set fields, we use `alignof(std::set<std::max_align_t>)` to set the alignment,
+   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_multiset<int64_t>)), otherField->GetAlignment());
+
+   FileRaii fileGuard("test_ntuple_rfield_stdmultiset.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto set_field = model->MakeField<std::unordered_multiset<float>>({"mySet", "multi float set"});
+      auto mySet2 = RFieldBase::Create("mySet2", "std::unordered_multiset<CustomStruct>").Unwrap();
+
+      model->AddField(std::move(mySet2));
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "set_ntuple", fileGuard.GetPath());
+      auto set_field2 = ntuple->GetModel().GetDefaultEntry().GetPtr<std::unordered_multiset<CustomStruct>>("mySet2");
+      for (int i = 0; i < 2; i++) {
+         *set_field = {static_cast<float>(i), static_cast<float>(i), 3.14, 0.42};
+         *set_field2 = {CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"},
+                        CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"},
+                        CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"}};
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("set_ntuple", fileGuard.GetPath());
+   EXPECT_EQ(2, ntuple->GetNEntries());
+
+   auto viewSet = ntuple->GetView<std::unordered_multiset<float>>("mySet");
+   auto viewSet2 = ntuple->GetView<std::unordered_multiset<CustomStruct>>("mySet2");
+   for (auto i : ntuple->GetEntryRange()) {
+      EXPECT_EQ(std::unordered_multiset<float>({static_cast<float>(i), static_cast<float>(i), 3.14, 0.42}), viewSet(i));
+
+      auto customStructSet = std::unordered_multiset<CustomStruct>(
+         {CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"},
+          CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"}});
+      EXPECT_EQ(customStructSet, viewSet2(i));
+   }
+}
+
 TEST(RNTuple, StdMap)
 {
    auto field = RField<std::map<char, int64_t>>("mapField");


### PR DESCRIPTION
This PR adds support for `std::multiset` and `std::unordered_multiset` fields. The on-disk representation is exactly the same as `std::(unordered)_set`, so the only addition is the type name resolution for type-erased fields and the `RField` template specializations.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)