### PR TITLE
[ntuple] Add support for `std::(unordered)_multimap` fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -951,9 +951,9 @@ This means that they have the same on-disk representation as `std::vector<T>`, u
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
-#### std::map\<K, V\> and std::unordered_map\<K, V\>
+#### std::map\<K, V\>, std::unordered_map\<K, V\>, std::multimap\<K, V\>
 
-An (unordered) map is stored using a collection parent field,
+An (unordered) (multi)map is stored using a collection parent field,
 whose principal column is of type `(Split)Index[64|32]` and a child field of type `std::pair<K, V>` named `_0`.
 
 ### std::atomic\<T\>

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -951,7 +951,7 @@ This means that they have the same on-disk representation as `std::vector<T>`, u
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
-#### std::map\<K, V\>, std::unordered_map\<K, V\>, std::multimap\<K, V\>
+#### std::map\<K, V\>, std::unordered_map\<K, V\>, std::multimap\<K, V\>, std::unordered_multimap\<K, V\>
 
 An (unordered) (multi)map is stored using a collection parent field,
 whose principal column is of type `(Split)Index[64|32]` and a child field of type `std::pair<K, V>` named `_0`.

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -278,7 +278,7 @@ public:
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Template specializations for C++ std::[unordered_]map
+/// Template specializations for C++ std::[unordered_][multi]map
 ////////////////////////////////////////////////////////////////////////////////
 
 /// The generic field for a std::map<KeyType, ValueType> and std::unordered_map<KeyType, ValueType>
@@ -341,6 +341,32 @@ public:
    static std::string TypeName()
    {
       return "std::unordered_map<" + RField<KeyT>::TypeName() + "," + RField<ValueT>::TypeName() + ">";
+   }
+
+   explicit RField(std::string_view name)
+      : RMapField(name, TypeName(), std::make_unique<RField<std::pair<KeyT, ValueT>>>("_0"))
+   {
+   }
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
+};
+
+template <typename KeyT, typename ValueT>
+class RField<std::multimap<KeyT, ValueT>> final : public RMapField {
+   using ContainerT = typename std::multimap<KeyT, ValueT>;
+
+protected:
+   void ConstructValue(void *where) const final { new (where) ContainerT(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
+
+public:
+   static std::string TypeName()
+   {
+      return "std::multimap<" + RField<KeyT>::TypeName() + "," + RField<ValueT>::TypeName() + ">";
    }
 
    explicit RField(std::string_view name)

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -381,6 +381,32 @@ public:
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
+template <typename KeyT, typename ValueT>
+class RField<std::unordered_multimap<KeyT, ValueT>> final : public RMapField {
+   using ContainerT = typename std::unordered_multimap<KeyT, ValueT>;
+
+protected:
+   void ConstructValue(void *where) const final { new (where) ContainerT(); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
+
+public:
+   static std::string TypeName()
+   {
+      return "std::unordered_multimap<" + RField<KeyT>::TypeName() + "," + RField<ValueT>::TypeName() + ">";
+   }
+
+   explicit RField(std::string_view name)
+      : RMapField(name, TypeName(), std::make_unique<RField<std::pair<KeyT, ValueT>>>("_0"))
+   {
+   }
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Template specializations for C++ std::[unordered_]set
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -190,6 +190,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 14) == "unordered_map<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 9) == "multimap<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
 
@@ -794,6 +796,20 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
 
       result = std::make_unique<RMapField>(fieldName, "std::unordered_map<" + keyTypeName + "," + valueTypeName + ">",
+                                           std::move(itemField));
+   } else if (canonicalType.substr(0, 14) == "std::multimap<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(14, canonicalType.length() - 15));
+      if (innerTypes.size() != 2)
+         return R__FORWARD_RESULT(fnFail("the type list for std::multimap must have exactly two elements"));
+
+      auto itemField = Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">").Unwrap();
+
+      // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
+      // the inner type names are properly normalized.
+      auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
+      auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+
+      result = std::make_unique<RMapField>(fieldName, "std::multimap<" + keyTypeName + "," + valueTypeName + ">",
                                            std::move(itemField));
    } else if (canonicalType.substr(0, 12) == "std::atomic<") {
       std::string itemTypeName = canonicalType.substr(12, canonicalType.length() - 13);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -192,6 +192,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 9) == "multimap<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 19) == "unordered_multimap<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
 
@@ -811,6 +813,20 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
       result = std::make_unique<RMapField>(fieldName, "std::multimap<" + keyTypeName + "," + valueTypeName + ">",
                                            std::move(itemField));
+   } else if (canonicalType.substr(0, 24) == "std::unordered_multimap<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(24, canonicalType.length() - 25));
+      if (innerTypes.size() != 2)
+         return R__FORWARD_RESULT(fnFail("the type list for std::unordered_multimap must have exactly two elements"));
+
+      auto itemField = Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">").Unwrap();
+
+      // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
+      // the inner type names are properly normalized.
+      auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
+      auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+
+      result = std::make_unique<RMapField>(
+         fieldName, "std::unordered_multimap<" + keyTypeName + "," + valueTypeName + ">", std::move(itemField));
    } else if (canonicalType.substr(0, 12) == "std::atomic<") {
       std::string itemTypeName = canonicalType.substr(12, canonicalType.length() - 13);
       auto itemField = Create("_0", itemTypeName).Unwrap();

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -32,4 +32,8 @@
 #pragma link C++ class std::multimap<std::string, float>+;
 #pragma link C++ class std::multimap<int, CustomStruct>+;
 
+#pragma link C++ class std::unordered_multimap<char, std::int64_t>+;
+#pragma link C++ class std::unordered_multimap<std::string, float>+;
+#pragma link C++ class std::unordered_multimap<int, CustomStruct>+;
+
 #endif

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -28,4 +28,8 @@
 #pragma link C++ class std::unordered_map<int, CustomStruct>+;
 #pragma link C++ class std::unordered_map<float, std::vector<bool>>+;
 
+#pragma link C++ class std::multimap<char, std::int64_t>+;
+#pragma link C++ class std::multimap<std::string, float>+;
+#pragma link C++ class std::multimap<int, CustomStruct>+;
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -679,6 +679,64 @@ TEST(RNTuple, StdUnorderedMap)
    EXPECT_EQ(customStructMap, *myMap2);
 }
 
+TEST(RNTuple, StdMultiMap)
+{
+   auto field = RField<std::multimap<char, int64_t>>("mapField");
+   EXPECT_STREQ("std::multimap<char,std::int64_t>", field.GetTypeName().c_str());
+   auto otherField = RFieldBase::Create("test", "std::multimap<char, int64_t>").Unwrap();
+   EXPECT_STREQ(field.GetTypeName().c_str(), otherField->GetTypeName().c_str());
+   EXPECT_EQ((sizeof(std::multimap<char, int64_t>)), field.GetValueSize());
+   EXPECT_EQ((sizeof(std::multimap<char, int64_t>)), otherField->GetValueSize());
+   EXPECT_EQ((alignof(std::multimap<char, int64_t>)), field.GetAlignment());
+   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
+   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::multimap<char, int64_t>)), otherField->GetAlignment());
+   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
+   // test should fail.
+   EXPECT_EQ((alignof(std::multimap<char, char>)), otherField->GetAlignment());
+
+   FileRaii fileGuard("test_ntuple_rfield_stdmultimap.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto map_field = model->MakeField<std::multimap<std::string, float>>({"myMap", "string to float multimap"});
+
+      auto myMap2 = RFieldBase::Create("myMap2", "std::multimap<int, CustomStruct>").Unwrap();
+
+      model->AddField(std::move(myMap2));
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "map_ntuple", fileGuard.GetPath());
+      auto map_field2 = ntuple->GetModel().GetDefaultEntry().GetPtr<std::multimap<int, CustomStruct>>("myMap2");
+      for (int i = 0; i < 2; i++) {
+         *map_field = {{"foo", static_cast<float>(i + 0.1)},
+                       {"bar", static_cast<float>(i * 0.2)},
+                       {"bar", static_cast<float>(i * 0.2)},
+                       {"baz", static_cast<float>(i * 0.3)}};
+         *map_field2 = {{i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                        {i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                        {i + 1, CustomStruct{3.f, {4.f, 5.f}, {{1.f}, {2.f}}, "baz"}}};
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("map_ntuple", fileGuard.GetPath());
+   EXPECT_EQ(2, ntuple->GetNEntries());
+
+   auto viewMap = ntuple->GetView<std::multimap<std::string, float>>("myMap");
+   auto viewMap2 = ntuple->GetView<std::multimap<int, CustomStruct>>("myMap2");
+   for (auto i : ntuple->GetEntryRange()) {
+      std::multimap<std::string, float> map1{{"foo", static_cast<float>(i + 0.1)},
+                                             {"bar", static_cast<float>(i * 0.2)},
+                                             {"bar", static_cast<float>(i * 0.2)},
+                                             {"baz", static_cast<float>(i * 0.3)}};
+      EXPECT_EQ(map1, viewMap(i));
+
+      std::multimap<int, CustomStruct> map2{{i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                                            {i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                                            {i + 1, CustomStruct{3.f, {4.f, 5.f}, {{1.f}, {2.f}}, "baz"}}};
+      EXPECT_EQ(map2, viewMap2(i));
+   }
+}
+
 TEST(RNTuple, Int64)
 {
    {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -737,6 +737,66 @@ TEST(RNTuple, StdMultiMap)
    }
 }
 
+TEST(RNTuple, StdUnorderedMultiMap)
+{
+   auto field = RField<std::unordered_multimap<char, int64_t>>("mapField");
+   EXPECT_STREQ("std::unordered_multimap<char,std::int64_t>", field.GetTypeName().c_str());
+   auto otherField = RFieldBase::Create("test", "std::unordered_multimap<char, int64_t>").Unwrap();
+   EXPECT_STREQ(field.GetTypeName().c_str(), otherField->GetTypeName().c_str());
+   EXPECT_EQ((sizeof(std::unordered_multimap<char, int64_t>)), field.GetValueSize());
+   EXPECT_EQ((sizeof(std::unordered_multimap<char, int64_t>)), otherField->GetValueSize());
+   EXPECT_EQ((alignof(std::unordered_multimap<char, int64_t>)), field.GetAlignment());
+   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
+   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_multimap<char, int64_t>)), otherField->GetAlignment());
+   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
+   // test should fail.
+   EXPECT_EQ((alignof(std::unordered_multimap<char, char>)), otherField->GetAlignment());
+
+   FileRaii fileGuard("test_ntuple_rfield_stdmultimap.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto map_field =
+         model->MakeField<std::unordered_multimap<std::string, float>>({"myMap", "string to float unordered_multimap"});
+
+      auto myMap2 = RFieldBase::Create("myMap2", "std::unordered_multimap<int, CustomStruct>").Unwrap();
+
+      model->AddField(std::move(myMap2));
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "map_ntuple", fileGuard.GetPath());
+      auto map_field2 =
+         ntuple->GetModel().GetDefaultEntry().GetPtr<std::unordered_multimap<int, CustomStruct>>("myMap2");
+      for (int i = 0; i < 2; i++) {
+         *map_field = {{"foo", static_cast<float>(i + 0.1)},
+                       {"bar", static_cast<float>(i * 0.2)},
+                       {"bar", static_cast<float>(i * 0.2)},
+                       {"baz", static_cast<float>(i * 0.3)}};
+         *map_field2 = {{i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                        {i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                        {i + 1, CustomStruct{3.f, {4.f, 5.f}, {{1.f}, {2.f}}, "baz"}}};
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("map_ntuple", fileGuard.GetPath());
+   EXPECT_EQ(2, ntuple->GetNEntries());
+
+   auto viewMap = ntuple->GetView<std::unordered_multimap<std::string, float>>("myMap");
+   auto viewMap2 = ntuple->GetView<std::unordered_multimap<int, CustomStruct>>("myMap2");
+   for (auto i : ntuple->GetEntryRange()) {
+      std::unordered_multimap<std::string, float> map1{{"foo", static_cast<float>(i + 0.1)},
+                                                       {"bar", static_cast<float>(i * 0.2)},
+                                                       {"bar", static_cast<float>(i * 0.2)},
+                                                       {"baz", static_cast<float>(i * 0.3)}};
+      EXPECT_EQ(map1, viewMap(i));
+
+      std::unordered_multimap<int, CustomStruct> map2{{i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                                                      {i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}},
+                                                      {i + 1, CustomStruct{3.f, {4.f, 5.f}, {{1.f}, {2.f}}, "baz"}}};
+      EXPECT_EQ(map2, viewMap2(i));
+   }
+}
+
 TEST(RNTuple, Int64)
 {
    {


### PR DESCRIPTION
This PR adds support for `std::multimap` and `std::unordered_multimap` fields. The on-disk representation is exactly the same as `std::(unordered)_map`, so the only addition is the type name resolution for type-erased fields and the `RField` template specializations.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
