### PR TITLE
[ntuple] Add support for "large locators", drop string locator

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -233,7 +233,7 @@ In this case, the locator should be interpreted like a frame, i.e. size indicate
 _Offset_:
 For on-disk / in-file locators, the 64bit byte offset of the referenced byte range counted from the start of the file.
 
-For non-disk locators, i.e. `T` == 1, the locator format is as follows
+For non-standard locators, i.e. `T` == 1, the locator format is as follows
 
 ```
  0                   1                   2                   3
@@ -266,10 +266,10 @@ followed by a locator.
 
 ### Well-known Payload Formats
 
-This section describes the well-known payload formats used in non-disk locators.
+This section describes the well-known payload formats used in non-standard locators.
 Note that locators having a different value for _Type_ may share a given payload format (see the table above).
 
-- _Large_: Like the standard on-disk locator but with a 64bit offset
+- _Large_: Like the standard on-disk locator but with a 64bit size
 ```
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -208,7 +208,7 @@ struct RNTupleLocator {
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
    std::variant<std::uint64_t, std::string, RNTupleLocatorObject64> fPosition{};
-   std::uint32_t fBytesOnStorage = 0;
+   std::uint64_t fBytesOnStorage = 0;
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.
    ELocatorType fType = kTypeFile;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -204,10 +204,10 @@ struct RNTupleLocator {
       kTypePageZero = kLastSerializableType + 1,
    };
 
+   std::uint64_t fBytesOnStorage = 0;
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
-   std::variant<std::uint64_t, std::string, RNTupleLocatorObject64> fPosition{};
-   std::uint64_t fBytesOnStorage = 0;
+   std::variant<std::uint64_t, RNTupleLocatorObject64> fPosition{};
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.
    ELocatorType fType = kTypeFile;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -197,6 +197,8 @@ struct RNTupleLocator {
    /// Values for the _Type_ field in non-disk locators.  Serializable types must have the MSb == 0; see
    /// `doc/specifications.md` for details
    enum ELocatorType : std::uint8_t {
+      // The kTypeFile locator may translate to an on-disk standard locator (type 0x00) or a large locator (type 0x01),
+      // if the size of the referenced data block is >2GB
       kTypeFile = 0x00,
       kTypeDAOS = 0x02,
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -198,7 +198,6 @@ struct RNTupleLocator {
    /// `doc/specifications.md` for details
    enum ELocatorType : std::uint8_t {
       kTypeFile = 0x00,
-      kTypeURI = 0x01,
       kTypeDAOS = 0x02,
 
       kLastSerializableType = 0x7f,

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -119,7 +119,10 @@ public:
 
    ColumnId_t GetColumnId() const { return fColumnId; }
    /// The space taken by column elements in the buffer
-   std::uint32_t GetNBytes() const { return fElementSize * fNElements; }
+   std::size_t GetNBytes() const
+   {
+      return static_cast<std::size_t>(fElementSize) * static_cast<std::size_t>(fNElements);
+   }
    std::uint32_t GetElementSize() const { return fElementSize; }
    std::uint32_t GetNElements() const { return fNElements; }
    std::uint32_t GetMaxElements() const { return fMaxElements; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -89,13 +89,13 @@ public:
    struct RSealedPage {
    private:
       const void *fBuffer = nullptr;
-      std::uint32_t fBufferSize = 0; ///< Size of the page payload and the trailing checksum (if available)
+      std::size_t fBufferSize = 0; ///< Size of the page payload and the trailing checksum (if available)
       std::uint32_t fNElements = 0;
       bool fHasChecksum = false; ///< If set, the last 8 bytes of the buffer are the xxhash of the rest of the buffer
 
    public:
       RSealedPage() = default;
-      RSealedPage(const void *buffer, std::uint32_t bufferSize, std::uint32_t nElements, bool hasChecksum = false)
+      RSealedPage(const void *buffer, std::size_t bufferSize, std::uint32_t nElements, bool hasChecksum = false)
          : fBuffer(buffer), fBufferSize(bufferSize), fNElements(nElements), fHasChecksum(hasChecksum)
       {
       }
@@ -107,13 +107,13 @@ public:
       const void *GetBuffer() const { return fBuffer; }
       void SetBuffer(const void *buffer) { fBuffer = buffer; }
 
-      std::uint32_t GetDataSize() const
+      std::size_t GetDataSize() const
       {
          assert(fBufferSize >= fHasChecksum * kNBytesPageChecksum);
          return fBufferSize - fHasChecksum * kNBytesPageChecksum;
       }
-      std::uint32_t GetBufferSize() const { return fBufferSize; }
-      void SetBufferSize(std::uint32_t bufferSize) { fBufferSize = bufferSize; }
+      std::size_t GetBufferSize() const { return fBufferSize; }
+      void SetBufferSize(std::size_t bufferSize) { fBufferSize = bufferSize; }
 
       std::uint32_t GetNElements() const { return fNElements; }
       void SetNElements(std::uint32_t nElements) { fNElements = nElements; }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -215,8 +215,8 @@ struct RTFKey {
    RTFKey(std::uint64_t seekKey, std::uint64_t seekPdir, const RTFString &clName, const RTFString &objName,
           const RTFString &titleName, std::size_t szObjInMem, std::size_t szObjOnDisk = 0)
    {
-      R__ASSERT(szObjInMem < std::numeric_limits<std::int32_t>::max());
-      R__ASSERT(szObjOnDisk < std::numeric_limits<std::int32_t>::max());
+      R__ASSERT(szObjInMem <= std::numeric_limits<std::uint32_t>::max());
+      R__ASSERT(szObjOnDisk <= std::numeric_limits<std::uint32_t>::max());
       fObjLen = szObjInMem;
       if ((seekKey > static_cast<unsigned int>(std::numeric_limits<std::int32_t>::max())) ||
           (seekPdir > static_cast<unsigned int>(std::numeric_limits<std::int32_t>::max()))) {
@@ -1209,6 +1209,10 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const v
 
    const std::uint64_t maxKeySize = fNTupleAnchor.fMaxKeySize;
    R__ASSERT(maxKeySize > 0);
+   // We don't need the object length except for seeing compression ratios in TFile::Map()
+   // Make sure that the on-disk object length fits into the TKey header.
+   if (static_cast<std::uint64_t>(len) > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()))
+      len = nbytes;
 
    if (nbytes <= maxKeySize) {
       // Fast path: only write 1 key.

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -414,7 +414,9 @@ std::uint32_t SerializeLocatorPayloadObject64(const ROOT::Experimental::RNTupleL
 void DeserializeLocatorPayloadObject64(const unsigned char *buffer, ROOT::Experimental::RNTupleLocator &locator)
 {
    auto &data = locator.fPosition.emplace<ROOT::Experimental::RNTupleLocatorObject64>();
-   RNTupleSerializer::DeserializeUInt32(buffer, locator.fBytesOnStorage);
+   std::uint32_t size;
+   RNTupleSerializer::DeserializeUInt32(buffer, size);
+   locator.fBytesOnStorage = size;
    RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint32_t), data.fLocation);
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -551,8 +551,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
 
    R__ASSERT(isAdoptedBuffer);
 
-   RSealedPage sealedPage{pageBuf, static_cast<std::uint32_t>(nBytesZipped + nBytesChecksum),
-                          config.fPage->GetNElements(), config.fWriteChecksum};
+   RSealedPage sealedPage{pageBuf, nBytesZipped + nBytesChecksum, config.fPage->GetNElements(), config.fWriteChecksum};
    sealedPage.ChecksumIfEnabled();
 
    return sealedPage;

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -370,28 +370,6 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(2u, locator.fBytesOnStorage);
    EXPECT_EQ(RNTupleLocator::kTypeFile, locator.fType);
 
-   locator.fPosition.emplace<std::string>("X");
-   locator.fType = RNTupleLocator::kTypeURI;
-   EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, nullptr));
-   EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, buffer));
-   locator = RNTupleLocator{};
-   try {
-      RNTupleSerializer::DeserializeLocator(buffer, 4, locator).Unwrap();
-      FAIL() << "too short locator buffer should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("too short"));
-   }
-   EXPECT_EQ(5u, RNTupleSerializer::DeserializeLocator(buffer, 5, locator).Unwrap());
-   EXPECT_EQ(0u, locator.fBytesOnStorage);
-   EXPECT_EQ(RNTupleLocator::kTypeURI, locator.fType);
-   EXPECT_EQ("X", locator.GetPosition<std::string>());
-
-   locator.fPosition.emplace<std::string>("abcdefghijkl");
-   EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
-   locator = RNTupleLocator{};
-   EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
-   EXPECT_EQ("abcdefghijkl", locator.GetPosition<std::string>());
-
    locator.fType = RNTupleLocator::kTypeDAOS;
    locator.fPosition.emplace<RNTupleLocatorObject64>(RNTupleLocatorObject64{1337U});
    locator.fBytesOnStorage = 420420U;


### PR DESCRIPTION
- Adds a locator type that can reference blocks >4GB on disk
- The new locator replaces the previously available but unused string locator
- Makes that DAOS locator support >4GB blocks
- Adds some fixes for pages >2GB