### PR TITLE
[RF] Improve `MarkovChain` interfaces and `MCMCInterval`

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -72,6 +72,7 @@ The following people have contributed to this new version:
 
 * The `RooAbsReal::plotSliceOn()` function that was deprecated since at least ROOT 6 was removed. Use `plotOn(frame,Slice(...))` instead.
 * The `RooTemplateProxy` constructors that take a `proxyOwnsArg` parameter to manually pass ownership are deprecated and replaced by a new constructor that takes ownership via `std::unique_ptr<T>`. They will be removed in ROOT 6.36.
+* The `RooStats::MarkovChain::GetAsDataSet` and `RooStats::MarkovChain::GetAsDataHist` functions are deprecated and will be removed in ROOT 6.36. The same functionality can be implemented by calling `RooAbsData::reduce` on the Markov Chain's `RooDataSet*` (obtained using `MarkovChain::GetAsConstDataSet`) and then obtaining it's binned clone(for `RooDataHist`).
 
 ## Core Libraries
 

--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -72,7 +72,19 @@ The following people have contributed to this new version:
 
 * The `RooAbsReal::plotSliceOn()` function that was deprecated since at least ROOT 6 was removed. Use `plotOn(frame,Slice(...))` instead.
 * The `RooTemplateProxy` constructors that take a `proxyOwnsArg` parameter to manually pass ownership are deprecated and replaced by a new constructor that takes ownership via `std::unique_ptr<T>`. They will be removed in ROOT 6.36.
-* The `RooStats::MarkovChain::GetAsDataSet` and `RooStats::MarkovChain::GetAsDataHist` functions are deprecated and will be removed in ROOT 6.36. The same functionality can be implemented by calling `RooAbsData::reduce` on the Markov Chain's `RooDataSet*` (obtained using `MarkovChain::GetAsConstDataSet`) and then obtaining it's binned clone(for `RooDataHist`).
+* The `RooStats::MarkovChain::GetAsDataSet` and `RooStats::MarkovChain::GetAsDataHist` functions are deprecated and will be removed in ROOT 6.36. The same functionality can be implemented by calling `RooAbsData::reduce` on the Markov Chain's `RooDataSet*` (obtained using `MarkovChain::GetAsConstDataSet`) and then obtaining its binned clone(for `RooDataHist`).
+
+  An example in Python would be:
+
+  ```py
+  mcInt = mc.GetInterval() # Obtain the MCMCInterval from a configured MCMCCalculator
+  mkc = mcInt.GetChain() # Obtain the MarkovChain
+  mkcData = mkc.GetAsConstDataSet()
+  mcIntParams = mcInt.GetParameters()
+
+  chainDataset = mkcData.reduce(SelectVars=mcIntParams, EventRange=(mcInt.GetNumBurnInSteps(), mkc.Size()))
+  chainDataHist = chainDataset.binnedClone()
+  ```
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -68,11 +68,11 @@ public:
 
   // Reduction methods
   RooFit::OwningPtr<RooAbsData> reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},const RooCmdArg& arg3={},const RooCmdArg& arg4={},
-                     const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
-  RooFit::OwningPtr<RooAbsData> reduce(const char* cut) ;
-  RooFit::OwningPtr<RooAbsData> reduce(const RooFormulaVar& cutVar) ;
-  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
-  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) ;
+                     const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) const;
+  RooFit::OwningPtr<RooAbsData> reduce(const char* cut) const;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooFormulaVar& cutVar) const;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const char* cut=nullptr) const;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) const;
 
   RooAbsDataStore* store() { return _dstore.get(); }
   const RooAbsDataStore* store() const { return _dstore.get(); }
@@ -340,7 +340,7 @@ protected:
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
 
   virtual std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
-                           std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max()) = 0 ;
+                           std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max()) const = 0 ;
 
   RooRealVar* dataRealVar(const char* methodname, const RooRealVar& extVar) const ;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -233,7 +233,7 @@ public:
 
   void initialize(const char* binningName=nullptr,bool fillTree=true) ;
   std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
-                  std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max()) override;
+                  std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max()) const override;
   double interpolateDim(int iDim, double xval, size_t centralIdx, int intOrder, bool correctForBinSize, bool cdfBoundaries) ;
   const std::vector<double>& calculatePartialBinVolume(const RooArgSet& dimSet) const ;
   void checkBinBounds() const;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -125,7 +125,7 @@ protected:
 
   // Cache copy feature is not publicly accessible
   std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
-                        std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
+                        std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) const override;
 
   RooArgSet _varsNoWgt;          ///< Vars without weight variable
   RooRealVar *_wgtVar = nullptr; ///< Pointer to weight variable (if set)

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -397,7 +397,7 @@ void RooAbsData::setDirtyProp(bool flag)
 /// </table>
 
 RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,const RooCmdArg& arg4,
-                const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8)
+                const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8) const
 {
   // Define configuration for this method
   RooCmdConfig pc("RooAbsData::reduce(" + std::string(GetName()) + ")");
@@ -469,7 +469,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooCmdArg& arg1,const Roo
 /// other variables, such as intermediate formula objects, use the equivalent
 /// reduce method specifying the as a RooFormulVar reference.
 
-RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const char* cut)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const char* cut) const
 {
   RooFormulaVar cutVar(cut,cut,*get()) ;
   auto ret = reduceEng(*get(),&cutVar,nullptr,0,std::numeric_limits<std::size_t>::max()) ;
@@ -482,7 +482,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const char* cut)
 /// The 'cutVar' formula variable is used to select the subset of data points to be
 /// retained in the reduced data collection.
 
-RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooFormulaVar& cutVar)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooFormulaVar& cutVar) const
 {
   auto ret = reduceEng(*get(),&cutVar,nullptr,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
@@ -497,7 +497,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooFormulaVar& cutVar)
 /// other variables, such as intermediate formula objects, use the equivalent
 /// reduce method specifying the as a RooFormulVar reference.
 
-RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const char* cut) const
 {
   // Make sure varSubset doesn't contain any variable not in this dataset
   RooArgSet varSubset2(varSubset) ;
@@ -527,7 +527,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, con
 /// The 'cutVar' formula variable is used to select the subset of data points to be
 /// retained in the reduced data collection.
 
-RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) const
 {
   // Make sure varSubset doesn't contain any variable not in this dataset
   RooArgSet varSubset2(varSubset) ;

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -914,7 +914,7 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
 std::unique_ptr<RooAbsData> RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,
-    std::size_t nStart, std::size_t nStop)
+    std::size_t nStart, std::size_t nStop) const
 {
   checkInit() ;
   RooArgSet myVarSubset;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -682,7 +682,7 @@ void RooDataSet::initialize(const char* wgtVarName)
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
 std::unique_ptr<RooAbsData> RooDataSet::reduceEng(const RooArgSet &varSubset, const RooFormulaVar *cutVar,
-                                                  const char *cutRange, std::size_t nStart, std::size_t nStop)
+                                                  const char *cutRange, std::size_t nStart, std::size_t nStop) const
 {
    checkInit();
    RooArgSet tmp(varSubset);

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -20,6 +20,9 @@
 #include "RooDataSet.h"
 #include "RooDataHist.h"
 #include "THnSparse.h"
+
+#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
+
 //#include "RooArgSet.h"
 //#include "RooMsgService.h"
 //#include "RooRealVar.h"
@@ -68,11 +71,13 @@ namespace RooStats {
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataSet.  You own the returned RooDataSet*
+      /// \deprecated Will be removed in ROOT 6.36.
       virtual RooFit::OwningPtr<RooDataSet> GetAsDataSet(const RooCmdArg& arg1,
                                        const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                        const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
                                        const RooCmdArg& arg8={} ) const;
+      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet)")
 
       virtual const RooDataSet* GetAsConstDataSet() const { return fChain; }
 
@@ -84,12 +89,14 @@ namespace RooStats {
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataHist.  You own the returned RooDataHist*
+      /// \deprecated Will be removed in ROOT 6.36.
       virtual RooFit::OwningPtr<RooDataHist> GetAsDataHist(const RooCmdArg & arg1,
                                          const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                          const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                          const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
                                          const RooCmdArg& arg8={} ) const;
-
+      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet) and then obtaining its binned clone.")
+      
       /// Get a clone of the markov chain on which this interval is based
       /// as a sparse histogram.  You own the returned THnSparse*
       virtual THnSparse* GetAsSparseHist(RooAbsCollection* whichVars = nullptr) const;

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -295,14 +295,14 @@ void MCMCInterval::CreateKeysPdf()
       fProduct = nullptr;
       return;
    }
+   
+   std::unique_ptr<RooAbsData> chain{fChain->GetAsConstDataSet()->reduce(SelectVars(fParameters), EventRange(fNumBurnInSteps, fChain->Size()))};
 
-   std::unique_ptr<RooDataSet> chain{fChain->GetAsDataSet(SelectVars(fParameters),
-         EventRange(fNumBurnInSteps, fChain->Size()))};
    RooArgList* paramsList = new RooArgList();
    for (Int_t i = 0; i < fDimension; i++)
       paramsList->add(*fAxes[i]);
 
-   fKeysPdf = new RooNDKeysPdf("keysPDF", "Keys PDF", *paramsList, *chain, "a");
+   fKeysPdf = new RooNDKeysPdf("keysPDF", "Keys PDF", *paramsList, static_cast<RooDataSet&>(*chain), "a");
    fCutoffVar = new RooRealVar("cutoff", "cutoff", 0);
    fHeaviside = new Heaviside("heaviside", "Heaviside", *fKeysPdf, *fCutoffVar);
    fProduct = new RooProduct("product", "Keys PDF & Heaviside Product",
@@ -449,8 +449,8 @@ void MCMCInterval::CreateDataHist()
       return;
    }
 
-   fDataHist = std::unique_ptr<RooDataHist>{fChain->GetAsDataHist(SelectVars(fParameters),
-         EventRange(fNumBurnInSteps, fChain->Size()))}.release();
+   std::unique_ptr<RooAbsData> data{fChain->GetAsConstDataSet()->reduce(SelectVars(fParameters), EventRange(fNumBurnInSteps, fChain->Size()))};
+   fDataHist = static_cast<RooDataSet &>(*data).binnedClone();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -139,6 +139,9 @@ RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(RooArgSet* whichVars) co
    return RooFit::makeOwningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
 }
 
+/// \deprecated Will be removed in ROOT 6.36. Please implement this functionality by calling RooAbsData::reduce on the Markov Chain's RooDataSet*
+/// (obtained using MarkovChain::GetAsConstDataSet)
+
 RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(const RooCmdArg &arg1, const RooCmdArg &arg2,
                                                         const RooCmdArg &arg3, const RooCmdArg &arg4,
                                                         const RooCmdArg &arg5, const RooCmdArg &arg6,
@@ -162,6 +165,9 @@ RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) 
    std::unique_ptr<RooAbsData> data{fChain->reduce(args)};
    return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
 }
+
+/// \deprecated Will be removed in ROOT 6.36. Please implement this functionality by calling RooAbsData::reduce on the Markov Chain's RooDataSet*
+/// (obtained using MarkovChain::GetAsConstDataSet), and then obtaining its binned clone.
 
 RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(const RooCmdArg &arg1, const RooCmdArg &arg2,
                                                           const RooCmdArg &arg3, const RooCmdArg &arg4,


### PR DESCRIPTION
Removes MarkovChain interfaces that are one-time used in `MCMCInterval`  

Now obtain the reduced markov chain data (also as Hist ) by calling `reduce` on the RooDataSet  (which can be directly accessed through  `MarkovChain::GetAsConstDataSet`).  

Updates all `reduce` and `reduceEng`methods to const across `RooAbsData` and other RooFit classes with overrides.