### PR TITLE
[RF] Deprecate HistFactory-internal fitting and plotting routine

### DIFF
--- a/README/ReleaseNotes/v634/index.md
+++ b/README/ReleaseNotes/v634/index.md
@@ -111,6 +111,7 @@ The [TUnfold package](https://www.desy.de/~sschmitt/tunfold.html) inside ROOT is
 
 * The function `RooFit::bindFunction()` now supports arbitrary many input variables when binding a Python function.
 
+* The `ExportOnly()` attribute of the `RooStats::HistFactory::Measurement` object is now switched on by default, and the associated getter and setter functions are deprecated. They will be removed in ROOT 6.36. If you want to fit the model as well instead of just exporting it to a RooWorkspace, please do so with your own code as demonstrated in the `hf001` tutorial.
 
 ## Graphics Backends
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
@@ -8,6 +8,8 @@
 #include "RooWorkspace.h"
 #include "RooPlot.h"
 
+#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -22,9 +24,18 @@ namespace RooStats{
             HistoToWorkspaceFactoryFast::Configuration const& cfg={}
     );
 
-    void FormatFrameForLikelihood(RooPlot* frame, std::string xTitle=std::string("#sigma / #sigma_{SM}"), std::string yTitle=std::string("-log likelihood"));
-    void FitModel(RooWorkspace *, std::string data_name="obsData");
-    void FitModelAndPlot(const std::string& measurementName, const std::string& fileNamePrefix, RooWorkspace &, std::string, std::string, TFile&, std::ostream&);
+    void FormatFrameForLikelihood(RooPlot* frame, std::string xTitle=std::string("#sigma / #sigma_{SM}"), std::string yTitle=std::string("-log likelihood"))
+#ifndef ROOFIT_BUILDS_ITSELF
+        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.")
+#endif
+        ;
+    void FitModel(RooWorkspace *, std::string data_name="obsData")
+        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.");
+    void FitModelAndPlot(const std::string& measurementName, const std::string& fileNamePrefix, RooWorkspace &, std::string, std::string, TFile&, std::ostream&)
+#ifndef ROOFIT_BUILDS_ITSELF
+        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.")
+#endif
+        ;
   }
 }
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -23,6 +23,8 @@
 #include "RooStats/HistFactory/Channel.h"
 #include "RooStats/HistFactory/Asimov.h"
 
+#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
+
 class TFile;
 
 namespace RooStats{
@@ -95,9 +97,21 @@ public:
   int GetBinLow() { return fBinLow; }
   int GetBinHigh() { return fBinHigh; }
 
-  /// do not produce any plots or tables, just save the model
-  void SetExportOnly( bool ExportOnly ) { fExportOnly = ExportOnly; }
-  bool GetExportOnly() { return fExportOnly; }
+  /// Do not produce any plots or tables, just save the model.
+  ///
+  /// \deprecated Will be removed in ROOT 6.36. ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.
+  void SetExportOnly( bool ExportOnly )
+#ifndef ROOFIT_BUILDS_ITSELF
+  R__DEPRECATED(6,36, "ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.")
+#endif
+  { fExportOnly = ExportOnly; }
+
+  /// \deprecated Will be removed in ROOT 6.36. ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.
+  bool GetExportOnly()
+#ifndef ROOFIT_BUILDS_ITSELF
+  R__DEPRECATED(6,36, "ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.")
+#endif
+  { return fExportOnly; }
 
   void PrintTree( std::ostream& = std::cout ); /// Print to a stream
   void PrintXML( std::string Directory="", std::string NewOutputPrefix="" );
@@ -140,7 +154,7 @@ private:
   double fLumiRelErr;
   int fBinLow;
   int fBinHigh;
-  bool fExportOnly;
+  bool fExportOnly = true;
   std::string fInterpolationScheme;
 
   /// Channels that make up this measurement

--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -353,7 +353,6 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
    measurement.SetLumiRelErr(.10);
    measurement.SetBinLow(0);
    measurement.SetBinHigh(1);
-   measurement.SetExportOnly(false);
 
    cxcoutIHF << "Creating new measurement:\n";
 

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -32,6 +32,7 @@
 #include <fstream>
 #include <sstream>
 
+static void formatFrameForLikelihoodImpl(RooPlot* frame, std::string YTitle);
 
 /** ********************************************************************************************
   \ingroup HistFactory
@@ -266,8 +267,9 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
   return RooFit::makeOwningPtr(std::move(ws));
 }
 
-
 ///////////////////////////////////////////////
+/// \deprecated Will be removed in ROOT 6.36. Please write your own plotting code inspired by the hf001 tutorial.
+
 void RooStats::HistFactory::FitModelAndPlot(const std::string &MeasurementName, const std::string &FileNamePrefix,
                                             RooWorkspace &combined, std::string channel, std::string data_name,
                                             TFile &outFile, std::ostream &tableStream)
@@ -407,6 +409,8 @@ void RooStats::HistFactory::FitModelAndPlot(const std::string &MeasurementName, 
 }
 
 
+/// \deprecated Will be removed in ROOT 6.36. Please write your own plotting code inspired by the hf001 tutorial.
+
 void RooStats::HistFactory::FitModel(RooWorkspace * combined, std::string data_name )
 {
    using namespace RooFit;
@@ -435,9 +439,7 @@ void RooStats::HistFactory::FitModel(RooWorkspace * combined, std::string data_n
 
   }
 
-
-void RooStats::HistFactory::FormatFrameForLikelihood(RooPlot* frame, std::string /*XTitle*/,
-                       std::string YTitle)
+void formatFrameForLikelihoodImpl(RooPlot* frame, std::string YTitle)
 {
    using namespace RooFit;
 
@@ -468,4 +470,12 @@ void RooStats::HistFactory::FormatFrameForLikelihood(RooPlot* frame, std::string
     frame->addObject(line);
     frame->addObject(line90);
     frame->addObject(line95);
+}
+
+/// \deprecated Will be removed in ROOT 6.36. Please write your own plotting code inspired by the hf001 tutorial.
+
+void RooStats::HistFactory::FormatFrameForLikelihood(RooPlot* frame, std::string /*XTitle*/,
+                       std::string YTitle)
+{
+   formatFrameForLikelihoodImpl(frame, YTitle);
 }

--- a/roofit/histfactory/src/Measurement.cxx
+++ b/roofit/histfactory/src/Measurement.cxx
@@ -37,7 +37,7 @@ ClassImp(RooStats::HistFactory::Measurement);
 
 /// Standard constructor
 RooStats::HistFactory::Measurement::Measurement()
-   : fLumi(1.0), fLumiRelErr(.10), fBinLow(0), fBinHigh(1), fExportOnly(false)
+   : fLumi(1.0), fLumiRelErr(.10), fBinLow(0), fBinHigh(1)
 {
 
 }
@@ -52,7 +52,7 @@ RooStats::HistFactory::Measurement::Measurement(const Measurement& other) :
 
 /// Standard constructor specifying name and title of measurement
 RooStats::HistFactory::Measurement::Measurement(const char *Name, const char *Title)
-   : TNamed(Name, Title), fLumi(1.0), fLumiRelErr(.10), fBinLow(0), fBinHigh(1), fExportOnly(false)
+   : TNamed(Name, Title), fLumi(1.0), fLumiRelErr(.10), fBinLow(0), fBinHigh(1)
 {
 
 }

--- a/roofit/histfactory/test/stressHistFactory.cxx
+++ b/roofit/histfactory/test/stressHistFactory.cxx
@@ -45,9 +45,6 @@ void buildAPI_XML_TestModel(TString prefix)
 
    HistFactory::Measurement meas("Test", "API_XML_TestModel");
 
-   // do not fit, just export the workspace
-   meas.SetExportOnly(true);
-
    // put output in separate sub-directory
    meas.SetOutputFilePrefix(prefix.Data());
 

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -275,8 +275,6 @@ public:
          meas.AddConstantParam("gamma_stat_channel1_bin_1");
       }
 
-      meas.SetExportOnly(true);
-
       meas.SetLumi(1.0);
       meas.SetLumiRelErr(0.10);
 

--- a/roofit/histfactory/test/testHistFactoryPlotting.cxx
+++ b/roofit/histfactory/test/testHistFactoryPlotting.cxx
@@ -93,7 +93,6 @@ TEST(HistFactoryPlotting, ComponentSelection)
    // -- Define the measurement
    RooStats::HistFactory::Measurement meas("B2D0MuNu", "B2D0MuNu fit");
 
-   meas.SetExportOnly(true);    // Tells histfactory to not run the fit
    meas.SetPOI("num_histoSig"); // set to Bogus parma. of interest
    meas.SetLumi(1.0);
    meas.SetLumiRelErr(0.1);
@@ -120,7 +119,6 @@ TEST(HistFactoryPlotting, ComponentSelection)
 
    // add channel to measurements
    meas.AddChannel(B2D0MuNu);
-   meas.SetExportOnly(true);
    meas.CollectHistograms();
 
    // --------------------------------------

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -490,6 +490,10 @@ if(fftw3)
   target_compile_definitions(RooFitCore PUBLIC ROOFIT_MATH_FFTW3)
 endif()
 
+# To avoid deprecation warnings when including old test statistics headers.
+# RooFit has to include them to build the documentation.
+target_compile_definitions(RooFitCore PUBLIC ROOFIT_BUILDS_ITSELF)
+
 target_include_directories(RooFitCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
 
 # For recent clang, this can facilitate auto-vectorisation.


### PR DESCRIPTION
If you build a HistFactory workspace with `MakeModelAndMeasurementFast`, by default there is also a fit and some plotting happening. Nobody uses that. People use HistFactory to build models and then they use their own plotting and fitting code.

Therefore, this commit suggests to enable
`RooStats::HistFactory::Measurement::ExportOnly()` by default and deprecate the code related to the internal plotting and fitting.

Instead, an example on how to do plotting and fitting with HistFactory models will be added to the `hf001` tutorial by another commit (#16323).