### PR TITLE
Make it possible to disable TPython in build

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 if(pyroot)
   add_subdirectory(pyroot)
-  add_subdirectory(tpython)
   add_subdirectory(jupyroot)
 
   if(dataframe)
@@ -16,6 +15,10 @@ if(pyroot)
     message(STATUS "Requirements to enable distributed RDataFrame:")
     message(STATUS "    dataframe: required:ON, actual:${dataframe}")
   endif()
+endif()
+
+if(tpython)
+  add_subdirectory(tpython)
 endif()
 
 if(r)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -170,6 +170,7 @@ ROOT_BUILD_OPTION(tmva-gpu OFF "Build TMVA with GPU support for deep learning (r
 ROOT_BUILD_OPTION(tmva-sofie OFF "Build TMVA with support for sofie - fast inference code generation (requires protobuf 3)")
 ROOT_BUILD_OPTION(tmva-pymva ON "Enable support for Python in TMVA (requires numpy)")
 ROOT_BUILD_OPTION(tmva-rmva OFF "Enable support for R in TMVA")
+ROOT_BUILD_OPTION(tpython ON "Build the TPython class that allows you to run Python code from C++")
 ROOT_BUILD_OPTION(spectrum ON "Enable support for TSpectrum")
 ROOT_BUILD_OPTION(unfold OFF "Enable the unfold package [GPL]")
 ROOT_BUILD_OPTION(unuran OFF "Enable support for UNURAN (package for generating non-uniform random numbers) [GPL]")
@@ -476,4 +477,9 @@ endif()
 #---distributed RDataFrame pyspark tests require both dataframe and pyroot----------------------------------
 if(test_distrdf_pyspark OR test_distrdf_dask AND (NOT dataframe OR NOT pyroot))
     message(FATAL_ERROR "Running the tests for distributed RDataFrame requires both RDataFrame and PyROOT to be enabled (build with -Ddataframe=ON and -Dpyroot=ON)")
+endif()
+
+#---TPython requires PyROOT
+if(tpython AND NOT pyroot)
+    message(FATAL_ERROR "-Dtpython=ON requires -Dpyroot=ON)")
 endif()


### PR DESCRIPTION
The TPython library has one big caveat: it requires linking against `libpython`, which is not allowed in some context like the Python package manager.

To avoid this problem that is blocking `pip install root`, this commit suggests to make TPython optional at build time. This makes also sense considering how TPython and PyROOT are used: if you intend to use ROOT via PyROOT from pip install ROOT, you probably won't need the functionality to run Python code from C++ that TPython provides.

Possibly supersedes #15891, @vepadulano.

