### PR TITLE
[ntuple] Implement staged cluster committing

### DIFF
--- a/tree/ntuple/v7/doc/architecture.md
+++ b/tree/ntuple/v7/doc/architecture.md
@@ -334,10 +334,10 @@ The caller has to ensure that the lifetime of the object lasts during the I/O op
 
 An RNTuple writer that is constructed without a `TFile` object (`RNTupleWriter::Recreate()`) assumes exclusive access to the underlying file.
 An RNTuple writer that uses a `TFile` for writing (`RNTupleWriter::Append()`) assumes that the `TFile` object outlives the writer's lifetime.
-The serial writer assumes exclusive access to the underlying file during construction, destruction and `Fill()` as well as `CommitCluster()`.
-For `FlushColumns()` and `FillNoCommit()`, the sequential writer assumes exclusive access only if buffered writing is turned off.
-The parallel writer assumes exclusive access to the underlying file during all operations on the writer (e.g. construction and destruction) and all operations on any created fill context (e.g. `Fill()` and `CommitCluster()`).
-Notable exceptions are `FlushColumns()` and `FillNoCommit()` which are guaranteed to never access the underlying `TFile` during parallel writing (which is always buffered).
+The serial writer assumes exclusive access to the underlying file during construction, destruction and `Fill()` as well as `CommitCluster()` and `FlushCluster()`.
+For `FlushColumns()` and `FillNoFlush()`, the sequential writer assumes exclusive access only if buffered writing is turned off.
+The parallel writer assumes exclusive access to the underlying file during all operations on the writer (e.g. construction and destruction) and all operations on any created fill context (e.g. `Fill()` and `FlushCluster()`).
+Notable exceptions are `FlushColumns()` and `FillNoFlush()` which are guaranteed to never access the underlying `TFile` during parallel writing (which is always buffered).
 
 A `TFile` does not take ownership of any `RNTuple` objects.
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
@@ -29,8 +29,8 @@ namespace Experimental {
 \ingroup NTuple
 \brief A status object after filling an entry
 
-After passing an instance to RNTupleWriter::FillNoCommit or RNTupleFillContext::FillNoCommit, the caller must check
-ShouldCommitCluster and call RNTupleWriter::CommitCluster or RNTupleFillContext::CommitCluster if necessary.
+After passing an instance to RNTupleWriter::FillNoFlush or RNTupleFillContext::FillNoFlush, the caller must check
+ShouldFlushCluster and call RNTupleWriter::FlushCluster or RNTupleFillContext::FlushCluster if necessary.
 */
 // clang-format on
 class RNTupleFillStatus {
@@ -38,22 +38,22 @@ class RNTupleFillStatus {
 
 private:
    /// Number of entries written into the current cluster
-   NTupleSize_t fNEntriesSinceLastCommit = 0;
+   NTupleSize_t fNEntriesSinceLastFlush = 0;
    /// Number of bytes written into the current cluster
    std::size_t fUnzippedClusterSize = 0;
    /// Number of bytes written for the last entry
    std::size_t fLastEntrySize = 0;
-   bool fShouldCommitCluster = false;
+   bool fShouldFlushCluster = false;
 
 public:
    /// Return the number of entries written into the current cluster.
-   NTupleSize_t GetNEntries() const { return fNEntriesSinceLastCommit; }
+   NTupleSize_t GetNEntries() const { return fNEntriesSinceLastFlush; }
    /// Return the number of bytes written into the current cluster.
    std::size_t GetUnzippedClusterSize() const { return fUnzippedClusterSize; }
    /// Return the number of bytes for the last entry.
    std::size_t GetLastEntrySize() const { return fLastEntrySize; }
-   /// Return true if the caller should call CommitCluster.
-   bool ShouldCommitCluster() const { return fShouldCommitCluster; }
+   /// Return true if the caller should call FlushCluster.
+   bool ShouldFlushCluster() const { return fShouldFlushCluster; }
 }; // class RNTupleFillContext
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -54,7 +54,7 @@ CreateRNTupleWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Interna
 An output ntuple can be filled with entries. The caller has to make sure that the data that gets filled into an ntuple
 is not modified for the time of the Fill() call. The fill call serializes the C++ object into the column format and
 writes data into the corresponding column page buffers.  Writing of the buffers to storage is deferred and can be
-triggered by CommitCluster() or by destructing the writer.  On I/O errors, an exception is thrown.
+triggered by FlushCluster() or by destructing the writer.  On I/O errors, an exception is thrown.
 */
 // clang-format on
 class RNTupleWriter {
@@ -108,23 +108,27 @@ public:
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(REntry &entry) { return fFillContext.Fill(entry); }
    /// Fill an entry into this ntuple, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
-   /// and check RNTupleFillStatus::ShouldCommitCluster.
-   void FillNoCommit(REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoCommit(entry, status); }
+   /// and check RNTupleFillStatus::ShouldFlushCluster.
+   void FillNoFlush(REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoFlush(entry, status); }
    /// Flush column data, preparing for CommitCluster or to reduce memory usage. This will trigger compression of pages,
    /// but not actually write to storage (unless buffered writing is turned off).
    void FlushColumns() { fFillContext.FlushColumns(); }
+   /// Flush so far filled entries to storage
+   void FlushCluster() { fFillContext.FlushCluster(); }
    /// Ensure that the data from the so far seen Fill calls has been written to storage
    void CommitCluster(bool commitClusterGroup = false)
    {
-      fFillContext.CommitCluster();
+      fFillContext.FlushCluster();
       if (commitClusterGroup)
          CommitClusterGroup();
    }
 
    std::unique_ptr<REntry> CreateEntry() { return fFillContext.CreateEntry(); }
 
+   /// Return the entry number that was last flushed in a cluster.
+   NTupleSize_t GetLastFlushed() const { return fFillContext.GetLastFlushed(); }
    /// Return the entry number that was last committed in a cluster.
-   NTupleSize_t GetLastCommitted() const { return fFillContext.GetLastCommitted(); }
+   NTupleSize_t GetLastCommitted() const { return fFillContext.GetLastFlushed(); }
    /// Return the entry number that was last committed in a cluster group.
    NTupleSize_t GetLastCommittedClusterGroup() const { return fLastCommittedClusterGroup; }
    /// Return the number of entries filled so far.

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -80,12 +80,14 @@ public:
       }
    }
 
-   std::uint64_t CommitCluster(NTupleSize_t) final
+   RStagedCluster StageCluster(NTupleSize_t) final
    {
-      std::uint64_t bytes = fNBytesCurrentCluster;
+      RStagedCluster stagedCluster;
+      stagedCluster.fNBytesWritten = fNBytesCurrentCluster;
       fNBytesCurrentCluster = 0;
-      return bytes;
+      return stagedCluster;
    }
+   void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
 };

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -22,6 +22,7 @@
 #include <ROOT/RPageStorage.hxx>
 
 #include <deque>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <tuple>
@@ -131,6 +132,7 @@ private:
    DescriptorId_t fNColumns = 0;
 
    void ConnectFields(const std::vector<RFieldBase *> &fields, NTupleSize_t firstEntry);
+   void FlushClusterImpl(std::function<void(void)> FlushClusterFn);
 
 public:
    explicit RPageSinkBuf(std::unique_ptr<RPageSink> inner);
@@ -153,6 +155,8 @@ public:
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final;
+   RStagedCluster StageCluster(NTupleSize_t nNewEntries) final;
+   void CommitStagedClusters(std::span<RStagedCluster> clusters) final;
    void CommitClusterGroup() final;
    void CommitDatasetImpl() final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -126,7 +126,7 @@ protected:
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator>
    CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask) final;
-   std::uint64_t CommitClusterImpl() final;
+   std::uint64_t StageClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    using RPagePersistentSink::CommitDatasetImpl;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -92,7 +92,7 @@ protected:
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator>
    CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask) final;
-   std::uint64_t CommitClusterImpl() final;
+   std::uint64_t StageClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    using RPagePersistentSink::CommitDatasetImpl;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -98,6 +98,8 @@ public:
       fInnerSink->CommitSealedPageV(ranges);
    }
    std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final { return fInnerSink->CommitCluster(nNewEntries); }
+   RStagedCluster StageCluster(NTupleSize_t nNewEntries) final { return fInnerSink->StageCluster(nNewEntries); }
+   void CommitStagedClusters(std::span<RStagedCluster> clusters) final { fInnerSink->CommitStagedClusters(clusters); }
    void CommitClusterGroup() final
    {
       throw RException(R__FAIL("should never commit cluster group via RPageSynchronizingSink"));

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -428,7 +428,7 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
    return locators;
 }
 
-std::uint64_t ROOT::Experimental::Internal::RPageSinkDaos::CommitClusterImpl()
+std::uint64_t ROOT::Experimental::Internal::RPageSinkDaos::StageClusterImpl()
 {
    return std::exchange(fNBytesCurrentCluster, 0);
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -221,7 +221,7 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
    return locators;
 }
 
-std::uint64_t ROOT::Experimental::Internal::RPageSinkFile::CommitClusterImpl()
+std::uint64_t ROOT::Experimental::Internal::RPageSinkFile::StageClusterImpl()
 {
    auto result = fNBytesCurrentCluster;
    fNBytesCurrentCluster = 0;

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -355,7 +355,7 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
       auto model = RNTupleModel::CreateBare();
       auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
 
-      int CommitClusterCalled = 0;
+      int FlushClusterCalled = 0;
       RNTupleFillStatus status;
 
       RNTupleWriteOptions options;
@@ -366,13 +366,13 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto entry = ntuple->CreateEntry();
       for (int i = 0; i < 100; i++) {
-         ntuple->FillNoCommit(*entry, status);
-         if (status.ShouldCommitCluster()) {
-            ntuple->CommitCluster();
-            CommitClusterCalled++;
+         ntuple->FillNoFlush(*entry, status);
+         if (status.ShouldFlushCluster()) {
+            ntuple->FlushCluster();
+            FlushClusterCalled++;
          }
       }
-      EXPECT_EQ(20, CommitClusterCalled);
+      EXPECT_EQ(20, FlushClusterCalled);
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -55,7 +55,8 @@ protected:
    void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitSealedPage(ROOT::Experimental::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}
-   std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }
+   RStagedCluster StageCluster(NTupleSize_t) final { return {}; }
+   void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
 

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -80,6 +80,163 @@ TEST(RNTupleParallelWriter, Basics)
    }
 }
 
+TEST(RNTupleParallelWriter, Staged)
+{
+   FileRaii fileGuard("test_ntuple_parallel_staged.root");
+
+   {
+      auto model = RNTupleModel::CreateBare();
+      model->MakeField<float>("pt");
+
+      auto writer = RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+
+      // Create two RNTupleFillContext to prepare clusters in parallel.
+      auto c1 = writer->CreateFillContext();
+      auto e1 = c1->CreateEntry();
+      auto pt1 = e1->GetPtr<float>("pt");
+
+      auto c2 = writer->CreateFillContext();
+      auto e2 = c2->CreateEntry();
+      auto pt2 = e2->GetPtr<float>("pt");
+
+      // Turn on staged cluster committing to logically append staged clusters with an explicit call.
+      c1->EnableStagedClusterCommitting();
+      c2->EnableStagedClusterCommitting();
+
+      // Fill one entry per context and stage a cluster each.
+      *pt1 = 3.0;
+      c1->Fill(*e1);
+      c1->FlushCluster();
+
+      *pt2 = 1.0;
+      c2->Fill(*e2);
+      c2->FlushCluster();
+
+      // Stage another cluster per context.
+      *pt1 = 4.0;
+      c1->Fill(*e1);
+      c1->FlushCluster();
+
+      *pt2 = 2.0;
+      c2->Fill(*e2);
+      c2->FlushCluster();
+
+      // Commit the staged clusters.
+      c2->CommitStagedClusters();
+      c1->CommitStagedClusters();
+   }
+
+   auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
+   const auto &model = reader->GetModel();
+
+   ASSERT_EQ(reader->GetNEntries(), 4);
+   auto pt = model.GetDefaultEntry().GetPtr<float>("pt");
+
+   reader->LoadEntry(0);
+   EXPECT_EQ(*pt, 1.0);
+   reader->LoadEntry(1);
+   EXPECT_EQ(*pt, 2.0);
+   reader->LoadEntry(2);
+   EXPECT_EQ(*pt, 3.0);
+   reader->LoadEntry(3);
+   EXPECT_EQ(*pt, 4.0);
+}
+
+TEST(RNTupleParallelWriter, StagedMultiColumn)
+{
+   // Based on MultiColumnRepresentationSimple from ntuple_multi_column.cxx
+   using ROOT::Experimental::kUnknownCompressionSettings;
+   FileRaii fileGuard("test_ntuple_parallel_staged_multi_column.root");
+
+   {
+      auto model = RNTupleModel::CreateBare();
+      auto fldPx = RFieldBase::Create("px", "float").Unwrap();
+      fldPx->SetColumnRepresentatives({{EColumnType::kReal32}, {EColumnType::kReal16}});
+      model->AddField(std::move(fldPx));
+
+      auto writer = RNTupleParallelWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+
+      auto c = writer->CreateFillContext();
+      c->EnableStagedClusterCommitting();
+      auto e = c->CreateEntry();
+      auto px = e->GetPtr<float>("px");
+
+      *px = 1.0;
+      c->Fill(*e);
+      c->FlushCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(c->GetModel().GetField("px")), 1);
+      *px = 2.0;
+      c->Fill(*e);
+      c->FlushCluster();
+      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(c->GetModel().GetField("px")), 0);
+      *px = 3.0;
+      c->Fill(*e);
+      c->FlushCluster();
+
+      c->CommitStagedClusters();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(3u, reader->GetModel().GetField("px").GetNElements());
+
+   const auto &desc = reader->GetDescriptor();
+   EXPECT_EQ(3u, desc.GetNClusters());
+
+   const auto &fieldDesc = desc.GetFieldDescriptor(desc.FindFieldId("px"));
+   EXPECT_EQ(1u, fieldDesc.GetColumnCardinality());
+   EXPECT_EQ(2u, fieldDesc.GetLogicalColumnIds().size());
+
+   const auto &colDesc32 = desc.GetColumnDescriptor(fieldDesc.GetLogicalColumnIds()[0]);
+   const auto &colDesc16 = desc.GetColumnDescriptor(fieldDesc.GetLogicalColumnIds()[1]);
+
+   EXPECT_EQ(EColumnType::kReal32, colDesc32.GetType());
+   EXPECT_EQ(0u, colDesc32.GetRepresentationIndex());
+   EXPECT_EQ(EColumnType::kReal16, colDesc16.GetType());
+   EXPECT_EQ(1u, colDesc16.GetRepresentationIndex());
+
+   const auto &clusterDesc0 = desc.GetClusterDescriptor(0);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+
+   const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+
+   const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
+   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+
+   auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(1.0, *ptrPx);
+   reader->LoadEntry(1);
+   EXPECT_FLOAT_EQ(2.0, *ptrPx);
+   reader->LoadEntry(2);
+   EXPECT_FLOAT_EQ(3.0, *ptrPx);
+
+   auto viewPx = reader->GetView<float>("px");
+   EXPECT_FLOAT_EQ(1.0, viewPx(0));
+   EXPECT_FLOAT_EQ(2.0, viewPx(1));
+   EXPECT_FLOAT_EQ(3.0, viewPx(2));
+}
+
 TEST(RNTupleParallelWriter, Options)
 {
    FileRaii fileGuard("test_ntuple_parallel_options.root");

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -17,17 +17,17 @@ TEST(RNTupleParallelWriter, Basics)
       // Fill one entry per context and commit a cluster each.
       *pt1 = 1.0;
       c1->Fill(*e1);
-      c1->CommitCluster();
+      c1->FlushCluster();
 
       *pt2 = 2.0;
       c2->Fill(*e2);
-      c2->CommitCluster();
+      c2->FlushCluster();
 
       // The two contexts should act independently.
       EXPECT_EQ(c1->GetNEntries(), 1);
       EXPECT_EQ(c2->GetNEntries(), 1);
-      EXPECT_EQ(c1->GetLastCommitted(), 1);
-      EXPECT_EQ(c2->GetLastCommitted(), 1);
+      EXPECT_EQ(c1->GetLastFlushed(), 1);
+      EXPECT_EQ(c2->GetLastFlushed(), 1);
 
       // Fill another entry per context without explicitly committing a cluster.
       *pt1 = 3.0;

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -51,7 +51,8 @@ protected:
       fCounters.fNCommitSealedPage++;
    }
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) override { fCounters.fNCommitSealedPageV++; }
-   std::uint64_t CommitCluster(NTupleSize_t) final { return 0; }
+   RStagedCluster StageCluster(NTupleSize_t) final { return {}; }
+   void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
 

--- a/tutorials/v7/ntuple/ntpl013_staged.C
+++ b/tutorials/v7/ntuple/ntpl013_staged.C
@@ -1,0 +1,212 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Example of staged cluster committing in multi-threaded writing using RNTupleParallelWriter.
+///
+/// \macro_code
+///
+/// \date September 2024
+/// \author The ROOT Team
+
+// NOTE: The RNTuple classes are experimental at this point.
+// Functionality, interface, and data format is still subject to changes.
+// Do not use for real data!
+
+#include <ROOT/RNTupleFillContext.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleParallelWriter.hxx>
+
+#include <TRandom3.h>
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+// Import classes from experimental namespace for the time being
+using ROOT::Experimental::NTupleSize_t;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleParallelWriter;
+using ROOT::Experimental::RNTupleWriteOptions;
+
+// Where to store the ntuple of this example
+constexpr char const *kNTupleFileName = "ntpl013_staged.root";
+
+// Number of parallel threads to fill the ntuple
+constexpr int kNWriterThreads = 4;
+
+// Number of events to generate is kNEventsPerThread * kNWriterThreads
+constexpr int kNEventsPerThread = 25000;
+
+// Number of events per block
+constexpr int kNEventsPerBlock = 10000;
+
+// Thread function to generate and write events
+void FillData(int id, RNTupleParallelWriter *writer)
+{
+   // static variables that are shared between threads; this is done for simplicity in this tutorial, use proper data
+   // structures in real code!
+   static std::mutex g_Mutex;
+   static NTupleSize_t g_WrittenEntries = 0;
+
+   using generator = std::mt19937;
+   generator gen;
+
+   // Create a fill context and turn on staged cluster committing.
+   auto fillContext = writer->CreateFillContext();
+   fillContext->EnableStagedClusterCommitting();
+   auto entry = fillContext->CreateEntry();
+
+   auto eventId = entry->GetPtr<std::uint32_t>("eventId");
+   auto eventIdStart = id * kNEventsPerThread;
+   auto rndm = entry->GetPtr<float>("rndm");
+
+   for (int i = 0; i < kNEventsPerThread; i++) {
+      // Prepare the entry with an id and a random number.
+      *eventId = eventIdStart + i;
+      auto d = static_cast<double>(gen()) / generator::max();
+      *rndm = static_cast<float>(d);
+
+      // Fill might auto-flush a cluster, which will be staged.
+      fillContext->Fill(*entry);
+   }
+
+   // It is important to first FlushCluster() so that a cluster with the remaining entries is staged.
+   fillContext->FlushCluster();
+   {
+      std::lock_guard g(g_Mutex);
+      fillContext->CommitStagedClusters();
+      std::cout << "Thread #" << id << " wrote events #" << eventIdStart << " - #"
+                << (eventIdStart + kNEventsPerThread - 1) << " as entries #" << g_WrittenEntries << " - #"
+                << (g_WrittenEntries + kNEventsPerThread - 1) << std::endl;
+      g_WrittenEntries += kNEventsPerThread;
+   }
+}
+
+// Generate kNEvents with multiple threads in kNTupleFileName
+void Write()
+{
+   std::cout << " === Writing with staged cluster committing ===" << std::endl;
+
+   // Create the data model
+   auto model = RNTupleModel::CreateBare();
+   model->MakeField<std::uint32_t>("eventId");
+   model->MakeField<float>("rndm");
+
+   // Create RNTupleWriteOptions to make the writing commit multiple clusters.
+   // This is for demonstration purposes only to have multiple clusters per
+   // thread that are implicitly flushed, and should not be copied into real
+   // code!
+   RNTupleWriteOptions options;
+   options.SetApproxZippedClusterSize(32'000);
+
+   // We hand over the data model to a newly created ntuple of name "NTuple", stored in kNTupleFileName
+   auto writer = RNTupleParallelWriter::Recreate(std::move(model), "NTuple", kNTupleFileName, options);
+
+   std::vector<std::thread> threads;
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads.emplace_back(FillData, i, writer.get());
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads[i].join();
+
+   // The writer unique pointer goes out of scope here.  On destruction, the writer flushes unwritten data to disk
+   // and closes the attached ROOT file.
+}
+
+void FillDataInBlocks(int id, RNTupleParallelWriter *writer)
+{
+   // static variables that are shared between threads; this is done for simplicity in this tutorial, use proper data
+   // structures in real code!
+   static std::mutex g_Mutex;
+   static NTupleSize_t g_WrittenEntries = 0;
+
+   using generator = std::mt19937;
+   generator gen;
+
+   // Create a fill context and turn on staged cluster committing.
+   auto fillContext = writer->CreateFillContext();
+   fillContext->EnableStagedClusterCommitting();
+   auto entry = fillContext->CreateEntry();
+
+   auto eventId = entry->GetPtr<std::uint32_t>("eventId");
+   auto eventIdStart = id * kNEventsPerThread;
+   int startOfBlock = 0;
+   auto rndm = entry->GetPtr<float>("rndm");
+
+   for (int i = 0; i < kNEventsPerThread; i++) {
+      // Prepare the entry with an id and a random number.
+      *eventId = eventIdStart + i;
+      auto d = static_cast<double>(gen()) / generator::max();
+      *rndm = static_cast<float>(d);
+
+      // Fill might auto-flush a cluster, which will be staged.
+      fillContext->Fill(*entry);
+
+      if ((i + 1) % kNEventsPerBlock == 0) {
+         // Decide to flush this cluster and logically append all staged clusters to the ntuple.
+         fillContext->FlushCluster();
+         {
+            std::lock_guard g(g_Mutex);
+            fillContext->CommitStagedClusters();
+            auto firstEvent = eventIdStart + startOfBlock;
+            auto lastEvent = eventIdStart + i;
+            std::cout << "Thread #" << id << " wrote events #" << firstEvent << " - #" << lastEvent << " as entries #"
+                      << g_WrittenEntries << " - #" << (g_WrittenEntries + kNEventsPerBlock - 1) << std::endl;
+            g_WrittenEntries += kNEventsPerBlock;
+            startOfBlock += kNEventsPerBlock;
+         }
+      }
+   }
+
+   // Flush the remaining data and commit staged clusters.
+   fillContext->FlushCluster();
+   {
+      std::lock_guard g(g_Mutex);
+      fillContext->CommitStagedClusters();
+      auto firstEvent = eventIdStart + startOfBlock;
+      auto lastEvent = eventIdStart + kNEventsPerThread - 1;
+      auto numEvents = kNEventsPerThread - startOfBlock;
+      std::cout << "Thread #" << id << " wrote events #" << firstEvent << " - #" << lastEvent << " as entries #"
+                << g_WrittenEntries << " - #" << (g_WrittenEntries + numEvents - 1) << std::endl;
+      g_WrittenEntries += numEvents;
+   }
+}
+
+// Generate kNEvents with multiple threads in kNTupleFileName, and sequence them in blocks of kNEventsPerBlock entries
+void WriteInBlocks()
+{
+   std::cout << "\n === ... with sequencing in blocks of " << kNEventsPerBlock << " events ===" << std::endl;
+
+   // Create the data model
+   auto model = RNTupleModel::CreateBare();
+   model->MakeField<std::uint32_t>("eventId");
+   model->MakeField<float>("rndm");
+
+   // Create RNTupleWriteOptions to make the writing commit multiple clusters.
+   // This is for demonstration purposes only to have multiple clusters per
+   // thread and also per block that are implicitly flushed, and can be mixed
+   // with explicit calls to FlushCluster(). This should not be copied into real
+   // code!
+   RNTupleWriteOptions options;
+   options.SetApproxZippedClusterSize(32'000);
+
+   // We hand over the data model to a newly created ntuple of name "NTuple", stored in kNTupleFileName
+   auto writer = RNTupleParallelWriter::Recreate(std::move(model), "NTuple", kNTupleFileName, options);
+
+   std::vector<std::thread> threads;
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads.emplace_back(FillDataInBlocks, i, writer.get());
+   for (int i = 0; i < kNWriterThreads; ++i)
+      threads[i].join();
+
+   // The writer unique pointer goes out of scope here.  On destruction, the writer flushes unwritten data to disk
+   // and closes the attached ROOT file.
+}
+
+void ntpl013_staged()
+{
+   Write();
+   WriteInBlocks();
+}


### PR DESCRIPTION
With multiple concurrent `RNTupleFillContext`s, the order of clusters is generally indeterminate and entries are only partially ordered. With staged cluster committing, this restriction can be partially lifted by splitting a cluster commit into two phases:
1. Once full, or when manually triggered, all fields are committed which triggers flushing of all columns. All pages are compressed and staged via the page sink. The result is a `RStagedCluster` that records all information for the second phase. This step can be repeated multiple times as entries are filled into the context.
2. When appropriate for the application, all staged clusters can be committed, which logically appends them to the RNTuple. This is implemented in a single critical section, which guarantees that the clusters and their entries are consecutive.

Moreover, by synchronizing the second phase between multiple contexts, the application can enforce a total ordering of all contained entries at reasonable resource consumption: During the first phase, all write buffers are flushed and will be reused for the following cluster. The metadata stored in `RStagedCluster` should require only minimal memory, which will accumulate while staging more clusters.

Staged cluster committing is expected to be slightly slower than the default mode, but should still scale well as the second phase only updates the metadata which is a lightweight operation compared to preparing and filling entries, compressing pages, and writing them to disk.

A noteworthy disadvantage is that staged cluster committing will lead to non-linear files, where sequentially iterating over clusters may require seeking to distant file offsets. The impact resulting from this will depend on the storage technology and the read pattern.

Closes #16326