### PR TITLE
[RF] Remove RooRealMPFE from public interface

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -16,10 +16,6 @@ if(roofit_multiprocess)
 endif()
 
 if(roofit_legacy_eval_backend)
-  set(LegacyEvalBackendHeaders
-    RooRealMPFE.h
-  )
-
   set(LegacyEvalBackendSources
     src/BidirMMapPipe.cxx
     src/BidirMMapPipe.h
@@ -239,7 +235,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooWorkspace.h
     RooWorkspaceHandle.h
     RooWrapperPdf.h
-    ${LegacyEvalBackendHeaders}
   SOURCES
     src/BatchModeDataHelpers.cxx
     src/ConstraintHelpers.cxx

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -171,7 +171,6 @@
 #pragma link C++ class RooRealBinding+ ;
 #pragma link C++ class RooRealConstant+ ;
 #pragma link C++ class RooRealIntegral+ ;
-#pragma link C++ class RooRealMPFE+ ;
 #pragma link C++ class RooRealProxy+;
 #pragma read sourceClass="RooRealProxy" targetClass="RooTemplateProxy<RooAbsReal>";
 #pragma link C++ class RooTemplateProxy<RooAbsPdf>+;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -39,7 +39,7 @@ In extended mode, a
 #include <RooMsgService.h>
 #include <RooNaNPacker.h>
 #include <RooProdPdf.h>
-#include <RooRealMPFE.h>
+#include "RooRealMPFE.h"
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
 

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -89,10 +89,8 @@ RooMPSentinel& RooMPSentinel::instance() {
 }
 
 
-using std::cout, std::endl, std::string, std::ostringstream, std::list, std::pair;
+using std::cout, std::endl, std::string, std::ostringstream, std::list;
 using namespace RooFit;
-
-ClassImp(RooRealMPFE);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -327,7 +325,7 @@ void RooRealMPFE::serverLoop()
        printStream(oss2,kName|kClassName|kArgs,kInline);
        objidstr = oss2.str();
      }
-     std::map<const RooAbsArg*,pair<string,list<EvalError> > >::const_iterator iter = evalErrorIter();
+     std::map<const RooAbsArg*,std::pair<string,list<EvalError> > >::const_iterator iter = evalErrorIter();
      const RooAbsArg* ptr = nullptr;
      for (int i = 0; i < numEvalErrorItems(); ++i) {
        list<EvalError>::const_iterator iter2 = iter->second.second.begin();

--- a/roofit/roofitcore/src/RooRealMPFE.h
+++ b/roofit/roofitcore/src/RooRealMPFE.h
@@ -85,8 +85,6 @@ public:
   RooRealMPFE* _updateMaster ; ///<! Update master
   mutable bool _retrieveDispatched ; ///<!
   mutable double _evalCarry; ///<!
-
-  ClassDefOverride(RooRealMPFE,2) // Multi-process front-end for parallel calculation of a real valued function
 };
 
 #endif


### PR DESCRIPTION
The RooRealMPFE class is an implementation detail of the old RooFit multiprocessing. It should not be part of the public interface, and also not have a `ClassDef` that allows you to do IO with it.