### PR TITLE
New color schemes

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -65,10 +65,10 @@ enum ESysConstants {
 enum EColor { kWhite   =0,   kBlack    =1,   kGray   =920,
               kRed     =632, kGreen    =416, kBlue   =600, kYellow =400, kMagenta =616, kCyan    =432,
               kOrange  =800, kSpring   =820, kTeal   =840, kAzure  =860, kViolet  =880, kPink    =900,
-              kGrape   =111, kBrown    =112, kAsh    =113,
-              kP6Blue  =120, kP6Yellow =121, kP6Red  =122, kP6Grape=123, kP6Gray   =124, kP6Violet=125,
-              kP8Blue  =130, kP8Orange =131, kP8Red  =132, kP8Pink =133, kP8Green  =134, kP8Cyan  =135, kP8Azure  =136, kP8Gray  =137,
-              kP10Blue =140, kP10Yellow=141, kP10Red =142, kP10Gray=143, kP10Violet=144, kP10Brown=145, kP10Orange=146, kP10Green=147, kP10Ash=148, kP10Cyan=149
+              kGrape   =340, kBrown    =341, kAsh    =342,
+              kP6Blue  =343, kP6Yellow =344, kP6Red  =345, kP6Grape=346, kP6Gray   =347, kP6Violet=348,
+              kP8Blue  =349, kP8Orange =350, kP8Red  =351, kP8Pink =352, kP8Green  =353, kP8Cyan  =354, kP8Azure  =355, kP8Gray  =356,
+              kP10Blue =357, kP10Yellow=358, kP10Red =359, kP10Gray=360, kP10Violet=361, kP10Brown=362, kP10Orange=363, kP10Green=364, kP10Ash=365, kP10Cyan=366
             };
 
 // There is several streamer concepts.

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -62,9 +62,14 @@ enum ESysConstants {
    kItimerResolution = 10      // interval-timer resolution in ms
 };
 
-enum EColor { kWhite =0,   kBlack =1,   kGray=920,
-              kRed   =632, kGreen =416, kBlue=600, kYellow=400, kMagenta=616, kCyan=432,
-              kOrange=800, kSpring=820, kTeal=840, kAzure =860, kViolet =880, kPink=900 };
+enum EColor { kWhite   =0,   kBlack    =1,   kGray   =920,
+              kRed     =632, kGreen    =416, kBlue   =600, kYellow =400, kMagenta =616, kCyan    =432,
+              kOrange  =800, kSpring   =820, kTeal   =840, kAzure  =860, kViolet  =880, kPink    =900,
+              kGrape   =106, kBrown    =107, kAsh    =108,
+              kP6Blue  =100, kP6Yellow =101, kP6Red  =102, kP6Grape=103, kP6Gray   =104, kP6Violet=105,
+              kP8Blue  =111, kP8Orange =112, kP8Red  =113, kP8Pink =114, kP8Green  =115, kP8Cyan  =116, kP8Azure  =117, kP8Gray  =118,
+              kP10Blue =120, kP10Yellow=121, kP10Red =122, kP10Gray=123, kP10Violet=124, kP10Brown=125, kP10Orange=126, kP10Green=127, kP10Ash=128, kP10Cyan=129
+            };
 
 // There is several streamer concepts.
 class TClassStreamer;   // Streamer functor for a class

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -65,10 +65,10 @@ enum ESysConstants {
 enum EColor { kWhite   =0,   kBlack    =1,   kGray   =920,
               kRed     =632, kGreen    =416, kBlue   =600, kYellow =400, kMagenta =616, kCyan    =432,
               kOrange  =800, kSpring   =820, kTeal   =840, kAzure  =860, kViolet  =880, kPink    =900,
-              kGrape   =106, kBrown    =107, kAsh    =108,
-              kP6Blue  =100, kP6Yellow =101, kP6Red  =102, kP6Grape=103, kP6Gray   =104, kP6Violet=105,
-              kP8Blue  =111, kP8Orange =112, kP8Red  =113, kP8Pink =114, kP8Green  =115, kP8Cyan  =116, kP8Azure  =117, kP8Gray  =118,
-              kP10Blue =120, kP10Yellow=121, kP10Red =122, kP10Gray=123, kP10Violet=124, kP10Brown=125, kP10Orange=126, kP10Green=127, kP10Ash=128, kP10Cyan=129
+              kGrape   =111, kBrown    =112, kAsh    =113,
+              kP6Blue  =120, kP6Yellow =121, kP6Red  =122, kP6Grape=123, kP6Gray   =124, kP6Violet=125,
+              kP8Blue  =130, kP8Orange =131, kP8Red  =132, kP8Pink =133, kP8Green  =134, kP8Cyan  =135, kP8Azure  =136, kP8Gray  =137,
+              kP10Blue =140, kP10Yellow=141, kP10Red =142, kP10Gray=143, kP10Violet=144, kP10Brown=145, kP10Orange=146, kP10Green=147, kP10Ash=148, kP10Cyan=149
             };
 
 // There is several streamer concepts.

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -65,10 +65,10 @@ enum ESysConstants {
 enum EColor { kWhite   =0,   kBlack    =1,   kGray   =920,
               kRed     =632, kGreen    =416, kBlue   =600, kYellow =400, kMagenta =616, kCyan    =432,
               kOrange  =800, kSpring   =820, kTeal   =840, kAzure  =860, kViolet  =880, kPink    =900,
-              kGrape   =340, kBrown    =341, kAsh    =342,
-              kP6Blue  =343, kP6Yellow =344, kP6Red  =345, kP6Grape=346, kP6Gray   =347, kP6Violet=348,
-              kP8Blue  =349, kP8Orange =350, kP8Red  =351, kP8Pink =352, kP8Green  =353, kP8Cyan  =354, kP8Azure  =355, kP8Gray  =356,
-              kP10Blue =357, kP10Yellow=358, kP10Red =359, kP10Gray=360, kP10Violet=361, kP10Brown=362, kP10Orange=363, kP10Green=364, kP10Ash=365, kP10Cyan=366
+              kGrape   =100, kBrown    =101, kAsh    =102,
+              kP6Blue  =103, kP6Yellow =104, kP6Red  =105, kP6Grape=106, kP6Gray   =107, kP6Violet=108,
+              kP8Blue  =109, kP8Orange =110, kP8Red  =111, kP8Pink =112, kP8Green  =113, kP8Cyan  =114, kP8Azure  =115, kP8Gray  =116,
+              kP10Blue =117, kP10Yellow=118, kP10Red =119, kP10Gray=120, kP10Violet=121, kP10Brown=122, kP10Orange=123, kP10Green=124, kP10Ash=125, kP10Cyan=126
             };
 
 // There is several streamer concepts.

--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -69,6 +69,7 @@ public:
    void          Print(Option_t *option="") const override;
    virtual void  SetAlpha(Float_t a) { fAlpha = a; }
    virtual void  SetRGB(Float_t r, Float_t g, Float_t b);
+   void          SetName(const char* name) override;
 
    static void    InitializeColors();
    static void    HLS2RGB(Float_t h, Float_t l, Float_t s, Float_t &r, Float_t &g, Float_t &b);

--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -90,6 +90,7 @@ public:
    static Int_t   GetColorTransparent(Int_t color, Float_t a);
    static Int_t   GetColorByName(const char *colorname);
    static Int_t   GetFreeColorIndex();
+   static Int_t   GetFirstFreeColorIndex();
    static const TArrayI& GetPalette();
    static Int_t   GetLinearGradient(Double_t angle, const std::vector<Int_t> &colors, const std::vector<Double_t> &positions = {});
    static Int_t   GetRadialGradient(Double_t r, const std::vector<Int_t> &colors, const std::vector<Double_t> &positions = {});

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2068,17 +2068,22 @@ Int_t TColor::GetColorBright(Int_t n)
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
 
+   // check if the bright color already exists, if yes return it
+   TString nameb = TString::Format("%s_bright",color->GetName()).Data();
+   Int_t nb = GetColorByName(nameb.Data());
+   TColor *colorb = nullptr;
+   if (nb >= 0) {
+      colorb = (TColor*)colors->At(nb);
+      return colorb->GetNumber();
+   }
+
    //Get the rgb of the new bright color corresponding to color n
    Float_t r,g,b;
    HLStoRGB(color->GetHue(), 1.2f*color->GetLight(), color->GetSaturation(), r, g, b);
 
-   // check if the dark color already exist
-   TString nameb = TString::Format("%s_bright",color->GetName()).Data();
-   if (GetColorByName(nameb.Data())>=0) return color->GetNumber();
-
    //Build the bright color
-   Int_t nb = GetFirstFreeColorIndex();
-   auto colorb = new TColor(nb,r,g,b);
+   nb = GetFirstFreeColorIndex();
+   colorb = new TColor(nb,r,g,b);
    colorb->SetName(nameb.Data());
    colorb->SetTitle(colorb->AsHexString());
    colors->AddAtAndExpand(colorb,nb);
@@ -2102,18 +2107,22 @@ Int_t TColor::GetColorDark(Int_t n)
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
 
+   // check if the dark color already exists, if yes return it
+   TString named = TString::Format("%s_dark",color->GetName()).Data();
+   Int_t nd = GetColorByName(named.Data());
+   TColor *colord = nullptr;
+   if (nd >= 0) {
+      colord = (TColor*)colors->At(nd);
+      return colord->GetNumber();
+   }
+
    //Get the rgb of the new dark color corresponding to color n
    Float_t r,g,b;
    HLStoRGB(color->GetHue(), 0.7f*color->GetLight(), color->GetSaturation(), r, g, b);
 
-   // check if the dark color already exist
-   TString named = TString::Format("%s_dark",color->GetName()).Data();
-   if (GetColorByName(named.Data())>=0) return color->GetNumber();
-
    //Build the dark color
-   Int_t nd = GetFirstFreeColorIndex();
-
-   auto colord = new TColor(nd,r,g,b);
+   nd = GetFirstFreeColorIndex();
+   colord = new TColor(nd,r,g,b);
    colord->SetName(named.Data());
    colord->SetTitle(colord->AsHexString());
    colors->AddAtAndExpand(colord,nd);

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1238,6 +1238,7 @@ void TColor::InitializeColors()
       new TColor(19,.95,.95,.95,"grey19");
       new TColor(50, 0.83,0.35,0.33);
 
+      // define the Petroff color schemes
       new TColor(kGrape,    111./255.,  45./255., 168./255., "kGrape");
       new TColor(kBrown,    165./255.,  42./255.,  42./255., "kBrown");
       new TColor(kAsh,      178./255., 190./255., 181./255., "kAsh");

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2044,19 +2044,19 @@ Int_t TColor::GetColor(Int_t r, Int_t g, Int_t b, Float_t a)
 Int_t TColor::GetColorByName(const char *colorname)
 {
    TObjArray *colors = (TObjArray*) gROOT->GetListOfColors();
-   const Int_t ncolors = colors->GetSize();
-   TColor *color = nullptr;
-   TString colname;
-
-   for (Int_t i = 0; i<ncolors; i++) {
-      color = (TColor*)colors->At(i);
-      if (color) {
-         colname = color->GetName();
-         if (!colname.CompareTo(colorname)) return i;
-      }
-   }
-
-   return -1;
+//    const Int_t ncolors = colors->GetSize();
+//    TColor *color = nullptr;
+//    TString colname;
+//
+//    for (Int_t i = 0; i<ncolors; i++) {
+//       color = (TColor*)colors->At(i);
+//       if (color) {
+//          colname = color->GetName();
+//          if (!colname.CompareTo(colorname)) return i;
+//       }
+//    }
+   if (auto color = static_cast<TColor *>(colors->FindObject(colorname))) return color->GetNumber();
+   else return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2116,10 +2116,11 @@ Int_t TColor::GetColorDark(Int_t n)
 
    // check if the dark color already exist
    TString named = TString::Format("%s_dark",color->GetName()).Data();
-   if (GetColorByName(named.Data())>=0) return color->GetNumber();
+   if (GetColorByName(named.Data())>=0) {printf("%d found\n",color->GetNumber());return color->GetNumber();}
 
    //Build the dark color
    Int_t nd = GetFirstFreeColorIndex();
+
    auto colord = new TColor(nd,r,g,b);
    colord->SetName(named.Data());
    colord->SetTitle(colord->AsHexString());

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2044,19 +2044,11 @@ Int_t TColor::GetColor(Int_t r, Int_t g, Int_t b, Float_t a)
 Int_t TColor::GetColorByName(const char *colorname)
 {
    TObjArray *colors = (TObjArray*) gROOT->GetListOfColors();
-//    const Int_t ncolors = colors->GetSize();
-//    TColor *color = nullptr;
-//    TString colname;
-//
-//    for (Int_t i = 0; i<ncolors; i++) {
-//       color = (TColor*)colors->At(i);
-//       if (color) {
-//          colname = color->GetName();
-//          if (!colname.CompareTo(colorname)) return i;
-//       }
-//    }
-   if (auto color = static_cast<TColor *>(colors->FindObject(colorname))) return color->GetNumber();
-   else return -1;
+   if (auto color = static_cast<TColor *>(colors->FindObject(colorname))) {
+      return color->GetNumber();
+   } else {
+     return -1;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2116,7 +2108,7 @@ Int_t TColor::GetColorDark(Int_t n)
 
    // check if the dark color already exist
    TString named = TString::Format("%s_dark",color->GetName()).Data();
-   if (GetColorByName(named.Data())>=0) {printf("%d found\n",color->GetNumber());return color->GetNumber();}
+   if (GetColorByName(named.Data())>=0) return color->GetNumber();
 
    //Build the dark color
    Int_t nd = GetFirstFreeColorIndex();

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -63,6 +63,7 @@ The color creation and management class.
   - [Basic colors](\ref C01)
   - [The color wheel](\ref C02)
   - [Bright and dark colors](\ref C03)
+  - [Accessible Color Schemes](\ref C031)
   - [Gray scale view of of canvas with colors](\ref C04)
   - [Color palettes](\ref C05)
   - [High quality predefined palettes](\ref C06)
@@ -193,6 +194,25 @@ boxes (see TWbox, TPave, TPaveText, TPaveLabel, etc).
       Int_t dark   = TColor::GetColorDark(color_index);
       Int_t bright = TColor::GetColorBright(color_index);
    ~~~
+
+\anchor C031
+## Accessible Color Schemes
+Choosing an appropriate color scheme is essential for making results easy to understand and
+interpret. Factors like colorblindness and converting colors to grayscale for publications
+can impact accessibility. Furthermore, results should be aesthetically pleasing. The following
+three color schemes, recommended by M. Petroff in [arXiv:2107.02270v2](https://arxiv.org/pdf/2107.02270)
+and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
+under the MIT License, meet these criteria.
+
+These three color schemes are available as color sets with 6, 8, and 10 colors, named
+`kP[6, 8, 10]ColorName`. For example, `kP6Red` represents the red color within the P6 color scheme.
+
+Begin_Macro
+../../../tutorials/graphics/accessiblecolorschemes.C
+End_Macro
+
+The example thstackcolorscheme.C illustrates how to use these color schemes in THStack drawings.
+It also demonstrates that they are effective in grayscale.
 
 \anchor C04
 ## Grayscale view of of canvas with colors
@@ -1051,6 +1071,7 @@ TColor::TColor(): TNamed()
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal color constructor. Initialize a color structure.
 /// Compute the RGB and HLS color components.
+/// The color title is set to its hexadecimal value.
 
 TColor::TColor(Int_t color, Float_t r, Float_t g, Float_t b, const char *name,
                Float_t a)
@@ -1090,6 +1111,7 @@ TColor::TColor(Int_t color, Float_t r, Float_t g, Float_t b, const char *name,
    SetRGB(r, g, b);
    fAlpha = a;
    gDefinedColors++;
+   SetTitle(AsHexString());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1216,6 +1238,37 @@ void TColor::InitializeColors()
       new TColor(19,.95,.95,.95,"grey19");
       new TColor(50, 0.83,0.35,0.33);
 
+      new TColor(kGrape,    111./255.,  45./255., 168./255., "kGrape");
+      new TColor(kBrown,    165./255.,  42./255.,  42./255., "kBrown");
+      new TColor(kAsh,      178./255., 190./255., 181./255., "kAsh");
+
+      new TColor(kP6Blue,    87./255., 144./255., 252./255., "kP6Blue");
+      new TColor(kP6Yellow, 248./255., 156./255.,  32./255., "kP6Yellow");
+      new TColor(kP6Red,    228./255.,  37./255.,  54./255., "kP6Red");
+      new TColor(kP6Grape,  150./255.,  74./255., 139./255., "kP6Grape");
+      new TColor(kP6Gray,   156./255., 156./255., 161./255., "kP6Gray");
+      new TColor(kP6Violet, 112./255.,  33./255., 221./255., "kP6Violet");
+
+      new TColor(kP8Blue,    24./255.,  69./255., 251./255., "kP8Blue");
+      new TColor(kP8Orange,        1.,  94./255.,   2./255., "kP8Orange");
+      new TColor(kP8Red,    201./255.,  31./255.,  22./255., "kP8Red");
+      new TColor(kP8Pink,   200./255.,  73./255., 169./255., "kP8Pink");
+      new TColor(kP8Green,  173./255., 173./255., 125./255., "kP8Green");
+      new TColor(kP8Cyan,   134./255., 200./255., 221./255., "kP8Cyan");
+      new TColor(kP8Azure,   87./255., 141./255., 255./255., "kP8Azure");
+      new TColor(kP8Gray,   101./255.,  99./255., 100./255., "kP8Gray");
+
+      new TColor(kP10Blue,    63./255., 144./255., 218./255., "kP10Blue");
+      new TColor(kP10Yellow,        1., 169./255.,  14./255., "kP10Yellow");
+      new TColor(kP10Red,    189./255.,  31./255.,   1./255., "kP10Red");
+      new TColor(kP10Gray,   148./255., 164./255., 162./255., "kP10Gray");
+      new TColor(kP10Violet, 131./255.,  45./255., 182./255., "kP10Violet");
+      new TColor(kP10Brown,  169./255., 107./255.,  89./255., "kP10Brown");
+      new TColor(kP10Orange, 231./255.,  99./255.,        0., "kP10Orange");
+      new TColor(kP10Green,  185./255., 172./255., 112./255., "kP10Green");
+      new TColor(kP10Ash,    113./255., 117./255., 129./255., "kP10Ash");
+      new TColor(kP10Cyan,   146./255., 218./255., 221./255., "kP10Cyan");
+
       // Initialize the Pretty Palette Spectrum Violet->Red
       //   The color model used here is based on the HLS model which
       //   is much more suitable for creating palettes than RGB.
@@ -1332,7 +1385,6 @@ void TColor::CreateColorsCircle(Int_t offset, const char *name, UChar_t *rgb)
       TColor *color = gROOT->GetColor(colorn);
       if (!color) {
          color = new TColor(colorn,rgb[3*n]/255.,rgb[3*n+1]/255.,rgb[3*n+2]/255.);
-         color->SetTitle(color->AsHexString());
          if      (n>10) colorname.Form("%s+%d",name,n-10);
          else if (n<10) colorname.Form("%s-%d",name,10-n);
          else           colorname.Form("%s",name);
@@ -1352,7 +1404,6 @@ void TColor::CreateColorsRectangle(Int_t offset, const char *name, UChar_t *rgb)
       TColor *color = gROOT->GetColor(colorn);
       if (!color) {
          color = new TColor(colorn,rgb[3*n]/255.,rgb[3*n+1]/255.,rgb[3*n+2]/255.);
-         color->SetTitle(color->AsHexString());
          if      (n>9) colorname.Form("%s+%d",name,n-9);
          else if (n<9) colorname.Form("%s-%d",name,9-n);
          else          colorname.Form("%s",name);

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1850,21 +1850,27 @@ void TColor::SetRGB(Float_t r, Float_t g, Float_t b)
    // now define associated colors for WBOX shading
    Float_t dr, dg, db, lr, lg, lb;
 
+   // Get list of all defined colors
+   auto colors = (TObjArray*) gROOT->GetListOfColors();
+
    // set dark color
-   HLStoRGB(fHue, 0.7f*fLight, fSaturation, dr, dg, db);
-   TColor *dark = gROOT->GetColor(100+fNumber);
-   if (dark) {
-      if (nplanes > 8) dark->SetRGB(dr, dg, db);
-      else             dark->SetRGB(0.3f,0.3f,0.3f);
+   Int_t nd = GetColorByName(TString::Format("%s_dark",GetName()).Data());
+   if (nd >= 0) {
+      HLStoRGB(fHue, 0.7f*fLight, fSaturation, dr, dg, db);
+      TColor *colord = (TColor*)colors->At(nd);
+      if (nplanes > 8) colord->SetRGB(dr, dg, db);
+      else             colord->SetRGB(0.3f,0.3f,0.3f);
    }
 
-   // set light color
-   HLStoRGB(fHue, 1.2f*fLight, fSaturation, lr, lg, lb);
-   TColor *light = gROOT->GetColor(150+fNumber);
-   if (light) {
-      if (nplanes > 8) light->SetRGB(lr, lg, lb);
-      else             light->SetRGB(0.8f,0.8f,0.8f);
+   // set bright color
+   Int_t nb = GetColorByName(TString::Format("%s_bright",GetName()).Data());
+   if (nb >= 0) {
+      HLStoRGB(fHue, 1.2f*fLight, fSaturation, lr, lg, lb);
+      TColor *colorb = (TColor*)colors->At(nb);
+      if (nplanes > 8) colorb->SetRGB(lr, lg, lb);
+      else             colorb->SetRGB(0.8f,0.8f,0.8f);
    }
+
    gDefinedColors++;
 }
 

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2098,6 +2098,10 @@ Int_t TColor::GetColorBright(Int_t n)
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
 
+   // in case color is not named, assign a unique name.
+   if (strlen(color->GetName()) == 0)
+      color->SetName(TString::Format("Color%d",n).Data());
+
    // check if the bright color already exists, if yes return it
    TString nameb = TString::Format("%s_bright",color->GetName()).Data();
    Int_t nb = GetColorByName(nameb.Data());
@@ -2136,6 +2140,10 @@ Int_t TColor::GetColorDark(Int_t n)
    TColor *color = nullptr;
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
+
+   // in case color is not named, assign a unique name.
+   if (strlen(color->GetName()) == 0)
+      color->SetName(TString::Format("Color%d",n).Data());
 
    // check if the dark color already exists, if yes return it
    TString named = TString::Format("%s_dark",color->GetName()).Data();

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -202,7 +202,8 @@ and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
 under the MIT License, meet these criteria.
 
 These three color schemes are available as color sets with 6, 8, and 10 colors, named
-`kP[6, 8, 10]ColorName`. For example, `kP6Red` represents the red color within the P6 color scheme.
+`kP[6, 8, 10]ColorName`. For example, `kP6Red` represents the red color within the P6 color scheme
+(`P` for Petroff or Preferred).
 
 Begin_Macro
 ../../../tutorials/graphics/accessiblecolorschemes.C

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1857,6 +1857,7 @@ void TColor::SetRGB(Float_t r, Float_t g, Float_t b)
    if (fRed < 0) return;
 
    RGBtoHLS(r, g, b, fHue, fLight, fSaturation);
+   SetTitle(AsHexString());
 
    Int_t nplanes = 16;
    if (gVirtualX) gVirtualX->GetPlanes(nplanes);

--- a/documentation/users-guide/Graphics.md
+++ b/documentation/users-guide/Graphics.md
@@ -2312,11 +2312,13 @@ At initialization time, a table of basic colors is generated when the
 first Canvas constructor is called. This table is a linked list, which
 can be accessed from the ***`gROOT`*** object (see
 `TROOT::GetListOfColors()`). Each color has an index and when a basic
-color is defined, two "companion" colors are defined:
-
--   the dark version (color index + 100)
-
--   the bright version (color index + 150)
+color is defined, two "companion" colors are defined: the dark version and the bright version.
+Two static functions are available that return the bright or dark color number corresponding
+to a given color index. If these variants don't already exist, they are created as needed:
+```
+   Int_t dark   = TColor::GetColorDark(color_index);
+   Int_t bright = TColor::GetColorBright(color_index);
+```
 
 The dark and bright colors are used to give 3-D effects when drawing
 various boxes (see **`TWbox`**, **`TPave`**, **`TPaveText`**,

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3670,7 +3670,7 @@ void TPad::PaintBorder(Color_t color, Bool_t tops)
    Short_t px1,py1,px2,py2;
    Double_t xl, xt, yl, yt;
 
-   // GetDarkColor() and GetLightColor() use GetFillColor()
+   // GetColorDark() and GetColorBright() use GetFillColor()
    Color_t oldcolor = GetFillColor();
    SetFillColor(color);
    TAttFill::Modify();

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -5075,7 +5075,6 @@ void THistPainter::PaintBar(Option_t *)
       } else {
          umin = xmin + bar*(xmax-xmin)/10.;
          umax = xmax - bar*(xmax-xmin)/10.;
-         //box.SetFillColor(hcolor+150); //bright
          box.SetFillColor(TColor::GetColorBright(hcolor)); //bright
          box.PaintBox(xmin,ymin,umin,ymax);
          box.SetFillColor(hcolor);

--- a/tutorials/graphics/accessiblecolorschemes.C
+++ b/tutorials/graphics/accessiblecolorschemes.C
@@ -1,0 +1,65 @@
+/// \file
+/// \ingroup tutorial_graphics
+/// \notebook
+/// Choosing an appropriate color scheme is essential for making results easy to understand and
+/// interpret. Factors like colorblindness and converting colors to grayscale for publications
+/// can impact accessibility. Furthermore, results should be aesthetically pleasing. The following
+/// three color schemes, recommended by M. Petroff in [arXiv:2107.02270v2](https://arxiv.org/pdf/2107.02270)
+/// and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
+/// under the MIT License, meet these criteria.
+///
+/// \macro_image
+/// \macro_code
+///
+/// \author Olivier Couet
+
+void box(double x1, double y1, double x2, double y2,int col) {
+   auto b1 = new TBox(x1, y1, x2, y2);
+   b1->SetFillColor(col);
+   b1->Draw();
+
+   TColor *c = gROOT->GetColor(col);
+   auto tc = new TLatex((x2+x1)/2., 0.01+(y2+y1)/2., Form("#splitline{%s}{%s}",c->GetName(),c->GetTitle()));
+   tc->SetTextFont(42);
+   tc->SetTextAlign(23);
+   tc->SetTextSize(0.020);
+   tc->Draw();
+}
+
+void accessiblecolorschemes() {
+   auto C = new TCanvas("C","C",600,800);
+   int c;
+   double x, y;
+   double w = 0.2;
+   double h = 0.08;
+   auto t = new TText();
+   t->SetTextSize(0.025);
+   t->SetTextFont(42);
+
+   // 6-colors scheme
+   x = 0.1;
+   y = 0.1;
+   t->DrawText(x, y-h/2., "6-colors scheme");
+   for (c=kP6Blue; c<kP6Blue+6; c++) {
+      box(x, y, x+w, y+h,c);
+      y = y+h;
+   }
+
+   // 8-color scheme
+   y = 0.1;
+   x = 0.4;
+   t->DrawText(x, y-h/2., "8-colors scheme");
+   for (c=kP8Blue; c<kP8Blue+8; c++) {
+      box(x, y, x+w, y+h,c);
+      y = y+h;
+   }
+
+   // 10-color scheme
+   y = 0.1;
+   x = 0.7;
+   t->DrawText(x, y-h/2., "10-colors scheme");
+   for (c=kP10Blue; c<kP10Blue+10; c++) {
+      box(x, y, x+w, y+h,c);
+      y = y+h;
+   }
+}

--- a/tutorials/graphics/triangles.C
+++ b/tutorials/graphics/triangles.C
@@ -1,39 +1,39 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Generate small triangles randomly in the canvas.
-/// Each triangle has a unique id and a random color in the color palette
+/// Create small triangles at random positions on the canvas.
+/// Assign a unique ID to each triangle, and give each one a random color from the color palette.
 ///
 /// ~~~{.cpp}
 /// root > .x triangles.C
 /// ~~~
 ///
-/// Then click on any triangle. A message showing the triangle number
-/// and its color will be printed.
+/// When a triangle is clicked, a message displaying its unique number and color will be printed.
 ///
 /// \macro_image
 /// \macro_code
 ///
 /// \author Rene Brun
 
-void triangles(Int_t ntriangles=50)
+void triangles(int ntriangles=50)
 {
-   TCanvas *c1 = new TCanvas("c1","triangles",10,10,700,700);
+   auto c1 = new TCanvas("c1","triangles",10,10,700,700);
+   gStyle->SetPalette(kCMYK);
    TRandom r;
-   Double_t dx = 0.2; Double_t dy = 0.2;
-   Int_t ncolors = gStyle->GetNumberOfColors();
-   Double_t x[4],y[4];
-   for (Int_t i=0;i<ntriangles;i++) {
+   double dx = 0.2; double dy = 0.2;
+   int ncolors = TColor::GetNumberOfColors();
+   double x[4],y[4];
+   for (int i=0;i<ntriangles;i++) {
       x[0] = r.Uniform(.05,.95); y[0] = r.Uniform(.05,.95);
       x[1] = x[0] + dx*r.Rndm(); y[1] = y[0] + dy*r.Rndm();
       x[2] = x[1] - dx*r.Rndm(); y[2] = y[1] - dy*r.Rndm();
       x[3] = x[0];               y[3] = y[0];
-      TPolyLine *pl = new TPolyLine(4,x,y);
+      auto pl = new TPolyLine(4,x,y);
       pl->SetUniqueID(i);
-      Int_t ci = ncolors*r.Rndm();
+      int ci = ncolors*r.Rndm();
       TColor *c = gROOT->GetColor(TColor::GetColorPalette(ci));
       c->SetAlpha(r.Rndm());
-      pl->SetFillColor(ci);
+      pl->SetFillColor(c->GetNumber());
       pl->Draw("f");
    }
    c1->AddExec("ex","TriangleClicked()");

--- a/tutorials/hist/thstackcolorscheme.C
+++ b/tutorials/hist/thstackcolorscheme.C
@@ -1,0 +1,61 @@
+/// \file
+/// \ingroup tutorial_hist
+/// \notebook
+///
+/// This example demonstrates how to use the accessible color schemes (in this case, the one
+/// with six colors) to represent THStack. It also shows that the grayscale version is an
+/// acceptable alternative.
+///
+/// \macro_image
+/// \macro_code
+///
+/// \author Olivier Couet
+
+void thstackcolorscheme()
+{
+   auto c1 = new TCanvas();
+   auto hs = new THStack("hs","Stacked 1D histograms colored using 6-colors scheme");
+
+   // Create six 1-d histograms  and add them in the stack
+   auto h1st = new TH1F("h1st","A",100,-4,4);
+   h1st->FillRandom("gaus",20000);
+   h1st->SetFillColor(kP6Blue);
+   hs->Add(h1st);
+
+   auto h2st = new TH1F("h2st","B",100,-4,4);
+   h2st->FillRandom("gaus",15000);
+   h2st->SetFillColor(kP6Yellow);
+   hs->Add(h2st);
+
+   auto h3st = new TH1F("h3st","C",100,-4,4);
+   h3st->FillRandom("gaus",10000);
+   h3st->SetFillColor(kP6Red);
+   hs->Add(h3st);
+
+   auto h4st = new TH1F("h4st","D",100,-4,4);
+   h4st->FillRandom("gaus",10000);
+   h4st->SetFillColor(kP6Grape);
+   hs->Add(h4st);
+
+   auto h5st = new TH1F("h5st","E",100,-4,4);
+   h5st->FillRandom("gaus",10000);
+   h5st->SetFillColor(kP6Gray);
+   hs->Add(h5st);
+
+   auto h6st = new TH1F("h6st","F",100,-4,4);
+   h6st->FillRandom("gaus",10000);
+   h6st->SetFillColor(kP6Violet);
+   hs->Add(h6st);
+
+   // draw the stack with colors
+   hs->Draw();
+   TLegend *l = gPad->BuildLegend(.8,.55,1.,.9,"","F");
+   l->SetLineWidth(0);
+   l->SetFillStyle(0);
+
+   // draw the stack using gray-scale
+   auto c2 = new TCanvas();
+   c2->SetGrayscale();
+   hs->Draw();
+   l->Draw();
+}


### PR DESCRIPTION
# This Pull request:
Choosing an appropriate color scheme is essential for making results easy to understand and
interpret. Factors like colorblindness and converting colors to grayscale for publications
can impact accessibility. Furthermore, results should be aesthetically pleasing. The following
three color schemes, recommended by M. Petroff in [arXiv:2107.02270v2](https://arxiv.org/pdf/2107.02270)
and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
under the MIT License, meet these criteria.

## Changes or fixes:
- Implement the new three colors scheme in TColor.cxx et RTypes.h
- Add 3 missing colors (kBrown, kGrape and kAsh)
- Automaticallically set the name of a new color to its hexadecimal value
- Implement two new tutorials illustrating these new color schemes
- Update the doc
- Improve the dark and bright colors management. Modify the documentation accordingly.


## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)


