### PR TITLE
[RF] Added new printout RooCmdArg to recreate constructor call

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -138,23 +138,20 @@ endif()
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tf_pycallables tf_pycallables.py)
 
 if(roofit)
-  # RooAbsCollection and subclasses pythonizations
+
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabspdf_fitto roofit/rooabspdf_fitto.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooarglist roofit/rooarglist.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roocmdarg roofit/roocmdarg.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_numpy roofit/roodatahist_numpy.py PYTHON_DEPS numpy)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_ploton roofit/roodatahist_ploton.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset roofit/roodataset.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py PYTHON_DEPS numpy)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roolinkedlist roofit/roolinkedlist.py)
+
   if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 4 OR win_broken_tests)
     ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabscollection roofit/rooabscollection.py)
   endif()
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooarglist roofit/rooarglist.py)
-
-  # RooDataHist pythonisations
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_ploton roofit/roodatahist_ploton.py)
-
-  # RooDataSet pythonisations
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset roofit/roodataset.py)
-
-  # RooWorkspace pythonizations
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabspdf_fitto roofit/rooabspdf_fitto.py)
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
-
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_roolinkedlist roofit/roolinkedlist.py)
 
   if(NOT MSVC OR win_broken_tests)
     # Test pythonizations for the RooFitHS3 package, which is not built on Windows.
@@ -167,10 +164,6 @@ if(roofit)
     # RooWorkspace pythonization that fails on Windows
     ROOT_ADD_PYUNITTEST(pyroot_roofit_rooworkspace roofit/rooworkspace.py)
   endif()
-
-  # NumPy compatibility
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py PYTHON_DEPS numpy)
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_numpy roofit/roodatahist_numpy.py PYTHON_DEPS numpy)
 
 endif()
 

--- a/bindings/pyroot/pythonizations/test/roofit/roocmdarg.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roocmdarg.py
@@ -1,0 +1,83 @@
+import unittest
+
+import ROOT
+
+# Necessary inside the "eval" call
+RooArgSet = ROOT.RooArgSet
+RooCmdArg = ROOT.RooCmdArg
+
+x = ROOT.RooRealVar("x", "x", 1.0)
+y = ROOT.RooRealVar("y", "y", 2.0)
+z = ROOT.RooRealVar("z", "z", 3.0)
+
+
+def args_equal(arg_1, arg_2):
+    same = True
+
+    same &= str(arg_1.GetName()) == str(arg_2.GetName())
+    same &= str(arg_1.GetTitle()) == str(arg_2.GetTitle())
+
+    for i in range(2):
+        same &= arg_1.getInt(i) == arg_2.getInt(i)
+
+    for i in range(2):
+        same &= arg_1.getDouble(i) == arg_2.getDouble(i)
+
+    for i in range(3):
+        same &= str(arg_1.getString(i)) == str(arg_2.getString(i))
+
+    same &= arg_1.procSubArgs() == arg_2.procSubArgs()
+    same &= arg_1.prefixSubArgs() == arg_2.prefixSubArgs()
+
+    for i in range(2):
+        same &= arg_1.getObject(i) == arg_2.getObject(i)
+
+    def set_equal(set_1, set_2):
+        if set_1 == ROOT.nullptr and set_2 == ROOT.nullptr:
+            return True
+        if set_1 == ROOT.nullptr and set_2 != ROOT.nullptr:
+            return False
+        if set_1 != ROOT.nullptr and set_2 == ROOT.nullptr:
+            return False
+
+        if set_1.size() != set_2.size():
+            return False
+
+        return set_2.hasSameLayout(set_1)
+
+    for i in range(2):
+        same &= set_equal(arg_1.getSet(i), arg_2.getSet(i))
+
+    return same
+
+
+class TestRooArgList(unittest.TestCase):
+    """
+    Test for RooCmdArg pythonizations.
+    """
+
+    def test_constructor_eval(self):
+
+        set_1 = ROOT.RooArgSet(x, y)
+        set_2 = ROOT.RooArgSet(y, z)
+
+        def do_test(*args):
+            arg_1 = ROOT.RooCmdArg(*args)
+
+            # The arg should be able to recreate itself by emitting the right
+            # constructor code:
+            arg_2 = eval(arg_1.constructorCode())
+
+            self.assertTrue(args_equal(arg_1, arg_2))
+
+        nullp = ROOT.nullptr
+
+        # only fill the non-object fields:
+        do_test("Test", -1, 3, 4.2, 4.7, "hello", "world", nullp, nullp, nullp, "s3", nullp, nullp)
+
+        # RooArgSet tests:
+        do_test("Test", -1, 3, 4.2, 4.7, "hello", "world", nullp, nullp, nullp, "s3", set_1, set_2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -39,6 +39,7 @@ public:
             const char* s1=nullptr, const char* s2=nullptr,
             const TObject* o1=nullptr, const TObject* o2=nullptr, const RooCmdArg* ca=nullptr, const char* s3=nullptr,
             const RooArgSet* c1=nullptr, const RooArgSet* c2=nullptr) ;
+
   RooCmdArg(const RooCmdArg& other) ;
   RooCmdArg& operator=(const RooCmdArg& other) ;
   void addArg(const RooCmdArg& arg) ;
@@ -106,6 +107,8 @@ public:
 
   bool procSubArgs() const { return _procSubArgs; }
   bool prefixSubArgs() const { return _prefixSubArgs; }
+
+  std::string constructorCode() const;
 
 private:
 


### PR DESCRIPTION
# This Pull request:

- Adds new Constructor interfaces to RooCmdArg
- Adds new printouts to RooCmdArg

## Changes or fixes:

RooCmdArg is a bit of an old-style piece of code that doesn't really work well with python.
Also, when talking among statistics code developers, it's commonplace to have to "exchange" fit arguments between codes ("what arguments to you pass to make it converge?").
For this purpose, it's very convenient to:
- be able to print the command arguments in a human-readable format, and
- directly use these printouts to copy&paste them into some other piece of code to make comparison studies

The changes in this PR make this possible with little effort.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

