### PR TITLE
[RF] Fixup deprecation warnings in MarkovChain.h

### DIFF
--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -76,8 +76,8 @@ namespace RooStats {
                                        const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                        const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
-                                       const RooCmdArg& arg8={} ) const;
-      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet)")
+                                       const RooCmdArg& arg8={} ) const
+      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet)");
 
       virtual const RooDataSet* GetAsConstDataSet() const { return fChain; }
 
@@ -94,9 +94,9 @@ namespace RooStats {
                                          const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                          const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                          const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
-                                         const RooCmdArg& arg8={} ) const;
-      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet) and then obtaining its binned clone.")
-      
+                                         const RooCmdArg& arg8={} ) const
+      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet) and then obtaining its binned clone.");
+
       /// Get a clone of the markov chain on which this interval is based
       /// as a sparse histogram.  You own the returned THnSparse*
       virtual THnSparse* GetAsSparseHist(RooAbsCollection* whichVars = nullptr) const;


### PR DESCRIPTION
The semicolons were at the wrong place, making the deprecation macros refer to the wrong funciton. Follows up on f1bc9d96df.