### PR TITLE
[RF] Use `ROOT::Math::Minimizer` in RooMinimizer directly

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -185,7 +185,6 @@ public:
    std::string const &minimizerType() const { return _cfg.minimizerType; }
 
    RooFit::OwningPtr<RooFitResult> lastMinuitFit();
-   RooFit::OwningPtr<RooFitResult> lastMinuitFit(const RooArgList &varList);
 
    void saveStatus(const char *label, int status) { _statusHistory.emplace_back(label, status); }
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -77,8 +77,6 @@ public:
       bool profile = false;        // local config
       bool timingAnalysis = false; // local config
       std::string minimizerType;   // local config
-   private:
-      int getDefaultWorkers();
    };
 
    explicit RooMinimizer(RooAbsReal &function, Config const &cfg = {});

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -39,7 +39,6 @@ class RooArgList;
 class RooRealVar;
 class RooArgSet;
 class RooPlot;
-class RooDataSet;
 namespace RooFit {
 namespace TestStatistics {
 class LikelihoodGradientJob;
@@ -167,17 +166,6 @@ public:
                     double n4 = 0.0, double n5 = 0.0, double n6 = 0.0, unsigned int npoints = 50);
 
    void setProfile(bool flag = true) { _cfg.profile = flag; }
-   /// Enable or disable the logging of function evaluations to a RooDataSet.
-   /// \see RooMinimizer::getLogDataSet().
-   /// param[in] flag Boolean flag to disable or enable the functionality.
-   void setLoggingToDataSet(bool flag = true) { _loggingToDataSet = flag; }
-
-   /// If logging of function evaluations to a RooDataSet is enabled, returns a
-   /// pointer to a dataset with one row per evaluation of the RooAbsReal passed
-   /// to the minimizer. As columns, there are all floating parameters and the
-   /// values they had for that evaluation.
-   /// \see RooMinimizer::setLoggingToDataSet(bool).
-   RooDataSet *getLogDataSet() const { return _logDataSet.get(); }
 
    int getPrintLevel();
 
@@ -247,13 +235,11 @@ private:
    std::unique_ptr<ROOT::Math::Minimizer> _minimizer; ///<! pointer to used minimizer
    int _status = -99;
    bool _profileStart = false;
-   bool _loggingToDataSet = false;
    TStopwatch _timer;
    TStopwatch _cumulTimer;
    std::unique_ptr<TMatrixDSym> _extV;
    std::unique_ptr<RooAbsMinimizerFcn> _fcn;
    std::vector<std::pair<std::string, int>> _statusHistory;
-   std::unique_ptr<RooDataSet> _logDataSet;
    RooMinimizer::Config _cfg; // local config object
 
    ClassDefOverride(RooMinimizer, 0) // RooFit interface to ROOT::Math::Minimizer

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -346,18 +346,20 @@ void RooAbsMinimizerFcn::SetPdfParamErr(int index, double loVal, double hiVal)
 }
 
 /// Transfer MINUIT fit results back into RooFit objects.
-void RooAbsMinimizerFcn::BackProp(const ROOT::Fit::FitResult &results)
+void RooAbsMinimizerFcn::BackProp()
 {
+   auto const &results = _context->fitter()->Result();
+
    for (unsigned int index = 0; index < _nDim; index++) {
-      double value = results.Value(index);
+      double value = results.fParams[index];
       SetPdfParamVal(index, value);
 
       // Set the parabolic error
-      double err = results.Error(index);
+      double err = results.fErrors[index];
       SetPdfParamErr(index, err);
 
-      double eminus = results.LowerError(index);
-      double eplus = results.UpperError(index);
+      double eminus = results.lowerError(index);
+      double eplus = results.upperError(index);
 
       if (eplus > 0 || eminus < 0) {
          // Store the asymmetric error, if it is available

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -543,17 +543,3 @@ void RooAbsMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constV
       setOptimizeConstOnFunction(RooAbsArg::ValueChange, true);
    }
 }
-
-std::vector<double> RooAbsMinimizerFcn::getParameterValues() const
-{
-   // TODO: make a cache for this somewhere so it doesn't have to be recreated on each call
-   std::vector<double> values;
-   values.reserve(_nDim);
-
-   for (std::size_t index = 0; index < _nDim; ++index) {
-      RooRealVar *par = static_cast<RooRealVar *>(_floatParamList->at(index));
-      values.push_back(par->getVal());
-   }
-
-   return values;
-}

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -483,17 +483,6 @@ double RooAbsMinimizerFcn::applyEvalErrorHandling(double fvalue) const
 
 void RooAbsMinimizerFcn::finishDoEval() const
 {
-
-   if (_context->_loggingToDataSet) {
-
-      if (!_context->_logDataSet) {
-         const char *name = "minimizer_log_dataset";
-         _context->_logDataSet = std::make_unique<RooDataSet>(name, name, *_floatParamList);
-      }
-
-      _context->_logDataSet->add(*_floatParamList);
-   }
-
    _evalCounter++;
 }
 

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -57,7 +57,7 @@ public:
    double &getOffset() const { return _funcOffset; }
 
    /// Put Minuit results back into RooFit objects.
-   void BackProp(const ROOT::Fit::FitResult &results);
+   void BackProp();
 
    /// RooMinimizer sometimes needs the name of the minimized function. Implement this in the derived class.
    virtual std::string getFunctionName() const = 0;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -80,8 +80,6 @@ public:
 
    void setOptimizeConst(Int_t flag);
 
-   std::vector<double> getParameterValues() const;
-
    bool SetPdfParamVal(int index, double value) const;
 
    /// Enable or disable offsetting on the function to be minimized, which enhances numerical precision.

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -881,15 +881,6 @@ double &RooMinimizer::fcnOffset() const
    return _fcn->getOffset();
 }
 
-int RooMinimizer::Config::getDefaultWorkers()
-{
-#ifdef ROOFIT_MULTIPROCESS
-   return RooFit::MultiProcess::Config::getDefaultNWorkers();
-#else
-   return 0;
-#endif
-}
-
 std::unique_ptr<RooAbsReal::EvalErrorContext> RooMinimizer::makeEvalErrorContext() const
 {
    RooAbsReal::clearEvalErrorLog();

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -18,16 +18,13 @@
 \class RooMinimizer
 \ingroup Roofitcore
 
-Wrapper class around ROOT::Fit:Fitter that
+Wrapper class around ROOT::Math::Minimizer that
 provides a seamless interface between the minimizer functionality
 and the native RooFit interface.
-By default the Minimizer is MINUIT for classic mode and MINUIT2
-for parallelized mode (activated with the `RooFit::ModularL(true)`
-parameter or by passing a RooRealL function as the minimization
-target).
+By default the Minimizer is Minuit 2.
 RooMinimizer can minimize any RooAbsReal function with respect to
-its parameters. Usual choices for minimization are RooNLLVar
-and RooChi2Var
+its parameters. Usual choices for minimization are the object returned by
+RooAbsPdf::createNLL() or RooAbsReal::createChi2().
 RooMinimizer has methods corresponding to MINUIT functions like
 hesse(), migrad(), minos() etc. In each of these function calls
 the state of the MINUIT engine is synchronized with the state
@@ -61,11 +58,11 @@ automatic PDF optimization.
 #include "RooFit/MultiProcess/ProcessTimer.h"
 #endif
 
-#include "TClass.h"
-#include "Math/Minimizer.h"
-#include "TMarker.h"
-#include "TGraph.h"
-#include "Fit/FitConfig.h"
+#include <Fit/BasicFCN.h>
+#include <Math/Minimizer.h>
+#include <TClass.h>
+#include <TGraph.h>
+#include <TMarker.h>
 
 #include <fstream>
 #include <iostream>
@@ -108,7 +105,7 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
          RooFit::MultiProcess::Config::setTimingAnalysis(_cfg.timingAnalysis);
 
          _fcn = std::make_unique<RooFit::TestStatistics::MinuitFcnGrad>(
-            nll_real->getRooAbsL(), this, getConfig().ParamsSettings(),
+            nll_real->getRooAbsL(), this, _config.ParamsSettings(),
             RooFit::TestStatistics::LikelihoodMode{
                static_cast<RooFit::TestStatistics::LikelihoodMode>(int(_cfg.enableParallelDescent))},
             RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
@@ -146,8 +143,7 @@ void RooMinimizer::initMinimizerFirstPart()
    RooSentinel::activate();
    setMinimizerType("");
 
-   _theFitter = std::make_unique<ROOT::Fit::Fitter>();
-   getConfig().SetMinimizer(_cfg.minimizerType.c_str());
+   _config.SetMinimizer(_cfg.minimizerType.c_str());
    setEps(1.0); // default tolerance
 }
 
@@ -155,8 +151,8 @@ void RooMinimizer::initMinimizerFirstPart()
 void RooMinimizer::initMinimizerFcnDependentPart(double defaultErrorLevel)
 {
    // default max number of calls
-   getConfig().MinimizerOptions().SetMaxIterations(500 * _fcn->getNDim());
-   getConfig().MinimizerOptions().SetMaxFunctionCalls(500 * _fcn->getNDim());
+   _config.MinimizerOptions().SetMaxIterations(500 * _fcn->getNDim());
+   _config.MinimizerOptions().SetMaxFunctionCalls(500 * _fcn->getNDim());
 
    // Shut up for now
    setPrintLevel(-1);
@@ -165,7 +161,7 @@ void RooMinimizer::initMinimizerFcnDependentPart(double defaultErrorLevel)
    setErrorLevel(defaultErrorLevel);
 
    // Declare our parameters to MINUIT
-   _fcn->Synchronize(getConfig().ParamsSettings());
+   _fcn->Synchronize(_config.ParamsSettings());
 
    // Now set default verbosity
    setPrintLevel(RooMsgService::instance().silentMode() ? -1 : 1);
@@ -192,7 +188,7 @@ RooMinimizer::~RooMinimizer() = default;
 
 void RooMinimizer::setStrategy(int istrat)
 {
-   getConfig().MinimizerOptions().SetStrategy(istrat);
+   _config.MinimizerOptions().SetStrategy(istrat);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,7 +197,7 @@ void RooMinimizer::setStrategy(int istrat)
 
 void RooMinimizer::setMaxIterations(int n)
 {
-   getConfig().MinimizerOptions().SetMaxIterations(n);
+   _config.MinimizerOptions().SetMaxIterations(n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -210,7 +206,7 @@ void RooMinimizer::setMaxIterations(int n)
 
 void RooMinimizer::setMaxFunctionCalls(int n)
 {
-   getConfig().MinimizerOptions().SetMaxFunctionCalls(n);
+   _config.MinimizerOptions().SetMaxFunctionCalls(n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -221,7 +217,7 @@ void RooMinimizer::setMaxFunctionCalls(int n)
 
 void RooMinimizer::setErrorLevel(double level)
 {
-   getConfig().MinimizerOptions().SetErrorDef(level);
+   _config.MinimizerOptions().SetErrorDef(level);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -229,7 +225,7 @@ void RooMinimizer::setErrorLevel(double level)
 
 void RooMinimizer::setEps(double eps)
 {
-   getConfig().MinimizerOptions().SetTolerance(eps);
+   _config.MinimizerOptions().SetTolerance(eps);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -265,7 +261,7 @@ void RooMinimizer::setMinimizerType(std::string const &type)
 void RooMinimizer::determineStatus(bool fitterReturnValue)
 {
    // Minuit-given status:
-   _status = ((fitterReturnValue) ? getResult().Status() : -1);
+   _status = fitterReturnValue ? _result->fStatus : -1;
 
    // RooFit-based additional failed state information:
    if (evalCounter() <= _fcn->GetNumInvalidNLL()) {
@@ -293,20 +289,20 @@ int RooMinimizer::minimize(const char *type, const char *alg)
                              "ProcessTimer.");
 #endif
    }
-   _fcn->Synchronize(getConfig().ParamsSettings());
+   _fcn->Synchronize(_config.ParamsSettings());
 
    setMinimizerType(type);
-   getConfig().SetMinimizer(_cfg.minimizerType.c_str(), alg);
+   _config.SetMinimizer(_cfg.minimizerType.c_str(), alg);
 
    profileStart();
    {
       auto ctx = makeEvalErrorContext();
 
-      bool ret = _theFitter->FitFCN(*_fcn->getMultiGenFcn());
+      bool ret = fitFCN(*_fcn->getMultiGenFcn());
       determineStatus(ret);
    }
    profileStop();
-   _fcn->BackProp(getResult());
+   _fcn->BackProp();
 
    saveStatus("MINIMIZE", _status);
 
@@ -326,7 +322,7 @@ int RooMinimizer::migrad()
 
 int RooMinimizer::exec(std::string const &algoName, std::string const &statusName)
 {
-   _fcn->Synchronize(getConfig().ParamsSettings());
+   _fcn->Synchronize(_config.ParamsSettings());
    profileStart();
    {
       auto ctx = makeEvalErrorContext();
@@ -334,20 +330,20 @@ int RooMinimizer::exec(std::string const &algoName, std::string const &statusNam
       bool ret = false;
       if (algoName == "hesse") {
          // HESSE has a special entry point in the ROOT::Math::Fitter
-         getConfig().SetMinimizer(_cfg.minimizerType.c_str());
-         ret = _theFitter->CalculateHessErrors();
+         _config.SetMinimizer(_cfg.minimizerType.c_str());
+         ret = calculateHessErrors();
       } else if (algoName == "minos") {
          // MINOS has a special entry point in the ROOT::Math::Fitter
-         getConfig().SetMinimizer(_cfg.minimizerType.c_str());
-         ret = _theFitter->CalculateMinosErrors();
+         _config.SetMinimizer(_cfg.minimizerType.c_str());
+         ret = calculateMinosErrors();
       } else {
-         getConfig().SetMinimizer(_cfg.minimizerType.c_str(), algoName.c_str());
-         ret = _theFitter->FitFCN(*_fcn->getMultiGenFcn());
+         _config.SetMinimizer(_cfg.minimizerType.c_str(), algoName.c_str());
+         ret = fitFCN(*_fcn->getMultiGenFcn());
       }
       determineStatus(ret);
    }
    profileStop();
-   _fcn->BackProp(getResult());
+   _fcn->BackProp();
 
    saveStatus(statusName.c_str(), _status);
 
@@ -362,7 +358,7 @@ int RooMinimizer::exec(std::string const &algoName, std::string const &statusNam
 
 int RooMinimizer::hesse()
 {
-   if (getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       coutW(Minimization) << "RooMinimizer::hesse: Error, run Migrad before Hesse!" << std::endl;
       _status = -1;
       return _status;
@@ -379,7 +375,7 @@ int RooMinimizer::hesse()
 
 int RooMinimizer::minos()
 {
-   if (getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << std::endl;
       _status = -1;
       return _status;
@@ -396,12 +392,12 @@ int RooMinimizer::minos()
 
 int RooMinimizer::minos(const RooArgSet &minosParamList)
 {
-   if (getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << std::endl;
       _status = -1;
    } else if (!minosParamList.empty()) {
 
-      _fcn->Synchronize(getConfig().ParamsSettings());
+      _fcn->Synchronize(_config.ParamsSettings());
       profileStart();
       {
          auto ctx = makeEvalErrorContext();
@@ -418,17 +414,17 @@ int RooMinimizer::minos(const RooArgSet &minosParamList)
 
          if (!paramInd.empty()) {
             // set the parameter indices
-            getConfig().SetMinosErrors(paramInd);
+            _config.SetMinosErrors(paramInd);
 
-            getConfig().SetMinimizer(_cfg.minimizerType.c_str());
-            bool ret = _theFitter->CalculateMinosErrors();
+            _config.SetMinimizer(_cfg.minimizerType.c_str());
+            bool ret = calculateMinosErrors();
             determineStatus(ret);
             // to avoid that following minimization computes automatically the Minos errors
-            getConfig().SetMinosErrors(false);
+            _config.SetMinosErrors(false);
          }
       }
       profileStop();
-      _fcn->BackProp(getResult());
+      _fcn->BackProp();
 
       saveStatus("MINOS", _status);
    }
@@ -474,7 +470,7 @@ int RooMinimizer::improve()
 
 void RooMinimizer::setPrintLevel(int newLevel)
 {
-   getConfig().MinimizerOptions().SetPrintLevel(newLevel + 1);
+   _config.MinimizerOptions().SetPrintLevel(newLevel + 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -482,7 +478,7 @@ void RooMinimizer::setPrintLevel(int newLevel)
 
 int RooMinimizer::getPrintLevel()
 {
-   return getConfig().MinimizerOptions().PrintLevel() + 1;
+   return _config.MinimizerOptions().PrintLevel() + 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -504,15 +500,13 @@ void RooMinimizer::optimizeConst(int flag)
 
 RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const char *userTitle)
 {
-   if (getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       coutW(Minimization) << "RooMinimizer::save: Error, run minimization before!" << std::endl;
       return nullptr;
    }
 
-   TString name;
-   TString title;
-   name = userName ? userName : Form("%s", _fcn->getFunctionName().c_str());
-   title = userTitle ? userTitle : Form("%s", _fcn->getFunctionTitle().c_str());
+   TString name = userName ? userName : Form("%s", _fcn->getFunctionName().c_str());
+   TString title = userTitle ? userTitle : Form("%s", _fcn->getFunctionTitle().c_str());
    auto fitRes = std::make_unique<RooFitResult>(name, title);
 
    // Move eventual fixed parameters in floatList to constList
@@ -537,23 +531,12 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const c
    removeOffset = -_fcn->getOffset();
 
    fitRes->setStatus(_status);
-   fitRes->setCovQual(getMinimizer()->CovMatrixStatus());
-   fitRes->setMinNLL(getResult().MinFcnValue() + removeOffset);
-   fitRes->setEDM(getResult().Edm());
+   fitRes->setCovQual(_minimizer->CovMatrixStatus());
+   fitRes->setMinNLL(_result->fVal + removeOffset);
+   fitRes->setEDM(_result->fEdm);
    fitRes->setFinalParList(saveFloatFinalList);
    if (!_extV) {
-      const std::size_t nParams = getResult().Parameters().size();
-      std::vector<double> globalCC;
-      TMatrixDSym corrs(nParams);
-      TMatrixDSym covs(nParams);
-      for (std::size_t ic = 0; ic < nParams; ic++) {
-         globalCC.push_back(getResult().GlobalCC(ic));
-         for (std::size_t ii = 0; ii < nParams; ii++) {
-            corrs(ic, ii) = getResult().Correlation(ic, ii);
-            covs(ic, ii) = getResult().CovMatrix(ic, ii);
-         }
-      }
-      fitRes->fillCorrMatrix(globalCC, corrs, covs);
+      fillCorrMatrix(*fitRes);
    } else {
       fitRes->setCovarianceMatrix(*_extV);
    }
@@ -561,6 +544,43 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const c
    fitRes->setStatusHistory(_statusHistory);
 
    return RooFit::makeOwningPtr(std::move(fitRes));
+}
+
+namespace {
+
+/// retrieve covariance matrix element
+double covMatrix(std::vector<double> const &covMat, unsigned int i, unsigned int j)
+{
+   if (covMat.empty())
+      return 0; // no matrix is available in case of non-valid fits
+   return j < i ? covMat[j + i * (i + 1) / 2] : covMat[i + j * (j + 1) / 2];
+}
+
+/// retrieve correlation elements
+double correlation(std::vector<double> const &covMat, unsigned int i, unsigned int j)
+{
+   if (covMat.empty())
+      return 0; // no matrix is available in case of non-valid fits
+   double tmp = covMatrix(covMat, i, i) * covMatrix(covMat, j, j);
+   return tmp > 0 ? covMatrix(covMat, i, j) / std::sqrt(tmp) : 0;
+}
+
+} // namespace
+
+void RooMinimizer::fillCorrMatrix(RooFitResult &fitRes)
+{
+   const std::size_t nParams = _fcn->getNDim();
+   std::vector<double> globalCC;
+   TMatrixDSym corrs(nParams);
+   TMatrixDSym covs(nParams);
+   for (std::size_t ic = 0; ic < nParams; ic++) {
+      globalCC.push_back(_result->fGlobalCC[ic]);
+      for (std::size_t ii = 0; ii < nParams; ii++) {
+         corrs(ic, ii) = correlation(_result->fCovMatrix, ic, ii);
+         covs(ic, ii) = covMatrix(_result->fCovMatrix, ic, ii);
+      }
+   }
+   fitRes.fillCorrMatrix(globalCC, corrs, covs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -610,13 +630,13 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
 
    // check first if a inimizer is available. If not means
    // the minimization is not done , so do it
-   if (getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       coutW(Minimization) << "RooMinimizer::contour: Error, run Migrad before contours!" << std::endl;
       return frame;
    }
 
    // remember our original value of ERRDEF
-   double errdef = getMinimizer()->ErrorDef();
+   double errdef = _minimizer->ErrorDef();
 
    double n[6];
    n[0] = n1;
@@ -630,12 +650,12 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
       if (n[ic] > 0) {
 
          // set the value corresponding to an n1-sigma contour
-         getMinimizer()->SetErrorDef(n[ic] * n[ic] * errdef);
+         _minimizer->SetErrorDef(n[ic] * n[ic] * errdef);
 
          // calculate and draw the contour
          std::vector<double> xcoor(npoints + 1);
          std::vector<double> ycoor(npoints + 1);
-         bool ret = getMinimizer()->Contour(index1, index2, npoints, xcoor.data(), ycoor.data());
+         bool ret = _minimizer->Contour(index1, index2, npoints, xcoor.data(), ycoor.data());
 
          if (!ret) {
             coutE(Minimization) << "RooMinimizer::contour(" << GetName()
@@ -655,7 +675,7 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
    }
 
    // restore the original ERRDEF
-   getMinimizer()->SetErrorDef(errdef);
+   _minimizer->SetErrorDef(errdef);
 
    // restore parameter values
    params->assign(paramSave);
@@ -712,8 +732,7 @@ void RooMinimizer::profileStop()
 
 ROOT::Math::IMultiGenFunction *RooMinimizer::getMultiGenFcn() const
 {
-   auto *fitterFcn = _theFitter->GetFCN();
-   return fitterFcn ? fitterFcn : _fcn->getMultiGenFcn();
+   return _fcn->getMultiGenFcn();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -737,17 +756,17 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    // Import the results of the last fit performed, interpreting
    // the fit parameters as the given varList of parameters.
 
-   if (_theFitter == nullptr || getMinimizer() == nullptr) {
+   if (_minimizer == nullptr) {
       oocoutE(nullptr, InputArguments) << "RooMinimizer::save: Error, run minimization before!" << std::endl;
       return nullptr;
    }
 
    // Verify length of supplied varList
-   if (!varList.empty() && varList.size() != getResult().NTotalParameters()) {
+   if (!varList.empty() && varList.size() != _fcn->getNDim()) {
       oocoutE(nullptr, InputArguments)
          << "RooMinimizer::lastMinuitFit: ERROR: supplied variable list must be either empty " << std::endl
-         << "                             or match the number of variables of the last fit ("
-         << getResult().NTotalParameters() << ")" << std::endl;
+         << "                             or match the number of variables of the last fit (" << _fcn->getNDim() << ")"
+         << std::endl;
       return nullptr;
    }
 
@@ -767,16 +786,15 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    RooArgList constPars("constPars");
    RooArgList floatPars("floatPars");
 
-   unsigned int i;
-   for (i = 0; i < getResult().NTotalParameters(); ++i) {
+   for (unsigned int i = 0; i < _fcn->getNDim(); ++i) {
 
-      TString varName(getResult().GetParameterName(i));
-      bool isConst(getResult().IsParameterFixed(i));
+      TString varName(_fcn->GetFloatParamList()->at(i)->GetName());
+      bool isConst(_result->isParameterFixed(i));
 
-      double xlo = getConfig().ParSettings(i).LowerLimit();
-      double xhi = getConfig().ParSettings(i).UpperLimit();
-      double xerr = getResult().Error(i);
-      double xval = getResult().Value(i);
+      double xlo = _config.ParSettings(i).LowerLimit();
+      double xhi = _config.ParSettings(i).UpperLimit();
+      double xerr = _result->error(i);
+      double xval = _result->fParams[i];
 
       std::unique_ptr<RooRealVar> var;
       if (varList.empty()) {
@@ -813,22 +831,11 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    res->setConstParList(constPars);
    res->setInitParList(floatPars);
    res->setFinalParList(floatPars);
-   res->setMinNLL(getResult().MinFcnValue());
-   res->setEDM(getResult().Edm());
-   res->setCovQual(getMinimizer()->CovMatrixStatus());
-   res->setStatus(getResult().Status());
-   std::vector<double> globalCC;
-   const std::size_t nParams = getResult().Parameters().size();
-   TMatrixDSym corrs(nParams);
-   TMatrixDSym covs(nParams);
-   for (unsigned int ic = 0; ic < nParams; ic++) {
-      globalCC.push_back(getResult().GlobalCC(ic));
-      for (unsigned int ii = 0; ii < nParams; ii++) {
-         corrs(ic, ii) = getResult().Correlation(ic, ii);
-         covs(ic, ii) = getResult().CovMatrix(ic, ii);
-      }
-   }
-   res->fillCorrMatrix(globalCC, corrs, covs);
+   res->setMinNLL(_result->fVal);
+   res->setEDM(_result->fEdm);
+   res->setCovQual(_minimizer->CovMatrixStatus());
+   res->setStatus(_result->fStatus);
+   fillCorrMatrix(*res);
 
    return RooFit::makeOwningPtr(std::move(res));
 }
@@ -847,11 +854,7 @@ void RooMinimizer::setRecoverFromNaNStrength(double strength)
 bool RooMinimizer::setLogFile(const char *logf)
 {
    _cfg.logf = logf;
-   if (_cfg.logf) {
-      return _fcn->SetLogFile(_cfg.logf);
-   } else {
-      return false;
-   }
+   return _cfg.logf ? _fcn->SetLogFile(_cfg.logf) : false;
 }
 
 int RooMinimizer::evalCounter() const
@@ -889,4 +892,328 @@ std::unique_ptr<RooAbsReal::EvalErrorContext> RooMinimizer::makeEvalErrorContext
    // performance overhead when having evaluation errors.
    auto m = _cfg.printEvalErrors < 0 ? RooAbsReal::CountErrors : RooAbsReal::CollectErrors;
    return std::make_unique<RooAbsReal::EvalErrorContext>(m);
+}
+
+bool RooMinimizer::fitFCN(const ROOT::Math::IMultiGenFunction &fcn)
+{
+   // fit a user provided FCN function
+   // create fit parameter settings
+   unsigned int npar = fcn.NDim();
+   if (npar == 0) {
+      coutE(Minimization) << "RooMinimizer::fitFCN(): FCN function has zero parameters" << std::endl;
+      return false;
+   }
+
+   // init the minimizer
+   initMinimizer();
+   // perform the minimization
+
+   // perform the minimization (assume we have already initialized the minimizer)
+
+   bool isValid = _minimizer->Minimize();
+
+   if (!_result)
+      _result = std::make_unique<FitResult>();
+
+   fillResult(isValid);
+
+   // set also new parameter values and errors in FitConfig
+   if (isValid)
+      updateFitConfig();
+
+   return isValid;
+}
+
+bool RooMinimizer::calculateHessErrors()
+{
+   // compute the Hesse errors according to configuration
+   // set in the parameters and append value in fit result
+
+   // update  minimizer (recreate if not done or if name has changed
+   if (!updateMinimizerOptions()) {
+      coutE(Minimization) << "RooMinimizer::calculateHessErrors() Error re-initializing the minimizer" << std::endl;
+      return false;
+   }
+
+   // run Hesse
+   bool ret = _minimizer->Hesse();
+   if (!ret)
+      coutE(Minimization) << "RooMinimizer::calculateHessErrors() Error when calculating Hessian" << std::endl;
+
+   // update minimizer results with what comes out from Hesse
+   // in case is empty - create from a FitConfig
+   if (_result->fParams.empty())
+      _result = std::make_unique<FitResult>(_config);
+
+   // re-give a minimizer instance in case it has been changed
+   ret |= update(ret);
+
+   // set also new errors in FitConfig
+   if (ret)
+      updateFitConfig();
+
+   return ret;
+}
+
+bool RooMinimizer::calculateMinosErrors()
+{
+   // compute the Minos errors according to configuration
+   // set in the parameters and append value in fit result
+   // normally Minos errors are computed just after the minimization
+   // (in DoMinimization) aftewr minimizing if the
+   //  FitConfig::MinosErrors() flag is set
+
+   // update  minimizer (but cannot re-create in this case). Must use an existing one
+   if (!updateMinimizerOptions(false)) {
+      coutE(Minimization) << "RooMinimizer::calculateHessErrors() Error re-initializing the minimizer" << std::endl;
+      return false;
+   }
+
+   const std::vector<unsigned int> &ipars = _config.MinosParams();
+   unsigned int n = (!ipars.empty()) ? ipars.size() : _fcn->getNDim();
+   bool ok = false;
+
+   int iparNewMin = 0;
+   int iparMax = n;
+   int iter = 0;
+   // rerun minos for the parameters run before a new Minimum has been found
+   do {
+      if (iparNewMin > 0)
+         coutI(Minimization) << "RooMinimizer::calculateMinosErrors() Run again Minos for some parameters because a "
+                                "new Minimum has been found"
+                             << std::endl;
+      iparNewMin = 0;
+      for (int i = 0; i < iparMax; ++i) {
+         double elow, eup;
+         unsigned int index = (!ipars.empty()) ? ipars[i] : i;
+         bool ret = _minimizer->GetMinosError(index, elow, eup);
+         // flags case when a new minimum has been found
+         if ((_minimizer->MinosStatus() & 8) != 0) {
+            iparNewMin = i;
+         }
+         if (ret)
+            _result->fMinosErrors.emplace(index, std::make_pair(elow, eup));
+         ok |= ret;
+      }
+
+      iparMax = iparNewMin;
+      iter++; // to avoid infinite looping
+   } while (iparNewMin > 0 && iter < 10);
+   if (!ok) {
+      coutE(Minimization)
+         << "RooMinimizer::calculateMinosErrors() Minos error calculation failed for all the selected parameters"
+         << std::endl;
+   }
+
+   // re-give a minimizer instance in case it has been changed
+   // but maintain previous valid status. Do not set result to false if minos failed
+   ok &= update(_result->fValid);
+
+   return ok;
+}
+
+void RooMinimizer::initMinimizer()
+{
+   _minimizer = std::unique_ptr<ROOT::Math::Minimizer>(_config.CreateMinimizer());
+   _minimizer->SetFunction(*getMultiGenFcn());
+   _minimizer->SetVariables(_config.ParamsSettings().begin(), _config.ParamsSettings().end());
+}
+
+bool RooMinimizer::updateMinimizerOptions(bool canDifferentMinim)
+{
+   // update minimizer options when re-doing a Fit or computing Hesse or Minos errors
+
+   // create a new minimizer if it is different type
+   // minimizer type string stored in FitResult is "minimizer name" + " / " + minimizer algo
+   std::string newMinimType = _config.MinimizerName();
+   if (_minimizer && _result && newMinimType != _result->fMinimType) {
+      // if a different minimizer is allowed (e.g. when calling Hesse)
+      if (canDifferentMinim) {
+         std::string msg = "Using now " + newMinimType;
+         coutI(Minimization) << "RooMinimizer::updateMinimizerOptions(): " << msg << std::endl;
+         initMinimizer();
+      } else {
+         std::string msg = "Cannot change minimizer. Continue using " + _result->fMinimType;
+         coutW(Minimization) << "RooMinimizer::updateMinimizerOptions() " << msg << std::endl;
+      }
+   }
+
+   // create minimizer if it was not done before
+   if (!_minimizer) {
+      initMinimizer();
+   }
+
+   // set new minimizer options (but not functions and parameters)
+   _minimizer->SetOptions(_config.MinimizerOptions());
+   return true;
+}
+
+void RooMinimizer::updateFitConfig()
+{
+   // update the fit configuration after a fit using the obtained result
+   if (_result->fParams.empty() || !_result->fValid)
+      return;
+   for (unsigned int i = 0; i < _config.NPar(); ++i) {
+      ROOT::Fit::ParameterSettings &par = _config.ParSettings(i);
+      par.SetValue(_result->fParams[i]);
+      if (_result->error(i) > 0)
+         par.SetStepSize(_result->error(i));
+   }
+}
+
+RooMinimizer::FitResult::FitResult(const ROOT::Fit::FitConfig &fconfig)
+   : fStatus(-99), // use this special convention to flag it when printing result
+     fCovStatus(0),
+     fParams(fconfig.NPar()),
+     fErrors(fconfig.NPar())
+{
+   // create a Fit result from a fit config (i.e. with initial parameter values
+   // and errors equal to step values
+   // The model function is NULL in this case
+
+   // set minimizer type and algorithm
+   fMinimType = fconfig.MinimizerType();
+   // append algorithm name for minimizer that support it
+   if ((fMinimType.find("Fumili") == std::string::npos) && (fMinimType.find("GSLMultiFit") == std::string::npos)) {
+      if (!fconfig.MinimizerAlgoType().empty())
+         fMinimType += " / " + fconfig.MinimizerAlgoType();
+   }
+
+   // get parameter values and errors (step sizes)
+   for (unsigned int i = 0; i < fconfig.NPar(); ++i) {
+      const ROOT::Fit::ParameterSettings &par = fconfig.ParSettings(i);
+      fParams[i] = par.Value();
+      fErrors[i] = par.StepSize();
+      if (par.IsFixed())
+         fFixedParams[i] = true;
+   }
+}
+
+void RooMinimizer::fillResult(bool isValid)
+{
+   ROOT::Math::Minimizer &min = *_minimizer;
+   ROOT::Fit::FitConfig const &fconfig = _config;
+
+   // Fill the FitResult after minimization using result from Minimizers
+
+   _result->fValid = isValid;
+   _result->fStatus = min.Status();
+   _result->fCovStatus = min.CovMatrixStatus();
+   _result->fVal = min.MinValue();
+   _result->fEdm = min.Edm();
+
+   _result->fMinimType = fconfig.MinimizerName();
+
+   const unsigned int npar = min.NDim();
+   if (npar == 0)
+      return;
+
+   if (min.X())
+      _result->fParams = std::vector<double>(min.X(), min.X() + npar);
+   else {
+      // case minimizer does not provide minimum values (it failed) take from configuration
+      _result->fParams.resize(npar);
+      for (unsigned int i = 0; i < npar; ++i) {
+         _result->fParams[i] = (fconfig.ParSettings(i).Value());
+      }
+   }
+
+   // check for fixed or limited parameters
+   for (unsigned int ipar = 0; ipar < npar; ++ipar) {
+      if (fconfig.ParSettings(ipar).IsFixed())
+         _result->fFixedParams[ipar] = true;
+   }
+
+   // fill error matrix
+   // if minimizer provides error provides also error matrix
+   // clear in case of re-filling an existing result
+   _result->fCovMatrix.clear();
+   _result->fGlobalCC.clear();
+
+   if (min.Errors() != nullptr) {
+      updateErrors();
+   }
+}
+
+bool RooMinimizer::update(bool isValid)
+{
+   ROOT::Math::Minimizer &min = *_minimizer;
+   ROOT::Fit::FitConfig const &fconfig = _config;
+
+   // update fit result with new status from minimizer
+   // ncalls if it is not zero is used instead of value from minimizer
+
+   // in case minimizer changes
+   _result->fMinimType = fconfig.MinimizerName();
+
+   const std::size_t npar = _result->fParams.size();
+
+   _result->fValid = isValid;
+   // update minimum value
+   _result->fVal = min.MinValue();
+   _result->fEdm = min.Edm();
+   _result->fStatus = min.Status();
+   _result->fCovStatus = min.CovMatrixStatus();
+
+   // copy parameter value and errors
+   std::copy(min.X(), min.X() + npar, _result->fParams.begin());
+
+   if (min.Errors() != nullptr) {
+      updateErrors();
+   }
+   return true;
+}
+
+void RooMinimizer::updateErrors()
+{
+   ROOT::Math::Minimizer &min = *_minimizer;
+   const std::size_t npar = _result->fParams.size();
+
+   _result->fErrors.resize(npar);
+   std::copy(min.Errors(), min.Errors() + npar, _result->fErrors.begin());
+
+   if (_result->fCovStatus != 0) {
+
+      // update error matrix
+      unsigned int r = npar * (npar + 1) / 2;
+      _result->fCovMatrix.resize(r);
+      unsigned int l = 0;
+      for (unsigned int i = 0; i < npar; ++i) {
+         for (unsigned int j = 0; j <= i; ++j)
+            _result->fCovMatrix[l++] = min.CovMatrix(i, j);
+      }
+   }
+   // minos errors are set separately when calling Fitter::CalculateMinosErrors()
+
+   // update global CC
+   _result->fGlobalCC.resize(npar);
+   for (unsigned int i = 0; i < npar; ++i) {
+      double globcc = min.GlobalCC(i);
+      if (globcc < 0) {
+         _result->fGlobalCC.clear();
+         break; // it is not supported by that minimizer
+      }
+      _result->fGlobalCC[i] = globcc;
+   }
+}
+
+double RooMinimizer::FitResult::lowerError(unsigned int i) const
+{
+   // return lower Minos error for parameter i
+   //  return the parabolic error if Minos error has not been calculated for the parameter i
+   auto itr = fMinosErrors.find(i);
+   return (itr != fMinosErrors.end()) ? itr->second.first : error(i);
+}
+
+double RooMinimizer::FitResult::upperError(unsigned int i) const
+{
+   // return upper Minos error for parameter i
+   //  return the parabolic error if Minos error has not been calculated for the parameter i
+   auto itr = fMinosErrors.find(i);
+   return (itr != fMinosErrors.end()) ? itr->second.second : error(i);
+}
+
+bool RooMinimizer::FitResult::isParameterFixed(unsigned int ipar) const
+{
+   return fFixedParams.find(ipar) != fFixedParams.end();
 }

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -72,7 +72,7 @@ ROOT_ADD_GTEST(testRooSTLRefCountList testRooSTLRefCountList.cxx LIBRARIES RooFi
 ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooTruthModel testRooTruthModel.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
-ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore ROOT::TestSupport)
+ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cxx LIBRARIES RooFitMultiProcess RooFitCore RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/TestStatistics/TestStatistics_ref.root)

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -63,6 +63,18 @@ ValAndError getValAndError(RooArgSet const &parsFinal, const char *name)
    return {var.getVal(), var.getError()};
 };
 
+std::vector<double> getParamVals(RooAbsMinimizerFcn &fcn)
+{
+   std::vector<double> values;
+   values.reserve(fcn.GetFloatParamList()->size());
+
+   for (auto *par : static_range_cast<RooRealVar *>(*fcn.GetFloatParamList())) {
+      values.push_back(par->getVal());
+   }
+
+   return values;
+}
+
 } // namespace
 
 using RooFit::TestStatistics::LikelihoodWrapper;
@@ -991,13 +1003,10 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
       RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
    RooMinimizerFcn vanilla_fcn(nll_vanilla.get(), &m_vanilla);
 
-   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()),
-             modularL_fcn(modularL_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(getParamVals(vanilla_fcn).data()), modularL_fcn(getParamVals(modularL_fcn).data()));
    // let's also check with absolutely certain same parameter values, both of them
-   EXPECT_EQ(vanilla_fcn(vanilla_fcn.getParameterValues().data()),
-             modularL_fcn(vanilla_fcn.getParameterValues().data()));
-   EXPECT_EQ(vanilla_fcn(modularL_fcn.getParameterValues().data()),
-             modularL_fcn(modularL_fcn.getParameterValues().data()));
+   EXPECT_EQ(vanilla_fcn(getParamVals(vanilla_fcn).data()), modularL_fcn(getParamVals(vanilla_fcn).data()));
+   EXPECT_EQ(vanilla_fcn(getParamVals(modularL_fcn).data()), modularL_fcn(getParamVals(modularL_fcn).data()));
 
    // reset static variables to automatic
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -24,8 +24,6 @@
 #include <RooSimultaneous.h>
 #include <RooWorkspace.h>
 
-#include <ROOT/TestSupport.hxx>
-
 #include <TMath.h>
 
 #include "gtest_wrapper.h"
@@ -293,14 +291,7 @@ TEST_P(TestStatisticTest, EmptyData)
    std::unique_ptr<RooDataSet> data{model.generate(x, 0)};
    std::unique_ptr<RooDataHist> dataHist{data->binnedClone()};
 
-   {
-      // We expect errors in the Hessian calculation because the likelihood is
-      // constant.
-      ROOT::TestSupport::CheckDiagsRAII checkDiag;
-      checkDiag.requiredDiag(kWarning, "ROOT::Math::Fitter::CalculateHessErrors", "Error when calculating Hessian");
-
-      model.fitTo(*data, _evalBackend, RooFit::PrintLevel(-1));
-   }
+   model.fitTo(*data, _evalBackend, RooFit::PrintLevel(-1));
 
    EXPECT_EQ(mean.getVal(), meanOrigVal) << "Fitting an empty RooDataSet changed \"mean\" value!";
    EXPECT_EQ(sigma.getVal(), sigmaOrigVal) << "Fitting an empty RooDataSet changed \"sigma\" value!";
@@ -311,14 +302,7 @@ TEST_P(TestStatisticTest, EmptyData)
    mean.setError(0.0);
    sigma.setError(0.0);
 
-   {
-      // We expect errors in the Hessian calculation because the likelihood is
-      // constant (same as above for the RooDataSet).
-      ROOT::TestSupport::CheckDiagsRAII checkDiag;
-      checkDiag.requiredDiag(kWarning, "ROOT::Math::Fitter::CalculateHessErrors", "Error when calculating Hessian");
-
-      model.fitTo(*dataHist, _evalBackend, RooFit::PrintLevel(-1));
-   }
+   model.fitTo(*dataHist, _evalBackend, RooFit::PrintLevel(-1));
 
    EXPECT_EQ(mean.getVal(), meanOrigVal) << "Fitting an empty RooDataSet changed \"mean\" value!";
    EXPECT_EQ(sigma.getVal(), sigmaOrigVal) << "Fitting an empty RooDataSet changed \"sigma\" value!";


### PR DESCRIPTION
Use one abstraction layer less when interacting with the minimizers in
RooFit.

More details in the commit descriptions.

