### PR TITLE
[ci] Disable the win x86 dbg platform

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -240,6 +240,10 @@ jobs:
             config: Debug
           - event_name: push
             config: Debug
+          # This is this platform is subject to timeouts when building from
+          # scratch.
+          - target_arch: x86
+            config: Debug 
 
     name: Windows 10 ${{ matrix.target_arch }} ${{ matrix.config }}
 


### PR DESCRIPTION
for all builds since it is subject to timeouts when the build happens from scratch.

This is of course a temporary measure, until we find a future proof solution for this issue.