### PR TITLE
[ntuple] Fix collection writer

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -131,9 +131,10 @@ private:
    {
       if constexpr (std::is_same_v<T, RNTupleCollectionWriter>) {
          const auto &v = fValues[token.fIndex];
-         if (!dynamic_cast<const RCollectionField *>(&v.GetField())) {
+         const auto &field = v.GetField();
+         if (typeid(field) != typeid(const RCollectionField &)) {
             throw RException(R__FAIL("type mismatch for field " + v.GetField().GetFieldName() + ": " +
-                                     v.GetField().GetTypeName() + " vs. RNTupleCollectionWriter"));
+                                     field.GetTypeName() + " vs. RNTupleCollectionWriter"));
          }
       } else if constexpr (!std::is_void_v<T>) {
          const auto &v = fValues[token.fIndex];

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -288,7 +288,6 @@ protected:
    void CommitClusterImpl() final;
 
 public:
-   static std::string TypeName() { return ""; }
    RCollectionField(std::string_view name, std::shared_ptr<RNTupleCollectionWriter> collectionWriter,
                     std::unique_ptr<RFieldZero> collectionParent);
    RCollectionField(RCollectionField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -277,10 +277,13 @@ private:
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
+
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
-   void ConstructValue(void *) const final {}
+
+   void ConstructValue(void *where) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -294,8 +297,8 @@ public:
    RCollectionField &operator=(RCollectionField &&other) = default;
    ~RCollectionField() override = default;
 
-   size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
-   size_t GetAlignment() const final { return alignof(ClusterSize_t); }
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
 };
 
 /// An artificial field that transforms an RNTuple column that contains the offset of collections into

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -591,6 +591,8 @@ protected:
 
    /// Called by `ConnectPageSource()` once connected; derived classes may override this as appropriate
    virtual void OnConnectPageSource() {}
+   /// Called by `ConnectPageSink()` once connected; derived classes may override this as appropriate
+   virtual void OnConnectPageSink() {}
 
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
    /// normalized type name and type alias

--- a/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
@@ -39,17 +39,20 @@ namespace Experimental {
 // clang-format on
 class RNTupleCollectionWriter {
    friend class RCollectionField;
+   friend class RNTupleModel; // TODO(jblomer) remove me
 
 private:
    std::size_t fBytesWritten = 0;
    ClusterSize_t fOffset;
    std::unique_ptr<REntry> fDefaultEntry;
 
-public:
+   // Constructed by RCollectionField::ConstructValue
    explicit RNTupleCollectionWriter(std::unique_ptr<REntry> defaultEntry)
       : fOffset(0), fDefaultEntry(std::move(defaultEntry))
    {
    }
+
+public:
    RNTupleCollectionWriter(const RNTupleCollectionWriter &) = delete;
    RNTupleCollectionWriter &operator=(const RNTupleCollectionWriter &) = delete;
    ~RNTupleCollectionWriter() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleCollectionWriter.hxx
@@ -33,7 +33,7 @@ namespace Experimental {
 /**
 \class ROOT::Experimental::RNTupleCollectionWriter
 \ingroup NTuple
-\brief A special type only prodcued by the collection field and used for writing untyped collections
+\brief A special type only produced by the collection field and used for writing untyped collections
 
 This class is tightly coupled to the RCollectionField. It fills the sub fields of the collection fields one-by-one.
 An instance can only be used with the exact RCollectionField that created it. Upon creation, the entry values need
@@ -50,8 +50,8 @@ private:
       kOrphaned,        // the collection field that created the writer is destructed
    };
 
-   // fBytesWriten and fElements are reset to zero by RCollectionField::Append and thus need to be mutable
-   mutable std::size_t fBytesWritten = 0;
+   // fNBytesWritten and fNElements are reset to zero by RCollectionField::Append and thus need to be mutable
+   mutable std::size_t fNBytesWritten = 0;
    mutable ClusterSize_t fNElements;
    /// The collection writer depends on the RCollectionField from which it was created. Filling collection elements
    /// only works when the collection field is connected to a page sink, and as long as the collection field is alive.
@@ -68,7 +68,7 @@ private:
    // Called by the RCollectionField after append
    void Reset() const
    {
-      fBytesWritten = 0;
+      fNBytesWritten = 0;
       fNElements = 0;
    }
 
@@ -84,10 +84,10 @@ public:
       if (fEnvironmentState != EEnvironmentState::kConnectedToSink) {
          throw RException(R__FAIL("invalid attempt to fill an untyped collection element without a valid field"));
       }
-      const std::size_t bytesWritten = fEntry.Append();
-      fBytesWritten += bytesWritten;
+      const std::size_t nBytesWritten = fEntry.Append();
+      fNBytesWritten += nBytesWritten;
       fNElements++;
-      return bytesWritten;
+      return nBytesWritten;
    }
 
    const REntry &GetEntry() const { return fEntry; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -239,6 +239,7 @@ public:
 
    /// Creates a new field given a `name` or `{name, description}` pair and a
    /// corresponding value that is managed by a shared pointer.
+   /// The returned pointer is empty for bare models.
    ///
    /// **Example: create some fields and fill an %RNTuple**
    /// ~~~ {.cpp}
@@ -315,7 +316,7 @@ public:
 
    /// Ingests a model for a sub collection and attaches it to the current model
    ///
-   /// Throws an exception if collectionModel is null.
+   /// Throws an exception if collectionModel is null. The returned pointer is empty for bare models.
    std::shared_ptr<RNTupleCollectionWriter>
    MakeCollection(std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel);
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -4000,12 +4000,12 @@ std::size_t ROOT::Experimental::RCollectionField::AppendImpl(const void *from)
    }
 
    // RCollectionFields return the bytes written by their subfields as accumulated by the RNTupleCollectionWriter
-   std::size_t bytesWritten = writer->fBytesWritten;
+   std::size_t nBytesWritten = writer->fNBytesWritten;
    fNWritten += writer->fNElements;
    writer->Reset();
 
    fPrincipalColumn->Append(&fNWritten);
-   return bytesWritten + fPrincipalColumn->GetElement()->GetPackedSize();
+   return nBytesWritten + fPrincipalColumn->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RCollectionField::ReadGlobalImpl(NTupleSize_t, void *)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1191,6 +1191,8 @@ void ROOT::Experimental::RFieldBase::ConnectPageSink(Internal::RPageSink &pageSi
          [this](Internal::RPageSink &sink) { sink.UpdateExtraTypeInfo(GetExtraTypeInfo()); });
    }
 
+   OnConnectPageSink();
+
    fState = EState::kConnectedToSink;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3935,6 +3935,26 @@ ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
    return std::make_unique<RCollectionField>(newName, fCollectionWriter, std::move(parent));
 }
 
+void ROOT::Experimental::RCollectionField::ConstructValue(void *where) const
+{
+   new (where) RNTupleCollectionWriter(nullptr);
+}
+
+std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RCollectionField::GetDeleter() const
+{
+   return std::make_unique<RTypedDeleter<RNTupleCollectionWriter>>();
+}
+
+std::size_t ROOT::Experimental::RCollectionField::GetValueSize() const
+{
+   return sizeof(RNTupleCollectionWriter);
+}
+
+std::size_t ROOT::Experimental::RCollectionField::GetAlignment() const
+{
+   return alignof(RNTupleCollectionWriter);
+}
+
 std::size_t ROOT::Experimental::RCollectionField::AppendImpl(const void *from)
 {
    // RCollectionFields are almost simple, but they return the bytes written by their subfields as accumulated by the

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -347,7 +347,8 @@ ROOT::Experimental::RNTupleModel::MakeCollection(std::string_view fieldName,
       throw RException(R__FAIL("null collectionModel"));
    }
 
-   auto collectionWriter = std::make_shared<RNTupleCollectionWriter>(std::move(collectionModel->fDefaultEntry));
+   auto rawCollectionWriter = new RNTupleCollectionWriter(std::move(collectionModel->fDefaultEntry));
+   auto collectionWriter = std::shared_ptr<RNTupleCollectionWriter>(rawCollectionWriter);
 
    auto field = std::make_unique<RCollectionField>(fieldName, collectionWriter, std::move(collectionModel->fFieldZero));
    field->SetDescription(collectionModel->GetDescription());

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -55,6 +55,7 @@ ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)
 
 ROOT_ADD_GTEST(rfield_check rfield_check.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct Physics)
+ROOT_ADD_GTEST(rfield_collection rfield_collection.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(rfield_string rfield_string.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_variant rfield_variant.cxx LIBRARIES ROOTNTuple CustomStruct)
 if(MSVC)

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -67,6 +67,7 @@ using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptor
 template <typename T, EColumnType C>
 using RColumnElement = ROOT::Experimental::Internal::RColumnElement<T, C>;
 using RColumnSwitch = ROOT::Experimental::RColumnSwitch;
+using ROOT::Experimental::RCollectionField;
 using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
 using RException = ROOT::Experimental::RException;
@@ -81,6 +82,7 @@ using RNTuple = ROOT::Experimental::RNTuple;
 using RNTupleAtomicCounter = ROOT::Experimental::Detail::RNTupleAtomicCounter;
 using RNTupleAtomicTimer = ROOT::Experimental::Detail::RNTupleAtomicTimer;
 using RNTupleCalcPerf = ROOT::Experimental::Detail::RNTupleCalcPerf;
+using ROOT::Experimental::RNTupleCollectionWriter;
 using RNTupleCompressor = ROOT::Experimental::Internal::RNTupleCompressor;
 using RNTupleDecompressor = ROOT::Experimental::Internal::RNTupleDecompressor;
 using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;

--- a/tree/ntuple/v7/test/rfield_collection.cxx
+++ b/tree/ntuple/v7/test/rfield_collection.cxx
@@ -1,0 +1,124 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTuple, CollectionFieldEntries)
+{
+   {
+      auto collectionModel = RNTupleModel::CreateBare();
+      collectionModel->MakeField<float>("E");
+      auto mainModel = RNTupleModel::CreateBare();
+      mainModel->MakeCollection("jets", std::move(collectionModel));
+      mainModel->Freeze();
+
+      auto entry = mainModel->CreateEntry();
+      EXPECT_FALSE(entry->GetPtr<RNTupleCollectionWriter>("jets")->GetEntry().GetPtr<float>("E"));
+   }
+
+   {
+      auto collectionModel = RNTupleModel::Create();
+      auto mainModel = RNTupleModel::CreateBare();
+      EXPECT_THROW(mainModel->MakeCollection("jets", std::move(collectionModel)), RException);
+   }
+
+   {
+      auto collectionModel = RNTupleModel::CreateBare();
+      collectionModel->MakeField<float>("E");
+      auto mainModel = RNTupleModel::Create();
+      mainModel->MakeCollection("jets", std::move(collectionModel));
+      mainModel->Freeze();
+      EXPECT_EQ(mainModel->GetModelId(), mainModel->GetDefaultEntry().GetModelId());
+      EXPECT_NE(mainModel->GetModelId(),
+                mainModel->GetDefaultEntry().GetPtr<RNTupleCollectionWriter>("jets")->GetEntry().GetModelId());
+      EXPECT_EQ(mainModel->GetDefaultEntry().GetPtr<RNTupleCollectionWriter>("jets")->GetEntry().GetModelId(),
+                dynamic_cast<const RCollectionField &>(mainModel->GetField("jets")).GetModelId());
+   }
+
+   {
+      auto collectionModel = RNTupleModel::Create();
+      auto ptrE = collectionModel->MakeField<float>("E");
+      auto mainModel = RNTupleModel::Create();
+      auto ptrCollectionWriter = mainModel->MakeCollection("jets", std::move(collectionModel));
+      mainModel->Freeze();
+
+      // We preserve the pointers from the collection model default entry...
+      EXPECT_EQ(mainModel->GetDefaultEntry().GetPtr<RNTupleCollectionWriter>("jets"), ptrCollectionWriter);
+      EXPECT_EQ(mainModel->GetDefaultEntry().GetPtr<RNTupleCollectionWriter>("jets")->GetEntry().GetPtr<float>("E"),
+                ptrE);
+
+      // But new main entries need to (re-)bind the collection writer entries
+      auto entry = mainModel->CreateEntry();
+      EXPECT_FALSE(entry->GetPtr<RNTupleCollectionWriter>("jets")->GetEntry().GetPtr<float>("E"));
+   }
+}
+
+TEST(RNTuple, CollectionFieldSafety)
+{
+   FileRaii fileGuard("test_ntuple_collectionfield_safety.root");
+
+   auto jetsModel = RNTupleModel::CreateBare();
+   jetsModel->MakeField<float>("E");
+   auto tracksModel = RNTupleModel::CreateBare();
+   tracksModel->MakeField<float>("E");
+
+   auto mainModel = RNTupleModel::CreateBare();
+   mainModel->MakeCollection("jets", std::move(jetsModel));
+   mainModel->MakeCollection("tracks", std::move(tracksModel));
+   mainModel->Freeze();
+
+   auto entry = mainModel->CreateEntry();
+   auto jetsWriter = entry->GetPtr<RNTupleCollectionWriter>("jets");
+   auto tracksWriter = entry->GetPtr<RNTupleCollectionWriter>("tracks");
+
+   // Ensure that we catch mixed-up collection writers
+   auto writer = RNTupleWriter::Recreate(std::move(mainModel), "ntpl", fileGuard.GetPath());
+   writer->Fill(*entry);
+   entry->BindValue<RNTupleCollectionWriter>("jets", tracksWriter);
+   entry->BindValue<RNTupleCollectionWriter>("tracks", jetsWriter);
+   EXPECT_THROW(writer->Fill(*entry), RException);
+
+   // Ensure that we cannot mix up tokens of collection writers
+   auto tokenJetsE = jetsWriter->GetEntry().GetToken("E");
+   auto tokenTracksE = tracksWriter->GetEntry().GetToken("E");
+
+   EXPECT_NO_THROW(jetsWriter->GetEntry().EmplaceNewValue(tokenJetsE));
+   EXPECT_THROW(jetsWriter->GetEntry().EmplaceNewValue(tokenTracksE), RException);
+}
+
+TEST(RNTuple, CollectionFieldMultiEntry)
+{
+   FileRaii fileGuard("test_ntuple_collectionfield_multi_entry.root");
+
+   auto particleModel = RNTupleModel::CreateBare();
+   particleModel->MakeField<float>("energy");
+   particleModel->Freeze();
+
+   auto model = RNTupleModel::CreateBare();
+   auto particles = model->MakeCollection("particles", std::move(particleModel));
+
+   auto writer = RNTupleWriter::Recreate(std::move(model), "events", fileGuard.GetPath());
+   auto entry1 = writer->CreateEntry();
+   auto entry2 = writer->CreateEntry();
+
+   auto particleWriter1 = entry1->GetPtr<RNTupleCollectionWriter>("particles");
+   particleWriter1->GetEntry().EmplaceNewValue("energy");
+   auto energy1 = particleWriter1->GetEntry().GetPtr<float>("energy");
+
+   auto particleWriter2 = entry2->GetPtr<RNTupleCollectionWriter>("particles");
+   particleWriter2->GetEntry().EmplaceNewValue("energy");
+   auto energy2 = particleWriter2->GetEntry().GetPtr<float>("energy");
+
+   *energy1 = 1.0;
+   particleWriter1->Fill();
+   writer->Fill(*entry1);
+
+   *energy2 = 2.0;
+   particleWriter2->Fill();
+   writer->Fill(*entry2);
+
+   writer.reset();
+
+   auto reader = RNTupleReader::Open("events", fileGuard.GetPath());
+   EXPECT_EQ(2u, reader->GetNEntries());
+   auto viewE = reader->GetView<float>("particles.energy");
+   EXPECT_FLOAT_EQ(1.0, viewE(0));
+   EXPECT_FLOAT_EQ(2.0, viewE(1));
+}

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -182,7 +182,6 @@ private:
       RImportLeafCountCollection &operator=(RImportLeafCountCollection &&other) = default;
       std::unique_ptr<RNTupleModel> fCollectionModel;             ///< The model for the collection itself
       std::shared_ptr<RNTupleCollectionWriter> fCollectionWriter; ///< Used to fill the collection elements per event
-      std::unique_ptr<REntry> fCollectionEntry; ///< Keeps the memory location of the collection members
       /// The number of elements for the collection for a particular event. Used as a destination for SetBranchAddress()
       /// of the count leaf
       std::unique_ptr<Int_t> fCountVal;


### PR DESCRIPTION
Lets the `RNTupleCollectionField` create `RNTupleCollectionWriter` instances on `CreateValue`, instead of storing a single collection writer in the field. As a result, untyped collections (`RNTupleModel::MakeCollection()` etc.) can be used with multiple entries.

Fixes #14642

