### PR TITLE
[gui] fix calloc usage in TGFileItem

### DIFF
--- a/gui/gui/src/TGFSContainer.cxx
+++ b/gui/gui/src/TGFSContainer.cxx
@@ -465,7 +465,7 @@ void TGFileItem::SetDNDData(TDNDData *data)
 {
    if (fDNDData.fDataLength > 0)
       free(fDNDData.fData);
-   fDNDData.fData = calloc(sizeof(unsigned char), data->fDataLength);
+   fDNDData.fData = calloc(data->fDataLength, sizeof(unsigned char));
    if (fDNDData.fData)
       memcpy(fDNDData.fData, data->fData, data->fDataLength);
    fDNDData.fDataLength = data->fDataLength;


### PR DESCRIPTION
Size of single element is second argument in the `calloc` call. 

Fix warning from gcc14:
```
git/webgui/gui/gui/src/TGFSContainer.cxx: In member function ‘void TGFileItem::SetDNDData(TDNDData*)’:
git/webgui/gui/gui/src/TGFSContainer.cxx:468:28: warning: ‘void* calloc(size_t, size_t)’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  468 |    fDNDData.fData = calloc(sizeof(unsigned char), data->fDataLength);
      |                            ^~~~~~~~~~~~~~~~~~~~~
git/webgui/gui/gui/src/TGFSContainer.cxx:468:28: note: earlier argument should specify number of elements, later size of each element
```
