### PR TITLE
[core] Do not provide source string length to `strncpy`

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -698,7 +698,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
             }
          }
          if (isPrintable) {
-            strncpy(line + kvalue, *ppointer, std::min( i, kline - kvalue));
+            strncpy(line + kvalue, *ppointer, kline - kvalue);
             line[kvalue+i] = 0;
          } else {
             line[kvalue] = 0;


### PR DESCRIPTION
Last argument in strncpy is length of destination buffer and should not depend from length of source string. Fixes warning from gcc14:
```
git/webgui/core/meta/src/TClass.cxx:701:20: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound depends on the length of the source argument [-Wstringop-truncation]
  701 |             strncpy(line + kvalue, *ppointer, std::min( i, kline - kvalue));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
git/webgui/core/meta/src/TClass.cxx:691:20: note: length computed here
  691 |          i = strlen(*ppointer);
      |              ~~~~~~^~~~~~~~~~~
```
