### PR TITLE
[minuti] fix gcc14 warning in MnPlot

### DIFF
--- a/math/minuit2/src/MnPlot.cxx
+++ b/math/minuit2/src/MnPlot.cxx
@@ -26,14 +26,13 @@ void MnPlot::operator()(const std::vector<std::pair<double, double>> &points) co
    std::string chpt;
    chpt.reserve(points.size() + 1);
 
-   for (std::vector<std::pair<double, double>>::const_iterator ipoint = points.begin(); ipoint != points.end();
-        ++ipoint) {
-      x.push_back((*ipoint).first);
-      y.push_back((*ipoint).second);
+   for (auto &ipoint : points) {
+      x.push_back(ipoint.first);
+      y.push_back(ipoint.second);
       chpt += '*';
    }
 
-   mnplot(&(x.front()), &(y.front()), chpt.data(), points.size(), Width(), Length());
+   mnplot(x.data(), y.data(), chpt.data(), points.size(), Width(), Length());
 }
 
 void MnPlot::operator()(double xmin, double ymin, const std::vector<std::pair<double, double>> &points) const
@@ -52,14 +51,13 @@ void MnPlot::operator()(double xmin, double ymin, const std::vector<std::pair<do
    chpt += ' ';
    chpt += 'X';
 
-   for (std::vector<std::pair<double, double>>::const_iterator ipoint = points.begin(); ipoint != points.end();
-        ++ipoint) {
-      x.push_back((*ipoint).first);
-      y.push_back((*ipoint).second);
+   for (auto &ipoint : points) {
+      x.push_back(ipoint.first);
+      y.push_back(ipoint.second);
       chpt += '*';
    }
 
-   mnplot(&(x.front()), &(y.front()), chpt.data(), points.size() + 2, Width(), Length());
+   mnplot(x.data(), y.data(), chpt.data(), points.size() + 2, Width(), Length());
 }
 
 } // namespace Minuit2

--- a/math/minuit2/src/MnPlot.cxx
+++ b/math/minuit2/src/MnPlot.cxx
@@ -9,6 +9,7 @@
 
 #include "Minuit2/MnPlot.h"
 
+#include <string>
 namespace ROOT {
 
 namespace Minuit2 {
@@ -22,17 +23,17 @@ void MnPlot::operator()(const std::vector<std::pair<double, double>> &points) co
    x.reserve(points.size());
    std::vector<double> y;
    y.reserve(points.size());
-   std::vector<char> chpt;
-   chpt.reserve(points.size());
+   std::string chpt;
+   chpt.reserve(points.size() + 1);
 
    for (std::vector<std::pair<double, double>>::const_iterator ipoint = points.begin(); ipoint != points.end();
         ++ipoint) {
       x.push_back((*ipoint).first);
       y.push_back((*ipoint).second);
-      chpt.push_back('*');
+      chpt += '*';
    }
 
-   mnplot(&(x.front()), &(y.front()), &(chpt.front()), points.size(), Width(), Length());
+   mnplot(&(x.front()), &(y.front()), chpt.data(), points.size(), Width(), Length());
 }
 
 void MnPlot::operator()(double xmin, double ymin, const std::vector<std::pair<double, double>> &points) const
@@ -46,19 +47,19 @@ void MnPlot::operator()(double xmin, double ymin, const std::vector<std::pair<do
    y.reserve(points.size() + 2);
    y.push_back(ymin);
    y.push_back(ymin);
-   std::vector<char> chpt;
-   chpt.reserve(points.size() + 2);
-   chpt.push_back(' ');
-   chpt.push_back('X');
+   std::string chpt;
+   chpt.reserve(points.size() + 3);
+   chpt += ' ';
+   chpt += 'X';
 
    for (std::vector<std::pair<double, double>>::const_iterator ipoint = points.begin(); ipoint != points.end();
         ++ipoint) {
       x.push_back((*ipoint).first);
       y.push_back((*ipoint).second);
-      chpt.push_back('*');
+      chpt += '*';
    }
 
-   mnplot(&(x.front()), &(y.front()), &(chpt.front()), points.size() + 2, Width(), Length());
+   mnplot(&(x.front()), &(y.front()), chpt.data(), points.size() + 2, Width(), Length());
 }
 
 } // namespace Minuit2


### PR DESCRIPTION
gcc14 issue warning when `std::vector<char>` is used.

Also simplify loop over points

```
In file included from /usr/include/c++/14/x86_64-suse-linux/bits/c++allocator.h:33,
                 from /usr/include/c++/14/bits/allocator.h:46,
                 from /usr/include/c++/14/vector:63,
                 from /home/linev/git/webgui/math/minuit2/inc/Minuit2/MnPlot.h:14,
                 from /home/linev/git/webgui/math/minuit2/src/MnPlot.cxx:10:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = char]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = char]’ at /usr/include/c++/14/bits/allocator.h:208:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = char]’ at /usr/include/c++/14/bits/alloc_traits.h:513:23,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...)::_Guard::~_Guard() [with _Args = {char}; _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/vector.tcc:616:18,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...) [with _Args = {char}; _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/vector.tcc:688:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {char}; _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/vector.tcc:123:21,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/stl_vector.h:1301:21,
    inlined from ‘void ROOT::Minuit2::MnPlot::operator()(double, double, const std::vector<std::pair<double, double> >&) const’ at git/webgui/math/minuit2/src/MnPlot.cxx:51:18:
/usr/include/c++/14/bits/new_allocator.h:172:33: warning: ‘void operator delete(void*, std::size_t)’ called on pointer ‘<unknown>’ with nonzero offset [1, 576460752303423489] [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = char]’,
    inlined from ‘constexpr _Tp* std::allocator< <template-parameter-1-1> >::allocate(std::size_t) [with _Tp = char]’ at /usr/include/c++/14/bits/allocator.h:196:40,
    inlined from ‘static constexpr _Tp* std::allocator_traits<std::allocator<_Up> >::allocate(allocator_type&, size_type) [with _Tp = char]’ at /usr/include/c++/14/bits/alloc_traits.h:478:28,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/stl_vector.h:380:33,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::reserve(size_type) [with _Tp = char; _Alloc = std::allocator<char>]’ at /usr/include/c++/14/bits/vector.tcc:79:33,
    inlined from ‘void ROOT::Minuit2::MnPlot::operator()(double, double, const std::vector<std::pair<double, double> >&) const’ at git/webgui/math/minuit2/src/MnPlot.cxx:50:16:
/usr/include/c++/14/bits/new_allocator.h:151:55: note: returned from ‘void* operator new(std::size_t)’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```