### PR TITLE
[ntuple] expose RNTuple(Un)ownedView instead of RNTupleView<T, bool>

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -82,8 +82,9 @@ class RFieldProvider : public RProvider {
          }
       }
 
-      template<typename T>
-      void FillHistogramImpl(const ROOT::Experimental::RFieldBase &field, ROOT::Experimental::RNTupleView<T, false> &view)
+      template <typename T>
+      void
+      FillHistogramImpl(const ROOT::Experimental::RFieldBase &field, ROOT::Experimental::RNTupleUnownedView<T> &view)
       {
          std::string title = "Drawing of RField "s + field.GetFieldName();
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -276,27 +276,27 @@ public:
    /// }
    /// ~~~
    template <typename T>
-   RNTupleView<T, false> GetView(std::string_view fieldName)
+   RNTupleUnownedView<T> GetView(std::string_view fieldName)
    {
       return GetView<T>(RetrieveFieldId(fieldName));
    }
 
    template <typename T>
-   RNTupleView<T, true> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
+   RNTupleOwnedView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
    template <typename T>
-   RNTupleView<T, false> GetView(DescriptorId_t fieldId)
+   RNTupleUnownedView<T> GetView(DescriptorId_t fieldId)
    {
-      return RNTupleView<T, false>(fieldId, fSource.get());
+      return RNTupleUnownedView<T>(fieldId, fSource.get());
    }
 
    template <typename T>
-   RNTupleView<T, true> GetView(DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
+   RNTupleOwnedView<T> GetView(DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
    {
-      return RNTupleView<T, true>(fieldId, fSource.get(), objPtr);
+      return RNTupleOwnedView<T>(fieldId, fSource.get(), objPtr);
    }
 
    /// Raises an exception if:


### PR DESCRIPTION
# This Pull request:
splits `RNTupleView<T, bool>` into `RNTupleUnownedView` and `RNTupleOwnedView`. `RNTupleView` is renamed to `Internal::RNTupleViewBase` and used as the base class for the new public classes.

# Notes
- I'm conflicted about the naming of the classes. For me it's ambiguous whether the `Unowned` and `Owned` labels should be changed to, respectively, `Owning` and `Unowning` (note the swap). On one hand you could say `RNTupleView<T, false>` is "Unowned" *by the user*; on the other, you could say it is "Owning" its memory. Thoughts about this?
- I made `RNTupleViewBase` not constructible (aside from friend classes) by giving it a protected destructor. Maybe we don't want to exclude this possibility (e.g. to allow users to use the base class in template metaprogramming), but in this case maybe we don't want to make it `Internal` either.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #16321

