### PR TITLE
[doxygen] use relative position for JSROOT drawings [skip-ci]

### DIFF
--- a/documentation/doxygen/MakeRCanvasJS.C
+++ b/documentation/doxygen/MakeRCanvasJS.C
@@ -37,7 +37,7 @@ void MakeRCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bo
 
    // Build the html file inlining the json picture
    FILE *fh = fopen(TString::Format("%s/macros/%s.html",OutDir,IN), "w");
-   fprintf(fh,"<div id=\"draw_json_%s\" style=\"width:700px; height:500px\"></div>\n", IN);
+   fprintf(fh,"<div id=\"draw_json_%s\" style=\"position: relative; width: 700px; height: 500px;\"></div>\n", IN);
    fprintf(fh,"<script type=\"module\">\n");
    fprintf(fh,"   import { settings, parse, draw } from './js/modules/main.mjs';\n");
    fprintf(fh,"   settings.HandleKeys = false;\n");

--- a/documentation/doxygen/MakeTCanvasJS.C
+++ b/documentation/doxygen/MakeTCanvasJS.C
@@ -37,7 +37,7 @@ void MakeTCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bo
    while ((canvas = (TCanvas*) next()) != nullptr) {
       ImageNum++;
       json_codes.push_back(TBufferJSON::ToJSON(canvas, TBufferJSON::kNoSpaces + TBufferJSON::kSameSuppression));
-      fprintf(fh,"   <div id=\"draw_pict%d_%s\" style=\"width:%dpx; height:%dpx\"></div>\n",
+      fprintf(fh,"   <div id=\"draw_pict%d_%s\" style=\"position: relative; width: %dpx; height: %dpx;\"></div>\n",
                   ImageNum,IN,canvas->GetWindowWidth(),canvas->GetWindowHeight());
    }
    fprintf(fh,"</center>\n");


### PR DESCRIPTION
Avoid expansion of JSROOT drawing on full HTML page

Like this one: https://root.cern/doc/master/rbox_8cxx.html
