### PR TITLE
[hist] Fix segfault when calling `GetNumberOfBins()` on an empty TH2Poly

### DIFF
--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -865,7 +865,7 @@ Double_t TH2Poly::GetBinError(Int_t bin) const
 /// it should be the size of the bin list
 Int_t  TH2Poly::GetNumberOfBins() const {
    Int_t nbins =  fNcells-kNOverflow;
-   if (nbins != fBins->GetSize())
+   if (nbins != (fBins ? fBins->GetSize() : 0))
       Fatal("GetNumberOfBins","Object has an invalid number of bins");
    return nbins;
 }

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -7,6 +7,7 @@
 ROOT_ADD_GTEST(testTProfile2Poly test_tprofile2poly.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTH2PolyBinError test_TH2Poly_BinError.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTH2PolyAdd test_TH2Poly_Add.cxx LIBRARIES Hist Matrix MathCore RIO)
+ROOT_ADD_GTEST(testTH2PolyGetNumberOfBins test_TH2Poly_GetNumberOfBins.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTHn THn.cxx LIBRARIES Hist Matrix MathCore RIO)
 ROOT_ADD_GTEST(testTH1 test_TH1.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTHStack test_THStack.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_TH2Poly_GetNumberOfBins.cxx
+++ b/hist/hist/test/test_TH2Poly_GetNumberOfBins.cxx
@@ -1,0 +1,14 @@
+// test TH2Poly GetNumberOfBins
+
+#include "gtest/gtest.h"
+
+#include "TH2Poly.h"
+
+TEST(TH2Poly, GetNumberOfBins)
+{
+   TH2Poly *h2p = new TH2Poly();
+   EXPECT_EQ(0, h2p->GetNumberOfBins());
+
+   h2p->AddBin(1, 1, 1, 1);
+   EXPECT_EQ(1, h2p->GetNumberOfBins());
+}

--- a/hist/hist/test/test_TH2Poly_GetNumberOfBins.cxx
+++ b/hist/hist/test/test_TH2Poly_GetNumberOfBins.cxx
@@ -6,9 +6,9 @@
 
 TEST(TH2Poly, GetNumberOfBins)
 {
-   TH2Poly *h2p = new TH2Poly();
-   EXPECT_EQ(0, h2p->GetNumberOfBins());
+   TH2Poly h2p;
+   EXPECT_EQ(0, h2p.GetNumberOfBins());
 
-   h2p->AddBin(1, 1, 1, 1);
-   EXPECT_EQ(1, h2p->GetNumberOfBins());
+   h2p.AddBin(1, 1, 1, 1);
+   EXPECT_EQ(1, h2p.GetNumberOfBins());
 }


### PR DESCRIPTION
# This Pull request:

This pull request fixes a segfault when calling `GetNumberOfBins()` on an empty TH2Poly by first checking whether `fBins` is null.

To reproduce the original segfault:
```c++
TH2Poly h; h.GetNumberOfBins();
```

## Changes or fixes:

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

