### PR TITLE
[hist][PyROOT] Pythonize the TF1 EvalPar interface for 2D NumPy arrays

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -97,6 +97,7 @@ set(py_sources
   ROOT/_pythonization/_tdirectoryfile.py
   ROOT/_pythonization/_tdirectory.py
   ROOT/_pythonization/_tfile.py
+  ROOT/_pythonization/_tf1.py
   ROOT/_pythonization/_tgraph.py
   ROOT/_pythonization/_th1.py
   ROOT/_pythonization/_titer.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
@@ -1,0 +1,106 @@
+# Author: Aaron Jomy CERN 09/2024
+# Author: Vincenzo Eduardo Padulano CERN 09/2024
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+r"""
+/**
+\class TF1
+\brief \parblock \endparblock
+\htmlonly
+<div class="pyrootbox">
+\endhtmlonly
+## PyROOT
+
+The TF1 class has several additions for its use from Python, which are also
+available in its subclasses TF2 and TF3.
+
+First, TF1 instance can be initialized with user-defined Python functions. Given a generic Python callable,
+the following can performed:
+
+\code{.py}
+def func(x: numpy.ndarray, pars: numpy.ndarray) -> float:
+    return pars[0] * x[0] * x[0] + x[1] * pars[0]
+
+my_func = ROOT.TF1("my_func", func, -10, 10, npar=2, ndim=2)
+\endcode
+
+Second, after performing the initialisation with a Python functor, the TF1 instance can be evaluated using the Pythonized
+`TF1::EvalPar` function. The pythonization allows passing in 1D(single set of x variables) or 2D(a dataset) NumPy arrays.
+
+The following example shows how we can create a TF1 instance with a Python function and evaluate it on a dataset:
+
+\code{.py}
+import ROOT
+import math
+import numpy as np
+
+def pyf_tf1_coulomb(x, p):
+    return p[1] * x[0] * x[1] / (p[0]**2) * math.exp(-p[2] / p[0])
+
+rtf1_coulomb = ROOT.TF1("my_func", pyf_tf1_coulomb, -10, 10, ndims = 2, npars = 3)
+
+# x dataset: 5 pairs of particle charges
+x = np.array([
+    [1.0, 10, 2.0],
+    [1.5, 10, 2.5],
+    [2.0, 10, 3.0],
+    [2.5, 10, 3.5],
+    [3.0, 10, 4.0]
+])
+
+params = np.array([
+    [1.0],       # Distance between charges r
+    [8.99e9],    # Coulomb constant k (in N·m²/C²)
+    [0.1]        # Additional factor for modulation
+])
+
+# Slice to avoid the dummy column of 10's
+res = rtf1_coulomb.EvalPar(x[:, ::2], params)
+        
+\endcode
+
+\htmlonly
+</div>
+\endhtmlonly
+*/
+"""
+
+from . import pythonization
+
+def _TF1_EvalPar(self, vars, params):
+
+    import ROOT
+    import numpy
+
+    x = numpy.ascontiguousarray(vars)
+
+    if x.ndim == 1:
+        return self._EvalPar(x, params)
+
+    interface = x.__array_interface__
+    shape = interface["shape"]
+
+    nrows = shape[0]
+    x_size = shape[1]
+
+    if x_size > self.GetNdim():
+        self.SetNdim(x_size)
+
+    out = numpy.zeros(len(x))
+    
+    ROOT.Internal.EvalParMultiDim(self, out, x, x_size, nrows, params)
+    return numpy.frombuffer(out, dtype=numpy.float64, count=nrows) 
+
+@pythonization('TF1')
+def pythonize_tf1(klass):
+
+    # Pythonizations for TH1::EvalPar
+    klass._EvalPar = klass.EvalPar
+    klass.EvalPar = _TF1_EvalPar

--- a/bindings/pyroot/pythonizations/test/tf_pycallables.py
+++ b/bindings/pyroot/pythonizations/test/tf_pycallables.py
@@ -23,9 +23,14 @@ class pyf_tf1_callable:
     def __call__(self, x, p):
         return p[0] * x[0] + p[1]
 
+def pyf_func(x, pars):
+    return pars[0] * x[0] * x[2] + x[1] * pars[1]
 
 def pyf_tf1_gauss(x, p):
     return p[0] * 1.0 / math.sqrt(2.0 * math.pi * p[2]**2) * math.exp(-(x[0] - p[1])**2 / 2.0 / p[2]**2)
+
+def pyf_tf1_coulomb(x, p):
+    return p[1] * x[0] * x[1] / (p[0]**2) * math.exp(-p[2] / p[0])
 
 
 class TF1(unittest.TestCase):
@@ -93,6 +98,58 @@ class TF1(unittest.TestCase):
         self.assertAlmostEqual(scale, 1.0, 2)
         self.assertAlmostEqual(mean, 0.0, 2)
         self.assertAlmostEqual(abs(std), 1.0, 2)
+
+    def test_evalpar(self):
+        """
+        Test the 2D Numpy array pythonisations for TF1::EvalPar
+        """
+        import numpy as np
+
+        rtf1_coulomb = ROOT.TF1("my_func", pyf_tf1_coulomb, -10, 10)
+
+        # x dataset: 5 pairs of particle charges
+        x = np.array([
+            [1.0, 10, 2.0],
+            [1.5, 10, 2.5],
+            [2.0, 10, 3.0],
+            [2.5, 10, 3.5],
+            [3.0, 10, 4.0]
+        ])
+
+        params = np.array([
+            [1.0],       # Distance between charges r
+            [8.99e9],    # Coulomb constant k (in N·m²/C²)
+            [0.1]        # Additional factor for modulation
+        ])
+
+        # Slice to avoid the dummy column of 10's
+        res = rtf1_coulomb.EvalPar(x[:, ::2], params)
+
+        for i in range(len(x)):
+            expected_value = pyf_tf1_coulomb(x[i, ::2], params)
+            self.assertEqual(res[i], expected_value)
+    
+    def test_evalpar_dynamic(self):
+        """
+        Test the 2D NumPy pythonisations with dynamic TF1 data dimensions
+        """
+        import numpy as np
+
+        # Here we do not set the ndims, defaults to 1
+        rtf1_func = ROOT.TF1("my_func", pyf_func, -10, 10)
+
+        # x dataset with ndims 3
+        x = np.array([[2., 2, 1],
+                [1., 2, 3],
+                [2., 2, 1],
+                [4., 3, 2]])
+
+        pars = np.array([2., 3.])
+        res = rtf1_func.EvalPar(x, pars)
+
+        for i in range(len(x)):
+            expected_value = pyf_func(x[i], pars)
+            self.assertEqual(res[i], expected_value)
 
 
 def pyf_tf2_params(x, p):

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -658,6 +658,11 @@ public:
       fNormalized = flag;
       Update();
    }
+   inline void SetNdim(Int_t ndim)
+   {
+      fNdim = ndim;
+      Update();
+   }
    virtual void     SetNpx(Int_t npx = 100); // *MENU*
    virtual void     SetParameter(Int_t param, Double_t value)
    {
@@ -786,6 +791,14 @@ namespace ROOT {
             f->SetTitle(title);
          }
       };
+
+      inline void
+      EvalParMultiDim(TF1 *func, Double_t *out, const Double_t *x, std::size_t size, std::size_t rows, Double_t *params)
+      {
+         for (size_t i = 0; i < rows; i++) {
+            out[i] = func->EvalPar(x + i * size, params);
+         }
+      }
    }
 }
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -492,9 +492,8 @@ TF1::TF1():
    SetFillStyle(0);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// F1 constructor using a formula definition
+/// TF1 constructor using a formula definition
 ///
 /// See TFormula constructor for explanation of the formula syntax.
 ///


### PR DESCRIPTION
Allows the user to pass a dataset (2D NumPy array) where `ROOT::TF1/TF2/TF3` classes can call `EvalPar` on a functor object/pycallable

This no longer requires a looped call the the TF classes evaluation but returns a buffer that contains the result, evaluated for each subarray in the dataset. This also adds support for non-contiguous array calls(e.g sliced arrays) via the pythonization which was not previously supported even in the 1D array case.

Motivating example:

```py
def func(x, pars):
    return pars[0] * x[0] * x[0] + x[1] * pars[0]

my_func = ROOT.TF1("my_func", func, -10, 10, npar=2, ndim=2)

# will be sliced to mimic x 
x_non_contiguous = np.array([[2., 2, 1],
              [1., 2, 3],
              [2., 2, 1],
              [4., 3, 2]])

x = np.array([[2., 1],
              [1., 3],
              [2., 1],
              [4., 2]])

pars = np.array([2.])

y = np.zeros(len(x))

# this loop is no longer required
for i in range(len(x)):
    y[i] = my_func.EvalPar(x[i], pars)

#Now supported:

#2D NumPy array to pass dataset directly
my_func.EvalPar(x, pars)

# non-contiguous data in both 1D and 2D
for i in range(len(x)):
    y[i] = my_func.EvalPar(x_non_contiguous[i, ::2], pars) 

my_func.EvalPar(x_non_contiguous[:, ::2], pars)
```

