### PR TITLE
[tree] Report info about missing branch from TBranchProxy

### DIFF
--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -18,12 +18,39 @@ of the autoloading of branches as well as all the generic setup routine.
 #include "TLeaf.h"
 #include "TBranchElement.h"
 #include "TBranchObject.h"
+#include "TCollection.h" // TRangeStaticCast
 #include "TStreamerElement.h"
 #include "TStreamerInfo.h"
+#include "ROOT/InternalTreeUtils.hxx" // GetFileNamesFromTree, GetTreeFullPaths
+
+#include <string>
+#include <string_view>
 
 ClassImp(ROOT::Detail::TBranchProxy);
 
 using namespace ROOT::Internal;
+
+namespace {
+/**
+ * \brief Find if the input branch name is the prefix for other sub-branches in the same tree.
+ */
+bool AreThereSubBranches(std::string_view parentBrName, TTree &tree)
+{
+   const std::string prefix = [&parentBrName]() {
+      if (parentBrName.back() == '.')
+         return std::string(parentBrName);
+      return std::string(parentBrName) + '.';
+   }();
+
+   for (auto *leaf : ROOT::Detail::TRangeStaticCast<TLeaf>(tree.GetListOfLeaves()))
+      // Compares the prefix string with the leaf name, checking if the first
+      // `prefix.size()` characters match those of the prefix, i.e. if the leaf
+      // name starts with the prefix
+      if (prefix.compare(0, prefix.size(), leaf->GetName(), prefix.size()) == 0)
+         return true;
+   return false;
+}
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
@@ -275,13 +302,19 @@ bool ROOT::Detail::TBranchProxy::Setup()
       // its mother's name
       fBranch = fDirector->GetTree()->GetBranch(fBranchName.Data());
       if (!fBranch) {
-         // FIXME
-         // While fixing ROOT-10019, this error was added to give to the user an even better experience
-         // in presence of a problem.
-         // It is not easy to distinguish the cases where this error is "expected"
-         // For now we do not print anything - see conversation here: https://github.com/root-project/root/pull/3746
-         //auto treeName = fDirector->GetTree()->GetName();
-         //::Error("TBranchProxy::Setup", "%s", Form("Unable to find branch %s in tree %s.\n",fBranchName.Data(), treeName));
+         if (!AreThereSubBranches(fBranchName.View(), *fDirector->GetTree())) {
+            // The next error refers specifically to the situation where the branch identified by fBranchName
+            // is not present and that is not expected. An example is when traversing a chain of files, the branch
+            // is missing from the file that we are switching into.
+            // Conversely, there are situations where the missing branch is indeed expected. A notable example is when
+            // the TTree contains a split object, the branch referring to the whole object type will actually be elided
+            // and will not be found by `TTree::GetBranch`, only the data members will be present as sub branches.
+            auto *tree = fDirector->GetTree()->GetTree(); // Double GetTree to extract the current TTree being processed
+            Error("TBranchProxy::Setup()", "%s",
+                  Form("Branch '%s' is not available from tree '%s' in file '%s'.", fBranchName.Data(),
+                       ROOT::Internal::TreeUtils::GetTreeFullPaths(*tree)[0].c_str(),
+                       ROOT::Internal::TreeUtils::GetFileNamesFromTree(*tree)[0].c_str()));
+         }
          return false;
       }
 

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -12,6 +12,7 @@
 
 #include "gtest/gtest.h"
 #include "ROOT/TestSupport.hxx"
+#include "ROOT/InternalTreeUtils.hxx" // GetFileNamesFromTree
 #include <cstdlib>
 #include <memory>
 
@@ -489,6 +490,10 @@ TEST(TTreeReaderBasic, DisappearingBranch)
 
    TChain c("t");
    c.Add("DisappearingBranch*.root");
+   diags.requiredDiag(kError, "TBranchProxy::Setup()",
+                      "Branch 'col1' is not available from tree 't' in file '" +
+                         ROOT::Internal::TreeUtils::GetFileNamesFromTree(c)[1] + "'.");
+
    TTreeReader r(&c);
    TTreeReaderValue<int> rv(r, "col1");
    r.Next();


### PR DESCRIPTION
When setting the branch proxy, report info about a missing branch to the user. This is done in the form of a printed error. The logic is only triggered if there are no other branch names in the list of available branches that begin with the current branch name being searched. This situation could arise for example with a skeleton analysis produced by TTree::MakeProxy and a TTree with a split object. In that case the generated code will try to create a TBranchProxy for the top-level branch, even though that branch is not available from the TTree, only the sub-branches are.

See for more details the discussion at https://github.com/root-project/root/pull/3746
