### PR TITLE
[RF] Don't share a single static fitter for all RooMinimizer instances

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -132,14 +132,13 @@ public:
    /// \see RooMinimizer::setLoggingToDataSet(bool).
    RooDataSet *getLogDataSet() const { return _logDataSet.get(); }
 
-   static int getPrintLevel();
+   int getPrintLevel();
 
    void setMinimizerType(std::string const &type);
    std::string const &minimizerType() const { return _cfg.minimizerType; }
 
-   static void cleanup();
-   static RooFit::OwningPtr<RooFitResult> lastMinuitFit();
-   static RooFit::OwningPtr<RooFitResult> lastMinuitFit(const RooArgList &varList);
+   RooFit::OwningPtr<RooFitResult> lastMinuitFit();
+   RooFit::OwningPtr<RooFitResult> lastMinuitFit(const RooArgList &varList);
 
    void saveStatus(const char *label, int status) { _statusHistory.emplace_back(label, status); }
 
@@ -193,7 +192,7 @@ private:
 
    std::unique_ptr<RooAbsMinimizerFcn> _fcn;
 
-   static std::unique_ptr<ROOT::Fit::Fitter> _theFitter;
+   std::unique_ptr<ROOT::Fit::Fitter> _theFitter;
 
    std::vector<std::pair<std::string, int>> _statusHistory;
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -148,8 +148,10 @@ public:
    int evalCounter() const;
    void zeroEvalCount();
 
-   ROOT::Fit::Fitter *fitter();
-   const ROOT::Fit::Fitter *fitter() const;
+   /// Return underlying ROOT fitter object
+   inline ROOT::Fit::Fitter *fitter() { return _theFitter.get(); }
+   /// Return underlying ROOT fitter object
+   inline const ROOT::Fit::Fitter *fitter() const { return _theFitter.get(); }
 
    ROOT::Math::IMultiGenFunction *getMultiGenFcn() const;
 
@@ -173,13 +175,20 @@ private:
    double &maxFCN();
    double &fcnOffset() const;
 
-   bool fitFcn() const;
-
    // constructor helper functions
    void initMinimizerFirstPart();
    void initMinimizerFcnDependentPart(double defaultErrorLevel);
 
    void determineStatus(bool fitterReturnValue);
+
+   // Some private functions to interact with the ROOT::Math::Fitter. This
+   // makes it clearer to the reader of the code which part of the Fitter
+   // interface is actually used by the RooMinimizer.
+   inline ROOT::Math::Minimizer *getMinimizer() const { return _theFitter->GetMinimizer(); }
+   inline ROOT::Fit::FitConfig &getConfig() const { return _theFitter->Config(); }
+   inline const ROOT::Fit::FitResult &getResult() const { return _theFitter->Result(); }
+
+   int exec(std::string const &algoName, std::string const &statusName);
 
    int _status = -99;
    bool _profileStart = false;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -16,8 +16,6 @@
 #define ROO_ABS_MINIMIZER_FCN
 
 #include "Math/IFunction.h"
-#include "Fit/ParameterSettings.h"
-#include "Fit/FitResult.h"
 
 #include "TMatrixDSym.h"
 
@@ -25,8 +23,6 @@
 #include "RooArgList.h"
 #include "RooMinimizer.h"
 #include "RooRealVar.h"
-
-#include <Fit/Fitter.h>
 
 #include <iostream>
 #include <fstream>

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -519,7 +519,7 @@ int RooMinimizer::simplex()
    profileStop();
    _fcn->BackProp(_theFitter->Result());
 
-   saveStatus("SEEK", _status);
+   saveStatus("SIMPLEX", _status);
 
    return _status;
 }

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -71,20 +71,7 @@ automatic PDF optimization.
 #include <iostream>
 #include <stdexcept> // logic_error
 
-using std::endl;
-
 ClassImp(RooMinimizer);
-
-std::unique_ptr<ROOT::Fit::Fitter> RooMinimizer::_theFitter = {};
-
-////////////////////////////////////////////////////////////////////////////////
-/// Cleanup method called by atexit handler installed by RooSentinel
-/// to delete all global heap objects when the program is terminated
-
-void RooMinimizer::cleanup()
-{
-   _theFitter.reset();
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct MINUIT interface to given function. Function can be anything,
@@ -385,7 +372,7 @@ int RooMinimizer::migrad()
 int RooMinimizer::hesse()
 {
    if (_theFitter->GetMinimizer() == nullptr) {
-      coutW(Minimization) << "RooMinimizer::hesse: Error, run Migrad before Hesse!" << endl;
+      coutW(Minimization) << "RooMinimizer::hesse: Error, run Migrad before Hesse!" << std::endl;
       _status = -1;
    } else {
 
@@ -416,7 +403,7 @@ int RooMinimizer::hesse()
 int RooMinimizer::minos()
 {
    if (_theFitter->GetMinimizer() == nullptr) {
-      coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << endl;
+      coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << std::endl;
       _status = -1;
    } else {
 
@@ -448,7 +435,7 @@ int RooMinimizer::minos()
 int RooMinimizer::minos(const RooArgSet &minosParamList)
 {
    if (_theFitter->GetMinimizer() == nullptr) {
-      coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << endl;
+      coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!" << std::endl;
       _status = -1;
    } else if (!minosParamList.empty()) {
 
@@ -598,7 +585,7 @@ void RooMinimizer::optimizeConst(int flag)
 RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const char *userTitle)
 {
    if (_theFitter->GetMinimizer() == nullptr) {
-      coutW(Minimization) << "RooMinimizer::save: Error, run minimization before!" << endl;
+      coutW(Minimization) << "RooMinimizer::save: Error, run minimization before!" << std::endl;
       return nullptr;
    }
 
@@ -682,14 +669,14 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
    int index1 = _fcn->GetFloatParamList()->index(&var1);
    if (index1 < 0) {
       coutE(Minimization) << "RooMinimizer::contour(" << GetName() << ") ERROR: " << var1.GetName()
-                          << " is not a floating parameter of " << _fcn->getFunctionName() << endl;
+                          << " is not a floating parameter of " << _fcn->getFunctionName() << std::endl;
       return nullptr;
    }
 
    int index2 = _fcn->GetFloatParamList()->index(&var2);
    if (index2 < 0) {
       coutE(Minimization) << "RooMinimizer::contour(" << GetName() << ") ERROR: " << var2.GetName()
-                          << " is not a floating parameter of PDF " << _fcn->getFunctionName() << endl;
+                          << " is not a floating parameter of PDF " << _fcn->getFunctionName() << std::endl;
       return nullptr;
    }
 
@@ -703,7 +690,7 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
    // check first if a inimizer is available. If not means
    // the minimization is not done , so do it
    if (_theFitter->GetMinimizer() == nullptr) {
-      coutW(Minimization) << "RooMinimizer::contour: Error, run Migrad before contours!" << endl;
+      coutW(Minimization) << "RooMinimizer::contour: Error, run Migrad before contours!" << std::endl;
       return frame;
    }
 
@@ -731,7 +718,7 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
 
          if (!ret) {
             coutE(Minimization) << "RooMinimizer::contour(" << GetName()
-                                << ") ERROR: MINUIT did not return a contour graph for n=" << n[ic] << endl;
+                                << ") ERROR: MINUIT did not return a contour graph for n=" << n[ic] << std::endl;
          } else {
             xcoor[npoints] = xcoor[0];
             ycoor[npoints] = ycoor[0];
@@ -830,16 +817,16 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    // the fit parameters as the given varList of parameters.
 
    if (_theFitter == nullptr || _theFitter->GetMinimizer() == nullptr) {
-      oocoutE(nullptr, InputArguments) << "RooMinimizer::save: Error, run minimization before!" << endl;
+      oocoutE(nullptr, InputArguments) << "RooMinimizer::save: Error, run minimization before!" << std::endl;
       return nullptr;
    }
 
    // Verify length of supplied varList
    if (!varList.empty() && varList.size() != _theFitter->Result().NTotalParameters()) {
       oocoutE(nullptr, InputArguments)
-         << "RooMinimizer::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
+         << "RooMinimizer::lastMinuitFit: ERROR: supplied variable list must be either empty " << std::endl
          << "                             or match the number of variables of the last fit ("
-         << _theFitter->Result().NTotalParameters() << ")" << endl;
+         << _theFitter->Result().NTotalParameters() << ")" << std::endl;
       return nullptr;
    }
 
@@ -847,7 +834,7 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    for (RooAbsArg *arg : varList) {
       if (!dynamic_cast<RooRealVar *>(arg)) {
          oocoutE(nullptr, InputArguments) << "RooMinimizer::lastMinuitFit: ERROR: variable '" << arg->GetName()
-                                          << "' is not of type RooRealVar" << endl;
+                                          << "' is not of type RooRealVar" << std::endl;
          return nullptr;
       }
    }
@@ -890,7 +877,7 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
 
          if (varName.CompareTo(var->GetName())) {
             oocoutI(nullptr, Eval) << "RooMinimizer::lastMinuitFit: fit parameter '" << varName
-                                   << "' stored in variable '" << var->GetName() << "'" << endl;
+                                   << "' stored in variable '" << var->GetName() << "'" << std::endl;
          }
       }
 

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -16,8 +16,6 @@
 #define ROO_MINIMIZER_FCN
 
 #include "Math/IFunction.h"
-#include "Fit/ParameterSettings.h"
-#include "Fit/FitResult.h"
 
 #include "RooAbsReal.h"
 #include "RooArgList.h"
@@ -26,10 +24,6 @@
 #include <vector>
 
 #include "RooAbsMinimizerFcn.h"
-
-template <typename T>
-class TMatrixTSym;
-using TMatrixDSym = TMatrixTSym<double>;
 
 // forward declaration
 class RooMinimizer;

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -101,8 +101,6 @@ class LikelihoodGradientJobTest : public ::testing::TestWithParam<std::tuple<std
       RooRandom::randomGenerator()->SetSeed(seed);
    }
 
-   void TearDown() override { RooMinimizer::cleanup(); }
-
 protected:
    std::size_t NWorkers = 0;
    std::size_t seed = 0;
@@ -615,9 +613,6 @@ class LikelihoodGradientJobErrorTest
          RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
       RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
          RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
-
-      // cleanup to make sure JobManager is shut down after any test
-      RooMinimizer::cleanup();
    }
 
 protected:
@@ -797,9 +792,6 @@ class LikelihoodGradientJobBinnedErrorTest : public ::testing::TestWithParam<std
          RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
       RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
          RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
-
-      // cleanup to make sure JobManager is shut down after any test
-      RooMinimizer::cleanup();
    }
 
 protected:

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -295,7 +295,6 @@ TEST(RooNaNPacker, FitAddPdf_DegenerateCoeff)
    for (auto tryRecover : std::initializer_list<double>{0., 10.}) {
       params.assign(evilValues);
 
-      RooMinimizer::cleanup();
       RooMinimizer minim(*nll);
       minim.setRecoverFromNaNStrength(tryRecover);
       minim.setPrintLevel(-1);


### PR DESCRIPTION
This improves thread safety in RooFit, as inspired by a recent forum
post where someone wanted to do multiple fits in parallel.

It was checked that this has no visible impact on performance.

Also, a small bugfix and general code improvements in separate commits.

