### PR TITLE
[ntuple] add Real32Quant column type

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -404,6 +404,7 @@ The flags field can have any of the following bits set:
 | 0x01     | Repetitive field, i.e. for every entry $n$ copies of the field are stored  |
 | 0x02     | Projected field                                                            |
 | 0x04     | Has ROOT type checksum as reported by TClass                               |
+| 0x08     | Field with a range of possible values                                      |
 
 If `flag==0x01` (_repetitive field_) is set, the field represents a fixed-size array.
 Another (sub) field with `Parent Field ID` equal to the ID of this field
@@ -415,8 +416,11 @@ the field has been created as a virtual field from another, non-projected source
 If a projected field has attached columns,
 these columns are alias columns to physical columns attached to the source field.
 
-If `flag==0x04` (type checksum) is set, the field metadata contain the checksum of the ROOT streamer info.
+If `flag==0x04` (_type checksum_) is set, the field metadata contain the checksum of the ROOT streamer info.
 This checksum is only used for I/O rules in order to find types that are identified by checksum.
+
+If `flag==0x08` (_field with range_) is set, the field metadata contain the range of valid values
+for this field (used e.g. for quantized real values, see Column Description section).
 
 Depending on the flags, the following optional values follow:
 
@@ -431,6 +435,14 @@ Depending on the flags, the following optional values follow:
 +             Source Field ID (if flag 0x02 is set)             +
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 +          ROOT Streamer Checksum (if flag 0x04 is set)         +
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                Min value(if flag 0x08 is set)                 +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                Max value(if flag 0x08 is set)                 +
+|                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
@@ -477,37 +489,38 @@ The representation index is consecutive starting at zero.
 
 The column type and bits on storage integers can have one of the following values
 
-| Type | Bits | Name         | Contents                                                                      |
-|------|------|--------------|-------------------------------------------------------------------------------|
-| 0x01 |   64 | Index64      | Parent columns of (nested) collections, counting is relative to the cluster   |
-| 0x02 |   32 | Index32      | Parent columns of (nested) collections, counting is relative to the cluster   |
-| 0x03 |   96 | Switch       | Tuple of a kIndex64 value followed by a 32 bits dispatch tag to a column ID   |
-| 0x04 |    8 | Byte         | An uninterpreted byte, e.g. part of a blob                                    |
-| 0x05 |    8 | Char         | ASCII character                                                               |
-| 0x06 |    1 | Bit          | Boolean value                                                                 |
-| 0x07 |   64 | Real64       | IEEE-754 double precision float                                               |
-| 0x08 |   32 | Real32       | IEEE-754 single precision float                                               |
-| 0x09 |   16 | Real16       | IEEE-754 half precision float                                                 |
-| 0x16 |   64 | Int64        | Two's complement, little-endian 8 byte signed integer                         |
-| 0x0A |   64 | UInt64       | Little-endian 8 byte unsigned integer                                         |
-| 0x17 |   32 | Int32        | Two's complement, little-endian 4 byte signed integer                         |
-| 0x0B |   32 | UInt32       | Little-endian 4 byte unsigned integer                                         |
-| 0x18 |   16 | Int16        | Two's complement, little-endian 2 byte signed integer                         |
-| 0x0C |   16 | UInt16       | Little-endian 2 byte unsigned integer                                         |
-| 0x19 |    8 | Int8         | Two's complement, 1 byte signed integer                                       |
-| 0x0D |    8 | UInt8        | 1 byte unsigned integer                                                       |
-| 0x0E |   64 | SplitIndex64 | Like Index64 but pages are stored in split + delta encoding                   |
-| 0x0F |   32 | SplitIndex32 | Like Index32 but pages are stored in split + delta encoding                   |
-| 0x10 |   64 | SplitReal64  | Like Real64 but in split encoding                                             |
-| 0x11 |   32 | SplitReal32  | Like Real32 but in split encoding                                             |
-| 0x12 |   16 | SplitReal16  | Like Real16 but in split encoding                                             |
-| 0x1A |   64 | SplitInt64   | Like Int64 but in split + zigzag encoding                                     |
-| 0x13 |   64 | SplitUInt64  | Like UInt64 but in split encoding                                             |
-| 0x1B |   64 | SplitInt32   | Like Int32 but in split + zigzag encoding                                     |
-| 0x14 |   32 | SplitUInt32  | Like UInt32 but in split encoding                                             |
-| 0x1C |   16 | SplitInt16   | Like Int16 but in split + zigzag encoding                                     |
-| 0x15 |   16 | SplitUInt16  | Like UInt16 but in split encoding                                             |
-| 0x1D |10-31 | Real32Trunc  | IEEE-754 single precision float with truncated mantissa                       |
+| Type | Bits | Name         | Contents                                                                                      |
+|------|------|--------------|-----------------------------------------------------------------------------------------------|
+| 0x01 |   64 | Index64      | Parent columns of (nested) collections, counting is relative to the cluster                   |
+| 0x02 |   32 | Index32      | Parent columns of (nested) collections, counting is relative to the cluster                   |
+| 0x03 |   96 | Switch       | Tuple of a kIndex64 value followed by a 32 bits dispatch tag to a column ID                   |
+| 0x04 |    8 | Byte         | An uninterpreted byte, e.g. part of a blob                                                    |
+| 0x05 |    8 | Char         | ASCII character                                                                               |
+| 0x06 |    1 | Bit          | Boolean value                                                                                 |
+| 0x07 |   64 | Real64       | IEEE-754 double precision float                                                               |
+| 0x08 |   32 | Real32       | IEEE-754 single precision float                                                               |
+| 0x09 |   16 | Real16       | IEEE-754 half precision float                                                                 |
+| 0x16 |   64 | Int64        | Two's complement, little-endian 8 byte signed integer                                         |
+| 0x0A |   64 | UInt64       | Little-endian 8 byte unsigned integer                                                         |
+| 0x17 |   32 | Int32        | Two's complement, little-endian 4 byte signed integer                                         |
+| 0x0B |   32 | UInt32       | Little-endian 4 byte unsigned integer                                                         |
+| 0x18 |   16 | Int16        | Two's complement, little-endian 2 byte signed integer                                         |
+| 0x0C |   16 | UInt16       | Little-endian 2 byte unsigned integer                                                         |
+| 0x19 |    8 | Int8         | Two's complement, 1 byte signed integer                                                       |
+| 0x0D |    8 | UInt8        | 1 byte unsigned integer                                                                       |
+| 0x0E |   64 | SplitIndex64 | Like Index64 but pages are stored in split + delta encoding                                   |
+| 0x0F |   32 | SplitIndex32 | Like Index32 but pages are stored in split + delta encoding                                   |
+| 0x10 |   64 | SplitReal64  | Like Real64 but in split encoding                                                             |
+| 0x11 |   32 | SplitReal32  | Like Real32 but in split encoding                                                             |
+| 0x12 |   16 | SplitReal16  | Like Real16 but in split encoding                                                             |
+| 0x1A |   64 | SplitInt64   | Like Int64 but in split + zigzag encoding                                                     |
+| 0x13 |   64 | SplitUInt64  | Like UInt64 but in split encoding                                                             |
+| 0x1B |   64 | SplitInt32   | Like Int32 but in split + zigzag encoding                                                     |
+| 0x14 |   32 | SplitUInt32  | Like UInt32 but in split encoding                                                             |
+| 0x1C |   16 | SplitInt16   | Like Int16 but in split + zigzag encoding                                                     |
+| 0x15 |   16 | SplitUInt16  | Like UInt16 but in split encoding                                                             |
+| 0x1D |10-31 | Real32Trunc  | IEEE-754 single precision float with truncated mantissa                                       |
+| 0x1E | 8-32 | Real32Quant  | Real value contained in a specified range with an underlying quantized integer representation |
 
 The "split encoding" columns apply a byte transformation encoding to all pages of that column
 and in addition, depending on the column type, delta or zigzag encoding:
@@ -528,6 +541,10 @@ not cluster-wise.
 
 The "Real32Trunc" type column is a variable-sized floating point column with lower precision than `Real32` and `SplitReal32`.
 It is a IEEE-754 single precision float with some of the mantissa's least significant bits truncated.
+
+The "Real32Quant" type column is a variable-sized real column that is internally represented as an integer within
+a specified range of values.
+The min and max values of the range is specified in its parent field metadata (see the Field Description section).
 
 Future versions of the file format may introduce additional column types
 without changing the minimum version of the header or introducing a feature flag.
@@ -840,6 +857,7 @@ Such cases are marked as `R` in the table.
 | (Split)Real32 |      |           |      |        |         |         |          |         |          |         |          |   W*  |   W    |
 | (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |       |   W*   |
 | Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W*  |        |
+| Real32Quant   |      |           |      |        |         |         |          |         |          |         |          |   W*  |        |
 
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.
 The default column for serialization is denoted with an asterix.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -520,7 +520,7 @@ The column type and bits on storage integers can have one of the following value
 | 0x1C |   16 | SplitInt16   | Like Int16 but in split + zigzag encoding                                                     |
 | 0x15 |   16 | SplitUInt16  | Like UInt16 but in split encoding                                                             |
 | 0x1D |10-31 | Real32Trunc  | IEEE-754 single precision float with truncated mantissa                                       |
-| 0x1E | 8-32 | Real32Quant  | Real value contained in a specified range with an underlying quantized integer representation |
+| 0x1E | 1-32 | Real32Quant  | Real value contained in a specified range with an underlying quantized integer representation |
 
 The "split encoding" columns apply a byte transformation encoding to all pages of that column
 and in addition, depending on the column type, delta or zigzag encoding:

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -856,8 +856,8 @@ Such cases are marked as `R` in the table.
 | Real16        |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | (Split)Real32 |      |           |      |        |         |         |          |         |          |         |          |   W*  |   W    |
 | (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |       |   W*   |
-| Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W*  |        |
-| Real32Quant   |      |           |      |        |         |         |          |         |          |         |          |   W*  |        |
+| Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W   |        |
+| Real32Quant   |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.
 The default column for serialization is denoted with an asterix.

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -333,7 +333,7 @@ public:
       assert(fElement);
       return fElement->GetBitsOnStorage();
    }
-   std::pair<double, double> GetValueRange() const
+   std::optional<std::pair<double, double>> GetValueRange() const
    {
       assert(fElement);
       return fElement->GetValueRange();

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -333,6 +333,11 @@ public:
       assert(fElement);
       return fElement->GetBitsOnStorage();
    }
+   std::pair<double, double> GetValueRange() const
+   {
+      assert(fElement);
+      return fElement->GetValueRange();
+   }
    std::uint32_t GetIndex() const { return fIndex; }
    std::uint16_t GetRepresentationIndex() const { return fRepresentationIndex; }
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
@@ -344,6 +349,7 @@ public:
 
    void SetBitsOnStorage(std::size_t bits) { fElement->SetBitsOnStorage(bits); }
    std::size_t GetWritePageCapacity() const { return fWritePage.GetCapacity(); }
+   void SetValueRange(double min, double max) { fElement->SetValueRange(min, max); }
 }; // class RColumn
 
 } // namespace ROOT::Experimental::Internal

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -89,6 +89,11 @@ public:
          throw RException(R__FAIL(std::string("internal error: cannot change bit width of this column type")));
    }
 
+   virtual void SetValueRange(double, double)
+   {
+      throw RException(R__FAIL(std::string("internal error: cannot change value range of this column type")));
+   }
+
    /// If the on-storage layout and the in-memory layout differ, packing creates an on-disk page from an in-memory page
    virtual void Pack(void *destination, const void *source, std::size_t count) const
    {

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -54,6 +54,8 @@ protected:
    /// Size of the C++ value that corresponds to the on-disk element
    std::size_t fSize;
    std::size_t fBitsOnStorage;
+   /// This is only meaningful for column elements that support it (e.g. Real32Quant)
+   std::pair<double, double> fValueRange = {0, 0};
 
    explicit RColumnElementBase(std::size_t size, std::size_t bitsOnStorage = 0)
       : fSize(size), fBitsOnStorage(bitsOnStorage ? bitsOnStorage : 8 * size)
@@ -108,6 +110,7 @@ public:
 
    std::size_t GetSize() const { return fSize; }
    std::size_t GetBitsOnStorage() const { return fBitsOnStorage; }
+   std::pair<double, double> GetValueRange() const { return fValueRange; }
    std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * fBitsOnStorage + 7) / 8; }
 }; // class RColumnElementBase
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -28,6 +28,7 @@
 #include <cstddef> // for std::byte
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
@@ -55,7 +56,7 @@ protected:
    std::size_t fSize;
    std::size_t fBitsOnStorage;
    /// This is only meaningful for column elements that support it (e.g. Real32Quant)
-   std::pair<double, double> fValueRange = {0, 0};
+   std::optional<std::pair<double, double>> fValueRange = std::nullopt;
 
    explicit RColumnElementBase(std::size_t size, std::size_t bitsOnStorage = 0)
       : fSize(size), fBitsOnStorage(bitsOnStorage ? bitsOnStorage : 8 * size)
@@ -110,7 +111,7 @@ public:
 
    std::size_t GetSize() const { return fSize; }
    std::size_t GetBitsOnStorage() const { return fBitsOnStorage; }
-   std::pair<double, double> GetValueRange() const { return fValueRange; }
+   std::optional<std::pair<double, double>> GetValueRange() const { return fValueRange; }
    std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * fBitsOnStorage + 7) / 8; }
 }; // class RColumnElementBase
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -71,6 +71,11 @@ class RFieldDescriptor {
    friend class Internal::RNTupleDescriptorBuilder;
    friend class Internal::RFieldDescriptorBuilder;
 
+public:
+   struct RValueRange {
+      double fMin, fMax;
+   };
+
 private:
    DescriptorId_t fFieldId = kInvalidDescriptorId;
    /// The version of the C++-type-to-column translation mechanics
@@ -105,6 +110,8 @@ private:
    /// For custom classes, we store the ROOT TClass reported checksum to facilitate the use of I/O rules that
    /// identify types by their checksum
    std::optional<std::uint32_t> fTypeChecksum;
+   /// Optional value range (used e.g. by quantized real fields)
+   std::optional<RValueRange> fValueRange;
 
 public:
    RFieldDescriptor() = default;
@@ -140,6 +147,7 @@ public:
    /// natively supported stdlib classes.
    /// The dictionary does not need to be available for this method.
    bool IsCustomClass() const;
+   std::optional<RValueRange> GetValueRange() const { return fValueRange; }
 };
 
 // clang-format off
@@ -1158,6 +1166,11 @@ public:
    RFieldDescriptorBuilder &TypeChecksum(const std::optional<std::uint32_t> typeChecksum)
    {
       fField.fTypeChecksum = typeChecksum;
+      return *this;
+   }
+   RFieldDescriptorBuilder &ValueRange(const std::optional<RFieldDescriptor::RValueRange> valueRange)
+   {
+      fField.fValueRange = valueRange;
       return *this;
    }
    DescriptorId_t GetParentId() const { return fField.fParentId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -155,7 +155,13 @@ class RColumnDescriptor {
 
 public:
    struct RValueRange {
-      double fMin, fMax;
+      double fMin = 0, fMax = 0;
+
+      RValueRange() = default;
+      RValueRange(double min, double max) : fMin(min), fMax(max) {}
+      RValueRange(std::pair<double, double> range) : fMin(range.first), fMax(range.second) {}
+
+      bool operator==(RValueRange other) const { return fMin == other.fMin && fMax == other.fMax; }
    };
 
 private:
@@ -1070,7 +1076,12 @@ public:
    }
    RColumnDescriptorBuilder &ValueRange(double min, double max)
    {
-      fColumn.fValueRange = { min, max };
+      fColumn.fValueRange = {min, max};
+      return *this;
+   }
+   RColumnDescriptorBuilder &ValueRange(std::optional<RColumnDescriptor::RValueRange> valueRange)
+   {
+      fColumn.fValueRange = valueRange;
       return *this;
    }
    DescriptorId_t GetFieldId() const { return fColumn.fFieldId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -68,9 +68,9 @@ public:
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
    static constexpr std::uint16_t kFlagProjectedField = 0x02;
    static constexpr std::uint16_t kFlagHasTypeChecksum = 0x04;
-   static constexpr std::uint16_t kFlagHasValueRange = 0x08;
 
    static constexpr std::uint16_t kFlagDeferredColumn = 0x08;
+   static constexpr std::uint16_t kFlagHasValueRange = 0x10;
 
    static constexpr DescriptorId_t kZeroFieldId = std::uint64_t(-2);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -68,6 +68,7 @@ public:
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
    static constexpr std::uint16_t kFlagProjectedField = 0x02;
    static constexpr std::uint16_t kFlagHasTypeChecksum = 0x04;
+   static constexpr std::uint16_t kFlagHasValueRange = 0x08;
 
    static constexpr std::uint16_t kFlagDeferredColumn = 0x08;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -79,6 +79,7 @@ enum class EColumnType {
    kSplitInt16,
    kSplitUInt16,
    kReal32Trunc,
+   kReal32Quant,
    kMax,
 };
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -57,6 +57,7 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    case EColumnType::kSplitInt16: return std::make_pair(16, 16);
    case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
    case EColumnType::kReal32Trunc: return std::make_pair(10, 31);
+   case EColumnType::kReal32Quant: return std::make_pair(8, 32);
    default: assert(false);
    }
    // never here
@@ -94,6 +95,7 @@ std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColum
    case EColumnType::kSplitInt16: return "SplitInt16";
    case EColumnType::kSplitUInt16: return "SplitUInt16";
    case EColumnType::kReal32Trunc: return "Real32Trunc";
+   case EColumnType::kReal32Quant: return "Real32Quant";
    default: return "UNKNOWN";
    }
 }
@@ -134,6 +136,7 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<float, EColumnType::kReal32Trunc>>();
+   case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<float, EColumnType::kReal32Quant>>();
    default: assert(false);
    }
    // never here
@@ -285,3 +288,4 @@ void ROOT::Experimental::Internal::BitPacking::UnpackBits(void *dst, const void 
    assert(prevWordLsb == 0);
    assert(dstIdx == count);
 }
+

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -288,4 +288,3 @@ void ROOT::Experimental::Internal::BitPacking::UnpackBits(void *dst, const void 
    assert(prevWordLsb == 0);
    assert(dstIdx == count);
 }
-

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -57,7 +57,7 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    case EColumnType::kSplitInt16: return std::make_pair(16, 16);
    case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
    case EColumnType::kReal32Trunc: return std::make_pair(10, 31);
-   case EColumnType::kReal32Quant: return std::make_pair(8, 32);
+   case EColumnType::kReal32Quant: return std::make_pair(1, 32);
    default: assert(false);
    }
    // never here

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -769,15 +769,15 @@ using Quantized_t = std::uint32_t;
 
 /// Converts the array `src` of `count` floating point numbers into an array of their quantized representations.
 /// Each element of `src` is assumed to be in the inclusive range [min, max].
-/// The quantized representation will consist of unsigned integers of at most `nQuantBits`, with `8 <= nQuantBits <=
-/// 32`. The unused bits are kept in the LSB of the quantized integers, to allow for easy bit packing of those integers
-/// via BitPacking::PackBits().
+/// The quantized representation will consist of unsigned integers of at most `nQuantBits` (with `nQuantBits <= 8 *
+/// sizeof(Quantized_t)`). The unused bits are kept in the LSB of the quantized integers, to allow for easy bit packing
+/// of those integers via BitPacking::PackBits().
 template <typename T>
 void QuantizeReals(Quantized_t *dst, const T *src, std::size_t count, double min, double max, std::size_t nQuantBits)
 {
    static_assert(std::is_floating_point_v<T>);
    static_assert(sizeof(T) <= sizeof(double));
-   R__ASSERT(nQuantBits >= 8 && nQuantBits <= 8 * sizeof(Quantized_t));
+   assert(1 <= nQuantBits && nQuantBits <= 8 * sizeof(Quantized_t));
 
    const std::size_t quantMax = (1ull << nQuantBits) - 1;
    const double scale = quantMax / (max - min);
@@ -805,7 +805,7 @@ void UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double m
 {
    static_assert(std::is_floating_point_v<T>);
    static_assert(sizeof(T) <= sizeof(double));
-   R__ASSERT(nQuantBits >= 8 && nQuantBits <= 8 * sizeof(Quantized_t));
+   assert(1 <= nQuantBits && nQuantBits <= 8 * sizeof(Quantized_t));
 
    const std::size_t quantMax = (1ull << nQuantBits) - 1;
    const double scale = (max - min) / quantMax;

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -857,7 +857,8 @@ public:
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
       auto quantized = std::make_unique<Quantize::Quantized_t[]>(count);
-      const auto [min, max] = fValueRange;
+      assert(fValueRange);
+      const auto [min, max] = *fValueRange;
       Quantize::QuantizeReals(quantized.get(), reinterpret_cast<const float *>(src), count, min, max, fBitsOnStorage);
       ROOT::Experimental::Internal::BitPacking::PackBits(dst, quantized.get(), count, sizeof(Quantize::Quantized_t),
                                                          fBitsOnStorage);
@@ -866,7 +867,8 @@ public:
    void Unpack(void *dst, const void *src, std::size_t count) const final
    {
       auto quantized = std::make_unique<Quantize::Quantized_t[]>(count);
-      const auto [min, max] = fValueRange;
+      assert(fValueRange);
+      const auto [min, max] = *fValueRange;
       ROOT::Experimental::Internal::BitPacking::UnpackBits(quantized.get(), src, count, sizeof(Quantize::Quantized_t),
                                                            fBitsOnStorage);
       Quantize::UnquantizeReals(reinterpret_cast<float *>(dst), quantized.get(), count, min, max, fBitsOnStorage);

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -818,7 +818,6 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
 
    const std::size_t quantMax = (1ull << nQuantBits) - 1;
    const double scale = (max - min) / quantMax;
-   const double bias = min * quantMax / (max - min);
    const std::size_t unusedBits = sizeof(Quantized_t) * 8 - nQuantBits;
 
    int nOutOfRange = 0;
@@ -831,7 +830,7 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
       ByteSwapIfNecessary(elem);
 
       const double fq = static_cast<double>(elem);
-      const double e = (fq + bias) * scale;
+      const double e = fq * scale + min;
       dst[i] = static_cast<T>(e);
 
       nOutOfRange += !(min <= dst[i] && dst[i] <= max);

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -788,12 +788,12 @@ int QuantizeReals(Quantized_t *dst, const T *src, std::size_t count, double min,
    int nOutOfRange = 0;
 
    for (std::size_t i = 0; i < count; ++i) {
-      T elem = src[i];
+      const T elem = src[i];
 
       nOutOfRange += !(min <= elem && elem <= max);
 
-      double e = (elem - min) * scale;
-      Quantized_t q = static_cast<Quantized_t>(e + 0.5);
+      const double e = 0.5 + (elem - min) * scale;
+      Quantized_t q = static_cast<Quantized_t>(e);
       ByteSwapIfNecessary(q);
 
       // double-check we actually used at most `nQuantBits`
@@ -830,8 +830,8 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
       elem >>= unusedBits;
       ByteSwapIfNecessary(elem);
 
-      double fq = static_cast<double>(elem);
-      double e = (fq + bias) * scale;
+      const double fq = static_cast<double>(elem);
+      const double e = (fq + bias) * scale;
       dst[i] = static_cast<T>(e);
 
       nOutOfRange += !(min <= dst[i] && dst[i] <= max);

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -788,7 +788,7 @@ void QuantizeReals(Quantized_t *dst, const T *src, std::size_t count, double min
       T elem = src[i];
       assert(min <= elem && elem <= max);
       double e = (elem - min) * scale;
-      Quantized_t q = static_cast<Quantized_t>(e);
+      Quantized_t q = static_cast<Quantized_t>(e + 0.5);
       ByteSwapIfNecessary(q);
 
       // double-check we actually used at most `nQuantBits`

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -856,6 +856,7 @@ public:
 
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
+      // TODO(gparolini): see if we can avoid this allocation
       auto quantized = std::make_unique<Quantize::Quantized_t[]>(count);
       assert(fValueRange);
       const auto [min, max] = *fValueRange;
@@ -866,6 +867,7 @@ public:
 
    void Unpack(void *dst, const void *src, std::size_t count) const final
    {
+      // TODO(gparolini): see if we can avoid this allocation
       auto quantized = std::make_unique<Quantize::Quantized_t[]>(count);
       assert(fValueRange);
       const auto [min, max] = *fValueRange;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -129,7 +129,8 @@ bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &
 {
    return fLogicalColumnId == other.fLogicalColumnId && fPhysicalColumnId == other.fPhysicalColumnId &&
           fBitsOnStorage == other.fBitsOnStorage && fType == other.fType && fFieldId == other.fFieldId &&
-          fIndex == other.fIndex && fRepresentationIndex == other.fRepresentationIndex;
+          fIndex == other.fIndex && fRepresentationIndex == other.fRepresentationIndex &&
+          fValueRange == other.fValueRange;
 }
 
 ROOT::Experimental::RColumnDescriptor ROOT::Experimental::RColumnDescriptor::Clone() const
@@ -143,6 +144,7 @@ ROOT::Experimental::RColumnDescriptor ROOT::Experimental::RColumnDescriptor::Clo
    clone.fIndex = fIndex;
    clone.fFirstElementIndex = fFirstElementIndex;
    clone.fRepresentationIndex = fRepresentationIndex;
+   clone.fValueRange = fValueRange;
    return clone;
 }
 

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -31,7 +31,7 @@ ROOT::Experimental::RNTupleFillContext::RNTupleFillContext(std::unique_ptr<RNTup
    : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleFillContext")
 {
    fModel->Freeze();
-   fSink->Init(*fModel.get());
+   fSink->Init(*fModel);
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1451,6 +1451,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeSchemaDescription(co
       columnBuilder.LogicalColumnId(aliasColumnIdRangeBegin + i).PhysicalColumnId(physicalId).FieldId(fieldId);
       const auto &physicalColumnDesc = descBuilder.GetDescriptor().GetColumnDescriptor(physicalId);
       columnBuilder.BitsOnStorage(physicalColumnDesc.GetBitsOnStorage());
+      columnBuilder.ValueRange(physicalColumnDesc.GetValueRange());
       columnBuilder.Type(physicalColumnDesc.GetType());
       columnBuilder.RepresentationIndex(physicalColumnDesc.GetRepresentationIndex());
       columnBuilder.Index(fnNextColumnIndex(columnBuilder.GetFieldId(), columnBuilder.GetRepresentationIndex()));

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -56,6 +56,7 @@ void ROOT::Experimental::Internal::RPageSourceFriends::AddVirtualField(const RNT
          .PhysicalColumnId(physicalId)
          .FieldId(virtualFieldId)
          .BitsOnStorage(c.GetBitsOnStorage())
+         .ValueRange(c.GetValueRange())
          .Type(c.GetType())
          .Index(c.GetIndex())
          .RepresentationIndex(c.GetRepresentationIndex());

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -723,6 +723,7 @@ ROOT::Experimental::Internal::RPagePersistentSink::AddColumn(DescriptorId_t fiel
       .PhysicalColumnId(columnId)
       .FieldId(fieldId)
       .BitsOnStorage(column.GetBitsOnStorage())
+      .ValueRange(column.GetValueRange())
       .Type(column.GetType())
       .Index(column.GetIndex())
       .RepresentationIndex(column.GetRepresentationIndex())
@@ -760,6 +761,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
             .PhysicalColumnId(source.GetLogicalId())
             .FieldId(fieldId)
             .BitsOnStorage(source.GetBitsOnStorage())
+            .ValueRange(source.GetValueRange())
             .Type(source.GetType())
             .Index(source.GetIndex())
             .RepresentationIndex(source.GetRepresentationIndex());

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -304,7 +304,7 @@ TEST(Packing, OnDiskEncoding)
       *e->GetPtr<ClusterSize_t>("index32") = 39916801;          // 0x0261 1501
       *e->GetPtr<ClusterSize_t>("index64") = 0x0706050403020100L;
       *e->GetPtr<float>("float32Trunc") = -3.75f; // 1 10000000 11100000000000000000000 == 0xC0700000
-      *e->GetPtr<float>("float32Quant") = 0.69f; // quantized to 87 == 0b1010111
+      *e->GetPtr<float>("float32Quant") = 0.69f; // quantized to 88 == 0b1011000
       e->GetPtr<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
@@ -392,8 +392,8 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expF32Trunc, sizeof(expF32Trunc)), 0);
 
    source->LoadSealedPage(fnGetColumnId("float32Quant"), RClusterIndex(0, 0), sealedPage);
-   // Two tightly packed 7bit quantized ints: 0b1101111 + 0b1010111 = 0b11011111010111 = 0x37d7
-   unsigned char expF32Quant[] = {0xd7, 0x37};
+   // Two tightly packed 7bit quantized ints: 0b1101111 + 0b1011000 = 0b11011111011000 = 0x37d8
+   unsigned char expF32Quant[] = {0xd8, 0x37};
    EXPECT_EQ(memcmp(sealedPage.GetBuffer(), expF32Quant, sizeof(expF32Quant)), 0);
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -672,6 +672,24 @@ TEST(Packing, Real32Quant)
    }
 
    {
+      RColumnElement<float, EColumnType::kReal32Quant> element;
+      element.SetBitsOnStorage(20);
+      element.SetValueRange(-10.f, 10.f);
+
+      float f[5] = { 3.4f, 5.f, -6.f, 10.f, -10.f };
+      unsigned char out[BitPacking::MinBufSize(std::size(f), 20)];
+      element.Pack(out, f, std::size(f));
+      float f2[std::size(f)];
+      element.Unpack(&f2, out, std::size(f));
+      for (size_t i = 0; i < std::size(f); ++i)
+         EXPECT_NEAR(f[i], f2[i], 0.01f);
+
+      f[3] = 11.f;
+      // should throw out of range
+      EXPECT_THROW(element.Pack(out, f, std::size(f)), RException);
+   }
+
+   {
       constexpr auto kBitsOnStorage = 1;
       RColumnElement<float, EColumnType::kReal32Quant> element;
       element.SetBitsOnStorage(kBitsOnStorage);

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -304,7 +304,7 @@ TEST(Packing, OnDiskEncoding)
       *e->GetPtr<ClusterSize_t>("index32") = 39916801;          // 0x0261 1501
       *e->GetPtr<ClusterSize_t>("index64") = 0x0706050403020100L;
       *e->GetPtr<float>("float32Trunc") = -3.75f; // 1 10000000 11100000000000000000000 == 0xC0700000
-      *e->GetPtr<float>("float32Quant") = 0.69f; // quantized to 88 == 0b1011000
+      *e->GetPtr<float>("float32Quant") = 0.69f;  // quantized to 88 == 0b1011000
       e->GetPtr<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
@@ -649,9 +649,9 @@ TEST(Packing, Real32Quant)
       constexpr auto kBitsOnStorage = 10;
       RColumnElement<float, EColumnType::kReal32Quant> element;
       element.SetBitsOnStorage(kBitsOnStorage);
+      element.SetValueRange(-5.f, 5.f);
       element.Pack(nullptr, nullptr, 0);
       element.Unpack(nullptr, nullptr, 0);
-      element.SetValueRange(-5.f, 5.f);
 
       float f1 = 3.5f;
       unsigned char out[8];


### PR DESCRIPTION
# This Pull request:
adds the `Real32Quant` column type to RNTuple. This column type stores floating point values on disk as integers with a user-defined precision (from 3 to 32 bits) and a user-defined value range. This allows to reduce the storage space required to save floats with a well-defined range with more precision than a simple truncation.

The conversion is defined as (pseudocode): 
```
def quantize(value, min, max, n_precision_bits)
{
  quantized_max = (1 << n_precision_bits) - 1;
  scale = quantized_max / (max - min);
  quantized = round((value - min) * scale);
  return quantized;
}
```

This change requires adding metadata to the on-disk information, more specifically in the Field Description (see specifications.md for more details).


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


