### PR TITLE
[math] Correctly delete copying and moving

### DIFF
--- a/math/fumili/inc/TFumiliMinimizer.h
+++ b/math/fumili/inc/TFumiliMinimizer.h
@@ -55,21 +55,6 @@ public:
    */
    ~TFumiliMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   TFumiliMinimizer(const TFumiliMinimizer &);
-
-   /**
-      Assignment operator
-   */
-   TFumiliMinimizer & operator = (const TFumiliMinimizer & rhs);
-
-public:
-
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/fumili/src/TFumiliMinimizer.cxx
+++ b/math/fumili/src/TFumiliMinimizer.cxx
@@ -163,19 +163,6 @@ TFumiliMinimizer::~TFumiliMinimizer()
    if (fFumili) delete fFumili;
 }
 
-TFumiliMinimizer::TFumiliMinimizer(const TFumiliMinimizer &) :
-   Minimizer()
-{
-   // Implementation of copy constructor (it is private).
-}
-
-TFumiliMinimizer & TFumiliMinimizer::operator = (const TFumiliMinimizer &rhs)
-{
-   // Implementation of assignment operator (private)
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 
 
 void TFumiliMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & func) {

--- a/math/mathcore/inc/Math/BasicMinimizer.h
+++ b/math/mathcore/inc/Math/BasicMinimizer.h
@@ -66,24 +66,6 @@ public:
    */
    ~BasicMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   BasicMinimizer(const BasicMinimizer &) : Minimizer() {}
-
-   /**
-      Assignment operator
-   */
-   BasicMinimizer & operator = (const BasicMinimizer & rhs) {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
-
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -120,39 +120,17 @@ class Minimizer {
 
 public:
 
-   /**
-      Default constructor
-   */
-   Minimizer () :
-      fValidError(false),
-      fStatus(-1)
-   {}
+   /// Default constructor.
+   Minimizer () {}
 
-   /**
-      Destructor (no operations)
-   */
+   /// Destructor (no operations).
    virtual ~Minimizer ()  {}
 
-
-
-
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   Minimizer(const Minimizer &) {}
-
-   /**
-      Assignment operator
-   */
-   Minimizer & operator = (const Minimizer & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
+   // usually copying is non trivial, so we delete this
+   Minimizer(Minimizer const&) = delete;
+   Minimizer &operator=(Minimizer const&) = delete;
+   Minimizer(Minimizer &&) = delete;
+   Minimizer &operator=(Minimizer &&) = delete;
 
    /// reset for consecutive minimization - implement if needed
    virtual void Clear() {}
@@ -381,16 +359,11 @@ public:
 
 protected:
 
-
-//private:
-
-
    // keep protected to be accessible by the derived classes
 
-
-   bool fValidError;            ///< flag to control if errors have been validated (Hesse has been run in case of Minuit)
+   bool fValidError = false;    ///< flag to control if errors have been validated (Hesse has been run in case of Minuit)
    MinimizerOptions fOptions;   ///< minimizer options
-   int fStatus;                 ///< status of minimizer
+   int fStatus = -1;            ///< status of minimizer
 };
 
    } // end namespace Math

--- a/math/mathcore/inc/Math/RootFinder.h
+++ b/math/mathcore/inc/Math/RootFinder.h
@@ -85,16 +85,11 @@ namespace ROOT {
          RootFinder(RootFinder::EType type = RootFinder::kBRENT);
          virtual ~RootFinder();
 
-      private:
-         // usually copying is non trivial, so we make this unaccessible
-         RootFinder(const RootFinder & ) {}
-         RootFinder & operator = (const RootFinder & rhs)
-         {
-            if (this == &rhs) return *this;  // time saving self-test
-            return *this;
-         }
-
-      public:
+         // usually copying is non trivial, so we delete this
+         RootFinder(const RootFinder & ) = delete;
+         RootFinder & operator = (const RootFinder & rhs) = delete;
+         RootFinder(RootFinder && ) = delete;
+         RootFinder & operator = (RootFinder && rhs) = delete;
 
          bool SetMethod(RootFinder::EType type = RootFinder::kBRENT);
 

--- a/math/mathmore/inc/Math/ChebyshevApprox.h
+++ b/math/mathmore/inc/Math/ChebyshevApprox.h
@@ -98,11 +98,13 @@ private:
    */
    ChebyshevApprox(size_t n);
 
-// usually copying is non trivial, so we make this unaccessible
-   ChebyshevApprox(const ChebyshevApprox &);
-   ChebyshevApprox & operator = (const ChebyshevApprox &);
-
 public:
+
+// usually copying is non trivial, so we delete this
+   ChebyshevApprox(const ChebyshevApprox &) = delete;
+   ChebyshevApprox & operator = (const ChebyshevApprox &) = delete;
+   ChebyshevApprox(ChebyshevApprox &&) = delete;
+   ChebyshevApprox & operator = (ChebyshevApprox &&) = delete;
 
    /**
        Evaluate the series at a given point x

--- a/math/mathmore/inc/Math/GSLMinimizer.h
+++ b/math/mathmore/inc/Math/GSLMinimizer.h
@@ -95,24 +95,6 @@ public:
    */
    ~GSLMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLMinimizer(const GSLMinimizer &) : BasicMinimizer() {}
-
-   /**
-      Assignment operator
-   */
-   GSLMinimizer & operator = (const GSLMinimizer & rhs) {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
-
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/mathmore/inc/Math/GSLMinimizer1D.h
+++ b/math/mathmore/inc/Math/GSLMinimizer1D.h
@@ -93,12 +93,11 @@ This class does not support copying
       */
       ~GSLMinimizer1D() override;
 
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      GSLMinimizer1D(const GSLMinimizer1D &);
-      GSLMinimizer1D & operator = (const GSLMinimizer1D &);
-
-   public:
+      // usually copying is non trivial, so we delete this
+      GSLMinimizer1D(const GSLMinimizer1D &) = delete;
+      GSLMinimizer1D & operator = (const GSLMinimizer1D &) = delete;
+      GSLMinimizer1D(GSLMinimizer1D &&) = delete;
+      GSLMinimizer1D & operator = (GSLMinimizer1D &&) = delete;
 
 
       /**

--- a/math/mathmore/inc/Math/GSLMultiRootFinder.h
+++ b/math/mathmore/inc/Math/GSLMultiRootFinder.h
@@ -138,12 +138,11 @@ namespace Math {
     /// destructor
     virtual ~GSLMultiRootFinder();
 
- private:
-    // usually copying is non trivial, so we make this unaccessible
-    GSLMultiRootFinder(const GSLMultiRootFinder &);
-    GSLMultiRootFinder & operator = (const GSLMultiRootFinder &);
-
- public:
+    // usually copying is non trivial, so we delete this
+    GSLMultiRootFinder(const GSLMultiRootFinder &) = delete;
+    GSLMultiRootFinder & operator = (const GSLMultiRootFinder &) = delete;
+    GSLMultiRootFinder(GSLMultiRootFinder &&) = delete;
+    GSLMultiRootFinder & operator = (GSLMultiRootFinder &&) = delete;
 
     /// set the type for an algorithm without derivatives
     void SetType(EType type) {

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -70,24 +70,6 @@ public:
    */
    ~GSLNLSMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLNLSMinimizer(const GSLNLSMinimizer &) : ROOT::Math::BasicMinimizer() {}
-
-   /**
-      Assignment operator
-   */
-   GSLNLSMinimizer & operator = (const GSLNLSMinimizer & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
-
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/mathmore/inc/Math/GSLRootFinder.h
+++ b/math/mathmore/inc/Math/GSLRootFinder.h
@@ -76,13 +76,11 @@ namespace Math {
     GSLRootFinder();
     ~GSLRootFinder() override;
 
- private:
-    // usually copying is non trivial, so we make this unaccessible
-    GSLRootFinder(const GSLRootFinder &);
-    GSLRootFinder & operator = (const GSLRootFinder &);
-
- public:
-
+    // usually copying is non trivial, so we delete this
+    GSLRootFinder(const GSLRootFinder &) = delete;
+    GSLRootFinder &operator=(const GSLRootFinder &) = delete;
+    GSLRootFinder(GSLRootFinder &&) = delete;
+    GSLRootFinder &operator=(GSLRootFinder &&) = delete;
 
 #if defined(__MAKECINT__) || defined(G__DICTIONARY)
     bool SetFunction( const IGradFunction & , double ) override {

--- a/math/mathmore/inc/Math/GSLRootFinderDeriv.h
+++ b/math/mathmore/inc/Math/GSLRootFinderDeriv.h
@@ -77,14 +77,11 @@ public:
    GSLRootFinderDeriv();
    ~GSLRootFinderDeriv() override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-   GSLRootFinderDeriv(const GSLRootFinderDeriv &);
-   GSLRootFinderDeriv & operator = (const GSLRootFinderDeriv &);
-
-public:
-
-
+   // usually copying is non trivial, so we delete this
+   GSLRootFinderDeriv(const GSLRootFinderDeriv &) = delete;
+   GSLRootFinderDeriv &operator=(const GSLRootFinderDeriv &) = delete;
+   GSLRootFinderDeriv(GSLRootFinderDeriv &&) = delete;
+   GSLRootFinderDeriv &operator=(GSLRootFinderDeriv &&) = delete;
 
 #if defined(__MAKECINT__) || defined(G__DICTIONARY)
    bool SetFunction( const IGenFunction & , double , double ) override {

--- a/math/mathmore/inc/Math/GSLSimAnMinimizer.h
+++ b/math/mathmore/inc/Math/GSLSimAnMinimizer.h
@@ -85,25 +85,6 @@ namespace ROOT {
       */
       ~GSLSimAnMinimizer() override;
 
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-
-      /**
-         Copy constructor
-      */
-      GSLSimAnMinimizer(const GSLSimAnMinimizer &) : ROOT::Math::BasicMinimizer() {}
-
-      /**
-         Assignment operator
-      */
-      GSLSimAnMinimizer &operator=(const GSLSimAnMinimizer &rhs)
-      {
-         if (this == &rhs)
-            return *this; // time saving self-test
-         return *this;
-      }
-
-   public:
       /// method to perform the minimization
       bool Minimize() override;
 

--- a/math/mathmore/inc/Math/GSLSimAnnealing.h
+++ b/math/mathmore/inc/Math/GSLSimAnnealing.h
@@ -204,24 +204,11 @@ public:
    */
    ~GSLSimAnnealing ()  {}
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLSimAnnealing(const GSLSimAnnealing &) {}
-
-   /**
-      Assignment operator
-   */
-   GSLSimAnnealing & operator = (const GSLSimAnnealing & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
-
+   // usually copying is non trivial, so we delete this
+   GSLSimAnnealing(const GSLSimAnnealing &) = delete;
+   GSLSimAnnealing & operator = (const GSLSimAnnealing & rhs) = delete;
+   GSLSimAnnealing(GSLSimAnnealing &&) = delete;
+   GSLSimAnnealing & operator = (GSLSimAnnealing && rhs) = delete;
 
    /**
       solve the simulated annealing given a multi-dim function, the initial vector parameters
@@ -239,10 +226,6 @@ public:
    GSLSimAnParams & Params() { return fParams; }
    const GSLSimAnParams & Params() const { return fParams; }
    void SetParams(const GSLSimAnParams & params) { fParams = params; }
-
-
-protected:
-
 
 private:
 

--- a/math/mathmore/inc/Math/Interpolator.h
+++ b/math/mathmore/inc/Math/Interpolator.h
@@ -84,12 +84,11 @@ public:
 
    virtual ~Interpolator();
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-   Interpolator(const Interpolator &);
-   Interpolator & operator = (const Interpolator &);
-
-public:
+   // usually copying is non trivial, so we delete this
+   Interpolator(const Interpolator &) = delete;
+   Interpolator & operator = (const Interpolator &) = delete;
+   Interpolator(Interpolator &&) = delete;
+   Interpolator & operator = (Interpolator &&) = delete;
 
    /**
       Set the data vector ( x[] and y[] )

--- a/math/mathmore/inc/Math/RootFinderAlgorithms.h
+++ b/math/mathmore/inc/Math/RootFinderAlgorithms.h
@@ -60,13 +60,6 @@ namespace Roots {
 
       Bisection();
       ~Bisection() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-
-      Bisection(const Bisection &);
-      Bisection & operator = (const Bisection &);
-
    };
 
 //________________________________________________________________________________________________________
@@ -82,12 +75,6 @@ namespace Roots {
 
       FalsePos();
       ~FalsePos() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      FalsePos(const FalsePos &);
-      FalsePos & operator = (const FalsePos &);
-
    };
 
 
@@ -107,12 +94,6 @@ namespace Roots {
 
       Brent();
       ~Brent() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      Brent(const Brent &);
-      Brent & operator = (const Brent &);
-
    };
 
 
@@ -135,12 +116,6 @@ namespace Roots {
 
       Newton();
       ~Newton() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      Newton(const Newton &);
-      Newton & operator = (const Newton &);
-
    };
 
 
@@ -158,12 +133,6 @@ namespace Roots {
 
       Secant();
       ~Secant() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      Secant(const Secant &);
-      Secant & operator = (const Secant &);
-
    };
 
 //________________________________________________________________________________________________________
@@ -181,12 +150,6 @@ namespace Roots {
 
       Steffenson();
       ~Steffenson() override;
-
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      Steffenson(const Steffenson &);
-      Steffenson & operator = (const Steffenson &);
-
    };
 
 

--- a/math/mathmore/src/ChebyshevApprox.cxx
+++ b/math/mathmore/src/ChebyshevApprox.cxx
@@ -79,19 +79,6 @@ fOrder(n) , fSeries(nullptr), fFunction(nullptr)
    fSeries = new GSLChebSeries(n);
 }
 
-ChebyshevApprox::ChebyshevApprox(const ChebyshevApprox & /*cheb */ )
-{
-   // cannot copy series because don't know original function
-}
-
-ChebyshevApprox & ChebyshevApprox::operator = (const ChebyshevApprox &rhs)
-{
-   // dummy assignment
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
 void ChebyshevApprox::Initialize( GSLFuncPointer f, void * params, double a, double b) {
    // initialize by passing a function and interval [a,b]
    // delete previous existing function pointer

--- a/math/mathmore/src/GSL1DMinimizerWrapper.h
+++ b/math/mathmore/src/GSL1DMinimizerWrapper.h
@@ -52,12 +52,11 @@ public:
       gsl_min_fminimizer_free(fMinimizer);
    }
 
-private:
-// usually copying is non trivial, so we make this unaccessible
+// usually copying is non trivial, so we delete this
    GSL1DMinimizerWrapper(const GSL1DMinimizerWrapper &) = delete;
    GSL1DMinimizerWrapper & operator = (const GSL1DMinimizerWrapper &) = delete;
-
-public:
+   GSL1DMinimizerWrapper(GSL1DMinimizerWrapper &&) = delete;
+   GSL1DMinimizerWrapper & operator = (GSL1DMinimizerWrapper &&) = delete;
 
    gsl_min_fminimizer * Get() const {
       return fMinimizer;

--- a/math/mathmore/src/GSLChebSeries.h
+++ b/math/mathmore/src/GSLChebSeries.h
@@ -53,12 +53,11 @@ public:
     gsl_cheb_free(m_cs);
   }
 
-private:
-// usually copying is non trivial, so we make this unaccessible
+// usually copying is non trivial, so we delete this
   GSLChebSeries(const GSLChebSeries &) = delete;
   GSLChebSeries & operator = (const GSLChebSeries &) = delete;
-
-public:
+  GSLChebSeries(GSLChebSeries &&) = delete;
+  GSLChebSeries & operator = (GSLChebSeries &&) = delete;
 
   gsl_cheb_series * get() const { return m_cs; }
 

--- a/math/mathmore/src/GSLInterpolator.cxx
+++ b/math/mathmore/src/GSLInterpolator.cxx
@@ -119,19 +119,5 @@ GSLInterpolator::~GSLInterpolator()
    if (fAccel != nullptr) gsl_interp_accel_free( fAccel);
 }
 
-GSLInterpolator::GSLInterpolator(const GSLInterpolator &)
-{
-   // dummy copy ctr
-}
-
-GSLInterpolator & GSLInterpolator::operator = (const GSLInterpolator &rhs)
-{
-   // dummy assignment operator
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
-
 } // namespace Math
 } // namespace ROOT

--- a/math/mathmore/src/GSLInterpolator.h
+++ b/math/mathmore/src/GSLInterpolator.h
@@ -61,12 +61,11 @@ namespace Math {
       GSLInterpolator(const Interpolation::Type type, const std::vector<double> & x, const std::vector<double> & y );
       virtual ~GSLInterpolator();
 
-   private:
-      // usually copying is non trivial, so we make this unaccessible
-      GSLInterpolator(const GSLInterpolator &);
-      GSLInterpolator & operator = (const GSLInterpolator &);
-
-   public:
+      // usually copying is non trivial, so we make delete this
+      GSLInterpolator(const GSLInterpolator &) = delete;
+      GSLInterpolator & operator = (const GSLInterpolator &) = delete;
+      GSLInterpolator(GSLInterpolator &&) = delete;
+      GSLInterpolator & operator = (GSLInterpolator &&) = delete;
 
       bool Init(unsigned int ndata, const double *x, const double *y);
 

--- a/math/mathmore/src/GSLMinimizer1D.cxx
+++ b/math/mathmore/src/GSLMinimizer1D.cxx
@@ -83,18 +83,6 @@ GSLMinimizer1D::~GSLMinimizer1D()
    if (fFunction)  delete  fFunction;
 }
 
-GSLMinimizer1D::GSLMinimizer1D(const GSLMinimizer1D &): IMinimizer1D()
-{
-   // dummy copy ctr
-}
-
-GSLMinimizer1D & GSLMinimizer1D::operator = (const GSLMinimizer1D &rhs)
-{
-   // dummy operator =
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 void GSLMinimizer1D::SetFunction(  GSLFuncPointer f, void * p, double xmin, double xlow, double xup) {
    // set the function to be minimized
    assert(fFunction);

--- a/math/mathmore/src/GSLMultiFit.h
+++ b/math/mathmore/src/GSLMultiFit.h
@@ -84,24 +84,11 @@ public:
 #endif
    }
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLMultiFit(const GSLMultiFit &) {}
-
-   /**
-      Assignment operator
-   */
-   GSLMultiFit & operator = (const GSLMultiFit & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-
-public:
+   // usually copying is non trivial, so we delete this
+   GSLMultiFit(const GSLMultiFit &) = delete;
+   GSLMultiFit & operator = (const GSLMultiFit & rhs) = delete;
+   GSLMultiFit(GSLMultiFit &&) = delete;
+   GSLMultiFit & operator = (GSLMultiFit && rhs) = delete;
 
    /// create the minimizer from the type and size of number of fitting points and number of parameters
    void CreateSolver(unsigned int npoints, unsigned int npar) {

--- a/math/mathmore/src/GSLMultiMinimizer.h
+++ b/math/mathmore/src/GSLMultiMinimizer.h
@@ -102,23 +102,11 @@ public:
       if (fVec != 0) gsl_vector_free(fVec);
    }
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLMultiMinimizer(const GSLMultiMinimizer &) {}
-
-   /**
-      Assignment operator
-   */
-   GSLMultiMinimizer & operator = (const GSLMultiMinimizer & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-public:
+   // usually copying is non trivial, so we delete this
+   GSLMultiMinimizer(const GSLMultiMinimizer &) = delete;
+   GSLMultiMinimizer & operator = (const GSLMultiMinimizer & rhs) = delete;
+   GSLMultiMinimizer(GSLMultiMinimizer &&) = delete;
+   GSLMultiMinimizer & operator = (GSLMultiMinimizer && rhs) = delete;
 
    /**
       set the function to be minimize the initial minimizer parameters,

--- a/math/mathmore/src/GSLMultiRootFinder.cxx
+++ b/math/mathmore/src/GSLMultiRootFinder.cxx
@@ -99,18 +99,6 @@ GSLMultiRootFinder::~GSLMultiRootFinder()
    if (fSolver) delete fSolver;
 }
 
-GSLMultiRootFinder::GSLMultiRootFinder(const GSLMultiRootFinder &)
-{
-}
-
-GSLMultiRootFinder & GSLMultiRootFinder::operator = (const GSLMultiRootFinder &rhs)
-{
-   // dummy operator=
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
 void GSLMultiRootFinder::SetType(const char * name) {
    // set type using a string
    std::pair<bool,int> type = GetType(name);

--- a/math/mathmore/src/GSLMultiRootSolver.h
+++ b/math/mathmore/src/GSLMultiRootSolver.h
@@ -175,24 +175,11 @@ public:
       if (fVec != nullptr) gsl_vector_free(fVec);
    }
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLMultiRootSolver(const GSLMultiRootSolver &) : GSLMultiRootBaseSolver() {}
-
-   /**
-      Assignment operator
-   */
-   GSLMultiRootSolver & operator = (const GSLMultiRootSolver & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-
-public:
+   // usually copying is non trivial, so we delete this
+   GSLMultiRootSolver(const GSLMultiRootSolver &) = delete;
+   GSLMultiRootSolver & operator = (const GSLMultiRootSolver & rhs) = delete;
+   GSLMultiRootSolver(GSLMultiRootSolver &&) = delete;
+   GSLMultiRootSolver & operator = (GSLMultiRootSolver && rhs) = delete;
 
 
    void  CreateSolver(const  gsl_multiroot_fsolver_type * type, unsigned int n) {
@@ -288,25 +275,11 @@ public:
       if (fVec != nullptr) gsl_vector_free(fVec);
    }
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   GSLMultiRootDerivSolver(const GSLMultiRootDerivSolver &) : GSLMultiRootBaseSolver() {}
-
-   /**
-      Assignment operator
-   */
-   GSLMultiRootDerivSolver & operator = (const GSLMultiRootDerivSolver & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
-
-
-public:
-
+   // usually copying is non trivial, so we delete this
+   GSLMultiRootDerivSolver(const GSLMultiRootDerivSolver &) = delete;
+   GSLMultiRootDerivSolver & operator = (const GSLMultiRootDerivSolver & rhs) = delete;
+   GSLMultiRootDerivSolver(GSLMultiRootDerivSolver &&) = delete;
+   GSLMultiRootDerivSolver & operator = (GSLMultiRootDerivSolver && rhs) = delete;
 
    /// create the solver from the type and size of number of fitting points and number of parameters
    void  CreateSolver(const gsl_multiroot_fdfsolver_type * type, unsigned int n) {

--- a/math/mathmore/src/GSLRootFSolver.h
+++ b/math/mathmore/src/GSLRootFSolver.h
@@ -64,10 +64,6 @@ public:
 
   gsl_root_fsolver * Solver() const { return fSolver; }
 
-
-protected:
-
-
 private:
 
   gsl_root_fsolver *fSolver;

--- a/math/mathmore/src/GSLRootFdFSolver.h
+++ b/math/mathmore/src/GSLRootFdFSolver.h
@@ -64,10 +64,6 @@ public:
 
   gsl_root_fdfsolver * Solver() const { return fSolver; }
 
-
-protected:
-
-
 private:
 
   gsl_root_fdfsolver *fSolver;

--- a/math/mathmore/src/GSLRootFinder.cxx
+++ b/math/mathmore/src/GSLRootFinder.cxx
@@ -62,18 +62,6 @@ GSLRootFinder::~GSLRootFinder()
    if (fFunction) delete fFunction;
 }
 
-GSLRootFinder::GSLRootFinder(const GSLRootFinder &): IRootFinderMethod()
-{
-}
-
-GSLRootFinder & GSLRootFinder::operator = (const GSLRootFinder &rhs)
-{
-   // dummy operator=
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
 bool GSLRootFinder::SetFunction(  GSLFuncPointer f, void * p, double xlow, double xup) {
    // set from GSL function
    fXlow = xlow;

--- a/math/mathmore/src/GSLRootFinderDeriv.cxx
+++ b/math/mathmore/src/GSLRootFinderDeriv.cxx
@@ -61,20 +61,6 @@ GSLRootFinderDeriv::~GSLRootFinderDeriv()
    if (fFunction) delete fFunction;
 }
 
-GSLRootFinderDeriv::GSLRootFinderDeriv(const GSLRootFinderDeriv &) : IRootFinderMethod()
-{
-}
-
-GSLRootFinderDeriv & GSLRootFinderDeriv::operator = (const GSLRootFinderDeriv &rhs)
-{
-   // private operator=
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
-
-
 
 bool GSLRootFinderDeriv::SetFunction(  GSLFuncPointer f, GSLFuncPointer df, GSLFdFPointer Fdf, void * p, double xstart) {
    fStatus = -1;

--- a/math/mathmore/src/Interpolator.cxx
+++ b/math/mathmore/src/Interpolator.cxx
@@ -61,18 +61,6 @@ Interpolator::~Interpolator()
    if (fInterp) delete fInterp;
 }
 
-Interpolator::Interpolator(const Interpolator &)
-{
-}
-
-Interpolator & Interpolator::operator = (const Interpolator &rhs)
-{
-   // dummy (private) assignment
-   if (this == &rhs) return *this;  // time saving self-test
-
-   return *this;
-}
-
 bool Interpolator::SetData(unsigned int ndata, const double * x, const double *y) {
    // set the interpolation data
    return fInterp->Init(ndata, x, y);

--- a/math/mathmore/src/RootFinderAlgorithms.cxx
+++ b/math/mathmore/src/RootFinderAlgorithms.cxx
@@ -56,19 +56,6 @@ Bisection::~Bisection()
    FreeSolver();
 }
 
-Bisection::Bisection(const Bisection &) : GSLRootFinder()
-{
-  // dummy copy ctr
-}
-
-Bisection & Bisection::operator = (const Bisection &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
-
 // falsepos method
 
 FalsePos::FalsePos()
@@ -84,18 +71,6 @@ FalsePos::~FalsePos()
    FreeSolver();
 }
 
-FalsePos::FalsePos(const FalsePos &) : GSLRootFinder()
-{
-  // dummy copy ctr
-}
-
-FalsePos & FalsePos::operator = (const FalsePos &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 // Brent method
 
 Brent::Brent()
@@ -109,18 +84,6 @@ Brent::~Brent()
 {
    // destructor
    FreeSolver();
-}
-
-Brent::Brent(const Brent &) : GSLRootFinder()
-{
-  // dummy copy ctr
-}
-
-Brent & Brent::operator = (const Brent &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
 }
 
 
@@ -143,18 +106,6 @@ Newton::~Newton()
    FreeSolver();
 }
 
-Newton::Newton(const Newton &) : GSLRootFinderDeriv()
-{
-  // dummy copy ctr
-}
-
-Newton & Newton::operator = (const Newton &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 // Secant
 
 Secant::Secant()
@@ -168,18 +119,6 @@ Secant::~Secant()
 {
    // destructor
    FreeSolver();
-}
-
-Secant::Secant(const Secant &) : GSLRootFinderDeriv()
-{
-  // dummy copy ctr
-}
-
-Secant & Secant::operator = (const Secant &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
 }
 
 // Steffenson
@@ -196,19 +135,6 @@ Steffenson::~Steffenson()
    // destructor
    FreeSolver();
 }
-
-Steffenson::Steffenson(const Steffenson &) : GSLRootFinderDeriv()
-{
-  // dummy copy ctr
-}
-
-Steffenson & Steffenson::operator = (const Steffenson &rhs)
-{
-   // dummy (private) operator=
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 
 
 } // end namespace GSLRoots

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -47,21 +47,6 @@ public:
    */
    ~TLinearMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   TLinearMinimizer(const TLinearMinimizer &);
-
-   /**
-      Assignment operator
-   */
-   TLinearMinimizer & operator = (const TLinearMinimizer & rhs);
-
-public:
-
    /// set the fit model function
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -67,21 +67,6 @@ public:
    */
    ~TMinuitMinimizer () override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   TMinuitMinimizer(const TMinuitMinimizer &);
-
-   /**
-      Assignment operator
-   */
-   TMinuitMinimizer & operator = (const TMinuitMinimizer & rhs);
-
-public:
-
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 

--- a/math/minuit/src/TLinearMinimizer.cxx
+++ b/math/minuit/src/TLinearMinimizer.cxx
@@ -103,20 +103,6 @@ TLinearMinimizer::~TLinearMinimizer()
    if (fFitter) delete fFitter;
 }
 
-TLinearMinimizer::TLinearMinimizer(const TLinearMinimizer &) :
-   Minimizer()
-{
-   // Implementation of copy constructor.
-}
-
-TLinearMinimizer & TLinearMinimizer::operator = (const TLinearMinimizer &rhs)
-{
-   // Implementation of assignment operator.
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
-
 void TLinearMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & objfunc) {
    // Set the function to be minimized. The function must be a Chi2 gradient function
    // When performing a linear fit we need the basis functions, which are the partial derivatives with respect to the parameters of the model function.

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -107,19 +107,6 @@ TMinuitMinimizer::~TMinuitMinimizer()
    }
 }
 
-TMinuitMinimizer::TMinuitMinimizer(const TMinuitMinimizer &) :
-   Minimizer()
-{
-   // Implementation of copy constructor (it is private).
-}
-
-TMinuitMinimizer & TMinuitMinimizer::operator = (const TMinuitMinimizer &rhs)
-{
-   // Implementation of assignment operator (private)
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 bool TMinuitMinimizer::UseStaticMinuit(bool on ) {
    // static method to control usage of global TMinuit instance
    bool prev = fgUseStaticMinuit;

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -69,20 +69,6 @@ public:
    */
    ~Minuit2Minimizer() override;
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
-
-   /**
-      Copy constructor
-   */
-   Minuit2Minimizer(const Minuit2Minimizer &);
-
-   /**
-      Assignment operator
-   */
-   Minuit2Minimizer &operator=(const Minuit2Minimizer &rhs);
-
-public:
    // clear resources (parameters) for consecutives minimizations
    void Clear() override;
 

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -153,19 +153,6 @@ Minuit2Minimizer::~Minuit2Minimizer()
       delete fMinimum;
 }
 
-Minuit2Minimizer::Minuit2Minimizer(const Minuit2Minimizer &) : ROOT::Math::Minimizer()
-{
-   // Implementation of copy constructor.
-}
-
-Minuit2Minimizer &Minuit2Minimizer::operator=(const Minuit2Minimizer &rhs)
-{
-   // Implementation of assignment operator.
-   if (this == &rhs)
-      return *this; // time saving self-test
-   return *this;
-}
-
 void Minuit2Minimizer::Clear()
 {
    // delete the state in case of consecutive minimizations

--- a/math/unuran/inc/TUnuran.h
+++ b/math/unuran/inc/TUnuran.h
@@ -91,20 +91,12 @@ public:
    */
    ~TUnuran ();
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
+   // usually copying is non trivial, so we delete this
+   TUnuran(const TUnuran &) = delete;
+   TUnuran & operator = (const TUnuran & rhs) = delete;
+   TUnuran(TUnuran &&) = delete;
+   TUnuran & operator = (TUnuran && rhs) = delete;
 
-   /**
-      Copy constructor
-   */
-   TUnuran(const TUnuran &);
-
-   /**
-      Assignment operator
-   */
-   TUnuran & operator = (const TUnuran & rhs);
-
-public:
    /**
       Initialize with Unuran string API interface.
       See  https://statmath.wu.ac.at/unuran/doc/unuran.html#StringAPI

--- a/math/unuran/src/TUnuran.cxx
+++ b/math/unuran/src/TUnuran.cxx
@@ -59,19 +59,6 @@ TUnuran::~TUnuran()
    if (fUdistr != nullptr) unur_distr_free(fUdistr);
 }
 
-//private (no impl.)
-TUnuran::TUnuran(const TUnuran &)
-{
-   // Implementation of copy constructor.
-}
-
-TUnuran & TUnuran::operator = (const TUnuran &rhs)
-{
-   // Implementation of assignment operator.
-   if (this == &rhs) return *this;  // time saving self-test
-   return *this;
-}
-
 bool  TUnuran::Init(const std::string & dist, const std::string & method)
 {
    // initialize with a string


### PR DESCRIPTION
Delete copying and moving from base classes where it's not intended. This also implicitly deletes copying an moving for child classes.

Making the copy constructor and copy assignment `private` was a hack.