### PR TITLE
[Minuit2] Add virtual `FCNBase::HasGradient()` method 

### DIFF
--- a/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
@@ -41,8 +41,6 @@ public:
    /// compute second derivatives (diagonal of Hessian)
    bool G2(const MinimumParameters &, MnAlgebraicVector &) const override;
 
-   virtual bool CheckGradient() const;
-
    virtual bool CanComputeG2() const;
 
    virtual bool CanComputeHessian() const;

--- a/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
@@ -17,14 +17,14 @@ namespace ROOT {
 
 namespace Minuit2 {
 
-class FCNGradientBase;
+class FCNBase;
 class MnUserTransformation;
 
 
 class AnalyticalGradientCalculator : public GradientCalculator {
 
 public:
-   AnalyticalGradientCalculator(const FCNGradientBase &fcn, const MnUserTransformation &state)
+   AnalyticalGradientCalculator(const FCNBase &fcn, const MnUserTransformation &state)
       : fGradFunc(fcn), fTransformation(state)
    {
    }
@@ -46,7 +46,7 @@ public:
    virtual bool CanComputeHessian() const;
 
 protected:
-   const FCNGradientBase &fGradFunc;
+   const FCNBase &fGradFunc;
    const MnUserTransformation &fTransformation;
 };
 

--- a/math/minuit2/inc/Minuit2/ExternalInternalGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/ExternalInternalGradientCalculator.h
@@ -16,7 +16,7 @@ namespace ROOT {
 
 namespace Minuit2 {
 
-class FCNGradientBase;
+class FCNBase;
 class MnUserTransformation;
 
 /// Similar to the AnalyticalGradientCalculator, the ExternalInternalGradientCalculator
@@ -30,7 +30,7 @@ class MnUserTransformation;
 class ExternalInternalGradientCalculator : public AnalyticalGradientCalculator {
 
 public:
-   ExternalInternalGradientCalculator(const FCNGradientBase &fcn, const MnUserTransformation &trafo)
+   ExternalInternalGradientCalculator(const FCNBase &fcn, const MnUserTransformation &trafo)
       : AnalyticalGradientCalculator(fcn, trafo)
    {
    }

--- a/math/minuit2/inc/Minuit2/FCNBase.h
+++ b/math/minuit2/inc/Minuit2/FCNBase.h
@@ -32,6 +32,10 @@ namespace Minuit2 {
   \ingroup Math
 */
 
+enum class GradientParameterSpace {
+  External, Internal
+};
+
 //______________________________________________________________________________
 /**
 
@@ -47,7 +51,6 @@ Interface (abstract class) defining the function to be minimized, which has to b
 class FCNBase : public GenericFunction {
 
 public:
-   ~FCNBase() override {}
 
    /**
 
@@ -106,6 +109,29 @@ public:
        Re-implement this function if needed.
    */
    virtual void SetErrorDef(double){};
+
+   virtual bool HasGradient() const { return false; }
+
+   virtual std::vector<double> Gradient(std::span<const double> ) const { return {}; }
+   virtual std::vector<double> GradientWithPrevResult(std::span<const double> parameters, double * /*previous_grad*/,
+                                                      double * /*previous_g2*/, double * /*previous_gstep*/) const
+   {
+      return Gradient(parameters);
+   };
+
+   virtual GradientParameterSpace gradParameterSpace() const {
+      return GradientParameterSpace::External;
+   };
+
+   /// return second derivatives (diagonal of the Hessian matrix)
+   virtual std::vector<double> G2(std::span<const double> ) const { return {};}
+
+   /// return Hessian
+   virtual std::vector<double> Hessian(std::span<const double> ) const { return {};}
+
+   virtual bool HasHessian() const { return false; }
+
+   virtual bool HasG2() const { return false; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FCNGradAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNGradAdapter.h
@@ -10,7 +10,7 @@
 #ifndef ROOT_Minuit2_FCNGradAdapter
 #define ROOT_Minuit2_FCNGradAdapter
 
-#include "Minuit2/FCNGradientBase.h"
+#include "Minuit2/FCNBase.h"
 #include "Minuit2/MnPrint.h"
 
 #include <vector>
@@ -32,12 +32,14 @@ template wrapped class for adapting to FCNBase signature a IGradFunction
 */
 
 template <class Function>
-class FCNGradAdapter : public FCNGradientBase {
+class FCNGradAdapter : public FCNBase {
 
 public:
    FCNGradAdapter(const Function &f, double up = 1.) : fFunc(f), fUp(up), fGrad(std::vector<double>(fFunc.NDim())) {}
 
    ~FCNGradAdapter() override {}
+
+   bool HasGradient() const override { return true; }
 
    double operator()(std::span<const double> v) const override { return fFunc.operator()(&v[0]); }
    double operator()(const double *v) const { return fFunc.operator()(v); }

--- a/math/minuit2/inc/Minuit2/FCNGradAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNGradAdapter.h
@@ -55,9 +55,6 @@ public:
       fFunc.GradientWithPrevResult(&v[0], &fGrad[0], previous_grad, previous_g2, previous_gstep);
       return fGrad;
    }
-   // forward interface
-   // virtual double operator()(int npar, double* params,int iflag = 4) const;
-   bool CheckGradient() const override { return false; }
 
    GradientParameterSpace gradParameterSpace() const override {
       if (fFunc.returnsInMinuit2ParameterSpace()) {

--- a/math/minuit2/inc/Minuit2/FCNGradientBase.h
+++ b/math/minuit2/inc/Minuit2/FCNGradientBase.h
@@ -20,15 +20,9 @@ namespace Minuit2 {
 
 //________________________________________________________________________
 /** Extension of the FCNBase for providing the analytical Gradient of the
-    function. The user-Gradient is checked at the beginning of the
-    minimization against the Minuit internal numerical Gradient in order to
-    spot problems in the analytical Gradient calculation. This can be turned
-    off by overriding CheckGradient() to make it return "false".
+    function.
     The size of the output Gradient vector must be equal to the size of the
     input Parameter vector.
-    Minuit does a check of the user Gradient at the beginning, if this is not
-    wanted the method "CheckGradient()" has to be overridden to return
-    "false".
  */
 
 enum class GradientParameterSpace {
@@ -46,8 +40,6 @@ public:
    {
       return Gradient(parameters);
    };
-
-   virtual bool CheckGradient() const { return true; }
 
    virtual GradientParameterSpace gradParameterSpace() const {
       return GradientParameterSpace::External;

--- a/math/minuit2/inc/Minuit2/FCNGradientBase.h
+++ b/math/minuit2/inc/Minuit2/FCNGradientBase.h
@@ -12,8 +12,6 @@
 
 #include "Minuit2/FCNBase.h"
 
-#include <vector>
-
 namespace ROOT {
 
 namespace Minuit2 {
@@ -25,37 +23,9 @@ namespace Minuit2 {
     input Parameter vector.
  */
 
-enum class GradientParameterSpace {
-  External, Internal
-};
-
 class FCNGradientBase : public FCNBase {
-
 public:
-   ~FCNGradientBase() override {}
-
-   virtual std::vector<double> Gradient(std::span<const double> ) const = 0;
-   virtual std::vector<double> GradientWithPrevResult(std::span<const double> parameters, double * /*previous_grad*/,
-                                                      double * /*previous_g2*/, double * /*previous_gstep*/) const
-   {
-      return Gradient(parameters);
-   };
-
-   virtual GradientParameterSpace gradParameterSpace() const {
-      return GradientParameterSpace::External;
-   };
-
-   /// return second derivatives (diagonal of the Hessian matrix)
-   virtual std::vector<double> G2(std::span<const double> ) const { return std::vector<double>();}
-
-   /// return Hessian
-   virtual std::vector<double> Hessian(std::span<const double> ) const { return std::vector<double>();}
-
-   virtual bool HasHessian() const { return false; }
-
-   virtual bool HasG2() const { return false; }
-
-
+   bool HasGradient() const final { return true; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FumiliFCNBase.h
+++ b/math/minuit2/inc/Minuit2/FumiliFCNBase.h
@@ -10,7 +10,7 @@
 #ifndef ROOT_Minuit2_FumiliFCNBase
 #define ROOT_Minuit2_FumiliFCNBase
 
-#include "Minuit2/FCNGradientBase.h"
+#include "Minuit2/FCNBase.h"
 #include <cassert>
 #include <vector>
 
@@ -43,7 +43,7 @@ section 5
 
  */
 
-class FumiliFCNBase : public FCNGradientBase {
+class FumiliFCNBase : public FCNBase {
 
 public:
    /**
@@ -52,6 +52,8 @@ public:
    */
 
    FumiliFCNBase() : fNumberOfParameters(0), fValue(0) {}
+
+   bool HasGradient() const override { return true; }
 
    /**
 

--- a/math/minuit2/inc/Minuit2/FumiliMinimizer.h
+++ b/math/minuit2/inc/Minuit2/FumiliMinimizer.h
@@ -88,9 +88,6 @@ public:
    FunctionMinimum Minimize(const FCNBase &, const MnUserParameterState &, const MnStrategy &, unsigned int maxfcn = 0,
                             double toler = 0.1) const override;
 
-   FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameterState &, const MnStrategy &,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const override;
-
    using ModularFunctionMinimizer::Minimize;
 
 private:

--- a/math/minuit2/inc/Minuit2/FunctionMinimizer.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimizer.h
@@ -21,7 +21,6 @@ namespace ROOT {
 namespace Minuit2 {
 
 class FCNBase;
-class FCNGradientBase;
 class FunctionMinimum;
 
 //_____________________________________________________________________________________
@@ -43,18 +42,8 @@ public:
    virtual FunctionMinimum Minimize(const FCNBase &, std::span<const double> par, std::span<const double> err,
                                     unsigned int strategy, unsigned int maxfcn, double toler) const = 0;
 
-   // starting values for parameters and errors and FCN with Gradient
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, std::span<const double> par,
-                                    std::span<const double> err, unsigned int strategy, unsigned int maxfcn,
-                                    double toler) const = 0;
-
    // starting values for parameters and covariance matrix
    virtual FunctionMinimum Minimize(const FCNBase &, std::span<const double> par, unsigned int nrow,
-                                    std::span<const double> cov, unsigned int strategy, unsigned int maxfcn,
-                                    double toler) const = 0;
-
-   // starting values for parameters and covariance matrix and FCN with Gradient
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, std::span<const double> par, unsigned int nrow,
                                     std::span<const double> cov, unsigned int strategy, unsigned int maxfcn,
                                     double toler) const = 0;
 };

--- a/math/minuit2/inc/Minuit2/MnApplication.h
+++ b/math/minuit2/inc/Minuit2/MnApplication.h
@@ -24,7 +24,6 @@ class MinuitParameter;
 class MnMachinePrecision;
 class ModularFunctionMinimizer;
 class FCNBase;
-class FCNGradientBase;
 
 //___________________________________________________________________________
 /**
@@ -39,10 +38,6 @@ class MnApplication {
 public:
    /// constructor from non-gradient functions
    MnApplication(const FCNBase &fcn, const MnUserParameterState &state, const MnStrategy &stra, unsigned int nfcn = 0);
-
-   /// constructor from gradient function
-   MnApplication(const FCNGradientBase &fcn, const MnUserParameterState &state, const MnStrategy &stra,
-                 unsigned int nfcn = 0);
 
    virtual ~MnApplication() {}
 
@@ -73,7 +68,6 @@ protected:
    MnUserParameterState fState;
    MnStrategy fStrategy;
    unsigned int fNumCall;
-   bool fUseGrad;
 
 public:
    // facade: forward interface of MnUserParameters and MnUserTransformation

--- a/math/minuit2/inc/Minuit2/MnHesse.h
+++ b/math/minuit2/inc/Minuit2/MnHesse.h
@@ -30,7 +30,6 @@ class MinimumState;
 class MnMachinePrecision;
 class MnFcn;
 class FunctionMinimum;
-class FCNGradientBase;
 
 //_______________________________________________________________________
 /**
@@ -97,8 +96,8 @@ private:
    /// internal function to compute the Hessian using numerical derivative computation
    MinimumState ComputeNumerical(const MnFcn &, const MinimumState &, const MnUserTransformation &, unsigned int maxcalls) const;
 
-   /// internal function to compute the Hessian using an analytical computation or externally provided in the FCNGradientBase class
-   MinimumState ComputeAnalytical(const FCNGradientBase &, const MinimumState &, const MnUserTransformation &) const;
+   /// internal function to compute the Hessian using an analytical computation or externally provided in the FCNBase class
+   MinimumState ComputeAnalytical(const FCNBase &, const MinimumState &, const MnUserTransformation &) const;
 
    MnStrategy fStrategy;
 };

--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -70,48 +70,6 @@ public:
    {
    }
 
-   // constructs from gradient FCN
-
-   /// construct from FCNGradientBase + std::vector for parameters and errors
-   MnMigrad(const FCNGradientBase &fcn, std::span<const double> par, std::span<const double> err,
-            unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, err), MnStrategy(stra)), fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + std::vector for parameters and covariance
-   MnMigrad(const FCNGradientBase &fcn, std::span<const double> par, unsigned int nrow,
-            std::span<const double> cov, unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov, nrow), MnStrategy(stra)),
-        fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + std::vector for parameters and MnUserCovariance
-   MnMigrad(const FCNGradientBase &fcn, std::span<const double> par, const MnUserCovariance &cov,
-            unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov), MnStrategy(stra)), fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameters
-   MnMigrad(const FCNGradientBase &fcn, const MnUserParameters &par, unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par), MnStrategy(stra)), fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameters + MnUserCovariance
-   MnMigrad(const FCNGradientBase &fcn, const MnUserParameters &par, const MnUserCovariance &cov, unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov), MnStrategy(stra)), fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameterState + MnStrategy
-   MnMigrad(const FCNGradientBase &fcn, const MnUserParameterState &par, const MnStrategy &str)
-      : MnApplication(fcn, MnUserParameterState(par), str), fMinimizer(VariableMetricMinimizer())
-   {
-   }
-
    ~MnMigrad() override {}
 
    /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication

--- a/math/minuit2/inc/Minuit2/MnMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnMinimize.h
@@ -67,48 +67,6 @@ public:
    {
    }
 
-   // interfaces using FCNGradientBase
-
-   /// construct from FCNGradientBase + std::vector for parameters and errors
-   MnMinimize(const FCNGradientBase &fcn, std::span<const double> par, std::span<const double> err,
-              unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, err), MnStrategy(stra)), fMinimizer(CombinedMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + std::vector for parameters and covariance
-   MnMinimize(const FCNGradientBase &fcn, std::span<const double> par, unsigned int nrow,
-              std::span<const double> cov, unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov, nrow), MnStrategy(stra)), fMinimizer(CombinedMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + std::vector for parameters and MnUserCovariance
-   MnMinimize(const FCNGradientBase &fcn, std::span<const double> par, const MnUserCovariance &cov,
-              unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov), MnStrategy(stra)), fMinimizer(CombinedMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameters
-   MnMinimize(const FCNGradientBase &fcn, const MnUserParameters &par, unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par), MnStrategy(stra)), fMinimizer(CombinedMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameters + MnUserCovariance
-   MnMinimize(const FCNGradientBase &fcn, const MnUserParameters &par, const MnUserCovariance &cov,
-              unsigned int stra = 1)
-      : MnApplication(fcn, MnUserParameterState(par, cov), MnStrategy(stra)), fMinimizer(CombinedMinimizer())
-   {
-   }
-
-   /// construct from FCNGradientBase + MnUserParameterState + MnStrategy
-   MnMinimize(const FCNGradientBase &fcn, const MnUserParameterState &par, const MnStrategy &str)
-      : MnApplication(fcn, MnUserParameterState(par), str), fMinimizer(CombinedMinimizer())
-   {
-   }
-
    MnMinimize(const MnMinimize &migr)
       : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer)
    {

--- a/math/minuit2/inc/Minuit2/ModularFunctionMinimizer.h
+++ b/math/minuit2/inc/Minuit2/ModularFunctionMinimizer.h
@@ -46,14 +46,7 @@ public:
    FunctionMinimum Minimize(const FCNBase &, std::span<const double>, std::span<const double>,
                                     unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override;
 
-   FunctionMinimum Minimize(const FCNGradientBase &, std::span<const double>, std::span<const double>,
-                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override;
-
    FunctionMinimum Minimize(const FCNBase &, std::span<const double>, unsigned int,
-                                    std::span<const double>, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const override;
-
-   FunctionMinimum Minimize(const FCNGradientBase &, std::span<const double>, unsigned int,
                                     std::span<const double>, unsigned int stra = 1, unsigned int maxfcn = 0,
                                     double toler = 0.1) const override;
 
@@ -61,19 +54,10 @@ public:
    virtual FunctionMinimum Minimize(const FCNBase &, const MnUserParameters &, const MnStrategy &,
                                     unsigned int maxfcn = 0, double toler = 0.1) const;
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameters &, const MnStrategy &,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const;
-
    virtual FunctionMinimum Minimize(const FCNBase &, const MnUserParameters &, const MnUserCovariance &,
                                     const MnStrategy &, unsigned int maxfcn = 0, double toler = 0.1) const;
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameters &, const MnUserCovariance &,
-                                    const MnStrategy &, unsigned int maxfcn = 0, double toler = 0.1) const;
-
    virtual FunctionMinimum Minimize(const FCNBase &, const MnUserParameterState &, const MnStrategy &,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const;
-
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameterState &, const MnStrategy &,
                                     unsigned int maxfcn = 0, double toler = 0.1) const;
 
    // for Fumili

--- a/math/minuit2/src/AnalyticalGradientCalculator.cxx
+++ b/math/minuit2/src/AnalyticalGradientCalculator.cxx
@@ -59,12 +59,6 @@ FunctionGradient AnalyticalGradientCalculator::operator()(const MinimumParameter
    return (*this)(par);
 }
 
-bool AnalyticalGradientCalculator::CheckGradient() const
-{
-   // check to be sure FCN implements analytical gradient
-   return fGradFunc.CheckGradient();
-}
-
 // G2 can be computed directly without Hessian or via the Hessian
 bool AnalyticalGradientCalculator::CanComputeG2() const {
    return fGradFunc.HasG2() || fGradFunc.HasHessian();

--- a/math/minuit2/src/AnalyticalGradientCalculator.cxx
+++ b/math/minuit2/src/AnalyticalGradientCalculator.cxx
@@ -8,7 +8,7 @@
  **********************************************************************/
 
 #include "Minuit2/AnalyticalGradientCalculator.h"
-#include "Minuit2/FCNGradientBase.h"
+#include "Minuit2/FCNBase.h"
 #include "Minuit2/MnUserTransformation.h"
 #include "Minuit2/FunctionGradient.h"
 #include "Minuit2/MinimumParameters.h"

--- a/math/minuit2/src/ExternalInternalGradientCalculator.cxx
+++ b/math/minuit2/src/ExternalInternalGradientCalculator.cxx
@@ -9,7 +9,7 @@
 
 #include <vector>
 #include "Minuit2/ExternalInternalGradientCalculator.h"
-#include "Minuit2/FCNGradientBase.h"
+#include "Minuit2/FCNBase.h"
 #include "Minuit2/MnUserTransformation.h"
 #include "Minuit2/FunctionGradient.h"
 #include "Minuit2/MinimumParameters.h"

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -549,16 +549,8 @@ bool Minuit2Minimizer::Minimize()
 
    const ROOT::Minuit2::MnStrategy strategy = customizedStrategy(strategyLevel, fOptions);
 
-   const ROOT::Minuit2::FCNGradientBase *gradFCN = dynamic_cast<const ROOT::Minuit2::FCNGradientBase *>(fMinuitFCN);
-   if (gradFCN != nullptr) {
-      // use gradient
-      // SetPrintLevel(3);
-      ROOT::Minuit2::FunctionMinimum min = GetMinimizer()->Minimize(*gradFCN, fState, strategy, maxfcn, tol);
-      fMinimum = new ROOT::Minuit2::FunctionMinimum(min);
-   } else {
-      ROOT::Minuit2::FunctionMinimum min = GetMinimizer()->Minimize(*GetFCN(), fState, strategy, maxfcn, tol);
-      fMinimum = new ROOT::Minuit2::FunctionMinimum(min);
-   }
+   ROOT::Minuit2::FunctionMinimum min = GetMinimizer()->Minimize(*fMinuitFCN, fState, strategy, maxfcn, tol);
+   fMinimum = new ROOT::Minuit2::FunctionMinimum(min);
 
    // check if Hesse needs to be run. We do it when is requested (IsValidError() == true , set by SetParabError(true) in fitConfig)
    // (IsValidError() means the flag to get correct error from the Minimizer is set (Minimizer::SetValidError())

--- a/math/minuit2/src/MnApplication.cxx
+++ b/math/minuit2/src/MnApplication.cxx
@@ -10,7 +10,7 @@
 #include "Minuit2/MnApplication.h"
 #include "Minuit2/FunctionMinimum.h"
 #include "Minuit2/ModularFunctionMinimizer.h"
-#include "Minuit2/FCNGradientBase.h"
+#include "Minuit2/FCNBase.h"
 #include "Minuit2/MnPrint.h"
 
 namespace ROOT {
@@ -20,14 +20,7 @@ namespace Minuit2 {
 // constructor from non-gradient functions
 MnApplication::MnApplication(const FCNBase &fcn, const MnUserParameterState &state, const MnStrategy &stra,
                              unsigned int nfcn)
-   : fFCN(fcn), fState(state), fStrategy(stra), fNumCall(nfcn), fUseGrad(false)
-{
-}
-
-// constructor from functions
-MnApplication::MnApplication(const FCNGradientBase &fcn, const MnUserParameterState &state, const MnStrategy &stra,
-                             unsigned int nfcn)
-   : fFCN(fcn), fState(state), fStrategy(stra), fNumCall(nfcn), fUseGrad(true)
+   : fFCN(fcn), fState(state), fStrategy(stra), fNumCall(nfcn)
 {
 }
 
@@ -43,11 +36,8 @@ FunctionMinimum MnApplication::operator()(unsigned int maxfcn, double toler)
       maxfcn = 200 + 100 * npar + 5 * npar * npar;
 
    const FCNBase &fcn = Fcnbase();
-   assert(!fUseGrad || dynamic_cast<const FCNGradientBase *>(&fcn) != nullptr);
 
-   FunctionMinimum min =
-      fUseGrad ? Minimizer().Minimize(static_cast<const FCNGradientBase &>(fcn), fState, fStrategy, maxfcn, toler)
-               : Minimizer().Minimize(fcn, fState, fStrategy, maxfcn, toler);
+   FunctionMinimum min = Minimizer().Minimize(fcn, fState, fStrategy, maxfcn, toler);
    fNumCall += min.NFcn();
    fState = min.UserState();
 

--- a/math/minuit2/src/ModularFunctionMinimizer.cxx
+++ b/math/minuit2/src/ModularFunctionMinimizer.cxx
@@ -21,7 +21,6 @@
 #include "Minuit2/MnUserTransformation.h"
 #include "Minuit2/MnUserFcn.h"
 #include "Minuit2/FCNBase.h"
-#include "Minuit2/FCNGradientBase.h"
 #include "Minuit2/MnStrategy.h"
 #include "Minuit2/MnHesse.h"
 #include "Minuit2/MnLineSearch.h"
@@ -44,36 +43,12 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, std::span
    return Minimize(fcn, st, strategy, maxfcn, toler);
 }
 
-FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, std::span<const double> par,
-                                                   std::span<const double> err, unsigned int stra,
-                                                   unsigned int maxfcn, double toler) const
-{
-   // minimize from FCNGradientBase (use analytical gradient provided in FCN)
-   // and std::vector of double's for parameter values and errors (step sizes)
-   MnUserParameterState st(par, err);
-   MnStrategy strategy(stra);
-   return Minimize(fcn, st, strategy, maxfcn, toler);
-}
-
 // move nrow before cov to avoid ambiguities when using default parameters
 FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, std::span<const double> par,
                                                    unsigned int nrow, std::span<const double> cov, unsigned int stra,
                                                    unsigned int maxfcn, double toler) const
 {
    // minimize from FCNBase using std::vector for parameter error and
-   // an std::vector of size n*(n+1)/2 for the covariance matrix  and n (rank of cov matrix)
-
-   MnUserParameterState st(par, cov, nrow);
-   MnStrategy strategy(stra);
-   return Minimize(fcn, st, strategy, maxfcn, toler);
-}
-
-FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, std::span<const double> par,
-                                                   unsigned int nrow, std::span<const double> cov, unsigned int stra,
-                                                   unsigned int maxfcn, double toler) const
-{
-   // minimize from FCNGradientBase (use analytical gradient provided in FCN)
-   // using std::vector for parameter error and
    // an std::vector of size n*(n+1)/2 for the covariance matrix  and n (rank of cov matrix)
 
    MnUserParameterState st(par, cov, nrow);
@@ -90,15 +65,6 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, const MnU
    return Minimize(fcn, st, strategy, maxfcn, toler);
 }
 
-FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, const MnUserParameters &upar,
-                                                   const MnStrategy &strategy, unsigned int maxfcn, double toler) const
-{
-   // minimize from FCNGradientBase (use analytical gradient provided in FCN)  and MnUserParameters object
-
-   MnUserParameterState st(upar);
-   return Minimize(fcn, st, strategy, maxfcn, toler);
-}
-
 FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, const MnUserParameters &upar,
                                                    const MnUserCovariance &cov, const MnStrategy &strategy,
                                                    unsigned int maxfcn, double toler) const
@@ -109,42 +75,27 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, const MnU
    return Minimize(fcn, st, strategy, maxfcn, toler);
 }
 
-FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, const MnUserParameters &upar,
-                                                   const MnUserCovariance &cov, const MnStrategy &strategy,
-                                                   unsigned int maxfcn, double toler) const
-{
-   // minimize from FCNGradientBase (use analytical gradient provided in FCN)  and
-   // MnUserParameters MnUserCovariance objects
-
-   MnUserParameterState st(upar, cov);
-   return Minimize(fcn, st, strategy, maxfcn, toler);
-}
-
 FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, const MnUserParameterState &st,
                                                    const MnStrategy &strategy, unsigned int maxfcn, double toler) const
 {
-   // minimize from a FCNBase and a MnUserparameterState - interface used by all the previous ones
-   // based on FCNBase. Create in this case a NumericalGradient calculator
-   // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
+   if (!fcn.HasGradient()) {
+      // minimize from a FCNBase and a MnUserparameterState - interface used by all the previous ones
+      // based on FCNBase. Create in this case a NumericalGradient calculator
+      // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
 
-   // need MnUserFcn for difference int-ext parameters
-   MnUserFcn mfcn(fcn, st.Trafo());
-   Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
+      // need MnUserFcn for difference int-ext parameters
+      MnUserFcn mfcn(fcn, st.Trafo());
+      Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
 
-   unsigned int npar = st.VariableParameters();
-   if (maxfcn == 0)
-      maxfcn = 200 + 100 * npar + 5 * npar * npar;
-   MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
+      unsigned int npar = st.VariableParameters();
+      if (maxfcn == 0)
+         maxfcn = 200 + 100 * npar + 5 * npar * npar;
+      MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
 
-   return Minimize(mfcn, gc, mnseeds, strategy, maxfcn, toler);
-}
-
-// use Gradient here
-FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, const MnUserParameterState &st,
-                                                   const MnStrategy &strategy, unsigned int maxfcn, double toler) const
-{
-   // minimize from a FCNGradientBase and a MnUserParameterState -
-   // interface based on FCNGradientBase (external/analytical gradients)
+      return Minimize(mfcn, gc, mnseeds, strategy, maxfcn, toler);
+   }
+   // minimize from a function with gradient and a MnUserParameterState -
+   // interface based on function with gradient (external/analytical gradients)
    // Create in this case an AnalyticalGradient calculator
    // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
 
@@ -164,9 +115,7 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, c
 
    // compute seed (will use internally numerical gradient in case calculator does not implement g2 computations)
    MinimumSeed mnseeds = SeedGenerator()(mfcn, *gc, st, strategy);
-   auto minimum = Minimize(mfcn, *gc, mnseeds, strategy, maxfcn, toler);
-
-   return minimum;
+   return Minimize(mfcn, *gc, mnseeds, strategy, maxfcn, toler);
 }
 
 FunctionMinimum ModularFunctionMinimizer::Minimize(const MnFcn &mfcn, const GradientCalculator &gc,


### PR DESCRIPTION
By introducing a virtual `FCNBase::HasGradient()` method and moving the
former `FCNGradientBase` interface to the base class, we don't need to
repeat lots of code just for dealing with both the `FCNBase` and
`FCNGradientBase` types.

This is a completely backwards compatible change that makes the Minuit 2
code more maintainable.

Another commit in this PR removed the unused `FCNGradientBase::CheckGradient()` member function.

