### PR TITLE
[CMake] Set the minimum required version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-if(APPLE)
-  cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
-else()
-  cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
-endif()
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 if(WIN32)
   # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD


### PR DESCRIPTION
This is required to build LLVM18.
This version of CMake was eleased in March 2021 https://github.com/Kitware/CMake/releases/tag/v3.20.0

Associated PR in roottest https://github.com/root-project/roottest/pull/1184
