### PR TITLE
[ntuple] disable a #pragma ignored for clang in ntuple_packing

### DIFF
--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -15,7 +15,9 @@
 // ‘void* memcpy(void*, const void*, size_t)’ forming offset [1, 7] is out of the bounds [0, 1] of object ‘c’ with type
 // ‘char’
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #endif
 
 template <typename PodT, typename NarrowT, EColumnType ColumnT>


### PR DESCRIPTION
clang doesn't know about -Wstringop-overflow (problem introduced in #16386)

