### PR TITLE
[ntuple] remove dense representation of nullable field

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.9.0
+# RNTuple Reference Specifications 0.2.10.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 
@@ -918,13 +918,9 @@ Within the repetition blocks, bits are stored in little-endian order, i.e. the l
 
 A unique pointer and an optional type have the same on disk representation.
 They are represented as a collection of `T`s of zero or one elements.
-A collection parent field has a single subfield named `_0` for `T`, where `T` must have RNTuple I/O support.
+The collection parent field has a principal column of type `(Split)Index[64|32]`.
+It has a single subfield named `_0` for `T`, where `T` must have RNTuple I/O support.
 Note that RNTuple does not support polymorphism, so the type `T` is expected to be `T` and not a child class of `T`.
-
-By default, the parent field has a principal column of type `(Split)Index[64|32]`.
-This is called sparse representation.
-The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
-In this second case, a default-constructed `T` (or, if applicable, a `T` constructed by the ROOT I/O constructor) is stored on disk for the non-existing instances.
 
 #### std::set\<T\>, std::unordered_set\<T\>, std::multiset\<T\>, std::unordered_multiset\<T\>
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -373,7 +373,7 @@ protected:
    /// principal column corresponds to the field type. For collection fields except fixed-sized arrays,
    /// the main column is the offset field.  Class fields have no column of their own.
    /// When reading, points to any column of the column team of the active representation. Usually, this is just
-   /// the first column, except for the nullable field.
+   /// the first column.
    /// When writing, points to the first column index of the currently active (not suppressed) column representation.
    Internal::RColumn *fPrincipalColumn = nullptr;
    /// Some fields have a second column in its column representation. In this case, fAuxiliaryColumn points into

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -290,8 +290,8 @@ TEST(RNTuple, MultiColumnRepresentationNullable)
       auto model = RNTupleModel::Create();
       auto fldScalar = RFieldBase::Create("scalar", "std::optional<float>").Unwrap();
       auto fldVector = RFieldBase::Create("vector", "std::vector<std::optional<float>>").Unwrap();
-      fldScalar->SetColumnRepresentatives({{EColumnType::kBit}, {EColumnType::kSplitIndex64}});
-      fldVector->GetSubFields()[0]->SetColumnRepresentatives({{EColumnType::kSplitIndex64}, {EColumnType::kBit}});
+      fldScalar->SetColumnRepresentatives({{EColumnType::kIndex32}, {EColumnType::kSplitIndex64}});
+      fldVector->GetSubFields()[0]->SetColumnRepresentatives({{EColumnType::kSplitIndex64}, {EColumnType::kIndex32}});
       model->AddField(std::move(fldScalar));
       model->AddField(std::move(fldVector));
       auto ptrScalar = model->GetDefaultEntry().GetPtr<std::optional<float>>("scalar");


### PR DESCRIPTION
We need to decide between the sparse and the dense representation because they result in different structural roles for the field (collection vs. leaf). Since there was very little measured benefit of the dense representation, this PR keeps the sparse representation as one and only representation.

