### PR TITLE
[runtime_cxxmodules] Enable on AArch64

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -318,12 +318,6 @@ elseif(APPLE)
   set(x11_defvalue OFF)
 endif()
 
-# Current limitations for modules:
-#---Modules are disabled on aarch64 platform (due ODR violations)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)
-  set(runtime_cxxmodules_defvalue OFF)
-endif()
-
 # builtin_openssl is only supported on macOS
 if(builtin_openssl AND NOT APPLE)
     message(FATAL_ERROR ">>> Option 'builtin_openssl' is only supported on macOS.")


### PR DESCRIPTION
It was disabled in commit a67863d33a ("Disable modules on aarch64 due to ODR violation") in 2019. I cannot reproduce these problems on `lxplus-arm`, so try to turn it back on.