### PR TITLE
[RDF] work around a bug that causes attempts to delete stack memory

### DIFF
--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -48,29 +48,36 @@ protected:
 // Create file `filename` containing a test tree `treeName` with `nevents` events
 void FillTree(const char *filename, const char *treeName, int nevents = 0)
 {
-   TFile f(filename, "RECREATE");
-   TTree t(treeName, treeName);
-   t.SetAutoFlush(1); // yes, one event per cluster: to make MT more meaningful
+   // NOTE(gparolini): these TFile and TTree are created on the heap to work around a know bug that can
+   // cause a TObject to be incorrectly marked as "on heap" and attempted to be freed despite
+   // living on the stack.
+   // The bug is caused by the magic bit pattern `kObjectAllocMemValue` used by TStorage to
+   // mark a heap object appearing by chance on the stack.
+   // This is not a problem with a clear solution and in fact the whole heap detection system relies on UB,
+   // so for now we are forced to work around the bug rather than fixing it.
+   auto t = std::make_unique<TTree>(treeName, treeName);
+   auto f = std::make_unique<TFile>(filename, "RECREATE");
+   t->SetAutoFlush(1); // yes, one event per cluster: to make MT more meaningful
    double b1;
    int b2;
    double b3[2];
    unsigned int n;
    int b4[2] = {21, 42};
-   t.Branch("b1", &b1);
-   t.Branch("b2", &b2);
-   t.Branch("b3", b3, "b3[2]/D");
-   t.Branch("n", &n);
-   t.Branch("b4", b4, "b4[n]/I");
+   t->Branch("b1", &b1);
+   t->Branch("b2", &b2);
+   t->Branch("b3", b3, "b3[2]/D");
+   t->Branch("n", &n);
+   t->Branch("b4", b4, "b4[n]/I");
    for (int i = 0; i < nevents; ++i) {
       b1 = i;
       b2 = i * i;
       b3[0] = b1;
       b3[1] = -b1;
       n = i % 2 + 1;
-      t.Fill();
+      t->Fill();
    }
-   t.Write();
-   f.Close();
+   t->Write();
+   f->Close();
 }
 
 TEST_P(RDFSimpleTests, CreateEmpty)


### PR DESCRIPTION
See in-code comment for more details.

Note: this bug is routinely seen on the CI, where it causes occasional failures to the tests in question. Despite this solution being very suboptimal (the bug is most likely still present in many places of our codebase and can be encountered by users in the wild) we should at least be able to remove the random CI failures on our side.

A proper solution would be nice, but it seems hard to come up with one that doesn't have big performance implications.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


