### PR TITLE
[DF] Fix typo in RDF conversion map

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_conversion_maps.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_conversion_maps.py
@@ -25,7 +25,7 @@ FUNDAMENTAL_PYTHON_TYPES = {
 TREE_TO_NUMBA = {
     'C': 'str', 
     'Char_t': 'int',
-    'UChat_t': 'unsigned int',
+    'UChar_t': 'unsigned int',
     'Short_t': 'int',
     'UShort_t': 'unsigned int',
     'Int_t': 'int',


### PR DESCRIPTION
This mapping should be fixed before shipping the RDF Numba execution pipeline to users