### PR TITLE
[webcanvas] introduce batch mode for images

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -112,9 +112,14 @@ public:
 
    static bool CanProduceImages(const std::string &browser = "");
 
+   static std::string GetImageFormat(const std::string &fname);
+
    static bool ProduceImage(const std::string &fname, const std::string &json, int width = 800, int height = 600, const char *batch_file = nullptr);
 
    static bool ProduceImages(const std::string &fname, const std::vector<std::string> &jsons, const std::vector<int> &widths, const std::vector<int> &heights, const char *batch_file = nullptr);
+
+   static bool ProduceImages(const std::string &fmt, const std::vector<std::string> &fnames, const std::vector<std::string> &jsons, const std::vector<int> &widths, const std::vector<int> &heights, const char *batch_file = nullptr);
+
 };
 
 } // namespace ROOT

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -117,6 +117,13 @@ protected:
    static std::string gCustomScripts;     ///<! custom JavaScript code or URL on JavaScript files to load before start drawing
    static std::vector<std::string> gCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
 
+   static UInt_t gBatchImageMode;           ///<! configured batch size
+   static std::string gBatchFormat;    ///<! images format for batch job
+   static std::vector<std::string> gBatchFiles; ///<! file names for batch job
+   static std::vector<std::string> gBatchJsons; ///<! converted jsons batch job
+   static std::vector<int> gBatchWidths;   ///<! batch job widths
+   static std::vector<int> gBatchHeights;  ///<! batch job heights
+
    void Lock() override {}
    void Unlock() override {}
    Bool_t IsLocked() override { return kFALSE; }
@@ -171,6 +178,8 @@ protected:
    void SetWindowGeometry(const std::vector<int> &arr);
 
    static std::string ProcessCustomScripts(bool batch);
+
+   static void FlushBatchImages();
 
 public:
    TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Bool_t readonly = kTRUE);
@@ -259,6 +268,8 @@ public:
    static bool ProduceImage(TPad *pad, const char *filename, Int_t width = 0, Int_t height = 0);
 
    static bool ProduceImages(std::vector<TPad *> pads, const char *filename, Int_t width = 0, Int_t height = 0);
+
+   static void BatchImageMode(UInt_t n = 100);
 
    static TCanvasImp *NewCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
 

--- a/tutorials/graphics/save_batch.C
+++ b/tutorials/graphics/save_batch.C
@@ -1,0 +1,31 @@
+/// \file
+/// \ingroup tutorial_graphics
+/// This macro demonstrates batch image mode of web canvas
+/// When enabled - several images converted into JSON before all together
+/// provided to headless browser to produce image files. Let significantly
+/// increase performance. Important - disable batch mode for flushing remaining images
+///
+/// \macro_code
+///
+/// \author Sergey Linev
+
+void save_batch()
+{
+   // 37 canvases will be collected together for conversion
+   TWebCanvas::BatchImageMode(37);
+
+   auto c = new TCanvas("canvas", "Canvas with histogram");
+
+   auto h1 = new TH1I("hist", "Histogram with random data", 100, -5., 5);
+   h1->SetDirectory(nullptr);
+   h1->FillRandom("gaus", 10000);
+   h1->Draw();
+
+   for(int n = 0; n < 100; ++n) {
+      h1->FillRandom("gaus", 10000);
+      c->SaveAs(TString::Format("batch_image_%03d.png", n));
+   }
+
+   // Important - disabling batch mode also flush remaining images
+   TWebCanvas::BatchImageMode(0);
+}


### PR DESCRIPTION
Enabled with `TWebCanvas::BatchImageMode()` static method.

Allows to process many images with single headless browser invocation and
increase performance of image production - without change of user code. 

When many canvases are stored as image in difference places, 
they first collected in batch as JSON and then processed
when at least `n` images are there. Only then headless browser invoked
and create all these images at once. 

Provide macro demonstrating this functionality.