### PR TITLE
[RF][PyROOT] Change the way pyzdocs generate pyroot blocks for classes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
@@ -134,6 +134,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
         "__weakref__",
         "__firstlineno__",
         "__static_attributes__",
+        "__cpp_name__"
     ]
 
     if not consider_base_classes:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
@@ -25,6 +25,7 @@ class RooAbsCollection(object):
     params.printLatex(Sibling=initParams, Columns =2)
     \endcode
     """
+    __cpp_name__ = 'RooAbsCollection'
 
     def addClone(self, arg, silent=False):
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
@@ -27,6 +27,8 @@ class RooAbsData(object):
     data.plotOn(frame, CutRange="r1")
     \endcode
     """
+    
+    __cpp_name__ = 'RooAbsData'
 
     @cpp_signature(
         "RooPlot *RooAbsData::plotOn(RooPlot* frame,"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
@@ -53,6 +53,8 @@ class RooAbsPdf(RooAbsReal):
     pdf.fitTo(data, Range="r1")
     \endcode"""
 
+    __cpp_name__ = 'RooAbsPdf'
+
     @cpp_signature("RooAbsPdf::fitTo()")
     def fitTo(self, *args, **kwargs):
         r"""The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
@@ -29,6 +29,8 @@ class RooAbsReal(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooAbsReal'
+
     @cpp_signature(
         "RooPlot* RooAbsReal::plotOn(RooPlot* frame,"
         "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
@@ -27,6 +27,8 @@ class RooAbsRealLValue(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooAbsRealLValue'
+
     @cpp_signature(
         "TH1 *RooAbsRealLValue::createHistogram(const char *name,"
         "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooarglist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooarglist.py
@@ -16,6 +16,9 @@ import operator
 
 
 class RooArgList(RooAbsCollection):
+
+    __cpp_name__ = 'RooArgList'
+
     def __getitem__(self, key):
         try:
             operator.index(key)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
@@ -17,6 +17,9 @@ import operator
 
 
 class RooArgSet(RooAbsCollection):
+
+    __cpp_name__ = 'RooArgSet'
+
     def __init__(self, *args, **kwargs):
         """Pythonization of RooArgSet constructor to support implicit
         conversion from Python sets.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roocategory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roocategory.py
@@ -28,6 +28,8 @@ class RooCategory(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooCategory'
+
     @cpp_signature("RooCategory(const char* name, const char* title, const std::map<std::string, int>& allowedStates);")
     def __init__(self, *args, **kwargs):
         r"""The RooCategory constructor is pythonized for converting python dict to std::map.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roochi2var.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roochi2var.py
@@ -17,6 +17,8 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 class RooChi2Var(object):
     r"""Constructor of RooChi2Var takes a RooCmdArg as argument also supports keyword arguments."""
 
+    __cpp_name__ = 'RooChi2Var'
+
     @cpp_signature(
         [
             "RooChi2Var(const char* name, const char* title, RooAbsReal& func, RooDataHist& data,"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
@@ -26,6 +26,8 @@ class RooDataHist(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooDataHist'
+
     @cpp_signature(
         [
             "RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, Double_t initWgt=1.0) ;",

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -27,6 +27,8 @@ class RooDataSet(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooDataSet'
+
     @cpp_signature(
         "RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
         "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},const RooCmdArg& arg5={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodecays.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodecays.py
@@ -27,6 +27,8 @@ class RooDecay(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooDecay'
+
     @cpp_signature(
         "RooDecay(const char *name, const char *title, RooRealVar& t, RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;"
     )
@@ -34,6 +36,7 @@ class RooDecay(object):
         r"""The RooDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
+        __cpp_name__ = 'RooDecay'
 
 
 class RooBDecay(object):
@@ -47,6 +50,7 @@ class RooBDecay(object):
         r"""The RooBDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
+        __cpp_name__ = 'RooBDecay'
 
 
 class RooBCPGenDecay(object):
@@ -55,10 +59,12 @@ class RooBCPGenDecay(object):
         "    RooAbsReal& tau, RooAbsReal& dm, RooAbsReal& avgMistag, RooAbsReal& a, RooAbsReal& b,"
         "    RooAbsReal& delMistag, RooAbsReal& mu, const RooResolutionModel& model, DecayType type=DoubleSided) ;"
     )
+
     def __init__(self, *args, **kwargs):
         r"""The RooBCPGenDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
+        __cpp_name__ = 'RooBCPGenDecay'
 
 
 class RooBCPEffDecay(object):
@@ -68,10 +74,12 @@ class RooBCPEffDecay(object):
         "    RooAbsReal& a, RooAbsReal& b, RooAbsReal& effRatio, RooAbsReal& delMistag,"
         "    const RooResolutionModel& model, DecayType type=DoubleSided) ;"
     )
+
     def __init__(self, *args, **kwargs):
         r"""The RooBCPEffDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
+        __cpp_name__ = 'RooBCPEffDecay'
 
 
 class RooBMixDecay(object):
@@ -84,3 +92,4 @@ class RooBMixDecay(object):
         r"""The RooBMixDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
+        __cpp_name__ = 'RooBMixDecay'

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roogenfitstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roogenfitstudy.py
@@ -19,6 +19,8 @@ class RooGenFitStudy(object):
     So far, this applies to RooGenFitStudy::setGenConfig.
     """
 
+    __cpp_name__ = 'RooGenFitStudy'
+
     @cpp_signature(
         [
             "RooGenFitStudy::setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;",

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
@@ -12,6 +12,9 @@
 
 
 class RooJSONFactoryWSTool(object):
+
+    __cpp_name__ = 'RooJSONFactoryWSTool'
+
     @classmethod
     def gendoc(cls):
         """Generate the importer and exporter documentation."""

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomcstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomcstudy.py
@@ -27,6 +27,8 @@ class RooMCStudy(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooMCStudy'
+    
     @cpp_signature(
         "RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,"
         "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomsgservice.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomsgservice.py
@@ -26,6 +26,8 @@ class RooMsgService(object):
     ROOT.RooMsgService.instance().addStream(ROOT.RooFit.DEBUG, Topic = ROOT.RooFit.Tracing, ClassName = "RooGaussian")
     \endcode"""
 
+    __cpp_name__ = 'RooMsgService'
+
     @cpp_signature(
         "Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1={}, const RooCmdArg& arg2={}, const RooCmdArg& arg3={},"
         "    const RooCmdArg& arg4={}, const RooCmdArg& arg5={}, const RooCmdArg& arg6={});"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roonllvar.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roonllvar.py
@@ -17,6 +17,8 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 class RooNLLVar(object):
     r"""RooNLLVar() constructor takes a RooCmdArg as argument also supports keyword arguments."""
 
+    __cpp_name__ = 'RooNLLVar'
+
     @cpp_signature(
         "RooNLLVar(const char* name, const char* title, RooAbsPdf& pdf, RooAbsData& data,"
         "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooprodpdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooprodpdf.py
@@ -30,6 +30,8 @@ class RooProdPdf(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooProdPdf'
+
     @cpp_signature(
         "RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet,"
         "    const RooCmdArg& arg1            , const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roorealvar.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roorealvar.py
@@ -11,6 +11,9 @@
 
 
 class RooRealVar(object):
+
+    __cpp_name__ = 'RooRealVar'
+
     def bins(self, range_name=None):
         """Return the binning of this RooRealVar as a numpy array."""
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
@@ -27,6 +27,8 @@ class RooSimultaneous(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooSimultaneous'
+
     @cpp_signature(
         "RooSimultaneous(const char *name, const char *title,"
         "                std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimwstool.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimwstool.py
@@ -27,6 +27,8 @@ class RooSimWSTool(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooSimWSTool'
+
     @cpp_signature(
         "RooSimultaneous *RooSimWSTool::build(const char* simPdfName, const char* protoPdfName,"
         "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roostats.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roostats.py
@@ -27,6 +27,8 @@ class SPlot(object):
     RooStats.SPlot(data, Strategy = 0)
     \endcode"""
 
+    __cpp_name__ = 'RooStats::SPlot'
+
     @cpp_signature(
         "SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* pdf,"
         "        const RooArgList &yieldsList, const RooArgSet &projDeps,"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roovectordatastore.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roovectordatastore.py
@@ -11,6 +11,9 @@
 
 
 class RooVectorDataStore(object):
+
+    __cpp_name__ = 'RooVectorDataStore'
+
     def to_numpy(self, copy=True):
         import numpy as np
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -20,6 +20,8 @@ class RooWorkspace(object):
     \endcode
     """
 
+    __cpp_name__ = 'RooWorkspace'
+
     @cpp_signature(
         "Bool_t RooWorkspace::import(const RooAbsArg& arg,"
         "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},"

--- a/documentation/doxygen/print_roofit_pyz_doctrings.py
+++ b/documentation/doxygen/print_roofit_pyz_doctrings.py
@@ -74,7 +74,7 @@ def write_pyroot_block_for_class(klass):
     if klass.__doc__ is None:
         return
 
-    print("\class " + klass.__name__)
+    print("\class " + klass.__cpp_name__)
     print("\\brief \parblock \endparblock")
     print("\htmlonly")
     print('<div class="pyrootbox">')


### PR DESCRIPTION
This introduces a `__cpp_name__` member to include classes under a namespace which is not captured by the pythonized class name. Fixes the bug where the generated PyROOT block would not show up on the class page for `RooStats::SPlot` but only for member functions. Also adds the missing anchors for `RooVectorDataStore` and `RooArgList`
