### PR TITLE
[reve] Correct secondary selection in RC.RendeQuTor.

### DIFF
--- a/ui5/eve7/lib/GlViewerRCore.js
+++ b/ui5/eve7/lib/GlViewerRCore.js
@@ -254,6 +254,17 @@ sap.ui.define([
             this.rqt.initFull(this.RQ_SSAA);
          }
          this.rqt.updateViewport(w, h);
+
+
+         // AMT secondary selection bug workaround for RenderCore PR #21
+         this.rqt.pick_instance = function(state)
+         {
+            return this.pick_instance_low_level(this.pqueue, state);
+         }
+         this.rqt.pick_instance_overlay = function(state)
+         {
+            return this.pick_instance_low_level(this.ovlpqueue, state);
+         }
       }
 
       setupEventHandlers()


### PR DESCRIPTION
The RenderCore changes introduced a bug in the secondary selection. 

The change was created with the PR #15812.

Temprary solution is that the GLViewerRCore.js overrides RenderQuTor pick function. 

The related change is  pending in RenderCore  https://github.com/UL-FRI-LGM/RenderCore/pull/21

