### PR TITLE
[webcanv] Implement "Help" menu

### DIFF
--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -118,6 +118,8 @@ private:
 
    int fJsonComp{23};                ///<! json compression for data send to client
 
+   std::vector<std::unique_ptr<ROOT::RWebDisplayHandle>> fHelpHandles; ///<! array of handles for help widgets
+
    /// Disable copy construction.
    RCanvasPainter(const RCanvasPainter &) = delete;
 
@@ -606,6 +608,11 @@ void RCanvasPainter::ProcessData(unsigned connid, const std::string &arg)
    } else if (check_header("CLEAR")) {
       fCanvas.Wipe();
       fCanvas.Modified();
+   } else if (check_header("SHOWURL:")) {
+      ROOT::RWebDisplayArgs args;
+      args.SetUrl(cdata);
+      args.SetStandalone(false);
+      fHelpHandles.emplace_back(ROOT::RWebDisplayHandle::Display(args));
    } else {
       R__LOG_ERROR(CanvasPainerLog()) << "Got not recognized message" << arg;
    }

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -249,7 +249,7 @@ RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
    std::string tmpfile;
 
    // these are secret parameters, hide them in temp file
-   if ((url.find("token=") || url.find("key=")) && !args.IsBatchMode() && !args.IsHeadless()) {
+   if (((url.find("token=") != std::string::npos) || (url.find("key=") != std::string::npos)) && !args.IsBatchMode() && !args.IsHeadless()) {
       TString filebase = "root_start_";
 
       auto f = gSystem->TempFileName(filebase, nullptr, ".html");

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -114,6 +114,8 @@ protected:
    PadClickedSignal_t fPadDblClickedSignal; ///<! signal emitted when simple mouse click performed on the pad
    ObjectSelectSignal_t fObjSelectSignal; ///<! signal emitted when new object selected in the pad
 
+   std::vector<std::unique_ptr<ROOT::RWebDisplayHandle>> fHelpHandles; ///<! array of handles for help widgets
+
    static std::string gCustomScripts;     ///<! custom JavaScript code or URL on JavaScript files to load before start drawing
    static std::vector<std::string> gCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -2139,6 +2139,14 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          }
       }
 
+   } else if (arg.compare(0, 8, "SHOWURL:") == 0) {
+
+      ROOT::RWebDisplayArgs args;
+      args.SetUrl(arg.substr(8));
+      args.SetStandalone(false);
+
+      fHelpHandles.emplace_back(ROOT::RWebDisplayHandle::Display(args));
+
    } else if (arg == "INTERRUPT"s) {
 
       gROOT->SetInterrupt();

--- a/tutorials/graphics/saveall.C
+++ b/tutorials/graphics/saveall.C
@@ -1,7 +1,8 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro creates 100 canvases and store them in different images files using TCanvas::SaveAll() method
+/// Creates many canvases and save as images or pdf.
+/// This macro creates 100 canvases and store them in different images files using TCanvas::SaveAll() method.
 /// Demonstrated how different output format can be used in batch mode.
 ///
 /// \macro_code

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -731,7 +731,22 @@ sap.ui.define([
          } else if (name == 'Start browser') {
             this.getCanvasPainter()?.sendWebsocket('START_BROWSER');
          }
+      },
 
+      onHelpMenuAction(oEvent) {
+         const item = oEvent.getParameter('item'),
+               name = item.getText();
+         let url = '';
+         if (name === 'ROOT')
+            url = 'https://root.cern';
+         else if (name === 'Canvas')
+            url = this.isv7() ? 'https://root.cern/doc/master/classROOT_1_1Experimental_1_1RCanvas.html' : 'https://root.cern/doc/master/classTCanvas.html';
+         else if (name === 'Tutorials')
+            url = this.isv7() ? 'https://root.cern/doc/master/group__tutorial__rcanvas.html' : 'https://root.cern/doc/master/group__tutorial__graphics.html';
+         else if (name === 'About')
+            url = 'https://root.cern/about/';
+         if (url)
+            this.getCanvasPainter()?.sendWebsocket('SHOWURL:' + url);
       },
 
       showMessage(msg) {

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -99,7 +99,18 @@
                </menu>
             </MenuButton>
             <ToolbarSpacer />
-            <Button text="Help" type="Transparent"/>
+            <MenuButton text="Help" type="Transparent">
+               <menu>
+                  <Menu itemSelected="onHelpMenuAction">
+                     <items>
+                        <MenuItem text="ROOT"/>
+                        <MenuItem text="Canvas"/>
+                        <MenuItem text="Tutorials"/>
+                        <MenuItem text="About" startsSection="true"/>
+                     </items>
+                  </Menu>
+               </menu>
+            </MenuButton>
          </OverflowToolbar>
       </customHeader>
       <subHeader>


### PR DESCRIPTION
Provides Help menu with items: 
* ROOT: link to main page
* Canvas: link to TCanvas/RCanvas docu
* Tutorials: link to correspondent tutorials
* About: link to about section of main page

Support in TCanvas and RCanvas

Fix problem in display of plain URL.

Improve checks how external commands processed in TWebCanvas