### PR TITLE
Improvements for TGeoParallelWorld (part 1)

### DIFF
--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -1656,13 +1656,12 @@ Double_t TGeoNavigator::Safety(Bool_t inside)
       return fSafety;
    }
    Double_t point[3];
-   Double_t safpar = TGeoShape::Big();
+   Double_t safpar = TGeoShape::Big(); // safety from parallel world
    if (!inside)
       fSafety = TGeoShape::Big();
+
    // Check if parallel navigation is enabled
-   if (fGeometry->IsParallelWorldNav()) {
-      safpar = fGeometry->GetParallelWorld()->Safety(fPoint);
-   }
+   const bool have_PW = fGeometry->IsParallelWorldNav();
 
    if (fIsOutside) {
       fSafety = fGeometry->GetTopVolume()->GetShape()->Safety(fPoint, kFALSE);
@@ -1670,6 +1669,11 @@ Double_t TGeoNavigator::Safety(Bool_t inside)
          fSafety = 0;
          fIsOnBoundary = kTRUE;
          return fSafety;
+      }
+
+      // cross-check against the parallel world safety, using fSafety as limit
+      if (have_PW) {
+         safpar = fGeometry->GetParallelWorld()->Safety(fPoint, fSafety);
       }
       return TMath::Min(fSafety, safpar);
    }
@@ -1689,6 +1693,10 @@ Double_t TGeoNavigator::Safety(Bool_t inside)
    }
 
    //---> Check against the parallel geometry safety
+   // cross-check against the parallel world safety, using fSafety as limit
+   if (have_PW) {
+      safpar = fGeometry->GetParallelWorld()->Safety(fPoint, fSafety);
+   }
    if (safpar < fSafety)
       fSafety = safpar;
 

--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -266,6 +266,11 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
       // loop over daughters
       for (i = 0; i < nd; i++) {
          current = fVolume->GetNode(i);
+         pnode = (TGeoPhysicalNode *)fPhysical->At(i);
+         if (pnode->IsMatchingState(nav)) {
+            step = TGeoShape::Big();
+            return nullptr;
+         }
          // validate only within stepmax
          if (voxels->IsSafeVoxel(point, i, stepmax))
             continue;
@@ -365,14 +370,17 @@ Double_t TGeoParallelWorld::Safety(Double_t point[3], Double_t safmax)
          dxyz += dxyz2 * dxyz2;
       if (dxyz >= safe * safe)
          continue;
+
       pnode = (TGeoPhysicalNode *)fPhysical->At(id);
       // Return if inside the current node
-      if (pnode->IsMatchingState(nav))
+      if (pnode->IsMatchingState(nav)) {
          return TGeoShape::Big();
+      }
+
       current = fVolume->GetNode(id);
       current->MasterToLocal(point, local);
       // Safety to current node
-      safnext = current->Safety(local, kFALSE);
+      safnext = current->GetVolume()->GetShape()->Safety(local, kFALSE);
       if (safnext < tolerance)
          return 0.;
       if (safnext < safe)

--- a/geom/geom/src/TGeoPhysicalNode.cxx
+++ b/geom/geom/src/TGeoPhysicalNode.cxx
@@ -557,8 +557,14 @@ Bool_t TGeoPhysicalNode::IsMatchingState(TGeoNavigator *nav) const
       Fatal("SetBranchAsState", "no state available");
       return kFALSE;
    }
+   // the first condition is that the levels of navigator and this physical node must match
+   if (cache->GetLevel() != fLevel) {
+      return kFALSE;
+   }
+   // now we compare the nodes at each level
+   // starting backwards since that enhances the probability of an early return
    TGeoNode **branch = (TGeoNode **)cache->GetBranch();
-   for (Int_t i = 1; i <= fLevel; i++)
+   for (Int_t i = fLevel; i >= 1; --i)
       if (fNodes->At(i) != branch[i])
          return kFALSE;
    return kTRUE;

--- a/geom/geom/src/TGeoVoxelFinder.cxx
+++ b/geom/geom/src/TGeoVoxelFinder.cxx
@@ -2258,9 +2258,10 @@ void TGeoVoxelFinder::SortAll(Option_t *)
    delete[] extra_right;
 
    if ((!fPriority[0]) && (!fPriority[1]) && (!fPriority[2])) {
-      SetInvalid();
-      if (nd > 1)
+      if (nd > 1) {
+         SetInvalid();
          Error("SortAll", "Volume %s: Cannot make slices on any axis", fVolume->GetName());
+      }
    }
 }
 


### PR DESCRIPTION
This pull request provides a bug fix:

- fixing wrong safety in TGeoParallelWorld due to double application of coordinate transformation) 
- fix a crash in VoxelFinder when we have only 1 primitive

as well as some optimizations for TGeoPallelWorld usage:

- call TGeoParallelWorld::Safety with existing limit from normal safety to speedup search
- make TGeoPhysicalNode::IsMatchingState faster
