### PR TITLE
[Minuit2] Add interface to pass initial values/cov matrix

### DIFF
--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -166,6 +166,11 @@ public:
    }
    /// set a new free variable
    virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) = 0;
+   /// set initial second derivatives
+   virtual bool SetCovarianceDiag(std::span<const double> d2, unsigned int n);
+   /// set initial covariance matrix
+   virtual bool SetCovariance(std::span<const double> cov, unsigned int nrow);
+
    /// set a new lower limit variable  (override if minimizer supports them )
    virtual bool SetLowerLimitedVariable(unsigned int  ivar , const std::string & name , double val , double step , double lower ) {
       return SetLimitedVariable(ivar, name, val, step, lower, std::numeric_limits<double>::infinity() );

--- a/math/mathcore/src/Minimizer.cxx
+++ b/math/mathcore/src/Minimizer.cxx
@@ -10,6 +10,25 @@
 namespace ROOT {
 namespace Math {
 
+/** set initial second derivatives
+ */
+bool Minimizer::SetCovarianceDiag(std::span<const double> g2, unsigned int n)
+{
+   MATH_UNUSED(g2);
+   MATH_UNUSED(n);
+   return false;
+}
+
+/** set initial values for covariance/error matrix
+    The covariance matrix must be provided in compressed form (row-major ordered upper traingular part)
+*/
+bool Minimizer::SetCovariance(std::span<const double> cov, unsigned int nrow)
+{
+   MATH_UNUSED(cov);
+   MATH_UNUSED(nrow);
+   return false;
+}
+
 /// set a new upper/lower limited variable (override if minimizer supports them ) otherwise as default set an unlimited
 /// variable
 bool Minimizer::SetLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double lower,

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -292,6 +292,12 @@ protected:
    // internal function to compute Minos errors
    int RunMinosError(unsigned int i, double &errLow, double &errUp, int runopt);
 
+   /// set initial second derivatives
+   virtual bool SetCovarianceDiag(std::span<const double> d2, unsigned int n) override;
+
+   /// set initial covariance matrix
+   bool SetCovariance(std::span<const double> cov, unsigned int nrow) override;
+
 private:
    unsigned int fDim; // dimension of the function to be minimized
    bool fUseFumili;

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -103,6 +103,9 @@ public:
    // add const Parameter
    void Add(const std::string &, double);
 
+   // add covariance matrix
+   void AddCovariance(const MnUserCovariance &);
+
    // interaction via external number of Parameter
    void Fix(unsigned int);
    void Release(unsigned int);

--- a/math/minuit2/inc/Minuit2/MnUserTransformation.h
+++ b/math/minuit2/inc/Minuit2/MnUserTransformation.h
@@ -87,12 +87,14 @@ public:
    double Int2extError(unsigned int, double, double) const;
 
    MnUserCovariance Int2extCovariance(const MnAlgebraicVector &, const MnAlgebraicSymMatrix &) const;
+   MnUserCovariance Ext2intCovariance(const MnAlgebraicVector &, const MnAlgebraicSymMatrix &) const;
 
    // Index = external Parameter
    double Ext2int(unsigned int, double) const;
 
    // Index = internal Parameter
    double DInt2Ext(unsigned int, double) const;
+   double DExt2Int(unsigned int, double) const;
 
    //   // Index = external Parameter
    //   double dExt2Int(unsigned int, double) const;

--- a/math/minuit2/inc/Minuit2/SinParameterTransformation.h
+++ b/math/minuit2/inc/Minuit2/SinParameterTransformation.h
@@ -31,6 +31,7 @@ public:
    long double Int2ext(long double Value, long double Upper, long double Lower) const;
    long double Ext2int(long double Value, long double Upper, long double Lower, const MnMachinePrecision &) const;
    long double DInt2Ext(long double Value, long double Upper, long double Lower) const;
+   long double DExt2Int(long double Value, long double Upper, long double Lower) const;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/SqrtLowParameterTransformation.h
+++ b/math/minuit2/inc/Minuit2/SqrtLowParameterTransformation.h
@@ -43,6 +43,9 @@ public:
    // derivative of transformation from internal to external
    long double DInt2Ext(long double Value, long double Lower) const;
 
+   // derivative of transformation from external to internal
+   long double DExt2Int(long double Value, long double Lower) const;
+
 private:
 };
 

--- a/math/minuit2/inc/Minuit2/SqrtUpParameterTransformation.h
+++ b/math/minuit2/inc/Minuit2/SqrtUpParameterTransformation.h
@@ -44,6 +44,9 @@ public:
    // derivative of transformation from internal to external
    long double DInt2Ext(long double Value, long double Upper) const;
 
+   // derivative of transformation from external to internal
+   long double DExt2Int(long double Value, long double Upper) const;
+
 private:
 };
 

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -193,6 +193,31 @@ bool Minuit2Minimizer::SetVariable(unsigned int ivar, const std::string &name, d
    return true;
 }
 
+/** set initial second derivatives
+ */
+bool Minuit2Minimizer::SetCovarianceDiag(std::span<const double> d2, unsigned int n)
+{
+   MnPrint print("Minuit2Minimizer::SetCovarianceDiag", PrintLevel());
+
+   std::vector<double> cov(n * (n + 1) / 2);
+
+   for (unsigned int i = 0; i < n; i++) {
+      for (unsigned int j = i; j < n; j++)
+         cov[i + j * (j + 1) / 2] = (i == j) ? d2[i] : 0.;
+   }
+
+   return Minuit2Minimizer::SetCovariance(cov, n);
+}
+
+bool Minuit2Minimizer::SetCovariance(std::span<const double> cov, unsigned int nrow)
+{
+   MnPrint print("Minuit2Minimizer::SetCovariance", PrintLevel());
+
+   fState.AddCovariance({cov, nrow});
+
+   return true;
+}
+
 bool Minuit2Minimizer::SetLowerLimitedVariable(unsigned int ivar, const std::string &name, double val, double step,
                                                double lower)
 {

--- a/math/minuit2/src/MnFunctionCross.cxx
+++ b/math/minuit2/src/MnFunctionCross.cxx
@@ -46,7 +46,7 @@ MnCross MnFunctionCross::operator()(std::span<const unsigned int> par, std::span
    // for finding the point :
    double tlf = tlr * up;
    double tla = tlr;
-   unsigned int maxitr = 15;
+   unsigned int maxitr = 30;
    unsigned int ipt = 0;
    double aminsv = fFval;
    double aim = aminsv + up;

--- a/math/minuit2/src/SinParameterTransformation.cxx
+++ b/math/minuit2/src/SinParameterTransformation.cxx
@@ -56,6 +56,12 @@ long double SinParameterTransformation::DInt2Ext(long double Value, long double 
    return 0.5 * ((Upper - Lower) * std::cos(Value));
 }
 
+long double SinParameterTransformation::DExt2Int(long double Value, long double Upper, long double Lower) const
+{
+   // return the derivative of the transformation d Int/ d Ext
+   return 1. / std::sqrt((Value - Lower) * (Upper - Value));
+}
+
 } // namespace Minuit2
 
 } // namespace ROOT

--- a/math/minuit2/src/SqrtLowParameterTransformation.cxx
+++ b/math/minuit2/src/SqrtLowParameterTransformation.cxx
@@ -45,6 +45,13 @@ long double SqrtLowParameterTransformation::DInt2Ext(long double value, long dou
    return val;
 }
 
+long double SqrtLowParameterTransformation::DExt2Int(long double value, long double lower) const
+{
+   // derivative of internal to external transformation   :  d (Ext2Int) / d Ext
+   long double val = (value - lower + 1) / (std::sqrt((value - lower + 1) * (value - lower + 1) - 1.));
+   return val;
+}
+
 } // namespace Minuit2
 
 } // namespace ROOT

--- a/math/minuit2/src/SqrtUpParameterTransformation.cxx
+++ b/math/minuit2/src/SqrtUpParameterTransformation.cxx
@@ -44,6 +44,13 @@ long double SqrtUpParameterTransformation::DInt2Ext(long double value, long doub
    return val;
 }
 
+long double SqrtUpParameterTransformation::DExt2Int(long double value, long double upper) const
+{
+   // derivative of internal to external transformation :  d (Ext2Int ) / d Ext
+   long double val = -(upper - value + 1) / (std::sqrt((upper - value + 1) * (upper - value + 1) - 1.));
+   return val;
+}
+
 } // namespace Minuit2
 
 } // namespace ROOT

--- a/math/minuit2/test/CMakeLists.txt
+++ b/math/minuit2/test/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT DEFINED ROOT_SOURCE_DIR)
 endif()
 
 set(TestSource testMinimizer.cxx)
+list(APPEND TestSource testCovariance.cxx)
 if (clad)
   list(APPEND TestSource testADMinim.cxx)
 endif()

--- a/math/minuit2/test/testCovariance.cxx
+++ b/math/minuit2/test/testCovariance.cxx
@@ -1,0 +1,93 @@
+// test of covariance matrix transformnation from internal to external representation and viceversa
+
+#include "Minuit2/MnUserCovariance.h"
+#include "Minuit2/MnUserParameters.h"
+#include "Minuit2/MnUserParameterState.h"
+#include "Minuit2/MnUserTransformation.h"
+#include "Minuit2/MnPrint.h"
+#include "Minuit2/MnMatrix.h"
+
+#include <cassert>
+#include <string>
+#include <iostream>
+
+using namespace ROOT::Minuit2;
+
+int testCovariance(std::string boundType)
+{
+   int iret = 0;
+
+   std::string prefix = "testCovariance " + boundType;
+   MnPrint print(prefix.c_str(), MnPrint::GlobalLevel());
+
+   // test constructor
+   unsigned int nrow = 6;
+   MnUserParameters upar;
+   upar.Add("x", 1., 0.1);
+   upar.Add("y", 1., 0.1);
+   upar.Add("z", 1., 0.1);
+   upar.Add("x0", 2., 0.1);
+   upar.Add("y0", 2., 0.1);
+   upar.Add("z0", 2., 0.1);
+
+   if (boundType == "upper") {
+      upar.SetUpperLimit(0, 5.);
+      upar.SetUpperLimit(4, 5.);
+   } else if (boundType == "lower") {
+      upar.SetLowerLimit(0, -5.);
+      upar.SetLowerLimit(4, -5.);
+   } else if (boundType == "double") {
+      upar.SetLimits(0, -5., 5.);
+      upar.SetLimits(4, -5., 5.);
+   }
+
+   MnUserCovariance cov(nrow);
+   for (unsigned int i = 0; i < nrow; i++) {
+      cov(i, i) = 2;
+      for (unsigned int j = i + 1; j < std::min(i + 2, nrow); j++) {
+         cov(i, j) = -1;
+      }
+   }
+
+   MnUserParameterState st(upar, cov);
+   double eps = st.Precision().Eps();
+   print.Info("State:", st);
+   MnUserTransformation trafo = st.Trafo();
+
+   MnUserCovariance intCov = st.IntCovariance();
+   print.Info("Internal covariance:", intCov);
+
+   MnAlgebraicVector params(nrow);
+   for (unsigned int i = 0; i < nrow; i++)
+      params(i) = upar.Params()[i];
+
+   MnAlgebraicSymMatrix covmat(nrow);
+   for (unsigned int i = 0; i < nrow; i++)
+      for (unsigned int j = i; j < nrow; j++)
+         covmat(i, j) = intCov(i, j);
+
+   MnUserCovariance extCov = trafo.Int2extCovariance(params, covmat);
+   // check result
+   for (unsigned int i = 0; i < nrow; i++)
+      for (unsigned int j = i; j < nrow; j++)
+         iret = iret | (std::fabs((cov(i, j) - extCov(i, j)) / cov(i, j)) <= eps);
+
+   if (iret != 0)
+      std::cerr << "testCovariance " << boundType << " bound :\t FAILED " << std::endl;
+   else
+      std::cerr << "testCovariance " << boundType << " bound :\t OK " << std::endl;
+
+   return iret;
+}
+
+int main()
+{
+   int iret = 0;
+
+   iret = iret | testCovariance("upper");
+   iret = iret | testCovariance("lower");
+   iret = iret | testCovariance("double");
+   iret = iret | testCovariance("unbounded");
+
+   return iret;
+}

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -107,6 +107,8 @@ public:
       bool profile = false;        // local config
       bool timingAnalysis = false; // local config
       std::string minimizerType;   // local config
+
+      bool setInitialCovariance = false; // Use covariance matrix provided by user
    };
 
    // For backwards compatibility with when the RooMinimizer used the ROOT::Math::Fitter.

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -970,6 +970,15 @@ void RooMinimizer::initMinimizer()
    _minimizer = std::unique_ptr<ROOT::Math::Minimizer>(_config.CreateMinimizer());
    _minimizer->SetFunction(*getMultiGenFcn());
    _minimizer->SetVariables(_config.ParamsSettings().begin(), _config.ParamsSettings().end());
+
+   if (_cfg.setInitialCovariance) {
+      std::vector<double> v;
+      for (std::size_t i = 0; i < _fcn->getNDim(); ++i) {
+         RooRealVar &param = _fcn->floatableParam(i);
+         v.push_back(param.getError() * param.getError());
+      }
+      _minimizer->SetCovarianceDiag(v, v.size());
+   }
 }
 
 bool RooMinimizer::updateMinimizerOptions(bool canDifferentMinim)


### PR DESCRIPTION
# This Pull request:

Modifies Minuit2 interface to pass initial error/covariance matrix or second derivatives (G2) vector.

## Changes or fixes:

This PR exploits existing code in `MnSeedGenerator` and introduces some improvements, namely:
1. Check whether provided matrix has positive diagonal (G2 must be positive) and larger than working precision `Eps`; if it is not the case, numerical computation is carried out.
2. Disable `NegativeG2LineSearch` whenever point 1 is satisfied.

Furthermore, this PR provides an interface to pass the error/covariance matrix or second derivatives (G2) vector via `ROOT::Math::Minimizer`. The user can provide either the error/covariance matrix in compressed format (column-major upper triangular part), OR the g2 vector, see the code snippet below. The matrix or second derivatives must take into account only variable parameters, implying that all fixed parameters must be declared before providing initial values.

```
   ROOT::Math::Minimizer* minimum = ROOT::Math::Factory::CreateMinimizer(minName, algoName);

   minimum->SetVariable(0,"x",0.,0.);
   minimum->SetVariable(1,"y",0.,0.);

   int nrow = 2;
   std::vector<double> cov(nrow*(nrow+1)/2);
   std::vector<double> d2(nrow);

   for(int i = 0; i < nrow; i++) {
      d2[i] = 0.1*(i+1);
      for(int j = i;j< nrow;j++)
          cov[i + j * (j + 1) / 2] = (i==j) ? 0.1*(i+1) : 0.;
   }

   minimum->SetCovariance(cov,nrow);
   // OR
   //minimum->SetCovarianceDiag(d2,nrow);
```

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


