### PR TITLE
[cling] Replace usage of TextInput with LineEditor

### DIFF
--- a/.github/workflows/sync_cling.yml
+++ b/.github/workflows/sync_cling.yml
@@ -6,7 +6,6 @@ on:
       - 'master'
     paths:
       - 'interpreter/cling/**'
-      - 'core/textinput/src/textinput/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/utilities/sync_cling.py
+++ b/.github/workflows/utilities/sync_cling.py
@@ -4,86 +4,96 @@ import subprocess
 import sys
 
 # Parameters
-CLING_TAG_ROOT_HASH_PREFIX='__internal-root-'
+CLING_TAG_ROOT_HASH_PREFIX = "__internal-root-"
 # Arbitrarily choose a commit hash which is "old enough"
 # In this case, we choose the first commit after the latest
 # cling release at the time of writing, 1.2, i.e. 5ea7949 (in cling)
 # 08f123f8e7 (in ROOT)
 # See Cling https://github.com/root-project/cling/commit/5ea7949
 # ROOT https://github.com/root-project/root/commit/08f123f8e7
-DEFAULT_STARTING_ROOT_HASH = '08f123f8e7'
-CLING_REPO_DIR_NAME = 'cling'
-ROOT_REPO_DIR_NAME = 'root'
-INTERP_DIR_NAME = 'interpreter/cling'
-DEST_INTERP_DIR_NAME = ''
+DEFAULT_STARTING_ROOT_HASH = "08f123f8e7"
+CLING_REPO_DIR_NAME = "cling"
+ROOT_REPO_DIR_NAME = "root"
+INTERP_DIR_NAME = "interpreter/cling"
+DEST_INTERP_DIR_NAME = ""
+
 
 def printError(msg):
-    print(f'*** Error: {msg}')
+    print(f"*** Error: {msg}")
+
 
 def printWarning(msg):
-    print(f'*** Warning: {msg}')
+    print(f"*** Warning: {msg}")
+
 
 def printInfo(msg):
-    print(f'Info: {msg}')
+    print(f"Info: {msg}")
 
-def execCommand(cmd, thisCwd = './', theInput = None, desc=""):
-    '''
+
+def execCommand(cmd, thisCwd="./", theInput=None, desc=""):
+    """
     Execute a command and return the output. For logging reasons, the command
     is also printed.
     If "desc" is specificed, the command is not printed but "desc".
-    '''
-    if '' == desc:
-        printInfo(f'In directory {thisCwd} *** {cmd} {"with std input" if theInput else ""}')
+    """
+    if "" == desc:
+        printInfo(f"In directory {thisCwd} *** {cmd} {'with std input' if theInput else ''}")
     else:
         print(desc)
-    compProc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
-                              cwd=thisCwd, input=theInput, encoding='latin1')
+    compProc = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, cwd=thisCwd, input=theInput, encoding="latin1"
+    )
     if 0 != compProc.returncode:
         print(f"Error:\n {compProc.stderr.strip()}")
         raise ValueError(f'Command "{cmd}" failed ({compProc.returncode})')
     out = compProc.stdout.strip()
     return out
 
+
 def getAllClingTags():
-    execCommand(f'git fetch --tags', CLING_REPO_DIR_NAME)
+    execCommand("git fetch --tags", CLING_REPO_DIR_NAME)
+
 
 def getRootSyncTag():
     # We try to get the tags, to get the latest ROOT commit that was synchronized
     getAllClingTags()
-    tagsStr = execCommand(f'git tag', CLING_REPO_DIR_NAME)
-    tags = tagsStr.split('\n')
-    if tags == ['']:
-        printInfo(f'No tags found locally. Looking in the source repository.')
-        tagsStr = execCommand(f'git ls-remote --tags origin', CLING_REPO_DIR_NAME)
-        tags = tagsStr.split('\n')
+    tagsStr = execCommand("git tag", CLING_REPO_DIR_NAME)
+    tags = tagsStr.split("\n")
+    if tags == [""]:
+        printInfo("No tags found locally. Looking in the source repository.")
+        tagsStr = execCommand("git ls-remote --tags origin", CLING_REPO_DIR_NAME)
+        tags = tagsStr.split("\n")
         print(tags)
-        tags = list(map(lambda t: t.split('/')[-1] if '/' in t else t, tags))
+        tags = list(map(lambda t: t.split("/")[-1] if "/" in t else t, tags))
         print(tags)
 
-    printInfo(f'Tags found: {str(tags)}')
+    printInfo(f"Tags found: {str(tags)}")
 
     rootTags = list(filter(lambda tag: tag.startswith(CLING_TAG_ROOT_HASH_PREFIX), tags))
     if not rootTags:
-        raise ValueError(f'No sync tags starting with {CLING_TAG_ROOT_HASH_PREFIX} were found!')
+        raise ValueError(f"No sync tags starting with {CLING_TAG_ROOT_HASH_PREFIX} were found!")
     if len(rootTags) > 1:
-        raise ValueError(f'More than one sync tag were found: {str(rootTags)}!')
+        raise ValueError(f"More than one sync tag were found: {str(rootTags)}!")
     return rootTags[0]
 
+
 def getStartingRootHash(rootTag):
-    printInfo('Getting the starting ROOT Hash from the tag')
+    printInfo("Getting the starting ROOT Hash from the tag")
     prefixLen = len(CLING_TAG_ROOT_HASH_PREFIX)
     defHashLen = len(DEFAULT_STARTING_ROOT_HASH)
-    hash = rootTag[prefixLen:prefixLen+defHashLen]
+    hash = rootTag[prefixLen : prefixLen + defHashLen]
     return hash
 
-def getHashes(repoDirName, startingHash, dirInRepoName=''):
-    out = execCommand(f'git log --oneline {startingHash}..HEAD {dirInRepoName}', thisCwd=repoDirName)
+
+def getHashes(repoDirName, startingHash, dirInRepoName=""):
+    out = execCommand(f"git log --oneline {startingHash}..HEAD {dirInRepoName}", thisCwd=repoDirName)
     hashes = []
     if not out:
         return hashes
     # skip the first line since it's '\n'
-    hashes = [line.split(' ', 1)[0] for line in out.split('\n')]
+    hashes = [line.split(" ", 1)[0] for line in out.split("\n")]
     return hashes
+
 
 def createPatches(rootHashes, interpHashes):
     patches = []
@@ -99,49 +109,52 @@ def createPatches(rootHashes, interpHashes):
     # directory and hash is there for debugging purposes.
     for rootHashtoSync in reversed(rootHashesToSync):
         keys = []
-        if rootHashtoSync in interpHashesSet: keys.append(INTERP_DIR_NAME)
+        if rootHashtoSync in interpHashesSet:
+            keys.append(INTERP_DIR_NAME)
         for key in keys:
             patchAsStr = execCommand(f"git format-patch -1 {rootHashtoSync} {key} --stdout", ROOT_REPO_DIR_NAME)
             patches.append([key, rootHashtoSync, patchAsStr])
     return patches
 
+
 def applyPatches(patches):
     for dirInRepo, hash, patchAsStr in patches:
-        ignorePathLevel = dirInRepo.count('/') + 2
+        ignorePathLevel = dirInRepo.count("/") + 2
         destDirName = DEST_INTERP_DIR_NAME
-        directoryOption = f'--directory {destDirName}' if destDirName else ''
-        printInfo(f'Applying {hash} restricted to {dirInRepo} to repository {CLING_REPO_DIR_NAME}')
-        execCommand(f'git am -p {ignorePathLevel} {directoryOption}', CLING_REPO_DIR_NAME, patchAsStr)
+        directoryOption = f"--directory {destDirName}" if destDirName else ""
+        printInfo(f"Applying {hash} restricted to {dirInRepo} to repository {CLING_REPO_DIR_NAME}")
+        execCommand(f"git am -p {ignorePathLevel} {directoryOption}", CLING_REPO_DIR_NAME, patchAsStr)
+
 
 def syncTagAndPush(oldSyncTag, rootSyncHash):
-    '''
+    """
     Replace the tag mentioning the previous root commit to which the repo was synchronized.
     Push the changes and tags upstream.
-    '''
+    """
     # We fetch the remote and local tags to make the following operations more resilient
-    remoteTags = execCommand(f'git ls-remote --tags origin', CLING_REPO_DIR_NAME)
-    localTags = execCommand(f'git tag', CLING_REPO_DIR_NAME)
+    remoteTags = execCommand("git ls-remote --tags origin", CLING_REPO_DIR_NAME)
+    localTags = execCommand("git tag", CLING_REPO_DIR_NAME)
 
     # Clean the old tag
-    printInfo(f'Found a sync tag ({oldSyncTag}): deleting it.')
+    printInfo(f"Found a sync tag ({oldSyncTag}): deleting it.")
     if oldSyncTag in localTags:
-        execCommand(f'git tag -d {oldSyncTag}', CLING_REPO_DIR_NAME)
+        execCommand(f"git tag -d {oldSyncTag}", CLING_REPO_DIR_NAME)
     if oldSyncTag in remoteTags:
-        execCommand(f'git push --delete origin  {oldSyncTag}', CLING_REPO_DIR_NAME)
+        execCommand(f"git push --delete origin  {oldSyncTag}", CLING_REPO_DIR_NAME)
     else:
-        printWarning(f'Tag {oldSyncTag} was not found in the upstream repository.')
+        printWarning(f"Tag {oldSyncTag} was not found in the upstream repository.")
 
     # Time to push the sync commits!
-    execCommand(f'git push', CLING_REPO_DIR_NAME)
+    execCommand("git push", CLING_REPO_DIR_NAME)
 
     # And finally we tag and push the tag
-    newTag = CLING_TAG_ROOT_HASH_PREFIX+rootSyncHash
-    printInfo(f'Creating a new tag ({newTag}).')
-    execCommand(f'git tag {newTag}', CLING_REPO_DIR_NAME)
-    execCommand(f'git push origin tag {newTag}', CLING_REPO_DIR_NAME)
+    newTag = CLING_TAG_ROOT_HASH_PREFIX + rootSyncHash
+    printInfo(f"Creating a new tag ({newTag}).")
+    execCommand(f"git tag {newTag}", CLING_REPO_DIR_NAME)
+    execCommand(f"git push origin tag {newTag}", CLING_REPO_DIR_NAME)
+
 
 def principal():
-
     # We want a starting hash not to deal with the entire commit history
     # of ROOT
     rootSyncTag = getRootSyncTag()
@@ -155,23 +168,23 @@ def principal():
     # If we have no commits to sync, we quit.
     if not interpHashes:
         # nothing to do, we have no commits to sync
-        printInfo('No commit to sync. Exiting now.')
+        printInfo("No commit to sync. Exiting now.")
         return 0
 
-    printInfo(f'We found:\n - {len(interpHashes)} patches from the directory {INTERP_DIR_NAME}')
+    printInfo(f"We found:\n - {len(interpHashes)} patches from the directory {INTERP_DIR_NAME}")
 
     # We now create the patches we want to apply to the cling repo
     patches = createPatches(rootHashes, interpHashes)
 
     # We now apply the patches
     if not patches:
-        printError('No patch was distilled: this status should not be reachable')
+        printError("No patch was distilled: this status should not be reachable")
         return 1
 
     # We now need to apply patches, update the tag that mentions the ROOT commit
     # to which the cling repo was synchronised and push everything.
     # First of all we need to acquire an identity
-    printInfo('Acquiring an identity in preparation to the upstreaming of the changes')
+    printInfo("Acquiring an identity in preparation to the upstreaming of the changes")
     execCommand('git config user.email "root@persona.com"', CLING_REPO_DIR_NAME)
     execCommand('git config user.name "Root Persona"', CLING_REPO_DIR_NAME)
 
@@ -179,5 +192,6 @@ def principal():
 
     syncTagAndPush(rootSyncTag, rootHashes[0])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(principal())

--- a/interpreter/cling/lib/CMakeLists.txt
+++ b/interpreter/cling/lib/CMakeLists.txt
@@ -8,8 +8,7 @@
 
 add_subdirectory(Interpreter)
 add_subdirectory(MetaProcessor)
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/UserInterface/textinput OR
-   CLING_INCLUDE_TESTS)
+if(CLING_INCLUDE_TESTS)
    add_subdirectory(UserInterface)
 endif()
 add_subdirectory(Utils)

--- a/interpreter/cling/lib/UserInterface/CMakeLists.txt
+++ b/interpreter/cling/lib/UserInterface/CMakeLists.txt
@@ -7,40 +7,12 @@
 #------------------------------------------------------------------------------
 
 set( LLVM_LINK_COMPONENTS
+  LineEditor
   support
 )
 
-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/textinput)
-  set(TEXTINPUTSRC ${CMAKE_SOURCE_DIR}/core/textinput/src/)
-  include_directories(${TEXTINPUTSRC})
-else()
-  # For cling, install textinput *.h in include/cling/UserInterface/textinput.
-  install(DIRECTORY ${TEXTINPUTSRC}textinput
-    DESTINATION include/cling/UserInterface
-    FILES_MATCHING
-    PATTERN "CMakeFiles" EXCLUDE
-    PATTERN "*.cpp" EXCLUDE
-    PATTERN "doc" EXCLUDE
-    PATTERN "*.h"
-    )
-endif()
-
 add_cling_library(clingUserInterface
   UserInterface.cpp
-  ${TEXTINPUTSRC}textinput/Editor.cpp
-  ${TEXTINPUTSRC}textinput/History.cpp
-  ${TEXTINPUTSRC}textinput/KeyBinding.cpp
-  ${TEXTINPUTSRC}textinput/Range.cpp
-  ${TEXTINPUTSRC}textinput/SignalHandler.cpp
-  ${TEXTINPUTSRC}textinput/StreamReader.cpp
-  ${TEXTINPUTSRC}textinput/StreamReaderUnix.cpp
-  ${TEXTINPUTSRC}textinput/StreamReaderWin.cpp
-  ${TEXTINPUTSRC}textinput/TerminalConfigUnix.cpp
-  ${TEXTINPUTSRC}textinput/TerminalDisplay.cpp
-  ${TEXTINPUTSRC}textinput/TerminalDisplayUnix.cpp
-  ${TEXTINPUTSRC}textinput/TerminalDisplayWin.cpp
-  ${TEXTINPUTSRC}textinput/TextInput.cpp
-  ${TEXTINPUTSRC}textinput/TextInputContext.cpp
 
   LINK_LIBS
   clingMetaProcessor

--- a/interpreter/cling/test/CodeGeneration/Statics.C
+++ b/interpreter/cling/test/CodeGeneration/Statics.C
@@ -37,5 +37,5 @@ inst02();
 // expected-no-diagnostics
 .q
 
-// CHECK-NEXT: TERD::~TERD::inst02
+// CHECK: TERD::~TERD::inst02
 // CHECK-NEXT: TERD::~TERD::inst01

--- a/interpreter/cling/test/CodeGeneration/const.C
+++ b/interpreter/cling/test/CodeGeneration/const.C
@@ -33,5 +33,5 @@ a.val
 a.getVal()
 // CHECK-NEXT: (int) 1
 
-// CHECK-NEXT: ~A(1), this = [[PTR]]
+// CHECK: ~A(1), this = [[PTR]]
 // CHECK-NOT: ~A

--- a/interpreter/cling/test/CodeUnloading/AtExit.C
+++ b/interpreter/cling/test/CodeUnloading/AtExit.C
@@ -115,7 +115,7 @@ struct ShutdownRecursion {
 
 // Reversed registration order
 
-// CHECK-NEXT: ~ShutdownRecursion
+// CHECK: ~ShutdownRecursion
 // CHECK-NEXT: ShutdownRecursion2
 // CHECK-NEXT: ShutdownRecursion1
 // CHECK-NEXT: ShutdownRecursion0

--- a/interpreter/cling/test/Driver/Inputs/cling_history
+++ b/interpreter/cling/test/Driver/Inputs/cling_history
@@ -1,8 +1,9 @@
-/*
-comment
- * */
-static const int i = 37;
-};
-// another comment
-using std::cout;
-std::cout << "test\n";
+_HiStOrY_V2_
+/*\012
+\011\011comment\012
+\040*\040*/\012
+\011static\040const\040int\040i\040=\04037;\012
+};\012
+//\040another\040comment\012
+using\040std::cout;\012
+std::cout\040<<\040"test\134n";\012

--- a/interpreter/cling/test/Interfaces/evaluate.C
+++ b/interpreter/cling/test/Interfaces/evaluate.C
@@ -224,7 +224,8 @@ gCling->evaluate("arrV", V);
 
 // Destruct the variables with static storage:
 // Destruct arrV:
-//CHECK-NEXT: MADE{7}:dtor
+// The error `err_verify_no_directives` will add a new line here.
+//CHECK: MADE{7}:dtor
 //CHECK-NEXT: MADE{6}:dtor
 //CHECK-NEXT: MADE{5}:dtor
 

--- a/interpreter/cling/test/Prompt/Continuation.C
+++ b/interpreter/cling/test/Prompt/Continuation.C
@@ -72,7 +72,7 @@ CLING_MULTILINE_MACRO("DOWHILE");
 #define CLING_MULTILINE_TRAILING_SPACE   \    
   "Trailing Space "   \    
   "And A Tab" \		
-  " End" // expected-warning@1 {{backslash and newline separated by space}} // expected-warning@2 {{backslash and newline separated by space}}
+  " End" // expected-warning@1 {{backslash and newline separated by space}} // expected-warning@2 {{backslash and newline separated by space}} // expected-warning@3 {{backslash and newline separated by space}}
 
 CLING_MULTILINE_TRAILING_SPACE
 // CHECK-NEXT: (const char[29]) "Trailing Space And A Tab End"

--- a/interpreter/cling/test/Prompt/DontWrap.C
+++ b/interpreter/cling/test/Prompt/DontWrap.C
@@ -350,6 +350,6 @@ N::X<int> funcReturnsXint() {
 funcReturnsXint()
 // CHECK-NEXT: (N::X<int>) @0x{{.*}}
 
-// CHECK-NEXT: Nested::~Nested(80)
+// CHECK: Nested::~Nested(80)
 
 // expected-no-diagnostics


### PR DESCRIPTION
# This Pull request:

- Replace all occurrences of TextInput with LLVM's LineEditor library in `CLING`. This moves the codebase closer to clang-repl and might help in future changes. This will help in removing this whole folder from `CLING` - https://github.com/root-project/cling/tree/master/lib/UserInterface/textinput
- Corresponding replacement should also be made in `ROOT` for complete removal of TextInput. Not as straightforward as this
- A couple of tests were adjusted to make the tests pass
- Upstreamed LLVM patch adding `setHistorySize`

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

