### PR TITLE
[rbrowser] Check modified widgets after macro execution

### DIFF
--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -896,6 +896,7 @@ void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
             if ((arr->size() == 6) && (arr->at(5) == "RUN")) {
                ProcessSaveFile(editor->fFileName, editor->fContent);
                ProcessRunMacro(editor->fFileName);
+               CheckWidgtesModified();
             }
          }
       }


### PR DESCRIPTION
It is most probable place where new canvases are created or existing are modified. 
Therefore need check for update.

Simple workaround for some macros execution
