### PR TITLE
[skip-ci][ntuple] separate ROOT embedding paragraph

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -41,18 +41,20 @@ Envelopes can reference other envelopes and pages by means of a **locator** or a
 for a file embedding, the locator consists of an offset and a size.
 The RNTuple format does _not_ establish a specific order of pages and envelopes.
 
-For the ROOT file embedding, pages and envelopes are stored in "invisible", non-indexed **RBlob** keys.
+Every embedding must define an **anchor** that contains the format version supported by the writer,
+and envelope links (location, compressed and uncompressed size) of the header and footer envelopes.
+
+## ROOT File embedding
+When an RNTuple is embedded in a ROOT file, its pages and envelopes are stored in "invisible", non-indexed **RBlob** keys.
 The RNTuple format does _not_ establish a semantic mapping from objects to keys or vice versa.
 For example, one key may hold a single page or a number of pages of the same cluster.
 The only relevant means of finding objects is the locator information, consisting of an offset and a size.
 
-Every embedding must define an **anchor** that contains the format version supported by the writer,
-and envelope links (location, compressed and uncompressed size) of the header and footer envelopes.
-For the ROOT file embedding, the **ROOT::Experimental::RNTuple** object acts as an anchor.
+For the ROOT file embedding, the `ROOT::Experimental::RNTuple` object acts as an anchor.
 
 ### Anchor schema
 
-The current (class version 6) **ROOT::Experimental::RNTuple** object has the following schema:
+The anchor for a ROOT file embedding has the following schema:
 
 ```
  0                   1                   2                   3


### PR DESCRIPTION
Adding an explicit section for the ROOT File embedding rather than having it in the Introduction. Slight rewording of the anchor schema introduction.