### PR TITLE
[geom] New BVH/VoxelGrid-based implementation of TGeoParallelWorld routines

### DIFF
--- a/geom/geom/inc/TGeoParallelWorld.h
+++ b/geom/geom/inc/TGeoParallelWorld.h
@@ -6,12 +6,14 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-// Author: Andrei Gheata   30/06/14
+// Authors: Andrei Gheata   30/06/14
+//          Sandro Wenzel   01/09/24
 
 #ifndef ROOT_TGeoParallelWorld
 #define ROOT_TGeoParallelWorld
 
 #include "TNamed.h"
+#include "TGeoVoxelGrid.h"
 
 // forward declarations
 class TGeoManager;
@@ -19,6 +21,22 @@ class TGeoPhysicalNode;
 class TGeoVolume;
 
 class TGeoParallelWorld : public TNamed {
+
+public:
+   // internal enum letting choose between
+   // VoxelFinder or BVH-based algorithms
+   enum class AccelerationMode { kVoxelFinder, kBVH };
+
+   // a structure for safety evaluation (caching) purpose
+   // to be stored per 3D grid voxel
+   struct SafetyVoxelInfo {
+      float min_safety{-1.f}; // the minimum safety from the mid-point of this voxel to any leaf bounding box
+      int idx_start{-1}; // the index into an external storage, where candidate bounding boxes to search for this voxel
+                         // are stored (if -1) --> VoxelInfo not yet initialized
+      unsigned int num_candidates{0}; // the number of candidate bounding boxes to search
+      bool isInitialized() const { return idx_start >= 0; }
+   };
+
 protected:
    TGeoManager *fGeoManager;     // base geometry
    TObjArray *fPaths;            // array of paths
@@ -27,6 +45,14 @@ protected:
    TGeoVolume *fVolume;          //! helper volume
    TGeoPhysicalNode *fLastState; //! Last PN touched
    TObjArray *fPhysical;         //! array of physical nodes
+
+   void *fBVH = nullptr; //! BVH helper structure for safety and navigation
+   TGeoVoxelGrid<SafetyVoxelInfo> *fSafetyVoxelCache =
+      nullptr;                                        //! A regular 3D cache layer for fast point-based safety lookups
+   std::vector<unsigned int> fSafetyCandidateStore{}; //! stores bounding boxes serving a quick safety candidates (to be
+                                                      //! used with the VoxelGrid and SafetyVoxelInfo)
+   void *fBoundingBoxes = nullptr;                    //! to keep the vector of primitive axis aligned bounding boxes
+   AccelerationMode fAccMode = AccelerationMode::kVoxelFinder; //! switch between different algorithm implementations
 
    TGeoParallelWorld(const TGeoParallelWorld &) = delete;
    TGeoParallelWorld &operator=(const TGeoParallelWorld &) = delete;
@@ -65,10 +91,52 @@ public:
    // Refresh structures in case of re-alignment
    void RefreshPhysicalNodes();
 
-   // Navigation interface
-   TGeoPhysicalNode *FindNode(Double_t point[3]);
-   TGeoPhysicalNode *FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax = 1.E30);
-   Double_t Safety(Double_t point[3], Double_t safmax = 1.E30);
+   // ability to choose algorithm implementation; should be called before CloseGeometry
+   void SetAccelerationMode(AccelerationMode const &mode) { fAccMode = mode; }
+   AccelerationMode const &GetAccelerationMode() const { return fAccMode; }
+
+   // BVH related functions for building, printing, checking
+   void BuildBVH();
+   void PrintBVH() const;
+   bool CheckBVH(void *, size_t) const;
+
+   // --- main navigation interfaces ----
+
+   // FindNode
+   TGeoPhysicalNode *FindNode(Double_t point[3])
+   {
+      switch (fAccMode) {
+      case AccelerationMode::kVoxelFinder: return FindNodeOrig(point);
+      case AccelerationMode::kBVH:
+         return FindNodeBVH(point);
+         // case AccelerationMode::kLoop : return FindNodeLoop(point);
+      }
+      return nullptr;
+   }
+
+   // main interface for Safety
+   Double_t Safety(Double_t point[3], Double_t safmax = 1.E30)
+   {
+      switch (fAccMode) {
+      case AccelerationMode::kVoxelFinder: return SafetyOrig(point, safmax);
+      case AccelerationMode::kBVH:
+         return VoxelSafety(point, safmax);
+         // case AccelerationMode::kLoop : return SafetyLoop(point, safmax);
+      }
+      return 0;
+   }
+
+   // main interface for FindNextBoundary
+   TGeoPhysicalNode *FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax = 1.E30)
+   {
+      switch (fAccMode) {
+      case AccelerationMode::kVoxelFinder: return FindNextBoundaryOrig(point, dir, step, stepmax);
+      case AccelerationMode::kBVH:
+         return FindNextBoundaryBVH(point, dir, step, stepmax);
+         // case AccelerationMode::kLoop : return FindNextBoundaryLoop(point, dir, step, stepmax);
+      }
+      return nullptr;
+   }
 
    // Getters
    TGeoManager *GetGeometry() const { return fGeoManager; }
@@ -78,6 +146,40 @@ public:
    // Utilities
    void CheckOverlaps(Double_t ovlp = 0.001); // default 10 microns
    void Draw(Option_t *option) override;
+
+private:
+   // various implementations for FindNextBoundary
+   TGeoPhysicalNode *FindNextBoundaryLoop(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax = 1.E30);
+   TGeoPhysicalNode *FindNextBoundaryOrig(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax = 1.E30);
+   TGeoPhysicalNode *FindNextBoundaryBVH(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax = 1.E30);
+
+   // various implementations for FindNode
+   TGeoPhysicalNode *FindNodeLoop(Double_t point[3]);
+   TGeoPhysicalNode *FindNodeOrig(Double_t point[3]);
+   TGeoPhysicalNode *FindNodeBVH(Double_t point[3]);
+
+   // various implementations for Safety
+   Double_t SafetyLoop(Double_t point[3], Double_t safmax = 1.E30);
+   Double_t SafetyBVH(Double_t point[3], Double_t safmax = 1.E30);
+   Double_t SafetyOrig(Double_t point[3], Double_t safmax = 1.E30);
+   Double_t VoxelSafety(Double_t point[3], Double_t safmax = 1.E30);
+
+   // helper functions related to local safety caching (3D voxel grid)
+
+   // Given a 3D point, returns the
+   // a) the min radius R such that there is at least one leaf bounding box fully enclosed
+   //    in the sphere of radius R around point
+   // b) the set of leaf bounding boxes who partially lie within radius + margin
+
+   // ... using BVH
+   std::pair<double, double>
+   GetBVHSafetyCandidates(double point[3], std::vector<int> &candidates, double margin = 0.) const;
+   // .... same with a simpler, slower algorithm
+   std::pair<double, double>
+   GetLoopSafetyCandidates(double point[3], std::vector<int> &candidates, double margin = 0.) const;
+
+   void InitSafetyVoxel(TGeoVoxelGridIndex const &);
+   void TestVoxelGrid(); // a debug method to play with the voxel grid
 
    ClassDefOverride(TGeoParallelWorld, 3) // parallel world base class
 };

--- a/geom/geom/inc/TGeoVoxelGrid.h
+++ b/geom/geom/inc/TGeoVoxelGrid.h
@@ -1,0 +1,176 @@
+/// \author Sandro Wenzel <sandro.wenzel@cern.ch>
+/// \date 2024-02-22
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGeoVoxelGrid
+#define ROOT_TGeoVoxelGrid
+
+// a simple structure to encode voxel indices, to address
+// individual voxels in the 3D grid.
+struct TGeoVoxelGridIndex {
+   int ix{-1};
+   int iy{-1};
+   int iz{-1};
+   size_t idx{std::numeric_limits<size_t>::max()};
+   bool isValid() const { return idx != std::numeric_limits<size_t>::max(); }
+};
+
+/// A finite 3D grid structure, mapping/binning arbitrary 3D cartesian points
+/// onto discrete "voxels". Each such voxel can store an object of type T.
+/// The precision of the voxel binning is done with S (float or double).
+template <typename T, typename S = float>
+class TGeoVoxelGrid {
+public:
+   TGeoVoxelGrid(S xmin, S ymin, S zmin, S xmax, S ymax, S zmax, S Lx_, S Ly_, S Lz_)
+      : fMinBound{xmin, ymin, zmin}, fMaxBound{xmax, ymax, zmax}, fLx(Lx_), fLy(Ly_), fLz(Lz_)
+   {
+
+      // Calculate the number of voxels in each dimension
+      fNx = static_cast<int>((fMaxBound[0] - fMinBound[0]) / fLx);
+      fNy = static_cast<int>((fMaxBound[1] - fMinBound[1]) / fLy);
+      fNz = static_cast<int>((fMaxBound[2] - fMinBound[2]) / fLz);
+
+      finvLx = 1. / fLx;
+      finvLy = 1. / fLy;
+      finvLz = 1. / fLz;
+
+      fHalfDiag = std::sqrt(fLx / 2. * fLx / 2. + fLy / 2. * fLy / 2. + fLz / 2. * fLz / 2.);
+
+      // Resize the grid to hold the voxels
+      fGrid.resize(fNx * fNy * fNz);
+   }
+
+   T &at(int i, int j, int k) { return fGrid[index(i, j, k)]; }
+
+   // check if point is covered by voxel structure
+   bool inside(std::array<S, 3> const &p) const
+   {
+      for (int i = 0; i < 3; ++i) {
+         if (p[i] < fMinBound[i] || p[i] > fMaxBound[i]) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   // Access a voxel given a 3D point P
+   T &at(std::array<S, 3> const &P)
+   {
+      int i, j, k;
+      pointToVoxelIndex(P, i, j, k); // Convert point to voxel index
+      return fGrid[index(i, j, k)];  // Return reference to voxel's data
+   }
+
+   T *at(TGeoVoxelGridIndex const &vi)
+   {
+      if (!vi.isValid()) {
+         return nullptr;
+      }
+      return &fGrid[vi.idx];
+   }
+
+   // Set the data of a voxel at point P
+   void set(std::array<S, 3> const &p, const T &value)
+   {
+      int i, j, k;
+      pointToVoxelIndex(p, i, j, k); // Convert point to voxel index
+      fGrid[index(i, j, k)] = value; // Set the value at the voxel
+   }
+
+   // Set the data of a voxel at point P
+   void set(int i, int j, int k, const T &value)
+   {
+      fGrid[index(i, j, k)] = value; // Set the value at the voxel
+   }
+
+   void set(TGeoVoxelGridIndex const &vi, const T &value) { fGrid[vi.idx] = value; }
+
+   // Get voxel dimensions
+   int getVoxelCountX() const { return fNx; }
+   int getVoxelCountY() const { return fNy; }
+   int getVoxelCountZ() const { return fNz; }
+
+   // returns the cartesian mid-point coordinates of a voxel given by a VoxelIndex
+   std::array<S, 3> getVoxelMidpoint(TGeoVoxelGridIndex const &vi) const
+   {
+      const S midX = fMinBound[0] + (vi.ix + 0.5) * fLx;
+      const S midY = fMinBound[1] + (vi.iy + 0.5) * fLy;
+      const S midZ = fMinBound[2] + (vi.iz + 0.5) * fLz;
+
+      return {midX, midY, midZ};
+   }
+
+   S getDiagonalLength() const { return fHalfDiag; }
+
+   // Convert a point p(x, y, z) to voxel indices (i, j, k)
+   // if point is outside set indices i,j,k to -1
+   void pointToVoxelIndex(std::array<S, 3> const &p, int &i, int &j, int &k) const
+   {
+      if (!inside(p)) {
+         i = -1;
+         j = -1;
+         k = -1;
+      }
+
+      i = static_cast<int>((p[0] - fMinBound[0]) * finvLx);
+      j = static_cast<int>((p[1] - fMinBound[1]) * finvLy);
+      k = static_cast<int>((p[2] - fMinBound[2]) * finvLz);
+
+      // Clamp the indices to valid ranges
+      i = std::min(i, fNx - 1);
+      j = std::min(j, fNy - 1);
+      k = std::min(k, fNz - 1);
+   }
+
+   // Convert a point p(x, y, z) to voxel index object
+   // if outside, an invalid index object will be returned
+   TGeoVoxelGridIndex pointToVoxelIndex(std::array<S, 3> const &p) const
+   {
+      if (!inside(p)) {
+         return TGeoVoxelGridIndex(); // invalid voxel index
+      }
+
+      int i = static_cast<int>((p[0] - fMinBound[0]) * finvLx);
+      int j = static_cast<int>((p[1] - fMinBound[1]) * finvLy);
+      int k = static_cast<int>((p[2] - fMinBound[2]) * finvLz);
+
+      // Clamp the indices to valid ranges
+      i = std::min(i, fNz - 1);
+      j = std::min(j, fNy - 1);
+      k = std::min(k, fNz - 1);
+
+      return TGeoVoxelGridIndex{i, j, k, index(i, j, k)};
+   }
+
+   TGeoVoxelGridIndex pointToVoxelIndex(S x, S y, S z) const { return pointToVoxelIndex(std::array<S, 3>{x, y, z}); }
+
+   // Convert voxel indices (i, j, k) to a linear index in the grid array
+   size_t index(int i, int j, int k) const { return i + fNx * (j + fNy * k); }
+
+   void indexToIndices(size_t idx, int &i, int &j, int &k) const
+   {
+      k = idx % fNz;
+      j = (idx / fNz) % fNy;
+      i = idx / (fNy * fNz);
+   }
+
+   // member data
+
+   std::array<S, 3> fMinBound;
+   std::array<S, 3> fMaxBound; // 3D bounds for grid structure
+   S fLx, fLy, fLz;            // Voxel dimensions
+   S finvLx, finvLy, finvLz;   // inverse voxel dimensions
+   S fHalfDiag;                // cached value for voxel half diagonal length
+
+   int fNx, fNy, fNz;    // Number of voxels in each dimension
+   std::vector<T> fGrid; // The actual voxel grid data container
+};
+
+#endif

--- a/geom/geom/inc/bvh/v2/CMakeLists.txt
+++ b/geom/geom/inc/bvh/v2/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(bvh INTERFACE)
+find_package(Threads)
+if (Threads_FOUND)
+    # Link with the threading library of the system, which may
+    # be required by standard header <thread> on some systems
+    target_link_libraries(bvh INTERFACE Threads::Threads)
+endif()
+
+target_include_directories(bvh INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>)
+
+set_target_properties(bvh PROPERTIES CXX_STANDARD 20)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION include/bvh/v2
+    FILES_MATCHING PATTERN "*.h"
+    PATTERN "c_api" EXCLUDE)
+
+if (BVH_BUILD_C_API)
+    add_subdirectory(c_api)
+endif()

--- a/geom/geom/inc/bvh/v2/README.md
+++ b/geom/geom/inc/bvh/v2/README.md
@@ -1,0 +1,13 @@
+These headers, providing routines to construct and navigate
+bounding volume hierarchies, have been copied from https://github.com/madmann91/bvh
+commit 66e445b92f68801a6dd8ef94.
+
+
+Minor changes have been subsequently been applied to achieve compilation with C++17:
+
+- inclusion of alternative span, when std::span is not found
+- replacement of C++20 defaulted comparison operators with actual implementation
+- old-style struct construction for objects of type "Reinsertion"
+- use of std::inner_product instead of std::transform_reduce (gcc 8.5 had problems)
+
+This is needed since ROOT should compile with C++17.

--- a/geom/geom/inc/bvh/v2/bbox.h
+++ b/geom/geom/inc/bvh/v2/bbox.h
@@ -1,0 +1,49 @@
+#ifndef BVH_V2_BBOX_H
+#define BVH_V2_BBOX_H
+
+#include "bvh/v2/vec.h"
+#include "bvh/v2/utils.h"
+
+#include <limits>
+
+namespace bvh::v2 {
+
+template <typename T, size_t N>
+struct BBox {
+    Vec<T, N> min, max;
+
+    BBox() = default;
+    BVH_ALWAYS_INLINE BBox(const Vec<T, N>& min, const Vec<T, N>& max) : min(min), max(max) {}
+    BVH_ALWAYS_INLINE explicit BBox(const Vec<T, N>& point) : BBox(point, point) {}
+
+    BVH_ALWAYS_INLINE BBox& extend(const Vec<T, N>& point) {
+        return extend(BBox(point));
+    }
+
+    BVH_ALWAYS_INLINE BBox& extend(const BBox& other) {
+        min = robust_min(min, other.min);
+        max = robust_max(max, other.max);
+        return *this;
+    }
+
+    BVH_ALWAYS_INLINE Vec<T, N> get_diagonal() const { return max - min; }
+    BVH_ALWAYS_INLINE Vec<T, N> get_center() const { return (max + min) * static_cast<T>(0.5); }
+
+    BVH_ALWAYS_INLINE T get_half_area() const {
+        auto d = get_diagonal();
+        static_assert(N == 2 || N == 3);
+        if constexpr (N == 3) return (d[0] + d[1]) * d[2] + d[0] * d[1];
+        if constexpr (N == 2) return d[0] + d[1];
+        return static_cast<T>(0.);
+    }
+
+    BVH_ALWAYS_INLINE static constexpr BBox make_empty() {
+        return BBox(
+            Vec<T, N>(+std::numeric_limits<T>::max()),
+            Vec<T, N>(-std::numeric_limits<T>::max()));
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/binned_sah_builder.h
+++ b/geom/geom/inc/bvh/v2/binned_sah_builder.h
@@ -1,0 +1,161 @@
+#ifndef BVH_V2_BINNED_SAH_BUILDER_H
+#define BVH_V2_BINNED_SAH_BUILDER_H
+
+#include "bvh/v2/top_down_sah_builder.h"
+
+#include <stack>
+#include <tuple>
+#include <algorithm>
+#include <optional>
+#include <numeric>
+#include <cassert>
+
+namespace bvh::v2 {
+
+/// Single-threaded top-down builder that partitions primitives based on a binned approximation of
+/// the Surface Area Heuristic (SAH). This builder is inspired by
+/// "On Fast Construction of SAH-based Bounding Volume Hierarchies", by I. Wald.
+template <typename Node, size_t BinCount = 8>
+class BinnedSahBuilder : public TopDownSahBuilder<Node> {
+    using typename TopDownSahBuilder<Node>::Scalar;
+    using typename TopDownSahBuilder<Node>::Vec;
+    using typename TopDownSahBuilder<Node>::BBox;
+
+    using TopDownSahBuilder<Node>::build;
+    using TopDownSahBuilder<Node>::config_;
+    using TopDownSahBuilder<Node>::bboxes_;
+    using TopDownSahBuilder<Node>::centers_;
+
+public:
+    using typename TopDownSahBuilder<Node>::Config;
+
+    BVH_ALWAYS_INLINE static Bvh<Node> build(
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config = {})
+    {
+        return BinnedSahBuilder(bboxes, centers, config).build();
+    }
+
+protected:
+    struct Split {
+        size_t bin_id;
+        Scalar cost;
+        size_t axis;
+    };
+
+    struct Bin {
+        BBox bbox = BBox::make_empty();
+        size_t prim_count = 0;
+
+        Bin() = default;
+
+        BVH_ALWAYS_INLINE Scalar get_cost(const SplitHeuristic<Scalar>& sah) const {
+            return sah.get_leaf_cost(0, prim_count, bbox);
+        }
+
+        BVH_ALWAYS_INLINE void add(const BBox& bbox, size_t prim_count = 1) {
+            this->bbox.extend(bbox);
+            this->prim_count += prim_count;
+        }
+
+        BVH_ALWAYS_INLINE void add(const Bin& bin) { add(bin.bbox, bin.prim_count); }
+    };
+
+    using Bins = std::array<Bin, BinCount>;
+    using PerAxisBins = std::array<Bins, Node::dimension>;
+
+    std::vector<size_t> prim_ids_;
+
+    BVH_ALWAYS_INLINE BinnedSahBuilder(
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config)
+        : TopDownSahBuilder<Node>(bboxes, centers, config)
+        , prim_ids_(bboxes.size())
+    {
+        std::iota(prim_ids_.begin(), prim_ids_.end(), 0);
+    }
+
+    std::vector<size_t>& get_prim_ids() override { return prim_ids_; }
+
+    BVH_ALWAYS_INLINE void fill_bins(
+        PerAxisBins& per_axis_bins,
+        const BBox& bbox,
+        size_t begin,
+        size_t end)
+    {
+        auto bin_scale = Vec(BinCount) / bbox.get_diagonal();
+        auto bin_offset = -bbox.min * bin_scale;
+
+        for (size_t i = begin; i < end; ++i) {
+            auto pos = fast_mul_add(centers_[prim_ids_[i]], bin_scale, bin_offset);
+            static_for<0, Node::dimension>([&] (size_t axis) {
+                size_t index = std::min(BinCount - 1,
+                    static_cast<size_t>(robust_max(pos[axis], static_cast<Scalar>(0.))));
+                per_axis_bins[axis][index].add(bboxes_[prim_ids_[i]]);
+            });
+        }
+    }
+
+    void find_best_split(size_t axis, const Bins& bins, Split& best_split) {
+        Bin right_accum;
+        std::array<Scalar, BinCount> right_costs;
+        for (size_t i = BinCount - 1; i > 0; --i) {
+            right_accum.add(bins[i]);
+            right_costs[i] = right_accum.get_cost(config_.sah);
+        }
+
+        Bin left_accum;
+        for (size_t i = 0; i < BinCount - 1; ++i) {
+            left_accum.add(bins[i]);
+            auto cost = left_accum.get_cost(config_.sah) + right_costs[i + 1];
+            if (cost < best_split.cost)
+                best_split = Split { i + 1, cost, axis };
+        }
+    }
+
+    size_t fallback_split(size_t axis, size_t begin, size_t end) {
+        size_t mid = (begin + end + 1) / 2;
+        std::partial_sort(
+            prim_ids_.begin() + begin,
+            prim_ids_.begin() + mid,
+            prim_ids_.begin() + end,
+            [&] (size_t i, size_t j) { return centers_[i][axis] < centers_[j][axis]; });
+        return mid;
+    }
+
+    std::optional<size_t> try_split(const BBox& bbox, size_t begin, size_t end) override {
+        PerAxisBins per_axis_bins;
+        fill_bins(per_axis_bins, bbox, begin, end);
+
+        auto largest_axis = bbox.get_diagonal().get_largest_axis();
+        auto best_split = Split { BinCount / 2, std::numeric_limits<Scalar>::max(), largest_axis };
+        for (size_t axis = 0; axis < Node::dimension; ++axis)
+            find_best_split(axis, per_axis_bins[axis], best_split);
+
+        // Make sure that the split is good before proceeding with it
+        auto leaf_cost = config_.sah.get_non_split_cost(begin, end, bbox);
+        if (best_split.cost >= leaf_cost) {
+            if (end - begin <= config_.max_leaf_size)
+                return std::nullopt;
+            return fallback_split(largest_axis, begin, end);
+        }
+
+        auto split_pos = fast_mul_add(
+            bbox.get_diagonal()[best_split.axis] / static_cast<Scalar>(BinCount),
+            static_cast<Scalar>(best_split.bin_id),
+            bbox.min[best_split.axis]);
+
+        size_t index = std::partition(prim_ids_.begin() + begin, prim_ids_.begin() + end,
+            [&] (size_t i) { return centers_[i][best_split.axis] < split_pos; }) - prim_ids_.begin();
+        if (index == begin || index == end)
+            return fallback_split(largest_axis, begin, end);
+
+        return std::make_optional(index);
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/bvh.h
+++ b/geom/geom/inc/bvh/v2/bvh.h
@@ -1,0 +1,247 @@
+#ifndef BVH_V2_BVH_H
+#define BVH_V2_BVH_H
+
+#include "bvh/v2/node.h"
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+#include <stack>
+#include <utility>
+#include <tuple>
+#include <algorithm>
+
+namespace bvh::v2 {
+
+template <typename Node>
+struct Bvh {
+    using Index = typename Node::Index;
+    using Scalar = typename Node::Scalar;
+    using Ray = bvh::v2::Ray<Scalar, Node::dimension>;
+
+    std::vector<Node> nodes;
+    std::vector<size_t> prim_ids;
+
+    Bvh() = default;
+    Bvh(Bvh&&) = default;
+
+    Bvh& operator = (Bvh&&) = default;
+
+    //bool operator == (const Bvh& other) const = default;
+    //bool operator != (const Bvh& other) const = default;
+    bool operator == (const Bvh& other) const {
+        return other.nodes == nodes && other.prim_ids == prim_ids;
+    }
+    bool operator != (const Bvh& other) const {
+        return other.nodes != nodes || other.prim_ids != prim_ids;
+    }
+
+    /// Returns whether the node located at the given index is the left child of its parent.
+    static BVH_ALWAYS_INLINE bool is_left_sibling(size_t node_id) { return node_id % 2 == 1; }
+
+    /// Returns the index of a sibling of a node.
+    static BVH_ALWAYS_INLINE size_t get_sibling_id(size_t node_id) {
+        return is_left_sibling(node_id) ? node_id + 1 : node_id - 1;
+    }
+
+    /// Returns the index of the left sibling of the node. This effectively returns the given index
+    /// unchanged if the node is the left sibling, or the other sibling index otherwise.
+    static BVH_ALWAYS_INLINE size_t get_left_sibling_id(size_t node_id) {
+        return is_left_sibling(node_id) ? node_id : node_id - 1;
+    }
+
+    /// Returns the index of the right sibling of the node. This effectively returns the given index
+    /// unchanged if the node is the right sibling, or the other sibling index otherwise.
+    static BVH_ALWAYS_INLINE size_t get_right_sibling_id(size_t node_id) {
+        return is_left_sibling(node_id) ? node_id + 1 : node_id;
+    }
+
+    /// Returns the root node of this BVH.
+    BVH_ALWAYS_INLINE const Node& get_root() const { return nodes[0]; }
+
+    /// Extracts the BVH rooted at the given node index.
+    inline Bvh extract_bvh(size_t root_id) const;
+
+    /// Traverses the BVH from the given index in `start` using the provided stack. Every leaf
+    /// encountered on the way is processed using the given `LeafFn` function, and every pair of
+    /// nodes is processed with the function in `HitFn`, which returns a triplet of booleans
+    /// indicating whether the first child should be processed, whether the second child should be
+    /// processed, and whether to traverse the second child first instead of the other way around.
+    template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn>
+    inline void traverse_top_down(Index start, Stack&, LeafFn&&, InnerFn&&) const;
+
+    /// Intersects the BVH with a single ray, using the given function to intersect the contents
+    /// of a leaf. The algorithm starts at the node index `start` and uses the given stack object.
+    /// When `IsAnyHit` is true, the function stops at the first intersection (useful for shadow
+    /// rays), otherwise it finds the closest intersection. When `IsRobust` is true, a slower but
+    /// numerically robust ray-box test is used, otherwise a fast, but less precise test is used.
+    template <bool IsAnyHit, bool IsRobust, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
+    inline void intersect(const Ray& ray, Index start, Stack&, LeafFn&&, InnerFn&& = {}) const;
+
+    /// Traverses this BVH from the bottom to the top, using the given function objects to process
+    /// leaves and inner nodes.
+    template <typename LeafFn = IgnoreArgs, typename InnerFn = IgnoreArgs>
+    inline void traverse_bottom_up(LeafFn&& = {}, InnerFn&& = {});
+
+    /// Refits the BVH, using the given function object to recompute the bounding box of the leaves.
+    template <typename LeafFn = IgnoreArgs>
+    inline void refit(LeafFn&& = {});
+
+    inline void serialize(OutputStream&) const;
+    static inline Bvh deserialize(InputStream&);
+};
+
+template <typename Node>
+Bvh<Node> Bvh<Node>::extract_bvh(size_t root_id) const {
+    assert(root_id != 0);
+
+    Bvh bvh;
+    bvh.nodes.emplace_back();
+
+    std::stack<std::pair<size_t, size_t>> stack;
+    stack.emplace(root_id, 0);
+    while (!stack.empty()) {
+        auto [src_id, dst_id] = stack.top();
+        stack.pop();
+        const auto& src_node = nodes[src_id];
+        auto& dst_node = bvh.nodes[dst_id];
+        dst_node = src_node;
+        if (src_node.is_leaf()) {
+            dst_node.index.set_first_id(bvh.prim_ids.size());
+            std::copy_n(
+                prim_ids.begin() + src_node.index.first_id(),
+                src_node.index.prim_count(),
+                std::back_inserter(bvh.prim_ids));
+        } else {
+            dst_node.index.set_first_id(bvh.nodes.size());
+            stack.emplace(src_node.index.first_id() + 0, bvh.nodes.size() + 0);
+            stack.emplace(src_node.index.first_id() + 1, bvh.nodes.size() + 1);
+            // Note: This may invalidate `dst_node` so has to happen after any access to it.
+            bvh.nodes.emplace_back();
+            bvh.nodes.emplace_back();
+        }
+    }
+    return bvh;
+}
+
+template <typename Node>
+template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn>
+void Bvh<Node>::traverse_top_down(Index start, Stack& stack, LeafFn&& leaf_fn, InnerFn&& inner_fn) const
+{
+    stack.push(start);
+restart:
+    while (!stack.is_empty()) {
+        auto top = stack.pop();
+        while (top.prim_count() == 0) {
+            auto& left  = nodes[top.first_id()];
+            auto& right = nodes[top.first_id() + 1];
+            auto [hit_left, hit_right, should_swap] = inner_fn(left, right);
+
+            if (hit_left) {
+                auto near_index = left.index;
+                if (hit_right) {
+                    auto far_index = right.index;
+                    if (should_swap)
+                        std::swap(near_index, far_index);
+                    stack.push(far_index);
+                }
+                top = near_index;
+            } else if (hit_right)
+                top = right.index;
+            else [[unlikely]]
+                goto restart;
+        }
+
+        [[maybe_unused]] auto was_hit = leaf_fn(top.first_id(), top.first_id() + top.prim_count());
+        if constexpr (IsAnyHit) {
+            if (was_hit) return;
+        }
+    }
+}
+
+template <typename Node>
+template <bool IsAnyHit, bool IsRobust, typename Stack, typename LeafFn, typename InnerFn>
+void Bvh<Node>::intersect(const Ray& ray, Index start, Stack& stack, LeafFn&& leaf_fn, InnerFn&& inner_fn) const {
+    auto inv_dir = ray.template get_inv_dir<!IsRobust>();
+    auto inv_org = -inv_dir * ray.org;
+    auto inv_dir_pad = ray.pad_inv_dir(inv_dir);
+    auto octant = ray.get_octant();
+
+    traverse_top_down<IsAnyHit>(start, stack, leaf_fn, [&] (const Node& left, const Node& right) {
+        inner_fn(left, right);
+        std::pair<Scalar, Scalar> intr_left, intr_right;
+        if constexpr (IsRobust) {
+            intr_left  = left .intersect_robust(ray, inv_dir, inv_dir_pad, octant);
+            intr_right = right.intersect_robust(ray, inv_dir, inv_dir_pad, octant);
+        } else {
+            intr_left  = left .intersect_fast(ray, inv_dir, inv_org, octant);
+            intr_right = right.intersect_fast(ray, inv_dir, inv_org, octant);
+        }
+        return std::make_tuple(
+            intr_left.first <= intr_left.second,
+            intr_right.first <= intr_right.second,
+            !IsAnyHit && intr_left.first > intr_right.first);
+    });
+}
+
+template <typename Node>
+template <typename LeafFn, typename InnerFn>
+void Bvh<Node>::traverse_bottom_up(LeafFn&& leaf_fn, InnerFn&& inner_fn) {
+    std::vector<size_t> parents(nodes.size(), 0);
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        if (nodes[i].is_leaf())
+            continue;
+        parents[nodes[i].index.first_id()] = i;
+        parents[nodes[i].index.first_id() + 1] = i;
+    }
+    std::vector<bool> seen(nodes.size(), false);
+    for (size_t i = nodes.size(); i-- > 0;) {
+        if (!nodes[i].is_leaf())
+            continue;
+        leaf_fn(nodes[i]);
+        seen[i] = true;
+        for (size_t j = parents[i];; j = parents[j]) {
+            auto& node = nodes[j];
+            if (seen[j] || !seen[node.index.first_id()] || !seen[node.index.first_id() + 1])
+                break;
+            inner_fn(nodes[j]);
+            seen[j] = true;
+        }
+    }
+}
+
+template <typename Node>
+template <typename LeafFn>
+void Bvh<Node>::refit(LeafFn&& leaf_fn) {
+    traverse_bottom_up(leaf_fn, [&] (Node& node) {
+        const auto& left  = nodes[node.index.first_id()];
+        const auto& right = nodes[node.index.first_id() + 1];
+        node.set_bbox(left.get_bbox().extend(right.get_bbox()));
+    });
+}
+
+template <typename Node>
+void Bvh<Node>::serialize(OutputStream& stream) const {
+    stream.write(nodes.size());
+    stream.write(prim_ids.size());
+    for (auto&& node : nodes)
+        node.serialize(stream);
+    for (auto&& prim_id : prim_ids)
+        stream.write(prim_id);
+}
+
+template <typename Node>
+Bvh<Node> Bvh<Node>::deserialize(InputStream& stream) {
+    Bvh bvh;
+    bvh.nodes.resize(stream.read<size_t>());
+    bvh.prim_ids.resize(stream.read<size_t>());
+    for (auto& node : bvh.nodes)
+        node = Node::deserialize(stream);
+    for (auto& prim_id : bvh.prim_ids)
+        prim_id = stream.read<size_t>();
+    return bvh;
+}
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/default_builder.h
+++ b/geom/geom/inc/bvh/v2/default_builder.h
@@ -1,0 +1,78 @@
+#ifndef BVH_V2_DEFAULT_BUILDER_H
+#define BVH_V2_DEFAULT_BUILDER_H
+
+#include "bvh/v2/mini_tree_builder.h"
+#include "bvh/v2/sweep_sah_builder.h"
+#include "bvh/v2/binned_sah_builder.h"
+#include "bvh/v2/reinsertion_optimizer.h"
+#include "bvh/v2/thread_pool.h"
+
+namespace bvh::v2 {
+
+/// This builder is only a wrapper around all the other builders, which selects the best builder
+/// depending on the desired BVH quality and whether a multi-threaded build is desired.
+template <typename Node>
+class DefaultBuilder {
+    using Scalar = typename Node::Scalar;
+    using Vec  = bvh::v2::Vec<Scalar, Node::dimension>;
+    using BBox = bvh::v2::BBox<Scalar, Node::dimension>;
+
+public:
+    enum class Quality { Low, Medium, High };
+
+    struct Config : TopDownSahBuilder<Node>::Config {
+        /// The quality of the BVH produced by the builder. The higher the quality the faster the
+        /// BVH is to traverse, but the slower it is to build.
+        Quality quality = Quality::High;
+
+        /// Threshold, in number of primitives, under which the builder operates in a single-thread.
+        size_t parallel_threshold = 1024;
+    };
+
+    /// Build a BVH in parallel using the given thread pool.
+    BVH_ALWAYS_INLINE static Bvh<Node> build(
+        ThreadPool& thread_pool,
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config = {})
+    {
+        if (bboxes.size() < config.parallel_threshold)
+            return build(bboxes, centers, config);
+        auto bvh = MiniTreeBuilder<Node>::build(
+            thread_pool, bboxes, centers, make_mini_tree_config(config));
+        if (config.quality == Quality::High)
+            ReinsertionOptimizer<Node>::optimize(thread_pool, bvh);
+        return bvh;
+    }
+
+    /// Build a BVH in a single-thread.
+    BVH_ALWAYS_INLINE static Bvh<Node> build(
+        std::span<const BBox>  bboxes,
+        std::span<const Vec> centers,
+        const Config& config = {})
+    {
+        if (config.quality == Quality::Low)
+            return BinnedSahBuilder<Node>::build(bboxes, centers, config);
+        else {
+            auto bvh = SweepSahBuilder<Node>::build(bboxes, centers, config);
+            if (config.quality == Quality::High)
+                ReinsertionOptimizer<Node>::optimize(bvh);
+            return bvh;
+        }
+    }
+
+private:
+    BVH_ALWAYS_INLINE static auto make_mini_tree_config(const Config& config) {
+        typename MiniTreeBuilder<Node>::Config mini_tree_config;
+        static_cast<typename TopDownSahBuilder<Node>::Config&>(mini_tree_config) = config;
+        mini_tree_config.enable_pruning = config.quality == Quality::Low ? false : true;
+        mini_tree_config.pruning_area_ratio =
+            config.quality == Quality::High ? static_cast<Scalar>(0.01) : static_cast<Scalar>(0.1);
+        mini_tree_config.parallel_threshold = config.parallel_threshold;
+        return mini_tree_config;
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/executor.h
+++ b/geom/geom/inc/bvh/v2/executor.h
@@ -1,0 +1,89 @@
+#ifndef BVH_V2_EXECUTOR_H
+#define BVH_V2_EXECUTOR_H
+
+#include "bvh/v2/thread_pool.h"
+
+#include <cstddef>
+#include <algorithm>
+#include <vector>
+
+namespace bvh::v2 {
+
+/// Helper object that provides iteration and reduction over one-dimensional ranges.
+template <typename Derived>
+struct Executor {
+    template <typename Loop>
+    inline void for_each(size_t begin, size_t end, const Loop& loop) {
+        return static_cast<Derived*>(this)->for_each(begin, end, loop);
+    }
+
+    template <typename T, typename Reduce, typename Join>
+    inline T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
+        return static_cast<Derived*>(this)->reduce(begin, end, init, reduce, join);
+    }
+};
+
+/// Executor that executes serially.
+struct SequentialExecutor : Executor<SequentialExecutor> {
+    template <typename Loop>
+    void for_each(size_t begin, size_t end, const Loop& loop) {
+        loop(begin, end);
+    }
+
+    template <typename T, typename Reduce, typename Join>
+    T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join&) {
+        T result(init);
+        reduce(result, begin, end);
+        return result;
+    }
+};
+
+/// Executor that executes in parallel using the given thread pool.
+struct ParallelExecutor : Executor<ParallelExecutor> {
+    ThreadPool& thread_pool;
+    size_t parallel_threshold;
+
+    ParallelExecutor(ThreadPool& thread_pool, size_t parallel_threshold = 1024)
+        : thread_pool(thread_pool), parallel_threshold(parallel_threshold)
+    {}
+
+    template <typename Loop>
+    void for_each(size_t begin, size_t end, const Loop& loop) {
+        if (end - begin < parallel_threshold)
+            return loop(begin, end);
+
+        auto chunk_size = std::max(size_t{1}, (end - begin) / thread_pool.get_thread_count());
+        for (size_t i = begin; i < end; i += chunk_size) {
+            size_t next = std::min(end, i + chunk_size);
+            thread_pool.push([=] (size_t) { loop(i, next); });
+        }
+        thread_pool.wait();
+    }
+
+    template <typename T, typename Reduce, typename Join>
+    T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
+        if (end - begin < parallel_threshold) {
+            T result(init);
+            reduce(result, begin, end);
+            return result;
+        }
+
+        auto chunk_size = std::max(size_t{1}, (end - begin) / thread_pool.get_thread_count());
+        std::vector<T> per_thread_result(thread_pool.get_thread_count(), init);
+        for (size_t i = begin; i < end; i += chunk_size) {
+            size_t next = std::min(end, i + chunk_size);
+            thread_pool.push([&, i, next] (size_t thread_id) {
+                auto& result = per_thread_result[thread_id];
+                reduce(result, i, next);
+            });
+        }
+        thread_pool.wait();
+        for (size_t i = 1; i < thread_pool.get_thread_count(); ++i)
+            join(per_thread_result[0], std::move(per_thread_result[i]));
+        return per_thread_result[0];
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/index.h
+++ b/geom/geom/inc/bvh/v2/index.h
@@ -1,0 +1,92 @@
+#ifndef BVH_V2_INDEX_H
+#define BVH_V2_INDEX_H
+
+#include "bvh/v2/utils.h"
+
+#include <cassert>
+#include <cstddef>
+
+namespace bvh::v2 {
+
+/// Packed index data structure. This index can either refer to a range of primitives for a BVH
+/// leaf, or to the children of a BVH node. In either case, the index corresponds to a contiguous
+/// range, which means that:
+///
+/// - For leaves, primitives in a BVH node should be accessed via:
+///
+///     size_t begin = index.first_id();
+///     size_t end   = begin + index.prim_count();
+///     for (size_t i = begin; i < end; ++i) {
+///         size_t prim_id = bvh.prim_ids[i];
+///         // ...
+///     }
+///
+///   Note that for efficiency, reordering the original data to avoid the indirection via
+///   `bvh.prim_ids` is preferable.
+///
+/// - For inner nodes, children should be accessed via:
+///
+///   auto& left_child = bvh.nodes[index.first_id()];
+///   auto& right_child = bvh.nodes[index.first_id() + 1];
+///
+template <size_t Bits, size_t PrimCountBits>
+struct Index {
+    using Type = UnsignedIntType<Bits>;
+
+    static constexpr size_t bits = Bits;
+    static constexpr size_t prim_count_bits = PrimCountBits;
+    static constexpr Type max_prim_count = make_bitmask<Type>(prim_count_bits);
+    static constexpr Type max_first_id   = make_bitmask<Type>(bits - prim_count_bits);
+
+    static_assert(PrimCountBits < Bits);
+
+    Type value;
+
+    Index() = default;
+    explicit Index(Type value) : value(value) {}
+
+    //bool operator == (const Index&) const = default;
+    //bool operator != (const Index&) const = default;
+    bool operator == (const Index& other) const {
+        return other.value == value;
+    }
+    bool operator != (const Index& other) const {
+        return other.value != value;
+    }
+
+    BVH_ALWAYS_INLINE Type first_id() const { return value >> prim_count_bits; }
+    BVH_ALWAYS_INLINE Type prim_count() const { return value & max_prim_count; }
+    BVH_ALWAYS_INLINE bool is_leaf() const { return prim_count() != 0; }
+    BVH_ALWAYS_INLINE bool is_inner() const { return !is_leaf(); }
+
+    BVH_ALWAYS_INLINE void set_first_id(size_t first_id) {
+        *this = Index { first_id, prim_count() };
+    }
+
+    BVH_ALWAYS_INLINE void set_prim_count(size_t prim_count) {
+        *this = Index { first_id(), prim_count };
+    }
+
+    static BVH_ALWAYS_INLINE Index make_leaf(size_t first_prim, size_t prim_count) {
+        assert(prim_count != 0);
+        return Index { first_prim, prim_count };
+    }
+
+    static BVH_ALWAYS_INLINE Index make_inner(size_t first_child) {
+        return Index { first_child, 0 };
+    }
+
+private:
+    explicit Index(size_t first_id, size_t prim_count)
+        : Index(
+            (static_cast<Type>(first_id) << prim_count_bits) |
+            (static_cast<Type>(prim_count) & max_prim_count))
+    {
+        assert(first_id   <= static_cast<size_t>(max_first_id));
+        assert(prim_count <= static_cast<size_t>(max_prim_count));
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/mini_tree_builder.h
+++ b/geom/geom/inc/bvh/v2/mini_tree_builder.h
@@ -1,0 +1,315 @@
+#ifndef BVH_V2_MINI_TREE_BUILDER_H
+#define BVH_V2_MINI_TREE_BUILDER_H
+
+#include "bvh/v2/sweep_sah_builder.h"
+#include "bvh/v2/binned_sah_builder.h"
+#include "bvh/v2/thread_pool.h"
+#include "bvh/v2/executor.h"
+
+#include <stack>
+#include <tuple>
+#include <algorithm>
+#include <optional>
+#include <numeric>
+#include <cassert>
+
+namespace bvh::v2 {
+
+/// Multi-threaded top-down builder that partitions primitives using a grid. Multiple instances
+/// of a single-threaded builder are run in parallel on that partition, generating many small
+/// trees. Finally, a top-level tree is built on these smaller trees to form the final BVH.
+/// This builder is inspired by
+/// "Rapid Bounding Volume Hierarchy Generation using Mini Trees", by P. Ganestam et al.
+template <typename Node, typename MortonCode = uint32_t>
+class MiniTreeBuilder {
+    using Scalar = typename Node::Scalar;
+    using Vec  = bvh::v2::Vec<Scalar, Node::dimension>;
+    using BBox = bvh::v2::BBox<Scalar, Node::dimension>;
+
+public:
+    struct Config : TopDownSahBuilder<Node>::Config {
+        /// Flag that turns on/off mini-tree pruning.
+        bool enable_pruning = true;
+
+        /// Threshold on the area of a mini-tree node above which it is pruned, expressed in
+        /// fraction of the area of bounding box around the entire set of primitives.
+        Scalar pruning_area_ratio = static_cast<Scalar>(0.01);
+
+        /// Minimum number of primitives per parallel task.
+        size_t parallel_threshold = 1024;
+
+        /// Log of the dimension of the grid used to split the workload horizontally.
+        size_t log2_grid_dim = 4;
+    };
+
+    /// Starts building a BVH with the given primitive data. The build algorithm is multi-threaded,
+    /// and runs on the given thread pool.
+    BVH_ALWAYS_INLINE static Bvh<Node> build(
+        ThreadPool& thread_pool,
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config = {})
+    {
+        MiniTreeBuilder builder(thread_pool, bboxes, centers, config);
+        auto mini_trees = builder.build_mini_trees();
+        if (config.enable_pruning)
+            mini_trees = builder.prune_mini_trees(std::move(mini_trees));
+        return builder.build_top_bvh(mini_trees);
+    }
+
+private:
+    friend struct BuildTask;
+
+    struct Bin {
+        std::vector<size_t> ids;
+
+        BVH_ALWAYS_INLINE void add(size_t id) { ids.push_back(id); }
+
+        BVH_ALWAYS_INLINE void merge(Bin&& other) {
+            if (ids.empty())
+                ids = std::move(other.ids);
+            else {
+                ids.insert(ids.end(), other.ids.begin(), other.ids.end());
+                other.ids.clear();
+            }
+        }
+    };
+
+    struct LocalBins {
+        std::vector<Bin> bins;
+
+        BVH_ALWAYS_INLINE Bin& operator [] (size_t i) { return bins[i]; }
+        BVH_ALWAYS_INLINE const Bin& operator [] (size_t i) const { return bins[i]; }
+
+        BVH_ALWAYS_INLINE void merge_small_bins(size_t threshold) {
+            for (size_t i = 0; i < bins.size();) {
+                size_t j = i + 1;
+                for (; j < bins.size() && bins[j].ids.size() + bins[i].ids.size() <= threshold; ++j)
+                    bins[i].merge(std::move(bins[j]));
+                i = j;
+            }
+        }
+
+        BVH_ALWAYS_INLINE void remove_empty_bins() {
+            bins.resize(std::remove_if(bins.begin(), bins.end(),
+                [] (const Bin& bin) { return bin.ids.empty(); }) - bins.begin());
+        }
+
+        BVH_ALWAYS_INLINE void merge(LocalBins&& other) {
+            bins.resize(std::max(bins.size(), other.bins.size()));
+            for (size_t i = 0, n = std::min(bins.size(), other.bins.size()); i < n; ++i)
+                bins[i].merge(std::move(other[i]));
+        }
+    };
+
+    struct BuildTask {
+        MiniTreeBuilder* builder;
+        Bvh<Node>& bvh;
+        std::vector<size_t> prim_ids;
+
+        std::vector<BBox> bboxes;
+        std::vector<Vec> centers;
+
+        BuildTask(
+            MiniTreeBuilder* builder,
+            Bvh<Node>& bvh,
+            std::vector<size_t>&& prim_ids)
+            : builder(builder)
+            , bvh(bvh)
+            , prim_ids(std::move(prim_ids))
+        {}
+
+        BVH_ALWAYS_INLINE void run() {
+            // Make sure that rebuilds produce the same BVH
+            std::sort(prim_ids.begin(), prim_ids.end());
+
+            // Extract bounding boxes and centers for this set of primitives
+            bboxes.resize(prim_ids.size());
+            centers.resize(prim_ids.size());
+            for (size_t i = 0; i < prim_ids.size(); ++i) {
+                bboxes[i] = builder->bboxes_[prim_ids[i]];
+                centers[i] = builder->centers_[prim_ids[i]];
+            }
+
+            bvh = BinnedSahBuilder<Node>::build(bboxes, centers, builder->config_);
+
+            // Permute primitive indices so that they index the proper set of primitives
+            for (size_t i = 0; i < bvh.prim_ids.size(); ++i)
+                bvh.prim_ids[i] = prim_ids[bvh.prim_ids[i]];
+        }
+    };
+
+    ParallelExecutor executor_;
+    std::span<const BBox> bboxes_;
+    std::span<const Vec> centers_;
+    const Config& config_;
+
+    BVH_ALWAYS_INLINE MiniTreeBuilder(
+        ThreadPool& thread_pool,
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config)
+        : executor_(thread_pool)
+        , bboxes_(bboxes)
+        , centers_(centers)
+        , config_(config)
+    {
+        assert(bboxes.size() == centers.size());
+    }
+
+    std::vector<Bvh<Node>> build_mini_trees() {
+        // Compute the bounding box of all centers
+        auto center_bbox = executor_.reduce(0, bboxes_.size(), BBox::make_empty(),
+            [this] (BBox& bbox, size_t begin, size_t end) {
+                for (size_t i = begin; i < end; ++i)
+                    bbox.extend(centers_[i]);
+            },
+            [] (BBox& bbox, const BBox& other) { bbox.extend(other); });
+
+        assert(config_.log2_grid_dim <= std::numeric_limits<MortonCode>::digits / Node::dimension);
+        auto bin_count = size_t{1} << (config_.log2_grid_dim * Node::dimension);
+        auto grid_dim = size_t{1} << config_.log2_grid_dim;
+        auto grid_scale = Vec(static_cast<Scalar>(grid_dim)) * safe_inverse(center_bbox.get_diagonal());
+        auto grid_offset = -center_bbox.min * grid_scale;
+
+        // Place primitives in bins
+        auto final_bins = executor_.reduce(0, bboxes_.size(), LocalBins {},
+            [&] (LocalBins& local_bins, size_t begin, size_t end) {
+                local_bins.bins.resize(bin_count);
+                for (size_t i = begin; i < end; ++i) {
+                    auto p = robust_max(fast_mul_add(centers_[i], grid_scale, grid_offset), Vec(0));
+                    auto x = std::min(grid_dim - 1, static_cast<size_t>(p[0]));
+                    auto y = std::min(grid_dim - 1, static_cast<size_t>(p[1]));
+                    auto z = std::min(grid_dim - 1, static_cast<size_t>(p[2]));
+                    local_bins[morton_encode(x, y, z) & (bin_count - 1)].add(i);
+                }
+            },
+            [&] (LocalBins& result, LocalBins&& other) { result.merge(std::move(other)); });
+
+        // Note: Merging small bins will deteriorate the quality of the top BVH if there is no
+        // pruning, since it will then produce larger mini-trees. For this reason, it is only enabled
+        // when mini-tree pruning is enabled.
+        if (config_.enable_pruning)
+            final_bins.merge_small_bins(config_.parallel_threshold);
+        final_bins.remove_empty_bins();
+
+        // Iterate over bins to collect groups of primitives and build BVHs over them in parallel
+        std::vector<Bvh<Node>> mini_trees(final_bins.bins.size());
+        for (size_t i = 0; i < final_bins.bins.size(); ++i) {
+            auto task = new BuildTask(this, mini_trees[i], std::move(final_bins[i].ids));
+            executor_.thread_pool.push([task] (size_t) { task->run(); delete task; });
+        }
+        executor_.thread_pool.wait();
+
+        return mini_trees;
+    }
+
+    std::vector<Bvh<Node>> prune_mini_trees(std::vector<Bvh<Node>>&& mini_trees) {
+        // Compute the area threshold based on the area of the entire set of primitives
+        auto avg_area = static_cast<Scalar>(0.);
+        for (auto& mini_tree : mini_trees)
+            avg_area += mini_tree.get_root().get_bbox().get_half_area();
+        avg_area /= static_cast<Scalar>(mini_trees.size());
+        auto threshold = avg_area * config_.pruning_area_ratio;
+
+        // Cull nodes whose area is above the threshold
+        std::stack<size_t> stack;
+        std::vector<std::pair<size_t, size_t>> pruned_roots;
+        for (size_t i = 0; i < mini_trees.size(); ++i) {
+            stack.push(0);
+            auto& mini_tree = mini_trees[i];
+            while (!stack.empty()) {
+                auto node_id = stack.top();
+                auto& node = mini_tree.nodes[node_id];
+                stack.pop();
+                if (node.get_bbox().get_half_area() < threshold || node.is_leaf()) {
+                    pruned_roots.emplace_back(i, node_id);
+                } else {
+                    stack.push(node.index.first_id());
+                    stack.push(node.index.first_id() + 1);
+                }
+            }
+        }
+
+        // Extract the BVHs rooted at the previously computed indices
+        std::vector<Bvh<Node>> pruned_trees(pruned_roots.size());
+        executor_.for_each(0, pruned_roots.size(),
+            [&] (size_t begin, size_t end) {
+                for (size_t i = begin; i < end; ++i) {
+                    if (pruned_roots[i].second == 0)
+                        pruned_trees[i] = std::move(mini_trees[pruned_roots[i].first]);
+                    else
+                        pruned_trees[i] = mini_trees[pruned_roots[i].first]
+                            .extract_bvh(pruned_roots[i].second);
+                }
+            });
+        return pruned_trees;
+    }
+
+    Bvh<Node> build_top_bvh(std::vector<Bvh<Node>>& mini_trees) {
+        // Build a BVH using the mini trees as leaves
+        std::vector<Vec> centers(mini_trees.size());
+        std::vector<BBox> bboxes(mini_trees.size());
+        for (size_t i = 0; i < mini_trees.size(); ++i) {
+            bboxes[i] = mini_trees[i].get_root().get_bbox();
+            centers[i] = bboxes[i].get_center();
+        }
+
+        typename SweepSahBuilder<Node>::Config config = config_;
+        config.max_leaf_size = config.min_leaf_size = 1; // Needs to have only one mini-tree in each leaf
+        auto bvh = SweepSahBuilder<Node>::build(bboxes, centers, config);
+
+        // Compute the offsets to apply to primitive and node indices
+        std::vector<size_t> node_offsets(mini_trees.size());
+        std::vector<size_t> prim_offsets(mini_trees.size());
+        size_t node_count = bvh.nodes.size();
+        size_t prim_count = 0;
+        for (size_t i = 0; i < mini_trees.size(); ++i) {
+            node_offsets[i] = node_count - 1; // Skip root node
+            prim_offsets[i] = prim_count;
+            node_count += mini_trees[i].nodes.size() - 1; // idem
+            prim_count += mini_trees[i].prim_ids.size();
+        }
+
+        // Helper function to copy and fix the child/primitive index of a node
+        auto copy_node = [&] (size_t i, Node& dst_node, const Node& src_node) {
+            dst_node = src_node;
+            dst_node.index.set_first_id(dst_node.index.first_id() +
+                (src_node.is_leaf() ? prim_offsets[i] : node_offsets[i]));
+        };
+
+        // Make the leaves of the top BVH point to the right internal nodes
+        for (auto& node : bvh.nodes) {
+            if (!node.is_leaf())
+                continue;
+            assert(node.index.prim_count() == 1);
+            size_t tree_id = bvh.prim_ids[node.index.first_id()];
+            copy_node(tree_id, node, mini_trees[tree_id].get_root());
+        }
+
+        bvh.nodes.resize(node_count);
+        bvh.prim_ids.resize(prim_count);
+        executor_.for_each(0, mini_trees.size(),
+            [&] (size_t begin, size_t end) {
+                for (size_t i = begin; i < end; ++i) {
+                    auto& mini_tree = mini_trees[i];
+
+                    // Copy the nodes of the mini tree with the offsets applied, without copying
+                    // the root node (since it is already copied to the top-level part of the BVH).
+                    for (size_t j = 1; j < mini_tree.nodes.size(); ++j)
+                        copy_node(i, bvh.nodes[node_offsets[i] + j], mini_tree.nodes[j]);
+
+                    std::copy(
+                        mini_tree.prim_ids.begin(),
+                        mini_tree.prim_ids.end(),
+                        bvh.prim_ids.begin() + prim_offsets[i]);
+                }
+            });
+
+        return bvh;
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/node.h
+++ b/geom/geom/inc/bvh/v2/node.h
@@ -1,0 +1,128 @@
+#ifndef BVH_V2_NODE_H
+#define BVH_V2_NODE_H
+
+#include "bvh/v2/index.h"
+#include "bvh/v2/vec.h"
+#include "bvh/v2/bbox.h"
+#include "bvh/v2/ray.h"
+#include "bvh/v2/stream.h"
+
+#include <cassert>
+#include <array>
+#include <limits>
+
+namespace bvh::v2 {
+
+/// Binary BVH node, containing its bounds and an index into its children or the primitives it
+/// contains. By definition, inner BVH nodes do not contain primitives; only leaves do.
+template <
+    typename T,
+    size_t Dim,
+    size_t IndexBits = sizeof(T) * CHAR_BIT,
+    size_t PrimCountBits = 4>
+struct Node {
+    using Scalar = T;
+    using Index = bvh::v2::Index<IndexBits, PrimCountBits>;
+
+    static constexpr size_t dimension = Dim;
+    static constexpr size_t prim_count_bits = PrimCountBits;
+    static constexpr size_t index_bits = IndexBits;
+
+    /// Bounds of the node, laid out in memory as `[min_x, max_x, min_y, max_y, ...]`. Users should
+    /// not really depend on a specific order and instead use `get_bbox()` and extract the `min`
+    /// and/or `max` components accordingly.
+    std::array<T, Dim * 2> bounds;
+
+    /// Index to the children of an inner node, or to the primitives for a leaf node.
+    Index index;
+
+    Node() = default;
+
+    // bool operator == (const Node&) const = default;
+    // bool operator != (const Node&) const = default;
+    bool operator != (const Node& other) const {
+        return other.bounds == bounds;
+    }
+    bool operator == (const Node& other) const {
+        return other.bounds != bounds;
+    }
+
+    BVH_ALWAYS_INLINE bool is_leaf() const { return index.is_leaf(); }
+
+    BVH_ALWAYS_INLINE BBox<T, Dim> get_bbox() const {
+        return BBox<T, Dim>(
+            Vec<T, Dim>::generate([&] (size_t i) { return bounds[i * 2]; }),
+            Vec<T, Dim>::generate([&] (size_t i) { return bounds[i * 2 + 1]; }));
+    }
+
+    BVH_ALWAYS_INLINE void set_bbox(const BBox<T, Dim>& bbox) {
+        static_for<0, Dim>([&] (size_t i) {
+            bounds[i * 2 + 0] = bbox.min[i];
+            bounds[i * 2 + 1] = bbox.max[i];
+        });
+    }
+
+    BVH_ALWAYS_INLINE Vec<T, Dim> get_min_bounds(const Octant& octant) const {
+        return Vec<T, Dim>::generate([&] (size_t i) { return bounds[2 * static_cast<uint32_t>(i) + octant[i]]; });
+    }
+
+    BVH_ALWAYS_INLINE Vec<T, Dim> get_max_bounds(const Octant& octant) const {
+        return Vec<T, Dim>::generate([&] (size_t i) { return bounds[2 * static_cast<uint32_t>(i) + 1 - octant[i]]; });
+    }
+
+    /// Robust ray-node intersection routine. See "Robust BVH Ray Traversal", by T. Ize.
+    BVH_ALWAYS_INLINE std::pair<T, T> intersect_robust(
+        const Ray<T, Dim>& ray,
+        const Vec<T, Dim>& inv_dir,
+        const Vec<T, Dim>& inv_dir_pad,
+        const Octant& octant) const
+    {
+        auto tmin = (get_min_bounds(octant) - ray.org) * inv_dir;
+        auto tmax = (get_max_bounds(octant) - ray.org) * inv_dir_pad;
+        return make_intersection_result(ray, tmin, tmax);
+    }
+
+    BVH_ALWAYS_INLINE std::pair<T, T> intersect_fast(
+        const Ray<T, Dim>& ray,
+        const Vec<T, Dim>& inv_dir,
+        const Vec<T, Dim>& inv_org,
+        const Octant& octant) const
+    {
+        auto tmin = fast_mul_add(get_min_bounds(octant), inv_dir, inv_org);
+        auto tmax = fast_mul_add(get_max_bounds(octant), inv_dir, inv_org);
+        return make_intersection_result(ray, tmin, tmax);
+    }
+
+    BVH_ALWAYS_INLINE void serialize(OutputStream& stream) const {
+        for (auto&& bound : bounds)
+            stream.write(bound);
+        stream.write(index.value);
+    }
+
+    static BVH_ALWAYS_INLINE Node deserialize(InputStream& stream) {
+        Node node;
+        for (auto& bound : node.bounds)
+            bound = stream.read<T>();
+        node.index = Index(stream.read<typename Index::Type>());
+        return node;
+    }
+
+private:
+    BVH_ALWAYS_INLINE static std::pair<T, T> make_intersection_result(
+        const Ray<T, Dim>& ray,
+        const Vec<T, Dim>& tmin,
+        const Vec<T, Dim>& tmax)
+    {
+        auto t0 = ray.tmin;
+        auto t1 = ray.tmax;
+        static_for<0, Dim>([&] (size_t i) {
+            t0 = robust_max(tmin[i], t0);
+            t1 = robust_min(tmax[i], t1);
+        });
+        return std::pair<T, T> { t0, t1 };
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/platform.h
+++ b/geom/geom/inc/bvh/v2/platform.h
@@ -1,0 +1,22 @@
+#ifndef BVH_V2_PLATFORM_H
+#define BVH_V2_PLATFORM_H
+
+#if defined(__clang__)
+#define BVH_CLANG_ENABLE_FP_CONTRACT \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"") \
+    _Pragma("STDC FP_CONTRACT ON") \
+    _Pragma("clang diagnostic pop")
+#else
+#define BVH_CLANG_ENABLE_FP_CONTRACT
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define BVH_ALWAYS_INLINE __attribute__((always_inline)) inline
+#elif defined(_MSC_VER)
+#define BVH_ALWAYS_INLINE __forceinline
+#else
+#define BVH_ALWAYS_INLINE inline
+#endif
+
+#endif

--- a/geom/geom/inc/bvh/v2/ray.h
+++ b/geom/geom/inc/bvh/v2/ray.h
@@ -1,0 +1,53 @@
+#ifndef BVH_V2_RAY_H
+#define BVH_V2_RAY_H
+
+#include "bvh/v2/vec.h"
+
+namespace bvh::v2 {
+
+struct Octant {
+    uint32_t value = 0;
+    static constexpr size_t max_dim = sizeof(value) * CHAR_BIT;
+
+    uint32_t operator [] (size_t i) const { return (value >> i) & uint32_t{1}; }
+};
+
+template <typename T, size_t N>
+struct Ray {
+    Vec<T, N> org, dir;
+    T tmin, tmax;
+
+    Ray() = default;
+    BVH_ALWAYS_INLINE Ray(
+        const Vec<T, N>& org,
+        const Vec<T, N>& dir,
+        T tmin = 0,
+        T tmax = std::numeric_limits<T>::max())
+        : org(org), dir(dir), tmin(tmin), tmax(tmax)
+    {}
+
+    template <bool SafeInverse = false>
+    BVH_ALWAYS_INLINE Vec<T, N> get_inv_dir() const {
+        return Vec<T, N>::generate([&] (size_t i) {
+            return SafeInverse ? safe_inverse(dir[i]) : static_cast<T>(1) / dir[i];
+        });
+    }
+
+    BVH_ALWAYS_INLINE Octant get_octant() const {
+        static_assert(N <= Octant::max_dim);
+        Octant octant;
+        static_for<0, N>([&] (size_t i) {
+            octant.value |= std::signbit(dir[i]) * (uint32_t{1} << i);
+        });
+        return octant;
+    }
+
+    // Pads the inverse direction according to T. Ize's "Robust BVH ray traversal"
+    BVH_ALWAYS_INLINE static Vec<T, N> pad_inv_dir(const Vec<T, N>& inv_dir) {
+        return Vec<T, N>::generate([&] (size_t i) { return add_ulp_magnitude(inv_dir[i], 2); });
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/reinsertion_optimizer.h
+++ b/geom/geom/inc/bvh/v2/reinsertion_optimizer.h
@@ -1,0 +1,272 @@
+#ifndef BVH_V2_REINSERTION_OPTIMIZER_H
+#define BVH_V2_REINSERTION_OPTIMIZER_H
+
+#include "bvh/v2/bvh.h"
+#include "bvh/v2/thread_pool.h"
+#include "bvh/v2/executor.h"
+
+#include <vector>
+#include <algorithm>
+
+namespace bvh::v2 {
+
+template <typename Node>
+class ReinsertionOptimizer {
+    using Scalar = typename Node::Scalar;
+    using BBox = bvh::v2::BBox<Scalar, Node::dimension>;
+
+public:
+    struct Config {
+        /// Fraction of the number of nodes to optimize per iteration.
+        Scalar batch_size_ratio = static_cast<Scalar>(0.05);
+
+        /// Maximum number of iterations.
+        size_t max_iter_count = 3;
+    };
+
+    static void optimize(ThreadPool& thread_pool, Bvh<Node>& bvh, const Config& config = {}) {
+        ParallelExecutor executor(thread_pool);
+        optimize(executor, bvh, config);
+    }
+
+    static void optimize(Bvh<Node>& bvh, const Config& config = {}) {
+        SequentialExecutor executor;
+        optimize(executor, bvh, config);
+    }
+
+private:
+    struct Candidate {
+        size_t node_id = 0;
+        Scalar cost = -std::numeric_limits<Scalar>::max();
+
+        BVH_ALWAYS_INLINE bool operator > (const Candidate& other) const {
+            return cost > other.cost;
+        }
+    };
+
+    struct Reinsertion {
+        size_t from = 0;
+        size_t to = 0;
+        Scalar area_diff = static_cast<Scalar>(0);
+
+        BVH_ALWAYS_INLINE bool operator > (const Reinsertion& other) const {
+            return area_diff > other.area_diff;
+        }
+    };
+
+    Bvh<Node>& bvh_;
+    std::vector<size_t> parents_;
+
+    ReinsertionOptimizer(Bvh<Node>& bvh, std::vector<size_t>&& parents)
+        : bvh_(bvh)
+        , parents_(std::move(parents))
+    {}
+
+    template <typename Derived>
+    static void optimize(Executor<Derived>& executor, Bvh<Node>& bvh, const Config& config) {
+        auto parents = compute_parents(executor, bvh);
+        ReinsertionOptimizer<Node>(bvh, std::move(parents)).optimize(executor, config);
+    }
+
+    template <typename Derived>
+    static std::vector<size_t> compute_parents(Executor<Derived>& executor, const Bvh<Node>& bvh) {
+        std::vector<size_t> parents(bvh.nodes.size());
+        parents[0] = 0;
+        executor.for_each(0, bvh.nodes.size(),
+            [&] (size_t begin, size_t end) {
+                for (size_t i = begin; i < end; ++i) {
+                    auto& node = bvh.nodes[i];
+                    if (!node.is_leaf()) {
+                        parents[node.index.first_id() + 0] = i;
+                        parents[node.index.first_id() + 1] = i;
+                    }
+                }
+            });
+        return parents;
+    }
+
+    BVH_ALWAYS_INLINE std::vector<Candidate> find_candidates(size_t target_count) {
+        // Gather the `target_count` nodes that have the highest cost.
+        // Note that this may produce fewer nodes if the BVH has fewer than `target_count` nodes.
+        const auto node_count = std::min(bvh_.nodes.size(), target_count + 1);
+        std::vector<Candidate> candidates;
+        for (size_t i = 1; i < node_count; ++i)
+            candidates.push_back(Candidate { i, bvh_.nodes[i].get_bbox().get_half_area() });
+        std::make_heap(candidates.begin(), candidates.end(), std::greater<>{});
+        for (size_t i = node_count; i < bvh_.nodes.size(); ++i) {
+            auto cost = bvh_.nodes[i].get_bbox().get_half_area();
+            if (candidates.front().cost < cost) {
+                std::pop_heap(candidates.begin(), candidates.end(), std::greater<>{});
+                candidates.back() = Candidate { i, cost };
+                std::push_heap(candidates.begin(), candidates.end(), std::greater<>{});
+            }
+        }
+        return candidates;
+    }
+
+    Reinsertion find_reinsertion(size_t node_id) {
+        assert(node_id != 0);
+
+        /*
+         * Here is an example that explains how the cost of a reinsertion is computed. For the
+         * reinsertion from A to C, in the figure below, we need to remove P1, replace it by B,
+         * and create a node that holds A and C and place it where C was.
+         *
+         *             R
+         *            / \
+         *          Pn   Q1
+         *          /     \
+         *        ...     ...
+         *        /         \
+         *       P1          C
+         *      / \
+         *     A   B
+         *
+         * The resulting area *decrease* is (SA(x) means the surface area of x):
+         *
+         *     SA(P1) +                                                : P1 was removed
+         *     SA(P2) - SA(B) +                                        : P2 now only contains B
+         *     SA(P3) - SA(B U sibling(P2)) +                          : Same but for P3
+         *     ... +
+         *     SA(Pn) - SA(B U sibling(P2) U ... U sibling(P(n - 1)) + : Same but for Pn
+         *     0 +                                                     : R does not change
+         *     SA(Q1) - SA(Q1 U A) +                                   : Q1 now contains A
+         *     SA(Q2) - SA(Q2 U A) +                                   : Q2 now contains A
+         *     ... +
+         *     -SA(A U C)                                              : For the parent of A and C
+         */
+
+        Reinsertion best_reinsertion { /*.from */ node_id, 0, 0 };
+        auto node_area   = bvh_.nodes[node_id].get_bbox().get_half_area();
+        auto parent_area = bvh_.nodes[parents_[node_id]].get_bbox().get_half_area();
+        auto area_diff = parent_area;
+        auto sibling_id = Bvh<Node>::get_sibling_id(node_id);
+        auto pivot_bbox = bvh_.nodes[sibling_id].get_bbox();
+        auto parent_id = parents_[node_id];
+        auto pivot_id = parent_id;
+
+        std::vector<std::pair<Scalar, size_t>> stack;
+        do {
+            // Try to find a reinsertion in the sibling at the current level of the tree
+            stack.emplace_back(area_diff, sibling_id);
+            while (!stack.empty()) {
+                auto top = stack.back();
+                stack.pop_back();
+                if (top.first - node_area <= best_reinsertion.area_diff)
+                    continue;
+
+                auto& dst_node = bvh_.nodes[top.second];
+                auto merged_area = dst_node.get_bbox().extend(bvh_.nodes[node_id].get_bbox()).get_half_area();
+                auto reinsert_area = top.first - merged_area;
+                if (reinsert_area > best_reinsertion.area_diff) {
+                    best_reinsertion.to = top.second;
+                    best_reinsertion.area_diff = reinsert_area;
+                }
+
+                if (!dst_node.is_leaf()) {
+                    auto child_area = reinsert_area + dst_node.get_bbox().get_half_area();
+                    stack.emplace_back(child_area, dst_node.index.first_id() + 0);
+                    stack.emplace_back(child_area, dst_node.index.first_id() + 1);
+                }
+            }
+
+            // Compute the bounding box on the path from the node to the root, and record the
+            // corresponding decrease in area.
+            if (pivot_id != parent_id) {
+                pivot_bbox.extend(bvh_.nodes[sibling_id].get_bbox());
+                area_diff += bvh_.nodes[pivot_id].get_bbox().get_half_area() - pivot_bbox.get_half_area();
+            }
+
+            sibling_id = Bvh<Node>::get_sibling_id(pivot_id);
+            pivot_id = parents_[pivot_id];
+        } while (pivot_id != 0);
+
+        if (best_reinsertion.to == Bvh<Node>::get_sibling_id(best_reinsertion.from) ||
+            best_reinsertion.to == parents_[best_reinsertion.from])
+            best_reinsertion = {};
+        return best_reinsertion;
+    }
+
+    BVH_ALWAYS_INLINE void reinsert_node(size_t from, size_t to) {
+        auto sibling_id = Bvh<Node>::get_sibling_id(from);
+        auto parent_id  = parents_[from];
+        auto sibling_node = bvh_.nodes[sibling_id];
+        auto dst_node     = bvh_.nodes[to];
+
+        bvh_.nodes[to].index = Node::Index::make_inner(Bvh<Node>::get_left_sibling_id(from));
+        bvh_.nodes[sibling_id] = dst_node;
+        bvh_.nodes[parent_id] = sibling_node;
+
+        if (!dst_node.is_leaf()) {
+            parents_[dst_node.index.first_id() + 0] = sibling_id;
+            parents_[dst_node.index.first_id() + 1] = sibling_id;
+        }
+        if (!sibling_node.is_leaf()) {
+            parents_[sibling_node.index.first_id() + 0] = parent_id;
+            parents_[sibling_node.index.first_id() + 1] = parent_id;
+        }
+
+        parents_[sibling_id] = to;
+        parents_[from] = to;
+        refit_from(to);
+        refit_from(parent_id);
+    }
+
+    BVH_ALWAYS_INLINE void refit_from(size_t index) {
+        do {
+            auto& node = bvh_.nodes[index];
+            if (!node.is_leaf()) {
+                node.set_bbox(
+                    bvh_.nodes[node.index.first_id() + 0].get_bbox().extend(
+                    bvh_.nodes[node.index.first_id() + 1].get_bbox()));
+            }
+            index = parents_[index];
+        } while (index != 0);
+    }
+
+    BVH_ALWAYS_INLINE auto get_conflicts(size_t from, size_t to) {
+        return std::array<size_t, 5> {
+            to, from,
+            Bvh<Node>::get_sibling_id(from),
+            parents_[to],
+            parents_[from]
+        };
+    }
+
+    template <typename Derived>
+    void optimize(Executor<Derived>& executor, const Config& config) {
+        auto batch_size = std::max(size_t{1},
+            static_cast<size_t>(static_cast<Scalar>(bvh_.nodes.size()) * config.batch_size_ratio));
+        std::vector<Reinsertion> reinsertions;
+        std::vector<bool> touched(bvh_.nodes.size());
+
+        for (size_t iter = 0; iter < config.max_iter_count; ++iter) {
+            auto candidates = find_candidates(batch_size);
+
+            std::fill(touched.begin(), touched.end(), false);
+            reinsertions.resize(candidates.size());
+            executor.for_each(0, candidates.size(),
+                [&] (size_t begin, size_t end) {
+                    for (size_t i = begin; i < end; ++i)
+                        reinsertions[i] = find_reinsertion(candidates[i].node_id);
+                });
+
+            reinsertions.erase(std::remove_if(reinsertions.begin(), reinsertions.end(),
+                [] (auto& r) { return r.area_diff <= 0; }), reinsertions.end());
+            std::sort(reinsertions.begin(), reinsertions.end(), std::greater<>{});
+
+            for (auto& reinsertion : reinsertions) {
+                auto conflicts = get_conflicts(reinsertion.from, reinsertion.to);
+                if (std::any_of(conflicts.begin(), conflicts.end(), [&] (size_t i) { return touched[i]; }))
+                    continue;
+                for (auto conflict : conflicts)
+                    touched[conflict] = true;
+                reinsert_node(reinsertion.from, reinsertion.to);
+            }
+        }
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/split_heuristic.h
+++ b/geom/geom/inc/bvh/v2/split_heuristic.h
@@ -1,0 +1,48 @@
+#ifndef BVH_V2_SPLIT_HEURISTIC_H
+#define BVH_V2_SPLIT_HEURISTIC_H
+
+#include "bvh/v2/bbox.h"
+#include "bvh/v2/utils.h"
+
+#include <cstddef>
+
+namespace bvh::v2 {
+
+template <typename T>
+class SplitHeuristic {
+public:
+    /// Creates an SAH evaluator object, used by top-down builders to determine where to split.
+    /// The two parameters are the log of the size of primitive clusters in base 2, and the ratio of
+    /// the cost of intersecting a node (a ray-box intersection) over the cost of intersecting a
+    /// primitive.
+    BVH_ALWAYS_INLINE SplitHeuristic(
+        size_t log_cluster_size = 0,
+        T cost_ratio = static_cast<T>(1.))
+        : log_cluster_size_(log_cluster_size)
+        , prim_offset_(make_bitmask<size_t>(log_cluster_size))
+        , cost_ratio_(cost_ratio)
+    {}
+
+    BVH_ALWAYS_INLINE size_t get_prim_count(size_t size) const {
+        return (size + prim_offset_) >> log_cluster_size_;
+    }
+
+    template <size_t N>
+    BVH_ALWAYS_INLINE T get_leaf_cost(size_t begin, size_t end, const BBox<T, N>& bbox) const {
+        return bbox.get_half_area() * static_cast<T>(get_prim_count(end - begin));
+    }
+
+    template <size_t N>
+    BVH_ALWAYS_INLINE T get_non_split_cost(size_t begin, size_t end, const BBox<T, N>& bbox) const {
+        return bbox.get_half_area() * (static_cast<T>(get_prim_count(end - begin)) - cost_ratio_);
+    }
+
+private:
+    size_t log_cluster_size_;
+    size_t prim_offset_;
+    T cost_ratio_;
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/stack.h
+++ b/geom/geom/inc/bvh/v2/stack.h
@@ -1,0 +1,54 @@
+#ifndef BVH_V2_STACK_H
+#define BVH_V2_STACK_H
+
+#include <vector>
+#include <cassert>
+
+namespace bvh::v2 {
+
+/// Fixed-size stack that can be used for a BVH traversal.
+template <typename T, unsigned Capacity>
+struct SmallStack {
+    static constexpr unsigned capacity = Capacity;
+
+    T elems[capacity];
+    unsigned size = 0;
+
+    bool is_empty() const { return size == 0; }
+    bool is_full() const { return size >= capacity; }
+
+    void push(const T& t) {
+        assert(!is_full());
+        elems[size++] = t;
+    }
+
+    T pop() {
+        assert(!is_empty());
+        return elems[--size];
+    }
+};
+
+/// Growing stack that can be used for BVH traversal. Its performance may be lower than a small,
+/// fixed-size stack, depending on the architecture.
+template <typename T>
+struct GrowingStack {
+    std::vector<T> elems;
+
+    bool is_empty() const { return elems.empty(); }
+    void push(const T& t) { elems.push_back(t); }
+
+    T pop() {
+        assert(!is_empty());
+        auto top = std::move(elems.back());
+        elems.pop_back();
+        return top;
+    }
+
+    void clear() {
+      elems.clear();
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/stream.h
+++ b/geom/geom/inc/bvh/v2/stream.h
@@ -1,0 +1,72 @@
+#ifndef BVH_V2_STREAM_H
+#define BVH_V2_STREAM_H
+
+#include <istream>
+#include <ostream>
+
+namespace bvh::v2 {
+
+/// Stream of data that can be used to deserialize data structures.
+class InputStream {
+public:
+    template <typename T>
+    T read(T&& default_val = {}) {
+        T data;
+        if (read_raw(&data, sizeof(T)) != sizeof(T))
+            data = std::move(default_val);
+        return data;
+    }
+
+protected:
+    virtual size_t read_raw(void*, size_t) = 0;
+};
+
+/// Stream of data that can be used to serialize data structures.
+class OutputStream {
+public:
+    template <typename T>
+    bool write(const T& data) { return write_raw(&data, sizeof(T)); }
+
+protected:
+    virtual bool write_raw(const void*, size_t) = 0;
+};
+
+/// Stream adapter for standard library input streams.
+class StdInputStream : public InputStream {
+public:
+    StdInputStream(std::istream& stream)
+        : stream_(stream)
+    {}
+
+    using InputStream::read;
+
+protected:
+    std::istream& stream_;
+
+    size_t read_raw(void* data, size_t size) override {
+        stream_.read(reinterpret_cast<char*>(data), static_cast<std::streamsize>(size));
+        return static_cast<size_t>(stream_.gcount());
+    }
+};
+
+/// Stream adapter for standard library output streams.
+class StdOutputStream : public OutputStream {
+public:
+    StdOutputStream(std::ostream& stream)
+        : stream_(stream)
+    {}
+
+    using OutputStream::write;
+
+protected:
+    std::ostream& stream_;
+
+    bool write_raw(const void* data, size_t size) override {
+        stream_.write(reinterpret_cast<const char*>(data), static_cast<std::streamsize>(size));
+        return stream_.good();
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/sweep_sah_builder.h
+++ b/geom/geom/inc/bvh/v2/sweep_sah_builder.h
@@ -1,0 +1,144 @@
+#ifndef BVH_V2_SWEEP_SAH_BUILDER_H
+#define BVH_V2_SWEEP_SAH_BUILDER_H
+
+#include "bvh/v2/top_down_sah_builder.h"
+
+#include <stack>
+#include <tuple>
+#include <algorithm>
+#include <optional>
+#include <numeric>
+#include <cassert>
+
+namespace bvh::v2 {
+
+/// Single-threaded top-down builder that partitions primitives based on the Surface
+/// Area Heuristic (SAH). Primitives are only sorted once along each axis.
+template <typename Node>
+class SweepSahBuilder : public TopDownSahBuilder<Node> {
+    using typename TopDownSahBuilder<Node>::Scalar;
+    using typename TopDownSahBuilder<Node>::Vec;
+    using typename TopDownSahBuilder<Node>::BBox;
+
+    using TopDownSahBuilder<Node>::build;
+    using TopDownSahBuilder<Node>::config_;
+    using TopDownSahBuilder<Node>::bboxes_;
+
+public:
+    using typename TopDownSahBuilder<Node>::Config;
+
+    BVH_ALWAYS_INLINE static Bvh<Node> build(
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config = {})
+    {
+        return SweepSahBuilder(bboxes, centers, config).build();
+    }
+
+protected:
+    struct Split {
+        size_t pos;
+        Scalar cost;
+        size_t axis;
+    };
+
+    std::vector<bool> marks_;
+    std::vector<Scalar> accum_;
+    std::vector<size_t> prim_ids_[Node::dimension];
+
+    BVH_ALWAYS_INLINE SweepSahBuilder(
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config)
+        : TopDownSahBuilder<Node>(bboxes, centers, config)
+    {
+        marks_.resize(bboxes.size());
+        accum_.resize(bboxes.size());
+        for (size_t axis = 0; axis < Node::dimension; ++axis) {
+            prim_ids_[axis].resize(bboxes.size());
+            std::iota(prim_ids_[axis].begin(), prim_ids_[axis].end(), 0);
+            std::sort(prim_ids_[axis].begin(), prim_ids_[axis].end(), [&] (size_t i, size_t j) {
+                return centers[i][axis] < centers[j][axis];
+            });
+        }
+    }
+
+    std::vector<size_t>& get_prim_ids() override { return prim_ids_[0]; }
+
+    void find_best_split(size_t axis, size_t begin, size_t end, Split& best_split) {
+        size_t first_right = begin;
+
+        // Sweep from the right to the left, computing the partial SAH cost
+        auto right_bbox = BBox::make_empty();
+        for (size_t i = end - 1; i > begin;) {
+            static constexpr size_t chunk_size = 32;
+            size_t next = i - std::min(i - begin, chunk_size);
+            auto right_cost = static_cast<Scalar>(0.);
+            for (; i > next; --i) {
+                right_bbox.extend(bboxes_[prim_ids_[axis][i]]);
+                accum_[i] = right_cost = config_.sah.get_leaf_cost(i, end, right_bbox);
+            }
+            // Every `chunk_size` elements, check that we are not above the maximum cost
+            if (right_cost > best_split.cost) {
+                first_right = i;
+                break;
+            }
+        }
+
+        // Sweep from the left to the right, computing the full cost
+        auto left_bbox = BBox::make_empty();
+        for (size_t i = begin; i < first_right; ++i)
+            left_bbox.extend(bboxes_[prim_ids_[axis][i]]);
+        for (size_t i = first_right; i < end - 1; ++i) {
+            left_bbox.extend(bboxes_[prim_ids_[axis][i]]);
+            auto left_cost = config_.sah.get_leaf_cost(begin, i + 1, left_bbox);
+            auto cost = left_cost + accum_[i + 1];
+            if (cost < best_split.cost)
+                best_split = Split { i + 1, cost, axis };
+            else if (left_cost > best_split.cost)
+                break;
+        }
+    }
+
+    BVH_ALWAYS_INLINE void mark_primitives(size_t axis, size_t begin, size_t split_pos, size_t end) {
+        for (size_t i = begin; i < split_pos; ++i) marks_[prim_ids_[axis][i]] = true;
+        for (size_t i = split_pos; i < end; ++i)   marks_[prim_ids_[axis][i]] = false;
+    }
+
+    std::optional<size_t> try_split(const BBox& bbox, size_t begin, size_t end) override {
+        // Find the best split over all axes
+        auto leaf_cost = config_.sah.get_non_split_cost(begin, end, bbox);
+        auto best_split = Split { (begin + end + 1) / 2, leaf_cost, 0 };
+        for (size_t axis = 0; axis < Node::dimension; ++axis)
+            find_best_split(axis, begin, end, best_split);
+
+        // Make sure that the split is good before proceeding with it
+        if (best_split.cost >= leaf_cost) {
+            if (end - begin <= config_.max_leaf_size)
+                return std::nullopt;
+
+            // If the number of primitives is too high, fallback on a split at the
+            // median on the largest axis.
+            best_split.pos = (begin + end + 1) / 2;
+            best_split.axis = bbox.get_diagonal().get_largest_axis();
+        }
+
+        // Partition primitives (keeping the order intact so that the next recursive calls do not
+        // need to sort primitives again).
+        mark_primitives(best_split.axis, begin, best_split.pos, end);
+        for (size_t axis = 0; axis < Node::dimension; ++axis) {
+            if (axis == best_split.axis)
+                continue;
+            std::stable_partition(
+                prim_ids_[axis].begin() + begin,
+                prim_ids_[axis].begin() + end,
+                [&] (size_t i) { return marks_[i]; });
+        }
+
+        return std::make_optional(best_split.pos);
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/thread_pool.h
+++ b/geom/geom/inc/bvh/v2/thread_pool.h
@@ -1,0 +1,104 @@
+#ifndef BVH_V2_THREAD_POOL_H
+#define BVH_V2_THREAD_POOL_H
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include <queue>
+#include <functional>
+
+namespace bvh::v2 {
+
+class ThreadPool {
+public:
+    using Task = std::function<void(size_t)>;
+
+    /// Creates a thread pool with the given number of threads (a value of 0 tries to autodetect
+    /// the number of threads and uses that as a thread count).
+    ThreadPool(size_t thread_count = 0) { start(thread_count); }
+
+    ~ThreadPool() {
+        wait();
+        stop();
+        join();
+    }
+
+    inline void push(Task&& fun);
+    inline void wait();
+
+    size_t get_thread_count() const { return threads_.size(); }
+
+private:
+    static inline void worker(ThreadPool*, size_t);
+
+    inline void start(size_t);
+    inline void stop();
+    inline void join();
+
+    int busy_count_ = 0;
+    bool should_stop_ = false;
+    std::mutex mutex_;
+    std::vector<std::thread> threads_;
+    std::condition_variable avail_;
+    std::condition_variable done_;
+    std::queue<Task> tasks_;
+};
+
+void ThreadPool::push(Task&& task) {
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        tasks_.emplace(std::move(task));
+    }
+    avail_.notify_one();
+}
+
+void ThreadPool::wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    done_.wait(lock, [this] { return busy_count_ == 0 && tasks_.empty(); });
+}
+
+void ThreadPool::worker(ThreadPool* pool, size_t thread_id) {
+    while (true) {
+        Task task;
+        {
+            std::unique_lock<std::mutex> lock(pool->mutex_);
+            pool->avail_.wait(lock, [pool] { return pool->should_stop_ || !pool->tasks_.empty(); });
+            if (pool->should_stop_ && pool->tasks_.empty())
+                break;
+            task = std::move(pool->tasks_.front());
+            pool->tasks_.pop();
+            pool->busy_count_++;
+        }
+        task(thread_id);
+        {
+            std::unique_lock<std::mutex> lock(pool->mutex_);
+            pool->busy_count_--;
+        }
+        pool->done_.notify_one();
+    }
+}
+
+void ThreadPool::start(size_t thread_count) {
+    if (thread_count == 0)
+        thread_count = std::max(1u, std::thread::hardware_concurrency());
+    for (size_t i = 0; i < thread_count; ++i)
+        threads_.emplace_back(worker, this, i);
+}
+
+void ThreadPool::stop() {
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        should_stop_ = true;
+    }
+    avail_.notify_all();
+}
+
+void ThreadPool::join() {
+    for (auto& thread : threads_)
+        thread.join();
+}
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/top_down_sah_builder.h
+++ b/geom/geom/inc/bvh/v2/top_down_sah_builder.h
@@ -1,0 +1,148 @@
+#ifndef BVH_V2_TOP_DOWN_SAH_BUILDER_H
+#define BVH_V2_TOP_DOWN_SAH_BUILDER_H
+
+#include "bvh/v2/bvh.h"
+#include "bvh/v2/vec.h"
+#include "bvh/v2/bbox.h"
+#include "bvh/v2/split_heuristic.h"
+#include <stack>
+#if __has_include(<span>)
+#include <span>
+#else
+// Falling back to ROOT span
+#include "ROOT/span.hxx"
+#endif
+#include <algorithm>
+#include <optional>
+#include <numeric>
+#include <cassert>
+
+namespace bvh::v2 {
+
+/// Base class for all SAH-based, top-down builders.
+template <typename Node>
+class TopDownSahBuilder {
+protected:
+    using Scalar = typename Node::Scalar;
+    using Vec  = bvh::v2::Vec<Scalar, Node::dimension>;
+    using BBox = bvh::v2::BBox<Scalar, Node::dimension>;
+
+public:
+    struct Config {
+        /// SAH heuristic parameters that control how primitives are partitioned.
+        SplitHeuristic<Scalar> sah;
+
+        /// Nodes containing less than this amount of primitives will not be split.
+        /// This is mostly to speed up BVH construction, and using large values may lead to lower
+        /// quality BVHs.
+        size_t min_leaf_size = 1;
+
+        /// Nodes that cannot be split based on the SAH and have a number of primitives larger than
+        /// this will be split using a fallback strategy. This should not happen often, but may
+        /// happen in worst-case scenarios or poorly designed scenes.
+        size_t max_leaf_size = 8;
+    };
+
+protected:
+    struct WorkItem {
+        size_t node_id;
+        size_t begin;
+        size_t end;
+
+        BVH_ALWAYS_INLINE size_t size() const { return end - begin; }
+    };
+
+    std::span<const BBox> bboxes_;
+    std::span<const Vec> centers_;
+    const Config& config_;
+
+    BVH_ALWAYS_INLINE TopDownSahBuilder(
+        std::span<const BBox> bboxes,
+        std::span<const Vec> centers,
+        const Config& config)
+        : bboxes_(bboxes)
+        , centers_(centers)
+        , config_(config)
+    {
+        assert(bboxes.size() == centers.size());
+        assert(config.min_leaf_size <= config.max_leaf_size);
+    }
+
+    virtual std::vector<size_t>& get_prim_ids() = 0;
+    virtual std::optional<size_t> try_split(const BBox& bbox, size_t begin, size_t end) = 0;
+
+    BVH_ALWAYS_INLINE const std::vector<size_t>& get_prim_ids() const {
+        return const_cast<TopDownSahBuilder*>(this)->get_prim_ids();
+    }
+
+    Bvh<Node> build() {
+        const auto prim_count = bboxes_.size();
+
+        Bvh<Node> bvh;
+        bvh.nodes.reserve((2 * prim_count) / config_.min_leaf_size);
+        bvh.nodes.emplace_back();
+        bvh.nodes.back().set_bbox(compute_bbox(0, prim_count));
+
+        std::stack<WorkItem> stack;
+        stack.push(WorkItem { 0, 0, prim_count });
+        while (!stack.empty()) {
+            auto item = stack.top();
+            stack.pop();
+
+            auto& node = bvh.nodes[item.node_id];
+            if (item.size() > config_.min_leaf_size) {
+                if (auto split_pos = try_split(node.get_bbox(), item.begin, item.end)) {
+                    auto first_child = bvh.nodes.size();
+                    node.index = Node::Index::make_inner(first_child);
+
+                    bvh.nodes.resize(first_child + 2);
+
+                    auto first_bbox   = compute_bbox(item.begin, *split_pos);
+                    auto second_bbox  = compute_bbox(*split_pos, item.end);
+                    auto first_range  = std::make_pair(item.begin, *split_pos);
+                    auto second_range = std::make_pair(*split_pos, item.end);
+
+                    // For "any-hit" queries, the left child is chosen first, so we make sure that
+                    // it is the child with the largest area, as it is more likely to contain an
+                    // an occluder. See "SATO: Surface Area Traversal Order for Shadow Ray Tracing",
+                    // by J. Nah and D. Manocha.
+                    if (first_bbox.get_half_area() < second_bbox.get_half_area()) {
+                        std::swap(first_bbox, second_bbox);
+                        std::swap(first_range, second_range);
+                    }
+
+                    auto first_item  = WorkItem { first_child + 0, first_range.first, first_range.second };
+                    auto second_item = WorkItem { first_child + 1, second_range.first, second_range.second };
+                    bvh.nodes[first_child + 0].set_bbox(first_bbox);
+                    bvh.nodes[first_child + 1].set_bbox(second_bbox);
+
+                    // Process the largest child item first, in order to minimize the stack size.
+                    if (first_item.size() < second_item.size())
+                        std::swap(first_item, second_item);
+
+                    stack.push(first_item);
+                    stack.push(second_item);
+                    continue;
+                }
+            }
+
+            node.index = Node::Index::make_leaf(item.begin, item.size());
+        }
+
+        bvh.prim_ids = std::move(get_prim_ids());
+        bvh.nodes.shrink_to_fit();
+        return bvh;
+    }
+
+    BVH_ALWAYS_INLINE BBox compute_bbox(size_t begin, size_t end) const {
+        const auto& prim_ids = get_prim_ids();
+        auto bbox = BBox::make_empty();
+        for (size_t i = begin; i < end; ++i)
+            bbox.extend(bboxes_[prim_ids[i]]);
+        return bbox;
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/utils.h
+++ b/geom/geom/inc/bvh/v2/utils.h
@@ -1,0 +1,133 @@
+#ifndef BVH_V2_UTILS_H
+#define BVH_V2_UTILS_H
+
+#include "bvh/v2/platform.h"
+
+#include <limits>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <cmath>
+#include <atomic>
+
+namespace bvh::v2 {
+
+/// Helper type that gives an unsigned integer type with the given number of bits.
+template <size_t Bits>
+struct UnsignedInt {};
+
+template <> struct UnsignedInt< 8> { using Type = uint8_t ; };
+template <> struct UnsignedInt<16> { using Type = uint16_t; };
+template <> struct UnsignedInt<32> { using Type = uint32_t; };
+template <> struct UnsignedInt<64> { using Type = uint64_t; };
+
+template <size_t Bits>
+using UnsignedIntType = typename UnsignedInt<Bits>::Type;
+
+/// Helper callable object that just ignores its arguments and returns nothing.
+struct IgnoreArgs {
+    template <typename... Args>
+    void operator () (Args&&...) const {}
+};
+
+/// Generates a bitmask with the given number of bits.
+template <typename T, std::enable_if_t<std::is_unsigned_v<T>, bool> = true>
+BVH_ALWAYS_INLINE constexpr T make_bitmask(size_t bits) {
+    return bits >= std::numeric_limits<T>::digits ? static_cast<T>(-1) : (static_cast<T>(1) << bits) - 1;
+}
+
+// These two functions are designed to return the second argument if the first one is a NaN.
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T robust_min(T a, T b) { return a < b ? a : b; }
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T robust_max(T a, T b) { return a > b ? a : b; }
+
+/// Adds the given number of ULPs (Units in the Last Place) to the given floating-point number.
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T add_ulp_magnitude(T t, unsigned ulp) {
+    if (!std::isfinite(t))
+        return t;
+    UnsignedIntType<sizeof(T) * CHAR_BIT> u;
+    std::memcpy(&u, &t, sizeof(T));
+    u += ulp;
+    std::memcpy(&t, &u, sizeof(T));
+    return t;
+}
+
+/// Computes the inverse of the given value, always returning a finite value.
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T safe_inverse(T x) {
+    return std::fabs(x) <= std::numeric_limits<T>::epsilon()
+        ? std::copysign(std::numeric_limits<T>::max(), x)
+        : static_cast<T>(1.) / x;
+}
+
+/// Fast multiply-add operation. Should translate into an FMA for architectures that support it. On
+/// architectures which do not support FMA in hardware, or on which FMA is slow, this defaults to a
+/// regular multiplication followed by an addition.
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma float_control(push)
+#pragma float_control(precise, off)
+#pragma fp_contract(on)
+#endif
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T fast_mul_add(T a, T b, T c) {
+#ifdef FP_FAST_FMAF
+    return std::fma(a, b, c);
+#elif defined(__clang__)
+    BVH_CLANG_ENABLE_FP_CONTRACT
+#endif
+    return a * b + c;
+}
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma float_control(pop)
+#endif
+
+/// Executes the given function once for every integer in the range `[Begin, End)`.
+template <size_t Begin, size_t End, typename F>
+BVH_ALWAYS_INLINE void static_for(F&& f) {
+    if constexpr (Begin < End) {
+        f(Begin);
+        static_for<Begin + 1, End>(std::forward<F>(f));
+    }
+}
+
+/// Computes the (rounded-up) compile-time log in base-2 of an unsigned integer.
+template <typename T, std::enable_if_t<std::is_unsigned_v<T>, bool> = true>
+inline constexpr T round_up_log2(T i, T p = 0) {
+    return (static_cast<T>(1) << p) >= i ? p : round_up_log2(i, p + 1);
+}
+
+/// Split an unsigned integer such that its bits are spaced by 2 zeros.
+/// For instance, split_bits(0b00110010) = 0b000000001001000000001000.
+template <typename T, std::enable_if_t<std::is_unsigned_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T split_bits(T x) {
+    constexpr size_t bit_count = sizeof(T) * CHAR_BIT;
+    constexpr size_t log_bits = round_up_log2(bit_count);
+    auto mask = static_cast<T>(-1) >> (bit_count / 2);
+    x &= mask;
+    for (size_t i = log_bits - 1, n = size_t{1} << i; i > 0; --i, n >>= 1) {
+        mask = (mask | (mask << n)) & ~(mask << (n / 2));
+        x = (x | (x << n)) & mask;
+    }
+    return x;
+}
+
+/// Morton-encode three unsigned integers into one.
+template <typename T, std::enable_if_t<std::is_unsigned_v<T>, bool> = true>
+BVH_ALWAYS_INLINE T morton_encode(T x, T y, T z) {
+    return split_bits(x) | (split_bits(y) << 1) | (split_bits(z) << 2);
+}
+
+/// Computes the maximum between an atomic variable and a value, and returns the value previously
+/// held by the atomic variable.
+template <typename T>
+BVH_ALWAYS_INLINE T atomic_max(std::atomic<T>& atomic, const T& value) {
+    auto prev_value = atomic;
+    while (prev_value < value && !atomic.compare_exchange_weak(prev_value, value));
+    return prev_value;
+}
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/inc/bvh/v2/vec.h
+++ b/geom/geom/inc/bvh/v2/vec.h
@@ -1,0 +1,133 @@
+#ifndef BVH_V2_VEC_H
+#define BVH_V2_VEC_H
+
+#include "bvh/v2/utils.h"
+
+#include <cstddef>
+#include <numeric>
+#include <cmath>
+#include <algorithm>
+
+namespace bvh::v2 {
+
+template <typename T, size_t N>
+struct Vec {
+    T values[N];
+
+    Vec() = default;
+    template <typename... Args>
+    BVH_ALWAYS_INLINE Vec(T x, T y, Args&&... args) : values { x, y, static_cast<T>(std::forward<Args>(args))... } {}
+    BVH_ALWAYS_INLINE explicit Vec(T x) { std::fill(values, values + N, x); }
+
+    template <typename Compare>
+    BVH_ALWAYS_INLINE size_t get_best_axis(Compare&& compare) const {
+        size_t axis = 0;
+        static_for<1, N>([&] (size_t i) { 
+            if (compare(values[i], values[axis]))
+                axis = i;
+        });
+        return axis;
+    }
+
+    // Note: These functions are designed to be robust to NaNs
+    BVH_ALWAYS_INLINE size_t get_largest_axis() const { return get_best_axis(std::greater<T>()); }
+    BVH_ALWAYS_INLINE size_t get_smallest_axis() const { return get_best_axis(std::less<T>()); }
+
+    BVH_ALWAYS_INLINE T& operator [] (size_t i) { return values[i]; }
+    BVH_ALWAYS_INLINE T operator [] (size_t i) const { return values[i]; }
+
+    template <typename F>
+    BVH_ALWAYS_INLINE static Vec<T, N> generate(F&& f) {
+        Vec<T, N> v;
+        static_for<0, N>([&] (size_t i) { v[i] = f(i); });
+        return v;
+    }
+};
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator + (const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a[i] + b[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator - (const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a[i] - b[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator - (const Vec<T, N>& a) {
+    return Vec<T, N>::generate([&] (size_t i) { return -a[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator * (const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a[i] * b[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator / (const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a[i] / b[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator * (const Vec<T, N>& a, T b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a[i] * b; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator * (T a, const Vec<T, N>& b) {
+    return b * a;
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> operator / (T a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return a / b[i]; });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> robust_min(const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return robust_min(a[i], b[i]); });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> robust_max(const Vec<T, N>& a, const Vec<T, N>& b) {
+    return Vec<T, N>::generate([&] (size_t i) { return robust_max(a[i], b[i]); });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE T dot(const Vec<T, N>& a, const Vec<T, N>& b) {
+    // return std::transform_reduce(a.values, a.values + N, b.values, T(0));
+    return std::inner_product(a.values, a.values + N, b.values, T(0));
+}
+
+template <typename T>
+BVH_ALWAYS_INLINE Vec<T, 3> cross(const Vec<T, 3>& a, const Vec<T, 3>& b) {
+    return Vec<T, 3>(
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]);
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> fast_mul_add(const Vec<T, N>& a, const Vec<T, N>& b, const Vec<T, N>& c) {
+    return Vec<T, N>::generate([&] (size_t i) { return fast_mul_add(a[i], b[i], c[i]); });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> safe_inverse(const Vec<T, N>& v) {
+    return Vec<T, N>::generate([&] (size_t i) { return safe_inverse(v[i]); });
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE T length(const Vec<T, N>& v) {
+    return std::sqrt(dot(v, v));
+}
+
+template <typename T, size_t N>
+BVH_ALWAYS_INLINE Vec<T, N> normalize(const Vec<T, N>& v) {
+    return v * (static_cast<T>(1.) / length(v));
+}
+
+} // namespace bvh::v2
+
+#endif

--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -31,6 +31,27 @@ method.
 #include "TGeoMatrix.h"
 #include "TGeoPhysicalNode.h"
 #include "TGeoNavigator.h"
+#include "TGeoBBox.h"
+#include "TGeoVoxelGrid.h"
+#include "TStopwatch.h"
+#include <iostream>
+#include <queue>
+#include <functional>
+#include <mutex>
+
+// this is for the bvh acceleration stuff
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+
+// V2 BVH
+#include <bvh/v2/bvh.h>
+#include <bvh/v2/vec.h>
+#include <bvh/v2/ray.h>
+#include <bvh/v2/node.h>
+#include <bvh/v2/stack.h>
+#include <bvh/v2/default_builder.h>
 
 ClassImp(TGeoParallelWorld);
 
@@ -165,6 +186,8 @@ Bool_t TGeoParallelWorld::CloseGeometry()
       Info("CloseGeometry", "Parallel world will use declared overlaps");
    else
       Info("CloseGeometry", "Parallel world will detect overlaps with other volumes");
+
+   Info("CloseGeometry", "Parallel world has %d volumes", fVolume->GetNdaughters());
    return kTRUE;
 }
 
@@ -194,13 +217,105 @@ void TGeoParallelWorld::RefreshPhysicalNodes()
    }
    // Voxelize the volume
    fVolume->GetShape()->ComputeBBox();
-   fVolume->Voxelize("ALL");
+   TStopwatch timer;
+   timer.Start();
+   auto verboselevel = TGeoManager::GetVerboseLevel();
+   if (fAccMode == AccelerationMode::kBVH) {
+      this->BuildBVH();
+      timer.Stop();
+      if (verboselevel > 2) {
+         Info("RefreshPhysicalNodes", "Initializing BVH took %f seconds", timer.RealTime());
+      }
+   }
+   if (fAccMode == AccelerationMode::kVoxelFinder) {
+      timer.Start();
+      fVolume->Voxelize("ALL");
+      timer.Stop();
+      if (verboselevel > 2) {
+         Info("RefreshPhysicalNodes", "Voxelization took %f seconds", timer.RealTime());
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Finds physical node containing the point.
+/// Uses BVH to do so. (Not the best algorithm since not O(1) but good enough.)
+/// An improved version could be implemented based on TGeoVoxelGrid caching.
+
+TGeoPhysicalNode *TGeoParallelWorld::FindNodeBVH(Double_t point[3])
+{
+   if (!fIsClosed) {
+      Fatal("FindNode", "Parallel geometry must be closed first");
+   }
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+   assert(mybvh);
+
+   Vec3 testpoint(point[0], point[1], point[2]);
+
+   TGeoPhysicalNode *nextnode = nullptr;
+
+   // This index stores the smallest object_id that contains the point
+   // only relevant if there are overlaps within the parallel world.
+   // We introduce this to make sure that the BVH traversal here, gives the same
+   // result as a simple loop iteration in increasing object_id order.
+   size_t min_contained_object_id = std::numeric_limits<size_t>::max();
+
+   auto contains = [](const Node &node, const Vec3 &p) {
+      auto box = node.get_bbox();
+      auto min = box.min;
+      auto max = box.max;
+      return (p[0] >= min[0] && p[0] <= max[0]) && (p[1] >= min[1] && p[1] <= max[1]) &&
+             (p[2] >= min[2] && p[2] <= max[2]);
+   };
+
+   auto leaf_fn = [&](size_t begin, size_t end) {
+      for (size_t prim_id = begin; prim_id < end; ++prim_id) {
+         auto objectid = mybvh->prim_ids[prim_id];
+         if (min_contained_object_id == std::numeric_limits<size_t>::max() || objectid < min_contained_object_id) {
+            auto object = fVolume->GetNode(objectid);
+            Double_t lpoint[3] = {0};
+            object->MasterToLocal(point, lpoint);
+            if (object->GetVolume()->Contains(lpoint)) {
+               nextnode = (TGeoPhysicalNode *)fPhysical->At(objectid);
+               min_contained_object_id = objectid;
+            }
+         }
+      }
+      return false; // false == go on with search even after this leaf
+   };
+
+   auto root = mybvh->nodes[0];
+   // quick check against the root node
+   if (!contains(root, testpoint)) {
+      nextnode = nullptr;
+   } else {
+      bvh::v2::GrowingStack<Bvh::Index> stack;
+      constexpr bool earlyExit = false; // needed in overlapping cases, in which we prioritize smaller object indices
+      mybvh->traverse_top_down<earlyExit>(root.index, stack, leaf_fn, [&](const Node &left, const Node &right) {
+         bool follow_left = contains(left, testpoint);
+         bool follow_right = contains(right, testpoint);
+         return std::make_tuple(follow_left, follow_right, false);
+      });
+   }
+
+   if (nextnode) {
+      fLastState = nextnode;
+   }
+   return nextnode;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Finds physical node containing the point
+/// (original version based on TGeoVoxelFinder)
 
-TGeoPhysicalNode *TGeoParallelWorld::FindNode(Double_t point[3])
+TGeoPhysicalNode *TGeoParallelWorld::FindNodeOrig(Double_t point[3])
 {
    if (!fIsClosed)
       Fatal("FindNode", "Parallel geometry must be closed first");
@@ -232,12 +347,176 @@ TGeoPhysicalNode *TGeoParallelWorld::FindNode(Double_t point[3])
    return nullptr;
 }
 
+///////////////////////////////////////////////////////////////////////////////////
+/// Finds physical node containing the point using simple algorithm (for debugging)
+
+TGeoPhysicalNode *TGeoParallelWorld::FindNodeLoop(Double_t point[3])
+{
+   if (!fIsClosed)
+      Fatal("FindNode", "Parallel geometry must be closed first");
+   Int_t nd = fVolume->GetNdaughters();
+   for (int id = 0; id < nd; id++) {
+      Double_t local[3] = {0};
+      auto node = fVolume->GetNode(id);
+      node->MasterToLocal(point, local);
+      if (node->GetVolume()->Contains(local)) {
+         // We found a node containing the point
+         fLastState = (TGeoPhysicalNode *)fPhysical->At(node->GetNumber());
+         return fLastState;
+      }
+   }
+   return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Prints the BVH
+
+void TGeoParallelWorld::PrintBVH() const
+{
+   using Scalar = float;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+
+   for (size_t i = 0; i < mybvh->nodes.size(); ++i) {
+      const auto &n = mybvh->nodes[i];
+      auto bbox = n.get_bbox();
+      auto min = bbox.min;
+      auto max = bbox.max;
+      long objectid = -1;
+      if (n.index.prim_count() > 0) {
+         objectid = mybvh->prim_ids[n.index.first_id()];
+      }
+      std::cout << "NODE id" << i << " "
+                << " prim_count: " << n.index.prim_count() << " first_id " << n.index.first_id() << " object_id "
+                << objectid << " ( " << min[0] << " , " << min[1] << " , " << min[2] << ")"
+                << " ( " << max[0] << " , " << max[1] << " , " << max[2] << ")"
+                << "\n";
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Same functionality as TGeoNavigator::FindNextDaughterBoundary for the
-/// parallel world
+/// parallel world. Uses BVH to do so.
 
 TGeoPhysicalNode *
-TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax)
+TGeoParallelWorld::FindNextBoundaryBVH(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax)
+{
+   if (!fIsClosed) {
+      Fatal("FindNextBoundary", "Parallel geometry must be closed first");
+   }
+
+   TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
+   // Fast return if not in an overlapping candidate
+   if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate()) {
+      return nullptr;
+   }
+   // last touched physical node in the parallel geometry
+   if (fLastState && fLastState->IsMatchingState(nav)) {
+      return nullptr;
+   }
+
+   double local_step = stepmax; // we need this otherwise the lambda get's confused
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   using Ray = bvh::v2::Ray<Scalar, 3>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+   if (!mybvh) {
+      Error("FindNextBoundary", "Cannot perform safety; No BVH initialized");
+      return nullptr;
+   }
+
+   auto truncate_roundup = [](double orig) {
+      float epsilon = std::numeric_limits<float>::epsilon() * std::fabs(orig);
+      // Add the bias to x before assigning it to y
+      return static_cast<float>(orig + epsilon);
+   };
+
+   // let's do very quick checks against the top node
+   const auto topnode_bbox = mybvh->get_root().get_bbox();
+   if ((-point[0] + topnode_bbox.min[0]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+   if ((-point[1] + topnode_bbox.min[1]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+   if ((-point[2] + topnode_bbox.min[2]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+   if ((point[0] - topnode_bbox.max[0]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+   if ((point[1] - topnode_bbox.max[1]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+   if ((point[2] - topnode_bbox.max[2]) > stepmax) {
+      step = stepmax;
+      return nullptr;
+   }
+
+   // the ray used for bvh interaction
+   Ray ray(Vec3(point[0], point[1], point[2]), // origin
+           Vec3(dir[0], dir[1], dir[2]),       // direction
+           0.0f,                               // minimum distance
+           truncate_roundup(local_step));
+
+   TGeoPhysicalNode *nextnode = nullptr;
+
+   static constexpr bool use_robust_traversal = true;
+
+   // Traverse the BVH and apply concrecte object intersection in BVH leafs
+   bvh::v2::GrowingStack<Bvh::Index> stack;
+   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+      for (size_t prim_id = begin; prim_id < end; ++prim_id) {
+         auto objectid = mybvh->prim_ids[prim_id];
+         auto object = fVolume->GetNode(objectid);
+
+         auto pnode = (TGeoPhysicalNode *)fPhysical->At(objectid);
+         if (pnode->IsMatchingState(nav)) {
+            // Info("FOO", "Matching state return");
+            step = TGeoShape::Big();
+            nextnode = nullptr;
+            return true;
+         }
+         Double_t lpoint[3], ldir[3];
+         object->MasterToLocal(point, lpoint);
+         object->MasterToLocalVect(dir, ldir);
+         auto thisstep = object->GetVolume()->GetShape()->DistFromOutside(lpoint, ldir, 3, local_step);
+         if (thisstep < local_step) {
+            local_step = thisstep;
+            nextnode = pnode;
+         }
+      }
+      return false; // go on after this
+   });
+
+   // nothing hit
+   if (!nextnode) {
+      local_step = TGeoShape::Big();
+   }
+   step = local_step;
+   return nextnode;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Same functionality as TGeoNavigator::FindNextDaughterBoundary for the
+/// parallel world.
+/// (original version based on TGeoVoxelFinder)
+
+TGeoPhysicalNode *
+TGeoParallelWorld::FindNextBoundaryOrig(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax)
 {
    if (!fIsClosed)
       Fatal("FindNextBoundary", "Parallel geometry must be closed first");
@@ -329,9 +608,541 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute safety for the parallel world
+/// Same functionality as TGeoNavigator::FindNextDaughterBoundary for the
+/// parallel world in a trivial loop version (for debugging)
 
-Double_t TGeoParallelWorld::Safety(Double_t point[3], Double_t safmax)
+TGeoPhysicalNode *
+TGeoParallelWorld::FindNextBoundaryLoop(Double_t point[3], Double_t dir[3], Double_t &step, Double_t stepmax)
+{
+   if (!fIsClosed) {
+      Fatal("FindNextBoundary", "Parallel geometry must be closed first");
+   }
+
+   TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
+   // Fast return if not in an overlapping candidate
+   if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate()) {
+      return nullptr;
+   }
+   // last touched physical node in the parallel geometry
+   if (fLastState && fLastState->IsMatchingState(nav)) {
+      return nullptr;
+   }
+
+   step = stepmax;
+   int nd = fVolume->GetNdaughters();
+   TGeoPhysicalNode *nextnode = nullptr;
+   for (int i = 0; i < nd; ++i) {
+      auto object = fVolume->GetNode(i);
+      // check actual distance/safety to object
+      Double_t lpoint[3], ldir[3];
+
+      object->MasterToLocal(point, lpoint);
+      object->MasterToLocalVect(dir, ldir);
+      auto thisstep = object->GetVolume()->GetShape()->DistFromOutside(lpoint, ldir, 3, step);
+      if (thisstep < step) {
+         step = thisstep;
+         nextnode = (TGeoPhysicalNode *)fPhysical->At(i);
+      }
+   }
+   // nothing hit
+   if (!nextnode) {
+      step = TGeoShape::Big();
+   }
+   return nextnode;
+}
+
+namespace {
+// some helpers for point - axis aligned bounding box functions
+// using bvh types
+
+// determines if a point is inside the bounding box
+template <typename T>
+bool contains(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   auto min = box.min;
+   auto max = box.max;
+   return (p[0] >= min[0] && p[0] <= max[0]) && (p[1] >= min[1] && p[1] <= max[1]) &&
+          (p[2] >= min[2] && p[2] <= max[2]);
+}
+
+// determines the largest squared distance of point to any of the bounding box corners
+template <typename T>
+auto RmaxSqToNode(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   // construct the 8 corners to get the maximal distance
+   const auto minCorner = box.min;
+   const auto maxCorner = box.max;
+   using Vec3 = bvh::v2::Vec<T, 3>;
+   // these are the corners of the bounding box
+   const std::array<bvh::v2::Vec<T, 3>, 8> corners{
+      Vec3{minCorner[0], minCorner[1], minCorner[2]}, Vec3{minCorner[0], minCorner[1], maxCorner[2]},
+      Vec3{minCorner[0], maxCorner[1], minCorner[2]}, Vec3{minCorner[0], maxCorner[1], maxCorner[2]},
+      Vec3{maxCorner[0], minCorner[1], minCorner[2]}, Vec3{maxCorner[0], minCorner[1], maxCorner[2]},
+      Vec3{maxCorner[0], maxCorner[1], minCorner[2]}, Vec3{maxCorner[0], maxCorner[1], maxCorner[2]}};
+
+   T Rmax_sq{0};
+   for (const auto &corner : corners) {
+      float R_sq = 0.;
+      const auto dx = corner[0] - p[0];
+      R_sq += dx * dx;
+      const auto dy = corner[1] - p[1];
+      R_sq += dy * dy;
+      const auto dz = corner[2] - p[2];
+      R_sq += dz * dz;
+      Rmax_sq = std::max(Rmax_sq, R_sq);
+   }
+   return Rmax_sq;
+};
+
+// determines the mininum squared distance of point to a bounding box ("safey square")
+template <typename T>
+auto SafetySqToNode(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   T sqDist{0.0};
+   for (int i = 0; i < 3; i++) {
+      T v = p[i];
+      if (v < box.min[i]) {
+         sqDist += (box.min[i] - v) * (box.min[i] - v);
+      } else if (v > box.max[i]) {
+         sqDist += (v - box.max[i]) * (v - box.max[i]);
+      }
+   }
+   return sqDist;
+};
+
+// Helper classes/structs used for priority queue - BVH traversal
+
+// structure keeping cost (value) for a BVH index
+struct BVHPrioElement {
+   size_t bvh_node_id;
+   float value;
+};
+
+// A priority queue for BVHPrioElement with an additional clear method
+// for quick reset
+template <typename Comparator>
+class BVHPrioQueue : public std::priority_queue<BVHPrioElement, std::vector<BVHPrioElement>, Comparator> {
+public:
+   using std::priority_queue<BVHPrioElement, std::vector<BVHPrioElement>,
+                             Comparator>::priority_queue; // constructor inclusion
+
+   // convenience method to quickly clear/reset the queue (instead of having to pop one by one)
+   void clear() { this->c.clear(); }
+};
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Method to find potentially relevant candidate bounding boxes for safety calculation
+/// given a point. Uses trivial algorithm to do so.
+
+std::pair<double, double>
+TGeoParallelWorld::GetLoopSafetyCandidates(double point[3], std::vector<int> &candidates, double margin) const
+{
+   // Given a 3D point, returns the
+   // a) the min radius R such that there is at least one leaf bounding box fully enclosed
+   //    in the sphere of radius R around point + the smallest squared safety
+   // b) the set of leaf bounding boxes who partially lie within radius + margin
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using BBox = bvh::v2::BBox<Scalar, 3>;
+   const auto bboxes_ptr = (std::vector<BBox> *)fBoundingBoxes;
+   auto &bboxes = (*bboxes_ptr);
+
+   auto cmp = [](BVHPrioElement a, BVHPrioElement b) { return a.value > b.value; };
+   static thread_local BVHPrioQueue<decltype(cmp)> queue(cmp);
+   queue.clear();
+
+   // testpoint object in float for quick BVH interaction
+   Vec3 testpoint(point[0], point[1], point[2]);
+   float best_enclosing_R_sq = std::numeric_limits<float>::max();
+   for (size_t i = 0; i < bboxes.size(); ++i) {
+      const auto &thisbox = bboxes[i];
+      auto safety_sq = SafetySqToNode(thisbox, testpoint);
+      const auto this_R_max_sq = RmaxSqToNode(thisbox, testpoint);
+      const auto inside = contains(thisbox, testpoint);
+      safety_sq = inside ? -1.f : safety_sq;
+      best_enclosing_R_sq = std::min(best_enclosing_R_sq, this_R_max_sq);
+      queue.emplace(BVHPrioElement{i, safety_sq});
+   }
+
+   // now we know the best enclosing R
+   // **and** we can fill the candidate set from the priority queue easily
+   float safety_sq_at_least = -1.f;
+
+   // final transform in order to take into account margin
+   if (margin != 0.) {
+      float best_enclosing_R = std::sqrt(best_enclosing_R_sq) + margin;
+      best_enclosing_R_sq = best_enclosing_R * best_enclosing_R;
+   }
+
+   if (queue.size() > 0) {
+      auto el = queue.top();
+      queue.pop();
+      safety_sq_at_least = el.value; // safety_sq;
+      while (el.value /*safety_sq*/ < best_enclosing_R_sq) {
+         candidates.emplace_back(el.bvh_node_id);
+         if (queue.size() > 0) {
+            el = queue.top();
+            queue.pop();
+         } else {
+            break;
+         }
+      }
+   }
+   return std::make_pair<double, double>(best_enclosing_R_sq, safety_sq_at_least);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Method to find potentially relevant candidate bounding boxes for safety calculation
+/// given a point. Uses BVH to do so.
+
+std::pair<double, double>
+TGeoParallelWorld::GetBVHSafetyCandidates(double point[3], std::vector<int> &candidates, double margin) const
+{
+   // Given a 3D point, returns the
+   // a) the min radius R such that there is at least one leaf bounding box fully enclosed
+   //    in the sphere of radius R around point
+   // b) the set of leaf bounding boxes who partially lie within radius + margin
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   using BBox = bvh::v2::BBox<Scalar, 3>;
+   // let's fetch the primitive bounding boxes
+   const auto bboxes = (std::vector<BBox> *)fBoundingBoxes;
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+
+   // testpoint object in float for quick BVH interaction
+   Vec3 testpoint(point[0], point[1], point[2]);
+
+   // comparator bringing out "smallest" value on top
+   auto cmp = [](BVHPrioElement a, BVHPrioElement b) { return a.value > b.value; };
+   static thread_local BVHPrioQueue<decltype(cmp)> queue(cmp);
+   queue.clear();
+   static thread_local BVHPrioQueue<decltype(cmp)> leaf_queue(cmp);
+   leaf_queue.clear();
+
+   auto currnode = mybvh->nodes[0]; // we start from the top BVH node
+   // algorithm is based on standard iterative tree traversal with priority queues
+   float best_enclosing_R_sq = std::numeric_limits<float>::max();
+   float best_enclosing_R_with_margin_sq = std::numeric_limits<float>::max();
+   float current_safety_sq = 0.f;
+   do {
+      if (currnode.is_leaf()) {
+         // we are in a leaf node and actually talk to primitives
+         const auto begin_prim_id = currnode.index.first_id();
+         const auto end_prim_id = begin_prim_id + currnode.index.prim_count();
+         for (auto p_id = begin_prim_id; p_id < end_prim_id; p_id++) {
+            const auto object_id = mybvh->prim_ids[p_id];
+            //
+            // fetch leaf_bounding box
+            const auto &leaf_bounding_box = (*bboxes)[object_id];
+            auto this_Rmax_sq = RmaxSqToNode(leaf_bounding_box, testpoint);
+            const bool inside = contains(leaf_bounding_box, testpoint);
+            const auto safety_sq = inside ? -1.f : SafetySqToNode(leaf_bounding_box, testpoint);
+
+            // update best Rmin
+            if (this_Rmax_sq < best_enclosing_R_sq) {
+               best_enclosing_R_sq = this_Rmax_sq;
+               const auto this_Rmax = std::sqrt(this_Rmax_sq);
+               best_enclosing_R_with_margin_sq = (this_Rmax + margin) * (this_Rmax + margin);
+            }
+
+            // best_enclosing_R_sq = std::min(best_enclosing_R_sq, this_Rmax_sq);
+            if (safety_sq <= best_enclosing_R_with_margin_sq) {
+               // update the priority queue of leaf bounding boxes
+               leaf_queue.emplace(BVHPrioElement{object_id, safety_sq});
+            }
+         }
+      } else {
+         // not a leave node ... for further traversal,
+         // we inject the children into priority queue based on distance to it's bounding box
+         const auto leftchild_id = currnode.index.first_id();
+         const auto rightchild_id = leftchild_id + 1;
+
+         for (size_t childid : {leftchild_id, rightchild_id}) {
+            if (childid >= mybvh->nodes.size()) {
+               continue;
+            }
+            const auto &node = mybvh->nodes[childid];
+            const auto &thisbbox = node.get_bbox();
+            auto inside = contains(thisbbox, testpoint);
+            const auto this_safety_sq = inside ? -1.f : SafetySqToNode(thisbbox, testpoint);
+            if (this_safety_sq <= best_enclosing_R_with_margin_sq) {
+               // this should be further considered
+               queue.push(BVHPrioElement{childid, this_safety_sq});
+            }
+         }
+      }
+
+      if (queue.size() > 0) {
+         auto currElement = queue.top();
+         currnode = mybvh->nodes[currElement.bvh_node_id];
+         current_safety_sq = currElement.value;
+         queue.pop();
+      } else {
+         break;
+      }
+   } while (current_safety_sq <= best_enclosing_R_with_margin_sq);
+
+   // now we know the best enclosing R
+   // **and** we can fill the candidate set from the leaf priority queue easily
+   float safety_sq_at_least = -1.f;
+   if (leaf_queue.size() > 0) {
+      auto el = leaf_queue.top();
+      leaf_queue.pop();
+      safety_sq_at_least = el.value;
+      while (el.value < best_enclosing_R_with_margin_sq) {
+         candidates.emplace_back(el.bvh_node_id);
+         if (leaf_queue.size() > 0) {
+            el = leaf_queue.top();
+            leaf_queue.pop();
+         } else {
+            break;
+         }
+      }
+   }
+   return std::make_pair<double, double>(best_enclosing_R_sq, safety_sq_at_least);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Method to initialize the safety voxel at a specific 3D voxel (grid) index
+///
+
+void TGeoParallelWorld::InitSafetyVoxel(TGeoVoxelGridIndex const &vi)
+{
+   static std::mutex g_mutex;
+   // this function modifies cache state ---> make writing thread-safe
+   const std::lock_guard<std::mutex> lock(g_mutex);
+
+   // determine voxel midpoint
+   const auto [mpx, mpy, mpz] = fSafetyVoxelCache->getVoxelMidpoint(vi);
+   static std::vector<int> candidates;
+   candidates.clear();
+   double point[3] = {mpx, mpy, mpz};
+   auto [encl_Rmax_sq, min_safety_sq] =
+      GetBVHSafetyCandidates(point, candidates, fSafetyVoxelCache->getDiagonalLength());
+
+   // cache information
+   auto voxelinfo = fSafetyVoxelCache->at(vi);
+   voxelinfo->min_safety = std::sqrt(min_safety_sq);
+   voxelinfo->idx_start = fSafetyCandidateStore.size();
+   voxelinfo->num_candidates = candidates.size();
+
+   // update flat candidate store
+   std::copy(candidates.begin(), candidates.end(), std::back_inserter(fSafetyCandidateStore));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute safety for the parallel world
+/// used BVH structure with addiditional on-the-fly 3D grid/voxel caching ---> essentially an O(1) algorithm !)
+
+double TGeoParallelWorld::VoxelSafety(double point[3], double safe_max)
+{
+   // (a): Very fast checks against top box and global caching
+   // (b): Use voxel cached best safety
+   // (c): Use voxel candidates (fetch them if they are not yet initialized)
+
+   TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
+   // Fast return if the state matches the last one recorded
+
+   if (fLastState && fLastState->IsMatchingState(nav)) {
+      return TGeoShape::Big();
+   }
+
+   // Fast return if not in an overlapping candidate
+   if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate()) {
+      return TGeoShape::Big();
+   }
+
+   // let's determine the voxel indices
+   TGeoVoxelGridIndex vi = fSafetyVoxelCache->pointToVoxelIndex((float)point[0], (float)point[1], (float)point[2]);
+   if (!vi.isValid()) {
+      return SafetyBVH(point, safe_max);
+   }
+
+   auto &voxelinfo = fSafetyVoxelCache->fGrid[vi.idx];
+   double bestsafety = safe_max;
+
+   if (!voxelinfo.isInitialized()) {
+      // initialize the cache at this voxel
+      InitSafetyVoxel(vi);
+   }
+
+   if (voxelinfo.min_safety > 0) {
+      // Nothing to do if this is already much further away than safe_max (within the margin limits of the voxel)
+      if (voxelinfo.min_safety - fSafetyVoxelCache->getDiagonalLength() > safe_max) {
+         return safe_max;
+      }
+
+      // see if the precalculated (mid-point) safety value can be used
+      auto midpoint = fSafetyVoxelCache->getVoxelMidpoint(vi);
+      double r_sq = 0;
+      for (int i = 0; i < 3; ++i) {
+         const auto d = (point[i] - midpoint[i]);
+         r_sq += d * d;
+      }
+      if (r_sq < voxelinfo.min_safety * voxelinfo.min_safety) {
+         // std::cout << " Still within cached safety ... remaining safety would be " << ls_eval - std::sqrt(r) << "\n";
+         return voxelinfo.min_safety - std::sqrt(r_sq);
+      }
+   }
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using BBox = bvh::v2::BBox<Scalar, 3>;
+   const auto bboxes_ptr = (std::vector<BBox> *)fBoundingBoxes;
+   auto &bboxes = (*bboxes_ptr);
+   Vec3 testpoint(point[0], point[1], point[2]);
+   // do the full calculation using all candidates here
+   for (size_t store_id = voxelinfo.idx_start; store_id < voxelinfo.idx_start + voxelinfo.num_candidates; ++store_id) {
+
+      const auto cand_id = fSafetyCandidateStore[store_id];
+
+      // check against bounding box
+      const auto &bbox = bboxes[cand_id];
+      const auto bbox_safe_sq = SafetySqToNode(bbox, testpoint);
+      if (bbox_safe_sq > bestsafety * bestsafety) {
+         continue;
+      }
+
+      // check against actual geometry primitive-safety
+      const auto primitive_node = fVolume->GetNode(cand_id);
+      const auto thissafety = primitive_node->Safety(point, false);
+      if (thissafety < bestsafety) {
+         bestsafety = std::max(0., thissafety);
+      }
+   }
+   return bestsafety;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute safety for the parallel world
+/// (using pure BVH traversal, mainly for debugging/fallback since VoxelSafety should be faster)
+
+double TGeoParallelWorld::SafetyBVH(double point[3], double safe_max)
+{
+   TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
+   // Fast return if the state matches the last one recorded
+   if (fLastState && fLastState->IsMatchingState(nav)) {
+      return TGeoShape::Big();
+   }
+   // Fast return if not in an overlapping candidate
+   if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate()) {
+      return TGeoShape::Big();
+   }
+
+   float smallest_safety = safe_max;
+   float smallest_safety_sq = smallest_safety * smallest_safety;
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+
+   // testpoint object in float for quick BVH interaction
+   Vec3 testpoint(point[0], point[1], point[2]);
+
+   auto currnode = mybvh->nodes[0]; // we start from the top BVH node
+   // we do a quick check on the top node
+   bool outside_top = !::contains(currnode.get_bbox(), testpoint);
+   const auto safety_sq_to_top = SafetySqToNode(currnode.get_bbox(), testpoint);
+   if (outside_top && safety_sq_to_top > smallest_safety_sq) {
+      // the top node is already further away than our limit, so we can simply return the limit
+      return smallest_safety;
+   }
+
+   // comparator bringing out "smallest" value on top
+   auto cmp = [](BVHPrioElement a, BVHPrioElement b) { return a.value > b.value; };
+   static thread_local BVHPrioQueue<decltype(cmp)> queue(cmp);
+   queue.clear();
+
+   // algorithm is based on standard iterative tree traversal with priority queues
+   float current_safety_to_node_sq = outside_top ? safety_sq_to_top : 0.f;
+   do {
+      if (currnode.is_leaf()) {
+         // we are in a leaf node and actually talk to TGeo primitives
+         const auto begin_prim_id = currnode.index.first_id();
+         const auto end_prim_id = begin_prim_id + currnode.index.prim_count();
+
+         for (auto p_id = begin_prim_id; p_id < end_prim_id; p_id++) {
+            const auto object_id = mybvh->prim_ids[p_id];
+
+            auto pnode = (TGeoPhysicalNode *)fPhysical->UncheckedAt(object_id);
+            // Return if inside the current node
+            if (pnode->IsMatchingState(nav)) {
+               return TGeoShape::Big();
+            }
+
+            auto object = fVolume->GetNode(object_id);
+            // check actual distance/safety to object
+            auto thissafety = object->Safety(point, false);
+
+            // this value (if not zero or negative) may be approximative but we know that it can actually not be smaller
+            // than the relevant distance to the bounding box of the node!! Hence we can correct it.
+
+            // if (thissafety > 1E-10 && thissafety * thissafety < current_safety_to_node_sq) {
+            //   thissafety = std::max(thissafety, double(std::sqrt(current_safety_to_node_sq)));
+            // }
+
+            if (thissafety < smallest_safety) {
+               smallest_safety = std::max(0., thissafety);
+               smallest_safety_sq = smallest_safety * smallest_safety;
+            }
+         }
+      } else {
+         // not a leave node ... for further traversal,
+         // we inject the children into priority queue based on distance to it's bounding box
+         const auto leftchild_id = currnode.index.first_id();
+         const auto rightchild_id = leftchild_id + 1;
+
+         for (size_t childid : {leftchild_id, rightchild_id}) {
+            if (childid >= mybvh->nodes.size()) {
+               continue;
+            }
+
+            const auto &node = mybvh->nodes[childid];
+            const auto inside = contains(node.get_bbox(), testpoint);
+
+            if (inside) {
+               // this must be further considered because we are inside the bounding box
+               queue.push(BVHPrioElement{childid, -1.});
+            } else {
+               auto safety_to_node_square = SafetySqToNode(node.get_bbox(), testpoint);
+               if (safety_to_node_square <= smallest_safety_sq) {
+                  // this should be further considered
+                  queue.push(BVHPrioElement{childid, safety_to_node_square});
+               }
+            }
+         }
+      }
+
+      if (queue.size() > 0) {
+         auto currElement = queue.top();
+         currnode = mybvh->nodes[currElement.bvh_node_id];
+         current_safety_to_node_sq = currElement.value;
+         queue.pop();
+      } else {
+         break;
+      }
+   } while (current_safety_to_node_sq <= smallest_safety_sq);
+
+   const auto s = std::max(0., double(smallest_safety));
+   return s;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute safety for the parallel world
+/// (original version based on TGeoVoxelFinder)
+
+Double_t TGeoParallelWorld::SafetyOrig(Double_t point[3], Double_t safmax)
 {
    TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
    // Fast return if the state matches the last one recorded
@@ -390,6 +1201,45 @@ Double_t TGeoParallelWorld::Safety(Double_t point[3], Double_t safmax)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Compute safety for the parallel world
+/// (trivial loop version for comparison/debugging)
+
+Double_t TGeoParallelWorld::SafetyLoop(Double_t point[3], Double_t safmax)
+{
+   TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
+   // Fast return if the state matches the last one recorded
+   if (fLastState && fLastState->IsMatchingState(nav))
+      return TGeoShape::Big();
+   // Fast return if not in an overlapping candidate
+   if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate())
+      return TGeoShape::Big();
+
+   Double_t local[3];
+   Double_t safe = safmax;
+   Double_t safnext;
+   const Double_t tolerance = TGeoShape::Tolerance();
+   Int_t nd = fVolume->GetNdaughters();
+
+   for (Int_t id = 0; id < nd; id++) {
+      auto current = fVolume->GetNode(id);
+      current->MasterToLocal(point, local);
+      if (current->GetVolume()->GetShape()->Contains(local)) {
+         safnext = 0.;
+      } else {
+         // Safety to current node
+         safnext = current->GetVolume()->GetShape()->Safety(local, kFALSE);
+      }
+      if (safnext < tolerance) {
+         return 0.;
+      }
+      if (safnext < safe) {
+         safe = safnext;
+      }
+   }
+   return safe;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Check overlaps within a tolerance value.
 
 void TGeoParallelWorld::CheckOverlaps(Double_t ovlp)
@@ -404,3 +1254,235 @@ void TGeoParallelWorld::Draw(Option_t *option)
 {
    fVolume->Draw(option);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Check/validate the BVH acceleration structure.
+
+bool TGeoParallelWorld::CheckBVH(void *bvh, size_t expected_leaf_count) const
+{
+   using Scalar = float;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   auto mybvh = (Bvh *)bvh;
+
+   size_t leaf_count = 0;
+   std::function<bool(Node const &)> checkNode = [&](Node const &nde) -> bool {
+      if (nde.is_leaf()) {
+         leaf_count += nde.index.prim_count();
+         return nde.index.prim_count() > 0;
+      }
+
+      // we do it recursively
+      auto thisbb = nde.get_bbox();
+
+      auto leftindex = nde.index.first_id();
+      auto rightindex = leftindex + 1;
+
+      auto leftnode = mybvh->nodes[leftindex];
+      auto rightnode = mybvh->nodes[rightindex];
+
+      auto leftbb = leftnode.get_bbox();
+      auto rightbb = rightnode.get_bbox();
+
+      // both of these boxes must be contained in the bounding box
+      // of the outer node
+      auto tmi = thisbb.min;
+      auto lmi = leftbb.min;
+      auto rmi = rightbb.min;
+
+      auto check1 = lmi[0] >= tmi[0] && lmi[1] >= tmi[1] && lmi[2] >= tmi[2];
+      auto check2 = rmi[0] >= tmi[0] && rmi[1] >= tmi[1] && rmi[2] >= tmi[2];
+
+      auto tma = thisbb.max;
+      auto lma = leftbb.max;
+      auto rma = rightbb.max;
+
+      auto check3 = lma[0] <= tma[0] && lma[1] <= tma[1] && lma[2] <= tma[2];
+      auto check4 = rma[0] <= tma[0] && rma[1] <= tma[1] && rma[2] <= tma[2];
+
+      auto check = check1 && check2 && check3 && check4;
+
+      return checkNode(leftnode) && checkNode(rightnode) && check;
+   };
+
+   auto check = checkNode(mybvh->nodes[0]);
+   return check && leaf_count == expected_leaf_count;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Build the BVH acceleration structure.
+
+void TGeoParallelWorld::BuildBVH()
+{
+   using Scalar = float;
+   using BBox = bvh::v2::BBox<Scalar, 3>;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   auto DaughterToMother = [](TGeoNode const *node, const Double_t *local, Double_t *master) {
+      TGeoMatrix *mat = node->GetMatrix();
+      if (!mat) {
+         memcpy(master, local, 3 * sizeof(Double_t));
+      } else {
+         mat->LocalToMaster(local, master);
+      }
+   };
+
+   // helper determining axis aligned bounding box from TGeoNode; code copied from the TGeoVoxelFinder
+   auto GetBoundingBoxInMother = [DaughterToMother](TGeoNode const *node) {
+      Double_t vert[24] = {0};
+      Double_t pt[3] = {0};
+      Double_t xyz[6] = {0};
+      TGeoBBox *box = (TGeoBBox *)node->GetVolume()->GetShape();
+      box->SetBoxPoints(&vert[0]);
+      for (Int_t point = 0; point < 8; point++) {
+         DaughterToMother(node, &vert[3 * point], &pt[0]);
+         if (!point) {
+            xyz[0] = xyz[1] = pt[0];
+            xyz[2] = xyz[3] = pt[1];
+            xyz[4] = xyz[5] = pt[2];
+            continue;
+         }
+         for (Int_t j = 0; j < 3; j++) {
+            if (pt[j] < xyz[2 * j]) {
+               xyz[2 * j] = pt[j];
+            }
+            if (pt[j] > xyz[2 * j + 1]) {
+               xyz[2 * j + 1] = pt[j];
+            }
+         }
+      }
+      BBox bbox;
+      bbox.min[0] = std::min(xyz[1], xyz[0]) - 0.001f;
+      bbox.min[1] = std::min(xyz[3], xyz[2]) - 0.001f;
+      bbox.min[2] = std::min(xyz[5], xyz[4]) - 0.001f;
+      bbox.max[0] = std::max(xyz[0], xyz[1]) + 0.001f;
+      bbox.max[1] = std::max(xyz[2], xyz[3]) + 0.001f;
+      bbox.max[2] = std::max(xyz[4], xyz[5]) + 0.001f;
+      return bbox;
+   };
+
+   // we need bounding boxes enclosing the primitives and centers of primitives
+   // (replaced here by centers of bounding boxes) to build the bvh
+   auto bboxes_ptr = new std::vector<BBox>();
+   fBoundingBoxes = (void *)bboxes_ptr;
+   auto &bboxes = *bboxes_ptr;
+   std::vector<Vec3> centers;
+
+   int nd = fVolume->GetNdaughters();
+   for (int i = 0; i < nd; ++i) {
+      auto node = fVolume->GetNode(i);
+      // fetch the bounding box of this node and add to the vector of bounding boxes
+      (bboxes).push_back(GetBoundingBoxInMother(node));
+      centers.emplace_back((bboxes).back().get_center());
+   }
+
+   // check if some previous object is registered and delete if necessary
+   if (fBVH) {
+      delete (Bvh *)fBVH;
+      fBVH = nullptr;
+   }
+
+   // create the bvh
+   typename bvh::v2::DefaultBuilder<Node>::Config config;
+   config.quality = bvh::v2::DefaultBuilder<Node>::Quality::High;
+   auto bvh = bvh::v2::DefaultBuilder<Node>::build(bboxes, centers, config);
+   auto bvhptr = new Bvh;
+   *bvhptr = std::move(bvh); // copy structure
+   fBVH = (void *)(bvhptr);
+
+   auto check = CheckBVH(fBVH, nd);
+   if (!check) {
+      Error("BuildBVH", "BVH corrupted\n");
+   } else {
+      Info("BuildBVH", "BVH good\n");
+   }
+
+   // now instantiate the 3D voxel grid for caching the safety candidates
+   // (note that the structure is merely reserved ... actual filling will happen on-the-fly later on)
+   const auto &topBB = bvhptr->get_root().get_bbox();
+   int N = std::cbrt(bboxes.size()) + 1;
+   // std::cout << "3D Safety GRID cache: Determined N to be " << N << "\n";
+   double Lx = (topBB.max[0] - topBB.min[0]) / N;
+   double Ly = (topBB.max[1] - topBB.min[1]) / N;
+   double Lz = (topBB.max[2] - topBB.min[2]) / N;
+   // TODO: Instead of equal number of voxels in each direction, we
+   // could impose equal "cubic" voxel size
+
+   if (fSafetyVoxelCache) {
+      delete fSafetyVoxelCache;
+      fSafetyCandidateStore.clear();
+   }
+
+   fSafetyVoxelCache = new TGeoVoxelGrid<SafetyVoxelInfo>(topBB.min[0], topBB.min[1], topBB.min[2], topBB.max[0],
+                                                          topBB.max[1], topBB.max[2], Lx, Ly, Lz);
+
+   // TestVoxelGrid();
+   return;
+}
+
+void TGeoParallelWorld::TestVoxelGrid()
+{
+   static bool done = false;
+   if (done) {
+      return;
+   }
+   done = true;
+
+   auto NX = fSafetyVoxelCache->getVoxelCountX();
+   auto NY = fSafetyVoxelCache->getVoxelCountY();
+   auto NZ = fSafetyVoxelCache->getVoxelCountZ();
+
+   std::vector<int> candidates1;
+   std::vector<int> candidates2;
+
+   for (int i = 0; i < NX; ++i) {
+      for (int j = 0; j < NY; ++j) {
+         for (int k = 0; k < NZ; ++k) {
+            size_t idx = fSafetyVoxelCache->index(i, j, k);
+            TGeoVoxelGridIndex vi{i, j, k, idx};
+
+            // midpoint
+            auto mp = fSafetyVoxelCache->getVoxelMidpoint(vi);
+
+            // let's do some tests
+            candidates1.clear();
+            candidates2.clear();
+            double point[3] = {mp[0], mp[1], mp[2]};
+            auto [encl_Rmax_sq_1, min_safety_sq_1] =
+               GetBVHSafetyCandidates(point, candidates1, fSafetyVoxelCache->getDiagonalLength());
+            auto [encl_Rmax_sq_2, min_safety_sq_2] =
+               GetLoopSafetyCandidates(point, candidates2, fSafetyVoxelCache->getDiagonalLength());
+            if (candidates1.size() != candidates2.size()) {
+               std::cerr << " i " << i << " " << j << " " << k << " RMAX 2 (BVH) " << encl_Rmax_sq_1 << " CANDSIZE "
+                         << candidates1.size() << " RMAX (LOOP) " << encl_Rmax_sq_2 << " CANDSIZE "
+                         << candidates2.size() << "\n";
+            }
+
+            // the candidate indices have to be the same
+            bool same_test1 = true;
+            for (auto &id : candidates1) {
+               auto ok = std::find(candidates2.begin(), candidates2.end(), id) != candidates2.end();
+               if (!ok) {
+                  same_test1 = false;
+                  break;
+               }
+            }
+            bool same_test2 = true;
+            for (auto &id : candidates2) {
+               auto ok = std::find(candidates1.begin(), candidates1.end(), id) != candidates1.end();
+               if (!ok) {
+                  same_test2 = false;
+                  break;
+               }
+            }
+            if (!(same_test1 && same_test2)) {
+               Error("VoxelTest", "Same test fails %d %d", same_test1, same_test2);
+            }
+         }
+      }
+   }
+}
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
This commit provides a rewrite of key functions of TGeoParallelWorld, achieving: 

  (a) faster initialization
  (b) faster execution of the Safety function (from ~O(N) to ~O(1)) 
  (c) faster or equal execution of FindNode/FindBoundary functions (~log(N)) 
  (d) less memory consumption (better memory scalability)

The development for this commit was motivated from a use case in ALICE, in which the parallel world "scene" can be very large (~100K volumes). In this case, TGeoVoxelFinder takes very long
to construct and consumes a very large amount of memory (GBs). In addition, the evaluation of the Safety function dominates the Geant simulation time.

The improvements in this commit are mainly achieved through:

* The use of a boundary volume hierarchy (BVH) as the base acceleration entity, replacing TGeoVoxelFinder.
BVH are the standard in industry/computer-graphics, for what concerns ray-object intersection tasks. The BVH is constructed from axis-aligned bounding boxes and employed in the FindBoundary/FindNode implementations

* The use of a 3D voxel grid (TGeoVoxelGrid) structure, able to store properties "local" or in the vicinity of a cartesian coordinate P. This structure allows to reduce the (typical) algorithmic complexity for "Safety" queries to ~O(1) (with a constant factor determined by the voxel size). Filling of the 3D voxel grid cache for Safety is done on-the-fly (using the BVH once).

* (Optional) Additional caching of "last-call" safety values for really quick return when the value is still valid at the next call.

Ideas for these improvements come from prior work in related libraries such as VecGeom.

-----

Implementation details:

* The implementation is, for now (until fully tested), provided in a backward compatible manner:

  - By default, nothing changes
  - Users have to activate the BVH mode by setting an environment variable TGEO_PW_USEBVH
  - Users may hence compare the 2 modes

* Functions for Safety, FindNode, FindBoundary dispatch to some internal implementation. This causes an extra lookup/jump, which can be removed once BVH is fully validated

* For the BVH, a well known open source implementation is included in header-only form. The headers are copied from https://github.com/madmann91/bvh commit 66e445b92f68801a6dd8ef943fe3038976ecb4ff.

* A new class, TGeoVoxelGrid is provided for the cartesian VoxelGrid container.

----

Performance examples:

In a test with the ALICE simulation framework including the ITS + TPC detectors with 48240 volumes on the parallel world, we see

* initialization time goes from TGeoVoxelFinder: 10s ---> BVH: 40ms
* Geant simulation time: 10s --> 2s
* memory usage: 3GB --> 1GB

Hence, this PR will make a big difference for the ALICE simulation program. It was verified, that identical results (number of hits, steps, etc) are obtained when going from TGeoVoxelFinder --> BVH+GRID.

----

Outlook:

Similar techniques could be applied to ordinary TGeoNavigator routines.

Checklist:

- [x] tested changes locally
