### PR TITLE
[rbrowser] correctly handle TCanvas recreation in macros

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -71,7 +71,7 @@ protected:
 
    void AddInitWidget(const std::string &kind);
 
-   void CheckWidgtesModified();
+   void CheckWidgtesModified(unsigned connid);
 
    void ProcessPostponedRequests();
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -242,9 +242,11 @@ public:
 
    std::string GetKind() const override { return "catched"s; }
 
-   std::string GetUrl() override { return fWindow->GetUrl(false); }
+   std::string GetUrl() override { return fWindow ? fWindow->GetUrl(false) : ""s; }
 
    std::string GetTitle() override { return fCatchedKind; }
+
+   bool IsValid() override { return fWindow != nullptr; }
 
    RBrowserCatchedWidget(const std::string &name, RWebWindow *win, const std::string &kind) :
       RBrowserWidget(name),
@@ -320,6 +322,14 @@ RBrowser::RBrowser(bool use_rcanvas)
       return widget ? true : false;
    });
 
+   fWebWindow->GetManager()->SetDeleteCallback([this](RWebWindow &win) -> void {
+      for (auto &widget : fWidgets) {
+         auto catched = dynamic_cast<RBrowserCatchedWidget *>(widget.get());
+         if (catched && (catched->fWindow == &win))
+            catched->fWindow = nullptr;
+      }
+   });
+
    Show();
 
    // add first canvas by default
@@ -339,8 +349,10 @@ RBrowser::RBrowser(bool use_rcanvas)
 
 RBrowser::~RBrowser()
 {
-   if (fWebWindow)
+   if (fWebWindow) {
       fWebWindow->GetManager()->SetShowCallback(nullptr);
+      fWebWindow->GetManager()->SetDeleteCallback(nullptr);
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -749,8 +761,20 @@ std::string RBrowser::NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget)
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// Check if any widget was modified and update if necessary
 
-void RBrowser::CheckWidgtesModified()
+void RBrowser::CheckWidgtesModified(unsigned connid)
 {
+   std::vector<std::string> del_names;
+
+   for (auto &widget : fWidgets)
+      if (!widget->IsValid())
+         del_names.push_back(widget->GetName());
+
+   if (!del_names.empty())
+      fWebWindow->Send(connid, "CLOSE_WIDGETS:"s + TBufferJSON::ToJSON(&del_names, TBufferJSON::kNoSpaces).Data());
+
+   for (auto name : del_names)
+      CloseTab(name);
+
    for (auto &widget : fWidgets)
       widget->CheckModified();
 }
@@ -867,7 +891,7 @@ void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
             widget->RefreshFromLogs(sPrompt + msg, GetRootLogs());
       }
 
-      CheckWidgtesModified();
+      CheckWidgtesModified(connid);
    } else if (kind == "GETHISTORY") {
 
       auto history = GetRootHistory();
@@ -896,7 +920,7 @@ void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
             if ((arr->size() == 6) && (arr->at(5) == "RUN")) {
                ProcessSaveFile(editor->fFileName, editor->fContent);
                ProcessRunMacro(editor->fFileName);
-               CheckWidgtesModified();
+               CheckWidgtesModified(connid);
             }
          }
       }

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -29,16 +29,30 @@ using namespace std::string_literals;
 
 class RBrowserTCanvasWidget : public RBrowserWidget {
 
-   std::unique_ptr<TCanvas> fCanvas; ///<! drawn canvas
+   TString fCanvasName; ///<! canvas name
+   TCanvas *fCanvas{nullptr}; ///<! last canvas pointer
    TWebCanvas *fWebCanvas{nullptr};  ///<! web implementation, owned by TCanvas
 
    std::multimap<TVirtualPad *, std::unique_ptr<Browsable::RHolder>> fObjects; ///<! objects holder, associated with pads
+
+   bool CheckCanvasPointer()
+   {
+      if (!fCanvas)
+         return false;
+
+      auto c = gROOT->GetListOfCanvases()->FindObject(fCanvasName.Data());
+      if (c && fCanvas == c)
+         return true;
+
+      fCanvas = nullptr;
+      return false;
+   }
 
    void SetPrivateCanvasFields(bool on_init)
    {
       Long_t offset = TCanvas::Class()->GetDataMemberOffset("fCanvasID");
       if (offset > 0) {
-         Int_t *id = (Int_t *)((char*) fCanvas.get() + offset);
+         Int_t *id = (Int_t *)((char *) fCanvas + offset);
          if (*id == fCanvas->GetCanvasID()) *id = on_init ? 111222333 : -1;
       } else {
          printf("ERROR: Cannot modify TCanvas::fCanvasID data member\n");
@@ -46,7 +60,7 @@ class RBrowserTCanvasWidget : public RBrowserWidget {
 
       offset = TCanvas::Class()->GetDataMemberOffset("fPixmapID");
       if (offset > 0) {
-         Int_t *id = (Int_t *)((char*) fCanvas.get() + offset);
+         Int_t *id = (Int_t *)((char *) fCanvas + offset);
          if (*id == fCanvas->GetPixmapID()) *id = on_init ? 332211 : -1;
       } else {
          printf("ERROR: Cannot modify TCanvas::fPixmapID data member\n");
@@ -54,15 +68,15 @@ class RBrowserTCanvasWidget : public RBrowserWidget {
 
       offset = TCanvas::Class()->GetDataMemberOffset("fMother");
       if (offset > 0) {
-         TPad **moth = (TPad **)((char*) fCanvas.get() + offset);
-         if (*moth == fCanvas->GetMother()) *moth = on_init ? fCanvas.get() : nullptr;
+         TPad **moth = (TPad **)((char *) fCanvas + offset);
+         if (*moth == fCanvas->GetMother()) *moth = on_init ? fCanvas : nullptr;
       } else {
          printf("ERROR: Cannot set TCanvas::fMother data member\n");
       }
 
       offset = TCanvas::Class()->GetDataMemberOffset("fCw");
       if (offset > 0) {
-         UInt_t *cw = (UInt_t *)((char*) fCanvas.get() + offset);
+         UInt_t *cw = (UInt_t *)((char *) fCanvas + offset);
          if (*cw == fCanvas->GetWw()) *cw = on_init ? 800 : 0;
       } else {
          printf("ERROR: Cannot set TCanvas::fCw data member\n");
@@ -70,32 +84,44 @@ class RBrowserTCanvasWidget : public RBrowserWidget {
 
       offset = TCanvas::Class()->GetDataMemberOffset("fCh");
       if (offset > 0) {
-         UInt_t *ch = (UInt_t *)((char*) fCanvas.get() + offset);
+         UInt_t *ch = (UInt_t *)((char *) fCanvas + offset);
          if (*ch == fCanvas->GetWh()) *ch = on_init ? 600 : 0;
       } else {
          printf("ERROR: Cannot set TCanvas::fCw data member\n");
       }
+   }
 
+   void RegisterCanvasInGlobalLists()
+   {
+      R__LOCKGUARD(gROOTMutex);
+      auto l1 = gROOT->GetListOfCleanups();
+      if (!l1->FindObject(fCanvas))
+         l1->Add(fCanvas);
+      auto l2 = gROOT->GetListOfCanvases();
+      if (!l2->FindObject(fCanvas))
+         l2->Add(fCanvas);
    }
 
 public:
 
    RBrowserTCanvasWidget(const std::string &name) : RBrowserWidget(name)
    {
-      fCanvas = std::make_unique<TCanvas>(kFALSE);
-      fCanvas->SetName(name.c_str());
-      fCanvas->SetTitle(name.c_str());
+      fCanvasName = name.c_str();
+
+      fCanvas = new TCanvas(kFALSE);
+      fCanvas->SetName(fCanvasName);
+      fCanvas->SetTitle(fCanvasName);
       fCanvas->ResetBit(TCanvas::kShowEditor);
       fCanvas->ResetBit(TCanvas::kShowToolBar);
       fCanvas->SetBit(TCanvas::kMenuBar, kTRUE);
-      fCanvas->SetCanvas(fCanvas.get());
+      fCanvas->SetCanvas(fCanvas);
       fCanvas->SetBatch(kTRUE); // mark canvas as batch
       fCanvas->SetEditable(kTRUE); // ensure fPrimitives are created
 
       Bool_t readonly = gEnv->GetValue("WebGui.FullCanvas", (Int_t) 1) == 0;
 
       // create implementation
-      fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600, readonly);
+      fWebCanvas = new TWebCanvas(fCanvas, "title", 0, 0, 800, 600, readonly);
 
       // use async mode to prevent blocking inside qt5/qt6/cef
       fWebCanvas->SetAsyncMode(kTRUE);
@@ -105,19 +131,19 @@ public:
       SetPrivateCanvasFields(true);
       fCanvas->cd();
 
-      R__LOCKGUARD(gROOTMutex);
-      gROOT->GetListOfCleanups()->Add(fCanvas.get());
+      RegisterCanvasInGlobalLists();
    }
 
    RBrowserTCanvasWidget(const std::string &name, std::unique_ptr<TCanvas> &canv) : RBrowserWidget(name)
    {
-      fCanvas = std::move(canv);
+      fCanvas = canv.release();
+      fCanvasName = fCanvas->GetName();
       fCanvas->SetBatch(kTRUE); // mark canvas as batch
 
       Bool_t readonly = gEnv->GetValue("WebGui.FullCanvas", (Int_t) 1) == 0;
 
       // create implementation
-      fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600, readonly);
+      fWebCanvas = new TWebCanvas(fCanvas, "title", 0, 0, 800, 600, readonly);
 
       // use async mode to prevent blocking inside qt5/qt6/cef
       fWebCanvas->SetAsyncMode(kTRUE);
@@ -127,20 +153,22 @@ public:
       SetPrivateCanvasFields(true);
       fCanvas->cd();
 
-      R__LOCKGUARD(gROOTMutex);
-      gROOT->GetListOfCleanups()->Add(fCanvas.get());
+      RegisterCanvasInGlobalLists();
    }
 
    virtual ~RBrowserTCanvasWidget()
    {
+      if (!fCanvas || !gROOT->GetListOfCanvases()->FindObject(fCanvas))
+         return;
+
       {
          R__LOCKGUARD(gROOTMutex);
-         gROOT->GetListOfCleanups()->Remove(fCanvas.get());
+         gROOT->GetListOfCleanups()->Remove(fCanvas);
       }
 
       SetPrivateCanvasFields(false);
 
-      gROOT->GetListOfCanvases()->Remove(fCanvas.get());
+      gROOT->GetListOfCanvases()->Remove(fCanvas);
 
       if ((fCanvas->GetCanvasID() == -1) && (fCanvas->GetCanvasImp() == fWebCanvas)) {
          fCanvas->SetCanvasImp(nullptr);
@@ -148,28 +176,33 @@ public:
       }
 
       fCanvas->Close();
+      delete fCanvas;
    }
 
    std::string GetKind() const override { return "tcanvas"s; }
 
    void SetActive() override
    {
-      fCanvas->cd();
+      if (CheckCanvasPointer())
+         fCanvas->cd();
    }
 
    void Show(const std::string &arg) override
    {
-      fWebCanvas->ShowWebWindow(arg);
+      if (CheckCanvasPointer())
+         fWebCanvas->ShowWebWindow(arg);
    }
 
    std::string GetUrl() override
    {
-      return fWebCanvas->GetWebWindow()->GetUrl(false);
+      if (CheckCanvasPointer())
+         return fWebCanvas->GetWebWindow()->GetUrl(false);
+      return ""s;
    }
 
    std::string GetTitle() override
    {
-      return fCanvas->GetName();
+      return fCanvasName.Data();
    }
 
    bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &opt = "") override
@@ -181,6 +214,9 @@ public:
       if (!obj)
          return false;
 
+      if (!CheckCanvasPointer())
+         return false;
+
       Browsable::RProvider::ExtendProgressHandle(elem.get(), obj.get());
 
       std::string drawopt = opt;
@@ -190,22 +226,22 @@ public:
       do {
          find_removed_pad = false;
          for (auto &entry : fObjects)
-            if ((entry.first != fCanvas.get()) && !fCanvas->FindObject(entry.first)) {
+            if ((entry.first != fCanvas) && !fCanvas->FindObject(entry.first)) {
                fObjects.erase(entry.first);
                find_removed_pad = true;
                break;
             }
       } while (find_removed_pad);
 
-      TVirtualPad *pad = fCanvas.get();
-      if (gPad && fCanvas.get()->FindObject(gPad))
+      TVirtualPad *pad = fCanvas;
+      if (gPad && fCanvas->FindObject(gPad))
          pad = gPad;
 
       if (drawopt.compare(0,8,"<append>") == 0) {
          drawopt.erase(0,8);
       } else {
          pad->GetListOfPrimitives()->Clear();
-         if (pad == fCanvas.get())
+         if (pad == fCanvas)
             fObjects.clear();
          else
             fObjects.erase(pad);
@@ -227,7 +263,7 @@ public:
 
    void CheckModified() override
    {
-      if (fCanvas->IsModified())
+      if (CheckCanvasPointer() && fCanvas->IsModified())
          fCanvas->UpdateAsync();
    }
 

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -41,7 +41,7 @@ class RBrowserTCanvasWidget : public RBrowserWidget {
          return false;
 
       auto c = gROOT->GetListOfCanvases()->FindObject(fCanvasName.Data());
-      if (c && fCanvas == c)
+      if (c && (fCanvas == c))
          return true;
 
       fCanvas = nullptr;
@@ -265,6 +265,11 @@ public:
    {
       if (CheckCanvasPointer() && fCanvas->IsModified())
          fCanvas->UpdateAsync();
+   }
+
+   bool IsValid() override
+   {
+      return CheckCanvasPointer();
    }
 
 };

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -65,6 +65,8 @@ public:
    std::string SendWidgetTitle();
 
    virtual void CheckModified() {}
+
+   virtual bool IsValid() { return true; }
 };
 
 class RBrowserWidgetProvider {

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -33,6 +33,10 @@ namespace ROOT {
 /// if returns true, normal show procedure will not be invoked
 using WebWindowShowCallback_t = std::function<bool(RWebWindow &, const RWebDisplayArgs &)>;
 
+/// function signature for callback when RWebWindow destroyed
+using WebWindowDeleteCallback_t = std::function<void(RWebWindow &)>;
+
+
 class RWebWindowsManager {
 
    friend class RWebWindow;
@@ -50,6 +54,7 @@ private:
    bool fExternalProcessEvents{false};    ///<! indicate that there are external process events engine
    std::unique_ptr<TExec> fAssgnExec;     ///<! special exec to assign thread id via ProcessEvents
    WebWindowShowCallback_t fShowCallback; ///<! function called for each RWebWindow::Show call
+   WebWindowDeleteCallback_t fDeleteCallback; ///<! function called when RWebWindow is destroyed
 
    /// Returns true if http server use special thread for requests processing (default off)
    bool IsUseHttpThread() const { return fUseHttpThrd; }
@@ -88,6 +93,9 @@ public:
 
    /// Assign show callback which can catch window showing, used by RBrowser
    void SetShowCallback(WebWindowShowCallback_t func) { fShowCallback = func; }
+
+   /// Assign show callback which can catch window showing, used by RBrowser
+   void SetDeleteCallback(WebWindowDeleteCallback_t func) { fDeleteCallback = func; }
 
    static std::shared_ptr<RWebWindowsManager> &Instance();
 

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -675,6 +675,9 @@ void RWebWindowsManager::Unregister(RWebWindow &win)
 {
    if (win.fWSHandler)
       fServer->UnregisterWS(win.fWSHandler);
+
+   if (fDeleteCallback)
+      fDeleteCallback(win);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -884,9 +884,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             this.websocket.send("WIDGET_SELECTED:" + item.getKey());
       },
 
-      doCloseTabItem(item) {
+      doCloseTabItem(item, skip_send) {
          let oTabContainer = this.byId("tabContainer");
-         if (item.getKey())
+         if (item.getKey() && !skip_send)
             this.websocket.send("CLOSE_TAB:" + item.getKey());
          // force connection to close
          item._jsroot_conn?.close(true);
@@ -1182,6 +1182,12 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          case "SELECT_WIDGET":
            this.findTab(msg, true); // set active
            break;
+         case "CLOSE_WIDGETS":
+            JSON.parse(msg).forEach(name => {
+               let tab = this.findTab(name);
+               if (tab) this.doCloseTabItem(tab, true);
+            });
+            break;
          case "BREPL":   // browser reply
             if (this.model) {
                let bresp = JSON.parse(msg);


### PR DESCRIPTION
When ROOT macros running, they typically create canvas "c1".
If run macro again and again - new canvas will be created but old will be deleted.
This was not handled before in RBrowser.
Now widget is closed if correspondent RWebWindow is destroyed.

Also change logic how TCanvas widget handle canvas pointer.
While ROOT manage canvas itself one cannot use `std::unique_ptr<TCanvas>` to hold pointer.
Instead canvas always searched by name and if gone - widget automatically closed.

Update slightly client part 