### PR TITLE
[vecops] declare constexpr data member also static

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -512,7 +512,7 @@ template <typename T>
 struct RVecInlineStorageSize {
 private:
 #ifdef R__HAS_HARDWARE_INTERFERENCE_SIZE
-   constexpr std::size_t cacheLineSize = std::hardware_destructive_interference_size;
+   static constexpr std::size_t cacheLineSize = std::hardware_destructive_interference_size;
 #else
    // safe bet: assume the typical 64 bytes
    static constexpr std::size_t cacheLineSize = 64;


### PR DESCRIPTION
Seen while building latest master with -Dasan=ON

```
/home/vpadulan/Programs/rootproject/rootbuild/master-2024-09-16-testing-asan/include/ROOT/RVec.hxx:515:4: error: non-stati
c data member cannot be constexpr; did you intend to make it static?
   constexpr std::size_t cacheLineSize = std::hardware_destructive_interference_size;
   ^
   static
```