### PR TITLE
[ntuple] Reduce default maximum page size to 128 KiB

### DIFF
--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -30,7 +30,7 @@ Page Sizes
 Pages contain consecutive elements of a certain column.
 They are the unit of compression and of addressability on storage.
 RNTuple puts a configurable maximum uncompressed size for pages.
-This limit is by default set to 1 MiB.
+This limit is by default set to 128 KiB, to avoid cache trashing.
 When the limit is reached, a page will be flushed to disk.
 
 In addition, RNTuple maintains a memory budget for the combined allocated size of the pages that are currently filled.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -72,7 +72,7 @@ protected:
    /// The total write buffer limit needs to be large enough to hold the initial pages of all columns.
    std::size_t fInitialNElementsPerPage = 64;
    /// Pages can grow only to the given limit in bytes.
-   std::size_t fMaxUnzippedPageSize = 1024 * 1024;
+   std::size_t fMaxUnzippedPageSize = 128 * 1024;
    /// The maximum size that the sum of all page buffers used for writing into a persistent sink are allowed to use.
    /// If set to zero, RNTuple will auto-adjust the budget based on the value of fApproxZippedClusterSize.
    /// If set manually, the size needs to be large enough to hold all initial page buffers.


### PR DESCRIPTION
Measurements with the parallel writer show a regression of compression bandwidth with large page sizes of up to 1 MiB because they do not fit into the L2 cache anymore. Reduce the default to be more cache friendly and restore scaling when fully using all cores of a machine.