### PR TITLE
[TPython] Enable TPython tests

### DIFF
--- a/bindings/tpython/test/CMakeLists.txt
+++ b/bindings/tpython/test/CMakeLists.txt
@@ -6,6 +6,23 @@
 
 # @author Jonas Rembser CERN, 2024
 
-# Test has to be temporarily disabled, because the Python ROOT module is not in
-# the path of the testing environment.
-# ROOT_ADD_GTEST(testTPython testTPython.cxx LIBRARIES ROOTTPython)
+# Even for the C++ tests, we need to setup the right environment to use PyROOT,
+# because we are using PyROOT from C++. This environment mimics the one used in
+# ROOT_ADD_PYUNITTEST.
+if(MSVC)
+  set(tpython_gtest_env ROOTSYS=${ROOTSYS}
+      PYTHONPATH=${ROOTSYS}/bin;$ENV{PYTHONPATH})
+else()
+  set(tpython_gtest_env ROOTSYS=${ROOTSYS}
+      PATH=${ROOTSYS}/bin:$ENV{PATH}
+      LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
+      PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+endif()
+
+if(NOT MSVC)
+    # These tests fail on Windows because of a problem with std::any
+  # input_line_33:7:52: error: address of overloaded function 'make_any' does not match required type 'std::any (int &&)'
+  #     new (ret) (std::any) (((std::any (&)(int &&))std::make_any<int, int, 0>)((int&&)*(int*)args[0]));
+  ROOT_ADD_GTEST(testTPython testTPython.cxx LIBRARIES ROOTTPython ENVIRONMENT ${tpython_gtest_env})
+  ROOT_ADD_PYUNITTEST(test_tpython test_tpython.py)
+endif()

--- a/bindings/tpython/test/testTPython.cxx
+++ b/bindings/tpython/test/testTPython.cxx
@@ -21,22 +21,22 @@ void task1(int i)
 // Test TPython::Exec from multiple threads.
 TEST(TPython, ExecMultithreading)
 {
-   std::size_t nThreads = 100;
+   int nThreads = 100;
 
    // Concurrently append to this array
    TPython::Exec("arr = []");
 
    std::vector<std::thread> threads;
-   for (std::size_t i = 0; i < nThreads; i++) {
+   for (int i = 0; i < nThreads; i++) {
       threads.emplace_back(task1, i);
    }
 
-   for (std::size_t i = 0; i < threads.size(); i++) {
+   for (int i = 0; i < threads.size(); i++) {
       threads[i].join();
    }
 
    // In the end, let's check if the size is correct.
    std::any len;
-   TPython::Exec("_anyresult = ROOT.std.make_any['std::size_t'](len(arr))", &len);
-   EXPECT_EQ(std::any_cast<std::size_t>(len), nThreads);
+   TPython::Exec("_anyresult = ROOT.std.make_any['int'](len(arr))", &len);
+   EXPECT_EQ(std::any_cast<int>(len), nThreads);
 }

--- a/bindings/tpython/test/test_tpython.py
+++ b/bindings/tpython/test/test_tpython.py
@@ -1,0 +1,37 @@
+import unittest
+
+
+class TPython(unittest.TestCase):
+    """
+    Testing features of TPython from Python, to see if they still work when the
+    Python interpreter was not initialized by TPython on the C++ side.
+    """
+
+    def test_exec(self):
+        """
+        Test TPython::Exec.
+        """
+        import ROOT
+
+        ROOT.gInterpreter.Declare(
+            """
+
+            // Test TPython::Exec from multiple threads.
+            int testTPythonExec(int nIn)
+            {
+               std::any out;
+               std::stringstream cmd;
+               cmd << "_anyresult = ROOT.std.make_any['int'](" << nIn << ")";
+               TPython::Exec(cmd.str().c_str(), &out);
+               return std::any_cast<int>(out);
+            }
+        """
+        )
+
+        n_in = 100
+        n_out = ROOT.testTPythonExec(n_in)
+        self.assertEqual(n_out, n_in)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1816,13 +1816,14 @@ endfunction()
 #                        [INCLUDE_DIRS label1 label2...] -- Extra target include directories
 #                        [REPEATS number] -- Repeats testsuite `number` times, stopping at the first failure.
 #                        [FAILREGEX ...] Fail test if this regex matches.
+#                        [ENVIRONMENT var1=val1 var2=val2 ...
 # Creates a new googletest exectuable, and registers it as a test.
 #----------------------------------------------------------------------------
 function(ROOT_ADD_GTEST test_suite)
   cmake_parse_arguments(ARG
     "WILLFAIL"
     "TIMEOUT;REPEATS;FAILREGEX"
-    "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS" ${ARGN})
+    "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS;ENVIRONMENT" ${ARGN})
 
   ROOT_GET_SOURCES(source_files . ${ARG_UNPARSED_ARGUMENTS})
   # Note we cannot use ROOT_EXECUTABLE without user-specified set of LIBRARIES to link with.
@@ -1870,6 +1871,7 @@ function(ROOT_ADD_GTEST test_suite)
     TIMEOUT "${ARG_TIMEOUT}"
     LABELS "${ARG_LABELS}"
     FAILREGEX "${ARG_FAILREGEX}"
+    ENVIRONMENT "${ARG_ENVIRONMENT}"
   )
 endfunction()
 


### PR DESCRIPTION
Except for Windows, but doing these new tests on some platforms is
better than on no platform. Otherwise we have no test coverage for using
TPython from different threads.