### PR TITLE
[webgui] Make default single connection

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -255,6 +255,8 @@ WebGui.HttpBind:
 WebGui.HttpLoopback:        yes
 # Require unique single-time token (key) for connecting with widget (default - yes)
 WebGui.OnetimeKey:          yes
+# Only single connection allowed to any web widget
+WebGui.SingleConnMode:      yes
 # Use https protocol for the http server (default - no)
 WebGui.UseHttps:            no
 WebGui.ServerCert:          rootserver.pem

--- a/documentation/users-guide/WebDisplay.md
+++ b/documentation/users-guide/WebDisplay.md
@@ -20,7 +20,8 @@ auto win = ROOT::RWebWindow::Create();
 // set HTML page which is showed when window displayed
 win->SetDefaultPage("file:page.html"); // set
 
-// allow unlimitted user connections to the window (default only 1)
+// allow unlimited user connections to the window (default only 1)
+ROOT::RWebWindowsManager::SetSingleConnMode(false);
 win->SetConnLimit(0);
 
 // configure predefined geometry

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -111,6 +111,7 @@ public:
 
    static void SetUseSessionKey(bool on = true);
    static void SetUseConnectionKey(bool on = true);
+   static void SetSingleConnMode(bool on = true);
 
    static void AddServerLocation(const std::string &server_prefix, const std::string &files_path);
    static std::map<std::string, std::string> GetServerLocations();

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -693,9 +693,11 @@ void RWebWindow::CheckInactiveConnections()
 
 void RWebWindow::SetConnLimit(unsigned lmt)
 {
+   bool single_conn_mode = RWebWindowWSHandler::GetBoolEnv("WebGui.SingleConnMode", 1) == 1;
+
    std::lock_guard<std::mutex> grd(fConnMutex);
 
-   fConnLimit = lmt;
+   fConnLimit = single_conn_mode ? 1 : lmt;
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -171,6 +171,18 @@ void RWebWindowsManager::SetUseConnectionKey(bool on)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
+/// Enable or disable single connection mode (default on)
+/// If enabled, one connection only with any web widget is possible
+/// Any attempt to establish more connections will fail
+/// if this mode is disabled some widgets like geom viewer or web canvas will be able to
+/// to serve several clients - only when they are connected with required authentication keys
+
+void RWebWindowsManager::SetSingleConnMode(bool on)
+{
+   gEnv->SetValue("WebGui.SingleConnMode", on ? "yes" : "no");
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 /// Configure server location which can be used for loading of custom scripts or files
 /// When THttpServer instance of RWebWindowsManager will be created,
 /// THttpServer::AddLocation() method with correspondent arguments will be invoked.
@@ -752,6 +764,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 ///
 ///      WebGui.Display: kind of display like chrome or firefox or browser, can be overwritten by --web=value command line argument
 ///      WebGui.OnetimeKey: if configured requires unique key every time window is connected (default yes)
+///      WebGui.SingleConnMode: if configured the only connection and the only user of any widget is possible (default yes)
 ///      WebGui.Chrome: full path to Google Chrome executable
 ///      WebGui.ChromeBatch: command to start chrome in batch, used for image production, like "$prog --headless --disable-gpu $geometry $url"
 ///      WebGui.ChromeHeadless: command to start chrome in headless mode, like "fork: --headless --disable-gpu $geometry $url"

--- a/tutorials/webgui/ping/ping.cxx
+++ b/tutorials/webgui/ping/ping.cxx
@@ -123,7 +123,8 @@ void ping(int nclients = 1, int test_mode = 0)
    // create window
    window = ROOT::RWebWindow::Create();
 
-   // configure maximal number of clients which allowed to connect
+   // configure number of clients are allowed to connect
+   ROOT::RWebWindowsManager::SetSingleConnMode(false);
    window->SetConnLimit(num_clients);
 
    // configure default html page


### PR DESCRIPTION
For all widgets default will be single connection. Each widget can be connected only once.
Only when such default mode disabled, some widgets will be possible to connect multiple times
