### PR TITLE
[cling] Work around constructor priority bug [v6.32]

### DIFF
--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -274,3 +274,48 @@ TEST_F(TClingTests, ROOT10499) {
    EXPECT_EQ((void*)&errno, (void*)gInterpreter->Calc("&errno"));
 #endif
 }
+
+// #15511
+TEST_F(TClingTests, ManyConstConstructors)
+{
+   std::vector<int> constructors;
+   std::ostringstream declareConstructors;
+   declareConstructors << "namespace issue_15511 { auto constructors = "
+                       << "reinterpret_cast<std::vector<int> *>(" << reinterpret_cast<uintptr_t>(&constructors)
+                       << "); }";
+   gInterpreter->Declare(declareConstructors.str().c_str());
+
+   gInterpreter->Declare(R"cpp(
+namespace issue_15511 {
+struct Constructor {
+  Constructor(int value) { constructors->push_back(value); }
+};
+
+const Constructor c0(0);
+const Constructor c1(1);
+const Constructor c2(2);
+const Constructor c3(3);
+const Constructor c4(4);
+const Constructor c5(5);
+const Constructor c6(6);
+const Constructor c7(7);
+const Constructor c8(8);
+const Constructor c9(9);
+const Constructor c10(10);
+const Constructor c11(11);
+const Constructor c12(12);
+const Constructor c13(13);
+const Constructor c14(14);
+const Constructor c15(15);
+const Constructor c16(16);
+const Constructor c17(17);
+const Constructor c18(18);
+const Constructor c19(19);
+}
+   )cpp");
+
+   ASSERT_EQ(constructors.size(), 20);
+   for (int i = 0; i < 20; i++) {
+      EXPECT_EQ(constructors[i], i);
+   }
+}

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -41,6 +41,70 @@ using namespace clang;
 using namespace llvm;
 
 namespace {
+  class WorkAroundConstructorPriorityBugPass
+      : public PassInfoMixin<WorkAroundConstructorPriorityBugPass> {
+  public:
+    PreservedAnalyses run(llvm::Module& M, ModuleAnalysisManager& AM) {
+      llvm::GlobalVariable* GlobalCtors = M.getNamedGlobal("llvm.global_ctors");
+      if (!GlobalCtors)
+        return PreservedAnalyses::all();
+
+      auto* OldCtors = llvm::dyn_cast_or_null<llvm::ConstantArray>(
+          GlobalCtors->getInitializer());
+      if (!OldCtors)
+        return PreservedAnalyses::all();
+
+      // LLVM had a bug where constructors with the same priority would not be
+      // stably sorted. This has been fixed upstream by
+      // https://github.com/llvm/llvm-project/pull/95532, but to avoid relying
+      // on a backport this pass works around the issue: The idea is that we
+      // lower the default priority of concerned constructors to make them sort
+      // correctly.
+      static constexpr uint64_t DefaultPriority = 65535;
+
+      unsigned NumCtors = OldCtors->getNumOperands();
+      const uint64_t NewDefaultPriorityStart = DefaultPriority - NumCtors;
+      uint64_t NewDefaultPriority = NewDefaultPriorityStart;
+
+      llvm::SmallVector<Constant*> NewCtors;
+      for (unsigned I = 0; I < NumCtors; I++) {
+        auto* Ctor =
+            llvm::dyn_cast<llvm::ConstantStruct>(OldCtors->getOperand(I));
+        auto* PriorityC = llvm::cast<llvm::ConstantInt>(Ctor->getOperand(0));
+        uint64_t Priority = PriorityC->getZExtValue();
+        if (Priority >= NewDefaultPriorityStart && Priority < DefaultPriority) {
+          llvm::errs() << "Found priority " << Priority
+                       << ", not changing anything\n";
+          return PreservedAnalyses::all();
+        }
+
+        if (Priority == DefaultPriority) {
+          Priority = NewDefaultPriority;
+          NewDefaultPriority++;
+        }
+
+        llvm::SmallVector<Constant*> NewCtorArgs;
+        NewCtorArgs.push_back(
+            llvm::ConstantInt::get(PriorityC->getType(), Priority));
+        // Copy the function and data Constant, if present.
+        NewCtorArgs.push_back(Ctor->getOperand(1));
+        if (Ctor->getNumOperands() >= 3) {
+          NewCtorArgs.push_back(Ctor->getOperand(2));
+        }
+
+        NewCtors.push_back(
+            llvm::ConstantStruct::get(Ctor->getType(), NewCtorArgs));
+      }
+
+      GlobalCtors->setInitializer(
+          llvm::ConstantArray::get(OldCtors->getType(), NewCtors));
+
+      return PreservedAnalyses::none();
+    }
+  };
+} // namespace
+
+namespace {
   class KeepLocalGVPass : public PassInfoMixin<KeepLocalGVPass> {
     bool runOnGlobal(GlobalValue& GV) {
       if (GV.isDeclaration())
@@ -350,6 +414,8 @@ void BackendPasses::CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
                                  PassInstrumentationCallbacks& PIC,
                                  StandardInstrumentations& SI) {
 
+  // TODO: Remove this pass once we upgrade past LLVM 19 that includes the fix.
+  MPM.addPass(WorkAroundConstructorPriorityBugPass());
   MPM.addPass(KeepLocalGVPass());
   MPM.addPass(PreventLocalOptPass());
   MPM.addPass(WeakTypeinfoVTablePass());


### PR DESCRIPTION
LLVM had a bug where constructors with the same priority would not be stably sorted. This has been fixed upstream by
https://github.com/llvm/llvm-project/pull/95532, but to avoid relying on a backport this commit works around the issue: The idea is that we lower the default priority of concerned constructors to make them sort correctly.

(cherry picked from commit https://github.com/root-project/root/commit/7db43f776d191807c1e4893312fabce7c60160bd, backport of https://github.com/root-project/root/pull/16420)