### PR TITLE
[core] Fix dupe quotes in forum bug report

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1036,10 +1036,8 @@ Steps to reproduce the behavior:
 -->
 
 ### Setup
-```
 )"+GetSetup()+
-R"(```
-
+R"(
 <!--
 Please specify also how you obtained ROOT, such as `dnf install` / binary download / you built it yourself.
 -->


### PR DESCRIPTION

# This Pull request:

## Changes or fixes:

A bug of dupe quotes that was introduced by this commit: https://github.com/root-project/root/commit/73039d1ab4e3487c71c45270f5c8129c6871170d

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

