### PR TITLE
Fix two CMake errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ function(relatedrepo_GetClosestMatch)
 
   # Otherwise, try to use a branch that matches `current_head` in the fork repository
   execute_process(COMMAND ${GIT_EXECUTABLE} ls-remote --heads --tags
-                  ${__ORIGIN_PREFIX}/${__REPO_NAME} ${current_head} OUTPUT_VARIABLE matching_refs)
+                  ${__ORIGIN_PREFIX}/${__REPO_NAME} ${current_head} OUTPUT_VARIABLE matching_refs ERROR_QUIET)
   if(NOT "${matching_refs}" STREQUAL "")
     set(${__FETCHURL_VARIABLE} ${__ORIGIN_PREFIX}/${__REPO_NAME} PARENT_SCOPE)
     return()
@@ -644,8 +644,12 @@ if(testing)
     endif()
     if(DEFINED repo_dir)
       execute_process(COMMAND ${GIT_EXECUTABLE} --git-dir=${repo_dir}/.git
-                      remote get-url origin OUTPUT_VARIABLE originurl OUTPUT_STRIP_TRAILING_WHITESPACE)
-
+                      remote get-url origin OUTPUT_VARIABLE originurl OUTPUT_STRIP_TRAILING_WHITESPACE
+                      RESULT_VARIABLE query_result
+                      ERROR_VARIABLE query_error)
+      if(NOT query_result EQUAL 0)
+        message(STATUS "Searching for \"origin\" repo of roottest: ${query_error}")
+      endif()
     else()
        # The fetch URL of the 'origin' remote is used to determine the prefix for other repositories by
        # removing the `/root(\.git)?` part.  If `GITHUB_PR_ORIGIN` is defined in the environment, its
@@ -657,7 +661,7 @@ if(testing)
                          remote get-url origin OUTPUT_VARIABLE originurl OUTPUT_STRIP_TRAILING_WHITESPACE)
        endif()
     endif()
-    string(REGEX REPLACE "/root(test)?(\.git)?$" "" originprefix ${originurl})
+    string(REGEX REPLACE "/root(test)?(\.git)?$" "" originprefix "${originurl}")
     relatedrepo_GetClosestMatch(REPO_NAME roottest
                                 ORIGIN_PREFIX ${originprefix} UPSTREAM_PREFIX ${upstreamprefix}
                                 FETCHURL_VARIABLE roottest_url FETCHREF_VARIABLE roottest_ref)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -668,11 +668,11 @@ if((opengl OR cocoa) AND NOT builtin_glew)
     find_package(GLEW REQUIRED)
   else()
     find_package(GLEW)
-    # Bug was reported on newer version of CMake on Mac OS X:
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/19662
-    # https://github.com/microsoft/vcpkg/pull/7967
-    if(GLEW_FOUND AND APPLE AND CMAKE_VERSION VERSION_GREATER 3.15)
-      message(FATAL_ERROR "Please enable builtin Glew due bug in latest CMake (use cmake option -Dbuiltin_glew=ON).")
+    if(GLEW_FOUND AND APPLE AND CMAKE_VERSION VERSION_GREATER 3.15 AND CMAKE_VERSION VERSION_LESS 3.25)
+      # Bug in CMake on Mac OS X until 3.25:
+      # https://gitlab.kitware.com/cmake/cmake/-/issues/19662
+      # https://github.com/microsoft/vcpkg/pull/7967
+      message(FATAL_ERROR "Please enable builtin Glew due a bug in CMake's FindGlew < v3.25 (use cmake option -Dbuiltin_glew=ON).")
       unset(GLEW_FOUND)
     elseif(GLEW_FOUND AND NOT TARGET GLEW::GLEW)
       add_library(GLEW::GLEW UNKNOWN IMPORTED)


### PR DESCRIPTION
- The first error fixed is an unquoted variable that creates an error in the case that the remote repos of roottest are not called origin. It's relatively common to give the remotes useful names, and those users shouldn't be punished with weird errors.
- Re-enable FindGLEW. ROOT claims that the latest version of CMake has an error in FindGLEW. In fact, the error was fixed after cmake 3.25, so we can use system GLEW again starting from 3.26