### PR TITLE
[ntuple] Mark missing fields for automatic schema evolution

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -140,6 +140,7 @@ protected:
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
+   void BeforeConnectPageSource(Internal::RPageSource &pageSource) final;
    void OnConnectPageSource() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -176,10 +176,12 @@ private:
    ENTupleStructure fStructure;
    /// For fixed sized arrays, the array length
    std::size_t fNRepetitions;
-   /// A field qualifies as simple if it is both mappable (which implies it has a single principal column) and has no
-   /// post-read callback
+   /// A field qualifies as simple if it is mappable (which implies it has a single principal column),
+   /// and it is not an artificial field and has no post-read callback
    bool fIsSimple;
-   /// A field that is artificial, ie missing on disk
+   /// A field that is not backed on disk but computed, e.g. a default-constructed missing field or
+   /// a field whose data is created by I/O customization rules. Subfields of artificial fields are
+   /// artificial, too.
    bool fIsArtificial = false;
    /// When the columns are connected to a page source or page sink, the field represents a field id in the
    /// corresponding RNTuple descriptor. This on-disk ID is set in RPageSink::Create() for writing and by

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -176,7 +176,8 @@ private:
    ENTupleStructure fStructure;
    /// For fixed sized arrays, the array length
    std::size_t fNRepetitions;
-   /// A field qualifies as simple if it is both mappable and has no post-read callback
+   /// A field qualifies as simple if it is both mappable (which implies it has a single principal column) and has no
+   /// post-read callback
    bool fIsSimple;
    /// A field that is artificial, ie missing on disk
    bool fIsArtificial = false;
@@ -221,6 +222,7 @@ private:
 
    void SetArtificial()
    {
+      fIsSimple = false;
       fIsArtificial = true;
       for (auto &field : fSubFields) {
          field->SetArtificial();
@@ -376,12 +378,8 @@ protected:
    /// to a single column and has no read callback.
    void Read(NTupleSize_t globalIndex, void *to)
    {
-      if (fIsSimple) {
-         if (!fIsArtificial) {
-            fPrincipalColumn->Read(globalIndex, to);
-         }
-         return;
-      }
+      if (fIsSimple)
+         return (void)fPrincipalColumn->Read(globalIndex, to);
 
       if (!fIsArtificial) {
          if (fTraits & kTraitMappable)
@@ -398,12 +396,8 @@ protected:
    /// to a single column and has no read callback.
    void Read(RClusterIndex clusterIndex, void *to)
    {
-      if (fIsSimple) {
-         if (!fIsArtificial) {
-            fPrincipalColumn->Read(clusterIndex, to);
-         }
-         return;
-      }
+      if (fIsSimple)
+         return (void)fPrincipalColumn->Read(clusterIndex, to);
 
       if (!fIsArtificial) {
          if (fTraits & kTraitMappable)

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -265,7 +265,7 @@ protected:
    std::uint32_t fOnDiskTypeChecksum = 0;
    /// Pointers into the static vector GetColumnRepresentations().GetSerializationTypes() when
    /// SetColumnRepresentatives is called.  Otherwise (if empty) GetColumnRepresentatives() returns a vector
-   /// with a single element, the default representation.
+   /// with a single element, the default representation.  Always empty for artificial fields.
    std::vector<std::reference_wrapper<const ColumnRepresentation_t>> fColumnRepresentatives;
 
    /// Factory method for the field's type. The caller owns the returned pointer
@@ -552,7 +552,8 @@ public:
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id);
 
-   /// Returns the fColumnRepresentative pointee or, if unset, the field's default representative
+   /// Returns the fColumnRepresentative pointee or, if unset (always the case for artificial fields), the field's
+   /// default representative
    RColumnRepresentations::Selection_t GetColumnRepresentatives() const;
    /// Fixes a column representative. This can only be done _before_ connecting the field to a page sink.
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -946,6 +946,8 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
    if (!fDescription.empty())
       throw RException(R__FAIL("setting description only valid when connecting to a page sink"));
 
+   BeforeConnectPageSource(pageSource);
+
    for (auto &f : fSubFields) {
       if (f->GetOnDiskId() == kInvalidDescriptorId) {
          f->SetOnDiskId(pageSource.GetSharedDescriptorGuard()->FindFieldId(f->GetFieldName(), GetOnDiskId()));
@@ -953,7 +955,8 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
       f->ConnectPageSource(pageSource);
    }
 
-   {
+   // TODO: Do we need to set fColumnRepresentatives?
+   if (!fIsArtificial) {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();
       GenerateColumns(desc);

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -879,7 +879,7 @@ size_t ROOT::Experimental::RFieldBase::AddReadCallback(ReadCallback_t func)
 void ROOT::Experimental::RFieldBase::RemoveReadCallback(size_t idx)
 {
    fReadCallbacks.erase(fReadCallbacks.begin() + idx);
-   fIsSimple = (fTraits & kTraitMappable) && fReadCallbacks.empty();
+   fIsSimple = (fTraits & kTraitMappable) && !fIsArtificial && fReadCallbacks.empty();
 }
 
 void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const RNTupleWriteOptions &options)

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -955,7 +955,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
       f->ConnectPageSource(pageSource);
    }
 
-   // TODO: Do we need to set fColumnRepresentatives?
+   // Do not generate columns nor set fColumnRepresentatives for artificial fields.
    if (!fIsArtificial) {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -210,11 +210,10 @@ void ROOT::Experimental::RClassField::BeforeConnectPageSource(Internal::RPageSou
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(GetOnDiskId());
-      // Check that we have the same type; only then we perform automatic schema evolution.
-      // TODO: should this throw? Right now, we allow reading back a field hierarchy with a different type as long as
-      // all columns match...
+      // Check that we have the same type.
       if (GetTypeName() != fieldDesc.GetTypeName())
-         return;
+         throw RException(R__FAIL("incompatible type name for field " + GetFieldName() + ": " + GetTypeName() +
+                                  " vs. " + fieldDesc.GetTypeName()));
 
       for (auto linkId : fieldDesc.GetLinkIds()) {
          const auto &subFieldDesc = desc.GetFieldDescriptor(linkId);

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -200,6 +200,7 @@ void ROOT::Experimental::RClassField::ReadInClusterImpl(RClusterIndex clusterInd
 
 void ROOT::Experimental::RClassField::BeforeConnectPageSource(Internal::RPageSource &pageSource)
 {
+   // This can happen for added base classes or non-simple members.
    if (GetOnDiskId() == kInvalidDescriptorId) {
       return;
    }

--- a/tree/ntuple/v7/test/ntuple_evolution.cxx
+++ b/tree/ntuple/v7/test/ntuple_evolution.cxx
@@ -457,6 +457,75 @@ struct AddedBaseDerived : public AddedBaseIntermediate {
    EXPECT_EVALUATE_EQ("ptrAddedBaseDerived->fDerived", 93);
 }
 
+TEST(RNTupleEvolution, AddedSecondBaseClass)
+{
+   FileRaii fileGuard("test_ntuple_evolution_added_second_base_class.root");
+
+   WriteOldInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct AddedSecondBaseFirst {
+   int fFirstBase = 1;
+};
+struct AddedSecondBaseDerived : public AddedSecondBaseFirst {
+   int fDerived = 3;
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("f", "AddedSecondBaseDerived").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      void *ptr = writer->GetModel().GetDefaultEntry().GetPtr<void>("f").get();
+      DeclarePointer("AddedSecondBaseDerived", "ptrAddedSecondBaseDerived", ptr);
+      ProcessLine("ptrAddedSecondBaseDerived->fFirstBase = 71;");
+      ProcessLine("ptrAddedSecondBaseDerived->fDerived = 93;");
+      writer->Fill();
+
+      // Reset / close the writer and flush the file.
+      {
+         // TStreamerInfo::Build will report a warning for interpreted classes (but only for base classes).
+         // See also https://github.com/root-project/root/issues/9371
+         ROOT::TestSupport::CheckDiagsRAII diagRAII;
+         diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                               /*matchFullMessage=*/false);
+         writer.reset();
+      }
+   });
+
+   ASSERT_TRUE(gInterpreter->Declare(R"(
+struct AddedSecondBaseFirst {
+   int fFirstBase = 1;
+};
+struct AddedSecondBaseSecond {
+   int fSecondBase = 2;
+};
+struct AddedSecondBaseDerived : public AddedSecondBaseFirst, public AddedSecondBaseSecond {
+   int fDerived = 3;
+};
+)"));
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   ASSERT_EQ(2, reader->GetNEntries());
+
+   void *ptr = reader->GetModel().GetDefaultEntry().GetPtr<void>("f").get();
+   DeclarePointer("AddedSecondBaseDerived", "ptrAddedSecondBaseDerived", ptr);
+
+   reader->LoadEntry(0);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fFirstBase", 1);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fSecondBase", 2);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fDerived", 3);
+
+   reader->LoadEntry(1);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fFirstBase", 71);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fSecondBase", 2);
+   EXPECT_EVALUATE_EQ("ptrAddedSecondBaseDerived->fDerived", 93);
+}
+
 TEST(RNTupleEvolution, RemovedBaseClass)
 {
    FileRaii fileGuard("test_ntuple_evolution_removed_base_class.root");

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1918,7 +1918,7 @@ TEST(RNTuple, TClass)
          auto viewKlass = ntuple->GetView<DerivedA>("klass");
          FAIL() << "GetView<a_base_class_of_T> should throw";
       } catch (const RException& err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk field information"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("incompatible type name for field"));
       }
    }
 }


### PR DESCRIPTION
They are skipped while reading in the same way as a transient member.