### PR TITLE
[RF] More systematic way to write debug macro from generated code

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -41,7 +41,8 @@ namespace Detail {
 /// @brief A class to maintain the context for squashing of RooFit models into code.
 class CodeSquashContext {
 public:
-   CodeSquashContext(std::map<RooFit::Detail::DataKey, std::size_t> const &outputSizes, std::vector<double> &xlarr, Experimental::RooFuncWrapper &wrapper);
+   CodeSquashContext(std::map<RooFit::Detail::DataKey, std::size_t> const &outputSizes, std::vector<double> &xlarr,
+                     Experimental::RooFuncWrapper &wrapper);
 
    void addResult(RooAbsArg const *key, std::string const &value);
    void addResult(const char *key, std::string const &value);
@@ -111,6 +112,8 @@ public:
 
    std::string buildArg(std::span<const double> arr);
    std::string buildArg(std::span<const int> arr) { return buildArgSpanImpl(arr); }
+
+   void collectFunction(std::string const &name);
 
    Experimental::RooFuncWrapper *_wrapper = nullptr;
 

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -61,6 +61,8 @@ public:
    void writeDebugMacro(std::string const &) const;
 
    std::string declareFunction(std::string const &funcBody);
+   void collectFunction(std::string const &funcName) { _collectedFunctions.emplace_back(funcName); }
+   std::vector<std::string> const &collectedFunctions() { return _collectedFunctions; }
 
    std::string buildCode(RooAbsReal const &head);
 
@@ -74,8 +76,6 @@ private:
                           RooSimultaneous const *simPdf);
 
    void buildFuncAndGradFunctors();
-
-   bool declareToInterpreter(std::string const &code);
 
    using Func = double (*)(double *, double const *, double const *);
    using Grad = void (*)(double *, double const *, double const *, double *);
@@ -98,7 +98,7 @@ private:
    std::map<RooFit::Detail::DataKey, ObsInfo> _obsInfos;
    std::map<RooFit::Detail::DataKey, std::size_t> _nodeOutputSizes;
    std::vector<double> _xlArr;
-   std::stringstream _allCode;
+   std::vector<std::string> _collectedFunctions;
 };
 
 } // namespace Experimental

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -169,9 +169,6 @@ void RooAddition::translate(RooFit::Detail::CodeSquashContext &ctx) const
    std::size_t i = 0;
    for (auto *component : static_range_cast<RooAbsReal *>(_set)) {
 
-      // if (dynamic_cast<RooNLLVarNew *>(component)) {
-      //    result += ctx.getResultFrom
-      // } else {
       if (!dynamic_cast<RooNLLVarNew *>(component) || _set.size() == 1) {
          result += ctx.getResult(*component);
          ++i;

--- a/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
+++ b/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
@@ -13,6 +13,8 @@
 
 #include <RooFit/Detail/CodeSquashContext.h>
 
+#include "RooFuncWrapper.h"
+
 #include "RooFitImplHelpers.h"
 
 #include <algorithm>
@@ -196,7 +198,7 @@ std::string CodeSquashContext::getTmpVarName() const
 /// @param valueToSave The actual string value to save as a temporary.
 void CodeSquashContext::addResult(RooAbsArg const *in, std::string const &valueToSave)
 {
-   //std::string savedName = RooFit::Detail::makeValidVarName(in->GetName());
+   // std::string savedName = RooFit::Detail::makeValidVarName(in->GetName());
    std::string savedName = getTmpVarName();
 
    // Only save values if they contain operations.
@@ -261,6 +263,13 @@ std::string CodeSquashContext::buildArg(std::span<const double> arr)
 bool CodeSquashContext::isScopeIndependent(RooAbsArg const *in) const
 {
    return !in->isReducerNode() && outputSize(in->namePtr()) == 1;
+}
+
+/// @brief Register a function that is only know to the interpreter to the context.
+/// This is useful to dump the standalone C++ code for the computation graph.
+void CodeSquashContext::collectFunction(std::string const &name)
+{
+   _wrapper->collectFunction(name);
 }
 
 } // namespace Detail

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -316,5 +316,7 @@ double RooFormulaVar::defaultErrorLevel() const
 void RooFormulaVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
    getVal(); // to trigger the creation of the TFormula
-   ctx.addResult(this, ctx.buildCall(_formula->getTFormula()->GetUniqueFuncName().Data(), _actualVars));
+   std::string funcName = _formula->getTFormula()->GetUniqueFuncName().Data();
+   ctx.collectFunction(funcName);
+   ctx.addResult(this, ctx.buildCall(funcName, _actualVars));
 }

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -27,6 +27,22 @@
 #include <TSystem.h>
 
 #include <fstream>
+#include <set>
+
+namespace {
+
+void replaceAll(std::string &str, const std::string &from, const std::string &to)
+{
+   if (from.empty())
+      return;
+   size_t start_pos = 0;
+   while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+      str.replace(start_pos, from.length(), to);
+      start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+   }
+}
+
+} // namespace
 
 namespace RooFit {
 
@@ -57,7 +73,7 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, RooAbsReal &
 
    func = buildCode(obj);
 
-   declareToInterpreter("#pragma cling optimize(2)");
+   gInterpreter->Declare("#pragma cling optimize(2)");
 
    // Declare the function and create its derivative.
    _funcName = declareFunction(func);
@@ -131,7 +147,8 @@ std::string RooFuncWrapper::declareFunction(std::string const &funcBody)
    std::stringstream bodyWithSigStrm;
    bodyWithSigStrm << "double " << funcName << "(double* params, double const* obs, double const* xlArr) {\n"
                    << funcBody << "\n}";
-   if (!declareToInterpreter(bodyWithSigStrm.str())) {
+   _collectedFunctions.emplace_back(funcName);
+   if (!gInterpreter->Declare(bodyWithSigStrm.str().c_str())) {
       std::stringstream errorMsg;
       errorMsg << "Function " << funcName << " could not be compiled. See above for details.";
       oocoutE(nullptr, InputArguments) << errorMsg.str() << std::endl;
@@ -146,7 +163,7 @@ void RooFuncWrapper::createGradient()
    std::string requestName = _funcName + "_req";
 
    // Calculate gradient
-   declareToInterpreter("#include <Math/CladDerivator.h>\n");
+   gInterpreter->Declare("#include <Math/CladDerivator.h>\n");
    // disable clang-format for making the following code unreadable.
    // clang-format off
    std::stringstream requestFuncStrm;
@@ -156,7 +173,7 @@ void RooFuncWrapper::createGradient()
                       "}\n"
                       "#pragma clad OFF";
    // clang-format on
-   if (!declareToInterpreter(requestFuncStrm.str())) {
+   if (!gInterpreter->Declare(requestFuncStrm.str().c_str())) {
       std::stringstream errorMsg;
       errorMsg << "Function " << GetName() << " could not be differentiated. See above for details.";
       oocoutE(nullptr, InputArguments) << errorMsg.str() << std::endl;
@@ -224,35 +241,64 @@ std::string RooFuncWrapper::buildCode(RooAbsReal const &head)
    return ctx.assembleCode(ctx.getResult(head));
 }
 
-/// @brief Declare code to the interpreter and keep track of all declared code in this RooFuncWrapper.
-bool RooFuncWrapper::declareToInterpreter(std::string const &code)
-{
-   _allCode << code << std::endl;
-   return gInterpreter->Declare(code.c_str());
-}
-
 /// @brief Dumps a macro "filename.C" that can be used to test and debug the generated code and gradient.
 void RooFuncWrapper::writeDebugMacro(std::string const &filename) const
 {
+   std::stringstream allCode;
+   std::set<std::string> seenFunctions;
+
+   // Remove duplicated declared functions
+   for (std::string const &name : _collectedFunctions) {
+      if (seenFunctions.count(name) > 0) {
+         continue;
+      }
+      seenFunctions.insert(name);
+      std::unique_ptr<TInterpreterValue> v = gInterpreter->MakeInterpreterValue();
+      gInterpreter->Evaluate(name.c_str(), *v);
+      std::string s = v->ToString();
+      for (int i = 0; i < 2; ++i) {
+         s = s.erase(0, s.find("\n") + 1);
+      }
+      allCode << s << std::endl;
+   }
+
    std::ofstream outFile;
    outFile.open(filename + ".C");
-   outFile << "#include <RooFit/Detail/MathFuncs.h>" << std::endl;
-   outFile << std::endl;
-   outFile << _allCode.str();
-   outFile << std::endl;
+   outFile << R"(//auto-generated test macro
+#include <RooFit/Detail/MathFuncs.h>
+#include <Math/CladDerivator.h>
+
+#pragma cling optimize(2)
+)" << allCode.str()
+           << R"(
+#pragma clad ON
+void gradient_request() {
+  clad::gradient()"
+           << _funcName << R"(, "params");
+}
+#pragma clad OFF
+)";
 
    updateGradientVarBuffer();
 
    auto writeVector = [&](std::string const &name, std::span<const double> vec) {
-      outFile << "std::vector<double> " << name << " = {";
+      std::stringstream decl;
+      decl << "std::vector<double> " << name << " = {";
       for (std::size_t i = 0; i < vec.size(); ++i) {
          if (i % 10 == 0)
-            outFile << "\n    ";
-         outFile << vec[i];
+            decl << "\n    ";
+         decl << vec[i];
          if (i < vec.size() - 1)
-            outFile << ", ";
+            decl << ", ";
       }
-      outFile << "\n};\n";
+      decl << "\n};\n";
+
+      std::string declStr = decl.str();
+
+      replaceAll(declStr, "inf", "std::numeric_limits<double>::infinity()");
+      replaceAll(declStr, "nan", "NAN");
+
+      outFile << declStr;
    };
 
    outFile << "// clang-format off\n" << std::endl;
@@ -271,10 +317,33 @@ void )" << filename
 {
    std::vector<double> gradientVec(parametersVec.size());
 
-   )" << _funcName
-           << R"((parametersVec.data(), observablesVec.data(), auxConstantsVec.data());
-   )" << _funcName
-           << R"(_grad_0(parametersVec.data(), observablesVec.data(), auxConstantsVec.data(), gradientVec.data());
+   auto func = [&](std::span<double> params) {
+      return )"
+           << _funcName << R"((params.data(), observablesVec.data(), auxConstantsVec.data());
+   };
+   auto grad = [&](std::span<double> params, std::span<double> out) {
+      return )"
+           << _funcName << R"(_grad_0(parametersVec.data(), observablesVec.data(), auxConstantsVec.data(),
+                                        out.data());
+   };
+
+   grad(parametersVec, gradientVec);
+
+   auto numDiff = [&](int i) {
+      const double eps = 1e-6;
+      std::vector<double> p{parametersVec};
+      p[i] = parametersVec[i] - eps;
+      double funcValDown = func(p);
+      p[i] = parametersVec[i] + eps;
+      double funcValUp = func(p);
+      return (funcValUp - funcValDown) / (2 * eps);
+   };
+
+   for (std::size_t i = 0; i < parametersVec.size(); ++i) {
+      std::cout << i << ":" << std::endl;
+      std::cout << "  numr : " << numDiff(i) << std::endl;
+      std::cout << "  clad : " << gradientVec[i] << std::endl;
+   }
 }
 )";
 }

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -205,5 +205,7 @@ void RooGenericPdf::writeToStream(ostream& os, bool compact) const
 void RooGenericPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
    getVal(); // to trigger the creation of the TFormula
-   ctx.addResult(this, ctx.buildCall(_formula->getTFormula()->GetUniqueFuncName().Data(), _actualVars));
+   std::string funcName = _formula->getTFormula()->GetUniqueFuncName().Data();
+   ctx.collectFunction(funcName);
+   ctx.addResult(this, ctx.buildCall(funcName, _actualVars));
 }

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -1050,6 +1050,9 @@ void RooRealIntegral::translate(RooFit::Detail::CodeSquashContext &ctx) const
    auto &intVar = static_cast<RooAbsRealLValue &>(*_intList[0]);
 
    RooFit::Experimental::RooFuncWrapper wrapper{GetName(), GetTitle(), *_function};
+   for (std::string const& name : wrapper.collectedFunctions()) {
+      ctx._wrapper->collectFunction(name);
+   }
 
    RooArgSet params;
    _function->getParameters(nullptr, params);


### PR DESCRIPTION
Fix the debug macro for the case where some functions are only known to the interpreter, by adding a new mechanism to register such functions in the code generation context.