### PR TITLE
[RF] Avoid instantiating RooNLLVar directly in testRooAbsL.cxx

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -556,6 +556,9 @@ class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTes
 
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
+#else
+TEST_P(LikelihoodJobSplitStrategies, DISABLED_SimBinnedConstrainedAndOffset)
+#endif
 {
    // Based on ConstrainedAndOffset, this test tests different parallelization strategies
 
@@ -617,7 +620,6 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
       RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
 }
-#endif // ROOFIT_LEGACY_EVAL_BACKEND
 
 INSTANTIATE_TEST_SUITE_P(SplitStrategies, LikelihoodJobSplitStrategies,
                          testing::Combine(

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -19,9 +19,6 @@
 #include <RooFitResult.h>
 #include "RooDataHist.h" // complete type in Binned test
 #include "RooCategory.h" // complete type in MultiBinnedConstraint test
-#ifdef ROOFIT_LEGACY_EVAL_BACKEND
-#include "../../src/RooNLLVar.h" // needed in BinnedDatasetTest.VSRooNLLVar
-#endif
 #include <RooFit/TestStatistics/RooUnbinnedL.h>
 #include <RooFit/TestStatistics/RooBinnedL.h>
 #include <RooFit/TestStatistics/RooSumL.h>
@@ -342,16 +339,7 @@ TEST_F(BinnedDatasetTest, VSRooNLLVar)
    pdf->setAttribute("BinnedLikelihood");
    data = std::unique_ptr<RooAbsData>{pdf->generateBinned(*w.var("x"))};
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-
-   // manually create NLL, ripping all relevant parts from RooAbsPdf::createNLL, except here we also set binnedL = true;
-   // this is necessary, because the RooNLLVar ctor doesn't create a binned likelihood otherwise
-   RooArgSet projDeps;
-   RooAbsTestStatistic::Configuration nll_config;
-   nll_config.verbose = false;
-   nll_config.cloneInputData = false;
-   nll_config.binnedL = true;
-   int extended = 2;
-   nll = std::make_unique<RooNLLVar>("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    auto AbsL_value = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
    auto RooNLL_value = nll->getVal();


### PR DESCRIPTION
This doesn't need to be done anymore, because with the recent improvements, the likelihood returned by `createNLL()` will be the correct binned likelihood.

This makes RooFit compile again without the `ROOFIT_LEGACY_EVAL_BACKEND` enabled.