### PR TITLE
[cmake][win] Change the `/Ob` compiler flag

### DIFF
--- a/cmake/modules/SetUpWindows.cmake
+++ b/cmake/modules/SetUpWindows.cmake
@@ -31,11 +31,11 @@ elseif(MSVC)
   math(EXPR VC_MINOR "${MSVC_VERSION} % 100")
 
   #---Select compiler flags----------------------------------------------------------------
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-MD -O2 -Ob1 -Z7 -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-MD -O2 -Ob2 -Z7 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_MINSIZEREL     "-MD -O1 -Ob1 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_RELEASE        "-MD -O2 -Ob2 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_DEBUG          "-MDd -Od -Ob0 -Z7")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-MD -O2 -Ob1 -Z7 -DNDEBUG")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-MD -O2 -Ob2 -Z7 -DNDEBUG")
   set(CMAKE_C_FLAGS_MINSIZEREL       "-MD -O1 -Ob1 -DNDEBUG")
   set(CMAKE_C_FLAGS_RELEASE          "-MD -O2 -Ob2 -DNDEBUG")
   set(CMAKE_C_FLAGS_DEBUG            "-MDd -Od -Ob0 -Z7")


### PR DESCRIPTION
Use `/Ob2` (Inline Function Expansion 2) with `RelWithDebInfo`.
This is the default value under `/O1` and `/O2`. Allows the compiler to expand any function not explicitly marked for no inlining.
This fixes the failing `test-check-nullptr` and `roottest-cling-exception-nullderef-e` tests with ROOT built in `RelWithDebInfo`.
