### PR TITLE
[rbrowser] fix BrowserListBinding.js [skip-ci]

### DIFF
--- a/ui5/browser/model/BrowserListBinding.js
+++ b/ui5/browser/model/BrowserListBinding.js
@@ -71,6 +71,11 @@ sap.ui.define([
 
         attachSelectionChanged: function() {
            // dummy for compatibility with newest 1.70.0 version
+        },
+
+        getNodeByIndex: function(indx) {
+            // required by openui5 from versions ~1.100.0
+            return this.getModel().getNodeByIndex(indx);
         }
 
     });


### PR DESCRIPTION
Add missing function which required now by recent openui5 versions. 
Let use this and previos ROOT versions with newest openui5
