### PR TITLE
cling: changes needed on MacOS to avoid G__Core.cxx generation failures complaining about time_point

### DIFF
--- a/interpreter/cling/include/cling/std_darwin.modulemap
+++ b/interpreter/cling/include/cling/std_darwin.modulemap
@@ -1137,7 +1137,10 @@ module std_private_chrono_system_clock           [system] {
   header "__chrono/system_clock.h"
   export std_private_chrono_time_point
 }
-module std_private_chrono_time_point             [system] { header "__chrono/time_point.h" }
+module std_private_chrono_time_point             [system] {
+  header "__chrono/time_point.h"
+  export std_private_chrono_file_clock
+}
 module std_private_chrono_weekday                [system] { header "__chrono/weekday.h" }
 module std_private_chrono_year                   [system] { header "__chrono/year.h" }
 module std_private_chrono_year_month             [system] { header "__chrono/year_month.h" }


### PR DESCRIPTION
On one installation of MacOS with Sonoma 14.6.1 and XCode 15.4 and clang-1500.3.9.4
(not sure about the xcode command line tool version), the generation of
G__Core.cxx failed until we applied the change in this commit.

On another installation of MacOS with the same version numbers the
change was not needed but the change did not hurt either.

```
In module 'std' imported from input_line_1:1:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__chrono/time_point.h:34:52:
error: missing '#include <__chrono/file_clock.h>'; '_FilesystemClock'
must be defined before it is used
template <class _Clock, class _Duration = typename _Clock::duration>
                                                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__chrono/time_point.h:34:1:
note: in instantiation of default argument for
'time_point<std::filesystem::_FilesystemClock>' required here
template <class _Clock, class _Duration = typename _Clock::duration>
^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__chrono/file_clock.h:51:8:
note: definition here is not reachable
struct _FilesystemClock {
       ^
```