### PR TITLE
[RF] Explicitly cast to double in RooAbsDataHelper

### DIFF
--- a/roofit/RDataFrameHelpers/inc/RooAbsDataHelper.h
+++ b/roofit/RDataFrameHelpers/inc/RooAbsDataHelper.h
@@ -76,7 +76,7 @@ public:
    void Exec(unsigned int slot, ColumnTypes... values)
    {
       auto &vector = _events[slot];
-      for (auto &&val : {values...}) {
+      for (auto &&val : {static_cast<double>(values)...}) {
          vector.push_back(val);
       }
 


### PR DESCRIPTION
We support only RooRealVar columns anyway, and by doing the cast to double explicit we can also support filling such datasets from arbitrary column types that convert to `double`.

This is a small quality-of-life improvement that addresses this forum post:
https://root-forum.cern.ch/t/dataframe-roofit-dataset-maker-with-mixture-of-column-types-crashes/61734/8