### PR TITLE
[asan] Fix asan configuration for MacOS

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -82,13 +82,10 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
 
      if(asan)
        # See also core/sanitizer/README.md for what's happening.
-
-       #This should be the right way to do it, but clang 10 seems to have a bug
-       #execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan_osx_dynamic.dylib OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
-       execute_process(COMMAND mdfind -name libclang_rt.asan_osx_dynamic.dylib OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+       execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan_osx_dynamic.dylib OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
        set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope)
-       set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address -static-libsan")
-       set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -static-libsan -Wl,-u,___asan_default_options -Wl,-u,___lsan_default_options -Wl,-u,___lsan_default_suppressions")
+       set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address")
+       set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -Wl,-U,__asan_default_options -Wl,-U,__lsan_default_options -Wl,-U,__lsan_default_suppressions")
      endif()
 
   else()


### PR DESCRIPTION
The `c++ --print-file-name` command now seems to work, and it is indeed the more appropriate way to get the location of the asan shared library on MacOS.

Also fix the following problems occurring when building on MacOS with -Dasan=ON

Error:
```
CMake Error at cmake/modules/CheckAtomic.cmake:59 (message):
  Host compiler appears to require libatomic, but cannot find it.
```
Fix: fix typos in asan symbols (extra `_`) and specify correct linker flag (-U)

Error:
```
error: static AddressSanitizer runtime is not supported on darwin
```
Fix: remove `-static-libsan` flag. This is required by latest MacOS Xcode
