### PR TITLE
[ntuple] fix treatment of "sharded cluster" flag

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -684,7 +684,7 @@ Followed by the page list envelope link.
 
 To compute the minimum entry number, take first entry number from all clusters in the cluster group,
 and take the minimum among these numbers.
-The entry span is the number of entries that are (partially for sharded clusters) covered by this cluster group.
+The entry span is the number of entries that are covered by this cluster group.
 The entry range allows for finding the right page list for random access requests to entries.
 The number of clusters information allows for using consistent cluster IDs even if cluster groups are accessed non-sequentially.
 
@@ -709,18 +709,18 @@ The cluster summary record frame contains the entry range of a cluster:
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       Number of Entries                       |
-+                                                       +-+-+-+-+
-|                                                       | Flags |
++                                               +-+-+-+-+-+-+-+-+
+|                                               |     Flags     |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
-If flag 0x01 (sharded cluster) is set,
-an additional 32bit integer containing the column group ID follows the flags field.
-If flags is zero, the cluster stores the entry range of _all_ the original columns
-_including_ the columns from extension headers.
-
 The order of the cluster summaries defines the cluster IDs,
 starting from the first cluster ID of the cluster group that corresponds to the page list.
+
+Flag 0x01 is reserved for a future specification version that will support sharded clusters.
+The future use of sharded clusters will break forward compatibility and thus introduce a corresponding feature flag.
+For now, readers should abort when this flag is set.
+Other flags should be ignored.
 
 #### Page Locations
 
@@ -1019,7 +1019,7 @@ The limits refer to a single RNTuple and do not consider combinations/joins such
 | Maximum number of cluster groups               | 4B (foreseen: <10k)          | List frame limits                                      |
 | Maximum number of clusters per group           | 4B (foreseen: <10k)          | List frame limits, cluster group summary encoding      |
 | Maximum number of pages per cluster per column | 4B                           | List frame limits                                      |
-| Maximum number of entries per cluster          | 2^60                         | Cluster summary encoding                               |
+| Maximum number of entries per cluster          | 2^56                         | Cluster summary encoding                               |
 | Maximum string length (meta-data)              | 4GB                          | String encoding                                        |
 | Maximum RBlob size                             | 128 PiB                      | 1GiB / 8B * 1GiB (with maxKeySize=1GiB, offsetSize=8B) |
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -53,7 +53,6 @@ class RColumnElementBase;
 
 namespace Internal {
 class RColumnDescriptorBuilder;
-class RColumnGroupDescriptorBuilder;
 class RClusterDescriptorBuilder;
 class RClusterGroupDescriptorBuilder;
 class RExtraTypeInfoDescriptorBuilder;
@@ -198,41 +197,6 @@ public:
    bool IsAliasColumn() const { return fPhysicalColumnId != fLogicalColumnId; }
    bool IsDeferredColumn() const { return fFirstElementIndex != 0; }
    bool IsSuppressedDeferredColumn() const { return fFirstElementIndex < 0; }
-};
-
-// clang-format off
-/**
-\class ROOT::Experimental::RColumnGroupDescriptor
-\ingroup NTuple
-\brief Meta-data for a sets of columns; non-trivial column groups are used for sharded clusters
-
-Clusters can span a subset of columns. Such subsets are described as a column group. An empty column group
-is used to denote the column group of all the columns. Every ntuple has at least one column group.
-*/
-// clang-format on
-class RColumnGroupDescriptor {
-   friend class Internal::RColumnGroupDescriptorBuilder;
-
-private:
-   DescriptorId_t fColumnGroupId = kInvalidDescriptorId;
-   std::unordered_set<DescriptorId_t> fPhysicalColumnIds;
-
-public:
-   RColumnGroupDescriptor() = default;
-   RColumnGroupDescriptor(const RColumnGroupDescriptor &other) = delete;
-   RColumnGroupDescriptor &operator=(const RColumnGroupDescriptor &other) = delete;
-   RColumnGroupDescriptor(RColumnGroupDescriptor &&other) = default;
-   RColumnGroupDescriptor &operator=(RColumnGroupDescriptor &&other) = default;
-
-   bool operator==(const RColumnGroupDescriptor &other) const;
-
-   DescriptorId_t GetId() const { return fColumnGroupId; }
-   const std::unordered_set<DescriptorId_t> &GetPhysicalColumnIds() const { return fPhysicalColumnIds; }
-   bool Contains(DescriptorId_t physicalId) const
-   {
-      return fPhysicalColumnIds.empty() || fPhysicalColumnIds.count(physicalId) > 0;
-   }
-   bool HasAllColumns() const { return fPhysicalColumnIds.empty(); }
 };
 
 // clang-format off
@@ -1316,30 +1280,6 @@ public:
    }
 
    RResult<RClusterGroupDescriptor> MoveDescriptor();
-};
-
-// clang-format off
-/**
-\class ROOT::Experimental::Internal::RColumnGroupDescriptorBuilder
-\ingroup NTuple
-\brief A helper class for piece-wise construction of an RColumnGroupDescriptor
-*/
-// clang-format on
-class RColumnGroupDescriptorBuilder {
-private:
-   RColumnGroupDescriptor fColumnGroup;
-
-public:
-   RColumnGroupDescriptorBuilder() = default;
-
-   RColumnGroupDescriptorBuilder &ColumnGroupId(DescriptorId_t columnGroupId)
-   {
-      fColumnGroup.fColumnGroupId = columnGroupId;
-      return *this;
-   }
-   void AddColumn(DescriptorId_t physicalId) { fColumnGroup.fPhysicalColumnIds.insert(physicalId); }
-
-   RResult<RColumnGroupDescriptor> MoveDescriptor();
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -88,8 +88,6 @@ public:
       std::uint64_t fFirstEntry = 0;
       std::uint64_t fNEntries = 0;
       std::uint8_t fFlags = 0;
-      /// -1 for "all columns"
-      std::int32_t fColumnGroupID = -1;
    };
 
    struct RClusterGroup {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -87,6 +87,7 @@ public:
    struct RClusterSummary {
       std::uint64_t fFirstEntry = 0;
       std::uint64_t fNEntries = 0;
+      std::uint8_t fFlags = 0;
       /// -1 for "all columns"
       std::int32_t fColumnGroupID = -1;
    };

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -534,13 +534,6 @@ std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTup
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ROOT::Experimental::RColumnGroupDescriptor::operator==(const RColumnGroupDescriptor &other) const
-{
-   return fColumnGroupId == other.fColumnGroupId && fPhysicalColumnIds == other.fPhysicalColumnIds;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 bool ROOT::Experimental::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
 {
    return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds &&
@@ -740,18 +733,6 @@ ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder::MoveDescriptor()
       return R__FAIL("unset cluster group ID");
    RClusterGroupDescriptor result;
    std::swap(result, fClusterGroup);
-   return result;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-ROOT::Experimental::RResult<ROOT::Experimental::RColumnGroupDescriptor>
-ROOT::Experimental::Internal::RColumnGroupDescriptorBuilder::MoveDescriptor()
-{
-   if (fColumnGroup.fColumnGroupId == kInvalidDescriptorId)
-      return R__FAIL("unset column group ID");
-   RColumnGroupDescriptor result;
-   std::swap(result, fColumnGroup);
    return result;
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1145,7 +1145,6 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeClusterSummary(const
 
    clusterSummary.fNEntries = nEntries;
    clusterSummary.fFlags = flags;
-   clusterSummary.fColumnGroupID = -1;
 
    return frameSize;
 }
@@ -1512,7 +1511,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
    pos += SerializeListFramePreamble(nClusters, *where);
    for (auto clusterId : physClusterIDs) {
       const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(clusterId));
-      RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), 0, -1};
+      RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), 0};
       pos += SerializeClusterSummary(summary, *where);
    }
    pos += SerializeFramePostscript(buffer ? clusterSummaryFrame : nullptr, pos - clusterSummaryFrame);
@@ -1794,8 +1793,6 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageList(const void 
       if (!result)
          return R__FORWARD_ERROR(result);
       bytes += result.Unwrap();
-      if (clusterSummary.fColumnGroupID >= 0)
-         return R__FAIL("sharded clusters are still unsupported");
 
       RClusterDescriptorBuilder builder;
       builder.ClusterId(clusterId).FirstEntryIndex(clusterSummary.fFirstEntry).NEntries(clusterSummary.fNEntries);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -456,7 +456,6 @@ TEST(RNTuple, SerializeClusterSummary)
    EXPECT_EQ(summary.fFirstEntry, reco.fFirstEntry);
    EXPECT_EQ(summary.fNEntries, reco.fNEntries);
    EXPECT_EQ(summary.fFlags, reco.fFlags);
-   EXPECT_EQ(summary.fColumnGroupID, reco.fColumnGroupID);
 
    summary.fFlags |= 0x01;
    EXPECT_EQ(24u, RNTupleSerializer::SerializeClusterSummary(summary, buffer));


### PR DESCRIPTION
Reserves the "sharded cluster" flag in the cluster summary but removes any additional s11n logic. Extends the cluster summary flags field to 8bits so that it can be handled with a standard C++ type.