### PR TITLE
[TMVA] Add `data()` interface to buffers

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
@@ -64,7 +64,8 @@ public:
     TCpuBuffer & operator=(const TCpuBuffer  &) = default;
     TCpuBuffer & operator=(      TCpuBuffer &&) = default;
 
-    operator AFloat * () const {return (* fBuffer) + fOffset;}
+    inline operator AFloat * () const { return data(); }
+    AFloat * data() const {return (* fBuffer) + fOffset;}
 
     class FakeIteratorBegin{
     private:

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -163,8 +163,8 @@ public:
 
    /** Return raw pointer to the elements stored contiguously in column-major
     *  order. */
-   AFloat *GetRawDataPointer() { return fBuffer; }
-   const AFloat *GetRawDataPointer() const { return fBuffer; }
+   AFloat *GetRawDataPointer() { return fBuffer.data(); }
+   const AFloat *GetRawDataPointer() const { return fBuffer.data(); }
 
    static Executor &GetThreadExecutor() { return TMVA::Config::Instance().GetThreadExecutor(); }
 

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuTensor.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuTensor.h
@@ -138,8 +138,8 @@ public:
 
    /** Return raw pointer to the elements stored contiguously in column-major
     *  order. */
-   AFloat *GetRawDataPointer() { return *(this->GetContainer()); }
-   const AFloat *GetRawDataPointer() const { return *(this->GetContainer()); }
+   AFloat *GetRawDataPointer() { return this->GetContainer()->data(); }
+   const AFloat *GetRawDataPointer() const { return this->GetContainer()->data(); }
 
    // for same API as CudaTensor (device buffer is the CpuBuffer)
    const TCpuBuffer<AFloat> & GetDeviceBuffer()     const {return *(this->GetContainer());}
@@ -242,7 +242,7 @@ public:
       // set all the tensor contents to zero
       void Zero()
       {
-         AFloat *data = *(this->GetContainer());
+         AFloat *data = this->GetContainer()->data();
          for (size_t i = 0; i < this->GetSize(); ++i)
             data[i] = 0;
       }

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaBuffers.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaBuffers.h
@@ -76,7 +76,8 @@ public:
    /** Sets the entire buffer to a constant value */
    void            SetConstVal(const AFloat constVal);
 
-   operator AFloat * () const;
+   inline operator AFloat * () const { return data(); }
+   AFloat * data() const;
 
    inline AFloat & operator[](size_t index);
    inline AFloat   operator[](size_t index) const;
@@ -131,7 +132,8 @@ public:
    /** Return sub-buffer of the current buffer. */
    TCudaDeviceBuffer GetSubBuffer(size_t offset, size_t size);
    /** Convert to raw device data pointer.*/
-   operator AFloat * () const;
+   inline operator AFloat * () const { return data(); }
+   AFloat * data() const;
 
    void CopyFrom(const TCudaHostBuffer<AFloat> &) const;
    void CopyTo(const TCudaHostBuffer<AFloat> &)   const;

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
@@ -160,8 +160,8 @@ public:
    size_t GetNcols() const {return fNCols;}
    size_t GetNoElements() const {return fNRows * fNCols;}
 
-   const AFloat * GetDataPointer() const {return fElementBuffer;}
-   AFloat *       GetDataPointer()       {return fElementBuffer;}
+   const AFloat * GetDataPointer() const {return fElementBuffer.data();}
+   AFloat *       GetDataPointer()       {return fElementBuffer.data();}
    const cublasHandle_t & GetCublasHandle() const    {return fCublasHandle;}
 
    inline  TCudaDeviceBuffer<AFloat> GetDeviceBuffer() const { return fElementBuffer;}
@@ -309,7 +309,7 @@ inline AFloat TCudaMatrix<AFloat>::GetDeviceReturn()
 template<typename AFloat>
 TCudaDeviceReference<AFloat> TCudaMatrix<AFloat>::operator()(size_t i, size_t j) const
 {
-    AFloat * elementPointer = fElementBuffer;
+    AFloat * elementPointer = fElementBuffer.data();
     elementPointer += j * fNRows + i;
     return TCudaDeviceReference<AFloat>(elementPointer);
 }

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
@@ -191,14 +191,14 @@ public:
    size_t GetNDim() const {return fNDim;}
    size_t GetSize() const {return fSize;}
 
-   const AFloat * GetDataPointer() const {return fElementBuffer;}
-   AFloat       * GetDataPointer()       {return fElementBuffer;}
-   const AFloat * GetData() const {return fElementBuffer;}
-   AFloat       * GetData()       {return fElementBuffer;}
+   const AFloat * GetDataPointer() const {return fElementBuffer.data();}
+   AFloat       * GetDataPointer()       {return fElementBuffer.data();}
+   const AFloat * GetData() const {return fElementBuffer.data();}
+   AFloat       * GetData()       {return fElementBuffer.data();}
 
    const AFloat * GetDataPointerAt(size_t i ) const {
-      return (const_cast<TCudaDeviceBuffer<AFloat>&>(fElementBuffer)).GetSubBuffer(i * GetFirstStride(), GetFirstStride() ); }
-   AFloat       * GetDataPointerAt(size_t i )       {return fElementBuffer.GetSubBuffer(i * GetFirstStride(), GetFirstStride() ); }
+      return const_cast<TCudaDeviceBuffer<AFloat>&>(fElementBuffer).GetSubBuffer(i * GetFirstStride(), GetFirstStride() ).data(); }
+   AFloat       * GetDataPointerAt(size_t i )       {return fElementBuffer.GetSubBuffer(i * GetFirstStride(), GetFirstStride() ).data(); }
 
 
    const TCudaDeviceBuffer<AFloat> & GetDeviceBuffer()     const {return fElementBuffer;}
@@ -224,9 +224,9 @@ public:
 
       std::unique_ptr<AFloat[]> hostBufferThis(new AFloat[fSize]);
       std::unique_ptr<AFloat[]> hostBufferOther(new AFloat[fSize]);
-      cudaMemcpy(hostBufferThis.get(), fElementBuffer, fSize * sizeof(AFloat),
+      cudaMemcpy(hostBufferThis.get(), fElementBuffer.data(), fSize * sizeof(AFloat),
                  cudaMemcpyDeviceToHost);
-      cudaMemcpy(hostBufferOther.get(), other.GetDeviceBuffer(), fSize * sizeof(AFloat),
+      cudaMemcpy(hostBufferOther.get(), other.GetDeviceBuffer().data(), fSize * sizeof(AFloat),
                  cudaMemcpyDeviceToHost);
 
       for (size_t i = 0; i < fSize; i++) {
@@ -240,7 +240,7 @@ public:
 
 
       std::unique_ptr<AFloat[]> hostBufferThis(new AFloat[fSize]);
-      cudaMemcpy(hostBufferThis.get(), fElementBuffer, fSize * sizeof(AFloat),
+      cudaMemcpy(hostBufferThis.get(), fElementBuffer.data(), fSize * sizeof(AFloat),
                  cudaMemcpyDeviceToHost);
 
       for (size_t i = 0; i < fSize; i++) {
@@ -387,7 +387,7 @@ public:
       size_t offset = (GetLayout() == MemoryLayout::RowMajor) ?
          i * ncols + j  : j * nrows + i;
 
-      AFloat * elementPointer = fElementBuffer + offset;
+      AFloat * elementPointer = fElementBuffer.data() + offset;
       return TCudaDeviceReference<AFloat>(elementPointer);
    }
    // element access ( for debugging)
@@ -401,7 +401,7 @@ public:
             i * fStrides[0] + j * fStrides[1] + k :
             i * fStrides[2] + k * fStrides[1] + j;
 
-      AFloat * elementPointer = fElementBuffer + offset;
+      AFloat * elementPointer = fElementBuffer.data() + offset;
 
       return TCudaDeviceReference<AFloat>(elementPointer);
    }
@@ -416,7 +416,7 @@ public:
             i * fStrides[0] + j * fStrides[1] + k * fStrides[2] + l:
             l * fStrides[3] + k * fStrides[2] + j * fStrides[1] + i;
 
-      AFloat * elementPointer = fElementBuffer + offset;
+      AFloat * elementPointer = fElementBuffer.data() + offset;
 
       return TCudaDeviceReference<AFloat>(elementPointer);
    }

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -214,7 +214,7 @@ public:
    {
       fSize = Internal::GetSizeFromShape(shape);
       fStrides = Internal::ComputeStridesFromShape(shape, layout);
-      fData = &(*container->begin());
+      fData = std::data(*fContainer);
    }
 
    /// \brief Construct a tensor owning data initialized with new container
@@ -228,7 +228,7 @@ public:
       fSize = Internal::GetSizeFromShape(shape);
       fStrides = Internal::ComputeStridesFromShape(shape, layout);
       fContainer = std::make_shared<Container_t>(fSize);
-      fData = &(*fContainer->begin());
+      fData = std::data(*fContainer);
    }
 
    // Access elements

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -50,7 +50,7 @@ TCudaHostBuffer<AFloat>::TCudaHostBuffer(size_t size) : fOffset(0), fSize(size),
 
 //______________________________________________________________________________
 template <typename AFloat>
-TCudaHostBuffer<AFloat>::operator AFloat *() const
+AFloat *TCudaHostBuffer<AFloat>::data() const
 {
    return (fHostPointer) ? *fHostPointer + fOffset : nullptr;
 }
@@ -124,7 +124,7 @@ TCudaDeviceBuffer<AFloat> TCudaDeviceBuffer<AFloat>::GetSubBuffer(size_t offset,
 
 //______________________________________________________________________________
 template <typename AFloat>
-TCudaDeviceBuffer<AFloat>::operator AFloat *() const
+AFloat *TCudaDeviceBuffer<AFloat>::data() const
 {
    return (fDevicePointer) ? *fDevicePointer + fOffset : nullptr;
 }
@@ -134,14 +134,14 @@ template <typename AFloat>
 void TCudaDeviceBuffer<AFloat>::CopyFrom(const TCudaHostBuffer<AFloat> &buffer) const
 {
    cudaStreamSynchronize(fComputeStream);
-   cudaMemcpyAsync(*this, buffer, fSize * sizeof(AFloat), cudaMemcpyHostToDevice, fComputeStream);
+   cudaMemcpyAsync(this->data(), buffer.data(), fSize * sizeof(AFloat), cudaMemcpyHostToDevice, fComputeStream);
 }
 
 //______________________________________________________________________________
 template <typename AFloat>
 void TCudaDeviceBuffer<AFloat>::CopyTo(const TCudaHostBuffer<AFloat> &buffer) const
 {
-   cudaMemcpyAsync(buffer, *this, fSize * sizeof(AFloat), cudaMemcpyDeviceToHost, fComputeStream);
+   cudaMemcpyAsync(buffer.data(), this->data(), fSize * sizeof(AFloat), cudaMemcpyDeviceToHost, fComputeStream);
    buffer.fComputeStream = fComputeStream;
 }
 

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaMatrix.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaMatrix.cu
@@ -85,7 +85,7 @@ TCudaMatrix<AFloat>::TCudaMatrix(const TMatrixT<AFloat> & Host)
       }
    }
 
-   cudaMemcpy(fElementBuffer, buffer, fNRows * fNCols * sizeof(AFloat),
+   cudaMemcpy(fElementBuffer.data(), buffer, fNRows * fNCols * sizeof(AFloat),
               cudaMemcpyHostToDevice);
 }
 
@@ -152,7 +152,7 @@ TCudaMatrix<AFloat>::operator TMatrixT<AFloat>() const
    TMatrixT<AFloat> hostMatrix(GetNrows(), GetNcols());
 
    AFloat * buffer = new AFloat[fNRows * fNCols];
-   cudaMemcpy(buffer, fElementBuffer, fNRows * fNCols * sizeof(AFloat),
+   cudaMemcpy(buffer, fElementBuffer.data(), fNRows * fNCols * sizeof(AFloat),
               cudaMemcpyDeviceToHost);
 
    size_t index = 0;

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaTensor.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaTensor.cu
@@ -110,7 +110,7 @@ TCudaTensor<AFloat>::TCudaTensor(const AFloat * host_data, const std::vector<siz
    //    }
    // }
 
-   cudaMemcpy(fElementBuffer, host_data, fSize * sizeof(AFloat),
+   cudaMemcpy(fElementBuffer.data(), host_data, fSize * sizeof(AFloat),
               cudaMemcpyHostToDevice);
 
    // no need to initialize cuda. Done in the other constructor that is called before
@@ -191,7 +191,7 @@ TCudaTensor<AFloat>::operator TMatrixT<AFloat>() const
 
      // This assume that tensor D1, D2, D3,D4 is converted in   D1 , D2*D3*D4
      TMatrixT<AFloat> hostMatrix( GetNrows(), GetNcols() );
-     cudaMemcpy(hostMatrix.GetMatrixArray(), fElementBuffer, fSize * sizeof(AFloat),
+     cudaMemcpy(hostMatrix.GetMatrixArray(), fElementBuffer.data(), fSize * sizeof(AFloat),
            cudaMemcpyDeviceToHost);
      return hostMatrix;
 
@@ -199,7 +199,7 @@ TCudaTensor<AFloat>::operator TMatrixT<AFloat>() const
    // else in case of column major tensor we need to transpose(this is what is done in TCudaMatrix)
    // Here we assume that D1, D2, D3 is converted in   a matrix  (D3, D1*D2)
    TMatrixT<AFloat> hostMatrix( GetNcols(), GetNrows() );
-   cudaMemcpy(hostMatrix.GetMatrixArray(), fElementBuffer, fSize * sizeof(AFloat),
+   cudaMemcpy(hostMatrix.GetMatrixArray(), fElementBuffer.data(), fSize * sizeof(AFloat),
               cudaMemcpyDeviceToHost);
    return hostMatrix.T();  // return transpose matrix
 
@@ -399,7 +399,7 @@ void TCudaTensor<AFloat>::Print(const char * name, bool truncate) const
    if (n > 10 && truncate) n = 10;
    std::cout << "Data : { ";
    for (size_t i = 0; i < n; ++i ) {
-      AFloat * elementPointer = fElementBuffer + i;
+      AFloat * elementPointer = fElementBuffer.data() + i;
       std::cout << AFloat( TCudaDeviceReference<AFloat>(elementPointer) );
       if (i < n-1) std::cout << " , ";
    }


### PR DESCRIPTION
Implicit casts of buffers to contiguous memory pointers are rather error prone. It would be better to follow the example of the STL containers and implement a `data()` member function.

Like this, we can also use `std::data()` to get a pointer to the contiguous data in the RTensor implementation, which closes #13498.

The new `data()` method is now used everywhere inside TMVA, but implicit casting is also kept for backwards compatibility.

Alternative to https://github.com/root-project/root/pull/13322.