### PR TITLE
[ntuple] Add test for reading an unknown column type

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -135,10 +135,11 @@ enum class EColumnCppType {
    kMax
 };
 
-inline constexpr EColumnCppType kTestFutureColumn = static_cast<EColumnCppType>((int)EColumnCppType::kMax + 1);
+inline constexpr EColumnCppType kTestFutureColumn =
+   static_cast<EColumnCppType>(std::numeric_limits<std::underlying_type_t<EColumnCppType>>::max() - 1);
 
 struct RTestFutureColumn {
-   int dummy;
+   std::uint32_t dummy;
 };
 
 std::unique_ptr<RColumnElementBase> GenerateColumnElement(EColumnCppType cppType, EColumnType colType);

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -132,6 +132,13 @@ enum class EColumnCppType {
    kDouble,
    kClusterSize,
    kColumnSwitch,
+   kMax
+};
+
+inline constexpr EColumnCppType kTestFutureColumn = static_cast<EColumnCppType>((int)EColumnCppType::kMax + 1);
+
+struct RTestFutureColumn {
+   int dummy;
 };
 
 std::unique_ptr<RColumnElementBase> GenerateColumnElement(EColumnCppType cppType, EColumnType colType);
@@ -169,6 +176,8 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
       return GenerateColumnElement(EColumnCppType::kClusterSize, type);
    else if constexpr (std::is_same_v<CppT, RColumnSwitch>)
       return GenerateColumnElement(EColumnCppType::kColumnSwitch, type);
+   else if constexpr (std::is_same_v<CppT, RTestFutureColumn>)
+      return GenerateColumnElement(kTestFutureColumn, type);
    else
       static_assert(!sizeof(CppT), "Unsupported Cpp type");
 }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -58,8 +58,10 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
    case EColumnType::kReal32Trunc: return std::make_pair(10, 31);
    case EColumnType::kReal32Quant: return std::make_pair(1, 32);
-   case kTestFutureType: return std::make_pair(32, 32);
-   default: assert(false);
+   default:
+      if (type == kTestFutureType)
+         return std::make_pair(32, 32);
+      assert(false);
    }
    // never here
    return std::make_pair(0, 0);
@@ -97,8 +99,10 @@ std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColum
    case EColumnType::kSplitUInt16: return "SplitUInt16";
    case EColumnType::kReal32Trunc: return "Real32Trunc";
    case EColumnType::kReal32Quant: return "Real32Quant";
-   case kTestFutureType: return "TestFutureType";
-   default: return "UNKNOWN";
+   default:
+      if (type == kTestFutureType)
+         return "TestFutureType";
+      return "UNKNOWN";
    }
 }
 
@@ -139,8 +143,10 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<float, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<float, EColumnType::kReal32Quant>>();
-   case kTestFutureType: return std::make_unique<RColumnElement<Internal::RTestFutureColumn, kTestFutureType>>();
-   default: assert(false);
+   default:
+      if (type == kTestFutureType)
+         return std::make_unique<RColumnElement<Internal::RTestFutureColumn, kTestFutureType>>();
+      assert(false);
    }
    // never here
    return nullptr;
@@ -165,8 +171,10 @@ ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, ECol
    case EColumnCppType::kDouble: return GenerateColumnElementInternal<double>(type);
    case EColumnCppType::kClusterSize: return GenerateColumnElementInternal<ClusterSize_t>(type);
    case EColumnCppType::kColumnSwitch: return GenerateColumnElementInternal<RColumnSwitch>(type);
-   case kTestFutureColumn: return GenerateColumnElementInternal<RTestFutureColumn>(type);
-   default: R__ASSERT(!"Invalid column cpp type");
+   default:
+      if (cppType == kTestFutureColumn)
+         return GenerateColumnElementInternal<RTestFutureColumn>(type);
+      R__ASSERT(!"Invalid column cpp type");
    }
    // never here
    return nullptr;

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -58,6 +58,7 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    case EColumnType::kSplitUInt16: return std::make_pair(16, 16);
    case EColumnType::kReal32Trunc: return std::make_pair(10, 31);
    case EColumnType::kReal32Quant: return std::make_pair(1, 32);
+   case kTestFutureType: return std::make_pair(32, 32);
    default: assert(false);
    }
    // never here
@@ -96,6 +97,7 @@ std::string ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColum
    case EColumnType::kSplitUInt16: return "SplitUInt16";
    case EColumnType::kReal32Trunc: return "Real32Trunc";
    case EColumnType::kReal32Quant: return "Real32Quant";
+   case kTestFutureType: return "TestFutureType";
    default: return "UNKNOWN";
    }
 }
@@ -137,6 +139,7 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<float, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<float, EColumnType::kReal32Quant>>();
+   case kTestFutureType: return std::make_unique<RColumnElement<Internal::RTestFutureColumn, kTestFutureType>>();
    default: assert(false);
    }
    // never here
@@ -162,6 +165,7 @@ ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, ECol
    case EColumnCppType::kDouble: return GenerateColumnElementInternal<double>(type);
    case EColumnCppType::kClusterSize: return GenerateColumnElementInternal<ClusterSize_t>(type);
    case EColumnCppType::kColumnSwitch: return GenerateColumnElementInternal<RColumnSwitch>(type);
+   case kTestFutureColumn: return GenerateColumnElementInternal<RTestFutureColumn>(type);
    default: R__ASSERT(!"Invalid column cpp type");
    }
    // never here

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -268,7 +268,8 @@ using ROOT::Experimental::EColumnType;
 using ROOT::Experimental::Internal::RColumnElementBase;
 
 // testing value for an unknown future column type
-inline constexpr EColumnType kTestFutureType = static_cast<EColumnType>(int(EColumnType::kMax) + 1);
+inline constexpr EColumnType kTestFutureType =
+   static_cast<EColumnType>(std::numeric_limits<std::underlying_type_t<EColumnType>>::max() - 1);
 
 template <typename CppT, EColumnType>
 class RColumnElement;
@@ -306,8 +307,10 @@ std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType ty
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitUInt16>>();
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Quant>>();
-   case kTestFutureType: return std::make_unique<RColumnElement<CppT, kTestFutureType>>();
-   default: R__ASSERT(false);
+   default:
+      if (type == kTestFutureType)
+         return std::make_unique<RColumnElement<CppT, kTestFutureType>>();
+      R__ASSERT(false);
    }
    // never here
    return nullptr;

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -267,6 +267,9 @@ namespace {
 using ROOT::Experimental::EColumnType;
 using ROOT::Experimental::Internal::RColumnElementBase;
 
+// testing value for an unknown future column type
+inline constexpr EColumnType kTestFutureType = static_cast<EColumnType>(int(EColumnType::kMax) + 1);
+
 template <typename CppT, EColumnType>
 class RColumnElement;
 
@@ -303,6 +306,7 @@ std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType ty
    case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitUInt16>>();
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Quant>>();
+   case kTestFutureType: return std::make_unique<RColumnElement<CppT, kTestFutureType>>();
    default: R__ASSERT(false);
    }
    // never here
@@ -1087,6 +1091,20 @@ DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSpl
                             RColumnElementDeltaSplitLE, <std::uint64_t, std::uint64_t>);
 DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSplitIndex32, 32,
                             RColumnElementDeltaSplitLE, <std::uint64_t, std::uint32_t>);
+
+template <>
+class RColumnElement<ROOT::Experimental::Internal::RTestFutureColumn, kTestFutureType> final
+   : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::Internal::RTestFutureColumn);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   RColumnElement() : RColumnElementBase(kSize, kBitsOnStorage) {}
+
+   bool IsMappable() const { return kIsMappable; }
+   void Pack(void *, const void *, std::size_t) const {}
+   void Unpack(void *, const void *, std::size_t) const {}
+};
 
 inline void
 RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(void *dst, const void *src, std::size_t count) const

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -20,6 +20,8 @@
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
+#include "RColumnElement.hxx"
+
 #include <RVersion.h>
 #include <TBufferFile.h>
 #include <TClass.h>
@@ -709,6 +711,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnType(ROOT::Exper
    case EColumnType::kSplitUInt16: return SerializeUInt16(0x15, buffer);
    case EColumnType::kReal32Trunc: return SerializeUInt16(0x1D, buffer);
    case EColumnType::kReal32Quant: return SerializeUInt16(0x1E, buffer);
+   case kTestFutureType: return SerializeUInt16(0x99, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
@@ -722,6 +725,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeColumnType(const voi
    auto result = DeserializeUInt16(buffer, onDiskType);
 
    switch (onDiskType) {
+   case 0x00: return R__FAIL("unexpected on-disk column type");
    case 0x01: type = EColumnType::kIndex64; break;
    case 0x02: type = EColumnType::kIndex32; break;
    case 0x03: type = EColumnType::kSwitch; break;
@@ -751,7 +755,11 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeColumnType(const voi
    case 0x15: type = EColumnType::kSplitUInt16; break;
    case 0x1D: type = EColumnType::kReal32Trunc; break;
    case 0x1E: type = EColumnType::kReal32Quant; break;
-   default: return R__FAIL("unexpected on-disk column type");
+   // case 0x99 => kTestFutureType missing on purpose
+   default:
+      // may be a column type introduced by a future version
+      type = EColumnType::kUnknown;
+      break;
    }
    return result;
 }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -711,8 +711,10 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnType(ROOT::Exper
    case EColumnType::kSplitUInt16: return SerializeUInt16(0x15, buffer);
    case EColumnType::kReal32Trunc: return SerializeUInt16(0x1D, buffer);
    case EColumnType::kReal32Quant: return SerializeUInt16(0x1E, buffer);
-   case kTestFutureType: return SerializeUInt16(0x99, buffer);
-   default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
+   default:
+      if (type == kTestFutureType)
+         return SerializeUInt16(0x99, buffer);
+      throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -65,6 +65,7 @@ TEST(RNTuple, SerializeColumnType)
    RNTupleSerializer::SerializeUInt16(5000, buffer);
    auto res = RNTupleSerializer::DeserializeColumnType(buffer, type);
    EXPECT_TRUE(bool(res));
+   EXPECT_EQ(type, EColumnType::kUnknown);
 
    for (int i = 1; i < static_cast<int>(EColumnType::kMax); ++i) {
       RNTupleSerializer::SerializeColumnType(static_cast<EColumnType>(i), buffer);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -63,12 +63,8 @@ TEST(RNTuple, SerializeColumnType)
    }
 
    RNTupleSerializer::SerializeUInt16(5000, buffer);
-   try {
-      RNTupleSerializer::DeserializeColumnType(buffer, type).Unwrap();
-      FAIL() << "unexpected on disk column type should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("unexpected on-disk column type"));
-   }
+   auto res = RNTupleSerializer::DeserializeColumnType(buffer, type);
+   EXPECT_TRUE(bool(res));
 
    for (int i = 1; i < static_cast<int>(EColumnType::kMax); ++i) {
       RNTupleSerializer::SerializeColumnType(static_cast<EColumnType>(i), buffer);


### PR DESCRIPTION
# This Pull request:
avoids throwing an exception when creating the descriptor for an RNTuple containing an unknown column type. We want to support this case for forward compatibility. Also adds a unit test testing this specific case.
Some dedicated code needs to be added to the internals of RNTuple to support this kind of test case, but it's not exposed to the user.

## Remarks
Currently the test just checks that we can read back the descriptor. A future PR will add a "fwd compatibility mode" to the read options that'll allow a user to reconstruct the model skipping over fields containing unknown column types.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


