### PR TITLE
[io] Fix TFileMerger getDirectory not considering full path

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -545,7 +545,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
 
    std::map<std::tuple<std::string, std::string, std::string>, TDirectory*> dirtodelete;
    auto getDirectory = [&dirtodelete](TDirectory *parent, const char *name, const TString &pathname) {
-      auto mapkey = std::make_tuple(parent->GetName(), std::string{name}, std::string{pathname});
+      auto mapkey = std::make_tuple(parent->GetName(), name, pathname.Data());
       auto result = dirtodelete.find(mapkey);
       if (result != dirtodelete.end()) {
          return result->second;

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -50,6 +50,7 @@ to be merged, like the standalone hadd program.
 #endif
 
 #include <cstring>
+#include <map>
 
 ClassImp(TFileMerger);
 
@@ -132,7 +133,7 @@ Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
       Printf("%s Source file %d: %s", fMsgPrefix.Data(), fFileList.GetEntries() + fExcessFiles.GetEntries() + 1, url);
    }
 
-   TFile *newfile = 0;
+   TFile *newfile = nullptr;
    TString localcopy;
 
    if (fFileList.GetEntries() >= (fMaxOpenedFiles-1)) {
@@ -164,7 +165,7 @@ Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
    // Zombie files should also be skipped
    if (newfile && newfile->IsZombie()) {
       delete newfile;
-      newfile = 0;
+      newfile = nullptr;
    }
 
    if (!newfile) {
@@ -542,17 +543,19 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
    }
    Bool_t canBeMerged = kTRUE;
 
-   TList dirtodelete;
-   auto getDirectory = [&dirtodelete](TDirectory *parent, const char *name, const TString &pathname)
-   {
-      TDirectory *result = dynamic_cast<TDirectory*>(parent->GetList()->FindObject(name));
-      if (!result) {
-         result = parent->GetDirectory(pathname);
-         if (result && result != parent)
-            dirtodelete.Add(result);
+   std::map<std::tuple<std::string, std::string, std::string>, TDirectory*> dirtodelete;
+   auto getDirectory = [&dirtodelete](TDirectory *parent, const char *name, const TString &pathname) {
+      auto mapkey = std::make_tuple(parent->GetName(), std::string{name}, std::string{pathname});
+      auto result = dirtodelete.find(mapkey);
+      if (result != dirtodelete.end()) {
+         return result->second;
       }
 
-      return result;
+      auto dir = dynamic_cast<TDirectory *>(parent->GetDirectory(pathname));
+      if (dir)
+         dirtodelete[mapkey] = dir;
+
+      return dir;
    };
 
    if ( cl->InheritsFrom( TDirectory::Class() ) ) {
@@ -786,8 +789,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       // Let's also delete the directory from the other source (thanks to the 'allNames'
       // mechanism above we will not process the directories when tranversing the next
       // files).
-      TIter deliter(&dirtodelete);
-      while(TObject *ndir = deliter()) {
+      for (const auto &[_, ndir] : dirtodelete) {
          // For consistency (and performance), we reset the MustCleanup be also for those
          // 'key' retrieved indirectly.
          ndir->ResetBit(kMustCleanup);
@@ -804,7 +806,6 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       }
    }
    info.Reset();
-   dirtodelete.Clear("nodelete");  // If needed the delete is done explicitly above.
    return kTRUE;
 }
 


### PR DESCRIPTION
# This Pull request:
fixes `getDirectory` inside `TFileMerger.cxx` which is looking up objects by name rather than by full path.

Added regression test: https://github.com/root-project/roottest/pull/1191

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #16190 and #16474

