### PR TITLE
[skip-ci][ntuple] bump specification minor

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.10.0
+# RNTuple Reference Specifications 0.2.11.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 


### PR DESCRIPTION
#16390 should have bumped the specification minor version, but due to simultaneous changes to the specs, it didn't really get bumped
