### PR TITLE
[ntuple] Introduce schema IDs and use for field tokens

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -62,13 +62,15 @@ public:
       friend class RNTupleModel;
 
       std::size_t fIndex;     ///< the index in fValues that belongs to the top-level field
-      std::uint64_t fModelId; ///< Safety check to prevent tokens from other models being used
-      RFieldToken(std::size_t index, std::uint64_t modelId) : fIndex(index), fModelId(modelId) {}
+      std::uint64_t fSchemaId; ///< Safety check to prevent tokens from other models being used
+      RFieldToken(std::size_t index, std::uint64_t schemaId) : fIndex(index), fSchemaId(schemaId) {}
    };
 
 private:
-   /// The entry must be linked to a specific model (or one if its clones), identified by a model ID
+   /// The entry must be linked to a specific model, identified by a model ID
    std::uint64_t fModelId = 0;
+   /// The entry and its tokens are also linked to a specific schema, identified by a schema ID
+   std::uint64_t fSchemaId = 0;
    /// Corresponds to the top-level fields of the linked model
    std::vector<RFieldBase::RValue> fValues;
    /// For fast lookup of token IDs given a top-level field name
@@ -77,7 +79,7 @@ private:
    // Creation of entries is done by the RNTupleModel class
 
    REntry() = default;
-   explicit REntry(std::uint64_t modelId) : fModelId(modelId) {}
+   explicit REntry(std::uint64_t modelId, std::uint64_t schemaId) : fModelId(modelId), fSchemaId(schemaId) {}
 
    void AddValue(RFieldBase::RValue &&value)
    {
@@ -118,9 +120,9 @@ private:
 
    void EnsureMatchingModel(RFieldToken token) const
    {
-      if (fModelId != token.fModelId) {
+      if (fSchemaId != token.fSchemaId) {
          throw RException(R__FAIL("invalid token for this entry, "
-                                  "make sure to use a token from the same model as this entry."));
+                                  "make sure to use a token from a model with the same schema as this entry."));
       }
    }
 
@@ -152,7 +154,7 @@ public:
       if (it == fFieldName2Token.end()) {
          throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
       }
-      return RFieldToken(it->second, fModelId);
+      return RFieldToken(it->second, fSchemaId);
    }
 
    void EmplaceNewValue(RFieldToken token)
@@ -206,6 +208,7 @@ public:
    }
 
    std::uint64_t GetModelId() const { return fModelId; }
+   std::uint64_t GetSchemaId() const { return fSchemaId; }
 
    ConstIterator_t begin() const { return fValues.cbegin(); }
    ConstIterator_t end() const { return fValues.cend(); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -207,6 +207,8 @@ private:
    /// Every model has a unique ID to distinguish it from other models. Entries are linked to models via the ID.
    /// Cloned models get a new model ID.
    std::uint64_t fModelId = 0;
+   /// Models have a separate schema ID to remember that the clone of a frozen model still has the same schema.
+   std::uint64_t fSchemaId = 0;
    /// Changed by Freeze() / Unfreeze() and by the RUpdater.
    bool fIsFrozen = false;
 
@@ -312,6 +314,7 @@ public:
    bool IsFrozen() const { return fIsFrozen; }
    bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }
+   std::uint64_t GetSchemaId() const { return fSchemaId; }
 
    /// Ingests a model for a sub collection and attaches it to the current model
    ///

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -423,9 +423,6 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
 
 ROOT::Experimental::REntry::RFieldToken ROOT::Experimental::RNTupleModel::GetToken(std::string_view fieldName) const
 {
-   if (!IsFrozen())
-      throw RException(R__FAIL("invalid attempt to get field token of unfrozen model"));
-
    const auto &topLevelFields = fFieldZero->GetSubFields();
    auto it = std::find_if(topLevelFields.begin(), topLevelFields.end(),
                           [&fieldName](const RFieldBase *f) { return f->GetFieldName() == fieldName; });

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -861,6 +861,11 @@ TEST(REntry, Basics)
    EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetToken("pt")).get());
    EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetDefaultEntry().GetToken("pt")).get());
 
+   // Using tokens across frozen clones works
+   auto clone = model->Clone();
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(clone->GetToken("pt")).get());
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(clone->GetDefaultEntry().GetToken("pt")).get());
+
    // Tokens from a new model are incompatible
    auto model2 = RNTupleModel::Create();
    model2->MakeField<float>("pt");

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -861,7 +861,11 @@ TEST(REntry, Basics)
    EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetToken("pt")).get());
    EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetDefaultEntry().GetToken("pt")).get());
 
-   auto model2 = model->Clone();
+   // Tokens from a new model are incompatible
+   auto model2 = RNTupleModel::Create();
+   model2->MakeField<float>("pt");
+   model2->Freeze();
+   EXPECT_THROW(e->GetPtr<void>(model2->GetToken("pt")), ROOT::Experimental::RException);
    EXPECT_THROW(e->GetPtr<void>(model2->GetDefaultEntry().GetToken("pt")), ROOT::Experimental::RException);
    std::shared_ptr<double> ptrDouble;
    EXPECT_THROW(e->BindValue("pt", ptrDouble), ROOT::Experimental::RException);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -580,6 +580,7 @@ TEST(RNTuple, ModelId)
    auto m2 = RNTupleModel::Create();
    EXPECT_FALSE(m1->IsFrozen());
    EXPECT_NE(m1->GetModelId(), m2->GetModelId());
+   EXPECT_NE(m1->GetSchemaId(), m2->GetSchemaId());
 
    m1->Freeze();
    EXPECT_TRUE(m1->IsFrozen());
@@ -607,10 +608,19 @@ TEST(RNTuple, ModelId)
    auto m1c = m1->Clone();
    EXPECT_TRUE(m1c->IsFrozen());
    EXPECT_NE(m1->GetModelId(), m1c->GetModelId());
+   EXPECT_EQ(m1->GetSchemaId(), m1c->GetSchemaId());
 
    auto m2c = m2->Clone();
    EXPECT_FALSE(m2c->IsFrozen());
    EXPECT_NE(m2->GetModelId(), m2c->GetModelId());
+   EXPECT_NE(m2->GetSchemaId(), m2c->GetSchemaId());
+
+   // Now unfreeze the cloned model again and it should get new ids.
+   id = m1c->GetModelId();
+   m1c->Unfreeze();
+   EXPECT_FALSE(m1c->IsFrozen());
+   EXPECT_NE(m1c->GetModelId(), id);
+   EXPECT_NE(m1c->GetSchemaId(), m1->GetSchemaId());
 }
 
 TEST(RNTuple, Entry)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -853,9 +853,13 @@ TEST(REntry, Basics)
    EXPECT_THROW(e->GetToken("eta"), ROOT::Experimental::RException);
    EXPECT_THROW(model->GetToken("eta"), ROOT::Experimental::RException);
 
-   std::shared_ptr<float> ptrPt;
+   auto ptrPt = std::make_shared<float>();
    e->BindValue("pt", ptrPt);
    EXPECT_EQ(ptrPt.get(), e->GetPtr<float>("pt").get());
+
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(e->GetToken("pt")).get());
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetToken("pt")).get());
+   EXPECT_EQ(ptrPt.get(), e->GetPtr<void>(model->GetDefaultEntry().GetToken("pt")).get());
 
    auto model2 = model->Clone();
    EXPECT_THROW(e->GetPtr<void>(model2->GetDefaultEntry().GetToken("pt")), ROOT::Experimental::RException);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -603,7 +603,13 @@ TEST(RNTuple, ModelId)
    EXPECT_TRUE(m1->IsFrozen());
    EXPECT_EQ(id, m1->GetModelId());
 
+   // At this point, m1 is frozen while m2 is not.
+   auto m1c = m1->Clone();
+   EXPECT_TRUE(m1c->IsFrozen());
+   EXPECT_NE(m1->GetModelId(), m1c->GetModelId());
+
    auto m2c = m2->Clone();
+   EXPECT_FALSE(m2c->IsFrozen());
    EXPECT_NE(m2->GetModelId(), m2c->GetModelId());
 }
 

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -80,6 +80,20 @@ TEST(RNTupleParallelWriter, Basics)
    }
 }
 
+TEST(RNTupleParallelWriter, Tokens)
+{
+   FileRaii fileGuard("test_ntuple_parallel_tokens.root");
+
+   auto model = RNTupleModel::CreateBare();
+   model->MakeField<float>("pt");
+   auto token = model->GetToken("pt");
+
+   auto writer = RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+   auto context = writer->CreateFillContext();
+   auto entry = context->CreateEntry();
+   auto pt = entry->GetPtr<float>(token);
+}
+
 TEST(RNTupleParallelWriter, Staged)
 {
    FileRaii fileGuard("test_ntuple_parallel_staged.root");


### PR DESCRIPTION
When cloning a frozen `RNTupleModel`, the schema ID will not change. This allows to use one set of field tokens for all model clones during parallel writing. Also allow creating tokens during model construction, before freezing, with already works when going via the default entry.

Closes #16236