### PR TITLE
[skip-ci][ntuple] fix RNTupleInspector documentation

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -64,7 +64,7 @@ using ROOT::Experimental::RNTupleInspector;
 
 auto file = TFile::Open("data.rntuple");
 auto rntuple = std::unique_ptr<RNTuple>(file->Get<RNTuple>("NTupleName"));
-auto inspector = RNTupleInspector::Create(rntuple);
+auto inspector = RNTupleInspector::Create(*rntuple);
 
 std::cout << "The compression factor is " << inspector->GetCompressionFactor()
           << " using compression settings " << inspector->GetCompressionSettings()


### PR DESCRIPTION
the argument of a RNTupleInspector is now a ref, not a pointer, so the class documentation is incorrect