### PR TITLE
[ntuple] outline dtor of RNTupleInspector

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -175,7 +175,7 @@ public:
    RNTupleInspector &operator=(const RNTupleInspector &other) = delete;
    RNTupleInspector(RNTupleInspector &&other) = delete;
    RNTupleInspector &operator=(RNTupleInspector &&other) = delete;
-   ~RNTupleInspector() = default;
+   ~RNTupleInspector();
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create a new RNTupleInspector.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -41,6 +41,9 @@ ROOT::Experimental::RNTupleInspector::RNTupleInspector(
    CollectFieldTreeInfo(fDescriptor->GetFieldZeroId());
 }
 
+// NOTE: outlined to avoid including RPageStorage in the header
+ROOT::Experimental::RNTupleInspector::~RNTupleInspector() = default;
+
 void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 {
    fCompressedSize = 0;


### PR DESCRIPTION
# This Pull request:
moves the dtor of RNTupleInspector to the cxx to avoid including (or having the user include) RPageStorage.hxx (otherwise ~unique_ptr<RPageSource> complains about incomplete type).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

