### PR TITLE
[ntuple] don't split UInts when compression is 0

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1222,6 +1222,9 @@ void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const RNTupleWriteOpt
          case EColumnType::kSplitInt64: colType = EColumnType::kInt64; break;
          case EColumnType::kSplitInt32: colType = EColumnType::kInt32; break;
          case EColumnType::kSplitInt16: colType = EColumnType::kInt16; break;
+         case EColumnType::kSplitUInt64: colType = EColumnType::kUInt64; break;
+         case EColumnType::kSplitUInt32: colType = EColumnType::kUInt32; break;
+         case EColumnType::kSplitUInt16: colType = EColumnType::kUInt16; break;
          default: break;
          }
       }


### PR DESCRIPTION
# This Pull request:
adds UInts to `RField::AutoAdjustColumnTypes` to make sure we don't split them when compression is 0, similarly to Int and Real types.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

