### PR TITLE
[cling] Add interfaces that expose JIT

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -36,6 +36,7 @@ namespace llvm {
   template <typename T> class SmallVectorImpl;
   namespace orc {
     class DefinitionGenerator;
+    class LLJIT;
   }
 }
 
@@ -770,6 +771,11 @@ namespace cling {
     void setCallbacks(std::unique_ptr<InterpreterCallbacks> C);
     const InterpreterCallbacks* getCallbacks() const {return m_Callbacks.get();}
     InterpreterCallbacks* getCallbacks() { return m_Callbacks.get(); }
+
+    ///\brief Returns the JIT managed by the Interpreter.
+    /// Accesses and returns the JIT held in the IncrementalJIT instance
+    /// managed by m_Executor
+    llvm::orc::LLJIT* getExecutionEngine();
 
     const DynamicLibraryManager* getDynamicLibraryManager() const;
     DynamicLibraryManager* getDynamicLibraryManager();

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -154,6 +154,9 @@ namespace cling {
 
     void setCallbacks(InterpreterCallbacks* callbacks);
 
+    ///\brief Return the LLJIT held by the IncrementalJIT
+    llvm::orc::LLJIT* getLLJIT() { return m_JIT ? m_JIT->getLLJIT() : nullptr; }
+
     const DynamicLibraryManager& getDynamicLibraryManager() const {
       return const_cast<IncrementalExecutor*>(this)->m_DyLibManager;
     }

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -102,6 +102,9 @@ public:
     return Jit->initialize(Jit->getMainJITDylib());
   }
 
+  /// @brief Return a pointer to the JIT held by IncrementalJIT object
+  llvm::orc::LLJIT* getLLJIT() { return Jit.get(); }
+
   /// @brief Get the TargetMachine used by the JIT.
   /// Non-const because BackendPasses need to update OptLevel.
   llvm::TargetMachine &getTargetMachine() { return *m_TM; }

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1670,6 +1670,13 @@ namespace cling {
       ->addCallback(std::move(C));
   }
 
+  llvm::orc::LLJIT* Interpreter::getExecutionEngine() {
+    if (!m_Executor)
+      return nullptr;
+
+    return m_Executor->getLLJIT();
+  }
+
   const DynamicLibraryManager* Interpreter::getDynamicLibraryManager() const {
     assert(m_Executor.get() && "We must have an executor");
     return &m_Executor->getDynamicLibraryManager();


### PR DESCRIPTION
This allows us to access the `llvm::orc::LLJIT` similar to the `getExecutionEngine` interface in clang-repl which is required for the functioning of libInterOp starting from LLVM 16

cc: @vgvassilev @devajithvs 