### PR TITLE
TCling::RefreshClassInfo: Error if shadowing namespace.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6644,9 +6644,13 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::NamedDecl *def, bool alia
          cl->ResetCaches();
          TClass::RemoveClassDeclId(cci->GetDeclId());
          if (def) {
-            // It's a tag decl, not a namespace decl.
-            cci->Init(*cci->GetType());
-            TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
+            if (cci->GetType()) {
+               // It's a tag decl, not a namespace decl.
+               cci->Init(*cci->GetType());
+               TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
+            } else {
+               Error("RefreshClassInfo", "Should not need to update the classInfo a non type decl: %s", oldDef->getNameAsString().c_str());
+            }
          }
       }
    } else if (!cl->TestBit(TClass::kLoading) && !cl->fHasRootPcmInfo) {

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -409,3 +409,16 @@ const Constructor c19(19);
       EXPECT_EQ(constructors[i], i);
    }
 }
+
+// #8828
+TEST_F(TClingTests, RefreshNSShadowing)
+{
+   // These two lines would make the test fail because of two reasons:
+   // - An assertion failure "Assertion failed: (detail::isPresent(Val) && "dyn_cast on a non-existent value"), function dyn_cast, file Casting.h, line 662."
+   // - An error "Error in <TInterpreter::RefreshClassInfo>: Should not need to update the classInfo a non type decl: Detail"
+   // This is why there is no check performed.
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kError, "TInterpreter::RefreshClassInfo", "Should not need to update the classInfo a non type decl: Detail");
+   gInterpreter->Declare("namespace std { namespace Detail {} }; auto c = TClass::GetClass(\"Detail\");");
+   gInterpreter->ProcessLine("namespace Detail {}");
+}


### PR DESCRIPTION
Fixes #8828
```
root [0] namespace std { namespace Detail {} }
root [1] auto c = TClass::GetClass("Detail")
(TClass *) 0x12ef3d7b0
root [2] namespace Detail {}
Error in <TInterpreter::RefreshClassInfo>: Should not need to update the classInfo a non type decl: Detail
```

