### PR TITLE
[ntuple] allow double -> Real32Quant mapping

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -1,4 +1,4 @@
-# RNTuple Reference Specifications 0.2.11.0
+# RNTuple Reference Specifications 0.2.12.0
 
 **Note:** This is work in progress. The RNTuple specification is not yet finalized.
 
@@ -864,7 +864,7 @@ Such cases are marked as `R` in the table.
 | Real16        |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | (Split)Real32 |      |           |      |        |         |         |          |         |          |         |          |   W*  |   W    |
 | (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |       |   W*   |
-| Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W   |        |
+| Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | Real32Quant   |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -350,7 +350,7 @@ extern template class RSimpleField<double>;
 extern template class RSimpleField<float>;
 
 template <typename T>
-class RFloatField : public RSimpleField<T> {
+class RRealField : public RSimpleField<T> {
    using Base = RSimpleField<T>;
 
    using Base::fAvailableColumns;
@@ -362,7 +362,7 @@ class RFloatField : public RSimpleField<T> {
    double fValueMax = std::numeric_limits<T>::max();
 
 protected:
-   void OnClone(RFloatField<T> &cloned) const
+   void OnClone(RRealField<T> &cloned) const
    {
       cloned.fBitWidth = fBitWidth;
       cloned.fValueMin = fValueMin;
@@ -418,14 +418,14 @@ protected:
       fPrincipalColumn = fAvailableColumns[0].get();
    }
 
-   ~RFloatField() override = default;
+   ~RRealField() override = default;
 
 public:
    using Base::SetColumnRepresentatives;
 
-   RFloatField(std::string_view name, std::string_view typeName) : RSimpleField<T>(name, typeName) {}
-   RFloatField(RFloatField &&other) = default;
-   RFloatField &operator=(RFloatField &&other) = default;
+   RRealField(std::string_view name, std::string_view typeName) : RSimpleField<T>(name, typeName) {}
+   RRealField(RRealField &&other) = default;
+   RRealField &operator=(RRealField &&other) = default;
 
    /// Sets this field to use a half precision representation, occupying half as much storage space (16 bits:
    /// 1 sign bit, 5 exponent bits, 10 mantissa bits) on disk.
@@ -471,7 +471,7 @@ public:
 };
 
 template <>
-class RField<float> final : public RFloatField<float> {
+class RField<float> final : public RRealField<float> {
    const RColumnRepresentations &GetColumnRepresentations() const final;
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
@@ -484,13 +484,13 @@ class RField<float> final : public RFloatField<float> {
 public:
    static std::string TypeName() { return "float"; }
 
-   explicit RField(std::string_view name) : RFloatField<float>(name, TypeName()) {}
+   explicit RField(std::string_view name) : RRealField<float>(name, TypeName()) {}
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
 template <>
-class RField<double> final : public RFloatField<double> {
+class RField<double> final : public RRealField<double> {
    const RColumnRepresentations &GetColumnRepresentations() const final;
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
@@ -503,7 +503,7 @@ class RField<double> final : public RFloatField<double> {
 public:
    static std::string TypeName() { return "double"; }
 
-   explicit RField(std::string_view name) : RFloatField<double>(name, TypeName()) {}
+   explicit RField(std::string_view name) : RRealField<double>(name, TypeName()) {}
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -432,9 +432,12 @@ public:
    /// This is mutually exclusive with `SetTruncated` and `SetQuantized`.
    void SetHalfPrecision() { SetColumnRepresentatives({{EColumnType::kReal16}}); }
 
-   /// Set the precision of this field to `nBits`. The remaining (sizeof(T)*8 - `nBits`) bits will be truncated
-   /// from the number's mantissa. `nBits` must be $10 <= nBits <= 31$ (this means that at least 1 bit
+   /// Set the on-disk representation of this field to a single-precision float truncated to `nBits`.
+   /// The remaining (32 - `nBits`) bits will be truncated from the number's mantissa.
+   /// `nBits` must be $10 <= nBits <= 31$ (this means that at least 1 bit
    /// of mantissa is always preserved). Note that this effectively rounds the number towards 0.
+   /// For a double-precision field, this implies first a cast to single-precision, then the truncation.
+   /// This is mutually exclusive with `SetHalfPrecision` and `SetQuantized`.
    void SetTruncated(std::size_t nBits)
    {
       const auto &[minBits, maxBits] = Internal::RColumnElementBase::GetValidBitRange(EColumnType::kReal32Trunc);
@@ -448,6 +451,7 @@ public:
    }
 
    /// Sets this field to use a quantized integer representation using `nBits` per value.
+   /// It must be $1 <= nBits <= 32$.
    /// This call promises that this field will only contain values contained in `[minValue, maxValue]` inclusive.
    /// If a value outside this range is assigned to this field, the behavior is undefined.
    /// This is mutually exclusive with `SetTruncated` and `SetHalfPrecision`.

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -13,6 +13,7 @@
 
 #include <bitset>
 #include <cassert>
+#include <type_traits>
 
 // NOTE: some tests might define R__LITTLE_ENDIAN to simulate a different-endianness machine
 #ifndef R__LITTLE_ENDIAN
@@ -748,16 +749,17 @@ public:
    }
 };
 
-template <>
-class RColumnElement<float, EColumnType::kReal32Trunc> : public RColumnElementBase {
+template <typename T>
+class RColumnElementTrunc : public RColumnElementBase {
 public:
+   static_assert(std::is_floating_point_v<T>);
    static constexpr bool kIsMappable = false;
-   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kSize = sizeof(T);
 
    // NOTE: setting bitsOnStorage == 0 by default. This is an invalid value that helps us
-   // catch misusages where RColumnElement is used without having explicitly set its bit width
+   // catch misuses where RColumnElement is used without having explicitly set its bit width
    // (which should never happen).
-   RColumnElement() : RColumnElementBase(kSize, 0) {}
+   RColumnElementTrunc() : RColumnElementBase(kSize, 0) {}
 
    void SetBitsOnStorage(std::size_t bitsOnStorage) final
    {
@@ -767,7 +769,11 @@ public:
    }
 
    bool IsMappable() const final { return kIsMappable; }
+};
 
+template <>
+class RColumnElement<float, EColumnType::kReal32Trunc> : public RColumnElementTrunc<float> {
+public:
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
       using namespace ROOT::Experimental::Internal::BitPacking;
@@ -799,12 +805,62 @@ public:
    }
 };
 
+template <>
+class RColumnElement<double, EColumnType::kReal32Trunc> : public RColumnElementTrunc<double> {
+public:
+   void Pack(void *dst, const void *src, std::size_t count) const final
+   {
+      using namespace ROOT::Experimental::Internal::BitPacking;
+
+      R__ASSERT(GetPackedSize(count) == MinBufSize(count, fBitsOnStorage));
+
+      // Cast doubles to float before packing them
+      // TODO(gparolini): avoid this allocation
+      auto srcFloat = std::make_unique<float[]>(count);
+      const double *srcDouble = reinterpret_cast<const double *>(src);
+      for (std::size_t i = 0; i < count; ++i)
+         srcFloat[i] = static_cast<float>(srcDouble[i]);
+
+#if R__LITTLE_ENDIAN == 0
+      // TODO(gparolini): to avoid this extra allocation we might want to perform byte swapping
+      // directly in the Pack/UnpackBits functions.
+      auto bswapped = std::make_unique<float[]>(count);
+      CopyBswap<sizeof(float)>(bswapped.get(), srcFloat.get(), count);
+      const float *srcLe = bswapped.get();
+#else
+      const float *srcLe = reinterpret_cast<const float *>(srcFloat.get());
+#endif
+      PackBits(dst, srcLe, count, sizeof(float), fBitsOnStorage);
+   }
+
+   void Unpack(void *dst, const void *src, std::size_t count) const final
+   {
+      using namespace ROOT::Experimental::Internal::BitPacking;
+
+      R__ASSERT(GetPackedSize(count) == MinBufSize(count, fBitsOnStorage));
+
+      // TODO(gparolini): avoid this allocation
+      auto dstFloat = std::make_unique<float[]>(count);
+      UnpackBits(dstFloat.get(), src, count, sizeof(float), fBitsOnStorage);
+#if R__LITTLE_ENDIAN == 0
+      InPlaceBswap<sizeof(float)>(dstFloat.get(), count);
+#endif
+
+      double *dstDouble = reinterpret_cast<double *>(dst);
+      for (std::size_t i = 0; i < count; ++i)
+         dstDouble[i] = static_cast<double>(dstFloat[i]);
+   }
+};
+
 namespace Quantize {
 
 using Quantized_t = std::uint32_t;
 
 [[maybe_unused]] inline std::size_t LeadingZeroes(std::uint32_t x)
 {
+   if (x == 0)
+      return 64;
+
 #ifdef _MSC_VER
    unsigned long idx = 0;
    _BitScanForward(&idx, x);
@@ -816,6 +872,9 @@ using Quantized_t = std::uint32_t;
 
 [[maybe_unused]] inline std::size_t TrailingZeroes(std::uint32_t x)
 {
+   if (x == 0)
+      return 64;
+
 #ifdef _MSC_VER
    unsigned long idx = 0;
    _BitScanReverse(&idx, x);
@@ -876,6 +935,9 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
    const std::size_t quantMax = (1ull << nQuantBits) - 1;
    const double scale = (max - min) / quantMax;
    const std::size_t unusedBits = sizeof(Quantized_t) * 8 - nQuantBits;
+   const double eps = std::numeric_limits<double>::epsilon();
+   const double emin = -eps * scale + min;
+   const double emax = (static_cast<double>(quantMax) + eps) * scale + min;
 
    int nOutOfRange = 0;
 
@@ -890,7 +952,7 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
       const double e = fq * scale + min;
       dst[i] = static_cast<T>(e);
 
-      nOutOfRange += !(min <= dst[i] && dst[i] <= max);
+      nOutOfRange += !(emin <= dst[i] && dst[i] <= emax);
    }
 
    return nOutOfRange;
@@ -931,8 +993,8 @@ public:
       auto quantized = std::make_unique<Quantize::Quantized_t[]>(count);
       assert(fValueRange);
       const auto [min, max] = *fValueRange;
-      const int nOutOfRange = Quantize::QuantizeReals(quantized.get(), reinterpret_cast<const float *>(src), count, min,
-                                                      max, fBitsOnStorage);
+      const int nOutOfRange =
+         Quantize::QuantizeReals(quantized.get(), reinterpret_cast<const T *>(src), count, min, max, fBitsOnStorage);
       if (nOutOfRange) {
          throw RException(R__FAIL(std::to_string(nOutOfRange) +
                                   " values were found of of range for quantization while packing (range is [" +
@@ -951,7 +1013,7 @@ public:
       const auto [min, max] = *fValueRange;
       Internal::BitPacking::UnpackBits(quantized.get(), src, count, sizeof(Quantize::Quantized_t), fBitsOnStorage);
       [[maybe_unused]] const int nOutOfRange =
-         Quantize::UnquantizeReals(reinterpret_cast<float *>(dst), quantized.get(), count, min, max, fBitsOnStorage);
+         Quantize::UnquantizeReals(reinterpret_cast<T *>(dst), quantized.get(), count, min, max, fBitsOnStorage);
       // NOTE: here, differently from Pack(), we don't ever expect to have values out of range, since the quantized
       // integers we pass to UnquantizeReals are by construction limited in value to the proper range. In Pack()
       // this is not the case, as the user may give us float values that are out of range.

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1502,6 +1502,7 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
                                                   {EColumnType::kSplitReal32},
                                                   {EColumnType::kReal32},
                                                   {EColumnType::kReal16},
+                                                  {EColumnType::kReal32Trunc},
                                                   {EColumnType::kReal32Quant}},
                                                  {});
    return representations;


### PR DESCRIPTION
Introducing the intermediate class RFloatField<T> that is inherited by RField<float> and RField<double> which exposes the SetHalfPrecision(), SetTruncated() and SetQuantized() methods for both classes.

This also adds the previously-missing but advertised `double -> Real16` mapping and the `double -> Real32Trunc` mapping

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


