### PR TITLE
[ntuple] Make write buffer size configurable

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -123,11 +123,10 @@ private:
       /// is shorter than 255 characters, we should need at most ~600 bytes. However, the header also needs to be
       /// aligned to kBlockAlign...
       static constexpr std::size_t kHeaderBlockSize = 4096;
-      /// Testing suggests that 4MiB gives best performance at a reasonable memory consumption.
-      static constexpr std::size_t kBlockSize = 4 * 1024 * 1024;
 
       // fHeaderBlock and fBlock are raw pointers because we have to manually call operator new and delete.
       unsigned char *fHeaderBlock = nullptr;
+      std::size_t fBlockSize = 0;
       std::uint64_t fBlockOffset = 0;
       unsigned char *fBlock = nullptr;
 
@@ -149,7 +148,7 @@ private:
       RFileSimple &operator=(RFileSimple &&other) = delete;
       ~RFileSimple();
 
-      void AllocateBuffers();
+      void AllocateBuffers(std::size_t bufferSize);
       void Flush();
 
       /// Writes bytes in the open stream, either at fFilePos or at the given offset

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -127,9 +127,9 @@ private:
       static constexpr std::size_t kBlockSize = 4 * 1024 * 1024;
 
       // fHeaderBlock and fBlock are raw pointers because we have to manually call operator new and delete.
-      unsigned char *fHeaderBlock;
+      unsigned char *fHeaderBlock = nullptr;
       std::uint64_t fBlockOffset = 0;
-      unsigned char *fBlock;
+      unsigned char *fBlock = nullptr;
 
       /// For the simplest cases, a C file stream can be used for writing
       FILE *fFile = nullptr;
@@ -149,6 +149,7 @@ private:
       RFileSimple &operator=(RFileSimple &&other) = delete;
       ~RFileSimple();
 
+      void AllocateBuffers();
       void Flush();
 
       /// Writes bytes in the open stream, either at fFilePos or at the given offset

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -86,6 +86,9 @@ protected:
    /// Whether to use Direct I/O for writing. Note that this introduces alignment requirements that may very between
    /// filesystems and platforms.
    bool fUseDirectIO = false;
+   /// Buffer size to use for writing to files, must be a multiple of 4096 bytes. Testing suggests that 4MiB gives best
+   /// performance (with Direct I/O) at a reasonable memory consumption.
+   std::size_t fWriteBufferSize = 4 * 1024 * 1024;
    /// Whether to use implicit multi-threading to compress pages. Only has an effect if buffered writing is turned on.
    EImplicitMT fUseImplicitMT = EImplicitMT::kDefault;
    /// If set, checksums will be calculated and written for every page.
@@ -126,6 +129,9 @@ public:
 
    bool GetUseDirectIO() const { return fUseDirectIO; }
    void SetUseDirectIO(bool val) { fUseDirectIO = val; }
+
+   std::size_t GetWriteBufferSize() const { return fWriteBufferSize; }
+   void SetWriteBufferSize(std::size_t val) { fWriteBufferSize = val; }
 
    EImplicitMT GetUseImplicitMT() const { return fUseImplicitMT; }
    void SetUseImplicitMT(EImplicitMT val) { fUseImplicitMT = val; }


### PR DESCRIPTION
Also don't allocate them when using `RProperFile`.