### PR TITLE
[PyROOT] Prevent construction of aggregate initializer for std::tuple

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -1720,7 +1720,8 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
     }
 #endif
 
-    if (Cppyy::IsAggregate(((CPPClass*)pyclass)->fCppType) && name.compare(0, 5, "std::", 5) != 0) {
+    if (Cppyy::IsAggregate(((CPPClass*)pyclass)->fCppType) && name.compare(0, 5, "std::", 5) != 0 &&
+        name.compare(0, 6, "tuple<", 6) != 0) {
     // create a pseudo-constructor to allow initializer-style object creation
         Cppyy::TCppType_t kls = ((CPPClass*)pyclass)->fCppType;
         Cppyy::TCppIndex_t ndata = Cppyy::GetNumDatamembers(kls);


### PR DESCRIPTION
Prevents failures induced by #16338 for python3.8