### PR TITLE
[DF] Also check if fOutputFiles is empty before warning untriggered snapshot

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1672,7 +1672,7 @@ public:
    SnapshotHelperMT(SnapshotHelperMT &&) = default;
    ~SnapshotHelperMT()
    {
-      if (!fTreeName.empty() /*not moved from*/ && fOptions.fLazy &&
+      if (!fTreeName.empty() /*not moved from*/ && fOptions.fLazy && !fOutputFiles.empty() &&
           std::all_of(fOutputFiles.begin(), fOutputFiles.end(), [](const auto &f) { return !f; }) /* never run */)
          Warning("Snapshot", "A lazy Snapshot action was booked but never triggered.");
    }

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -1213,6 +1213,14 @@ TEST(RDFSnapshotMore, LazyNotTriggeredMT)
    ROOT::DisableImplicitMT();
 }
 
+TEST(RDFSnapshotMore, LazyTriggeredMT)
+{
+   TIMTEnabler _(4);
+   auto fname = "LazyTriggeredMT.root";
+   ROOT_EXPECT_NODIAG(*ReturnLazySnapshot(fname));
+   gSystem->Unlink(fname);
+}
+
 TEST(RDFSnapshotMore, EmptyBuffersMT)
 {
    const auto fname = "emptybuffersmt.root";


### PR DESCRIPTION
Fixes #14132

# This Pull request:

## Changes or fixes:
Also check if `fOutputFiles` is empty before giving warning "A lazy Snapshot action was booked but never triggered".

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #14132 (the other issue with broken `gDirectory` seems to have gone in latest ROOT (6.32.06), so can consider as this bug is fixed)

