### PR TITLE
[CMake] Assume macOS 10.15 Catalina or newer

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -4,55 +4,35 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-set(ROOT_ARCHITECTURE macosx)
 set(ROOT_PLATFORM macosx)
 
 if (CMAKE_SYSTEM_NAME MATCHES Darwin)
-  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
-                  COMMAND cut -d . -f 1-2
-                  OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+  MESSAGE(STATUS "Found a macOS system")
 
-  MESSAGE(STATUS "Found a macOS system ${MACOSX_VERSION}")
-
-  if(MACOSX_VERSION VERSION_GREATER 10.7 AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+  if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     set(libcxx ON CACHE BOOL "Build using libc++" FORCE)
   endif()
 
-  if(MACOSX_VERSION VERSION_GREATER 10.4)
-    #TODO: check haveconfig and rpath -> set rpath true
-    #TODO: check Thread, define link command
-    #TODO: more stuff check configure script
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES 64)
-       if(CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
-          MESSAGE(STATUS "Found an AArch64 system")
-          set(ROOT_ARCHITECTURE macosxarm64)
-       else()
-          MESSAGE(STATUS "Found an x86_64 system")
-          set(ROOT_ARCHITECTURE macosx64)
-          SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64")
-       endif()
-
-       SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
-       SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -m64")
-       SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -m64")
-       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
-       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
-    else()
-       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
-       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
-       SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m32")
-    endif()
+  #TODO: check haveconfig and rpath -> set rpath true
+  #TODO: check Thread, define link command
+  #TODO: more stuff check configure script
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
+     MESSAGE(STATUS "Found an AArch64 system")
+     set(ROOT_ARCHITECTURE macosxarm64)
+  else()
+     MESSAGE(STATUS "Found an x86_64 system")
+     set(ROOT_ARCHITECTURE macosx64)
+     SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64")
   endif()
 
-  if(MACOSX_VERSION VERSION_GREATER 10.6)
-    set(MACOSX_SSL_DEPRECATED ON)
-  endif()
-  if(MACOSX_VERSION VERSION_GREATER 10.7)
-    set(MACOSX_ODBC_DEPRECATED ON)
-  endif()
-  if(MACOSX_VERSION VERSION_GREATER 10.8)
-    set(MACOSX_GLU_DEPRECATED ON)
-  endif()
+  SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+  SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -m64")
+  SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -m64")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+
+  set(MACOSX_SSL_DEPRECATED ON)
+  set(MACOSX_GLU_DEPRECATED ON)
 
   if (CMAKE_COMPILER_IS_GNUCXX)
      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wshadow -Wall -Woverloaded-virtual -fsigned-char -fno-common")
@@ -91,9 +71,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
   else()
     MESSAGE(FATAL_ERROR "There is no setup for this compiler with ID=${CMAKE_CXX_COMPILER_ID} up to now. Don't know what to do. Stop cmake at this point.")
   endif()
-
-  #---Set Linker flags----------------------------------------------------------------------
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mmacosx-version-min=${MACOSX_VERSION}")
 else (CMAKE_SYSTEM_NAME MATCHES Darwin)
   MESSAGE(FATAL_ERROR "There is no setup for this this Apple system up to now. Don't know waht to do. Stop cmake at this point.")
 endif (CMAKE_SYSTEM_NAME MATCHES Darwin)

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -272,47 +272,13 @@ openbsd)
    auxcflags="${cxxversionflag}"
    auxlibs="-lm -lstdc++"
    ;;
-macosx)
-   # MacOS X with gcc (GNU cc v3.1) and possible fink (fink.sf.net)
-   macosx_major=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 1 | sed -e 's/^[[:space:]]*//'`
-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
-   # cannot find the one linked to libGraf if relocated after built
-   if [ $macosx_major -eq 10 -a $macosx_minor -le 4 ]; then
-      rootlibs="$rootlibs -lfreetype"
-   fi
-   if [ $macosx_major -eq 10 -a $macosx_minor -le 3 ]; then
-      finkdir=`which fink 2>&1 | sed -ne "s/\/bin\/fink//p"`
-      auxcflags=`[ -d ${finkdir}/include ] && echo -I${finkdir}/include`
-      auxcflags="-Wno-long-double $auxcflags"
-      auxlibs="-lm `[ -d ${finkdir}/lib ] && echo -L${finkdir}/lib` -ldl"
-      forcelibs=$rootulibs
-      forceglibs=$rootuglibs
-      forceevelibs=$rootuevelibs
-   else
-      auxcflags="${cxxversionflag} -m32"
-      auxldflags="-m32"
-      auxlibs="-lm -ldl"
-   fi
-   ;;
 macosxicc)
    # MacOS X with Intel icc compiler
-   macosx_major=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 1 | sed -e 's/^[[:space:]]*//'`
-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
-   # cannot find the one linked to libGraf if relocated after built
-   if [ $macosx_major -eq 10 -a $macosx_minor -le 4 ]; then
-      rootlibs="$rootlibs -lfreetype"
-   fi
    auxcflags="${cxxversionflag}"
    auxlibs="-lm -ldl"
    ;;
 macosx64|macosxarm64)
    # MacOS X with gcc (GNU cc v4.x) in 64 bit mode
-   macosx_major=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 1 | sed -e 's/^[[:space:]]*//'`
-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
-   # cannot find the one linked to libGraf if relocated after built
-   if [ $macosx_major -eq 10 -a $macosx_minor -le 4 ]; then
-      rootlibs="$rootlibs -lfreetype"
-   fi
    auxcflags="${cxxversionflag} -m64"
    auxldflags="-m64"
    auxlibs="-lm -ldl"
@@ -387,17 +353,11 @@ openbsd* | linux*)
    done
    ;;
 macosx*)
-   if [ \( $macosx_major -eq 10 -a $macosx_minor -ge 5 \) -o $macosx_major -gt 10  ]; then
-      auxcflags="-pthread $auxcflags"
-      auxlibs="-lpthread $auxlibs"
-   else
-      auxlibs="-lpthread $auxlibs"
-   fi
+   auxcflags="-pthread $auxcflags"
+   auxlibs="-lpthread $auxlibs"
    for f in $features ; do
       if test "x$f" = "xrpath" ; then
-         if [ \( $macosx_major -eq 10 -a $macosx_minor -ge 5 \) -o $macosx_major -gt 10  ]; then
-            auxlibs="-Wl,-rpath,$libdir $auxlibs"
-         fi
+         auxlibs="-Wl,-rpath,$libdir $auxlibs"
       fi
       if test "x$f" = "xlibcxx" ; then
          auxcflags="-stdlib=libc++ $auxcflags"


### PR DESCRIPTION
**TLDR: Assume macOS 10.15 or newer. This is upstreaming one of the patches from nix Darwin.**

In some environments that are indepent of the Apple SDKs like nix Darwin, the `sw_vers` executable that is used in `SetUpMacOS.cmake` is not available.

However, it is not actually needed anymore, because the most recent macOS version for which there are different code branches in the CMake is OS X 10.8 Mountain Lion, which is end of life since about 10 years.

Therefore, this commit suggests to remove the macOS version check and assume we always have OS X 10.9 or newer.

Furthermore, the following simplifications are suggested:

  * remove 32-bit code branch, since the last macOS version that
    supported 32 bit CPUs was 10.14 Mojave, end-of-life since three
    years: https://en.wikipedia.org/wiki/MacOS_version_history
    This effectively sets our oldest supported macOS version to 10.15
    from the perspective of CMake (although, I think in practice the
    minimum supported version is probably newer because of LLVM
    constraints).

  * don't add `-mmacosx-version-min=${MACOSX_VERSION}` linker flag,
    which I believe is not needed anymore. It is also patched out in
    nix, and things work just fine.

    See also:

      * https://github.com/root-project/root/commit/e298ce70e310b2dd2f4fbbdcfd3f90d1deeef7f4

      * https://its.cern.ch/jira/browse/ROOT-6836

      * https://github.com/guitargeek/nixpkgs/blob/master/pkgs/applications/science/misc/root/sw_vers.patch#L49