### PR TITLE
[ntuple] add default constructor to REntry::RFieldToken

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -61,9 +61,12 @@ public:
       friend class REntry;
       friend class RNTupleModel;
 
-      std::size_t fIndex;     ///< the index in fValues that belongs to the top-level field
-      std::uint64_t fSchemaId; ///< Safety check to prevent tokens from other models being used
+      std::size_t fIndex = 0;                      ///< the index in fValues that belongs to the top-level field
+      std::uint64_t fSchemaId = std::uint64_t(-1); ///< Safety check to prevent tokens from other models being used
       RFieldToken(std::size_t index, std::uint64_t schemaId) : fIndex(index), fSchemaId(schemaId) {}
+
+   public:
+      RFieldToken() = default; // The default constructed token cannot be used by any entry
    };
 
 private:

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -875,6 +875,10 @@ TEST(REntry, Basics)
    std::shared_ptr<double> ptrDouble;
    EXPECT_THROW(e->BindValue("pt", ptrDouble), ROOT::Experimental::RException);
 
+   // Default constructed tokens cannot be used
+   ROOT::Experimental::REntry::RFieldToken token;
+   EXPECT_THROW(e->GetPtr<void>(token), ROOT::Experimental::RException);
+
    float pt;
    e->BindRawPtr("pt", &pt);
    EXPECT_EQ(&pt, e->GetPtr<void>("pt").get());


### PR DESCRIPTION
Addresses point 9 in the HEP-CCE/SOP interface review.

