### PR TITLE
[jsroot] 7.7.4 30/09/2024 for 6.32 branch

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,5 +1,18 @@
 # JSROOT changelog
 
+## Changes in 7.7.4
+1. Fix - TGraph Y range selection, do not cross 0
+2. Fix - correctly handle `#font[id]` in latex
+3. Fix - store canvas with embed geometry drawing
+4. Fix - upgrade rollup and import.meta polyfill
+
+
+## Changes in 7.7.3
+1. Fix - correctly handle in I/O empty std::map
+2. Fix - reading of small (<1KB) ROOT files
+3. Fix - race condition in zstd initialization #318
+
+
 ## Changes in 7.7.2
 1. Fix - hide empty title on the canvas
 2. Fix - properly handle zooming in THStack histogram

--- a/js/modules/base/FontHandler.mjs
+++ b/js/modules/base/FontHandler.mjs
@@ -70,6 +70,11 @@ class FontHandler {
       this.painter = painter;
    }
 
+   /** @summary Force setting of style and weight, used in latex */
+   setUseFullStyle(flag) {
+      this.full_style = flag;
+   }
+
    /** @summary Assigns font-related attributes */
    addCustomFontToSvg(svg) {
       if (!this.base64 || !this.name)
@@ -96,8 +101,8 @@ class FontHandler {
       selection.attr('font-family', this.name)
                .attr('font-size', this.size)
                .attr('xml:space', 'preserve')
-               .attr('font-weight', this.weight || null)
-               .attr('font-style', this.style || null);
+               .attr('font-weight', this.weight || (this.full_style ? 'normal' : null))
+               .attr('font-style', this.style || (this.full_style ? 'normal' : null));
    }
 
    /** @summary Set font size (optional) */

--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -903,6 +903,7 @@ function parseLatex(node, arg, label, curr) {
             subpos.color = curr.painter.getColor(foundarg);
          else if (found.name === '#font[') {
             subpos.font = new FontHandler(foundarg);
+            subpos.font.setUseFullStyle(true); // while embedding - need to enforce full style
             subpos.ufont = true; // mark that custom font is applied
          } else
             subpos.fsize *= foundarg;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -1,10 +1,10 @@
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = '7.7.2',
+const version_id = '7.7.4',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '19/06/2024',
+version_date = '30/09/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/draw/TTree.mjs
+++ b/js/modules/draw/TTree.mjs
@@ -43,7 +43,7 @@ TDrawSelector.prototype.ShowProgress = function(value) {
       msg = `TTree draw ${(value * 100).toFixed(ndig)} % `;
    }
 
-   showProgress(msg, -1, () => { this._break = 1; });
+   showProgress(msg, 0, () => { this._break = 1; });
    return ret;
 };
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -1266,7 +1266,7 @@ class TAxisPainter extends ObjectPainter {
                             .style('cursor', 'crosshair');
 
             if (this.vertical) {
-               const rw = (labelsMaxWidth || 2*labelSize) + 3;
+               const rw = Math.max(labelsMaxWidth, 2*labelSize) + 3;
                r.attr('x', (side > 0) ? -rw : 0).attr('y', 0)
                 .attr('width', rw).attr('height', h);
             } else {

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -2186,15 +2186,23 @@ class TPadPainter extends ObjectPainter {
             btns.remove();
          }
 
-         const main = pp.getFramePainter();
-         if (!isFunc(main?.render3D) || !isFunc(main?.access3dKind)) return;
+         const fp = pp.getFramePainter();
+         if (!isFunc(fp?.access3dKind)) return;
 
-         const can3d = main.access3dKind();
+         const can3d = fp.access3dKind();
          if ((can3d !== constants.Embed3D.Overlay) && (can3d !== constants.Embed3D.Embed)) return;
 
-         const sz2 = main.getSizeFor3d(constants.Embed3D.Embed), // get size and position of DOM element as it will be embed
+         let main, canvas;
+         if (isFunc(fp.render3D)) {
+            main = fp;
+            canvas = fp.renderer?.domElement;
+         } else {
+            main = fp.getMainPainter();
+            canvas = main?._renderer?.domElement;
+         }
+         if (!isFunc(main?.render3D) || !isObject(canvas)) return;
 
-         canvas = main.renderer.domElement;
+         const sz2 = fp.getSizeFor3d(constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
          main.render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately
          const dataUrl = canvas.toDataURL('image/png');
 

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -2760,7 +2760,7 @@ class HierarchyPainter extends BasePainter {
    async listServerDir(dirname) {
       return httpRequest(dirname, 'text').then(res => {
          if (!res) return false;
-         const h = { _name: 'Files', _kind: kTopFolder, _childs: [], _isopen: true };
+         const h = { _name: 'Files', _kind: kTopFolder, _childs: [], _isopen: true }, fmap = {};
          let p = 0;
          while (p < res.length) {
             p = res.indexOf('a href="', p+1);
@@ -2771,6 +2771,10 @@ class HierarchyPainter extends BasePainter {
 
             const fname = res.slice(p, p2);
             p = p2 + 1;
+
+            if (fmap[fname]) continue;
+            fmap[fname] = true;
+
             if ((fname.lastIndexOf('.root') === fname.length - 5) && (fname.length > 5)) {
                h._childs.push({
                   _name: fname, _title: dirname + fname, _url: dirname + fname, _kind: kindTFile,

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -312,6 +312,11 @@ class TGraphPainter extends ObjectPainter {
       let uxmin = xmin - dx, uxmax = xmax + dx,
           minimum = ymin - dy, maximum = ymax + dy;
 
+      if ((ymin > 0) && (minimum <= 0))
+         minimum = (1 - margin) * ymin;
+      if ((ymax < 0) && (maximum >= 0))
+         maximum = (1 - margin) * ymax;
+
       if (!this._not_adjust_hrange) {
          const pad_logx = this.getPadPainter()?.getPadLog('x');
 
@@ -337,7 +342,10 @@ class TGraphPainter extends ObjectPainter {
 
       if (graph.fMinimum !== kNoZoom) minimum = ymin = graph.fMinimum;
       if (graph.fMaximum !== kNoZoom) maximum = graph.fMaximum;
-      if ((minimum < 0) && (ymin >= 0)) minimum = (1 - margin)*ymin;
+      if ((minimum < 0) && (ymin >= 0))
+         minimum = (1 - margin)*ymin;
+      if ((ymax < 0) && (maximum >= 0))
+         maximum = (1 - margin) * ymax;
 
       setHistogramTitle(histo, this.getObject().fTitle);
 

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -1610,7 +1610,7 @@ class TH2Painter extends THistPainter {
                if (draw_colors && (colindx !== null))
                   item.style('fill', this._color_palette.getColor(colindx));
                else if (draw_fill)
-                  item.call('fill', this.createAttFill(gr).func);
+                  item.call(this.createAttFill(gr).func);
                else
                   item.style('fill', 'none');
                if (draw_lines)

--- a/js/modules/main.mjs
+++ b/js/modules/main.mjs
@@ -27,7 +27,7 @@ export { openFile, FileProxy } from './io.mjs';
 
 export * from './gui/display.mjs';
 
-export { HierarchyPainter, getHPainter } from './gui/HierarchyPainter.mjs';
+export { HierarchyPainter } from './gui/HierarchyPainter.mjs';
 
 export { readStyleFromURL, buildGUI } from './gui.mjs';
 


### PR DESCRIPTION
1. Fix - TGraph Y range selection, do not cross 0
2. Fix - correctly handle `#font[id]` in latex
3. Fix - store canvas with embed geometry drawing
4. Fix - upgrade rollup and exclude import.meta polyfill
5. Fix - correctly handle in I/O empty std::map
6. Fix - reading of small (<1KB) ROOT files
7. Fix - race condition in zstd initialization #318

