### PR TITLE
[Core] Also build test support in case of `testing=OFF`

### DIFF
--- a/core/testsupport/CMakeLists.txt
+++ b/core/testsupport/CMakeLists.txt
@@ -4,10 +4,6 @@
 # higher than kInfo are issued by tests.
 # Stephan Hageboeck, CERN, 2022
 
-if(NOT testing)
-  return()
-endif()
-
 set(libname TestSupport)
 set(header_dir ROOT/)
 


### PR DESCRIPTION
This allows downstream packages to also use the `ROOT_ADD_GTEST` macro in CMake with all its convenience.