### PR TITLE
[tmva][pyroot] fix compiler warnings

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -208,6 +208,12 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+// More recent versions of python change the second argument from a ssize_t to
+// a union, therefore technically requiring an additional parenthesis.
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+#endif
 PyObject _CPyCppyy_NullPtrStruct = {
     _PyObject_EXTRA_INIT
     1, &PyNullPtr_t_Type
@@ -217,6 +223,9 @@ PyObject _CPyCppyy_DefaultStruct = {
     _PyObject_EXTRA_INIT
     1, &PyDefault_t_Type
 };
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -128,10 +128,6 @@ public:
 
       size_t jump= groupSize/fShapeX[fAttrAxis];
       //candidates to check in group
-      size_t prod =1;
-      for(size_t i = fAttrAxis+1; i < size; i++){
-         prod *= fShapeX[i];
-      }
       size_t numOfChecksInGrp=groupSize/jump;
       size_t numOfCheckersInGrp=groupSize/numOfChecksInGrp;
 


### PR DESCRIPTION
Remove an unused variable and fix some clang warnings (suggest-braces)  that make ROOT not compile with -Werror

