### PR TITLE
[CI] Add a cpu label to github workflows; update actions.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -358,48 +358,42 @@ jobs:
         include:
           - image: fedora39
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: alma9
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: ubuntu20
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: ubuntu22
             overrides: ["imt=Off", "LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: ubuntu2404
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: debian125
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           # Special builds
           - image: alma9
             is_special: true
             property: modules_off
             overrides: ["runtime_cxxmodules=Off"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: alma9
             is_special: true
             property: march_native
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "fortran=OFF"]
-            runs-on: [self-hosted, root-ci, linux, x64]
           - image: alma9
             is_special: true
             property: arm64
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "ccache=ON"]
-            runs-on: [self-hosted, root-ci, linux, ARM64]
+            architecture: ARM64
           - image: alma9-clang
             is_special: true
             property: clang
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
-            runs-on: [self-hosted, root-ci, linux, x64]
 
-    runs-on: ${{ matrix.runs-on }}
+    runs-on:
+      - self-hosted
+      - linux
+      - ${{ matrix.architecture == null && 'x64' || matrix.architecture }}
+      - ${{ matrix.extra-runs-on == null && 'cpu' || matrix.extra-runs-on }}
 
     name: |
       ${{ matrix.image }} ${{ matrix.property }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -202,14 +202,14 @@ jobs:
 
       - name: Upload test results
         if:   ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results ${{ matrix.platform }} ${{ matrix.arch }}
           path: /Users/sftnight/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries ${{ matrix.platform }} ${{ matrix.arch }}
           path: /Users/sftnight/ROOT-CI/packages/root_v*
@@ -323,14 +323,14 @@ jobs:
 
       - name: Upload test results
         if:   ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results Windows ${{ matrix.target_arch }} ${{ matrix.config }}
           path: C:/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries ${{ matrix.target_arch }} ${{ matrix.config }}
           path: C:/ROOT-CI/packages/root_v*
@@ -530,14 +530,14 @@ jobs:
 
       - name: Upload test results
         if:   ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results ${{ matrix.image }}
           path: /github/home/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries ${{ matrix.image }} ${{ matrix.property }}
           path: /github/home/ROOT-CI/packages/root_v*
@@ -559,7 +559,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Event File
         path: ${{ github.event_path }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -526,7 +526,7 @@ jobs:
         if:   ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Test Results ${{ matrix.image }}
+          name: Test Results ${{ matrix.image }} ${{ matrix.property }}
           path: /github/home/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -50,10 +50,11 @@ jobs:
     permissions:
       contents: read
 
-    runs-on: 
+    runs-on:
       - self-hosted
       - linux
       - x64
+      - cpu
 
     name: Build and test to determine coverage
 

--- a/.github/workflows/testsecurity.yml
+++ b/.github/workflows/testsecurity.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   no-container:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, cpu]
     steps:
       - name: Print debug info
         run:  'printf "%s@%s\\n" $(whoami) $(hostname); pwd; ls -la; ls -la /'
@@ -27,7 +27,7 @@ jobs:
       matrix:
         image: ["","","","","","","","","","","","","","","","","","","",""]
 
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, cpu]
 
     container:
       image: ubuntu


### PR DESCRIPTION
The GPU runner was attracting CPU-only jobs, since all runner labels in use so far were automatic github labels. Here, a unique label is added to steer the jobs correctly.

Furthermore, the upload-artifact action starts warning about an imminent deprecation, so it's updated to v4 here.
This uncovered a name clash, where two builds on the same image would race to upload artifacts. This seems to be OK in v3, but not in v4.