### PR TITLE
[ntuple] Refactor `RNTupleProcessor`, add `RNTupleChainProcessor` subclass

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -35,6 +35,7 @@ namespace Experimental {
 
 namespace Internal {
 class RNTupleProcessor;
+class RNTupleChainProcessor;
 }
 
 // clang-format off
@@ -52,6 +53,7 @@ class REntry {
    friend class RNTupleReader;
    friend class RNTupleFillContext;
    friend class RNTupleProcessor;
+   friend class RNTupleChainProcessor;
 
 public:
    /// The field token identifies a top-level field in this entry. It can be used for fast indexing in REntry's

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -55,11 +55,10 @@ using ROOT::Experimental::RNTupleProcessor;
 using ROOT::Experimental::RNTupleSourceSpec;
 
 std::vector<RNTupleSourceSpec> ntuples = {{"ntuple1", "ntuple1.root"}, {"ntuple2", "ntuple2.root"}};
-RNTupleProcessor processor(ntuples);
-auto ptrPt = processor.GetEntry().GetPtr<float>("pt");
+auto processor = RNTupleProcessor::CreateChain(ntuples);
 
 for (const auto &entry : processor) {
-   std::cout << "pt = " << *ptrPt << std::endl;
+   std::cout << "pt = " << *entry.GetPtr<float>("pt") << std::endl;
 }
 ~~~
 
@@ -70,14 +69,12 @@ The RNTupleProcessor constructor also (optionally) accepts an RNTupleModel, whic
 read. If no model is provided, a default model based on the descriptor of the first specified RNTuple will be used.
 If a field that was present in the first RNTuple is not found in a subsequent one, an error will be thrown.
 
-The object returned by the RNTupleProcessor iterator is a view on the current state of the processor, and provides
-access to the global entry index (i.e., the entry index taking into account all processed ntuples), local entry index
-(i.e. the entry index for only the currently processed ntuple), the index of the ntuple currently being processed (with
-respect to the order of provided RNTupleSpecs) and the actual REntry containing the values for the current entry.
+The RNTupleProcessor provides an iterator which gives access to the REntry containing the field data for the current
+entry. Additional bookkeeping information can be obtained through the RNTupleProcessor itself.
 */
 // clang-format on
 class RNTupleProcessor {
-private:
+protected:
    // clang-format off
    /**
    \class ROOT::Experimental::RNTupleProcessor::RFieldContext
@@ -92,6 +89,7 @@ private:
    // clang-format on
    class RFieldContext {
       friend class RNTupleProcessor;
+      friend class RNTupleChainProcessor;
 
    private:
       std::unique_ptr<RFieldBase> fProtoField;
@@ -115,6 +113,10 @@ private:
    std::unique_ptr<Internal::RPageSource> fPageSource;
    std::vector<RFieldContext> fFieldContexts;
 
+   NTupleSize_t fNEntriesProcessed;  //< Total number of entries processed so far
+   std::size_t fCurrentNTupleNumber; //< Index of the currently open RNTuple
+   NTupleSize_t fLocalEntryNumber;   //< Entry number within the current ntuple
+
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Connect an RNTuple for processing.
    ///
@@ -124,13 +126,50 @@ private:
    ///
    /// Creates and attaches new page source for the specified RNTuple, and connects the fields that are known by
    /// the processor to it.
-   NTupleSize_t ConnectNTuple(const RNTupleSourceSpec &ntuple);
+   virtual NTupleSize_t ConnectNTuple(const RNTupleSourceSpec &ntuple) = 0;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Creates and connects concrete fields to the current page source, based on the proto-fields.
-   void ConnectFields();
+   virtual void ConnectFields() = 0;
+
+   //////////////////////////////////////////////////////////////////////////
+   /// \brief Advance the processor to the next available entry.
+   ///
+   /// \return The new (global) entry number of after advancing, or kInvalidNTupleIndex if the last entry has been
+   /// processed.
+   ///
+   /// Checks if the end of the currently connected RNTuple is reached. If this is the case, either the next RNTuple
+   /// is connected or the iterator has reached the end.
+   virtual NTupleSize_t Advance() = 0;
+
+   RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples)
+      : fNTuples(ntuples), fNEntriesProcessed(0), fCurrentNTupleNumber(0), fLocalEntryNumber(0)
+   {
+   }
 
 public:
+   RNTupleProcessor(const RNTupleProcessor &) = delete;
+   RNTupleProcessor(RNTupleProcessor &&) = delete;
+   RNTupleProcessor &operator=(const RNTupleProcessor &) = delete;
+   RNTupleProcessor &operator=(RNTupleProcessor &&) = delete;
+   virtual ~RNTupleProcessor() = default;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the total number of entries processed so far.
+   ///
+   /// When only one RNTuple is present in the processor chain, the return value is equal to GetLocalEntryNumber.
+   NTupleSize_t GetNEntriesProcessed() const { return fNEntriesProcessed; }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the index to the RNTuple currently being processed, according to the sources specified upon creation.
+   std::size_t GetCurrentNTupleNumber() const { return fCurrentNTupleNumber; }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the entry number local to the RNTuple that is currently being processed.
+   ///
+   /// When only one RNTuple is present in the processor chain, the return value is equal to GetGlobalEntryNumber.
+   NTupleSize_t GetLocalEntryNumber() const { return fLocalEntryNumber; }
+
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Returns a reference to the entry used by the processor.
    ///
@@ -146,106 +185,84 @@ public:
    */
    // clang-format on
    class RIterator {
-   public:
-      // clang-format off
-      /**
-      \class ROOT::Experimental::RNTupleProcessor::RIterator::RProcessorState
-      \ingroup NTuple
-      \brief View on the RNTupleProcessor iterator state.
-      */
-      // clang-format on
-      class RProcessorState {
-         friend class RIterator;
-
-      private:
-         const REntry &fEntry;
-         NTupleSize_t fGlobalEntryIndex;
-         NTupleSize_t fLocalEntryIndex;
-         /// Index of the currently open RNTuple in the chain of ntuples
-         std::size_t fNTupleIndex;
-
-      public:
-         RProcessorState(const REntry &entry, NTupleSize_t globalEntryIndex, NTupleSize_t localEntryIndex,
-                         std::size_t ntupleIndex)
-            : fEntry(entry),
-              fGlobalEntryIndex(globalEntryIndex),
-              fLocalEntryIndex(localEntryIndex),
-              fNTupleIndex(ntupleIndex)
-         {
-         }
-
-         const REntry *operator->() const { return &fEntry; }
-         const REntry &GetEntry() const { return fEntry; }
-         NTupleSize_t GetGlobalEntryIndex() const { return fGlobalEntryIndex; }
-         NTupleSize_t GetLocalEntryIndex() const { return fLocalEntryIndex; }
-         std::size_t GetNTupleIndex() const { return fNTupleIndex; }
-      };
-
    private:
       RNTupleProcessor &fProcessor;
-      RProcessorState fState;
+      NTupleSize_t fNEntriesProcessed;
 
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
-      using value_type = RProcessorState;
+      using value_type = REntry;
       using difference_type = std::ptrdiff_t;
-      using pointer = RProcessorState *;
-      using reference = const RProcessorState &;
+      using pointer = REntry *;
+      using reference = const REntry &;
 
-      RIterator(RNTupleProcessor &processor, std::size_t ntupleIndex, NTupleSize_t globalEntryIndex)
-         : fProcessor(processor), fState(processor.GetEntry(), globalEntryIndex, 0, ntupleIndex)
+      RIterator(RNTupleProcessor &processor, NTupleSize_t globalEntryNumber)
+         : fProcessor(processor), fNEntriesProcessed(globalEntryNumber)
       {
-      }
-
-      //////////////////////////////////////////////////////////////////////////
-      /// \brief Increments the entry index.
-      ///
-      /// Checks if the end of the currently connected RNTuple is reached. If this is the case, either the next RNTuple
-      /// is connected or the iterator has reached the end.
-      void Advance()
-      {
-         ++fState.fGlobalEntryIndex;
-
-         if (++fState.fLocalEntryIndex >= fProcessor.fPageSource->GetNEntries()) {
-            do {
-               if (++fState.fNTupleIndex >= fProcessor.fNTuples.size()) {
-                  fState.fGlobalEntryIndex = kInvalidNTupleIndex;
-                  return;
-               }
-               // Skip over empty ntuples we might encounter.
-            } while (fProcessor.ConnectNTuple(fProcessor.fNTuples.at(fState.fNTupleIndex)) == 0);
-
-            fState.fLocalEntryIndex = 0;
-         }
-         fProcessor.fEntry->Read(fState.fLocalEntryIndex);
       }
 
       iterator operator++()
       {
-         Advance();
+         fNEntriesProcessed = fProcessor.Advance();
          return *this;
       }
 
       iterator operator++(int)
       {
          auto obj = *this;
-         Advance();
+         obj.fNEntriesProcessed = fProcessor.Advance();
          return obj;
       }
 
       reference operator*()
       {
-         fProcessor.fEntry->Read(fState.fLocalEntryIndex);
-         return fState;
+         fProcessor.fEntry->Read(fProcessor.fLocalEntryNumber);
+         return *fProcessor.fEntry;
       }
 
-      bool operator!=(const iterator &rh) const { return fState.fGlobalEntryIndex != rh.fState.fGlobalEntryIndex; }
-      bool operator==(const iterator &rh) const { return fState.fGlobalEntryIndex == rh.fState.fGlobalEntryIndex; }
+      friend bool operator!=(const iterator &lh, const iterator &rh)
+      {
+         return lh.fNEntriesProcessed != rh.fNEntriesProcessed;
+      }
+      friend bool operator==(const iterator &lh, const iterator &rh)
+      {
+         return lh.fNEntriesProcessed == rh.fNEntriesProcessed;
+      }
    };
 
+   RIterator begin() { return RIterator(*this, 0); }
+   RIterator end() { return RIterator(*this, kInvalidNTupleIndex); }
+
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Constructs a new RNTupleProcessor.
+   /// \brief Create a new RNTuple processor chain for vertical concatenation of RNTuples.
+   ///
+   /// \param[in] ntuples A list specifying the names and locations of the ntuples to process.
+   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
+   /// one will be created based on the descriptor of the first ntuple specified.
+   ///
+   /// \return A pointer to the newly created RNTupleProcessor.
+   static std::unique_ptr<RNTupleProcessor>
+   CreateChain(const std::vector<RNTupleSourceSpec> &ntuples, std::unique_ptr<RNTupleModel> model = nullptr);
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleChainProcessor
+\ingroup NTuple
+\brief Processor specializiation for vertically concatenated RNTuples (chains).
+*/
+// clang-format on
+class RNTupleChainProcessor : public RNTupleProcessor {
+   friend class RNTupleProcessor;
+
+private:
+   NTupleSize_t ConnectNTuple(const RNTupleSourceSpec &ntuple) final;
+   void ConnectFields() final;
+   NTupleSize_t Advance() final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Constructs a new RNTupleChainProcessor.
    ///
    /// \param[in] ntuples The source specification (name and storage location) for each RNTuple to process.
    /// \param[in] model The model that specifies which fields should be read by the processor. The pointer returned by
@@ -253,10 +270,7 @@ public:
    /// specified, it is created from the descriptor of the first RNTuple specified in `ntuples`.
    ///
    /// RNTuples are processed in the order in which they are specified.
-   RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples, std::unique_ptr<RNTupleModel> model = nullptr);
-
-   RIterator begin() { return RIterator(*this, 0, 0); }
-   RIterator end() { return RIterator(*this, fNTuples.size(), kInvalidNTupleIndex); }
+   RNTupleChainProcessor(const std::vector<RNTupleSourceSpec> &ntuples, std::unique_ptr<RNTupleModel> model = nullptr);
 };
 
 } // namespace Experimental


### PR DESCRIPTION
This PR provides some refactoring around the `RNTupleProcessor`. Most notably, the `RNTupleProcessor` class has been changed into an abstract class only providing the generic interfaces. A subclass, `RNTupleChainProcessor` has been added to take care of the internal machinery for vertically concatenated ("chained") ntuples.

The rationale behind this refactoring is that in this way, we can also provide an `RNTupleJoinProcessor` subclass which takes care of horizontal concatenations, using the same class design. Once this has been added, the `RNTupleProcessor` base class could be used to take care of combinations of chain- and join-based processors and the scheduling thereof.