### PR TITLE
[ntuple] Fix reading vectors of bitsets

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -104,6 +104,7 @@ protected:
    void ConstructValue(void *where) const final { memset(where, 0, GetValueSize()); }
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
+   void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
 
 public:
    RBitsetField(std::string_view fieldName, std::size_t N);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3296,6 +3296,19 @@ void ROOT::Experimental::RBitsetField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 }
 
+void ROOT::Experimental::RBitsetField::ReadInClusterImpl(RClusterIndex clusterIndex, void *to)
+{
+   auto *asULongArray = static_cast<Word_t *>(to);
+   bool elementValue;
+   for (std::size_t i = 0; i < fN; ++i) {
+      fPrincipalColumn->Read(RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() * fN) + i,
+                             &elementValue);
+      Word_t mask = static_cast<Word_t>(1) << (i % kBitsPerWord);
+      Word_t bit = static_cast<Word_t>(elementValue) << (i % kBitsPerWord);
+      asULongArray[i / kBitsPerWord] = (asULongArray[i / kBitsPerWord] & ~mask) | bit;
+   }
+}
+
 void ROOT::Experimental::RBitsetField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitBitsetField(*this);

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -464,3 +464,33 @@ TEST(RNTuple, VectorOfString)
    EXPECT_EQ(1u, ptrVecOfStr->size());
    EXPECT_STREQ("xyz", ptrVecOfStr->at(0).c_str());
 }
+
+TEST(RNTuple, VectorOfBitset)
+{
+   FileRaii fileGuard("test_ntuple_vector_of_bitset.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrVecOfBitset = model->MakeField<std::vector<std::bitset<3>>>("f");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      ptrVecOfBitset->emplace_back("101");
+      ptrVecOfBitset->emplace_back("010");
+      writer->Fill();
+      writer->CommitCluster();
+      ptrVecOfBitset->clear();
+      ptrVecOfBitset->emplace_back("111");
+      ptrVecOfBitset->emplace_back("000");
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto ptrVecOfBitset = reader->GetModel().GetDefaultEntry().GetPtr<std::vector<std::bitset<3>>>("f");
+   reader->LoadEntry(0);
+   EXPECT_EQ(2u, ptrVecOfBitset->size());
+   EXPECT_EQ("101", ptrVecOfBitset->at(0).to_string());
+   EXPECT_EQ("010", ptrVecOfBitset->at(1).to_string());
+   reader->LoadEntry(1);
+   EXPECT_EQ(2u, ptrVecOfBitset->size());
+   EXPECT_EQ("111", ptrVecOfBitset->at(0).to_string());
+   EXPECT_EQ("000", ptrVecOfBitset->at(1).to_string());
+}


### PR DESCRIPTION
Add custom implementation of RBitsetField::ReadInClusterImpl(). Without, in an attempt to read the field with cluster-local addressing, the implementation in the base class translates the cluster-local index to a global index.  It does it incorrectly though because RFieldBase::ReadInClusterImpl() does not take into account the fact that the bitset field is backed by a repetitive column.

When reading the sub field of vectors, reading with cluster-local addressing is used.

@Dr15Jones FYI.