### PR TITLE
[pyroot] fix clang warning due to changes in PyObject

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -208,15 +208,23 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
-PyObject _CPyCppyy_NullPtrStruct = {
-    _PyObject_EXTRA_INIT
-    1, &PyNullPtr_t_Type
-};
+PyObject _CPyCppyy_NullPtrStruct = {_PyObject_EXTRA_INIT
+// In 3.12.0-beta this field was changed from a ssize_t to a union
+#if PY_VERSION_HEX >= 0x30c00b1
+                                    {1},
+#else
+                                    1,
+#endif
+                                    &PyNullPtr_t_Type};
 
-PyObject _CPyCppyy_DefaultStruct = {
-    _PyObject_EXTRA_INIT
-    1, &PyDefault_t_Type
-};
+PyObject _CPyCppyy_DefaultStruct = {_PyObject_EXTRA_INIT
+// In 3.12.0-beta this field was changed from a ssize_t to a union
+#if PY_VERSION_HEX >= 0x30c00b1
+                                    {1},
+#else
+                                    1,
+#endif
+                                    &PyDefault_t_Type};
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)


### PR DESCRIPTION
[This commit](https://github.com/python/cpython/commit/ea2c0016502472aa8baa3149050ada776d17a009#diff-87272721a5cf1cd9915d6f503f6a7bbefa2f26c935c7ce83ca78706afd0ad05a) changed a PyObject field from a ssize_t to a union, so clang now wants parentheses around the object (this prevents building root with -Werror).
This was introduced in 3.12.0-beta1, aka PY_VERSION_HEX == 0x30c00b1. 

