### PR TITLE
[ntuple] add fwd compat for unknown field structural role

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -71,6 +71,8 @@ public:
 };
 
 /// Used in RFieldBase::Check() to record field creation failures.
+/// Also used when deserializing a field that contains unknown values that may come from
+/// future RNTuple versions (e.g. an unknown Structure)
 class RInvalidField final : public RFieldBase {
    std::string fError;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -584,7 +584,7 @@ public:
       /// with an RNTupleReader, but it is useful, e.g., to accurately merge data.
       bool fReconstructProjections = false;
       /// Normally creating a model will fail if any of the reconstructed fields contains an unknown column type.
-      /// If this option is enabled, the model will be created and all fields containing an unknown column (directly
+      /// If this option is enabled, the model will be created and all fields containing unknown data (directly
       /// or indirectly) will be skipped instead.
       bool fForwardCompatible = false;
    };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -88,7 +88,7 @@ enum class EColumnType {
  * Leaf fields contain just data, collection fields resolve to offset columns, record fields have no
  * materialization on the primitive column layer.
  */
-enum ENTupleStructure {
+enum ENTupleStructure : std::uint16_t {
    kInvalid,
    kLeaf,
    kCollection,
@@ -263,15 +263,8 @@ auto MakeAliasedSharedPtr(T *rawPtr)
    return std::shared_ptr<T>(fgRawPtrCtrlBlock, rawPtr);
 }
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wenum-constexpr-conversion"
-#endif
 inline constexpr ENTupleStructure kTestFutureFieldStructure =
    static_cast<ENTupleStructure>(std::numeric_limits<std::underlying_type_t<ENTupleStructure>>::max() - 1);
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 } // namespace Internal
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -89,12 +89,13 @@ enum class EColumnType {
  * materialization on the primitive column layer.
  */
 enum ENTupleStructure {
+   kInvalid,
    kLeaf,
    kCollection,
    kRecord,
    kVariant,
    kUnsplit,
-   kInvalid,
+   kUnknown
 };
 
 /// Integer type long enough to hold the maximum number of entries in a column
@@ -106,9 +107,22 @@ struct RClusterSize {
 
    RClusterSize() : fValue(0) {}
    explicit constexpr RClusterSize(ValueType value) : fValue(value) {}
-   RClusterSize& operator =(const ValueType value) { fValue = value; return *this; }
-   RClusterSize& operator +=(const ValueType value) { fValue += value; return *this; }
-   RClusterSize operator++(int) { auto result = *this; fValue++; return result; }
+   RClusterSize &operator=(const ValueType value)
+   {
+      fValue = value;
+      return *this;
+   }
+   RClusterSize &operator+=(const ValueType value)
+   {
+      fValue += value;
+      return *this;
+   }
+   RClusterSize operator++(int)
+   {
+      auto result = *this;
+      fValue++;
+      return result;
+   }
    operator ValueType() const { return fValue; }
 
    ValueType fValue;
@@ -147,7 +161,7 @@ private:
 
 public:
    RColumnSwitch() = default;
-   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) { }
+   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) {}
    ClusterSize_t GetIndex() const { return fIndex; }
    std::uint32_t GetTag() const { return fTag; }
 };
@@ -165,17 +179,29 @@ class RClusterIndex {
 private:
    DescriptorId_t fClusterId = kInvalidDescriptorId;
    ClusterSize_t::ValueType fIndex = kInvalidClusterIndex;
+
 public:
    RClusterIndex() = default;
    RClusterIndex(const RClusterIndex &other) = default;
-   RClusterIndex &operator =(const RClusterIndex &other) = default;
+   RClusterIndex &operator=(const RClusterIndex &other) = default;
    constexpr RClusterIndex(DescriptorId_t clusterId, ClusterSize_t::ValueType index)
-      : fClusterId(clusterId), fIndex(index) {}
+      : fClusterId(clusterId), fIndex(index)
+   {
+   }
 
-   RClusterIndex  operator+(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex + off); }
-   RClusterIndex  operator-(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex - off); }
-   RClusterIndex  operator++(int) /* postfix */        { auto r = *this; fIndex++; return r; }
-   RClusterIndex& operator++()    /* prefix */         { ++fIndex; return *this; }
+   RClusterIndex operator+(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex + off); }
+   RClusterIndex operator-(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex - off); }
+   RClusterIndex operator++(int) /* postfix */
+   {
+      auto r = *this;
+      fIndex++;
+      return r;
+   }
+   RClusterIndex &operator++() /* prefix */
+   {
+      ++fIndex;
+      return *this;
+   }
    bool operator==(RClusterIndex other) const { return fClusterId == other.fClusterId && fIndex == other.fIndex; }
    bool operator!=(RClusterIndex other) const { return !(*this == other); }
 
@@ -218,7 +244,8 @@ struct RNTupleLocator {
    /// Reserved for use by concrete storage backends
    std::uint8_t fReserved = 0;
 
-   bool operator==(const RNTupleLocator &other) const {
+   bool operator==(const RNTupleLocator &other) const
+   {
       return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage && fType == other.fType;
    }
    template <typename T>
@@ -235,6 +262,16 @@ auto MakeAliasedSharedPtr(T *rawPtr)
    const static std::shared_ptr<T> fgRawPtrCtrlBlock;
    return std::shared_ptr<T>(fgRawPtrCtrlBlock, rawPtr);
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wenum-constexpr-conversion"
+#endif
+inline constexpr ENTupleStructure kTestFutureFieldStructure =
+   static_cast<ENTupleStructure>(std::numeric_limits<std::underlying_type_t<ENTupleStructure>>::max() - 1);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 } // namespace Internal
 
 } // namespace Experimental

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -77,9 +77,13 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
    // The structure may be unknown if the descriptor comes from a deserialized field with an unknown structural role.
    // For forward compatibility, we allow this case and return an InvalidField.
    if (GetStructure() == ENTupleStructure::kUnknown) {
-      auto invalidField = std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), "");
-      invalidField->SetOnDiskId(fFieldId);
-      return invalidField;
+      if (continueOnError) {
+         auto invalidField = std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), "");
+         invalidField->SetOnDiskId(fFieldId);
+         return invalidField;
+      } else {
+         throw RException(R__FAIL("unexpected on-disk field structure value for field \"" + GetFieldName() + "\""));
+      }
    }
 
    if (GetTypeName().empty()) {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -74,6 +74,14 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       return unsplitField;
    }
 
+   // The structure may be unknown if the descriptor comes from a deserialized field with an unknown structural role.
+   // For forward compatibility, we allow this case and return an InvalidField.
+   if (GetStructure() == ENTupleStructure::kUnknown) {
+      auto invalidField = std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), "");
+      invalidField->SetOnDiskId(fFieldId);
+      return invalidField;
+   }
+
    if (GetTypeName().empty()) {
       switch (GetStructure()) {
       case ENTupleStructure::kRecord: {

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -777,6 +777,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeFieldStructure(ROOT::E
    case ENTupleStructure::kRecord: return SerializeUInt16(0x02, buffer);
    case ENTupleStructure::kVariant: return SerializeUInt16(0x03, buffer);
    case ENTupleStructure::kUnsplit: return SerializeUInt16(0x04, buffer);
+   case ROOT::Experimental::Internal::kTestFutureFieldStructure: return SerializeUInt16(0x99, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected field structure type"));
    }
 }
@@ -793,7 +794,8 @@ RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    case 0x02: structure = ENTupleStructure::kRecord; break;
    case 0x03: structure = ENTupleStructure::kVariant; break;
    case 0x04: structure = ENTupleStructure::kUnsplit; break;
-   default: return R__FAIL("unexpected on-disk field structure value");
+   // case 0x99 => kTestFutureFieldStructure intentionally missing
+   default: structure = ENTupleStructure::kUnknown;
    }
    return result;
 }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -87,12 +87,8 @@ TEST(RNTuple, SerializeFieldStructure)
    }
 
    RNTupleSerializer::SerializeUInt16(5000, buffer);
-   try {
-      RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
-      FAIL() << "unexpected on disk field structure value should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("unexpected on-disk field structure value"));
-   }
+   RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
+   EXPECT_EQ(structure, ENTupleStructure::kUnknown);
 
    for (int i = 0; i < static_cast<int>(ENTupleStructure::kInvalid); ++i) {
       RNTupleSerializer::SerializeFieldStructure(static_cast<ENTupleStructure>(i), buffer);


### PR DESCRIPTION
Instead of throwing when deserializing a field with an unknown structural role, we assign to it structure == ENTupleStructure::kUnknown. 
FieldDescriptors with Unknown structural role will generate RInvalidFields upon calling CreateField(). 
This allows getting the descriptor for a future RNTuple from an old ROOT version.

A `fForwardCompatible` option is added to RCreateModelOptions to tell RNTuple to not throw when reconstructing the model for an RNTuple containing fields with an unknown structural role.


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


