### PR TITLE
[skip-ci][clang-format] +AllowShortEnumsOnASingleLine: false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false


### PR DESCRIPTION
Without this, clang-format will try to collapse "short" enums on a single line.
Unfortunately, this hinders readability in some cases, as this for example is considered "short":
```
enum ENTupleStructure { kInvalid, kLeaf, kCollection, kRecord, kVariant, kUnsplit, kUnknown };
```