### PR TITLE
[CMake] Improvements related to `opengl` build configuration flag

### DIFF
--- a/builtins/glew/CMakeLists.txt
+++ b/builtins/glew/CMakeLists.txt
@@ -45,7 +45,7 @@ target_compile_options(GLEW PRIVATE ${GLEW_DEFINITIONS})
 target_include_directories(GLEW INTERFACE $<BUILD_INTERFACE:${GLEW_INCLUDE_DIR}>)
 target_link_libraries(GLEW PRIVATE OpenGL::GL OpenGL::GLU)
 
-add_library(GLEW::GLEW ALIAS GLEW)
+target_link_libraries(GLEW::GLEW INTERFACE GLEW)
 
 set(GLEW_LIBRARY $<TARGET_FILE:GLEW> CACHE INTERNAL "")
 set(GLEW_LIBRARIES GLEW::GLEW CACHE INTERNAL "")

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -634,6 +634,12 @@ if(NOT WIN32 AND NOT APPLE)
     set(opengl OFF CACHE BOOL "OpenGL requires x11" FORCE)
   endif()
 endif()
+# The opengl flag enables the graf3d features that depend on OpenGL, and these
+# features also depend on asimage. Therefore, the configuration will fail if
+# asimage is off. See also: https://github.com/root-project/root/issues/16250
+if(opengl AND NOT asimage)
+  message(FATAL_ERROR "OpenGL features enabled with \"opengl=ON\" require \"asimage=ON\"")
+endif()
 
 #---Check for GLEW -------------------------------------------------------------------
 # Glew is required by various graf3d features that are enabled with opengl=ON,

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -100,9 +100,6 @@ if(cocoa)
   if(APPLE)
     set(x11 OFF CACHE BOOL "Disabled because cocoa requested (${x11_description})" FORCE)
     set(builtin_freetype ON CACHE BOOL "Enabled because needed for Cocoa graphics (${builtin_freetype_description})" FORCE)
-    if(NOT opengl)
-      message(FATAL_ERROR "Option \"cocoa=ON\" requires \"opengl=ON\"!")
-    endif()
   else()
     message(STATUS "Cocoa option can only be enabled on MacOSX platform")
     set(cocoa OFF CACHE BOOL "Disabled because only available on MacOSX (${cocoa_description})" FORCE)
@@ -607,7 +604,9 @@ endif()
 find_package(Python3 3.8 COMPONENTS ${python_components})
 
 #---Check for OpenGL installation-------------------------------------------------------
-if(opengl)
+# OpenGL is required by various graf3d features that are enabled with opengl=ON,
+# or by the Cocoa-related code that always requires it.
+if(opengl OR cocoa)
   message(STATUS "Looking for OpenGL")
   if(APPLE)
     set(CMAKE_FIND_FRAMEWORK FIRST)
@@ -637,8 +636,9 @@ if(NOT WIN32 AND NOT APPLE)
 endif()
 
 #---Check for GLEW -------------------------------------------------------------------
-# Opengl is "must" requirement for Glew.
-if(opengl AND NOT builtin_glew)
+# Glew is required by various graf3d features that are enabled with opengl=ON,
+# or by the Cocoa-related code that always requires it.
+if((opengl OR cocoa) AND NOT builtin_glew)
   message(STATUS "Looking for GLEW")
   if(fail-on-missing)
     find_package(GLEW REQUIRED)
@@ -665,6 +665,7 @@ endif()
 
 if(builtin_glew)
   list(APPEND ROOT_BUILTINS GLEW)
+  add_library(GLEW::GLEW INTERFACE IMPORTED GLOBAL)
   add_subdirectory(builtins/glew)
 endif()
 

--- a/graf2d/cocoa/CMakeLists.txt
+++ b/graf2d/cocoa/CMakeLists.txt
@@ -39,7 +39,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(GCocoa
     "-framework Cocoa"
     "-framework OpenGL"
     ${FREETYPE_LIBRARIES}
-    RGlew
+    GLEW::GLEW
 )
 
 target_include_directories(GCocoa PRIVATE ${CMAKE_SOURCE_DIR}/graf3d/gl/inc)
@@ -48,11 +48,4 @@ target_include_directories(GCocoa PRIVATE ${CMAKE_SOURCE_DIR}/graf3d/gl/inc)
 target_compile_options(GCocoa PRIVATE -ObjC++ -Wno-deprecated-declarations)
 target_include_directories(GCocoa PRIVATE ${FREETYPE_INCLUDE_DIRS})
 
-if(opengl) # special case when cocoa is enabled but not opengl (i.e. gminimal=ON)
-  target_include_directories(GCocoa PRIVATE ${OPENGL_INCLUDE_DIR})
-else()
-  target_include_directories(GCocoa PRIVATE
-    ${CMAKE_SOURCE_DIR}/graf3d/gl/inc
-  )
-endif(opengl)
-
+target_include_directories(GCocoa PRIVATE ${OPENGL_INCLUDE_DIR})

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -13,11 +13,7 @@
 
 #include "TGCocoa.h"
 
-// We want to pickup ROOT's glew and not the system OpenGL coming from:
-// ROOTOpenGLView.h ->QuartzWindow.h->Cocoa.h
-// Allowing TU's which include the system GL and then glew (from TGLIncludes)
-// leads to gltypes.h redefinition errors.
-#include "TGLIncludes.h"
+#include <GL/glew.h>
 
 #include "ROOTOpenGLView.h"
 #include "CocoaConstants.h"


### PR DESCRIPTION
1) Don't force user to build graf3d OpenGL features if `cocoa=ON`

2) Require asimage=ON in case of opengl=ON

More detail in the commit description. I have tested on macOS that the first commit does what it should.

Closes #16250.