### PR TITLE
[v6-28][CI] Update upload-artifact action; refine runner selection

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -193,14 +193,14 @@ jobs:
 
       - name: Upload test results
         if:   ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results ${{ matrix.platform }} ${{ matrix.arch }}
           path: /Users/sftnight/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries ${{ matrix.platform }} ${{ matrix.arch }}
           path: /Users/sftnight/ROOT-CI/packages/root_v*
@@ -363,14 +363,14 @@ jobs:
 
       - name: Upload test results
         if:   ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results ${{ matrix.image }}
           path: /github/home/ROOT-CI/build/TestResults.xml
 
       - name: Upload binaries
         if:   ${{ !cancelled() && (inputs.binaries || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries ${{ matrix.image }}
           path: /github/home/ROOT-CI/packages/root_v*
@@ -387,7 +387,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Event File
         path: ${{ github.event_path }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -241,6 +241,7 @@ jobs:
       - self-hosted
       - linux
       - x64
+      - cpu
 
     name: ${{ matrix.image }} ${{ join( matrix.overrides, ', ' ) }}
 


### PR DESCRIPTION
- [CI] Update upload-artifact action to v4: Github will deprecate the v3 action soon.
- [CI] Add a 'cpu' label to self-hosted runner selection: Don't want it to run on GPU-enabled nodes.