### PR TITLE
[ntuple] Add type cast support from double to float

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -874,7 +874,7 @@ Such cases are marked as `R` in the table.
 | (Split)UInt64 |  R   |           |  R   |   R    |    R    |    R    |    R     |    R    |    R     |    R    |    W*    |       |        |
 | Real16        |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | (Split)Real32 |      |           |      |        |         |         |          |         |          |         |          |   W*  |   W    |
-| (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |       |   W*   |
+| (Split)Real64 |      |           |      |        |         |         |          |         |          |         |          |   R   |   W*   |
 | Real32Trunc   |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 | Real32Quant   |      |           |      |        |         |         |          |         |          |         |          |   W   |   W    |
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -1390,6 +1390,8 @@ DECLARE_RCOLUMNELEMENT_SPEC(std::uint64_t, EColumnType::kBit, 1, RColumnElementI
 
 DECLARE_RCOLUMNELEMENT_SPEC(float, EColumnType::kReal32, 32, RColumnElementLE, <float>);
 DECLARE_RCOLUMNELEMENT_SPEC(float, EColumnType::kSplitReal32, 32, RColumnElementSplitLE, <float, float>);
+DECLARE_RCOLUMNELEMENT_SPEC(float, EColumnType::kReal64, 64, RColumnElementCastLE, <float, double>);
+DECLARE_RCOLUMNELEMENT_SPEC(float, EColumnType::kSplitReal64, 64, RColumnElementSplitLE, <float, double>);
 
 DECLARE_RCOLUMNELEMENT_SPEC(double, EColumnType::kReal64, 64, RColumnElementLE, <double>);
 DECLARE_RCOLUMNELEMENT_SPEC(double, EColumnType::kSplitReal64, 64, RColumnElementSplitLE, <double, double>);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1525,7 +1525,7 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
                                                   {EColumnType::kReal16},
                                                   {EColumnType::kReal32Trunc},
                                                   {EColumnType::kReal32Quant}},
-                                                 {});
+                                                 {{EColumnType::kSplitReal64}, {EColumnType::kReal64}});
    return representations;
 }
 

--- a/tree/ntuple/v7/test/ntuple_cast.cxx
+++ b/tree/ntuple/v7/test/ntuple_cast.cxx
@@ -235,6 +235,7 @@ TEST(RNTuple, TypeCastReal)
    // Read back each pointer as the "opposite" type
    auto castModel = RNTupleModel::Create();
    auto ptrFloat = castModel->MakeField<double>("float");
+   auto ptrDouble = castModel->MakeField<float>("double");
    auto ptrFloatHalf = castModel->MakeField<double>("float_half");
    auto ptrDoubleHalf = castModel->MakeField<float>("double_half");
    auto ptrFloatTrunc = castModel->MakeField<double>("float_trunc");
@@ -243,14 +244,6 @@ TEST(RNTuple, TypeCastReal)
    auto ptrDoubleQuant = castModel->MakeField<float>("double_quant");
    auto ptrDouble32 = castModel->MakeField<float>("double32");
 
-   {
-      auto castModelWrong = castModel->Clone();
-      castModelWrong->MakeField<float>("double");
-      // Should fail because we try to cast a Field<double> to a Field<float>
-      EXPECT_THROW(RNTupleReader::Open(std::move(castModelWrong), "ntpl", fileGuard.GetPath()), RException);
-   }
-
-   auto ptrDouble = castModel->MakeField<double>("double");
    auto reader = RNTupleReader::Open(std::move(castModel), "ntpl", fileGuard.GetPath());
    reader->LoadEntry(0);
    EXPECT_FLOAT_EQ(*ptrFloat, 42.4242);


### PR DESCRIPTION
Enables reading a double on disk to a float in memory (relevant for schema evolution).

There is no bounds checking yet for floating point conversions. That will come as a separate PR.
