### PR TITLE
[webcanvas] Fix THStack handling

### DIFF
--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -50,7 +50,7 @@ protected:
 
    void BuildStack();
 
-   void BuildAndPaint(Option_t *chopt, Bool_t paint);
+   void BuildAndPaint(Option_t *chopt, Bool_t paint, Bool_t rebuild_stack = kFALSE);
 
 public:
 
@@ -64,7 +64,7 @@ public:
    THStack(const THStack &hstack);
    ~THStack() override;
    virtual void     Add(TH1 *h, Option_t *option="");
-   void             BuildPrimitives(Option_t *chopt = "") { BuildAndPaint(chopt, kFALSE); }
+   void             BuildPrimitives(Option_t *chopt = "", Bool_t rebuild_stack = kFALSE) { BuildAndPaint(chopt, kFALSE, rebuild_stack); }
    void             Browse(TBrowser *b)  override;
    Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;
    void             Draw(Option_t *chopt="")  override;

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -712,7 +712,7 @@ void THStack::Paint(Option_t *chopt)
 ////////////////////////////////////////////////////////////////////////////////
 /// Create all additional objects and stack (if specified).
 
-void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
+void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stack)
 {
    if (!fHists) return;
    if (!fHists->GetSize()) return;
@@ -818,11 +818,17 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
    Bool_t candle   = loption.Contains("candle");
    Bool_t violin   = loption.Contains("violin");
 
-   // do not delete the stack. Another pad may contain the same object
-   // drawn in stack mode!
-   //if (nostack && fStack) {fStack->Delete(); delete fStack; fStack = 0;}
 
-   if (!nostack && !candle && !violin) BuildStack();
+   if (!nostack && !candle && !violin) {
+      // do not delete the stack by default - only when needed.
+      // Another pad may contain the same object and use it
+      if (rebuild_stack && fStack) {
+         fStack->Delete();
+         delete fStack;
+         fStack = nullptr;
+      }
+      BuildStack();
+   }
 
    Double_t themax,themin;
    if (fMaximum == -1111) themax = GetMaximum(option);


### PR DESCRIPTION
Extend `THStack::BuildPrimitives()` method and let rebuild list of stacked histograms.

Fixes problem when `THStack::GetXaxis()` called in web mode - internal redrawing of the current pad lead to creation but then deletion of `fHistogram`. 

Behavior of normal graphics not changed

