### PR TITLE
[ntuple] fix missing return in RField::Check

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -892,7 +892,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    } catch (RException &e) {
       auto error = e.GetError();
       if (createContext.GetContinueOnError()) {
-         std::unique_ptr<RFieldBase>(std::make_unique<RInvalidField>(fieldName, canonicalType, error.GetReport()));
+         return std::unique_ptr<RFieldBase>(
+            std::make_unique<RInvalidField>(fieldName, canonicalType, error.GetReport()));
       } else {
          return error;
       }

--- a/tree/ntuple/v7/test/rfield_check.cxx
+++ b/tree/ntuple/v7/test/rfield_check.cxx
@@ -36,10 +36,10 @@ TEST(RField, Check)
    EXPECT_EQ(2u, report.size());
    EXPECT_EQ("f.timestamp", report[0].fFieldName);
    EXPECT_THAT(report[0].fTypeName, testing::HasSubstr("chrono::time_point"));
-   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("unknown type"));
+   EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("is not supported"));
    EXPECT_EQ("f.rd", report[1].fFieldName);
    EXPECT_THAT(report[1].fTypeName, testing::HasSubstr("random_device"));
-   EXPECT_THAT(report[1].fErrMsg, testing::HasSubstr("unknown type"));
+   EXPECT_THAT(report[1].fErrMsg, testing::HasSubstr("is not supported"));
 
    report = RFieldBase::Check("f", "long double");
    EXPECT_EQ(1u, report.size());


### PR DESCRIPTION
Also adjust `rfield_check` that was checking the wrong message.
