### PR TITLE
[ntuple] add forward-compatibility mode to read unknown column types

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -65,7 +65,7 @@ This is and can only be partially enforced through C++.
 */
 // clang-format on
 class RFieldBase {
-   friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
+   friend struct ROOT::Experimental::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Experimental::Internal::RFieldRepresentationModifier; // used for unit tests
    friend void Internal::CallFlushColumnsOnField(RFieldBase &);
    friend void Internal::CallCommitClusterOnField(RFieldBase &);
@@ -434,7 +434,7 @@ protected:
    /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
    /// single type name
    static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &canonicalType,
-                                                      const std::string &typeAlias, bool fContinueOnError = false);
+                                                      const std::string &typeAlias, bool continueOnError = false);
 
 public:
    template <bool IsConstT>
@@ -514,7 +514,12 @@ public:
    const std::string &GetTypeAlias() const { return fTypeAlias; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
-   NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
+   NTupleSize_t GetNElements() const
+   {
+      if (fState == EState::kUnconnected)
+         throw RException(R__FAIL("Cannot call GetNElements() on an unconnected field!"));
+      return fPrincipalColumn->GetNElements();
+   }
    const RFieldBase *GetParent() const { return fParent; }
    std::vector<RFieldBase *> GetSubFields();
    std::vector<const RFieldBase *> GetSubFields() const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -118,7 +118,7 @@ public:
    RFieldDescriptor Clone() const;
    /// In general, we create a field simply from the C++ type name. For untyped fields, however, we potentially need
    /// access to sub fields, which is provided by the ntuple descriptor argument.
-   std::unique_ptr<RFieldBase> CreateField(const RNTupleDescriptor &ntplDesc) const;
+   std::unique_ptr<RFieldBase> CreateField(const RNTupleDescriptor &ntplDesc, bool continueOnError = false) const;
 
    DescriptorId_t GetId() const { return fFieldId; }
    std::uint32_t GetFieldVersion() const { return fFieldVersion; }
@@ -583,6 +583,10 @@ public:
       /// If set to true, projected fields will be reconstructed as such. This will prevent the model to be used
       /// with an RNTupleReader, but it is useful, e.g., to accurately merge data.
       bool fReconstructProjections = false;
+      /// Normally creating a model will fail if any of the reconstructed fields contains an unknown column type.
+      /// If this option is enabled, the model will be created and all fields containing an unknown column (directly
+      /// or indirectly) will be skipped instead.
+      bool fForwardCompatible = false;
    };
 
    RNTupleDescriptor() = default;


### PR DESCRIPTION
# This Pull request:
adds an option to CreateModel: `fForwardCompatible`. If true, the model will be created successfully even if the RNTuple contains unknown column types, and all fields that recursively contain one will be skipped and won't appear in the model.

## Notes:
Depends on #16627
#16602 will be rebased on this.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

