### PR TITLE
[webcanv] support multipage PDF syntax

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -120,6 +120,7 @@ protected:
    static std::vector<std::string> gCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
 
    static UInt_t gBatchImageMode;           ///<! configured batch size
+   static std::string gBatchMultiPdf;           ///<! name of current multi-page pdf file
    static std::vector<std::string> gBatchFiles; ///<! file names for batch job
    static std::vector<std::string> gBatchJsons; ///<! converted jsons batch job
    static std::vector<int> gBatchWidths;   ///<! batch job widths


### PR DESCRIPTION
While webcanvas has internal batch buffer, one can reuse it also 
for creating PDF with several pages. Directly syntax supported:

```
   c1->Print("kern.pdf(");
   c2->Print("kern.pdf");
   c3->Print("kern.pdf");
   c4->Print("kern.pdf");
   c5->Print("kern.pdf)");
```

It is equivalent to:

```
TCanvas::SaveAll({c1,c2,c3,c4,c5}, "kern.pdf");
```

Also one can use "kern.pdf[" and "kern.pdf]" arguments, when PDF is open/closed without including of canvas into the output PDF
