### PR TITLE
Disable `test-stressgraphics-firefox` on Mac

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -183,7 +183,7 @@ if(ROOT_opengl_FOUND)
                    FAILREGEX "FAILED|Error in"
                    LABELS longtest)
   endif()
-  if(FIREFOX_EXECUTABLE)
+  if(FIREFOX_EXECUTABLE AND NOT APPLE)
      ROOT_ADD_TEST(test-stressgraphics-firefox
                    RUN_SERIAL
                    ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}


### PR DESCRIPTION
Seems to be headless usage of Firefox not yet tested there

