### PR TITLE
[RooFit] - Set initial errors on some parameters that are missing their initial errors (norm and gamma factors)

### DIFF
--- a/roofit/histfactory/src/HistFactoryImpl.cxx
+++ b/roofit/histfactory/src/HistFactoryImpl.cxx
@@ -58,6 +58,8 @@ void configureConstrainedGammas(RooArgList const &gammas, std::span<const double
       // Set reasonable ranges
       gamma.setMax(1. + 5. * sigmaRel);
       gamma.setMin(0.);
+      // Set initial error too
+      gamma.setError(sigmaRel);
 
       // Give reasonable starting point for pre-fit errors by setting it to the
       // absolute sigma Mostly useful for pre-fit plotting.

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -469,6 +469,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
           cxcoutI(HistFactory) << "making normFactor: " << norm.GetName() << endl;
           // remove "doRatio" and name can be changed when ws gets imported to the combined model.
           emplace<RooRealVar>(proto, varname, norm.GetVal(), norm.GetLow(), norm.GetHigh());
+          proto.var(varname)->setError(0); // ensure factor is assigned an initial error, even if its zero
         }
 
         prodNames.push_back(varname);


### PR DESCRIPTION
xRooFit wants all floating parameters to have errors defined on them, so this PR gives them some default values (0 for normFactors, and the correct uncert for gamma factors)
