### PR TITLE
[ntuple] Move `RNTupleProcessor` out of `Internal`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -51,7 +51,7 @@ class REntry {
    friend class RNTupleModel;
    friend class RNTupleReader;
    friend class RNTupleFillContext;
-   friend class Internal::RNTupleProcessor;
+   friend class RNTupleProcessor;
 
 public:
    /// The field token identifies a top-level field in this entry. It can be used for fast indexing in REntry's

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -31,7 +31,6 @@
 
 namespace ROOT {
 namespace Experimental {
-namespace Internal {
 
 /// Helper type representing the name and storage location of an RNTuple.
 struct RNTupleSourceSpec {
@@ -260,7 +259,6 @@ public:
    RIterator end() { return RIterator(*this, fNTuples.size(), kInvalidNTupleIndex); }
 };
 
-} // namespace Internal
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -17,8 +17,7 @@
 
 #include <ROOT/RFieldBase.hxx>
 
-ROOT::Experimental::NTupleSize_t
-ROOT::Experimental::Internal::RNTupleProcessor::ConnectNTuple(const RNTupleSourceSpec &ntuple)
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleProcessor::ConnectNTuple(const RNTupleSourceSpec &ntuple)
 {
    for (auto &fieldContext : fFieldContexts) {
       fieldContext.ResetConcreteField();
@@ -29,7 +28,7 @@ ROOT::Experimental::Internal::RNTupleProcessor::ConnectNTuple(const RNTupleSourc
    return fPageSource->GetNEntries();
 }
 
-void ROOT::Experimental::Internal::RNTupleProcessor::ConnectFields()
+void ROOT::Experimental::RNTupleProcessor::ConnectFields()
 {
    auto desc = fPageSource->GetSharedDescriptorGuard();
 
@@ -51,8 +50,8 @@ void ROOT::Experimental::Internal::RNTupleProcessor::ConnectFields()
    }
 }
 
-ROOT::Experimental::Internal::RNTupleProcessor::RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples,
-                                                                 std::unique_ptr<RNTupleModel> model)
+ROOT::Experimental::RNTupleProcessor::RNTupleProcessor(const std::vector<RNTupleSourceSpec> &ntuples,
+                                                       std::unique_ptr<RNTupleModel> model)
    : fNTuples(ntuples)
 {
    if (fNTuples.empty())

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -3,9 +3,9 @@
 #include <ROOT/RNTupleProcessor.hxx>
 
 using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleProcessor;
+using ROOT::Experimental::RNTupleSourceSpec;
 using ROOT::Experimental::RNTupleWriter;
-using ROOT::Experimental::Internal::RNTupleProcessor;
-using ROOT::Experimental::Internal::RNTupleSourceSpec;
 
 TEST(RNTupleProcessor, Basic)
 {

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -2,11 +2,6 @@
 
 #include <ROOT/RNTupleProcessor.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleProcessor;
-using ROOT::Experimental::RNTupleSourceSpec;
-using ROOT::Experimental::RNTupleWriter;
-
 TEST(RNTupleProcessor, Basic)
 {
    FileRaii fileGuard("test_ntuple_processor_basic.root");

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -15,6 +15,7 @@
 #include <ROOT/RNTupleReadOptions.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleParallelWriter.hxx>
+#include <ROOT/RNTupleProcessor.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
@@ -100,7 +101,9 @@ using ENTupleMergingMode = ROOT::Experimental::Internal::ENTupleMergingMode;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTuplePlainCounter = ROOT::Experimental::Detail::RNTuplePlainCounter;
 using RNTuplePlainTimer = ROOT::Experimental::Detail::RNTuplePlainTimer;
+using RNTupleProcessor = ROOT::Experimental::RNTupleProcessor;
 using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
+using RNTupleSourceSpec = ROOT::Experimental::RNTupleSourceSpec;
 using RPage = ROOT::Experimental::Internal::RPage;
 using RPageAllocatorHeap = ROOT::Experimental::Internal::RPageAllocatorHeap;
 using RPagePool = ROOT::Experimental::Internal::RPagePool;

--- a/tutorials/v7/ntuple/ntpl012_processor.C
+++ b/tutorials/v7/ntuple/ntpl012_processor.C
@@ -23,9 +23,9 @@
 
 // Import classes from the `Experimental` namespace for the time being.
 using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleProcessor;
+using ROOT::Experimental::RNTupleSourceSpec;
 using ROOT::Experimental::RNTupleWriter;
-using ROOT::Experimental::Internal::RNTupleProcessor;
-using ROOT::Experimental::Internal::RNTupleSourceSpec;
 
 // Number of events to generate for each ntuple.
 constexpr int kNEvents = 10000;


### PR DESCRIPTION
This PR moves the `RNTupleProcessor` out of the internal namespace. The rationale behind this change is that it will not only be used internally (e.g. RDataFrame), but we also foresee use by (experiment framework) developers looking for ways to combine multiple RNTuples at runtime.