### PR TITLE
[ntuple] Fix read request coalescing when opening file from anchor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -89,6 +89,8 @@ public:
    void ReadBuffer(void *buffer, size_t nbytes, std::uint64_t offset);
 
    std::uint64_t GetMaxKeySize() const { return fMaxKeySize; }
+   /// If the reader is not used to retrieve the anchor, we need to set the max key size manually
+   void SetMaxKeySize(std::uint64_t maxKeySize) { fMaxKeySize = maxKeySize; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -785,8 +785,6 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
       return R__FAIL("RNTuple anchor checksum mismatch");
    }
 
-   fMaxKeySize = ntuple->fMaxKeySize;
-
    return CreateAnchor(ntuple->fVersionEpoch, ntuple->fVersionMajor, ntuple->fVersionMinor, ntuple->fVersionPatch,
                        ntuple->fSeekHeader, ntuple->fNBytesHeader, ntuple->fLenHeader, ntuple->fSeekFooter,
                        ntuple->fNBytesFooter, ntuple->fLenFooter, ntuple->fMaxKeySize);
@@ -815,8 +813,6 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleBare(std::string_view nt
    auto checksum = XXH3_64bits(ntuple.GetPtrCkData(), ntuple.GetSizeCkData());
    if (checksum != static_cast<uint64_t>(onDiskChecksum))
       return R__FAIL("RNTuple bare file: anchor checksum mismatch");
-
-   fMaxKeySize = ntuple.fMaxKeySize;
 
    return CreateAnchor(ntuple.fVersionEpoch, ntuple.fVersionMajor, ntuple.fVersionMinor, ntuple.fVersionPatch,
                        ntuple.fSeekHeader, ntuple.fNBytesHeader, ntuple.fLenHeader, ntuple.fSeekFooter,

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -313,8 +313,11 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadStructureImpl()
 {
    // If we constructed the page source with (ntuple name, path), we need to find the anchor first.
    // Otherwise, the page source was created by OpenFromAnchor()
-   if (!fAnchor)
+   if (!fAnchor) {
       fAnchor = fReader.GetNTuple(fNTupleName).Unwrap();
+   } else {
+      fReader.SetMaxKeySize(fAnchor->GetMaxKeySize());
+   }
 
    // TOOD(jblomer): can the epoch check be factored out across anchors?
    if (fAnchor->GetVersionEpoch() != RNTuple::kVersionEpoch) {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -315,9 +315,8 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadStructureImpl()
    // Otherwise, the page source was created by OpenFromAnchor()
    if (!fAnchor) {
       fAnchor = fReader.GetNTuple(fNTupleName).Unwrap();
-   } else {
-      fReader.SetMaxKeySize(fAnchor->GetMaxKeySize());
    }
+   fReader.SetMaxKeySize(fAnchor->GetMaxKeySize());
 
    // TOOD(jblomer): can the epoch check be factored out across anchors?
    if (fAnchor->GetVersionEpoch() != RNTuple::kVersionEpoch) {

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -381,8 +381,8 @@ TEST(MiniFile, MultiKeyBlob)
 
       auto rawFile = RRawFile::Create(fileGuard.GetPath());
       auto reader = RMiniFileReader{rawFile.get()};
-      // Force reader to read the max key size
-      (void)reader.GetNTuple("ntpl");
+      auto ntuple = reader.GetNTuple("ntpl").Unwrap();
+      reader.SetMaxKeySize(ntuple.GetMaxKeySize());
       reader.ReadBuffer(data.get(), dataSize, blobOffset);
 
       EXPECT_EQ(data[0], 0x99);
@@ -419,8 +419,8 @@ TEST(MiniFile, MultiKeyBlob_ExactlyMax)
 
       auto rawFile = RRawFile::Create(fileGuard.GetPath());
       auto reader = RMiniFileReader{rawFile.get()};
-      // Force reader to read the max key size
-      (void)reader.GetNTuple("ntpl");
+      auto ntuple = reader.GetNTuple("ntpl").Unwrap();
+      reader.SetMaxKeySize(ntuple.GetMaxKeySize());
       rawFile->ReadAt(data.get(), dataSize, blobOffset);
 
       // If we didn't split the key, we expect to find all zeroes at the end of `data`.
@@ -458,8 +458,8 @@ TEST(MiniFile, MultiKeyBlob_ExactlyTwo)
 
       auto rawFile = RRawFile::Create(fileGuard.GetPath());
       auto reader = RMiniFileReader{rawFile.get()};
-      // Force reader to read the max key size
-      (void)reader.GetNTuple("ntpl");
+      auto ntuple = reader.GetNTuple("ntpl").Unwrap();
+      reader.SetMaxKeySize(ntuple.GetMaxKeySize());
 
       rawFile->ReadAt(data.get(), dataSize, blobOffset);
       // If the blob was split into exactly two keys, there should be only one pointer to the next chunk.
@@ -502,8 +502,8 @@ TEST(MiniFile, MultiKeyBlob_SmallKey)
 
       auto rawFile = RRawFile::Create(fileGuard.GetPath());
       auto reader = RMiniFileReader{rawFile.get()};
-      // Force reader to read the max key size
-      (void)reader.GetNTuple("ntpl");
+      auto ntuple = reader.GetNTuple("ntpl").Unwrap();
+      reader.SetMaxKeySize(ntuple.GetMaxKeySize());
       reader.ReadBuffer(data.get(), dataSize, blobOffset);
 
       EXPECT_EQ(data[0], 0x99);


### PR DESCRIPTION
When we open an RNTuple from an anchor, we don't read the anchor with the mini file reader and therefore we must initialize the max key size manually from the given anchor. Otherwise, page coalescing won't work.

@Dr15Jones FYI.
