### PR TITLE
Avoid XRootD dependency in public headers

### DIFF
--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -23,9 +23,6 @@
 
 #include "TFile.h"
 #include "TSemaphore.h"
-#ifndef __CLING__
-#include <XrdCl/XrdClFileSystem.hh>
-#endif
 
 namespace XrdCl {
    class File;
@@ -33,19 +30,11 @@ namespace XrdCl {
 }
 class XrdSysCondVar;
 
-#ifdef __CLING__
-namespace XrdCl {
-   struct OpenFlags {
-      enum    Flags {None = 0};
-   };
-}
-#endif
-
 class TNetXNGFile: public TFile {
 private:
    XrdCl::File            *fFile;        // Underlying XRootD file
    XrdCl::URL             *fUrl;         // URL of the current file
-   XrdCl::OpenFlags::Flags fMode;        // Open mode of the current file
+   int                     fMode;        // Open mode of the current file
    XrdSysCondVar          *fInitCondVar; // Used to block an async open request
    // if requested
    Int_t                   fReadvIorMax; // Max size of a single readv chunk
@@ -54,9 +43,7 @@ private:
    TString                 fNewUrl;
 
 public:
-   TNetXNGFile() : TFile(),
-      fFile(nullptr), fUrl(nullptr), fMode(XrdCl::OpenFlags::None), fInitCondVar(nullptr),
-      fReadvIorMax(0), fReadvIovMax(0) {}
+   TNetXNGFile();
    TNetXNGFile(const char *url, const char *lurl, Option_t *mode, const char *title,
                Int_t compress, Int_t netopt, Bool_t parallelopen);
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
@@ -83,8 +70,6 @@ private:
    virtual Bool_t IsUseable() const;
    virtual Bool_t GetVectorReadLimits();
    virtual void   SetEnv();
-   Int_t ParseOpenMode(Option_t *in, TString &modestr,
-                       XrdCl::OpenFlags::Flags &mode, Bool_t assumeRead);
 
    TNetXNGFile(const TNetXNGFile &other);             // Not implemented
    TNetXNGFile &operator =(const TNetXNGFile &other); // Not implemented


### PR DESCRIPTION
This means that we won't have to install any headers from xrootd when using `builtin_xrootd=ON`. This makes systems that have both XRootD standalone and ROOT with builtin XRootD installed more stable.