### PR TITLE
[Do not merge][PyROOT] Don't call `ClearProxiedObjects()` in hard shutdown mode

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -187,10 +187,6 @@ def cleanup():
     if "libROOTPythonizations" in sys.modules:
         backend = sys.modules["libROOTPythonizations"]
 
-        # Make sure all the objects regulated by PyROOT are deleted and their
-        # Python proxies are properly nonified.
-        backend.ClearProxiedObjects()
-
         from ROOT import PyConfig
 
         if PyConfig.ShutDown:
@@ -198,6 +194,11 @@ def cleanup():
             # Running it here ensures that it is done before any ROOT libraries
             # are off-loaded, with unspecified order of static object destruction.
             backend.gROOT.EndOfProcessCleanups()
+        else:
+            # Make sure all the objects regulated by PyROOT are deleted and their
+            # Python proxies are properly nonified.
+            backend.ClearProxiedObjects()
+
 
 
 atexit.register(cleanup)

--- a/tutorials/hist/fillrandom.py
+++ b/tutorials/hist/fillrandom.py
@@ -19,6 +19,7 @@ pad1.cd()
 ROOT.gBenchmark.Start("fillrandom")
 
 form1 = ROOT.TFormula("form1","abs(sin(x)/x)")
+ROOT.SetOwnership(form1, False)
 sqroot = ROOT.TF1("sqroot","x*gaus(0) + [3]*form1",0,10)
 sqroot.SetParameters(10,4,1,20)
 pad1.SetGridx()

--- a/tutorials/pyroot/formula1.py
+++ b/tutorials/pyroot/formula1.py
@@ -8,19 +8,20 @@
 ##
 ## \author Wim Lavrijsen
 
-from ROOT import TCanvas, TFormula, TF1
-from ROOT import gROOT, gObjectTable
+import ROOT
 
-c1 = TCanvas( 'c1', 'Example with Formula', 200, 10, 700, 500 )
+c1 = ROOT.TCanvas( 'c1', 'Example with Formula', 200, 10, 700, 500 )
 
 # We create a formula object and compute the value of this formula
 # for two different values of the x variable.
-form1 = TFormula( 'form1', 'sqrt(abs(x))' )
+form1 = ROOT.TFormula( 'form1', 'sqrt(abs(x))' )
+ROOT.SetOwnership(form1, False)
 form1.Eval( 2 )
 form1.Eval( -45 )
 
 # Create a one dimensional function and draw it
-fun1 = TF1( 'fun1', 'abs(sin(x)/x)', 0, 10 )
+fun1 = ROOT.TF1( 'fun1', 'abs(sin(x)/x)', 0, 10 )
+ROOT.SetOwnership(fun1, False)
 c1.SetGridx()
 c1.SetGridy()
 fun1.Draw()
@@ -28,5 +29,5 @@ c1.Update()
 
 # Before leaving this demo, we print the list of objects known to ROOT
 #
-if ( gObjectTable ):
-    gObjectTable.Print()
+if ( ROOT.gObjectTable ):
+    ROOT.gObjectTable.Print()

--- a/tutorials/roofit/rf615_simulation_based_inference.py
+++ b/tutorials/roofit/rf615_simulation_based_inference.py
@@ -234,13 +234,3 @@ for nll in [nll_gauss, nllr_learned, nll_morph]:
     result = minimizer.save()
     ROOT.SetOwnership(result, True)
     result.Print()
-
-del nll_morph
-del nllr_learned
-del nll_gauss
-del workspace
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]

--- a/tutorials/roofit/rf617_simulation_based_inference_multidimensional.py
+++ b/tutorials/roofit/rf617_simulation_based_inference_multidimensional.py
@@ -307,8 +307,3 @@ for nll in [nll_gauss, nllr_learned, nll_morph]:
     minimizer.minimize("Minuit2")
     result = minimizer.save()
     result.Print()
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]

--- a/tutorials/roofit/rf618_mixture_models.py
+++ b/tutorials/roofit/rf618_mixture_models.py
@@ -193,15 +193,3 @@ minimizer.minimize("Minuit2")
 result = minimizer.save()
 ROOT.SetOwnership(result, True)
 result.Print()
-
-del minimizer
-del nll
-del pdf_learned_extended
-del n_pred
-del llh
-del nll_ratio
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]


### PR DESCRIPTION
The old PyROOT (pre 2019) had a slightly different `atexit` handler than the new one. The hard shutdown mode is different: `ClearProxiedObjects()` is called before the final `gROOT->EndOfProcessCleanups()`.

I had the impresstion that this is redundant, and indeed the old PyROOT didn't do it. This commit suggests to only call `ClearProxiedObjects()` in soft shutdown mode, in an attempt to avoid the frequent crashes seen at the end of PyROOT tutorials, especially on Ubuntu 24.10.

See also the original PRs where this functionality was introduced:

  * https://github.com/root-project/root/pull/4687
  * https://github.com/root-project/root/pull/4753