### PR TITLE
[RF] Disable `stressHistFactroy` tests if ROOT was not built with XML

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -102,6 +102,8 @@ if(xml)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hist2workspace-argparse.py
     ${CMAKE_BINARY_DIR}/ginclude/hist2workspaceCommandLineOptionsHelp.h
   )
+
+  target_compile_definitions(HistFactory PUBLIC HISTFACTORY_XML)
 endif()
 
 if(MSVC)

--- a/roofit/histfactory/test/stressHistFactory.cxx
+++ b/roofit/histfactory/test/stressHistFactory.cxx
@@ -466,7 +466,11 @@ private:
    }
 };
 
+#ifdef HISTFACTORY_XML
 TEST(HistFactory, PdfComparison)
+#else
+TEST(HistFactory, DISABLED_PdfComparison)
+#endif
 {
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 


### PR DESCRIPTION
If `xml=OFF`, the test can still be compiled, which is always good for coverage. But it can't be run: the `hist2workspace` executable is missing.

This was discovered in this PR:
  * https://github.com/root-project/root/pull/16674