### PR TITLE
[ntuple] Initialize variables to silence compiler warnings

### DIFF
--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -307,7 +307,7 @@ TEST(RNTuple, ViewFrameworkUse)
    std::optional<ROOT::Experimental::RNTupleView<void>> viewPy;
    std::optional<ROOT::Experimental::RNTupleView<void>> viewPz;
 
-   float px, py, pz;
+   float px = 0, py = 0, pz = 0;
    for (auto i : reader->GetEntryRange()) {
       if (i > 1) {
          if (!viewPx) {


### PR DESCRIPTION
Clang warns that "variable 'px' may be uninitialized when used here" because it does not understand the interplay with `RNTupleView`.