### PR TITLE
[ntuple] Add MT index building

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
@@ -17,6 +17,9 @@
 #define ROOT7_RNTupleIndex
 
 #include <ROOT/RField.hxx>
+#ifdef R__USE_IMT
+#include "ROOT/TThreadExecutor.hxx"
+#endif
 
 #include <memory>
 #include <string>
@@ -125,6 +128,10 @@ private:
 
    /// Only built indexes can be queried.
    bool fIsBuilt = false;
+
+#ifdef R__USE_IMT
+   std::unique_ptr<ROOT::TThreadExecutor> fPool;
+#endif
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an a new RNTupleIndex for the RNTuple represented by the provided page source.

--- a/tree/ntuple/v7/test/ntuple_index.cxx
+++ b/tree/ntuple/v7/test/ntuple_index.cxx
@@ -247,13 +247,13 @@ TEST(RNTupleIndex, MultipleMatches)
 
    auto entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(1);
    auto expected = std::vector<std::uint64_t>{0, 1, 2, 3, 4};
-   EXPECT_EQ(expected, *entryIdxs);
+   EXPECT_EQ(expected, entryIdxs);
    entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(2);
    expected = {5, 6, 7};
-   EXPECT_EQ(expected, *entryIdxs);
+   EXPECT_EQ(expected, entryIdxs);
    entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(3);
    expected = {8, 9};
-   EXPECT_EQ(expected, *entryIdxs);
+   EXPECT_EQ(expected, entryIdxs);
    entryIdxs = index->GetAllEntryNumbers<std::uint64_t>(4);
-   EXPECT_EQ(nullptr, entryIdxs);
+   EXPECT_EQ(0, entryIdxs.size());
 }


### PR DESCRIPTION
This PR introduces the first steps towards MT support for the `RNTupleIndex`, by enabling mulithreaded building of the index. To enable this, the index itself now manages multiple _index partitions_, which are essentially sub-indices for a particular entry range. These entry ranges are currently set according to the cluster boundaries, but further benchmarking and evaluation will be required to determine the optimal partitioning scheme.

