### PR TITLE
[df] Unify local and distributed API

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/__init__.py
@@ -3,13 +3,15 @@
 #  @date 2021-11
 
 ################################################################################
-# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 from __future__ import annotations
+import warnings
+
 
 def RDataFrame(*args, **kwargs):
     """
@@ -18,6 +20,26 @@ def RDataFrame(*args, **kwargs):
 
     from DistRDF.Backends.Dask import Backend
     daskclient = kwargs.get("daskclient", None)
-    daskbackend = Backend.DaskBackend(daskclient=daskclient)
+    executor = kwargs.get("executor", None)
+    msg_warn = (
+        "The keyword argument 'daskclient' is not necessary anymore and will "
+        "be removed in a future release. To provide the distributed.Client "
+        "object, use 'executor' instead."
+    )
+    msg_err = (
+        "Both the 'daskclient' and 'executor' keyword arguments were provided. "
+        "This is not supported. Please provide only the 'executor' argument."
+    )
+
+    if executor is not None and daskclient is not None:
+        warnings.warn(msg_warn, FutureWarning)
+        raise ValueError(msg_err)
+
+    if daskclient is not None:
+        warnings.warn(msg_warn, FutureWarning)
+        executor = daskclient
+        daskclient = None
+
+    daskbackend = Backend.DaskBackend(daskclient=executor)
 
     return daskbackend.make_dataframe(*args, **kwargs)

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/__init__.py
@@ -1,15 +1,17 @@
-## @author Vincenzo Eduardo Padulano
+#  @author Vincenzo Eduardo Padulano
 #  @author Enric Tejedor
 #  @date 2021-02
 
 ################################################################################
-# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 from __future__ import annotations
+import warnings
+
 
 def RDataFrame(*args, **kwargs):
     """
@@ -18,6 +20,26 @@ def RDataFrame(*args, **kwargs):
 
     from DistRDF.Backends.Spark import Backend
     sparkcontext = kwargs.get("sparkcontext", None)
-    spark = Backend.SparkBackend(sparkcontext=sparkcontext)
+    executor = kwargs.get("executor", None)
+    msg_warn = (
+        "The keyword argument 'sparkcontext' is not necessary anymore and will "
+        "be removed in a future release. To provide the SparkContext object, "
+        "use 'executor' instead."
+    )
+    msg_err = (
+        "Both the 'sparkcontext' and 'executor' keyword arguments were provided. "
+        "This is not supported. Please provide only the 'executor' argument."
+    )
+
+    if executor is not None and sparkcontext is not None:
+        warnings.warn(msg_warn, FutureWarning)
+        raise ValueError(msg_err)
+
+    if sparkcontext is not None:
+        warnings.warn(msg_warn, FutureWarning)
+        executor = sparkcontext
+        sparkcontext = None
+
+    spark = Backend.SparkBackend(sparkcontext=executor)
 
     return spark.make_dataframe(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -15,7 +15,8 @@ if(dataframe)
         ROOT/_pythonization/_rdfdescription.py
         ROOT/_pythonization/_rdf_conversion_maps.py
         ROOT/_pythonization/_rdf_pyz.py
-        ROOT/_pythonization/_rdisplay.py)
+        ROOT/_pythonization/_rdisplay.py
+        ROOT/_pythonization/_rdf_namespace.py)
 endif()
 
 if(roofit)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_namespace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_namespace.py
@@ -1,0 +1,85 @@
+# Author: Vincenzo Eduardo Padulano CERN 10/2024
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+"""
+This module contains utilities to help in the organization of the RDataFrame
+namespace and the interaction between the C++ and Python functionalities
+"""
+
+
+def _create_distributed_module(parent):
+    """
+    Create the ROOT.RDF.Experimental.Distributed python module.
+
+    This module will be injected into the ROOT.RDF namespace.
+
+    Arguments:
+        parent: The ROOT.RDF namespace. Needed to define __package__.
+
+    Returns:
+        types.ModuleType: The ROOT.RDF.Experimental.Distributed submodule.
+    """
+    import DistRDF
+
+    return DistRDF.create_distributed_module(parent)
+
+
+def _rungraphs(distrdf_rungraphs, rdf_rungraphs):
+    """
+    Create a callable that correctly dispatches either to the local or
+    distributed version of RunGraphs.
+    """
+
+    def rungraphs(handles):
+        # Caveat: we should not call `hasattr` on the result pointer, since
+        # this will implicitly trigger the connected computation graph
+        if len(handles) > 0 and "DistRDF" in str(type(handles[0])):
+            return distrdf_rungraphs(handles)
+        else:
+            return rdf_rungraphs(handles)
+
+    return rungraphs
+
+
+def _variationsfor(distrdf_variationsfor, rdf_variationsfor):
+    """
+    Create a callable that correctly dispatches either to the local or
+    distributed version of VariationsFor.
+    """
+
+    def variationsfor(resptr):
+        # Caveat: we should not call `hasattr` on the result pointer, since
+        # this will implicitly trigger the connected computation graph
+        if "DistRDF" in str(type(resptr)):
+            return distrdf_variationsfor(resptr)
+        else:
+            # Help local VariationsFor with the type of the value held by the result pointer
+            inner_type = type(resptr).__name__
+            inner_type = inner_type[
+                inner_type.index("<") + 1: inner_type.rindex(">")]
+            return rdf_variationsfor[inner_type](resptr)
+
+    return variationsfor
+
+
+def _rdataframe(local_rdf, distributed_rdf):
+    """
+    Create a callable that correctly dispatches either to the local or
+    distributed RDataFrame constructor, depending on whether the "executor"
+    keyword argument is absent or not.
+    """
+
+    def rdataframe(*args, **kwargs):
+        if kwargs.get("executor", None) is not None:
+            return distributed_rdf(*args, **kwargs)
+        else:
+            return local_rdf(*args, **kwargs)
+
+    return rdataframe

--- a/tutorials/analysis/dataframe/distrdf001_spark_connection.py
+++ b/tutorials/analysis/dataframe/distrdf001_spark_connection.py
@@ -18,9 +18,6 @@
 import pyspark
 import ROOT
 
-# Point RDataFrame calls to Spark RDataFrame object
-RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-
 # Setup the connection to Spark
 # First create a dictionary with keys representing Spark specific configuration
 # parameters. In this tutorial we use the following configuration parameters:
@@ -55,7 +52,7 @@ sparkconf = pyspark.SparkConf().setAll(
 sparkcontext = pyspark.SparkContext(conf=sparkconf)
 
 # Create an RDataFrame that will use Spark as a backend for computations
-df = RDataFrame(1000, sparkcontext=sparkcontext)
+df = ROOT.RDataFrame(1000, executor=sparkcontext)
 
 # Set the random seed and define two columns of the dataset with random numbers.
 ROOT.gRandom.SetSeed(1)

--- a/tutorials/analysis/dataframe/distrdf002_dask_connection.py
+++ b/tutorials/analysis/dataframe/distrdf002_dask_connection.py
@@ -18,9 +18,6 @@
 from dask.distributed import LocalCluster, Client
 import ROOT
 
-# Point RDataFrame calls to Dask RDataFrame object
-RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-
 
 def create_connection():
     """
@@ -89,7 +86,7 @@ if __name__ == "__main__":
     # Create the connection to the mock Dask cluster on the local machine
     connection = create_connection()
     # Create an RDataFrame that will use Dask as a backend for computations
-    df = RDataFrame(1000, daskclient=connection)
+    df = ROOT.RDataFrame(1000, executor=connection)
 
     # Set the random seed and define two columns of the dataset with random numbers.
     ROOT.gRandom.SetSeed(1)

--- a/tutorials/analysis/dataframe/distrdf004_dask_lxbatch.py
+++ b/tutorials/analysis/dataframe/distrdf004_dask_lxbatch.py
@@ -28,7 +28,6 @@ from dask.distributed import Client
 from dask_lxplus import CernCluster
 
 import ROOT
-RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
 
 
 def create_connection() -> Client:
@@ -90,7 +89,7 @@ def run_analysis(connection: Client) -> None:
     Run a simple example with RDataFrame, using the previously created
     connection to the HTCondor cluster.
     """
-    df = RDataFrame(10_000, daskclient=connection).Define(
+    df = ROOT.RDataFrame(10_000, executor=connection).Define(
         "x", "gRandom->Rndm() * 100")
 
     nentries = df.Count()


### PR DESCRIPTION
Unify the main common entry points between local and distributed RDataFrame API. Currently these changes:

- The ROOT.RDataFrame constructor
- ROOT.RDF.RunGraphs
- ROOT.RDF.Experimental.VariationsFor

Anytime one of the above is called, a pythonization will dispatch to the appropriate RDataFrame flavour, depending on the arguments.

Previous usage of the distributed module with fully qualified names of functions still works, although usage of the unified API is preferrable and advisable.
