### PR TITLE
[cling] Windows: Fix declaration for C99 and re-enable Gnu.C test

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -507,9 +507,12 @@ namespace cling {
 #else
     const char* Spec = "__clrcall";
 #endif
+    const bool ParamNames = LangOpts.C99;
     Strm << Linkage << " " << Spec << " int (*__dllonexit("
-         << "int (" << Spec << " *f)(void**, void**), void**, void**))"
-         "(void**, void**)";
+         << "int (" << Spec << " *f)(void**, void**),"
+         << "void**" << (ParamNames ? " a" : "") << ","
+         << "void**" << (ParamNames ? " b" : "")
+         << "))(void**, void**)";
       if (EmitDefinitions)
         Strm << " { __cxa_atexit((void(*)(void*))f, 0, __dso_handle);"
                 " return f; }\n";

--- a/interpreter/cling/test/Driver/Gnu.C
+++ b/interpreter/cling/test/Driver/Gnu.C
@@ -7,10 +7,11 @@
 //------------------------------------------------------------------------------
 
 // RUN: cat %s | %cling -std=gnu99 -x c -Xclang -verify 2>&1 | FileCheck %s
-// RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++14 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++1z -Xclang -verify 2>&1 | FileCheck %s
-// UNSUPPORTED: system-windows
+
+// RUN: cat %s | %cling --noruntime -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
+// --noruntime is for Windows which cannot include VStudio C++ headers in C++11
 
 #ifdef __cplusplus
 extern "C" int printf(const char*, ...);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This is a rebased version of https://github.com/root-project/cling/pull/174 by @marsupial
The test was failing for a reason that likely shouldn't be ignored. This reverts commit https://github.com/root-project/cling/commit/5947e13cb99052b6f7a5b501244ee2be9be9d080.
## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)