### PR TITLE
[hist] add Scale function to context menu

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -358,7 +358,7 @@ public:
    virtual void     ResetStats();
            void     SaveAs(const char *filename = "hist", Option_t *option = "") const override;  // *MENU*
            void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
-   virtual void     Scale(Double_t c1=1, Option_t *option="");
+   virtual void     Scale(Double_t c1=1, Option_t *option="");  // *MENU*
    virtual void     SetAxisColor(Color_t color=1, Option_t *axis="X");
    virtual void     SetAxisRange(Double_t xmin, Double_t xmax, Option_t *axis="X");
    virtual void     SetBarOffset(Float_t offset=0.25) {fBarOffset = Short_t(1000*offset);}


### PR DESCRIPTION
So that you can right click on the histogram and scale it.

sibling PR is in https://github.com/root-project/roottest/pull/1203