### PR TITLE
[ntuple] Allow casting with RNTupleViews

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -139,12 +139,11 @@ protected:
       std::unique_ptr<RFieldBase> field;
       {
          const auto &desc = pageSource->GetSharedDescriptorGuard().GetRef();
-         field = desc.GetFieldDescriptor(fieldId).CreateField(desc);
-      }
-      if constexpr (!std::is_void_v<T>) {
-         if (field->GetTypeName() != RField<T>::TypeName()) {
-            throw RException(R__FAIL("type mismatch for field " + field->GetFieldName() + ": " + field->GetTypeName() +
-                                     " vs. " + RField<T>::TypeName()));
+         const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
+         if constexpr (std::is_void_v<T>) {
+            field = fieldDesc.CreateField(desc);
+         } else {
+            field = std::make_unique<RField<T>>(fieldDesc.GetFieldName());
          }
       }
       field->SetOnDiskId(fieldId);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1935,7 +1935,7 @@ TEST(RNTuple, TClass)
          auto viewKlass = ntuple->GetView<DerivedA>("klass");
          FAIL() << "GetView<a_base_class_of_T> should throw";
       } catch (const RException& err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("type mismatch for field klass"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk field information"));
       }
    }
 }


### PR DESCRIPTION
This conveniently also allows looking at columns through a `typedef` that might only be available with a dictionary.