### PR TITLE
[ntuple] fix RNTuple::Merge not passing mergeOpts to RNTupleMerger

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -121,7 +121,7 @@ try {
    RNTupleMerger merger;
    RNTupleMergeOptions mergerOpts;
    mergerOpts.fCompressionSettings = compression;
-   merger.Merge(sourcePtrs, *destination).ThrowOnError();
+   merger.Merge(sourcePtrs, *destination, mergerOpts).ThrowOnError();
 
    // Provide the caller with a merged anchor object (even though we've already
    // written it).


### PR DESCRIPTION
This is causing `hadd` to ignore the compression options when merging RNTuples. We didn't catch this bug because the unit tests were bypassing TFileMerger and calling directly into RNTupleMerger.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


