### PR TITLE
[webgui] adjust tutorials, minimal jsroot fix

### DIFF
--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -462,7 +462,7 @@ function parseLatex(node, arg, label, curr) {
       const gg = currG();
 
       // this is indicator that gg element will be the only one, one can use directly main container
-      if ((nelements === 1) && !label && !curr.x && !curr.y)
+      if ((nelements === 1) && !label && !curr.x && !curr.y && !is_a)
          return gg;
 
       return makeTranslate(gg.append(is_a ? 'svg:a' : 'svg:g'), curr.x, curr.y);

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '11/10/2024',
+version_date = '17/10/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -929,8 +929,11 @@ void THttpServer::ReplaceJSROOTLinks(std::shared_ptr<THttpCallArg> &arg, const s
       }
 
       static std::map<std::string, std::string> modules = {
-         {"jsroot", "main.mjs"}, {"jsroot/core", "core.mjs"}, {"jsroot/io", "io.mjs"}, {"jsroot/tree", "tree.mjs"},
-         {"jsroot/draw", "draw.mjs"}, {"jsroot/geom", "geom.mjs"}, {"jsroot/gui", "gui.mjs"}, {"jsroot/webwindow", "webwindow.mjs"}
+         {"jsroot", "main.mjs"}, {"jsroot/core", "core.mjs"},
+         {"jsroot/io", "io.mjs"}, {"jsroot/tree", "tree.mjs"},
+         {"jsroot/draw", "draw.mjs"}, {"jsroot/gui", "gui.mjs"},
+         {"jsroot/three", "three.mjs"}, {"jsroot/geom", "geom/TGeoPainter.mjs"},
+         {"jsroot/webwindow", "webwindow.mjs"}
       };
 
       if (std::string("qt5") == arg->GetWSPlatform()) {

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -281,7 +281,9 @@ set(gui_veto fit/fitpanel_playback.C
              roostats/ModelInspector.C
              tree/tvdemo.C
              eve/*.C
-             webgui/panel/server.cxx webgui/webwindow/server.cxx)
+             webgui/geom/geom_threejs.cxx
+             webgui/panel/server.cxx
+             webgui/webwindow/server.cxx)
 if (NOT webgui)
   list(APPEND gui_veto graphics/save_batch.C rcanvas/df104.py rcanvas/df105.py)
 endif()

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -282,7 +282,7 @@ set(gui_veto fit/fitpanel_playback.C
              tree/tvdemo.C
              eve/*.C
              webgui/geom/geom_threejs.cxx
-             webgui/panel/server.cxx
+             webgui/panel/webpanel.cxx
              webgui/webwindow/webwindow.cxx)
 if (NOT webgui)
   list(APPEND gui_veto graphics/save_batch.C rcanvas/df104.py rcanvas/df105.py)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -283,7 +283,7 @@ set(gui_veto fit/fitpanel_playback.C
              eve/*.C
              webgui/geom/geom_threejs.cxx
              webgui/panel/server.cxx
-             webgui/webwindow/server.cxx)
+             webgui/webwindow/webwindow.cxx)
 if (NOT webgui)
   list(APPEND gui_veto graphics/save_batch.C rcanvas/df104.py rcanvas/df105.py)
 endif()

--- a/tutorials/webcanv/haxis.cxx
+++ b/tutorials/webcanv/haxis.cxx
@@ -2,7 +2,7 @@
 /// \ingroup tutorial_webcanv
 /// \notebook -js
 /// Swap X/Y axes drawing and use to draw TH1 as bar and as markers.
-
+///
 /// Option "haxisg;y+" draw histogram axis as for "hbar" plus allow to draw grids plus draw Y labels on other side
 /// Option "bar,base0,same" draws histogram as bars with 0 as reference value
 /// Option "P,same" draws histogram as markers

--- a/tutorials/webcanv/latex_url.cxx
+++ b/tutorials/webcanv/latex_url.cxx
@@ -3,7 +3,7 @@
 /// \notebook -js
 /// Use of interactive URL links inside TLatex.
 ///
-/// JSROOT now supports #url[link]{label} syntax
+/// JSROOT now supports '#url[link]{label}' syntax
 /// It can be combined with any other latex commands like color ot font.
 /// While TLatex used in many places, one can add external links to histogram title,
 /// axis title, legend entry and so on.

--- a/tutorials/webcanv/triangle.cxx
+++ b/tutorials/webcanv/triangle.cxx
@@ -8,16 +8,11 @@
 /// It is also possible to use such "simple" class without loading of custom JS code,
 /// but then it requires appropriate Paint() method and will miss interactivity in browser
 ///
-/// This macro must be executed with ACLiC as follows:
+/// This macro must be executed with ACLiC like 'root --web triangle.cxx+'
 ///
-/// ~~~{.cpp}
-/// .x triangle.cxx+
-/// ~~~
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code
-///
-/// \author Sergey Linev
 ///
 /// \author Sergey Linev
 

--- a/tutorials/webgui/geom/geom_threejs.cxx
+++ b/tutorials/webgui/geom/geom_threejs.cxx
@@ -3,10 +3,10 @@
 /// \ingroup webwidgets
 /// The tutorial demonstrates how three.js model for geometry can be created and displayed.
 ///
-///  In server.cxx one uses RGeomDescription class from geometry viewer, which produces
-///  JSON data with all necessary information. Then RWebWindow is started and this information provided.
-///  In client.html one uses **build** function to create Object3D with geometry
-///  Then such object placed in three.js scene and rendered. Also simple animation is implemented
+/// In geom_threejs.cxx one uses RGeomDescription class from geometry viewer, which produces
+/// JSON data with all necessary information. Then RWebWindow is started and this information provided.
+/// In client.html one uses **build** function to create Object3D with geometry
+/// Then such object placed in three.js scene and rendered. Also simple animation is implemented
 ///
 /// \macro_code
 ///
@@ -16,10 +16,7 @@
 
 #include <ROOT/RWebWindow.hxx>
 
-
 std::shared_ptr<ROOT::RWebWindow> window;
-
-std::string json;
 
 TString base64;
 
@@ -35,7 +32,7 @@ void ProcessData(unsigned connid, const std::string &arg)
    }
 }
 
-void server()
+void geom_threejs()
 {
 
    TFile::SetCacheFileDir(".");
@@ -63,7 +60,7 @@ void server()
 
    data.Build(gGeoManager, "CMSE");
 
-   json = data.ProduceJson();
+   std::string json = data.ProduceJson();
 
    base64 = TBase64::Encode(json.c_str());
 
@@ -72,7 +69,13 @@ void server()
 
    // configure default html page
    // either HTML code can be specified or just name of file after 'file:' prefix
-   window->SetDefaultPage("file:client.html");
+   std::string fdir = __FILE__;
+   auto pos = fdir.find("geom_threejs.cxx");
+   if (pos > 0)
+      fdir.resize(pos);
+   else
+      fdir = gROOT->GetTutorialsDir() + std::string("/webgui/geom/");
+   window->SetDefaultPage("file:" + fdir + "geom_threejs.html");
 
    // this is call-back, invoked when message received from client
    window->SetDataCallBack(ProcessData);

--- a/tutorials/webgui/geom/geom_threejs.html
+++ b/tutorials/webgui/geom/geom_threejs.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Draw geometry with RGeomDescription</title>
+    <!--jsroot_importmap-->
   </head>
 
   <body style="overflow:hidden;margin:0px;">
@@ -10,11 +11,11 @@
 
   <script type="module">
 
-    import { connectWebWindow } from './jsrootsys/modules/webwindow.mjs';
-    import { parse } from './jsrootsys/modules/core.mjs';
+    import { connectWebWindow } from 'jsroot/webwindow';
+    import { parse } from 'jsroot';
     import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
-               MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from './jsrootsys/modules/three.mjs';
-    import { build, produceRenderOrder } from './jsrootsys/modules/geom/TGeoPainter.mjs';
+               MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'jsrootsys/modules/three.mjs';
+    import { build, produceRenderOrder } from 'jsrootsys/modules/geom/TGeoPainter.mjs';
 
     function drawGeometry(obj3d) {
 

--- a/tutorials/webgui/geom/geom_threejs.html
+++ b/tutorials/webgui/geom/geom_threejs.html
@@ -14,8 +14,8 @@
     import { connectWebWindow } from 'jsroot/webwindow';
     import { parse } from 'jsroot';
     import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
-               MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'jsrootsys/modules/three.mjs';
-    import { build, produceRenderOrder } from 'jsrootsys/modules/geom/TGeoPainter.mjs';
+               MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'jsroot/three';
+    import { build, produceRenderOrder } from 'jsroot/geom';
 
     function drawGeometry(obj3d) {
 

--- a/tutorials/webgui/panel/webpanel.cxx
+++ b/tutorials/webgui/panel/webpanel.cxx
@@ -65,7 +65,7 @@ void ProcessData(unsigned connid, const std::string &arg)
    }
 }
 
-void server()
+void webpanel()
 {
    // prepare model
    model = std::make_unique<TestPanelModel>();

--- a/tutorials/webgui/webwindow/webwindow.cxx
+++ b/tutorials/webgui/webwindow/webwindow.cxx
@@ -1,10 +1,10 @@
 /// \file
 /// \ingroup tutorial_webgui
 /// \ingroup webwidgets
-/// Minimal server/client code for working with RWebWindow class
+/// Minimal server/client code for working with RWebWindow class.
 ///
-/// File server.cxx shows how RWebWindow can be created and used
-/// In client.html simple client code is provided.
+/// File webwindow.cxx shows how RWebWindow can be created and used
+/// In webwindow.html simple client code is provided.
 ///
 /// \macro_code
 ///
@@ -14,7 +14,7 @@
 
 std::shared_ptr<ROOT::RWebWindow> window;
 
-int counter{0};
+int counter = 0;
 
 void ProcessData(unsigned connid, const std::string &arg)
 {
@@ -37,23 +37,20 @@ void ProcessData(unsigned connid, const std::string &arg)
    }
 }
 
-void server()
+void webwindow()
 {
    // create window
    window = ROOT::RWebWindow::Create();
 
-   // Detect macro file location to specify full path to the HTML file
-   std::string fname = __FILE__;
-   auto pos = fname.find("server.cxx");
-   if (pos > 0)
-      fname.resize(pos);
-   else
-      fname.clear();
-   fname.append("client.html");
-
    // configure default html page
    // either HTML code can be specified or just name of file after 'file:' prefix
-   window->SetDefaultPage("file:" + fname);
+   std::string fdir = __FILE__;
+   auto pos = fdir.find("webwindow.cxx");
+   if (pos > 0)
+      fdir.resize(pos);
+   else
+      fdir = gROOT->GetTutorialsDir() + std::string("/webgui/webwindow/");
+   window->SetDefaultPage("file:" + fdir + "webwindow.html");
 
    // this is call-back, invoked when message received from client
    window->SetDataCallBack(ProcessData);

--- a/tutorials/webgui/webwindow/webwindow.html
+++ b/tutorials/webgui/webwindow/webwindow.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>RWebWindow test</title>
+    <!--jsroot_importmap-->
   </head>
 
   <body>
@@ -14,7 +15,7 @@
 
   <script type="module">
 
-    import { connectWebWindow } from './jsrootsys/modules/webwindow.mjs';
+    import { connectWebWindow } from 'jsroot/webwindow';
 
     let conn_handle = null;
 


### PR DESCRIPTION
1. Fixing several formatting errors preventing doxygen generation
2. Rename files in `tutorials\webgui` to let correctly create doxygen
3. Fix jsroot_importmap generation for `jsroot/geom` and `jsroot/three`
4. Fix minimal error in JSROOT