### PR TITLE
[graf3d] use the proper type when interfacing with FT_Outline and FTContour

### DIFF
--- a/graf3d/ftgl/inc/FTContour.h
+++ b/graf3d/ftgl/inc/FTContour.h
@@ -18,6 +18,15 @@
 class FTGL_EXPORT FTContour
 {
     public:
+ #define FREETYPE_VER_HEX ((FREETYPE_MAJOR << 16) | (FREETYPE_MINOR << 8) | (FREETYPE_PATCH))
+ #if FREETYPE_VER_HEX >= 0x20d03
+    // enabled from 2.13.3
+    using PointTag_t = unsigned char;
+ #else
+    using PointTag_t = char;
+ #endif
+ #undef FREETYPE_VER_HEX
+
         /**
          * Constructor
          *
@@ -25,7 +34,7 @@ class FTGL_EXPORT FTContour
          * @param pointTags
          * @param numberOfPoints
          */
-        FTContour( FT_Vector* contour, char* pointTags, unsigned int numberOfPoints);
+        FTContour( FT_Vector* contour, PointTag_t* pointTags, unsigned int numberOfPoints);
 
         /**
          * Destructor

--- a/graf3d/ftgl/src/FTContour.cxx
+++ b/graf3d/ftgl/src/FTContour.cxx
@@ -70,11 +70,11 @@ void FTContour::evaluateCubicCurve()
 }
 
 
-FTContour::FTContour( FT_Vector* contour, char* pointTags, unsigned int numberOfPoints)
+FTContour::FTContour( FT_Vector* contour, PointTag_t* pointTags, unsigned int numberOfPoints)
 {
     for( unsigned int pointIndex = 0; pointIndex < numberOfPoints; ++ pointIndex)
     {
-        char pointTag = pointTags[pointIndex];
+        PointTag_t pointTag = pointTags[pointIndex];
 
         if( pointTag == FT_Curve_Tag_On || numberOfPoints < 2)
         {
@@ -93,9 +93,9 @@ FTContour::FTContour( FT_Vector* contour, char* pointTags, unsigned int numberOf
 
         if( pointTag == FT_Curve_Tag_Conic)
         {
-            char nextPointTag = ( pointIndex == numberOfPoints - 1)
-                                ? pointTags[0]
-                                : pointTags[pointIndex + 1];
+            PointTag_t nextPointTag = ( pointIndex == numberOfPoints - 1)
+                                      ? pointTags[0]
+                                      : pointTags[pointIndex + 1];
 
             while( nextPointTag == FT_Curve_Tag_Conic)
             {

--- a/graf3d/ftgl/src/FTVectoriser.cxx
+++ b/graf3d/ftgl/src/FTVectoriser.cxx
@@ -140,7 +140,7 @@ void FTVectoriser::ProcessContours()
     for( short contourIndex = 0; contourIndex < ftContourCount; ++contourIndex)
     {
         FT_Vector* pointList = &outline.points[startIndex];
-        char* tagList = &outline.tags[startIndex];
+        auto* tagList = &outline.tags[startIndex];
 
         endIndex = outline.contours[contourIndex];
         contourLength =  ( endIndex - startIndex) + 1;


### PR DESCRIPTION
Fixes a compiler warning.

Freetype 2.13.3 changed the type of a data member from char* to
unsigned char*, so we need to pass the correct type to FTContour to
avoid compiler warnings