### PR TITLE
[ntuple] Fixes to model/field cloning

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -124,6 +124,7 @@ private:
    std::size_t fMaxAlignment = 1;
 
 private:
+   RClassField(std::string_view fieldName, const RClassField &source); ///< Used by CloneImpl
    RClassField(std::string_view fieldName, std::string_view className, TClass *classp);
    void Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo info);
    /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -425,6 +425,9 @@ class RField<TObject> final : public RFieldBase {
    static std::size_t GetOffsetUniqueID() { return GetOffsetOfMember("fUniqueID"); }
    static std::size_t GetOffsetBits() { return GetOffsetOfMember("fBits"); }
 
+private:
+   RField(std::string_view fieldName, const RField<TObject> &source); ///< Used by CloneImpl()
+
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -271,18 +271,6 @@ std::tuple<const void *const *, const std::int32_t *, const std::int32_t *> GetR
    return {GetRVecDataMembers(const_cast<void *>(rvecPtr))};
 }
 
-/// Applies the field IDs from 'from' to 'to', where from and to are expected to be each other's clones.
-/// Used in RClassField and RCollectionClassField cloning. In these classes, we don't clone the subfields
-/// but we recreate them. Therefore, the on-disk IDs need to be fixed up.
-void SyncFieldIDs(const ROOT::Experimental::RFieldBase &from, ROOT::Experimental::RFieldBase &to)
-{
-   auto iFrom = from.cbegin();
-   auto iTo = to.begin();
-   for (; iFrom != from.cend(); ++iFrom, ++iTo) {
-      iTo->SetOnDiskId(iFrom->GetOnDiskId());
-   }
-}
-
 std::size_t EvalRVecValueSize(std::size_t alignOfT, std::size_t sizeOfT, std::size_t alignOfRVecT)
 {
    // the size of an RVec<T> is the size of its 4 data-members + optional padding:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2012,6 +2012,14 @@ std::size_t ROOT::Experimental::RField<TObject>::GetOffsetOfMember(const char *n
    throw RException(R__FAIL('\'' + std::string(name) + '\'' + " is an invalid data member"));
 }
 
+ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName, const RField<TObject> &source)
+   : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
+{
+   fTraits |= kTraitTypeChecksum;
+   Attach(source.GetSubFields()[0]->Clone("fUniqueID"));
+   Attach(source.GetSubFields()[1]->Clone("fBits"));
+}
+
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ENTupleStructure::kRecord, false /* isSimple */)
 {
@@ -2025,9 +2033,7 @@ ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
 std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RField<TObject>::CloneImpl(std::string_view newName) const
 {
-   auto result = std::make_unique<RField<TObject>>(newName);
-   SyncFieldIDs(*this, *result);
-   return result;
+   return std::unique_ptr<RField<TObject>>(new RField<TObject>(newName, *this));
 }
 
 std::size_t ROOT::Experimental::RField<TObject>::AppendImpl(const void *from)

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -45,6 +45,7 @@ TEST(RNTupleModel, Clone)
    model->MakeField<CustomEnumUInt32>("enum");
    model->Freeze();
 
+   // FIXME: This actually should be moved to before the Freeze.
    for (auto &f : model->GetFieldZero()) {
       if (f.GetTypeName() == "float") {
          f.SetColumnRepresentatives({{EColumnType::kReal32}});

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -34,3 +34,27 @@ TEST(RNTupleModel, EstimateWriteMemoryUsage)
    static constexpr std::size_t Expected4 = PageBufferBudget;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected4);
 }
+
+TEST(RNTupleModel, Clone)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("f");
+   model->MakeField<std::vector<float>>("vec");
+   model->MakeField<CustomStruct>("struct");
+   model->Freeze();
+
+   for (auto &f : model->GetFieldZero()) {
+      if (f.GetTypeName() == "float") {
+         f.SetColumnRepresentatives({{EColumnType::kReal32}});
+      }
+   }
+
+   auto clone = model->Clone();
+
+   for (const auto &f : clone->GetFieldZero()) {
+      if (f.GetTypeName() == "float") {
+         EXPECT_EQ(EColumnType::kReal32, f.GetColumnRepresentatives()[0][0]);
+      }
+   }
+   EXPECT_TRUE(clone->GetField("struct").GetTraits() & RFieldBase::kTraitTypeChecksum);
+}

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -42,6 +42,7 @@ TEST(RNTupleModel, Clone)
    model->MakeField<std::vector<float>>("vec");
    model->MakeField<CustomStruct>("struct");
    model->MakeField<TObject>("obj");
+   model->MakeField<CustomEnumUInt32>("enum");
    model->Freeze();
 
    for (auto &f : model->GetFieldZero()) {

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -41,11 +41,15 @@ TEST(RNTupleModel, Clone)
    model->MakeField<float>("f");
    model->MakeField<std::vector<float>>("vec");
    model->MakeField<CustomStruct>("struct");
+   model->MakeField<TObject>("obj");
    model->Freeze();
 
    for (auto &f : model->GetFieldZero()) {
       if (f.GetTypeName() == "float") {
          f.SetColumnRepresentatives({{EColumnType::kReal32}});
+      }
+      if (f.GetTypeName() == "std::uint32_t") {
+         f.SetColumnRepresentatives({{EColumnType::kUInt32}});
       }
    }
 
@@ -55,6 +59,10 @@ TEST(RNTupleModel, Clone)
       if (f.GetTypeName() == "float") {
          EXPECT_EQ(EColumnType::kReal32, f.GetColumnRepresentatives()[0][0]);
       }
+      if (f.GetTypeName() == "std::uint32_t") {
+         EXPECT_EQ(EColumnType::kUInt32, f.GetColumnRepresentatives()[0][0]);
+      }
    }
    EXPECT_TRUE(clone->GetField("struct").GetTraits() & RFieldBase::kTraitTypeChecksum);
+   EXPECT_TRUE(clone->GetField("obj").GetTraits() & RFieldBase::kTraitTypeChecksum);
 }


### PR DESCRIPTION
As a user-visible effect, fixes buffered writing when the model contains a class field or a TObject field and the column representation of (nested) members inside those fields were changed.

@Dr15Jones FYI.

