### PR TITLE
[ntuple] Mark RField methods as final and remove duplicate implementations

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -134,7 +134,7 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void ConstructValue(void *where) const override;
+   void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RClassDeleter>(fClass); }
 
    std::size_t AppendImpl(const void *from) final;
@@ -239,17 +239,6 @@ public:
 /// Classes with dictionaries that can be inspected by TClass
 template <typename T, typename = void>
 class RField final : public RClassField {
-protected:
-   void ConstructValue(void *where) const final
-   {
-      if constexpr (std::is_default_constructible_v<T>) {
-         new (where) T();
-      } else {
-         // If there is no default constructor, try with the IO constructor
-         new (where) T(static_cast<TRootIOCtor *>(nullptr));
-      }
-   }
-
 public:
    static std::string TypeName() { return ROOT::Internal::GetDemangledTypeName(typeid(T)); }
    RField(std::string_view name) : RClassField(name, TypeName())

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -153,7 +153,7 @@ public:
    size_t GetAlignment() const final { return fMaxAlignment; }
    std::uint32_t GetTypeVersion() const final;
    std::uint32_t GetTypeChecksum() const final;
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
 /// The field for a class in unsplit mode, which is using ROOT standard streaming

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -57,7 +57,7 @@ class RFieldVisitor;
 /// Therefore, the zero field must not be connected to a page source or sink.
 class RFieldZero final : public RFieldBase {
 protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    void ConstructValue(void *) const final {}
 
 public:
@@ -200,7 +200,7 @@ public:
    RUnsplitField(std::string_view fieldName, std::string_view className, std::string_view typeAlias = "");
    RUnsplitField(RUnsplitField &&other) = default;
    RUnsplitField &operator=(RUnsplitField &&other) = default;
-   ~RUnsplitField() override = default;
+   ~RUnsplitField() final = default;
 
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
@@ -258,7 +258,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 template <typename T>
@@ -368,7 +368,7 @@ public:
    explicit RField(std::string_view name) : RCardinalityField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(RNTupleCardinality<SizeT>); }
    size_t GetAlignment() const final { return alignof(RNTupleCardinality<SizeT>); }
@@ -431,7 +431,7 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void ConstructValue(void *where) const override;
+   void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<TObject>>(); }
 
    std::size_t AppendImpl(const void *from) final;
@@ -445,7 +445,7 @@ public:
    RField(std::string_view fieldName);
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -149,7 +149,7 @@ public:
    ~RClassField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const override;
+   size_t GetValueSize() const final;
    size_t GetAlignment() const final { return fMaxAlignment; }
    std::uint32_t GetTypeVersion() const final;
    std::uint32_t GetTypeChecksum() const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -262,13 +262,13 @@ public:
 };
 
 template <typename T>
-class RField<T, typename std::enable_if<std::is_enum_v<T>>::type> : public REnumField {
+class RField<T, typename std::enable_if<std::is_enum_v<T>>::type> final : public REnumField {
 public:
    static std::string TypeName() { return ROOT::Internal::GetDemangledTypeName(typeid(T)); }
    RField(std::string_view name) : REnumField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 /// An artificial field that transforms an RNTuple column that contains the offset of collections into

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -74,7 +74,7 @@ public:
    explicit RField(std::string_view name) : RSimpleField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
@@ -96,7 +96,7 @@ public:
    explicit RField(std::string_view name) : RSimpleField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
@@ -328,7 +328,7 @@ public:
    RField(std::string_view name) : RIntegralField<MappedType>(name) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    T *Map(NTupleSize_t globalIndex) { return reinterpret_cast<T *>(this->BaseType::Map(globalIndex)); }
    T *Map(RClusterIndex clusterIndex) { return reinterpret_cast<T *>(this->BaseType::Map(clusterIndex)); }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -274,7 +274,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -323,7 +323,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
@@ -349,7 +349,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
@@ -375,7 +375,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
@@ -401,7 +401,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
@@ -459,7 +459,7 @@ public:
    explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -426,7 +426,7 @@ public:
 };
 
 template <typename ItemT>
-class RField<std::set<ItemT>> : public RSetField {
+class RField<std::set<ItemT>> final : public RSetField {
    using ContainerT = typename std::set<ItemT>;
 
 protected:
@@ -439,7 +439,7 @@ public:
    explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
@@ -466,7 +466,7 @@ public:
 };
 
 template <typename ItemT>
-class RField<std::multiset<ItemT>> : public RSetField {
+class RField<std::multiset<ItemT>> final : public RSetField {
    using ContainerT = typename std::multiset<ItemT>;
 
 protected:
@@ -479,14 +479,14 @@ public:
    explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename ItemT>
-class RField<std::unordered_multiset<ItemT>> : public RSetField {
+class RField<std::unordered_multiset<ItemT>> final : public RSetField {
    using ContainerT = typename std::unordered_multiset<ItemT>;
 
 protected:
@@ -499,7 +499,7 @@ public:
    explicit RField(std::string_view name) : RSetField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -168,8 +168,8 @@ protected:
    void ConstructValue(void *where) const override;
    std::unique_ptr<RDeleter> GetDeleter() const override;
 
-   std::size_t AppendImpl(const void *from) override;
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
+   std::size_t AppendImpl(const void *from) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
    void CommitClusterImpl() final { fNWritten = 0; }
 
@@ -179,7 +179,7 @@ public:
    RProxiedCollectionField &operator=(RProxiedCollectionField &&other) = default;
    ~RProxiedCollectionField() override = default;
 
-   std::vector<RValue> SplitValue(const RValue &value) const override;
+   std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const override { return fProxy->Sizeof(); }
    size_t GetAlignment() const override { return alignof(std::max_align_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
@@ -289,16 +289,11 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   std::size_t AppendImpl(const void *from) final;
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
-
 public:
    RMapField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
    RMapField(RMapField &&other) = default;
    RMapField &operator=(RMapField &&other) = default;
    ~RMapField() override = default;
-
-   std::vector<RValue> SplitValue(const RValue &value) const final;
 
    size_t GetAlignment() const override { return std::alignment_of<std::map<std::max_align_t, std::max_align_t>>(); }
 };

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -180,8 +180,8 @@ public:
    ~RProxiedCollectionField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const override { return fProxy->Sizeof(); }
-   size_t GetAlignment() const override { return alignof(std::max_align_t); }
+   size_t GetValueSize() const final { return fProxy->Sizeof(); }
+   size_t GetAlignment() const final { return alignof(std::max_align_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
@@ -294,8 +294,6 @@ public:
    RMapField(RMapField &&other) = default;
    RMapField &operator=(RMapField &&other) = default;
    ~RMapField() override = default;
-
-   size_t GetAlignment() const override { return std::alignment_of<std::map<std::max_align_t, std::max_align_t>>(); }
 };
 
 template <typename KeyT, typename ValueT>
@@ -319,9 +317,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename KeyT, typename ValueT>
@@ -345,9 +340,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename KeyT, typename ValueT>
@@ -371,9 +363,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename KeyT, typename ValueT>
@@ -397,9 +386,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -416,8 +402,6 @@ public:
    RSetField(RSetField &&other) = default;
    RSetField &operator=(RSetField &&other) = default;
    ~RSetField() override = default;
-
-   size_t GetAlignment() const override { return std::alignment_of<std::set<std::max_align_t>>(); }
 };
 
 template <typename ItemT>
@@ -435,9 +419,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename ItemT>
@@ -455,9 +436,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename ItemT>
@@ -475,9 +453,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename ItemT>
@@ -495,9 +470,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -280,9 +280,6 @@ public:
 
 /// The generic field for a std::map<KeyType, ValueType> and std::unordered_map<KeyType, ValueType>
 class RMapField : public RProxiedCollectionField {
-private:
-   TClass *fItemClass;
-
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -165,8 +165,8 @@ protected:
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
 
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const override;
+   void ConstructValue(void *where) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -263,9 +263,6 @@ struct IsCollectionProxy : HasCollectionProxyMemberType<T> {
 /// ```
 template <typename T>
 class RField<T, typename std::enable_if<IsCollectionProxy<T>::value>::type> final : public RProxiedCollectionField {
-protected:
-   void ConstructValue(void *where) const final { new (where) T(); }
-
 public:
    static std::string TypeName() { return ROOT::Internal::GetDemangledTypeName(typeid(T)); }
    RField(std::string_view name) : RProxiedCollectionField(name, TypeName())
@@ -298,12 +295,6 @@ public:
 
 template <typename KeyT, typename ValueT>
 class RField<std::map<KeyT, ValueT>> final : public RMapField {
-   using ContainerT = typename std::map<KeyT, ValueT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName()
    {
@@ -321,12 +312,6 @@ public:
 
 template <typename KeyT, typename ValueT>
 class RField<std::unordered_map<KeyT, ValueT>> final : public RMapField {
-   using ContainerT = typename std::unordered_map<KeyT, ValueT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName()
    {
@@ -344,12 +329,6 @@ public:
 
 template <typename KeyT, typename ValueT>
 class RField<std::multimap<KeyT, ValueT>> final : public RMapField {
-   using ContainerT = typename std::multimap<KeyT, ValueT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName()
    {
@@ -367,12 +346,6 @@ public:
 
 template <typename KeyT, typename ValueT>
 class RField<std::unordered_multimap<KeyT, ValueT>> final : public RMapField {
-   using ContainerT = typename std::unordered_multimap<KeyT, ValueT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName()
    {
@@ -406,12 +379,6 @@ public:
 
 template <typename ItemT>
 class RField<std::set<ItemT>> final : public RSetField {
-   using ContainerT = typename std::set<ItemT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName() { return "std::set<" + RField<ItemT>::TypeName() + ">"; }
 
@@ -423,12 +390,6 @@ public:
 
 template <typename ItemT>
 class RField<std::unordered_set<ItemT>> final : public RSetField {
-   using ContainerT = typename std::unordered_set<ItemT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName() { return "std::unordered_set<" + RField<ItemT>::TypeName() + ">"; }
 
@@ -440,12 +401,6 @@ public:
 
 template <typename ItemT>
 class RField<std::multiset<ItemT>> final : public RSetField {
-   using ContainerT = typename std::multiset<ItemT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName() { return "std::multiset<" + RField<ItemT>::TypeName() + ">"; }
 
@@ -457,12 +412,6 @@ public:
 
 template <typename ItemT>
 class RField<std::unordered_multiset<ItemT>> final : public RSetField {
-   using ContainerT = typename std::unordered_multiset<ItemT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName() { return "std::unordered_multiset<" + RField<ItemT>::TypeName() + ">"; }
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -160,7 +160,7 @@ protected:
                            std::unique_ptr<RFieldBase> itemField);
 
 protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
@@ -280,9 +280,6 @@ public:
 
 /// The generic field for a std::map<KeyType, ValueType> and std::unordered_map<KeyType, ValueType>
 class RMapField : public RProxiedCollectionField {
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
-
 public:
    RMapField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
    RMapField(RMapField &&other) = default;
@@ -364,9 +361,6 @@ public:
 
 /// The generic field for a std::set<Type> and std::unordered_set<Type>
 class RSetField : public RProxiedCollectionField {
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
-
 public:
    RSetField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
    RSetField(RSetField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -182,7 +182,7 @@ public:
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final { return fProxy->Sizeof(); }
    size_t GetAlignment() const final { return alignof(std::max_align_t); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -62,8 +62,8 @@ protected:
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
 
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const override;
+   void ConstructValue(void *where) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -126,9 +126,6 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
 
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const override { return std::make_unique<RPairDeleter>(fClass); }
-
    RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields,
               const std::array<std::size_t, 2> &offsets);
 
@@ -166,9 +163,6 @@ protected:
       return std::make_unique<RField<std::pair<T1, T2>>>(newName, std::move(items));
    }
 
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
-
 public:
    static std::string TypeName() { return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">"; }
    explicit RField(std::string_view name, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields)
@@ -204,9 +198,6 @@ private:
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
-
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const override { return std::make_unique<RTupleDeleter>(fClass); }
 
    RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &&itemFields,
                const std::vector<std::size_t> &offsets);
@@ -272,9 +263,6 @@ protected:
          items.push_back(item->Clone(item->GetFieldName()));
       return std::make_unique<RField<std::tuple<ItemTs...>>>(newName, std::move(items));
    }
-
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    static std::string TypeName() { return "std::tuple<" + BuildItemTypes<ItemTs...>() + ">"; }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -180,7 +180,7 @@ public:
    explicit RField(std::string_view name) : RField(name, BuildItemFields<T1, T2>()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -287,7 +287,7 @@ public:
    explicit RField(std::string_view name) : RField(name, BuildItemFields<ItemTs...>()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -111,16 +111,6 @@ public:
 /// The generic field for `std::pair<T1, T2>` types
 class RPairField : public RRecordField {
 private:
-   class RPairDeleter : public RDeleter {
-   private:
-      TClass *fClass;
-
-   public:
-      explicit RPairDeleter(TClass *cl) : fClass(cl) {}
-      void operator()(void *objPtr, bool dtorOnly) final;
-   };
-
-   TClass *fClass = nullptr;
    static std::string GetTypeList(const std::array<std::unique_ptr<RFieldBase>, 2> &itemFields);
 
 protected:
@@ -184,16 +174,6 @@ public:
 /// The generic field for `std::tuple<Ts...>` types
 class RTupleField : public RRecordField {
 private:
-   class RTupleDeleter : public RDeleter {
-   private:
-      TClass *fClass;
-
-   public:
-      explicit RTupleDeleter(TClass *cl) : fClass(cl) {}
-      void operator()(void *objPtr, bool dtorOnly) final;
-   };
-
-   TClass *fClass = nullptr;
    static std::string GetTypeList(const std::vector<std::unique_ptr<RFieldBase>> &itemFields);
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -60,7 +60,7 @@ protected:
 
    std::size_t GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const;
 
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -114,8 +114,6 @@ private:
    static std::string GetTypeList(const std::array<std::unique_ptr<RFieldBase>, 2> &itemFields);
 
 protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
-
    RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields,
               const std::array<std::size_t, 2> &offsets);
 
@@ -145,14 +143,6 @@ private:
       return {offsetFirst, offsetSecond};
    }
 
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
-   {
-      std::array<std::unique_ptr<RFieldBase>, 2> items{fSubFields[0]->Clone(fSubFields[0]->GetFieldName()),
-                                                       fSubFields[1]->Clone(fSubFields[1]->GetFieldName())};
-      return std::make_unique<RField<std::pair<T1, T2>>>(newName, std::move(items));
-   }
-
 public:
    static std::string TypeName() { return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">"; }
    explicit RField(std::string_view name, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields)
@@ -177,8 +167,6 @@ private:
    static std::string GetTypeList(const std::vector<std::unique_ptr<RFieldBase>> &itemFields);
 
 protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
-
    RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &&itemFields,
                const std::vector<std::size_t> &offsets);
 
@@ -233,15 +221,6 @@ private:
       std::vector<std::size_t> result;
       _BuildItemOffsets<0, Ts...>(result, ContainerT());
       return result;
-   }
-
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
-   {
-      std::vector<std::unique_ptr<RFieldBase>> items;
-      for (auto &item : fSubFields)
-         items.push_back(item->Clone(item->GetFieldName()));
-      return std::make_unique<RField<std::tuple<ItemTs...>>>(newName, std::move(items));
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -75,7 +75,7 @@ public:
    explicit RField(std::string_view name) : RAtomicField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -127,7 +127,7 @@ public:
    explicit RField(std::string_view name) : RBitsetField(name, N) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -151,7 +151,7 @@ public:
    explicit RField(std::string_view name) : RSimpleField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
@@ -236,7 +236,7 @@ public:
    explicit RField(std::string_view name) : ROptionalField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 class RUniquePtrField : public RNullableField {
@@ -278,7 +278,7 @@ public:
    explicit RField(std::string_view name) : RUniquePtrField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -315,7 +315,7 @@ public:
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(std::string); }
    size_t GetAlignment() const final { return std::alignment_of<std::string>(); }
@@ -426,7 +426,7 @@ public:
    explicit RField(std::string_view name) : RVariantField(name, BuildItemFields<ItemTs...>()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -373,7 +373,7 @@ protected:
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
 
-   void ConstructValue(void *where) const override;
+   void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
@@ -394,8 +394,6 @@ public:
 
 template <typename... ItemTs>
 class RField<std::variant<ItemTs...>> final : public RVariantField {
-   using ContainerT = typename std::variant<ItemTs...>;
-
 private:
    template <typename HeadT, typename... TailTs>
    static std::string BuildItemTypes()
@@ -417,9 +415,6 @@ private:
       }
       return result;
    }
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
 
 public:
    static std::string TypeName() { return "std::variant<" + BuildItemTypes<ItemTs...>() + ">"; }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -159,8 +159,8 @@ public:
    ~RRVecField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const override;
-   size_t GetAlignment() const override;
+   size_t GetValueSize() const final;
+   size_t GetAlignment() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
    {
@@ -198,9 +198,6 @@ public:
    ~RField() final = default;
 
    static std::string TypeName() { return "ROOT::VecOps::RVec<" + RField<ItemT>::TypeName() + ">"; }
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
-   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -256,7 +253,7 @@ public:
    CreateUntyped(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField);
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const override { return sizeof(std::vector<char>); }
+   size_t GetValueSize() const final { return sizeof(std::vector<char>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
@@ -282,8 +279,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
-
-   size_t GetValueSize() const final { return sizeof(ContainerT); }
 };
 
 // std::vector<bool> is a template specialization and needs special treatment

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -62,7 +62,7 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void ConstructValue(void *where) const override;
+   void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
@@ -84,11 +84,6 @@ public:
 
 template <typename ItemT, std::size_t N>
 class RField<std::array<ItemT, N>> : public RArrayField {
-   using ContainerT = typename std::array<ItemT, N>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-
 public:
    static std::string TypeName() { return "std::array<" + RField<ItemT>::TypeName() + "," + std::to_string(N) + ">"; }
    explicit RField(std::string_view name) : RArrayField(name, std::make_unique<RField<ItemT>>("_0"), N) {}
@@ -141,8 +136,8 @@ protected:
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
 
-   void ConstructValue(void *where) const override;
-   std::unique_ptr<RDeleter> GetDeleter() const override;
+   void ConstructValue(void *where) const final;
+   std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
@@ -174,17 +169,12 @@ public:
 
 template <typename ItemT>
 class RField<ROOT::VecOps::RVec<ItemT>> final : public RRVecField {
-   using ContainerT = typename ROOT::VecOps::RVec<ItemT>;
-
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
       auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
       return std::make_unique<RField<ROOT::VecOps::RVec<ItemT>>>(newName, std::move(newItemField));
    }
-
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<ContainerT>>(); }
 
 public:
    RField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField)
@@ -235,7 +225,7 @@ protected:
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
 
-   void ConstructValue(void *where) const override { new (where) std::vector<char>(); }
+   void ConstructValue(void *where) const final { new (where) std::vector<char>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
@@ -268,11 +258,6 @@ public:
 
 template <typename ItemT>
 class RField<std::vector<ItemT>> final : public RVectorField {
-   using ContainerT = typename std::vector<ItemT>;
-
-protected:
-   void ConstructValue(void *where) const final { new (where) ContainerT(); }
-
 public:
    static std::string TypeName() { return "std::vector<" + RField<ItemT>::TypeName() + ">"; }
    explicit RField(std::string_view name) : RVectorField(name, std::make_unique<RField<ItemT>>("_0")) {}

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -103,7 +103,7 @@ public:
    explicit RField(std::string_view name) : RField<std::array<ItemT, N>>(name) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -219,7 +219,7 @@ public:
    explicit RField(std::string_view name) : RField(name, std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    static std::string TypeName() { return "ROOT::VecOps::RVec<" + RField<ItemT>::TypeName() + ">"; }
 
@@ -305,7 +305,7 @@ public:
    explicit RField(std::string_view name) : RVectorField(name, std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    size_t GetValueSize() const final { return sizeof(ContainerT); }
 };
@@ -339,7 +339,7 @@ public:
    explicit RField(std::string_view name);
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -131,7 +131,7 @@ protected:
    ClusterSize_t fNWritten;
    std::size_t fValueSize;
 
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
    void GenerateColumns(const RNTupleDescriptor &desc) final;
@@ -169,13 +169,6 @@ public:
 
 template <typename ItemT>
 class RField<ROOT::VecOps::RVec<ItemT>> final : public RRVecField {
-protected:
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
-   {
-      auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
-      return std::make_unique<RField<ROOT::VecOps::RVec<ItemT>>>(newName, std::move(newItemField));
-   }
-
 public:
    RField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField)
       : RRVecField(fieldName, std::move(itemField))
@@ -219,7 +212,7 @@ private:
 protected:
    RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField, bool isUntyped);
 
-   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3597,12 +3597,6 @@ ROOT::Experimental::RSetField::RSetField(std::string_view fieldName, std::string
 {
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase> ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
-{
-   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
-   return std::make_unique<RSetField>(newName, GetTypeName(), std::move(newItemField));
-}
-
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RMapField::RMapField(std::string_view fieldName, std::string_view typeName,
@@ -3616,12 +3610,6 @@ ROOT::Experimental::RMapField::RMapField(std::string_view fieldName, std::string
    fItemSize = itemClass->GetClassSize();
 
    Attach(std::move(itemField));
-}
-
-std::unique_ptr<ROOT::Experimental::RFieldBase> ROOT::Experimental::RMapField::CloneImpl(std::string_view newName) const
-{
-   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
-   return std::unique_ptr<RMapField>(new RMapField(newName, GetTypeName(), std::move(newItemField)));
 }
 
 //------------------------------------------------------------------------------
@@ -3899,16 +3887,6 @@ ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
    fOffsets[1] = secondElem->GetThisOffset();
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RPairField::CloneImpl(std::string_view newName) const
-{
-   std::array<std::unique_ptr<RFieldBase>, 2> items{fSubFields[0]->Clone(fSubFields[0]->GetFieldName()),
-                                                    fSubFields[1]->Clone(fSubFields[1]->GetFieldName())};
-
-   std::unique_ptr<RPairField> result(new RPairField(newName, std::move(items), {fOffsets[0], fOffsets[1]}));
-   return result;
-}
-
 //------------------------------------------------------------------------------
 
 std::string
@@ -3954,18 +3932,6 @@ ROOT::Experimental::RTupleField::RTupleField(std::string_view fieldName,
          throw RException(R__FAIL(memberName + ": no such member"));
       fOffsets.push_back(member->GetThisOffset());
    }
-}
-
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RTupleField::CloneImpl(std::string_view newName) const
-{
-   std::vector<std::unique_ptr<RFieldBase>> items;
-   items.reserve(fSubFields.size());
-   for (const auto &item : fSubFields)
-      items.push_back(item->Clone(item->GetFieldName()));
-
-   std::unique_ptr<RTupleField> result(new RTupleField(newName, std::move(items), fOffsets));
-   return result;
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3612,8 +3612,8 @@ ROOT::Experimental::RMapField::RMapField(std::string_view fieldName, std::string
    if (!dynamic_cast<RPairField *>(itemField.get()))
       throw RException(R__FAIL("RMapField inner field type must be of RPairField"));
 
-   fItemClass = fProxy->GetValueClass();
-   fItemSize = fItemClass->GetClassSize();
+   auto *itemClass = fProxy->GetValueClass();
+   fItemSize = itemClass->GetClassSize();
 
    Attach(std::move(itemField));
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -3910,11 +3910,6 @@ ROOT::Experimental::RPairField::CloneImpl(std::string_view newName) const
    return result;
 }
 
-void ROOT::Experimental::RPairField::ConstructValue(void *where) const
-{
-   fClass->New(where);
-}
-
 void ROOT::Experimental::RPairField::RPairDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    fClass->Destructor(objPtr, true /* dtorOnly */);
@@ -3979,11 +3974,6 @@ ROOT::Experimental::RTupleField::CloneImpl(std::string_view newName) const
    std::unique_ptr<RTupleField> result(new RTupleField(newName, std::move(items), fOffsets));
    result->fClass = fClass;
    return result;
-}
-
-void ROOT::Experimental::RTupleField::ConstructValue(void *where) const
-{
-   fClass->New(where);
 }
 
 void ROOT::Experimental::RTupleField::RTupleDeleter::operator()(void *objPtr, bool dtorOnly)

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -247,7 +247,7 @@ public:
    explicit RField(std::string_view name) : RSimpleField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() override = default;
+   ~RField() final = default;
 };
 
 TEST(RNTupleCompat, FutureColumnType)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -362,9 +362,7 @@ TEST(RNTuple, StdSet)
    EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
    EXPECT_EQ((sizeof(std::set<int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::set<int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::set<int64_t>)), field.GetAlignment());
-   // For type-erased set fields, we use `alignof(std::set<std::max_align_t>)` to set the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::set<int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::set<int64_t>)), otherField->GetAlignment());
 
    auto setSetField = RField<std::set<std::set<CustomStruct>>>("setSetField");
@@ -440,9 +438,7 @@ TEST(RNTuple, StdUnorderedSet)
    EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
    EXPECT_EQ((sizeof(std::unordered_set<int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::unordered_set<int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::unordered_set<int64_t>)), field.GetAlignment());
-   // For type-erased set fields, we use `alignof(std::set<std::max_align_t>)` to set the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_set<int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::unordered_set<int64_t>)), otherField->GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdunorderedset.root");
@@ -503,9 +499,7 @@ TEST(RNTuple, StdMultiSet)
    EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
    EXPECT_EQ((sizeof(std::multiset<int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::multiset<int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::multiset<int64_t>)), field.GetAlignment());
-   // For type-erased set fields, we use `alignof(std::set<std::max_align_t>)` to set the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::multiset<int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::multiset<int64_t>)), otherField->GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdmultiset.root");
@@ -550,9 +544,7 @@ TEST(RNTuple, StdUnorderedMultiSet)
    EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
    EXPECT_EQ((sizeof(std::unordered_multiset<int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::unordered_multiset<int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::unordered_multiset<int64_t>)), field.GetAlignment());
-   // For type-erased set fields, we use `alignof(std::set<std::max_align_t>)` to set the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_multiset<int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::unordered_multiset<int64_t>)), otherField->GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdmultiset.root");
@@ -597,13 +589,8 @@ TEST(RNTuple, StdMap)
    EXPECT_EQ(field.GetTypeName(), otherField->GetTypeName());
    EXPECT_EQ((sizeof(std::map<char, int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::map<char, int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::map<char, int64_t>)), field.GetAlignment());
-   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::map<char, int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::map<char, int64_t>)), otherField->GetAlignment());
-   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
-   // test should fail.
-   EXPECT_EQ((alignof(std::map<char, char>)), otherField->GetAlignment());
 
    auto mapMapField = RField<std::map<char, std::map<int, CustomStruct>>>("mapMapField");
    EXPECT_STREQ("std::map<char,std::map<std::int32_t,CustomStruct>>", mapMapField.GetTypeName().c_str());
@@ -699,13 +686,8 @@ TEST(RNTuple, StdUnorderedMap)
    EXPECT_STREQ(field.GetTypeName().c_str(), otherField->GetTypeName().c_str());
    EXPECT_EQ((sizeof(std::unordered_map<char, int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::unordered_map<char, int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::unordered_map<char, int64_t>)), field.GetAlignment());
-   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_map<char, int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::unordered_map<char, int64_t>)), otherField->GetAlignment());
-   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
-   // test should fail.
-   EXPECT_EQ((alignof(std::unordered_map<char, char>)), otherField->GetAlignment());
 
    EXPECT_THROW(RFieldBase::Create("myInvalidMap", "std::unordered_map<char>").Unwrap(), RException);
    EXPECT_THROW(RFieldBase::Create("myInvalidMap", "std::unordered_map<char, std::string, int>").Unwrap(), RException);
@@ -781,13 +763,8 @@ TEST(RNTuple, StdMultiMap)
    EXPECT_STREQ(field.GetTypeName().c_str(), otherField->GetTypeName().c_str());
    EXPECT_EQ((sizeof(std::multimap<char, int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::multimap<char, int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::multimap<char, int64_t>)), field.GetAlignment());
-   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::multimap<char, int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::multimap<char, int64_t>)), otherField->GetAlignment());
-   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
-   // test should fail.
-   EXPECT_EQ((alignof(std::multimap<char, char>)), otherField->GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdmultimap.root");
    {
@@ -839,13 +816,8 @@ TEST(RNTuple, StdUnorderedMultiMap)
    EXPECT_STREQ(field.GetTypeName().c_str(), otherField->GetTypeName().c_str());
    EXPECT_EQ((sizeof(std::unordered_multimap<char, int64_t>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::unordered_multimap<char, int64_t>)), otherField->GetValueSize());
-   EXPECT_EQ((alignof(std::unordered_multimap<char, int64_t>)), field.GetAlignment());
-   // For type-erased map fields, we use `alignof(std::map<std::max_align_t, std::max_align_t>)` to map the alignment,
-   // so the actual alignment may be smaller.
+   EXPECT_LE((alignof(std::unordered_multimap<char, int64_t>)), field.GetAlignment());
    EXPECT_LE((alignof(std::unordered_multimap<char, int64_t>)), otherField->GetAlignment());
-   // The assumption is that the alignment of inner items does not matter. If at any point there is a mismatch, this
-   // test should fail.
-   EXPECT_EQ((alignof(std::unordered_multimap<char, char>)), otherField->GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdmultimap.root");
    {
@@ -1550,8 +1522,8 @@ TEST(RNTuple, Optional)
    EXPECT_EQ(alignof(std::optional<Variant_t>), RField<std::optional<Variant_t>>("f").GetAlignment());
    EXPECT_EQ(sizeof(std::optional<std::string>), RField<std::optional<std::string>>("f").GetValueSize());
    EXPECT_EQ(alignof(std::optional<std::string>), RField<std::optional<std::string>>("f").GetAlignment());
-   EXPECT_EQ(sizeof(std::optional<Map_t>), RField<std::optional<Map_t>>("f").GetValueSize());
-   EXPECT_EQ(alignof(std::optional<Map_t>), RField<std::optional<Map_t>>("f").GetAlignment());
+   EXPECT_LE(sizeof(std::optional<Map_t>), RField<std::optional<Map_t>>("f").GetValueSize());
+   EXPECT_LE(alignof(std::optional<Map_t>), RField<std::optional<Map_t>>("f").GetAlignment());
 
    FileRaii fileGuard("test_ntuple_optional.root");
 


### PR DESCRIPTION
 * Mark (most) `RField` specializations as `final`; the only exception is `RField<std::array<ItemT, N>>` which is the base class of `RField<ItemT[N]>`.
 * Mark (most) overriden functions in the `RFieldBase` hierarchy as final; the only exception is `RSimpleField::GenerateColumns` which is overriden by `RRealField`.
 * Remove many duplicate implementations in the compile-time specialized classes: The reasoning is that we use the type-erased implementations with `RFieldBase::Create`, when reconstructing a model from disk, or when `Clone`ing a model. So if they are not performant, we have to fix them anyway. For completeness, there seems to be no performance change in the `iotools` benchmarks (with hot cache, to put emphasis on the RNTuple implementation).