### PR TITLE
[RF] Disable `rf615` tutorial test and `testLikelihoodJob` test that is prone to time out

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -15,14 +15,14 @@
 #include "RooFit/TestStatistics/LikelihoodGradientWrapper.h"
 #include "RooFit/TestStatistics/SharedOffset.h"
 
-#include "RooRandom.h"
-#include "RooWorkspace.h"
-#include "RooDataHist.h" // complete type in Binned test
 #include "RooCategory.h" // complete type in MultiBinnedConstraint test
-#include "RooHelpers.h"
-#include "RooMinimizer.h"
+#include "RooDataHist.h" // complete type in Binned test
 #include "RooFitResult.h"
 #include "RooGenericPdf.h"
+#include "RooHelpers.h"
+#include "RooMinimizer.h"
+#include "RooRandom.h"
+#include "RooWorkspace.h"
 #include "RooFit/TestStatistics/LikelihoodWrapper.h"
 #include "RooFit/TestStatistics/RooUnbinnedL.h"
 #include "RooFit/TestStatistics/RooRealL.h"
@@ -77,7 +77,8 @@ std::vector<double> getParamVals(RooAbsMinimizerFcn &fcn)
 
 } // namespace
 
-using RooFit::TestStatistics::LikelihoodWrapper;
+namespace RFMP = RooFit::MultiProcess;
+namespace RFTS = RooFit::TestStatistics;
 
 class Environment : public testing::Environment {
 public:
@@ -161,8 +162,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 
    values->assign(savedValues);
 
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
-                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+   RFTS::RooRealL likelihood("likelihood", "likelihood", std::make_unique<RFTS::RooUnbinnedL>(pdf, data.get()));
 
    // Convert to RooRealL to enter into minimizer
    RooMinimizer::Config cfg1;
@@ -211,8 +211,7 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
 
    // --------
 
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
-                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+   RFTS::RooRealL likelihood("likelihood", "likelihood", std::make_unique<RFTS::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
    cfg.parallelize = NWorkers;
    RooMinimizer m1(likelihood, cfg);
@@ -282,8 +281,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 
    // --------
 
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
-                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+   RFTS::RooRealL likelihood("likelihood", "likelihood", std::make_unique<RFTS::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg1;
    cfg1.parallelize = NWorkers;
    RooMinimizer m1(likelihood, cfg1);
@@ -402,12 +400,10 @@ TEST(SimBinnedConstrainedTestBasic, BasicParameters)
 
    // dummy offsets (normally they are shared with other objects):
    SharedOffset shared_offset;
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial,
-                                           RooFit::TestStatistics::NLLFactory{*pdf, *data}
-                                              .GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")})
-                                              .build(),
-                                           std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>(),
-                                           shared_offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(
+      RFTS::LikelihoodMode::serial,
+      RFTS::NLLFactory{*pdf, *data}.GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}).build(),
+      std::make_unique<RFTS::WrapperCalculationCleanFlags>(), shared_offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -426,9 +422,8 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    // This is a simultaneous fit, so its likelihood has multiple components. In that case, splitting over
    // components is always preferable, since it is more precise, due to component offsets matching
    // the (-log) function values better.
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1;
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
-      99999; // just a high number, so every component is a task
+   RFMP::Config::LikelihoodJob::defaultNEventTasks = 1;
+   RFMP::Config::LikelihoodJob::defaultNComponentTasks = 99999; // just a high number, so every component is a task
 
    std::unique_ptr<RooWorkspace> wPtr = makeSimBinnedConstrainedWorkspace();
    auto &w = *wPtr;
@@ -500,10 +495,8 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    EXPECT_FLOAT_EQ(mu_sig_nominal.error, mu_sig_GradientJob.error);
 
    // reset static variables to automatic
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-      RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
-      RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+   RFMP::Config::LikelihoodJob::defaultNEventTasks = RFMP::Config::LikelihoodJob::automaticNEventTasks;
+   RFMP::Config::LikelihoodJob::defaultNComponentTasks = RFMP::Config::LikelihoodJob::automaticNComponentTasks;
 }
 
 INSTANTIATE_TEST_SUITE_P(LikelihoodGradientJob, SimBinnedConstrainedTest, testing::Values(false, true),
@@ -556,8 +549,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
 
    values->assign(savedValues);
 
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
-                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+   RFTS::RooRealL likelihood("likelihood", "likelihood", std::make_unique<RFTS::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
    cfg.parallelize = NWorkers;
    cfg.enableParallelDescent = true;
@@ -612,19 +604,16 @@ class LikelihoodGradientJobErrorTest
 
       // we want to split only over components so we can test component-offsets precisely
       // (event-offsets give more variation)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-         1; // just one events task (i.e. don't split over events)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      RFMP::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
+      RFMP::Config::LikelihoodJob::defaultNComponentTasks =
          1000000; // assuming components < 1000000: each component = 1 separate task
    }
 
    void TearDown() override
    {
       // reset static variables to automatic
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-         RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
-         RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+      RFMP::Config::LikelihoodJob::defaultNEventTasks = RFMP::Config::LikelihoodJob::automaticNEventTasks;
+      RFMP::Config::LikelihoodJob::defaultNComponentTasks = RFMP::Config::LikelihoodJob::automaticNComponentTasks;
    }
 
 protected:
@@ -791,19 +780,16 @@ class LikelihoodGradientJobBinnedErrorTest : public ::testing::TestWithParam<std
 
       // we want to split only over components so we can test component-offsets precisely
       // (event-offsets give more variation)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-         1; // just one events task (i.e. don't split over events)
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      RFMP::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
+      RFMP::Config::LikelihoodJob::defaultNComponentTasks =
          1000000; // assuming components < 1000000: each component = 1 separate task
    }
 
    void TearDown() override
    {
       // reset static variables to automatic
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-         RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
-      RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
-         RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+      RFMP::Config::LikelihoodJob::defaultNEventTasks = RFMP::Config::LikelihoodJob::automaticNEventTasks;
+      RFMP::Config::LikelihoodJob::defaultNComponentTasks = RFMP::Config::LikelihoodJob::automaticNComponentTasks;
    }
 
 protected:
@@ -984,9 +970,8 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
    // set up minimizers
    RooMinimizer m_vanilla(*nll_vanilla);
    // we want to split only over components so we can test component-offsets
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-      1; // just one events task (i.e. don't split over events)
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+   RFMP::Config::LikelihoodJob::defaultNEventTasks = 1; // just one events task (i.e. don't split over events)
+   RFMP::Config::LikelihoodJob::defaultNComponentTasks =
       1000000; // assuming components < 1000000: each component = 1 separate task
    RooMinimizer::Config cfg;
    cfg.parallelize = 1;
@@ -995,12 +980,11 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
    RooMinimizer m_modularL(*nll_modularL, cfg);
 
    // now use these minimizers to build the corresponding external RooAbsMinimizerFcns
-   auto nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll_modularL.get());
-   RooFit::TestStatistics::MinuitFcnGrad modularL_fcn(
-      nll_real->getRooAbsL(), &m_modularL, m_modularL.fitter()->Config().ParamsSettings(),
-      cfg.enableParallelDescent ? RooFit::TestStatistics::LikelihoodMode::multiprocess
-                                : RooFit::TestStatistics::LikelihoodMode::serial,
-      RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   auto nll_real = dynamic_cast<RFTS::RooRealL *>(nll_modularL.get());
+   RFTS::MinuitFcnGrad modularL_fcn(nll_real->getRooAbsL(), &m_modularL, m_modularL.fitter()->Config().ParamsSettings(),
+                                    cfg.enableParallelDescent ? RFTS::LikelihoodMode::multiprocess
+                                                              : RFTS::LikelihoodMode::serial,
+                                    RFTS::LikelihoodGradientMode::multiprocess);
    RooMinimizerFcn vanilla_fcn(nll_vanilla.get(), &m_vanilla);
 
    EXPECT_EQ(vanilla_fcn(getParamVals(vanilla_fcn).data()), modularL_fcn(getParamVals(modularL_fcn).data()));
@@ -1009,8 +993,6 @@ TEST(MinuitFcnGrad, DISABLED_CompareToRooMinimizerFcn)
    EXPECT_EQ(vanilla_fcn(getParamVals(modularL_fcn).data()), modularL_fcn(getParamVals(modularL_fcn).data()));
 
    // reset static variables to automatic
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
-      RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
-   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
-      RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
+   RFMP::Config::LikelihoodJob::defaultNEventTasks = RFMP::Config::LikelihoodJob::automaticNEventTasks;
+   RFMP::Config::LikelihoodJob::defaultNComponentTasks = RFMP::Config::LikelihoodJob::automaticNComponentTasks;
 }

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -155,7 +155,10 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussian1DSelectedParameterValues)
    RFMP::Config::LikelihoodJob::defaultNComponentTasks = RFMP::Config::LikelihoodJob::automaticNComponentTasks;
 }
 
-TEST_F(LikelihoodJobTest, UnbinnedGaussian1DTwice)
+// This test was disabled because it was occasionally timing out on the CI.
+// Evaluating the same likelihood twice should not be a problem anymore, and if
+// it would be it would also manifest in other tests.
+TEST_F(LikelihoodJobTest, DISABLED_UnbinnedGaussian1DTwice)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
    likelihood = RFTS::buildLikelihood(pdf, data.get());

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -35,7 +35,7 @@
 #include "gtest/gtest.h"
 #include "../test_lib.h" // generate_1D_gaussian_pdf_nll
 
-using RooFit::TestStatistics::LikelihoodWrapper;
+namespace RFTS = RooFit::TestStatistics;
 
 class Environment : public testing::Environment {
 public:
@@ -62,7 +62,7 @@ protected:
    void SetUp() override
    {
       RooRandom::randomGenerator()->SetSeed(seed);
-      clean_flags = std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
+      clean_flags = std::make_unique<RFTS::WrapperCalculationCleanFlags>();
    }
 
    std::size_t seed = 23;
@@ -71,8 +71,8 @@ protected:
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
    std::unique_ptr<RooAbsData> data;
-   std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood;
-   std::shared_ptr<RooFit::TestStatistics::WrapperCalculationCleanFlags> clean_flags;
+   std::shared_ptr<RFTS::RooAbsL> likelihood;
+   std::shared_ptr<RFTS::WrapperCalculationCleanFlags> clean_flags;
 };
 
 class LikelihoodSerialBinnedDatasetTest : public LikelihoodSerialTest {
@@ -104,11 +104,10 @@ protected:
 TEST_F(LikelihoodSerialTest, UnbinnedGaussian1D)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -124,11 +123,10 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
    unsigned int N = 4;
 
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000, RooFit::EvalBackend::Legacy());
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -145,11 +143,10 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -174,11 +171,10 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
    int extended = 2;
    RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll_manual.getVal();
 
@@ -225,11 +221,10 @@ TEST_F(LikelihoodSerialTest, SimBinned)
 
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -275,11 +270,10 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.GlobalObservables(*w.var("alpha_bkg_obs")).build();
+   likelihood = RFTS::NLLFactory{*pdf, *data}.GlobalObservables(*w.var("alpha_bkg_obs")).build();
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -305,11 +299,10 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -339,11 +332,10 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
 
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
+   likelihood = RFTS::buildLikelihood(pdf, data.get());
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -410,13 +402,11 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
-                   .GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")})
-                   .build();
+   likelihood =
+      RFTS::NLLFactory{*pdf, *data}.GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}).build();
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -441,18 +431,17 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
+   likelihood = RFTS::NLLFactory{*pdf, *data}
                    .ConstrainedParameters(*w.var("alpha_bkg_A"))
                    .GlobalObservables(*w.var("alpha_bkg_obs_B"))
                    .build();
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
    nll_ts->enableOffsetting(true);
 
    nll_ts->evaluate();
-   // The RooFit::TestStatistics classes used for minimization (RooAbsL and Wrapper derivatives) will return offset
+   // The RFTS classes used for minimization (RooAbsL and Wrapper derivatives) will return offset
    // values, whereas RooNLLVar::getVal will always return the non-offset value, since that is the "actual" likelihood
    // value. RooRealL will also give the non-offset value, so that can be directly compared to the RooNLLVar::getVal
    // result (the nll0 vs nll2 comparison below). To compare to the raw RooAbsL/Wrapper value nll1, however, we need to
@@ -468,7 +457,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    EXPECT_FALSE(nll_ts_offset.Sum() == 0);
 
    // also check against RooRealL value
-   RooFit::TestStatistics::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
+   RFTS::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
 
    auto nll2 = nll_real.getVal();
 
@@ -486,11 +475,10 @@ TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000, backend);
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.EvalBackend(backend).build();
+   likelihood = RFTS::NLLFactory{*pdf, *data}.EvalBackend(backend).build();
    // dummy offsets (normally they are shared with other objects):
    SharedOffset offset;
-   auto nll_ts =
-      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
+   auto nll_ts = RFTS::LikelihoodWrapper::create(RFTS::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -88,8 +88,14 @@ if(MSVC AND NOT win_broken_tests)
   list(APPEND dataframe_veto dataframe/df037_TTreeEventMatching.C)
   list(APPEND dataframe_veto dataframe/df037_TTreeEventMatching.py)
   # The RooFit SBI tutorials fail on Windows for unknown reasons
-  list(APPEND roofit_veto roofit/rf615_simulation_based_inference.py roofit/rf617_simulation_based_inference_multidimensional.py)
+  list(APPEND roofit_veto roofit/rf617_simulation_based_inference_multidimensional.py)
 endif()
+
+# TODO: fix the problem and re-enable the tutorial test. The rf615 tutorial
+# occasionally fails on cleanup on different platforms, hinting to a PyROOT
+# issue. We disable the rf617 tutorial for now. as the covered RooFit
+# functionality is also covered by rf617 (the multidimensional case).
+list(APPEND roofit_veto roofit/rf615_simulation_based_inference.py)
 
 if (NOT dataframe)
     # RDataFrame


### PR DESCRIPTION
The rf615 tutorial occasionally fails on cleanup on different platforms, hinting to a PyROOT issue. We disable the rf617 tutorial for now. as the covered RooFit functionality is also covered by rf617 (the multidimensional case).