### PR TITLE
[ntuple] streamline field's CloneImpl() implementation

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -362,11 +362,13 @@ class RRealField : public RSimpleField<T> {
    double fValueMax = std::numeric_limits<T>::max();
 
 protected:
-   void OnClone(RRealField<T> &cloned) const
+   /// Called by derived fields' CloneImpl()
+   RRealField(std::string_view name, const RRealField &source)
+      : RSimpleField<T>(name, source.GetTypeName()),
+        fBitWidth(source.fBitWidth),
+        fValueMin(source.fValueMin),
+        fValueMax(source.fValueMax)
    {
-      cloned.fBitWidth = fBitWidth;
-      cloned.fValueMin = fValueMin;
-      cloned.fValueMax = fValueMax;
    }
 
    void GenerateColumns() final
@@ -474,11 +476,11 @@ template <>
 class RField<float> final : public RRealField<float> {
    const RColumnRepresentations &GetColumnRepresentations() const final;
 
+   RField(std::string_view name, const RField &source) : RRealField<float>(name, source) {}
+
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      auto cloned = std::make_unique<RField>(newName);
-      OnClone(*cloned);
-      return cloned;
+      return std::unique_ptr<RField>(new RField(newName, *this));
    }
 
 public:
@@ -493,11 +495,11 @@ template <>
 class RField<double> final : public RRealField<double> {
    const RColumnRepresentations &GetColumnRepresentations() const final;
 
+   RField(std::string_view name, const RField &source) : RRealField<double>(name, source) {}
+
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      auto cloned = std::make_unique<RField>(newName);
-      OnClone(*cloned);
-      return cloned;
+      return std::unique_ptr<RField>(new RField(newName, *this));
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -53,6 +53,8 @@ private:
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
+   RRecordField(std::string_view name, const RRecordField &source); // Used by CloneImpl()
+
 protected:
    std::size_t fMaxAlignment = 1;
    std::size_t fSize = 0;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -366,6 +366,8 @@ private:
    static std::uint8_t GetTag(const void *variantPtr, std::size_t tagOffset);
    static void SetTag(void *variantPtr, std::size_t tagOffset, std::uint8_t tag);
 
+   RVariantField(std::string_view name, const RVariantField &source); // Used by CloneImpl()
+
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 


### PR DESCRIPTION
Non-trivial clones go through a special constructor that resembles a copy constructor.
