### PR TITLE
[CI] S3 upload failures should not cancel the build

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -151,7 +151,11 @@ def main():
     # We also want to upload any successful build, even if it fails testing
     # later on.
     if not pull_request and not args.incremental and not args.coverage:
-        archive_and_upload(yyyy_mm_dd, obj_prefix)
+        try:
+            archive_and_upload(yyyy_mm_dd, obj_prefix)
+        except Exception as err:
+            build_utils.print_warning("failed to upload artifact:", err)
+
 
     if args.binaries:
         create_binaries(args.buildtype)

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -408,7 +408,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready # KEEP IN SYNC WITH env key below
-      options: --security-opt label=disable --rm ${{ matrix.property == 'gpu' && '--device nvidia.com/gpu=all' || '' }} # KEEP IN SYNC WITH env key below
+      options: --security-opt label=disable --rm ${{ matrix.property == 'gpu' && '--device nvidia.com/gpu=all -v /etc/resolv_container.conf:/etc/resolv.conf:ro ' || '' }} # KEEP IN SYNC WITH env key below
       volumes:
         - ${{ matrix.image }}_ccache_volume:/github/home/.cache/ccache
       env:
@@ -428,6 +428,8 @@ jobs:
         run: |
           ccache -p || true
           ccache -s || true
+      - name: Print resolv.conf
+        run: cat /etc/resolv.conf
 
       - name: Set up Python Virtual Env
         # if the `if` expr is false, `if` still has exit code 0.

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -408,7 +408,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready # KEEP IN SYNC WITH env key below
-      options: --security-opt label=disable --rm ${{ matrix.property == 'gpu' && '--device nvidia.com/gpu=all -v /etc/resolv_container.conf:/etc/resolv.conf:ro ' || '' }} # KEEP IN SYNC WITH env key below
+      options: --security-opt label=disable --rm ${{ matrix.property == 'gpu' && '--device nvidia.com/gpu=all -v /etc/resolv_container.conf:/etc/resolv.conf:ro --log-level=debug' || '' }} # KEEP IN SYNC WITH env key below
       volumes:
         - ${{ matrix.image }}_ccache_volume:/github/home/.cache/ccache
       env:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -391,10 +391,10 @@ jobs:
             property: clang
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
           # Disabled until DNS problems in containers are solved
-         #- image: ubuntu2404-cuda
-         #  is_special: true
-         #  property: gpu
-         #  extra-runs-on: gpu
+          - image: ubuntu2404-cuda
+            is_special: true
+            property: gpu
+            extra-runs-on: gpu
 
     runs-on:
       - self-hosted


### PR DESCRIPTION
Try splitting the build and the S3 upload step. These might not need to be intertwined.
