### PR TITLE
Make `requirements.txt` resolvable in Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,18 +5,18 @@ numpy
 pandas
 
 # TMVA: SOFIE
-graph_nets
+dm-sonnet ; python_version < "3.13"  # used for GNNs, not available for Python 3.13 yet
+graph_nets ; python_version < "3.13" # not available for Python 3.13 yet
 onnx
-dm-sonnet # used for GNNs
 
 # TMVA: PyMVA interfaces
 scikit-learn
 tensorflow<2.16 ; python_version < "3.12"
-torch<2.5
+torch<2.5 ; python_version < "3.13" # no torch version that fullfills version constraint available for Python 3.13
 xgboost
 
 # PyROOT: ROOT.Numba.Declare decorator
-numba>=0.48
+numba>=0.48 ; python_version < "3.13" # no numba available for Python 3.13 yet
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel


### PR DESCRIPTION
Some packages that we use in some unit tests and tutorials don't support Python 3.13 yet. They should be listed conditionally on the Python version to make the environment resolve.

This is required for building the Fedora 41 CI images.

Tested with Python 3.13 on Arch Linux.