### PR TITLE
[skip-ci][NFC][ntuple] document default RNTupleWriteOptions

### DIFF
--- a/tree/ntuple/v7/doc/BinaryFormatSpecification.md
+++ b/tree/ntuple/v7/doc/BinaryFormatSpecification.md
@@ -1033,13 +1033,12 @@ The limits refer to a single RNTuple and do not consider combinations/joins such
 
 ## Defaults
 
-This section summarizes default settings of
-[`RNTupleWriteOptions`](https://github.com/root-project/root/blob/96989396d03d17b877ecc3d7eb7293109d24e5cf/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx#L61-L75).
+This section summarizes default settings of `RNTupleWriteOptions`:
 
 | Default                                | Value                        |
 |----------------------------------------|------------------------------|
-| Approximate Zipped Cluster             | 50MB                         |
-| Max Unzipped Cluster                   | 500MB                        |
+| Approximate Zipped Cluster             | 100 MB                       |
+| Max Unzipped Cluster                   | 1 GiB                        |
 | Max Unzipped Page                      | 1 MiB                        |
 
 ## Glossary

--- a/tree/ntuple/v7/doc/BinaryFormatSpecification.md
+++ b/tree/ntuple/v7/doc/BinaryFormatSpecification.md
@@ -1031,6 +1031,17 @@ The limits refer to a single RNTuple and do not consider combinations/joins such
 | Maximum string length (meta-data)              | 4GB                          | String encoding                                        |
 | Maximum RBlob size                             | 128 PiB                      | 1GiB / 8B * 1GiB (with maxKeySize=1GiB, offsetSize=8B) |
 
+## Defaults
+
+This section summarizes default settings of
+[`RNTupleWriteOptions`](https://github.com/root-project/root/blob/96989396d03d17b877ecc3d7eb7293109d24e5cf/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx#L61-L75).
+
+| Default                                | Value                        |
+|----------------------------------------|------------------------------|
+| Approximate Zipped Cluster             | 50MB                         |
+| Max Unzipped Cluster                   | 500MB                        |
+| Max Unzipped Page                      | 1MB                          |
+
 ## Glossary
 
 ### Anchor

--- a/tree/ntuple/v7/doc/BinaryFormatSpecification.md
+++ b/tree/ntuple/v7/doc/BinaryFormatSpecification.md
@@ -1033,13 +1033,12 @@ The limits refer to a single RNTuple and do not consider combinations/joins such
 
 ## Defaults
 
-This section summarizes default settings of
-[`RNTupleWriteOptions`](https://github.com/root-project/root/blob/96989396d03d17b877ecc3d7eb7293109d24e5cf/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx#L61-L75).
+This section summarizes default settings of `RNTupleWriteOptions`.
 
 | Default                                | Value                        |
 |----------------------------------------|------------------------------|
-| Approximate Zipped Cluster             | 50MB                         |
-| Max Unzipped Cluster                   | 500MB                        |
+| Approximate Zipped Cluster             | 100 MB                       |
+| Max Unzipped Cluster                   | 1 GiB                        |
 | Max Unzipped Page                      | 1 MiB                        |
 
 ## Glossary

--- a/tree/ntuple/v7/doc/BinaryFormatSpecification.md
+++ b/tree/ntuple/v7/doc/BinaryFormatSpecification.md
@@ -1033,12 +1033,13 @@ The limits refer to a single RNTuple and do not consider combinations/joins such
 
 ## Defaults
 
-This section summarizes default settings of `RNTupleWriteOptions`:
+This section summarizes default settings of
+[`RNTupleWriteOptions`](https://github.com/root-project/root/blob/96989396d03d17b877ecc3d7eb7293109d24e5cf/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx#L61-L75).
 
 | Default                                | Value                        |
 |----------------------------------------|------------------------------|
-| Approximate Zipped Cluster             | 100 MB                       |
-| Max Unzipped Cluster                   | 1 GiB                        |
+| Approximate Zipped Cluster             | 50MB                         |
+| Max Unzipped Cluster                   | 500MB                        |
 | Max Unzipped Page                      | 1 MiB                        |
 
 ## Glossary

--- a/tree/ntuple/v7/doc/BinaryFormatSpecification.md
+++ b/tree/ntuple/v7/doc/BinaryFormatSpecification.md
@@ -1040,7 +1040,7 @@ This section summarizes default settings of
 |----------------------------------------|------------------------------|
 | Approximate Zipped Cluster             | 50MB                         |
 | Max Unzipped Cluster                   | 500MB                        |
-| Max Unzipped Page                      | 1MB                          |
+| Max Unzipped Page                      | 1 MiB                        |
 
 ## Glossary
 


### PR DESCRIPTION
# This Pull request:

document the default values in `RNTupleWriteOptions` next to the `Limits` section for reader's convenience.


## Checklist:

- [x] updated the docs (if necessary)

