### PR TITLE
[civetweb] Don't include `<openssl/engine.h>`

### DIFF
--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -1744,7 +1744,6 @@ typedef struct SSL_CTX SSL_CTX;
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
 #include <openssl/dh.h>
-#include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
We don't use it in our configuration of civetweb, and it will be removed in upcoming versions of Fedora and RHEL:

https://github.com/dotnet/runtime/issues/104775#issuecomment-2229857943