### PR TITLE
[ntuple] allow reading a RNTuple with an unknown locator type

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -122,7 +122,8 @@ public:
       std::uint64_t GetHeaderXxHash3() const { return fHeaderXxHash3; }
       /// Map an in-memory field ID to its on-disk counterpart. It is allowed to call this function multiple times for
       /// the same `memId`, in which case the return value is the on-disk ID assigned on the first call.
-      DescriptorId_t MapFieldId(DescriptorId_t memId) {
+      DescriptorId_t MapFieldId(DescriptorId_t memId)
+      {
          auto onDiskId = fOnDisk2MemFieldIDs.size();
          const auto &p = fMem2OnDiskFieldIDs.try_emplace(memId, onDiskId);
          if (p.second)
@@ -142,7 +143,8 @@ public:
             fOnDisk2MemColumnIDs.push_back(memId);
          return (*p.first).second;
       }
-      DescriptorId_t MapClusterId(DescriptorId_t memId) {
+      DescriptorId_t MapClusterId(DescriptorId_t memId)
+      {
          auto onDiskId = fOnDisk2MemClusterIDs.size();
          fMem2OnDiskClusterIDs[memId] = onDiskId;
          fOnDisk2MemClusterIDs.push_back(memId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -89,15 +89,7 @@ enum class EColumnType {
  * Leaf fields contain just data, collection fields resolve to offset columns, record fields have no
  * materialization on the primitive column layer.
  */
-enum ENTupleStructure : std::uint16_t {
-   kInvalid,
-   kLeaf,
-   kCollection,
-   kRecord,
-   kVariant,
-   kUnsplit,
-   kUnknown
-};
+enum ENTupleStructure : std::uint16_t { kInvalid, kLeaf, kCollection, kRecord, kVariant, kUnsplit, kUnknown };
 
 /// Integer type long enough to hold the maximum number of entries in a column
 using NTupleSize_t = std::uint64_t;
@@ -231,7 +223,6 @@ struct RNTupleLocator {
       kTypeFile = 0x00,
       kTypeDAOS = 0x02,
 
-      kTypeTestLocator = 0x7e, // used for unit tests
       kLastSerializableType = 0x7f,
       kTypePageZero = kLastSerializableType + 1,
       kTypeUnknown,
@@ -277,6 +268,10 @@ auto MakeAliasedSharedPtr(T *rawPtr)
 
 inline constexpr ENTupleStructure kTestFutureFieldStructure =
    static_cast<ENTupleStructure>(std::numeric_limits<std::underlying_type_t<ENTupleStructure>>::max() - 1);
+
+inline constexpr RNTupleLocator::ELocatorType kTestLocatorType = static_cast<RNTupleLocator::ELocatorType>(0x7e);
+static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializableType);
+
 } // namespace Internal
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -231,8 +231,10 @@ struct RNTupleLocator {
       kTypeFile = 0x00,
       kTypeDAOS = 0x02,
 
+      kTypeTestLocator = 0x7e, // used for unit tests
       kLastSerializableType = 0x7f,
       kTypePageZero = kLastSerializableType + 1,
+      kTypeUnknown,
    };
 
    std::uint64_t fBytesOnStorage = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -87,7 +87,7 @@ private:
 protected:
    using RPagePersistentSink::InitImpl;
    void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
-   RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
+   RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) override;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator>

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1051,12 +1051,14 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeLocator(const RNTupleL
       size += SerializeLocatorPayloadObject64(locator, payloadp);
       locatorType = 0x02;
       break;
-   case RNTupleLocator::kTypeTestLocator:
-      // For the testing locator, use the same payload as Object64. We're not gonna really read it back anyway.
-      size += SerializeLocatorPayloadObject64(locator, payloadp);
-      locatorType = 0x7e;
-      break;
-   default: throw RException(R__FAIL("locator has unknown type"));
+   default:
+      if (locator.fType == kTestLocatorType) {
+         // For the testing locator, use the same payload as Object64. We're not gonna really read it back anyway.
+         size += SerializeLocatorPayloadObject64(locator, payloadp);
+         locatorType = 0x7e;
+      } else {
+         throw RException(R__FAIL("locator has unknown type"));
+      }
    }
    std::int32_t head = sizeof(std::int32_t) + size;
    head |= locator.fReserved << 16;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1051,6 +1051,11 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeLocator(const RNTupleL
       size += SerializeLocatorPayloadObject64(locator, payloadp);
       locatorType = 0x02;
       break;
+   case RNTupleLocator::kTypeTestLocator:
+      // For the testing locator, use the same payload as Object64. We're not gonna really read it back anyway.
+      size += SerializeLocatorPayloadObject64(locator, payloadp);
+      locatorType = 0x7e;
+      break;
    default: throw RException(R__FAIL("locator has unknown type"));
    }
    std::int32_t head = sizeof(std::int32_t) + size;
@@ -1090,7 +1095,7 @@ RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
          locator.fType = RNTupleLocator::kTypeDAOS;
          DeserializeLocatorPayloadObject64(bytes, payloadSize, locator);
          break;
-      default: return R__FAIL("unsupported locator type: " + std::to_string(type));
+      default: locator.fType = RNTupleLocator::kTypeUnknown;
       }
       bytes += payloadSize;
    } else {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -343,6 +343,9 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 
+   if (clusterInfo.fPageInfo.fLocator.fType == RNTupleLocator::kTypeUnknown)
+      throw RException(R__FAIL("tried to read a page with an unknown locator"));
+
    return LoadPageImpl(columnHandle, clusterInfo, idxInCluster);
 }
 
@@ -371,6 +374,9 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
       clusterInfo.fColumnOffset = columnRange.fFirstElementIndex;
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
+
+   if (clusterInfo.fPageInfo.fLocator.fType == RNTupleLocator::kTypeUnknown)
+      throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
    return LoadPageImpl(columnHandle, clusterInfo, idxInCluster);
 }

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -447,7 +447,7 @@ class RPageSinkTestLocator : public RPageSinkFile {
       auto payload = ROOT::Experimental::RNTupleLocatorObject64{0x420};
       RNTupleLocator result;
       result.fPosition = payload;
-      result.fType = RNTupleLocator::kTypeTestLocator;
+      result.fType = ROOT::Experimental::Internal::kTestLocatorType;
       result.fBytesOnStorage = sealedPage.GetDataSize();
       return result;
    }

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -469,14 +469,11 @@ TEST(RNTupleCompat, UnknownLocatorType)
    // read back the ntuple, its descriptor and reconstruct the model (but not read pages)
 
    FileRaii fileGuard("test_ntuple_compat_future_locator.root");
-   fileGuard.PreserveFile();
 
    {
       auto model = RNTupleModel::Create();
       auto fieldPt = model->MakeField<float>("pt", 14.0);
       auto wopts = RNTupleWriteOptions();
-      wopts.SetCompression(0);
-      wopts.SetEnablePageChecksums(false);
       auto sink = std::make_unique<RPageSinkTestLocator>("ntpl", fileGuard.GetPath(), wopts);
       auto writer = CreateRNTupleWriter(std::move(model), std::move(sink));
       *fieldPt = 33.f;

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -87,12 +87,8 @@ TEST(RNTuple, SerializeFieldStructure)
    }
 
    RNTupleSerializer::SerializeUInt16(5000, buffer);
-   try {
-      RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
-      FAIL() << "unexpected on disk field structure value should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("unexpected on-disk field structure value"));
-   }
+   RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
+   EXPECT_EQ(structure, ENTupleStructure::kUnknown);
 
    for (int i = 0; i < static_cast<int>(ENTupleStructure::kInvalid); ++i) {
       RNTupleSerializer::SerializeFieldStructure(static_cast<ENTupleStructure>(i), buffer);
@@ -401,12 +397,8 @@ TEST(RNTuple, SerializeLocator)
 #else
    *head = (0x3 << 24) | *head;
 #endif
-   try {
-      RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap();
-      FAIL() << "unsupported locator type should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("unsupported locator type"));
-   }
+   RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap();
+   EXPECT_EQ(locator.fType, RNTupleLocator::kTypeUnknown);
 }
 
 TEST(RNTuple, SerializeEnvelopeLink)

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -87,8 +87,12 @@ TEST(RNTuple, SerializeFieldStructure)
    }
 
    RNTupleSerializer::SerializeUInt16(5000, buffer);
-   RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
-   EXPECT_EQ(structure, ENTupleStructure::kUnknown);
+   try {
+      RNTupleSerializer::DeserializeFieldStructure(buffer, structure).Unwrap();
+      FAIL() << "unexpected on disk field structure value should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("unexpected on-disk field structure value"));
+   }
 
    for (int i = 0; i < static_cast<int>(ENTupleStructure::kInvalid); ++i) {
       RNTupleSerializer::SerializeFieldStructure(static_cast<ENTupleStructure>(i), buffer);


### PR DESCRIPTION
# This Pull request:
allows loading a RNTuple containing locators of unknown types. Rather than failing upon reading the RNTuple, we will throw an exception only when attempting to load a page containing an unknown locator type. This allows reconstructing the model and reading the descriptor.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


