### PR TITLE
[ntuple] Fixes and cleanups for `RRecordField` and subclasses

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -46,7 +46,7 @@ private:
       std::vector<std::size_t> fOffsets;
 
    public:
-      RRecordDeleter(std::vector<std::unique_ptr<RDeleter>> &itemDeleters, const std::vector<std::size_t> &offsets)
+      RRecordDeleter(std::vector<std::unique_ptr<RDeleter>> itemDeleters, const std::vector<std::size_t> &offsets)
          : fItemDeleters(std::move(itemDeleters)), fOffsets(offsets)
       {
       }
@@ -73,10 +73,10 @@ protected:
 
    RRecordField(std::string_view fieldName, std::string_view typeName);
 
-   void AttachItemFields(std::vector<std::unique_ptr<RFieldBase>> &&itemFields);
+   void AttachItemFields(std::vector<std::unique_ptr<RFieldBase>> itemFields);
 
    template <std::size_t N>
-   void AttachItemFields(std::array<std::unique_ptr<RFieldBase>, N> &&itemFields)
+   void AttachItemFields(std::array<std::unique_ptr<RFieldBase>, N> itemFields)
    {
       fTraits |= kTraitTrivialType;
       for (unsigned i = 0; i < N; ++i) {
@@ -90,8 +90,7 @@ protected:
 public:
    /// Construct a RRecordField based on a vector of child fields. The ownership of the child fields is transferred
    /// to the RRecordField instance.
-   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &&itemFields);
-   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &itemFields);
+   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields);
    RRecordField(RRecordField &&other) = default;
    RRecordField &operator=(RRecordField &&other) = default;
    ~RRecordField() override = default;
@@ -114,11 +113,11 @@ private:
    static std::string GetTypeList(const std::array<std::unique_ptr<RFieldBase>, 2> &itemFields);
 
 protected:
-   RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields,
+   RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> itemFields,
               const std::array<std::size_t, 2> &offsets);
 
 public:
-   RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> &itemFields);
+   RPairField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, 2> itemFields);
    RPairField(RPairField &&other) = default;
    RPairField &operator=(RPairField &&other) = default;
    ~RPairField() override = default;
@@ -165,11 +164,11 @@ private:
    static std::string GetTypeList(const std::vector<std::unique_ptr<RFieldBase>> &itemFields);
 
 protected:
-   RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &&itemFields,
+   RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
                const std::vector<std::size_t> &offsets);
 
 public:
-   RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &itemFields);
+   RTupleField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields);
    RTupleField(RTupleField &&other) = default;
    RTupleField &operator=(RTupleField &&other) = default;
    ~RTupleField() override = default;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -147,13 +147,11 @@ private:
 
 public:
    static std::string TypeName() { return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">"; }
-   explicit RField(std::string_view name, std::array<std::unique_ptr<RFieldBase>, 2> &&itemFields)
-      : RPairField(name, std::move(itemFields), BuildItemOffsets())
+   explicit RField(std::string_view name) : RPairField(name, BuildItemFields<T1, T2>(), BuildItemOffsets())
    {
       fMaxAlignment = std::max(alignof(T1), alignof(T2));
       fSize = sizeof(ContainerT);
    }
-   explicit RField(std::string_view name) : RField(name, BuildItemFields<T1, T2>()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
@@ -227,13 +225,12 @@ private:
 
 public:
    static std::string TypeName() { return "std::tuple<" + BuildItemTypes<ItemTs...>() + ">"; }
-   explicit RField(std::string_view name, std::vector<std::unique_ptr<RFieldBase>> &&itemFields)
-      : RTupleField(name, std::move(itemFields), BuildItemOffsets<ItemTs...>())
+   explicit RField(std::string_view name)
+      : RTupleField(name, BuildItemFields<ItemTs...>(), BuildItemOffsets<ItemTs...>())
    {
       fMaxAlignment = std::max({alignof(ItemTs)...});
       fSize = sizeof(ContainerT);
    }
-   explicit RField(std::string_view name) : RField(name, BuildItemFields<ItemTs...>()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() final = default;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -128,10 +128,9 @@ class RField<std::pair<T1, T2>> final : public RPairField {
    using ContainerT = typename std::pair<T1, T2>;
 
 private:
-   template <typename Ty1, typename Ty2>
    static std::array<std::unique_ptr<RFieldBase>, 2> BuildItemFields()
    {
-      return {std::make_unique<RField<Ty1>>("_0"), std::make_unique<RField<Ty2>>("_1")};
+      return {std::make_unique<RField<T1>>("_0"), std::make_unique<RField<T2>>("_1")};
    }
 
    static std::array<std::size_t, 2> BuildItemOffsets()
@@ -144,7 +143,7 @@ private:
 
 public:
    static std::string TypeName() { return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">"; }
-   explicit RField(std::string_view name) : RPairField(name, BuildItemFields<T1, T2>(), BuildItemOffsets())
+   explicit RField(std::string_view name) : RPairField(name, BuildItemFields(), BuildItemOffsets())
    {
       fMaxAlignment = std::max(alignof(T1), alignof(T2));
       fSize = sizeof(ContainerT);
@@ -195,11 +194,10 @@ private:
       if constexpr (sizeof...(TailTs) > 0)
          _BuildItemFields<TailTs...>(itemFields, index + 1);
    }
-   template <typename... Ts>
    static std::vector<std::unique_ptr<RFieldBase>> BuildItemFields()
    {
       std::vector<std::unique_ptr<RFieldBase>> result;
-      _BuildItemFields<Ts...>(result);
+      _BuildItemFields<ItemTs...>(result);
       return result;
    }
 
@@ -212,18 +210,16 @@ private:
       if constexpr (sizeof...(TailTs) > 0)
          _BuildItemOffsets<Index + 1, TailTs...>(offsets, tuple);
    }
-   template <typename... Ts>
    static std::vector<std::size_t> BuildItemOffsets()
    {
       std::vector<std::size_t> result;
-      _BuildItemOffsets<0, Ts...>(result, ContainerT());
+      _BuildItemOffsets<0, ItemTs...>(result, ContainerT());
       return result;
    }
 
 public:
    static std::string TypeName() { return "std::tuple<" + BuildItemTypes<ItemTs...>() + ">"; }
-   explicit RField(std::string_view name)
-      : RTupleField(name, BuildItemFields<ItemTs...>(), BuildItemOffsets<ItemTs...>())
+   explicit RField(std::string_view name) : RTupleField(name, BuildItemFields(), BuildItemOffsets())
    {
       fMaxAlignment = std::max({alignof(ItemTs)...});
       fSize = sizeof(ContainerT);

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -71,17 +71,15 @@ protected:
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final;
 
-   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> &&itemFields,
-                const std::vector<std::size_t> &offsets, std::string_view typeName = "");
+   RRecordField(std::string_view fieldName, std::string_view typeName);
+
+   void AttachItemFields(std::vector<std::unique_ptr<RFieldBase>> &&itemFields);
 
    template <std::size_t N>
-   RRecordField(std::string_view fieldName, std::array<std::unique_ptr<RFieldBase>, N> &&itemFields,
-                const std::array<std::size_t, N> &offsets, std::string_view typeName = "")
-      : ROOT::Experimental::RFieldBase(fieldName, typeName, ENTupleStructure::kRecord, false /* isSimple */)
+   void AttachItemFields(std::array<std::unique_ptr<RFieldBase>, N> &&itemFields)
    {
       fTraits |= kTraitTrivialType;
       for (unsigned i = 0; i < N; ++i) {
-         fOffsets.push_back(offsets[i]);
          fMaxAlignment = std::max(fMaxAlignment, itemFields[i]->GetAlignment());
          fSize += GetItemPadding(fSize, itemFields[i]->GetAlignment()) + itemFields[i]->GetValueSize();
          fTraits &= itemFields[i]->GetTraits();

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -85,6 +85,9 @@ protected:
          fTraits &= itemFields[i]->GetTraits();
          Attach(std::move(itemFields[i]));
       }
+      // Trailing padding: although this is implementation-dependent, most add enough padding to comply with the
+      // requirements of the type with strictest alignment
+      fSize += GetItemPadding(fSize, fMaxAlignment);
    }
 
 public:
@@ -145,8 +148,8 @@ public:
    static std::string TypeName() { return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">"; }
    explicit RField(std::string_view name) : RPairField(name, BuildItemFields(), BuildItemOffsets())
    {
-      fMaxAlignment = std::max(alignof(T1), alignof(T2));
-      fSize = sizeof(ContainerT);
+      R__ASSERT(fMaxAlignment >= std::max(alignof(T1), alignof(T2)));
+      R__ASSERT(fSize >= sizeof(ContainerT));
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
@@ -221,8 +224,8 @@ public:
    static std::string TypeName() { return "std::tuple<" + BuildItemTypes<ItemTs...>() + ">"; }
    explicit RField(std::string_view name) : RTupleField(name, BuildItemFields(), BuildItemOffsets())
    {
-      fMaxAlignment = std::max({alignof(ItemTs)...});
-      fSize = sizeof(ContainerT);
+      R__ASSERT(fMaxAlignment >= std::max({alignof(ItemTs)...}));
+      R__ASSERT(fSize >= sizeof(ContainerT));
    }
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2522,6 +2522,9 @@ void ROOT::Experimental::RRecordField::RRecordField::AttachItemFields(
       fTraits &= item->GetTraits();
       Attach(std::move(item));
    }
+   // Trailing padding: although this is implementation-dependent, most add enough padding to comply with the
+   // requirements of the type with strictest alignment
+   fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
 ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -97,7 +97,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
                return field;
             memberFields.emplace_back(std::move(field));
          }
-         auto recordField = std::make_unique<RRecordField>(GetFieldName(), memberFields);
+         auto recordField = std::make_unique<RRecordField>(GetFieldName(), std::move(memberFields));
          recordField->SetOnDiskId(fFieldId);
          return recordField;
       }

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -594,7 +594,8 @@ TEST(RNTupleDescriptor, BuildStreamerInfos)
    streamerInfoMap = fnBuildStreamerInfosOf(*RFieldBase::Create("f", "std::unordered_map<int, float>").Unwrap());
    EXPECT_TRUE(streamerInfoMap.empty());
 
-   streamerInfoMap = fnBuildStreamerInfosOf(ROOT::Experimental::RRecordField("f", {}));
+   std::vector<std::unique_ptr<RFieldBase>> itemFields;
+   streamerInfoMap = fnBuildStreamerInfosOf(ROOT::Experimental::RRecordField("f", std::move(itemFields)));
    EXPECT_TRUE(streamerInfoMap.empty());
 
    streamerInfoMap = fnBuildStreamerInfosOf(*RFieldBase::Create("f", "CustomStruct").Unwrap());

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -349,7 +349,7 @@ TEST(RNTupleShow, Collections)
       std::vector<std::unique_ptr<RFieldBase>> leafFields;
       leafFields.emplace_back(std::make_unique<RField<short>>("myShort"));
       leafFields.emplace_back(std::make_unique<RField<float>>("myFloat"));
-      auto recordField = std::make_unique<RRecordField>("_0", leafFields);
+      auto recordField = std::make_unique<RRecordField>("_0", std::move(leafFields));
       EXPECT_EQ(offsetof(MyStruct, myShort), recordField->GetOffsets()[0]);
       EXPECT_EQ(offsetof(MyStruct, myFloat), recordField->GetOffsets()[1]);
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -138,7 +138,7 @@ TEST(RNTuple, CreateField)
    std::vector<std::unique_ptr<RFieldBase>> itemFields;
    itemFields.push_back(std::make_unique<RField<std::uint32_t>>("u32"));
    itemFields.push_back(std::make_unique<RField<std::uint8_t>>("u8"));
-   ROOT::Experimental::RRecordField record("test", itemFields);
+   ROOT::Experimental::RRecordField record("test", std::move(itemFields));
    EXPECT_EQ(alignof(std::uint32_t), record.GetAlignment());
    // Check that trailing padding is added after `u8` to comply with the alignment requirements of uint32_t
    EXPECT_EQ(sizeof(std::uint32_t) + alignof(std::uint32_t), record.GetValueSize());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -307,6 +307,14 @@ TEST(RNTuple, StdTuple)
          "tupleTupleField");
    EXPECT_STREQ("std::tuple<std::tuple<std::int64_t,float,char,float>,std::vector<std::tuple<char,char,char>>>",
                 tupleTupleField.GetTypeName().c_str());
+   using TupleMapSetType = std::tuple<std::map<char, int64_t>, std::set<int64_t>>;
+   auto tupleMapSetField = RField<TupleMapSetType>("tupleMapSetField");
+   EXPECT_LE(sizeof(TupleMapSetType), tupleMapSetField.GetValueSize());
+   EXPECT_LE(alignof(TupleMapSetType), tupleMapSetField.GetAlignment());
+   using TupleUnorderedMapSetType = std::tuple<std::unordered_map<char, int64_t>, std::unordered_set<int64_t>>;
+   auto tupleUnorderedMapSetField = RField<TupleUnorderedMapSetType>("tupleUnorderedMapSetField");
+   EXPECT_LE(sizeof(TupleUnorderedMapSetType), tupleUnorderedMapSetField.GetValueSize());
+   EXPECT_LE(alignof(TupleUnorderedMapSetType), tupleUnorderedMapSetField.GetAlignment());
 
    FileRaii fileGuard("test_ntuple_rfield_stdtuple.root");
    {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -317,7 +317,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       auto &c = p.second;
 
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
-      auto recordField = std::make_unique<RRecordField>("_0", c.fLeafFields);
+      auto recordField = std::make_unique<RRecordField>("_0", std::move(c.fLeafFields));
       c.fRecordField = recordField.get();
       auto collectionField = RVectorField::CreateUntyped(c.fFieldName, std::move(recordField));
       fModel->AddField(std::move(collectionField));


### PR DESCRIPTION
 * Remove dangerous `RField` constructors, where the user could pass subfields into typed `RField<std::pair<T1, T2>>` and `RField<std::tuple<ItemTs...>>` without checks.
 * Avoid UB in `RRecordField` construction, related to unspecified order of evaluation of function arguments.
 * Take container of `unique_ptr`'s by value, to signal ownership handover.
 * Fix `fSize` calculation in `RRecordField::AttachItemFields`, to have less (critical) logic in the typed `RField` constructors.