### PR TITLE
[ntuple] Remove RFieldBase::GetNElements()

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -75,6 +75,7 @@ SOURCES
   v7/src/RNTupleUtil.cxx
   v7/src/RNTupleWriteOptions.cxx
   v7/src/RNTupleWriter.cxx
+  v7/src/RNTupleView.cxx
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx
   v7/src/RPagePool.cxx

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -515,12 +515,6 @@ public:
    const std::string &GetTypeAlias() const { return fTypeAlias; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
-   NTupleSize_t GetNElements() const
-   {
-      if (fState == EState::kUnconnected)
-         throw RException(R__FAIL("Cannot call GetNElements() on an unconnected field!"));
-      return fPrincipalColumn->GetNElements();
-   }
    const RFieldBase *GetParent() const { return fParent; }
    std::vector<RFieldBase *> GetSubFields();
    std::vector<const RFieldBase *> GetSubFields() const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -721,7 +721,7 @@ public:
       using iterator = RIterator;
       using value_type = RFieldDescriptor;
       using difference_type = std::ptrdiff_t;
-      using pointer = RColumnDescriptor *;
+      using pointer = const RColumnDescriptor *;
       using reference = const RColumnDescriptor &;
 
       RIterator(const RNTupleDescriptor &ntuple, const std::vector<DescriptorId_t> &columns, std::size_t index)
@@ -734,6 +734,7 @@ public:
          return *this;
       }
       reference operator*() { return fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
+      pointer operator->() { return &fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
       bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
    };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -286,19 +286,25 @@ public:
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource));
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range);
    }
 
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource), objPtr);
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, objPtr);
    }
 
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId, T *rawPtr)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource), rawPtr);
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
    template <typename T>
@@ -310,7 +316,9 @@ public:
    template <typename T>
    RNTupleDirectAccessView<T> GetDirectAccessView(DescriptorId_t fieldId)
    {
-      return RNTupleDirectAccessView<T>(RNTupleDirectAccessView<T>::CreateField(fieldId, *fSource));
+      auto field = RNTupleDirectAccessView<T>::CreateField(fieldId, *fSource);
+      auto range = Internal::GetFieldRange(field, *fSource);
+      return RNTupleDirectAccessView<T>(std::move(field), range);
    }
 
    /// Raises an exception if:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -286,19 +286,19 @@ public:
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, fSource.get()));
+      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource));
    }
 
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, fSource.get()), objPtr);
+      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource), objPtr);
    }
 
    template <typename T>
    RNTupleView<T> GetView(DescriptorId_t fieldId, T *rawPtr)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, fSource.get()), rawPtr);
+      return RNTupleView<T>(RNTupleView<T>::CreateField(fieldId, *fSource), rawPtr);
    }
 
    template <typename T>
@@ -310,7 +310,7 @@ public:
    template <typename T>
    RNTupleDirectAccessView<T> GetDirectAccessView(DescriptorId_t fieldId)
    {
-      return RNTupleDirectAccessView<T>(RNTupleDirectAccessView<T>::CreateField(fieldId, fSource.get()));
+      return RNTupleDirectAccessView<T>(RNTupleDirectAccessView<T>::CreateField(fieldId, *fSource));
    }
 
    /// Raises an exception if:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -118,8 +118,8 @@ public:
 namespace Internal {
 
 /// Helper to get the iteration space of the given field that needs to be connected to the given page source.
-/// The indexes are given by the number of elements of the principle column of the field or, if none exists,
-/// by the number of elements of the first principle column found in the sbufields searched by BFS.
+/// The indexes are given by the number of elements of the principal column of the field or, if none exists,
+/// by the number of elements of the first principal column found in the subfields searched by BFS.
 /// If the field hierarchy is empty on columns, throw an exception.
 RNTupleGlobalRange GetFieldRange(const RFieldBase &field, const RPageSource &pageSource);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -69,7 +69,7 @@ public:
    RNTupleGlobalRange(NTupleSize_t start, NTupleSize_t end) : fStart(start), fEnd(end) {}
    RIterator begin() { return RIterator(fStart); }
    RIterator end() { return RIterator(fEnd); }
-   NTupleSize_t count() { return fEnd - fStart; }
+   NTupleSize_t size() { return fEnd - fStart; }
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -134,11 +134,11 @@ protected:
    std::unique_ptr<RFieldBase> fField;
    RFieldBase::RValue fValue;
 
-   static std::unique_ptr<RFieldBase> CreateField(DescriptorId_t fieldId, Internal::RPageSource *pageSource)
+   static std::unique_ptr<RFieldBase> CreateField(DescriptorId_t fieldId, Internal::RPageSource &pageSource)
    {
       std::unique_ptr<RFieldBase> field;
       {
-         const auto &desc = pageSource->GetSharedDescriptorGuard().GetRef();
+         const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
          const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
          if constexpr (std::is_void_v<T>) {
             field = fieldDesc.CreateField(desc);
@@ -147,7 +147,7 @@ protected:
          }
       }
       field->SetOnDiskId(fieldId);
-      Internal::CallConnectPageSourceOnField(*field, *pageSource);
+      Internal::CallConnectPageSourceOnField(*field, pageSource);
       return field;
    }
 
@@ -269,9 +269,9 @@ class RNTupleDirectAccessView {
 protected:
    RField<T> fField;
 
-   static RField<T> CreateField(DescriptorId_t fieldId, Internal::RPageSource *pageSource)
+   static RField<T> CreateField(DescriptorId_t fieldId, Internal::RPageSource &pageSource)
    {
-      const auto &desc = pageSource->GetSharedDescriptorGuard().GetRef();
+      const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
       if (fieldDesc.GetTypeName() != RField<T>::TypeName()) {
          throw RException(R__FAIL("type mismatch for field " + fieldDesc.GetFieldName() + ": " +
@@ -279,7 +279,7 @@ protected:
       }
       RField<T> field(fieldDesc.GetFieldName());
       field.SetOnDiskId(fieldId);
-      Internal::CallConnectPageSourceOnField(field, *pageSource);
+      Internal::CallConnectPageSourceOnField(field, pageSource);
       return field;
    }
 
@@ -374,14 +374,14 @@ public:
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName)
    {
-      return RNTupleView<T>(RNTupleView<T>::CreateField(GetFieldId(fieldName), fSource));
+      return RNTupleView<T>(RNTupleView<T>::CreateField(GetFieldId(fieldName), *fSource));
    }
 
    /// Raises an exception if there is no field with the given name.
    template <typename T>
    RNTupleDirectAccessView<T> GetDirectAccessView(std::string_view fieldName)
    {
-      return RNTupleDirectAccessView<T>(RNTupleDirectAccessView<T>::CreateField(GetFieldId(fieldName), fSource));
+      return RNTupleDirectAccessView<T>(RNTupleDirectAccessView<T>::CreateField(GetFieldId(fieldName), *fSource));
    }
 
    /// Raises an exception if there is no field with the given name.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -69,6 +69,7 @@ public:
    RNTupleGlobalRange(NTupleSize_t start, NTupleSize_t end) : fStart(start), fEnd(end) {}
    RIterator begin() { return RIterator(fStart); }
    RIterator end() { return RIterator(fEnd); }
+   NTupleSize_t count() { return fEnd - fStart; }
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -113,6 +113,16 @@ public:
    RIterator end() { return RIterator(RClusterIndex(fClusterId, fEnd)); }
 };
 
+namespace Internal {
+
+/// Helper to get the iteration space of the given field that needs to be connected to the given page source.
+/// The indexes are given by the number of elements of the principle column of the field or, if none exists,
+/// by the number of elements of the first principle column found in the sbufields searched by BFS.
+/// If the field hierarchy is empty on columns, throw an exception.
+RNTupleGlobalRange GetFieldRange(const RFieldBase &field, const RPageSource &pageSource);
+
+} // namespace Internal
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleViewBase

--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -1,0 +1,48 @@
+/// \file RNTupleView.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2024-10-28
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RError.hxx>
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleView.hxx>
+#include <ROOT/RPageStorage.hxx>
+
+ROOT::Experimental::RNTupleGlobalRange
+ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPageSource &pageSource)
+{
+   const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
+
+   auto fnGetPrincipalColumnId = [&desc](DescriptorId_t fieldId) -> DescriptorId_t {
+      auto columnIterable = desc.GetColumnIterable(fieldId);
+      return (columnIterable.size() > 0) ? columnIterable.begin()->GetPhysicalId() : kInvalidDescriptorId;
+   };
+
+   auto columnId = fnGetPrincipalColumnId(field.GetOnDiskId());
+   if (columnId == kInvalidDescriptorId) {
+      for (const auto &f : field) {
+         columnId = fnGetPrincipalColumnId(f.GetOnDiskId());
+         if (columnId != kInvalidDescriptorId)
+            break;
+      }
+   }
+
+   if (columnId == kInvalidDescriptorId) {
+      throw RException(R__FAIL("field iteration over empty field is unsupported: " +
+                               desc.GetQualifiedFieldName(field.GetOnDiskId())));
+   }
+
+   auto arraySize = std::max(std::uint64_t(1), desc.GetFieldDescriptor(field.GetOnDiskId()).GetNRepetitions());
+   return RNTupleGlobalRange(0, desc.GetNElements(columnId) / arraySize);
+}

--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -39,7 +39,7 @@ ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPage
    }
 
    if (columnId == kInvalidDescriptorId) {
-      throw RException(R__FAIL("field iteration over empty field is unsupported: " +
+      throw RException(R__FAIL("field iteration over empty fields is unsupported: " +
                                desc.GetQualifiedFieldName(field.GetOnDiskId())));
    }
 

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -29,7 +29,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().count());
+   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().size());
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(3u, desc.GetNClusters());

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -29,7 +29,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   EXPECT_EQ(3u, reader->GetModel().GetConstField("px").GetNElements());
+   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().count());
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(3u, desc.GetNClusters());

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -193,7 +193,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().count());
+   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().size());
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(3u, desc.GetNClusters());

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -193,7 +193,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   EXPECT_EQ(3u, reader->GetModel().GetConstField("px").GetNElements());
+   EXPECT_EQ(3u, reader->GetView<float>("px").GetFieldRange().count());
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(3u, desc.GetNClusters());

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -459,6 +459,6 @@ TEST(RNTuple, ViewFieldIteration)
       auto viewEmpty = reader->GetView<void>("empty");
       FAIL() << "creating a view on an empty field should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field iteration over empty field is unsupported"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("field iteration over empty fields is unsupported"));
    }
 }


### PR DESCRIPTION
There is not a well-defined good way to determine the number of things in a field without any further input. This has been used by the views, to iterate all the data of a (sub)field, independent of entry boundaries. This field range is now determined directly by the view from the descriptor.

Fixes #16588