### PR TITLE
[RF] Avoid using variable-length arrays in RooFit multiprocessing tests

### DIFF
--- a/roofit/multiprocess/test/utils.h
+++ b/roofit/multiprocess/test/utils.h
@@ -50,7 +50,8 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
    RooArgSet obs_set;
 
    // create gaussian parameters
-   double mean[n], sigma[n];
+   std::vector<double> mean(n);
+   std::vector<double> sigma(n);
    for (unsigned ix = 0; ix < n; ++ix) {
       mean[ix] = RooRandom::randomGenerator()->Gaus(0, 2);
       sigma[ix] = 0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2));

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -259,8 +259,8 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
    std::unique_ptr<RooFitResult> m0result{m0.save()};
    double minNll0 = m0result->minNll();
    double edm0 = m0result->edm();
-   double mean0[N];
-   double std0[N];
+   std::vector<double> mean0(N);
+   std::vector<double> std0(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;
@@ -294,8 +294,8 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
    std::unique_ptr<RooFitResult> m1result{m1.save()};
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
-   double mean1[N];
-   double std1[N];
+   std::vector<double> mean1(N);
+   std::vector<double> std1(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;


### PR DESCRIPTION
These VLAs are not part of the C++ standard and cause compiler warnings.

In this case, the arrays were only used to contain reference values, which can absolutely be done with `std::vector` on the heap.