### PR TITLE
[CPyCppyy] Initialize new PyTypeObject fields introduced in Python 3.13

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -310,6 +310,9 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -288,6 +288,9 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                            // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                            // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -1102,6 +1102,9 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1055,6 +1055,9 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                                // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                                // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -707,6 +707,9 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -164,6 +164,9 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                  // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                  // tp_versions_used
+#endif
 };
 
 
@@ -203,6 +206,9 @@ static PyTypeObject PyDefault_t_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                 // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                 // tp_versions_used
 #endif
 };
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -170,6 +170,9 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -341,6 +344,9 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 
@@ -397,6 +403,9 @@ PyTypeObject IndexIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 
@@ -465,6 +474,9 @@ PyTypeObject VectorIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
@@ -959,6 +959,9 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                            // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                            // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -960,6 +960,9 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                                // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                                // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
@@ -120,6 +120,9 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 
@@ -253,6 +256,9 @@ PyTypeObject TupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 


### PR DESCRIPTION
This is to avoid compilier warnings, as usual.

Commit will also be ported to `wlav/CPyCppyy`.