### PR TITLE
[webcanv] use batch mode for stored JSON

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -45,7 +45,7 @@ Jupyter.CodeCell.options_default.highlight_modes['magic_{cppMIME}'] = {{'reg':[/
 console.log("JupyROOT - %%cpp magic configured");
 """
 
-_jsNotDrawableClassesPatterns = ["TEve*","TF3","TPolyLine3D"]
+_jsNotDrawableClassesPatterns = ["TEve*"]
 
 _jsCanvasWidth = 800
 _jsCanvasHeight = 600
@@ -299,7 +299,7 @@ def produceCanvasJson(canvas):
        canvas.Draw()
 
    if TWebCanvasAvailable():
-       return ROOT.TWebCanvas.CreateCanvasJSON(canvas, 3)
+       return ROOT.TWebCanvas.CreateCanvasJSON(canvas, 23, True)
 
    # Add extra primitives to canvas with custom colors, palette, gStyle
 

--- a/documentation/doxygen/MakeTCanvasJS.C
+++ b/documentation/doxygen/MakeTCanvasJS.C
@@ -40,7 +40,7 @@ void MakeTCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bo
    fprintf(fh,"<center>\n");
    while ((canvas = (TCanvas*) next()) != nullptr) {
       ImageNum++;
-      json_codes.push_back(TWebCanvas::CreateCanvasJSON(canvas, TBufferJSON::kNoSpaces + TBufferJSON::kSameSuppression));
+      json_codes.push_back(TWebCanvas::CreateCanvasJSON(canvas, TBufferJSON::kNoSpaces + TBufferJSON::kSameSuppression, kTRUE));
       fprintf(fh,"   <div id=\"draw_pict%d_%s\" style=\"position: relative; width: %dpx; height: %dpx;\"></div>\n",
                   ImageNum,IN,canvas->GetWindowWidth(),canvas->GetWindowHeight());
    }

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -1136,6 +1136,8 @@ bool RWebDisplayHandle::ProduceImages(const std::vector<std::string> &fnames, co
       if (p != std::string::npos) {
          auto jsroot_build = THttpServer::ReadFileContent(std::string(jsrootsys) + "/build/jsroot.js");
          if (!jsroot_build.empty()) {
+            // insert actual jsroot file location
+            jsroot_build = std::regex_replace(jsroot_build, std::regex("'\\$jsrootsys'"), std::string("'file://") + jsrootsys + "/'");
             filecont.erase(p, jsroot_include.length());
             filecont.insert(p, "<script id=\"jsroot\">" + jsroot_build + "</script>");
          }

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -2442,15 +2442,21 @@ TString TWebCanvas::CreateCanvasJSON(TCanvas *c, Int_t json_compression, Bool_t 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Create JSON painting output for given canvas and store into the file
 /// See TBufferJSON::ExportToFile() method for more details about option
-/// If option string starts with symbol 'b', JSON for batch mode will be generated
+/// If option string starts with symbol 'b', JSON for batch mode will be generated (default)
+/// If option string starts with symbol 'i', JSON for interactive mode will be generated
 
 Int_t TWebCanvas::StoreCanvasJSON(TCanvas *c, const char *filename, const char *option)
 {
    Int_t res = 0;
-   Bool_t batchmode = kFALSE;
-   if (option && *option == 'b') {
-      batchmode = kTRUE;
-      ++option;
+   Bool_t batchmode = kTRUE;
+   if (option) {
+      if (*option == 'b') {
+         batchmode = kTRUE;
+         ++option;
+      } else if (*option == 'i') {
+         batchmode = kFALSE;
+         ++option;
+      }
    }
 
    if (!c)

--- a/js/changes.md
+++ b/js/changes.md
@@ -38,6 +38,7 @@
 35. Fix - unzooming on log scale was extending range forevever
 36. Fix - do not force style 8 for hist markers
 37. Fix - ensure minimal hist title height
+38. Fix - disable Bloom effects on Android TGeo displays
 
 
 ## Changes in 7.7.4

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '17/10/2024',
+version_date = '29/10/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -22,7 +22,9 @@ internals = {
    id_counter: 1
 },
 
-_src = import.meta?.url;
+_src = import.meta?.url,
+
+_src_dir = '$jsrootsys';
 
 
 /** @summary Location of JSROOT modules
@@ -30,17 +32,25 @@ _src = import.meta?.url;
   * @private */
 let source_dir = '';
 
-if (_src && isStr(_src)) {
-   const pos = _src.indexOf('modules/core.mjs');
-   if (pos >= 0) {
+if (_src_dir[0] !== '$')
+   source_dir = _src_dir;
+else if (_src && isStr(_src)) {
+   let pos = _src.indexOf('modules/core.mjs');
+   if (pos < 0)
+      pos = _src.indexOf('build/jsroot.js');
+   if (pos < 0)
+      pos = _src.indexOf('build/jsroot.min.js');
+   if (pos >= 0)
       source_dir = _src.slice(0, pos);
-      if (!nodejs)
-         console.log(`Set jsroot source_dir to ${source_dir}, ${version}`);
-   } else {
-      if (!nodejs)
-         console.log(`jsroot bundle, ${version}`);
+   else
       internals.ignore_v6 = true;
-   }
+}
+
+if (!nodejs) {
+   if (source_dir)
+      console.log(`Set jsroot source_dir to ${source_dir}, ${version}`);
+   else
+      console.log(`jsroot bundle, ${version}`);
 }
 
 /** @summary Is batch mode flag

--- a/js/modules/geom/TGeoPainter.mjs
+++ b/js/modules/geom/TGeoPainter.mjs
@@ -1714,7 +1714,7 @@ class TGeoPainter extends ObjectPainter {
    ensureBloom(on) {
       if (on === undefined) {
          if (this.ctrl.highlight_bloom === 0)
-             this.ctrl.highlight_bloom = this._webgl;
+             this.ctrl.highlight_bloom = this._webgl && ((typeof navigator === 'undefined') || !/android/i.test(navigator.userAgent));
 
          on = this.ctrl.highlight_bloom && this.ctrl.getMaterialCfg()?.emissive;
       }

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -324,7 +324,8 @@ if ((typeof globalThis !== 'undefined') && !globalThis.JSROOT) {
 
    globalThis.JSROOT._complete_loading = _sync;
 
-   let pr = Promise.all([import('../modules/core.mjs'), import('../modules/draw.mjs'), import('../modules/gui/HierarchyPainter.mjs')]).then(arr => {
+   let pr = Promise.all([import('../modules/core.mjs'), import('../modules/draw.mjs'),
+            import('../modules/gui/HierarchyPainter.mjs'), import('../modules/gui/display.mjs')]).then(arr => {
 
       Object.assign(globalThis.JSROOT, arr[0], arr[1], arr[2]);
 
@@ -332,7 +333,7 @@ if ((typeof globalThis !== 'undefined') && !globalThis.JSROOT) {
 
       globalThis.JSROOT._ = arr[0].internals;
 
-      getHPainter = arr[2].getHPainter;
+      getHPainter = arr[3].getHPainter;
 
       globalThis.JSROOT.hpainter = getHPainter();
    });


### PR DESCRIPTION
When created JSON should be used outside ROOT application and without running THttpServer,
it is better to use batch mode for generation of  JSON files. Places are:

1. jupyter
2. doxygen
3. c1->SaveAs("file.json")

Produced JSON is more robust and can be processed as is - how it is performed by the batch image production.
Main difference - extra JS modules directly embed into JSON. And `TF1` always store its values

Also configure `source_dir` of JSROOT when producing images. This let use local mathjax.

Update JSROOT with Android/TGeo fix.
