### PR TITLE
[ntuple] make CreateAnchor a public internal free function

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -72,11 +72,6 @@ private:
    /// Used when the file turns out to be a TFile container
    RResult<RNTuple> GetNTupleProper(std::string_view ntupleName);
 
-   RNTuple CreateAnchor(std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor,
-                        std::uint16_t versionPatch, std::uint64_t seekHeader, std::uint64_t nbytesHeader,
-                        std::uint64_t lenHeader, std::uint64_t seekFooter, std::uint64_t nbytesFooter,
-                        std::uint64_t lenFooter, std::uint64_t maxKeySize);
-
 public:
    RMiniFileReader() = default;
    /// Uses the given raw file to read byte ranges

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -27,10 +27,18 @@ class TFileMergeInfo;
 namespace ROOT {
 namespace Experimental {
 
+class RNTuple;
+
 namespace Internal {
 class RMiniFileReader;
 class RNTupleFileWriter;
 class RPageSourceFile;
+
+RNTuple CreateAnchor(std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor,
+                     std::uint16_t versionPatch, std::uint64_t seekHeader, std::uint64_t nbytesHeader,
+                     std::uint64_t lenHeader, std::uint64_t seekFooter, std::uint64_t nbytesFooter,
+                     std::uint64_t lenFooter, std::uint64_t maxKeySize);
+
 } // namespace Internal
 
 // clang-format off
@@ -59,9 +67,13 @@ auto reader = RNTupleReader::Open(ntpl);
 */
 // clang-format on
 class RNTuple final {
-   friend class Internal::RMiniFileReader;
    friend class Internal::RNTupleFileWriter;
    friend class Internal::RPageSourceFile;
+
+   friend ROOT::Experimental::RNTuple ROOT::Experimental::Internal::CreateAnchor(
+      std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor, std::uint16_t versionPatch,
+      std::uint64_t seekHeader, std::uint64_t nbytesHeader, std::uint64_t lenHeader, std::uint64_t seekFooter,
+      std::uint64_t nbytesFooter, std::uint64_t lenFooter, std::uint64_t maxKeySize);
 
 public:
    static constexpr std::uint16_t kVersionEpoch = 0;
@@ -120,10 +132,7 @@ public:
    /// Merge this NTuple with the input list entries
    Long64_t Merge(TCollection *input, TFileMergeInfo *mergeInfo);
 
-   /// NOTE: if you change this version you also need to update:
-   ///    - RTFNTuple::fClassVersion in RMiniFile.cxx
-   ///    - RTFStreamerInfoObject::fVersionRNTuple in RMiniFile.cxx
-   ///    - RTFStreamerInfoObject::fStreamers in RMiniFile.cxx
+   /// NOTE: if you change this version you also need to update RTFNTuple::fClassVersion in RMiniFile.cxx
    ClassDefNV(RNTuple, 6);
 }; // class RNTuple
 

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -664,26 +664,6 @@ static size_t ComputeNumChunks(size_t nbytes, size_t maxChunkSize)
 
 ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(ROOT::Internal::RRawFile *rawFile) : fRawFile(rawFile) {}
 
-ROOT::Experimental::RNTuple ROOT::Experimental::Internal::RMiniFileReader::CreateAnchor(
-   std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor, std::uint16_t versionPatch,
-   std::uint64_t seekHeader, std::uint64_t nbytesHeader, std::uint64_t lenHeader, std::uint64_t seekFooter,
-   std::uint64_t nbytesFooter, std::uint64_t lenFooter, std::uint64_t maxKeySize)
-{
-   RNTuple ntuple;
-   ntuple.fVersionEpoch = versionEpoch;
-   ntuple.fVersionMajor = versionMajor;
-   ntuple.fVersionMinor = versionMinor;
-   ntuple.fVersionPatch = versionPatch;
-   ntuple.fSeekHeader = seekHeader;
-   ntuple.fNBytesHeader = nbytesHeader;
-   ntuple.fLenHeader = lenHeader;
-   ntuple.fSeekFooter = seekFooter;
-   ntuple.fNBytesFooter = nbytesFooter;
-   ntuple.fLenFooter = lenFooter;
-   ntuple.fMaxKeySize = maxKeySize;
-   return ntuple;
-}
-
 ROOT::Experimental::RResult<ROOT::Experimental::RNTuple>
 ROOT::Experimental::Internal::RMiniFileReader::GetNTuple(std::string_view ntupleName)
 {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -89,3 +89,24 @@ void ROOT::Experimental::RNTuple::Streamer(TBuffer &buf)
       buf << checksum;
    }
 }
+
+
+ROOT::Experimental::RNTuple ROOT::Experimental::Internal::CreateAnchor(
+   std::uint16_t versionEpoch, std::uint16_t versionMajor, std::uint16_t versionMinor, std::uint16_t versionPatch,
+   std::uint64_t seekHeader, std::uint64_t nbytesHeader, std::uint64_t lenHeader, std::uint64_t seekFooter,
+   std::uint64_t nbytesFooter, std::uint64_t lenFooter, std::uint64_t maxKeySize)
+{
+   RNTuple ntuple;
+   ntuple.fVersionEpoch = versionEpoch;
+   ntuple.fVersionMajor = versionMajor;
+   ntuple.fVersionMinor = versionMinor;
+   ntuple.fVersionPatch = versionPatch;
+   ntuple.fSeekHeader = seekHeader;
+   ntuple.fNBytesHeader = nbytesHeader;
+   ntuple.fLenHeader = lenHeader;
+   ntuple.fSeekFooter = seekFooter;
+   ntuple.fNBytesFooter = nbytesFooter;
+   ntuple.fLenFooter = lenFooter;
+   ntuple.fMaxKeySize = maxKeySize;
+   return ntuple;
+}


### PR DESCRIPTION
This allows programs (such as 3rd party readers) to create a RNTuple anchor while keeping it clear that "regular" users are not meant to do that.