### PR TITLE
[TMVA] Disable a crashing cuDNN test.

### DIFF
--- a/tmva/tmva/test/DNN/LSTM/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/LSTM/CMakeLists.txt
@@ -32,6 +32,8 @@ if (tmva-gpu AND tmva-cudnn)
    add_executable(testLSTMBackpropagationCudnn TestLSTMBackpropagationCudnn.cxx)
    target_link_libraries(testLSTMBackpropagationCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
    ROOT_ADD_TEST(TMVA-DNN-LSTM-BackpropagationCudnn COMMAND testLSTMBackpropagationCudnn)
+   # Test crashes on ubuntu2404-cuda-12.6.1. See root-project/root#16790:
+   set_tests_properties(TMVA-DNN-LSTM-BackpropagationCudnn PROPERTIES DISABLED True)
 
    # LSTM - Full Test GPU
    add_executable(testFullLSTMCudnn TestFullLSTMCudnn.cxx)


### PR DESCRIPTION
The test TMVA-DNN-LSTM-BackpropagationCudnn crashes on ubuntu2404 cuda-12.6.1 with cudnn with the following stack trace:
```
   0x00007fda7f0b5540 in <unknown> from /usr/lib64/libcuda.so.1
   0x00007fda7ed1491e in <unknown> from /usr/lib64/libcuda.so.1
   0x00007fda7f08f040 in <unknown> from /usr/lib64/libcuda.so.1
   0x00007fda7ed0ef22 in <unknown> from /usr/lib64/libcuda.so.1
   0x00007fda7eed2bae in <unknown> from /usr/lib64/libcuda.so.1
   0x00007fdaaa248b01 in <unknown> from /usr/local/cuda-12.6/targets/x86_64-linux/lib/libcudart.so.12
   0x00007fdaaa218baa in <unknown> from /usr/local/cuda-12.6/targets/x86_64-linux/lib/libcudart.so.12
   0x00007fdaaa270721 in cudaMemcpy + 0x211 from /usr/local/cuda-12.6/targets/x86_64-linux/lib/libcudart.so.12
   0x000055d25af29e37 in bool testLSTMBackpropagation<TMVA::DNN::TCudnn<double> >(unsigned long, unsigned long, unsigned long, unsigned long, TMVA::DNN::TCudnn<double>::Scalar_t, std::vector<bool, std::allocator<bool> >, bool) + 0x4d37 from /github/home/ROOT-CI/build/tmva/tmva/test/DNN/LSTM/testLSTMBackpropagationCudnn
```

Disabling it now, #16790 opened to track progress.
