### PR TITLE
[hist] remove default parameter in TH1::GetQuantiles, as is the case with TF1::GetQuantiles

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -304,7 +304,7 @@ public:
 
    TVirtualHistPainter *GetPainter(Option_t *option="");
 
-   virtual Int_t    GetQuantiles(Int_t n, Double_t *xp, const Double_t *p = nullptr);
+   virtual Int_t    GetQuantiles(Int_t n, Double_t *xp, const Double_t *p);
    virtual Double_t GetRandom(TRandom * rng = nullptr) const;
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t GetStdDev(Int_t axis=1) const;

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4552,7 +4552,7 @@ TVirtualHistPainter *TH1::GetPainter(Option_t *option)
 ///
 /// \param[in] n maximum size of array xp and size of array p (if given)
 /// \param[out] xp array to be filled with nq quantiles evaluated at (p). Memory has to be preallocated by caller.
-/// If p is null (default value), then xp is actually set to the (first n) histogram bin edges
+/// If p is null, then xp is actually set to the (first n) histogram bin edges
 /// \param[in] p array of cumulative probabilities where quantiles should be evaluated.
 ///   - if p is null, the CDF of the histogram will be used instead as array, and will
 ///     have a size = number of bins + 1 in h. It will correspond to the
@@ -4572,8 +4572,8 @@ TVirtualHistPainter *TH1::GetPainter(Option_t *option)
 ///
 /// ~~~ {.cpp}
 /// TGraph *gr = new TGraph(nprob);
-/// h1->GetQuantiles(nprob,gr->GetX());
-/// h2->GetQuantiles(nprob,gr->GetY());
+/// h1->GetQuantiles(nprob,gr->GetX(),p);
+/// h2->GetQuantiles(nprob,gr->GetY(),p);
 /// gr->Draw("alp");
 /// ~~~
 ///


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/16784

The currently default parameter of p = nullptr is a very weird use case, which calculates F-1(F(bin_edges)), ie it just returns the bin edges. So force user to really decide if he wants to pass that nullptr as argument.

Warning: this PR might break some preexisting scripts though relying on this weird feature.