### PR TITLE
Fix problem with rootbrowse in web mode

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -819,12 +819,6 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    TStyle::BuildStyles();
    SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
 
-   const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
-   if (!webdisplay || !*webdisplay)
-      webdisplay = gEnv->GetValue("WebGui.Display", "");
-   if (webdisplay && *webdisplay)
-      SetWebDisplay(webdisplay);
-
    // Setup default (batch) graphics and GUI environment
    gBatchGuiFactory = new TGuiFactory;
    gGuiFactory      = gBatchGuiFactory;
@@ -841,6 +835,12 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    else
       fBatch = kTRUE;
 #endif
+
+   const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
+   if (!webdisplay || !*webdisplay)
+      webdisplay = gEnv->GetValue("WebGui.Display", "");
+   if (webdisplay && *webdisplay)
+      SetWebDisplay(webdisplay);
 
    int i = 0;
    while (initfunc && initfunc[i]) {

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -789,7 +789,7 @@ REPLACE_HELP = "replace object if already existing"
 
 def _openBrowser(rootFile=None):
     browser = ROOT.TBrowser()
-    if ROOT.gSystem.InheritsFrom("TMacOSXSystem"):
+    if ROOT.gSystem.InheritsFrom("TMacOSXSystem") or ROOT.gEnv.GetValue("Browser.Name", "") == "ROOT::RWebBrowserImp":
         print("Press ctrl+c to exit.")
         try:
             while True:

--- a/main/python/rootbrowse.py
+++ b/main/python/rootbrowse.py
@@ -15,6 +15,8 @@ import ROOT
 # Help strings
 description = "Open a ROOT file in a TBrowser"
 
+WEBON_HELP = "Configure webdisplay like chrome or qt6web"
+
 WEBOFF_HELP = "Invoke the normal TBrowser (not the web version)"
 
 EPILOG = """Examples:
@@ -30,7 +32,8 @@ def get_argparse():
 	parser = cmdLineUtils.getParserSingleFile(description, EPILOG)
 	parser.prog = 'rootbrowse'
 
-	parser.add_argument("-w", "--webOff", help=WEBOFF_HELP, action= "store_true")
+	parser.add_argument("-w", "--web", help=WEBON_HELP)
+	parser.add_argument("-wf", "--webOff", help=WEBOFF_HELP, action="store_true")
 	return parser
 
 
@@ -41,6 +44,9 @@ def execute():
 	args = cmdLineUtils.getArgs(parser)
 	if args.webOff:
 		ROOT.gROOT.SetWebDisplay("off")
+	elif args.web:
+		ROOT.gROOT.SetWebDisplay(args.web)
+
 
 	# Process rootBrowse
 	return cmdLineUtils.rootBrowse(args.FILE)


### PR DESCRIPTION
Let configure web display kind when running `rootbrowse`

More important - run event loop when web-based browser is started.
In contrary to normal `TBrowser` one needs event loop running

Fix web-display configuration problem when `WebGui.Display: something` configured in rootrc file.
In such case always web-batch-mode kind was selected.

Addressing [question on forum](https://root-forum.cern.ch/t/is-there-an-option-to-customize-rootbrowse/62066/)