### PR TITLE
Fix rootbrowse problem in web mode [6.32]

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -819,12 +819,6 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    TStyle::BuildStyles();
    SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
 
-   const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
-   if (!webdisplay || !*webdisplay)
-      webdisplay = gEnv->GetValue("WebGui.Display", "");
-   if (webdisplay && *webdisplay)
-      SetWebDisplay(webdisplay);
-
    // Setup default (batch) graphics and GUI environment
    gBatchGuiFactory = new TGuiFactory;
    gGuiFactory      = gBatchGuiFactory;
@@ -841,6 +835,12 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    else
       fBatch = kTRUE;
 #endif
+
+   const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
+   if (!webdisplay || !*webdisplay)
+      webdisplay = gEnv->GetValue("WebGui.Display", "");
+   if (webdisplay && *webdisplay)
+      SetWebDisplay(webdisplay);
 
    int i = 0;
    while (initfunc && initfunc[i]) {

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -789,7 +789,7 @@ REPLACE_HELP = "replace object if already existing"
 
 def _openBrowser(rootFile=None):
     browser = ROOT.TBrowser()
-    if ROOT.gSystem.InheritsFrom("TMacOSXSystem"):
+    if ROOT.gSystem.InheritsFrom("TMacOSXSystem") or ROOT.gROOT.IsWebDisplay():
         print("Press ctrl+c to exit.")
         try:
             while True:


### PR DESCRIPTION
If web mode enabled (via .rootrc parameter), run event loop.
Correctly set web mode from .rootrc

Partial backport of #16807 