### PR TITLE
[ntuple] fix IMT reading with type cast

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -73,7 +73,7 @@ public:
    /// If CppT == void, use the default C++ type for the given column type
    template <typename CppT = void>
    static std::unique_ptr<RColumnElementBase> Generate(EColumnType type);
-   static const char *GetTypeName(EColumnType type);
+   static const char *GetColumnTypeName(EColumnType type);
    /// Most types have a fixed on-disk bit width. Some low-precision column types
    /// have a range of possible bit widths. Return the minimum and maximum allowed
    /// bit size per type.

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -70,6 +70,13 @@ public:
    struct RIdentifier {
       std::type_index fInMemoryType = std::type_index(typeid(void));
       EColumnType fOnDiskType = EColumnType::kUnknown;
+
+      bool operator==(const RIdentifier &other) const
+      {
+         return this->fInMemoryType == other.fInMemoryType && this->fOnDiskType == other.fOnDiskType;
+      }
+
+      bool operator!=(const RIdentifier &other) const { return !(*this == other); }
    };
 
    RColumnElementBase(const RColumnElementBase &other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -125,76 +125,20 @@ public:
    virtual RIdentifier GetIdentifier() const = 0;
 }; // class RColumnElementBase
 
-// All supported C++ in-memory types
-enum class EColumnCppType {
-   kChar,
-   kBool,
-   kByte,
-   kUint8,
-   kUint16,
-   kUint32,
-   kUint64,
-   kInt8,
-   kInt16,
-   kInt32,
-   kInt64,
-   kFloat,
-   kDouble,
-   kClusterSize,
-   kColumnSwitch,
-   kMax
-};
-
-inline constexpr EColumnCppType kTestFutureColumn =
-   static_cast<EColumnCppType>(std::numeric_limits<std::underlying_type_t<EColumnCppType>>::max() - 1);
-
 struct RTestFutureColumn {
    std::uint32_t dummy;
 };
 
-std::unique_ptr<RColumnElementBase> GenerateColumnElement(EColumnCppType cppType, EColumnType colType);
+std::unique_ptr<RColumnElementBase> GenerateColumnElement(std::type_index inMemoryType, EColumnType onDiskType);
 
 template <typename CppT>
-std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
+std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType onDiskType)
 {
-   if constexpr (std::is_same_v<CppT, char>)
-      return GenerateColumnElement(EColumnCppType::kChar, type);
-   else if constexpr (std::is_same_v<CppT, bool>)
-      return GenerateColumnElement(EColumnCppType::kBool, type);
-   else if constexpr (std::is_same_v<CppT, std::byte>)
-      return GenerateColumnElement(EColumnCppType::kByte, type);
-   else if constexpr (std::is_same_v<CppT, std::uint8_t>)
-      return GenerateColumnElement(EColumnCppType::kUint8, type);
-   else if constexpr (std::is_same_v<CppT, std::uint16_t>)
-      return GenerateColumnElement(EColumnCppType::kUint16, type);
-   else if constexpr (std::is_same_v<CppT, std::uint32_t>)
-      return GenerateColumnElement(EColumnCppType::kUint32, type);
-   else if constexpr (std::is_same_v<CppT, std::uint64_t>)
-      return GenerateColumnElement(EColumnCppType::kUint64, type);
-   else if constexpr (std::is_same_v<CppT, std::int8_t>)
-      return GenerateColumnElement(EColumnCppType::kInt8, type);
-   else if constexpr (std::is_same_v<CppT, std::int16_t>)
-      return GenerateColumnElement(EColumnCppType::kInt16, type);
-   else if constexpr (std::is_same_v<CppT, std::int32_t>)
-      return GenerateColumnElement(EColumnCppType::kInt32, type);
-   else if constexpr (std::is_same_v<CppT, std::int64_t>)
-      return GenerateColumnElement(EColumnCppType::kInt64, type);
-   else if constexpr (std::is_same_v<CppT, float>)
-      return GenerateColumnElement(EColumnCppType::kFloat, type);
-   else if constexpr (std::is_same_v<CppT, double>)
-      return GenerateColumnElement(EColumnCppType::kDouble, type);
-   else if constexpr (std::is_same_v<CppT, ClusterSize_t>)
-      return GenerateColumnElement(EColumnCppType::kClusterSize, type);
-   else if constexpr (std::is_same_v<CppT, RColumnSwitch>)
-      return GenerateColumnElement(EColumnCppType::kColumnSwitch, type);
-   else if constexpr (std::is_same_v<CppT, RTestFutureColumn>)
-      return GenerateColumnElement(kTestFutureColumn, type);
-   else
-      static_assert(!sizeof(CppT), "Unsupported Cpp type");
+   return GenerateColumnElement(std::type_index(typeid(CppT)), onDiskType);
 }
 
 template <>
-std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate<void>(EColumnType type);
+std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate<void>(EColumnType onDiskType);
 
 } // namespace ROOT::Experimental::Internal
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -31,6 +31,7 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <typeindex>
 #include <typeinfo>
 #include <utility>
 
@@ -64,6 +65,13 @@ protected:
    }
 
 public:
+   /// Every concrete RColumnElement type is identified by its on-disk type (column type) and the
+   /// in-memory C++ type, given by a type index.
+   struct RIdentifier {
+      std::type_index fInMemoryType = std::type_index(typeid(void));
+      EColumnType fOnDiskType = EColumnType::kUnknown;
+   };
+
    RColumnElementBase(const RColumnElementBase &other) = default;
    RColumnElementBase(RColumnElementBase &&other) = default;
    RColumnElementBase &operator=(const RColumnElementBase &other) = delete;
@@ -113,6 +121,8 @@ public:
    std::size_t GetBitsOnStorage() const { return fBitsOnStorage; }
    std::optional<std::pair<double, double>> GetValueRange() const { return fValueRange; }
    std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * fBitsOnStorage + 7) / 8; }
+
+   virtual RIdentifier GetIdentifier() const = 0;
 }; // class RColumnElementBase
 
 // All supported C++ in-memory types

--- a/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElementBase.hxx
@@ -131,6 +131,8 @@ struct RTestFutureColumn {
 
 std::unique_ptr<RColumnElementBase> GenerateColumnElement(std::type_index inMemoryType, EColumnType onDiskType);
 
+std::unique_ptr<RColumnElementBase> GenerateColumnElement(const RColumnElementBase::RIdentifier &elementId);
+
 template <typename CppT>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType onDiskType)
 {

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -67,7 +67,7 @@ ROOT::Experimental::Internal::RColumnElementBase::GetValidBitRange(EColumnType t
    return std::make_pair(0, 0);
 }
 
-const char *ROOT::Experimental::Internal::RColumnElementBase::GetTypeName(EColumnType type)
+const char *ROOT::Experimental::Internal::RColumnElementBase::GetColumnTypeName(EColumnType type)
 {
    switch (type) {
    case EColumnType::kIndex64: return "Index64";

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -108,9 +108,9 @@ const char *ROOT::Experimental::Internal::RColumnElementBase::GetColumnTypeName(
 
 template <>
 std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
-ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType type)
+ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType onDiskType)
 {
-   switch (type) {
+   switch (onDiskType) {
    case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
    case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
@@ -144,7 +144,7 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<float, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<float, EColumnType::kReal32Quant>>();
    default:
-      if (type == kTestFutureType)
+      if (onDiskType == kTestFutureType)
          return std::make_unique<RColumnElement<Internal::RTestFutureColumn, kTestFutureType>>();
       assert(false);
    }
@@ -153,28 +153,42 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType typ
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
-ROOT::Experimental::Internal::GenerateColumnElement(EColumnCppType cppType, EColumnType type)
+ROOT::Experimental::Internal::GenerateColumnElement(std::type_index inMemoryType, EColumnType onDiskType)
 {
-   switch (cppType) {
-   case EColumnCppType::kChar: return GenerateColumnElementInternal<char>(type);
-   case EColumnCppType::kBool: return GenerateColumnElementInternal<bool>(type);
-   case EColumnCppType::kByte: return GenerateColumnElementInternal<std::byte>(type);
-   case EColumnCppType::kUint8: return GenerateColumnElementInternal<std::uint8_t>(type);
-   case EColumnCppType::kUint16: return GenerateColumnElementInternal<std::uint16_t>(type);
-   case EColumnCppType::kUint32: return GenerateColumnElementInternal<std::uint32_t>(type);
-   case EColumnCppType::kUint64: return GenerateColumnElementInternal<std::uint64_t>(type);
-   case EColumnCppType::kInt8: return GenerateColumnElementInternal<std::int8_t>(type);
-   case EColumnCppType::kInt16: return GenerateColumnElementInternal<std::int16_t>(type);
-   case EColumnCppType::kInt32: return GenerateColumnElementInternal<std::int32_t>(type);
-   case EColumnCppType::kInt64: return GenerateColumnElementInternal<std::int64_t>(type);
-   case EColumnCppType::kFloat: return GenerateColumnElementInternal<float>(type);
-   case EColumnCppType::kDouble: return GenerateColumnElementInternal<double>(type);
-   case EColumnCppType::kClusterSize: return GenerateColumnElementInternal<ClusterSize_t>(type);
-   case EColumnCppType::kColumnSwitch: return GenerateColumnElementInternal<RColumnSwitch>(type);
-   default:
-      if (cppType == kTestFutureColumn)
-         return GenerateColumnElementInternal<RTestFutureColumn>(type);
-      R__ASSERT(!"Invalid column cpp type");
+   if (inMemoryType == std::type_index(typeid(char))) {
+      return GenerateColumnElementInternal<char>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(bool))) {
+      return GenerateColumnElementInternal<bool>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::byte))) {
+      return GenerateColumnElementInternal<std::byte>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::uint8_t))) {
+      return GenerateColumnElementInternal<std::uint8_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::uint16_t))) {
+      return GenerateColumnElementInternal<std::uint16_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::uint32_t))) {
+      return GenerateColumnElementInternal<std::uint32_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::uint64_t))) {
+      return GenerateColumnElementInternal<std::uint64_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::int8_t))) {
+      return GenerateColumnElementInternal<std::int8_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::int16_t))) {
+      return GenerateColumnElementInternal<std::int16_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::int32_t))) {
+      return GenerateColumnElementInternal<std::int32_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(std::int64_t))) {
+      return GenerateColumnElementInternal<std::int64_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(float))) {
+      return GenerateColumnElementInternal<float>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(double))) {
+      return GenerateColumnElementInternal<double>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(ClusterSize_t))) {
+      return GenerateColumnElementInternal<ClusterSize_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(RColumnSwitch))) {
+      return GenerateColumnElementInternal<RColumnSwitch>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(RTestFutureColumn))) {
+      return GenerateColumnElementInternal<RTestFutureColumn>(onDiskType);
+   } else {
+      R__ASSERT(!"Invalid memory type in GenerateColumnElement");
    }
    // never here
    return nullptr;

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -194,6 +194,12 @@ ROOT::Experimental::Internal::GenerateColumnElement(std::type_index inMemoryType
    return nullptr;
 }
 
+std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
+ROOT::Experimental::Internal::GenerateColumnElement(const RColumnElementBase::RIdentifier &elementId)
+{
+   return GenerateColumnElement(elementId.fInMemoryType, elementId.fOnDiskType);
+}
+
 void ROOT::Experimental::Internal::BitPacking::PackBits(void *dst, const void *src, std::size_t count,
                                                         std::size_t sizeofSrc, std::size_t nDstBits)
 {

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -327,9 +327,9 @@ template <typename CppT, EColumnType>
 class RColumnElement;
 
 template <typename CppT>
-std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType type)
+std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType onDiskType)
 {
-   switch (type) {
+   switch (onDiskType) {
    case EColumnType::kIndex64: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex64>>();
    case EColumnType::kIndex32: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex32>>();
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<CppT, EColumnType::kSwitch>>();
@@ -360,7 +360,7 @@ std::unique_ptr<RColumnElementBase> GenerateColumnElementInternal(EColumnType ty
    case EColumnType::kReal32Trunc: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Trunc>>();
    case EColumnType::kReal32Quant: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32Quant>>();
    default:
-      if (type == kTestFutureType)
+      if (onDiskType == kTestFutureType)
          return std::make_unique<RColumnElement<CppT, kTestFutureType>>();
       R__ASSERT(false);
    }

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -599,6 +599,8 @@ public:
          R__FAIL(std::string("internal error: no column mapping for this C++ type: ") + typeid(CppT).name() + " --> " +
                  GetColumnTypeName(ColumnT)));
    }
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(CppT), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -606,6 +608,7 @@ class RColumnElement<bool, EColumnType::kUnknown> : public RColumnElementBase {
 public:
    static constexpr std::size_t kSize = sizeof(bool);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(bool), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -613,6 +616,7 @@ class RColumnElement<std::byte, EColumnType::kUnknown> : public RColumnElementBa
 public:
    static constexpr std::size_t kSize = sizeof(std::byte);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::byte), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -620,6 +624,7 @@ class RColumnElement<char, EColumnType::kUnknown> : public RColumnElementBase {
 public:
    static constexpr std::size_t kSize = sizeof(char);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(char), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -627,6 +632,7 @@ class RColumnElement<std::int8_t, EColumnType::kUnknown> : public RColumnElement
 public:
    static constexpr std::size_t kSize = sizeof(std::int8_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::int8_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -634,6 +640,7 @@ class RColumnElement<std::uint8_t, EColumnType::kUnknown> : public RColumnElemen
 public:
    static constexpr std::size_t kSize = sizeof(std::uint8_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::uint8_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -641,6 +648,7 @@ class RColumnElement<std::int16_t, EColumnType::kUnknown> : public RColumnElemen
 public:
    static constexpr std::size_t kSize = sizeof(std::int16_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::int16_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -648,6 +656,7 @@ class RColumnElement<std::uint16_t, EColumnType::kUnknown> : public RColumnEleme
 public:
    static constexpr std::size_t kSize = sizeof(std::uint16_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::uint16_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -655,6 +664,7 @@ class RColumnElement<std::int32_t, EColumnType::kUnknown> : public RColumnElemen
 public:
    static constexpr std::size_t kSize = sizeof(std::int32_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::int32_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -662,6 +672,7 @@ class RColumnElement<std::uint32_t, EColumnType::kUnknown> : public RColumnEleme
 public:
    static constexpr std::size_t kSize = sizeof(std::uint32_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::uint32_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -669,6 +680,7 @@ class RColumnElement<std::int64_t, EColumnType::kUnknown> : public RColumnElemen
 public:
    static constexpr std::size_t kSize = sizeof(std::int64_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::int64_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -676,6 +688,7 @@ class RColumnElement<std::uint64_t, EColumnType::kUnknown> : public RColumnEleme
 public:
    static constexpr std::size_t kSize = sizeof(std::uint64_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(std::uint64_t), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -683,6 +696,7 @@ class RColumnElement<float, EColumnType::kUnknown> : public RColumnElementBase {
 public:
    static constexpr std::size_t kSize = sizeof(float);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(float), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -690,6 +704,7 @@ class RColumnElement<double, EColumnType::kUnknown> : public RColumnElementBase 
 public:
    static constexpr std::size_t kSize = sizeof(double);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(double), EColumnType::kUnknown}; }
 };
 
 template <>
@@ -697,6 +712,10 @@ class RColumnElement<ROOT::Experimental::ClusterSize_t, EColumnType::kUnknown> :
 public:
    static constexpr std::size_t kSize = sizeof(ROOT::Experimental::ClusterSize_t);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final
+   {
+      return RIdentifier{typeid(ROOT::Experimental::ClusterSize_t), EColumnType::kUnknown};
+   }
 };
 
 template <>
@@ -704,6 +723,10 @@ class RColumnElement<ROOT::Experimental::RColumnSwitch, EColumnType::kUnknown> :
 public:
    static constexpr std::size_t kSize = sizeof(ROOT::Experimental::RColumnSwitch);
    RColumnElement() : RColumnElementBase(kSize) {}
+   RIdentifier GetIdentifier() const final
+   {
+      return RIdentifier{typeid(ROOT::Experimental::RColumnSwitch), EColumnType::kUnknown};
+   }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -755,6 +778,11 @@ public:
             ROOT::Experimental::RColumnSwitch(ROOT::Experimental::ClusterSize_t{element.fIndex}, element.fTag);
       }
    }
+
+   RIdentifier GetIdentifier() const final
+   {
+      return RIdentifier{typeid(ROOT::Experimental::RColumnSwitch), EColumnType::kSwitch};
+   }
 };
 
 template <>
@@ -768,6 +796,8 @@ public:
 
    void Pack(void *dst, const void *src, std::size_t count) const final;
    void Unpack(void *dst, const void *src, std::size_t count) const final;
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(bool), EColumnType::kBit}; }
 };
 
 template <>
@@ -801,6 +831,8 @@ public:
          floatArray[i] = ROOT::Experimental::Internal::HalfToFloat(val);
       }
    }
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(float), EColumnType::kReal16}; }
 };
 
 template <>
@@ -834,6 +866,8 @@ public:
          doubleArray[i] = static_cast<double>(ROOT::Experimental::Internal::HalfToFloat(val));
       }
    }
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(double), EColumnType::kReal16}; }
 };
 
 template <typename T>
@@ -856,6 +890,8 @@ public:
    }
 
    bool IsMappable() const final { return kIsMappable; }
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(T), EColumnType::kReal32Trunc}; }
 };
 
 template <>
@@ -1106,6 +1142,8 @@ public:
       // this is not the case, as the user may give us float values that are out of range.
       assert(nOutOfRange == 0);
    }
+
+   RIdentifier GetIdentifier() const final { return RIdentifier{typeid(T), EColumnType::kReal32Quant}; }
 };
 
 template <>
@@ -1114,13 +1152,17 @@ class RColumnElement<float, EColumnType::kReal32Quant> : public RColumnElementQu
 template <>
 class RColumnElement<double, EColumnType::kReal32Quant> : public RColumnElementQuantized<double> {};
 
-#define __RCOLUMNELEMENT_SPEC_BODY(CppT, BaseT, BitsOnStorage)  \
-   static constexpr std::size_t kSize = sizeof(CppT);           \
-   static constexpr std::size_t kBitsOnStorage = BitsOnStorage; \
-   RColumnElement() : BaseT(kSize, kBitsOnStorage) {}           \
-   bool IsMappable() const final                                \
-   {                                                            \
-      return kIsMappable;                                       \
+#define __RCOLUMNELEMENT_SPEC_BODY(CppT, ColumnT, BaseT, BitsOnStorage) \
+   static constexpr std::size_t kSize = sizeof(CppT);                   \
+   static constexpr std::size_t kBitsOnStorage = BitsOnStorage;         \
+   RColumnElement() : BaseT(kSize, kBitsOnStorage) {}                   \
+   bool IsMappable() const final                                        \
+   {                                                                    \
+      return kIsMappable;                                               \
+   }                                                                    \
+   RIdentifier GetIdentifier() const final                              \
+   {                                                                    \
+      return RIdentifier{typeid(CppT), ColumnT};                        \
    }
 /// These macros are used to declare `RColumnElement` template specializations below.  Additional arguments can be used
 /// to forward template parameters to the base class, e.g.
@@ -1132,14 +1174,14 @@ class RColumnElement<double, EColumnType::kReal32Quant> : public RColumnElementQ
    template <>                                                                \
    class RColumnElement<CppT, ColumnT> : public BaseT __VA_ARGS__ {           \
    public:                                                                    \
-      __RCOLUMNELEMENT_SPEC_BODY(CppT, BaseT, BitsOnStorage)                  \
+      __RCOLUMNELEMENT_SPEC_BODY(CppT, ColumnT, BaseT, BitsOnStorage)         \
    }
-#define DECLARE_RCOLUMNELEMENT_SPEC_SIMPLE(CppT, ColumnT, BitsOnStorage)  \
-   template <>                                                            \
-   class RColumnElement<CppT, ColumnT> : public RColumnElementBase {      \
-   public:                                                                \
-      static constexpr bool kIsMappable = true;                           \
-      __RCOLUMNELEMENT_SPEC_BODY(CppT, RColumnElementBase, BitsOnStorage) \
+#define DECLARE_RCOLUMNELEMENT_SPEC_SIMPLE(CppT, ColumnT, BitsOnStorage)           \
+   template <>                                                                     \
+   class RColumnElement<CppT, ColumnT> : public RColumnElementBase {               \
+   public:                                                                         \
+      static constexpr bool kIsMappable = true;                                    \
+      __RCOLUMNELEMENT_SPEC_BODY(CppT, ColumnT, RColumnElementBase, BitsOnStorage) \
    }
 
 DECLARE_RCOLUMNELEMENT_SPEC(bool, EColumnType::kChar, 8, RColumnElementBoolAsUnsplitInt, <char>);
@@ -1419,6 +1461,11 @@ public:
    bool IsMappable() const { return kIsMappable; }
    void Pack(void *, const void *, std::size_t) const {}
    void Unpack(void *, const void *, std::size_t) const {}
+
+   RIdentifier GetIdentifier() const final
+   {
+      return RIdentifier{typeid(ROOT::Experimental::Internal::RTestFutureColumn), kTestFutureType};
+   }
 };
 
 inline void

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -597,7 +597,7 @@ public:
    {
       throw ROOT::Experimental::RException(
          R__FAIL(std::string("internal error: no column mapping for this C++ type: ") + typeid(CppT).name() + " --> " +
-                 GetTypeName(ColumnT)));
+                 GetColumnTypeName(ColumnT)));
    }
 };
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1186,7 +1186,7 @@ ROOT::Experimental::RFieldBase::EnsureCompatibleColumnTypes(const RNTupleDescrip
    for (const auto &t : onDiskTypes) {
       if (!columnTypeNames.empty())
          columnTypeNames += ", ";
-      columnTypeNames += std::string("`") + Internal::RColumnElementBase::GetTypeName(t) + "`";
+      columnTypeNames += std::string("`") + Internal::RColumnElementBase::GetColumnTypeName(t) + "`";
    }
    throw RException(R__FAIL("On-disk column types {" + columnTypeNames + "} for field `" + GetQualifiedFieldName() +
                             "` cannot be matched to its in-memory type `" + GetTypeName() + "` " +

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -194,7 +194,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       std::string nameAndType = std::string("  ") + col.fFieldName + " [#" + std::to_string(col.fColumnIndex);
       if (col.fRepresentationIndex > 0)
          nameAndType += " / R." + std::to_string(col.fRepresentationIndex);
-      nameAndType += "]  --  " + std::string{Internal::RColumnElementBase::GetTypeName(col.fType)};
+      nameAndType += "]  --  " + std::string{Internal::RColumnElementBase::GetColumnTypeName(col.fType)};
       std::string id = std::string("{id:") + std::to_string(col.fLogicalColumnId) + "}";
       if (col.fLogicalColumnId != col.fPhysicalColumnId)
          id += " --alias--> " + std::to_string(col.fPhysicalColumnId);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -283,7 +283,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
                fCounters->fSzUnzip.Add(element->GetSize() * sealedPage.GetNElements());
 
                newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-               fPagePool.PreloadPage(std::move(newPage));
+               fPagePool.PreloadPage(std::move(newPage), element->GetIdentifier().fInMemoryType);
             };
 
             fTaskScheduler->AddTask(taskFunc);
@@ -333,7 +333,8 @@ ROOT::Experimental::Internal::RPageRef
 ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
 {
    const auto columnId = columnHandle.fPhysicalId;
-   auto cachedPageRef = fPagePool.GetPage(columnId, globalIndex);
+   const auto columnElementId = columnHandle.fColumn->GetElement()->GetIdentifier();
+   auto cachedPageRef = fPagePool.GetPage(columnId, columnElementId.fInMemoryType, globalIndex);
    if (!cachedPageRef.Get().IsNull())
       return cachedPageRef;
 
@@ -369,7 +370,8 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();
    const auto columnId = columnHandle.fPhysicalId;
-   auto cachedPageRef = fPagePool.GetPage(columnId, clusterIndex);
+   const auto columnElementId = columnHandle.fColumn->GetElement()->GetIdentifier();
+   auto cachedPageRef = fPagePool.GetPage(columnId, columnElementId.fInMemoryType, clusterIndex);
    if (!cachedPageRef.Get().IsNull())
       return cachedPageRef;
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -604,13 +604,14 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
 
    const auto element = columnHandle.fColumn->GetElement();
    const auto elementSize = element->GetSize();
+   const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
    if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
       auto pageZero = RPage::MakePageZero(columnId, elementSize);
       pageZero.GrowUnchecked(pageInfo.fNElements);
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
-      return fPagePool.RegisterPage(std::move(pageZero));
+      return fPagePool.RegisterPage(std::move(pageZero), elementInMemoryType);
    }
 
    RSealedPage sealedPage;
@@ -639,7 +640,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPageRef = fPagePool.GetPage(columnId, RClusterIndex(clusterId, idxInCluster));
+      auto cachedPageRef = fPagePool.GetPage(columnId, elementInMemoryType, RClusterIndex(clusterId, idxInCluster));
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 
@@ -659,7 +660,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
    newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
-   return fPagePool.RegisterPage(std::move(newPage));
+   return fPagePool.RegisterPage(std::move(newPage), elementInMemoryType);
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RPageSource>

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -100,7 +100,7 @@ public:
    RPageRef LoadPage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
       auto page = RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId).Unwrap();
-      return fPagePool.RegisterPage(std::move(page));
+      return fPagePool.RegisterPage(std::move(page), std::type_index(typeid(void)));
    }
    RPageRef LoadPage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPageRef(); }
    void LoadSealedPage(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::RClusterIndex, RSealedPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -5,6 +5,7 @@
 #include <TRandom3.h>
 #include <TROOT.h>
 
+#include <algorithm>
 #include <random>
 
 TEST(RNTuple, RealWorld1)
@@ -75,6 +76,87 @@ TEST(RNTuple, RealWorld1)
    EXPECT_EQ(chksumRead, chksumWrite);
 }
 
+TEST(RNTuple, Double32IMT)
+{
+   // Tests if parallel decompression correctly compresses the on-disk float to an in-memory double
+#ifdef R__USE_IMT
+   IMTRAII _;
+#endif
+   FileRaii fileGuard("test_ntuple_double32_imt.root");
+
+   constexpr int kNEvents = 10;
+
+   {
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("pt", "Double32_t").Unwrap());
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+
+      auto ptrPt = writer->GetModel().GetDefaultEntry().GetPtr<double>("pt");
+
+      for (int i = 0; i < kNEvents; ++i) {
+         *ptrPt = i;
+         writer->Fill();
+      }
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto viewPt = reader->GetView<double>("pt");
+   for (int i = 0; i < kNEvents; ++i) {
+      EXPECT_DOUBLE_EQ(i, viewPt(i));
+   }
+}
+
+TEST(RNTuple, MultiColumnExpansion)
+{
+   // Tests if on-disk columns that expand to multiple in-memory types are correctly handled
+#ifdef R__USE_IMT
+   IMTRAII _;
+#endif
+   FileRaii fileGuard("test_ntuple_multi_column_expansion.root");
+
+   constexpr int kNEvents = 1000;
+
+   {
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("pt", "Double32_t").Unwrap());
+      RNTupleWriteOptions options;
+      options.SetMaxUnzippedPageSize(32);
+      options.SetInitialNElementsPerPage(1);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+
+      auto ptrPt = writer->GetModel().GetDefaultEntry().GetPtr<double>("pt");
+
+      for (int i = 0; i < kNEvents; ++i) {
+         *ptrPt = i;
+         writer->Fill();
+         if (i % 50 == 0)
+            writer->CommitCluster();
+      }
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto viewPt = reader->GetView<double>("pt");
+   auto viewPtAsFloat = reader->GetView<float>("pt");
+
+   std::random_device rd;
+   std::mt19937 gen(rd());
+   std::vector<unsigned int> indexes;
+   indexes.reserve(kNEvents);
+   for (unsigned int i = 0; i < kNEvents; ++i)
+      indexes.emplace_back(i);
+   std::shuffle(indexes.begin(), indexes.end(), gen);
+
+   std::bernoulli_distribution dist(0.5);
+   for (auto idx : indexes) {
+      if (dist(gen)) {
+         EXPECT_DOUBLE_EQ(idx, viewPt(idx));
+         EXPECT_DOUBLE_EQ(idx, viewPtAsFloat(idx));
+      } else {
+         EXPECT_DOUBLE_EQ(idx, viewPtAsFloat(idx));
+         EXPECT_DOUBLE_EQ(idx, viewPt(idx));
+      }
+   }
+}
 
 // Stress test the asynchronous cluster pool by a deliberately unfavourable read pattern
 TEST(RNTuple, RandomAccess)

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -17,7 +17,7 @@ TEST(Pages, Pool)
    RPagePool pool;
 
    {
-      auto pageRef = pool.GetPage(0, 0);
+      auto pageRef = pool.GetPage(0, std::type_index(typeid(void)), 0);
       EXPECT_TRUE(pageRef.Get().IsNull());
    } // returning empty page should not crash
 
@@ -29,26 +29,30 @@ TEST(Pages, Pool)
    EXPECT_FALSE(page.IsNull());
 
    {
-      auto registeredPage = pool.RegisterPage(std::move(page));
+      auto registeredPage = pool.RegisterPage(std::move(page), std::type_index(typeid(void)));
 
       {
-         auto pageRef = pool.GetPage(0, 0);
+         auto pageRef = pool.GetPage(0, std::type_index(typeid(void)), 0);
          EXPECT_TRUE(pageRef.Get().IsNull());
-         pageRef = pool.GetPage(0, 55);
+         pageRef = pool.GetPage(0, std::type_index(typeid(void)), 55);
          EXPECT_TRUE(pageRef.Get().IsNull());
-         pageRef = pool.GetPage(1, 55);
+         pageRef = pool.GetPage(1, std::type_index(typeid(int)), 55);
+         EXPECT_TRUE(pageRef.Get().IsNull());
+         pageRef = pool.GetPage(1, std::type_index(typeid(void)), 55);
          EXPECT_FALSE(pageRef.Get().IsNull());
          EXPECT_EQ(50U, pageRef.Get().GetGlobalRangeFirst());
          EXPECT_EQ(59U, pageRef.Get().GetGlobalRangeLast());
          EXPECT_EQ(10U, pageRef.Get().GetClusterRangeFirst());
          EXPECT_EQ(19U, pageRef.Get().GetClusterRangeLast());
 
-         auto pageRef2 = pool.GetPage(1, ROOT::Experimental::RClusterIndex(0, 15));
+         auto pageRef2 = pool.GetPage(1, std::type_index(typeid(void)), ROOT::Experimental::RClusterIndex(0, 15));
          EXPECT_TRUE(pageRef2.Get().IsNull());
-         pageRef2 = pool.GetPage(1, ROOT::Experimental::RClusterIndex(2, 15));
+         pageRef2 = pool.GetPage(1, std::type_index(typeid(int)), ROOT::Experimental::RClusterIndex(2, 15));
+         EXPECT_TRUE(pageRef2.Get().IsNull());
+         pageRef2 = pool.GetPage(1, std::type_index(typeid(void)), ROOT::Experimental::RClusterIndex(2, 15));
          EXPECT_FALSE(pageRef2.Get().IsNull());
       }
    }
-   auto pageRef = pool.GetPage(1, 55);
+   auto pageRef = pool.GetPage(1, std::type_index(typeid(void)), 55);
    EXPECT_TRUE(pageRef.Get().IsNull());
 }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -248,7 +248,7 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
       output << " column type    | count   | # elements      | compressed bytes  | uncompressed bytes\n"
              << "----------------|---------|-----------------|-------------------|--------------------" << std::endl;
       for (const auto &[colType, typeInfo] : colTypeInfo) {
-         output << std::setw(15) << Internal::RColumnElementBase::GetTypeName(colType) << " |" << std::setw(8)
+         output << std::setw(15) << Internal::RColumnElementBase::GetColumnTypeName(colType) << " |" << std::setw(8)
                 << typeInfo.count << " |" << std::setw(16) << typeInfo.nElems << " |" << std::setw(18)
                 << typeInfo.compressedSize << " |" << std::setw(18) << typeInfo.uncompressedSize << " " << std::endl;
       }
@@ -256,8 +256,8 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
    case ENTupleInspectorPrintFormat::kCSV:
       output << "columnType,count,nElements,compressedSize,uncompressedSize" << std::endl;
       for (const auto &[colType, typeInfo] : colTypeInfo) {
-         output << Internal::RColumnElementBase::GetTypeName(colType) << "," << typeInfo.count << "," << typeInfo.nElems
-                << "," << typeInfo.compressedSize << "," << typeInfo.uncompressedSize << std::endl;
+         output << Internal::RColumnElementBase::GetColumnTypeName(colType) << "," << typeInfo.count << ","
+                << typeInfo.nElems << "," << typeInfo.compressedSize << "," << typeInfo.uncompressedSize << std::endl;
       }
       break;
    default: throw RException(R__FAIL("Invalid print format"));
@@ -300,7 +300,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnTypeInfoAsHist(ROOT::Experimental
       default: throw RException(R__FAIL("Unknown histogram type"));
       }
 
-      hist->AddBinContent(hist->GetXaxis()->FindBin(Internal::RColumnElementBase::GetTypeName(colInfo.GetType())),
+      hist->AddBinContent(hist->GetXaxis()->FindBin(Internal::RColumnElementBase::GetColumnTypeName(colInfo.GetType())),
                           data);
    }
 
@@ -322,10 +322,10 @@ ROOT::Experimental::RNTupleInspector::GetPageSizeDistribution(ROOT::Experimental
                                                               std::string histName, std::string histTitle, size_t nBins)
 {
    if (histName.empty())
-      histName = "pageSizeHistCol" + std::string{Internal::RColumnElementBase::GetTypeName(colType)};
+      histName = "pageSizeHistCol" + std::string{Internal::RColumnElementBase::GetColumnTypeName(colType)};
    if (histTitle.empty())
       histTitle = "Page size distribution for columns with type " +
-                  std::string{Internal::RColumnElementBase::GetTypeName(colType)};
+                  std::string{Internal::RColumnElementBase::GetColumnTypeName(colType)};
 
    auto perTypeHist = GetPageSizeDistribution({colType}, histName, histTitle, nBins);
 
@@ -415,8 +415,8 @@ std::unique_ptr<THStack> ROOT::Experimental::RNTupleInspector::GetPageSizeDistri
 
    for (const auto &[colType, pageSizesForColType] : pageSizes) {
       auto hist = std::make_unique<TH1D>(
-         TString::Format("%s%s", histName.c_str(), Internal::RColumnElementBase::GetTypeName(colType)),
-         Internal::RColumnElementBase::GetTypeName(colType), nBins, histMin,
+         TString::Format("%s%s", histName.c_str(), Internal::RColumnElementBase::GetColumnTypeName(colType)),
+         Internal::RColumnElementBase::GetColumnTypeName(colType), nBins, histMin,
          histMax + ((histMax - histMin) / static_cast<double>(nBins)));
 
       for (const auto pageSize : pageSizesForColType) {


### PR DESCRIPTION
Fixes reading in IMT mode (parallel decompression) of columns that are unpacked into non-default in-memory types. This has been a conceptional issue: the parallel decompression and the page pool were not aware, so far, of the possibility of non-default in-memory types of pages. The issues was discovered in IMT reading of `Double32_t` in CMS MiniAODs.

Both, parallel decompression and the page pool are now fixed to handle non-default and multiple target in-memory types into which pages can be unsealed. The page pool will require more work. That's for a follow-up PR.

Fixes #16815

@Dr15Jones FYI.

