### PR TITLE
Implement `TBrowser::IsWeb()` method

### DIFF
--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -92,6 +92,7 @@ public:
    void          BrowseObject(TObject *obj)    { if (fImp) fImp->BrowseObj(obj); }
    void          ExecuteDefaultAction(TObject *obj);
    TBrowserImp  *GetBrowserImp() const         { return fImp; }
+   Bool_t        IsWeb() const                 { return fImp ? fImp->IsWeb() : kFALSE; }
    void          SetBrowserImp(TBrowserImp *i) { fImp = i; }
    TContextMenu *GetContextMenu() const        { return fContextMenu; }
    Bool_t        GetRefreshFlag() const        { return fNeedRefresh; }

--- a/core/gui/inc/TBrowserImp.h
+++ b/core/gui/inc/TBrowserImp.h
@@ -55,6 +55,7 @@ public:
    virtual void      Show() { }
    virtual void      SetDrawOption(Option_t * = "") { }
    virtual Option_t *GetDrawOption() const { return nullptr; }
+   virtual Bool_t    IsWeb() const { return kFALSE; }
 
    virtual Longptr_t ExecPlugin(const char *, const char *, const char *, Int_t, Int_t) { return 0; }
    virtual void      SetStatusText(const char *, Int_t) { }

--- a/gui/browserv7/inc/ROOT/RWebBrowserImp.hxx
+++ b/gui/browserv7/inc/ROOT/RWebBrowserImp.hxx
@@ -36,6 +36,7 @@ public:
    void      Refresh(Bool_t = kFALSE) final;
    void      Show() final;
    void      BrowseObj(TObject *) final;
+   Bool_t    IsWeb() const final { return kTRUE; }
 
    static TBrowserImp *NewBrowser(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt = "");
    static TBrowserImp *NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -939,6 +939,9 @@ void RWebWindowsManager::Terminate()
    if (fServer)
       fServer->SetTerminate();
 
+   // set flag which sometimes checked in TSystem::ProcessEvents
+   gROOT->SetInterrupt(kTRUE);
+
    if (gApplication)
       TTimer::SingleShot(100, "TApplication",  gApplication, "Terminate()");
 }

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -789,7 +789,7 @@ REPLACE_HELP = "replace object if already existing"
 
 def _openBrowser(rootFile=None):
     browser = ROOT.TBrowser()
-    if ROOT.gSystem.InheritsFrom("TMacOSXSystem") or ROOT.gEnv.GetValue("Browser.Name", "") == "ROOT::RWebBrowserImp":
+    if ROOT.gSystem.InheritsFrom("TMacOSXSystem") or browser.IsWeb():
         print("Press ctrl+c to exit.")
         try:
             while True:

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -793,7 +793,8 @@ def _openBrowser(rootFile=None):
         print("Press ctrl+c to exit.")
         try:
             while True:
-                ROOT.gSystem.ProcessEvents()
+                if ROOT.gROOT.IsInterrupted() or ROOT.gSystem.ProcessEvents():
+                    break
                 sleep(0.01)
         except (KeyboardInterrupt, SystemExit):
             pass


### PR DESCRIPTION
Returns kTRUE if web-based browser is used.
Works exactly the same way as `TWebCanvas::IsWeb()` - via TBrowserImp class.

Use flag in `cmdLineUtils.py` to run event loop for web-based TBrowser.
Also add check of `gROOT.IsInterrupted()` and `gSystem.ProcessEvents()` to break such event loop.
