### PR TITLE
[RF] Remove the deprecated RooFit code to be removed in ROOT 6.36

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -14,6 +14,8 @@ The following people have contributed to this new version:
 
 ## Deprecation and Removal
 
+* The RooFit legacy interfaces that were deprecated in ROOT 6.34 and scheduled for removal in ROOT 6.36 are removed. See the RooFit section in the 6.34 release notes for a full list.
+
 ## Python Interface
 
 ## RDataFrame

--- a/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
@@ -8,8 +8,6 @@
 #include "RooWorkspace.h"
 #include "RooPlot.h"
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -24,18 +22,6 @@ namespace RooStats{
             HistoToWorkspaceFactoryFast::Configuration const& cfg={}
     );
 
-    void FormatFrameForLikelihood(RooPlot* frame, std::string xTitle=std::string("#sigma / #sigma_{SM}"), std::string yTitle=std::string("-log likelihood"))
-#ifndef ROOFIT_BUILDS_ITSELF
-        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.")
-#endif
-        ;
-    void FitModel(RooWorkspace *, std::string data_name="obsData")
-        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.");
-    void FitModelAndPlot(const std::string& measurementName, const std::string& fileNamePrefix, RooWorkspace &, std::string, std::string, TFile&, std::ostream&)
-#ifndef ROOFIT_BUILDS_ITSELF
-        R__DEPRECATED(6,36, "Please write your own plotting code inspired by the hf001 tutorial.")
-#endif
-        ;
   }
 }
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -23,8 +23,6 @@
 #include "RooStats/HistFactory/Channel.h"
 #include "RooStats/HistFactory/Asimov.h"
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
 class TFile;
 
 namespace RooStats{
@@ -96,22 +94,6 @@ public:
   void SetBinHigh ( int BinHigh ) { fBinHigh = BinHigh; }
   int GetBinLow() { return fBinLow; }
   int GetBinHigh() { return fBinHigh; }
-
-  /// Do not produce any plots or tables, just save the model.
-  ///
-  /// \deprecated Will be removed in ROOT 6.36. ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.
-  void SetExportOnly( bool ExportOnly )
-#ifndef ROOFIT_BUILDS_ITSELF
-  R__DEPRECATED(6,36, "ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.")
-#endif
-  { fExportOnly = ExportOnly; }
-
-  /// \deprecated Will be removed in ROOT 6.36. ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.
-  bool GetExportOnly()
-#ifndef ROOFIT_BUILDS_ITSELF
-  R__DEPRECATED(6,36, "ExportOnly() == true is the default since ROOT 6.34 and it can't be disabled anymore in 6.36.")
-#endif
-  { return fExportOnly; }
 
   void PrintTree( std::ostream& = std::cout ); /// Print to a stream
   void PrintXML( std::string Directory="", std::string NewOutputPrefix="" );

--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -380,7 +380,8 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
       } else if (curAttrName == "Mode") {
          cout << "\n INFO: Mode attribute is deprecated and no longer supported, will ignore\n";
       } else if (curAttrName == "ExportOnly") {
-         measurement.SetExportOnly(CheckTrueFalse(curAttrValue, "Measurement"));
+         // ignored
+         cxcoutIHF << "The \"ExportOnly\" attribute is ignored it is always \"true\" for any Measurement." << std::endl;
       } else {
          cxcoutEHF << "Found unknown XML attribute in Measurement: " << curAttrName << "\n";
          throw hf_exc();

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -29,8 +29,6 @@
 #include <TObjArray.h>
 #include <TRefArray.h>
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
 #include <deque>
 #include <iostream>
 #include <map>
@@ -126,35 +124,6 @@ public:
   bool dependsOn(TNamed const* namePtr, const RooAbsArg* ignoreArg=nullptr, bool valueOnly=false) const ;
   bool overlaps(const RooAbsArg& testArg, bool valueOnly=false) const ;
   bool hasClients() const { return !_clientList.empty(); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  /// \name Legacy RooFit interface.
-  /// This is a collection of functions that remain supported, but more elegant
-  /// interfaces are usually available.
-  /// @{
-
-  // --- Obsolete functions for backward compatibility
-  R__DEPRECATED(6,36, "Use getObservables().")
-  RooFit::OwningPtr<RooArgSet> getDependents(const RooArgSet& set) const;
-  R__DEPRECATED(6,36, "Use getObservables().")
-  RooFit::OwningPtr<RooArgSet> getDependents(const RooAbsData* set) const;
-  R__DEPRECATED(6,36, "Use getObservables().")
-  RooFit::OwningPtr<RooArgSet> getDependents(const RooArgSet* depList) const;
-  /// \deprecated Use observableOverlaps()
-  R__DEPRECATED(6,36, "Use observableOverlaps().")
-  inline bool dependentOverlaps(const RooAbsData* dset, const RooAbsArg& testArg) const { return observableOverlaps(dset,testArg) ; }
-  /// \deprecated Use observableOverlaps()
-  R__DEPRECATED(6,36, "Use observableOverlaps().")
-  inline bool dependentOverlaps(const RooArgSet* depList, const RooAbsArg& testArg) const { return observableOverlaps(depList, testArg) ; }
-  /// \deprecated Use checkObservables()
-  R__DEPRECATED(6,36, "Use checkObservables().")
-  inline bool checkDependents(const RooArgSet* nset) const { return checkObservables(nset) ; }
-  /// \deprecated Use recursiveCheckObservables()
-  R__DEPRECATED(6,36, "Use recursiveCheckObservables().")
-  inline bool recursiveCheckDependents(const RooArgSet* nset) const { return recursiveCheckObservables(nset) ; }
-  // --- End obsolete functions for backward compatibility
-  /// @}
-  ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
   /// \anchor clientServerInterface

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -19,8 +19,6 @@
 #include "RooPrintable.h"
 #include "TNamed.h"
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
 #include <memory>
 #include <cfloat>
 
@@ -47,12 +45,8 @@ public:
   using Items = std::vector<std::pair<TObject*,std::string>>;
 
   RooPlot() ;
-  RooPlot(const char* name, const char* title, const RooAbsRealLValue &var, double xmin, double xmax, Int_t nBins)
-     R__DEPRECATED(6,36, "Use the constructor that doesn't take the name and title, and then call SetName() and SetTitle() on the RooPlot.");
   RooPlot(const RooAbsRealLValue &var, double xmin, double xmax, Int_t nBins);
   RooPlot(double xmin, double xmax, int nBins=100);
-  RooPlot(double xmin, double xmax, double ymin, double ymax)
-     R__DEPRECATED(6,36, "Use RooPlot(double xmin, double xmax); SetMinimum(ymin); SetMaximum(ymax);");
   RooPlot(const RooAbsRealLValue &var1, const RooAbsRealLValue &var2);
   RooPlot(const RooAbsRealLValue &var1, const RooAbsRealLValue &var2,
      double xmin, double xmax, double ymin, double ymax);

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -22,8 +22,6 @@
 #include "RooAbsCategory.h"
 #include "RooMsgService.h"
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
 #include <string>
 
 /**
@@ -176,31 +174,6 @@ public:
     // not happen.
   }
 
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-  /// Constructor with owner.
-  ///
-  /// \deprecated Kept for backwards compatibility and will be removed in ROOT 6.36.
-  ///             Either use RooTemplateProxy(const char*, const char*, RooAbsArg*, bool, bool),
-  ///             and transfer the ownership with RooTemplateProxy::putOwnedArg(),
-  ///             or use RooTemplateProxy(const char*, const char*, RooAbsArg*, std::unique_ptr<T>, bool, bool)
-  ///             if you want the proxy to own the argument.
-  ///             depending if you want to transfer ownership or not.
-  ///
-  /// \param[in] theName Name of this proxy (for printing).
-  /// \param[in] desc Description what this proxy should act as.
-  /// \param[in] owner The object that owns the proxy. This is important for tracking
-  ///            of client-server dependencies.
-  /// \param[in] valueServer Notify the owner if value changes.
-  /// \param[in] shapeServer Notify the owner if shape (e.g. binning) changes.
-  /// \param[in] proxyOwnsArg Proxy will delete the payload if owning.
-  template<typename Bool = bool, typename = std::enable_if_t<std::is_same<Bool,bool>::value>>
-  R__DEPRECATED(6,36, "Use RooTemplateProxy(const char*, const char*, RooAbsArg*, bool, bool) and transfer the ownership with RooTemplateProxy::putOwnedArg().")
-  RooTemplateProxy(const char* theName, const char* desc, RooAbsArg* owner,
-       Bool valueServer, bool shapeServer, bool proxyOwnsArg)
-  : RooArgProxy(theName, desc, owner, valueServer, shapeServer, proxyOwnsArg)
-  {}
-#endif
-
   ////////////////////////////////////////////////////////////////////////////////
   /// Constructor with owner and proxied object.
   /// \param[in] theName Name of this proxy (for printing).
@@ -213,29 +186,6 @@ public:
   RooTemplateProxy(const char* theName, const char* desc, RooAbsArg* owner, T& ref,
       bool valueServer=true, bool shapeServer=false) :
         RooArgProxy(theName, desc, owner, const_cast<typename std::remove_const<T>::type&>(ref), valueServer, shapeServer, false) { }
-
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-  ////////////////////////////////////////////////////////////////////////////////
-  /// Constructor with owner and proxied object.
-  ///
-  /// \deprecated Kept for backwards compatibility and will be removed in ROOT 6.36.
-  ///             Please use RooTemplateProxy(const char*, const char*, RooAbsArg*, std::unique_ptr<T>, bool, bool)
-  ///             or RooTemplateProxy(const char*, const char*, RooAbsArg*, T&, bool, bool),
-  ///             depending if you want to transfer ownership or not.
-  ///
-  /// \param[in] theName Name of this proxy (for printing).
-  /// \param[in] desc Description what this proxy should act as.
-  /// \param[in] owner The object that owns the proxy. This is important for tracking
-  ///            of client-server dependencies.
-  /// \param[in] ref Reference to the object that the proxy should hold.
-  /// \param[in] valueServer Notify the owner if value changes.
-  /// \param[in] shapeServer Notify the owner if shape (e.g. binning) changes.
-  /// \param[in] proxyOwnsArg Proxy will delete the payload if owning.
-  R__DEPRECATED(6,36, "Use constructors without proxyOwnsArg argument, taking the one that accepts a std::unique_ptr<T> if you want to pass ownership.")
-  RooTemplateProxy(const char* theName, const char* desc, RooAbsArg* owner, T& ref,
-      bool valueServer, bool shapeServer, bool proxyOwnsArg) :
-        RooArgProxy(theName, desc, owner, const_cast<typename std::remove_const<T>::type&>(ref), valueServer, shapeServer, proxyOwnsArg) { }
-#endif
 
    ////////////////////////////////////////////////////////////////////////////////
    /// Constructor with owner and proxied object, taking ownership of the proxied object.

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -777,25 +777,6 @@ bool RooAbsArg::getObservables(const RooAbsCollection* dataList, RooArgSet& outp
 }
 
 
-/// \deprecated Use getObservables()
-RooFit::OwningPtr<RooArgSet> RooAbsArg::getDependents(const RooArgSet &set) const
-{
-   return getObservables(set);
-}
-
-/// \deprecated Use getObservables()
-RooFit::OwningPtr<RooArgSet> RooAbsArg::getDependents(const RooAbsData *set) const
-{
-   return getObservables(set);
-}
-
-/// \deprecated Use getObservables()
-RooFit::OwningPtr<RooArgSet> RooAbsArg::getDependents(const RooArgSet *depList) const
-{
-   return getObservables(depList);
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a RooArgSet with all components (branch nodes) of the
 /// expression tree headed by this object.

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -106,23 +106,6 @@ RooPlot::RooPlot(double xmin, double xmax, int nBins)
 
 }
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Construct of a two-dimensional RooPlot with ranges [xmin,xmax] x [ymin,ymax]
-
-RooPlot::RooPlot(double xmin, double xmax, double ymin, double ymax) :
-  _defYmax(0)
-{
-  _hist = new TH1D(histName(),"A RooPlot",100,xmin,xmax) ;
-  _hist->Sumw2(false) ;
-  _hist->GetSumw2()->Set(0) ;
-  _hist->SetDirectory(nullptr);
-
-  SetMinimum(ymin);
-  SetMaximum(ymax);
-  initialize();
-}
-
 namespace {
 
 const RooAbsRealLValue& validateFiniteLimits(const RooAbsRealLValue &var)
@@ -166,29 +149,6 @@ RooPlot::RooPlot(const RooAbsRealLValue &var1, const RooAbsRealLValue &var2, dou
    SetMaximum(ymax);
    SetXTitle(var1.getTitle(true));
    SetYTitle(var2.getTitle(true));
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Create an 1-dimensional with all properties taken from 'var', but
-/// with an explicit range [xmin,xmax] and a default binning of 'nbins'
-
-RooPlot::RooPlot(const char *name, const char *title, const RooAbsRealLValue &var, double xmin, double xmax,
-                 Int_t nbins)
-   : _hist(new TH1D(name, title, nbins, xmin, xmax)),
-     _plotVar(const_cast<RooAbsRealLValue *>(&var)),
-     _normBinWidth((xmax - xmin) / nbins)
-{
-  _hist->Sumw2(false) ;
-  _hist->GetSumw2()->Set(0) ;
-  _hist->SetDirectory(nullptr);
-
-  // In the past, the plot variable was cloned, but there was no apparent reason for doing so.
-
-  TString xtitle= var.getTitle(true);
-  SetXTitle(xtitle.Data());
-
-  initialize();
 }
 
 

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -21,13 +21,6 @@
 #include "RooDataHist.h"
 #include "THnSparse.h"
 
-#include <ROOT/RConfig.hxx> // for the R__DEPRECATED macro
-
-//#include "RooArgSet.h"
-//#include "RooMsgService.h"
-//#include "RooRealVar.h"
-
-
 namespace RooStats {
 
    class MarkovChain : public TNamed {
@@ -68,17 +61,6 @@ namespace RooStats {
       /// all variables (including NLL value and weight);
       /// Note: caller owns the returned data set
       virtual RooFit::OwningPtr<RooDataSet> GetAsDataSet(RooArgSet* whichVars = nullptr) const;
-
-      /// Get a clone of the markov chain on which this interval is based
-      /// as a RooDataSet.  You own the returned RooDataSet*
-      /// \deprecated Will be removed in ROOT 6.36.
-      virtual RooFit::OwningPtr<RooDataSet> GetAsDataSet(const RooCmdArg& arg1,
-                                       const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
-                                       const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
-                                       const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
-                                       const RooCmdArg& arg8={} ) const
-      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet)");
-
       virtual const RooDataSet* GetAsConstDataSet() const { return fChain; }
 
       /// get this MarkovChain as a RooDataHist whose entries contain the values
@@ -86,16 +68,6 @@ namespace RooStats {
       /// all variables (including NLL value and weight);
       /// Note: caller owns the returned data hist
       virtual RooFit::OwningPtr<RooDataHist> GetAsDataHist(RooArgSet* whichVars = nullptr) const;
-
-      /// Get a clone of the markov chain on which this interval is based
-      /// as a RooDataHist.  You own the returned RooDataHist*
-      /// \deprecated Will be removed in ROOT 6.36.
-      virtual RooFit::OwningPtr<RooDataHist> GetAsDataHist(const RooCmdArg & arg1,
-                                         const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
-                                         const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
-                                         const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
-                                         const RooCmdArg& arg8={} ) const
-      R__DEPRECATED(6,36, "This functionality can be implemented by calling RooAbsData::reduce on the Markov Chain's RooDataSet* (obtained using MarkovChain::GetAsConstDataSet) and then obtaining its binned clone.");
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a sparse histogram.  You own the returned THnSparse*

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -139,18 +139,6 @@ RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(RooArgSet* whichVars) co
    return RooFit::makeOwningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
 }
 
-/// \deprecated Will be removed in ROOT 6.36. Please implement this functionality by calling RooAbsData::reduce on the Markov Chain's RooDataSet*
-/// (obtained using MarkovChain::GetAsConstDataSet)
-
-RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(const RooCmdArg &arg1, const RooCmdArg &arg2,
-                                                        const RooCmdArg &arg3, const RooCmdArg &arg4,
-                                                        const RooCmdArg &arg5, const RooCmdArg &arg6,
-                                                        const RooCmdArg &arg7, const RooCmdArg &arg8) const
-{
-   return RooFit::makeOwningPtr<RooDataSet>(
-      std::unique_ptr<RooAbsData>{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)});
-}
-
 RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) const
 {
    RooArgSet args;
@@ -164,18 +152,6 @@ RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) 
 
    std::unique_ptr<RooAbsData> data{fChain->reduce(args)};
    return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
-}
-
-/// \deprecated Will be removed in ROOT 6.36. Please implement this functionality by calling RooAbsData::reduce on the Markov Chain's RooDataSet*
-/// (obtained using MarkovChain::GetAsConstDataSet), and then obtaining its binned clone.
-
-RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(const RooCmdArg &arg1, const RooCmdArg &arg2,
-                                                          const RooCmdArg &arg3, const RooCmdArg &arg4,
-                                                          const RooCmdArg &arg5, const RooCmdArg &arg6,
-                                                          const RooCmdArg &arg7, const RooCmdArg &arg8) const
-{
-   std::unique_ptr<RooAbsData> data{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)};
-   return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet &>(*data).binnedClone()});
 }
 
 THnSparse* MarkovChain::GetAsSparseHist(RooAbsCollection* whichVars) const


### PR DESCRIPTION
Execute on what was announced in the 6.34 release notes and indicated by deprecation macros and doxygen tags.

As ROOT 6.36 will be the next release after ROOT 6.34 and the current `master` branch is leading up to that next release, the code should be removed now.