### PR TITLE
[TPython] Remove the deprecated TPython code to be removed in ROOT 6.36

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -15,6 +15,7 @@ The following people have contributed to this new version:
 ## Deprecation and Removal
 
 * The RooFit legacy interfaces that were deprecated in ROOT 6.34 and scheduled for removal in ROOT 6.36 are removed. See the RooFit section in the 6.34 release notes for a full list.
+* The `TPython::Eval()` function that was deprecated in ROOT 6.34 and scheduled for removal in ROOT 6.36 is removed.
 
 ## Python Interface
 

--- a/bindings/tpython/inc/TPython.h
+++ b/bindings/tpython/inc/TPython.h
@@ -20,16 +20,15 @@
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-// Bindings
-#include "TPyReturn.h"
-
 // ROOT
 #include "TObject.h"
 
-#include "ROOT/RConfig.hxx" // R__DEPRECATED
-
 #include <any>
 #include <cstdint>
+
+// Python
+struct _object;
+typedef _object PyObject;
 
 namespace ROOT {
 namespace Internal {
@@ -58,9 +57,6 @@ public:
 
    // execute a python statement (e.g. "import ROOT" )
    static Bool_t Exec(const char *cmd, std::any *result = nullptr, std::string const& resultName="_anyresult");
-
-   // evaluate a python expression (e.g. "1+1")
-   static const TPyReturn Eval(const char *expr) R__DEPRECATED(6,36, "Use TPython::Exec() with an std::any output parameter instead.");
 
    // bind a ROOT object with, at the python side, the name "label"
    static Bool_t Bind(TObject *object, const char *label);


### PR DESCRIPTION
Execute on what was announced in the 6.34 release notes and indicated by deprecation macros and doxygen tags.

As ROOT 6.36 will be the next release after ROOT 6.34 and the current `master` branch is leading up to that next release, the code should be removed now.