### PR TITLE
[ntuple] forbid creating a RNTupleWriter with an XML TFile

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1109,6 +1109,8 @@ std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
 ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TFile &file,
                                                         std::uint64_t maxKeySize)
 {
+   assert(file.IsBinary());
+
    auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
    writer->fFileProper.fFile = &file;
    return writer;

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -25,6 +25,7 @@
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 
+#include <TFile.h>
 #include <TROOT.h>
 
 #include <utility>
@@ -95,6 +96,10 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriter>
 ROOT::Experimental::RNTupleWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, TFile &file,
                                           const RNTupleWriteOptions &options)
 {
+   if (!file.IsBinary())
+      throw RException(R__FAIL("RNTupleWriter only supports writing to a ROOT file. Cannot write into " +
+                               std::string(file.GetName())));
+
    auto sink = std::make_unique<Internal::RPageSinkFile>(ntupleName, file, options);
    return Create(std::move(model), std::move(sink), options);
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -765,3 +765,13 @@ TEST(RNTupleWriter, ForbidModelWithSubfields)
                   testing::HasSubstr("cannot create an RNTupleWriter from a model with registered subfields"));
    }
 }
+
+TEST(RNTupleWriter, ForbidNonRootTFiles)
+{
+   FileRaii fileGuard("test_ntuple_writer_forbid_xml.xml");
+
+   auto model = RNTupleModel::Create();
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   // Opening an XML TFile should fail
+   EXPECT_THROW(RNTupleWriter::Append(std::move(model), "ntpl", *file), RException);
+}


### PR DESCRIPTION
RMiniFile only knows how to write into proper ROOT files. 
I went with the blacklist approach because there are a bunch of valid cases that are not just TFiles that we want to support (e.g. TMemFile, TBufferMergerFile, ...).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

