### PR TITLE
[RF] Remove unused private code in RooAbsCollection

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -408,15 +408,6 @@ protected:
 
 private:
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 34, 00)
-  // TODO: Remove this friend declaration and function in 6.34, where it's not
-  // needed anymore because the deprecated legacy iterators will be removed.
-  friend class RooWorkspace;
-  std::unique_ptr<LegacyIterator_t> makeLegacyIterator (bool forward = true) const;
-#else
-#error "Please remove this unneeded code."
-#endif
-
   bool replaceImpl(const RooAbsArg& var1, const RooAbsArg& var2);
 
   using HashAssistedFind = RooFit::Detail::HashAssistedFind;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1583,18 +1583,6 @@ void RooAbsCollection::sortTopologically() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Factory for legacy iterators.
-
-std::unique_ptr<RooAbsCollection::LegacyIterator_t> RooAbsCollection::makeLegacyIterator (bool forward) const {
-   if (!forward) {
-      ccoutE(DataHandling) << "The legacy RooFit collection iterators don't support reverse iterations, any more. "
-                           << "Use begin() and end()" << std::endl;
-   }
-  return std::make_unique<LegacyIterator_t>(_list);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Insert an element into the owned collections.
 void RooAbsCollection::insert(RooAbsArg* item) {
   _list.push_back(item);


### PR DESCRIPTION
Backporting a commit of #16830, removing some unused code that I reminded us to remove with a preprocessor macro.

