### PR TITLE
[ntuple] check field range validity only on access

### DIFF
--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -39,8 +39,7 @@ ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPage
    }
 
    if (columnId == kInvalidDescriptorId) {
-      throw RException(R__FAIL("field iteration over empty fields is unsupported: " +
-                               desc.GetQualifiedFieldName(field.GetOnDiskId())));
+      return RNTupleGlobalRange(kInvalidNTupleIndex, kInvalidNTupleIndex);
    }
 
    auto arraySize = std::max(std::uint64_t(1), desc.GetFieldDescriptor(field.GetOnDiskId()).GetNRepetitions());

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -455,9 +455,10 @@ TEST(RNTuple, ViewFieldIteration)
    auto viewArray = reader->GetView<void>("array");
    EXPECT_EQ(1u, viewArray.GetFieldRange().size());
 
+   auto viewEmpty = reader->GetView<void>("empty");
    try {
-      auto viewEmpty = reader->GetView<void>("empty");
-      FAIL() << "creating a view on an empty field should throw";
+      viewEmpty.GetFieldRange();
+      FAIL() << "accessing the field range of a view on an empty field should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field iteration over empty fields is unsupported"));
    }


### PR DESCRIPTION
The field range of a view is determined on construction. If the field is empty (no columns), the field range remains undefined. Currently, in this case the creation of the view fails. Change this to instead only fail on the attempt to actually access the field range (as opposed to, e.g., iterate over the entry range of the empty field).

Fixes #16826 

@amete FYI

