### PR TITLE
[ntuple] Enforce valid naming upon field creation

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -214,8 +214,9 @@ private:
    /// Changed by Freeze() / Unfreeze() and by the RUpdater.
    bool fIsFrozen = false;
 
-   /// Checks that user-provided field names are valid in the context
-   /// of this NTuple model. Throws an RException for invalid names.
+   /// Checks that user-provided field names are valid in the context of this RNTuple model.
+   /// Throws an RException for invalid names, empty names (which is reserved for the zero field) and duplicate field
+   /// names.
    void EnsureValidFieldName(std::string_view fieldName);
 
    /// Throws an RException if fFrozen is true

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -565,6 +565,7 @@ ROOT::Experimental::RFieldBase::RFieldBase(std::string_view name, std::string_vi
      fPrincipalColumn(nullptr),
      fTraits(isSimple ? kTraitMappable : 0)
 {
+   EnsureValidFieldName(name);
 }
 
 std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const
@@ -896,9 +897,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
 ROOT::Experimental::RResult<void> ROOT::Experimental::RFieldBase::EnsureValidFieldName(std::string_view fieldName)
 {
-   if (fieldName.empty()) {
-      return R__FAIL("name cannot be empty string \"\"");
-   } else if (fieldName.find('.') != std::string::npos) {
+   if (fieldName.find('.') != std::string::npos) {
       return R__FAIL("name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
    }
    return RResult<void>::Success();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -910,6 +910,9 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
       if (!validName) {
          return R__FORWARD_ERROR(validName);
       }
+      if (fField.GetFieldName().empty()) {
+         return R__FAIL("name cannot be empty string \"\"");
+      }
    }
    return fField.Clone();
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -212,6 +212,9 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
    if (!nameValid) {
       nameValid.Throw();
    }
+   if (fieldName.empty()) {
+      throw RException(R__FAIL("name cannot be empty string \"\""));
+   }
    auto fieldNameStr = std::string(fieldName);
    if (fFieldNames.count(fieldNameStr) > 0)
       throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists in NTuple model"));

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 ROOT_ADD_GTEST(ntuple_view ntuple_view.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)
 
-ROOT_ADD_GTEST(rfield_check rfield_check.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(rfield_basics rfield_basics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct Physics)
 ROOT_ADD_GTEST(rfield_string rfield_string.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_variant rfield_variant.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/rfield_basics.cxx
+++ b/tree/ntuple/v7/test/rfield_basics.cxx
@@ -42,3 +42,22 @@ TEST(RField, Check)
    EXPECT_EQ("long double", report[0].fTypeName);
    EXPECT_THAT(report[0].fErrMsg, testing::HasSubstr("unknown type"));
 }
+
+TEST(RField, ValidNaming)
+{
+   try {
+      RFieldBase::Create("x.y", "float").Unwrap();
+      FAIL() << "creating a field with an invalid name should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain dot characters '.'"));
+   }
+
+   auto field = RFieldBase::Create("x", "float").Unwrap();
+
+   try {
+      field->Clone("x.y");
+      FAIL() << "cloning a field with an invalid name should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain dot characters '.'"));
+   }
+}

--- a/tree/ntuple/v7/test/rfield_basics.cxx
+++ b/tree/ntuple/v7/test/rfield_basics.cxx
@@ -1,9 +1,4 @@
-#include <ROOT/RField.hxx>
-
-#include "CustomStruct.hxx"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "ntuple_test.hxx"
 
 class NoDict {};
 

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -121,7 +121,7 @@ TEST(RNTuple, InsideCollection)
    ASSERT_NE(idKlass, ROOT::Experimental::kInvalidDescriptorId);
    auto idA = source->GetSharedDescriptorGuard()->FindFieldId("a", idKlass);
    ASSERT_NE(idA, ROOT::Experimental::kInvalidDescriptorId);
-   auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec.a", "float").Unwrap());
+   auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec_a", "float").Unwrap());
    fieldInner->SetOnDiskId(idA);
 
    auto field = std::make_unique<ROOT::Experimental::RVectorField>("klassVec", std::move(fieldInner));


### PR DESCRIPTION
Before, field name checking only took place in `RNTupleModel`. This PR performs the check upon construction of the `RFieldBase`. To still allow for special cases where fields can have an empty name, e.g. the zero field, this specific check has been moved out of `RFieldBase::EnsureValidFieldName` and to the places where this should actually be enforced.

Fixes #16834 

