### PR TITLE
[ntuple] allow for writing into TFile subdir

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -69,8 +69,9 @@ private:
 
    /// Used when the file container turns out to be a bare file
    RResult<RNTuple> GetNTupleBare(std::string_view ntupleName);
-   /// Used when the file turns out to be a TFile container
-   RResult<RNTuple> GetNTupleProper(std::string_view ntupleName);
+   /// Used when the file turns out to be a TFile container. The ntuplePath variable is either the ntuple name
+   /// or an ntuple name preceded by a directory (`myNtuple` or `foo/bar/myNtuple` or `/foo/bar/myNtuple`)
+   RResult<RNTuple> GetNTupleProper(std::string_view ntuplePath);
 
    /// Searches for a key with the given name and type in the key index of the directory starting at offsetDir.
    /// The offset points to the start of the TDirectory DATA section, without the key and without the name and title

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -223,11 +223,9 @@ public:
    static std::unique_ptr<RNTupleFileWriter> Recreate(std::string_view ntupleName, std::string_view path,
                                                       EContainerFormat containerFormat,
                                                       const RNTupleWriteOptions &options);
-   /// Add a new RNTuple identified by ntupleName to the existing TFile.
-   static std::unique_ptr<RNTupleFileWriter> Append(std::string_view ntupleName, TFile &file, std::uint64_t maxKeySize);
-   /// Add a new RNTuple identified by ntupleName to the existing directory, which must be a directory in a file.
+   /// The directory parameter can also be a TFile object (TFile inherits from TDirectory).
    static std::unique_ptr<RNTupleFileWriter>
-   Append(std::string_view ntupleName, TDirectory &directory, std::uint64_t maxKeySize);
+   Append(std::string_view ntupleName, TDirectory &fileOrDirectory, std::uint64_t maxKeySize);
 
    RNTupleFileWriter(const RNTupleFileWriter &other) = delete;
    RNTupleFileWriter(RNTupleFileWriter &&other) = delete;

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -72,6 +72,12 @@ private:
    /// Used when the file turns out to be a TFile container
    RResult<RNTuple> GetNTupleProper(std::string_view ntupleName);
 
+   /// Searches for a key with the given name and type in the key index of the directory starting at offsetDir.
+   /// The offset points to the start of the TDirectory DATA section, without the key and without the name and title
+   /// of the TFile record (the root directory).
+   /// Return 0 if the key was not found. Otherwise returns the offset of found key.
+   std::uint64_t SearchInDirectory(std::uint64_t &offsetDir, std::string_view keyName, std::string_view typeName);
+
 public:
    RMiniFileReader() = default;
    /// Uses the given raw file to read byte ranges

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -27,7 +27,7 @@
 #include <memory>
 #include <string>
 
-class TCollection;
+class TDirectory;
 class TFile;
 class TFileMergeInfo;
 class TVirtualStreamerInfo;
@@ -107,7 +107,10 @@ public:
 
 private:
    struct RFileProper {
+      /// If fDirectory is set, fFile is equal to fDirectory->GetFile()
       TFile *fFile = nullptr;
+      /// A sub directory in fFile or nullptr if the data is stored in the root directory of the file
+      TDirectory *fDirectory = nullptr;
       /// Low-level writing using a TFile
       void Write(const void *buffer, size_t nbytes, std::int64_t offset);
       /// Reserves an RBlob opaque key as data record and returns the offset of the record. If keyBuffer is specified,
@@ -215,6 +218,9 @@ public:
                                                       const RNTupleWriteOptions &options);
    /// Add a new RNTuple identified by ntupleName to the existing TFile.
    static std::unique_ptr<RNTupleFileWriter> Append(std::string_view ntupleName, TFile &file, std::uint64_t maxKeySize);
+   /// Add a new RNTuple identified by ntupleName to the existing directory, which must be a directory in a file.
+   static std::unique_ptr<RNTupleFileWriter>
+   Append(std::string_view ntupleName, TDirectory &directory, std::uint64_t maxKeySize);
 
    RNTupleFileWriter(const RNTupleFileWriter &other) = delete;
    RNTupleFileWriter(RNTupleFileWriter &&other) = delete;

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -28,7 +28,6 @@
 #include <string>
 
 class TDirectory;
-class TFile;
 class TFileMergeInfo;
 class TVirtualStreamerInfo;
 
@@ -114,8 +113,6 @@ public:
 
 private:
    struct RFileProper {
-      /// If fDirectory is set, fFile is equal to fDirectory->GetFile()
-      TFile *fFile = nullptr;
       /// A sub directory in fFile or nullptr if the data is stored in the root directory of the file
       TDirectory *fDirectory = nullptr;
       /// Low-level writing using a TFile
@@ -124,7 +121,7 @@ private:
       /// it must be written *before* the returned offset. (Note that the array type is purely documentation, the
       /// argument is actually just a pointer.)
       std::uint64_t ReserveBlobKey(size_t nbytes, size_t len, unsigned char keyBuffer[kBlobKeyLen] = nullptr);
-      operator bool() const { return fFile; }
+      operator bool() const { return fDirectory; }
    };
 
    struct RFileSimple {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
@@ -24,7 +24,7 @@
 #include <string_view>
 #include <vector>
 
-class TFile;
+class TDirectory;
 
 namespace ROOT {
 namespace Experimental {
@@ -86,7 +86,7 @@ public:
                                                           const RNTupleWriteOptions &options = RNTupleWriteOptions());
    /// Append an ntuple to the existing file, which must not be accessed while data is filled into any created context.
    static std::unique_ptr<RNTupleParallelWriter> Append(std::unique_ptr<RNTupleModel> model,
-                                                        std::string_view ntupleName, TFile &file,
+                                                        std::string_view ntupleName, TDirectory &fileOrDirectory,
                                                         const RNTupleWriteOptions &options = RNTupleWriteOptions());
 
    ~RNTupleParallelWriter();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -32,7 +32,7 @@
 #include <string_view>
 #include <utility>
 
-class TFile;
+class TDirectory;
 
 namespace ROOT {
 namespace Experimental {
@@ -94,7 +94,7 @@ public:
             std::string_view storage, const RNTupleWriteOptions &options = RNTupleWriteOptions());
    /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
-                                                TFile &file,
+                                                TDirectory &fileOrDirectory,
                                                 const RNTupleWriteOptions &options = RNTupleWriteOptions());
    RNTupleWriter(const RNTupleWriter &) = delete;
    RNTupleWriter &operator=(const RNTupleWriter &) = delete;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -31,7 +31,7 @@
 #include <string>
 #include <utility>
 
-class TFile;
+class TDirectory;
 
 namespace ROOT {
 class RNTuple; // for making RPageSourceFile a friend of RNTuple
@@ -99,7 +99,7 @@ protected:
 
 public:
    RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options);
-   RPageSinkFile(std::string_view ntupleName, TFile &file, const RNTupleWriteOptions &options);
+   RPageSinkFile(std::string_view ntupleName, TDirectory &fileOrDirectory, const RNTupleWriteOptions &options);
    RPageSinkFile(const RPageSinkFile &) = delete;
    RPageSinkFile &operator=(const RPageSinkFile &) = delete;
    RPageSinkFile(RPageSinkFile &&) = default;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1165,28 +1165,18 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Recreate(std::string_view ntupl
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
-ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TFile &file,
+ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TDirectory &fileOrDirectory,
                                                         std::uint64_t maxKeySize)
 {
-   assert(file.IsBinary());
-
-   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
-   writer->fFileProper.fFile = &file;
-   return writer;
-}
-
-std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
-ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TDirectory &directory,
-                                                        std::uint64_t maxKeySize)
-{
-   TFile *file = directory.GetFile();
+   TFile *file = fileOrDirectory.GetFile();
    if (!file)
       throw RException(R__FAIL("invalid attempt to add an RNTuple to a directory that is not backed by a file"));
    assert(file->IsBinary());
 
    auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
    writer->fFileProper.fFile = file;
-   writer->fFileProper.fDirectory = &directory;
+   if (file != &fileOrDirectory)
+      writer->fFileProper.fDirectory = &fileOrDirectory;
    return writer;
 }
 

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -455,8 +455,8 @@ struct RTFKeyList {
    explicit RTFKeyList(std::uint32_t nKeys) : fNKeys(nKeys) {}
 };
 
-/// A streamed TFile object
-struct RTFFile {
+/// A streamed TDirectory (TFile) object
+struct RTFDirectory {
    static constexpr unsigned kBigFileVersion = 1000;
 
    RUInt16BE fClassVersion{5};
@@ -478,13 +478,13 @@ struct RTFFile {
       } fInfoLong;
    };
 
-   RTFFile() : fInfoShort() {}
+   RTFDirectory() : fInfoShort() {}
 
    // In case of a short TFile record (<2G), 3 padding ints are written after the UUID
    std::uint32_t GetSize() const
    {
       if (fClassVersion >= kBigFileVersion)
-         return sizeof(RTFFile);
+         return sizeof(RTFDirectory);
       return 18 + sizeof(fInfoShort);
    }
 
@@ -589,7 +589,7 @@ namespace Internal {
 /// and the TFile record need to be updated
 struct RTFileControlBlock {
    RTFHeader fHeader;
-   RTFFile fFileRecord;
+   RTFDirectory fFileRecord;
    std::uint64_t fSeekNTuple{0}; // Remember the offset for the keys list
    std::uint64_t fSeekFileRecord{0};
 };
@@ -679,7 +679,7 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
    offset += name.GetSize();
    ReadBuffer(&name, 1, offset);
    offset += name.GetSize();
-   RTFFile file;
+   RTFDirectory file;
    ReadBuffer(&file, sizeof(file), offset);
 
    RUInt32BE nKeys;
@@ -1462,7 +1462,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileSkeleton(int def
 
    // First record of the file: the TFile object at offset kBEGIN (= 100)
    RTFKey keyRoot(RTFHeader::kBEGIN, 0, strTFile, strFileName, strEmpty,
-                  sizeof(RTFFile) + strFileName.GetSize() + strEmpty.GetSize() + uuid.GetSize());
+                  sizeof(RTFDirectory) + strFileName.GetSize() + strEmpty.GetSize() + uuid.GetSize());
    std::uint32_t nbytesName = keyRoot.fKeyLen + strFileName.GetSize() + 1;
    fFileSimple.fControlBlock->fFileRecord.fNBytesName = nbytesName;
    fFileSimple.fControlBlock->fHeader.SetNbytesName(nbytesName);

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -663,6 +663,48 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTuple(std::string_view ntuple
    return GetNTupleBare(ntupleName);
 }
 
+/// Searches for a key with the given name and type in the key index of the given directory.
+/// Return 0 if the key was not found.
+std::uint64_t ROOT::Experimental::Internal::RMiniFileReader::SearchInDirectory(std::uint64_t &offsetDir,
+                                                                               std::string_view keyName,
+                                                                               std::string_view typeName)
+{
+   RTFDirectory directory;
+   ReadBuffer(&directory, sizeof(directory), offsetDir);
+
+   RTFKey key;
+   RUInt32BE nKeys;
+   std::uint64_t offset = directory.GetSeekKeys();
+   ReadBuffer(&key, sizeof(key), offset);
+   offset += key.fKeyLen;
+   ReadBuffer(&nKeys, sizeof(nKeys), offset);
+   offset += sizeof(nKeys);
+
+   for (unsigned int i = 0; i < nKeys; ++i) {
+      ReadBuffer(&key, sizeof(key), offset);
+      auto offsetNextKey = offset + key.fKeyLen;
+
+      offset += key.GetHeaderSize();
+      RTFString name;
+      ReadBuffer(&name, 1, offset);
+      ReadBuffer(&name, name.GetSize(), offset);
+      if (std::string_view(name.fData, name.fLName) != typeName) {
+         offset = offsetNextKey;
+         continue;
+      }
+      offset += name.GetSize();
+      ReadBuffer(&name, 1, offset);
+      ReadBuffer(&name, name.GetSize(), offset);
+      if (std::string_view(name.fData, name.fLName) == keyName) {
+         return key.GetSeekKey();
+      }
+      offset = offsetNextKey;
+   }
+
+   // Not found
+   return 0;
+}
+
 ROOT::Experimental::RResult<ROOT::RNTuple>
 ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view ntupleName)
 {
@@ -674,45 +716,18 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
    ReadBuffer(&key, sizeof(key), fileHeader.fBEGIN);
    // Skip over the entire key length, including the class name, object name, and title stored in it.
    std::uint64_t offset = fileHeader.fBEGIN + key.fKeyLen;
-   // Skip over the name and title of the TNamed preceding the TFile entry.
+   // Skip over the name and title of the TNamed preceding the TFile (root TDirectory) entry.
    ReadBuffer(&name, 1, offset);
    offset += name.GetSize();
    ReadBuffer(&name, 1, offset);
    offset += name.GetSize();
-   RTFDirectory file;
-   ReadBuffer(&file, sizeof(file), offset);
 
-   RUInt32BE nKeys;
-   offset = file.GetSeekKeys();
-   ReadBuffer(&key, sizeof(key), offset);
-   offset += key.fKeyLen;
-   ReadBuffer(&nKeys, sizeof(nKeys), offset);
-   offset += sizeof(nKeys);
-   bool found = false;
-   for (unsigned int i = 0; i < nKeys; ++i) {
-      ReadBuffer(&key, sizeof(key), offset);
-      auto offsetNextKey = offset + key.fKeyLen;
-
-      offset += key.GetHeaderSize();
-      ReadBuffer(&name, 1, offset);
-      ReadBuffer(&name, name.GetSize(), offset);
-      if (std::string_view(name.fData, name.fLName) != kNTupleClassName) {
-         offset = offsetNextKey;
-         continue;
-      }
-      offset += name.GetSize();
-      ReadBuffer(&name, 1, offset);
-      ReadBuffer(&name, name.GetSize(), offset);
-      if (std::string_view(name.fData, name.fLName) == ntupleName) {
-         found = true;
-         break;
-      }
-      offset = offsetNextKey;
-   }
-   if (!found) {
+   offset = SearchInDirectory(offset, ntupleName, kNTupleClassName);
+   if (offset == 0) {
       return R__FAIL("no RNTuple named '" + std::string(ntupleName) + "' in file '" + fRawFile->GetUrl() + "'");
    }
 
+   ReadBuffer(&key, sizeof(key), offset);
    offset = key.GetSeekKey() + key.fKeyLen;
 
    // size of a RTFNTuple version 2 (min supported version); future anchor versions can grow.

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -24,6 +24,7 @@
 
 #include <Byteswap.h>
 #include <TBufferFile.h>
+#include <TDirectory.h>
 #include <TError.h>
 #include <TFile.h>
 #include <TKey.h>
@@ -1140,6 +1141,21 @@ ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleN
    return writer;
 }
 
+std::unique_ptr<ROOT::Experimental::Internal::RNTupleFileWriter>
+ROOT::Experimental::Internal::RNTupleFileWriter::Append(std::string_view ntupleName, TDirectory &directory,
+                                                        std::uint64_t maxKeySize)
+{
+   TFile *file = directory.GetFile();
+   if (!file)
+      throw RException(R__FAIL("invalid attempt to add an RNTuple to a directory that is not backed by a file"));
+   assert(file->IsBinary());
+
+   auto writer = std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, maxKeySize));
+   writer->fFileProper.fFile = file;
+   writer->fFileProper.fDirectory = &directory;
+   return writer;
+}
+
 void ROOT::Experimental::Internal::RNTupleFileWriter::UpdateStreamerInfos(
    const RNTupleSerializer::StreamerInfoMap_t &streamerInfos)
 {
@@ -1150,7 +1166,8 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::Commit()
 {
    if (fFileProper) {
       // Easy case, the ROOT file header and the RNTuple streaming is taken care of by TFile
-      fFileProper.fFile->WriteObject(&fNTupleAnchor, fNTupleName.c_str());
+      TDirectory *d = fFileProper.fDirectory ? fFileProper.fDirectory : fFileProper.fFile;
+      d->WriteObject(&fNTupleAnchor, fNTupleName.c_str());
 
       // Make sure the streamer info records used in the RNTuple are written to the file
       TBufferFile buf(TBuffer::kWrite);

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -167,13 +167,13 @@ ROOT::Experimental::RNTupleParallelWriter::Recreate(std::unique_ptr<RNTupleModel
 
 std::unique_ptr<ROOT::Experimental::RNTupleParallelWriter>
 ROOT::Experimental::RNTupleParallelWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
-                                                  TFile &file, const RNTupleWriteOptions &options)
+                                                  TDirectory &fileOrDirectory, const RNTupleWriteOptions &options)
 {
    if (!options.GetUseBufferedWrite()) {
       throw RException(R__FAIL("parallel writing requires buffering"));
    }
 
-   auto sink = std::make_unique<Internal::RPageSinkFile>(ntupleName, file, options);
+   auto sink = std::make_unique<Internal::RPageSinkFile>(ntupleName, fileOrDirectory, options);
    // Cannot use std::make_unique because the constructor of RNTupleParallelWriter is private.
    return std::unique_ptr<RNTupleParallelWriter>(new RNTupleParallelWriter(std::move(model), std::move(sink)));
 }

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -92,14 +92,20 @@ ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std:
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleWriter>
-ROOT::Experimental::RNTupleWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, TFile &file,
-                                          const RNTupleWriteOptions &options)
+ROOT::Experimental::RNTupleWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
+                                          TDirectory &fileOrDirectory, const RNTupleWriteOptions &options)
 {
-   if (!file.IsBinary())
+   auto file = fileOrDirectory.GetFile();
+   if (!file) {
+      throw RException(R__FAIL("RNTupleWriter only supports writing to a ROOT file. Cannot write into a directory "
+                               "that is not backed by a file"));
+   }
+   if (!file->IsBinary()) {
       throw RException(R__FAIL("RNTupleWriter only supports writing to a ROOT file. Cannot write into " +
-                               std::string(file.GetName())));
+                               std::string(file->GetName())));
+   }
 
-   auto sink = std::make_unique<Internal::RPageSinkFile>(ntupleName, file, options);
+   auto sink = std::make_unique<Internal::RPageSinkFile>(ntupleName, fileOrDirectory, options);
    return Create(std::move(model), std::move(sink), options);
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -29,8 +29,8 @@
 #include <ROOT/RNTupleUtil.hxx>
 
 #include <RVersion.h>
+#include <TDirectory.h>
 #include <TError.h>
-#include <TFile.h>
 
 #include <algorithm>
 #include <cstdio>
@@ -59,11 +59,11 @@ ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntup
    fWriter = RNTupleFileWriter::Recreate(ntupleName, path, RNTupleFileWriter::EContainerFormat::kTFile, options);
 }
 
-ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, TFile &file,
+ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, TDirectory &fileOrDirectory,
                                                            const RNTupleWriteOptions &options)
    : RPageSinkFile(ntupleName, options)
 {
-   fWriter = RNTupleFileWriter::Append(ntupleName, file, options.GetMaxKeySize());
+   fWriter = RNTupleFileWriter::Append(ntupleName, fileOrDirectory, options.GetMaxKeySize());
 }
 
 ROOT::Experimental::Internal::RPageSinkFile::~RPageSinkFile() {}

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -198,6 +198,25 @@ TEST(RNTuple, WriteReadInlinedModel)
    EXPECT_FLOAT_EQ(3.2, (*readvpz)[2]);
 }
 
+TEST(RNTuple, WriteReadSubdir)
+{
+   FileRaii fileGuard("test_ntuple_writeread_subdir.root");
+
+   auto model = RNTupleModel::Create();
+   *model->MakeField<float>("pt") = 137.0;
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto dir = file->mkdir("foo");
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *dir);
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("/foo/ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(137.0, *reader->GetModel().GetDefaultEntry().GetPtr<float>("pt"));
+}
+
 TEST(RNTuple, FileAnchor)
 {
    FileRaii fileGuard("test_ntuple_file_anchor.root");


### PR DESCRIPTION
With the patch, `RNTupleWriter::Append()` can take a sub directory in a TFile. On the reading side, the RNTupleReader understands a ntuple name of the form `[/]foo/bar/ntpl` and opens it correctly. Opening from the anchor directly anyway worked.

Fixes #14007 

