### PR TITLE
[ntuple] Enforce RNTuple naming rules

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -475,8 +475,6 @@ public:
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing sub field (sub type).
    static std::vector<RCheckResult> Check(const std::string &fieldName, const std::string &typeName);
-   /// Check whether a given string is a valid field name
-   static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 
    /// Generates an object of the field type and allocates new initialized memory according to the type.
    /// Implemented at the end of this header because the implementation is using RField<T>::TypeName()

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -19,8 +19,10 @@
 #include <cstdint>
 
 #include <string>
+#include <string_view>
 #include <variant>
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RLogger.hxx>
 #include <ROOT/RNTupleReadOptions.hxx>
 
@@ -270,6 +272,9 @@ inline constexpr ENTupleStructure kTestFutureFieldStructure =
 
 inline constexpr RNTupleLocator::ELocatorType kTestLocatorType = static_cast<RNTupleLocator::ELocatorType>(0x7e);
 static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializableType);
+
+/// Check whether a given string is a valid name according to the RNTuple specification
+RResult<void> EnsureValidNameForRNTuple(std::string_view name, std::string_view where);
 
 } // namespace Internal
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -565,7 +565,7 @@ ROOT::Experimental::RFieldBase::RFieldBase(std::string_view name, std::string_vi
      fPrincipalColumn(nullptr),
      fTraits(isSimple ? kTraitMappable : 0)
 {
-   EnsureValidFieldName(name);
+   ROOT::Experimental::Internal::EnsureValidNameForRNTuple(name, "Field");
 }
 
 std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const
@@ -893,14 +893,6 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       return result;
    }
    return R__FORWARD_RESULT(fnFail("unknown type: " + canonicalType));
-}
-
-ROOT::Experimental::RResult<void> ROOT::Experimental::RFieldBase::EnsureValidFieldName(std::string_view fieldName)
-{
-   if (fieldName.find('.') != std::string::npos) {
-      return R__FAIL("name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
-   }
-   return RResult<void>::Success();
 }
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -792,7 +792,7 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureFieldExists(Descri
 ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureValidDescriptor() const
 {
    // Reuse field name validity check
-   auto validName = RFieldBase::EnsureValidFieldName(fDescriptor.GetName());
+   auto validName = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fDescriptor.GetName(), "Field");
    if (!validName) {
       return R__FORWARD_ERROR(validName);
    }
@@ -906,7 +906,7 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
    }
    // FieldZero is usually named "" and would be a false positive here
    if (fField.GetParentId() != kInvalidDescriptorId) {
-      auto validName = RFieldBase::EnsureValidFieldName(fField.GetFieldName());
+      auto validName = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fField.GetFieldName(), "Field");
       if (!validName) {
          return R__FORWARD_ERROR(validName);
       }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -208,7 +208,7 @@ ROOT::Experimental::RNTupleModel::RUpdater::AddProjectedField(std::unique_ptr<RF
 
 void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
-   RResult<void> nameValid = RFieldBase::EnsureValidFieldName(fieldName);
+   RResult<void> nameValid = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fieldName, "Field");
    if (!nameValid) {
       nameValid.Throw();
    }

--- a/tree/ntuple/v7/src/RNTupleUtil.cxx
+++ b/tree/ntuple/v7/src/RNTupleUtil.cxx
@@ -2,6 +2,8 @@
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch> & Max Orok <maxwellorok@gmail.com>
 /// \date 2020-07-14
+/// \author Vincenzo Eduardo Padulano, CERN
+/// \date 2024-11-08
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
@@ -18,10 +20,34 @@
 #include "ROOT/RLogger.hxx"
 #include "ROOT/RMiniFile.hxx"
 
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <iostream>
 
 ROOT::Experimental::RLogChannel &ROOT::Experimental::NTupleLog() {
    static RLogChannel sLog("ROOT.NTuple");
    return sLog;
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Internal::EnsureValidNameForRNTuple(std::string_view name, std::string_view where)
+{
+   using codeAndRepr = std::pair<const char *, const char *>;
+   constexpr static std::array<codeAndRepr, 4> forbiddenChars{codeAndRepr{"\u002E", "."}, codeAndRepr{"\u002F", "/"},
+                                                              codeAndRepr{"\u0020", "space"},
+                                                              codeAndRepr{"\u005C", "\\"}};
+
+   for (auto &&[code, repr] : forbiddenChars) {
+      if (name.find(code) != std::string_view::npos)
+         return R__FAIL(std::string(where) + " name '" + std::string(name) + "' cannot contain character '" + repr +
+                        "'.");
+   }
+
+   if (std::count_if(name.begin(), name.end(), [](unsigned char c) { return std::iscntrl(c); }))
+      return R__FAIL(std::string(where) + " name '" + std::string(name) +
+                     "' cannot contain character classified as control character. These notably include newline, tab, "
+                     "carriage return.");
+
+   return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -627,6 +627,7 @@ bool ROOT::Experimental::Internal::RWritePageMemoryManager::TryUpdate(RColumn &c
 ROOT::Experimental::Internal::RPageSink::RPageSink(std::string_view name, const RNTupleWriteOptions &options)
    : RPageStorage(name), fOptions(options.Clone()), fWritePageMemoryManager(options.GetPageBufferBudget())
 {
+   ROOT::Experimental::Internal::EnsureValidNameForRNTuple(name, "RNTuple").ThrowOnError();
 }
 
 ROOT::Experimental::Internal::RPageSink::~RPageSink() {}

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -15,7 +15,7 @@ TEST(RNTupleModel, EnforceValidFieldNames)
       auto field3 = model->MakeField<float>("pt.pt", 42.0);
       FAIL() << "field name with periods should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain dot characters '.'"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain character '.'"));
    }
 
    // Previous failures to create 'pt' should not block the name

--- a/tree/ntuple/v7/test/rfield_basics.cxx
+++ b/tree/ntuple/v7/test/rfield_basics.cxx
@@ -49,7 +49,7 @@ TEST(RField, ValidNaming)
       RFieldBase::Create("x.y", "float").Unwrap();
       FAIL() << "creating a field with an invalid name should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain dot characters '.'"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain character '.'"));
    }
 
    auto field = RFieldBase::Create("x", "float").Unwrap();
@@ -58,6 +58,6 @@ TEST(RField, ValidNaming)
       field->Clone("x.y");
       FAIL() << "cloning a field with an invalid name should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain dot characters '.'"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'x.y' cannot contain character '.'"));
    }
 }


### PR DESCRIPTION
RNTuple naming rules are enforced when creating a field or a new RNTuple for writing. The function responsible for doing this check is extracted into a utility header.

