### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -1,0 +1,5 @@
+builtin_zstd=ON
+builtin_zlib=ON
+builtin_nlohmannjson=On
+builtin_vdt=On
+pythia8=Off

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -358,6 +358,8 @@ jobs:
         include:
           - image: fedora40
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
+          - image: fedora41
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9

--- a/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/DispatchPtr.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/include/CPyCppyy/DispatchPtr.h
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    PyObject* Get() const;
+    PyObject* Get(bool borrowed=true) const;
 
 private:
     PyObject* fPyHardRef;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
@@ -413,7 +413,16 @@ void CPyCppyy::ExecScript(const std::string& name, const std::vector<std::string
                           << std::endl;
             }
          };
+
+#if PY_VERSION_HEX < 0x30d00f0
          WideStringListAppendHelper(&fConfig.argv, Py_GetProgramName());
+#else
+         PyObject* progname = PySys_GetObject("executable");    // borrowed
+         wchar_t buf[4096];
+         Py_ssize_t sz = CPyCppyy_PyUnicode_AsWideChar(progname, buf, 4095);
+         if (0 < sz)
+             WideStringListAppendHelper(&fConfig.argv, buf);
+#endif
          for (const auto &iarg : argv2) {
             WideStringListAppendHelper(&fConfig.argv, iarg.c_str());
          }

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -479,12 +479,14 @@ static PyObject* meta_getattro(PyObject* pyclass, PyObject* pyname)
     // try all outstanding using namespaces in turn to find the attribute (will cache
     // locally later; TODO: doing so may cause pathological cases)
         for (auto pyref : *klass->fImp.fUsing) {
-            PyObject* pyuscope = PyWeakref_GetObject(pyref);
+            PyObject* pyuscope = CPyCppyy_GetWeakRef(pyref);
             if (pyuscope) {
                 attr = PyObject_GetAttr(pyuscope, pyname);
-                if (attr) break;
-                PyErr_Clear();
+                if (!attr) PyErr_Clear();
+                Py_DECREF(pyuscope);
             }
+            if (attr)
+                break;
         }
     }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -351,6 +351,24 @@ inline PyObject* CPyCppyy_tp_call(PyObject* cb, PyObject* args, size_t, PyObject
 }
 #endif
 
+// weakref forced strong reference
+#if PY_VERSION_HEX < 0x30d00f0
+static inline PyObject* CPyCppyy_GetWeakRef(PyObject* ref) {
+    PyObject* pyobject = PyWeakref_GetObject(ref);
+    if (!pyobject || pyobject == Py_None)
+        return nullptr;
+    Py_INCREF(pyobject);
+    return pyobject;
+}
+#else
+static inline PyObject* CPyCppyy_GetWeakRef(PyObject* ref) {
+    PyObject* pyobject = nullptr;
+    if (PyWeakref_GetRef(ref, &pyobject) != -1)
+        return pyobject;
+    return nullptr;
+}
+#endif
+
 // Py_TYPE as inline function
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
 static inline

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -214,23 +214,15 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
-PyObject _CPyCppyy_NullPtrStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyNullPtr_t_Type};
+PyObject _CPyCppyy_NullPtrStruct = {
+    _PyObject_EXTRA_INIT
+    1, &PyNullPtr_t_Type
+};
 
-PyObject _CPyCppyy_DefaultStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyDefault_t_Type};
+PyObject _CPyCppyy_DefaultStruct = {
+    _PyObject_EXTRA_INIT
+    1, &PyDefault_t_Type
+};
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -484,7 +484,12 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
 // Python class to keep the inheritance tree intact)
     for (const auto& name : protected_names) {
          PyObject* disp_dct = PyObject_GetAttr(disp_proxy, PyStrings::gDict);
+#if PY_VERSION_HEX < 0x30d00f0
          PyObject* pyf = PyMapping_GetItemString(disp_dct, (char*)name.c_str());
+#else
+         PyObject* pyf = nullptr;
+         PyMapping_GetOptionalItemString(disp_dct, (char*)name.c_str(), &pyf);
+#endif
          if (pyf) {
              PyObject_SetAttrString((PyObject*)klass, (char*)name.c_str(), pyf);
              Py_DECREF(pyf);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
@@ -499,11 +499,9 @@ PyObject* CPyCppyy::GetScopeProxy(Cppyy::TCppScope_t scope)
 // Retrieve scope proxy from the known ones.
     PyClassMap_t::iterator pci = gPyClasses.find(scope);
     if (pci != gPyClasses.end()) {
-        PyObject* pyclass = PyWeakref_GetObject(pci->second);
-        if (pyclass != Py_None) {
-            Py_INCREF(pyclass);
+        PyObject* pyclass = CPyCppyy_GetWeakRef(pci->second);
+        if (pyclass)
             return pyclass;
-        }
     }
 
     return nullptr;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -528,8 +528,9 @@ PyObject* VectorData(PyObject* self, PyObject*)
 
 
 //---------------------------------------------------------------------------
-PyObject* VectorArray(PyObject* self, PyObject* /* args */)
+PyObject* VectorArray(PyObject* self, PyObject* /* args */, PyObject* /* kwargs */)
 {
+    // TODO: kwargs are ignored as the only known use is NumPy passing copy=False
     PyObject* pydata = VectorData(self, nullptr);
     PyObject* view = PyObject_CallMethodNoArgs(pydata, PyStrings::gArray);
     Py_DECREF(pydata);
@@ -1809,7 +1810,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
             Utility::AddToClass(pyclass, "data", (PyCFunction)VectorData);
 
         // numpy array conversion
-            Utility::AddToClass(pyclass, "__array__", (PyCFunction)VectorArray);
+            Utility::AddToClass(pyclass, "__array__", (PyCFunction)VectorArray, METH_VARARGS | METH_KEYWORDS /* unused */);
 
         // checked getitem
             if (HasAttrDirect(pyclass, PyStrings::gLen)) {

--- a/bindings/pyroot/cppyy/cppyy/doc/source/changelog.rst
+++ b/bindings/pyroot/cppyy/cppyy/doc/source/changelog.rst
@@ -18,9 +18,15 @@ master
 * Improved overload selection for classes with deep hierarchies
 * Fixed regression when calling static methods with default args on instances
 * Fixed regression for pickling enums (in global scope only)
+* Proper error handling on ``memoryview(array.array('B', []))``
 * Auto-cast elements of std::vector<T*>, with T a class type
 * Add a ``Sequence_Check()`` method to the public API
 * Fix offset calculation of ``std::vector<unsigned>`` datamember on Mac arm
+* Extend API to define executor and converter aliases
+* Use importlib.metadata instead of pkg_resources for py3.11 and later
+* Added out-of-bounds handling for small char-based enums
+* Fixes for py3.12 and py3.13
+* Upgrade backend to Clang16
 
 
 2023-11-15: 3.1.2

--- a/bindings/pyroot/cppyy/cppyy/python/cppyy/__init__.py
+++ b/bindings/pyroot/cppyy/cppyy/python/cppyy/__init__.py
@@ -305,18 +305,27 @@ if not ispypy:
 
     if apipath_extra is None:
         try:
-            import pkg_resources as pr
+            if 0x30a0000 <= sys.hexversion:
+                import importlib.metadata as m
 
-            d = pr.get_distribution('CPyCppyy')
-            for line in d.get_metadata_lines('RECORD'):
-                if 'API.h' in line:
-                    part = line[0:line.find(',')]
+                for p in m.files('CPyCppyy'):
+                    if p.match('API.h'):
+                        ape = p.locate()
+                        break
+                del p, m
+            else:
+                import pkg_resources as pr
 
-            ape = os.path.join(d.location, part)
+                d = pr.get_distribution('CPyCppyy')
+                for line in d.get_metadata_lines('RECORD'):
+                    if 'API.h' in line:
+                        ape = os.path.join(d.location, line[0:line.find(',')])
+                        break
+                del line, d, pr
+
             if os.path.exists(ape):
                 apipath_extra = os.path.dirname(os.path.dirname(ape))
-
-            del part, d, pr
+            del ape
         except Exception:
             pass
 

--- a/bindings/pyroot/cppyy/cppyy/python/cppyy/_stdcpp_fix.py
+++ b/bindings/pyroot/cppyy/cppyy/python/cppyy/_stdcpp_fix.py
@@ -1,6 +1,6 @@
 import sys
 
-# It may be that the interpreter (wether python or pypy-c) was not linked
+# It may be that the interpreter (whether python or pypy-c) was not linked
 # with C++; force its loading before doing anything else (note that not
 # linking with C++ spells trouble anyway for any C++ libraries ...)
 if 'linux' in sys.platform and 'GCC' in sys.version:

--- a/bindings/pyroot/cppyy/cppyy/test/advancedcpp.cxx
+++ b/bindings/pyroot/cppyy/cppyy/test/advancedcpp.cxx
@@ -73,12 +73,12 @@ double pass_double_through_const_ref(const double& d) { return d; }
 
 
 // for math conversions testing
-bool operator==(const some_comparable& c1, const some_comparable& c2 )
+bool operator==(const some_comparable& c1, const some_comparable& c2)
 {
    return &c1 != &c2;              // the opposite of a pointer comparison
 }
 
-bool operator!=( const some_comparable& c1, const some_comparable& c2 )
+bool operator!=(const some_comparable& c1, const some_comparable& c2)
 {
    return &c1 == &c2;              // the opposite of a pointer comparison
 }

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -1038,10 +1038,10 @@ class TestDATATYPES:
         struct Comparable1 {
             Comparable1(int i) : fInt(i) {}
             int fInt;
-            static bool __eq__(const Comparable1& self, const Comparable1& other){
+            static bool __eq__(const Comparable1& self, const Comparable1& other) {
                 return self.fInt == other.fInt;
             }
-            static bool __ne__(const Comparable1& self, const Comparable1& other){
+            static bool __ne__(const Comparable1& self, const Comparable1& other) {
                 return self.fInt != other.fInt;
             }
         };
@@ -1049,10 +1049,10 @@ class TestDATATYPES:
         struct Comparable2 {
             Comparable2(int i) : fInt(i) {}
             int fInt;
-            bool __eq__(const Comparable2& other){
+            bool __eq__(const Comparable2& other) {
                 return fInt == other.fInt;
             }
-            bool __ne__(const Comparable2& other){
+            bool __ne__(const Comparable2& other) {
                 return fInt != other.fInt;
             }
         }; }""")

--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -528,7 +528,7 @@ class TestFRAGILE:
         err = get_errmsg(cppdef_exc)
         assert "FailedtoparsethegivenC++code" in err
         assert "error:" in err
-        assert "expectedunqualified-id" in err
+        assert "invaliddigit" in err
         assert "1aap=42;" in err
 
     def test22_cppexec(self):

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1704,9 +1704,9 @@ class TestSTLDEQUE:
         """Return by value of a deque used to crash"""
 
         import cppyy
-        assert cppyy.cppdef("""std::deque<long double> f() {
+        assert cppyy.cppdef("""std::deque<long double> emptyf() {
             std::deque<long double> d; d.push_back(0); return d ; }""")
-        x = cppyy.gbl.f()
+        x = cppyy.gbl.emptyf()
         assert x
         del x
 

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Always-convert-returned-std-string.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Always-convert-returned-std-string.patch
@@ -88,6 +88,9 @@ index 3ab4c8b3a1..ae0e31cac8 100644
          Utility::AddToClass(pyclass, "__str__", (PyCFunction)UTF8Str, METH_NOARGS);
      }
 +#endif
+ 
+     if (Cppyy::IsAggregate(((CPPClass*)pyclass)->fCppType) && name.compare(0, 5, "std::", 5) != 0) {
+     // create a pseudo-constructor to allow initializer-style object creation
 -- 
 2.44.0
 

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Don-t-attempt-to-expose-protected-data-members.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Don-t-attempt-to-expose-protected-data-members.patch
@@ -1,0 +1,77 @@
+From 8f54f8c5434ff593b5a3acc3f97e4cd5f0310fdd Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Thu, 7 Nov 2024 10:19:04 +0100
+Subject: [PATCH] [CPyCppyy] Don't attempt to expose protected data members in
+ dispatcher
+
+This mechanism crashes in Python 3.13, and it also didn't work before
+with previous Python 3 versions:
+
+```python
+import cppyy
+
+cppyy.cppdef("""
+
+class MyBaseClass {
+public:
+   virtual ~MyBaseClass() = default;
+protected:
+   int protectedFunc() { return 5; }
+   int _protectedData = 4;
+};
+
+""")
+
+class MyDerivedClass(cppyy.gbl.MyBaseClass):
+    pass
+
+my_obj = MyDerivedClass()
+
+print(my_obj.protectedFunc()) # works!
+print(my_obj._protectedData) # doesn't work!
+```
+
+Here is the output with Python 3.8 on lxplus for example:
+
+```txt
+5
+Traceback (most recent call last):
+  File "/afs/cern.ch/user/r/rembserj/repro.py", line 21, in <module>
+    print(my_obj._protectedData) # doesn't work!
+AttributeError: 'MyDerivedClass' object has no attribute '_protectedData'
+```
+
+It actually worked in the past before the cppyy upgrade in ROOT 6.32.
+
+Therefore, there is still a regression that should be fixed.
+
+However, commenting out the code that now doesn't work anyway still
+helps to avoid the crashes in Python 3.13, so this commit suggests to do
+this.
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+index cdef2b8c7b..0fd1705966 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+@@ -407,6 +407,7 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
+ 
+ // destructor: default is fine
+ 
++#if 0 // doesn't work
+ // pull in data members that are protected
+     bool setPublic = false;
+     for (const auto& binfo : base_infos) {
+@@ -426,6 +427,7 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
+             }
+         }
+     }
++#endif
+ 
+ // initialize the dispatch pointer for all direct bases that have one
+     BaseInfos_t::size_type disp_inited = 0;
+-- 
+2.47.0
+

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Prevent-construction-of-agg-init-for-tuple.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Prevent-construction-of-agg-init-for-tuple.patch
@@ -1,0 +1,27 @@
+From 3b62eaa9ec2dfabccca52910d8239af7d9e56c9a Mon Sep 17 00:00:00 2001
+From: maximusron <aaronjomyjoseph@gmail.com>
+Date: Sun, 29 Sep 2024 09:32:17 +0200
+Subject: [PATCH] [PyROOT] Prevent construction of aggregate initializer for
+ std::tuple
+
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+index b5d5290e46..2196b94ff3 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+@@ -1720,7 +1720,8 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
+     }
+ #endif
+ 
+-    if (Cppyy::IsAggregate(((CPPClass*)pyclass)->fCppType) && name.compare(0, 5, "std::", 5) != 0) {
++    if (Cppyy::IsAggregate(((CPPClass*)pyclass)->fCppType) && name.compare(0, 5, "std::", 5) != 0 &&
++        name.compare(0, 6, "tuple<", 6) != 0) {
+     // create a pseudo-constructor to allow initializer-style object creation
+         Cppyy::TCppType_t kls = ((CPPClass*)pyclass)->fCppType;
+         Cppyy::TCppIndex_t ndata = Cppyy::GetNumDatamembers(kls);
+-- 
+2.47.0
+

--- a/bindings/pyroot/cppyy/sync-upstream
+++ b/bindings/pyroot/cppyy/sync-upstream
@@ -46,6 +46,7 @@ git apply patches/CPyCppyy-Always-convert-returned-std-string.patch
 git apply patches/CPyCppyy-Disable-implicit-conversion-to-smart-ptr.patch
 git apply patches/CPyCppyy-TString_converter.patch
 git apply patches/CPyCppyy-Remove-implicit-conversion-of-any-ctypes-ptr.patch
+git apply patches/CPyCppyy-Prevent-construction-of-agg-init-for-tuple.patch
 git apply patches/cppyy-No-CppyyLegacy-namespace.patch
 git apply patches/cppyy-Remove-Windows-workaround.patch
 git apply patches/cppyy-Don-t-enable-cling-autoloading.patch

--- a/bindings/tpython/src/TPyClassGenerator.cxx
+++ b/bindings/tpython/src/TPyClassGenerator.cxx
@@ -87,7 +87,12 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             std::string func_name = PyUnicode_AsUTF8(key);
 
             // figure out number of variables required
+#if PY_VERSION_HEX < 0x30d00f0
             PyObject *func_code = PyObject_GetAttrString(attr, (char *)"func_code");
+#else
+            PyObject *func_code = nullptr;
+            PyObject_GetOptionalAttrString(attr, (char *)"func_code", &func_code);
+#endif
             PyObject *var_names = func_code ? PyObject_GetAttrString(func_code, (char *)"co_varnames") : NULL;
             int nVars = var_names ? PyTuple_GET_SIZE(var_names) : 0 /* TODO: probably large number, all default? */;
             if (nVars < 0)


### PR DESCRIPTION
1. Sync with upstream cppyy, mostly to avoid warnings when building with Python 3.13.
2. Use GetOptional family of C Python API where necessary

A regression in ROOT 6.32 was unearthed in the process: #16852.