### PR TITLE
[skip-ci] Implement the preview of the tutorials

### DIFF
--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -448,7 +448,10 @@ void FilterTutorial()
 
       // \preview found
       if (gLineString.find("\\preview") != string::npos) {
-         ReplaceAll(gLineString, "\\preview", StringFormat("\\htmlonly <img src=\"pict1_%s.png\" valign=\"middle\" width=\"120\"/>\\endhtmlonly",gMacroName.c_str()));
+         string name = gMacroName;
+         int width = 120;
+         ReplaceAll(name,".C","_8C.html");
+         ReplaceAll(gLineString, "\\preview", StringFormat("\\htmlonly <a href=\"%s\"><img src=\"pict1_%s.png\" valign=\"middle\" width=\"%d\"/></a>\\endhtmlonly",name.c_str(),gMacroName.c_str(),width));
       }
 
       // \macro_output found

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -432,7 +432,7 @@ void FilterTutorial()
          ReplaceAll(gLineString, "\\macro_code", StringFormat("\\include %s",gMacroName.c_str()));
       }
 
-      // notebook found
+      // \notebook found
       if (gLineString.find("\\notebook") != string::npos) {
          // Notebooks are generated in dedicated step:
          worklist_py << "converttonotebook.py " << gFileName << " " << gOutDir << "/notebooks/" << std::endl;
@@ -444,6 +444,11 @@ void FilterTutorial()
              gLineString = "/// ";
          }
          gLineString += StringFormat( "\\htmlonly <a href=\"https://nbviewer.jupyter.org/url/root.cern/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src= notebook.gif alt=\"View in nbviewer\" style=\"height:1.5em\" ></a> <a href=\"https://cern.ch/swanserver/cgi-bin/go?projurl=https://root.cern/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src=\"https://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png\"  alt=\"Open in SWAN\" style=\"height:1.5em\" ></a> <br/>\\endhtmlonly \n", gMacroName.c_str() , gMacroName.c_str());
+      }
+
+      // \preview found
+      if (gLineString.find("\\preview") != string::npos) {
+         ReplaceAll(gLineString, "\\preview", StringFormat("\\htmlonly <img src=\"pict1_%s.png\" valign=\"middle\" width=\"120\"/>\\endhtmlonly",gMacroName.c_str()));
       }
 
       // \macro_output found

--- a/tutorials/graphics/AtlasExample.C
+++ b/tutorials/graphics/AtlasExample.C
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
+/// \preview
 /// Show how ATLAS Style looks like. It is based on a style file from BaBar.
 ///
 /// \macro_image

--- a/tutorials/graphics/accessiblecolorschemes.C
+++ b/tutorials/graphics/accessiblecolorschemes.C
@@ -1,14 +1,14 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Choosing an appropriate color scheme is essential for making results easy to understand and
-/// interpret. Factors like colorblindness and converting colors to grayscale for publications
+/// \preview Choosing an appropriate color scheme is essential for making results easy to understand and interpret.
+/// Factors like colorblindness and converting colors to grayscale for publications
 /// can impact accessibility. Furthermore, results should be aesthetically pleasing. The following
 /// three color schemes, recommended by M. Petroff in [arXiv:2107.02270v2](https://arxiv.org/pdf/2107.02270)
 /// and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
 /// under the MIT License, meet these criteria.
 ///
-/// \macro_image
+/// \macro_image Hello !!
 /// \macro_code
 ///
 /// \author Olivier Couet

--- a/tutorials/graphics/accessiblecolorschemes.C
+++ b/tutorials/graphics/accessiblecolorschemes.C
@@ -8,7 +8,7 @@
 /// and available on [GitHub](https://github.com/mpetroff/accessible-color-cycles)
 /// under the MIT License, meet these criteria.
 ///
-/// \macro_image Hello !!
+/// \macro_image
 /// \macro_code
 ///
 /// \author Olivier Couet

--- a/tutorials/graphics/archi.C
+++ b/tutorials/graphics/archi.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro displays the ROOT architecture.
+/// \preview This macro displays the ROOT architecture.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/graphics/arrows.C
+++ b/tutorials/graphics/arrows.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Draw arrows.
+/// \preview Draw arrows.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/graphics/canvas.C
+++ b/tutorials/graphics/canvas.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Example of primitives in a canvas.
+/// \preview Example of primitives in a canvas.
 /// One of the first actions in a ROOT session is the creation of a Canvas.
 /// Here we create a Canvas named "c1".
 ///

--- a/tutorials/graphics/canvas2.C
+++ b/tutorials/graphics/canvas2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example of canvas partitioning.
+/// \preview Example of canvas partitioning.
 /// Sometimes the Divide() method is not appropriate to divide a Canvas.
 /// Because of the left and right margins, all the pads do not have the
 /// same width and height. CanvasPartition does that properly. This

--- a/tutorials/graphics/ellipse.C
+++ b/tutorials/graphics/ellipse.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Draw ellipses.
+/// \preview Draw ellipses.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/graphics/inside.C
+++ b/tutorials/graphics/inside.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Test the IsInside methods of various graphics primitives.
+/// \preview Test the IsInside methods of various graphics primitives.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/graphics/mandelbrot.C
+++ b/tutorials/graphics/mandelbrot.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Using TExec to handle keyboard events and TComplex to draw the Mandelbrot set.
+/// \preview Using TExec to handle keyboard events and TComplex to draw the Mandelbrot set.
 ///
 /// Pressing the keys 'z' and 'u' will zoom and unzoom the picture
 /// near the mouse location, 'r' will reset to the default view.

--- a/tutorials/graphics/schroedinger_hydrogen.C
+++ b/tutorials/graphics/schroedinger_hydrogen.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Plot the Amplitude of a Hydrogen Atom.
+/// \preview Plot the Amplitude of a Hydrogen Atom.
 ///
 /// Visualize the Amplitude of a Hydrogen Atom in the n = 2, l = 0, m = 0 state.
 /// Demonstrates how TH2F can be used in Quantum Mechanics.


### PR DESCRIPTION
Display a preview of the tutorial graphics output.

a new directive `\preview` allows to do that.
<img width="884" alt="Screenshot 2024-11-07 at 11 52 40" src="https://github.com/user-attachments/assets/45048d8b-78cb-4581-8c89-ba6694dfbfcc">
