### PR TITLE
[ntuple] Merger: properly handle columns with different representations 

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -162,6 +162,7 @@ public:
       RValueRange(std::pair<double, double> range) : fMin(range.first), fMax(range.second) {}
 
       bool operator==(RValueRange other) const { return fMin == other.fMin && fMax == other.fMax; }
+      bool operator!=(RValueRange other) const { return !(*this == other); }
    };
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -49,7 +49,7 @@ enum class ENTupleMergeErrBehavior {
    kSkip
 };
 
-struct RColumnInfo;
+struct RColumnMergeInfo;
 struct RNTupleMergeData;
 struct RSealedPageMergeData;
 
@@ -80,12 +80,12 @@ class RNTupleMerger final {
    std::unique_ptr<RPageAllocator> fPageAlloc;
    std::optional<TTaskGroup> fTaskGroup;
 
-   void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId, std::span<RColumnInfo> commonColumns,
-                           RCluster::ColumnSet_t commonColumnSet, RSealedPageMergeData &sealedPageData,
-                           const RNTupleMergeData &mergeData);
+   void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
+                           std::span<RColumnMergeInfo> commonColumns, RCluster::ColumnSet_t commonColumnSet,
+                           RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData);
 
-   void MergeSourceClusters(RPageSource &source, std::span<RColumnInfo> commonColumns,
-                            std::span<RColumnInfo> extraDstColumns, RNTupleMergeData &mergeData);
+   void MergeSourceClusters(RPageSource &source, std::span<RColumnMergeInfo> commonColumns,
+                            std::span<RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData);
 
 public:
    RNTupleMerger();

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -283,17 +283,13 @@ CompareDescriptorStructure(const RNTupleDescriptor &dst, const RNTupleDescriptor
    std::vector<std::string> errors;
    RDescriptorsComparison res;
 
-   struct RCommonField {
-      const RFieldDescriptor *fDst;
-      const RFieldDescriptor *fSrc;
-   };
    std::vector<RCommonField> commonFields;
 
    for (const auto &dstField : dst.GetTopLevelFields()) {
       const auto srcFieldId = src.FindFieldId(dstField.GetFieldName());
       if (srcFieldId != kInvalidDescriptorId) {
          const auto &srcField = src.GetFieldDescriptor(srcFieldId);
-         commonFields.push_back({&dstField, &srcField});
+         commonFields.push_back({&srcField, &dstField});
       } else {
          res.fExtraDstFields.emplace_back(&dstField);
       }
@@ -428,7 +424,7 @@ CompareDescriptorStructure(const RNTupleDescriptor &dst, const RNTupleDescriptor
       return R__FAIL(errMsg);
 
    res.fCommonFields.reserve(commonFields.size());
-   for (const auto &[dstField, srcField] : commonFields) {
+   for (const auto &[srcField, dstField] : commonFields) {
       res.fCommonFields.emplace_back(srcField, dstField);
    }
 

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -1094,9 +1094,9 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
       fieldFooDbl.SetColumnRepresentatives({{EColumnType::kReal32}});
       auto ntuple = RNTupleWriter::Recreate(std::move(clonedModel), "ntuple", fileGuard2.GetPath());
       auto e = ntuple->CreateEntry();
-      auto pFoo = e->GetPtr<double>("foo");
+      auto pFoo2 = e->GetPtr<double>("foo");
       for (size_t i = 0; i < 10; ++i) {
-         *pFoo = i * 567;
+         *pFoo2 = i * 567;
          ntuple->Fill();
       }
    }
@@ -1125,8 +1125,9 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
          auto res = merger.Merge(sourcePtrs, *destination, opts);
          // TODO(gparolini): we want to support this in the future
          EXPECT_FALSE(bool(res));
-         if (res.GetError())
+         if (res.GetError()) {
             EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("different column type"));
+         }
          // EXPECT_TRUE(bool(res));
       }
       {
@@ -1134,8 +1135,9 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
          auto res = merger.Merge(sourcePtrs, *destination);
          // TODO(gparolini): we want to support this in the future
          EXPECT_FALSE(bool(res));
-         if (res.GetError())
+         if (res.GetError()) {
             EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("different column type"));
+         }
          // EXPECT_TRUE(bool(res));
       }
    }


### PR DESCRIPTION
The merger was calling RColumnElementBase::Generate() without specifying
the in-memory type. This would lead the element to be created with the
default in-memory type, which is wrong in some cases (e.g. when dealing
with fields with a different representation than the default)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


