### PR TITLE
[ntuple] Add zip timer to `RPageSinkBuf`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -100,7 +100,9 @@ private:
    /// I/O performance counters that get registered in fMetrics
    struct RCounters {
       Detail::RNTuplePlainCounter &fParallelZip;
+      Detail::RNTupleAtomicCounter &fTimeWallZip;
       Detail::RNTuplePlainCounter &fTimeWallCriticalSection;
+      Detail::RNTupleTickCounter<Detail::RNTupleAtomicCounter> &fTimeCpuZip;
       Detail::RNTupleTickCounter<Detail::RNTuplePlainCounter> &fTimeCpuCriticalSection;
    };
    std::unique_ptr<RCounters> fCounters;


### PR DESCRIPTION
There is a zip timer in `RPagePersistentSink`, used in `RPageSink{File,Daos}::CommitPageImpl`, but this code path not taken with buffered writing.