### PR TITLE
[ntuple] Improve RPagePool

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -18,6 +18,7 @@
 
 #include <ROOT/RNTupleUtil.hxx>
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -152,6 +153,7 @@ public:
    /// return value is ignored.
    void *GrowUnchecked(ClusterSize_t::ValueType nElements)
    {
+      assert(fNElements + nElements <= fMaxElements);
       auto offset = GetNBytes();
       fNElements += nElements;
       return static_cast<unsigned char *>(fBuffer) + offset;

--- a/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
@@ -50,7 +50,7 @@ public:
 
    /// Reserves memory large enough to hold nElements of the given size. The page is immediately tagged with
    /// a column id. Returns a default constructed page on out-of-memory condition.
-   virtual RPage NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) = 0;
+   virtual RPage NewPage(std::size_t elementSize, std::size_t nElements) = 0;
 };
 
 // clang-format off
@@ -65,7 +65,7 @@ protected:
    void DeletePage(RPage &page) final;
 
 public:
-   RPage NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) final;
+   RPage NewPage(std::size_t elementSize, std::size_t nElements) final;
 };
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 #include <vector>
 
 namespace ROOT {
@@ -72,6 +73,8 @@ private:
    ///   - searching by page
    std::vector<RPage> fPages;
    std::vector<RPageInfo> fPageInfos;
+   /// Used in ReleasePage() to find the page index in fPages/fPageInfos
+   std::unordered_map<void *, std::size_t> fLookupByBuffer;
    std::mutex fLock;
 
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -90,7 +90,7 @@ private:
    std::mutex fLock; ///< The page pool is accessed concurrently due to parallel decompression
 
    /// Add a new page to the fLookupByBuffer and fLookupByKey data structures.
-   void AddPage(const RPage &page, const RKey &key, std::size_t index);
+   REntry &AddPage(RPage page, const RKey &key, std::int64_t initialRefCounter);
 
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -62,20 +62,17 @@ public:
    };
 
 private:
-   struct RPageInfo {
+   /// Every page in the page pool is annotated with a search key and a reference counter.
+   struct REntry {
+      RPage fPage;
       RKey fKey;
       std::int32_t fRefCounter = 0;
    };
 
-   /// TODO(jblomer): should be an efficient index structure that allows
-   ///   - random insert
-   ///   - random delete
-   ///   - searching by page
-   std::vector<RPage> fPages;
-   std::vector<RPageInfo> fPageInfos;
-   /// Used in ReleasePage() to find the page index in fPages/fPageInfos
+   std::vector<REntry> fEntries; ///< All cached pages in the page pool
+   /// Used in ReleasePage() to find the page index in fPages
    std::unordered_map<void *, std::size_t> fLookupByBuffer;
-   std::mutex fLock;
+   std::mutex fLock; ///< The page pool is accessed concurrently due to parallel decompression
 
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -48,6 +48,7 @@ class RPagePool {
    // TODO(jblomer): move column ID from RPage to this struct
    struct RPageInfo {
       std::type_index fInMemoryType = std::type_index(typeid(void));
+      std::int32_t fRefCounter = 0;
    };
 
    /// TODO(jblomer): should be an efficient index structure that allows
@@ -56,7 +57,6 @@ class RPagePool {
    ///   - searching by page
    std::vector<RPage> fPages;
    std::vector<RPageInfo> fPageInfos;
-   std::vector<std::int32_t> fReferences;
    std::mutex fLock;
 
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -76,7 +76,7 @@ private:
    struct REntry {
       RPage fPage;
       RKey fKey;
-      std::int32_t fRefCounter = 0;
+      std::int64_t fRefCounter = 0;
    };
 
    std::vector<REntry> fEntries; ///< All cached pages in the page pool

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -61,7 +61,6 @@ public:
    };
 
 private:
-   // TODO(jblomer): move column ID from RPage to this struct
    struct RPageInfo {
       RKey fKey;
       std::int32_t fRefCounter = 0;
@@ -116,7 +115,6 @@ class RPageRef {
    RPageRef(const RPage &page, RPagePool *pagePool) : fPagePool(pagePool)
    {
       // We leave the fPage::fPageAllocator member unset (nullptr), since fPage is a non-owning view on the page
-      fPage.fColumnId = page.fColumnId;
       fPage.fBuffer = page.fBuffer;
       fPage.fElementSize = page.fElementSize;
       fPage.fNElements = page.fNElements;
@@ -147,10 +145,9 @@ public:
          fPagePool->ReleasePage(fPage);
    }
 
-   /// Used by the friend virtual page source to map the physical column and cluster IDs to ther virtual counterparts
-   void ChangeIds(DescriptorId_t columnId, DescriptorId_t clusterId)
+   /// Used by the friend virtual page source to map the cluster ID to its virtual counterpart
+   void ChangeClusterId(DescriptorId_t clusterId)
    {
-      fPage.fColumnId = columnId;
       fPage.fClusterInfo = RPage::RClusterInfo(clusterId, fPage.fClusterInfo.GetIndexOffset());
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -724,7 +724,7 @@ public:
    /// currently always makes a memory copy, even if the sealed page is uncompressed and in the final memory layout.
    /// The optimization of directly mapping pages is left to the concrete page source implementations.
    RResult<RPage> static UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element,
-                                    DescriptorId_t physicalColumnId, RPageAllocator &pageAlloc);
+                                    RPageAllocator &pageAlloc);
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleReadOptions &GetReadOptions() const { return fOptions; }
@@ -790,9 +790,7 @@ public:
    void UnzipCluster(RCluster *cluster);
 
    // TODO(gparolini): for symmetry with SealPage(), we should either make this private or SealPage() public.
-   RResult<RPage>
-   UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
-
+   RResult<RPage> UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element);
 }; // class RPageSource
 
 } // namespace Internal

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -88,7 +88,7 @@ bool ROOT::Experimental::Internal::RColumn::TryMapPage(NTupleSize_t globalIndex)
    std::size_t iTeam = 1;
    do {
       fReadPageRef = fPageSource->LoadPage(fTeam.at(fLastGoodTeamIdx)->GetHandleSource(), globalIndex);
-      if (fReadPageRef.Get().IsValid())
+      if (!fReadPageRef.Get().IsNull())
          break;
       fLastGoodTeamIdx = (fLastGoodTeamIdx + 1) % nTeam;
       iTeam++;
@@ -103,7 +103,7 @@ bool ROOT::Experimental::Internal::RColumn::TryMapPage(RClusterIndex clusterInde
    std::size_t iTeam = 1;
    do {
       fReadPageRef = fPageSource->LoadPage(fTeam.at(fLastGoodTeamIdx)->GetHandleSource(), clusterIndex);
-      if (fReadPageRef.Get().IsValid())
+      if (!fReadPageRef.Get().IsNull())
          break;
       fLastGoodTeamIdx = (fLastGoodTeamIdx + 1) % nTeam;
       iTeam++;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -136,8 +136,6 @@ try {
 namespace {
 // Functor used to change the compression of a page to `options.fCompressionSettings`.
 struct RChangeCompressionFunc {
-   DescriptorId_t fOutputColumnId;
-
    const RColumnElementBase &fSrcColElement;
    const RColumnElementBase &fDstColElement;
    const RNTupleMergeOptions &fMergeOptions;
@@ -148,7 +146,7 @@ struct RChangeCompressionFunc {
 
    void operator()() const
    {
-      auto page = RPageSource::UnsealPage(fSealedPage, fSrcColElement, fOutputColumnId, fPageAlloc).Unwrap();
+      auto page = RPageSource::UnsealPage(fSealedPage, fSrcColElement, fPageAlloc).Unwrap();
       RPageSink::RSealPageConfig sealConf;
       sealConf.fElement = &fDstColElement;
       sealConf.fPage = &page;
@@ -546,8 +544,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
             auto &buffer = sealedPageData.fBuffers[pageBufferBaseIdx + pageIdx];
             buffer = std::make_unique<std::uint8_t[]>(uncompressedSize + checksumSize);
             RChangeCompressionFunc compressTask{
-               column.fOutputId, *srcColElement, *dstColElement, mergeData.fMergeOpts,
-               sealedPage,       *fPageAlloc,    buffer.get(),
+               *srcColElement, *dstColElement, mergeData.fMergeOpts, sealedPage, *fPageAlloc, buffer.get(),
             };
 
             if (fTaskGroup)

--- a/tree/ntuple/v7/src/RPageAllocator.cxx
+++ b/tree/ntuple/v7/src/RPageAllocator.cxx
@@ -20,14 +20,13 @@
 
 #include <algorithm>
 
-ROOT::Experimental::Internal::RPage ROOT::Experimental::Internal::RPageAllocatorHeap::NewPage(ColumnId_t columnId,
-                                                                                              std::size_t elementSize,
-                                                                                              std::size_t nElements)
+ROOT::Experimental::Internal::RPage
+ROOT::Experimental::Internal::RPageAllocatorHeap::NewPage(std::size_t elementSize, std::size_t nElements)
 {
    R__ASSERT((elementSize > 0) && (nElements > 0));
    auto nbytes = elementSize * nElements;
    auto buffer = new unsigned char[nbytes];
-   return RPage(columnId, buffer, this, elementSize, nElements);
+   return RPage(buffer, this, elementSize, nElements);
 }
 
 void ROOT::Experimental::Internal::RPageAllocatorHeap::DeletePage(RPage &page)

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -26,12 +26,7 @@ void ROOT::Experimental::Internal::RPagePool::AddPage(const RPage &page, const R
 {
    assert(fLookupByBuffer.count(page.GetBuffer()) == 0);
    fLookupByBuffer[page.GetBuffer()] = index;
-   auto itr = fLookupByKey.find(key);
-   if (itr == fLookupByKey.end()) {
-      fLookupByKey.emplace(key, std::vector<size_t>({index}));
-   } else {
-      itr->second.emplace_back(index);
-   }
+   fLookupByKey[key].emplace_back(index);
 }
 
 ROOT::Experimental::Internal::RPageRef ROOT::Experimental::Internal::RPagePool::RegisterPage(RPage page, RKey key)

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -55,6 +55,7 @@ void ROOT::Experimental::Internal::RPagePool::ReleasePage(const RPage &page)
    const auto idx = itrLookup->second;
    const auto N = fEntries.size();
 
+   assert(fEntries[idx].fRefCounter >= 1);
    if (--fEntries[idx].fRefCounter == 0) {
       fLookupByBuffer.erase(itrLookup);
 

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -50,11 +50,13 @@ void ROOT::Experimental::Internal::RPagePool::ReleasePage(const RPage &page)
    if (page.IsNull()) return;
    std::lock_guard<std::mutex> lockGuard(fLock);
 
-   const auto idx = fLookupByBuffer.at(page.GetBuffer());
+   auto itrLookup = fLookupByBuffer.find(page.GetBuffer());
+   assert(itrLookup != fLookupByBuffer.end());
+   const auto idx = itrLookup->second;
    const auto N = fEntries.size();
 
    if (--fEntries[idx].fRefCounter == 0) {
-      fLookupByBuffer.erase(page.GetBuffer());
+      fLookupByBuffer.erase(itrLookup);
 
       auto itrPageSet = fLookupByKey.find(fEntries[idx].fKey);
       assert(itrPageSet != fLookupByKey.end());

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -188,7 +188,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
    }
 
    // TODO avoid frequent (de)allocations by holding on to allocated buffers in RColumnBuf
-   zipItem.fPage = fPageAllocator->NewPage(columnHandle.fPhysicalId, page.GetElementSize(), page.GetNElements());
+   zipItem.fPage = fPageAllocator->NewPage(page.GetElementSize(), page.GetNElements());
    // make sure the page is aware of how many elements it will have
    zipItem.fPage.GrowUnchecked(page.GetNElements());
    memcpy(zipItem.fPage.GetBuffer(), page.GetBuffer(), page.GetNBytes());

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -169,11 +169,11 @@ ROOT::Experimental::Internal::RPageSourceFriends::LoadPage(ColumnHandle_t column
 
    auto pageRef = fSources[originColumnId.fSourceIdx]->LoadPage(columnHandle, globalIndex);
    // Suppressed column
-   if (!pageRef.Get().IsValid())
+   if (pageRef.Get().IsNull())
       return RPageRef();
 
    auto virtualClusterId = fIdBiMap.GetVirtualId({originColumnId.fSourceIdx, pageRef.Get().GetClusterInfo().GetId()});
-   pageRef.ChangeIds(virtualColumnId, virtualClusterId);
+   pageRef.ChangeClusterId(virtualClusterId);
 
    return pageRef;
 }
@@ -188,10 +188,10 @@ ROOT::Experimental::Internal::RPageSourceFriends::LoadPage(ColumnHandle_t column
 
    auto pageRef = fSources[originColumnId.fSourceIdx]->LoadPage(columnHandle, originClusterIndex);
    // Suppressed column
-   if (!pageRef.Get().IsValid())
+   if (pageRef.Get().IsNull())
       return RPageRef();
 
-   pageRef.ChangeIds(virtualColumnId, clusterIndex.GetClusterId());
+   pageRef.ChangeClusterId(clusterIndex.GetClusterId());
    return pageRef;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -283,7 +283,8 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
                fCounters->fSzUnzip.Add(element->GetSize() * sealedPage.GetNElements());
 
                newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-               fPagePool.PreloadPage(std::move(newPage), element->GetIdentifier().fInMemoryType);
+               fPagePool.PreloadPage(std::move(newPage),
+                                     RPagePool::RKey{columnId, element->GetIdentifier().fInMemoryType});
             };
 
             fTaskScheduler->AddTask(taskFunc);
@@ -334,7 +335,7 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
 {
    const auto columnId = columnHandle.fPhysicalId;
    const auto columnElementId = columnHandle.fColumn->GetElement()->GetIdentifier();
-   auto cachedPageRef = fPagePool.GetPage(columnId, columnElementId.fInMemoryType, globalIndex);
+   auto cachedPageRef = fPagePool.GetPage(RPagePool::RKey{columnId, columnElementId.fInMemoryType}, globalIndex);
    if (!cachedPageRef.Get().IsNull())
       return cachedPageRef;
 
@@ -371,7 +372,7 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
    const auto idxInCluster = clusterIndex.GetIndex();
    const auto columnId = columnHandle.fPhysicalId;
    const auto columnElementId = columnHandle.fColumn->GetElement()->GetIdentifier();
-   auto cachedPageRef = fPagePool.GetPage(columnId, columnElementId.fInMemoryType, clusterIndex);
+   auto cachedPageRef = fPagePool.GetPage(RPagePool::RKey{columnId, columnElementId.fInMemoryType}, clusterIndex);
    if (!cachedPageRef.Get().IsNull())
       return cachedPageRef;
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <string_view>
@@ -506,8 +507,9 @@ ROOT::Experimental::Internal::RPageSource::UnsealPage(const RSealedPage &sealedP
    // Unsealing a page zero is a no-op.  `RPageRange::ExtendToFitColumnRange()` guarantees that the page zero buffer is
    // large enough to hold `sealedPage.fNElements`
    if (sealedPage.GetBuffer() == RPage::GetPageZeroBuffer()) {
-      auto page = RPage::MakePageZero(element.GetSize());
+      auto page = pageAlloc.NewPage(element.GetSize(), sealedPage.GetNElements());
       page.GrowUnchecked(sealedPage.GetNElements());
+      memset(page.GetBuffer(), 0, page.GetNBytes());
       return page;
    }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <utility>
 #include <regex>
@@ -600,8 +601,9 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
    if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
-      auto pageZero = RPage::MakePageZero(elementSize);
+      auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.fNElements);
       pageZero.GrowUnchecked(pageInfo.fNElements);
+      memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -604,7 +604,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       pageZero.GrowUnchecked(pageInfo.fNElements);
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
-      return fPagePool.RegisterPage(std::move(pageZero), elementInMemoryType);
+      return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
 
    RSealedPage sealedPage;
@@ -633,7 +633,8 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPageRef = fPagePool.GetPage(columnId, elementInMemoryType, RClusterIndex(clusterId, idxInCluster));
+      auto cachedPageRef =
+         fPagePool.GetPage(RPagePool::RKey{columnId, elementInMemoryType}, RClusterIndex(clusterId, idxInCluster));
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 
@@ -653,7 +654,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
    newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
-   return fPagePool.RegisterPage(std::move(newPage), elementInMemoryType);
+   return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RPageSource>

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -600,7 +600,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
    if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
-      auto pageZero = RPage::MakePageZero(columnId, elementSize);
+      auto pageZero = RPage::MakePageZero(elementSize);
       pageZero.GrowUnchecked(pageInfo.fNElements);
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
@@ -647,7 +647,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage(sealedPage, *element, columnId).Unwrap();
+      newPage = UnsealPage(sealedPage, *element).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -424,7 +424,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
    if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
-      auto pageZero = RPage::MakePageZero(columnId, elementSize);
+      auto pageZero = RPage::MakePageZero(elementSize);
       pageZero.GrowUnchecked(pageInfo.fNElements);
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
@@ -467,7 +467,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    RPage newPage;
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      newPage = UnsealPage(sealedPage, *element, columnId).Unwrap();
+      newPage = UnsealPage(sealedPage, *element).Unwrap();
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -428,7 +428,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       pageZero.GrowUnchecked(pageInfo.fNElements);
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
-      return fPagePool.RegisterPage(std::move(pageZero), elementInMemoryType);
+      return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
 
    RSealedPage sealedPage;
@@ -453,7 +453,8 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPageRef = fPagePool.GetPage(columnId, elementInMemoryType, RClusterIndex(clusterId, idxInCluster));
+      auto cachedPageRef =
+         fPagePool.GetPage(RPagePool::RKey{columnId, elementInMemoryType}, RClusterIndex(clusterId, idxInCluster));
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 
@@ -473,7 +474,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
-   return fPagePool.RegisterPage(std::move(newPage), elementInMemoryType);
+   return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RPageSource>

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -424,8 +424,9 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
    if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
-      auto pageZero = RPage::MakePageZero(elementSize);
+      auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.fNElements);
       pageZero.GrowUnchecked(pageInfo.fNElements);
+      memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
       pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -100,7 +100,8 @@ public:
    RPageRef LoadPage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
       auto page = RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId).Unwrap();
-      return fPagePool.RegisterPage(std::move(page), std::type_index(typeid(void)));
+      ROOT::Experimental::Internal::RPagePool::RKey key{columnHandle.fPhysicalId, std::type_index(typeid(void))};
+      return fPagePool.RegisterPage(std::move(page), key);
    }
    RPageRef LoadPage(ColumnHandle_t, ROOT::Experimental::RClusterIndex) final { return RPageRef(); }
    void LoadSealedPage(ROOT::Experimental::DescriptorId_t, ROOT::Experimental::RClusterIndex, RSealedPage &) final {}

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -99,7 +99,7 @@ public:
 
    RPageRef LoadPage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
-      auto page = RPageSource::UnsealPage(fPages[i], fElement, columnHandle.fPhysicalId).Unwrap();
+      auto page = RPageSource::UnsealPage(fPages[i], fElement).Unwrap();
       ROOT::Experimental::Internal::RPagePool::RKey key{columnHandle.fPhysicalId, std::type_index(typeid(void))};
       return fPagePool.RegisterPage(std::move(page), key);
    }
@@ -120,7 +120,7 @@ TEST(RColumnElementEndian, ByteCopy)
    RPageSinkMock sink1(element);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, nullptr, 4, 4);
+   RPage page1(buf1, nullptr, 4, 4);
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
@@ -146,7 +146,7 @@ TEST(RColumnElementEndian, Cast)
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
                            0x07, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x08, 0x09,
                            0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, nullptr, 8, 4);
+   RPage page1(buf1, nullptr, 8, 4);
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
@@ -172,7 +172,7 @@ TEST(RColumnElementEndian, Split)
    RPageSinkMock sink1(splitElement);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, nullptr, 8, 2);
+   RPage page1(buf1, nullptr, 8, 2);
    page1.GrowUnchecked(2);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
@@ -200,7 +200,7 @@ TEST(RColumnElementEndian, DeltaSplit)
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
                            0x07, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x08, 0x09,
                            0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, nullptr, 8, 4);
+   RPage page1(buf1, nullptr, 8, 4);
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 
@@ -227,7 +227,7 @@ TEST(RColumnElementEndian, Real32Trunc)
    RPageSinkMock sink1(element);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, nullptr, sizeof(float), 4);
+   RPage page1(buf1, nullptr, sizeof(float), 4);
    page1.GrowUnchecked(4);
    sink1.CommitPage(RPageStorage::ColumnHandle_t{}, page1);
 

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -16,11 +16,11 @@
 
 TEST(RNTuple, DISABLED_Limits_ManyFields)
 {
-   // Writing and reading a model with 40k integer fields takes around 2s and seems to have more than linear
-   // complexity (80k fields take 9s).
+   // Writing and reading a model with 100k integer fields takes around 2s and seems to have more than linear
+   // complexity (200k fields take 7.5s).
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
-   static constexpr int NumFields = 40'000;
+   static constexpr int NumFields = 100'000;
 
    {
       auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -4,7 +4,7 @@ TEST(Pages, Allocation)
 {
    RPageAllocatorHeap allocator;
 
-   auto page = allocator.NewPage(42, 4, 16);
+   auto page = allocator.NewPage(4, 16);
    EXPECT_FALSE(page.IsNull());
    EXPECT_EQ(16U, page.GetMaxElements());
    EXPECT_EQ(0U, page.GetNElements());
@@ -22,7 +22,7 @@ TEST(Pages, Pool)
    } // returning empty page should not crash
 
    RPage::RClusterInfo clusterInfo(2, 40);
-   auto page = allocator.NewPage(1, 1, 10);
+   auto page = allocator.NewPage(1, 10);
    page.GrowUnchecked(10);
    EXPECT_EQ(page.GetMaxElements(), page.GetNElements());
    page.SetWindow(50, clusterInfo);

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -17,7 +17,7 @@ TEST(Pages, Pool)
    RPagePool pool;
 
    {
-      auto pageRef = pool.GetPage(0, std::type_index(typeid(void)), 0);
+      auto pageRef = pool.GetPage(RPagePool::RKey{0, std::type_index(typeid(void))}, 0);
       EXPECT_TRUE(pageRef.Get().IsNull());
    } // returning empty page should not crash
 
@@ -29,30 +29,33 @@ TEST(Pages, Pool)
    EXPECT_FALSE(page.IsNull());
 
    {
-      auto registeredPage = pool.RegisterPage(std::move(page), std::type_index(typeid(void)));
+      auto registeredPage = pool.RegisterPage(std::move(page), RPagePool::RKey{1, std::type_index(typeid(void))});
 
       {
-         auto pageRef = pool.GetPage(0, std::type_index(typeid(void)), 0);
+         auto pageRef = pool.GetPage(RPagePool::RKey{0, std::type_index(typeid(void))}, 0);
          EXPECT_TRUE(pageRef.Get().IsNull());
-         pageRef = pool.GetPage(0, std::type_index(typeid(void)), 55);
+         pageRef = pool.GetPage(RPagePool::RKey{0, std::type_index(typeid(void))}, 55);
          EXPECT_TRUE(pageRef.Get().IsNull());
-         pageRef = pool.GetPage(1, std::type_index(typeid(int)), 55);
+         pageRef = pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(int))}, 55);
          EXPECT_TRUE(pageRef.Get().IsNull());
-         pageRef = pool.GetPage(1, std::type_index(typeid(void)), 55);
+         pageRef = pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(void))}, 55);
          EXPECT_FALSE(pageRef.Get().IsNull());
          EXPECT_EQ(50U, pageRef.Get().GetGlobalRangeFirst());
          EXPECT_EQ(59U, pageRef.Get().GetGlobalRangeLast());
          EXPECT_EQ(10U, pageRef.Get().GetClusterRangeFirst());
          EXPECT_EQ(19U, pageRef.Get().GetClusterRangeLast());
 
-         auto pageRef2 = pool.GetPage(1, std::type_index(typeid(void)), ROOT::Experimental::RClusterIndex(0, 15));
+         auto pageRef2 =
+            pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(void))}, ROOT::Experimental::RClusterIndex(0, 15));
          EXPECT_TRUE(pageRef2.Get().IsNull());
-         pageRef2 = pool.GetPage(1, std::type_index(typeid(int)), ROOT::Experimental::RClusterIndex(2, 15));
+         pageRef2 =
+            pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(int))}, ROOT::Experimental::RClusterIndex(2, 15));
          EXPECT_TRUE(pageRef2.Get().IsNull());
-         pageRef2 = pool.GetPage(1, std::type_index(typeid(void)), ROOT::Experimental::RClusterIndex(2, 15));
+         pageRef2 =
+            pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(void))}, ROOT::Experimental::RClusterIndex(2, 15));
          EXPECT_FALSE(pageRef2.Get().IsNull());
       }
    }
-   auto pageRef = pool.GetPage(1, std::type_index(typeid(void)), 55);
+   auto pageRef = pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(void))}, 55);
    EXPECT_TRUE(pageRef.Get().IsNull());
 }

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -319,7 +319,7 @@ TEST_F(RPageStorageDaos, CagedPages)
 
       auto colType = desc->GetColumnDescriptor(colId).GetType();
       auto elem = ROOT::Experimental::Internal::RColumnElementBase::Generate<std::uint32_t>(colType);
-      auto page = pageSource->UnsealPage(sealedPage, *elem, colId).Unwrap();
+      auto page = pageSource->UnsealPage(sealedPage, *elem).Unwrap();
       EXPECT_GT(page.GetNElements(), 0);
       auto ptrData = static_cast<std::uint32_t *>(page.GetBuffer());
       for (std::uint32_t i = 0; i < page.GetNElements(); ++i) {


### PR DESCRIPTION
Improve the lookup complexity for pages in the page pool from linear to constant in well-behaved cases, i.e. if there is a small number of pages per column and cluster. Some smaller cleanups around the RPage/RPagePool logic.

