### PR TITLE
[webcanvas] select axes fonts in GED [6.34]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -4,18 +4,18 @@
 1. Let use custom time zone for time display, support '&utc' and '&cet' in URL parameters
 2. Support gStyle.fLegendFillStyle
 3. Let change histogram min/max values via context menu
-4. Support Z-scale zooming with TScatter
+4. Support Z-scale zooming with `TScatter`
 5. Implement "haxis" draw option for histogram to draw only axes for hbar
 6. Implement "axisg" and "haxisg" to draw axes with grids
-7. Support TH1 marker, text and line drawing superimposed with "haxis"
+7. Support `TH1` marker, text and line drawing superimposed with "haxis"
 8. Support `TBox`, `TLatex`, `TLine`, `TMarker` drawing on "frame", support drawing on swapped axes
 9. `TProfile` and `TProfile2D` projections https://github.com/root-project/root/issues/15851
-10. Draw total histogram from TEfficiency when draw option starts with 'b'
-11. Let redraw TEfficiency, THStack and TMultiGraph with different draw options via hist context menu
-12. Support 'pads' draw options for TMultiGraph, support context menu for it
-13. Let drop object on sub-pads
+10. Draw total histogram from `TEfficiency` when draw option starts with 'b'
+11. Let redraw `TEfficiency`, `THStack` and `TMultiGraph` with different draw options via hist context menu
+12. Support 'pads' draw options for `TMultiGraph`, support context menu for it
+13. Let drop objects on sub-pads
 14. Properly loads ES6 modules for web canvas
-15. Improve performance of TH3/RH3 drawing by using THREE.InstancedMesh
+15. Improve performance of `TH3`/`RH3` drawing by using THREE.InstancedMesh
 16. Implement batch mode with '&batch' URL parameter to create SVG/PNG images with default GUI
 17. Adjust node.js implementation to produce identical output with normal browser
 18. Create necessary infrastructure for testing with 'puppeteer'
@@ -29,15 +29,16 @@
 26. Create unified svg2pdf/jspdf ES6 modules, integrate in jsroot builds
 27. Let create multipage PDF document - in TWebCanvas batch mode
 28. Let add external links via `#url[link]{label}` syntax - including jsPDF support
-29. Support TAttMarker style with line width bigger than 1
+29. Support `TAttMarker` style with line width bigger than 1
 30. Provide link to ROOT class documentation from context menus
-31. Internals - upgrade to eslint 9
-32. Internals - do not select pad (aka gPad) for objects drawing, always use assigned pad painter
-33. Fix - properly save zoomed ranges in drawingJSON()
-34. Fix - properly redraw `TMultiGraph`
-35. Fix - show empty bin in `TProfile2D` if it has entries #316
-36. Fix - unzooming on log scale was extending range forevever
-37. Fix - display empty hist bin if fSumw2 not zero
+31. Implement axis labels and title rotations on lego plots
+32. Internals - upgrade to eslint 9
+33. Internals - do not select pad (aka gPad) for objects drawing, always use assigned pad painter
+34. Fix - properly save zoomed ranges in drawingJSON()
+35. Fix - properly redraw `TMultiGraph`
+36. Fix - show empty bin in `TProfile2D` if it has entries #316
+37. Fix - unzooming on log scale was extending range forevever
+38. Fix - display empty hist bin if fSumw2 not zero
 
 
 ## Changes in 7.7.5

--- a/js/modules/base/FontHandler.mjs
+++ b/js/modules/base/FontHandler.mjs
@@ -100,6 +100,7 @@ class FontHandler {
 
       this.size = Math.round(size || 11);
       this.scale = scale;
+      this.index = 0;
 
       this.func = this.setFont.bind(this);
 
@@ -107,8 +108,11 @@ class FontHandler {
 
       if (fontIndex && isObject(fontIndex))
          cfg = fontIndex;
-      else
-         cfg = root_fonts[(fontIndex && Number.isInteger(fontIndex)) ? Math.floor(fontIndex / 10) : 0];
+      else {
+         if (fontIndex && Number.isInteger(fontIndex))
+            this.index = Math.floor(fontIndex / 10);
+         cfg = root_fonts[this.index];
+      }
 
       if (cfg) {
          this.cfg = cfg;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '7/11/2024',
+version_date = '8/11/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/RAxisPainter.mjs
+++ b/js/modules/gpad/RAxisPainter.mjs
@@ -355,6 +355,9 @@ class RAxisPainter extends RObjectPainter {
       return this.v7EvalAttr('labels_center', false);
    }
 
+   /** @summary Is labels should be rotated */
+   isRotateLabels() { return false; }
+
    /** @summary Used to move axis labels instead of zooming
      * @private */
    processLabelsMove(arg, pos) {

--- a/js/modules/gpad/RFramePainter.mjs
+++ b/js/modules/gpad/RFramePainter.mjs
@@ -668,9 +668,14 @@ class RFramePainter extends RObjectPainter {
       this._frame_height = h;
       this._frame_rotate = rotate;
       this._frame_fixpos = fixpos;
+      this._frame_trans = trans;
 
-      if (this.mode3d) return this; // no need for real draw in mode3d
+      return this.mode3d ? this : this.createFrameG();
+   }
 
+   /** @summary Create frame element and update all attributes
+     * @private */
+   createFrameG() {
       // this is svg:g object - container for every other items belonging to frame
       this.draw_g = this.getFrameSvg();
 
@@ -699,20 +704,20 @@ class RFramePainter extends RObjectPainter {
 
       this.axes_drawn = false;
 
-      this.draw_g.attr('transform', trans);
+      this.draw_g.attr('transform', this._frame_trans);
 
       top_rect.attr('x', 0)
               .attr('y', 0)
-              .attr('width', w)
-              .attr('height', h)
+              .attr('width', this._frame_width)
+              .attr('height', this._frame_height)
               .attr('rx', this.lineatt.rx || null)
               .attr('ry', this.lineatt.ry || null)
               .call(this.fillatt.func)
               .call(this.lineatt.func);
 
-      main_svg.attr('width', w)
-              .attr('height', h)
-              .attr('viewBox', `0 0 ${w} ${h}`);
+      main_svg.attr('width', this._frame_width)
+              .attr('height', this._frame_height)
+              .attr('viewBox', `0 0 ${this._frame_width} ${this._frame_height}`);
 
       let pr = Promise.resolve(true);
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -793,6 +793,16 @@ class TAxisPainter extends ObjectPainter {
       return this.getObject()?.TestBit(EAxisBits.kCenterLabels);
    }
 
+   /** @summary Is labels should be rotated */
+   isRotateLabels() {
+      return this.getObject()?.TestBit(EAxisBits.kLabelsVert);
+   }
+
+   /** @summary Is title should be rotated */
+   isRotateTitle() {
+      return this.getObject()?.TestBit(EAxisBits.kRotateTitle);
+   }
+
    /** @summary Add interactive elements to draw axes title */
    addTitleDrag(title_g, vertical, offset_k, reverse, axis_length) {
       if (!settings.MoveResize || this.isBatchMode()) return;
@@ -996,7 +1006,7 @@ class TAxisPainter extends ObjectPainter {
             label_g = [axis_g.append('svg:g').attr('class', 'axis_labels')],
             lbl_pos = handle.lbl_pos || handle.major,
             tilt_angle = gStyle.AxisTiltAngle ?? 25;
-      let rotate_lbls = axis.TestBit(EAxisBits.kLabelsVert),
+      let rotate_lbls = this.isRotateLabels(),
           textscale = 1, flipscale = 1, maxtextlen = 0, applied_scale = 0,
           lbl_tilt = false, any_modified = false, max_textwidth = 0, max_tiltsize = 0;
 
@@ -1296,9 +1306,6 @@ class TAxisPainter extends ObjectPainter {
       if (this.is_gaxis)
          draw_lines = axis.fLineColor !== 0;
 
-      // indicate that attributes created not for TAttLine, therefore cannot be updated as TAttLine in GED
-      this.lineatt.not_standard = true;
-
       if (!this.is_gaxis || (this.name === 'zaxis')) {
          axis_g = layer.selectChild(`.${this.name}_container`);
          if (axis_g.empty())
@@ -1386,7 +1393,7 @@ class TAxisPainter extends ObjectPainter {
          if (!title_g)
             return;
 
-         const rotate = axis.TestBit(EAxisBits.kRotateTitle) ? -1 : 1,
+         const rotate = this.isRotateTitle() ? -1 : 1,
                xor_reverse = swap_side ^ this.titleOpposite, myxor = (rotate < 0) ^ xor_reverse;
 
          let title_offest_k = side;

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -2492,9 +2492,14 @@ class TFramePainter extends ObjectPainter {
       this._frame_height = h;
       this._frame_rotate = rotate;
       this._frame_fixpos = fixpos;
+      this._frame_trans = trans;
 
-      if (this.mode3d) return this; // no need to create any elements in 3d mode
+      return this.mode3d ? this : this.createFrameG();
+   }
 
+   /** @summary Create frame element and update all attributes
+    * @private */
+   createFrameG() {
       // this is svg:g object - container for every other items belonging to frame
       this.draw_g = this.getFrameSvg();
 
@@ -2524,15 +2529,15 @@ class TFramePainter extends ObjectPainter {
 
       this.axes_drawn = this.axes2_drawn = false;
 
-      this.draw_g.attr('transform', trans);
+      this.draw_g.attr('transform', this._frame_trans);
 
-      top_rect.attr('d', `M0,0H${w}V${h}H0Z`)
+      top_rect.attr('d', `M0,0H${this._frame_width}V${this._frame_height}H0Z`)
               .call(this.fillatt.func)
               .call(this.lineatt.func);
 
-      main_svg.attr('width', w)
-              .attr('height', h)
-              .attr('viewBox', `0 0 ${w} ${h}`);
+      main_svg.attr('width', this._frame_width)
+              .attr('height', this._frame_height)
+              .attr('viewBox', `0 0 ${this._frame_width} ${this._frame_height}`);
 
       return this;
    }

--- a/js/modules/hist/TH2Painter.mjs
+++ b/js/modules/hist/TH2Painter.mjs
@@ -165,7 +165,7 @@ function drawTH2PolyLego(painter) {
       geometry.setAttribute('position', new THREE.BufferAttribute(pos, 3));
       geometry.computeVertexNormals();
 
-      const material = new THREE.MeshBasicMaterial(getMaterialArgs(painter._color_palette?.getColor(colindx), { vertexColors: false })),
+      const material = new THREE.MeshBasicMaterial(getMaterialArgs(painter._color_palette?.getColor(colindx), { vertexColors: false, side: THREE.DoubleSide })),
             mesh = new THREE.Mesh(geometry, material);
 
       pmain.add3DMesh(mesh);

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -1011,7 +1011,7 @@ class TGraphPainter extends ObjectPainter {
              rect = { x1: -5, x2: 5, y1: -5, y2: 5 };
 
           const matchx = (pnt.x >= d.grx1 + rect.x1) && (pnt.x <= d.grx1 + rect.x2),
-              matchy = (pnt.y >= d.gry1 + rect.y1) && (pnt.y <= d.gry1 + rect.y2);
+                matchy = (pnt.y >= d.gry1 + rect.y1) && (pnt.y <= d.gry1 + rect.y2);
 
           if (matchx && (matchy || (pnt.nproc > 1))) {
              best_dist2 = dist2;

--- a/ui5/canv/view/Axis.fragment.xml
+++ b/ui5/canv/view/Axis.fragment.xml
@@ -16,18 +16,50 @@
              <Label text="Ticks:" wrapping="true"/>
          </VBox>
          <VBox>
-            <StepInput min="-1.000" max="1.000" step="0.01" value="{/axis_ticksize}" editable="true" displayValuePrecision="3"/>
+            <StepInput min="-1.000" max="1.000" step="0.01" value="{/axis_ticksize}" editable="true" displayValuePrecision="3" tooltip="Axis ticks size"/>
          </VBox>
       </HBox>
-      <jsroot:ColorButton text="Title" attrcolor="{/color_title}" tooltip="Title color"/>
-      <CheckBox text="Center title" selected="{/center_title}"/>
-      <CheckBox text="Rotate title" selected="{/rotate_title}"/>
+      <HBox>
+         <jsroot:ColorButton text="Title" attrcolor="{/color_title}" tooltip="Title color"/>
+         <CheckBox text="Center" selected="{/center_title}" tooltip="Center axis title"/>
+         <CheckBox text="Rotate" selected="{/rotate_title}" tooltip="Rotate axis title"/>
+      </HBox>
+      <HBox justifyContent="SpaceBetween" alignItems="Center" visible="{= ${/mode2d}}">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Font:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <Select selectedKey="{/font_title}" tooltip="Title font style">
+               <layoutData>
+                  <FlexItemData growFactor="5"/>
+               </layoutData>
+               <items>
+                  <core:Item text="none" key="0"/>
+                  <core:Item text="Times New Roman italic" key="1"/>
+                  <core:Item text="Times New Roman bold" key="2"/>
+                  <core:Item text="Times New Roman bold italic" key="3"/>
+                  <core:Item text="Arial" key="4"/>
+                  <core:Item text="Arial oblique" key="5"/>
+                  <core:Item text="Arial bold" key="6"/>
+                  <core:Item text="Arial bold oblique" key="7"/>
+                  <core:Item text="Courier New" key="8"/>
+                  <core:Item text="Courier New oblique" key="9"/>
+                  <core:Item text="Courier New bold" key="10"/>
+                  <core:Item text="Courier New bold oblique" key="11"/>
+                  <core:Item text="Symbol" key="12"/>
+                  <core:Item text="Times New Roman" key="13"/>
+                  <core:Item text="Wingdings" key="14"/>
+                  <core:Item text="Symbol italic" key="15"/>
+               </items>
+            </Select>
+         </VBox>
+      </HBox>
       <HBox justifyContent="SpaceBetween" alignItems="Center">
           <VBox class="sapUiSmallMarginEnd">
              <Label text="Offset:" wrapping="true"/>
          </VBox>
          <VBox>
-            <StepInput min="0.00" max="3.00" step="0.1" value="{/axis/fTitleOffset}" editable="true" displayValuePrecision="3"/>
+            <StepInput min="0.00" max="3.00" step="0.1" value="{/axis/fTitleOffset}" editable="true" displayValuePrecision="3" tooltip="Axis title offset"/>
          </VBox>
       </HBox>
       <HBox justifyContent="SpaceBetween" alignItems="Center">
@@ -35,18 +67,50 @@
              <Label text="Size:" wrapping="true"/>
          </VBox>
          <VBox>
-            <StepInput min="0.01" max="0.50" step="0.01" value="{/axis/fTitleSize}" editable="true" displayValuePrecision="3"/>
+            <StepInput min="0.01" max="0.50" step="0.01" value="{/axis/fTitleSize}" editable="true" displayValuePrecision="3" tooltip="Axis title size"/>
          </VBox>
       </HBox>
-      <jsroot:ColorButton text="Labels" attrcolor="{/color_label}" tooltip="Labels color"/>
-      <CheckBox text="Center label" selected="{/center_label}"/>
-      <CheckBox text="Rotate label" selected="{/vert_label}"/>
+      <HBox>
+         <jsroot:ColorButton text="Labels" attrcolor="{/color_label}" tooltip="Labels color"/>
+         <CheckBox text="Center" selected="{/center_label}" tooltip="Centered labels position"/>
+         <CheckBox text="Rotate" selected="{/vert_label}" tooltip="Rotate labels"/>
+      </HBox>
+      <HBox justifyContent="SpaceBetween" alignItems="Center" visible="{= ${/mode2d}}">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Font:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <Select selectedKey="{/font_label}" tooltip="Labels font style">
+               <layoutData>
+                  <FlexItemData growFactor="5"/>
+               </layoutData>
+               <items>
+                  <core:Item text="none" key="0"/>
+                  <core:Item text="Times New Roman italic" key="1"/>
+                  <core:Item text="Times New Roman bold" key="2"/>
+                  <core:Item text="Times New Roman bold italic" key="3"/>
+                  <core:Item text="Arial" key="4"/>
+                  <core:Item text="Arial oblique" key="5"/>
+                  <core:Item text="Arial bold" key="6"/>
+                  <core:Item text="Arial bold oblique" key="7"/>
+                  <core:Item text="Courier New" key="8"/>
+                  <core:Item text="Courier New oblique" key="9"/>
+                  <core:Item text="Courier New bold" key="10"/>
+                  <core:Item text="Courier New bold oblique" key="11"/>
+                  <core:Item text="Symbol" key="12"/>
+                  <core:Item text="Times New Roman" key="13"/>
+                  <core:Item text="Wingdings" key="14"/>
+                  <core:Item text="Symbol italic" key="15"/>
+               </items>
+            </Select>
+         </VBox>
+      </HBox>
       <HBox justifyContent="SpaceBetween" alignItems="Center">
           <VBox class="sapUiSmallMarginEnd">
              <Label text="Offset:" wrapping="true"/>
          </VBox>
          <VBox>
-            <StepInput min="0.00" max="0.20" step="0.01" value="{/axis/fLabelOffset}" editable="true" displayValuePrecision="3"/>
+            <StepInput min="0.00" max="0.20" step="0.01" value="{/axis/fLabelOffset}" editable="true" displayValuePrecision="3" tooltip="Axis labels offset"/>
          </VBox>
       </HBox>
       <HBox justifyContent="SpaceBetween" alignItems="Center">
@@ -54,7 +118,7 @@
              <Label text="Size:" wrapping="true"/>
          </VBox>
          <VBox>
-            <StepInput min="0.00" max="0.50" step="0.01" value="{/axis/fLabelSize}" editable="true" displayValuePrecision="3"/>
+            <StepInput min="0.00" max="0.50" step="0.01" value="{/axis/fLabelSize}" editable="true" displayValuePrecision="3" tooltip="Axis labels size"/>
          </VBox>
       </HBox>
       <HBox justifyContent="SpaceBetween" alignItems="Center" visible="{/is_gaxis}">


### PR DESCRIPTION
1. Select title and labels fonts for axis
2. Support labels and title rotation on lego plots
3. Properly center labels on 3d plots
4. Fix toggling 2d/3d mode with canvas resize in-between

Backport of #16865 