### PR TITLE
[pyroot] fix clang warning due to changes in PyObject

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -214,15 +214,23 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
-PyObject _CPyCppyy_NullPtrStruct = {
-    _PyObject_EXTRA_INIT
-    1, &PyNullPtr_t_Type
-};
+PyObject _CPyCppyy_NullPtrStruct = {_PyObject_EXTRA_INIT
+// In 3.12.0-beta this field was changed from a ssize_t to a union
+#if PY_VERSION_HEX >= 0x30c00b1
+                                    {1},
+#else
+                                    1,
+#endif
+                                    &PyNullPtr_t_Type};
 
-PyObject _CPyCppyy_DefaultStruct = {
-    _PyObject_EXTRA_INIT
-    1, &PyDefault_t_Type
-};
+PyObject _CPyCppyy_DefaultStruct = {_PyObject_EXTRA_INIT
+// In 3.12.0-beta this field was changed from a ssize_t to a union
+#if PY_VERSION_HEX >= 0x30c00b1
+                                    {1},
+#else
+                                    1,
+#endif
+                                    &PyDefault_t_Type};
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)


### PR DESCRIPTION
Re-applying a commit by @silverweed that was accidentally reverted.

Original PR: #16599.

This patch will now be upstreamed, so it won't be accidentally reverted again:
https://github.com/wlav/CPyCppyy/pull/43