### PR TITLE
Exclude JSROOT modules from clang-format check

### DIFF
--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -3,7 +3,7 @@
 set -ex
 
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
-COMMIT_FILES=$(git diff --name-status $BASE_COMMIT | grep -i -v LinkDef | grep -v -E '^D +' | sed -E 's,^.[[:space:]]+,,')
+COMMIT_FILES=$(git diff --name-status $BASE_COMMIT | grep -i -v '.mjs$' | grep -i -v LinkDef | grep -v -E '^D +' | sed -E 's,^.[[:space:]]+,,')
 
 RESULT_OUTPUT="no modified files to format"
 if [ ! -z "$COMMIT_FILES" ]; then


### PR DESCRIPTION
Avoid parsing of JavaScritpt code by tool primary dedicated for C++

Like in this case: https://github.com/root-project/root/actions/runs/11779886401/job/32809280148?pr=16883


