### PR TITLE
[hist] Generalize TGraph constructor to take any types

### DIFF
--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -82,9 +82,33 @@ public:
 
    TGraph();
    TGraph(Int_t n);
-   TGraph(Int_t n, const Int_t *x, const Int_t *y);
-   TGraph(Int_t n, const Float_t *x, const Float_t *y);
-   TGraph(Int_t n, const Double_t *x, const Double_t *y);
+
+   /// Graph normal constructor.
+   template<class Tx, class Ty>
+   TGraph(Int_t n, const Tx *x, const Ty *y) : TNamed("Graph", "Graph"), TAttFill(0, 1000)
+   {
+      fNpoints = !x || !y ? 0 : n;
+      if (!CtorAllocate())
+         return;
+      for (Int_t i = 0; i < n; i++) {
+         fX[i] = static_cast<Double_t>(x[i]);
+         fY[i] = static_cast<Double_t>(y[i]);
+      }
+   }
+
+   /// Default X-Points constructor. The points along the x-axis get the default
+   /// values `start`, `start+step`, `start+2*step`, `start+3*step`, etc ...
+   template<class Ty>
+   TGraph(Int_t n, const Ty *y, Double_t start, Double_t step) : TNamed("Graph", "Graph"), TAttFill(0, 1000)
+   {
+      fNpoints = !y ? 0 : n;
+      if (!CtorAllocate()) return;
+      for (Int_t i = 0; i < n; i++) {
+         fX[i] = start+i*step;
+         fY[i] = static_cast<Double_t>(y[i]);
+      }
+   }
+
    TGraph(Int_t n, const Double_t *y, Double_t start=0., Double_t step=1.);
    TGraph(const TGraph &gr);
    TGraph& operator=(const TGraph&);

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -108,7 +108,6 @@ End_Macro
 TGraph::TGraph() : TAttFill(0, 1000)
 {
    fNpoints = -1;  //will be reset to 0 in CtorAllocate
-   if (!CtorAllocate()) return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -121,78 +120,6 @@ TGraph::TGraph(Int_t n)
    fNpoints = n;
    if (!CtorAllocate()) return;
    FillZero(0, fNpoints);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Graph normal constructor with ints.
-
-TGraph::TGraph(Int_t n, const Int_t *x, const Int_t *y)
-   : TNamed("Graph", "Graph"), TAttFill(0, 1000)
-{
-   if (!x || !y) {
-      fNpoints = 0;
-   } else {
-      fNpoints = n;
-   }
-   if (!CtorAllocate()) return;
-   for (Int_t i = 0; i < n; i++) {
-      fX[i] = (Double_t)x[i];
-      fY[i] = (Double_t)y[i];
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Graph normal constructor with floats.
-
-TGraph::TGraph(Int_t n, const Float_t *x, const Float_t *y)
-   : TNamed("Graph", "Graph"), TAttFill(0, 1000)
-{
-   if (!x || !y) {
-      fNpoints = 0;
-   } else {
-      fNpoints = n;
-   }
-   if (!CtorAllocate()) return;
-   for (Int_t i = 0; i < n; i++) {
-      fX[i] = x[i];
-      fY[i] = y[i];
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default X-Points constructor. The points along the x-axis get the default
-/// values `start`, `start+step`, `start+2*step`, `start+3*step`, etc ...
-
-TGraph::TGraph(Int_t n, const Double_t *y, Double_t start, Double_t step)
-   : TNamed("Graph", "Graph"), TAttFill(0, 1000)
-{
-   if (!y) {
-      fNpoints = 0;
-   } else {
-      fNpoints = n;
-   }
-   if (!CtorAllocate()) return;
-   for (Int_t i = 0; i < n; i++) {
-      fX[i] = start+i*step;
-      fY[i] = y[i];
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Graph normal constructor with doubles.
-
-TGraph::TGraph(Int_t n, const Double_t *x, const Double_t *y)
-   : TNamed("Graph", "Graph"), TAttFill(0, 1000)
-{
-   if (!x || !y) {
-      fNpoints = 0;
-   } else {
-      fNpoints = n;
-   }
-   if (!CtorAllocate()) return;
-   n = fNpoints * sizeof(Double_t);
-   memcpy(fX, x, n);
-   memcpy(fY, y, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tutorials/fit/fitConvolution.py
+++ b/tutorials/fit/fitConvolution.py
@@ -11,15 +11,21 @@
 
 import ROOT
 
+n = 1000000
+
 # Construction of histogram to fit.
 h_ExpGauss = ROOT.TH1F("h_ExpGauss", "Exponential convoluted by Gaussian", 100, 0.0, 5.0)
-for i in range(1000000):
+for i in range(n):
     # Gives a alpha of -0.3 in the exp.
     x = ROOT.gRandom.Exp(1.0 / 0.3)
     x += ROOT.gRandom.Gaus(0.0, 3.0)
     # Probability density function of the addition of two variables is the
     # convolution of two density functions.
     h_ExpGauss.Fill(x)
+
+rng = ROOT.gRandom.vec # to be decided
+
+h.Fill(rng.Exp(n, 1.0 / 0.3) + rng.Gaus(n, 0.0, 3.0))
 
 f_conv = ROOT.TF1Convolution("expo", "gaus", -1, 6, True)
 f_conv.SetRange(-1.0, 6.0)


### PR DESCRIPTION
Generalize TGraph constructor to take any types convertible to `double`.

Like this, we can also create TGraphs from `int64`, which can easily happen in user code when people want to pass arrays of integers.