### PR TITLE
[ntuple] Fixup `RNTupleIndex` error messages

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleIndex.hxx
@@ -160,7 +160,7 @@ public:
    NTupleSize_t GetFirstEntryNumber(Ts... values) const
    {
       if (sizeof...(Ts) != fIndexFields.size())
-         throw RException(R__FAIL("Number of values must match number of indexed fields."));
+         throw RException(R__FAIL("number of values must match number of indexed fields"));
 
       std::vector<void *> valuePtrs;
       valuePtrs.reserve(sizeof...(Ts));
@@ -186,7 +186,7 @@ public:
    const std::vector<NTupleSize_t> *GetAllEntryNumbers(Ts... values) const
    {
       if (sizeof...(Ts) != fIndexFields.size())
-         throw RException(R__FAIL("Number of values must match number of indexed fields."));
+         throw RException(R__FAIL("number of values must match number of indexed fields"));
 
       std::vector<void *> valuePtrs;
       valuePtrs.reserve(sizeof...(Ts));

--- a/tree/ntuple/v7/src/RNTupleIndex.cxx
+++ b/tree/ntuple/v7/src/RNTupleIndex.cxx
@@ -45,7 +45,8 @@ ROOT::Experimental::Internal::RNTupleIndex::RNTupleIndex(const std::vector<std::
    for (const auto &fieldName : fieldNames) {
       auto fieldId = desc->FindFieldId(fieldName);
       if (fieldId == kInvalidDescriptorId)
-         throw RException(R__FAIL("Could not find field \"" + std::string(fieldName) + "."));
+         throw RException(R__FAIL("could not find join field \"" + std::string(fieldName) + "\" in RNTuple \"" +
+                                  fPageSource->GetNTupleName() + "\""));
 
       const auto &fieldDesc = desc->GetFieldDescriptor(fieldId);
       auto field = fieldDesc.CreateField(desc.GetRef());
@@ -59,7 +60,7 @@ ROOT::Experimental::Internal::RNTupleIndex::RNTupleIndex(const std::vector<std::
 void ROOT::Experimental::Internal::RNTupleIndex::EnsureBuilt() const
 {
    if (!fIsBuilt)
-      throw RException(R__FAIL("Index has not been built yet"));
+      throw RException(R__FAIL("index has not been built yet"));
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::RNTupleIndex>
@@ -88,8 +89,8 @@ void ROOT::Experimental::Internal::RNTupleIndex::Build()
 
    for (const auto &field : fIndexFields) {
       if (allowedTypes.find(field->GetTypeName()) == allowedTypes.end()) {
-         throw RException(R__FAIL("Cannot use field \"" + field->GetFieldName() + "\" with type \"" +
-                                  field->GetTypeName() + "\" for indexing. Only integral types are allowed."));
+         throw RException(R__FAIL("cannot use field \"" + field->GetFieldName() + "\" with type \"" +
+                                  field->GetTypeName() + "\" for indexing: only integral types are allowed"));
       }
       fieldValues.emplace_back(field->CreateValue());
    }
@@ -125,7 +126,7 @@ const std::vector<ROOT::Experimental::NTupleSize_t> *
 ROOT::Experimental::Internal::RNTupleIndex::GetAllEntryNumbers(const std::vector<void *> &valuePtrs) const
 {
    if (valuePtrs.size() != fIndexFields.size())
-      throw RException(R__FAIL("Number of value pointers must match number of indexed fields."));
+      throw RException(R__FAIL("number of value pointers must match number of indexed fields"));
 
    EnsureBuilt();
 

--- a/tree/ntuple/v7/test/ntuple_index.cxx
+++ b/tree/ntuple/v7/test/ntuple_index.cxx
@@ -54,7 +54,7 @@ TEST(RNTupleIndex, DeferBuild)
       index->GetFirstEntryNumber<std::uint64_t>(0);
       FAIL() << "querying an unbuilt index should not be possible";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("Index has not been built yet"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("index has not been built yet"));
    }
 
    index->Build();
@@ -90,7 +90,7 @@ TEST(RNTupleIndex, InvalidTypes)
       EXPECT_THAT(
          err.what(),
          testing::HasSubstr(
-            "Cannot use field \"fldFloat\" with type \"float\" for indexing. Only integral types are allowed."));
+            "cannot use field \"fldFloat\" with type \"float\" for indexing: only integral types are allowed"));
    }
 
    try {
@@ -100,15 +100,15 @@ TEST(RNTupleIndex, InvalidTypes)
       EXPECT_THAT(
          err.what(),
          testing::HasSubstr(
-            "Cannot use field \"fldString\" with type \"std::string\" for indexing. Only integral types are allowed."));
+            "cannot use field \"fldString\" with type \"std::string\" for indexing: only integral types are allowed"));
    }
 
    try {
       RNTupleIndex::Create({"fldStruct"}, *pageSource);
       FAIL() << "non-integral-type field should not be allowed as index fields";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("Cannot use field \"fldStruct\" with type \"CustomStruct\" for "
-                                                 "indexing. Only integral types are allowed."));
+      EXPECT_THAT(err.what(), testing::HasSubstr("cannot use field \"fldStruct\" with type \"CustomStruct\" for "
+                                                 "indexing: only integral types are allowed"));
    }
 }
 
@@ -210,14 +210,14 @@ TEST(RNTupleIndex, MultipleFields)
       index->GetAllEntryNumbers<std::int16_t, std::uint64_t, std::uint64_t>(0, 2, 3);
       FAIL() << "querying the index with more values than index values should not be possible";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("Number of values must match number of indexed fields."));
+      EXPECT_THAT(err.what(), testing::HasSubstr("number of values must match number of indexed fields"));
    }
 
    try {
       index->GetAllEntryNumbers({0});
       FAIL() << "querying the index with fewer values than index values should not be possible";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("Number of value pointers must match number of indexed fields."));
+      EXPECT_THAT(err.what(), testing::HasSubstr("number of value pointers must match number of indexed fields"));
    }
 }
 


### PR DESCRIPTION
The error message format was inconsistent with (most of) the other RNTuple error messages, which are typically not capitalized and don't end with a period.

In addition, the error message in the constructor when a join field is not present has been expanded to now also contain the name of the RNTuple.
