### PR TITLE
Fix buffer overflow when opening the Fit Panel

### DIFF
--- a/gui/gui/src/TGNumberEntry.cxx
+++ b/gui/gui/src/TGNumberEntry.cxx
@@ -305,13 +305,13 @@ static char *RealToStr(char *text, const RealInfo_t & ri)
    StrInt(p, TMath::Abs(ri.fIntNum), 0);
    p += strlen(p);
    if ((ri.fStyle == kRSFrac) || (ri.fStyle == kRSFracExpo)) {
-      strlcpy(p, ".", 256-strlen(p));
+      strlcpy(p, ".", 256-strlen(text));
       p++;
       StrInt(p, TMath::Abs(ri.fFracNum), ri.fFracDigits);
       p += strlen(p);
    }
    if ((ri.fStyle == kRSExpo) || (ri.fStyle == kRSFracExpo)) {
-      strlcpy(p, "e", 256-strlen(p));
+      strlcpy(p, "e", 256-strlen(text));
       p++;
       StrInt(p, ri.fExpoNum, 0);
       p += strlen(p);


### PR DESCRIPTION
Fedora 40 build for 6.32.06 crashes when opening the parameter dialog of the Fit Panel
with a "buffer overflow detected" message.

Such behavior is caused by calls to `strlcpy` with an incorrect size of the destination buffer,
which this PR fixes.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)