### PR TITLE
[CI] Disable GPU runs.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -392,10 +392,11 @@ jobs:
             is_special: true
             property: clang
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
-          - image: ubuntu2404-cuda
-            is_special: true
-            property: gpu
-            extra-runs-on: gpu
+          # Disabled until DNS problems in containers are solved
+         #- image: ubuntu2404-cuda
+         #  is_special: true
+         #  property: gpu
+         #  extra-runs-on: gpu
 
     runs-on:
       - self-hosted


### PR DESCRIPTION
Due to DNS problems on the GPU runner, the build is too unstable to be part of the CI.

