### PR TITLE
[ntuple] Reduce includes of RColumnElement.hxx

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -267,6 +267,9 @@ auto MakeAliasedSharedPtr(T *rawPtr)
    return std::shared_ptr<T>(fgRawPtrCtrlBlock, rawPtr);
 }
 
+inline constexpr EColumnType kTestFutureType =
+   static_cast<EColumnType>(std::numeric_limits<std::underlying_type_t<EColumnType>>::max() - 1);
+
 inline constexpr ENTupleStructure kTestFutureFieldStructure =
    static_cast<ENTupleStructure>(std::numeric_limits<std::underlying_type_t<ENTupleStructure>>::max() - 1);
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -317,11 +317,8 @@ inline void CastZigzagSplitUnpack(void *destination, const void *source, std::si
 namespace {
 
 using ROOT::Experimental::EColumnType;
+using ROOT::Experimental::Internal::kTestFutureType;
 using ROOT::Experimental::Internal::RColumnElementBase;
-
-// testing value for an unknown future column type
-inline constexpr EColumnType kTestFutureType =
-   static_cast<EColumnType>(std::numeric_limits<std::underlying_type_t<EColumnType>>::max() - 1);
 
 template <typename CppT, EColumnType>
 class RColumnElement;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -20,8 +20,6 @@
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
-#include "RColumnElement.hxx"
-
 #include <RVersion.h>
 #include <TBufferFile.h>
 #include <TClass.h>

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -8,8 +8,6 @@
 #include <memory>
 #include <cstdio>
 
-#include "../src/RColumnElement.hxx"
-
 TEST(RNTupleCompat, Epoch)
 {
    FileRaii fileGuard("test_ntuple_compat_epoch.root");
@@ -165,7 +163,7 @@ protected:
    }
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
-      static const RColumnRepresentations representations{{{kTestFutureType}}, {}};
+      static const RColumnRepresentations representations{{{Internal::kTestFutureType}}, {}};
       return representations;
    }
 


### PR DESCRIPTION
This internal header should only be included once into the `ROOTNTuple` library and as little as possible in the tests because it defines symbols in anonymous namespaces, to avoid ODR violations in the test `ntuple_endian.cxx`.

Achieve this by moving `kTestFutureType` to `RNTupleUtil.hxx`, next to other definitions used for compatibility tests. This leaves includes in `RColumnElement.cxx` (for the `ROOTNTuple` library), as well as the two tests `ntuple_endian.cxx` and `ntuple_packing.cxx` that unit test individual instantiations. This should also avoid compiler warnings seen recently.