### PR TITLE
[CI] Test GPU CI

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -392,11 +392,10 @@ jobs:
             is_special: true
             property: clang
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
-          # Disabled until DNS problems in containers are solved
-         #- image: ubuntu2404-cuda
-         #  is_special: true
-         #  property: gpu
-         #  extra-runs-on: gpu
+          - image: ubuntu2404-cuda
+            is_special: true
+            property: gpu
+            extra-runs-on: gpu
 
     runs-on:
       - self-hosted


### PR DESCRIPTION
Due to the recurring DNS problems, the machine was reinstalled with Alma8. This is to test the setup.