### PR TITLE
[metacling] Prevent nullptr access if compiler instance was not created

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1536,6 +1536,8 @@ TCling::TCling(const char *name, const char *title, const char* const argv[], vo
                                                        llvmResourceDir, extensions,
                                                        interpLibHandle);
 
+   if (!fInterpreter->getCI()) // Compiler instance could not be created. See https://its.cern.ch/jira/browse/ROOT-10239
+      exit(1);
    // Don't check whether modules' files exist.
    fInterpreter->getCI()->getPreprocessorOpts().DisablePCHOrModuleValidation =
       DisableValidationForModuleKind::All;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1536,8 +1536,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[], vo
                                                        llvmResourceDir, extensions,
                                                        interpLibHandle);
 
-   if (!fInterpreter->getCI()) // Compiler instance could not be created. See https://its.cern.ch/jira/browse/ROOT-10239
-      exit(1);
+   if (!fInterpreter->getCI()) { // Compiler instance could not be created. See https://its.cern.ch/jira/browse/ROOT-10239
+      std::cerr << "Exiting now since compiler instance is not available." << std::endl;
+      exit(EXIT_FAILURE);
+   }
    // Don't check whether modules' files exist.
    fInterpreter->getCI()->getPreprocessorOpts().DisablePCHOrModuleValidation =
       DisableValidationForModuleKind::All;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

exit with error1 code instead of crashing

Fixes https://its.cern.ch/jira/browse/ROOT-10239

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)