### PR TITLE
[PyROOT] Retain C++ memory ownership for TStyle

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -80,13 +80,13 @@ set(py_sources
   ROOT/_facade.py
   ROOT/__init__.py
   ROOT/_numbadeclare.py
+  ROOT/_pythonization/__init__.py
   ROOT/_pythonization/_cppinstance.py
   ROOT/_pythonization/_drawables.py
   ROOT/_pythonization/_generic.py
-  ROOT/_pythonization/__init__.py
   ROOT/_pythonization/_pyz_utils.py
-  ROOT/_pythonization/_rvec.py
   ROOT/_pythonization/_runtime_error.py
+  ROOT/_pythonization/_rvec.py
   ROOT/_pythonization/_stl_vector.py
   ROOT/_pythonization/_tarray.py
   ROOT/_pythonization/_tclass.py
@@ -94,11 +94,11 @@ set(py_sources
   ROOT/_pythonization/_tcollection.py
   ROOT/_pythonization/_tcomplex.py
   ROOT/_pythonization/_tcontext.py
-  ROOT/_pythonization/_tdirectoryfile.py
   ROOT/_pythonization/_tdirectory.py
+  ROOT/_pythonization/_tdirectoryfile.py
+  ROOT/_pythonization/_tf1.py
   ROOT/_pythonization/_tfile.py
   ROOT/_pythonization/_tformula.py
-  ROOT/_pythonization/_tf1.py
   ROOT/_pythonization/_tgraph.py
   ROOT/_pythonization/_th1.py
   ROOT/_pythonization/_titer.py
@@ -106,6 +106,7 @@ set(py_sources
   ROOT/_pythonization/_tobjstring.py
   ROOT/_pythonization/_tseqcollection.py
   ROOT/_pythonization/_tstring.py
+  ROOT/_pythonization/_tstyle.py
   ROOT/_pythonization/_ttree.py
   ROOT/_pythonization/_tvector3.py
   ROOT/_pythonization/_tvectort.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tstyle.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tstyle.py
@@ -1,0 +1,29 @@
+# Author: Jonas Rembser CERN 11/2024
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from . import pythonization
+
+
+def _TStyle_Constructor(self, *args, **kwargs):
+    """
+    Forward the arguments to the C++ constructor and retain ownership. This
+    helps avoiding double deletes due to ROOT automatic memory management.
+    """
+    self._cpp_constructor(*args, **kwargs)
+    import ROOT
+
+    ROOT.SetOwnership(self, False)
+
+
+@pythonization("TStyle")
+def pythonize_tstyle(klass):
+
+    klass._cpp_constructor = klass.__init__
+    klass.__init__ = _TStyle_Constructor

--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -43,6 +43,15 @@ class MemoryStlString(unittest.TestCase):
         delta = after - before
         self.assertLess(delta, 16)
 
+    def test_tstyle_memory_management(self):
+        """Regression test for https://github.com/root-project/root/issues/16918"""
+
+        h1 = ROOT.TH1F("h1", "", 100, 0, 10)
+
+        style = ROOT.TStyle("NewSTYLE", "")
+        groot = ROOT.ROOT.GetROOT()
+        groot.SetStyle(style.GetName())
+        groot.ForceStyle()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Similar to 18a7c1fd74c, since also any instantiated TStyle is owned by ROOT.

Closes #16918.

See:
https://github.com/root-project/root/blob/master/core/base/src/TStyle.cxx#L212