### PR TITLE
[tree] remove stray newline when printf with toponly

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7326,7 +7326,7 @@ void TTree::Print(Option_t* option) const
          if (count[l] < 0) continue;
          leaf = (TLeaf *)const_cast<TTree*>(this)->GetListOfLeaves()->At(l);
          br   = leaf->GetBranch();
-         Printf("branch: %-20s %9lld\n",br->GetName(),count[l]);
+         Printf("branch: %-20s %9lld",br->GetName(),count[l]);
       }
       delete [] count;
    } else {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-9961

The "bug" was introduced by https://github.com/root-project/root/commit/cd678fce958f93f18175a50017b105366c98f3e6