### PR TITLE
[CI] Enable ccache for linux builds.

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -4,3 +4,4 @@ builtin_tbb=ON
 builtin_vdt=On
 fortran=OFF
 tmva-sofie=On
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
@@ -2,3 +2,4 @@ builtin_nlohmannjson=ON
 builtin_vdt=On
 tmva-sofie=On
 BLA_VENDOR=OpenBLAS
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -2,3 +2,4 @@ builtin_nlohmannjson=ON
 builtin_vdt=On
 tmva-sofie=On
 BLA_VENDOR=OpenBLAS
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/debian125.txt
+++ b/.github/workflows/root-ci-config/buildconfig/debian125.txt
@@ -1,2 +1,3 @@
 pythia8=OFF
 mysql=OFF
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/fedora39.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora39.txt
@@ -1,2 +1,3 @@
 builtin_nlohmannjson=On
 builtin_vdt=On
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/fedora40.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora40.txt
@@ -2,3 +2,4 @@ builtin_zstd=ON
 builtin_zlib=ON
 builtin_nlohmannjson=On
 builtin_vdt=On
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -3,3 +3,4 @@ builtin_zlib=ON
 builtin_nlohmannjson=On
 builtin_vdt=On
 pythia8=Off
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu22.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu22.txt
@@ -2,3 +2,4 @@ builtin_vdt=ON
 pythia8=OFF
 r=ON
 tmva-sofie=ON
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu2404.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu2404.txt
@@ -1,2 +1,3 @@
 pythia8=OFF
 tmva-sofie=ON
+ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu2410.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu2410.txt
@@ -1,2 +1,3 @@
 pythia8=OFF
 tmva-cpu=OFF
+ccache=On

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -424,8 +424,17 @@ jobs:
         CONTAINER_OPTIONS: "--security-opt label=disable --rm ${{ matrix.property == 'gpu' && '--device nvidia.com/gpu=all' || '' }}" #KEEP IN SYNC WITH ABOVE
 
     steps:
-      - name: ccache info
+      - name: Configure large ccache
+        if: ${{ matrix.is_special }}
         run: |
+          ccache -o max_size=5G
+          ccache -p || true
+          ccache -s || true
+
+      - name: Configure small ccache
+        if: ${{ !matrix.is_special }}
+        run: |
+          ccache -o max_size=1.5G
           ccache -p || true
           ccache -s || true
 
@@ -555,7 +564,6 @@ jobs:
 
       - name: ccache info (post)
         run: |
-          ccache -p || true
           ccache -s || true
 
   event_file:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -384,7 +384,7 @@ jobs:
           - image: alma9
             is_special: true
             property: arm64
-            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "ccache=ON"]
+            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo"]
             architecture: ARM64
           - image: alma9-clang
             is_special: true


### PR DESCRIPTION
- Configure ccache at the beginning of the actions workflow.
  - Use a large cache of 5G for special builds
  - Use a a smaller one of 1.5G for the "standard" ones. This is to protect the general-purpose nodes from running out of space, as they are running many different containers over time.
- Enable ccache for all Linux builds in `master`.