### PR TITLE
[ntuple] Merger: fix handling of compression-related options

### DIFF
--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -427,8 +427,10 @@ int main( int argc, char **argv )
          else
             newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
          delete firstInput;
+         fileMerger.SetMergeOptions(TString("first_source_compression"));
       } else {
          newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
+         fileMerger.SetMergeOptions(TString("default_compression"));
       }
    }
    if (verbosity > 1) {
@@ -487,7 +489,7 @@ int main( int argc, char **argv )
          }
       }
       merger.SetNotrees(noTrees);
-      merger.SetMergeOptions(cacheSize);
+      merger.SetMergeOptions(TString(merger.GetMergeOptions()) + " " + cacheSize);
       merger.SetIOFeatures(features);
       Bool_t status;
       if (append)

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -151,9 +151,9 @@ try {
 
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
-      auto source = RPageSourceFile::CreateFromAnchor(*outNTuple);
-      source->Attach();
-      auto desc = source->GetSharedDescriptorGuard();
+      auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
+      outSource->Attach();
+      auto desc = outSource->GetSharedDescriptorGuard();
       destination->InitFromDescriptor(desc.GetRef());
    }
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -881,8 +881,21 @@ RNTupleMerger::RNTupleMerger()
 }
 
 RResult<void>
-RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination, const RNTupleMergeOptions &mergeOpts)
+RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination, const RNTupleMergeOptions &mergeOptsIn)
 {
+   RNTupleMergeOptions mergeOpts = mergeOptsIn;
+   {
+      const auto dstCompSettings = destination.GetWriteOptions().GetCompression();
+      if (mergeOpts.fCompressionSettings == kUnknownCompressionSettings) {
+         mergeOpts.fCompressionSettings = dstCompSettings;
+      } else if (mergeOpts.fCompressionSettings != dstCompSettings) {
+         return R__FAIL(std::string("The compression given to RNTupleMergeOptions is different from that of the "
+                                    "sink! (opts: ") +
+                        std::to_string(mergeOpts.fCompressionSettings) + ", sink: " + std::to_string(dstCompSettings) +
+                        ") This is currently unsupported.");
+      }
+   }
+
    RNTupleMergeData mergeData{sources, destination, mergeOpts};
 
    std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple


### PR DESCRIPTION
Currently the RNTupleMerger has a pretty confusing and unintuitive handling of `hadd`'s compression options.
To simplify the situation, this PR implements these simpler rules:
1. the output RNTuple and its container file always have the same compression
2.  if the user explicitly passes a compression settings (`-f[0-9]`), use that compression
3. if the user doesn't pass any compression flag, use 505 as the output compression
4. if the user passes `-ff` or `-fk`, open the first source file, grab the RNTuple inside it, peek the first column range we can find and use its compression settings as the output compression. This is different from the current behavior of using the same compression as the first source *file*, as that behavior is probably not what the user wants.

This requires passing more information from hadd to the RNTupleMerger. I added a couple of TString merge options to do so, which won't impact the existing merging code as they only get interpreted by the RNTupleMerger.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


