### PR TITLE
[RF] Add old getter for covariance matrix

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -60,6 +60,7 @@ public:
       double Edm() const { return fEdm; }
       bool IsValid() const { return fValid; }
       int Status() const { return fStatus; }
+      void GetCovarianceMatrix(TMatrixDSym &cov) const;
 
       bool isParameterFixed(unsigned int ipar) const;
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -1179,3 +1179,14 @@ bool RooMinimizer::FitResult::isParameterFixed(unsigned int ipar) const
 {
    return fFixedParams.find(ipar) != fFixedParams.end();
 }
+
+void RooMinimizer::FitResult::GetCovarianceMatrix(TMatrixDSym &covs) const
+{
+   const size_t nParams = fParams.size();
+   covs.ResizeTo(nParams, nParams);
+   for (std::size_t ic = 0; ic < nParams; ic++) {
+      for (std::size_t ii = 0; ii < nParams; ii++) {
+         covs(ic, ii) = covMatrix(fCovMatrix, ic, ii);
+      }
+   }
+}


### PR DESCRIPTION
# This Pull request:

In older ROOT versions, `RooMinimizer::FitResult` used to have a method called `GetCovarianceMatrix`.
This MR reinstates that old method for compatibility reasons. 

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

