### PR TITLE
[RF] Change return type of `RooRealVar::format()` to std::string

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -44,6 +44,13 @@ The following people have contributed to this new version:
 
 ## RooFit
 
+### Breaking function signature changes
+
+  * The `RooRealVar::format()` function was changed to return a `std::string` instead of a `TString *`.
+    The former return type was not memory safe, since the caller had to delete the `TString`.
+    This pattern was not appropriate for a modern C++ library.
+    If you absolutely need the old return type, wrap the call to `format()` inside `new TString{var.format(..)}`. However, this is not recommended.
+
 ## IO
 
 ## RDataFrame

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -118,8 +118,8 @@ public:
   Int_t defaultPrintContents(Option_t* opt) const override ;
 
 
-  TString* format(const RooCmdArg& formatArg) const ;
-  TString* format(Int_t sigDigits, const char *options) const ;
+  std::string format(const RooCmdArg& formatArg) const ;
+  std::string format(Int_t sigDigits, const char *options) const ;
 
   static void printScientific(bool flag=false) ;
   static void printSigDigits(Int_t ndig=5) ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1456,9 +1456,9 @@ void RooAbsCollection::printLatex(std::ostream& ofs, Int_t ncol, const char* opt
    RooRealVar* par = static_cast<RooRealVar*>((static_cast<RooArgList*>(listListRRV.At(k)))->at(i+j*nrow)) ;
    if (par) {
      if (option) {
-       ofs << *std::unique_ptr<TString>{par->format(sigDigit,(k==0)?option:sibOption.Data())};
+       ofs << par->format(sigDigit,(k==0)?option:sibOption.Data());
      } else {
-       ofs << *std::unique_ptr<TString>{par->format((k==0)?*formatCmd:sibFormatCmd)};
+       ofs << par->format((k==0)?*formatCmd:sibFormatCmd);
      }
    }
    if (!(j==ncol-1 && k==nlist-1)) {

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1243,21 +1243,12 @@ RooPlot* RooAbsData::statOn(RooPlot* frame, const char* what, const char *label,
   meanv->setPlotLabel("Mean") ;
   std::unique_ptr<RooRealVar> rms{rmsVar(*static_cast<RooRealVar*>(frame->getPlotVar()),cutSpec,cutRange)};
   rms->setPlotLabel("RMS") ;
-  std::unique_ptr<TString> rmsText;
-  std::unique_ptr<TString> meanText;
-  std::unique_ptr<TString> NText;
-  if (options) {
-    rmsText.reset(rms->format(sigDigits,options));
-    meanText.reset(meanv->format(sigDigits,options));
-    NText.reset(N.format(sigDigits,options));
-  } else {
-    rmsText.reset(rms->format(*formatCmd));
-    meanText.reset(meanv->format(*formatCmd));
-    NText.reset(N.format(*formatCmd));
-  }
-  if (showR) box->AddText(rmsText->Data());
-  if (showM) box->AddText(meanText->Data());
-  if (showN) box->AddText(NText->Data());
+  std::string rmsText = options ? rms->format(sigDigits,options) : rms->format(*formatCmd);
+  std::string meanText = options ? meanv->format(sigDigits,options) : meanv->format(*formatCmd);
+  std::string NText = options ? N.format(sigDigits,options) : N.format(*formatCmd);
+  if (showR) box->AddText(rmsText.c_str());
+  if (showM) box->AddText(meanText.c_str());
+  if (showN) box->AddText(NText.c_str());
 
   // add the optional label if specified
   if(showLabel) box->AddText(label);

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2371,8 +2371,7 @@ RooPlot* RooAbsPdf::paramOn(RooPlot* frame, const RooArgSet& params, bool showCo
     auto var = static_cast<const RooRealVar*>(param);
     if(var->isConstant() && !showConstants) continue;
 
-    std::unique_ptr<TString> formatted{formatCmd ? var->format(*formatCmd) : var->format(2, "NELU")};
-    box->AddText(formatted->Data());
+    box->AddText((formatCmd ? var->format(*formatCmd) : var->format(2, "NELU")).c_str());
   }
 
   // add the optional label if specified

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -1033,8 +1033,8 @@ void fitGaussToPulls(RooPlot& frame, RooDataSet& fitParData)
    const char * options = "ELU";
    std::stringstream ss;
    ss << "Fit parameters:\n"
-      << "#mu: " << *std::unique_ptr<TString>{pullMean.format(sigDigits, options)}
-      << "\n#sigma: " << *std::unique_ptr<TString>{pullSigma.format(sigDigits, options)};
+      << "#mu: " << pullMean.format(sigDigits, options)
+      << "\n#sigma: " << pullSigma.format(sigDigits, options);
    // We set the parameters constant to disable the default label. Still, we
    // use param() on as a wrapper for the text box generation.
    pullMean.setConstant(true);

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -706,7 +706,7 @@ void RooRealVar::writeToStream(ostream& os, bool compact) const
 
       os << " " ;
     } else {
-      os << std::unique_ptr<TString>{format(_printSigDigits,"EFA")}->Data() << " " ;
+      os << format(_printSigDigits,"EFA") << " " ;
     }
 
     // Append limits if not constants
@@ -830,7 +830,7 @@ void RooRealVar::printMultiline(ostream& os, Int_t contents, bool verbose, TStri
 /// taken by paramOn() and translates them to an option string
 /// parsed by RooRealVar::format(Int_t sigDigits, const char *options)
 
-TString* RooRealVar::format(const RooCmdArg& formatArg) const
+std::string RooRealVar::format(const RooCmdArg& formatArg) const
 {
   RooCmdArg tmp(formatArg) ;
   tmp.setProcessRecArgs(true) ;
@@ -849,7 +849,7 @@ TString* RooRealVar::format(const RooCmdArg& formatArg) const
   // Process & check varargs
   pc.process(tmp) ;
   if (!pc.ok(true)) {
-    return nullptr ;
+    return "";
   }
 
   // Extract values from named arguments
@@ -900,7 +900,7 @@ TString* RooRealVar::format(const RooCmdArg& formatArg) const
 /// F = force fixed precision
 ///
 
-TString *RooRealVar::format(Int_t sigDigits, const char *options) const
+std::string RooRealVar::format(Int_t sigDigits, const char *options) const
 {
   // parse the options string
   TString opts(options);
@@ -944,89 +944,83 @@ TString *RooRealVar::format(Int_t sigDigits, const char *options) const
   if (_value<0) whereVal -= 1 ;
   snprintf(fmtVal,16,"%%.%df", whereVal < 0 ? -whereVal : 0);
   snprintf(fmtErr,16,"%%.%df", whereErr < 0 ? -whereErr : 0);
-  TString *text= new TString();
-  if(latexMode) text->Append("$");
+  std::string text;
+  if(latexMode) text += "$";
   // begin the string with "<name> = " if requested
   if(showName || showTitle) {
     if (latexTableMode && latexVerbatimName) {
-      text->Append("\\verb+") ;
+      text += "\\verb+";
     }
-    text->Append(label);
-    if (latexVerbatimName) text->Append("+") ;
+    text += label;
+    if (latexVerbatimName) text += "+";
 
     if (!latexTableMode) {
-      text->Append(" = ");
+      text += " = ";
     } else {
-      text->Append(" $ & $ ");
+      text += " $ & $ ";
     }
   }
 
   // Add leading space if value is positive
-  if (_value>=0) text->Append(" ") ;
+  if (_value>=0) text += " ";
 
   // append our value if requested
   char buffer[256];
   if(!hideValue) {
     chopAt(_value, whereVal);
     snprintf(buffer, 256,fmtVal, _value);
-    text->Append(buffer);
+    text += buffer;
   }
 
   // append our error if requested and this variable is not constant
   if(hasError(false) && showError && !(asymError && hasAsymError(false))) {
     if(tlatexMode) {
-      text->Append(" #pm ");
-    }
-    else if(latexMode) {
-      text->Append("\\pm ");
+      text += " #pm ";
     }
     else {
-      text->Append(" +/- ");
+      text += latexMode ? "\\pm " : " +/- ";
     }
     snprintf(buffer, 256,fmtErr, getError());
-    text->Append(buffer);
+    text += buffer;
   }
 
   if (asymError && hasAsymError() && showError) {
     if(tlatexMode) {
-      text->Append(" #pm ");
-      text->Append("_{") ;
+      text += " #pm _{";
       snprintf(buffer, 256,fmtErr, getAsymErrorLo());
-      text->Append(buffer);
-      text->Append("}^{+") ;
+      text += buffer;
+      text += "}^{+";
       snprintf(buffer, 256,fmtErr, getAsymErrorHi());
-      text->Append(buffer);
-      text->Append("}") ;
+      text += buffer;
+      text += "}";
     }
     else if(latexMode) {
-      text->Append("\\pm ");
-      text->Append("_{") ;
+      text += "\\pm _{";
       snprintf(buffer, 256,fmtErr, getAsymErrorLo());
-      text->Append(buffer);
-      text->Append("}^{+") ;
+      text += buffer;
+      text += "}^{+";
       snprintf(buffer, 256,fmtErr, getAsymErrorHi());
-      text->Append(buffer);
-      text->Append("}") ;
+      text += buffer;
+      text += "}";
     }
     else {
-      text->Append(" +/- ");
-      text->Append(" (") ;
+      text += " +/-  (";
       snprintf(buffer, 256, fmtErr, getAsymErrorLo());
-      text->Append(buffer);
-      text->Append(", ") ;
+      text += buffer;
+      text += ", ";
       snprintf(buffer, 256, fmtErr, getAsymErrorHi());
-      text->Append(buffer);
-      text->Append(")") ;
+      text += buffer;
+      text += ")";
     }
 
   }
 
   // append our units if requested
   if(!_unit.IsNull() && showUnit) {
-    text->Append(' ');
-    text->Append(_unit);
+    text += ' ';
+    text += _unit;
   }
-  if(latexMode) text->Append("$");
+  if(latexMode) text += "$";
   return text;
 }
 

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -103,6 +103,7 @@ public:
       }
    }
 
+   RooFit::EvalBackend const &evalBackend() { return _evalBackend; }
    RooWorkspace &ws() { return _ws; }
    RooDataSet &data() { return *_data; }
    RooDataSet &dataWithMeanSigmaGlobs() { return *_dataWithMeanSigmaGlobs; }
@@ -323,7 +324,7 @@ TEST_P(GlobsTest, ResetDataToWrongData)
    wrongData->setGlobalObservables({gm, gs});
 
    // check that the fit works when using the dataset with the correct values
-   std::unique_ptr<RooAbsReal> nll{model.createNLL(dataWithMeanSigmaGlobs())};
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(dataWithMeanSigmaGlobs(), EvalBackend(evalBackend()))};
    auto res2 = minimize(model, *nll, dataWithMeanSigmaGlobs(), minimizerCfg());
    EXPECT_TRUE(res1->isIdentical(*res2)) << "fitting an model with internal "
                                             "constraints in a RooPrdPdf gave a different result when global "
@@ -362,7 +363,7 @@ TEST_P(GlobsTest, ResetDataToCorrectData)
    resetParameters();
 
    // check that the fit doesn't work when using the dataset with the wrong values
-   std::unique_ptr<RooAbsReal> nll{model.createNLL(*wrongData)};
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*wrongData, EvalBackend(evalBackend()))};
    auto res2 = minimize(model, *nll, *wrongData, minimizerCfg());
    EXPECT_TRUE(isNotIdentical(*res1, *res2)) << "fitting an model with internal "
                                                 "constraints in a RooPrdPdf ignored the global "
@@ -426,8 +427,8 @@ TEST_P(GlobsTest, ResetDataButSourceFromModel)
    resetParameters();
 
    // check that the fit works when using the dataset with the correct values
-   std::unique_ptr<RooAbsReal> nll{
-      model.createNLL(dataWithMeanSigmaGlobs(), GlobalObservablesSource("model"), GlobalObservables(gm, gs))};
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(dataWithMeanSigmaGlobs(), GlobalObservablesSource("model"),
+                                                   GlobalObservables(gm, gs), EvalBackend(evalBackend()))};
    auto res2 = minimize(model, *nll, dataWithMeanSigmaGlobs(), minimizerCfg());
    EXPECT_TRUE(res1->isIdentical(*res2));
 


### PR DESCRIPTION
Returning a TString by raw pointer that the caller needs to delete is not memory safe and an outdated pattern, which merits a breaking change documented in the 6.36 release notes.