### PR TITLE
[ntuple] Simplify `RNTuple::Streamer()`

### DIFF
--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -27,23 +27,12 @@
 void ROOT::RNTuple::Streamer(TBuffer &buf)
 {
    if (buf.IsReading()) {
-      UInt_t offClassBuf;
-      UInt_t bcnt;
-      auto classVersion = buf.ReadVersion(&offClassBuf, &bcnt);
-
-      // Strip class version from checksum calculation
-      UInt_t lenStrip = sizeof(Version_t);
-
-      if (bcnt < lenStrip)
-         throw Experimental::RException(R__FAIL("invalid anchor byte count: " + std::to_string(bcnt)));
-
-      auto lenCkData = bcnt - lenStrip;
       // Skip byte count and class version
-      auto offCkData = offClassBuf + sizeof(UInt_t) + sizeof(Version_t);
-      auto expectedChecksum = XXH3_64bits(buf.Buffer() + offCkData, lenCkData);
+      auto offCkData = buf.Length() + sizeof(UInt_t) + sizeof(Version_t);
+      buf.ReadClassBuffer(RNTuple::Class(), this);
+      std::uint64_t expectedChecksum = XXH3_64bits(buf.Buffer() + offCkData, buf.Length() - offCkData);
 
       std::uint64_t onDiskChecksum;
-      buf.ReadClassBuffer(RNTuple::Class(), this, classVersion, offClassBuf, bcnt);
       if (static_cast<std::size_t>(buf.BufferSize()) < buf.Length() + sizeof(onDiskChecksum))
          throw Experimental::RException(R__FAIL("the buffer containing RNTuple is too small to contain the checksum!"));
       buf >> onDiskChecksum;


### PR DESCRIPTION
This makes the writing and reading paths symmetric.