### PR TITLE
Avoid compiler warnings

### DIFF
--- a/graf3d/gl/src/TGLSdfFontMakerLowLevel.icxx
+++ b/graf3d/gl/src/TGLSdfFontMakerLowLevel.icxx
@@ -2144,10 +2144,15 @@ bool Font::load_ttf_file( const char *filename ) {
     fseek( f, 0, SEEK_SET );
 
     uint8_t *ttf = (unsigned char*) malloc( fsize );
-    fread( ttf, 1, fsize, f );
+    size_t result = fread( ttf, 1, fsize, f );
+    bool res = false;
+    if (result != fsize) {
+        perror("Error reading file");
+    } else {
+        res = load_ttf_mem( ttf );
+    }
     fclose( f );
 
-    bool res = load_ttf_mem( ttf );
     free( ttf );
     return res;
 }


### PR DESCRIPTION
  1. If you are using the `[[unlikely]]` attribute for your `if` of `else`, the curly brackets need to be written. Otherwise, the attribute will refer to the first statement in the code branch, which is meaningless because the statement will always be executed once the code branch is taken.

  2. The `if constexpr` can be tricky with unused variables, because if the branch is not taken, it's clear at compile time and all variables only used in that branch are effectively unused. There was a case where the `if constexpr` branch used one variable, and the corresponding `else` used another variable of the same type. To avoid redundant computations and compiler warnings, only a single variable is now defined to what is needed respecively.

  3. The return value of `fread` was unchecked. This commit suggest to do what is also done in tutorials for that function: https://www.tutorialspoint.com/c_standard_library/c_function_fread.htm