### PR TITLE
[6.34] Various fixes to RNTupleMerger

### DIFF
--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -427,8 +427,10 @@ int main( int argc, char **argv )
          else
             newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
          delete firstInput;
+         fileMerger.SetMergeOptions(TString("first_source_compression"));
       } else {
          newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault;
+         fileMerger.SetMergeOptions(TString("default_compression"));
       }
    }
    if (verbosity > 1) {
@@ -487,7 +489,7 @@ int main( int argc, char **argv )
          }
       }
       merger.SetNotrees(noTrees);
-      merger.SetMergeOptions(cacheSize);
+      merger.SetMergeOptions(TString(merger.GetMergeOptions()) + " " + cacheSize);
       merger.SetIOFeatures(features);
       Bool_t status;
       if (append)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -81,7 +81,7 @@ class RNTupleMerger final {
    std::optional<TTaskGroup> fTaskGroup;
 
    void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
-                           std::span<RColumnMergeInfo> commonColumns, RCluster::ColumnSet_t commonColumnSet,
+                           std::span<RColumnMergeInfo> commonColumns, const RCluster::ColumnSet_t &commonColumnSet,
                            RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData);
 
    void MergeSourceClusters(RPageSource &source, std::span<RColumnMergeInfo> commonColumns,

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -476,7 +476,8 @@ static void ExtendDestinationModel(std::span<const RFieldDescriptor *> newFields
 // Merges all columns appearing both in the source and destination RNTuples, just copying them if their
 // compression matches ("fast merge") or by unsealing and resealing them with the proper compression.
 void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
-                                       std::span<RColumnMergeInfo> commonColumns, RCluster::ColumnSet_t commonColumnSet,
+                                       std::span<RColumnMergeInfo> commonColumns,
+                                       const RCluster::ColumnSet_t &commonColumnSet,
                                        RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData)
 {
    assert(commonColumns.size() == commonColumnSet.size());
@@ -511,7 +512,6 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
       const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings;
       const bool needsCompressionChange = mergeData.fMergeOpts.fCompressionSettings != kUnknownCompressionSettings &&
                                           colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings;
-
       if (needsCompressionChange && mergeData.fMergeOpts.fExtraVerbose)
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
               colRangeCompressionSettings, mergeData.fMergeOpts.fCompressionSettings);
@@ -759,7 +759,7 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
       RColumnMergeInfo info{};
       info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex());
-      info.fInputId = srcColumnId;
+      info.fInputId = srcColumn.GetPhysicalId();
       // Since the parent field is only relevant for extra dst columns, the choice of src or dstFieldDesc as a parent
       // is arbitrary (they're the same field).
       info.fParentField = &dstFieldDesc;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -516,10 +516,10 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
               colRangeCompressionSettings, mergeData.fMergeOpts.fCompressionSettings);
 
-      // If the column range is already uncompressed we don't need to allocate any new buffer, so we don't
-      // bother reserving memory for them.
       size_t pageBufferBaseIdx = sealedPageData.fBuffers.size();
-      if (colRangeCompressionSettings != 0)
+      // If the column range already has the right compression we don't need to allocate any new buffer, so we don't
+      // bother reserving memory for them.
+      if (needsCompressionChange)
          sealedPageData.fBuffers.resize(sealedPageData.fBuffers.size() + pages.fPageInfos.size());
 
       // Loop over the pages

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -151,9 +151,9 @@ try {
 
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
-      auto source = RPageSourceFile::CreateFromAnchor(*outNTuple);
-      source->Attach();
-      auto desc = source->GetSharedDescriptorGuard();
+      auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
+      outSource->Attach();
+      auto desc = outSource->GetSharedDescriptorGuard();
       destination->InitFromDescriptor(desc.GetRef());
    }
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -849,7 +849,9 @@ RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination, c
 
       // Create sink from the input model if not initialized
       if (!destination.IsInitialized()) {
-         model = srcDescriptor->CreateModel();
+         auto opts = RNTupleDescriptor::RCreateModelOptions();
+         opts.fReconstructProjections = true;
+         model = srcDescriptor->CreateModel(opts);
          destination.Init(*model);
       }
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -78,22 +78,25 @@ try {
       // pointer we just got.
    }
 
-   // The "fast" option is present if and only if we don't want to change compression.
-   const int compression =
-      mergeInfo->fOptions.Contains("fast") ? kUnknownCompressionSettings : outFile->GetCompressionSettings();
-
-   RNTupleWriteOptions writeOpts;
-   writeOpts.SetUseBufferedWrite(false);
-   if (compression != kUnknownCompressionSettings)
-      writeOpts.SetCompression(compression);
-   auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
-
-   // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
-   if (outNTuple) {
-      auto source = RPageSourceFile::CreateFromAnchor(*outNTuple);
-      source->Attach();
-      auto desc = source->GetSharedDescriptorGuard();
-      destination->InitFromDescriptor(desc.GetRef());
+   const bool defaultComp = mergeInfo->fOptions.Contains("default_compression");
+   const bool firstSrcComp = mergeInfo->fOptions.Contains("first_source_compression");
+   if (defaultComp && firstSrcComp) {
+      // this should never happen through hadd, but a user may call RNTuple::Merge() from custom code...
+      Warning(
+         "RNTuple::Merge",
+         "Passed both options \"default_compression\" and \"first_source_compression\": only the latter will apply.");
+   }
+   int compression = kUnknownCompressionSettings;
+   if (firstSrcComp) {
+      // user passed -ff or -fk: use the same compression as the first RNTuple we find in the sources.
+      // (do nothing here, the compression will be fetched below)
+   } else if (!defaultComp) {
+      // compression was explicitly passed by the user: use it.
+      compression = outFile->GetCompressionSettings();
+   } else {
+      // user passed no compression-related options: use default
+      compression = RCompressionSetting::EDefaults::kUseGeneralPurpose;
+      Info("RNTuple::Merge", "Using the default compression: %d", compression);
    }
 
    // The remaining entries are the input files
@@ -108,7 +111,50 @@ try {
                inFile->GetName());
          return -1;
       }
-      sources.push_back(RPageSourceFile::CreateFromAnchor(*anchor));
+
+      auto source = RPageSourceFile::CreateFromAnchor(*anchor);
+      if (compression == kUnknownCompressionSettings) {
+         // Get the compression of this RNTuple and use it as the output compression.
+         // We currently assume all column ranges have the same compression, so we just peek at the first one.
+         source->Attach();
+         auto descriptor = source->GetSharedDescriptorGuard();
+         auto clusterIter = descriptor->GetClusterIterable();
+         auto firstCluster = clusterIter.begin();
+         if (firstCluster == clusterIter.end()) {
+            Error("RNTuple::Merge",
+                  "Asked to use the first source's compression as the output compression, but the "
+                  "first source (file '%s') has an empty RNTuple, therefore the output compression could not be "
+                  "determined.",
+                  inFile->GetName());
+            return -1;
+         }
+         auto colRangeIter = (*firstCluster).GetColumnRangeIterable();
+         auto firstColRange = colRangeIter.begin();
+         if (firstColRange == colRangeIter.end()) {
+            Error("RNTuple::Merge",
+                  "Asked to use the first source's compression as the output compression, but the "
+                  "first source (file '%s') has an empty RNTuple, therefore the output compression could not be "
+                  "determined.",
+                  inFile->GetName());
+            return -1;
+         }
+         compression = (*firstColRange).fCompressionSettings;
+         Info("RNTuple::Merge", "Using the first RNTuple's compression: %d", compression);
+      }
+      sources.push_back(std::move(source));
+   }
+
+   RNTupleWriteOptions writeOpts;
+   assert(compression != kUnknownCompressionSettings);
+   writeOpts.SetCompression(compression);
+   auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
+
+   // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
+   if (outNTuple) {
+      auto source = RPageSourceFile::CreateFromAnchor(*outNTuple);
+      source->Attach();
+      auto desc = source->GetSharedDescriptorGuard();
+      destination->InitFromDescriptor(desc.GetRef());
    }
 
    // Interface conversion
@@ -510,8 +556,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
 
       // Each column range potentially has a distinct compression settings
       const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings;
-      const bool needsCompressionChange = mergeData.fMergeOpts.fCompressionSettings != kUnknownCompressionSettings &&
-                                          colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings;
+      const bool needsCompressionChange = colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings;
       if (needsCompressionChange && mergeData.fMergeOpts.fExtraVerbose)
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
               colRangeCompressionSettings, mergeData.fMergeOpts.fCompressionSettings);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -781,6 +781,16 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
          info.fColumnType = dstColumn.GetType();
          mergeData.fColumnIdMap[info.fColumnName] = {info.fOutputId, info.fColumnType};
       }
+
+      if (mergeData.fMergeOpts.fExtraVerbose) {
+         Info("RNTuple::Merge",
+              "Adding column %s with log.id %" PRIu64 ", phys.id %" PRIu64 ", type %s "
+              " -> log.id %" PRIu64 ", type %s",
+              info.fColumnName.c_str(), srcColumnId, srcColumn.GetPhysicalId(),
+              RColumnElementBase::GetColumnTypeName(srcColumn.GetType()), info.fOutputId,
+              RColumnElementBase::GetColumnTypeName(info.fColumnType));
+      }
+
       // Since we disallow merging fields of different types, src and dstFieldDesc must have the same type name.
       assert(srcFieldDesc.GetTypeName() == dstFieldDesc.GetTypeName());
       info.fInMemoryType = ColumnInMemoryType(srcFieldDesc.GetTypeName(), info.fColumnType);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -755,6 +755,10 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
    // NOTE: here we can match the src and dst columns by column index because we forbid merging fields with
    // different column representations.
    for (auto i = 0u; i < srcFieldDesc.GetLogicalColumnIds().size(); ++i) {
+      // We don't want to try and merge alias columns
+      if (srcFieldDesc.IsProjectedField())
+         continue;
+
       auto srcColumnId = srcFieldDesc.GetLogicalColumnIds()[i];
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
       RColumnMergeInfo info{};


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/16939, https://github.com/root-project/root/pull/16944/ and https://github.com/root-project/root/pull/16949.

This set of changes prevents the RNTupleMerger and hadd to write corrupted data in some circumstances and fixes hadd's behavior wrt the compression-related flags.