### PR TITLE
[gui] Fix TGScrollbar handling of missing pictures

### DIFF
--- a/gui/gui/inc/TGClient.h
+++ b/gui/gui/inc/TGClient.h
@@ -125,6 +125,7 @@ public:
 
    TGPicturePool   *GetPicturePool() const { return fPicturePool; }
    const TGPicture *GetPicture(const char *name);
+   const TGPicture *GetPictureOrEmpty(const char *name);
    const TGPicture *GetPicture(const char *name, UInt_t new_width, UInt_t new_height);
    void             FreePicture(const TGPicture *pic);
 

--- a/gui/gui/inc/TGPicture.h
+++ b/gui/gui/inc/TGPicture.h
@@ -87,7 +87,6 @@ public:
 
 
 class TGPicturePool : public TObject {
-
 protected:
    const TGClient    *fClient;    ///< client for which we keep icon pool
    TString            fPath;      ///< icon search path
@@ -103,6 +102,7 @@ public:
 
    const char      *GetPath() const { return fPath; }
    const TGPicture *GetPicture(const char *name);
+   const TGPicture *GetPictureOrEmpty(const char *name);
    const TGPicture *GetPicture(const char *name, char **xpm);
    const TGPicture *GetPicture(const char *name, UInt_t new_width, UInt_t new_height);
    const TGPicture *GetPicture(const char *name, Pixmap_t pxmap, Pixmap_t mask =  0);

--- a/gui/gui/inc/TGScrollBar.h
+++ b/gui/gui/inc/TGScrollBar.h
@@ -95,7 +95,8 @@ public:
 
    TGScrollBar(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
                UInt_t options = kChildFrame,
-               Pixel_t back = GetDefaultFrameBackground());
+               Pixel_t back = GetDefaultFrameBackground(),
+               const char *headPicName = "", const char *tailPicName = "");
    ~TGScrollBar() override;
 
    void           GrabPointer(Bool_t grab) { fGrabPointer = grab; }

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -291,6 +291,12 @@ const TGPicture *TGClient::GetPicture(const char *name)
    return fPicturePool->GetPicture(name);
 }
 
+const TGPicture *TGClient::GetPictureOrEmpty(const char *name)
+{
+   return fPicturePool->GetPictureOrEmpty(name);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Get picture with specified size from pool (picture will be scaled if
 /// necessary). Picture must be freed using TGClient::FreePicture(). If

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -291,6 +291,9 @@ const TGPicture *TGClient::GetPicture(const char *name)
    return fPicturePool->GetPicture(name);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// @copydoc TGPicturePool::GetPictureOrEmpty(const char*)
+
 const TGPicture *TGClient::GetPictureOrEmpty(const char *name)
 {
    return fPicturePool->GetPictureOrEmpty(name);

--- a/gui/gui/src/TGPicture.cxx
+++ b/gui/gui/src/TGPicture.cxx
@@ -130,6 +130,10 @@ const TGPicture *TGPicturePool::GetPicture(const char *name)
    return pic;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Like TGPicturePool::GetPicture() but, instead of returning null when the 
+/// picture is not found, it returns a valid empty picture.
+
 const TGPicture *TGPicturePool::GetPictureOrEmpty(const char *name)
 {
    static const TGPicture fEmptyPic { "Empty" };

--- a/gui/gui/src/TGPicture.cxx
+++ b/gui/gui/src/TGPicture.cxx
@@ -130,6 +130,15 @@ const TGPicture *TGPicturePool::GetPicture(const char *name)
    return pic;
 }
 
+const TGPicture *TGPicturePool::GetPictureOrEmpty(const char *name)
+{
+   static const TGPicture fEmptyPic { "Empty" };
+   const TGPicture *pic = GetPicture(name);
+   if (!pic)
+      pic = &fEmptyPic;
+   return pic;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Get picture with specified size from pool (picture will be scaled if
 /// necessary). Picture must be freed using TGPicturePool::FreePicture(). If

--- a/gui/gui/src/TGScrollBar.cxx
+++ b/gui/gui/src/TGScrollBar.cxx
@@ -430,13 +430,9 @@ TGHScrollBar::TGHScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
     TGScrollBar(p, w, h, options, back)
 {
-   fHeadPic = fClient->GetPicture("arrow_left.xpm");
-   fTailPic = fClient->GetPicture("arrow_right.xpm");
+   fHeadPic = fClient->GetPictureOrEmpty("arrow_left.xpm");
+   fTailPic = fClient->GetPictureOrEmpty("arrow_right.xpm");
 
-   if (!fHeadPic || !fTailPic) {
-      Error("TGHScrollBar", "arrow_*.xpm not found");
-      return;
-   }
    fHead   = new TGScrollBarElement(this, fHeadPic, fgScrollBarWidth, fgScrollBarWidth,
                                     kRaisedFrame);
    fTail   = new TGScrollBarElement(this, fTailPic, fgScrollBarWidth, fgScrollBarWidth,
@@ -687,13 +683,9 @@ TGVScrollBar::TGVScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
     TGScrollBar(p, w, h, options, back)
 {
-   fHeadPic = fClient->GetPicture("arrow_up.xpm");
-   fTailPic = fClient->GetPicture("arrow_down.xpm");
+   fHeadPic = fClient->GetPictureOrEmpty("arrow_up.xpm");
+   fTailPic = fClient->GetPictureOrEmpty("arrow_down.xpm");
 
-   if (!fHeadPic || !fTailPic) {
-      Error("TGVScrollBar", "arrow_*.xpm not found");
-      return;
-   }
    fHead   = new TGScrollBarElement(this, fHeadPic, fgScrollBarWidth, fgScrollBarWidth,
                                     kRaisedFrame);
    fTail   = new TGScrollBarElement(this, fTailPic, fgScrollBarWidth, fgScrollBarWidth,

--- a/gui/gui/src/TGScrollBar.cxx
+++ b/gui/gui/src/TGScrollBar.cxx
@@ -306,7 +306,7 @@ Bool_t TGScrollBarElement::HandleCrossing(Event_t *event)
 /// Constructor.
 
 TGScrollBar::TGScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
-                         UInt_t options, Pixel_t back) :
+                         UInt_t options, Pixel_t back, const char *headPicName, const char *tailPicName) :
    TGFrame(p, w, h, options | kOwnBackground, back),
    fX0(0), fY0(0), fXp(0), fYp(0), fDragging(kFALSE), fGrabPointer(kTRUE),
    fRange(0), fPsize(0), fPos(0), fSliderSize(0), fSliderRange(0),
@@ -323,6 +323,31 @@ TGScrollBar::TGScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
       SetBackgroundPixmap(GetBckgndPixmap());
    SetWindowName();
    AddInput(kEnterWindowMask | kLeaveWindowMask);
+
+   fHeadPic = fClient->GetPictureOrEmpty(headPicName);
+   fTailPic = fClient->GetPictureOrEmpty(tailPicName);
+
+   fHead   = new TGScrollBarElement(this, fHeadPic, fgScrollBarWidth, fgScrollBarWidth,
+                                    kRaisedFrame);
+   fTail   = new TGScrollBarElement(this, fTailPic, fgScrollBarWidth, fgScrollBarWidth,
+                                    kRaisedFrame);
+   fSlider = new TGScrollBarElement(this, 0, fgScrollBarWidth, 50,
+                                    kRaisedFrame);
+
+   gVirtualX->GrabButton(fId, kAnyButton, kAnyModifier, kButtonPressMask |
+                         kButtonReleaseMask | kPointerMotionMask, kNone, kNone);
+
+   fDragging = kFALSE;
+   fX0 = fY0 = (fgScrollBarWidth = TMath::Max(fgScrollBarWidth, 5));
+   fPos = 0;
+
+   fSliderSize  = 50;
+   fSliderRange = 1;
+
+   fHead->SetEditDisabled(kEditDisable | kEditDisableGrab);
+   fTail->SetEditDisabled(kEditDisable | kEditDisableGrab);
+   fSlider->SetEditDisabled(kEditDisable | kEditDisableGrab);
+   fEditDisabled = kEditDisableLayout | kEditDisableBtnEnable;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -428,35 +453,11 @@ void TGScrollBar::ChangeBackground(Pixel_t back)
 
 TGHScrollBar::TGHScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
-    TGScrollBar(p, w, h, options, back)
+    TGScrollBar(p, w, h, options, back, "arrow_left.xpm", "arrow_right.xpm")
 {
-   fHeadPic = fClient->GetPictureOrEmpty("arrow_left.xpm");
-   fTailPic = fClient->GetPictureOrEmpty("arrow_right.xpm");
-
-   fHead   = new TGScrollBarElement(this, fHeadPic, fgScrollBarWidth, fgScrollBarWidth,
-                                    kRaisedFrame);
-   fTail   = new TGScrollBarElement(this, fTailPic, fgScrollBarWidth, fgScrollBarWidth,
-                                    kRaisedFrame);
-   fSlider = new TGScrollBarElement(this, 0, fgScrollBarWidth, 50,
-                                    kRaisedFrame);
-
-   gVirtualX->GrabButton(fId, kAnyButton, kAnyModifier, kButtonPressMask |
-                         kButtonReleaseMask | kPointerMotionMask, kNone, kNone);
-
-   fDragging = kFALSE;
-   fX0 = fY0 = (fgScrollBarWidth = TMath::Max(fgScrollBarWidth, 5));
-   fPos = 0;
-
    fRange = TMath::Max((Int_t) w - (fgScrollBarWidth << 1), 1);
    fPsize = fRange >> 1;
-
-   fSliderSize  = 50;
-   fSliderRange = 1;
-
-   fHead->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fTail->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fSlider->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fEditDisabled = kEditDisableLayout | kEditDisableHeight | kEditDisableBtnEnable;
+   fEditDisabled |= kEditDisableHeight;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -681,35 +682,11 @@ void TGHScrollBar::SetPosition(Int_t pos)
 
 TGVScrollBar::TGVScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
-    TGScrollBar(p, w, h, options, back)
+    TGScrollBar(p, w, h, options, back, "arrow_up.xpm", "arrow_down.xpm")
 {
-   fHeadPic = fClient->GetPictureOrEmpty("arrow_up.xpm");
-   fTailPic = fClient->GetPictureOrEmpty("arrow_down.xpm");
-
-   fHead   = new TGScrollBarElement(this, fHeadPic, fgScrollBarWidth, fgScrollBarWidth,
-                                    kRaisedFrame);
-   fTail   = new TGScrollBarElement(this, fTailPic, fgScrollBarWidth, fgScrollBarWidth,
-                                    kRaisedFrame);
-   fSlider = new TGScrollBarElement(this, 0, fgScrollBarWidth, 50,
-                                    kRaisedFrame);
-
-   gVirtualX->GrabButton(fId, kAnyButton, kAnyModifier, kButtonPressMask |
-                         kButtonReleaseMask | kPointerMotionMask, kNone, kNone);
-
-   fDragging = kFALSE;
-   fX0 = fY0 = (fgScrollBarWidth = TMath::Max(fgScrollBarWidth, 5));
-   fPos = 0;
-
    fRange = TMath::Max((Int_t) h - (fgScrollBarWidth << 1), 1);
    fPsize = fRange >> 1;
-
-   fSliderSize  = 50;
-   fSliderRange = 1;
-
-   fHead->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fTail->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fSlider->SetEditDisabled(kEditDisable | kEditDisableGrab);
-   fEditDisabled = kEditDisableLayout | kEditDisableWidth | kEditDisableBtnEnable;
+   fEditDisabled |= kEditDisableWidth;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGScrollBar.cxx
+++ b/gui/gui/src/TGScrollBar.cxx
@@ -304,7 +304,13 @@ Bool_t TGScrollBarElement::HandleCrossing(Event_t *event)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
-
+/// \param p The parent window
+/// \param w The scrollbar width
+/// \param h The scrollbar height
+/// \param options A bitmask of options (\see EFrameType)
+/// \param back The background color
+/// \param headPicName Filename of the "head" picture (e.g. left arrow for a horizontal scrollbar)
+/// \param tailPicName Filename of the "tail" picture (e.g. right arrow for a horizontal scrollbar)
 TGScrollBar::TGScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                          UInt_t options, Pixel_t back, const char *headPicName, const char *tailPicName) :
    TGFrame(p, w, h, options | kOwnBackground, back),


### PR DESCRIPTION
Currently if any of the arrow_*.xpm pictures are not found, the ctor of TG[HV]Scrollbar returns early, causing some pointers to not be initialized. The application later dereferences those pointers and crashes.

This commit changes the behavior by returning a valid empty picture when the expected ones are not found, which allows the following logic to work normally.
