### PR TITLE
Expansion of the TStreamerInfo actions.

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -406,6 +406,7 @@ public:
    void               ForceReload (TClass* oldcl);
    Bool_t             HasDataMemberInfo() const { return fIsSyntheticPair || fHasRootPcmInfo || HasInterpreterInfo(); }
    Bool_t             HasDefaultConstructor(Bool_t testio = kFALSE) const;
+   Bool_t             HasDirectStreamerInfoUse() const { return fStreamerImpl == &TClass::StreamerStreamerInfo; }
    Bool_t             HasInterpreterInfoInMemory() const { return nullptr != fClassInfo; }
    Bool_t             HasInterpreterInfo() const { return fCanLoadClassInfo || fClassInfo; }
    UInt_t             GetCheckSum(ECheckSum code = kCurrentCheckSum) const;

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -52,6 +52,8 @@ protected:
    Double_t         fXmax;            //!Maximum of data member if a range is specified  [xmin,xmax,nbits]
    Double_t         fFactor;          //!Conversion factor if a range is specified fFactor = (1<<nbits/(xmax-xmin)
 
+   friend class TStreamerSTL;
+
 public:
 
    enum ESTLtype {
@@ -409,6 +411,7 @@ public:
    Bool_t         CannotSplit() const override;
    Bool_t         IsaPointer() const override;
    Bool_t         IsBase() const override;
+   TClass        *GetClassPointer() const override;
    Int_t          GetSTLtype() const {return fSTLtype;}
    Int_t          GetCtype()   const {return fCtype;}
    const char    *GetInclude() const override;

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -480,8 +480,10 @@ void TStreamerElement::ls(Option_t *) const
 void TStreamerElement::SetArrayDim(Int_t dim)
 {
    fArrayDim = dim;
-   if (dim) fType += TVirtualStreamerInfo::kOffsetL;
-   fNewType = fType;
+   if (dim) {
+      fType += TVirtualStreamerInfo::kOffsetL;
+      fNewType += TVirtualStreamerInfo::kOffsetL;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1715,7 +1717,10 @@ TStreamerSTL::TStreamerSTL(const char *name, const char *title, Int_t offset,
       fCtype = proxy.GetType();
       if (proxy.HasPointers()) fCtype += TVirtualStreamerInfo::kOffsetP;
    }
-   if (TStreamerSTL::IsaPointer()) fType = TVirtualStreamerInfo::kSTLp;
+   if (TStreamerSTL::IsaPointer()) {
+      fType = TVirtualStreamerInfo::kSTLp;
+      fNewType = fType;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1794,7 +1799,10 @@ TStreamerSTL::TStreamerSTL(const char *name, const char *title, Int_t offset,
       }
    }
 
-   if (TStreamerSTL::IsaPointer()) fType = TVirtualStreamerInfo::kSTLp;
+   if (TStreamerSTL::IsaPointer()) {
+      fType = TVirtualStreamerInfo::kSTLp;
+      fNewType = fType;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -175,7 +175,7 @@ namespace TStreamerInfoActions {
 
    typedef std::vector<TConfiguredAction> ActionContainer_t;
    class TActionSequence : public TObject {
-      TActionSequence() {};
+      TActionSequence() = delete;
    public:
       enum class EStatusBits {
          kVectorPtrLooper = BIT(14)

--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -216,7 +216,9 @@ namespace TStreamerInfoActions {
 
       TActionSequence *CreateCopy();
       static TActionSequence *CreateReadMemberWiseActions(TVirtualStreamerInfo *info, TVirtualCollectionProxy &proxy);
+      static TActionSequence *CreateReadMemberWiseActions(TVirtualStreamerInfo &info, TLoopConfiguration *loopConfig);  // 2nd arg should be unique_ptr
       static TActionSequence *CreateWriteMemberWiseActions(TVirtualStreamerInfo *info, TVirtualCollectionProxy &proxy);
+      static TActionSequence *CreateWriteMemberWiseActions(TVirtualStreamerInfo &info, TLoopConfiguration *loopConfig);  // 2nd arg should be unique_ptr
       TActionSequence *CreateSubSequence(const std::vector<Int_t> &element_ids, size_t offset);
 
       TActionSequence *CreateSubSequence(const TIDs &element_ids, size_t offset, SequenceGetter_t create);

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -535,8 +535,10 @@ void TStreamerInfo::Build(Bool_t isTransient)
             element = new TStreamerSTLstring(dmName, dmTitle, offset, dmFull, dmIsPtr);
          } else if (dm->IsSTLContainer()) {
             TVirtualCollectionProxy *proxy = TClass::GetClass(dmType /* the underlying type */)->GetCollectionProxy();
-            if (proxy) element = new TStreamerSTL(dmName, dmTitle, offset, dmFull, *proxy, dmIsPtr);
-            else element = new TStreamerSTL(dmName, dmTitle, offset, dmFull, dmFull, dmIsPtr);
+            if (proxy)
+               element = new TStreamerSTL(dmName, dmTitle, offset, dmFull, *proxy, dmIsPtr);
+            else
+               element = new TStreamerSTL(dmName, dmTitle, offset, dmFull, dmFull, dmIsPtr);
             bool hasCustomAlloc = proxy ? proxy->GetProperties() & TVirtualCollectionProxy::kCustomAlloc : kFALSE;
             if (((TStreamerSTL*)element)->GetSTLtype() != ROOT::kSTLvector || hasCustomAlloc) {
                auto printErrorMsg = [&](const char* category)

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -372,6 +372,13 @@ namespace TStreamerInfoActions
    }
 
    template <typename T>
+   static INLINE_TEMPLATE_ARGS Int_t WriteBasicZero(TBuffer &buf, void *, const TConfiguration *)
+   {
+      buf << T{0};
+      return 0;
+   }
+
+   template <typename T>
    INLINE_TEMPLATE_ARGS Int_t WriteBasicType(TBuffer &buf, void *addr, const TConfiguration *config)
    {
       T *x = (T *)(((char *)addr) + config->fOffset);
@@ -4056,6 +4063,33 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
       case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteBasicType<ULong64_t>,new TConfiguration(info,i,compinfo,offset) );
       // the simple type missing are kBits and kCounter.
 
+      // Handling of the error case where we are asked to write a missing data member.
+      case TStreamerInfo::kBool + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Bool_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kChar + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Char_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kShort + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Short_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kInt + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Int_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Long_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong64 + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Long64_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kFloat + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Float_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kDouble + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<Double_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUChar + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<UChar_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUShort + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<UShort_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUInt + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<UInt_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<ULong_t>>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong64 + TStreamerInfo::kSkip:
+         return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicZero<ULong64_t>>,  new TConfiguration(info,i,compinfo,offset) );
 
       // Conversions.
       case TStreamerInfo::kConv + TStreamerInfo::kBool:
@@ -5470,6 +5504,9 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
             //       "Ignoring request to write the missing data member %s in %s version %d checksum 0x%x",
             //       element->GetName(), info.GetName(), info.GetClassVersion(), info.GetCheckSum());
             continue;
+            //
+            // Instead of skipping the field we could write a zero there with:
+            // onfileType += TVirtualStreamerInfo::kSkip;
          }
       }
 

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1638,7 +1638,7 @@ namespace TStreamerInfoActions
    struct CollectionLooper {
 
       static std::unique_ptr<TStreamerInfoActions::TActionSequence>
-         CreateActionSquence(TStreamerInfo &info, TLoopConfiguration *loopConfig)
+         CreateReadActionSquence(TStreamerInfo &info, TLoopConfiguration *loopConfig)
       {
          TLoopConfiguration *localLoopConfig = loopConfig ? loopConfig->Copy() : nullptr;
          std::unique_ptr<TStreamerInfoActions::TActionSequence> actions(
@@ -2592,7 +2592,7 @@ namespace TStreamerInfoActions
       using WriteStreamerLoop = CollectionLooper<VectorPtrLooper>::WriteStreamerLoop<kIsText, const void *>;
 
       static std::unique_ptr<TStreamerInfoActions::TActionSequence>
-         CreateActionSquence(TStreamerInfo &info, TLoopConfiguration *)
+         CreateReadActionSquence(TStreamerInfo &info, TLoopConfiguration *)
       {
          using unique_ptr = std::unique_ptr<TStreamerInfoActions::TActionSequence>;
          return unique_ptr(info.GetReadMemberWiseActions(kTRUE)->CreateCopy());
@@ -3820,7 +3820,7 @@ GetCollectionReadAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopConf
             auto baseinfo = (TStreamerInfo *)baseEl->GetBaseStreamerInfo();
             assert(baseinfo);
             TLoopConfiguration *baseLoopConfig = loopConfig ? loopConfig->Copy() : nullptr;
-            auto baseActions = Looper::CreateActionSquence(*baseinfo, baseLoopConfig);
+            auto baseActions = Looper::CreateReadActionSquence(*baseinfo, baseLoopConfig);
             baseActions->AddToOffset(baseEl->GetOffset());
             return TConfiguredAction( Looper::SubSequenceAction, new TConfSubSequence(info, i, compinfo, 0, std::move(baseActions)));
 

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4895,13 +4895,6 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
          writeSequence->AddAction( GenericWriteAction, new TGenericConfiguration(this,i,compinfo) );
          break;
    }
-#if defined(CDJ_NO_COMPILE)
-   if (element->TestBit(TStreamerElement::kCache)) {
-      TConfiguredAction action( writeSequence->fActions.back() );  // Action is moved, we must pop it next.
-      writeSequence->fActions.pop_back();
-      writeSequence->AddAction( UseCache, new TConfigurationUseCache(this,action,element->TestBit(TStreamerElement::kRepeat)) );
-   }
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4993,88 +4986,6 @@ void TStreamerInfo::AddWriteTextAction(TStreamerInfoActions::TActionSequence *wr
       writeSequence->AddAction(WriteStreamerCase, new TGenericConfiguration(this, i, compinfo));
       break;
 
-   // case TStreamerInfo::kBits:    writeSequence->AddAction( WriteBasicType<BitsMarker>, new
-   // TConfiguration(this,i,compinfo,compinfo->fOffset) );    break;
-   /*case TStreamerInfo::kFloat16: {
-       if (element->GetFactor() != 0) {
-          writeSequence->AddAction( WriteBasicType_WithFactor<float>, new
-    TConfWithFactor(this,i,compinfo,compinfo->fOffset,element->GetFactor(),element->GetXmin()) );
-       } else {
-          Int_t nbits = (Int_t)element->GetXmin();
-          if (!nbits) nbits = 12;
-          writeSequence->AddAction( WriteBasicType_NoFactor<float>, new
-    TConfNoFactor(this,i,compinfo,compinfo->fOffset,nbits) );
-       }
-       break;
-    } */
-   /*case TStreamerInfo::kDouble32: {
-      if (element->GetFactor() != 0) {
-         writeSequence->AddAction( WriteBasicType_WithFactor<double>, new
-   TConfWithFactor(this,i,compinfo,compinfo->fOffset,element->GetFactor(),element->GetXmin()) );
-      } else {
-         Int_t nbits = (Int_t)element->GetXmin();
-         if (!nbits) {
-            writeSequence->AddAction( ConvertBasicType<float,double>, new
-   TConfiguration(this,i,compinfo,compinfo->fOffset) );
-         } else {
-            writeSequence->AddAction( WriteBasicType_NoFactor<double>, new
-   TConfNoFactor(this,i,compinfo,compinfo->fOffset,nbits) );
-         }
-      }
-      break;
-   } */
-   // case TStreamerInfo::kTNamed:  writeSequence->AddAction( WriteTNamed, new
-   // TConfiguration(this,i,compinfo,compinfo->fOffset) );    break;
-   // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
-   // Streamer alltogether.
-   // case TStreamerInfo::kTObject: writeSequence->AddAction( WriteTObject, new
-   // TConfiguration(this,i,compinfo,compinfo->fOffset) );    break;
-   // case TStreamerInfo::kTString: writeSequence->AddAction( WriteTString, new
-   // TConfiguration(this,i,compinfo,compinfo->fOffset) );    break;
-   /*case TStreamerInfo::kSTL: {
-      TClass *newClass = element->GetNewClass();
-      TClass *oldClass = element->GetClassPointer();
-      Bool_t isSTLbase = element->IsBase() && element->IsA()!=TStreamerBase::Class();
-
-      if (element->GetArrayLength() <= 1) {
-         if (newClass && newClass != oldClass) {
-            if (element->GetStreamer()) {
-               writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseChangedClass,WriteSTLObjectWiseStreamer>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,newClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-            } else {
-               writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseChangedClass,WriteSTLObjectWiseFastArray>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,newClass,element->GetTypeName(),isSTLbase));
-            }
-         } else {
-            if (element->GetStreamer()) {
-               writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseSameClass,WriteSTLObjectWiseStreamer>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-            } else {
-               writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseSameClass,WriteSTLObjectWiseFastArray>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,element->GetTypeName(),isSTLbase));
-            }
-         }
-      } else {
-         if (newClass && newClass != oldClass) {
-            if (element->GetStreamer()) {
-               writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseChangedClass,WriteSTLObjectWiseStreamer>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,newClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-            } else {
-               writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseChangedClass,WriteSTLObjectWiseFastArray>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,newClass,element->GetTypeName(),isSTLbase));
-            }
-         } else {
-            if (element->GetStreamer()) {
-               writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseSameClass,WriteSTLObjectWiseStreamer>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-            } else {
-               writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseSameClass,WriteSTLObjectWiseFastArray>, new
-   TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,element->GetTypeName(),isSTLbase));
-            }
-         }
-      }
-      break;
-   } */
    default: generic = kTRUE; break;
    }
 
@@ -5090,15 +5001,6 @@ void TStreamerInfo::AddWriteTextAction(TStreamerInfoActions::TActionSequence *wr
       // use generic write action when special handling is not provided
       if (generic)
          writeSequence->AddAction(GenericWriteAction, new TGenericConfiguration(this, i, compinfo));
-
-#if defined(CDJ_NO_COMPILE)
-   if (element->TestBit(TStreamerElement::kCache)) {
-      TConfiguredAction action(writeSequence->fActions.back()); // Action is moved, we must pop it next.
-      writeSequence->fActions.pop_back();
-      writeSequence->AddAction(UseCache,
-                               new TConfigurationUseCache(this, action, element->TestBit(TStreamerElement::kRepeat)));
-   }
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4845,6 +4845,13 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
             }
          }
          break;
+      case TStreamerInfo::kStreamer:
+         if (fOldVersion >= 3)
+            writeSequence->AddAction( WriteStreamerCase, new TGenericConfiguration(this,i,compinfo, compinfo->fOffset) );
+         else
+            // Use the slower path for legacy files
+            writeSequence->AddAction( GenericWriteAction, new TGenericConfiguration(this,i,compinfo) );
+         break;
       case TStreamerInfo::kAny:
          if (compinfo->fStreamer)
             writeSequence->AddAction( WriteViaExtStreamer, new TGenericConfiguration(this, i, compinfo, compinfo->fOffset) );

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4845,42 +4845,6 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
         }
         break;
      } */
-     /*case TStreamerInfo::kSTL: {
-        TClass *newClass = element->GetNewClass();
-        TClass *oldClass = element->GetClassPointer();
-        Bool_t isSTLbase = element->IsBase() && element->IsA()!=TStreamerBase::Class();
-
-        if (element->GetArrayLength() <= 1) {
-           if (newClass && newClass != oldClass) {
-              if (element->GetStreamer()) {
-                 writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseChangedClass,WriteSTLObjectWiseStreamer>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,newClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-              } else {
-                 writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseChangedClass,WriteSTLObjectWiseFastArray>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,newClass,element->GetTypeName(),isSTLbase));
-              }
-           } else {
-              if (element->GetStreamer()) {
-                 writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseSameClass,WriteSTLObjectWiseStreamer>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-              } else {
-                 writeSequence->AddAction(WriteSTL<WriteSTLMemberWiseSameClass,WriteSTLObjectWiseFastArray>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,1,oldClass,element->GetTypeName(),isSTLbase));
-              }
-           }
-        } else {
-           if (newClass && newClass != oldClass) {
-              if (element->GetStreamer()) {
-                 writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseChangedClass,WriteSTLObjectWiseStreamer>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,newClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-              } else {
-                 writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseChangedClass,WriteSTLObjectWiseFastArray>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,newClass,element->GetTypeName(),isSTLbase));
-              }
-           } else {
-              if (element->GetStreamer()) {
-                 writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseSameClass,WriteSTLObjectWiseStreamer>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,element->GetStreamer(),element->GetTypeName(),isSTLbase));
-              } else {
-                 writeSequence->AddAction(WriteSTL<WriteArraySTLMemberWiseSameClass,WriteSTLObjectWiseFastArray>, new TConfigSTL(false, this,i,compinfo,compinfo->fOffset,element->GetArrayLength(),oldClass,element->GetTypeName(),isSTLbase));
-              }
-           }
-        }
-        break;
-     } */
       default:
          writeSequence->AddAction( GenericWriteAction, new TGenericConfiguration(this,i,compinfo) );
          break;

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -2121,7 +2121,7 @@ namespace TStreamerInfoActions
       };
 
       template <Int_t (*iter_action)(TBuffer&,void *,const TConfiguration*)>
-      static INLINE_TEMPLATE_ARGS Int_t ReadAction(TBuffer &buf, void *start, const void *end, const TLoopConfiguration *loopconfig, const TConfiguration *config)
+      static INLINE_TEMPLATE_ARGS Int_t LoopOverCollection(TBuffer &buf, void *start, const void *end, const TLoopConfiguration *loopconfig, const TConfiguration *config)
       {
          const Int_t incr = ((TVectorLoopConfig*)loopconfig)->fIncrement;
          //Idea: can we factor out the addition of fOffset
@@ -2587,7 +2587,7 @@ namespace TStreamerInfoActions
       };
 
       template <Int_t (*action)(TBuffer&,void *,const TConfiguration*)>
-      static INLINE_TEMPLATE_ARGS Int_t ReadAction(TBuffer &buf, void *start, const void *end, const TConfiguration *config)
+      static INLINE_TEMPLATE_ARGS Int_t LoopOverCollection(TBuffer &buf, void *start, const void *end, const TConfiguration *config)
       {
          for(void *iter = start; iter != end; iter = (char*)iter + sizeof(void*) ) {
             action(buf, *(void**)iter, config);
@@ -2943,7 +2943,7 @@ public:
       };
 
       template <Int_t (*iter_action)(TBuffer&,void *,const TConfiguration*)>
-      static INLINE_TEMPLATE_ARGS Int_t ReadAction(TBuffer &buf, void *start, const void *end, const TLoopConfiguration *loopconf, const TConfiguration *config)
+      static INLINE_TEMPLATE_ARGS Int_t LoopOverCollection(TBuffer &buf, void *start, const void *end, const TLoopConfiguration *loopconf, const TConfiguration *config)
       {
          TGenericLoopConfig *loopconfig = (TGenericLoopConfig*)loopconf;
 
@@ -3448,11 +3448,11 @@ static TConfiguredAction GetNumericCollectionReadAction(Int_t type, TConfigSTL *
          delete conf;
          return TConfiguredAction( Looper::ReadCollectionFloat16, alternate );
          // if (element->GetFactor() != 0) {
-         //    return TConfiguredAction( Looper::template ReadAction<ReadBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          // } else {
          //    Int_t nbits = (Int_t)element->GetXmin();
          //    if (!nbits) nbits = 12;
-         //    return TConfiguredAction( Looper::template ReadAction<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          // }
          break;
       }
@@ -3461,13 +3461,13 @@ static TConfiguredAction GetNumericCollectionReadAction(Int_t type, TConfigSTL *
          delete conf;
          return TConfiguredAction( Looper::ReadCollectionDouble32, alternate );
          // if (element->GetFactor() != 0) {
-         //    return TConfiguredAction( Looper::template ReadAction<ReadBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          // } else {
          //    Int_t nbits = (Int_t)element->GetXmin();
          //    if (!nbits) {
-         //       return TConfiguredAction( Looper::template ReadAction<ConvertBasicType<float,double> >, new TConfiguration(info,i,compinfo,offset) );
+         //       return TConfiguredAction( Looper::template LoopOverCollection<ConvertBasicType<float,double> >, new TConfiguration(info,i,compinfo,offset) );
          //    } else {
-         //       return TConfiguredAction( Looper::template ReadAction<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+         //       return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          //    }
          // }
          break;
@@ -3587,35 +3587,35 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
       case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ReadBasicType<UInt_t>,   new TConfiguration(info,i,compinfo,offset) );    break;
       case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ReadBasicType<ULong_t>,  new TConfiguration(info,i,compinfo,offset) );   break;
       case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ReadBasicType<ULong64_t>, new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kBits: return TConfiguredAction( Looper::template ReadAction<TStreamerInfoActions::ReadBasicType<BitsMarker> > , new TBitsConfiguration(info,i,compinfo,offset) ); break;
+      case TStreamerInfo::kBits: return TConfiguredAction( Looper::template LoopOverCollection<TStreamerInfoActions::ReadBasicType<BitsMarker> > , new TBitsConfiguration(info,i,compinfo,offset) ); break;
       case TStreamerInfo::kFloat16: {
          if (element->GetFactor() != 0) {
-            return TConfiguredAction( Looper::template ReadAction<ReadBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+            return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          } else {
             Int_t nbits = (Int_t)element->GetXmin();
             if (!nbits) nbits = 12;
-            return TConfiguredAction( Looper::template ReadAction<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+            return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          }
          break;
       }
       case TStreamerInfo::kDouble32: {
          if (element->GetFactor() != 0) {
-            return TConfiguredAction( Looper::template ReadAction<ReadBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+            return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          } else {
             Int_t nbits = (Int_t)element->GetXmin();
             if (!nbits) {
-               return TConfiguredAction( Looper::template ReadAction<ConvertBasicType<float,double>::Action >, new TConfiguration(info,i,compinfo,offset) );
+               return TConfiguredAction( Looper::template LoopOverCollection<ConvertBasicType<float,double>::Action >, new TConfiguration(info,i,compinfo,offset) );
             } else {
-               return TConfiguredAction( Looper::template ReadAction<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+               return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
             }
          }
          break;
       }
-      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template ReadAction<ReadTNamed >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template LoopOverCollection<ReadTNamed >, new TConfiguration(info,i,compinfo,offset) );    break;
          // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
          // Streamer alltogether.
-      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template ReadAction<ReadTObject >, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template ReadAction<ReadTString >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template LoopOverCollection<ReadTObject >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template LoopOverCollection<ReadTString >, new TConfiguration(info,i,compinfo,offset) );    break;
       case TStreamerInfo::kArtificial:
       case TStreamerInfo::kCacheNew:
       case TStreamerInfo::kCacheDelete:

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1978,6 +1978,17 @@ namespace TStreamerInfoActions
 
    };
 
+   // The Scalar 'looper' only process one element.
+   struct ScalarLooper : public CollectionLooper<ScalarLooper>
+   {
+      template <Int_t (*iter_action)(TBuffer&,void *,const TConfiguration*)>
+      static INLINE_TEMPLATE_ARGS Int_t LoopOverCollection(TBuffer &buf, void *start, const void * /* end */, const TLoopConfiguration *, const TConfiguration *config)
+      {
+         iter_action(buf, start, config);
+         return 0;
+      }
+   };
+
    struct VectorLooper : public CollectionLooper<VectorLooper> {
 
       template <typename T>

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4178,6 +4178,12 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
          } else
             return TConfiguredAction( Looper::WriteBase, new TGenericConfiguration(info, i, compinfo) );
       }
+      case TStreamerInfo::kStreamLoop:
+      case TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop: {
+         bool isPtrPtr = (strstr(compinfo->fElem->GetTypeName(), "**") != 0);
+         return TConfiguredAction(Looper::template WriteStreamerLoop<false>::Action,
+                                  new TConfStreamerLoop(info, i, compinfo, offset, isPtrPtr));
+      }
       case TStreamerInfo::kStreamer:
          if (info->GetOldVersion() >= 3)
             return TConfiguredAction( Looper::WriteStreamerCase, new TGenericConfiguration(info, i, compinfo) );

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4820,6 +4820,10 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
      case TStreamerInfo::kTObject: writeSequence->AddAction( WriteTObject, new TConfiguration(this, i, compinfo, compinfo->fOffset) );    break;
      case TStreamerInfo::kTString: writeSequence->AddAction( WriteTString, new TConfiguration(this, i, compinfo, compinfo->fOffset) );    break;
 
+      case TStreamerInfo::kStreamLoop:
+      case TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop:
+         writeSequence->AddAction( WriteStreamerLoop<false>, new TGenericConfiguration(this, i, compinfo, compinfo->fOffset) );
+         break;
       case TStreamerInfo::kBase:
          if (compinfo->fStreamer)
             writeSequence->AddAction( WriteStreamerCase, new TGenericConfiguration(this,i,compinfo, compinfo->fOffset) );

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4845,6 +4845,20 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
             }
          }
          break;
+      case TStreamerInfo::kAny:
+         if (compinfo->fStreamer)
+            writeSequence->AddAction( WriteViaExtStreamer, new TGenericConfiguration(this, i, compinfo, compinfo->fOffset) );
+         else {
+            if (compinfo->fNewClass && compinfo->fNewClass->fStreamerImpl == &TClass::StreamerStreamerInfo)
+              writeSequence->AddAction( WriteViaClassBuffer,
+                 new TConfObject(this, i, compinfo, compinfo->fOffset, compinfo->fClass, compinfo->fNewClass) );
+            else if (compinfo->fClass && compinfo->fClass->fStreamerImpl == &TClass::StreamerStreamerInfo)
+              writeSequence->AddAction( WriteViaClassBuffer,
+                 new TConfObject(this, i, compinfo, compinfo->fOffset, compinfo->fClass, nullptr) );
+            else // Use the slower path for unusual cases
+              writeSequence->AddAction( GenericWriteAction, new TGenericConfiguration(this, i, compinfo) );
+         }
+         break;
 
        // case TStreamerInfo::kBits:    writeSequence->AddAction( WriteBasicType<BitsMarker>, new TConfiguration(this,i,compinfo,compinfo->fOffset) );    break;
      /*case TStreamerInfo::kFloat16: {

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -3574,20 +3574,20 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
 {
    switch (type) {
       // Read basic types.
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ReadBasicType<Bool_t>, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ReadBasicType<Char_t>, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ReadBasicType<Short_t>,new TConfiguration(info,i,compinfo,offset) );   break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ReadBasicType<Int_t>,  new TConfiguration(info,i,compinfo,offset) );     break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ReadBasicType<Long_t>, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ReadBasicType<Long64_t>, new TConfiguration(info,i,compinfo,offset) );  break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ReadBasicType<Float_t>,  new TConfiguration(info,i,compinfo,offset) );   break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ReadBasicType<Double_t>, new TConfiguration(info,i,compinfo,offset) );  break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ReadBasicType<UChar_t>,  new TConfiguration(info,i,compinfo,offset) );   break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ReadBasicType<UShort_t>, new TConfiguration(info,i,compinfo,offset) );  break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ReadBasicType<UInt_t>,   new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ReadBasicType<ULong_t>,  new TConfiguration(info,i,compinfo,offset) );   break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ReadBasicType<ULong64_t>, new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kBits: return TConfiguredAction( Looper::template LoopOverCollection<TStreamerInfoActions::ReadBasicType<BitsMarker> > , new TBitsConfiguration(info,i,compinfo,offset) ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ReadBasicType<Bool_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ReadBasicType<Char_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ReadBasicType<Short_t>,new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ReadBasicType<Int_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ReadBasicType<Long_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ReadBasicType<Long64_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ReadBasicType<Float_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ReadBasicType<Double_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ReadBasicType<UChar_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ReadBasicType<UShort_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ReadBasicType<UInt_t>,   new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ReadBasicType<ULong_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ReadBasicType<ULong64_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kBits: return TConfiguredAction( Looper::template LoopOverCollection<TStreamerInfoActions::ReadBasicType<BitsMarker> > , new TBitsConfiguration(info,i,compinfo,offset) );
       case TStreamerInfo::kFloat16: {
          if (element->GetFactor() != 0) {
             return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
@@ -3596,7 +3596,6 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
             if (!nbits) nbits = 12;
             return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          }
-         break;
       }
       case TStreamerInfo::kDouble32: {
          if (element->GetFactor() != 0) {
@@ -3609,7 +3608,6 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
                return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
             }
          }
-         break;
       }
       case TStreamerInfo::kTNamed:
          return TConfiguredAction( Looper::template LoopOverCollection<ReadTNamed >, new TConfiguration(info, i, compinfo, offset) );
@@ -3622,52 +3620,38 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
       case TStreamerInfo::kArtificial:
       case TStreamerInfo::kCacheNew:
       case TStreamerInfo::kCacheDelete:
-      case TStreamerInfo::kSTL:  return TConfiguredAction( Looper::GenericRead, new TGenericConfiguration(info,i,compinfo) ); break;
-      case TStreamerInfo::kBase: return TConfiguredAction( Looper::ReadBase, new TGenericConfiguration(info,i,compinfo) ); break;
+      case TStreamerInfo::kSTL:  return TConfiguredAction( Looper::GenericRead, new TGenericConfiguration(info, i, compinfo) );
+      case TStreamerInfo::kBase: return TConfiguredAction( Looper::ReadBase, new TGenericConfiguration(info, i, compinfo) );
 
       // Conversions.
       case TStreamerInfo::kConv + TStreamerInfo::kBool:
          return GetCollectionReadConvertAction<Looper,Bool_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kChar:
          return GetCollectionReadConvertAction<Looper,Char_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kShort:
          return GetCollectionReadConvertAction<Looper,Short_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kInt:
          return GetCollectionReadConvertAction<Looper,Int_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kLong:
          return GetCollectionReadConvertAction<Looper,Long_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kLong64:
          return GetCollectionReadConvertAction<Looper,Long64_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kFloat:
          return GetCollectionReadConvertAction<Looper,Float_t>( element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kDouble:
          return GetCollectionReadConvertAction<Looper,Double_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUChar:
          return GetCollectionReadConvertAction<Looper,UChar_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUShort:
          return GetCollectionReadConvertAction<Looper,UShort_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUInt:
          return GetCollectionReadConvertAction<Looper,UInt_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kULong:
          return GetCollectionReadConvertAction<Looper,ULong_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kULong64:
          return GetCollectionReadConvertAction<Looper,ULong64_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kBits:
          return GetCollectionReadConvertAction<Looper,BitsMarker>(element->GetNewType(), new TBitsConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kFloat16: {
          if (element->GetFactor() != 0) {
             return GetCollectionReadConvertAction<Looper,WithFactorMarker<float> >(element->GetNewType(), new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
@@ -3676,7 +3660,6 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
             if (!nbits) nbits = 12;
             return GetCollectionReadConvertAction<Looper,NoFactorMarker<float> >(element->GetNewType(), new TConfNoFactor(info,i,compinfo,offset,nbits) );
          }
-         break;
       }
       case TStreamerInfo::kConv + TStreamerInfo::kDouble32: {
          if (element->GetFactor() != 0) {
@@ -3689,11 +3672,9 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
                return GetCollectionReadConvertAction<Looper,NoFactorMarker<double> >(element->GetNewType(), new TConfNoFactor(info,i,compinfo,offset,nbits) );
             }
          }
-         break;
       }
       default:
          return TConfiguredAction( Looper::GenericRead, new TGenericConfiguration(info,i,compinfo) );
-         break;
    }
    R__ASSERT(0); // We should never be here
    return TConfiguredAction();
@@ -3703,20 +3684,20 @@ template <typename Looper, typename From>
 static TConfiguredAction GetConvertCollectionWriteActionFrom(Int_t onfileType, TConfiguration *conf)
 {
    switch (onfileType) {
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,bool>::Action, conf ); break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,char>::Action, conf ); break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,short>::Action, conf );  break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Int_t>::Action, conf ); break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Long_t>::Action, conf ); break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Long64_t>::Action, conf ); break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,float>::Action, conf ); break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,double>::Action, conf ); break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UChar_t>::Action, conf ); break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UShort_t>::Action, conf ); break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UInt_t>::Action, conf ); break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,ULong_t>::Action, conf ); break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,ULong64_t>::Action, conf );  break;
-      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UInt_t>::Action, conf );  break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,char>::Action, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,short>::Action, conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Int_t>::Action, conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Long_t>::Action, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,Long64_t>::Action, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,float>::Action, conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,double>::Action, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UChar_t>::Action, conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UShort_t>::Action, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UInt_t>::Action, conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,ULong_t>::Action, conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,ULong64_t>::Action, conf );
+      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,UInt_t>::Action, conf );
 
       // Supporting this requires adding TBuffer::WiteFastArrayWithNbits
       // and the proper struct WriteConvertCollectionBasicType<Memory, NoFactorMarker<Onfile>> here

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1760,9 +1760,7 @@ namespace TStreamerInfoActions
             // Read the class version and byte count from the buffer.
             UInt_t start = 0;
             UInt_t count = 0;
-            buf.ReadVersion(&start, &count, cl);
-            // Loop over the entries in the clones array or the STL container.
-            //for (Int_t k = 0; k < narr; ++k) {
+            buf.ReadVersion(&pos, &count, config->fInfo->IsA());
 
                Int_t* counter = (Int_t*) ((char *) addr /*entry pointer*/ + eoffset /*entry offset*/ + config->fCompInfo->fMethod /*counter offset*/);
                // And call the private streamer, passing it the buffer, the object, and the counter.
@@ -1790,7 +1788,7 @@ namespace TStreamerInfoActions
          // Read the class version and byte count from the buffer.
          UInt_t start = 0;
          UInt_t count = 0;
-         buf.ReadVersion(&start, &count, cl);
+         buf.ReadVersion(&start, &count, config->fInfo->IsA());
          if (fileVersion > 51508) {
             // -- Newer versions allow polymorphic pointers.
             // Loop over the entries in the clones array or the STL container.

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4178,6 +4178,11 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
          } else
             return TConfiguredAction( Looper::WriteBase, new TGenericConfiguration(info, i, compinfo) );
       }
+      case TStreamerInfo::kStreamer:
+         if (info->GetOldVersion() >= 3)
+            return TConfiguredAction( Looper::WriteStreamerCase, new TGenericConfiguration(info, i, compinfo) );
+         else
+            return TConfiguredAction( Looper::GenericWrite, new TGenericConfiguration(info, i, compinfo) );
       default:
          return TConfiguredAction( Looper::GenericWrite, new TConfiguration(info,i,compinfo,0 /* 0 because we call the legacy code */) );
    }

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -188,6 +188,19 @@ namespace TStreamerInfoActions
 
    };
 
+   struct TConfObject : public TConfiguration
+   {
+      TClassRef fOnfileClass;
+      TClassRef fInMemoryClass;
+
+      TConfObject(TVirtualStreamerInfo *info, UInt_t id, TCompInfo_t *compinfo, Int_t offset,
+                  TClass *onfileClass, TClass *inMemoryClass) :
+                  TConfiguration(info, id, compinfo, offset),
+                  fOnfileClass(onfileClass),
+                  fInMemoryClass(inMemoryClass ? inMemoryClass : onfileClass)  {};
+      TConfiguration *Copy() override { return new TConfObject(*this); }
+   };
+
    Int_t GenericReadAction(TBuffer &buf, void *addr, const TConfiguration *config)
    {
       char *obj = (char*)addr;

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -5064,43 +5064,32 @@ void TStreamerInfo::AddWriteTextAction(TStreamerInfoActions::TActionSequence *wr
    switch (compinfo->fType) {
    // write basic types
    case TStreamerInfo::kBool:
-      writeSequence->AddAction(WriteBasicType<Bool_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kChar:
-      writeSequence->AddAction(WriteBasicType<Char_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kShort:
-      writeSequence->AddAction(WriteBasicType<Short_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kInt:
-      writeSequence->AddAction(WriteBasicType<Int_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kLong:
-      writeSequence->AddAction(WriteBasicType<Long_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kLong64:
-      writeSequence->AddAction(WriteBasicType<Long64_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kFloat:
-      writeSequence->AddAction(WriteBasicType<Float_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kDouble:
-      writeSequence->AddAction(WriteBasicType<Double_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kUChar:
-      writeSequence->AddAction(WriteBasicType<UChar_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kUShort:
-      writeSequence->AddAction(WriteBasicType<UShort_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kUInt:
-      writeSequence->AddAction(WriteBasicType<UInt_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kULong:
-      writeSequence->AddAction(WriteBasicType<ULong_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
-      break;
    case TStreamerInfo::kULong64:
-      writeSequence->AddAction(WriteBasicType<ULong64_t>, new TConfiguration(this, i, compinfo, compinfo->fOffset));
+   case TStreamerInfo::kFloat16:
+   case TStreamerInfo::kDouble32:
+   case TStreamerInfo::kConv + TStreamerInfo::kChar:
+   case TStreamerInfo::kConv + TStreamerInfo::kShort:
+   case TStreamerInfo::kConv + TStreamerInfo::kInt:
+   case TStreamerInfo::kConv + TStreamerInfo::kLong:
+   case TStreamerInfo::kConv + TStreamerInfo::kLong64:
+   case TStreamerInfo::kConv + TStreamerInfo::kUChar:
+   case TStreamerInfo::kConv + TStreamerInfo::kUShort:
+   case TStreamerInfo::kConv + TStreamerInfo::kUInt:
+   case TStreamerInfo::kConv + TStreamerInfo::kULong:
+   case TStreamerInfo::kConv + TStreamerInfo::kULong64:
+      // Actually same action for this level
+      AddWriteAction(writeSequence, i, compinfo);
       break;
 
    case TStreamerInfo::kTObject:

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -3611,11 +3611,14 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
          }
          break;
       }
-      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template LoopOverCollection<ReadTNamed >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTNamed:
+         return TConfiguredAction( Looper::template LoopOverCollection<ReadTNamed >, new TConfiguration(info, i, compinfo, offset) );
          // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
          // Streamer alltogether.
-      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template LoopOverCollection<ReadTObject >, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template LoopOverCollection<ReadTString >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTObject:
+         return TConfiguredAction( Looper::template LoopOverCollection<ReadTObject >, new TConfiguration(info, i, compinfo,offset) );
+      case TStreamerInfo::kTString:
+         return TConfiguredAction( Looper::template LoopOverCollection<ReadTString >, new TConfiguration(info, i, compinfo,offset) );
       case TStreamerInfo::kArtificial:
       case TStreamerInfo::kCacheNew:
       case TStreamerInfo::kCacheDelete:
@@ -3916,6 +3919,12 @@ static TConfiguredAction GetCollectionWriteAction(TVirtualStreamerInfo *info, TS
          }
          break;
       }
+      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template LoopOverCollection<WriteTNamed >, new TConfiguration(info,i,compinfo,offset) );    break;
+         // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
+         // Streamer alltogether.
+      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template LoopOverCollection<WriteTObject >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template LoopOverCollection<WriteTString >, new TConfiguration(info,i,compinfo,offset) );    break;
+
       default:
          return TConfiguredAction( Looper::GenericWrite, new TConfiguration(info,i,compinfo,0 /* 0 because we call the legacy code */) );
    }
@@ -3950,11 +3959,11 @@ static TConfiguredAction GetNumericCollectionWriteAction(Int_t type, TConfigSTL 
          delete conf;
          return TConfiguredAction( Looper::WriteCollectionFloat16, alternate );
          // if (element->GetFactor() != 0) {
-         //    return TConfiguredAction( Looper::template WriteAction<WriteBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_WithFactor<float> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          // } else {
          //    Int_t nbits = (Int_t)element->GetXmin();
          //    if (!nbits) nbits = 12;
-         //    return TConfiguredAction( Looper::template WriteAction<WriteBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          // }
          break;
       }
@@ -3963,13 +3972,13 @@ static TConfiguredAction GetNumericCollectionWriteAction(Int_t type, TConfigSTL 
          delete conf;
          return TConfiguredAction( Looper::WriteCollectionDouble32, alternate );
          // if (element->GetFactor() != 0) {
-         //    return TConfiguredAction( Looper::template WriteAction<WriteBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
+         //    return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_WithFactor<double> >, new TConfWithFactor(info,i,compinfo,offset,element->GetFactor(),element->GetXmin()) );
          // } else {
          //    Int_t nbits = (Int_t)element->GetXmin();
          //    if (!nbits) {
-         //       return TConfiguredAction( Looper::template WriteAction<ConvertBasicType<float,double> >, new TConfiguration(info,i,compinfo,offset) );
+         //       return TConfiguredAction( Looper::template LoopOverCollection<ConvertBasicType<float,double> >, new TConfiguration(info,i,compinfo,offset) );
          //    } else {
-         //       return TConfiguredAction( Looper::template WriteAction<WriteBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
+         //       return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          //    }
          // }
          break;

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4189,6 +4189,19 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
             return TConfiguredAction( Looper::WriteStreamerCase, new TGenericConfiguration(info, i, compinfo) );
          else
             return TConfiguredAction( Looper::GenericWrite, new TGenericConfiguration(info, i, compinfo) );
+      case TStreamerInfo::kAny:
+         if (compinfo->fStreamer)
+            return TConfiguredAction( Looper::template LoopOverCollection<WriteViaExtStreamer >, new TConfiguration(info, i, compinfo,offset) );
+         else {
+            if (compinfo->fNewClass && compinfo->fNewClass->HasDirectStreamerInfoUse())
+              return TConfiguredAction( Looper::template LoopOverCollection<WriteViaClassBuffer>,
+                                        new TConfObject(info, i, compinfo, compinfo->fOffset, compinfo->fClass, compinfo->fNewClass) );
+            else if (compinfo->fClass && compinfo->fClass->HasDirectStreamerInfoUse())
+              return TConfiguredAction( Looper::template LoopOverCollection<WriteViaClassBuffer>,
+                                        new TConfObject(info, i, compinfo, compinfo->fOffset, compinfo->fClass, nullptr) );
+            else // Use the slower path for unusual cases
+              return TConfiguredAction( Looper::GenericWrite, new TGenericConfiguration(info, i, compinfo) );
+         }
       default:
          return TConfiguredAction( Looper::GenericWrite, new TConfiguration(info,i,compinfo,0 /* 0 because we call the legacy code */) );
    }

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -3693,6 +3693,19 @@ static TConfiguredAction GetCollectionReadAction(TVirtualStreamerInfo *info, TSt
             return TConfiguredAction( Looper::ReadStreamerCase, new TGenericConfiguration(info, i, compinfo) );
          else
             return TConfiguredAction( Looper::GenericRead, new TGenericConfiguration(info, i, compinfo) );
+      case TStreamerInfo::kAny:
+         if (compinfo->fStreamer)
+            return TConfiguredAction( Looper::template LoopOverCollection<ReadViaExtStreamer >, new TConfiguration(info, i, compinfo,offset) );
+         else {
+            if (compinfo->fNewClass && compinfo->fNewClass->HasDirectStreamerInfoUse())
+              return TConfiguredAction( Looper::template LoopOverCollection<ReadViaClassBuffer>,
+                                        new TConfObject(info, i, compinfo, compinfo->fOffset, compinfo->fClass, compinfo->fNewClass) );
+            else if (compinfo->fClass && compinfo->fClass->HasDirectStreamerInfoUse())
+              return TConfiguredAction( Looper::template LoopOverCollection<ReadViaClassBuffer>,
+                                        new TConfObject(info, i, compinfo, compinfo->fOffset, compinfo->fClass, nullptr) );
+            else // Use the slower path for unusual cases
+              return TConfiguredAction( Looper::GenericRead, new TGenericConfiguration(info, i, compinfo) );
+         }
 
       // Conversions.
       case TStreamerInfo::kConv + TStreamerInfo::kBool:

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4420,6 +4420,10 @@ void TStreamerInfo::AddReadAction(TStreamerInfoActions::TActionSequence *readSeq
          }
          break;
       }
+      case TStreamerInfo::kStreamLoop:
+      case TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop:
+         readSequence->AddAction( ReadStreamerLoop<false>, new TGenericConfiguration(this, i, compinfo, compinfo->fOffset) );
+         break;
       case TStreamerInfo::kStreamer:
          if (fOldVersion >= 3)
             readSequence->AddAction( ReadStreamerCase, new TGenericConfiguration(this,i,compinfo, compinfo->fOffset) );

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -203,7 +203,7 @@ namespace TStreamerInfoActions
                   TClass *onfileClass, TClass *inMemoryClass) :
                   TConfiguration(info, id, compinfo, offset),
                   fOnfileClass(onfileClass),
-                  fInMemoryClass(inMemoryClass ? inMemoryClass : onfileClass)  {};
+                  fInMemoryClass(inMemoryClass ? inMemoryClass : onfileClass)  {}
       TConfiguration *Copy() override { return new TConfObject(*this); }
    };
 

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -3615,25 +3615,24 @@ template <typename Looper, typename From>
 static TConfiguredAction GetCollectionReadConvertAction(Int_t newtype, TConfiguration *conf)
 {
    switch (newtype) {
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertBasicType<From,bool>::Action, conf ); break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ConvertBasicType<From,char>::Action, conf ); break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ConvertBasicType<From,short>::Action, conf );  break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ConvertBasicType<From,Int_t>::Action, conf ); break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ConvertBasicType<From,Long_t>::Action, conf ); break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ConvertBasicType<From,Long64_t>::Action, conf ); break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ConvertBasicType<From,float>::Action, conf ); break;
-      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template ConvertBasicType<From,float>::Action, conf ); break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ConvertBasicType<From,double>::Action, conf ); break;
-      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template ConvertBasicType<From,double>::Action, conf ); break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ConvertBasicType<From,UChar_t>::Action, conf ); break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ConvertBasicType<From,UShort_t>::Action, conf ); break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ConvertBasicType<From,UInt_t>::Action, conf ); break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ConvertBasicType<From,ULong_t>::Action, conf ); break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ConvertBasicType<From,ULong64_t>::Action, conf );  break;
-      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template ConvertBasicType<From,UInt_t>::Action, conf ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertBasicType<From,bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ConvertBasicType<From,char>::Action, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ConvertBasicType<From,short>::Action, conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ConvertBasicType<From,Int_t>::Action, conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ConvertBasicType<From,Long_t>::Action, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ConvertBasicType<From,Long64_t>::Action, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ConvertBasicType<From,float>::Action, conf );
+      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template ConvertBasicType<From,float>::Action, conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ConvertBasicType<From,double>::Action, conf );
+      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template ConvertBasicType<From,double>::Action, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ConvertBasicType<From,UChar_t>::Action, conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ConvertBasicType<From,UShort_t>::Action, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ConvertBasicType<From,UInt_t>::Action, conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ConvertBasicType<From,ULong_t>::Action, conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ConvertBasicType<From,ULong64_t>::Action, conf );
+      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template ConvertBasicType<From,UInt_t>::Action, conf );
       default:
          return TConfiguredAction( Looper::GenericRead, conf );
-         break;
    }
    R__ASSERT(0); // We should never be here
    return TConfiguredAction();
@@ -3648,19 +3647,19 @@ static TConfiguredAction GetNumericCollectionReadAction(Int_t type, TConfigSTL *
       // Read basic types.
 
       // Because of std::vector of bool is not backed up by an array of bool we have to converted it first.
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<bool,bool>::Action, conf );    break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ReadCollectionBasicType<Char_t>, conf );    break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ReadCollectionBasicType<Short_t>,conf );   break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ReadCollectionBasicType<Int_t>,  conf );     break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ReadCollectionBasicType<Long_t>, conf );    break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ReadCollectionBasicType<Long64_t>, conf );  break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ReadCollectionBasicType<Float_t>,  conf );   break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ReadCollectionBasicType<Double_t>, conf );  break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ReadCollectionBasicType<UChar_t>,  conf );   break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ReadCollectionBasicType<UShort_t>, conf );  break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ReadCollectionBasicType<UInt_t>,   conf );    break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ReadCollectionBasicType<ULong_t>,  conf );   break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ReadCollectionBasicType<ULong64_t>, conf ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<bool,bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ReadCollectionBasicType<Char_t>, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ReadCollectionBasicType<Short_t>,conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ReadCollectionBasicType<Int_t>,  conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ReadCollectionBasicType<Long_t>, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ReadCollectionBasicType<Long64_t>, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ReadCollectionBasicType<Float_t>,  conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ReadCollectionBasicType<Double_t>, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ReadCollectionBasicType<UChar_t>,  conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ReadCollectionBasicType<UShort_t>, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ReadCollectionBasicType<UInt_t>,   conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ReadCollectionBasicType<ULong_t>,  conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ReadCollectionBasicType<ULong64_t>, conf );
       case TStreamerInfo::kBits:    Error("GetNumericCollectionReadAction","There is no support for kBits outside of a TObject."); break;
       case TStreamerInfo::kFloat16: {
          TConfigSTL *alternate = new TConfSTLNoFactor(conf,12);
@@ -3673,7 +3672,6 @@ static TConfiguredAction GetNumericCollectionReadAction(Int_t type, TConfigSTL *
          //    if (!nbits) nbits = 12;
          //    return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          // }
-         break;
       }
       case TStreamerInfo::kDouble32: {
          TConfigSTL *alternate = new TConfSTLNoFactor(conf,0);
@@ -3689,7 +3687,6 @@ static TConfiguredAction GetNumericCollectionReadAction(Int_t type, TConfigSTL *
          //       return TConfiguredAction( Looper::template LoopOverCollection<ReadBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          //    }
          // }
-         break;
       }
    }
    Fatal("GetNumericCollectionReadAction","Is confused about %d",type);
@@ -3701,22 +3698,22 @@ template <typename Looper, typename From>
 static TConfiguredAction GetConvertCollectionReadActionFrom(Int_t newtype, TConfiguration *conf)
 {
    switch (newtype) {
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,bool>::Action, conf ); break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,char>::Action, conf ); break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,short>::Action, conf );  break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Int_t>::Action, conf ); break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Long_t>::Action, conf ); break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Long64_t>::Action, conf ); break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,float>::Action, conf ); break;
-      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,float>::Action, conf ); break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,double>::Action, conf ); break;
-      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,double>::Action, conf ); break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UChar_t>::Action, conf ); break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UShort_t>::Action, conf ); break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UInt_t>::Action, conf ); break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,ULong_t>::Action, conf ); break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,ULong64_t>::Action, conf );  break;
-      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UInt_t>::Action, conf );  break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,char>::Action, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,short>::Action, conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Int_t>::Action, conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Long_t>::Action, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,Long64_t>::Action, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,float>::Action, conf );
+      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,float>::Action, conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,double>::Action, conf );
+      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,double>::Action, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UChar_t>::Action, conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UShort_t>::Action, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UInt_t>::Action, conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,ULong_t>::Action, conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,ULong64_t>::Action, conf );
+      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template ConvertCollectionBasicType<From,UInt_t>::Action, conf );
       default:
          break;
    }
@@ -3734,49 +3731,34 @@ static TConfiguredAction GetConvertCollectionReadAction(Int_t oldtype, Int_t new
    switch (oldtype) {
       case TStreamerInfo::kBool:
          return GetConvertCollectionReadActionFrom<Looper,Bool_t>(newtype, conf );
-         break;
       case TStreamerInfo::kChar:
          return GetConvertCollectionReadActionFrom<Looper,Char_t>(newtype, conf );
-         break;
       case TStreamerInfo::kShort:
          return GetConvertCollectionReadActionFrom<Looper,Short_t>(newtype, conf );
-         break;
       case TStreamerInfo::kInt:
          return GetConvertCollectionReadActionFrom<Looper,Int_t>(newtype, conf );
-         break;
       case TStreamerInfo::kLong:
          return GetConvertCollectionReadActionFrom<Looper,Long_t>(newtype, conf );
-         break;
       case TStreamerInfo::kLong64:
          return GetConvertCollectionReadActionFrom<Looper,Long64_t>(newtype, conf );
-         break;
       case TStreamerInfo::kFloat:
          return GetConvertCollectionReadActionFrom<Looper,Float_t>( newtype, conf );
-         break;
       case TStreamerInfo::kDouble:
          return GetConvertCollectionReadActionFrom<Looper,Double_t>(newtype, conf );
-         break;
       case TStreamerInfo::kUChar:
          return GetConvertCollectionReadActionFrom<Looper,UChar_t>(newtype, conf );
-         break;
       case TStreamerInfo::kUShort:
          return GetConvertCollectionReadActionFrom<Looper,UShort_t>(newtype, conf );
-         break;
       case TStreamerInfo::kUInt:
          return GetConvertCollectionReadActionFrom<Looper,UInt_t>(newtype, conf );
-         break;
       case TStreamerInfo::kULong:
          return GetConvertCollectionReadActionFrom<Looper,ULong_t>(newtype, conf );
-         break;
       case TStreamerInfo::kULong64:
          return GetConvertCollectionReadActionFrom<Looper,ULong64_t>(newtype, conf );
-         break;
       case TStreamerInfo::kFloat16:
          return GetConvertCollectionReadActionFrom<Looper,NoFactorMarker<Float16_t> >( newtype, conf );
-         break;
       case TStreamerInfo::kDouble32:
          return GetConvertCollectionReadActionFrom<Looper,NoFactorMarker<Double32_t> >( newtype, conf );
-         break;
       case TStreamerInfo::kBits:
          Error("GetConvertCollectionReadAction","There is no support for kBits outside of a TObject.");
          break;
@@ -3961,11 +3943,11 @@ static TConfiguredAction GetConvertCollectionWriteActionFrom(Int_t onfileType, T
       case TStreamerInfo::kFloat16:
          Error("GetConvertCollectionWriteActionFrom", "Write Conversion to Float16_t not yet supported");
          return TConfiguredAction();
-         // return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,NoFactorMarker<Float16_t>>::Action, conf ); break;
+         // return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,NoFactorMarker<Float16_t>>::Action, conf );
       case TStreamerInfo::kDouble32:
          Error("GetConvertCollectionWriteActionFrom", "Write Conversion to Double32_t not yet supported");
          return TConfiguredAction();
-         // return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,NoFactorMarker<Double32_t>>::Action, conf ); break;
+         // return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<From,NoFactorMarker<Double32_t>>::Action, conf );
       default:
          break;
    }
@@ -3983,49 +3965,34 @@ static TConfiguredAction GetConvertCollectionWriteAction(Int_t onfileType, Int_t
    switch (memoryType) {
       case TStreamerInfo::kBool:
          return GetConvertCollectionWriteActionFrom<Looper,Bool_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kChar:
          return GetConvertCollectionWriteActionFrom<Looper,Char_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kShort:
          return GetConvertCollectionWriteActionFrom<Looper,Short_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kInt:
          return GetConvertCollectionWriteActionFrom<Looper,Int_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kLong:
          return GetConvertCollectionWriteActionFrom<Looper,Long_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kLong64:
          return GetConvertCollectionWriteActionFrom<Looper,Long64_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kFloat:
          return GetConvertCollectionWriteActionFrom<Looper,Float_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kDouble:
          return GetConvertCollectionWriteActionFrom<Looper,Double_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kUChar:
          return GetConvertCollectionWriteActionFrom<Looper,UChar_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kUShort:
          return GetConvertCollectionWriteActionFrom<Looper,UShort_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kUInt:
          return GetConvertCollectionWriteActionFrom<Looper,UInt_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kULong:
          return GetConvertCollectionWriteActionFrom<Looper,ULong_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kULong64:
          return GetConvertCollectionWriteActionFrom<Looper,ULong64_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kFloat16:
          return GetConvertCollectionWriteActionFrom<Looper,Float16_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kDouble32:
          return GetConvertCollectionWriteActionFrom<Looper,Double32_t>(onfileType, conf );
-         break;
       case TStreamerInfo::kBits:
          Error("GetConvertCollectionWriteActionFrom","There is no support for kBits outside of a TObject.");
          break;
@@ -4044,25 +4011,24 @@ template <typename Looper, typename Onfile>
 static TConfiguredAction GetCollectionWriteConvertAction(Int_t newtype, TConfiguration *conf)
 {
    switch (newtype) {
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, bool>::Action, conf ); break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, char>::Action, conf ); break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, short>::Action, conf );  break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Int_t>::Action, conf ); break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Long_t>::Action, conf ); break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Long64_t>::Action, conf ); break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, float>::Action, conf ); break;
-      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, float>::Action, conf ); break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, double>::Action, conf ); break;
-      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, double>::Action, conf ); break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UChar_t>::Action, conf ); break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UShort_t>::Action, conf ); break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UInt_t>::Action, conf ); break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, ULong_t>::Action, conf ); break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, ULong64_t>::Action, conf );  break;
-      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UInt_t>::Action, conf ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, char>::Action, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, short>::Action, conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Int_t>::Action, conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Long_t>::Action, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, Long64_t>::Action, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, float>::Action, conf );
+      case TStreamerInfo::kFloat16: return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, float>::Action, conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, double>::Action, conf );
+      case TStreamerInfo::kDouble32:return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, double>::Action, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UChar_t>::Action, conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UShort_t>::Action, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UInt_t>::Action, conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, ULong_t>::Action, conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, ULong64_t>::Action, conf );
+      case TStreamerInfo::kBits:    return TConfiguredAction( Looper::template WriteConvertBasicType<Onfile, UInt_t>::Action, conf );
       default:
          return TConfiguredAction( Looper::GenericRead, conf );
-         break;
    }
    R__ASSERT(0); // We should never be here
    return TConfiguredAction();
@@ -4075,67 +4041,53 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
 {
    switch (type) {
       // write basic types
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteBasicType<Bool_t>,   new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteBasicType<Char_t>,   new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteBasicType<Short_t>,  new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteBasicType<Int_t>,    new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteBasicType<Long_t>,   new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteBasicType<Long64_t>, new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteBasicType<Float_t>,  new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteBasicType<Double_t>, new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteBasicType<UChar_t>,  new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteBasicType<UShort_t>, new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteBasicType<UInt_t>,   new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteBasicType<ULong_t>,  new TConfiguration(info,i,compinfo,offset) ); break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteBasicType<ULong64_t>,new TConfiguration(info,i,compinfo,offset) ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteBasicType<Bool_t>,   new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteBasicType<Char_t>,   new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteBasicType<Short_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteBasicType<Int_t>,    new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteBasicType<Long_t>,   new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteBasicType<Long64_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteBasicType<Float_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteBasicType<Double_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteBasicType<UChar_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteBasicType<UShort_t>, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteBasicType<UInt_t>,   new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteBasicType<ULong_t>,  new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteBasicType<ULong64_t>,new TConfiguration(info,i,compinfo,offset) );
       // the simple type missing are kBits and kCounter.
 
 
       // Conversions.
       case TStreamerInfo::kConv + TStreamerInfo::kBool:
          return GetCollectionWriteConvertAction<Looper,Bool_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kChar:
          return GetCollectionWriteConvertAction<Looper,Char_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kShort:
          return GetCollectionWriteConvertAction<Looper,Short_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kInt:
          return GetCollectionWriteConvertAction<Looper,Int_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kLong:
          return GetCollectionWriteConvertAction<Looper,Long_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kLong64:
          return GetCollectionWriteConvertAction<Looper,Long64_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kFloat:
          return GetCollectionWriteConvertAction<Looper,Float_t>( element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kDouble:
          return GetCollectionWriteConvertAction<Looper,Double_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUChar:
          return GetCollectionWriteConvertAction<Looper,UChar_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUShort:
          return GetCollectionWriteConvertAction<Looper,UShort_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kUInt:
          return GetCollectionWriteConvertAction<Looper,UInt_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kULong:
          return GetCollectionWriteConvertAction<Looper,ULong_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
       case TStreamerInfo::kConv + TStreamerInfo::kULong64:
          return GetCollectionWriteConvertAction<Looper,ULong64_t>(element->GetNewType(), new TConfiguration(info,i,compinfo,offset) );
-         break;
 #ifdef NOT_YET
       /* The conversion writing acceleration was not yet written for kBits */
       case TStreamerInfo::kConv + TStreamerInfo::kBits:
          return GetCollectionWriteConvertAction<Looper,BitsMarker>(element->GetNewType(), new TBitsConfiguration(info,i,compinfo,offset) );
-         break;
 #endif
       case TStreamerInfo::kConv + TStreamerInfo::kFloat16: {
          if (element->GetFactor() != 0) {
@@ -4160,11 +4112,11 @@ GetCollectionWriteAction(TVirtualStreamerInfo *info, TLoopConfiguration *loopCon
          }
          break;
       }
-      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template LoopOverCollection<WriteTNamed >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTNamed:  return TConfiguredAction( Looper::template LoopOverCollection<WriteTNamed >, new TConfiguration(info,i,compinfo,offset) );
          // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
          // Streamer alltogether.
-      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template LoopOverCollection<WriteTObject >, new TConfiguration(info,i,compinfo,offset) );    break;
-      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template LoopOverCollection<WriteTString >, new TConfiguration(info,i,compinfo,offset) );    break;
+      case TStreamerInfo::kTObject: return TConfiguredAction( Looper::template LoopOverCollection<WriteTObject >, new TConfiguration(info,i,compinfo,offset) );
+      case TStreamerInfo::kTString: return TConfiguredAction( Looper::template LoopOverCollection<WriteTString >, new TConfiguration(info,i,compinfo,offset) );
       case TStreamerInfo::kBase: {
          TStreamerBase *baseEl = dynamic_cast<TStreamerBase*>(element);
          if (baseEl) {
@@ -4217,19 +4169,19 @@ static TConfiguredAction GetNumericCollectionWriteAction(Int_t type, TConfigSTL 
    switch (type) {
       // Write basic types.
       // Because of std::vector of bool is not backed up by an array of bool we have to converted it first.
-      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<bool,bool>::Action, conf );    break;
-      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteCollectionBasicType<Char_t>, conf );    break;
-      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteCollectionBasicType<Short_t>,conf );   break;
-      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteCollectionBasicType<Int_t>,  conf );     break;
-      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteCollectionBasicType<Long_t>, conf );    break;
-      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteCollectionBasicType<Long64_t>, conf );  break;
-      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteCollectionBasicType<Float_t>,  conf );   break;
-      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteCollectionBasicType<Double_t>, conf );  break;
-      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteCollectionBasicType<UChar_t>,  conf );   break;
-      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteCollectionBasicType<UShort_t>, conf );  break;
-      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteCollectionBasicType<UInt_t>,   conf );    break;
-      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteCollectionBasicType<ULong_t>,  conf );   break;
-      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteCollectionBasicType<ULong64_t>, conf ); break;
+      case TStreamerInfo::kBool:    return TConfiguredAction( Looper::template WriteConvertCollectionBasicType<bool,bool>::Action, conf );
+      case TStreamerInfo::kChar:    return TConfiguredAction( Looper::template WriteCollectionBasicType<Char_t>, conf );
+      case TStreamerInfo::kShort:   return TConfiguredAction( Looper::template WriteCollectionBasicType<Short_t>,conf );
+      case TStreamerInfo::kInt:     return TConfiguredAction( Looper::template WriteCollectionBasicType<Int_t>,  conf );
+      case TStreamerInfo::kLong:    return TConfiguredAction( Looper::template WriteCollectionBasicType<Long_t>, conf );
+      case TStreamerInfo::kLong64:  return TConfiguredAction( Looper::template WriteCollectionBasicType<Long64_t>, conf );
+      case TStreamerInfo::kFloat:   return TConfiguredAction( Looper::template WriteCollectionBasicType<Float_t>,  conf );
+      case TStreamerInfo::kDouble:  return TConfiguredAction( Looper::template WriteCollectionBasicType<Double_t>, conf );
+      case TStreamerInfo::kUChar:   return TConfiguredAction( Looper::template WriteCollectionBasicType<UChar_t>,  conf );
+      case TStreamerInfo::kUShort:  return TConfiguredAction( Looper::template WriteCollectionBasicType<UShort_t>, conf );
+      case TStreamerInfo::kUInt:    return TConfiguredAction( Looper::template WriteCollectionBasicType<UInt_t>,   conf );
+      case TStreamerInfo::kULong:   return TConfiguredAction( Looper::template WriteCollectionBasicType<ULong_t>,  conf );
+      case TStreamerInfo::kULong64: return TConfiguredAction( Looper::template WriteCollectionBasicType<ULong64_t>, conf );
       case TStreamerInfo::kBits:    Error("GetNumericCollectionWriteAction","There is no support for kBits outside of a TObject."); break;
       case TStreamerInfo::kFloat16: {
          TConfigSTL *alternate = new TConfSTLNoFactor(conf,12);
@@ -4242,7 +4194,6 @@ static TConfiguredAction GetNumericCollectionWriteAction(Int_t type, TConfigSTL 
          //    if (!nbits) nbits = 12;
          //    return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_NoFactor<float> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          // }
-         break;
       }
       case TStreamerInfo::kDouble32: {
          TConfigSTL *alternate = new TConfSTLNoFactor(conf,0);
@@ -4258,7 +4209,6 @@ static TConfiguredAction GetNumericCollectionWriteAction(Int_t type, TConfigSTL 
          //       return TConfiguredAction( Looper::template LoopOverCollection<WriteBasicType_NoFactor<double> >, new TConfNoFactor(info,i,compinfo,offset,nbits) );
          //    }
          // }
-         break;
       }
    }
    Fatal("GetNumericCollectionWriteAction","Is confused about %d",type);
@@ -4519,7 +4469,7 @@ static void AddReadConvertAction(TStreamerInfoActions::TActionSequence *sequence
    switch (newtype) {
       case TStreamerInfo::kBool:    sequence->AddAction( ConvertBasicType<From,bool>::Action,  conf ); break;
       case TStreamerInfo::kChar:    sequence->AddAction( ConvertBasicType<From,char>::Action,  conf ); break;
-      case TStreamerInfo::kShort:   sequence->AddAction( ConvertBasicType<From,short>::Action, conf );  break;
+      case TStreamerInfo::kShort:   sequence->AddAction( ConvertBasicType<From,short>::Action, conf ); break;
       case TStreamerInfo::kInt:     sequence->AddAction( ConvertBasicType<From,Int_t>::Action, conf ); break;
       case TStreamerInfo::kLong:    sequence->AddAction( ConvertBasicType<From,Long_t>::Action,conf ); break;
       case TStreamerInfo::kLong64:  sequence->AddAction( ConvertBasicType<From,Long64_t>::Action, conf ); break;
@@ -4531,7 +4481,7 @@ static void AddReadConvertAction(TStreamerInfoActions::TActionSequence *sequence
       case TStreamerInfo::kUShort:  sequence->AddAction( ConvertBasicType<From,UShort_t>::Action, conf ); break;
       case TStreamerInfo::kUInt:    sequence->AddAction( ConvertBasicType<From,UInt_t>::Action,   conf ); break;
       case TStreamerInfo::kULong:   sequence->AddAction( ConvertBasicType<From,ULong_t>::Action,  conf ); break;
-      case TStreamerInfo::kULong64: sequence->AddAction( ConvertBasicType<From,ULong64_t>::Action,conf );  break;
+      case TStreamerInfo::kULong64: sequence->AddAction( ConvertBasicType<From,ULong64_t>::Action,conf ); break;
       case TStreamerInfo::kBits:    sequence->AddAction( ConvertBasicType<From,UInt_t>::Action,   conf ); break;
    }
 }
@@ -4544,7 +4494,7 @@ static void AddWriteConvertAction(TStreamerInfoActions::TActionSequence *sequenc
    switch (newtype) {
       case TStreamerInfo::kBool:    sequence->AddAction( WriteConvertBasicType<Onfile, bool>::Action,  conf ); break;
       case TStreamerInfo::kChar:    sequence->AddAction( WriteConvertBasicType<Onfile, char>::Action,  conf ); break;
-      case TStreamerInfo::kShort:   sequence->AddAction( WriteConvertBasicType<Onfile, short>::Action, conf );  break;
+      case TStreamerInfo::kShort:   sequence->AddAction( WriteConvertBasicType<Onfile, short>::Action, conf ); break;
       case TStreamerInfo::kInt:     sequence->AddAction( WriteConvertBasicType<Onfile, Int_t>::Action, conf ); break;
       case TStreamerInfo::kLong:    sequence->AddAction( WriteConvertBasicType<Onfile, Long_t>::Action,conf ); break;
       case TStreamerInfo::kLong64:  sequence->AddAction( WriteConvertBasicType<Onfile, Long64_t>::Action, conf ); break;
@@ -4556,7 +4506,7 @@ static void AddWriteConvertAction(TStreamerInfoActions::TActionSequence *sequenc
       case TStreamerInfo::kUShort:  sequence->AddAction( WriteConvertBasicType<Onfile, UShort_t>::Action, conf ); break;
       case TStreamerInfo::kUInt:    sequence->AddAction( WriteConvertBasicType<Onfile, UInt_t>::Action,   conf ); break;
       case TStreamerInfo::kULong:   sequence->AddAction( WriteConvertBasicType<Onfile, ULong_t>::Action,  conf ); break;
-      case TStreamerInfo::kULong64: sequence->AddAction( WriteConvertBasicType<Onfile, ULong64_t>::Action,conf );  break;
+      case TStreamerInfo::kULong64: sequence->AddAction( WriteConvertBasicType<Onfile, ULong64_t>::Action,conf ); break;
       case TStreamerInfo::kBits:    sequence->AddAction( WriteConvertBasicType<Onfile, UInt_t>::Action,   conf ); break;
    }
 }
@@ -5105,7 +5055,7 @@ void TStreamerInfo::AddWriteAction(TStreamerInfoActions::TActionSequence *writeS
          break;
       }
 
-     case TStreamerInfo::kTNamed:  writeSequence->AddAction( WriteTNamed, new TConfiguration(this, i, compinfo, compinfo->fOffset) );    break;
+     case TStreamerInfo::kTNamed:  writeSequence->AddAction( WriteTNamed, new TConfiguration(this, i, compinfo, compinfo->fOffset) );     break;
         // Idea: We should calculate the CanIgnoreTObjectStreamer here and avoid calling the
         // Streamer alltogether.
      case TStreamerInfo::kTObject: writeSequence->AddAction( WriteTObject, new TConfiguration(this, i, compinfo, compinfo->fOffset) );    break;

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1973,7 +1973,12 @@ namespace TStreamerInfoActions
       }
    }
 
-   struct VectorLooper {
+   template<typename Looper>
+   struct CollectionLooper {
+
+   };
+
+   struct VectorLooper : public CollectionLooper<VectorLooper> {
 
       template <typename T>
       static INLINE_TEMPLATE_ARGS Int_t ReadBasicType(TBuffer &buf, void *iter, const void *end, const TLoopConfiguration *loopconfig, const TConfiguration *config)
@@ -2450,6 +2455,8 @@ namespace TStreamerInfoActions
    };
 
    struct VectorPtrLooper {
+      // Can not inherit/use CollectionLooper<VectorPtrLooper>, because this looper's
+      // function do not take a `TLoopConfiguration`.
 
       template <typename T>
       static INLINE_TEMPLATE_ARGS Int_t ReadBasicType(TBuffer &buf, void *iter, const void *end, const TConfiguration *config)
@@ -2880,7 +2887,7 @@ public:
 
     };
 
-   struct GenericLooper {
+   struct GenericLooper : public CollectionLooper<GenericLooper> {
 
       template <typename T>
       static INLINE_TEMPLATE_ARGS Int_t ReadBasicType(TBuffer &buf, void *start, const void *end, const TLoopConfiguration *loopconf, const TConfiguration *config)

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -44,6 +44,12 @@ using namespace TStreamerInfoActions;
 
 namespace TStreamerInfoActions
 {
+   enum class EMode
+   {
+      kRead,
+      kWrite
+   };
+
    bool IsDefaultVector(TVirtualCollectionProxy &proxy)
    {
       const auto props = proxy.GetProperties();

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -1381,7 +1381,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
             //  Backward compatibility. Some TStreamerElement's where without
             //  Streamer but were not removed from element list
             UInt_t start,count;
-            Version_t v = b.ReadVersion(&start, &count, cle);
+            Version_t v = b.ReadVersion(&start, &count, this->IsA());
             if (fOldVersion<3){   // case of old TStreamerInfo
                if (aElement->IsBase() && aElement->IsA()!=TStreamerBase::Class()) {
                   b.SetBufferOffset(start);  //it was no byte count

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -1183,7 +1183,29 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
                            Int_t nobjects;
                            b >> nobjects;
                            env = newProxy->Allocate(nobjects,true);
-                           subinfo->ReadBufferSTL(b,newProxy,nobjects,/* offset */ 0, vers>=7 );
+                           if (!nobjects && (vers>=7)) {
+                              // Do nothing but in version 6 of TStreamerInfo and below,
+                              // we were calling ReadBuffer for empty collection.
+                           } else {
+                              TStreamerInfoActions::TActionSequence *actions = nullptr;
+                              if (newProxy != oldProxy) {
+                                 actions = newProxy->GetConversionReadMemberWiseActions( oldProxy->GetValueClass(), vClVersion );
+                              } else {
+                                 actions = oldProxy->GetReadMemberWiseActions( vClVersion );
+                              }
+                              char startbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                              char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                              void *begin = &(startbuf[0]);
+                              void *end = &(endbuf[0]);
+                              newProxy->GetFunctionCreateIterators(/* read = */ kTRUE)(env, &begin, &end, newProxy);
+                              // We can not get here with a split vector of pointer, so we can indeed assume
+                              // that actions->fConfiguration != null.
+                              b.ApplySequence(*actions, begin, end);
+                              if (begin != &(startbuf[0])) {
+                                 // assert(end != endbuf);
+                                 newProxy->GetFunctionDeleteTwoIterators()(begin,end);
+                              }
+                           }
                            newProxy->Commit(env);
                         }
                      }
@@ -1271,7 +1293,30 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
                            Int_t nobjects;
                            b >> nobjects;
                            void* env = newProxy->Allocate(nobjects,true);
-                           subinfo->ReadBufferSTL(b,newProxy,nobjects,/* offset */ 0, vers >= 7);
+                           if (!nobjects && (vers>=7)) {
+                              // Do nothing but in version 6 of TStreamerInfo and below,
+                              // we were calling ReadBuffer for empty collection.
+                           } else {
+                              TStreamerInfoActions::TActionSequence *actions = nullptr;
+                              if (newProxy != oldProxy) {
+                                 actions = newProxy->GetConversionReadMemberWiseActions( oldProxy->GetValueClass(), vClVersion );
+                              } else {
+                                 actions = oldProxy->GetReadMemberWiseActions( vClVersion );
+                              }
+
+                              char startbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                              char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                              void *begin_iter = &(startbuf[0]);
+                              void *end_iter = &(endbuf[0]);
+                              newProxy->GetFunctionCreateIterators(/* read = */ kTRUE)(env, &begin_iter, &end_iter, newProxy);
+                              // We can not get here with a split vector of pointer, so we can indeed assume
+                              // that actions->fConfiguration != null.
+                              b.ApplySequence(*actions, begin_iter, end_iter);
+                              if (begin_iter != &(startbuf[0])) {
+                                 // assert(end != endbuf);
+                                 newProxy->GetFunctionDeleteTwoIterators()(begin_iter,end_iter);
+                              }
+                           }
                            newProxy->Commit(env);
                         }
                      }


### PR DESCRIPTION
This add TStreamerInfo actions for the case of base class, nested objects, externally assignment streamer and array thereof (`kBase`, `kAny`, `kStreamer`, `kStreamLoop`) for both scalar and collection cases.   It also expands the scope of the writing actions to cover the collections cases and the new cases (`kBase`, `kAny`, `kStreamer`, `kStreamLoop`)

Companion PR of https://github.com/root-project/roottest/pull/1224

When executing the streaming on an object, the execution of the case covered by the case `kBase`, `kAny`, `kStreamer`, `kStreamLoop` was migrated from using the legacy code within the source file `TStreamerInfoReadBuffer.cxx` and `TStreamerInfoWriteBuffer.cxx` which is based on a pair of 'giant' switch statement to the newer framework based on the composition of `TStreamerInfoActions` (and the corresponding collection: `TActionSequence`).  The change from `switch` statement to a set of function pointers allows to improve performance by executing for each data members only the code strictly necessary.

In its previous implementation (which is still used in a few rare cases involved backward compatibility), the case `kBase` (for both reading and writing) was forcing the use of the `switch` statement for all the data members of the base classes.  This prevented the use of the new convert-on-write actions (with no existing corresponding implementation in the write `switch` statement) that are necessary for supporting the `Enums` with non default size.