### PR TITLE
[win] Fix potential test failure on Windows

### DIFF
--- a/bindings/pyroot/pythonizations/test/pythonization_decorator.py
+++ b/bindings/pyroot/pythonizations/test/pythonization_decorator.py
@@ -13,7 +13,7 @@ class PythonizationDecorator(unittest.TestCase):
     # in some tests, and because of immediate pythonization they will be
     # processed by the pythonizors. Just ignore them
     exclude = [ 'TClass', 'TSystem', 'TUnixSystem', 'TMacOSXSystem',
-                'TWinNTSystem', 'TDictionary', 'TEnv', 'TInterpreter',
+                'TWinNTSystem', 'TDictionary', 'TEnv', 'TInterpreter', 'TApplication',
                 'TObject', 'TNamed', 'TROOT', 'TIter', 'TDirectory', 'TString' ]
 
     # Helpers


### PR DESCRIPTION
Fixes the following potential failure on some Windows machines:
```
2: ======================================================================
2: FAIL: test_all_global_classes_prefix (pythonization_decorator.PythonizationDecorator.test_all_global_classes_prefix)
2: ----------------------------------------------------------------------
2: Traceback (most recent call last):
2:   File "C:\root-dev\git\master\bindings\pyroot\pythonizations\test\pythonization_decorator.py", line 269, in test_all_global_classes_prefix
2:     self.assertEqual(executed.pop(0), class_name)
2: AssertionError: 'TApplication' != 'Foo'
2: - TApplication
2: + Foo
```