### PR TITLE
[core] Ensure non-repeated converted ids and valid return if empty input

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3315,7 +3315,7 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
    }
 
    // If out is empty, or if it starts with a number, it's not a valid C++ variable. Prepend a "_"
-   if (out.empty() || is_digit(out[0]))
+   if (out.empty() || isdigit(out[0]))
       out.insert(out.begin(), '_');
 }
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3315,7 +3315,7 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
    }
 
    // If out is empty, or if it starts with a number, it's not a valid C++ variable. Prepend a "_"
-   if (out.empty() || std::is_digit(out[0]))
+   if (out.empty() || is_digit(out[0]))
       out.insert(out.begin(), '_');
 }
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unordered_set>
+#include <cctype>
 
 #include "RConfigure.h"
 #include <ROOT/RConfig.hxx>
@@ -3313,10 +3314,9 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
          out.push_back(c);
    }
 
-   // Remove initial numbers if any
-   auto firstNonNumber = out.find_first_not_of("0123456789");
-   if (firstNonNumber != std::string::npos)
-      out.replace(0,firstNonNumber,"");
+   // If out is empty, or if it starts with a number, it's not a valid C++ variable. Prepend a "_"
+   if (out.empty() || std::is_digit(out[0]))
+      out.insert(out.begin(), "_");
 }
 
 static clang::SourceLocation

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3316,7 +3316,7 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
 
    // If out is empty, or if it starts with a number, it's not a valid C++ variable. Prepend a "_"
    if (out.empty() || std::is_digit(out[0]))
-      out.insert(out.begin(), "_");
+      out.insert(out.begin(), '_');
 }
 
 static clang::SourceLocation


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Suppose a TTree with valid branch names: "1_coef", "2_coef". With TTree MakeSelector, the converted cpp names now would lead to a duplication of variables. Fix this by prepending a char instead of removing the digits. Also, for the corner case that one passes an empty string, return the "minimally valid variable name in C++", ie just a "_". int _ is a valid variable name.

Related to https://github.com/root-project/root/pull/16992

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)
