### PR TITLE
Add support for NVIDIA nvc++ compiler

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -10,7 +10,10 @@
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "(Apple|)Clang|GNU|Intel|MSVC")
   if (CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
-    message(WARNING "NVHPC compiler: only supported at best effort level.")
+    message(WARNING "NVHPC compiler is only supported at best effort level.")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "24.11.0")
+      message(WARNING "Minimum version of NVHPC compiler is 24.11 . Version ${CMAKE_CXX_COMPILER_VERSION} detected.")
+    endif()
   else()
     message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}.")
   endif()

--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -9,7 +9,11 @@
 #---------------------------------------------------------------------------------------------------
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "(Apple|)Clang|GNU|Intel|MSVC")
-  message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}.")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
+    message(WARNING "NVHPC compiler: only supported at best effort level.")
+  else()
+    message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}.")
+  endif()
 endif()
 
 if(NOT GENERATOR_IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -242,23 +242,33 @@ if (UNIX)
   endif()
 
   if(NOT CLING_CXX_HEADERS)
-    if (CLING_CXX_PATH)
-      execute_process(COMMAND ${CLING_CXX_PATH} ${CLING_CXX_PATH_ARGS} -xc++ -E -v /dev/null
+    
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "NVHPC")
+        execute_process(COMMAND ${CLING_CXX_RLTV} -drygccinc
                       OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
-      set(CLING_CXX_PATH "${CLING_CXX_PATH} ${CLING_CXX_PATH_ARGS}")
+        execute_process(
+          COMMAND echo ${CLING_CXX_HEADERS}
+          COMMAND sed s/:/\\\n/g
+        OUTPUT_VARIABLE CLING_CXX_HEADERS)
     else()
-      # convert CMAKE_CXX_FLAGS to a list for execute_process
-      string(REPLACE "-fdiagnostics-color=always" "" cling_tmp_arg_list ${CMAKE_CXX_FLAGS})
-      string(REPLACE "-fcolor-diagnosics" "" cling_tmp_arg_list ${cling_tmp_arg_list})
-      string(REPLACE " " ";" cling_tmp_arg_list ${cling_tmp_arg_list})
-      execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${cling_tmp_arg_list} -xc++ -E -v /dev/null
-                      OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
-    endif()
+       if (CLING_CXX_PATH)
+         execute_process(COMMAND ${CLING_CXX_PATH} ${CLING_CXX_PATH_ARGS} -xc++ -E -v /dev/null
+                         OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
+         set(CLING_CXX_PATH "${CLING_CXX_PATH} ${CLING_CXX_PATH_ARGS}")
+       else()
+         # convert CMAKE_CXX_FLAGS to a list for execute_process
+         string(REPLACE "-fdiagnostics-color=always" "" cling_tmp_arg_list ${CMAKE_CXX_FLAGS})
+         string(REPLACE "-fcolor-diagnosics" "" cling_tmp_arg_list ${cling_tmp_arg_list})
+         string(REPLACE " " ";" cling_tmp_arg_list ${cling_tmp_arg_list})
+         execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${cling_tmp_arg_list} -xc++ -E -v /dev/null
+                         OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
+       endif()
 
-    execute_process(
-      COMMAND echo ${CLING_CXX_HEADERS}
-      COMMAND sed -n -e /^.include/,\$\{ -e /^\\\ \\\/.*++/p -e \}
-      OUTPUT_VARIABLE CLING_CXX_HEADERS)
+       execute_process(
+         COMMAND echo ${CLING_CXX_HEADERS}
+         COMMAND sed -n -e /^.include/,\$\{ -e /^\\\ \\\/.*++/p -e \}
+         OUTPUT_VARIABLE CLING_CXX_HEADERS)
+    endif()
 
     stripNewLine("${CLING_CXX_HEADERS}" CLING_CXX_HEADERS)
   endif()


### PR DESCRIPTION
# This Pull request:

Adds support for NVIDIA's nvc++ compiler

## Changes or fixes:
- check if at least ver 24.11 of nvc++ compiler is being used
- when building cling, nvc++ uses a different syntax than gcc to extract the system include header locations. Instead of -xc++ -E -v, and then a bunch of sed parsing, it uses the -drygccinc flag to produce a colon separated list of paths.

This allows clean compilation on ARM (NVIDIA Grace) CPUs. 

