### PR TITLE
[ntuple] Fixes lookup & searching in the descriptor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -427,6 +427,7 @@ class RClusterGroupDescriptor {
 private:
    DescriptorId_t fClusterGroupId = kInvalidDescriptorId;
    /// The cluster IDs can be empty if the corresponding page list is not loaded.
+   /// Otherwise, cluster ids are sorted by first entry number.
    std::vector<DescriptorId_t> fClusterIds;
    /// The page list that corresponds to the cluster group
    RNTupleLocator fPageListLocator;
@@ -1306,7 +1307,7 @@ public:
       fClusterGroup.fNClusters = nClusters;
       return *this;
    }
-   void AddClusters(const std::vector<DescriptorId_t> &clusterIds)
+   void AddSortedClusters(const std::vector<DescriptorId_t> &clusterIds)
    {
       if (clusterIds.size() != fClusterGroup.GetNClusters())
          throw RException(R__FAIL("mismatch of number of clusters"));

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -279,6 +279,10 @@ public:
       std::size_t ExtendToFitColumnRange(const RColumnRange &columnRange, const Internal::RColumnElementBase &element,
                                          std::size_t pageSize);
 
+      /// Has the same length than fPageInfos and stores the sum of the number of elements of all the pages
+      /// up to and including a given index. Used for binary search in Find().
+      std::vector<NTupleSize_t> fCumulativeNElements;
+
    public:
       /// We do not need to store the element size / uncompressed page size because we know to which column
       /// the page belongs
@@ -319,6 +323,7 @@ public:
          RPageRange clone;
          clone.fPhysicalColumnId = fPhysicalColumnId;
          clone.fPageInfos = fPageInfos;
+         clone.fCumulativeNElements = fCumulativeNElements;
          return clone;
       }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -572,6 +572,9 @@ private:
    std::vector<RExtraTypeInfoDescriptor> fExtraTypeInfoDescriptors;
    std::unique_ptr<RHeaderExtension> fHeaderExtension;
 
+   // We don't expose this publicy because when we add sharded clusters, this interface does not make sense anymore
+   DescriptorId_t FindClusterId(NTupleSize_t entryIdx) const;
+
 public:
    static constexpr unsigned int kFeatureFlagTest = 137; // Bit reserved for forward-compatibility testing
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -577,7 +577,7 @@ private:
    std::vector<RExtraTypeInfoDescriptor> fExtraTypeInfoDescriptors;
    std::unique_ptr<RHeaderExtension> fHeaderExtension;
 
-   // We don't expose this publicy because when we add sharded clusters, this interface does not make sense anymore
+   // We don't expose this publicly because when we add sharded clusters, this interface does not make sense anymore
    DescriptorId_t FindClusterId(NTupleSize_t entryIdx) const;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -561,6 +561,10 @@ private:
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
    std::unordered_map<DescriptorId_t, RClusterGroupDescriptor> fClusterGroupDescriptors;
+   /// References cluster groups sorted by entry range and thus allows for binary search.
+   /// Note that this list is empty during the descriptor building process and will only be
+   /// created when the final descriptor is extracted from the builder.
+   std::vector<DescriptorId_t> fSortedClusterGroupIds;
    /// May contain only a subset of all the available clusters, e.g. the clusters of the current file
    /// from a chain of files
    std::unordered_map<DescriptorId_t, RClusterDescriptor> fClusterDescriptors;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -494,6 +494,10 @@ ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindCl
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindNextClusterId(DescriptorId_t clusterId) const
 {
+   // TODO(jblomer): we may want to shortcut the common case and check if clusterId + 1 contains
+   // firstEntryInNextCluster. This shortcut would currently always trigger. We do not want, however, to depend
+   // on the linearity of the descriptor IDs, so we should only enable the shortcut if we can ensure that the
+   // binary search code path remains tested.
    const auto &clusterDesc = GetClusterDescriptor(clusterId);
    const auto firstEntryInNextCluster = clusterDesc.GetFirstEntryIndex() + clusterDesc.GetNEntries();
    return FindClusterId(firstEntryInNextCluster);
@@ -502,6 +506,10 @@ ROOT::Experimental::RNTupleDescriptor::FindNextClusterId(DescriptorId_t clusterI
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(DescriptorId_t clusterId) const
 {
+   // TODO(jblomer): we may want to shortcut the common case and check if clusterId - 1 contains
+   // firstEntryInNextCluster. This shortcut would currently always trigger. We do not want, however, to depend
+   // on the linearity of the descriptor IDs, so we should only enable the shortcut if we can ensure that the
+   // binary search code path remains tested.
    const auto &clusterDesc = GetClusterDescriptor(clusterId);
    if (clusterDesc.GetFirstEntryIndex() == 0)
       return kInvalidDescriptorId;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -488,8 +488,13 @@ ROOT::Experimental::RNTupleDescriptor::AddClusterGroupDetails(DescriptorId_t clu
          return R__FAIL("invalid attempt to re-populate existing cluster");
       }
    }
+   std::sort(clusterIds.begin(), clusterIds.end(),
+             [this](DescriptorId_t a, DescriptorId_t b)
+             {
+                return fClusterDescriptors[a].GetFirstEntryIndex() < fClusterDescriptors[b].GetFirstEntryIndex();
+             });
    auto cgBuilder = Internal::RClusterGroupDescriptorBuilder::FromSummary(iter->second);
-   cgBuilder.AddClusters(clusterIds);
+   cgBuilder.AddSortedClusters(clusterIds);
    iter->second = cgBuilder.MoveDescriptor().Unwrap();
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -1160,7 +1160,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitClusterGroup()
    for (auto i = fNextClusterInGroup; i < nClusters; ++i) {
       clusterIds.emplace_back(i);
    }
-   cgBuilder.AddClusters(clusterIds);
+   cgBuilder.AddSortedClusters(clusterIds);
    fDescriptorBuilder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
    fSerializationContext.MapClusterGroupId(clusterGroupId);
 

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -62,12 +62,10 @@ public:
                                    .MoveDescriptor()
                                    .Unwrap());
       }
-      descBuilder.AddClusterGroup(ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder()
-                                     .ClusterGroupId(0)
-                                     .MinEntry(0)
-                                     .EntrySpan(6)
-                                     .MoveDescriptor()
-                                     .Unwrap());
+      ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder cgBuilder;
+      cgBuilder.ClusterGroupId(0).MinEntry(0).EntrySpan(6).NClusters(6);
+      cgBuilder.AddSortedClusters({0, 1, 2, 3, 4, 5});
+      descBuilder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
       auto descriptorGuard = GetExclDescriptorGuard();
       descriptorGuard.MoveIn(descBuilder.MoveDescriptor());
    }

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -18,6 +18,7 @@ TEST(RNTuple, Limits_ManyFields)
 {
    // Writing and reading a model with 100k integer fields takes around 2.2s and seems to have slightly more than linear
    // complexity (200k fields take 7.5s).
+   // Peak RSS is around 750MB.
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
    static constexpr int NumFields = 100'000;
@@ -53,6 +54,7 @@ TEST(RNTuple, Limits_ManyClusters)
 {
    // Writing and reading 500k clusters takes around 3.3s and seems to have benign scaling behavior.
    // (1M clusters take around 6.6s).
+   // Peak RSS is around 850MB.
    FileRaii fileGuard("test_ntuple_limits_manyClusters.root");
 
    static constexpr int NumClusters = 500'000;
@@ -88,6 +90,7 @@ TEST(RNTuple, Limits_ManyClusterGroups)
 {
    // Writing and reading 25k cluster groups takes around 1.7s and seems to have quadratic complexity
    // (50k cluster groups takes around 6.5s).
+   // Peak RSS is around 275MB.
    FileRaii fileGuard("test_ntuple_limits_manyClusterGroups.root");
 
    static constexpr int NumClusterGroups = 25'000;
@@ -123,6 +126,7 @@ TEST(RNTuple, Limits_ManyPages)
 {
    // Writing and reading 1M pages (of two elements each) takes around 1.3 and seems to have benign scaling behavior
    // (2M pages take 2.6s).
+   // Peak RSS is around 600MB.
    FileRaii fileGuard("test_ntuple_limits_manyPages.root");
 
    static constexpr int NumPages = 1'000'000;
@@ -164,6 +168,7 @@ TEST(RNTuple, Limits_ManyPagesOneEntry)
 {
    // Writing and reading 1M pages (of four elements each) takes around 2.4s and seems to have benign scaling behavior
    // (2M pages take around 4.8s).
+   // Peak RSS is around 625MB.
    FileRaii fileGuard("test_ntuple_limits_manyPagesOneEntry.root");
 
    static constexpr int NumPages = 1'000'000;
@@ -207,6 +212,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
 {
    // Writing and reading one page with 600M elements takes around 18s and seems to have linear complexity
    // (900M elements take 27s)
+   // Peak RSS is around 14 GB.
    FileRaii fileGuard("test_ntuple_limits_largePage.root");
 
    // clang-format off
@@ -255,6 +261,7 @@ TEST(RNTuple, DISABLED_Limits_LargePageOneEntry)
 {
    // Writing and reading one page with 100M elements takes around 1.7s and seems to have linear complexity (200M
    // elements take 3.5s, 400M elements take around 7s).
+   // Peak RSS is around 1.4GB.
    FileRaii fileGuard("test_ntuple_limits_largePageOneEntry.root");
 
    static constexpr int NumElements = 100'000'000;

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -14,9 +14,9 @@
 // ./tree/ntuple/v7/test/ntuple_limits --gtest_also_run_disabled_tests --gtest_filter=*Limits_ManyClusters
 // ```
 
-TEST(RNTuple, DISABLED_Limits_ManyFields)
+TEST(RNTuple, Limits_ManyFields)
 {
-   // Writing and reading a model with 100k integer fields takes around 2s and seems to have more than linear
+   // Writing and reading a model with 100k integer fields takes around 2.2s and seems to have slightly more than linear
    // complexity (200k fields take 7.5s).
    FileRaii fileGuard("test_ntuple_limits_manyFields.root");
 
@@ -49,13 +49,13 @@ TEST(RNTuple, DISABLED_Limits_ManyFields)
    }
 }
 
-TEST(RNTuple, DISABLED_Limits_ManyClusters)
+TEST(RNTuple, Limits_ManyClusters)
 {
-   // Writing and reading 100k clusters takes between 80s - 100s and seems to have more than quadratic complexity
-   // (50k clusters take less than 15s).
+   // Writing and reading 500k clusters takes around 3.3s and seems to have benign scaling behavior.
+   // (1M clusters take around 6.6s).
    FileRaii fileGuard("test_ntuple_limits_manyClusters.root");
 
-   static constexpr int NumClusters = 100'000;
+   static constexpr int NumClusters = 500'000;
 
    {
       auto model = RNTupleModel::Create();
@@ -84,13 +84,13 @@ TEST(RNTuple, DISABLED_Limits_ManyClusters)
    }
 }
 
-TEST(RNTuple, DISABLED_Limits_ManyClusterGroups)
+TEST(RNTuple, Limits_ManyClusterGroups)
 {
-   // Writing and reading 100k cluster groups takes between 100s - 110s and seems to have more than quadratic complexity
-   // (50k cluster groups takes less than 20s).
+   // Writing and reading 25k cluster groups takes around 1.7s and seems to have quadratic complexity
+   // (50k cluster groups takes around 6.5s).
    FileRaii fileGuard("test_ntuple_limits_manyClusterGroups.root");
 
-   static constexpr int NumClusterGroups = 100'000;
+   static constexpr int NumClusterGroups = 25'000;
 
    {
       auto model = RNTupleModel::Create();
@@ -119,13 +119,13 @@ TEST(RNTuple, DISABLED_Limits_ManyClusterGroups)
    }
 }
 
-TEST(RNTuple, DISABLED_Limits_ManyPages)
+TEST(RNTuple, Limits_ManyPages)
 {
-   // Writing and reading 200k pages (of two elements each) takes around 13s and seems to have more than quadratic
-   // complexity (400k pages take 100s).
+   // Writing and reading 1M pages (of two elements each) takes around 1.3 and seems to have benign scaling behavior
+   // (2M pages take 2.6s).
    FileRaii fileGuard("test_ntuple_limits_manyPages.root");
 
-   static constexpr int NumPages = 200'000;
+   static constexpr int NumPages = 1'000'000;
    static constexpr int NumEntries = NumPages * 2;
 
    {
@@ -160,13 +160,13 @@ TEST(RNTuple, DISABLED_Limits_ManyPages)
    }
 }
 
-TEST(RNTuple, DISABLED_Limits_ManyPagesOneEntry)
+TEST(RNTuple, Limits_ManyPagesOneEntry)
 {
-   // Writing and reading 200k pages (of four elements each) takes around 13s and seems to have more than quadratic
-   // complexity (400k pages take around 100s).
+   // Writing and reading 1M pages (of four elements each) takes around 2.4s and seems to have benign scaling behavior
+   // (2M pages take around 4.8s).
    FileRaii fileGuard("test_ntuple_limits_manyPagesOneEntry.root");
 
-   static constexpr int NumPages = 200'000;
+   static constexpr int NumPages = 1'000'000;
    static constexpr int NumElements = NumPages * 4;
 
    {

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -697,7 +697,7 @@ TEST(RNTuple, SerializeFooter)
    cgLocator.fBytesOnStorage = 42;
    cgBuilder.ClusterGroupId(256).PageListLength(137).PageListLocator(cgLocator).NClusters(1).EntrySpan(100);
    std::vector<DescriptorId_t> clusterIds{84};
-   cgBuilder.AddClusters(clusterIds);
+   cgBuilder.AddSortedClusters(clusterIds);
    builder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();
@@ -1026,7 +1026,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
 
    RClusterGroupDescriptorBuilder cgBuilder;
    cgBuilder.ClusterGroupId(137).NClusters(2).EntrySpan(2);
-   cgBuilder.AddClusters({13, 17});
+   cgBuilder.AddSortedClusters({13, 17});
    builder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();
@@ -1212,7 +1212,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationProjection)
 
    RClusterGroupDescriptorBuilder cgBuilder;
    cgBuilder.ClusterGroupId(137).NClusters(2).EntrySpan(2);
-   cgBuilder.AddClusters({13, 17});
+   cgBuilder.AddSortedClusters({13, 17});
    builder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();
@@ -1337,7 +1337,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
 
    RClusterGroupDescriptorBuilder cgBuilder;
    cgBuilder.ClusterGroupId(137).NClusters(3).EntrySpan(4);
-   cgBuilder.AddClusters({13, 17, 19});
+   cgBuilder.AddSortedClusters({13, 17, 19});
    builder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();
@@ -1461,7 +1461,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
 
    RClusterGroupDescriptorBuilder cgBuilder;
    cgBuilder.ClusterGroupId(137).NClusters(2).EntrySpan(2);
-   cgBuilder.AddClusters({13, 17});
+   cgBuilder.AddSortedClusters({13, 17});
    builder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();


### PR DESCRIPTION
Fixes several instances of lookups in the descriptor from linear to logarithmic complexity. As a result, many of the limit tests results improve significantly. So much so that I think we can turn on most of them on a regular basis.

Relies on #16986

