### PR TITLE
Several fixes in TAxis

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -536,11 +536,14 @@ Double_t TAxis::GetBinUpEdge(Int_t bin) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return bin width
+///
+/// If `bin > fNbins` (overflow bin) or `bin < 1` (underflow bin), the returned bin width is `(fXmax - fXmin) / fNbins`.
 
 Double_t TAxis::GetBinWidth(Int_t bin) const
 {
    if (fNbins <= 0) return 0;
-   if (fXbins.fN <= 0 || bin >fNbins || bin <1) return (fXmax - fXmin) / Double_t(fNbins);
+   if (fXbins.fN <= 0 || bin >fNbins || bin <1)
+      return (fXmax - fXmin) / Double_t(fNbins);
    return fXbins.fArray[bin] - fXbins.fArray[bin-1];
 }
 


### PR DESCRIPTION
[This issue](https://github.com/root-project/root/issues/16976) revealed a graphics bug when displaying underflow and overflow bins for non-equidistant histogram bins with error bars. The problem arose from a mismatch in the bin width computation in TAxis::GetBinWidth. When the range included underflow or overflow bins, the bin width was calculated using the closest bins, unlike the approach in TAxis::GetBinLowEdge and TAxis::GetBinUpEdge, which apply a specific computation in such cases. This PR updates TAxis::GetBinWidth to follow the same logic as these methods.

This PR also updates the documentation for TAxis::SetRange and TAxis::SetRangeUser, clarifying the interpretation of ranges that extend beyond the normal bin limits. With these clarifications, the warning about bin numbers outside the valid range can now be suppressed.


