### PR TITLE
Add support for enums with non-default size

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -64,6 +64,9 @@ The following people have contributed to this new version:
     [RNTupleMergeOptions](https://root.cern/doc/v634/structROOT_1_1Experimental_1_1Internal_1_1RNTupleMergeOptions.html));
   * "rntuple.ErrBehavior=(Abort|Skip)": RNTuple-specific option that specifies the behavior of the RNTupleMerger on error (see link above);
   * "rntuple.ExtraVerbose": RNTuple-specific option that tells the RNTupleMerger to emit more information during the merge process.
+* Added support for `enum class` with a non default underlying size, for example `enum smallenum: std::int16_t`.  The default is 32 bits.  All enums, independently of their in memory size are stored on file using 32 bits to enable forward compatibility of the file; files created with a `enum class` with a non default underlying size can be read with old version of ROOT into a `enum` type of default size.
+* * Note: `enum class` with an underlying size strictly greater than 32 bits are not supported since they would be truncated when stored on file.
+* The version number of `TStreamerInfo` has been increase to 10 to encoded the addition of the support for `enum class` with a non default underlying size. This allows the opportunity to detect files written by old version of ROOT (`v9` and older of `TStreamerInfo`) where  `enum class` with a non default underlying size where stored incorrectly but recoverably.  Those files can be recover by using I/O customization rules that takes in consideration their size at the time of writing (this information is not recorded in the `ROOT` file).  See https://github.com/root-project/root/pull/17009#issuecomment-2522228598 for some examples.
 * New attribute for I/O customization rules: `CanIgnore`.  When using this attribute the rule will be ignored if the input is missing from the schema/class-layout they apply to instead of issue a `Warning`
 
 ## RDataFrame

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -39,8 +39,9 @@ private:
    std::string  fQualName;                // Fully qualified type name
    EDataType    fUnderlyingType = kInt_t; // Type (size) used to store the enum in memory
 
-   enum EBits {
-     kBitIsScopedEnum = BIT(14) ///< The enum is an enum class.
+   enum EStatusBits {
+     kBitIsScopedEnum = BIT(14), ///< The enum is an enum class.
+     kBitIsValid = BIT(15)       ///< The TEnum object was read from file (assumed valid)
    };
 
 public:

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -40,8 +40,8 @@ private:
    EDataType    fUnderlyingType = kInt_t; // Type (size) used to store the enum in memory
 
    enum EStatusBits {
-     kBitIsScopedEnum = BIT(14), ///< The enum is an enum class.
-     kBitIsValid = BIT(15)       ///< The TEnum object was read from file (assumed valid)
+      kBitIsScopedEnum = BIT(14), ///< The enum is an enum class.
+      kBitIsValid = BIT(15)       ///< The TEnum object was read from file (assumed valid)
    };
 
 public:

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -222,7 +222,11 @@ void TDataMember::Init(bool afterReading)
             fDataType = gROOT->GetType(name,kTRUE);
          }
       } else {
-         fDataType = gROOT->GetType("Int_t", kTRUE); // In rare instance we are called before Int_t has been added to the list of types in TROOT, the kTRUE insures it is there.
+         auto enumdesc = TEnum::GetEnum(GetFullTypeName(), TEnum::kNone);
+         if (enumdesc)
+            fDataType = TDataType::GetDataType(enumdesc->GetUnderlyingType());
+         else
+            fDataType = gROOT->GetType("Int_t", kTRUE); // In rare instance we are called before Int_t has been added to the list of types in TROOT, the kTRUE insures it is there.
       }
       //         if (!fDataType)
       //            Error("TDataMember", "basic data type %s not found in list of basic types",

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -226,7 +226,8 @@ void TDataMember::Init(bool afterReading)
          if (enumdesc)
             fDataType = TDataType::GetDataType(enumdesc->GetUnderlyingType());
          else
-            fDataType = gROOT->GetType("Int_t", kTRUE); // In rare instance we are called before Int_t has been added to the list of types in TROOT, the kTRUE insures it is there.
+            fDataType = gROOT->GetType("Int_t", kTRUE); // In rare instance we are called before Int_t has been added to
+                                                        // the list of types in TROOT, the kTRUE insures it is there.
       }
       //         if (!fDataType)
       //            Error("TDataMember", "basic data type %s not found in list of basic types",
@@ -511,15 +512,15 @@ Longptr_t TDataMember::GetOffsetCint() const
 Int_t TDataMember::GetUnitSize() const
 {
    if (IsaPointer()) return sizeof(void*);
-   if (IsEnum())
-   {
+   if (IsEnum()) {
       auto e = TEnum::GetEnum(GetTypeName());
       if (e)
          return TDataType::GetDataType(e->GetUnderlyingType())->Size();
       else
          return sizeof(Int_t);
    }
-   if (IsBasic()) return GetDataType()->Size();
+   if (IsBasic())
+      return GetDataType()->Size();
 
    TClass *cl = TClass::GetClass(GetTypeName());
    if (!cl) cl = TClass::GetClass(GetTrueTypeName());

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -507,8 +507,15 @@ Longptr_t TDataMember::GetOffsetCint() const
 Int_t TDataMember::GetUnitSize() const
 {
    if (IsaPointer()) return sizeof(void*);
-   if (IsEnum()    ) return sizeof(Int_t);
-   if (IsBasic()   ) return GetDataType()->Size();
+   if (IsEnum())
+   {
+      auto e = TEnum::GetEnum(GetTypeName());
+      if (e)
+         return TDataType::GetDataType(e->GetUnderlyingType())->Size();
+      else
+         return sizeof(Int_t);
+   }
+   if (IsBasic()) return GetDataType()->Size();
 
    TClass *cl = TClass::GetClass(GetTypeName());
    if (!cl) cl = TClass::GetClass(GetTrueTypeName());

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -123,6 +123,9 @@ void TEnum::AddConstant(TEnumConstant *constant)
 
 Bool_t TEnum::IsValid()
 {
+   if (TestBit(kBitIsValid))
+      return true;
+
    // Register the transaction when checking the validity of the object.
    if (!fInfo && UpdateInterpreterStateMarker()) {
       DeclId_t newId = gInterpreter->GetEnum(fClass, fName);
@@ -158,6 +161,7 @@ void TEnum::Update(DeclId_t id)
    if (fInfo)
       gInterpreter->ClassInfo_Delete(fInfo);
    if (!id) {
+      ResetBit(kBitIsValid);
       fInfo = nullptr;
       return;
    }
@@ -167,6 +171,9 @@ void TEnum::Update(DeclId_t id)
    if (fInfo) {
       SetBit(kBitIsScopedEnum, gInterpreter->ClassInfo_IsScopedEnum(fInfo));
       fUnderlyingType = gInterpreter->ClassInfo_GetUnderlyingType(fInfo);
+      SetBit(kBitIsValid);
+   } else {
+      ResetBit(kBitIsValid);
    }
 }
 

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -1889,19 +1889,17 @@ TClass *TStreamerSTL::GetClassPointer() const
    TClass *cl = TClass::GetClass(className, kTRUE, quiet);
 
    auto proxy = cl->GetCollectionProxy();
-   if (fNewClass && proxy->GetValueClass() == nullptr) {
+   if (!fNewClass && proxy && proxy->GetValueClass() == nullptr) {
       // Collection of numerical type, let check if it is an enum.
       TClassEdit::TSplitType arglist(fTypeName, TClassEdit::kDropStlDefault);
       if ( arglist.fElements[1].size() >= 2 ) {
          auto enumdesc = TEnum::GetEnum(arglist.fElements[1].c_str());
          if (enumdesc || gCling->ClassInfo_IsEnum(arglist.fElements[1].c_str())) {
-            if (fNewClass == nullptr) {
-               ((TStreamerElement*)this)->fNewClass = cl;
-               if (proxy->HasPointers())
-                  cl = TClass::GetClass("vector<Int_t*>");
-               else
-                  cl = TClass::GetClass("vector<Int_t>");
-            }
+            ((TStreamerElement*)this)->fNewClass = cl;
+            if (proxy->HasPointers())
+               cl = TClass::GetClass("vector<Int_t*>");
+            else
+               cl = TClass::GetClass("vector<Int_t>");
          }
       }
    }

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -1895,7 +1895,7 @@ TClass *TStreamerSTL::GetClassPointer() const
       if ( arglist.fElements[1].size() >= 2 ) {
          auto enumdesc = TEnum::GetEnum(arglist.fElements[1].c_str());
          if (enumdesc || gCling->ClassInfo_IsEnum(arglist.fElements[1].c_str())) {
-            ((TStreamerElement*)this)->fNewClass = cl;
+            ((TStreamerElement *)this)->fNewClass = cl;
             if (proxy->HasPointers())
                cl = TClass::GetClass("vector<Int_t*>");
             else

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -251,7 +251,7 @@ public:
    Int_t               WriteBufferAux      (TBuffer &b, const T &arr, TCompInfo *const*const compinfo, Int_t first, Int_t last, Int_t narr,Int_t eoffset,Int_t mode);
 
    //WARNING this class version must be the same as TVirtualStreamerInfo
-   ClassDefOverride(TStreamerInfo,9)  //Streamer information for one class version
+   ClassDefOverride(TStreamerInfo, 10)  //Streamer information for one class version
 };
 
 

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -251,7 +251,7 @@ public:
    Int_t               WriteBufferAux      (TBuffer &b, const T &arr, TCompInfo *const*const compinfo, Int_t first, Int_t last, Int_t narr,Int_t eoffset,Int_t mode);
 
    //WARNING this class version must be the same as TVirtualStreamerInfo
-   ClassDefOverride(TStreamerInfo, 10)  //Streamer information for one class version
+   ClassDefOverride(TStreamerInfo, 10) // Streamer information for one class version
 };
 
 

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -397,11 +397,12 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent,
             } else {
                fSize = fundType->Size();
             }
-         } else if (TEnum::GetEnum( intype.c_str(), TEnum::kNone) ) {
+         } else if (auto e = TEnum::GetEnum( intype.c_str(), TEnum::kNone) ) {
+            R__ASSERT(e->IsValid());
             // This is a known enum.
             fCase = kIsEnum;
-            fSize = sizeof(Int_t);
-            fKind = kInt_t;
+            fSize = TDataType::GetDataType(e->GetUnderlyingType())->Size();
+            fKind = e->GetUnderlyingType();
             if (isPointer) {
                fCase |= kIsPointer;
                fSize = sizeof(void*);

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -397,7 +397,7 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent,
             } else {
                fSize = fundType->Size();
             }
-         } else if (auto e = TEnum::GetEnum( intype.c_str(), TEnum::kNone) ) {
+         } else if (auto e = TEnum::GetEnum(intype.c_str(), TEnum::kNone)) {
             R__ASSERT(e->IsValid());
             // This is a known enum.
             fCase = kIsEnum;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -647,11 +647,14 @@ void TStreamerInfo::Build(Bool_t isTransient)
                // decided to keep the file format unchanged and to always
                // store the enum constant as an int.
                auto memType = enumdesc->GetUnderlyingType();
-               if (TDataType::GetDataType(memType)->Size() > 4) // 4 is the onfile space for an Int_t.
-                  Warning(
+               if (TDataType::GetDataType(memType)->Size() > 4) {
+                  // 4 is the onfile space for an Int_t.
+                  Error(
                      "Build",
-                     "The underlying type (%s) for the enum %s is larger than 4 bytes and may result in data loss.",
-                     TDataType::GetTypeName(memType), dm->GetFullTypeName());
+                     "Discarding %s %s::%s because the underlying type (%s) for the enum %s is larger than 4 bytes and may result in data loss.",
+                      dmFull, GetName(), dmName, TDataType::GetTypeName(memType), dm->GetFullTypeName());
+                  continue;
+               }
                element->SetType(TStreamerInfo::kInt);
             }
          }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -640,6 +640,15 @@ void TStreamerInfo::Build(Bool_t isTransient)
             // Here we treat data members such as int, float, double[4]
             element = new TStreamerBasicType(dmName, dmTitle, offset, dtype, dmFull);
          }
+         if (dm->IsEnum()) {
+            if (auto enumdesc = TEnum::GetEnum(dm->GetFullTypeName(), TEnum::kNone))
+            {
+               // NOTE: We might simplify this by having the dm->fDataType being 'correct'.
+               // If we do we need to also make sure to update the old type accordingly
+               element->SetNewType(enumdesc->GetUnderlyingType());
+               element->SetType(TStreamerInfo::kInt);
+            }
+         }
       } else {
          // try STL container or string
          static const char* full_string_name = "basic_string<char,char_traits<char>,allocator<char> >";
@@ -2310,6 +2319,13 @@ void TStreamerInfo::BuildOld()
             } else {
                // All the values of EDataType have the same semantic in EReadWrite
                newType = (EReadWrite)theType->GetType();
+            }
+            if (dm->IsEnum()) {
+               if (auto enumdesc = TEnum::GetEnum(dm->GetFullTypeName(), TEnum::kNone))
+               {
+                  // NOTE: We might simplify this by having the dm->fDataType being 'correct'.
+                  newType = enumdesc->GetUnderlyingType();
+               }
             }
             if ((newType == ::kChar_t) && dmIsPtr && !isArray && !hasCount) {
                newType = ::kCharStar;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -641,18 +641,17 @@ void TStreamerInfo::Build(Bool_t isTransient)
             element = new TStreamerBasicType(dmName, dmTitle, offset, dtype, dmFull);
          }
          if (dm->IsEnum()) {
-            if (auto enumdesc = TEnum::GetEnum(dm->GetFullTypeName(), TEnum::kNone))
-            {
+            if (auto enumdesc = TEnum::GetEnum(dm->GetFullTypeName(), TEnum::kNone)) {
                // When introducing support for non-default sized enum, it was
                // decided to keep the file format unchanged and to always
                // store the enum constant as an int.
                auto memType = enumdesc->GetUnderlyingType();
                if (TDataType::GetDataType(memType)->Size() > 4) {
                   // 4 is the onfile space for an Int_t.
-                  Error(
-                     "Build",
-                     "Discarding %s %s::%s because the underlying type (%s) for the enum %s is larger than 4 bytes and may result in data loss.",
-                      dmFull, GetName(), dmName, TDataType::GetTypeName(memType), dm->GetFullTypeName());
+                  Error("Build",
+                        "Discarding %s %s::%s because the underlying type (%s) for the enum %s is larger than 4 bytes "
+                        "and may result in data loss.",
+                        dmFull, GetName(), dmName, TDataType::GetTypeName(memType), dm->GetFullTypeName());
                   continue;
                }
                element->SetType(TStreamerInfo::kInt);

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -557,8 +557,8 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
          if ((left_datatype && left_datatype->GetType() == kInt_t && right_enum)
             || (right_datatype && right_datatype->GetType() == kInt_t && left_enum))
             return true;
-         if ((left_datatype && right_enum && left_datatype->GetType() == right_enum->GetUnderlyingType())
-            || (right_datatype && left_enum && right_datatype->GetType() == left_enum->GetUnderlyingType()))
+         if ((left_datatype && right_enum && left_datatype->GetType() == right_enum->GetUnderlyingType()) ||
+             (right_datatype && left_enum && right_datatype->GetType() == left_enum->GetUnderlyingType()))
             return true;
          if (!left_datatype || !right_datatype)
             return false;

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -557,6 +557,9 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
          if ((left_datatype && left_datatype->GetType() == kInt_t && right_enum)
             || (right_datatype && right_datatype->GetType() == kInt_t && left_enum))
             return true;
+         if ((left_datatype && right_enum && left_datatype->GetType() == right_enum->GetUnderlyingType())
+            || (right_datatype && left_enum && right_datatype->GetType() == left_enum->GetUnderlyingType()))
+            return true;
          if (!left_datatype || !right_datatype)
             return false;
          auto l = left_datatype->GetType();

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -615,6 +615,9 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
             if ((dictdt && dictdt->GetType() == kInt_t && actualenum)
                 ||(actualdt && actualdt->GetType() == kInt_t && dictenum))
                complainAboutMismatch = false;
+            if ((dictdt && actualenum && dictdt->GetType() == actualenum->GetUnderlyingType())
+                ||(actualdt && dictenum && actualdt->GetType() == dictenum->GetUnderlyingType()))
+               complainAboutMismatch = false;
          }
          if (complainAboutMismatch) {
             Error(errPrefix,

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -615,8 +615,8 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
             if ((dictdt && dictdt->GetType() == kInt_t && actualenum)
                 ||(actualdt && actualdt->GetType() == kInt_t && dictenum))
                complainAboutMismatch = false;
-            if ((dictdt && actualenum && dictdt->GetType() == actualenum->GetUnderlyingType())
-                ||(actualdt && dictenum && actualdt->GetType() == dictenum->GetUnderlyingType()))
+            if ((dictdt && actualenum && dictdt->GetType() == actualenum->GetUnderlyingType()) ||
+                (actualdt && dictenum && actualdt->GetType() == dictenum->GetUnderlyingType()))
                complainAboutMismatch = false;
          }
          if (complainAboutMismatch) {


### PR DESCRIPTION
This PR Is chained (includes all commit from) https://github.com/root-project/root/pull/16995.

The companion roottest PR is https://github.com/root-project/roottest/pull/1226

It also requires an increase in the TStreamerInfo class version number (to mark which files/StreamerInfo have weird data for non-default size enum and which files are correct).

This fixes https://github.com/root-project/root/issues/16312.  However files produced without this PR and with enum with a non default size will have data that is incorrectly saved but potential recoverable.   The way the data is written will dependent on the size of the enum at the time of writing.  Since this size is not recorded in the file, we can ***not*** have a general solution to read those corrupted files. However when that enum size used at write time is known, the techniques described [here](https://github.com/root-project/root/issues/16312#issuecomment-2334773138) and [here](https://github.com/root-project/root/issues/16312#issuecomment-2334928339) can be used to recover those weird files.

If reading both the corrupted files (using the above mentioned work-around) and the new files (correctly written with this PR) the recommendation is to increase the version number of the classes that contain an enum with non-default size so that the rules or custom streamer can distinguish the old and new files.