### PR TITLE
[ntuple] fix out-of-bounds in Real32Quant test

### DIFF
--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -901,7 +901,7 @@ TEST(Packing, Real32QuantFloat)
       element.SetValueRange(-10.f, 10.f);
 
       float f1 = -5.f;
-      unsigned char out[1];
+      unsigned char out[4];
       element.Pack(out, &f1, 1);
       float f2;
       element.Unpack(&f2, out, 1);
@@ -1027,7 +1027,7 @@ TEST(Packing, Real32QuantDouble)
       element.SetValueRange(-10.f, 10.f);
 
       double f1 = -5.f;
-      unsigned char out[1];
+      unsigned char out[4];
       element.Pack(out, &f1, 1);
       double f2;
       element.Unpack(&f2, out, 1);


### PR DESCRIPTION
A wrong copypaste caused UB in a test for Real32Quant (allocating only 1 byte of storage when 4 were needed)


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


