### PR TITLE
[ntuple] Allow configuration of initial page size

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -50,10 +50,12 @@ private:
    RPageStorage::ColumnHandle_t fHandleSink;
    RPageStorage::ColumnHandle_t fHandleSource;
    /// The page into which new elements are being written. The page will initially be small
-   /// (just enough to hold RNTupleWriteOptions::fInitialNElementsPerPage elements) and expand as needed and
+   /// (RNTupleWriteOptions::fInitialUnzippedPageSize, which corresponds to fInitialElements) and expand as needed and
    /// as memory for page buffers is still available (RNTupleWriteOptions::fPageBufferBudget) or the maximum page
    /// size is reached (RNTupleWriteOptions::fMaxUnzippedPageSize).
    RPage fWritePage;
+   /// The initial number of elements in a page
+   NTupleSize_t fInitialNElements = 1;
    /// The number of elements written resp. available in the column
    NTupleSize_t fNElements = 0;
    /// The currently mapped page for reading

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -65,12 +65,11 @@ protected:
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
    /// on how large the I/O buffer can grow during writing.
    std::size_t fMaxUnzippedClusterSize = 10 * fApproxZippedClusterSize;
-   /// Initially, columns start with a page large enough to hold the given number of elements. The initial
-   /// page size is the given number of elements multiplied by the column's element size.
-   /// If more elements are needed, pages are increased up until the byte limit given by fMaxUnzippedPageSize
-   /// or until the total page buffer limit is reached (as a sum of all page buffers).
+   /// Initially, columns start with a page of this size. The default value is chosen to accomodate at least 32 elements
+   /// of 64 bits, or 64 elements of 32 bits. If more elements are needed, pages are increased up until the byte limit
+   /// given by fMaxUnzippedPageSize or until the total page buffer limit is reached (as a sum of all page buffers).
    /// The total write buffer limit needs to be large enough to hold the initial pages of all columns.
-   std::size_t fInitialNElementsPerPage = 64;
+   std::size_t fInitialUnzippedPageSize = 256;
    /// Pages can grow only to the given limit in bytes.
    std::size_t fMaxUnzippedPageSize = 1024 * 1024;
    /// The maximum size that the sum of all page buffers used for writing into a persistent sink are allowed to use.
@@ -115,8 +114,8 @@ public:
    std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
    void SetMaxUnzippedClusterSize(std::size_t val);
 
-   std::size_t GetInitialNElementsPerPage() const { return fInitialNElementsPerPage; }
-   void SetInitialNElementsPerPage(std::size_t val);
+   std::size_t GetInitialUnzippedPageSize() const { return fInitialUnzippedPageSize; }
+   void SetInitialUnzippedPageSize(std::size_t val);
 
    std::size_t GetMaxUnzippedPageSize() const { return fMaxUnzippedPageSize; }
    void SetMaxUnzippedPageSize(std::size_t val);

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -528,10 +528,7 @@ std::size_t ROOT::Experimental::RNTupleModel::EstimateWriteMemoryUsage(const RNT
    for (auto &&field : *fFieldZero) {
       for (const auto &r : field.GetColumnRepresentatives()) {
          nColumns += r.size();
-         for (auto columnType : r) {
-            minPageBufferSize +=
-               options.GetInitialNElementsPerPage() * Internal::RColumnElementBase::Generate(columnType)->GetSize();
-         }
+         minPageBufferSize += r.size() * options.GetInitialUnzippedPageSize();
       }
    }
    bytes = std::min(options.GetPageBufferBudget(), nColumns * options.GetMaxUnzippedPageSize());

--- a/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriteOptions.cxx
@@ -21,21 +21,24 @@
 namespace {
 
 void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClusterSize,
-                         std::size_t initialNElementsPerPage, std::size_t maxUnzippedPageSize)
+                         std::size_t initialUnzippedPageSize, std::size_t maxUnzippedPageSize)
 {
    using RException = ROOT::Experimental::RException;
    if (zippedClusterSize == 0) {
       throw RException(R__FAIL("invalid target cluster size: 0"));
    }
+   if (initialUnzippedPageSize == 0) {
+      throw RException(R__FAIL("invalid initial page size: 0"));
+   }
    if (maxUnzippedPageSize == 0) {
       throw RException(R__FAIL("invalid maximum page size: 0"));
-   }
-   if (initialNElementsPerPage == 0) {
-      throw RException(R__FAIL("invalid initial number of elements per page: 0"));
    }
    if (zippedClusterSize > unzippedClusterSize) {
       throw RException(R__FAIL("compressed target cluster size must not be larger than "
                                "maximum uncompressed cluster size"));
+   }
+   if (initialUnzippedPageSize > maxUnzippedPageSize) {
+      throw RException(R__FAIL("initial page size must not be larger than maximum page size"));
    }
    if (maxUnzippedPageSize > unzippedClusterSize) {
       throw RException(R__FAIL("maximum page size must not be larger than "
@@ -52,25 +55,25 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriteOptions> ROOT::Experimental::RNT
 
 void ROOT::Experimental::RNTupleWriteOptions::SetApproxZippedClusterSize(std::size_t val)
 {
-   EnsureValidTunables(val, fMaxUnzippedClusterSize, fInitialNElementsPerPage, fMaxUnzippedPageSize);
+   EnsureValidTunables(val, fMaxUnzippedClusterSize, fInitialUnzippedPageSize, fMaxUnzippedPageSize);
    fApproxZippedClusterSize = val;
 }
 
 void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedClusterSize(std::size_t val)
 {
-   EnsureValidTunables(fApproxZippedClusterSize, val, fInitialNElementsPerPage, fMaxUnzippedPageSize);
+   EnsureValidTunables(fApproxZippedClusterSize, val, fInitialUnzippedPageSize, fMaxUnzippedPageSize);
    fMaxUnzippedClusterSize = val;
 }
 
-void ROOT::Experimental::RNTupleWriteOptions::SetInitialNElementsPerPage(std::size_t val)
+void ROOT::Experimental::RNTupleWriteOptions::SetInitialUnzippedPageSize(std::size_t val)
 {
    EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, val, fMaxUnzippedPageSize);
-   fInitialNElementsPerPage = val;
+   fInitialUnzippedPageSize = val;
 }
 
 void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedPageSize(std::size_t val)
 {
-   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, fInitialNElementsPerPage, val);
+   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, fInitialUnzippedPageSize, val);
    fMaxUnzippedPageSize = val;
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -397,7 +397,7 @@ TEST(RNTuple, PageSize)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetInitialNElementsPerPage(10);
+      opt.SetInitialUnzippedPageSize(40);
       opt.SetMaxUnzippedPageSize(200);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opt);
       for (int i = 0; i < 1000; i++) {

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -120,8 +120,8 @@ TEST(RNTuple, MultiColumnExpansion)
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("pt", "Double32_t").Unwrap());
       RNTupleWriteOptions options;
+      options.SetInitialUnzippedPageSize(8);
       options.SetMaxUnzippedPageSize(32);
-      options.SetInitialNElementsPerPage(1);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
 
       auto ptrPt = writer->GetModel().GetDefaultEntry().GetPtr<double>("pt");

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -133,7 +133,7 @@ TEST(RNTuple, DISABLED_Limits_ManyPages)
       auto id = model->MakeField<int>("id");
       RNTupleWriteOptions options;
       // Two elements per page.
-      options.SetInitialNElementsPerPage(1);
+      options.SetInitialUnzippedPageSize(8);
       options.SetMaxUnzippedPageSize(8);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
@@ -174,7 +174,7 @@ TEST(RNTuple, DISABLED_Limits_ManyPagesOneEntry)
       auto ids = model->MakeField<std::vector<int>>("ids");
       RNTupleWriteOptions options;
       // Four elements per page (must fit two 64-bit indices!)
-      options.SetInitialNElementsPerPage(1);
+      options.SetInitialUnzippedPageSize(16);
       options.SetMaxUnzippedPageSize(16);
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -110,27 +110,26 @@ TEST(RNTupleModel, EstimateWriteMemoryUsage)
    auto customStructVec = model->MakeField<std::vector<CustomStruct>>("CustomStructVec");
 
    static constexpr std::size_t NumColumns = 10;
-   static constexpr std::size_t ColumnElementsSize = 8 + 4 + 8 + 4 + 8 + 8 + 4 + 8 + 1 + 1;
-   static constexpr std::size_t InitialNElementsPerPage = 1;
+   static constexpr std::size_t InitialPageSize = 8;
    static constexpr std::size_t MaxPageSize = 100;
    static constexpr std::size_t ClusterSize = 6789;
    RNTupleWriteOptions options;
-   options.SetInitialNElementsPerPage(InitialNElementsPerPage);
+   options.SetInitialUnzippedPageSize(InitialPageSize);
    options.SetMaxUnzippedPageSize(MaxPageSize);
    options.SetApproxZippedClusterSize(ClusterSize);
 
-   // Tail page optimization and buffered writing on, IMT not disabled.
-   static constexpr std::size_t Expected1 = NumColumns * MaxPageSize + ColumnElementsSize + 3 * ClusterSize;
+   // Buffered writing on, IMT not disabled.
+   static constexpr std::size_t Expected1 = NumColumns * MaxPageSize + NumColumns * InitialPageSize + 3 * ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected1);
 
    static constexpr std::size_t PageBufferBudget = 800;
    options.SetPageBufferBudget(PageBufferBudget);
-   static constexpr std::size_t Expected2 = PageBufferBudget + ColumnElementsSize + 3 * ClusterSize;
+   static constexpr std::size_t Expected2 = PageBufferBudget + NumColumns * InitialPageSize + 3 * ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected2);
 
    // Disable IMT.
    options.SetUseImplicitMT(RNTupleWriteOptions::EImplicitMT::kOff);
-   static constexpr std::size_t Expected3 = PageBufferBudget + ColumnElementsSize + ClusterSize;
+   static constexpr std::size_t Expected3 = PageBufferBudget + NumColumns * InitialPageSize + ClusterSize;
    EXPECT_EQ(model->EstimateWriteMemoryUsage(options), Expected3);
 
    // Disable buffered writing.

--- a/tree/ntuple/v7/test/ntuple_model.py
+++ b/tree/ntuple/v7/test/ntuple_model.py
@@ -29,14 +29,14 @@ class NTupleModel(unittest.TestCase):
         model.MakeField["std::vector<std::vector<float>>"]("f")
 
         options = RNTupleWriteOptions()
-        InitialNElementsPerPage = 1
+        InitialPageSize = 16
         MaxPageSize = 100
         ClusterSize = 6789
-        options.SetInitialNElementsPerPage(InitialNElementsPerPage)
+        options.SetInitialUnzippedPageSize(InitialPageSize)
         options.SetMaxUnzippedPageSize(MaxPageSize)
         options.SetApproxZippedClusterSize(ClusterSize)
 
-        Expected = 4 * MaxPageSize + (4 + 8 + 8 + 4) + 3 * ClusterSize
+        Expected = 4 * MaxPageSize + 4 * InitialPageSize + 3 * ClusterSize
         self.assertEqual(model.EstimateWriteMemoryUsage(options), Expected)
 
 

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -534,7 +534,7 @@ TEST(RNTupleInspector, PageSizeDistribution)
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
-      writeOptions.SetInitialNElementsPerPage(1);
+      writeOptions.SetInitialUnzippedPageSize(8);
       writeOptions.SetMaxUnzippedPageSize(64);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 


### PR DESCRIPTION
... instead of the initial number of elements. This allows the user to turn off the adaptive page size algorithm completely by specifying the same values for the initial and maximum page size.