### PR TITLE
[etc] use bash instead of sh in runfirefox.sh

### DIFF
--- a/etc/runfirefox.sh
+++ b/etc/runfirefox.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 dumpfile=$1
 shift


### PR DESCRIPTION
The `runfirefox.sh` script uses the shebang `#!/bin/sh` but uses bash constructs (like `[[`). 
