### PR TITLE
[windows] Fix several tree tutorials

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,15 @@ if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
   add_custom_command(TARGET Event POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libEvent.dll
                                      ${CMAKE_CURRENT_BINARY_DIR}/libEvent.dll)
+  if(NOT runtime_cxxmodules)
+    add_custom_command(TARGET Event POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libEvent_rdict.pcm
+                                       ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libEvent_rdict.pcm)
+  else()
+    add_custom_command(TARGET Event POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/Event.pcm
+                                     ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Event.pcm)
+  endif()
 endif()
 ROOT_EXECUTABLE(eventexe MainEvent.cxx LIBRARIES Event RIO Tree TreePlayer Hist Net)
 ROOT_ADD_TEST(test-event COMMAND eventexe)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,15 +51,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Event
                               SOURCES Event.cxx LINKDEF EventLinkDef.h
                               DEPENDENCIES Hist MathCore)
 if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
-  if(NOT runtime_cxxmodules)
-    add_custom_command(TARGET Event POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libEvent_rdict.pcm
-                                       ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libEvent_rdict.pcm)
-  else()
-    add_custom_command(TARGET Event POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/Event.pcm
-                                     ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Event.pcm)
-  endif()
+  add_custom_command(TARGET Event POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libEvent.dll
+                                     ${CMAKE_CURRENT_BINARY_DIR}/libEvent.dll)
 endif()
 ROOT_EXECUTABLE(eventexe MainEvent.cxx LIBRARIES Event RIO Tree TreePlayer Hist Net)
 ROOT_ADD_TEST(test-event COMMAND eventexe)

--- a/tutorials/tree/copytree.C
+++ b/tutorials/tree/copytree.C
@@ -12,9 +12,9 @@
 
 // Load the library at macro parsing time: we need this to use its content in the code
 #ifdef R__WIN32
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
 #else
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
 #endif
 
 void copytree()

--- a/tutorials/tree/copytree.C
+++ b/tutorials/tree/copytree.C
@@ -11,7 +11,11 @@
 /// \author Rene Brun
 
 // Load the library at macro parsing time: we need this to use its content in the code
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#ifdef R__WIN32
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+#else
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#endif
 
 void copytree()
 {

--- a/tutorials/tree/copytree2.C
+++ b/tutorials/tree/copytree2.C
@@ -13,9 +13,9 @@
 
 // Load the library at macro parsing time: we need this to use its content in the code
 #ifdef R__WIN32
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
 #else
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
 #endif
 
 void copytree2()

--- a/tutorials/tree/copytree2.C
+++ b/tutorials/tree/copytree2.C
@@ -12,7 +12,11 @@
 /// \author Rene Brun
 
 // Load the library at macro parsing time: we need this to use its content in the code
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#ifdef R__WIN32
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+#else
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#endif
 
 void copytree2()
 {

--- a/tutorials/tree/copytree3.C
+++ b/tutorials/tree/copytree3.C
@@ -12,9 +12,9 @@
 /// \author Rene Brun
 
 #ifdef R__WIN32
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
 #else
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
 #endif
 
 void copytree3()

--- a/tutorials/tree/copytree3.C
+++ b/tutorials/tree/copytree3.C
@@ -11,7 +11,11 @@
 ///
 /// \author Rene Brun
 
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#ifdef R__WIN32
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+#else
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#endif
 
 void copytree3()
 {

--- a/tutorials/tree/tree4.C
+++ b/tutorials/tree/tree4.C
@@ -50,9 +50,9 @@
 /// \author Rene Brun
 
 #ifdef R__WIN32
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
 #else
-  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
 #endif
 
 #include "TFile.h"

--- a/tutorials/tree/tree4.C
+++ b/tutorials/tree/tree4.C
@@ -49,7 +49,11 @@
 ///
 /// \author Rene Brun
 
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#ifdef R__WIN32
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
+#else
+  R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
+#endif
 
 #include "TFile.h"
 #include "TTree.h"

--- a/tutorials/tree/tree4.C
+++ b/tutorials/tree/tree4.C
@@ -49,11 +49,7 @@
 ///
 /// \author Rene Brun
 
-#ifdef R__WIN32
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent.dll)
-#else
 R__LOAD_LIBRARY($ROOTSYS/test/libEvent.so)
-#endif
 
 #include "TFile.h"
 #include "TTree.h"


### PR DESCRIPTION
- Copy ${ROOTSYS}/test/$<CONFIG>/libEvent.dll to ${ROOTSYS}/test/
- Fix dll name in several tree tutorials
