### PR TITLE
[ntuple] remove ArgsT template from MakeField

### DIFF
--- a/tree/dataframe/test/dataframe_unified_constructor.cxx
+++ b/tree/dataframe/test/dataframe_unified_constructor.cxx
@@ -20,7 +20,7 @@ protected:
       for (const auto &fName : fFileNames) {
          {
             auto modelWrite = RNTupleModel::Create();
-            auto pt = modelWrite->MakeField<float>("ntuple_pt", 11.f);
+            *modelWrite->MakeField<float>("ntuple_pt") = 11.f;
             auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), fNTupleName, fName);
             ntuple->Fill();
          }

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -51,15 +51,15 @@ protected:
 
    void SetUp() override {
       auto model = RNTupleModel::Create();
-      model->MakeField<float>("pt", 42.0);
-      model->MakeField<float>("energy", 7.0);
-      model->MakeField<std::string>("tag", "xyz");
-      model->MakeField<std::vector<float>>("jets", std::vector<float>{1.f, 2.f});
+      *model->MakeField<float>("pt") = 42;
+      *model->MakeField<float>("energy") = 7;
+      *model->MakeField<std::string>("tag") = "xyz";
+      *model->MakeField<std::vector<float>>("jets") = std::vector<float>{1.f, 2.f};
       auto fldNnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
       fldNnlo->push_back(std::vector<float>());
       fldNnlo->push_back(std::vector<float>{1.0});
       fldNnlo->push_back(std::vector<float>{1.0, 2.0, 4.0, 8.0});
-      model->MakeField<ROOT::RVecI>("rvec", ROOT::RVecI{1, 2, 3});
+      *model->MakeField<ROOT::RVecI>("rvec") = ROOT::RVecI{1, 2, 3};
       auto fldElectron = model->MakeField<Electron>("electron");
       fldElectron->pt = 137.0;
       auto fldVecElectron = model->MakeField<std::vector<Electron>>("VecElectron");

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -96,9 +96,9 @@ private:
    std::shared_ptr<T> AddValue(RField<T> &field)
    {
       fFieldName2Token[field.GetQualifiedFieldName()] = fValues.size();
-      auto ptr = std::make_shared<T>();
-      fValues.emplace_back(field.BindValue(ptr));
-      return ptr;
+      auto value = field.CreateValue();
+      fValues.emplace_back(value);
+      return value.template GetPtr<T>();
    }
 
    /// Update the RValue for a field in the entry. To be used when its underlying RFieldBase changes, which typically

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -92,11 +92,11 @@ private:
    }
 
    /// While building the entry, adds a new value to the list and return the value's shared pointer
-   template <typename T, typename... ArgsT>
-   std::shared_ptr<T> AddValue(RField<T> &field, ArgsT &&...args)
+   template <typename T>
+   std::shared_ptr<T> AddValue(RField<T> &field)
    {
       fFieldName2Token[field.GetQualifiedFieldName()] = fValues.size();
-      auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);
+      auto ptr = std::make_shared<T>();
       fValues.emplace_back(field.BindValue(ptr));
       return ptr;
    }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -194,20 +194,22 @@ public:
 class ROptionalField : public RNullableField {
    class ROptionalDeleter : public RDeleter {
    private:
-      std::unique_ptr<RDeleter> fItemDeleter;
+      std::unique_ptr<RDeleter> fItemDeleter; // nullptr for trivially destructible items
+      std::size_t fEngagementPtrOffset = 0;
 
    public:
-      explicit ROptionalDeleter(std::unique_ptr<RDeleter> itemDeleter) : fItemDeleter(std::move(itemDeleter)) {}
+      ROptionalDeleter(std::unique_ptr<RDeleter> itemDeleter, std::size_t engagementPtrOffset)
+         : fItemDeleter(std::move(itemDeleter)), fEngagementPtrOffset(engagementPtrOffset) {}
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
    std::unique_ptr<RDeleter> fItemDeleter;
 
-   /// Given a pointer to an std::optional<T> in `optionalPtr`, extract a pointer to the value T* and a pointer
-   /// to the engagement boolean. Assumes that an std::optional<T> is stored as
-   /// `struct { T t; bool engagement; };`
-   std::pair<const void *, const bool *> GetValueAndEngagementPtrs(const void *optionalPtr) const;
-   std::pair<void *, bool *> GetValueAndEngagementPtrs(void *optionalPtr) const;
+   /// Given a pointer to an std::optional<T> in `optionalPtr`, extract a pointer to the engagement boolean.
+   /// Assumes that an std::optional<T> is stored as `struct { T t; bool engagement; };`
+   const bool *GetEngagementPtr(const void *optionalPtr) const;
+   bool *GetEngagementPtr(void *optionalPtr) const;
+   std::size_t GetEngagementPtrOffset() const;
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -176,10 +176,10 @@ public:
       /// Upon completion, `BeginUpdate()` can be called again to begin a new set of changes.
       void CommitUpdate();
 
-      template <typename T, typename... ArgsT>
-      std::shared_ptr<T> MakeField(const NameWithDescription_t &fieldNameDesc, ArgsT &&...args)
+      template <typename T>
+      std::shared_ptr<T> MakeField(const NameWithDescription_t &fieldNameDesc)
       {
-         auto objPtr = fOpenChangeset.fModel.MakeField<T>(fieldNameDesc, std::forward<ArgsT>(args)...);
+         auto objPtr = fOpenChangeset.fModel.MakeField<T>(fieldNameDesc);
          auto fieldZero = fOpenChangeset.fModel.fFieldZero.get();
          auto it = std::find_if(fieldZero->begin(), fieldZero->end(),
                                 [&](const auto &f) { return f.GetFieldName() == fieldNameDesc.fName; });
@@ -247,7 +247,7 @@ public:
    static std::unique_ptr<RNTupleModel> CreateBare(std::unique_ptr<RFieldZero> fieldZero);
 
    /// Creates a new field given a `name` or `{name, description}` pair and a
-   /// corresponding value that is managed by a shared pointer.
+   /// corresponding, default-constructed value that is managed by a shared pointer.
    ///
    /// **Example: create some fields and fill an %RNTuple**
    /// ~~~ {.cpp}
@@ -273,15 +273,6 @@ public:
    /// }
    /// ~~~
    ///
-   /// **Example: create a field with an initial value**
-   /// ~~~ {.cpp}
-   /// #include <ROOT/RNTupleModel.hxx>
-   /// using ROOT::Experimental::RNTupleModel;
-   ///
-   /// auto model = RNTupleModel::Create();
-   /// // pt's initial value is 42.0
-   /// auto pt = model->MakeField<float>("pt", 42.0);
-   /// ~~~
    /// **Example: create a field with a description**
    /// ~~~ {.cpp}
    /// #include <ROOT/RNTupleModel.hxx>
@@ -292,8 +283,8 @@ public:
    ///    "hadronFlavour", "flavour from hadron ghost clustering"
    /// });
    /// ~~~
-   template <typename T, typename... ArgsT>
-   std::shared_ptr<T> MakeField(const NameWithDescription_t &fieldNameDesc, ArgsT &&...args)
+   template <typename T>
+   std::shared_ptr<T> MakeField(const NameWithDescription_t &fieldNameDesc)
    {
       EnsureNotFrozen();
       EnsureValidFieldName(fieldNameDesc.fName);
@@ -301,7 +292,7 @@ public:
       field->SetDescription(fieldNameDesc.fDescription);
       std::shared_ptr<T> ptr;
       if (fDefaultEntry)
-         ptr = fDefaultEntry->AddValue<T>(*field, std::forward<ArgsT>(args)...);
+         ptr = fDefaultEntry->AddValue<T>(*field);
       fFieldNames.insert(field->GetFieldName());
       fFieldZero->Attach(std::move(field));
       return ptr;

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -188,7 +188,7 @@ void DestroyRVecWithChecks(std::size_t alignOfT, void **beginPtr, char *begin, s
    auto paddingMiddle = dataMemberSz % alignOfT;
    if (paddingMiddle != 0)
       paddingMiddle = alignOfT - paddingMiddle;
-   const bool isSmall = (reinterpret_cast<void *>(begin) == (beginPtr + dataMemberSz + paddingMiddle));
+   const bool isSmall = (begin == (reinterpret_cast<char *>(beginPtr) + dataMemberSz + paddingMiddle));
 
    const bool owns = (*capacityPtr != -1);
    if (!isSmall && owns)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -4,11 +4,11 @@ TEST(RNTuple, ReconstructModel)
 {
    FileRaii fileGuard("test_ntuple_reconstruct.root");
    auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt", 42.0);
-   auto fieldNnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
-   auto fieldKlass = model->MakeField<CustomStruct>("klass");
-   auto fieldArray = model->MakeField<std::array<double, 2>>("array");
-   auto fieldVariant = model->MakeField<std::variant<double, std::variant<std::string, double>>>("variant");
+   *model->MakeField<float>("pt") = 42.0;
+   model->MakeField<std::vector<std::vector<float>>>("nnlo");
+   model->MakeField<CustomStruct>("klass");
+   model->MakeField<std::array<double, 2>>("array");
+   model->MakeField<std::variant<double, std::variant<std::string, double>>>("variant");
    model->Freeze();
    {
       RPageSinkFile sink("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions());
@@ -63,13 +63,13 @@ TEST(RNTuple, MultipleInFile)
    auto file = TFile::Open(fileGuard.GetPath().c_str(), "RECREATE");
    {
       auto model = RNTupleModel::Create();
-      auto fieldPt = model->MakeField<float>("pt", 42.0);
+      *model->MakeField<float>("pt") = 42.0;
       auto ntuple = RNTupleWriter::Append(std::move(model), "first", *file);
       ntuple->Fill();
    }
    {
       auto model = RNTupleModel::Create();
-      auto fieldPt = model->MakeField<float>("E", 1.0);
+      *model->MakeField<float>("E") = 1.0;
       auto ntuple = RNTupleWriter::Append(std::move(model), "second", *file);
       ntuple->Fill();
    }
@@ -100,10 +100,10 @@ TEST(RNTuple, WriteRead)
    FileRaii fileGuard("test_ntuple_writeread.root");
 
    auto modelWrite = RNTupleModel::Create();
-   auto wrSignal = modelWrite->MakeField<bool>("signal", true);
-   auto wrPt = modelWrite->MakeField<float>("pt", 42.0);
-   auto wrEnergy = modelWrite->MakeField<float>("energy", 7.0);
-   auto wrTag = modelWrite->MakeField<std::string>("tag", "xyz");
+   *modelWrite->MakeField<bool>("signal") = true;
+   *modelWrite->MakeField<float>("pt") = 42.0;
+   *modelWrite->MakeField<float>("energy") = 7.0;
+   *modelWrite->MakeField<std::string>("tag") = "xyz";
    auto wrJets = modelWrite->MakeField<std::vector<float>>("jets");
    wrJets->push_back(1.0);
    wrJets->push_back(2.0);
@@ -204,14 +204,14 @@ TEST(RNTuple, FileAnchor)
 
    {
       auto model = RNTupleModel::Create();
-      model->MakeField<int>("a", 42);
+      *model->MakeField<int>("a") = 42;
       auto writer = RNTupleWriter::Recreate(std::move(model), "A", fileGuard.GetPath());
       writer->Fill();
    }
 
    {
       auto model = RNTupleModel::Create();
-      model->MakeField<int>("b", 137);
+      *model->MakeField<int>("b") = 137;
       auto f = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "UPDATE"));
       {
          auto writer = RNTupleWriter::Append(std::move(model), "B", *f);
@@ -242,8 +242,8 @@ TEST(RNTuple, Clusters)
    FileRaii fileGuard("test_ntuple_clusters.root");
 
    auto modelWrite = RNTupleModel::Create();
-   auto wrPt = modelWrite->MakeField<float>("pt", 42.0);
-   auto wrTag = modelWrite->MakeField<std::string>("tag", "xyz");
+   auto wrPt = modelWrite->MakeField<float>("pt");
+   auto wrTag = modelWrite->MakeField<std::string>("tag");
    auto wrNnlo = modelWrite->MakeField<std::vector<std::vector<float>>>("nnlo");
    auto wrFourVec = modelWrite->MakeField<std::array<float, 4>>("fourVec");
    wrNnlo->push_back(std::vector<float>());
@@ -259,6 +259,8 @@ TEST(RNTuple, Clusters)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      *wrPt = 42.0;
+      *wrTag = "xyz";
       writer->Fill();
       writer->CommitCluster();
       *wrPt = 24.0;
@@ -317,7 +319,7 @@ TEST(RNTuple, ClusterEntries)
 {
    FileRaii fileGuard("test_ntuple_cluster_entries.root");
    auto model = RNTupleModel::Create();
-   auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+   *model->MakeField<float>({"pt", "transverse momentum"}) = 42.0;
 
    {
       RNTupleWriteOptions opt;
@@ -338,7 +340,7 @@ TEST(RNTuple, ClusterEntriesAuto)
 {
    FileRaii fileGuard("test_ntuple_cluster_entries_auto.root");
    auto model = RNTupleModel::Create();
-   auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+   model->MakeField<float>({"pt", "transverse momentum"});
 
    {
       RNTupleWriteOptions options;
@@ -362,7 +364,7 @@ TEST(RNTuple, ClusterEntriesAutoStatus)
    FileRaii fileGuard("test_ntuple_cluster_entries_auto_status.root");
    {
       auto model = RNTupleModel::CreateBare();
-      auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+      model->MakeField<float>({"pt", "transverse momentum"});
 
       int FlushClusterCalled = 0;
       RNTupleFillStatus status;
@@ -393,7 +395,7 @@ TEST(RNTuple, PageSize)
 {
    FileRaii fileGuard("test_ntuple_elements_per_page.root");
    auto model = RNTupleModel::Create();
-   auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+   *model->MakeField<float>({"pt", "transverse momentum"}) = 42.0;
 
    {
       RNTupleWriteOptions opt;
@@ -596,7 +598,7 @@ TEST(RNTuple, ReadCallback)
    FileRaii fileGuard("test_ntuple_readcb.ntuple");
    {
       auto model = RNTupleModel::Create();
-      auto fieldI32 = model->MakeField<std::int32_t>("i32", 0);
+      auto fieldI32 = model->MakeField<std::int32_t>("i32");
       auto fieldKlass = model->MakeField<CustomStruct>("klass");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       fieldKlass->a = 42.0;

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -89,7 +89,7 @@ TEST(RNTupleChecksum, OmitPageChecksum)
    FileRaii fileGuard("test_ntuple_omit_page_checksum.root");
 
    auto model = RNTupleModel::Create();
-   auto ptrPx = model->MakeField<float>("px", 1.0);
+   *model->MakeField<float>("px") = 1.0;
    RNTupleWriteOptions options;
    options.SetCompression(0);
    options.SetEnablePageChecksums(false);
@@ -130,9 +130,9 @@ TEST(RNTupleChecksum, Merge)
 
    {
       auto model = RNTupleModel::Create();
-      auto ptrPx = model->MakeField<float>("px", 4.0);
-      auto ptrPy = model->MakeField<float>("py", 5.0);
-      auto ptrPz = model->MakeField<float>("pz", 6.0);
+      *model->MakeField<float>("px") = 4.0;
+      *model->MakeField<float>("py") = 5.0;
+      *model->MakeField<float>("pz") = 6.0;
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       writer->Fill();
    }

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -315,11 +315,12 @@ TEST(PageStorageFile, LoadClusters)
    FileRaii fileGuard("test_pagestoragefile_loadclusters.root");
 
    auto modelWrite = ROOT::Experimental::RNTupleModel::Create();
-   auto wrPt = modelWrite->MakeField<float>("pt", 42.0);
-   auto wrTag = modelWrite->MakeField<std::int32_t>("tag", 0);
+   auto wrPt = modelWrite->MakeField<float>("pt");
+   auto wrTag = modelWrite->MakeField<std::int32_t>("tag");
 
    {
       auto writer = ROOT::Experimental::RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+      *wrPt = 42.0;
       writer->Fill();
       writer->CommitCluster();
       *wrPt = 24.0;
@@ -376,7 +377,7 @@ TEST(PageStorageFile, LoadClustersIMT)
 
    {
       auto model = ROOT::Experimental::RNTupleModel::Create();
-      auto wrPt = model->MakeField<float>("pt", 42.0);
+      *model->MakeField<float>("pt") = 42.0;
 
       auto writer = ROOT::Experimental::RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
       writer->Fill();

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -397,7 +397,7 @@ TEST(RNTupleCompat, UnknownLocatorType)
 
    {
       auto model = RNTupleModel::Create();
-      auto fieldPt = model->MakeField<float>("pt", 14.0);
+      auto fieldPt = model->MakeField<float>("pt");
       auto wopts = RNTupleWriteOptions();
       auto sink = std::make_unique<RPageSinkTestLocator>("ntpl", fileGuard.GetPath(), wopts);
       auto writer = CreateRNTupleWriter(std::move(model), std::move(sink));

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -275,7 +275,7 @@ TEST(RNTuple, LargeFile2)
 
    // Start out with a mini-file created small file
    auto model = RNTupleModel::Create();
-   auto pt = model->MakeField<float>("pt", 42.0);
+   *model->MakeField<float>("pt") = 42.0;
    auto writer = RNTupleWriter::Recreate(std::move(model), "small", fileGuard.GetPath());
    writer->Fill();
    writer = nullptr;

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -42,10 +42,10 @@ TEST(RPageStorageFriends, Basic)
    FileRaii fileGuard2("test_ntuple_friends_basic2.root");
 
    auto model1 = RNTupleModel::Create();
-   auto fieldPt = model1->MakeField<float>("pt", 42.0);
+   auto fieldPt = model1->MakeField<float>("pt");
 
    auto model2 = RNTupleModel::Create();
-   auto fieldEta = model2->MakeField<float>("eta", 24.0);
+   auto fieldEta = model2->MakeField<float>("eta");
 
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(model1), "ntpl1", fileGuard1.GetPath());
@@ -127,7 +127,7 @@ TEST(RPageStorageFriends, FailOnEntryCountMismatch)
    FileRaii fileGuard2("test_ntuple_friends_count2.root");
 
    auto model1 = RNTupleModel::Create();
-   auto fieldPt = model1->MakeField<float>("pt", 42.0);
+   auto fieldPt = model1->MakeField<float>("pt");
    auto model2 = RNTupleModel::Create();
 
    {

--- a/tree/ntuple/v7/test/ntuple_index.cxx
+++ b/tree/ntuple/v7/test/ntuple_index.cxx
@@ -68,11 +68,11 @@ TEST(RNTupleIndex, InvalidTypes)
    FileRaii fileGuard("test_ntuple_index_invalid_types.root");
    {
       auto model = RNTupleModel::Create();
-      auto fldInt = model->MakeField<std::int8_t>("fldInt", 99);
-      auto fldFloat = model->MakeField<float>("fldFloat", 2.5);
-      auto fldString = model->MakeField<std::string>("fldString", "foo");
-      auto fldStruct = model->MakeField<CustomStruct>(
-         "fldStruct", CustomStruct{0.1, {2.f, 4.f}, {{1.f}, {3.f, 5.f}}, "bar", std::byte(8)});
+      *model->MakeField<std::int8_t>("fldInt") = 99;
+      *model->MakeField<float>("fldFloat") = 2.5;
+      *model->MakeField<std::string>("fldString") = "foo";
+      *model->MakeField<CustomStruct>("fldStruct") =
+         CustomStruct{0.1, {2.f, 4.f}, {{1.f}, {3.f, 5.f}}, "bar", std::byte(8)};
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       ntuple->Fill();

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -27,7 +27,7 @@ TEST(RNTuple, DISABLED_Limits_ManyFields)
 
       for (int i = 0; i < NumFields; i++) {
          std::string name = "f" + std::to_string(i);
-         model->MakeField<int>(name, i);
+         *model->MakeField<int>(name) = i;
       }
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -33,12 +33,13 @@ TEST(RPageStorage, ReadSealedPages)
    // Hence the second cluster should have more than a single page per column.  We write uncompressed
    // pages so that we can meaningfully peek into the content of read sealed pages later on.
    auto model = RNTupleModel::Create();
-   auto wrPt = model->MakeField<std::int32_t>("pt", 42);
+   auto wrPt = model->MakeField<std::int32_t>("pt");
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
       options.SetMaxUnzippedPageSize(4096);
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), options);
+      *wrPt = 42;
       writer->Fill();
       writer->CommitCluster();
       for (unsigned i = 0; i < 100000; ++i) {
@@ -94,8 +95,8 @@ TEST(RNTupleMerger, MergeSymmetric)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -107,8 +108,8 @@ TEST(RNTupleMerger, MergeSymmetric)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldBar = model->MakeField<int>("bar");
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 567;
@@ -202,7 +203,7 @@ TEST(RNTupleMerger, MergeAsymmetric1)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -213,7 +214,7 @@ TEST(RNTupleMerger, MergeAsymmetric1)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldBar = i * 765;
@@ -270,8 +271,8 @@ TEST(RNTupleMerger, MergeAsymmetric2)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -283,7 +284,7 @@ TEST(RNTupleMerger, MergeAsymmetric2)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldBar = i * 765;
@@ -340,7 +341,7 @@ TEST(RNTupleMerger, MergeAsymmetric3)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -351,8 +352,8 @@ TEST(RNTupleMerger, MergeAsymmetric3)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 567;
@@ -521,7 +522,8 @@ TEST(RNTupleMerger, MergeInconsistentTypes)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<std::string>("foo", "0");
+      auto fieldFoo = model->MakeField<std::string>("foo");
+      *fieldFoo = "0";
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = std::to_string(i * 123);
@@ -532,7 +534,7 @@ TEST(RNTupleMerger, MergeInconsistentTypes)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<float>("foo", 0);
+      auto fieldFoo = model->MakeField<float>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 5.67;
@@ -577,8 +579,8 @@ TEST(RNTupleMerger, MergeThroughTFileMerger)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -590,8 +592,8 @@ TEST(RNTupleMerger, MergeThroughTFileMerger)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldBar = model->MakeField<int>("bar");
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 567;
@@ -662,8 +664,8 @@ TEST(RNTupleMerger, MergeThroughTFileMergerIncremental)
    FileRaii fileGuardIn("test_ntuple_merge_in.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuardIn.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -675,8 +677,8 @@ TEST(RNTupleMerger, MergeThroughTFileMergerIncremental)
    FileRaii fileGuardOut("test_ntuple_merge_out.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldBar = model->MakeField<int>("bar");
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuardOut.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 567;
@@ -743,8 +745,8 @@ TEST(RNTupleMerger, MergeThroughTFileMergerKey)
    FileRaii fileGuardIn("test_ntuple_merge_in.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuardIn.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
@@ -785,7 +787,7 @@ TEST(RNTupleMerger, MergeThroughTBufferMerger)
          auto file1 = merger.GetFile();
 
          auto model = RNTupleModel::Create();
-         auto pt = model->MakeField<float>("pt", 42.0);
+         *model->MakeField<float>("pt") = 42.0;
          auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file1);
          writer->Fill();
       }
@@ -837,7 +839,7 @@ TEST(RNTupleMerger, ChangeCompression)
    FileRaii fileGuard("test_ntuple_merge_changecomp_in.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       for (size_t i = 0; i < 1000; ++i) {
          *fieldFoo = i * 123;
@@ -963,9 +965,9 @@ TEST(RNTupleMerger, MergeLateModelExtension)
    FileRaii fileGuard1("test_ntuple_merge_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo", 0);
-      auto fieldVfoo = model->MakeField<std::vector<int>>("vfoo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo");
+      auto fieldVfoo = model->MakeField<std::vector<int>>("vfoo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath(), RNTupleWriteOptions());
       for (size_t i = 0; i < 10; ++i) {
          fieldFoo->insert(std::make_pair(std::to_string(i), i * 123));
@@ -978,9 +980,9 @@ TEST(RNTupleMerger, MergeLateModelExtension)
    FileRaii fileGuard2("test_ntuple_merge_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBaz = model->MakeField<int>("baz", 0);
-      auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo", 0);
-      auto fieldVfoo = model->MakeField<std::vector<int>>("vfoo", 0);
+      auto fieldBaz = model->MakeField<int>("baz");
+      auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo");
+      auto fieldVfoo = model->MakeField<std::vector<int>>("vfoo");
       auto wopts = RNTupleWriteOptions();
       wopts.SetCompression(0);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath(), wopts);
@@ -1048,8 +1050,8 @@ TEST(RNTupleMerger, MergeCompression)
    FileRaii fileGuard1("test_ntuple_merge_comp_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
-      auto fieldBar = model->MakeField<int>("bar", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
+      auto fieldBar = model->MakeField<int>("bar");
       auto writeOpts = RNTupleWriteOptions();
       writeOpts.SetCompression(505);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath(), writeOpts);
@@ -1063,8 +1065,8 @@ TEST(RNTupleMerger, MergeCompression)
    FileRaii fileGuard2("test_ntuple_merge_comp_in_2.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldBar = model->MakeField<int>("bar", 0);
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldBar = model->MakeField<int>("bar");
+      auto fieldFoo = model->MakeField<int>("foo");
       auto writeOpts = RNTupleWriteOptions();
       writeOpts.SetCompression(404);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath(), writeOpts);
@@ -1124,7 +1126,7 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
    FileRaii fileGuard1("test_ntuple_merge_diff_rep_in_1.root");
 
    auto model = RNTupleModel::Create();
-   auto pFoo = model->MakeField<double>("foo", 0);
+   auto pFoo = model->MakeField<double>("foo");
    auto clonedModel = model->Clone();
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
@@ -1250,7 +1252,7 @@ TEST(RNTupleMerger, Double32)
 
    {
       auto model = RNTupleModel::Create();
-      auto pFoo = model->MakeField<Double32_t>("foo", 0);
+      auto pFoo = model->MakeField<Double32_t>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *pFoo = i * 123;
@@ -1262,7 +1264,7 @@ TEST(RNTupleMerger, Double32)
 
    {
       auto model = RNTupleModel::Create();
-      auto pFoo = model->MakeField<double>("foo", 0);
+      auto pFoo = model->MakeField<double>("foo");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
       for (size_t i = 0; i < 10; ++i) {
          *pFoo = i * 321;
@@ -1337,7 +1339,7 @@ TEST(RNTupleMerger, MergeProjectedFields)
    FileRaii fileGuard1("test_ntuple_merge_proj_in_1.root");
    {
       auto model = RNTupleModel::Create();
-      auto fieldFoo = model->MakeField<int>("foo", 0);
+      auto fieldFoo = model->MakeField<int>("foo");
       auto projBar = RFieldBase::Create("bar", "int").Unwrap();
       model->AddProjectedField(std::move(projBar), [](const std::string &) { return "foo"; });
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -6,23 +6,23 @@ TEST(RNTupleModel, EnforceValidFieldNames)
 
    // MakeField
    try {
-      auto field3 = model->MakeField<float>("", 42.0);
+      auto field3 = model->MakeField<float>("");
       FAIL() << "empty string as field name should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("name cannot be empty string"));
    }
    try {
-      auto field3 = model->MakeField<float>("pt.pt", 42.0);
+      auto field3 = model->MakeField<float>("pt.pt");
       FAIL() << "field name with periods should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain character '.'"));
    }
 
    // Previous failures to create 'pt' should not block the name
-   auto field = model->MakeField<float>("pt", 42.0);
+   auto field = model->MakeField<float>("pt");
 
    try {
-      auto field2 = model->MakeField<float>("pt", 42.0);
+      model->MakeField<float>("pt");
       FAIL() << "repeated field names should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
@@ -42,7 +42,7 @@ TEST(RNTupleModel, FieldDescriptions)
    FileRaii fileGuard("test_ntuple_field_descriptions.root");
    auto model = RNTupleModel::Create();
 
-   auto pt = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+   model->MakeField<float>({"pt", "transverse momentum"});
 
    auto charge = std::make_unique<RField<float>>(RField<float>("charge"));
    charge->SetDescription("electric charge");
@@ -177,13 +177,13 @@ TEST(RNTupleModel, RegisterSubfield)
    FileRaii fileGuard("test_rentry_subfields.root");
    {
       auto model = RNTupleModel::Create();
-      model->MakeField<float>("a", 3.14f);
-      model->MakeField<CustomStruct>("struct", CustomStruct{1.f, {2.f, 3.f}, {{4.f}, {5.f, 6.f, 7.f}}, "foo"});
-      model->MakeField<std::vector<CustomStruct>>(
-         "structVec", std::vector{CustomStruct{.1f, {.2f, .3f}, {{.4f}, {.5f, .6f, .7f}}, "bar"},
-                                  CustomStruct{-1.f, {-2.f, -3.f}, {{-4.f}, {-5.f, -6.f, -7.f}}, "baz"}});
-      model->MakeField<std::pair<CustomStruct, int>>(
-         "structPair", std::pair{CustomStruct{.1f, {.2f, .3f}, {{.4f}, {.5f, .6f, .7f}}, "bar"}, 42});
+      *model->MakeField<float>("a") = 3.14f;
+      *model->MakeField<CustomStruct>("struct") = CustomStruct{1.f, {2.f, 3.f}, {{4.f}, {5.f, 6.f, 7.f}}, "foo"};
+      *model->MakeField<std::vector<CustomStruct>>("structVec") =
+         std::vector{CustomStruct{.1f, {.2f, .3f}, {{.4f}, {.5f, .6f, .7f}}, "bar"},
+                     CustomStruct{-1.f, {-2.f, -3.f}, {{-4.f}, {-5.f, -6.f, -7.f}}, "baz"}};
+      *model->MakeField<std::pair<CustomStruct, int>>("structPair") =
+         std::pair{CustomStruct{.1f, {.2f, .3f}, {{.4f}, {.5f, .6f, .7f}}, "bar"}, 42};
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       ntuple->Fill();

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -5,8 +5,8 @@ TEST(RNTupleProjection, Basics)
    FileRaii fileGuard("test_ntuple_projection_basics.root");
 
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("met", 42.0);
-   model->MakeField<std::atomic<int>>("atomicNumber", 7);
+   *model->MakeField<float>("met") = 42.0;
+   *model->MakeField<std::atomic<int>>("atomicNumber") = 7;
    auto fvec = model->MakeField<std::vector<float>>("vec");
    fvec->emplace_back(1.0);
    fvec->emplace_back(2.0);
@@ -73,7 +73,7 @@ TEST(RNTupleProjection, CatchInvalidMappings)
    FileRaii fileGuard("test_ntuple_projection_catch_invalid_mappings.root");
 
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("met", 42.0);
+   model->MakeField<float>("met");
    model->MakeField<std::vector<float>>("vec");
    model->MakeField<std::variant<int, float>>("variant");
    model->MakeField<std::vector<std::vector<float>>>("nnlo");
@@ -165,7 +165,7 @@ TEST(RNTupleProjection, CatchReaderWithProjectedFields)
    FileRaii fileGuard("test_ntuple_projection_catch_reader_with_projected_fields.root");
 
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("met", 42.0);
+   model->MakeField<float>("met");
 
    auto f1 = RFieldBase::Create("missingE", "float").Unwrap();
    model->AddProjectedField(std::move(f1), [](const std::string &) { return "met"; });

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -67,10 +67,11 @@ TEST(RNTuple, Basics)
 
    {
       auto model = RNTupleModel::Create();
-      auto wrPt = model->MakeField<float>("pt", 42.0);
+      auto wrPt = model->MakeField<float>("pt");
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       EXPECT_EQ(ntuple->GetNEntries(), 0);
+      *wrPt = 42.0;
       ntuple->Fill();
       EXPECT_EQ(ntuple->GetNEntries(), 1);
       EXPECT_EQ(ntuple->GetLastCommitted(), 0);
@@ -502,7 +503,7 @@ TEST(RNTuple, TMemFile)
 
    {
       auto model = RNTupleModel::Create();
-      auto pt = model->MakeField<float>("pt", 42.0);
+      *model->MakeField<float>("pt") = 42.0;
 
       auto writer = RNTupleWriter::Append(std::move(model), "ntpl", file);
       writer->Fill();
@@ -681,7 +682,7 @@ TEST(RPageSinkBuf, ParallelZipIMT)
          FileRaii fileGuard(filename);
 
          auto model = ROOT::Experimental::RNTupleModel::Create();
-         auto wrPt = model->MakeField<float>("pt", 42.0);
+         *model->MakeField<float>("pt") = 42.0;
 
          RNTupleWriteOptions options;
          options.SetInitialNElementsPerPage(1);
@@ -764,7 +765,7 @@ TEST(RPageSink, Empty)
 
    {
       auto model = RNTupleModel::Create();
-      auto wrPt = model->MakeField<float>("pt", 42.0);
+      model->MakeField<float>("pt");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
    }
 
@@ -780,8 +781,9 @@ TEST(RPageSink, MultipleClusterGroups)
 
    {
       auto model = RNTupleModel::Create();
-      auto wrPt = model->MakeField<float>("pt", 42.0);
+      auto wrPt = model->MakeField<float>("pt");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+      *wrPt = 42.0;
       ntuple->Fill();
       ntuple->CommitCluster();
       // This pattern should work: CommitCluster(false) followed by CommitCluster(true) and
@@ -1072,8 +1074,8 @@ TEST(RPageSink, SamePageMerging)
 
    for (auto enable : {true, false}) {
       auto model = RNTupleModel::Create();
-      model->MakeField<float>("px", 1.0);
-      model->MakeField<float>("py", 1.0);
+      *model->MakeField<float>("px") = 1.0;
+      *model->MakeField<float>("py") = 1.0;
       RNTupleWriteOptions options;
       options.SetEnablePageChecksums(enable);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -48,13 +48,14 @@ TEST_F(RPageStorageDaos, Basics)
    std::string daosUri = RegisterLabel("ntuple-test-basics");
    const std::string_view ntupleName("ntuple");
    auto model = RNTupleModel::Create();
-   auto wrPt = model->MakeField<float>("pt", 42.0);
+   auto wrPt = model->MakeField<float>("pt");
 
    {
       RNTupleWriteOptionsDaos options;
       options.SetMaxCageSize(0); // Disable caging mechanism.
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, daosUri, options);
 
+      *wrPt = 42.0;
       ntuple->Fill();
       ntuple->CommitCluster();
       *wrPt = 24.0;
@@ -143,7 +144,7 @@ TEST_F(RPageStorageDaos, Options)
 
    {
       auto model = RNTupleModel::Create();
-      auto wrPt = model->MakeField<float>("pt", 42.0);
+      model->MakeField<float>("pt");
 
       RNTupleWriteOptionsDaos options;
       options.SetMaxCageSize(0);
@@ -172,16 +173,18 @@ TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
 
    {
       auto model1 = RNTupleModel::Create();
-      auto wrPt = model1->MakeField<float>("pt", 34.0);
+      auto wrPt = model1->MakeField<float>("pt");
       auto ntuple = RNTupleWriter::Recreate(std::move(model1), ntupleName1, daosUri, options);
+      *wrPt = 34.0;
       ntuple->Fill();
       *wrPt = 160.0;
       ntuple->Fill();
    }
    {
       auto model2 = RNTupleModel::Create();
-      auto wrPt = model2->MakeField<float>("pt", 81.0);
+      auto wrPt = model2->MakeField<float>("pt");
       auto ntuple = RNTupleWriter::Recreate(std::move(model2), ntupleName2, daosUri, options);
+      *wrPt = 81.0;
       ntuple->Fill();
       *wrPt = 96.0;
       ntuple->Fill();
@@ -220,8 +223,8 @@ TEST_F(RPageStorageDaos, DisabledSamePageMerging)
 {
    std::string daosUri = RegisterLabel("ntuple-test-disabled-same-page-merging");
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("px", 1.0);
-   model->MakeField<float>("py", 1.0);
+   *model->MakeField<float>("px") = 1.0;
+   *model->MakeField<float>("py") = 1.0;
    RNTupleWriteOptionsDaos options;
    options.SetEnablePageChecksums(true);
    auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", daosUri, options);

--- a/tree/ntuple/v7/test/ntuple_test.cxx
+++ b/tree/ntuple/v7/test/ntuple_test.cxx
@@ -8,9 +8,9 @@ void CreateCorruptedRNTuple(const std::string &uri)
    options.SetCompression(0);
 
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("px", 1.0);
-   model->MakeField<float>("py", 2.0);
-   model->MakeField<float>("pz", 3.0);
+   *model->MakeField<float>("px") = 1.0;
+   *model->MakeField<float>("py") = 2.0;
+   *model->MakeField<float>("pz") = 3.0;
    model->Freeze();
    auto modelClone = model->Clone(); // required later to write the corrupted version
    auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", uri, options);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -2000,8 +2000,9 @@ TEST(RNTuple, IOConstructor)
    FileRaii fileGuard("test_ntuple_ioconstructor.ntuple");
 
    auto model = RNTupleModel::Create();
-   auto fldObj = RFieldBase::Create("obj", "IOConstructor").Unwrap();
-   model->AddField(std::move(fldObj));
+   model->MakeField<IOConstructor>("obj1");
+   auto fldObj2 = RFieldBase::Create("obj2", "IOConstructor").Unwrap();
+   model->AddField(std::move(fldObj2));
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       writer->Fill();
@@ -2009,8 +2010,8 @@ TEST(RNTuple, IOConstructor)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(1U, ntuple->GetNEntries());
-   auto obj = ntuple->GetModel().GetDefaultEntry().GetPtr<IOConstructor>("obj");
-   EXPECT_EQ(7, obj->a);
+   auto obj2 = ntuple->GetModel().GetDefaultEntry().GetPtr<IOConstructor>("obj2");
+   EXPECT_EQ(7, obj2->a);
 }
 
 TEST(RNTuple, TClassTemplateBased)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1138,7 +1138,7 @@ TEST(RNTuple, Byte)
 
    {
       auto model = RNTupleModel::Create();
-      auto f = model->MakeField<std::byte>("b", std::byte{137});
+      *model->MakeField<std::byte>("b") = std::byte{137};
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       writer->Fill();
    }
@@ -1379,7 +1379,8 @@ TEST(RNTuple, Bitset)
    auto f1 = model->MakeField<std::bitset<66>>("f1");
    EXPECT_EQ(std::string("std::bitset<66>"), model->GetConstField("f1").GetTypeName());
    EXPECT_EQ(sizeof(std::bitset<66>), model->GetConstField("f1").GetValueSize());
-   auto f2 = model->MakeField<std::bitset<8>>("f2", "10101010");
+   auto f2 = model->MakeField<std::bitset<8>>("f2");
+   *f2 = std::bitset<8>("10101010");
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -9,8 +9,8 @@ TEST(RNTuple, View)
    FileRaii fileGuard("test_ntuple_view.root");
 
    auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt", 42.0);
-   auto fieldTag = model->MakeField<std::string>("tag", "xyz");
+   *model->MakeField<float>("pt") = 42.0;
+   *model->MakeField<std::string>("tag") = "xyz";
    auto fieldJets = model->MakeField<std::vector<std::int32_t>>("jets");
    fieldJets->push_back(1);
    fieldJets->push_back(2);
@@ -62,13 +62,17 @@ TEST(RNTuple, ViewCast)
    FileRaii fileGuard("test_ntuple_view_cast.root");
 
    auto model = RNTupleModel::Create();
-   auto fieldF = model->MakeField<float>("f", 1.0);
-   auto fieldD = model->MakeField<double>("d", 2.0);
-   auto field32 = model->MakeField<std::uint32_t>("u32", 32);
-   auto field64 = model->MakeField<std::int64_t>("i64", -64);
+   auto fieldF = model->MakeField<float>("f");
+   auto fieldD = model->MakeField<double>("d");
+   auto field32 = model->MakeField<std::uint32_t>("u32");
+   auto field64 = model->MakeField<std::int64_t>("i64");
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      *fieldF = 1.0;
+      *fieldD = 2.0;
+      *field32 = 32;
+      *field64 = -64;
       writer->Fill();
       *fieldF = -42.0;
       *fieldD = -63.0;
@@ -100,11 +104,12 @@ TEST(RNTuple, DirectAccessView)
    FileRaii fileGuard("test_ntuple_direct_access_view.root");
 
    auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt", 42.0);
+   auto fieldPt = model->MakeField<float>("pt");
    auto fieldVec = model->MakeField<std::vector<float>>("vec");
    {
       RNTupleWriteOptions opt;
       auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath(), opt);
+      *fieldPt = 42.0;
       writer->Fill();
       writer->CommitCluster();
       *fieldPt = 137.0;
@@ -132,7 +137,7 @@ TEST(RNTuple, VoidView)
    FileRaii fileGuard("test_ntuple_voidview.root");
 
    auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt", 42.0);
+   *model->MakeField<float>("pt") = 42.0;
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
@@ -190,7 +195,7 @@ TEST(RNTuple, ViewWithExternalAddress)
    FileRaii fileGuard("test_ntuple_viewexternal.root");
 
    auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt", 42.0);
+   *model->MakeField<float>("pt") = 42.0;
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
@@ -295,16 +300,16 @@ TEST(RNTuple, ViewStandardIntegerTypes)
 
    {
       auto model = RNTupleModel::Create();
-      auto c = model->MakeField<char>("c", 'a');
-      auto uc = model->MakeField<unsigned char>("uc", 1);
-      auto s = model->MakeField<short>("s", 2);
-      auto us = model->MakeField<unsigned short>("us", 3);
-      auto i = model->MakeField<int>("i", 4);
-      auto ui = model->MakeField<unsigned int>("ui", 5);
-      auto l = model->MakeField<long>("l", 6);
-      auto ul = model->MakeField<unsigned long>("ul", 7);
-      auto ll = model->MakeField<long long>("ll", 8);
-      auto ull = model->MakeField<unsigned long long>("ull", 9);
+      *model->MakeField<char>("c") = 'a';
+      *model->MakeField<unsigned char>("uc") = 1;
+      *model->MakeField<short>("s") = 2;
+      *model->MakeField<unsigned short>("us") = 3;
+      *model->MakeField<int>("i") = 4;
+      *model->MakeField<unsigned int>("ui") = 5;
+      *model->MakeField<long>("l") = 6;
+      *model->MakeField<unsigned long>("ul") = 7;
+      *model->MakeField<long long>("ll") = 8;
+      *model->MakeField<unsigned long long>("ull") = 9;
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -75,7 +75,7 @@ TEST(RNTupleInspector, UnknownCompression)
    {
       auto model = RNTupleModel::Create();
 
-      auto vecFld = model->MakeField<std::vector<float>>("vecFld", refVec);
+      *model->MakeField<std::vector<float>>("vecFld") = refVec;
 
       RNTupleWriteOptions opts;
       opts.SetCompression(505);
@@ -87,7 +87,7 @@ TEST(RNTupleInspector, UnknownCompression)
       auto modelUpdater = ntuple->CreateModelUpdater();
 
       modelUpdater->BeginUpdate();
-      auto extVecField = modelUpdater->MakeField<std::vector<float>>("extVecFld", refVec);
+      *modelUpdater->MakeField<std::vector<float>>("extVecFld") = refVec;
       modelUpdater->CommitUpdate();
 
       ntuple->Fill();

--- a/tutorials/v7/ntuple/ntpl010_skim.C
+++ b/tutorials/v7/ntuple/ntpl010_skim.C
@@ -88,7 +88,7 @@ void ntpl010_skim()
    }
 
    // Add an additional field to the skimmed dataset
-   auto ptrSkip = skimModel->MakeField<std::uint16_t>("skip", 0);
+   auto ptrSkip = skimModel->MakeField<std::uint16_t>("skip");
 
    auto writer = RNTupleWriter::Recreate(std::move(skimModel), kNTupleOutputName, kNTupleOutputFileName);
 


### PR DESCRIPTION
Remove the parameter pack from RNTupleModel::MakeField() that has been
used to set an initial value for a field. This API only makes sense with
a default model. E.g., it is confusing with bare models (initial value
ignored) or with the parallel writer or if multiple entries are created.

In practice, the functionality to set an initial value is only useful
for tests and can in many cases be replaced by immediately dereferencing
the shared pointer returned from MakeField().

Companion PR: https://github.com/root-project/roottest/pull/1228
