### PR TITLE
[skip-ci] Make sure the python box is displayed first

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -13,10 +13,10 @@ r"""
 \class TDirectory
 \brief \parblock \endparblock
 \htmlonly
+<details open>
+<summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
-\anchor python
-## PyROOT
 
 It is possible to retrieve the content of a TDirectory object
 just like getting items from a Python dictionary.
@@ -47,6 +47,7 @@ and TFile, which inherit it. Please refer to the documentation of those classes
 for more information.
 \htmlonly
 </div>
+</details>
 \endhtmlonly
 */
 """

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
@@ -13,10 +13,10 @@ r"""
 \class TDirectoryFile
 \brief \parblock \endparblock
 \htmlonly
+<details open>
+<summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
-\anchor python
-## PyROOT
 
 In the same way as for TDirectory, it is possible to inspect the content of a
 TDirectoryFile object from Python as if the subdirectories and objects it
@@ -52,6 +52,7 @@ d.WriteObject(obj, 'keyName')
 \endcode
 \htmlonly
 </div>
+</details>
 \endhtmlonly
 */
 """

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
@@ -14,10 +14,10 @@ r"""
 \class TF1
 \brief \parblock \endparblock
 \htmlonly
+<details open>
+<summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
-\anchor python
-## PyROOT
 
 The TF1 class has several additions for its use from Python, which are also
 available in its subclasses TF2 and TF3.
@@ -64,11 +64,11 @@ params = np.array([
 
 # Slice to avoid the dummy column of 10's
 res = rtf1_coulomb.EvalPar(x[:, ::2], params)
-        
-\endcode
 
+\endcode
 \htmlonly
 </div>
+</details>
 \endhtmlonly
 */
 """
@@ -95,9 +95,9 @@ def _TF1_EvalPar(self, vars, params):
         self.SetNdim(x_size)
 
     out = numpy.zeros(len(x))
-    
+
     ROOT.Internal.EvalParMultiDim(self, out, x, x_size, nrows, params)
-    return numpy.frombuffer(out, dtype=numpy.float64, count=nrows) 
+    return numpy.frombuffer(out, dtype=numpy.float64, count=nrows)
 
 
 def _TF1_Constructor(self, *args, **kwargs):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -14,10 +14,10 @@ r'''
 \class TFile
 \brief \parblock \endparblock
 \htmlonly
+<details open>
+<summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
-\anchor python
-## PyROOT
 
 In the same way as for TDirectory, it is possible to get the content of a
 TFile object with the familiar item-getting syntax.
@@ -69,6 +69,7 @@ statement, you can use the context manager functionality offered by TContext.
 
 \htmlonly
 </div>
+</details>
 \endhtmlonly
 */
 '''

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
@@ -13,10 +13,10 @@ r"""
 \class TTree
 \brief \parblock \endparblock
 \htmlonly
+<details open>
+<summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
-\anchor python
-## PyROOT
 
 The TTree class has several additions for its use from Python, which are also
 available in its subclasses e.g. TChain and TNtuple.
@@ -127,6 +127,7 @@ ds.SetBranchAddress('structb', ms)
 \endcode
 \htmlonly
 </div>
+</details>
 \endhtmlonly
 */
 """

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -8,6 +8,11 @@
 # This line is mandatory. Do not comment it
 echo "INPUT = ./mainpage.md                    \\" > Doxyfile_INPUT
 
+# Add to the list of files to be analyzed the .pyzdoc files created by extract_docstrings.py
+# and print_roofit_pyz_doctrings.py
+ls $DOXYGEN_PYZDOC_PATH/*.pyzdoc | sed -e "s/$/ \\\\/"  \
+>> Doxyfile_INPUT
+
 echo "        ../../core/base/                 \\" >> Doxyfile_INPUT
 echo "        ../../core/dictgen/              \\" >> Doxyfile_INPUT
 echo "        ../../core/cont/                 \\" >> Doxyfile_INPUT
@@ -82,10 +87,4 @@ echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 # echo "        ../../graf3d/x3d/                \\" >> Doxyfile_INPUT
 # echo "        ../../net/rootd/                 \\" >> Doxyfile_INPUT
 # echo "        ../../net/rpdutils/              \\" >> Doxyfile_INPUT
-
-
-# Add to the list of files to be analyzed the .pyzdoc files created by extract_docstrings.py
-# and print_roofit_pyz_doctrings.py
-ls $DOXYGEN_PYZDOC_PATH/*.pyzdoc | sed -e "s/$/ \\\\/"  \
->> Doxyfile_INPUT
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -17,7 +17,6 @@
 \sa \ref IO
 \sa \ref rootio (or `io/doc/TFile` folder in your codebase)
 
-<details>
 <summary>ROOT file data format specification</summary>
 
 A ROOT file is composed of a header, followed by consecutive data records
@@ -78,8 +77,6 @@ Begin_Macro
 End_Macro
 
 The structure of a directory is shown in TDirectoryFile::TDirectoryFile
-
-</details>
 */
 
 #include <ROOT/RConfig.hxx>


### PR DESCRIPTION
Ensure that the Python box is displayed before the C++ description. It appears "minimized" by default and can be expanded as needed. To achieve this behavior, modifications are required in the Pythonization files, similar to the changes made in _tf1.py in this PR.