### PR TITLE
[skip-ci] Add `python` anchor tag to PyROOT docs

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rvec.py
@@ -15,6 +15,7 @@ r"""
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 The ROOT::RVec class has additional features in Python, which allow to adopt memory

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tarray.py
@@ -15,6 +15,7 @@ r'''
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 When used from Python, the subclasses of TArray (TArrayC, TArrayS, TArrayI, TArrayL, TArrayF and TArrayD) benefit from the following extra features:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcontext.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcontext.py
@@ -15,6 +15,7 @@ r'''
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 The functionality offered by TContext can be used in PyROOT with a context manager. Here are a few examples:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -15,6 +15,7 @@ r"""
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 It is possible to retrieve the content of a TDirectory object

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
@@ -15,6 +15,7 @@ r"""
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 In the same way as for TDirectory, it is possible to inspect the content of a

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
@@ -16,6 +16,7 @@ r"""
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 The TF1 class has several additions for its use from Python, which are also

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -16,6 +16,7 @@ r'''
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 In the same way as for TDirectory, it is possible to get the content of a

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
@@ -15,6 +15,7 @@ r"""
 \htmlonly
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 ## PyROOT
 
 The TTree class has several additions for its use from Python, which are also


### PR DESCRIPTION
Adding a `python` Doxygen anchor tag adds the possibility to directly link to PyROOT-specific docs, by appending "#python" to the doxygen link. For example, to get the PyROOT documentation for TTree, one can now use "https://root.cern/doc/master/classTTree.html#python".

