### PR TITLE
[RF] Skip normalization over nEvents in RooSimultaneous if necessary

### DIFF
--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -458,6 +458,13 @@ double RooSimultaneous::evaluate() const
 
       for (auto *proxy2 : static_range_cast<RooRealProxy *>(_pdfProxyList)) {
          auto &pdf2 = static_cast<RooAbsPdf const &>(proxy2->arg());
+         if(!pdf2.canBeExtended()) {
+            // If one of the pdfs can't be expected, reset the normalization
+            // factor to one and break out of the loop.
+            nEvtTot = 1.0;
+            nEvtCat = 1.0;
+            break;
+         }
          const double nEvt = pdf2.expectedEvents(_normSet);
          nEvtTot += nEvt;
          if (&pdf2 == &pdf) {

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -407,3 +407,19 @@ TEST(RooSimultaneous, ConditionalProdPdf)
    // RooSimultaneous, and one for the RooCategory.
    EXPECT_EQ(countGraphNodes(*compiledSim), countGraphNodes(*compiled) + 2);
 }
+
+// Test that we can evaluate a RooSimultaneous also if only a fraction of the
+// channels can be extended.
+TEST(RooSimultaneous, PartiallyExtendedPdfs)
+{
+   RooWorkspace ws;
+   ws.factory("Gaussian::pdfA(x_a[-10, 10], mu_a[0, -10, 10], sigma_a[2.0, 0.1, 10.0])");
+   ws.factory("Gaussian::pdfB(x_b[-10, 10], mu_b[0, -10, 10], sigma_b[2.0, 0.1, 10.0])");
+   ws.factory("PROD::pdfAprod(pdfA)");
+   ws.factory("ExtendPdf::pdfBext(pdfB, n_b[1000., 100., 10000.])");
+   ws.factory("SIMUL::simPdf( cat[A=0,B=1], A=pdfAprod, B=pdfBext)");
+
+   RooArgSet observables{*ws.var("x_a"), *ws.var("x_b")};
+
+   std::cout << ws.pdf("simPdf")->getVal() << std::endl;
+}


### PR DESCRIPTION
If only one of the pdfs in the RooSimultaneous can't provide an expected
number of events, calculating the relative number of events is futile
and will result in exceptions when trying to ask these pdfs for the
expected number of events.

This fixes a bug reported by @gartrog from ATLAS (crash when printing
workspaces with such pdfs).