### PR TITLE
[ntuple] Add RNTuple[Parallel]Writer::CommitDataset()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -194,6 +194,12 @@ public:
    };
 
 private:
+   // The states a model can be in. Possible transitions are between kBuilding and kFrozen.
+   enum class EState {
+      kBuilding,
+      kFrozen
+   };
+
    /// Hierarchy of fields consisting of simple types and collections (sub trees)
    std::unique_ptr<RFieldZero> fFieldZero;
    /// Contains field values corresponding to the created top-level fields, as well as registered subfields
@@ -212,7 +218,7 @@ private:
    /// Models have a separate schema ID to remember that the clone of a frozen model still has the same schema.
    std::uint64_t fSchemaId = 0;
    /// Changed by Freeze() / Unfreeze() and by the RUpdater.
-   bool fIsFrozen = false;
+   EState fModelState = EState::kBuilding;
 
    /// Checks that user-provided field names are valid in the context of this RNTuple model.
    /// Throws an RException for invalid names, empty names (which is reserved for the zero field) and duplicate field
@@ -361,7 +367,7 @@ public:
 
    void Freeze();
    void Unfreeze();
-   bool IsFrozen() const { return fIsFrozen; }
+   bool IsFrozen() const { return fModelState == EState::kFrozen; }
    bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }
    std::uint64_t GetSchemaId() const { return fSchemaId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -131,7 +131,7 @@ Models have a unique model identifier that faciliates checking whether entries a
 
 A model is subject to a state transition during its lifetime: it starts in a building state, in which fields can be
 added and modified.  Once the schema is finalized, the model gets frozen.  Only frozen models can create entries.
-From frozen, models move into a retired state.  In this state, the model is only partially usable: it can be cloned
+From frozen, models move into a expired state.  In this state, the model is only partially usable: it can be cloned
 and queried, but it can't be unfrozen anymore and no new entries can be created.  This state is used for models
 that were used for writing and are no longer connected to a page sink.
 */
@@ -198,11 +198,11 @@ public:
 
 private:
    // The states a model can be in. Possible transitions are between kBuilding and kFrozen
-   // and from kFrozen to kRetired.
+   // and from kFrozen to kExpired.
    enum class EState {
       kBuilding,
       kFrozen,
-      kRetired
+      kExpired
    };
 
    /// Hierarchy of fields consisting of simple types and collections (sub trees)
@@ -218,7 +218,7 @@ private:
    /// Keeps track of which subfields have been registered to be included in entries belonging to this model.
    std::unordered_set<std::string> fRegisteredSubfields;
    /// Every model has a unique ID to distinguish it from other models. Entries are linked to models via the ID.
-   /// Cloned models get a new model ID. Retired models are cloned into frozen models.
+   /// Cloned models get a new model ID. Expired models are cloned into frozen models.
    std::uint64_t fModelId = 0;
    /// Models have a separate schema ID to remember that the clone of a frozen model still has the same schema.
    std::uint64_t fSchemaId = 0;
@@ -372,9 +372,9 @@ public:
 
    void Freeze();
    void Unfreeze();
-   void Retire();
-   bool IsRetired() const { return fModelState == EState::kRetired; }
-   bool IsFrozen() const { return (fModelState == EState::kFrozen) || (fModelState == EState::kRetired); }
+   void Expire();
+   bool IsExpired() const { return fModelState == EState::kExpired; }
+   bool IsFrozen() const { return (fModelState == EState::kFrozen) || (fModelState == EState::kExpired); }
    bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }
    std::uint64_t GetSchemaId() const { return fSchemaId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -372,6 +372,7 @@ public:
 
    void Freeze();
    void Unfreeze();
+   void Retire();
    bool IsFrozen() const { return (fModelState == EState::kFrozen) || (fModelState == EState::kRetired); }
    bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -373,6 +373,7 @@ public:
    void Freeze();
    void Unfreeze();
    void Retire();
+   bool IsRetired() const { return fModelState == EState::kRetired; }
    bool IsFrozen() const { return (fModelState == EState::kFrozen) || (fModelState == EState::kRetired); }
    bool IsBare() const { return !fDefaultEntry; }
    std::uint64_t GetModelId() const { return fModelId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleParallelWriter.hxx
@@ -95,8 +95,11 @@ public:
    /// thread-safe and may be called from multiple threads in parallel at any time, also after some data has already
    /// been written.
    ///
-   /// Note that all fill contexts must be destroyed before the RNTupleParallelWriter is destructed.
+   /// Note that all fill contexts must be destroyed before RNTupleParallelWriter::CommitDataset() is called.
    std::shared_ptr<RNTupleFillContext> CreateFillContext();
+
+   /// Automatically called by the destructor
+   void CommitDataset();
 
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -122,7 +122,7 @@ public:
       if (commitClusterGroup)
          CommitClusterGroup();
    }
-   /// Closes the underlying file (page sink) and retires the model. Automatically called on destruct.
+   /// Closes the underlying file (page sink) and expires the model. Automatically called on destruct.
    /// Once the dataset is committed, calls to Fill(), [Commit|Flush]Cluster(), FlushColumns(), CreateEntry(),
    /// and model updating fail.
    void CommitDataset();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -73,7 +73,7 @@ private:
 
    RNTupleWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Internal::RPageSink> sink);
 
-   RNTupleModel &GetUpdatableModel() { return *fFillContext.fModel; }
+   RNTupleModel &GetUpdatableModel();
    Internal::RPageSink &GetSink() { return *fFillContext.fSink; }
 
    // Helper function that is called from CommitCluster() when necessary
@@ -122,6 +122,10 @@ public:
       if (commitClusterGroup)
          CommitClusterGroup();
    }
+   /// Closes the underlying file (page sink) and retires the model. Automatically called on destruct.
+   /// Once the dataset is committed, calls to Fill(), [Commit|Flush]Cluster(), FlushColumns(), CreateEntry(),
+   /// and model updating fail.
+   void CommitDataset();
 
    std::unique_ptr<REntry> CreateEntry() { return fFillContext.CreateEntry(); }
 

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -95,6 +95,9 @@ void ROOT::Experimental::RNTupleFillContext::CommitStagedClusters()
    if (fStagedClusters.empty()) {
       return;
    }
+   if (fModel->IsRetired()) {
+      throw RException(R__FAIL("invalid attempt to commit staged clusters after dataset was committed"));
+   }
 
    fSink->CommitStagedClusters(fStagedClusters);
    fStagedClusters.clear();

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -95,7 +95,7 @@ void ROOT::Experimental::RNTupleFillContext::CommitStagedClusters()
    if (fStagedClusters.empty()) {
       return;
    }
-   if (fModel->IsRetired()) {
+   if (fModel->IsExpired()) {
       throw RException(R__FAIL("invalid attempt to commit staged clusters after dataset was committed"));
    }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -35,8 +35,8 @@ std::uint64_t GetNewModelId()
 ROOT::Experimental::RFieldZero &
 ROOT::Experimental::Internal::GetFieldZeroOfModel(ROOT::Experimental::RNTupleModel &model)
 {
-   if (model.IsRetired()) {
-      throw RException(R__FAIL("invalid use of retired model"));
+   if (model.IsExpired()) {
+      throw RException(R__FAIL("invalid use of expired model"));
    }
    return *model.fFieldZero;
 }
@@ -44,8 +44,8 @@ ROOT::Experimental::Internal::GetFieldZeroOfModel(ROOT::Experimental::RNTupleMod
 ROOT::Experimental::Internal::RProjectedFields &
 ROOT::Experimental::Internal::GetProjectedFieldsOfModel(ROOT::Experimental::RNTupleModel &model)
 {
-   if (model.IsRetired()) {
-      throw RException(R__FAIL("invalid use of retired model"));
+   if (model.IsExpired()) {
+      throw RException(R__FAIL("invalid use of expired model"));
    }
    return *model.fProjectedFields;
 }
@@ -280,7 +280,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    } else {
       cloneModel->fSchemaId = cloneModel->fModelId;
    }
-   cloneModel->fModelState = (fModelState == EState::kRetired) ? EState::kFrozen : fModelState;
+   cloneModel->fModelState = (fModelState == EState::kExpired) ? EState::kFrozen : fModelState;
    cloneModel->fFieldNames = fFieldNames;
    cloneModel->fDescription = fDescription;
    cloneModel->fProjectedFields = fProjectedFields->Clone(*cloneModel);
@@ -450,7 +450,7 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
-   case EState::kRetired: throw RException(R__FAIL("invalid attempt to create entry of retired model"));
+   case EState::kExpired: throw RException(R__FAIL("invalid attempt to create entry of expired model"));
    case EState::kFrozen: break;
    }
 
@@ -468,7 +468,7 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
-   case EState::kRetired: throw RException(R__FAIL("invalid attempt to create entry of retired model"));
+   case EState::kExpired: throw RException(R__FAIL("invalid attempt to create entry of expired model"));
    case EState::kFrozen: break;
    }
 
@@ -498,7 +498,7 @@ ROOT::Experimental::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::CreateBu
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create bulk of unfrozen model"));
-   case EState::kRetired: throw RException(R__FAIL("invalid attempt to create bulk of retired model"));
+   case EState::kExpired: throw RException(R__FAIL("invalid attempt to create bulk of expired model"));
    case EState::kFrozen: break;
    }
 
@@ -508,24 +508,24 @@ ROOT::Experimental::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::CreateBu
    return f->CreateBulk();
 }
 
-void ROOT::Experimental::RNTupleModel::Retire()
+void ROOT::Experimental::RNTupleModel::Expire()
 {
    switch (fModelState) {
-   case EState::kRetired: return;
-   case EState::kBuilding: throw RException(R__FAIL("invalid attempt to retire unfrozen model"));
+   case EState::kExpired: return;
+   case EState::kBuilding: throw RException(R__FAIL("invalid attempt to expire unfrozen model"));
    case EState::kFrozen: break;
    }
 
    // Ensure that Fill() does not work anymore
    fModelId = 0;
-   fModelState = EState::kRetired;
+   fModelState = EState::kExpired;
 }
 
 void ROOT::Experimental::RNTupleModel::Unfreeze()
 {
    switch (fModelState) {
    case EState::kBuilding: return;
-   case EState::kRetired: throw RException(R__FAIL("invalid attempt to unfreeze retired model"));
+   case EState::kExpired: throw RException(R__FAIL("invalid attempt to unfreeze expired model"));
    case EState::kFrozen: break;
    }
 
@@ -540,8 +540,8 @@ void ROOT::Experimental::RNTupleModel::Unfreeze()
 
 void ROOT::Experimental::RNTupleModel::Freeze()
 {
-   if (fModelState == EState::kRetired)
-      throw RException(R__FAIL("invalid attempt to freeze retired model"));
+   if (fModelState == EState::kExpired)
+      throw RException(R__FAIL("invalid attempt to freeze expired model"));
 
    fModelState = EState::kFrozen;
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -35,12 +35,18 @@ std::uint64_t GetNewModelId()
 ROOT::Experimental::RFieldZero &
 ROOT::Experimental::Internal::GetFieldZeroOfModel(ROOT::Experimental::RNTupleModel &model)
 {
+   if (model.IsRetired()) {
+      throw RException(R__FAIL("invalid use of retired model"));
+   }
    return *model.fFieldZero;
 }
 
 ROOT::Experimental::Internal::RProjectedFields &
 ROOT::Experimental::Internal::GetProjectedFieldsOfModel(ROOT::Experimental::RNTupleModel &model)
 {
+   if (model.IsRetired()) {
+      throw RException(R__FAIL("invalid use of retired model"));
+   }
    return *model.fProjectedFields;
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -269,12 +269,12 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    cloneModel->fModelId = GetNewModelId();
    // For a frozen model, we can keep the schema id because adding new fields is forbidden. It is reset in Unfreeze()
    // if called by the user.
-   if (fIsFrozen) {
+   if (IsFrozen()) {
       cloneModel->fSchemaId = fSchemaId;
    } else {
       cloneModel->fSchemaId = cloneModel->fModelId;
    }
-   cloneModel->fIsFrozen = fIsFrozen;
+   cloneModel->fModelState = fModelState;
    cloneModel->fFieldNames = fFieldNames;
    cloneModel->fDescription = fDescription;
    cloneModel->fProjectedFields = fProjectedFields->Clone(*cloneModel);
@@ -504,12 +504,12 @@ void ROOT::Experimental::RNTupleModel::Unfreeze()
       fDefaultEntry->fModelId = fModelId;
       fDefaultEntry->fSchemaId = fSchemaId;
    }
-   fIsFrozen = false;
+   fModelState = EState::kBuilding;
 }
 
 void ROOT::Experimental::RNTupleModel::Freeze()
 {
-   fIsFrozen = true;
+   fModelState = EState::kFrozen;
 }
 
 void ROOT::Experimental::RNTupleModel::SetDescription(std::string_view description)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -502,6 +502,19 @@ ROOT::Experimental::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::CreateBu
    return f->CreateBulk();
 }
 
+void ROOT::Experimental::RNTupleModel::Retire()
+{
+   switch (fModelState) {
+   case EState::kRetired: return;
+   case EState::kBuilding: throw RException(R__FAIL("invalid attempt to retire unfrozen model"));
+   case EState::kFrozen: break;
+   }
+
+   // Ensure that Fill() does not work anymore
+   fModelId = 0;
+   fModelState = EState::kRetired;
+}
+
 void ROOT::Experimental::RNTupleModel::Unfreeze()
 {
    switch (fModelState) {

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -137,7 +137,7 @@ ROOT::Experimental::RNTupleParallelWriter::~RNTupleParallelWriter()
 
 void ROOT::Experimental::RNTupleParallelWriter::CommitDataset()
 {
-   if (fModel->IsRetired())
+   if (fModel->IsExpired())
       return;
 
    for (const auto &context : fFillContexts) {
@@ -149,7 +149,7 @@ void ROOT::Experimental::RNTupleParallelWriter::CommitDataset()
    // Now commit all clusters as a cluster group and then the dataset.
    fSink->CommitClusterGroup();
    fSink->CommitDataset();
-   fModel->Retire();
+   fModel->Expire();
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleParallelWriter>

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -113,20 +113,20 @@ void ROOT::Experimental::RNTupleWriter::CommitClusterGroup()
 
 ROOT::Experimental::RNTupleModel &ROOT::Experimental::RNTupleWriter::GetUpdatableModel()
 {
-   if (fFillContext.fModel->IsRetired()) {
-      throw RException(R__FAIL("invalid attempt to update retired model"));
+   if (fFillContext.fModel->IsExpired()) {
+      throw RException(R__FAIL("invalid attempt to update expired model"));
    }
    return *fFillContext.fModel;
 }
 
 void ROOT::Experimental::RNTupleWriter::CommitDataset()
 {
-   if (fFillContext.GetModel().IsRetired())
+   if (fFillContext.GetModel().IsExpired())
       return;
 
    CommitCluster(true /* commitClusterGroup */);
    fFillContext.fSink->CommitDataset();
-   fFillContext.fModel->Retire();
+   fFillContext.fModel->Expire();
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleWriter>

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -317,20 +317,20 @@ TEST(RNTupleModel, CloneRegisteredSubfield)
    EXPECT_TRUE(clone->GetDefaultEntry().GetPtr<float>("struct.a"));
 }
 
-TEST(RNTupleModel, Retire)
+TEST(RNTupleModel, Expire)
 {
    auto model = RNTupleModel::Create();
    model->MakeField<CustomStruct>("struct")->a = 1.0;
 
    try {
-      model->Retire();
-      FAIL() << "attempting retire unfrozen model should fail";
+      model->Expire();
+      FAIL() << "attempting expire unfrozen model should fail";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to retire unfrozen model"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to expire unfrozen model"));
    }
 
    model->Freeze();
-   model->Retire();
+   model->Expire();
 
    EXPECT_EQ(0u, model->GetModelId());
    EXPECT_NE(0, model->GetSchemaId());
@@ -357,7 +357,7 @@ TEST(RNTupleModel, Retire)
    EXPECT_THROW(model->GetMutableField("struct"), RException);
    EXPECT_THROW(model->SetDescription("x"), RException);
 
-   FileRaii fileGuard("test_ntuple_model_retire.root");
+   FileRaii fileGuard("test_ntuple_model_expire.root");
    EXPECT_THROW(RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath()), RException);
    auto writer = RNTupleWriter::Recreate(std::move(clone), "ntpl", fileGuard.GetPath());
    writer.reset();
@@ -365,9 +365,9 @@ TEST(RNTupleModel, Retire)
    EXPECT_EQ(0u, reader->GetNEntries());
 }
 
-TEST(RNTupleModel, RetireWithWriter)
+TEST(RNTupleModel, ExpireWithWriter)
 {
-   FileRaii fileGuard("test_ntuple_model_retire_with_writer.root");
+   FileRaii fileGuard("test_ntuple_model_expire_with_writer.root");
 
    auto model = RNTupleModel::Create();
    *model->MakeField<float>("pt") = 1.0;

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -327,3 +327,22 @@ TEST(RNTupleFillContext, FlushColumns)
    EXPECT_EQ(pageInfos[0].fNElements, 1);
    EXPECT_EQ(pageInfos[1].fNElements, 1);
 }
+
+TEST(RNTupleParallelWriter, ExplicitCommit)
+{
+   FileRaii fileGuard("test_ntuple_parallel_explicit_commit.root");
+
+   auto model = RNTupleModel::CreateBare();
+   model->MakeField<float>("pt");
+   auto writer = RNTupleParallelWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+
+   auto ctx = writer->CreateFillContext();
+   auto entry = ctx->CreateEntry();
+   ctx->Fill(*entry);
+
+   EXPECT_THROW(writer->CommitDataset(), RException);
+   ctx.reset();
+
+   writer->CommitDataset();
+   writer->CommitDataset(); // noop
+}


### PR DESCRIPTION
Allows for explicit dataset commits. This is useful
- for the use in Python
- to extract the final metrics before destruction
- to properly handle exceptions during the final commit

