### PR TITLE
[skip-ci] [doc] Re-introduce python anchor in docs

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -17,6 +17,7 @@ r"""
 <summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 
 It is possible to retrieve the content of a TDirectory object
 just like getting items from a Python dictionary.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
@@ -17,6 +17,7 @@ r"""
 <summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 
 In the same way as for TDirectory, it is possible to inspect the content of a
 TDirectoryFile object from Python as if the subdirectories and objects it

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
@@ -18,6 +18,7 @@ r"""
 <summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 
 The TF1 class has several additions for its use from Python, which are also
 available in its subclasses TF2 and TF3.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -18,6 +18,7 @@ r'''
 <summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 
 In the same way as for TDirectory, it is possible to get the content of a
 TFile object with the familiar item-getting syntax.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
@@ -17,6 +17,7 @@ r"""
 <summary  style="font-size:20px; color: #425788;"><b>Python interface</b></summary>
 <div class="pyrootbox">
 \endhtmlonly
+\anchor python
 
 The TTree class has several additions for its use from Python, which are also
 available in its subclasses e.g. TChain and TNtuple.


### PR DESCRIPTION
Re-introducing changes of https://github.com/root-project/root/commit/322a3a5906eda9acfb3a68f52e3be1be925170d2 which got erroneously removed by https://github.com/root-project/root/commit/41f67b698150140342e28560046266756f0570d5