### PR TITLE
[skip-ci] add note on coordinate system negation pitfalls

### DIFF
--- a/documentation/users-guide/MathLibraries.md
+++ b/documentation/users-guide/MathLibraries.md
@@ -2083,6 +2083,9 @@ method, with any vector (`q`) implementing `x()`, `y()` and `z()`.
 Note that the multiplication between two vectors using the operator `*`
 is not supported because it is ambiguous.
 
+> [!note]
+> For the vectors using the 4D coordinate systems based on mass instead of energy (such as **`ROOT::Math::PxPyPzM4D`** or **`ROOT::Math::PtEtaPhiM4D`**) the unary operator `-` (negation) doesn't perform a 4-vector negation. Instead, it negates only the spatial components, which might result in unintuive behaviours (for instance, for PxPyPzM4D coordinate system, $\textbf{v}+ \left(-\textbf{v}\right) \neq \textbf{v} -\textbf{v}$).
+
 #### Other Methods
 
 ``` {.cpp}


### PR DESCRIPTION
# This Pull request:
Adds a short note about an unintuitive behavior of 4-vector negation for coordinate systems based on mass instead of energy.
The behavior itself is documented in the affected coordinate systems ([`PtEtaPhiM4D::Negate`](https://root.cern/doc/v632/classROOT_1_1Math_1_1PtEtaPhiM4D.html#a3be54ee433d7f3821fb3067289668630), [`PxPyPzM4D::Negate`](https://root.cern/doc/v632/classROOT_1_1Math_1_1PxPyPzM4D.html#a735fc7329a1c390b601e0bb27afd64c0)) but the visibility of this information is a bit limited, hence issues like #15842

The doxygen should be able to translate markdown github-style admonitions to standard doxygen `\note` https://doxygen.nl/manual/markdown.html

@Zehvogel

