### PR TITLE
Support ipython tab completion when getting item TFile and RooWorkspace

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -110,6 +110,13 @@ class RooWorkspace(object):
             raise AttributeError('Resetting the "' + name + '" attribute of a RooWorkspace is not allowed!')
         object.__setattr__(self, name, value)
 
+    def _ipython_key_completions_(self):
+        r"""
+        Support tab completion for `__getitem__`, suggesting all components in
+        the workspace.
+        """
+        return [c.GetName() for c in self.components()]
+
 
 def RooWorkspace_import(self, *args, **kwargs):
     r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -126,12 +126,21 @@ def _TDirectory_WriteObject(self, obj, *args):
     return self.WriteObjectAny(obj, type(obj).__cpp_name__, *args)
 
 
+def _ipython_key_completions_(self):
+    r"""
+    Support tab completion for `__getitem__`, suggesting the names of all
+    objects in the file.
+    """
+    return [k.GetName() for k in self.GetListOfKeys()]
+
+
 def pythonize_tdirectory():
     klass = cppyy.gbl.TDirectory
     klass.__getitem__ = _TDirectory_getitem
     klass.__getattr__ = _TDirectory_getattr
     klass._WriteObject = klass.WriteObject
     klass.WriteObject = _TDirectory_WriteObject
+    klass._ipython_key_completions_ = _ipython_key_completions_
 
 
 # Instant pythonization (executed at `import ROOT` time), no need of a


### PR DESCRIPTION
This makes it more efficient to explore files with RooFit workspaces in ipython and the jupyter notebook.