### PR TITLE
[Python] Don't import print function from `__future__` in tutorials

### DIFF
--- a/tmva/sofie/test/Conv1dModelGenerator.py
+++ b/tmva/sofie/test/Conv1dModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tmva/sofie/test/Conv2dModelGenerator.py
+++ b/tmva/sofie/test/Conv2dModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tmva/sofie/test/Conv3dModelGenerator.py
+++ b/tmva/sofie/test/Conv3dModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tmva/sofie/test/ConvTrans2dModelGenerator.py
+++ b/tmva/sofie/test/ConvTrans2dModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tmva/sofie/test/LinearModelGenerator.py
+++ b/tmva/sofie/test/LinearModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tmva/sofie/test/RecurrentModelGenerator.py
+++ b/tmva/sofie/test/RecurrentModelGenerator.py
@@ -2,7 +2,6 @@
 
 ### generate COnv2d model using Pytorch
 
-from __future__ import print_function
 import numpy as np
 import argparse
 import torch

--- a/tutorials/histfactory/makeQuickModel.py
+++ b/tutorials/histfactory/makeQuickModel.py
@@ -8,7 +8,6 @@
 # as well as potentially uncertainties on those
 # values, and returns a fitted signal value
 # and errors
-from __future__ import print_function
 
 
 def main():

--- a/tutorials/pyroot/graph.py
+++ b/tutorials/pyroot/graph.py
@@ -9,7 +9,6 @@
 ##
 ## \author Wim Lavrijsen
 
-from __future__ import print_function
 from ROOT import TCanvas, TGraph
 from ROOT import gROOT
 from math import sin

--- a/tutorials/pyroot/gui_ex.py
+++ b/tutorials/pyroot/gui_ex.py
@@ -5,7 +5,6 @@
 ## \macro_code
 ##
 ## \author Wim Lavrijsen
-from __future__ import print_function
 
 import os, sys, ROOT
 

--- a/tutorials/pyroot/parse_CSV_file_with_TTree_ReadStream.py
+++ b/tutorials/pyroot/parse_CSV_file_with_TTree_ReadStream.py
@@ -35,7 +35,6 @@
 ## \macro_code
 ##
 ## \author Michael Marino
-from __future__ import print_function
 
 import ROOT
 import sys

--- a/tutorials/roofit/rf109_chi2residpull.py
+++ b/tutorials/roofit/rf109_chi2residpull.py
@@ -12,7 +12,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C version)
 
-from __future__ import print_function
 import ROOT
 
 # Set up model

--- a/tutorials/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/rf110_normintegration.py
@@ -11,7 +11,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 # Set up model

--- a/tutorials/roofit/rf203_ranges.py
+++ b/tutorials/roofit/rf203_ranges.py
@@ -10,7 +10,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 # Set up model

--- a/tutorials/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/rf308_normintegration2d.py
@@ -11,7 +11,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 # Set up model

--- a/tutorials/roofit/rf402_datahandling.py
+++ b/tutorials/roofit/rf402_datahandling.py
@@ -10,7 +10,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 import math
 

--- a/tutorials/roofit/rf403_weightedevts.py
+++ b/tutorials/roofit/rf403_weightedevts.py
@@ -12,7 +12,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf404_categories.py
+++ b/tutorials/roofit/rf404_categories.py
@@ -9,7 +9,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf505_asciicfg.py
+++ b/tutorials/roofit/rf505_asciicfg.py
@@ -9,7 +9,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf508_listsetmanip.py
+++ b/tutorials/roofit/rf508_listsetmanip.py
@@ -11,7 +11,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf602_chi2fit.py
+++ b/tutorials/roofit/rf602_chi2fit.py
@@ -11,7 +11,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf604_constraints.py
+++ b/tutorials/roofit/rf604_constraints.py
@@ -9,7 +9,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf607_fitresult.py
+++ b/tutorials/roofit/rf607_fitresult.py
@@ -10,7 +10,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 

--- a/tutorials/roofit/rf901_numintconfig.py
+++ b/tutorials/roofit/rf901_numintconfig.py
@@ -9,7 +9,6 @@
 ## \date February 2018
 ## \authors Clemens Lange, Wouter Verkerke (C++ version)
 
-from __future__ import print_function
 import ROOT
 
 


### PR DESCRIPTION
This is not necessary anymore, as ROOT is only supporting Python 3 anyway.