### PR TITLE
[core] Fix compiler warning about missing return

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -251,6 +251,9 @@ static bool IsCopyConstructorDeleted(QualType QT)
    }
 
    assert(0 && "did not find a copy constructor?");
+   // Should never happen and the return value is somewhat arbitrary, but we did not see a deleted copy ctor. The user
+   // will be told if the generated code doesn't compile.
+   return false;
 }
 
 void TClingCallFunc::make_narg_ctor(const unsigned N, ostringstream &typedefbuf,


### PR DESCRIPTION
Commit 23bdb810d9 ("Optimize IsCopyConstructorDeleted") removed the fall-through return statement, leading compilers to complain that "control reaches end of non-void function".