### PR TITLE
Fix path to `getProof.C` in test

### DIFF
--- a/test/stressProof.cxx
+++ b/test/stressProof.cxx
@@ -136,7 +136,7 @@
 #include "TProofProgressMemoryPlot.h"
 #include "TObjString.h"
 
-#include "proof/getProof.C"
+#include "legacy/proof/getProof.C"
 
 #define PT_NUMTEST 29
 


### PR DESCRIPTION
Fixup following up on #17036.