### PR TITLE
[skip-ci] Add dedicated page for python specific user documentation

### DIFF
--- a/bindings/pyroot/pythonizations/doc/index.md
+++ b/bindings/pyroot/pythonizations/doc/index.md
@@ -1,0 +1,4 @@
+\defgroup Pythonizations PyROOT pythonizations
+\brief PyROOT specific pythonizations.
+
+This page lists PyROOT specific user functions as well as all the ROOT classes with pythonizations - special, more pythonic interfaces for PyROOT. 

--- a/bindings/pyroot/pythonizations/doc/index.md
+++ b/bindings/pyroot/pythonizations/doc/index.md
@@ -1,4 +1,4 @@
-\defgroup Pythonizations PyROOT pythonizations
-\brief PyROOT specific pythonizations.
+\defgroup Pythonizations Python interface
+\brief Python-specific functionalities offered by ROOT
 
-This page lists PyROOT specific user functions as well as all the ROOT classes with pythonizations - special, more pythonic interfaces for PyROOT. 
+This page lists the so-called "pythonizations", that is those functionalities offered by ROOT for classes and functions which are specific to Python usage of the package and provide a more pythonic experience.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -23,6 +23,7 @@ from ._generic import pythonize_generic
 
 def pythonization(class_name, ns='::', is_prefix=False):
     '''
+    \ingroup Pythonizations
     Decorator that allows to pythonize C++ classes. To pythonize means to add
     some extra behaviour to a C++ class that is used from Python via PyROOT,
     so that such a class can be used in an easier / more "pythonic" way.
@@ -53,6 +54,7 @@ def pythonization(class_name, ns='::', is_prefix=False):
         function: function that receives the user-defined function and
             decorates it.
     '''
+# \cond INTERNALS
 
     # Type check and parsing of target argument.
     # Retrieve the scope(s) of the class(es)/prefix(es) to register the
@@ -300,3 +302,4 @@ def _register_pythonizations():
     for _, module_name, _ in  pkgutil.walk_packages(__path__):
         if module_name not in exclude:
             importlib.import_module(__name__ + '.' + module_name)
+# \endcond

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -54,7 +54,6 @@ def pythonization(class_name, ns='::', is_prefix=False):
         function: function that receives the user-defined function and
             decorates it.
     '''
-# \cond INTERNALS
 
     # Type check and parsing of target argument.
     # Retrieve the scope(s) of the class(es)/prefix(es) to register the
@@ -73,6 +72,8 @@ def pythonization(class_name, ns='::', is_prefix=False):
     else:
         def passes_filter(class_name):
             return class_name in target
+        
+# \cond INTERNALS
 
     def pythonization_impl(user_pythonizor):
         '''

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -16,7 +16,9 @@ import sys
 import traceback
 
 import cppyy
+# \cond INTERNALS
 gbl_namespace = cppyy.gbl
+# \endcond
 
 from ._generic import pythonize_generic
 
@@ -73,8 +75,6 @@ def pythonization(class_name, ns='::', is_prefix=False):
         def passes_filter(class_name):
             return class_name in target
         
-# \cond INTERNALS
-
     def pythonization_impl(user_pythonizor):
         '''
         The real decorator. Accepts a user-provided function and decorates it.
@@ -134,6 +134,8 @@ def pythonization(class_name, ns='::', is_prefix=False):
         return user_pythonizor
 
     return pythonization_impl
+
+# \cond INTERNALS
 
 def _check_target(target):
     '''

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -74,7 +74,7 @@ def pythonization(class_name, ns='::', is_prefix=False):
     else:
         def passes_filter(class_name):
             return class_name in target
-        
+
     def pythonization_impl(user_pythonizor):
         '''
         The real decorator. Accepts a user-provided function and decorates it.

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -247,7 +247,7 @@ MULTILINE_CPP_IS_BRIEF = NO
 # documentation blocks is shown as doxygen documentation.
 # The default value is: YES.
 
-PYTHON_DOCSTRING       = YES
+PYTHON_DOCSTRING       = NO
 
 # If the INHERIT_DOCS tag is set to YES then an undocumented member inherits the
 # documentation from any documented member that it re-implements.

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -199,7 +199,8 @@ void FilterPythonBox()
                                     "<b>Python interface</b></summary>\n"
                                     "<div class=\"pyrootbox\">\n"
                                     "\\endhtmlonly\n"
-                                    "\\anchor python", class_name.c_str());
+                                    "\\anchor python\n"
+                                    "\\ingroup Pythonizations", class_name.c_str());
       }
       if (gLineString.find("\\endpythondoc") != string::npos)
          ReplaceAll(gLineString, "\\endpythondoc", "\\htmlonly </div> </details> \\endhtmlonly\n*/");

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -75,6 +75,7 @@ echo "        ../../sql/                       \\" >> Doxyfile_INPUT
 echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
 echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
 echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
+echo "        ../../bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py          \\" >> Doxyfile_INPUT
 echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT


### PR DESCRIPTION
# This Pull request:

Adds dedicated documentation page for listing PyROOT specific functions (such as `@pythonization`) and all the classes with python specific documentation.
The page should appear in the Reference Guide, left menu under `Functional Parts`.

## Changes or fixes:
- `\ingroup Pythonizations` can be used to add classes/functions/files to this page. The directive is added to `\pythondoc` #17052 so all the classes with `Python Interface` box should be added automatically
- `\cond` ,`\endcond` directives in `bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py` to hide internal functions from doxygen so they don't appear in search-box or file documentation
-  `PYTHON_DOCSTRING = YES`  in Doxyfile to have `"""`, `"""!` and `'''` docstrings appear as formated with Doxygen instead of `verbatim`
- `../../bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py ` explicitly added to `Doxygen_INPUT` in `makeinput.sh`. The Doxyfile has `EXCLUDE_PATTERNS` to exclude all the `*/bindings/pyroot/*.py` unless added explicitly.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

