### PR TITLE
Implement 'R','D','G' draw options for `TGraphPolar`, fix 'O' option

### DIFF
--- a/graf2d/graf/inc/TGraphPolar.h
+++ b/graf2d/graf/inc/TGraphPolar.h
@@ -38,6 +38,8 @@ public:
 
    TGraphPolargram *GetPolargram() {return fPolargram;}
 
+   TGraphPolargram *CreatePolargram(const char *opt);
+
    void             Draw(Option_t* options = "") override;
    Bool_t           GetOptionAxis() {return fOptionAxis;}
    void             SetMaxRadial(Double_t maximum = 1); //*MENU*

--- a/graf2d/graf/inc/TGraphPolargram.h
+++ b/graf2d/graf/inc/TGraphPolargram.h
@@ -58,12 +58,11 @@ private:
 
 public:
    // TGraphPolarGram status bits
-   enum { kLabelOrtho    = BIT(14)
-        };
+   enum { kLabelOrtho = BIT(14) };
 
-   TGraphPolargram(const char* name, Double_t rmin, Double_t rmax,
-                                     Double_t tmin, Double_t tmax);
    TGraphPolargram(const char* name="");
+   TGraphPolargram(const char* name, Double_t rmin, Double_t rmax,
+                                     Double_t tmin, Double_t tmax, const char *opt = "");
    ~TGraphPolargram() override;
 
    Color_t  GetPolarColorLabel() { return fPolarLabelColor;}

--- a/graf2d/graf/src/TGraphPolargram.cxx
+++ b/graf2d/graf/src/TGraphPolargram.cxx
@@ -55,8 +55,8 @@ ClassImp(TGraphPolargram);
 /// TGraphPolargram Constructor.
 
 TGraphPolargram::TGraphPolargram(const char* name, Double_t rmin, Double_t rmax,
-                                 Double_t tmin, Double_t tmax):
-                                 TNamed(name,"Polargram")
+                                 Double_t tmin, Double_t tmax, const char *opt):
+                                 TNamed(name, "Polargram")
 {
    Init();
    fNdivRad          = 508;
@@ -66,6 +66,22 @@ TGraphPolargram::TGraphPolargram(const char* name, Double_t rmin, Double_t rmax,
    fRwrmin           = rmin;
    fRwtmin           = tmin;
    fRwtmax           = tmax;
+
+   TString s = opt;
+   s.ToUpper();
+   if (s.Contains("R")) {
+      fRadian = kTRUE;
+      fRwtmin = 0;
+      fRwtmax = 2*TMath::Pi();
+   } else if (s.Contains("D")) {
+      fDegree = kTRUE;
+      fRwtmin = 0;
+      fRwtmax = 360;
+   } else if (s.Contains("G")) {
+      fGrad   = kTRUE;
+      fRwtmin = 0;
+      fRwtmax = 200;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -348,22 +364,21 @@ void TGraphPolargram::Init()
 
 void TGraphPolargram::Paint(Option_t * chopt)
 {
-   Int_t optionpoldiv, optionraddiv;
-   Bool_t optionLabels = kTRUE;
-
    TString opt = chopt;
    opt.ToUpper();
 
-   if(opt.Contains('P')) optionpoldiv=1; else optionpoldiv=0;
-   if(opt.Contains('R')) optionraddiv=1; else optionraddiv=0;
-   if(opt.Contains('O')) SetBit(TGraphPolargram::kLabelOrtho);
-   else ResetBit(TGraphPolargram::kLabelOrtho);
-   if(!opt.Contains('P') && !opt.Contains('R')) optionpoldiv=optionraddiv=1;
-   if(opt.Contains('N')) optionLabels = kFALSE;
+   Bool_t optionpoldiv = opt.Contains('P'),
+          optionraddiv = opt.Contains('R'),
+          optionLabels = !opt.Contains('N');
 
-   if(optionraddiv) PaintRadialDivisions(kTRUE);
-   else PaintRadialDivisions(kFALSE);
-   if(optionpoldiv) PaintPolarDivisions(optionLabels);
+   if (!optionpoldiv && !optionraddiv)
+      optionpoldiv = optionraddiv = kTRUE;
+
+   SetBit(TGraphPolargram::kLabelOrtho, opt.Contains('O'));
+
+   PaintRadialDivisions(optionraddiv);
+   if (optionpoldiv)
+      PaintPolarDivisions(optionLabels);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -476,11 +476,16 @@ The drawing options for the polar graphs are the following:
 
 | Option   | Description                                                       |
 |----------|-------------------------------------------------------------------|
-| "O"      | Polar labels are drawn orthogonally to the polargram radius. |
 | "P"      | Polymarker are drawn at each point position. |
 | "E"      | Draw error bars. |
 | "F"      | Draw fill area (closed polygon). |
+| "L"      | Draw line. |
+| "C"      | Draw curve. |
 | "A"      | Force axis redrawing even if a polargram already exists. |
+| "R"      | Use radians for angle coordinates. |
+| "D"      | Use degrees for angle coordinates. |
+| "G"      | Use grads for angle coordinates. |
+| "O"      | Polar labels are drawn orthogonally to the polargram radius. |
 | "N"      | Disable the display of the polar labels. |
 
 
@@ -503,11 +508,7 @@ Begin_Macro(source)
    grP1->SetMarkerSize(1.);
    grP1->SetMarkerColor(4);
    grP1->SetLineColor(4);
-   grP1->Draw("ALP");
-
-   // Update, otherwise GetPolargram returns 0
-   c46->Update();
-   grP1->GetPolargram()->SetToRadian();
+   grP1->Draw("ARLP");
 }
 End_Macro
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -5,7 +5,7 @@
 1. Adjust histogram title drawing with native implementation
 1. Improve float to string convertion when 'g' is specified
 1. Support "same" option for first histogram, draw direcly on pad
-1. Support different angle coordiantes in `TGraphPolargram`
+1. Support different angle coordiantes in `TGraphPolargram`, handle 'N' and 'O' draw options
 1. Fix - handle `TPave` NDC position also when fInit is not set
 1. Fix - correctly position title according to gStyle->GetTitleAlign()
 1. Fix - correctly handle tooltip events for `TGraphPolar`

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '26/11/2024',
+version_date = '27/11/2024',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/tutorials/graphs/graphpolar.C
+++ b/tutorials/graphs/graphpolar.C
@@ -12,51 +12,49 @@ void graphpolar()
 {
    // Illustrates how to use TGraphPolar
 
-   TCanvas * CPol = new TCanvas("CPol","TGraphPolar Examples",1200,600);
+   auto CPol = new TCanvas("CPol","TGraphPolar Examples",1200,600);
    CPol->Divide(2,1);
    CPol->cd(1);
 
    Double_t xmin=0;
-   Double_t xmax=TMath::Pi()*2;
+   Double_t xmax = TMath::Pi()*2;
 
    Double_t x[1000];
    Double_t y[1000];
    Double_t xval1[20];
    Double_t yval1[20];
 
-   TF1 * fplot = new TF1("fplot","cos(2*x)*cos(20*x)",xmin,xmax);
+   TF1 fplot("fplot","cos(2*x)*cos(20*x)",xmin,xmax);
 
-   for (Int_t ipt = 0; ipt < 1000; ipt++){
+   for(Int_t ipt = 0; ipt < 1000; ipt++){
       x[ipt] = ipt*(xmax-xmin)/1000+xmin;
-      y[ipt] = fplot->Eval(x[ipt]);
+      y[ipt] = fplot.Eval(x[ipt]);
    }
 
-   TGraphPolar * grP = new TGraphPolar(1000,x,y);
+   auto grP = new TGraphPolar(1000,x,y);
    grP->SetLineColor(2);
    grP->SetLineWidth(2);
    grP->SetFillStyle(3012);
    grP->SetFillColor(2);
-   grP->Draw("AFL");
+   grP->Draw("ARFL"); // AR - radian coordinates, F - fill, L - line
 
    for (Int_t ipt = 0; ipt < 20; ipt++){
       xval1[ipt] = x[1000/20*ipt];
       yval1[ipt] = y[1000/20*ipt];
    }
 
-   TGraphPolar * grP1 = new TGraphPolar(20,xval1,yval1);
+   auto grP1 = new TGraphPolar(20,xval1,yval1);
    grP1->SetMarkerStyle(29);
    grP1->SetMarkerSize(2);
    grP1->SetMarkerColor(4);
    grP1->SetLineColor(4);
-   grP1->Draw("CP");
+   grP1->Draw("CP"); // C - curve, P - markers
 
    // Update, otherwise GetPolargram returns 0
    CPol->Update();
-   if (grP1->GetPolargram()) {
-      grP1->GetPolargram()->SetTextColor(8);
-      grP1->GetPolargram()->SetRangePolar(-TMath::Pi(),TMath::Pi());
-      grP1->GetPolargram()->SetNdivPolar(703);
-      grP1->GetPolargram()->SetToRadian();
+   if (grP->GetPolargram()) {
+      grP->GetPolargram()->SetTextColor(8);
+      grP->GetPolargram()->SetNdivPolar(703);
    }
 
    CPol->cd(2);
@@ -71,19 +69,16 @@ void graphpolar()
       ey[ipt] = 0.2;
    }
 
-   TGraphPolar * grPE = new TGraphPolar(30,x2,y2,ex,ey);
+   auto grPE = new TGraphPolar(30,x2,y2,ex,ey);
    grPE->SetMarkerStyle(22);
    grPE->SetMarkerSize(1.5);
    grPE->SetMarkerColor(5);
    grPE->SetLineColor(6);
    grPE->SetLineWidth(2);
-   grPE->Draw("EP");
+   grPE->Draw("AREP"); // AR - radian, E - errors, P - markers
+
    // Update, otherwise GetPolargram returns 0
    CPol->Update();
-
-   if (grPE->GetPolargram()) {
+   if (grPE->GetPolargram())
       grPE->GetPolargram()->SetTextSize(0.03);
-      grPE->GetPolargram()->SetTwoPi();
-      grPE->GetPolargram()->SetToRadian();
-   }
 }

--- a/tutorials/graphs/graphpolar2.C
+++ b/tutorials/graphs/graphpolar2.C
@@ -10,21 +10,21 @@
 
 void graphpolar2()
 {
-   TCanvas * CPol = new TCanvas("CPol","TGraphPolar Example",500,500);
+   auto CPol = new TCanvas("CPol","TGraphPolar Example",500,500);
 
    Double_t theta[8];
    Double_t radius[8];
    Double_t etheta[8];
    Double_t eradius[8];
 
-   for (int i=0; i<8; i++) {
-      theta[i]   = (i+1)*(TMath::Pi()/4.);
-      radius[i]  = (i+1)*0.05;
-      etheta[i]  = TMath::Pi()/8.;
+   for (int i = 0; i < 8; i++) {
+      theta[i] = (i + 1) * (TMath::Pi() / 4.);
+      radius[i] = (i + 1) * 0.05;
+      etheta[i] = TMath::Pi() / 8.;
       eradius[i] = 0.05;
    }
 
-   TGraphPolar * grP1 = new TGraphPolar(8, theta, radius, etheta, eradius);
+   auto grP1 = new TGraphPolar(8, theta, radius, etheta, eradius);
    grP1->SetTitle("");
 
    grP1->SetMarkerStyle(20);
@@ -32,10 +32,5 @@ void graphpolar2()
    grP1->SetMarkerColor(4);
    grP1->SetLineColor(2);
    grP1->SetLineWidth(3);
-   grP1->Draw("PE");
-
-   CPol->Update();
-
-   if (grP1->GetPolargram())
-      grP1->GetPolargram()->SetToRadian();
+   grP1->Draw("RPE"); // R - radian, P - markers, E - errors
 }

--- a/tutorials/graphs/graphpolar3.C
+++ b/tutorials/graphs/graphpolar3.C
@@ -17,13 +17,13 @@ void graphpolar3()
    Double_t r[1000];
    Double_t theta[1000];
 
-   TF1 *fp1 = new TF1("fplot","cos(x)",rmin,rmax);
+   TF1 fp1("fplot","cos(x)", rmin, rmax);
    for (Int_t ipt = 0; ipt < 1000; ipt++) {
       r[ipt] = ipt*(rmax-rmin)/1000+rmin;
-      theta[ipt] = fp1->Eval(r[ipt]);
+      theta[ipt] = fp1.Eval(r[ipt]);
    }
 
-   TGraphPolar *grP1 = new TGraphPolar(1000, r, theta);
+   auto grP1 = new TGraphPolar(1000, r, theta);
    grP1->SetTitle("");
    grP1->SetLineColor(2);
    grP1->Draw("AOL");


### PR DESCRIPTION
These three options clearly specify angle axis range in `TGraphPolar`.
No longer required to update pad and access `TGraphPolargram` to change this setting.

Implement `TGraphPolar::CreatePolagram()` method to directly create `TGraphPolargram` instance 
which is match to data. Use it in native painter and in TWebCanvas.

Fix handling of 'O' option (orthogonal labels) for TGraphPolar, was not working. Used in `graphpolar3.C` tutorial.

Mention these and several other existing options in documentation.

Implement support of new options in JSROOT.
