### PR TITLE
unify 'pythonization' spelling

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -53,7 +53,7 @@ def _TDirectory_getitem(self, key):
     - Raising an AttributeError if the object does not exist
     - Caching the result of a successful get for future re-attempts.
     Once cached, the same object is retrieved every time.
-    This pythonisation is inherited by TDirectoryFile and TFile.
+    This pythonization is inherited by TDirectoryFile and TFile.
 
     Example:
     ```

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectoryfile.py
@@ -80,7 +80,7 @@ def pythonize_tdirectoryfile(klass):
     """
     TDirectoryFile inherits from TDirectory the pythonized attr syntax (__getattr__)
     and WriteObject method.
-    On the other side, the Get() method is pythonised only in TDirectoryFile.
+    On the other side, the Get() method is pythonized only in TDirectoryFile.
     Thus, the situation is now the following:
 
     1) __getattr__ : TDirectory --> TDirectoryFile --> TFile

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
@@ -32,10 +32,10 @@ a tree as described above if performance is not an issue or when dealing with
 a small dataset. To read and process the entries of a tree in a much faster
 way, please use ROOT::RDataFrame.
 
-Two methods of TTree have been pythonised to facilitate their: TTree::Branch and
+Two methods of TTree have been pythonized to facilitate their: TTree::Branch and
 TTree::SetBranchAddress.
 
-### Pythonisation of TTree::Branch
+### Pythonization of TTree::Branch
 
 The following example shows how we can create different types of branches of a TTree.
 `Branch` links the new branch with a given Python object. It is therefore possible to
@@ -98,7 +98,7 @@ with ROOT.TFile("outfile.root", "RECREATE") as ofile:
     t.Write()
 \endcode
 
-### Pythonisation of TTree::SetBranchAddress
+### Pythonization of TTree::SetBranchAddress
 
 This section is to be considered for advanced users. Simple event
 loops reading tree entries in Python can be performed as shown above.

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -25,11 +25,11 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS nu
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_set stl_set.py)
 
-# TObject and subclasses pythonisations
+# TObject and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_contains tobject_contains.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_comparisonops tobject_comparisonops.py)
 
-# TClass pythonisations
+# TClass pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tclass_dynamiccast tclass_dynamiccast.py)
 
 # TContext pythonizations
@@ -67,22 +67,22 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_itemaccess tseqcollection_itemaccess.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_listmethods tseqcollection_listmethods.py)
 
-# TIter pythonisations
+# TIter pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_titer_iterator titer_iterator.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_getitem tarray_getitem.py)
 
-# TVectorT pythonisations
+# TVectorT pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_len tvectort_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_getitem tvectort_getitem.py)
 
-# TVector3 pythonisations
+# TVector3 pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvector3_len tvector3_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvector3_getitem tvector3_getitem.py)
 
-# TString pythonisations
+# TString pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_comparisonops tstring_comparisonops.py)
@@ -90,7 +90,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_comparisonops tstring_comparisonops.py)
 # TString converter
 ROOT_ADD_PYUNITTEST(pyroot_conv_tstring tstring_converter.py)
 
-# TObjString pythonisations
+# TObjString pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_len tobjstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_str_repr tobjstring_str_repr.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_comparisonops tobjstring_comparisonops.py)

--- a/bindings/pyroot/pythonizations/test/tclass_dynamiccast.py
+++ b/bindings/pyroot/pythonizations/test/tclass_dynamiccast.py
@@ -5,7 +5,7 @@ from ROOT import TClass, TObject, TObjString
 
 class TClassDynamicCast(unittest.TestCase):
     """
-    Test for the pythonisation of TClass::DynamicCast, which adds an
+    Test for the pythonization of TClass::DynamicCast, which adds an
     an extra cast before returning the Python proxy to the user so that
     it has the right type.
     """

--- a/bindings/pyroot/pythonizations/test/tf_pycallables.py
+++ b/bindings/pyroot/pythonizations/test/tf_pycallables.py
@@ -101,7 +101,7 @@ class TF1(unittest.TestCase):
 
     def test_evalpar(self):
         """
-        Test the 2D Numpy array pythonisations for TF1::EvalPar
+        Test the 2D Numpy array pythonizations for TF1::EvalPar
         """
         import numpy as np
 
@@ -131,7 +131,7 @@ class TF1(unittest.TestCase):
     
     def test_evalpar_dynamic(self):
         """
-        Test the 2D NumPy pythonisations with dynamic TF1 data dimensions
+        Test the 2D NumPy pythonizations with dynamic TF1 data dimensions
         """
         import numpy as np
 

--- a/bindings/pyroot/pythonizations/test/tobject_comparisonops.py
+++ b/bindings/pyroot/pythonizations/test/tobject_comparisonops.py
@@ -8,7 +8,7 @@ class TObjectComparisonOps(unittest.TestCase):
     """
     Test for the comparison operators of TObject and subclasses:
     __eq__, __ne__, __lt__, __le__, __gt__, __ge__.
-    Such pythonisations rely on TObject::IsEqual and TObject::Compare,
+    Such pythonizations rely on TObject::IsEqual and TObject::Compare,
     which can be reimplemented in subclasses.
     """
 

--- a/bindings/pyroot/pythonizations/test/tobject_contains.py
+++ b/bindings/pyroot/pythonizations/test/tobject_contains.py
@@ -5,10 +5,10 @@ import ROOT
 
 class TObjectContains(unittest.TestCase):
     """
-    Test for the __contains__ pythonisation of TObject and subclasses.
-    Such pythonisation relies on TObject::FindObject, which is redefined
+    Test for the __contains__ pythonization of TObject and subclasses.
+    Such pythonization relies on TObject::FindObject, which is redefined
     in some of its subclasses, such as TCollection.
-    Thanks to this pythonisation, we can use the syntax `obj in col`
+    Thanks to this pythonization, we can use the syntax `obj in col`
     to know if col contains obj.
     """
 


### PR DESCRIPTION
# This Pull request:

Unifies spelling of 'pythonization' across the codebase.

## Changes or fixes:

Typos in docstrings and comments: 'pythonisation' -> 'pythonizations'
Luckily all the file-names already have the form with 'z'


