### PR TITLE
[ntuple] Implement minimal Python API

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -65,6 +65,11 @@ if(tmva)
     endif()
 endif()
 
+if(root7)
+    list(APPEND PYROOT_EXTRA_PYTHON_SOURCES
+        ROOT/_pythonization/_rntuple.py)
+endif()
+
 list(APPEND PYROOT_EXTRA_HEADERS
      inc/TPyDispatcher.h)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -95,7 +95,15 @@ def _RNTupleWriter_Fill(self, *args):
     return self._Fill(*args)
 
 
+def _RNTupleWriter_exit(self, *args):
+    self.CommitDataset()
+    return False
+
+
 @pythonization("RNTupleWriter", ns="ROOT::Experimental")
 def pythonize_RNTupleWriter(klass):
     klass._Fill = klass.Fill
     klass.Fill = _RNTupleWriter_Fill
+
+    klass.__enter__ = lambda writer: writer
+    klass.__exit__ = _RNTupleWriter_exit

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -1,0 +1,71 @@
+# Author: Jonas Hahnfeld CERN 11/2024
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from . import pythonization
+from ._pyz_utils import MethodTemplateGetter, MethodTemplateWrapper
+
+
+def _RNTupleModel_CreateBare(*args):
+    if len(args) >= 1:
+        raise ValueError("no support for passing explicit RFieldZero")
+    import ROOT
+
+    return ROOT.Experimental.RNTupleModel._CreateBare()
+
+
+def _RNTupleModel_GetDefaultEntry(self):
+    raise RuntimeError("default entries are not supported in Python, call CreateEntry")
+
+
+class _RNTupleModel_MakeField(MethodTemplateWrapper):
+    def __call__(self, *args):
+        self._original_method(*args)
+        # We do not support default entries in Python, so do not even return the nullptr.
+        return
+
+
+@pythonization("RNTupleModel", ns="ROOT::Experimental")
+def pythonize_RNTupleModel(klass):
+    # We do not support default entries in Python, so always create a bare model.
+    klass.Create = _RNTupleModel_CreateBare
+    klass._CreateBare = klass.CreateBare
+    klass.CreateBare = _RNTupleModel_CreateBare
+
+    klass.GetDefaultEntry = _RNTupleModel_GetDefaultEntry
+
+    klass.MakeField = MethodTemplateGetter(klass.MakeField, _RNTupleModel_MakeField)
+
+
+def _RNTupleReader_LoadEntry(self, *args):
+    if len(args) < 2:
+        raise ValueError(
+            "default entries are not supported in Python, pass explicit entry"
+        )
+    return self._LoadEntry(*args)
+
+
+@pythonization("RNTupleReader", ns="ROOT::Experimental")
+def pythonize_RNTupleReader(klass):
+    klass._LoadEntry = klass.LoadEntry
+    klass.LoadEntry = _RNTupleReader_LoadEntry
+
+
+def _RNTupleWriter_Fill(self, *args):
+    if len(args) < 1:
+        raise ValueError(
+            "default entries are not supported in Python, pass explicit entry"
+        )
+    return self._Fill(*args)
+
+
+@pythonization("RNTupleWriter", ns="ROOT::Experimental")
+def pythonize_RNTupleWriter(klass):
+    klass._Fill = klass.Fill
+    klass.Fill = _RNTupleWriter_Fill

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -15,7 +15,8 @@ class RNTupleBasics(unittest.TestCase):
         model = RNTupleModel.Create()
         model.MakeField["int"]("f")
         writer = RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_write_read.root")
-        writer.Fill()
+        entry = writer.CreateEntry()
+        writer.Fill(entry)
         del writer
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -14,11 +14,10 @@ class RNTupleBasics(unittest.TestCase):
 
         model = RNTupleModel.Create()
         model.MakeField["int"]("f")
-        writer = RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_write_read.root")
-        entry = writer.CreateEntry()
-        entry["f"] = 42
-        writer.Fill(entry)
-        del writer
+        with RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_write_read.root") as writer:
+            entry = writer.CreateEntry()
+            entry["f"] = 42
+            writer.Fill(entry)
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
         self.assertEqual(reader.GetNEntries(), 1)

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -16,8 +16,12 @@ class RNTupleBasics(unittest.TestCase):
         model.MakeField["int"]("f")
         writer = RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_write_read.root")
         entry = writer.CreateEntry()
+        entry["f"] = 42
         writer.Fill(entry)
         del writer
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
         self.assertEqual(reader.GetNEntries(), 1)
+        entry = reader.GetModel().CreateEntry()
+        reader.LoadEntry(0, entry)
+        self.assertEqual(entry["f"], 42)


### PR DESCRIPTION
Forbid default entries in Python, pythonize `REntry` to behave as a dict, and provide context manager functions for `RNTupleWriter`.