### PR TITLE
[skip-ci] Add documentation with short example with TF1.SetParameters from numpy array

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tf1.py
@@ -26,7 +26,7 @@ my_func = ROOT.TF1("my_func", func, -10, 10, npar=2, ndim=2)
 \endcode
 
 Second, after performing the initialisation with a Python functor, the TF1 instance can be evaluated using the Pythonized
-`TF1::EvalPar` function. The pythonization allows passing in 1D(single set of x variables) or 2D(a dataset) NumPy arrays.
+TF1.EvalPar function. The pythonization allows passing in 1D(single set of x variables) or 2D(a dataset) NumPy arrays.
 
 The following example shows how we can create a TF1 instance with a Python function and evaluate it on a dataset:
 
@@ -57,6 +57,22 @@ params = np.array([
 
 # Slice to avoid the dummy column of 10's
 res = rtf1_coulomb.EvalPar(x[:, ::2], params)
+\endcode
+
+The below example defines a TF1 instance using the ROOT constructor, and sets its parameters using the Pythonized TF1.SetParameters function (i.e. without evaluating).
+\code{.py}
+import numpy as np
+
+# for illustration, a sinusoidal function with six parameters
+myFunction = ROOT.TF1("myExampleFunction", "[0] + [1] * x + [2]*sin([3] * x) + [4]*cos([5] * x)", -5, 5)
+
+# declare the parameters as a numpy.array or array.array 
+myParams = np.array([0.04, 0.4, 3.0, 3.14, 1.5, 3.14])
+
+# note: the following line would also work by setting all six parameters equal to 3.0
+# myParams = np.array([3.0] * 6) 
+
+myFunction.SetParameters(myParams)
 \endcode
 
 \endpythondoc


### PR DESCRIPTION
# This Pull request:

Adds a short code snippet where a TF1 is initialized in the ROOT constructor, and parameters are set from a np.array (also tested with array.array) using SetParameters.

## Changes or fixes:

This PR addresses the [Hackathon to-do item "Explore setting multiple parameters for a fit at once"](https://github.com/orgs/root-project/projects/18?pane=issue&itemId=88467009).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

