### PR TITLE
[WIP] Add support for the Univeral Histogram Interface (UHI)

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -78,6 +78,7 @@ set(py_sources
   ROOT/_application.py
   ROOT/_asan.py
   ROOT/_facade.py
+  ROOT/_uhi.py
   ROOT/__init__.py
   ROOT/_numbadeclare.py
   ROOT/_pythonization/__init__.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -12,53 +12,7 @@ from ._application import PyROOTApplication
 from ._numbadeclare import _NumbaDeclareDecorator
 
 from ._pythonization import pythonization
-
-## ------------------------------------------------
-## ------------------------------------------------
-# TODO(lukas) Move this to a separate file
-class loc:
-    def __init__(self, value):
-        self.value = value
-        self.offset = 0 
-
-    def __add__(self, add_value):
-        self.offset = self.offset + add_value
-        return self
-
-    def __sub__(self, sub_value):
-        self.offset = self.offset - sub_value
-        return self
-
-    def __call__(self, histogram):
-        return histogram.FindBin(self.value) + self.offset
-
-def underflow(histogram):
-    return 0
-
-def overflow(histogram):
-    return histogram.GetNcells() - 1
-
-class rebin:
-    def __init__(self, ngroup, new_name = ""):
-        self.ngroup = ngroup
-        self.new_name = new_name
-
-    def __call__(self, histogram):
-        return histogram.Rebin(self.ngroup, self.new_name)
-
-class sum:
-    def __call__(self, histogram):
-        return histogram.Integral()
-
-## ------------------------------------------------
-## ------------------------------------------------
-
-def add_uhi_helper(module):
-    module.loc = loc
-    module.underflow = underflow
-    module.overflow = overflow
-    module.rebin = rebin
-    module.sum = sum
+from ._uhi import add_uhi_helper
 
 class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -22,7 +22,6 @@ class loc:
         self.offset = 0 
 
     def __add__(self, add_value):
-        print("loc add")
         self.offset = self.offset + add_value
         return self
 
@@ -39,6 +38,14 @@ def underflow(histogram):
 def overflow(histogram):
     return histogram.GetNcells() - 1
 
+class rebin:
+    def __init__(self, ngroup, new_name = ""):
+        self.ngroup = ngroup
+        self.new_name = new_name
+
+    def __call__(self, histogram):
+        return histogram.Rebin(self.ngroup, self.new_name)
+
 ## ------------------------------------------------
 ## ------------------------------------------------
 
@@ -46,6 +53,7 @@ def add_uhi_helper(module):
     module.loc = loc
     module.underflow = underflow
     module.overflow = overflow
+    module.rebin = rebin
 
 class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -46,6 +46,10 @@ class rebin:
     def __call__(self, histogram):
         return histogram.Rebin(self.ngroup, self.new_name)
 
+class sum:
+    def __call__(self, histogram):
+        return histogram.Integral()
+
 ## ------------------------------------------------
 ## ------------------------------------------------
 
@@ -54,6 +58,7 @@ def add_uhi_helper(module):
     module.underflow = underflow
     module.overflow = overflow
     module.rebin = rebin
+    module.sum = sum
 
 class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -13,6 +13,39 @@ from ._numbadeclare import _NumbaDeclareDecorator
 
 from ._pythonization import pythonization
 
+## ------------------------------------------------
+## ------------------------------------------------
+# TODO(lukas) Move this to a separate file
+class loc:
+    def __init__(self, value):
+        self.value = value
+        self.offset = 0 
+
+    def __add__(self, add_value):
+        print("loc add")
+        self.offset = self.offset + add_value
+        return self
+
+    def __sub__(self, sub_value):
+        self.offset = self.offset - sub_value
+        return self
+
+    def __call__(self, histogram):
+        return histogram.FindBin(self.value) + self.offset
+
+def underflow(histogram):
+    return 0
+
+def overflow(histogram):
+    return histogram.GetNcells() - 1
+
+## ------------------------------------------------
+## ------------------------------------------------
+
+def add_uhi_helper(module):
+    module.loc = loc
+    module.underflow = underflow
+    module.overflow = overflow
 
 class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""
@@ -78,6 +111,7 @@ class ROOTFacade(types.ModuleType):
     def __init__(self, module, is_ipython):
         types.ModuleType.__init__(self, module.__name__)
 
+        add_uhi_helper(self)
         self.module = module
 
         self.__all__ = module.__all__

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -13,6 +13,7 @@ from . import pythonization
 
 # Multiplication by constant
 
+
 def _imul(self, c):
     # Parameters:
     # - self: histogram
@@ -22,24 +23,41 @@ def _imul(self, c):
     self.Scale(c)
     return self
 
+
 def _getbin(self, bin_or_callable):
     # print("getitem called with", index_or_callable)
     print(type(bin_or_callable))
     if callable(bin_or_callable):
         bin = bin_or_callable(self)
     elif isinstance(bin_or_callable, int):
-        # bin 0 is underflow bin which is treated 
+        # bin 0 is underflow bin which is treated
         # in a callable
         bin = bin_or_callable + 1
     else:
-        raise TypeError(f"Expected 'bin_or_callable' to be of type int or callable, but got {type(bin_or_callable).__name__} instead.")
-        
+        raise TypeError(
+            f"Expected 'bin_or_callable' to be of type int or callable, but got {type(bin_or_callable).__name__} instead."
+        )
+
     print("getitem at", bin)
     return bin
 
-def _getitem(self, bin_or_callable):
-    bin = _getbin(self, bin_or_callable)
+
+def _getitem(self, index):
+    if isinstance(index, slice):
+        # handle slicing
+        print(
+            f"Slice object received: start={index.start}, stop={index.stop}, step={index.step}"
+        )
+        if index.start != None or index.stop != None:
+            raise NotImplementedError(
+                f"ROOT does not support slicing histograms if start and stop are not None. If you need this functionality please open a github issue (https://github.com/orgs/root-project/root) or a ROOT forum post (https://root-forum.cern.ch/)."
+            )
+        if callable(index.step):
+            return index.step(self)
+        return self
+    bin = _getbin(self, index)
     return self.GetBinContent(bin)
+
 
 def _setitem(self, bin_or_callable, value):
     bin = _getbin(self, bin_or_callable)
@@ -47,7 +65,7 @@ def _setitem(self, bin_or_callable, value):
     return self.SetBinContent(bin, value)
 
 
-@pythonization('TH1')
+@pythonization("TH1")
 def pythonize_th1(klass):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -41,20 +41,24 @@ def _getbin(self, bin_or_callable):
     print("getitem at", bin)
     return bin
 
+def _slice(self, slice):
+    print(
+        f"Slice object received: start={slice.start}, stop={slice.stop}, step={slice.step}"
+    )
+    if slice.start != None or slice.stop != None:
+        raise NotImplementedError(
+            f"ROOT does not support slicing histograms if start and stop are not None. If you need this functionality please open a github issue (https://github.com/orgs/root-project/root) or a ROOT forum post (https://root-forum.cern.ch/)."
+        )
+    if callable(slice.step):
+        return slice.step(self)
+    elif type(slice.step) is int:
+        raise TypeError("Skipping is not supported as of UHI v0.5.1")
+    return self
 
 def _getitem(self, index):
     if isinstance(index, slice):
         # handle slicing
-        print(
-            f"Slice object received: start={index.start}, stop={index.stop}, step={index.step}"
-        )
-        if index.start != None or index.stop != None:
-            raise NotImplementedError(
-                f"ROOT does not support slicing histograms if start and stop are not None. If you need this functionality please open a github issue (https://github.com/orgs/root-project/root) or a ROOT forum post (https://root-forum.cern.ch/)."
-            )
-        if callable(index.step):
-            return index.step(self)
-        return self
+        return _slice(self, index)
     bin = _getbin(self, index)
     return self.GetBinContent(bin)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -22,11 +22,40 @@ def _imul(self, c):
     self.Scale(c)
     return self
 
+def _getbin(self, bin_or_callable):
+    # print("getitem called with", index_or_callable)
+    print(type(bin_or_callable))
+    if callable(bin_or_callable):
+        bin = bin_or_callable(self)
+    elif isinstance(bin_or_callable, int):
+        # bin 0 is underflow bin which is treated 
+        # in a callable
+        bin = bin_or_callable + 1
+    else:
+        raise TypeError(f"Expected 'bin_or_callable' to be of type int or callable, but got {type(bin_or_callable).__name__} instead.")
+        
+    print("getitem at", bin)
+    return bin
+
+def _getitem(self, bin_or_callable):
+    bin = _getbin(self, bin_or_callable)
+    return self.GetBinContent(bin)
+
+def _setitem(self, bin_or_callable, value):
+    bin = _getbin(self, bin_or_callable)
+    print("type of bin ", type(bin))
+    return self.SetBinContent(bin, value)
+
 
 @pythonization('TH1')
 def pythonize_th1(klass):
     # Parameters:
     # klass: class to be pythonized
+    print("pythonize TH1")
 
     # Support hist *= scalar
     klass.__imul__ = _imul
+
+    # UHI pythonizations
+    klass.__getitem__ = _getitem
+    klass.__setitem__ = _setitem

--- a/bindings/pyroot/pythonizations/python/ROOT/_uhi.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_uhi.py
@@ -1,0 +1,55 @@
+# Author: Lukas Breitwieser, CERN, 11/2024
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+class loc:
+    def __init__(self, value):
+        self.value = value
+        self.offset = 0 
+
+    def __add__(self, add_value):
+        self.offset = self.offset + add_value
+        return self
+
+    def __sub__(self, sub_value):
+        self.offset = self.offset - sub_value
+        return self
+
+    def __call__(self, histogram):
+        return histogram.FindBin(self.value) + self.offset
+
+def underflow(histogram):
+    return 0
+
+def overflow(histogram):
+    return histogram.GetNcells() - 1
+
+class rebin:
+    def __init__(self, ngroup, new_name = ""):
+        self.ngroup = ngroup
+        self.new_name = new_name
+
+    def __call__(self, histogram):
+        return histogram.Rebin(self.ngroup, self.new_name)
+
+class sum:
+    def __call__(self, histogram):
+        return histogram.Integral()
+
+"""
+    Helper functions used by the facade to add UHI related symbols 
+    to the module
+"""
+def add_uhi_helper(module):
+    module.loc = loc
+    module.underflow = underflow
+    module.overflow = overflow
+    module.rebin = rebin
+    module.sum = sum
+


### PR DESCRIPTION
# Current Status

## Working implementation for TH1 including basic tests

### Access
``` python
v = h[2]
v = h[ROOT.underflow]        # return the bin contents of underflow
v = h[ROOT.overflow]4        # return the bin contents of overflow
v = h[ROOT.loc(1.4)]         # return the bin content of the bin that stores the value 1.4 (data coordinates) 
v = h[ROOT.loc(1.4) + 1]     # return the bin content of the next bin that stores the value 1.4 (data coordinates) 
v = h[ROOT.loc(1.4) - 1]     # return the bin content of the previous bin that stores the value 1.4 (data coordinates) 
```

### Setting
``` python
h[2]
h[ROOT.underflow] = 3         # set the content of the underflow bin
h[ROOT.overflow] = 4          # set the content of the overflow bin
h[ROOT.loc(1.4)] = 5.0        # set the bin contents in data coordinates 
h[ROOT.loc(1.4) + 1] = 7.0
h[ROOT.loc(1.4) - 1] = 9.0
```

### Slicing, rebinning, reduction
``` python
h == h[:]             # Slice over everything
h2 = h[::rebin(2)]    # Modification operations (rebin)
v2 = h[::sum]         # Projection operations # (name may change)
```

### Unsupported by UHI, and therefore raising exceptions:
``` python
h[1.0]                # Indexing with a float is disallowed
v2 = h[::sum]         # Projection operations # (name may change)
```

### Currently not supported due to missing slicing funcionality on the cpp side
``` python
h2 = h[a:b]           # Slice of histogram (includes flow bins)
h2 = h[:b]            # Leaving out endpoints is okay
```

#### This applies also to derivatives, like:

If slicing is implemented, the following list will work too.

``` python
h2 = h[loc(v):]       # Slices can be in data coordinates, too
h2 = h[a:b:rebin(2)]  # Modifications can combine with slices
v2 = h[a:b:sum]       # Adding endpoints to projection operations
v2 = h[0:len:sum]     #   removes under or overflow from the calculation
h2 = h[v, a:b]        #   A single value v is like v:v+1:sum
h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
```

## TODO

- Generalize to multiple dimensions
- Implement dictionary of slices on specific axes
``` python
h[{0: slice(None, None, bh.rebin(2))}] # rebin axis 0 by two
```
- Implement Ellipsis
``` python
h[...] = array(...)
```
- Implement
``` python
h[:] = np.ones(10)
```
- Dig deeper to clarify some questions about the API. Open questions like: When is a copy returned, when are the modifications done in-place? ...
- Add more error checks
- Improve testing coverage



