### PR TITLE
[RF] Add codegen for integral of RooNormalizedPdf

### DIFF
--- a/roofit/codegen/inc/RooFit/CodegenImpl.h
+++ b/roofit/codegen/inc/RooFit/CodegenImpl.h
@@ -114,6 +114,8 @@ void codegenImpl(RooRecursiveFraction &arg, CodegenContext &ctx);
 void codegenImpl(RooStats::HistFactory::FlexibleInterpVar &arg, CodegenContext &ctx);
 void codegenImpl(RooUniform &arg, CodegenContext &ctx);
 
+std::string
+codegenIntegralImpl(RooFit::Detail::RooNormalizedPdf &arg, int code, const char *rangeName, CodegenContext &ctx);
 std::string codegenIntegralImpl(RooAbsReal &arg, int code, const char *rangeName, CodegenContext &ctx);
 std::string codegenIntegralImpl(RooBernstein &arg, int code, const char *rangeName, CodegenContext &ctx);
 std::string codegenIntegralImpl(RooBifurGauss &arg, int code, const char *rangeName, CodegenContext &ctx);

--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -653,6 +653,13 @@ void codegenImpl(RooUniform &arg, CodegenContext &ctx)
 /// \param[in] ctx An object to manage auxiliary information for code-squashing.
 ///
 /// \returns The representative code string of the integral for the given object.
+std::string
+codegenIntegralImpl(RooFit::Detail::RooNormalizedPdf &arg, int code, const char *rangeName, CodegenContext &ctx)
+{
+   // Dispatch to the pdf's integral function.
+   return codegenIntegral(const_cast<RooAbsPdf &>(arg.pdf()), code, rangeName, ctx);
+}
+
 std::string codegenIntegralImpl(RooAbsReal &arg, int, const char *, CodegenContext &)
 {
    std::stringstream errorMsg;


### PR DESCRIPTION
Passes args through to the underlying pdf's normalised analytical integral
