### PR TITLE
[tutorials] Categorise tutorials by labels (proof of concept)

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -61,6 +61,7 @@ doxygen: filter pyzdoc
 	$(call MkDir,$(DOXYGEN_EXAMPLE_PATH))
 	$(call MkDir,$(DOXYGEN_NOTEBOOK_PATH))
 	./makehtmlfooter.sh > htmlfooter.html
+	$(Python3_EXECUTABLE) categorise_tutorials.py $(DOXYGEN_SOURCE_DIRECTORY)/tutorials/ > $(DOXYGEN_SOURCE_DIRECTORY)/tutorials/index_categories.md
 	./makeinput.sh
 	doxygen
 	bash ./CleanNamespaces.sh

--- a/documentation/doxygen/categorise_tutorials.py
+++ b/documentation/doxygen/categorise_tutorials.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+"""!
+@brief  Generate index of tutorials grouped by categories
+@author Vít Kučera <vit.kucera@cern.ch>
+@date   2024-11-27
+"""
+
+import argparse
+import glob
+import pathlib
+import re
+import sys
+
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(description="Generate index of tutorials grouped by categories")
+    parser.add_argument("path", type=str, help="directory to scan")
+    args = parser.parse_args()
+
+    # supported file extensions and their Doxygen string patterns
+    prefixes_doxygen = {
+        ".C": r"/// \\",
+        ".py": r"# +\\",
+    }
+    suffixes_files = prefixes_doxygen.keys()
+
+    # parsed Doxygen fields and their titles
+    fields_doxygen = {
+        "keywords": "Keywords",
+        "classes": "Classes"
+    }
+
+    # dictionary with categorised tutorial file paths
+    dic_categorised = {
+        cat: {} for cat in fields_doxygen
+    }
+
+    path_base = args.path
+    len_path_base = len(path_base)
+    paths_all = []
+    for suffix in suffixes_files:
+        paths_all += glob.glob(f"{path_base}/**/*{suffix}")
+    # print(paths_all)
+
+    # Process files.
+    for path in paths_all:
+        suffix = pathlib.Path(path).suffix
+        if suffix not in suffixes_files:
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as file:
+                for line in file.readlines():
+                    line = line.strip()
+                    # Look for Doxygen fields.
+                    for field in fields_doxygen:
+                        if not (match := re.match(rf"{prefixes_doxygen[suffix]}{field} (.*)", line)):
+                            continue
+                        value = match.group(1)
+                        # Split the field value into items.
+                        items = [v.strip() for v in value.split(",")]
+                        # Add the file path in the matching categories.
+                        for item in items:
+                            if item not in dic_categorised[field]:
+                                dic_categorised[field][item] = []
+                            dic_categorised[field][item].append(path[len_path_base:])
+        except IOError:
+            print(f'Failed to open file "{path}".')
+            sys.exit(1)
+    # print(dic_categorised)
+
+    # Generate the Markdown index.
+
+    header = "\\defgroup Tutorials Tutorials" \
+        "\n\n## Grouped by categories"
+
+    print(header)
+    for field, items in dic_categorised.items():
+        if not items:
+            continue
+        print(f"\n### {fields_doxygen[field]}\n")
+        for item, list_files in items.items():
+            print(f"- {item}")
+            print("  - " + ", ".join(list_files))
+
+
+if __name__ == "__main__":
+    main()

--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -13,70 +13,90 @@ echo "INPUT = ./mainpage.md                    \\" > Doxyfile_INPUT
 ls $DOXYGEN_PYZDOC_PATH/*.pyzdoc | sed -e "s/$/ \\\\/"  \
 >> Doxyfile_INPUT
 
-echo "        ../../core/base/                 \\" >> Doxyfile_INPUT
-echo "        ../../core/dictgen/              \\" >> Doxyfile_INPUT
-echo "        ../../core/cont/                 \\" >> Doxyfile_INPUT
-echo "        ../../core/foundation/           \\" >> Doxyfile_INPUT
-echo "        ../../core/gui/                  \\" >> Doxyfile_INPUT
-echo "        ../../core/macosx/               \\" >> Doxyfile_INPUT
-echo "        ../../core/meta/                 \\" >> Doxyfile_INPUT
-echo "        ../../core/metacling/            \\" >> Doxyfile_INPUT
-echo "        ../../core/clingutils/           \\" >> Doxyfile_INPUT
-echo "        ../../core/multiproc/            \\" >> Doxyfile_INPUT
-echo "        ../../core/rint/                 \\" >> Doxyfile_INPUT
-echo "        ../../core/testsupport/          \\" >> Doxyfile_INPUT
-echo "        ../../core/thread/               \\" >> Doxyfile_INPUT
-echo "        ../../core/unix/                 \\" >> Doxyfile_INPUT
-echo "        ../../core/winnt/                \\" >> Doxyfile_INPUT
-echo "        ../../core/imt/                  \\" >> Doxyfile_INPUT
-echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
-echo "        ../../geom/                      \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
-echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
-echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
-echo "        ../../gui/                       \\" >> Doxyfile_INPUT
-echo "        ../../hist/                      \\" >> Doxyfile_INPUT
-echo "        ../../html/                      \\" >> Doxyfile_INPUT
-echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
-echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
-echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
-echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
-echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
-echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
-echo "        ../../math/                      \\" >> Doxyfile_INPUT
-echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
-echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
-echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
-echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
-echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
-echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
-echo "        ../../proof/                     \\" >> Doxyfile_INPUT
-echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
-echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
-echo "        ../../tree/                      \\" >> Doxyfile_INPUT
-echo "        ../../sql/                       \\" >> Doxyfile_INPUT
-echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
-echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
-echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
-echo "        ../../bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py          \\" >> Doxyfile_INPUT
-echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
+# echo "        ../../core/base/                 \\" >> Doxyfile_INPUT
+# echo "        ../../core/dictgen/              \\" >> Doxyfile_INPUT
+# echo "        ../../core/cont/                 \\" >> Doxyfile_INPUT
+# echo "        ../../core/foundation/           \\" >> Doxyfile_INPUT
+# echo "        ../../core/gui/                  \\" >> Doxyfile_INPUT
+# echo "        ../../core/macosx/               \\" >> Doxyfile_INPUT
+# echo "        ../../core/meta/                 \\" >> Doxyfile_INPUT
+# echo "        ../../core/metacling/            \\" >> Doxyfile_INPUT
+# echo "        ../../core/clingutils/           \\" >> Doxyfile_INPUT
+# echo "        ../../core/multiproc/            \\" >> Doxyfile_INPUT
+# echo "        ../../core/rint/                 \\" >> Doxyfile_INPUT
+# echo "        ../../core/testsupport/          \\" >> Doxyfile_INPUT
+# echo "        ../../core/thread/               \\" >> Doxyfile_INPUT
+# echo "        ../../core/unix/                 \\" >> Doxyfile_INPUT
+# echo "        ../../core/winnt/                \\" >> Doxyfile_INPUT
+# echo "        ../../core/imt/                  \\" >> Doxyfile_INPUT
+# echo "        ../../core/zip/inc/Compression.h \\" >> Doxyfile_INPUT
+# echo "        ../../geom/                      \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/asimage/            \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/cocoa/              \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/fitsio/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpad/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gpadv7/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/graf/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/gviz/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/postscript/         \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/quartz/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/win32gdk/           \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf2d/x11ttf/             \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/eve7/               \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/g3d/                \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gl/                 \\" >> Doxyfile_INPUT
+# echo "        ../../graf3d/gviz3d/             \\" >> Doxyfile_INPUT
+# echo "        ../../gui/                       \\" >> Doxyfile_INPUT
+# echo "        ../../hist/                      \\" >> Doxyfile_INPUT
+# echo "        ../../html/                      \\" >> Doxyfile_INPUT
+# echo "        ../../io/doc/TFile               \\" >> Doxyfile_INPUT
+# echo "        ../../io/dcache/                 \\" >> Doxyfile_INPUT
+# echo "        ../../io/io/                     \\" >> Doxyfile_INPUT
+# echo "        ../../io/sql/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xml/                    \\" >> Doxyfile_INPUT
+# echo "        ../../io/xmlparser/              \\" >> Doxyfile_INPUT
+# echo "        ../../main/src/hadd.cxx          \\" >> Doxyfile_INPUT
+# echo "        ../../math/                      \\" >> Doxyfile_INPUT
+# echo "        ../../montecarlo/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/doc/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/auth/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/davix/                 \\" >> Doxyfile_INPUT
+# echo "        ../../net/http/                  \\" >> Doxyfile_INPUT
+# echo "        ../../net/net/                   \\" >> Doxyfile_INPUT
+# echo "        ../../net/netxng/                \\" >> Doxyfile_INPUT
+# echo "        ../../net/httpsniff/             \\" >> Doxyfile_INPUT
+# echo "        ../../proof/                     \\" >> Doxyfile_INPUT
+# echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
+# echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
+# echo "        ../../tree/                      \\" >> Doxyfile_INPUT
+# echo "        ../../sql/                       \\" >> Doxyfile_INPUT
+
+echo "        ../../tutorials/index.md                 \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/index_categories.md                 \\" >> Doxyfile_INPUT
+
+echo "        ../../tutorials/fit/fitCircle.C                 \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/fit/fit2a.C                 \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/fit/exampleFit3D.C                 \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/fit/NumericalMinimization.py                 \\" >> Doxyfile_INPUT
+
+echo "        ../../graf2d/graf/inc/TArc.h                 \\" >> Doxyfile_INPUT
+echo "        ../../graf2d/graf/inc/TCutG.h                 \\" >> Doxyfile_INPUT
+echo "        ../../hist/hist/inc/Math/WrappedMultiTF1.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Fit/BinData.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Fit/FitResult.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Fit/Fitter.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Math/Factory.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Math/Functor.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/Math/Minimizer.h                 \\" >> Doxyfile_INPUT
+echo "        ../../math/mathcore/inc/TRandom3.h                 \\" >> Doxyfile_INPUT
+
+# echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py          \\" >> Doxyfile_INPUT
+# echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/lzma/                 \\" >> Doxyfile_INPUT
@@ -88,4 +108,3 @@ echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 # echo "        ../../graf3d/x3d/                \\" >> Doxyfile_INPUT
 # echo "        ../../net/rootd/                 \\" >> Doxyfile_INPUT
 # echo "        ../../net/rpdutils/              \\" >> Doxyfile_INPUT
-

--- a/tutorials/fit/NumericalMinimization.py
+++ b/tutorials/fit/NumericalMinimization.py
@@ -9,6 +9,8 @@
 #  randomSeed: = <0 : fixed value: 0 random with seed 0; >0 random with given seed
 #
 #  \macro_code
+#  \classes ROOT::Math::Minimizer, Factory, ROOT::Math::Functor
+#  \keywords minimizer
 #
 #  \author Lorenzo Moneta
 

--- a/tutorials/fit/exampleFit3D.C
+++ b/tutorials/fit/exampleFit3D.C
@@ -11,6 +11,8 @@
 ///
 /// \macro_output
 /// \macro_code
+/// \classes ROOT::Fit::BinData, ROOT::Math::WrappedMultiTF1, ROOT::Fit::Fitter
+/// \keywords 3D
 ///
 /// \author Lorenzo Moneta
 

--- a/tutorials/fit/fit2a.C
+++ b/tutorials/fit/fit2a.C
@@ -19,6 +19,8 @@
 /// \macro_image
 /// \macro_output
 /// \macro_code
+/// \classes TCutG
+/// \keywords 2D
 ///
 /// \author Rene Brun
 

--- a/tutorials/fit/fitCircle.C
+++ b/tutorials/fit/fitCircle.C
@@ -14,6 +14,8 @@
 /// \macro_image
 /// \macro_output
 /// \macro_code
+/// \classes TRandom3, ROOT::Math::Functor, ROOT::Fit::Fitter, TArc, ROOT::Fit::FitResult
+/// \keywords circle, 2D
 ///
 /// \author Rene Brun
 

--- a/tutorials/index_categories.md
+++ b/tutorials/index_categories.md
@@ -1,0 +1,37 @@
+\defgroup Tutorials Tutorials
+
+## Grouped by categories
+
+### Keywords
+
+- circle
+  - fit/fitCircle.C
+- 2D
+  - fit/fitCircle.C, fit/fit2a.C
+- 3D
+  - fit/exampleFit3D.C
+- minimizer
+  - fit/NumericalMinimization.py
+
+### Classes
+
+- TRandom3
+  - fit/fitCircle.C
+- ROOT::Math::Functor
+  - fit/fitCircle.C, fit/NumericalMinimization.py
+- ROOT::Fit::Fitter
+  - fit/fitCircle.C, fit/exampleFit3D.C
+- TArc
+  - fit/fitCircle.C
+- ROOT::Fit::FitResult
+  - fit/fitCircle.C
+- ROOT::Fit::BinData
+  - fit/exampleFit3D.C
+- ROOT::Math::WrappedMultiTF1
+  - fit/exampleFit3D.C
+- TCutG
+  - fit/fit2a.C
+- ROOT::Math::Minimizer
+  - fit/NumericalMinimization.py
+- Factory
+  - fit/NumericalMinimization.py


### PR DESCRIPTION
Adds a support for labelling tutorial files with custom documentation comments (`\classes`, `\keywords`) and for generating an index page with links to tutorial files grouped by categories and labels.
![tutorial-index-categories](https://github.com/user-attachments/assets/9ce22db9-ffda-40d4-ba64-36b9e98b0a49)
