### PR TITLE
[python] Clarify ownership of TCanvas, TFile

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -89,6 +89,7 @@ set(py_sources
   ROOT/_pythonization/_rvec.py
   ROOT/_pythonization/_stl_vector.py
   ROOT/_pythonization/_tarray.py
+  ROOT/_pythonization/_tcanvas.py
   ROOT/_pythonization/_tclass.py
   ROOT/_pythonization/_tclonesarray.py
   ROOT/_pythonization/_tcollection.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcanvas.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcanvas.py
@@ -1,0 +1,28 @@
+# Author: Vincenzo Eduardo Padulano CERN 11/2024
+# Author: Jonas Rembser CERN 11/2024
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+from . import pythonization
+
+
+def _TCanvas_Constructor(self, *args, **kwargs):
+    """
+    Forward the arguments to the C++ constructor and retain ownership. This
+    helps avoiding double deletes due to ROOT automatic memory management.
+    """
+    self._cpp_constructor(*args, **kwargs)
+    import ROOT
+    ROOT.SetOwnership(self, False)
+
+
+@pythonization('TCanvas')
+def pythonize_tcanvas(klass):
+
+    klass._cpp_constructor = klass.__init__
+    klass.__init__ = _TCanvas_Constructor

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -77,6 +77,8 @@ def _TFileConstructor(self, *args):
     if len(args) >= 1:
         if self.IsZombie():
             raise OSError('Failed to open file {}'.format(args[0]))
+    import ROOT
+    ROOT.SetOwnership(self, False)
 
 
 def _TFileOpen(klass, *args):


### PR DESCRIPTION
Testing more TObject-derived classes in the wake of recent Python ownership model improvements