### PR TITLE
Disable test-webgui-ping for Mac [6.34] [skip-ci]

### DIFF
--- a/gui/webdisplay/test/CMakeLists.txt
+++ b/gui/webdisplay/test/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 
 # test only can be run if Firefox or Chrome are detected on the system
+if(NOT APPLE)
 if (CHROME_EXECUTABLE OR FIREFOX_EXECUTABLE)
   ROOT_ADD_TEST(test-webgui-ping
                 RUN_SERIAL
@@ -17,4 +18,5 @@ if (CHROME_EXECUTABLE OR FIREFOX_EXECUTABLE)
                 COMMAND root.exe -b -q -l ping.cxx
                 PASSREGEX "PING-PONG TEST COMPLETED"
                 TIMEOUT 300)
+endif()
 endif()


### PR DESCRIPTION
For some reasons chrome does not exit normally after the test, therefore disable it until problem is identified

