### PR TITLE
Allow to set the line width of candle markers

### DIFF
--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -142,6 +142,8 @@ private:
    Double_t      fCandleBoxRange;    ///< Candle plot, The fraction which is covered by the box (0 < x < 1), default 0.5
    Bool_t        fCandleScaled;      ///< Candle plot, shall the box-width be scaled to each other by the integral of a box?
    Bool_t        fViolinScaled;      ///< Violin plot, shall the violin or histos be scaled to each other by the maximum height?
+   Int_t         fCandleCircleLineWidth; ///< Line width of the circle marker of a candle plot ([1,5]).
+   Int_t         fCandleCrossLineWidth; ///< Line width of the cross marker of a candle plot ([1,5]).
    Float_t       fXAxisExpXOffset;   ///< X axis exponent label X offset
    Float_t       fXAxisExpYOffset;   ///< X axis exponent label Y offset
    Float_t       fYAxisExpXOffset;   ///< Y axis exponent label X offset
@@ -291,6 +293,8 @@ public:
    Double_t         GetCandleBoxRange() const {return fCandleBoxRange;}
    Bool_t           GetCandleScaled() const {return fCandleScaled;}
    Bool_t           GetViolinScaled() const {return fViolinScaled;}
+   Int_t            GetCandleCircleLineWidth() const {return fCandleCircleLineWidth;}
+   Int_t            GetCandleCrossLineWidth() const {return fCandleCrossLineWidth;}
    Bool_t           GetOrthoCamera() const {return fOrthoCamera;}
 
    Bool_t           IsReading() const {return fIsReading;}
@@ -424,12 +428,14 @@ public:
    void             SetCandleBoxRange(Double_t bRange=0.5);
    void             SetCandleScaled(Bool_t on=kFALSE) {fCandleScaled=on;}
    void             SetViolinScaled(Bool_t on=kTRUE) {fViolinScaled=on;}
+   void             SetCandleCircleLineWidth (Int_t CircleLineWidth=1);
+   void             SetCandleCrossLineWidth (Int_t CrossLineWidth=1);
    void             SetOrthoCamera(Bool_t on=kTRUE) {fOrthoCamera=on;}
 
    void             SavePrimitive(std::ostream &out, Option_t * = "") override;
    void             SaveSource(const char *filename, Option_t *option = nullptr);
 
-   ClassDefOverride(TStyle, 23);  //A collection of all graphics attributes
+   ClassDefOverride(TStyle, 24);  //A collection of all graphics attributes
 };
 
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1964,6 +1964,31 @@ void TStyle::SetCandleBoxRange(Double_t bRange)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set the line width of the circle marker of a candle plot ([1,5]).
+
+void TStyle::SetCandleCircleLineWidth(Int_t CircleLineWidth)
+{
+   if (CircleLineWidth<1 || CircleLineWidth>5) {
+      Error("SetCandleCircleLineWidth", "illegal line width %d. It must be in the range [1,5]\n", (int)CircleLineWidth);
+      fCandleCircleLineWidth = 1;
+   }
+   fCandleCircleLineWidth = CircleLineWidth;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set the line width of the cross marker of a candle plot ([1,5]).
+
+void TStyle::SetCandleCrossLineWidth(Int_t CrossLineWidth)
+{
+   if (CrossLineWidth<1 || CrossLineWidth>5) {
+      Error("SetCandleCrossLineWidth", "illegal line width %d. It must be in the range [1,5]\n", (int)CrossLineWidth);
+      fCandleCrossLineWidth = 1;
+   }
+   fCandleCrossLineWidth = CrossLineWidth;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Save the current style in a C++ macro file.
 
 void TStyle::SaveSource(const char *filename, Option_t *option)

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1983,6 +1983,7 @@ void TStyle::SetCandleCrossLineWidth(Int_t CrossLineWidth)
    if (CrossLineWidth<1 || CrossLineWidth>5) {
       Error("SetCandleCrossLineWidth", "illegal line width %d. It must be in the range [1,5]\n", (int)CrossLineWidth);
       fCandleCrossLineWidth = 1;
+      return;
    }
    fCandleCrossLineWidth = CrossLineWidth;
 }

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1971,6 +1971,7 @@ void TStyle::SetCandleCircleLineWidth(Int_t CircleLineWidth)
    if (CircleLineWidth<1 || CircleLineWidth>5) {
       Error("SetCandleCircleLineWidth", "illegal line width %d. It must be in the range [1,5]\n", (int)CircleLineWidth);
       fCandleCircleLineWidth = 1;
+      return;
    }
    fCandleCircleLineWidth = CircleLineWidth;
 }

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -769,8 +769,9 @@ void TCandle::Paint(Option_t *)
       if (doLogY) {
          if (myMedianY[0] > 0) myMedianY[0] = TMath::Log10(myMedianY[0]); else isValid = false;
       }
-
-      SetMarkerStyle(24);
+      Int_t mw = gStyle->GetCandleCircleLineWidth();
+      if (mw == 1) SetMarkerStyle(24);
+      else         SetMarkerStyle(18*mw+17);
       TAttMarker::Modify();
 
       if (isValid) gPad->PaintPolyMarker(1,myMedianX,myMedianY); // A circle for the fMedian
@@ -798,7 +799,9 @@ void TCandle::Paint(Option_t *)
          if (myMeanY[0] > 0) myMeanY[0] = TMath::Log10(myMeanY[0]); else isValid = false;
       }
 
-      SetMarkerStyle(24);
+      Int_t mw = gStyle->GetCandleCircleLineWidth();
+      if (mw == 1) SetMarkerStyle(24);
+      else         SetMarkerStyle(18*mw+17);
       TAttMarker::Modify();
 
       if (isValid) gPad->PaintPolyMarker(1,myMeanX,myMeanY); // A circle for the fMean
@@ -830,7 +833,9 @@ void TCandle::Paint(Option_t *)
       if (IsOption(kPointsAllScat)) { //Draw outliers and "all" values scattered
          SetMarkerStyle(0);
       } else {
-         SetMarkerStyle(5);
+         Int_t mw = gStyle->GetCandleCrossLineWidth();
+         if (mw == 1) SetMarkerStyle(5);
+         else         SetMarkerStyle(18*mw+16);
       }
       TAttMarker::Modify();
       gPad->PaintPolyMarker(fNDrawPoints,fDrawPointsX, fDrawPointsY);


### PR DESCRIPTION
Implement:
```
gStyle->SetCandleCircleLineWidth(w);
gStyle->SetCandleCrossLineWidth(w);
```
As requested here: https://root-forum.cern.ch/t/how-to-make-marker-thicker/62338

Example:
```
void candleplot() {

   gStyle->SetTimeOffset(0);
   TDatime dateBegin(2010,1,1,0,0,0);
   TDatime dateEnd(2011,1,1,0,0,0);

   auto h1 = new TH2I("h1","Machine A + B",12,dateBegin.Convert(),dateEnd.Convert(),1000,0,1000);

   h1->GetXaxis()->SetTimeDisplay(1);
   h1->GetXaxis()->SetTimeFormat("%m/%y");
   h1->GetXaxis()->SetTitle("Date [month/year]");

   float Rand;
   for (int i = dateBegin.Convert(); i < dateEnd.Convert(); i+=86400*30) {
      for (int j = 0; j < 1000; j++) {
         Rand = gRandom->Gaus(500+sin(i/10000000.)*100,50); h1->Fill(i,Rand);
      }
   }
   gStyle->SetCandleCircleLineWidth(5);
   gStyle->SetCandleCrossLineWidth(3);

   h1->SetBarWidth(0.4);
   h1->SetBarOffset(-0.25);
   h1->SetFillColor(kYellow);
   h1->SetFillStyle(1001);
   h1->SetMarkerStyle(106);
   h1->SetMarkerSize(2);

   h1->Draw("candle3");
}
```
<img width="683" alt="Screenshot 2024-11-28 at 15 54 52" src="https://github.com/user-attachments/assets/3301b351-8d36-4a58-92e5-c8abebe34ccf">

  