### PR TITLE
Do not use tilted `TGaxis` in tutorials

### DIFF
--- a/documentation/users-guide/Graphics.md
+++ b/documentation/users-guide/Graphics.md
@@ -1919,9 +1919,9 @@ The first script is:
   axis7->SetLabelOffset(0.01);
   axis7->Draw();
 
-  // one can make axis top->bottom. However because of a problem,
-  // the two x values should not be equal
-  TGaxis *axis8 = new TGaxis(6.5,0.8,6.499,-0.8,0,90,50510,"-");
+  // One can make a vertical axis going top->bottom.
+  // However one need to adjust labels align to avoid overlapping.
+  TGaxis *axis8 = new TGaxis(6.5,0.8,6.5,-0.8,0,90,50510,"-L");
   axis8->SetName("axis8");
   axis8->Draw();
 }

--- a/tutorials/graphics/gaxis.C
+++ b/tutorials/graphics/gaxis.C
@@ -8,7 +8,8 @@
 ///
 /// \authors Rene Brun, Olivier Couet
 
-void gaxis(){
+void gaxis()
+{
    auto c1 = new TCanvas("c1","Examples of TGaxis",10,10,700,500);
    c1->Range(-10,-1,10,1);
 
@@ -41,8 +42,8 @@ void gaxis(){
    auto axis8 = new TGaxis(8,-0.8,8,0.8,0,9000,50510,"+L");
    axis8->Draw();
 
-   // One can make a vertical axis going top->bottom. However the two x values should be
-   // slightly different to avoid labels overlapping.
-   auto axis9 = new TGaxis(6.5,0.8,6.499,-0.8,0,90,50510,"-");
+   // One can make a vertical axis going top->bottom.
+   // However one need to adjust labels align to avoid overlapping.
+   auto axis9 = new TGaxis(6.5,0.8,6.5,-0.8,0,90,50510,"-L");
    axis9->Draw();
 }

--- a/tutorials/hist/reverseaxis.C
+++ b/tutorials/hist/reverseaxis.C
@@ -8,8 +8,41 @@
 ///
 /// \author Olivier Couet
 
-void ReverseXAxis (TH1 *h);
-void ReverseYAxis (TH1 *h);
+void ReverseXAxis(TH1 *h)
+{
+   // Remove the current axis
+   h->GetXaxis()->SetLabelOffset(999);
+   h->GetXaxis()->SetTickLength(0);
+
+   // Redraw the new axis
+   auto newxaxis = new TGaxis(gPad->GetUxmax(),
+                              gPad->GetUymin(),
+                              gPad->GetUxmin(),
+                              gPad->GetUymin(),
+                              h->GetXaxis()->GetXmin(),
+                              h->GetXaxis()->GetXmax(),
+                              510,"-");
+   newxaxis->SetLabelOffset(-0.03);
+   newxaxis->Draw();
+}
+
+void ReverseYAxis(TH1 *h)
+{
+   // Remove the current axis
+   h->GetYaxis()->SetLabelOffset(999);
+   h->GetYaxis()->SetTickLength(0);
+
+   // Redraw the new axis
+   auto newyaxis = new TGaxis(gPad->GetUxmin(),
+                              gPad->GetUymax(),
+                              gPad->GetUxmin(),
+                              gPad->GetUymin(),
+                              h->GetYaxis()->GetXmin(),
+                              h->GetYaxis()->GetXmax(),
+                              510,"+R");
+   newyaxis->SetLabelOffset(0.01);
+   newyaxis->Draw();
+}
 
 void reverseaxis()
 {
@@ -22,44 +55,8 @@ void reverseaxis()
    }
    TCanvas *c1 = new TCanvas("c1");
    hpxpy->Draw("colz");
+   c1->Update();
    ReverseXAxis(hpxpy);
    ReverseYAxis(hpxpy);
 }
 
-void ReverseXAxis(TH1 *h)
-{
-   // Remove the current axis
-   h->GetXaxis()->SetLabelOffset(999);
-   h->GetXaxis()->SetTickLength(0);
-
-   // Redraw the new axis
-   gPad->Update();
-   TGaxis *newaxis = new TGaxis(gPad->GetUxmax(),
-                                gPad->GetUymin(),
-                                gPad->GetUxmin(),
-                                gPad->GetUymin(),
-                                h->GetXaxis()->GetXmin(),
-                                h->GetXaxis()->GetXmax(),
-                                510,"-");
-   newaxis->SetLabelOffset(-0.03);
-   newaxis->Draw();
-}
-
-void ReverseYAxis(TH1 *h)
-{
-   // Remove the current axis
-   h->GetYaxis()->SetLabelOffset(999);
-   h->GetYaxis()->SetTickLength(0);
-
-   // Redraw the new axis
-   gPad->Update();
-   TGaxis *newaxis = new TGaxis(gPad->GetUxmin(),
-                                gPad->GetUymax(),
-                                gPad->GetUxmin()-0.001,
-                                gPad->GetUymin(),
-                                h->GetYaxis()->GetXmin(),
-                                h->GetYaxis()->GetXmax(),
-                                510,"+");
-   newaxis->SetLabelOffset(-0.03);
-   newaxis->Draw();
-}


### PR DESCRIPTION
To change labels align `TGaxis` was slightly tilt.
Same can be achieved just by providing "L" as draw option of the `TGaxis`. 
This looks much more logical.

Adjust in tutorials and in documentation.

