### PR TITLE
[skip-ci] [python] Fix syntax warning in docstring

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py
@@ -24,7 +24,7 @@ from ._generic import pythonize_generic
 
 
 def pythonization(class_name, ns='::', is_prefix=False):
-    '''
+    r'''
     \ingroup Pythonizations
     Decorator that allows to pythonize C++ classes. To pythonize means to add
     some extra behaviour to a C++ class that is used from Python via PyROOT,


### PR DESCRIPTION
Avoids the following warning
```
lib/ROOT/_pythonization/__init__.py:27: SyntaxWarning: invalid escape sequence '\i'
```
caused by the `\ingroup` doxygen tag, by writing the docstring as a raw string literal.