### PR TITLE
[skip-ci] Add a note in reference about the coordinate system negation pitfalls

### DIFF
--- a/math/genvector/doc/index.md
+++ b/math/genvector/doc/index.md
@@ -162,6 +162,9 @@ v3 = v1 - v2;
 Note that the multiplication between two vectors using the `operator *` is not supported
 because it is ambiguous.
 
+> [!note]
+> For the vectors using the 4D coordinate systems based on mass instead of energy (such as **`ROOT::Math::PxPyPzM4D`** or **`ROOT::Math::PtEtaPhiM4D`**) the unary operator `-` (negation) doesn't perform a 4-vector negation. Instead, it negates only the spatial components, which might result in unintuive behaviours (for instance, for PxPyPzM4D coordinate system, \f$\textbf{v}+ \left(-\textbf{v}\right) \neq \textbf{v} -\textbf{v}\f$).
+
 ### Other Methods
 
 The vector classes support methods for:


### PR DESCRIPTION
# This Pull request:

Adds a short note about an unintuitive behavior of 4-vector negation for coordinate systems based on mass instead of energy (#15842)

This the same note as in #17049 but this time it will also appear in the Reference Documentation

![image](https://github.com/user-attachments/assets/44b7f82f-5e04-4b2a-85d7-f6d3ca085100)


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

