### PR TITLE
[df] Ensure proper graph dependencies for local info in distributed mode

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -105,7 +105,7 @@ class HeadNode(Node, ABC):
 
         # Internal RDataFrame object, useful to expose information such as
         # column names.
-        self._localdf = localdf
+        self.rdf_node = localdf
 
         # A dictionary where the keys are the IDs of the objects to live visualize
         # and the values are the corresponding callback functions 
@@ -119,8 +119,8 @@ class HeadNode(Node, ABC):
         the garbage collector, the cppyy memory regulator and the C++ object
         destructor.
         """
-        if hasattr(self, "_localdf"):
-            del self._localdf
+        if hasattr(self, "rdf_node"):
+            del self.rdf_node
 
     @property
     def npartitions(self) -> Optional[int]:

--- a/bindings/experimental/distrdf/python/DistRDF/Node.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Node.py
@@ -59,9 +59,12 @@ class Node(object):
         rdf_node: A reference to the result of calling a function of the
             RDataFrame API with the current operation. This is practically a
             node of the true computation graph, which is being executed in some
-            distributed task. It is a transient attribute. On the client, it
-            is always None. The value is computed and stored only during a task
-            on a worker.
+            distributed task. It is a transient attribute. On the client, this
+            is filled when the operation being called is a transformation. It is
+            done to ensure information regarding e.g. column names and types is
+            populated and available locally with the right dependencies. On a
+            worker, this attribute can represent any node of the C++ computation
+            graph and its created and processed within the worker.
     """
 
     def __init__(self, get_head: Callable[[], HeadNode], node_id: int = 0,

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -73,10 +73,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         node = Proxy.NodeProxy(hn)
         # Set of operations to build the graph
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0").Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0").Filter("mock_col>0")
         n4 = n2.Count()
         n5 = n1.Count()
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
         graph_dict = hn._generate_graph_dict()
@@ -107,10 +107,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Set of operations to build the graph
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0").Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0").Filter("mock_col>0")
         n4 = n2.Count()
         n5 = n1.Count()
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Until here the graph would be:
         # [1, 2, 2, 3, 3, 2]
@@ -152,11 +152,11 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Graph nodes
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         n3 = n2.Filter("mock_col>0")
         n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Transformation pruning, n5 was earlier a transformation node
         n5 = n1.Count()  # noqa: avoid PEP8 F841
@@ -189,11 +189,11 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Graph nodes
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         n3 = n2.Filter("mock_col>0")
         n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Remove user references from n4, n3, n2
         n4 = n3 = n2 = None  # noqa: avoid PEP8 F841
@@ -226,11 +226,11 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Graph nodes
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         n3 = n2.Filter("mock_col>0")
         n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Remove references from n2 (which shouldn't affect the graph)
         n2 = None
@@ -265,12 +265,12 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Graph nodes
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         n3 = n2.Filter("mock_col>0")
         n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Filter("mock_col>0")
         n6 = n5.Count()
-        n7 = node.Filter("mock_col>0")
+        n7 = n1.Filter("mock_col>0")
 
         # This is to make sure action nodes with
         # already computed values are pruned.
@@ -307,11 +307,11 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
 
         # Graph nodes
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         n3 = n2.Filter("mock_col>0")
         n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Count()  # noqa: avoid PEP8 F841
-        n6 = node.Filter("mock_col>0")  # noqa: avoid PEP8 F841
+        n6 = n1.Filter("mock_col>0")  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
         graph_dict = hn._generate_graph_dict()
@@ -340,7 +340,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         node = Proxy.NodeProxy(hn)
         # Create three branches
         n1 = node.Define("mock_col", "1")
-        n2 = node.Filter("mock_col>0")
+        n2 = n1.Filter("mock_col>0")
         # Append 1000 nodes per branch
         for i in range(1000):
             n1 = n1.Define(f"mock_col_{i}", "1")


### PR DESCRIPTION
Fixes #17145

In distributed RDataFrame, transformation operations (such as Define) from which other parts of the API depend upon (such as GetColumnNames or GetColumnType) are executed not only in the distributed tasks but also locally, to ensure those other functions can be called. Before this commit, this was done by simply appending the call to the local RDataFrame instance attached to the head node. This behaviour was limited, for example in case the same column name was used in two separate branches of the computation graph, one could see errors such as:
```
  File "/cvmfs/sft-nightlies.cern.ch/lcg/views/dev3cuda/Tue/x86_64-el8-gcc11-opt/lib/DistRDF/Proxy.py", line 275, in get_proxy_for
    _update_internal_df_with_transformation(node, operation)
  File "/cvmfs/sft-nightlies.cern.ch/lcg/views/dev3cuda/Tue/x86_64-el8-gcc11-opt/lib/DistRDF/Proxy.py", line 63, in _update_internal_df_with_transformation
    node.get_head()._localdf = rdf_operation(*operation.args, **operation.kwargs)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/sft-nightlies.cern.ch/lcg/views/dev3cuda/Tue/x86_64-el8-gcc11-opt/lib/ROOT/_pythonization/_rdf_pyz.py", line 394, in _PyDefine
    return rdf._OriginalDefine(col_name, callable_or_str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Template method resolution failed:
  ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void>::Define(string_view name, string_view expression) =>
    runtime_error: RDataFrame::Define: cannot define column "nj4". A column with that name has already been Define'd. Use Redefine to force redefinition.
  ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void>::Define(string_view name, string_view expression) =>
    runtime_error: RDataFrame::Define: cannot define column "nj4". A column with that name has already been Define'd. Use Redefine to force redefinition.
  Failed to instantiate "Define(ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void>&,std::string,std::string)"
  Failed to instantiate "Define(ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void>*,std::string,std::string)"
  Failed to instantiate "Define(ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void>,std::string,std::string)"
```

With this commit, the order of node creation in the computation graph is respected and transformations are chained to the correct parent node.

This improvement highlighted some minor issues in unittests, which are now improved as well. A new test for this specific issue has also been added.

