### PR TITLE
[TMVA] Fix warning on x86

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -79,7 +79,7 @@ public:
          size_t output_length = ConvertShapeToLength(output_shape);
          // (input_length == output_length) is the easy case : (2,3,4) -> (2,12)
          if (input_length != output_length) {
-            if ((output_length == 0 && fAllowZero == 0) || output_length > SIZE_MAX) {
+            if ((output_length == 0 && fAllowZero == 0) || static_cast<long>(output_length)  < 0) {
                // in this case value 0 or -1 in shape are automatically corrected
                bool replacementDone = false;
                for (size_t i = 0; i < output_shape.size(); i++) {

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -79,7 +79,7 @@ public:
          size_t output_length = ConvertShapeToLength(output_shape);
          // (input_length == output_length) is the easy case : (2,3,4) -> (2,12)
          if (input_length != output_length) {
-            if ((output_length == 0 && fAllowZero == 0) || output_length > INT64_MAX) {
+            if ((output_length == 0 && fAllowZero == 0) || output_length > SIZE_MAX) {
                // in this case value 0 or -1 in shape are automatically corrected
                bool replacementDone = false;
                for (size_t i = 0; i < output_shape.size(); i++) {


### PR DESCRIPTION
Fix the following warning on 32 bit:
```
TMVA/ROperator_Reshape.hxx(82,74): warning GECC553F5: result of comparison of constant 9223372036854775807 with expression of type 'size_t' (aka 'unsigned int') is always false [-Wtautological-constant-out-of-range-compare]
            if ((output_length == 0 && fAllowZero == 0) || output_length > INT64_MAX) {
```