### PR TITLE
[Minuit2] Remove deleted header file reference

### DIFF
--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -33,7 +33,6 @@ set(MINUIT2_HEADERS
     FumiliStandardChi2FCN.h
     FumiliStandardMaximumLikelihoodFCN.h
     FunctionGradient.h
-    FunctionMinimizer.h
     FunctionMinimum.h
     GenericFunction.h
     GradientCalculator.h


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`math/minuit2/inc/Minuit2/FunctionMinimizer.h` was removed in 91bb4d7 (https://github.com/root-project/root/pull/16443) but there is still a reference to `FunctionMinimizer.h` in `math/minuit2/src/CMakeLists.txt` and this is causing the Minuit2 build to fail (e.g., https://github.com/Homebrew/homebrew-core/pull/199470#pullrequestreview-2470163494).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)