### PR TITLE
Fix wrong interaction between VariationsFor,Vary,GetMergeableValue

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
@@ -568,8 +568,8 @@ type-erased RMergeableValueBase objects.
 */
 class RMergeableVariationsBase : public RMergeableValueBase {
 protected:
-   std::vector<std::string> fKeys;
-   std::vector<std::unique_ptr<RMergeableValueBase>> fValues;
+   std::vector<std::string> fKeys{};
+   std::vector<std::unique_ptr<RMergeableValueBase>> fValues{};
 
 public:
    /**
@@ -591,6 +591,7 @@ public:
    {
    }
    RMergeableVariationsBase &operator=(RMergeableVariationsBase &&) = delete;
+   ~RMergeableVariationsBase() override = default;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Constructor that initializes data members.
@@ -660,6 +661,7 @@ public:
    RMergeableVariations &operator=(const RMergeableVariations &) = delete;
    RMergeableVariations(RMergeableVariations &&) = delete;
    RMergeableVariations &operator=(RMergeableVariations &&) = delete;
+   ~RMergeableVariations() final = default;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Constructor that initializes data members.

--- a/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
@@ -211,17 +211,16 @@ template <typename T>
 std::unique_ptr<RMergeableVariations<T>> GetMergeableValue(ROOT::RDF::Experimental::RResultMap<T> &rmap)
 {
    rmap.RunEventLoopIfNeeded();
-
-   std::unique_ptr<RMergeableVariationsBase> mVariationsBase;
    if (rmap.fVariedAction != nullptr) {
-      auto mValueBase = rmap.fVariedAction->GetMergeableValue();
-      mVariationsBase.reset(static_cast<RMergeableVariationsBase *>(mValueBase.release())); // downcast unique_ptr
+      std::unique_ptr<RMergeableVariationsBase> mVariationsBase{
+         static_cast<RMergeableVariationsBase *>(rmap.fVariedAction->GetMergeableValue().release())};
+      mVariationsBase->AddNominal(rmap.fNominalAction->GetMergeableValue());
+      return std::make_unique<RMergeableVariations<T>>(std::move(*mVariationsBase));
    } else {
-      mVariationsBase = std::unique_ptr<RMergeableVariationsBase>({}, {});
+      auto ret = std::make_unique<RMergeableVariations<T>>();
+      ret->AddNominal(rmap.fNominalAction->GetMergeableValue());
+      return ret;
    }
-   mVariationsBase->AddNominal(rmap.fNominalAction->GetMergeableValue());
-
-   return std::make_unique<RMergeableVariations<T>>(std::move(*mVariationsBase));
 }
 } // namespace RDF
 } // namespace Detail


### PR DESCRIPTION
In case VariationsFor is called on a branch of the computation graph without a Vary, the resulting map should be created just with the nominal value. When interacting with GetMergeableValue, it was instead creating a corrupted mergeable value for the map of variations, leading to segfaults. This commit cleanes the function logic and ensures that a correct, empty RMergeableVariations<T> is created when there are no variations in the branch, so that the nominal value can be added right after.

Fixes #17158 

Sibling roottest PR at https://github.com/root-project/roottest/pull/1229