### PR TITLE
[PyROOT] Whitelist `libgcc_s` library in imported library test

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -70,6 +70,7 @@ class ImportLoadLibs(unittest.TestCase):
             'libnss_.*',
             'ld.*',
             'libffi',
+            'libgcc_s',
             # AddressSanitizer runtime and ROOT configuration
             'libclang_rt.asan-.*',
             'libROOTSanitizerConfig',


### PR DESCRIPTION
On some platforms, the low-level runtime library provided by GCC will also be loaded when importing ROOT. Therefore, it needs to be added to the whitelist such that the ROOT Python module tests don't fail because of it.

Fixes a test failure that I saw on my workstation with NixOS.