### PR TITLE
[RF] Fix some design issues with the RooTreeDataStore

### DIFF
--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -138,7 +138,6 @@ public:
 
   virtual bool hasFilledCache() const { return false ; }
 
-  virtual const TTree* tree() const { return nullptr ; }
   virtual void dump() {}
 
   virtual void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr,

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -83,7 +83,6 @@ public:
 
   // Add one or more columns
   virtual RooAbsArg* addColumn(RooAbsArg& var, bool adjustRange=true) = 0 ;
-  RooArgSet* addColumns(const RooArgList& varList);
 
   // Merge column-wise
   virtual RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) = 0 ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -110,7 +110,6 @@ public:
   bool merge(std::list<RooDataSet*> dsetList) ;
 
   virtual RooAbsArg* addColumn(RooAbsArg& var, bool adjustRange=true) ;
-  virtual RooArgSet* addColumns(const RooArgList& varList) ;
 
   void printMultiline(std::ostream& os, Int_t contents, bool verbose=false, TString indent="") const override;
   void printArgs(std::ostream& os) const override;

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -105,16 +105,8 @@ public:
   void restoreAlternateBuffers() ;
 
   // Tree access
-  TTree& tree() { return *_tree ; }
-  const TTree* tree() const override { return _tree ; }
-
-  // Forwarded from TTree
-  Stat_t GetEntries() const;
-  void Reset(Option_t* option=nullptr);
-  Int_t Fill();
-  Int_t GetEntry(Int_t entry = 0, Int_t getall = 0);
-
-  void   Draw(Option_t* option = "") override ;
+  TTree* tree() { return _tree ; }
+  TTree const *tree() const { return _tree ; }
 
   // Constant term  optimizer interface
   void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=false) override ;

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2291,7 +2291,7 @@ RooAbsArg* RooAbsArg::cloneTree(const char* newname) const
 void RooAbsArg::attachToStore(RooAbsDataStore& store)
 {
   if (dynamic_cast<RooTreeDataStore*>(&store)) {
-    attachToTree((static_cast<RooTreeDataStore&>(store)).tree()) ;
+    attachToTree(*static_cast<RooTreeDataStore&>(store).tree()) ;
   } else if (dynamic_cast<RooVectorDataStore*>(&store)) {
     attachToVStore(static_cast<RooVectorDataStore&>(store)) ;
   }

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -2410,7 +2410,7 @@ bool RooAbsData::hasFilledCache() const
 const TTree *RooAbsData::tree() const
 {
    if (storageType == RooAbsData::Tree) {
-      return _dstore->tree();
+      return static_cast<RooTreeDataStore&>(*_dstore).tree();
    } else {
       coutW(InputArguments) << "RooAbsData::tree(" << GetName() << ") WARNING: is not of StorageType::Tree. "
                             << "Use GetClonedTree() instead or convert to tree storage." << std::endl;
@@ -2425,11 +2425,10 @@ const TTree *RooAbsData::tree() const
 TTree *RooAbsData::GetClonedTree() const
 {
    if (storageType == RooAbsData::Tree) {
-      auto tmp = const_cast<TTree *>(_dstore->tree());
-      return tmp->CloneTree();
+      return static_cast<RooTreeDataStore&>(*_dstore).tree()->CloneTree();
    } else {
       RooTreeDataStore buffer(GetName(), GetTitle(), *get(), *_dstore);
-      return buffer.tree().CloneTree();
+      return buffer.tree()->CloneTree();
    }
 }
 

--- a/roofit/roofitcore/src/RooAbsDataStore.cxx
+++ b/roofit/roofitcore/src/RooAbsDataStore.cxx
@@ -55,13 +55,3 @@ void RooAbsDataStore::printMultiline(std::ostream& os, Int_t /*content*/, bool v
     os << indent << "  Caches " << _cachedVars << std::endl ;
   }
 }
-
-
-RooArgSet* RooAbsDataStore::addColumns(const RooArgList& varList)
-{
-  auto * holderSet = new RooArgSet{};
-  for(RooAbsArg * var : varList) {
-    holderSet->add(*addColumn(*var));
-  }
-  return holderSet;
-}

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1159,26 +1159,6 @@ RooAbsArg* RooDataSet::addColumn(RooAbsArg& var, bool adjustRange)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add a column with the values of the given list of (function)
-/// argument to this dataset. Each function value is calculated for
-/// each event using the observable values of the event in case the
-/// function depends on variables with names that are identical to
-/// the observable names in the dataset
-
-RooArgSet* RooDataSet::addColumns(const RooArgList& varList)
-{
-  auto * holderSet = new RooArgSet{};
-  for(RooAbsArg * var : varList) {
-    holderSet->add(*addColumn(*var));
-  }
-  return holderSet;
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Special plot method for 'X-Y' datasets used in \f$ \chi^2 \f$ fitting.
 /// For general plotting, see RooAbsData::plotOn().
 ///

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -553,7 +553,8 @@ const RooArgSet* RooTreeDataStore::get(Int_t index) const
 {
   checkInit() ;
 
-  Int_t ret = const_cast<RooTreeDataStore*>(this)->GetEntry(index, 1);
+  Int_t ret = _tree->GetEntry(index, 1);
+  _cacheTree->GetEntry(index,1);
 
   if(!ret) return nullptr;
 
@@ -805,7 +806,7 @@ RooAbsArg* RooTreeDataStore::addColumn(RooAbsArg& newVar, bool adjustRange)
 
 
   // Fill values of placeholder
-  for (int i=0 ; i<GetEntries() ; i++) {
+  for (int i=0 ; i < _tree->GetEntries() ; i++) {
     get(i) ;
 
     newVarClone->syncCache(&_vars) ;
@@ -933,7 +934,7 @@ Int_t RooTreeDataStore::numEntries() const
 
 void RooTreeDataStore::reset()
 {
-  Reset() ;
+  _tree->Reset() ;
 }
 
 
@@ -967,7 +968,7 @@ void RooTreeDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet, c
   //resetBuffers() ;
 
   // Refill regular and cached variables of current tree from clone
-  for (int i=0 ; i<GetEntries() ; i++) {
+  for (int i=0 ; i < _tree->GetEntries() ; i++) {
     get(i) ;
 
     // Evaluate the cached variables and store the results
@@ -1084,56 +1085,6 @@ void RooTreeDataStore::checkInit() const
   }
 }
 
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface function to TTree::GetEntries
-
-Stat_t RooTreeDataStore::GetEntries() const
-{
-   return _tree->GetEntries() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface function to TTree::Reset
-
-void RooTreeDataStore::Reset(Option_t* option)
-{
-   _tree->Reset(option) ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface function to TTree::Fill
-
-Int_t RooTreeDataStore::Fill()
-{
-   return _tree->Fill() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface function to TTree::GetEntry
-
-Int_t RooTreeDataStore::GetEntry(Int_t entry, Int_t getall)
-{
-   Int_t ret1 = _tree->GetEntry(entry,getall) ;
-   if (!ret1) return 0 ;
-   _cacheTree->GetEntry(entry,getall) ;
-   return ret1 ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-void RooTreeDataStore::Draw(Option_t* option)
-{
-  _tree->Draw(option) ;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Stream an object of class RooTreeDataStore.
 
@@ -1203,7 +1154,7 @@ std::span<const double> RooTreeDataStore::getWeightBatch(std::size_t first, std:
     _weightBuffer = std::make_unique<std::vector<double>>();
     _weightBuffer->reserve(len);
 
-    for (std::size_t i = 0; i < GetEntries(); ++i) {
+    for (int i = 0; i < _tree->GetEntries(); ++i) {
       _weightBuffer->push_back(weight(i));
     }
   }


### PR DESCRIPTION
1. The RooAbsDataStore has a virtual function `tree()` which is not meaningful for a general data store. This function should be removed.

2. The RooTreeDataStore has one `const` version on `tree()` and one non-const version. One returns a pointer and the other a reference, which is very confusing.

3. The RooTreeDataStore has some methods that just forward to the underlying TTree, but they were not used.

Changes to the data store classes can be made without impacting users because they are implementation details of the RooFit dataset classes.