### PR TITLE
[RF] Fix creating yield histograms from extended pdfs

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -56,6 +56,14 @@ The following people have contributed to this new version:
     This pattern was not appropriate for a modern C++ library.
     If you absolutely need the old return type, wrap the call to `format()` inside `new TString{var.format(..)}`. However, this is not recommended.
 
+### Fix for `RooAbsReal::createHistogram()` with extended pdfs
+
+There was a problem with [RooAbsReal::createHistogram()](https://root.cern.ch/doc/master/classRooAbsReal.html#a9451168bb4159899fe1854f591f69814) when using it to get histograms with predicted yields for extended pdfs.
+The `Scale(bool)` argument was always set internally to `false` in case `createHistogram()` was called on an extended pdf. There was no way for the user to override that.
+This meant that one could not get yield histograms that were correctly scaled by the bin volumes using that function.
+This release changes that behavior, meaning the `Scale(bool)` command argument is now respected for extended pdfs.
+
+
 ## IO
 
 * New options have been added to TFileMerger (which can be passed as whitespace-separated TStrings via `TFileMerger::SetMergeOptions`)

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1408,8 +1408,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
 
   double scaleFactor(1.0) ;
   if (doExtended) {
-    scaleFactor = pdfSelf->expectedEvents(vars) ;
-    doScaling=false ;
+     scaleFactor = pdfSelf->expectedEvents(vars);
   }
 
   fillHistogram(histo,vars,scaleFactor,intObs,doScaling,projObs,false) ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1016,27 +1016,18 @@ TH1 *RooAbsReal::fillHistogram(TH1 *hist, const RooArgList &plotVars,
     zvar= dynamic_cast<RooRealVar*>(plotClones.find(plotVars.at(2)->GetName()));
     zaxis= hist->GetZaxis();
     assert(nullptr != zvar && nullptr != zaxis);
-    if (scaleForDensity) {
-      scaleFactor*= (zaxis->GetXmax() - zaxis->GetXmin())/zbins;
-    }
     // fall through to next case...
   case 2:
     ybins= hist->GetNbinsY();
     yvar= dynamic_cast<RooRealVar*>(plotClones.find(plotVars.at(1)->GetName()));
     yaxis= hist->GetYaxis();
     assert(nullptr != yvar && nullptr != yaxis);
-    if (scaleForDensity) {
-      scaleFactor*= (yaxis->GetXmax() - yaxis->GetXmin())/ybins;
-    }
     // fall through to next case...
   case 1:
     xbins= hist->GetNbinsX();
     xvar= dynamic_cast<RooRealVar*>(plotClones.find(plotVars.at(0)->GetName()));
     xaxis= hist->GetXaxis();
     assert(nullptr != xvar && nullptr != xaxis);
-    if (scaleForDensity) {
-      scaleFactor*= (xaxis->GetXmax() - xaxis->GetXmin())/xbins;
-    }
     break;
   default:
     coutE(InputArguments) << ClassName() << "::" << GetName() << ":fillHistogram: cannot fill histogram with "
@@ -1074,7 +1065,13 @@ TH1 *RooAbsReal::fillHistogram(TH1 *hist, const RooArgList &plotVars,
       break;
     }
 
-    double result= scaleFactor*projected->getVal();
+    // Bin volume scaling
+    double scaleFactorBin = scaleFactor;
+    scaleFactorBin *= scaleForDensity && hdim > 2 ? hist->GetZaxis()->GetBinWidth(zbin) : 1.0;
+    scaleFactorBin *= scaleForDensity && hdim > 1 ? hist->GetYaxis()->GetBinWidth(ybin) : 1.0;
+    scaleFactorBin *= scaleForDensity && hdim > 0 ? hist->GetXaxis()->GetBinWidth(xbin) : 1.0;
+
+    double result= scaleFactorBin * projected->getVal();
     if (RooAbsReal::numEvalErrors()>0) {
       coutW(Plotting) << "WARNING: Function evaluation error(s) at coordinates [x]=" << xvar->getVal() ;
       if (hdim==2) ccoutW(Plotting) << " [y]=" << yvar->getVal() ;

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -39,7 +39,7 @@ ROOT_ADD_GTEST(testRooRealVar testRooRealVar.cxx LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooRealVar_data1.root)
 
   ROOT_ADD_GTEST(testRooAbsReal testRooAbsReal.cxx
-    LIBRARIES RooFitCore
+    LIBRARIES RooFit RooFitCore
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_1.root ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_2.root)
 if(NOT MSVC OR win_broken_tests)
   # Disabled on Windows because it causes the following error:


### PR DESCRIPTION
When using the `Extended()` keyword argument in `createHistogram()` the
[docs](https://root.cern.ch/doc/master/classRooAbsReal.html#a9451168bb4159899fe1854f591f69814) say it has the following effect:

> Plot event yield instead of probability density (for extended pdfs only)

However, to get yields out of the probability densities, one has to not
only multiply with the total number of expected events, but also with
the bin volumes. I don't understand why the bin volume multiplication is
disable in *exactly* this case. This commit suggests to not do that
anymore, in order to be able to correctly produce predicted yields
histograms.

Thanks to the following forum post for noticing this:
https://root-forum.cern.ch/t/bin-content-of-pdf-and-generated-data/62370

This change of behavior is also mentioned in the release notes.

A unit test to validate that the yield histogram can now be correctly
created is also added.