### PR TITLE
[df] Add support for Alias() in DistRDF

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Operation.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Operation.py
@@ -89,6 +89,7 @@ class Transformation(Operation):
 
 
 SUPPORTED_OPERATIONS: Dict[str, Union[Action, InstantAction, Transformation]] = {
+    "Alias": Transformation,
     "AsNumpy": AsNumpy,
     "Count": Action,
     "Define": Transformation,

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -699,6 +699,7 @@ h.Draw()
 
 The main goal of this package is to support running any RDataFrame application distributedly. Nonetheless, not all
 parts of the RDataFrame API currently work with this package. The subset that is currently available is:
+- Alias
 - AsNumpy
 - Count
 - Define


### PR DESCRIPTION
# This Pull request:

Adds `Alias()` to the list of actions supported in distributed RDF.

## Changes or fixes:

Alias is just added to the list of operations supported (and to the documentation).
Nothing more is needed to get it working.

## Checklist:

- [X] tested changes locally
- [X] updated the docs


