### PR TITLE
[df] [DRAFT] Progress bar in DistRDF RunGraphs 

### DIFF
--- a/bindings/experimental/distrdf/CMakeLists.txt
+++ b/bindings/experimental/distrdf/CMakeLists.txt
@@ -27,6 +27,7 @@ set(py_sources
   DistRDF/Backends/Dask/__init__.py
   DistRDF/Backends/Dask/Backend.py
   DistRDF/LiveVisualize.py
+  DistRDF/TaskProgressBar.py
 )
 
 # Add custom rules to copy the Python sources into the build directory

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
@@ -166,7 +166,7 @@ class DaskBackend(Base.BaseBackend):
                                         Callable],
                                         Base.TaskResult],
                         reducer: Callable[[Base.TaskResult, Base.TaskResult], Base.TaskResult],
-                        ) -> Base.TaskResult:
+                        **kwargs) -> Base.TaskResult:
         """
         Performs map-reduce using Dask framework.
 
@@ -177,6 +177,8 @@ class DaskBackend(Base.BaseBackend):
 
             reducer (function): A function that merges two lists that were
                 returned by the mapper.
+
+            **kwargs: options. The only used one is progressBar (default: True)
 
         Returns:
             list: A list representing the values of action nodes returned
@@ -201,7 +203,8 @@ class DaskBackend(Base.BaseBackend):
         # it in this class, it won't be shown. Full details at
         # https://docs.dask.org/en/latest/diagnostics-distributed.html#dask.distributed.progress
         final_results = mergeables_lists.pop().persist()
-        progress(final_results)
+        if kwargs.get("progressBar", True):
+            progress(final_results)
 
         return final_results.compute()
 

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -182,7 +182,7 @@ class HeadNode(Node, ABC):
     def _handle_returned_values(self, values: TaskResult) -> Iterable:
         pass
 
-    def _execute_and_retrieve_results(self, mapper, local_nodes) -> TaskResult:
+    def _execute_and_retrieve_results(self, mapper, local_nodes, **kwargs) -> TaskResult:
         if self.drawables_dict is not None:
             # Prepare a dictionary with additional information for live visualization
             drawables_info_dict = {
@@ -200,11 +200,11 @@ class HeadNode(Node, ABC):
                 # Filter: Only include nodes requested by the user
                 if node.node_id in self.drawables_dict
             }
-            return self.backend.ProcessAndMergeLive(self._build_ranges(), mapper, distrdf_reducer, drawables_info_dict)
+            return self.backend.ProcessAndMergeLive(self._build_ranges(), mapper, distrdf_reducer, drawables_info_dict, **kwargs)
         else:
-            return self.backend.ProcessAndMerge(self._build_ranges(), mapper, distrdf_reducer)
+            return self.backend.ProcessAndMerge(self._build_ranges(), mapper, distrdf_reducer, **kwargs)
 
-    def execute_graph(self) -> None:
+    def execute_graph(self, **kwargs) -> None:
         """
         Executes an RDataFrame computation graph on a distributed backend.
 
@@ -248,7 +248,7 @@ class HeadNode(Node, ABC):
         # Execute graph distributedly and return the aggregated results from all tasks
         # using the appropriate backend method based on whether or not live visualization is enabled
         try:
-            returned_values = self._execute_and_retrieve_results(mapper, local_nodes)
+            returned_values = self._execute_and_retrieve_results(mapper, local_nodes, **kwargs)
         finally:
             # Cleanup the current execution artifacts from the caches on the workers
             self.backend.cleanup_cache(self.exec_id)

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -44,7 +44,7 @@ def _managed_tcontext():
         ctxt.__destruct__()
 
 
-def execute_graph(node: Node) -> None:
+def execute_graph(node: Node, progressBar=True) -> None:
     """
     Executes the distributed RDataFrame computation graph the input node
     belongs to. If the node already has a value, this is a no-op.
@@ -55,7 +55,7 @@ def execute_graph(node: Node) -> None:
         with _managed_tcontext():
             # All the information needed to reconstruct the computation graph on
             # the workers is contained in the head node
-            node.get_head().execute_graph()
+            node.get_head().execute_graph(progressBar=progressBar)
 
 def _update_internal_df_with_transformation(node:Node, operation: Operation) -> None:
     """Propagate transform operations to the headnode internal RDataFrame"""

--- a/bindings/experimental/distrdf/python/DistRDF/TaskProgressBar.py
+++ b/bindings/experimental/distrdf/python/DistRDF/TaskProgressBar.py
@@ -1,0 +1,68 @@
+#  @author Giovanni Petrucciani
+#  @date 2024-12
+
+################################################################################
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+from __future__ import annotations
+
+import time
+
+class TaskProgressBar:
+    def __init__(self, tasks, pollInterval=0.5):
+        self._tasks = list(tasks)
+        self._pollInterval = pollInterval
+    def run(self) -> None:
+        if not self._tasks:
+            return
+        try:
+            import tqdm
+            self._run_tqdm(tqdm.tqdm)
+        except ImportError:
+            self._run_basic()
+        self._tasks.clear()
+    def _run_tqdm(self, tqdm) -> None:
+        total = len(self._tasks)
+        with tqdm(total=total) as pbar:
+            waited = 0
+            last = 0
+            while True:
+                ndone = sum(f.done() for f in self._tasks)
+                waited += 1
+                if (ndone != last) or (waited > 10):
+                    pbar.update(ndone-last)
+                    last = ndone
+                    waited = 0
+                if ndone == total:
+                    break
+                time.sleep(self._pollInterval)
+    def _run_basic(self) -> None:
+        total = len(self._tasks)
+        started = time.monotonic()
+        waited = 0
+        last = 0
+        interval = int(max(1, 2/self._pollInterval)) # one dot every 2 s
+        while True:
+            ndone = sum(f.done() for f in self._tasks)
+            waited += 1
+            now = time.monotonic()
+            if ndone != last:
+                print(f"after {now-started:.0f}s, {ndone}/{total} done ({ndone/total*100:3.0}%%)", 
+                      end = ("\n" if ndone == total else ""),
+                      flush=True)
+                last = ndone
+                waited = 0
+                if ndone == total:
+                    break
+            elif waited == interval:
+                print(".", end="", flush=True)
+                waited = 0
+                if now - started > 10*60:
+                    interval = int(max(1, 2*60/self._pollInterval)) # one dot every 2 mins
+                elif now - started > 60:
+                    interval = int(max(1, 10/self._pollInterval)) # one dot every 10 s
+            time.sleep(self._pollInterval)

--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -102,9 +102,11 @@ def RunGraphs(proxies: Iterable, progressBar=True) -> int:
     # Submit all computation graphs concurrently from multiple Python threads.
     # The submission is not computationally intensive
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(uniqueproxies)) as executor:
-        futures = [executor.submit(execute_graph, proxy.proxied_node, progressBar=None) for proxy in uniqueproxies]
+        pbar = TaskProgressBar() if progressBar else False
+        futures = [executor.submit(execute_graph, proxy.proxied_node, progressBar=pbar) for proxy in uniqueproxies]
         if progressBar:
-            TaskProgressBar(futures).run()
+            pbar.addFutures(futures)
+            pbar.run()
         concurrent.futures.wait(futures)
 
     return len(uniqueproxies)


### PR DESCRIPTION
This draft PR attempts to add a better progress bar in DistRDF RunGraphs. It works, at least for the dask case, but some things still need to be done, and some aspects of the implementation may need discussion - but having the code pushed to a PR may be useful so that people can have a look at it before the discussion.

Currently, RunGraphs submits all graphs asynchronously, and at least in the dask case they all get progress bars that all write in the same line in the terminal overwriting themselves (or, do not appear at all in the notebook case).

### Part 1
To address this, the **first commit** of this PR does two things:
 * add an option to disable the dask progress bar on an individual graphs, and enable it in RunGraphs
 * make a separate progress bar that tracks the status of all the graphs.
The implementation uses tqdm if available, and falls back to some simple printouts if that module is missing.

The futures are checked by just polling the `done()` method; callbacks could also be used, at least in the tqdm case, but probably the overhead of polling is small.

The limitation of this approach is that it doesn't track the fine-grained processing within each graph, so if the nuber of graphs is comparable to that of the slots then the progress may stay at 0% for a long while and then jump to 100%.

### Part 2 

To improve on this, the **second commit** changes the dask computation graph to use the futures API instead of the delayed API, and then adds also the individual fine-grained futures to the progress bar to track.

This provides a more granular tracking for dask tasks, but not for spark ones (they use a different API; maybe the same logic can be implemented for those too but I didn't try yet) - spark tasks still get the coarse-grained tracking, though. 

One slight inconvenience of this is that since also the submit is asynchronous and parallel, the total number of futures to watch can initially increase with time as new tasks are submitted, so the progress bar won't be monotonic at the start. One could avoid this by making the submission sequential or waiting for all submissions to be complete before showing the bar, but they would require more changes to the code and potentially slow down the submission itself.

I don't know whether moving from dask delayed to futures has other drawbacks, and so whether this second part is something that can be considered or not.

### Next steps

If all the above looks reasonable to you, next steps could be
- [ ] test in a jupyter notebook (may need a bit of extra code for the tqdm part)
- [ ] test that it works with spark
- [ ] improve the documentation (and, if needed, the code quality)
- [ ] possibly add the more granular tracking also to the spark part

### For testing

A script to test this is in `/afs/cern.ch/user/g/gpetrucc/public/distrdf_rungraphs_test.py`  and can be run from lxplus9 with `python3 /afs/cern.ch/user/g/gpetrucc/public/distrdf_rungraphs_test.py -j 4 dask`.
