### PR TITLE
[RDF] preserve order of messages in RDisplay::Print()

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -289,7 +289,7 @@ private:
 
    void EnsureCurrentColumnWidth(size_t w);
 
-   std::string AsStringInternal(bool considerDots) const;
+   void ToStream(std::ostream &out, std::ostream &err, bool considerDots) const;
 
 public:
    ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#17081 changed the order or printing in `RDisplay::Print()` so that all warnings are now printed before the actual message. This PR restores the original order of printing.