### PR TITLE
[ntuple] `RMiniFile` improvements and preparations for parallel writing

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -155,6 +155,8 @@ private:
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
                              std::uint64_t directoryOffset = 100, const std::string &className = "",
                              const std::string &objectName = "", const std::string &title = "");
+      /// Writes an RBlob opaque key with the provided buffer as data record and returns the offset of the record
+      std::uint64_t WriteBlobKey(const void *buffer, std::size_t nbytes, std::size_t len);
       operator bool() const { return fFile; }
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -107,7 +107,7 @@ private:
       /// Low-level writing using a TFile
       void Write(const void *buffer, size_t nbytes, std::int64_t offset);
       /// Writes an RBlob opaque key with the provided buffer as data record and returns the offset of the record
-      std::uint64_t WriteKey(const void *buffer, size_t nbytes, size_t len);
+      std::uint64_t WriteBlobKey(const void *buffer, size_t nbytes, size_t len);
       operator bool() const { return fFile; }
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -110,8 +110,8 @@ private:
       TFile *fFile = nullptr;
       /// Low-level writing using a TFile
       void Write(const void *buffer, size_t nbytes, std::int64_t offset);
-      /// Writes an RBlob opaque key with the provided buffer as data record and returns the offset of the record
-      std::uint64_t WriteBlobKey(const void *buffer, size_t nbytes, size_t len);
+      /// Reserves an RBlob opaque key as data record and returns the offset of the record
+      std::uint64_t ReserveBlobKey(size_t nbytes, size_t len);
       operator bool() const { return fFile; }
    };
 
@@ -159,8 +159,8 @@ private:
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
                              std::uint64_t directoryOffset = 100, const std::string &className = "",
                              const std::string &objectName = "", const std::string &title = "");
-      /// Writes an RBlob opaque key with the provided buffer as data record and returns the offset of the record
-      std::uint64_t WriteBlobKey(const void *buffer, std::size_t nbytes, std::size_t len);
+      /// Reserves an RBlob opaque key as data record and returns the offset of the record
+      std::uint64_t ReserveBlobKey(std::size_t nbytes, std::size_t len);
       operator bool() const { return fFile; }
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -110,8 +110,10 @@ private:
       TFile *fFile = nullptr;
       /// Low-level writing using a TFile
       void Write(const void *buffer, size_t nbytes, std::int64_t offset);
-      /// Reserves an RBlob opaque key as data record and returns the offset of the record
-      std::uint64_t ReserveBlobKey(size_t nbytes, size_t len);
+      /// Reserves an RBlob opaque key as data record and returns the offset of the record. If keyBuffer is specified,
+      /// it must be written *before* the returned offset. (Note that the array type is purely documentation, the
+      /// argument is actually just a pointer.)
+      std::uint64_t ReserveBlobKey(size_t nbytes, size_t len, unsigned char keyBuffer[kBlobKeyLen] = nullptr);
       operator bool() const { return fFile; }
    };
 
@@ -159,8 +161,10 @@ private:
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
                              std::uint64_t directoryOffset = 100, const std::string &className = "",
                              const std::string &objectName = "", const std::string &title = "");
-      /// Reserves an RBlob opaque key as data record and returns the offset of the record
-      std::uint64_t ReserveBlobKey(std::size_t nbytes, std::size_t len);
+      /// Reserves an RBlob opaque key as data record and returns the offset of the record. If keyBuffer is specified,
+      /// it must be written *before* the returned offset. (Note that the array type is purely documentation, the
+      /// argument is actually just a pointer.)
+      std::uint64_t ReserveBlobKey(std::size_t nbytes, std::size_t len, unsigned char keyBuffer[kBlobKeyLen] = nullptr);
       operator bool() const { return fFile; }
    };
 
@@ -224,8 +228,9 @@ public:
    std::uint64_t WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);
    /// Writes a new record as an RBlob key into the file
    std::uint64_t WriteBlob(const void *data, size_t nbytes, size_t len);
-   /// Reserves a new record as an RBlob key in the file.
-   std::uint64_t ReserveBlob(size_t nbytes, size_t len);
+   /// Reserves a new record as an RBlob key in the file. If keyBuffer is specified, it must be written *before* the
+   /// returned offset. (Note that the array type is purely documentation, the argument is actually just a pointer.)
+   std::uint64_t ReserveBlob(size_t nbytes, size_t len, unsigned char keyBuffer[kBlobKeyLen] = nullptr);
    /// Write into a reserved record; the caller is responsible for making sure that the written byte range is in the
    /// previously reserved key.
    void WriteIntoReservedBlob(const void *buffer, size_t nbytes, std::int64_t offset);

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -101,6 +101,10 @@ A stand-alone version of RNTuple can remove the TFile based writer.
 */
 // clang-format on
 class RNTupleFileWriter {
+public:
+   /// The key length of a blob. It is always a big key (version > 1000) with class name RBlob.
+   static constexpr std::size_t kBlobKeyLen = 42;
+
 private:
    struct RFileProper {
       TFile *fFile = nullptr;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -996,8 +996,8 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::Write(const v
       throw RException(R__FAIL("WriteBuffer failed."));
 }
 
-std::uint64_t
-ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::WriteKey(const void *buffer, size_t nbytes, size_t len)
+std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::WriteBlobKey(const void *buffer,
+                                                                                         size_t nbytes, size_t len)
 {
    std::uint64_t offsetKey;
    RKeyBlob keyBlob(fFile);
@@ -1165,7 +1165,7 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const v
             offset = fFileSimple.WriteKey(payload, nBytes, length, -1, RTFHeader::kBEGIN, kBlobClassName);
          }
       } else {
-         offset = fFileProper.WriteKey(payload, nBytes, length);
+         offset = fFileProper.WriteBlobKey(payload, nBytes, length);
       }
       return offset;
    };
@@ -1241,7 +1241,7 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::ReserveBlob(size_
          offset = fFileSimple.WriteKey(/*buffer=*/nullptr, nbytes, len, -1, RTFHeader::kBEGIN, kBlobClassName);
       }
    } else {
-      offset = fFileProper.WriteKey(/*buffer=*/nullptr, nbytes, len);
+      offset = fFileProper.WriteBlobKey(/*buffer=*/nullptr, nbytes, len);
    }
    return offset;
 }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -984,6 +984,13 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Writ
    return offsetData;
 }
 
+std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::WriteBlobKey(const void *buffer,
+                                                                                         std::size_t nbytes,
+                                                                                         std::size_t len)
+{
+   return WriteKey(buffer, nbytes, len, -1, RTFHeader::kBEGIN, kBlobClassName);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::Write(const void *buffer, size_t nbytes,
@@ -1162,7 +1169,7 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const v
             fFileSimple.Write(payload, nBytes);
             fFileSimple.fKeyOffset += nBytes;
          } else {
-            offset = fFileSimple.WriteKey(payload, nBytes, length, -1, RTFHeader::kBEGIN, kBlobClassName);
+            offset = fFileSimple.WriteBlobKey(payload, nBytes, length);
          }
       } else {
          offset = fFileProper.WriteBlobKey(payload, nBytes, length);
@@ -1238,7 +1245,7 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::ReserveBlob(size_
          offset = fFileSimple.fKeyOffset;
          fFileSimple.fKeyOffset += nbytes;
       } else {
-         offset = fFileSimple.WriteKey(/*buffer=*/nullptr, nbytes, len, -1, RTFHeader::kBEGIN, kBlobClassName);
+         offset = fFileSimple.WriteBlobKey(/*buffer=*/nullptr, nbytes, len);
       }
    } else {
       offset = fFileProper.WriteBlobKey(/*buffer=*/nullptr, nbytes, len);

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1009,7 +1009,7 @@ ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::WriteKey(const voi
    RTFString strClass{kBlobClassName};
    RTFString strObject;
    RTFString strTitle;
-   RTFKey keyHeader(offset, offset, strClass, strObject, strTitle, len, nbytes);
+   RTFKey keyHeader(offset, RTFHeader::kBEGIN, strClass, strObject, strTitle, len, nbytes);
 
    Write(&keyHeader, keyHeader.GetHeaderSize(), offset);
    offset += keyHeader.GetHeaderSize();

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1011,9 +1011,8 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Writ
    return offsetData;
 }
 
-std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::WriteBlobKey(const void *buffer,
-                                                                                         std::size_t nbytes,
-                                                                                         std::size_t len)
+std::uint64_t
+ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::ReserveBlobKey(std::size_t nbytes, std::size_t len)
 {
    unsigned char keyBuffer[kBlobKeyLen];
    PrepareBlobKey(fKeyOffset, nbytes, len, keyBuffer);
@@ -1022,8 +1021,6 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Writ
    auto offsetData = fKeyOffset + kBlobKeyLen;
    // The next key starts after the data.
    fKeyOffset = offsetData + nbytes;
-   if (buffer)
-      Write(buffer, nbytes);
 
    return offsetData;
 }
@@ -1040,8 +1037,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::Write(const v
       throw RException(R__FAIL("WriteBuffer failed."));
 }
 
-std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::WriteBlobKey(const void *buffer,
-                                                                                         size_t nbytes, size_t len)
+std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::ReserveBlobKey(size_t nbytes, size_t len)
 {
    std::uint64_t offsetKey;
    RKeyBlob keyBlob(fFile);
@@ -1054,8 +1050,6 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::Writ
 
    Write(keyBuffer, kBlobKeyLen, offsetKey);
    auto offsetData = offsetKey + kBlobKeyLen;
-   if (buffer)
-      Write(buffer, nbytes, offsetData);
 
    return offsetData;
 }
@@ -1262,10 +1256,10 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::ReserveBlob(size_
          offset = fFileSimple.fKeyOffset;
          fFileSimple.fKeyOffset += nbytes;
       } else {
-         offset = fFileSimple.WriteBlobKey(/*buffer=*/nullptr, nbytes, len);
+         offset = fFileSimple.ReserveBlobKey(nbytes, len);
       }
    } else {
-      offset = fFileProper.WriteBlobKey(/*buffer=*/nullptr, nbytes, len);
+      offset = fFileProper.ReserveBlobKey(nbytes, len);
    }
    return offset;
 }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1189,18 +1189,8 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::Commit()
 std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const void *data, size_t nbytes, size_t len)
 {
    auto writeKey = [this](const void *payload, size_t nBytes, size_t length) {
-      std::uint64_t offset;
-      if (fFileSimple) {
-         if (fIsBare) {
-            offset = fFileSimple.fKeyOffset;
-            fFileSimple.Write(payload, nBytes);
-            fFileSimple.fKeyOffset += nBytes;
-         } else {
-            offset = fFileSimple.WriteBlobKey(payload, nBytes, length);
-         }
-      } else {
-         offset = fFileProper.WriteBlobKey(payload, nBytes, length);
-      }
+      std::uint64_t offset = ReserveBlob(nBytes, length);
+      WriteIntoReservedBlob(payload, nBytes, offset);
       return offset;
    };
 

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -183,47 +183,59 @@ TEST(MiniFile, SimpleKeys)
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "TFile");
+   EXPECT_EQ(key->GetSeekKey(), 100);
+   EXPECT_EQ(key->GetSeekPdir(), 0);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob1], blob1);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob2);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob2], blob2);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob3);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob3], blob3);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob4);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob4Write], blob4);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob5);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob6);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob6], blob6);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "ROOT::RNTuple");
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    // KeysList
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetName(), "StreamerInfo");
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    // FreeSegments
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    EXPECT_EQ(offset, size);
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -300,47 +300,58 @@ TEST(MiniFile, ProperKeys)
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "TFile");
+   EXPECT_EQ(key->GetSeekPdir(), 0);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob1], blob1);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob2);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob2], blob2);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob3);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob3], blob3);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob4);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob4Write], blob4);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob5);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob6);
+   EXPECT_EQ(key->GetSeekPdir(), 100);
    EXPECT_EQ(buffer[offBlob6], blob6);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "ROOT::RNTuple");
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    // KeysList
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetName(), "StreamerInfo");
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    ASSERT_TRUE(readNextKey());
    // FreeSegments
+   EXPECT_EQ(key->GetSeekPdir(), 100);
 
    EXPECT_EQ(offset, size);
 }


### PR DESCRIPTION
 * Fix directory of `RBlob`s from `RFileProper`
 * Simplify methods and implementations for reserving / writing `RBlob` keys
 * Allow reserving blobs without writing key