### PR TITLE
[tutorials] Fix paths in multicore tutorials

### DIFF
--- a/tutorials/multicore/mp103_processSelector.C
+++ b/tutorials/multicore/mp103_processSelector.C
@@ -32,7 +32,7 @@ int mp103_processSelector()
    gROOT->SetBatch(kTRUE);
 
    TString selectorPath = gROOT->GetTutorialDir();
-   selectorPath += "/tree/h1analysis.C+";
+   selectorPath += "/io/tree/h1analysis.C+";
    std::cout << "selector used is: " << selectorPath << "\n";
    auto sel = TSelector::GetSelector(selectorPath);
 

--- a/tutorials/multicore/mp104_processH1.C
+++ b/tutorials/multicore/mp104_processH1.C
@@ -67,7 +67,7 @@ int mp104_processH1()
    // Run the analysis with a selector
 
    TString selectorPath = gROOT->GetTutorialDir();
-   selectorPath += "/tree/h1analysisTreeReader.C+";
+   selectorPath += "/io/tree/h1analysisTreeReader.C+";
    std::cout << tutname << "processing the H1 dataset with selector '" << selectorPath << "'\n";
    auto sel = TSelector::GetSelector(selectorPath);
 

--- a/tutorials/multicore/mp105_processEntryList.C
+++ b/tutorials/multicore/mp105_processEntryList.C
@@ -83,7 +83,7 @@ int mp105_processEntryList()
 
    // Run the analysis with a selector
    TString selectorPath = gROOT->GetTutorialDir();
-   selectorPath += "/tree/h1analysisTreeReader.C+";
+   selectorPath += "/io/tree/h1analysisTreeReader.C+";
    std::cout << tutname << "processing the entry list with selector '" << selectorPath << "'\n";
    auto sel = TSelector::GetSelector(selectorPath);
 


### PR DESCRIPTION
# This Pull request:

Fixes failures caused by https://github.com/root-project/root/pull/17097
```
1031:tutorial-multicore-mp103_processSelector
1032:tutorial-multicore-mp104_processH1
1033:tutorial-multicore-mp105_processEntryList
```

