### PR TITLE
Clarify SetOption() usage in TPave classes

### DIFF
--- a/graf2d/graf/inc/TPaveStats.h
+++ b/graf2d/graf/inc/TPaveStats.h
@@ -48,6 +48,8 @@ public:
    virtual void     SetStatFormat(const char *format="6.4g");   // *MENU*
    void             SetOptFit(Int_t fit=1);                     // *MENU*
    void             SetOptStat(Int_t stat=1);                   // *MENU*
+   void             SetOption(Option_t *option="br") override;  // *MENU*
+   void             SetDrawOption(Option_t *option="") override;
    void             SetParent(TObject*obj) override { fParent = obj; }
    void             UseCurrentStyle() override;
 

--- a/graf2d/graf/inc/TPaveStats.h
+++ b/graf2d/graf/inc/TPaveStats.h
@@ -44,7 +44,6 @@ public:
    void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SaveStyle(); // *MENU*
    void             SetAllWith(const char *, Option_t *, Double_t) override {}
-   void             SetMargin(Float_t) override { }
    virtual void     SetFitFormat(const char *format="5.4g");    // *MENU*
    virtual void     SetStatFormat(const char *format="6.4g");   // *MENU*
    void             SetOptFit(Int_t fit=1);                     // *MENU*

--- a/graf2d/graf/src/TPaveStats.cxx
+++ b/graf2d/graf/src/TPaveStats.cxx
@@ -320,6 +320,29 @@ void TPaveStats::SetStatFormat(const char *form)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Change drawing option for stats box
+/// While stats should not appear in pad list of primitives,
+/// this is the only way to modify drawing option.
+/// SetDrawOption will not have effect
+/// Redefined here to add **MENU** qualifier to show it in context menu
+
+void TPaveStats::SetOption(Option_t *option)
+{
+   TPaveText::SetOption(option);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Invalid method to change drawing option for stats box
+/// While stats box should never appear in pad list of primitives, this method cannot work
+/// Please use SetOption() method insted
+/// Redefined here to remove **MENU** qualifier and exclude it from context menu
+
+void TPaveStats::SetDrawOption(Option_t *option)
+{
+   TPaveText::SetDrawOption(option);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Paint the pave stat.
 
 void TPaveStats::Paint(Option_t *option)

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -826,12 +826,12 @@ void TPaveText::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
 void TPaveText::SetAllWith(const char *text, Option_t *option, Double_t value)
 {
-   TString opt=option;
+   TString opt = option;
    opt.ToLower();
-   TText *line;
    TIter next(fLines);
-   while ((line = (TText*) next())) {
-      if (strstr(line->GetTitle(),text)) {
+   while (auto obj = next()) {
+      auto line = dynamic_cast<TText *> (obj);
+      if (line && strstr(line->GetTitle(),text)) {
          if (opt == "align") line->SetTextAlign(Int_t(value));
          if (opt == "color") line->SetTextColor(Int_t(value));
          if (opt == "font")  line->SetTextFont(Int_t(value));

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -777,7 +777,7 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
 
       frame = pad->GetFrame();
       if(frame)
-         primitives->AddFirst(frame);
+         primitives->AddFirst(frame, "");
    }
 
    if (!need_title.empty() && gStyle->GetOptTitle()) {
@@ -796,7 +796,7 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
             title->SetTextSize(gStyle->GetTitleFontSize());
          title->AddText(need_title.c_str());
          title->SetBit(kCanDelete);
-         primitives->Add(title);
+         primitives->Add(title, title->GetOption());
       }
    }
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -4890,7 +4890,7 @@ void TGraphPainter::PaintStats(TGraph *theGraph, TF1 *fit)
    }
 
    if (!done) functions->Add(stats);
-   stats->Paint();
+   stats->Paint(stats->GetOption());
 }
 
 

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -8819,7 +8819,7 @@ void THistPainter::PaintStat(Int_t dostat, TF1 *fit)
    }
 
    if (!done) fFunctions->Add(stats);
-   stats->Paint();
+   stats->Paint(stats->GetOption());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9032,7 +9032,7 @@ void THistPainter::PaintStat2(Int_t dostat, TF1 *fit)
    }
 
    if (!done) fFunctions->Add(stats);
-   stats->Paint();
+   stats->Paint(stats->GetOption());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9246,7 +9246,7 @@ void THistPainter::PaintStat3(Int_t dostat, TF1 *fit)
    }
 
    if (!done) fFunctions->Add(stats);
-   stats->Paint();
+   stats->Paint(stats->GetOption());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. It must be used for TPaveStats - while it never appears in list of primitives
2. When call stats->Paint() - specify draw option, otherwise always default is used
3. Mark `TPaveStats::SetOption()` with `**MENU**` qualifier, hide from menu `TPaveStats::SetDrawOption()`
4. Let change margin in `TPaveStats` via context menu
5. Fix bug in `TPaveText::SetAllWith()` method
6. Adjust TWebCanvas to always add object to primitives with draw option