### PR TITLE
std::string_view for TNamed

### DIFF
--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -69,7 +69,7 @@ public:
    void          Print(Option_t *option="") const override;
    virtual void  SetAlpha(Float_t a) { fAlpha = a; }
    virtual void  SetRGB(Float_t r, Float_t g, Float_t b);
-   void          SetName(const char* name) override;
+   void          SetName(const std::string_view name) override;
 
    static void    InitializeColors();
    static void    HLS2RGB(Float_t h, Float_t l, Float_t s, Float_t &r, Float_t &g, Float_t &b);

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -256,7 +256,7 @@ public:
    virtual void        SetBufferSize(Int_t /* bufsize */) {}
    virtual void        SetModified() {}
    virtual void        SetMother(TObject *mother) {fMother = (TObject*)mother;}
-           void        SetName(const char* newname) override;
+           void        SetName(const std::string_view name) override;
    virtual void        SetTRefAction(TObject * /*ref*/, TObject * /*parent*/) {}
    virtual void        SetSeekDir(Long64_t) {}
    virtual void        SetWritable(Bool_t) {}

--- a/core/base/inc/TNamed.h
+++ b/core/base/inc/TNamed.h
@@ -34,8 +34,7 @@ protected:
 
 public:
    TNamed(): fName(), fTitle() { } // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
-   TNamed(const char *name, const char *title) : fName(name), fTitle(title) { }
-   TNamed(const TString &name, const TString &title) : fName(name), fTitle(title) { }
+   TNamed(const std::string_view name, const std::string_view title) : fName(name), fTitle(title) { }
    TNamed(const TNamed &named);
    TNamed& operator=(const TNamed& rhs);
    virtual ~TNamed();
@@ -48,9 +47,9 @@ public:
             const char  *GetTitle() const override { return fTitle; }
             ULong_t  Hash() const override { return fName.Hash(); }
             Bool_t   IsSortable() const override { return kTRUE; }
-   virtual  void     SetName(const char *name); // *MENU*
-   virtual  void     SetNameTitle(const char *name, const char *title);
-   virtual  void     SetTitle(const char *title=""); // *MENU*
+   virtual  void     SetName(const std::string_view name); // *MENU*
+   virtual  void     SetNameTitle(const std::string_view name, const std::string_view title);
+   virtual  void     SetTitle(const std::string_view title=""); // *MENU*
             void     ls(Option_t *option="") const override;
             void     Print(Option_t *option="") const override;
    virtual  Int_t    Sizeof() const;

--- a/core/base/inc/TSystemDirectory.h
+++ b/core/base/inc/TSystemDirectory.h
@@ -63,8 +63,8 @@ public:
    void        DrawClass() const override { }
    TObject    *DrawClone(Option_t *) const override { return nullptr; }
    void        SetDrawOption(Option_t *) override { }
-   void        SetName(const char *name) override { TSystemFile::SetName(name); }
-   void        SetTitle(const char *title) override { TSystemFile::SetTitle(title); }
+   void        SetName(const std::string_view name) override { TSystemFile::SetName(name); }
+   void        SetTitle(const std::string_view title) override { TSystemFile::SetTitle(title); }
    void        Delete(Option_t *) override { }
    void        Copy(TObject & ) const override { }
 

--- a/core/base/inc/TSystemFile.h
+++ b/core/base/inc/TSystemFile.h
@@ -53,8 +53,8 @@ public:
    void        DrawClass() const override { }
    TObject    *DrawClone(Option_t *) const override { return nullptr; }
    void        SetDrawOption(Option_t *) override { }
-   void        SetName(const char *name) override { TNamed::SetName(name); }
-   void        SetTitle(const char *title)  override { TNamed::SetTitle(title); }
+   void        SetName(const std::string_view name) override { TNamed::SetName(name); }
+   void        SetTitle(const std::string_view title) override { TNamed::SetTitle(title); }
    void        Delete(Option_t *) override { }
    void        Copy(TObject &) const override { }
 

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1824,7 +1824,7 @@ void TColor::RGB2HLS(Int_t r, Int_t g, Int_t b, Int_t &h, Int_t &l, Int_t &s)
 /// Set the color name and change also the name of the "dark" and "bright" associated
 /// colors if they exist.
 
-void TColor::SetName(const char* name)
+void TColor::SetName(const std::string_view name)
 {
    Int_t nd = GetColorByName(TString::Format("%s_dark",fName.Data()).Data());
    Int_t nb = GetColorByName(TString::Format("%s_bright",fName.Data()).Data());

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1284,7 +1284,7 @@ Int_t TDirectory::SaveObjectAs(const TObject *obj, const char *filename, Option_
 /// DO NOT use this method to 'rename a directory'.
 /// Renaming a directory is currently NOT supported.
 
-void TDirectory::SetName(const char* newname)
+void TDirectory::SetName(const std::string_view newname)
 {
    TNamed::SetName(newname);
 }

--- a/core/base/src/TNamed.cxx
+++ b/core/base/src/TNamed.cxx
@@ -137,7 +137,7 @@ void TNamed::Print(Option_t *) const
 /// the container must be Rehash()'ed after SetName(). For example the list
 /// of objects in the current directory is a THashList.
 
-void TNamed::SetName(const char *name)
+void TNamed::SetName(const std::string_view name)
 {
    fName = name;
    if (gPad && TestBit(kMustCleanup)) gPad->Modified();
@@ -151,7 +151,7 @@ void TNamed::SetName(const char *name)
 /// after SetName(). For example the list of objects in the current
 /// directory is a THashList.
 
-void TNamed::SetNameTitle(const char *name, const char *title)
+void TNamed::SetNameTitle(const std::string_view name, const std::string_view title)
 {
    fName  = name;
    fTitle = title;
@@ -161,7 +161,7 @@ void TNamed::SetNameTitle(const char *name, const char *title)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the title of the TNamed.
 
-void TNamed::SetTitle(const char *title)
+void TNamed::SetTitle(const std::string_view title)
 {
    fTitle = title;
    if (gPad && TestBit(kMustCleanup)) gPad->Modified();

--- a/core/gui/inc/TContextMenu.h
+++ b/core/gui/inc/TContextMenu.h
@@ -97,7 +97,7 @@ public:
    virtual void SetMethod(TFunction *m) { fSelectedMethod = m; }
    virtual void SetCalledObject(TObject *o) { fCalledObject = o; }
    virtual void SetSelectedMenuItem(TClassMenuItem *mi) { fSelectedMenuItem = mi; }
-   void SetNameTitle(const char *name, const char *title) override { TNamed::SetNameTitle(name, title); }
+   void SetNameTitle(const std::string_view name, const std::string_view title) override { TNamed::SetNameTitle(name, title); }
    virtual void SetObject(TObject *o) { fSelectedObject = o; }
    virtual void SetPad(TVirtualPad *p) { fSelectedPad = p; }
 

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -24,7 +24,7 @@ namespace ROOT {
          private:
             TString fDimensions;
          public:
-            TSources(const char *name = nullptr, const char *title = nullptr, const char *dims = nullptr) : TNamed(name,title), fDimensions(dims) {}
+            TSources(const std::string_view name = "", const std::string_view title = "", const std::string_view dims = "") : TNamed(name,title), fDimensions(dims) {}
             const char *GetDimensions() { return fDimensions; }
 
             ClassDefOverride(TSources,2);

--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -94,7 +94,7 @@ public:
    void  SetEditable(Bool_t on = kTRUE) override { fEditable = on; }             //*TOGGLE*
    Bool_t IsEditable() const override { return fEditable; }
    void  Browse(TBrowser *) override;
-   void  SetTitle(const char *title = "") override;                              // *MENU*
+   void  SetTitle(const std::string_view title = "") override;                              // *MENU*
    const char *GetTitle() const override;
    const char *GetIconName() const override {  return GetTitle(); }
 

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -6294,7 +6294,7 @@ const char *TASImage::GetTitle() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Set a title for an image.
 
-void TASImage::SetTitle(const char *title)
+void TASImage::SetTitle(const std::string_view title)
 {
    if (fTitle.IsNull()) {
       CreateThumbnail();
@@ -6308,7 +6308,7 @@ void TASImage::SetTitle(const char *title)
    int stop = fTitle.Index("*/") - 1;
 
    if ((start > 0) && (stop - start > 0)) {
-      fTitle.Replace(start, stop - start, title);
+      fTitle.Replace(start, stop - start, title.data());
    }
 }
 

--- a/graf3d/eve/inc/TEveScene.h
+++ b/graf3d/eve/inc/TEveScene.h
@@ -60,7 +60,7 @@ public:
    TGLScenePad* GetGLScene() const { return fGLScene; }
    void SetGLScene(TGLScenePad* s) { fGLScene = s; }
 
-   void SetName(const char* n) override;
+   void SetName(const std::string_view name) override;
    void Paint(Option_t* option = "") override;
 
    void DestroyElementRenderers(TEveElement* element);

--- a/graf3d/eve/src/TEveScene.cxx
+++ b/graf3d/eve/src/TEveScene.cxx
@@ -174,10 +174,10 @@ void TEveScene::RetransHierarchicallyRecurse(TEveElement* el, const TEveTrans& t
 ////////////////////////////////////////////////////////////////////////////////
 /// Set scene's name.
 
-void TEveScene::SetName(const char* n)
+void TEveScene::SetName(const std::string_view name)
 {
-   TEveElementList::SetName(n);
-   fGLScene->SetName(n);
+   TEveElementList::SetName(name);
+   fGLScene->SetName(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/inc/TNode.h
+++ b/graf3d/g3d/inc/TNode.h
@@ -83,9 +83,9 @@ public:
    void        Paint(Option_t *option="") override;
    void        RecursiveRemove(TObject *obj) override;
    virtual void        SetMatrix(TRotMatrix *matrix=nullptr) {fMatrix = matrix;}
-   void        SetName(const char *name) override;
+   void        SetName(const std::string_view name) override;
    virtual void        SetParent(TNode *parent);
-   void        SetNameTitle(const char *name, const char *title) override;
+   void        SetNameTitle(const std::string_view name, const std::string_view title) override;
    virtual void        SetPosition( Double_t x=0, Double_t y=0, Double_t z=0) {fX=x; fY=y; fZ=z;}
    virtual void        SetVisibility(Int_t vis=1); // *MENU*
    void        Sizeof3D() const override;

--- a/graf3d/g3d/inc/TRotMatrix.h
+++ b/graf3d/g3d/inc/TRotMatrix.h
@@ -61,11 +61,9 @@ public:
    virtual Bool_t    IsReflection() const {return TestBit(kReflection);}  // Return kTRUE if this matrix defines the reflection
    virtual const     Double_t* SetAngles(Double_t theta1, Double_t phi1,Double_t theta2, Double_t phi2, Double_t theta3, Double_t phi3);
    virtual void      SetMatrix(const Double_t *matrix);
-   void      SetName(const char *name) override;
+   void      SetName(const std::string_view /*name*/) override {};
 
    ClassDefOverride(TRotMatrix,2)  //Rotation Matrix for 3-D geometry objects
 };
-
-inline void TRotMatrix::SetName(const char *) { }
 
 #endif

--- a/graf3d/g3d/inc/TShape.h
+++ b/graf3d/g3d/inc/TShape.h
@@ -57,7 +57,7 @@ public:
    virtual Int_t   GetNumber()     const {return fNumber;}
    Int_t           GetVisibility() const {return fVisibility;}
    void    Paint(Option_t *option="") override;
-   void    SetName(const char *name) override;
+   void    SetName(const std::string_view /*name*/) override {};
    virtual void    SetPoints(Double_t *points) const ;
    virtual void    SetVisibility(Int_t vis) {fVisibility = vis;} // *MENU*
    void            TransformPoints(Double_t *points, UInt_t NbPnts) const;
@@ -66,7 +66,5 @@ public:
 };
 
 R__EXTERN TNode *gNode;
-
-inline void TShape::SetName(const char *) { }
 
 #endif

--- a/graf3d/g3d/src/TNode.cxx
+++ b/graf3d/g3d/src/TNode.cxx
@@ -690,7 +690,7 @@ void TNode::RecursiveRemove(TObject *obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of this Node
 
-void TNode::SetName(const char *name)
+void TNode::SetName(const std::string_view name)
 {
    if (gPad) gPad->Modified();
 
@@ -704,7 +704,7 @@ void TNode::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name and title of this Node
 
-void TNode::SetNameTitle(const char *name, const char *title)
+void TNode::SetNameTitle(const std::string_view name, const std::string_view title)
 {
    if (gPad) gPad->Modified();
 

--- a/graf3d/gl/inc/TGLSceneBase.h
+++ b/graf3d/gl/inc/TGLSceneBase.h
@@ -80,9 +80,9 @@ public:
 
    virtual const char  *GetName()  const { return fName; }
    virtual const char  *GetTitle() const { return fTitle; }
-   virtual void  SetName (const char *name)  { fName = name; }
-   virtual void  SetTitle(const char *title) { fTitle = title; }
-   virtual void  SetNameTitle(const char *name, const char *title) { SetName(name); SetTitle(title); }
+   virtual void  SetName (const std::string_view name) { fName = name; }
+   virtual void  SetTitle(const std::string_view title) { fTitle = title; }
+   virtual void  SetNameTitle(const std::string_view name, const std::string_view title) { SetName(name); SetTitle(title); }
 
    virtual TGLSceneInfo* CreateSceneInfo(TGLViewerBase* view);
    virtual void          RebuildSceneInfo(TGLRnrCtx& ctx);

--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -136,7 +136,7 @@ public:
       void          SetBetaBinParameters(Int_t bin, Double_t alpha, Double_t beta);
       void          SetConfidenceLevel(Double_t level);
       void          SetDirectory(TDirectory* dir);
-      void          SetName(const char* name) override;
+      void          SetName(const std::string_view name) override;
       Bool_t        SetPassedEvents(Int_t bin,Int_t events);
       Bool_t        SetPassedHistogram(const TH1& rPassed,Option_t* opt);
       void          SetPosteriorMode(Bool_t on = true) { SetBit(kPosteriorMode,on); SetShortestInterval(on); }
@@ -153,7 +153,7 @@ public:
       Bool_t        SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t * yBins, Int_t nz,
                             const Double_t *zBins);
 
-      void          SetTitle(const char* title) override;
+      void          SetTitle(const std::string_view title) override;
       Bool_t        SetTotalEvents(Int_t bin, Double_t events);
       Bool_t        SetTotalHistogram(const TH1& rTotal,Option_t* opt);
       void          SetUseWeightedEvents(Bool_t on = kTRUE);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -711,7 +711,7 @@ public:
    virtual void     SetRange(Double_t xmin, Double_t ymin,  Double_t xmax, Double_t ymax);
    virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin,  Double_t xmax, Double_t ymax, Double_t zmax);
    virtual void     SetSavedPoint(Int_t point, Double_t value);
-   void     SetTitle(const char *title = "") override; // *MENU*
+   void     SetTitle(const std::string_view title = "") override; // *MENU*
    virtual void     SetVectorized(Bool_t vectorized)
    {
       if (fType == EFType::kFormula && fFormula)

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -272,7 +272,7 @@ public:
    Bool_t IsVectorized() const { return fVectorized; }
    Bool_t         IsLinear() const { return TestBit(kLinear); }
    void           Print(Option_t *option = "") const override;
-   void           SetName(const char* name) override;
+   void           SetName(const std::string_view name) override;
    void           SetParameter(const char* name, Double_t value);
    void           SetParameter(Int_t param, Double_t value);
    void           SetParameters(const Double_t *params);

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -191,10 +191,10 @@ public:
    virtual void          SetPoint(Int_t i, Double_t x, Double_t y);
    virtual void          SetPointX(Int_t i, Double_t x);
    virtual void          SetPointY(Int_t i, Double_t y);
-   void                  SetName(const char *name="") override; // *MENU*
-   void                  SetNameTitle(const char *name="", const char *title="") override;
+   void                  SetName(const std::string_view name="") override; // *MENU*
+   void                  SetNameTitle(const std::string_view name="", const std::string_view title="") override;
    virtual void          SetStats(Bool_t stats=kTRUE); // *MENU*
-   void                  SetTitle(const char *title="") override;    // *MENU*
+   void                  SetTitle(const std::string_view title="") override;    // *MENU*
    virtual void          Sort(Bool_t (*greater)(const TGraph*, Int_t, Int_t)=&TGraph::CompareX,
                               Bool_t ascending=kTRUE, Int_t low=0, Int_t high=-1111);
    void                  UseCurrentStyle() override;

--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -160,12 +160,12 @@ public:
    void                  SetMaximum(Double_t maximum=-1111); // *MENU*
    void                  SetMinimum(Double_t minimum=-1111); // *MENU*
    void                  SetMaxIter(Int_t n=100000) {fMaxIter = n;} // *MENU*
-   void          SetName(const char *name) override; // *MENU*
-   void          SetNameTitle(const char *name, const char *title) override;
+   void          SetName(const std::string_view name) override; // *MENU*
+   void          SetNameTitle(const std::string_view name, const std::string_view title) override;
    void                  SetNpx(Int_t npx=40); // *MENU*
    void                  SetNpy(Int_t npx=40); // *MENU*
    virtual void          SetPoint(Int_t point, Double_t x, Double_t y, Double_t z); // *MENU*
-   void          SetTitle(const char *title="") override; // *MENU*
+   void          SetTitle(const std::string_view title="") override; // *MENU*
 
 
    ClassDefOverride(TGraph2D,1)  //Set of n x[n],y[n],z[n] points with 3-d graphics including Delaunay triangulation

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -405,8 +405,8 @@ public:
    virtual void     SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; } // *MENU*
    virtual void     SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; } // *MENU*
 
-           void     SetName(const char *name) override; // *MENU*
-           void     SetNameTitle(const char *name, const char *title) override;
+           void     SetName(const std::string_view name) override; // *MENU*
+           void     SetNameTitle(const std::string_view name, const std::string_view title) override;
    virtual void     SetNdivisions(Int_t n=510, Option_t *axis="X");
    virtual void     SetNormFactor(Double_t factor=1) {fNormFactor = factor;}
    virtual void     SetStats(Bool_t stats=kTRUE); // *MENU*
@@ -416,7 +416,7 @@ public:
    virtual void     SetTitleOffset(Float_t offset=1, Option_t *axis="X");
    virtual void     SetTitleSize(Float_t size=0.02, Option_t *axis="X");
            void     SetStatOverflows(EStatOverflows statOverflows) { fStatOverflows = statOverflows; } ///< See GetStatOverflows for more information.
-           void     SetTitle(const char *title) override;  // *MENU*
+           void     SetTitle(const std::string_view title) override;  // *MENU*
    virtual void     SetXTitle(const char *title) {fXaxis.SetTitle(title);}
    virtual void     SetYTitle(const char *title) {fYaxis.SetTitle(title);}
    virtual void     SetZTitle(const char *title) {fZaxis.SetTitle(title);}

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -190,7 +190,7 @@ protected:
    void SetBinError(Long64_t bin, Double_t e) { SetBinError2(bin, e*e); }
    void AddBinContent(const Int_t* x, Double_t v = 1.) { AddBinContent(GetBin(x), v); }
    void SetEntries(Double_t entries) { fEntries = entries; }
-   void SetTitle(const char *title) override;
+   void SetTitle(const std::string_view title) override;
 
    std::vector<Double_t> GetBinCenter(const std::vector<Int_t> &idx) const;
 

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -3544,13 +3544,13 @@ void TEfficiency::SetDirectory(TDirectory* dir)
 /// Note: The names of the internal histograms are set to "name + _total" and
 ///      "name + _passed" respectively.
 
-void TEfficiency::SetName(const char* name)
+void TEfficiency::SetName(const std::string_view name)
 {
    TNamed::SetName(name);
 
    //setting the names (appending the correct ending)
-   TString name_total = name + TString("_total");
-   TString name_passed = name + TString("_passed");
+   TString name_total = TString(name) + TString("_total");
+   TString name_passed = TString(name) + TString("_passed");
    fTotalHistogram->SetName(name_total);
    fPassedHistogram->SetName(name_passed);
 }
@@ -3723,12 +3723,12 @@ void TEfficiency::SetStatisticOption(EStatOption option)
 /// Example: Setting the title to "My Efficiency" and label the axis
 ///     pEff->SetTitle("My Efficiency;x label;eff");
 
-void TEfficiency::SetTitle(const char* title)
+void TEfficiency::SetTitle(const std::string_view title)
 {
 
    //setting the titles (looking for the first semicolon and insert the tokens there)
-   TString title_passed = title;
-   TString title_total = title;
+   TString title_passed(title);
+   TString title_total(title);
    Ssiz_t pos = title_passed.First(";");
    if (pos != kNPOS) {
       title_passed.Insert(pos," (passed)");

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3555,9 +3555,9 @@ void TF1::SetSavedPoint(Int_t point, Double_t value)
 ///  the function title is "fffffff" and "xxxx" and "yyyy" are the
 ///  titles for the X and Y axis respectively.
 
-void TF1::SetTitle(const char *title)
+void TF1::SetTitle(const std::string_view title)
 {
-   if (!title) return;
+   if (title.empty()) return;
    fTitle = title;
    if (!fHistogram) return;
    fHistogram->SetTitle(title);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -452,11 +452,11 @@ TFormula::TFormula()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static bool IsReservedName(const char* name)
+static bool IsReservedName(const std::string_view name)
 {
-   if (strlen(name)!=1) return false;
+   if (name.size()!=1) return false;
    for (auto const & specialName : {"x","y","z","t"}){
-      if (strcmp(name,specialName)==0) return true;
+      if (name==specialName) return true;
    }
    return false;
 }
@@ -2637,12 +2637,12 @@ void TFormula::AddVariables(const TString *vars, const Int_t size)
 /// Set the name of the formula. We need to allow the list of function to
 /// properly handle the hashes.
 
-void TFormula::SetName(const char* name)
+void TFormula::SetName(const std::string_view name)
 {
    if (IsReservedName(name)) {
       Error("SetName", "The name \'%s\' is reserved as a TFormula variable name.\n"
                        "\tThis function will not be renamed.",
-            name);
+            name.data());
    } else {
       // Here we need to remove and re-add to keep the hashes consistent with
       // the underlying names.

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2383,7 +2383,7 @@ void TGraph::SetPointY(Int_t i, Double_t y)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set graph name.
-void TGraph::SetName(const char *name)
+void TGraph::SetName(const std::string_view name)
 {
    fName = name;
    if (fHistogram) fHistogram->SetName(name);
@@ -2399,7 +2399,7 @@ void TGraph::SetName(const char *name)
 /// To insert the character `;` in one of the titles, one should use `#;`
 /// or `#semicolon`.
 
-void TGraph::SetTitle(const char* title)
+void TGraph::SetTitle(const std::string_view title)
 {
    fTitle = title;
    fTitle.ReplaceAll("#;",2,"#semicolon",10);
@@ -2419,7 +2419,7 @@ void TGraph::SetTitle(const char* title)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set graph name and title
 
-void TGraph::SetNameTitle(const char *name, const char *title)
+void TGraph::SetNameTitle(const std::string_view name, const std::string_view title)
 {
    SetName(name);
    SetTitle(title);

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1638,7 +1638,7 @@ void TGraph2D::SetMinimum(Double_t minimum)
 ////////////////////////////////////////////////////////////////////////////////
 /// Changes the name of this 2D graph
 
-void TGraph2D::SetName(const char *name)
+void TGraph2D::SetName(const std::string_view name)
 {
    //  2D graphs are named objects in a THashList.
    //  We must update the hashlist if we change the name
@@ -1652,7 +1652,7 @@ void TGraph2D::SetName(const char *name)
 /// Change the name and title of this 2D graph
 ///
 
-void TGraph2D::SetNameTitle(const char *name, const char *title)
+void TGraph2D::SetNameTitle(const std::string_view name, const std::string_view title)
 {
    //  2D graphs are named objects in a THashList.
    //  We must update the hashlist if we change the name
@@ -1759,7 +1759,7 @@ void TGraph2D::SetPoint(Int_t n, Double_t x, Double_t y, Double_t z)
 /// g->SetTitle("Graph title; X axis title; Y axis title; Z axis title");
 /// ~~~
 
-void TGraph2D::SetTitle(const char* title)
+void TGraph2D::SetTitle(const std::string_view title)
 {
    fTitle = title;
    if (fHistogram) fHistogram->SetTitle(title);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6746,7 +6746,7 @@ void TH1::SetDefaultSumw2(Bool_t sumw2)
 /// To insert the character `;` in one of the titles, one should use `#;`
 /// or `#semicolon`.
 
-void TH1::SetTitle(const char *title)
+void TH1::SetTitle(const std::string_view title)
 {
    fTitle = title;
    fTitle.ReplaceAll("#;",2,"#semicolon",10);
@@ -8992,7 +8992,7 @@ void TH1::SetError(const Double_t *error)
 /// Change the name of this histogram
 ///
 
-void TH1::SetName(const char *name)
+void TH1::SetName(const std::string_view name)
 {
    //  Histograms are named objects in a THashList.
    //  We must update the hashlist if we change the name
@@ -9006,7 +9006,7 @@ void TH1::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name and title of this histogram
 
-void TH1::SetNameTitle(const char *name, const char *title)
+void TH1::SetNameTitle(const std::string_view name, const std::string_view title)
 {
    //  Histograms are named objects in a THashList.
    //  We must update the hashlist if we change the name

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -1193,7 +1193,7 @@ void THnBase::SetBinEdges(Int_t idim, const Double_t* bins)
 /// To insert the character ";" in one of the titles, one should use "#;"
 /// or "#semicolon".
 
-void THnBase::SetTitle(const char *title)
+void THnBase::SetTitle(const std::string_view title)
 {
    fTitle = title;
    fTitle.ReplaceAll("#;",2,"#semicolon",10);

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -505,8 +505,8 @@ public:
     return _namePtr ;
   }
 
-  void SetName(const char* name) override ;
-  void SetNameTitle(const char *name, const char *title) override ;
+  void SetName(const std::string_view name) override ;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override ;
 
   virtual bool importWorkspaceHook(RooWorkspace &ws)
   {

--- a/roofit/roofitcore/inc/RooAbsBinning.h
+++ b/roofit/roofitcore/inc/RooAbsBinning.h
@@ -25,8 +25,8 @@ class RooAbsReal ;
 class RooAbsBinning : public TNamed, public RooPrintable {
 public:
 
-  RooAbsBinning(const char* name=nullptr) : TNamed{name, name} {}
-  RooAbsBinning(const RooAbsBinning& other, const char* name=nullptr) : TNamed(name,name), RooPrintable(other) {
+  RooAbsBinning(const std::string_view name="") : TNamed{name, name} {}
+  RooAbsBinning(const RooAbsBinning& other, const std::string_view name="") : TNamed(name,name), RooPrintable(other) {
     // Copy constructor
   }
   TObject* Clone(const char* newname=nullptr) const override { return clone(newname) ; }

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -300,8 +300,8 @@ public:
     return _namePtr ;
   }
 
-  void SetName(const char* name) override ;
-  void SetNameTitle(const char *name, const char *title) override ;
+  void SetName(const std::string_view name) override ;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override ;
 
   /// Returns a unique ID that is different for every instantiated RooAbsData object.
   /// This ID can be used whether two RooAbsData are the same object, which is safer

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -140,8 +140,8 @@ public:
   void printValue(std::ostream& os) const override;
   void printDataHistogram(std::ostream& os, RooRealVar* obs) const;
 
-  void SetName(const char *name) override;
-  void SetNameTitle(const char *name, const char* title) override;
+  void SetName(const std::string_view name) override;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override;
 
   Int_t getIndex(const RooAbsCollection& coord, bool fast = false) const;
   /// \copydoc getIndex(const RooAbsCollection&,bool) const

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -110,8 +110,8 @@ public:
   void printArgs(std::ostream& os) const override;
   void printValue(std::ostream& os) const override;
 
-  void SetName(const char *name) override;
-  void SetNameTitle(const char *name, const char* title) override;
+  void SetName(const std::string_view name) override;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override;
 
   static void cleanup();
 

--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -154,8 +154,8 @@ public:
   bool isIdenticalNoCov(const RooFitResult& other, double tol=1e-6, double tolErr=1e-3, bool verbose=true) const ;
   bool isIdentical(const RooFitResult& other, double tol=1e-6, double tolCorr=1e-4, bool verbose=true) const ;
 
-  void SetName(const char *name) override ;
-  void SetNameTitle(const char *name, const char* title) override ;
+  void SetName(const std::string_view name) override ;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override ;
 
 
 

--- a/roofit/roofitcore/inc/RooLinTransBinning.h
+++ b/roofit/roofitcore/inc/RooLinTransBinning.h
@@ -22,7 +22,7 @@
 class RooLinTransBinning : public RooAbsBinning {
 public:
 
-  RooLinTransBinning(const char* name=nullptr) : RooAbsBinning(name) { }
+  RooLinTransBinning(const std::string_view name="") : RooAbsBinning(name) { }
   RooLinTransBinning(const RooAbsBinning& input, double slope=1.0, double offset=0.0, const char* name=nullptr);
   RooLinTransBinning(const RooLinTransBinning&, const char* name=nullptr);
   RooAbsBinning* clone(const char* name=nullptr) const override { return new RooLinTransBinning(*this,name) ; }

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -92,9 +92,9 @@ public:
   void SetMarkerColor(Color_t tcolor = 1) ;
   void SetMarkerSize(Size_t msize = 1) ;
   void SetMarkerStyle(Style_t mstyle = 1) ;
-  void SetName(const char *name) override ;
-  void SetTitle(const char *name) override ;
-  void SetNameTitle(const char *name, const char* title) override ;
+  void SetName(const std::string_view name) override ;
+  void SetTitle(const std::string_view title) override ;
+  void SetNameTitle(const std::string_view name, const std::string_view title) override ;
   void SetNdivisions(Int_t n = 510, Option_t* axis = "X") ;
   void SetOption(Option_t* option = " ") ;
   void SetStats(bool stats = true) ;

--- a/roofit/roofitcore/inc/RooUniformBinning.h
+++ b/roofit/roofitcore/inc/RooUniformBinning.h
@@ -22,7 +22,7 @@
 class RooUniformBinning : public RooAbsBinning {
 public:
 
-  RooUniformBinning(const char* name=nullptr) : RooAbsBinning{name} {}
+  RooUniformBinning(const std::string_view name="") : RooAbsBinning{name} {}
   RooUniformBinning(double xlo, double xhi, Int_t nBins, const char* name=nullptr) ;
   RooUniformBinning(const RooUniformBinning& other, const char* name=nullptr) ;
   RooAbsBinning* clone(const char* name=nullptr) const override { return new RooUniformBinning(*this,name?name:GetName()) ; }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2345,7 +2345,7 @@ void RooAbsArg::wireAllCaches()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooAbsArg::SetName(const char* name)
+void RooAbsArg::SetName(const std::string_view name)
 {
   TNamed::SetName(name) ;
   auto newPtr = RooNameReg::instance().constPtr(GetName()) ;
@@ -2362,7 +2362,7 @@ void RooAbsArg::SetName(const char* name)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooAbsArg::SetNameTitle(const char *name, const char *title)
+void RooAbsArg::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   TNamed::SetTitle(title) ;
   SetName(name);

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -2488,7 +2488,7 @@ void RooAbsData::setGlobalObservables(RooArgSet const& globalObservables) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooAbsData::SetName(const char* name)
+void RooAbsData::SetName(const std::string_view name)
 {
   TNamed::SetName(name) ;
   auto newPtr = RooNameReg::instance().constPtr(GetName()) ;
@@ -2505,7 +2505,7 @@ void RooAbsData::SetName(const char* name)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooAbsData::SetNameTitle(const char *name, const char *title)
+void RooAbsData::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   TNamed::SetTitle(title) ;
   SetName(name);

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -2227,7 +2227,7 @@ TIterator* RooDataHist::sliceIterator(RooAbsArg& sliceArg, const RooArgSet& othe
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of the RooDataHist
 
-void RooDataHist::SetName(const char *name)
+void RooDataHist::SetName(const std::string_view name)
 {
   if (_dir) _dir->GetList()->Remove(this);
   // We need to use the function from RooAbsData, because it already overrides TNamed::SetName
@@ -2239,7 +2239,7 @@ void RooDataHist::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the title of this RooDataHist
 
-void RooDataHist::SetNameTitle(const char *name, const char* title)
+void RooDataHist::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   SetName(name);
   SetTitle(title);

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1644,7 +1644,7 @@ void RooDataSet::printArgs(ostream& os) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of this dataset into the given name
 
-void RooDataSet::SetName(const char *name)
+void RooDataSet::SetName(const std::string_view name)
 {
   if (_dir) _dir->GetList()->Remove(this);
   // We need to use the function from RooAbsData, because it already overrides TNamed::SetName
@@ -1656,7 +1656,7 @@ void RooDataSet::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the title of this dataset into the given name
 
-void RooDataSet::SetNameTitle(const char *name, const char* title)
+void RooDataSet::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   SetName(name);
   SetTitle(title);

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -1366,7 +1366,7 @@ RooAbsPdf* RooFitResult::createHessePdf(const RooArgSet& params) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Change name of RooFitResult object
 
-void RooFitResult::SetName(const char *name)
+void RooFitResult::SetName(const std::string_view name)
 {
   if (_dir) _dir->GetList()->Remove(this);
   TNamed::SetName(name) ;
@@ -1377,7 +1377,7 @@ void RooFitResult::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change name and title of RooFitResult object
 
-void RooFitResult::SetNameTitle(const char *name, const char* title)
+void RooFitResult::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   if (_dir) _dir->GetList()->Remove(this);
   TNamed::SetNameTitle(name,title) ;

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1178,7 +1178,7 @@ double RooPlot::getFitRangeNEvt(double xlo, double xhi) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the name of the RooPlot to 'name'
 
-void RooPlot::SetName(const char *name)
+void RooPlot::SetName(const std::string_view name)
 {
   if (_dir) _dir->GetList()->Remove(this);
   TNamed::SetName(name) ;
@@ -1189,7 +1189,7 @@ void RooPlot::SetName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the name and title of the RooPlot to 'name' and 'title'
 
-void RooPlot::SetNameTitle(const char *name, const char* title)
+void RooPlot::SetNameTitle(const std::string_view name, const std::string_view title)
 {
   if (_dir) _dir->GetList()->Remove(this);
   TNamed::SetNameTitle(name,title) ;
@@ -1200,7 +1200,7 @@ void RooPlot::SetNameTitle(const char *name, const char* title)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the title of the RooPlot to 'title'
 
-void RooPlot::SetTitle(const char* title)
+void RooPlot::SetTitle(const std::string_view title)
 {
   TNamed::SetTitle(title) ;
   _hist->SetTitle(title) ;

--- a/roofit/roostats/src/MCMCIntervalPlot.cxx
+++ b/roofit/roostats/src/MCMCIntervalPlot.cxx
@@ -267,7 +267,7 @@ void MCMCIntervalPlot::DrawKeysPdfInterval(const Option_t* options)
       if (frame != nullptr && fPosteriorKeysPdf != nullptr) {
          // draw shading in interval
          if (isEmpty) {
-            frame->SetTitle(nullptr);
+            frame->SetTitle("");
          } else {
             frame->SetTitle(GetTitle());
          }
@@ -321,7 +321,7 @@ void MCMCIntervalPlot::DrawKeysPdfInterval(const Option_t* options)
       if (!isEmpty) {
          contHist->SetTitle(GetTitle());
       } else {
-         contHist->SetTitle(nullptr);
+         contHist->SetTitle("");
       }
 
       contHist->SetStats(false);
@@ -360,7 +360,7 @@ void MCMCIntervalPlot::DrawHistInterval(const Option_t* options)
       TH1F* hist = reinterpret_cast<TH1F*>(DrawPosteriorHist(options, nullptr, false));
       if (hist == nullptr) return;
       if (isEmpty) {
-         hist->SetTitle(nullptr);
+         hist->SetTitle("");
       } else {
          hist->SetTitle(GetTitle());
       }
@@ -421,7 +421,7 @@ void MCMCIntervalPlot::DrawHistInterval(const Option_t* options)
       if (!isEmpty) {
          fPosteriorHist->SetTitle(GetTitle());
       } else {
-         fPosteriorHist->SetTitle(nullptr);
+         fPosteriorHist->SetTitle("");
       }
       delete axes;
 
@@ -458,7 +458,7 @@ void MCMCIntervalPlot::DrawTailFractionInterval(const Option_t* options)
       TH1F* hist = reinterpret_cast<TH1F*>(DrawPosteriorHist(options, nullptr, false));
       if (hist == nullptr) return;
       if (isEmpty) {
-         hist->SetTitle(nullptr);
+         hist->SetTitle("");
       } else {
          hist->SetTitle(GetTitle());
       }

--- a/roofit/xroofit/inc/RooFit/xRooFit/xRooNode.h
+++ b/roofit/xroofit/inc/RooFit/xRooFit/xRooNode.h
@@ -134,8 +134,8 @@ public:
 
    ~xRooNode() override;
 
-   void SetName(const char *name) override;   // *MENU*
-   void SetTitle(const char *title) override; // *MENU*
+   void SetName(const std::string_view name) override;   // *MENU*
+   void SetTitle(const std::string_view title) override; // *MENU*
 
    /** @private */
    const char *GetNodeType() const;

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -877,7 +877,8 @@ public:
    {
       return (binning() && strlen(binning()->GetTitle())) ? binning()->GetTitle() : GetParent()->GetTitle();
    }
-   void SetTitle(const char *title) override
+
+   void SetTitle(const std::string_view title) override
    {
       if (binning()) {
          const_cast<RooAbsBinning *>(binning())->SetTitle(title);
@@ -5113,21 +5114,21 @@ TGListTree *xRooNode::GetListTree(TBrowser *b) const
    return nullptr;
 }
 
-void xRooNode::SetName(const char *name)
+void xRooNode::SetName(const std::string_view name)
 {
    TNamed::SetName(name);
    if (auto a = get<RooAbsArg>(); a)
-      a->setStringAttribute("alias", name);
+      a->setStringAttribute("alias", name.data());
    for (auto o : *gROOT->GetListOfBrowsers()) {
       if (auto b = dynamic_cast<TBrowser *>(o); b) {
          if (auto item = GetTreeItem(b); item) {
-            item->SetText(name);
+            item->SetText(name.data());
          }
       }
    }
 }
 
-void xRooNode::SetTitle(const char *title)
+void xRooNode::SetTitle(const std::string_view title)
 {
    if (auto o = (get<TNamed>()); o) {
       if (auto c = mainChild(); c.get()) {

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -164,7 +164,7 @@ public:
    virtual void      SetEntryListFile(const char *filename="", Option_t *opt="");
    void      SetEventList(TEventList *evlist) override;
    void      SetMakeClass(Int_t make) override { TTree::SetMakeClass(make); if (fTree) fTree->SetMakeClass(make);}
-   void      SetName(const char *name) override;
+   void      SetName(const std::string_view name) override;
    virtual void      SetPacketSize(Int_t size = 100);
    virtual void      SetProof(bool on = true, bool refresh = false, bool gettreeheader = false);
    void      SetWeight(Double_t w=1, Option_t *option="") override;

--- a/tree/tree/inc/TEventList.h
+++ b/tree/tree/inc/TEventList.h
@@ -63,7 +63,7 @@ public:
    virtual void      Resize(Int_t delta=0);
    virtual void      SetDelta(Int_t delta=100) {fDelta = delta;}
    virtual void      SetDirectory(TDirectory *dir);
-   void      SetName(const char *name) override; // *MENU*
+   void      SetName(const std::string_view name) override; // *MENU*
    virtual void      SetReapplyCut(bool apply = false) {fReapply = apply;}; // *TOGGLE*
    virtual void      Sort();
    virtual void      Subtract(const TEventList *list);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -663,7 +663,7 @@ public:
    virtual void            SetMaxEntryLoop(Long64_t maxev = kMaxEntries) { fMaxEntryLoop = maxev; } // *MENU*
    static  void            SetMaxTreeSize(Long64_t maxsize = 100000000000LL);
    virtual void            SetMaxVirtualSize(Long64_t size = 0) { fMaxVirtualSize = size; } // *MENU*
-           void            SetName(const char* name) override; // *MENU*
+           void            SetName(const std::string_view name) override; // *MENU*
 
    /**
     * @brief Sets the address of the object to be notified when the tree is loaded.

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2966,7 +2966,7 @@ void TChain::SetEventList(TEventList *evlist)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of this TChain.
 
-void TChain::SetName(const char* name)
+void TChain::SetName(const std::string_view name)
 {
    if (fGlobalRegistration) {
       // Should this be extended to include the call to TTree::SetName?

--- a/tree/tree/src/TEventList.cxx
+++ b/tree/tree/src/TEventList.cxx
@@ -364,7 +364,7 @@ void TEventList::SetDirectory(TDirectory *dir)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of this TEventList.
 
-void TEventList::SetName(const char *name)
+void TEventList::SetName(const std::string_view name)
 {
    //  TEventLists are named objects in a THashList.
    //  We must update the hashlist if we change the name

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -9193,7 +9193,7 @@ void TTree::SetMaxTreeSize(Long64_t maxsize)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the name of this tree.
 
-void TTree::SetName(const char* name)
+void TTree::SetName(const std::string_view name)
 {
    if (gPad) {
       gPad->Modified();

--- a/tree/treeviewer/inc/TParallelCoordVar.h
+++ b/tree/treeviewer/inc/TParallelCoordVar.h
@@ -108,7 +108,7 @@ public:
    void           SetInitMax(Double_t max) {fMaxInit = max;}
    void           SetLiveRangesUpdate(bool on);
    void           SetLogScale(bool log); // *TOGGLE* *GETTER=GetLogScale
-   void           SetTitle(const char* /*title*/) override {} // To hide TNamed::SetTitle.
+   void           SetTitle(const std::string_view /*title*/) override {} // To hide TNamed::SetTitle.
    void           SetValues(Long64_t length, Double_t* val);
    void           SetX(Double_t x, bool gl);    // Set a new x position in case of a vertical display.
    void           SetY(Double_t y, bool gl);    // Set a new y position in case of a horizontal display.


### PR DESCRIPTION
# This Pull request: Move from char* to string_view for TNamed

## Changes or fixes:

As ROOT is now compiled using C++17, it is possible to use std::string_view in place of char*. For now only TNamed 'SetName' 'SetTitle' 'SetNameTitle' has been moved to std::string_view. Usage of std::string_view in other PR would allow to used std::string directly such as : 

```cpp
std::string name{"name"};
TH1F::TH1F th1(name,"title",1,0);
```
This PR is concentrating on TNamed as it quite low level in the class hierarchy.

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)