### PR TITLE
[PyROOT] Don't assume ownership of TTree created by `CloneTree()`

### DIFF
--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -1,5 +1,6 @@
-import gc
 import ROOT
+import gc
+import os
 import unittest
 
 
@@ -70,6 +71,19 @@ class MemoryStlString(unittest.TestCase):
         # The test is just that the memory regulation works correctly and the
         # application does not segfault
         c = ROOT.TColor(42, 42, 42)
+
+    def test_ttree_clone_in_file_context(self):
+        """Test that CloneTree() doesn't give the ownership to Python when
+        TFile is opened."""
+
+        filename = "test_ttree_clone_in_file_context"
+
+        ttree = ROOT.TTree("tree", "tree")
+
+        with ROOT.TFile(filename, "RECREATE") as infile:
+            ttree_clone = ttree.CloneTree()
+
+        os.remove(filename)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Just like in the case of the TTree constructor, Python does not own the TTree if the current directory is a TFile.

Fixes a failure in the CMSSW unit tests: https://github.com/cms-sw/cmsdist/pull/9542

Needs to be backported to the 6.34 release branch.