### PR TITLE
[json] correctly store/restore `TList`

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1757,8 +1757,11 @@ void TBufferJSON::JsonReadCollection(TCollection *col, const TClass *)
 
          map->Add(tobj, static_cast<TObject *>(subobj2));
       } else if (lst) {
-         std::string opt = json->at("opt").at(n).get<std::string>();
-         lst->Add(tobj, opt.c_str());
+         auto &elem = json->at("opt").at(n);
+         if (elem.is_null())
+            lst->Add(tobj);
+         else
+            lst->Add(tobj, elem.get<std::string>().c_str());
       } else {
          // generic method, all kinds of TCollection should work
          col->Add(tobj);

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1610,12 +1610,8 @@ void TBufferJSON::JsonWriteCollection(TCollection *col, const TClass *)
    // collection treated as JS Array
    AppendOutput("[");
 
-   TMap *map = nullptr;
-   TList *lst = nullptr;
-   if (col->InheritsFrom(TList::Class()))
-      lst = dynamic_cast<TList *>(col);
-   else if (col->InheritsFrom(TMap::Class()))
-      map = dynamic_cast<TMap *>(col);
+   auto map = dynamic_cast<TMap *>(col);
+   auto lst = dynamic_cast<TList *>(col);
 
    TString sopt;
    Bool_t first = kTRUE;

--- a/io/io/test/TBufferJSONTests.cxx
+++ b/io/io/test/TBufferJSONTests.cxx
@@ -1,5 +1,6 @@
 #include "TBufferJSON.h"
 #include "TNamed.h"
+#include "TList.h"
 #include <string>
 
 #include "gtest/gtest.h"
@@ -45,5 +46,51 @@ TEST(TBufferJSON, utf8_3)
    auto named1 = TBufferJSON::FromJSON<TNamed>(json.Data());
 
    EXPECT_EQ(str0, named1->GetTitle());
+}
+
+TEST(TBufferJSON, TList_Add_Without_Option)
+{
+   TList lst0;
+   lst0.Add(new TNamed("name0", "title0"));  // without option
+   lst0.Add(new TNamed("name1", "title1"), ""); // with empty option
+   lst0.Add(new TNamed("name2", "title2"), "option2"); // with non-empty option
+   auto json = TBufferJSON::ToJSON(&lst0);
+
+   // auto f = new TMemFile("test.root", "RECREATE");
+   // f->WriteTObject(&lst0, "list");
+
+   lst0.Delete();
+
+   auto lst1 = TBufferJSON::FromJSON<TList>(json.Data());
+
+   // auto lst1 = f->Get<TList>("list");
+   // delete f;
+
+   EXPECT_NE(lst1, nullptr);
+
+   auto link = lst1->FirstLink();
+
+   EXPECT_STREQ("name0", link->GetObject()->GetName());
+   EXPECT_STREQ("title0", link->GetObject()->GetTitle());
+   EXPECT_STREQ("", link->GetAddOption()); // by default empty string returned
+   EXPECT_EQ(dynamic_cast<TObjOptLink *>(link), nullptr);
+
+   link = link->Next();
+
+   EXPECT_STREQ("name1", link->GetObject()->GetName());
+   EXPECT_STREQ("title1", link->GetObject()->GetTitle());
+   EXPECT_STREQ("", link->GetAddOption());
+   EXPECT_NE(dynamic_cast<TObjOptLink *>(link), nullptr); // this will fail in normal ROOT I/O
+
+   link = link->Next();
+
+   EXPECT_STREQ("name2", link->GetObject()->GetName());
+   EXPECT_STREQ("title2", link->GetObject()->GetTitle());
+   EXPECT_STREQ("option2", link->GetAddOption());
+   EXPECT_NE(dynamic_cast<TObjOptLink *>(link), nullptr);
+
+   link = link->Next();
+
+   EXPECT_EQ(link, nullptr);
 }
 


### PR DESCRIPTION
There is principal difference between `lst->Add(obj)` and `lst->Add(obj, "")`
In first case `TObjLink` is created, in second `TObjOptLink`.
When such `TList` was stored in JSON and read back, all entries in the `TList` were `TObjOptLink`
Now such situation marked specially and reconstructed `TList` object is correct.

Modify storage and reading part.
Add correspondent test.

IMPORTANT!!!

Normal ROOT I/O also has problem with such `TList`. When read from the buffer, 
all entries with **empty** options converted into `TObjLink`. But `TObjLink::GetOption()` returns not empty string 
but `obj->GetOption()`. 

This can change drawing of TCanvas, when such canvas read from the file. 
There are many classes like `TH1` or `TPave` implementing `GetOption()` method and 
potentially returning non-empty string.

