### PR TITLE
[graf2d] mimick TPDF behavior with box strokes also in TLatex

### DIFF
--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -258,10 +258,13 @@ void TTeXDump::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
    if (fillis==1) {
       SetColor(fFillColor);
       PrintStr("@");
-      PrintStr("\\draw [color=c, fill=c");
       if (fCurrentAlpha != 1.) {
+         PrintStr("\\fill [c");
          PrintStr(", fill opacity=");
          WriteReal(fCurrentAlpha, kFALSE);
+      }
+      else {
+         PrintStr("\\draw [color=c, fill=c");
       }
       PrintStr("] (");
       WriteReal(x1c, kFALSE);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

box stroke is only painted if opacity is 100%, as is the case with TPDF

See https://root-forum.cern.ch/t/image-quality-issue-when-saving-th2ds-drawn-with-colz-option-as-a-pdf/62334/18?u=ferhue