### PR TITLE
[6.34] builtins: update Davix to add patch for gcc14 in rapidjson

### DIFF
--- a/builtins/davix/CMakeLists.txt
+++ b/builtins/davix/CMakeLists.txt
@@ -10,9 +10,9 @@ find_package(libuuid REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-set(DAVIX_VERSION "0.8.7")
+set(DAVIX_VERSION "0.8.7p1")
 set(DAVIX_URL "http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources")
-set(DAVIX_URLHASH "SHA256=78c24e14edd7e4e560392d67147ec8658c2aa0d3640415bdf6bc513afcf695e6")
+set(DAVIX_URLHASH "SHA256=d4eee9f20aa032893ce488273cc0bfb62bcad8e2a1afa6b260130508eaf3ce54")
 set(DAVIX_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/DAVIX-prefix)
 set(DAVIX_LIBNAME ${CMAKE_STATIC_LIBRARY_PREFIX}davix${CMAKE_STATIC_LIBRARY_SUFFIX})
 


### PR DESCRIPTION
BP of https://github.com/root-project/root/pull/17192


