### PR TITLE
strlen microoptimization: use compiletime-constant instead of runtime-constant

### DIFF
--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -195,7 +195,7 @@ tryfile:
       // allow url of form: "proto://"
    } else {
       if (defaultIsFile) {
-         const std::size_t bufferSize = strlen("file:") + strlen(u0) + 1;
+         const std::size_t bufferSize = std::char_traits<char>::length("file:") + strlen(u0) + 1;
          char *newu = new char [bufferSize];
          snprintf(newu, bufferSize, "file:%s", u0);
          delete [] u0;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -624,7 +624,8 @@ bool TClassEdit::IsDefAlloc(const char *allocname, const char *classname)
    string_view a( allocname );
    // In Windows, allocname might be 'class const std::allocator<int>',
    // (never 'const class ...'), so we start by stripping the 'class ', if any
-   constexpr static int clalloclen = std::char_traits<char>::length("class ");
+   constexpr auto length = std::char_traits<char>::length;
+   constexpr static int clalloclen = length("class ");
    if (a.compare(0,clalloclen,"class ") == 0) {
       a.remove_prefix(clalloclen);
    }
@@ -634,7 +635,7 @@ bool TClassEdit::IsDefAlloc(const char *allocname, const char *classname)
    if (a=="__default_alloc_template<true,0>")   return true;
    if (a=="__malloc_alloc_template<0>")         return true;
 
-   constexpr static int alloclen = std::char_traits<char>::length("allocator<");
+   constexpr static int alloclen = length("allocator<");
    if (a.compare(0,alloclen,"allocator<") != 0) {
       return false;
    }
@@ -683,7 +684,8 @@ bool TClassEdit::IsDefAlloc(const char *allocname,
    string_view a( allocname );
    RemoveStd(a);
 
-   constexpr static int alloclen = std::char_traits<char>::length("allocator<");
+   constexpr auto length = std::char_traits<char>::length;
+   constexpr static int alloclen = length("allocator<");
    if (a.compare(0,alloclen,"allocator<") != 0) {
       return false;
    }
@@ -691,7 +693,7 @@ bool TClassEdit::IsDefAlloc(const char *allocname,
 
    RemoveStd(a);
 
-   constexpr static int pairlen = std::char_traits<char>::length("pair<");
+   constexpr static int pairlen = length("pair<");
    if (a.compare(0,pairlen,"pair<") != 0) {
       return false;
    }
@@ -1424,32 +1426,33 @@ int TClassEdit::IsSTLCont(const char *type, int testAlloc)
 
 bool TClassEdit::IsStdClass(const char *classname)
 {
+   constexpr auto length = std::char_traits<char>::length;
    classname += StdLen( classname );
    if ( strcmp(classname,"string")==0 ) return true;
-   if ( strncmp(classname,"bitset<",std::char_traits<char>::length("bitset<"))==0) return true;
+   if ( strncmp(classname,"bitset<",length("bitset<"))==0) return true;
    if ( IsStdPair(classname) ) return true;
    if ( strcmp(classname,"allocator")==0) return true;
-   if ( strncmp(classname,"allocator<",std::char_traits<char>::length("allocator<"))==0) return true;
-   if ( strncmp(classname,"greater<",std::char_traits<char>::length("greater<"))==0) return true;
-   if ( strncmp(classname,"less<",std::char_traits<char>::length("less<"))==0) return true;
-   if ( strncmp(classname,"equal_to<",std::char_traits<char>::length("equal_to<"))==0) return true;
-   if ( strncmp(classname,"hash<",std::char_traits<char>::length("hash<"))==0) return true;
-   if ( strncmp(classname,"auto_ptr<",std::char_traits<char>::length("auto_ptr<"))==0) return true;
+   if ( strncmp(classname,"allocator<",length("allocator<"))==0) return true;
+   if ( strncmp(classname,"greater<",length("greater<"))==0) return true;
+   if ( strncmp(classname,"less<",length("less<"))==0) return true;
+   if ( strncmp(classname,"equal_to<",length("equal_to<"))==0) return true;
+   if ( strncmp(classname,"hash<",length("hash<"))==0) return true;
+   if ( strncmp(classname,"auto_ptr<",length("auto_ptr<"))==0) return true;
 
-   if ( strncmp(classname,"vector<",std::char_traits<char>::length("vector<"))==0) return true;
-   if ( strncmp(classname,"list<",std::char_traits<char>::length("list<"))==0) return true;
-   if ( strncmp(classname,"forward_list<",std::char_traits<char>::length("forward_list<"))==0) return true;
-   if ( strncmp(classname,"deque<",std::char_traits<char>::length("deque<"))==0) return true;
-   if ( strncmp(classname,"map<",std::char_traits<char>::length("map<"))==0) return true;
-   if ( strncmp(classname,"multimap<",std::char_traits<char>::length("multimap<"))==0) return true;
-   if ( strncmp(classname,"set<",std::char_traits<char>::length("set<"))==0) return true;
-   if ( strncmp(classname,"multiset<",std::char_traits<char>::length("multiset<"))==0) return true;
-   if ( strncmp(classname,"unordered_set<",std::char_traits<char>::length("unordered_set<"))==0) return true;
-   if ( strncmp(classname,"unordered_multiset<",std::char_traits<char>::length("unordered_multiset<"))==0) return true;
-   if ( strncmp(classname,"unordered_map<",std::char_traits<char>::length("unordered_map<"))==0) return true;
-   if ( strncmp(classname,"unordered_multimap<",std::char_traits<char>::length("unordered_multimap<"))==0) return true;
-   if ( strncmp(classname,"bitset<",std::char_traits<char>::length("bitset<"))==0) return true;
-   if ( strncmp(classname,"ROOT::VecOps::RVec<",std::char_traits<char>::length("ROOT::VecOps::RVec<"))==0) return true;
+   if ( strncmp(classname,"vector<",length("vector<"))==0) return true;
+   if ( strncmp(classname,"list<",length("list<"))==0) return true;
+   if ( strncmp(classname,"forward_list<",length("forward_list<"))==0) return true;
+   if ( strncmp(classname,"deque<",length("deque<"))==0) return true;
+   if ( strncmp(classname,"map<",length("map<"))==0) return true;
+   if ( strncmp(classname,"multimap<",length("multimap<"))==0) return true;
+   if ( strncmp(classname,"set<",length("set<"))==0) return true;
+   if ( strncmp(classname,"multiset<",length("multiset<"))==0) return true;
+   if ( strncmp(classname,"unordered_set<",length("unordered_set<"))==0) return true;
+   if ( strncmp(classname,"unordered_multiset<",length("unordered_multiset<"))==0) return true;
+   if ( strncmp(classname,"unordered_map<",length("unordered_map<"))==0) return true;
+   if ( strncmp(classname,"unordered_multimap<",length("unordered_multimap<"))==0) return true;
+   if ( strncmp(classname,"bitset<",length("bitset<"))==0) return true;
+   if ( strncmp(classname,"ROOT::VecOps::RVec<",length("ROOT::VecOps::RVec<"))==0) return true;
 
    return false;
 }

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1084,7 +1084,9 @@ int TClassEdit::GetSplit(const char *type, vector<string>& output, int &nestedLo
             if (full.compare(offset, 5, "std::") == 0) {
                offset += 5;
             }
-            static const char* char_traits_s = "char_traits<char>";
+            constexpr auto char_traits_s = "char_traits<char>";
+            // or 
+            // static constexpr char const* const char_traits_s = "char_traits<char>";
             static constexpr unsigned int char_traits_len = std::char_traits<char>::length(char_traits_s);
             if (full.compare(offset, char_traits_len, char_traits_s) == 0) {
                offset += char_traits_len;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1083,7 +1083,7 @@ int TClassEdit::GetSplit(const char *type, vector<string>& output, int &nestedLo
                offset += 5;
             }
             static const char* char_traits_s = "char_traits<char>";
-            static const unsigned int char_traits_len = strlen(char_traits_s);
+            static constexpr unsigned int char_traits_len = std::char_traits<char>::length(char_traits_s);
             if (full.compare(offset, char_traits_len, char_traits_s) == 0) {
                offset += char_traits_len;
                if ( full[offset] == '>') {
@@ -1347,7 +1347,7 @@ bool TClassEdit::IsInterpreterDetail(const char *type)
 bool TClassEdit::IsSTLBitset(const char *classname)
 {
    size_t offset = StdLen(classname);
-   if ( strncmp(classname+offset,"bitset<",strlen("bitset<"))==0) return true;
+   if ( strncmp(classname+offset,"bitset<",std::char_traits<char>::length("bitset<"))==0) return true;
    return false;
 }
 
@@ -1426,30 +1426,30 @@ bool TClassEdit::IsStdClass(const char *classname)
 {
    classname += StdLen( classname );
    if ( strcmp(classname,"string")==0 ) return true;
-   if ( strncmp(classname,"bitset<",strlen("bitset<"))==0) return true;
+   if ( strncmp(classname,"bitset<",std::char_traits<char>::length("bitset<"))==0) return true;
    if ( IsStdPair(classname) ) return true;
    if ( strcmp(classname,"allocator")==0) return true;
-   if ( strncmp(classname,"allocator<",strlen("allocator<"))==0) return true;
-   if ( strncmp(classname,"greater<",strlen("greater<"))==0) return true;
-   if ( strncmp(classname,"less<",strlen("less<"))==0) return true;
-   if ( strncmp(classname,"equal_to<",strlen("equal_to<"))==0) return true;
-   if ( strncmp(classname,"hash<",strlen("hash<"))==0) return true;
-   if ( strncmp(classname,"auto_ptr<",strlen("auto_ptr<"))==0) return true;
+   if ( strncmp(classname,"allocator<",std::char_traits<char>::length("allocator<"))==0) return true;
+   if ( strncmp(classname,"greater<",std::char_traits<char>::length("greater<"))==0) return true;
+   if ( strncmp(classname,"less<",std::char_traits<char>::length("less<"))==0) return true;
+   if ( strncmp(classname,"equal_to<",std::char_traits<char>::length("equal_to<"))==0) return true;
+   if ( strncmp(classname,"hash<",std::char_traits<char>::length("hash<"))==0) return true;
+   if ( strncmp(classname,"auto_ptr<",std::char_traits<char>::length("auto_ptr<"))==0) return true;
 
-   if ( strncmp(classname,"vector<",strlen("vector<"))==0) return true;
-   if ( strncmp(classname,"list<",strlen("list<"))==0) return true;
-   if ( strncmp(classname,"forward_list<",strlen("forward_list<"))==0) return true;
-   if ( strncmp(classname,"deque<",strlen("deque<"))==0) return true;
-   if ( strncmp(classname,"map<",strlen("map<"))==0) return true;
-   if ( strncmp(classname,"multimap<",strlen("multimap<"))==0) return true;
-   if ( strncmp(classname,"set<",strlen("set<"))==0) return true;
-   if ( strncmp(classname,"multiset<",strlen("multiset<"))==0) return true;
-   if ( strncmp(classname,"unordered_set<",strlen("unordered_set<"))==0) return true;
-   if ( strncmp(classname,"unordered_multiset<",strlen("unordered_multiset<"))==0) return true;
-   if ( strncmp(classname,"unordered_map<",strlen("unordered_map<"))==0) return true;
-   if ( strncmp(classname,"unordered_multimap<",strlen("unordered_multimap<"))==0) return true;
-   if ( strncmp(classname,"bitset<",strlen("bitset<"))==0) return true;
-   if ( strncmp(classname,"ROOT::VecOps::RVec<",strlen("ROOT::VecOps::RVec<"))==0) return true;
+   if ( strncmp(classname,"vector<",std::char_traits<char>::length("vector<"))==0) return true;
+   if ( strncmp(classname,"list<",std::char_traits<char>::length("list<"))==0) return true;
+   if ( strncmp(classname,"forward_list<",std::char_traits<char>::length("forward_list<"))==0) return true;
+   if ( strncmp(classname,"deque<",std::char_traits<char>::length("deque<"))==0) return true;
+   if ( strncmp(classname,"map<",std::char_traits<char>::length("map<"))==0) return true;
+   if ( strncmp(classname,"multimap<",std::char_traits<char>::length("multimap<"))==0) return true;
+   if ( strncmp(classname,"set<",std::char_traits<char>::length("set<"))==0) return true;
+   if ( strncmp(classname,"multiset<",std::char_traits<char>::length("multiset<"))==0) return true;
+   if ( strncmp(classname,"unordered_set<",std::char_traits<char>::length("unordered_set<"))==0) return true;
+   if ( strncmp(classname,"unordered_multiset<",std::char_traits<char>::length("unordered_multiset<"))==0) return true;
+   if ( strncmp(classname,"unordered_map<",std::char_traits<char>::length("unordered_map<"))==0) return true;
+   if ( strncmp(classname,"unordered_multimap<",std::char_traits<char>::length("unordered_multimap<"))==0) return true;
+   if ( strncmp(classname,"bitset<",std::char_traits<char>::length("bitset<"))==0) return true;
+   if ( strncmp(classname,"ROOT::VecOps::RVec<",std::char_traits<char>::length("ROOT::VecOps::RVec<"))==0) return true;
 
    return false;
 }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3220,7 +3220,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
             return pairinfo->GetClass();
       } else {
          //  Check if we have an STL container that might provide it.
-         static const size_t slen = strlen("pair");
+         static constexpr size_t slen = std::char_traits<char>::length("pair");
          static const char *associativeContainer[] = { "map", "unordered_map", "multimap",
             "unordered_multimap", "set", "unordered_set", "multiset", "unordered_multiset" };
          for(auto contname : associativeContainer) {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4096,7 +4096,7 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload, Bool_t silent)
    // Handle the special case of 'tuple' where we ignore the real implementation
    // details and just overlay a 'simpler'/'simplistic' version that is easy
    // for the I/O to understand and handle.
-   if (strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
+   if (strncmp(cl->GetName(),"tuple<",std::char_traits<char>::length("tuple<"))==0) {
       if (!reload)
          name = AlternateTuple(cl->GetName(), fInterpreter->getLookupHelper(), silent);
       if (reload || name.empty()) {

--- a/graf3d/gl/src/gl2ps.cxx
+++ b/graf3d/gl/src/gl2ps.cxx
@@ -4429,10 +4429,10 @@ static int gl2psPrintPDFShaderMask(int obj, int childobj)
                   obj,
                   (int)gl2ps->viewport[0], (int)gl2ps->viewport[1],
                   (int)gl2ps->viewport[2], (int)gl2ps->viewport[3]);
-
+  constexpr auto length = std::char_traits<char>::length;
   len = (childobj>0)
-    ? std::char_traits<char>::length("/TrSh sh\n") + (int)log10((double)childobj)+1
-    : std::char_traits<char>::length("/TrSh0 sh\n");
+    ? length("/TrSh sh\n") + (int)log10((double)childobj)+1
+    : length("/TrSh0 sh\n");
 
   offs += fprintf(gl2ps->stream,
                   "/Length %d\n"

--- a/graf3d/gl/src/gl2ps.cxx
+++ b/graf3d/gl/src/gl2ps.cxx
@@ -64,6 +64,7 @@
 #include <stdarg.h>
 #include <time.h>
 #include <float.h>
+#include <string>
 
 #if defined(GL2PS_HAVE_ZLIB)
 #include <zlib.h>
@@ -4430,8 +4431,8 @@ static int gl2psPrintPDFShaderMask(int obj, int childobj)
                   (int)gl2ps->viewport[2], (int)gl2ps->viewport[3]);
 
   len = (childobj>0)
-    ? strlen("/TrSh sh\n") + (int)log10((double)childobj)+1
-    : strlen("/TrSh0 sh\n");
+    ? std::char_traits<char>::length("/TrSh sh\n") + (int)log10((double)childobj)+1
+    : std::char_traits<char>::length("/TrSh0 sh\n");
 
   offs += fprintf(gl2ps->stream,
                   "/Length %d\n"

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -760,14 +760,15 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       //for robust fitting, see if # of good points is defined
       // decode parameters for robust fitting
       Double_t h=0;
+      constexpr auto length = std::char_traits<char>::length;
       if (opt.Contains("H=0.")) {
          int start = opt.Index("H=0.");
-         int numpos = start + std::char_traits<char>::length("H=0.");
+         int numpos = start + length("H=0.");
          int numlen = 0;
          int len = opt.Length();
          while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
          TString num = opt(numpos,numlen);
-         opt.Remove(start+std::char_traits<char>::length("H"),std::char_traits<char>::length("=0.")+numlen);
+         opt.Remove(start+length("H"),length("=0.")+numlen);
          h = atof(num.Data());
          h*=TMath::Power(10, -numlen);
       }

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -762,12 +762,12 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       Double_t h=0;
       if (opt.Contains("H=0.")) {
          int start = opt.Index("H=0.");
-         int numpos = start + strlen("H=0.");
+         int numpos = start + std::char_traits<char>::length("H=0.");
          int numlen = 0;
          int len = opt.Length();
          while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
          TString num = opt(numpos,numlen);
-         opt.Remove(start+strlen("H"),strlen("=0.")+numlen);
+         opt.Remove(start+std::char_traits<char>::length("H"),std::char_traits<char>::length("=0.")+numlen);
          h = atof(num.Data());
          h*=TMath::Power(10, -numlen);
       }

--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -192,7 +192,7 @@ namespace cling {
        // FIXME: Once the C++ modules replaced the forward decls, remove this.
        if (D->getASTContext().getLangOpts().Modules &&
            llvm::StringRef(includeText).starts_with("include ")) {
-         includeText += strlen("include ");
+         includeText += std::char_traits<char>::length("include ");
        }
 
        assert((includeText[0] == '<' || includeText[0] == '"') &&

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -3086,7 +3086,7 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
       if (info->IsA() != TStreamerInfo::Class()) {
          continue;
       }
-      if (strncmp(info->GetName(), "auto_ptr<", strlen("auto_ptr<")) == 0) {
+      if (strncmp(info->GetName(), "auto_ptr<", std::char_traits<char>::length("auto_ptr<")) == 0) {
          continue;
       }
       TClass *cl = TClass::GetClass(info->GetName());
@@ -4129,7 +4129,7 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
    TString opts(options);
    Int_t ito = opts.Index("TIMEOUT=");
    if (ito != kNPOS) {
-      TString sto = opts(ito + strlen("TIMEOUT="), opts.Length());
+      TString sto = opts(ito + std::char_traits<char>::length("TIMEOUT="), opts.Length());
       while (!(sto.IsDigit()) && !(sto.IsNull())) { sto.Remove(sto.Length()-1,1); }
       if (!(sto.IsNull())) {
          // Timeout in millisecs

--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -524,7 +524,7 @@ UInt_t TMakeProject::GenerateIncludeForTemplate(FILE *fp, const char *clname, ch
                } else if (TClassEdit::IsStdPair(incName)) {
                   AddInclude(fp, "utility", kTRUE, inclist);
                   ninc += GenerateIncludeForTemplate(fp, incName, inclist, forward, extrainfos);
-               } else if (strncmp(incName.Data(), "auto_ptr<", strlen("auto_ptr<")) == 0) {
+               } else if (strncmp(incName.Data(), "auto_ptr<", std::char_traits<char>::length("auto_ptr<")) == 0) {
                   AddInclude(fp, "memory", kTRUE, inclist);
                   ninc += GenerateIncludeForTemplate(fp, incName, inclist, forward, extrainfos);
                } else if (TClassEdit::IsStdClass(incName)) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3836,7 +3836,7 @@ void TStreamerInfo::GenerateDeclaration(FILE *fp, FILE *sfp, const TList *subCla
                   // nothing to do.
                   break;
             }
-         } else if (strncmp(enamebasic.Data(), "auto_ptr<", strlen("auto_ptr<")) == 0) {
+         } else if (strncmp(enamebasic.Data(), "auto_ptr<", std::char_traits<char>::length("auto_ptr<")) == 0) {
             enamebasic = TMakeProject::UpdateAssociativeToVector(enamebasic);
          }
 
@@ -3986,7 +3986,7 @@ UInt_t TStreamerInfo::GenerateIncludes(FILE *fp, char *inclist, const TList *ext
       }
       if (TClassEdit::IsStdPair(element->GetTypeName())) {
          TMakeProject::AddInclude( fp, "utility", kTRUE, inclist);
-      } else if (strncmp(element->GetTypeName(),"auto_ptr<",strlen("auto_ptr<"))==0) {
+      } else if (strncmp(element->GetTypeName(),"auto_ptr<",std::char_traits<char>::length("auto_ptr<"))==0) {
          TMakeProject::AddInclude( fp, "memory", kTRUE, inclist);
       } else {
          TString incName( include, strlen(include)-1 );
@@ -4011,7 +4011,7 @@ Int_t TStreamerInfo::GenerateHeaderFile(const char *dirname, const TList *subCla
    // if (fClassVersion == -4) return 0;
    if ((fClass && fClass->GetCollectionType()) || TClassEdit::IsSTLCont(GetName())) return 0;
    if (TClassEdit::IsStdPair(GetName())) return 0;
-   if (strncmp(GetName(),"auto_ptr<",strlen("auto_ptr<"))==0) return 0;
+   if (strncmp(GetName(),"auto_ptr<",std::char_traits<char>::length("auto_ptr<"))==0) return 0;
 
    TClass *cl = TClass::GetClass(GetName());
    if (cl) {
@@ -5838,7 +5838,7 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
 
 TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &pairclassname, bool silent, size_t hint_pair_offset, size_t hint_pair_size)
 {
-   const static int pairlen = strlen("pair<");
+   const static int pairlen = std::char_traits<char>::length("pair<");
    if (pairclassname.compare(0, pairlen, "pair<") != 0) {
       if (!silent)
          Error("GenerateInfoForPair", "The class name passed is not a pair: %s", pairclassname.c_str());

--- a/io/sql/src/TSQLObjectData.cxx
+++ b/io/sql/src/TSQLObjectData.cxx
@@ -238,7 +238,7 @@ Bool_t TSQLObjectData::ExtractBlobValues()
       fBlobTypeName = name;
    } else {
       fBlobPrefixName = name;
-      separ += strlen(":"); // SQLNameSeparator()
+      separ += std::char_traits<char>::length(":"); // SQLNameSeparator()
       fBlobTypeName = separ;
    }
 

--- a/main/src/h2root.cxx
+++ b/main/src/h2root.cxx
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
    if (argc > 2) {
       file_out=argv[2];
    } else {
-      Int_t nchf = strlen(file_in)+strlen(".root")+1;
+      Int_t nchf = strlen(file_in)+std::char_traits<char>::length(".root")+1;
       file_out= new char[nchf];
       strlcpy(file_out,file_in,nchf);
       char *dot = strrchr(file_out,'.');

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -211,7 +211,7 @@ int main( int argc, char **argv )
          ++ffirst;
       } else if ( strcmp(argv[a],"-cachesize=") == 0 ) {
          int size;
-         static const size_t arglen = strlen("-cachesize=");
+         static constexpr size_t arglen = std::char_traits<char>::length("-cachesize=");
          auto parseResult = ROOT::FromHumanReadableSize(argv[a]+arglen,size);
          if (parseResult == ROOT::EFromHumanReadableSize::kParseFail) {
             std::cerr << "Error: could not parse the cache size passed after -cachesize: "

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2425,7 +2425,7 @@ void TBranch::Print(Option_t *option) const
    }
    Printf("*Baskets :%9d : Basket Size=%11d bytes  Compression= %6.2f     *",fWriteBasket,fBasketSize,cx);
 
-   if (strncmp(option,"basketsInfo",strlen("basketsInfo"))==0) {
+   if (strncmp(option,"basketsInfo",std::char_traits<char>::length("basketsInfo"))==0) {
       Int_t nbaskets = fWriteBasket;
       for (Int_t i=0;i<nbaskets;i++) {
          Printf("*Basket #%4d  entry=%6lld  pos=%6lld  size=%5d",

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3836,8 +3836,8 @@ static void PrintElements(const TStreamerInfo *info, const TStreamerInfoActions:
 void TBranchElement::Print(Option_t* option) const
 {
    Int_t nbranches = fBranches.GetEntriesFast();
-   if (strncmp(option,"debugAddress",strlen("debugAddress"))==0) {
-      if (strlen(option)==strlen("debugAddress")) {
+   if (strncmp(option,"debugAddress",std::char_traits<char>::length("debugAddress"))==0) {
+      if (strlen(option)==std::char_traits<char>::length("debugAddress")) {
          Printf("%-24s %-16s %2s %4s %-16s %-16s %8s %8s %s %s\n",
                 "Branch Name", "Streamer Class", "ID", "Type", "Class", "Parent", "pOffset", "fOffset", "fObject", "fOnfileObject");
       }
@@ -3859,7 +3859,7 @@ void TBranchElement::Print(Option_t* option) const
       }
       return;
    }
-   if (strncmp(option,"debugInfo",strlen("debugInfo"))==0)  {
+   if (strncmp(option,"debugInfo",std::char_traits<char>::length("debugInfo"))==0)  {
       Printf("Branch %s uses:",GetName());
       if (fID>=0) {
          // GetInfoImp()->GetElement(fID)->ls();
@@ -3892,7 +3892,7 @@ void TBranchElement::Print(Option_t* option) const
          if (fFillActionSequence) fFillActionSequence->Print(option);
       }
       TString suboption = "debugInfoSub";
-      suboption += (option+strlen("debugInfo"));
+      suboption += (option+std::char_traits<char>::length("debugInfo"));
       for (Int_t i = 0; i < nbranches; ++i) {
          TBranchElement* subbranch = (TBranchElement*)fBranches.At(i);
          subbranch->Print(suboption);

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3835,9 +3835,10 @@ static void PrintElements(const TStreamerInfo *info, const TStreamerInfoActions:
 
 void TBranchElement::Print(Option_t* option) const
 {
+   constexpr auto length = std::char_traits<char>::length;
    Int_t nbranches = fBranches.GetEntriesFast();
-   if (strncmp(option,"debugAddress",std::char_traits<char>::length("debugAddress"))==0) {
-      if (strlen(option)==std::char_traits<char>::length("debugAddress")) {
+   if (strncmp(option,"debugAddress",length("debugAddress"))==0) {
+      if (strlen(option)==length("debugAddress")) {
          Printf("%-24s %-16s %2s %4s %-16s %-16s %8s %8s %s %s\n",
                 "Branch Name", "Streamer Class", "ID", "Type", "Class", "Parent", "pOffset", "fOffset", "fObject", "fOnfileObject");
       }
@@ -3859,7 +3860,7 @@ void TBranchElement::Print(Option_t* option) const
       }
       return;
    }
-   if (strncmp(option,"debugInfo",std::char_traits<char>::length("debugInfo"))==0)  {
+   if (strncmp(option,"debugInfo",length("debugInfo"))==0)  {
       Printf("Branch %s uses:",GetName());
       if (fID>=0) {
          // GetInfoImp()->GetElement(fID)->ls();
@@ -3892,7 +3893,7 @@ void TBranchElement::Print(Option_t* option) const
          if (fFillActionSequence) fFillActionSequence->Print(option);
       }
       TString suboption = "debugInfoSub";
-      suboption += (option+std::char_traits<char>::length("debugInfo"));
+      suboption += (option+length("debugInfo"));
       for (Int_t i = 0; i < nbranches; ++i) {
          TBranchElement* subbranch = (TBranchElement*)fBranches.At(i);
          subbranch->Print(suboption);

--- a/tree/tree/src/TBranchSTL.cxx
+++ b/tree/tree/src/TBranchSTL.cxx
@@ -602,8 +602,9 @@ bool TBranchSTL::IsFolder() const
 
 void TBranchSTL::Print(const char *option) const
 {
-   if (strncmp(option,"debugAddress",std::char_traits<char>::length("debugAddress"))==0) {
-      if (std::char_traits<char>::length(GetName())>24) Printf("%-24s\n%-24s ", GetName(),"");
+   constexpr auto length = std::char_traits<char>::length;
+   if (strncmp(option,"debugAddress",length("debugAddress"))==0) {
+      if (length(GetName())>24) Printf("%-24s\n%-24s ", GetName(),"");
       else Printf("%-24s ", GetName());
 
       TBranchElement *parent = dynamic_cast<TBranchElement*>(GetMother()->GetSubBranch(this));
@@ -620,7 +621,7 @@ void TBranchSTL::Print(const char *option) const
          TBranch *br = (TBranch *)fBranches.UncheckedAt(i);
          br->Print("debugAddressSub");
       }
-   } else if (strncmp(option,"debugInfo",std::char_traits<char>::length("debugInfo"))==0)  {
+   } else if (strncmp(option,"debugInfo",length("debugInfo"))==0)  {
       Printf("Branch %s uses:\n",GetName());
       if (fID>=0) {
          GetInfo()->GetElement(fID)->ls();

--- a/tree/tree/src/TBranchSTL.cxx
+++ b/tree/tree/src/TBranchSTL.cxx
@@ -602,8 +602,8 @@ bool TBranchSTL::IsFolder() const
 
 void TBranchSTL::Print(const char *option) const
 {
-   if (strncmp(option,"debugAddress",strlen("debugAddress"))==0) {
-      if (strlen(GetName())>24) Printf("%-24s\n%-24s ", GetName(),"");
+   if (strncmp(option,"debugAddress",std::char_traits<char>::length("debugAddress"))==0) {
+      if (std::char_traits<char>::length(GetName())>24) Printf("%-24s\n%-24s ", GetName(),"");
       else Printf("%-24s ", GetName());
 
       TBranchElement *parent = dynamic_cast<TBranchElement*>(GetMother()->GetSubBranch(this));
@@ -620,7 +620,7 @@ void TBranchSTL::Print(const char *option) const
          TBranch *br = (TBranch *)fBranches.UncheckedAt(i);
          br->Print("debugAddressSub");
       }
-   } else if (strncmp(option,"debugInfo",strlen("debugInfo"))==0)  {
+   } else if (strncmp(option,"debugInfo",std::char_traits<char>::length("debugInfo"))==0)  {
       Printf("Branch %s uses:\n",GetName());
       if (fID>=0) {
          GetInfo()->GetElement(fID)->ls();

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7246,7 +7246,7 @@ void TTree::Print(Option_t* option) const
    if (!option)
       option = "";
 
-   if (strncmp(option,"clusters",strlen("clusters"))==0) {
+   if (strncmp(option,"clusters",std::char_traits<char>::length("clusters"))==0) {
       Printf("%-16s %-16s %-16s %8s %20s",
              "Cluster Range #", "Entry Start", "Last Entry", "Size", "Number of clusters");
       Int_t index= 0;

--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -1020,7 +1020,7 @@ TFormLeafInfoNumerical::TFormLeafInfoNumerical(TVirtualCollectionProxy *collecti
       if (fKind == TStreamerInfo::kOffsetL + TStreamerInfo::kChar) {
          // Could be a bool
          if (strcmp( collection->GetCollectionClass()->GetName(), "vector<bool>") == 0
-             || strncmp( collection->GetCollectionClass()->GetName(), "bitset<", strlen("bitset<") ) ==0 ) {
+             || strncmp( collection->GetCollectionClass()->GetName(), "bitset<", std::char_traits<char>::length("bitset<") ) ==0 ) {
             fIsBool = true;
             fKind = (EDataType)18;
          }

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -797,6 +797,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
    fprintf(fp,"\n// Header file for the classes stored in the TTree if any.\n");
    TList listOfHeaders;
    listOfHeaders.SetOwner();
+   constexpr auto length = std::char_traits<char>::length;
    for (l=0;l<nleaves;l++) {
       TLeaf *leaf = (TLeaf*)leaves->UncheckedAt(l);
       TBranch *branch = leaf->GetBranch();
@@ -812,11 +813,11 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
                fprintf(fp,"#include <%s>\n",declfile+precstl_len);
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+precstl_len));
             } else if (strncmp(declfile,"/usr/include/",13) == 0) {
-               fprintf(fp,"#include <%s>\n",declfile+std::char_traits<char>::length("/include/c++/"));
-               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+std::char_traits<char>::length("/include/c++/")));
+               fprintf(fp,"#include <%s>\n",declfile+length("/include/c++/"));
+               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+length("/include/c++/")));
             } else if (strstr(declfile,"/include/c++/") != nullptr) {
-               fprintf(fp,"#include <%s>\n",declfile+std::char_traits<char>::length("/include/c++/"));
-               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+std::char_traits<char>::length("/include/c++/")));
+               fprintf(fp,"#include <%s>\n",declfile+length("/include/c++/"));
+               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+length("/include/c++/")));
             } else if (strncmp(declfile,rootinclude,rootinclude_len) == 0) {
                fprintf(fp,"#include <%s>\n",declfile+rootinclude_len);
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+rootinclude_len));
@@ -2359,7 +2360,7 @@ void TTreePlayer::RecursiveRemove(TObject *obj)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \brief Loop on Tree and print entries passing selection. Interactive 
+/// \brief Loop on Tree and print entries passing selection. Interactive
 /// pagination break is on by default.
 /// \param varexp If varexp is 0 (or "") then print only first 8 columns.
 /// If varexp = "*" print all columns. Otherwise a columns selection can
@@ -2449,7 +2450,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
                            Option_t * option,
                            Long64_t nentries, Long64_t firstentry)
 {
-
+   constexpr auto length = std::char_traits<char>::length;
    TString opt = option;
    opt.ToLower();
    UInt_t ui;
@@ -2461,23 +2462,23 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
 
    if (opt.Contains("lenmax=")) {
       int start = opt.Index("lenmax=");
-      int numpos = start + std::char_traits<char>::length("lenmax=");
+      int numpos = start + length("lenmax=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,std::char_traits<char>::length("lenmax")+numlen);
+      opt.Remove(start,length("lenmax")+numlen);
 
       lenmax = atoi(num.Data());
    }
    if (opt.Contains("colsize=")) {
       int start = opt.Index("colsize=");
-      int numpos = start + std::char_traits<char>::length("colsize=");
+      int numpos = start + length("colsize=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,std::char_traits<char>::length("size")+numlen);
+      opt.Remove(start,length("size")+numlen);
 
       colDefaultSize = atoi(num.Data());
       colPrecision = colDefaultSize;
@@ -2485,19 +2486,19 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    }
    if (opt.Contains("precision=")) {
       int start = opt.Index("precision=");
-      int numpos = start + std::char_traits<char>::length("precision=");
+      int numpos = start + length("precision=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,std::char_traits<char>::length("precision")+numlen);
+      opt.Remove(start,length("precision")+numlen);
 
       colPrecision = atoi(num.Data());
    }
    TString defFormat = Form("%d.%d",colDefaultSize,colPrecision);
    if (opt.Contains("col=")) {
       int start = opt.Index("col=");
-      int numpos = start + std::char_traits<char>::length("col=");
+      int numpos = start + length("col=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) &&
@@ -2522,7 +2523,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
               || opt[numpos+numlen]=='.'
               || opt[numpos+numlen]==':')) numlen++;
       TString flist = opt(numpos,numlen);
-      opt.Remove(start,std::char_traits<char>::length("col")+numlen);
+      opt.Remove(start,length("col")+numlen);
 
       int i = 0;
       while(i<flist.Length() && flist[i]==':') {

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -812,11 +812,11 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
                fprintf(fp,"#include <%s>\n",declfile+precstl_len);
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+precstl_len));
             } else if (strncmp(declfile,"/usr/include/",13) == 0) {
-               fprintf(fp,"#include <%s>\n",declfile+strlen("/include/c++/"));
-               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+strlen("/include/c++/")));
+               fprintf(fp,"#include <%s>\n",declfile+std::char_traits<char>::length("/include/c++/"));
+               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+std::char_traits<char>::length("/include/c++/")));
             } else if (strstr(declfile,"/include/c++/") != nullptr) {
-               fprintf(fp,"#include <%s>\n",declfile+strlen("/include/c++/"));
-               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+strlen("/include/c++/")));
+               fprintf(fp,"#include <%s>\n",declfile+std::char_traits<char>::length("/include/c++/"));
+               listOfHeaders.Add(new TNamed(cl->GetName(),declfile+std::char_traits<char>::length("/include/c++/")));
             } else if (strncmp(declfile,rootinclude,rootinclude_len) == 0) {
                fprintf(fp,"#include <%s>\n",declfile+rootinclude_len);
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+rootinclude_len));
@@ -2461,23 +2461,23 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
 
    if (opt.Contains("lenmax=")) {
       int start = opt.Index("lenmax=");
-      int numpos = start + strlen("lenmax=");
+      int numpos = start + std::char_traits<char>::length("lenmax=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,strlen("lenmax")+numlen);
+      opt.Remove(start,std::char_traits<char>::length("lenmax")+numlen);
 
       lenmax = atoi(num.Data());
    }
    if (opt.Contains("colsize=")) {
       int start = opt.Index("colsize=");
-      int numpos = start + strlen("colsize=");
+      int numpos = start + std::char_traits<char>::length("colsize=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,strlen("size")+numlen);
+      opt.Remove(start,std::char_traits<char>::length("size")+numlen);
 
       colDefaultSize = atoi(num.Data());
       colPrecision = colDefaultSize;
@@ -2485,19 +2485,19 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    }
    if (opt.Contains("precision=")) {
       int start = opt.Index("precision=");
-      int numpos = start + strlen("precision=");
+      int numpos = start + std::char_traits<char>::length("precision=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) && isdigit(opt[numpos+numlen]) ) numlen++;
       TString num = opt(numpos,numlen);
-      opt.Remove(start,strlen("precision")+numlen);
+      opt.Remove(start,std::char_traits<char>::length("precision")+numlen);
 
       colPrecision = atoi(num.Data());
    }
    TString defFormat = Form("%d.%d",colDefaultSize,colPrecision);
    if (opt.Contains("col=")) {
       int start = opt.Index("col=");
-      int numpos = start + strlen("col=");
+      int numpos = start + std::char_traits<char>::length("col=");
       int numlen = 0;
       int len = opt.Length();
       while( (numpos+numlen<len) &&
@@ -2522,7 +2522,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
               || opt[numpos+numlen]=='.'
               || opt[numpos+numlen]==':')) numlen++;
       TString flist = opt(numpos,numlen);
-      opt.Remove(start,strlen("col")+numlen);
+      opt.Remove(start,std::char_traits<char>::length("col")+numlen);
 
       int i = 0;
       while(i<flist.Length() && flist[i]==':') {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`strlen` cannot be a constexpr in all platforms otherwise.

This has probably no measurable performance gain, so feel free to close if you deem it's not worth.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)
