### PR TITLE
Fix vector subscript out of range

### DIFF
--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -349,7 +349,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::LoadEntry()
    }
 
    std::vector<NTupleSize_t> indexEntryNumbers;
-   indexEntryNumbers.reserve(fJoinIndices.size());
+   indexEntryNumbers.resize(fJoinIndices.size());
    if (IsUsingIndex()) {
       for (unsigned i = 0; i < fJoinIndices.size(); ++i) {
          auto &joinIndex = fJoinIndices[i];


### PR DESCRIPTION
Fix the following runtime error with `ntuple-processor-join`:
```
[ RUN      ] RNTupleJoinProcessorTest.UnalignedSingleJoinField
C:\...\include\vector(1889) : Assertion failed: vector subscript out of range
```
