### PR TITLE
[ci] Overwrite files when unzipping test results

### DIFF
--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -35,7 +35,7 @@ jobs:
            do
              IFS=$'\t' read name url <<< "$artifact"
              gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
+             unzip -d "$name" -o "$name.zip"
            done
 
       - name: Publish Test Results


### PR DESCRIPTION
We always want to look at the latest test results; for example when rerunning a job with test failures in a workflow, its results should overwrite previous results.