### PR TITLE
[io] Add a reliable way to close the TFileMerger's output file from Python

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -107,6 +107,7 @@ set(py_sources
   ROOT/_pythonization/_tf2.py
   ROOT/_pythonization/_tf3.py
   ROOT/_pythonization/_tfile.py
+  ROOT/_pythonization/_tfilemerger.py
   ROOT/_pythonization/_tformula.py
   ROOT/_pythonization/_tgraph.py
   ROOT/_pythonization/_th1.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfilemerger.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfilemerger.py
@@ -1,0 +1,31 @@
+# Author: Giacomo Parolini CERN  12/2024
+
+################################################################################
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from . import pythonization
+
+def _TFileMergerExit(obj, exc_type, exc_val, exc_tb):
+    """
+    Close the merger's output file.
+    Signature and return value are imposed by Python, see
+    https://docs.python.org/3/library/stdtypes.html#typecontextmanager
+    """
+    obj.CloseOutputFile()
+    return False
+
+
+@pythonization('TFileMerger')
+def pythonize_tfile_merger(klass):
+    """
+    TFileMerger works as a context manager.
+    """
+    # Pythonization for __enter__ and __exit__ methods
+    # These make TFileMerger usable in a `with` statement as a context manager
+    klass.__enter__ = lambda merger: merger
+    klass.__exit__ = _TFileMergerExit

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfilemerger.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfilemerger.py
@@ -1,7 +1,7 @@
 # Author: Giacomo Parolini CERN  12/2024
 
 ################################################################################
-# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -55,6 +55,8 @@ protected:
    TList          fMergeList;                 ///< list of TObjString containing the name of the files need to be merged
    TList          fExcessFiles;               ///<! List of TObjString containing the name of the files not yet added to fFileList due to user or system limitation on the max number of files opened.
 
+   bool fOutFileWasExplicitlyClosed = false; ///<! the user has called CloseOutputFile(), so we shouldn't error out in RecursiveRemove
+
    Bool_t         OpenExcessFiles();
    virtual Bool_t AddFile(TFile *source, Bool_t own, Bool_t cpProgress);
    virtual Bool_t MergeRecursive(TDirectory *target, TList *sourcelist, Int_t type = kRegular | kAll);
@@ -101,6 +103,7 @@ public:
    void        AddObjectNames(const char *name) {fObjectNames += name; fObjectNames += " ";}
    const char *GetObjectNames() const {return fObjectNames.Data();}
    void        ClearObjectNames() {fObjectNames.Clear();}
+   void        CloseOutputFile();
 
     //--- file management interface
    virtual Bool_t SetCWD(const char * /*path*/) { MayNotUse("SetCWD"); return kFALSE; }

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -125,6 +125,15 @@ void TFileMerger::Reset()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Closes output file
+
+void TFileMerger::CloseOutputFile()
+{
+   fOutFileWasExplicitlyClosed = true;
+   SafeDelete(fOutputFile);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Add file to file merger.
 
 Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
@@ -291,6 +300,7 @@ Bool_t TFileMerger::OutputFile(const char *outputfile, Bool_t force)
 {
    Bool_t res = OutputFile(outputfile,(force?"RECREATE":"CREATE"),1); // 1 is the same as the default from the TFile constructor.
    fExplicitCompLevel = kFALSE;
+   fOutFileWasExplicitlyClosed = false;
    return res;
 }
 
@@ -1086,7 +1096,7 @@ Bool_t TFileMerger::OpenExcessFiles()
 
 void TFileMerger::RecursiveRemove(TObject *obj)
 {
-   if (obj == fOutputFile) {
+   if (obj == fOutputFile && !fOutFileWasExplicitlyClosed) {
       Fatal("RecursiveRemove","Output file of the TFile Merger (targeting %s) has been deleted (likely due to a TTree larger than 100Gb)", fOutputFilename.Data());
    }
 

--- a/tutorials/io/mergeFiles.py
+++ b/tutorials/io/mergeFiles.py
@@ -1,0 +1,70 @@
+# \file
+# \ingroup tutorial_io
+# \notebook -nodraw
+# Illustrates how to merge two files using TFileMerger from Python.
+# \author Giacomo Parolini
+
+import ROOT
+import os
+import random
+
+# abridged from hsimple.py
+def CreateInputFile(fname): 
+   with ROOT.TFile.Open( fname, "RECREATE", "Demo ROOT file with histograms" ) as hfile:
+      # Create some histograms, a profile histogram and an ntuple
+      hpx    = ROOT.TH1F( "hpx", "This is the px distribution", 100, -4, 4 )
+      hpxpy  = ROOT.TH2F( "hpxpy", "py vs px", 40, -4, 4, 40, -4, 4 )
+      hprof  = ROOT.TProfile( "hprof", "Profile of pz versus px", 100, -4, 4, 0, 20 )
+      ntuple = ROOT.TNtuple( "ntuple", "Demo ntuple", "px:py:pz:random:i" )
+
+      # Fill histograms randomly.
+      for i in range( 2000 ):
+         px = random.randrange(0, 1)
+         py = random.randrange(0, 1) 
+         pz = px*px + py*py
+         r = random.randrange(0, 1)
+
+       # Fill histograms.
+         hpx.Fill( px )
+         hpxpy.Fill( px, py )
+         hprof.Fill( px, pz )
+         ntuple.Fill( px, py, pz, r, i )
+      hfile.Write()
+
+
+def MergeFiles(files_to_cleanup, nfiles):
+   # NOTE: when the TFileMerger is used in a `with` statement, it will automatically
+   # close its output file when going out of scope.
+   with ROOT.TFileMerger(False) as fm:
+      fm.OutputFile("merged.root")
+      files_to_cleanup.append(fm.GetOutputFile().GetName())
+      for i in range(0, nfiles):
+         fm.AddFile(f"tomerge{i}.root")
+
+      # New merging flags must be bitwise OR-ed on top of the default ones.
+      # Here, as an example, we are doing an incremental merging, meaning we want to merge the new
+      # files with the current content of the output file.
+      # See TFileMerger docs for all the flags available: 
+      # https://root.cern/doc/master/classTFileMerger.html#a8ea43dc0722ce413c7332584d8c3ef0f
+      mode = ROOT.TFileMerger.kAll | ROOT.TFileMerger.kIncremental
+      fm.PartialMerge(mode)
+      fm.Reset()
+
+
+if __name__ == '__main__':
+   nfiles = 2
+   files_to_cleanup = []
+   try:
+      # Create the files to be merged
+      for i in range(0, nfiles):
+         fname = f"tomerge{i}.root"
+         CreateInputFile(fname)
+         files_to_cleanup.append(fname)
+
+      MergeFiles(files_to_cleanup, nfiles)
+
+   finally:
+      # Cleanup initial files
+      for filename in files_to_cleanup:
+         os.remove(filename)
+


### PR DESCRIPTION
`TFileMerger` lacks a reliable way to close the underlying output file when used from Python, as it relies on the destructor to do it.
This PR adds an explicit `CloseOutputFile` method and makes `TFileMerger` a context manager in pyroot, allowing for uses such as:

```
with ROOT.TFileMerger() as merger:
   merger.OutputFile("foo.root")
   # ...
# at this point `foo.root` has been closed
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #17223

