### PR TITLE
Many fixes in `TFileDrawMap`

### DIFF
--- a/tree/treeplayer/inc/TFileDrawMap.h
+++ b/tree/treeplayer/inc/TFileDrawMap.h
@@ -23,7 +23,9 @@
 
 #include "TNamed.h"
 
-class TH1;
+#include <map>
+
+class TH2;
 class TFile;
 class TDirectory;
 class TBox;
@@ -32,12 +34,12 @@ class TBranch;
 class TFileDrawMap : public TNamed {
 
 protected:
-   TFile         *fFile;           ///< Pointer to the file
-   TH1           *fFrame;          ///< Histogram used to draw the map frame
-   TString        fKeys;           ///< List of keys
-   TString        fOption;         ///< Drawing options
-   Int_t          fXsize;          ///< Size in bytes of X axis
-   Int_t          fYsize;          ///< Size in K/Mbytes of Y axis
+   TFile         *fFile = nullptr;      ///<! Pointer to the file, cannot be persistent
+   std::map<TBranch*, Int_t> fBranchColors; ///<! map of generated colors for the branches
+   TH2           *fFrame = nullptr;     ///< Histogram used to draw the map frame
+   TString        fKeys;                ///< List of keys
+   Int_t          fXsize = 0;           ///< Size in bytes of X axis
+   Int_t          fYsize = 0;           ///< Size in K/Mbytes of Y axis
 
    virtual void     DrawMarker(Int_t marker, Long64_t eseek);
    virtual bool     GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const;
@@ -47,7 +49,7 @@ protected:
 
 public:
    TFileDrawMap();
-   TFileDrawMap(const TFile *file, const char *keys, Option_t *option);
+   TFileDrawMap(const TFile *file, const char *keys, Option_t *option = "");
    ~TFileDrawMap() override;
 
    virtual void  AnimateTree(const char *branches=""); // *MENU*
@@ -59,7 +61,7 @@ public:
    virtual void  InspectObject(); // *MENU*
    void  Paint(Option_t *option) override;
 
-   ClassDefOverride(TFileDrawMap,1);  //Draw a 2-d map of the objects in a file
+   ClassDefOverride(TFileDrawMap,2);  //Draw a 2-d map of the objects in a file
 };
 
 #endif


### PR DESCRIPTION
1. Draw frame histogram and object only once
2. Use TH2 as frame histogram to properly handle zooming
3. In Paint method paint only TFileDrawMap itself
4. Keep generated branch colors to make reproducible painting
5. Make non-persistent TFile pointer, otherwise fails when reading

This version also reasonably works with web canvas
