### PR TITLE
[ntuple] create RNTupleExporter

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCluster.hxx
@@ -43,7 +43,7 @@ class ROnDiskPage {
 private:
    /// The memory location of the bytes
    const void *fAddress = nullptr;
-   /// The compressed and packed size of the page
+   /// The compressed and packed size of the page. This includes both payload and checksum (if present)
    std::uint32_t fSize = 0;
 
 public:

--- a/tree/ntupleutil/CMakeLists.txt
+++ b/tree/ntupleutil/CMakeLists.txt
@@ -16,9 +16,11 @@ endif()
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTupleUtil
 HEADERS
   ROOT/RNTupleImporter.hxx
+  ROOT/RNTupleExporter.hxx
   ROOT/RNTupleInspector.hxx
 SOURCES
   v7/src/RNTupleImporter.cxx
+  v7/src/RNTupleExporter.cxx
   v7/src/RNTupleInspector.cxx
 LINKDEF
   LinkDef.h

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
@@ -1,0 +1,54 @@
+/// \file ROOT/RNTupleExporter.hxx
+/// \ingroup NTuple ROOT7
+/// \author Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2024-12-10
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleExporter
+#define ROOT7_RNTupleExporter
+
+#include <filesystem>
+#include <vector>
+
+namespace ROOT::Experimental::Internal {
+
+class RPageSource;
+
+struct RExportPagesOptions {
+   enum RExportPageFlags {
+      kNone = 0x0,
+      kIncludeChecksums = 0x1,   
+      kReportExportedFileNames = 0x2,
+
+      kDefaults = kReportExportedFileNames
+   };
+
+   std::filesystem::path fOutputPath = ".";
+   std::uint64_t fFlags = kDefaults;
+};
+
+struct RExportPagesResult {
+   int fNPagesExported;
+   // This only gets filled if kReportExportedFileNames was part of the options flags
+   std::vector<std::string> fExportedFileNames;
+};
+
+class RNTupleExporter {
+public:
+   /// Given a page source, writes all its pages to individual files (1 per page).
+   /// If the source is not already attached, it will be attached by this process.
+   static RExportPagesResult ExportPages(RPageSource &source, const RExportPagesOptions &options = {});
+};
+
+} // namespace ROOT::Experimental::Internal
+
+#endif

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
@@ -16,7 +16,8 @@
 #ifndef ROOT7_RNTupleExporter
 #define ROOT7_RNTupleExporter
 
-#include <filesystem>
+#include <cstdint>
+#include <string>
 #include <vector>
 
 namespace ROOT::Experimental::Internal {
@@ -35,7 +36,7 @@ public:
          kDefaults = kShowProgressBar
       };
 
-      std::filesystem::path fOutputPath;
+      std::string fOutputPath;
       std::uint64_t fFlags;
 
       RPagesOptions() : fOutputPath("."), fFlags(kDefaults) {}

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -23,29 +23,31 @@ namespace ROOT::Experimental::Internal {
 
 class RPageSource;
 
-struct RExportPagesOptions {
-   enum RExportPageFlags {
-      kNone = 0x0,
-      kIncludeChecksums = 0x1,   
-      /// If enabled, the exporter will report the current progress on the stderr
-      kShowProgressBar = 0x2,
-
-      kDefaults = kShowProgressBar
-   };
-
-   std::filesystem::path fOutputPath = ".";
-   std::uint64_t fFlags = kDefaults;
-};
-
-struct RExportPagesResult {
-   std::vector<std::string> fExportedFileNames;
-};
-
 class RNTupleExporter {
 public:
+   struct RPagesOptions {
+      enum RExportPageFlags {
+         kNone = 0x0,
+         kIncludeChecksums = 0x1,
+         /// If enabled, the exporter will report the current progress on the stderr
+         kShowProgressBar = 0x2,
+
+         kDefaults = kShowProgressBar
+      };
+
+      std::filesystem::path fOutputPath;
+      std::uint64_t fFlags;
+
+      RPagesOptions() : fOutputPath("."), fFlags(kDefaults) {}
+   };
+
+   struct RPagesResult {
+      std::vector<std::string> fExportedFileNames;
+   };
+
    /// Given a page source, writes all its pages to individual files (1 per page).
    /// If the source is not already attached, it will be attached by this process.
-   static RExportPagesResult ExportPages(RPageSource &source, const RExportPagesOptions &options = {});
+   static RPagesResult ExportPages(RPageSource &source, const RPagesOptions &options = {});
 };
 
 } // namespace ROOT::Experimental::Internal

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleExporter.hxx
@@ -27,9 +27,10 @@ struct RExportPagesOptions {
    enum RExportPageFlags {
       kNone = 0x0,
       kIncludeChecksums = 0x1,   
-      kReportExportedFileNames = 0x2,
+      /// If enabled, the exporter will report the current progress on the stderr
+      kShowProgressBar = 0x2,
 
-      kDefaults = kReportExportedFileNames
+      kDefaults = kShowProgressBar
    };
 
    std::filesystem::path fOutputPath = ".";
@@ -37,8 +38,6 @@ struct RExportPagesOptions {
 };
 
 struct RExportPagesResult {
-   int fNPagesExported;
-   // This only gets filled if kReportExportedFileNames was part of the options flags
    std::vector<std::string> fExportedFileNames;
 };
 

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -1,0 +1,124 @@
+/// \file RNTupleExporter.cxx
+/// \ingroup NTuple ROOT7
+/// \author Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2024-12-10
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleExporter.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RClusterPool.hxx>
+#include <ROOT/RLogger.hxx>
+#include <fstream>
+#include <sstream>
+
+namespace ROOT::Experimental::Internal {
+
+struct RColumnExportInfo {
+   const RColumnDescriptor *fColDesc;
+   const RFieldDescriptor *fFieldDesc;
+   std::string fQualifiedName;
+
+   RColumnExportInfo(const RNTupleDescriptor &desc, const RColumnDescriptor &colDesc, const RFieldDescriptor &fieldDesc)
+      : fColDesc(&colDesc),
+        fFieldDesc(&fieldDesc),
+        fQualifiedName(desc.GetQualifiedFieldName(fieldDesc.GetId()) + '-' + std::to_string(colDesc.GetIndex()))
+   {
+   }
+};
+
+static void AddColumnsFromField(std::vector<RColumnExportInfo> &vec, const RNTupleDescriptor &desc,
+                                const RFieldDescriptor &fieldDesc)
+{
+   R__LOG_DEBUG(1) << "processing field \"" << desc.GetQualifiedFieldName(fieldDesc.GetId()) << "\"";
+
+   for (const auto &subfieldDesc : desc.GetFieldIterable(fieldDesc)) {
+      if (subfieldDesc.IsProjectedField())
+         continue;
+
+      for (const auto &colDesc : desc.GetColumnIterable(subfieldDesc)) {
+         vec.emplace_back(desc, colDesc, subfieldDesc);
+      }
+      AddColumnsFromField(vec, desc, subfieldDesc);
+   }
+}
+
+RExportPagesResult RNTupleExporter::ExportPages(RPageSource &source, const RExportPagesOptions &options)
+{
+   RExportPagesResult res = {};
+
+   // make sure the source is attached
+   source.Attach();
+
+   auto desc = source.GetSharedDescriptorGuard();
+   RClusterPool clusterPool{source};
+
+   // Collect column info
+   std::vector<RColumnExportInfo> columnInfos;
+   AddColumnsFromField(columnInfos, desc.GetRef(), desc->GetFieldZero());
+
+   // Collect ColumnSet for the cluster pool query
+   RCluster::ColumnSet_t columnSet;
+   columnSet.reserve(columnInfos.size());
+   for (const auto &colInfo : columnInfos) {
+      columnSet.emplace(colInfo.fColDesc->GetPhysicalId());
+   }
+
+   bool reportFilenames = (options.fFlags & RExportPagesOptions::kReportExportedFileNames) != 0;
+
+   // Iterate over the clusters in order and dump pages
+   DescriptorId_t clusterId = desc->FindClusterId(0, 0);
+   while (clusterId != kInvalidDescriptorId) {
+      const auto &clusterDesc = desc->GetClusterDescriptor(clusterId);
+      const RCluster *cluster = clusterPool.GetCluster(clusterId, columnSet);
+      for (const auto &colInfo : columnInfos) {
+         DescriptorId_t columnId = colInfo.fColDesc->GetPhysicalId();
+         const auto &pages = clusterDesc.GetPageRange(columnId);
+         const auto &colRange =clusterDesc.GetColumnRange(columnId);
+         std::uint64_t pageIdx = 0;
+         if (reportFilenames)
+            res.fExportedFileNames.reserve(res.fExportedFileNames.size() + pages.fPageInfos.size());
+
+         R__LOG_DEBUG(0) << "exporting column \"" << colInfo.fQualifiedName << "\" (" << pages.fPageInfos.size()
+                         << " pages)";
+
+         for (const auto &pageInfo : pages.fPageInfos) {
+            ROnDiskPage::Key key{columnId, pageIdx};
+            const ROnDiskPage *onDiskPage = cluster->GetOnDiskPage(key);
+
+            // dump the page
+            const void *pageBuf = onDiskPage->GetAddress();
+            const auto maybeChecksumSize = (options.fFlags & RExportPagesOptions::kIncludeChecksums) ? 8 : 0;
+            const std::uint64_t pageBufSize = pageInfo.fLocator.fBytesOnStorage + maybeChecksumSize;
+            std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
+            ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
+               << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings << ".page";
+            const auto outFileName = ss.str();
+            std::ofstream outFile{outFileName, std::ios_base::binary};
+            outFile.write(reinterpret_cast<const char *>(pageBuf), pageBufSize);
+
+            if (reportFilenames)
+               res.fExportedFileNames.push_back(outFileName);
+
+            ++pageIdx;
+            ++res.fNPagesExported;
+         }
+      }
+      clusterId = desc->FindNextClusterId(clusterId);
+   }
+
+   R__LOG_DEBUG(0) << "exported " << res.fNPagesExported << " pages.";
+
+   return res;
+}
+
+} // namespace ROOT::Experimental::Internal

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -134,7 +134,7 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.fHasChecksum;
             const std::size_t maybeChecksumSize = incChecksum * 8;
             const std::uint64_t pageBufSize = pageInfo.fLocator.fBytesOnStorage + maybeChecksumSize;
-            std::ostringstream ss{options.fOutputPath.string(), std::ios_base::ate};
+            std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
                << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings << ".page";
             const auto outFileName = ss.str();

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -80,9 +80,9 @@ int CountPages(const RNTupleDescriptor &desc, std::span<const RColumnExportInfo>
 
 } // namespace
 
-RExportPagesResult RNTupleExporter::ExportPages(RPageSource &source, const RExportPagesOptions &options)
+RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, const RPagesOptions &options)
 {
-   RExportPagesResult res = {};
+   RPagesResult res = {};
 
    // make sure the source is attached
    source.Attach();
@@ -103,7 +103,7 @@ RExportPagesResult RNTupleExporter::ExportPages(RPageSource &source, const RExpo
 
    const auto nPages = CountPages(desc.GetRef(), columnInfos);
 
-   const bool showProgress = (options.fFlags & RExportPagesOptions::kShowProgressBar) != 0;
+   const bool showProgress = (options.fFlags & RPagesOptions::kShowProgressBar) != 0;
    res.fExportedFileNames.reserve(nPages);
 
    // Iterate over the clusters in order and dump pages
@@ -131,7 +131,8 @@ RExportPagesResult RNTupleExporter::ExportPages(RPageSource &source, const RExpo
 
             // dump the page
             const void *pageBuf = onDiskPage->GetAddress();
-            const auto maybeChecksumSize = (options.fFlags & RExportPagesOptions::kIncludeChecksums) ? 8 : 0;
+            const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.fHasChecksum;
+            const std::size_t maybeChecksumSize = incChecksum * 8;
             const std::uint64_t pageBufSize = pageInfo.fLocator.fBytesOnStorage + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath.string(), std::ios_base::ate};
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -20,4 +20,5 @@ if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
 endif()
 
 ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)
+ROOT_ADD_GTEST(ntuple_exporter ntuple_exporter.cxx LIBRARIES ROOTNTupleUtil)
 ROOT_ADD_GTEST(ntuple_inspector ntuple_inspector.cxx LIBRARIES ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -22,3 +22,7 @@ endif()
 ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)
 ROOT_ADD_GTEST(ntuple_exporter ntuple_exporter.cxx LIBRARIES ROOTNTupleUtil)
 ROOT_ADD_GTEST(ntuple_inspector ntuple_inspector.cxx LIBRARIES ROOTNTupleUtil)
+
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    target_link_libraries(ntuple_exporter stdc++fs)
+endif()

--- a/tree/ntupleutil/v7/test/ntuple_exporter.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_exporter.cxx
@@ -6,7 +6,9 @@
 
 using namespace ROOT::Experimental;
 
-static std::string ReadFileToString(const char *fname)
+namespace {
+
+std::string ReadFileToString(const char *fname)
 {
    FILE *f = fopen(fname, "rb");
    if (!f) {
@@ -23,43 +25,67 @@ static std::string ReadFileToString(const char *fname)
    return str;
 }
 
+enum : bool {
+   kWithoutChecksums = false,
+   kWithChecksums = true,
+};
+
+void CreateExportRNTuple(std::string_view fileName, bool checksums)
+{
+   auto model = RNTupleModel::Create();
+   auto pFlt = model->MakeField<float>("flt");
+   auto pVec = model->MakeField<std::vector<int>>("vec");
+
+   auto opts = RNTupleWriteOptions();
+   opts.SetCompression(0);
+   opts.SetEnablePageChecksums(checksums);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileName, opts);
+   for (int i = 0; i < 10; ++i) {
+      *pFlt = i;
+      pVec->clear();
+      for (int j = -3; j < 3; ++j)
+         pVec->emplace_back(i - j);
+      writer->Fill();
+   }
+}
+
+// These are the expected contents of the pages of the RNTuple created by CreateExportRNTuple (including the checksums)
+const char kVecBytes[] =
+   "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xfe\xff\xff\xff\x04\x00\x00\x00"
+   "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x05\x00\x00\x00\x04\x00\x00\x00"
+   "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+   "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+   "\x03\x00\x00\x00\x02\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+   "\x03\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+   "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x0b\x00\x00\x00"
+   "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x0c\x00\x00\x00\x0b\x00\x00\x00"
+   "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x56\x4a\xe0\x51\xf5\x0b\xfc\x61";
+const char kVecIdxBytes[] =
+   "\x06\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x18\x00\x00\x00"
+   "\x00\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x2a\x00\x00\x00\x00\x00\x00\x00"
+   "\x30\x00\x00\x00\x00\x00\x00\x00\x36\x00\x00\x00\x00\x00\x00\x00\x3c\x00\x00\x00\x00\x00\x00\x00\xaa\xde\x1b\xde"
+   "\xb5\xf3\xbc\x1a";
+const char kFltBytes[] =
+   "\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40\x00\x00\x80\x40\x00\x00\xa0\x40\x00\x00\xc0"
+   "\x40"
+   "\x00\x00\xe0\x40\x00\x00\x00\x41\x00\x00\x10\x41\x1b\xad\x67\xa6\xe6\x61\x56\x9d";
+
+constexpr auto kVecBytesLenChecksums = std::size(kVecBytes) - 1;
+constexpr auto kVecIdxBytesLenChecksums = std::size(kVecIdxBytes) - 1;
+constexpr auto kFltBytesLenChecksums = std::size(kFltBytes) - 1;
+constexpr auto kVecBytesLenNoChecksums = kVecBytesLenChecksums - 8;
+constexpr auto kVecIdxBytesLenNoChecksums = kVecIdxBytesLenChecksums - 8;
+constexpr auto kFltBytesLenNoChecksums = kFltBytesLenChecksums - 8;
+
+} // namespace
+
 TEST(RNTupleExporter, ExportToFiles)
 {
-   static const char kVecBytes[] =
-      "\x5a\x53\x01\x9e\x00\x00\x40\x1f\x00\x28\xb5\x2f\xfd\x60\x40\x1e\xa5\x04\x00\x84\x07\x14\x12\x10\x0e\x0c\x0a\x08"
-      "\x06\x04\x02\x00\x01\x03\x05\x07\x09\x0b\x0d\x0f\x11\x16\x18\x1a\x1c\x1e\x20\x22\x24\x26\x28\x2a\x2c\x2e\x30\x32"
-      "\x34\x36\x38\x3a\x3c\x3e\x40\x42\x44\x46\x48\x4a\x4c\x4e\x50\x52\x54\x56\x58\x5a\x5c\x5e\x60\x62\x64\x66\x68\x6a"
-      "\x6c\x6e\x70\x72\x74\x76\x78\x7a\x7c\x7e\x80\x82\x84\x86\x88\x8a\x8c\x8e\x90\x92\x94\x96\x98\x9a\x9c\x9e\xa0\xa2"
-      "\xa4\xa6\xa8\xaa\xac\xae\xb0\xb2\xb4\xb6\xb8\xba\xbc\xbe\xc0\xc2\xc4\xc6\xc8\xca\xcc\xce\xd0\xd2\xd4\xd6\xd8\xda"
-      "\x00\x64\xa8\x11\xe0\xef\x7f\x06\xf0\x85\x31\x12\xf8\x1f\xff\xfe\xff\x9f\x01\x6c\x07\xf7\x46\x27\x1a\x53\x15";
-   static const char kVecIdxBytes[] = "\x5a\x53\x01\x16\x00\x00\x20\x03\x00\x28\xb5\x2f\xfd\x60\x20\x02\x65\x00"
-                                      "\x00\x18\x14\x14\x00\x02\x00\xb8\x40\x25\x7e\x02\x58";
-   static const char kFltBytes[] =
-      "\x5a\x53\x01\x81\x00\x00\x90\x01\x00\x28\xb5\x2f\xfd\x60\x90\x00\xbd\x03\x00\xa4\x06\x00\x00\x80\x00\x40\x80\xa0"
-      "\xc0\xe0\x00\x10\x20\x30\x40\x50\x60\x70\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xd0\xd8\xe0\xe8\xf0\xf8\x00\x04"
-      "\x08\x0c\x10\x14\x18\x1c\x20\x24\x28\x2c\x30\x34\x38\x3c\x40\x44\x48\x4c\x50\x54\x58\x5c\x60\x64\x68\x6c\x70\x74"
-      "\x78\x7c\x80\x82\x84\x86\x88\x8a\x8c\x8e\x90\x92\x94\x96\x98\x9a\x9c\x9e\xa0\xa2\xa4\xa6\xa8\xaa\xac\xae\xb0\xb2"
-      "\xb4\xb6\xb8\xba\xbc\xbe\xc0\xc2\xc4\xc6\x00\x3f\x40\x41\x42\x04\x10\x00\x80\x4a\x3d\x53\x38\x44\xaa\x0d";
-
+   // Dump pages of a regular RNTuple with checksums. Should not include checksums in the output.
    FileRaii fileGuard("ntuple_exporter.root");
 
    // Create RNTuple to export
-   {
-      auto model = RNTupleModel::Create();
-      auto pFlt = model->MakeField<float>("flt");
-      auto pVec = model->MakeField<std::vector<int>>("vec");
-
-      auto opts = RNTupleWriteOptions();
-      opts.SetCompression(505);
-      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
-      for (int i = 0; i < 100; ++i) {
-         *pFlt = i;
-         pVec->clear();
-         for (int j = -10; j < 10; ++j)
-            pVec->emplace_back(i - j);
-         writer->Fill();
-      }
-   }
+   CreateExportRNTuple(fileGuard.GetPath(), kWithChecksums);
 
    // Now export the pages
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
@@ -67,9 +93,9 @@ TEST(RNTupleExporter, ExportToFiles)
 
    EXPECT_EQ(res.fExportedFileNames.size(), 3);
 
-   FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_100_comp_505.page");
-   FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
-   FileRaii pageFlt("./cluster_0_flt-0_page_0_elems_100_comp_505.page");
+   FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_10_comp_0.page");
+   FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_60_comp_0.page");
+   FileRaii pageFlt("./cluster_0_flt-0_page_0_elems_10_comp_0.page");
 
    EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
                res.fExportedFileNames.end());
@@ -80,64 +106,30 @@ TEST(RNTupleExporter, ExportToFiles)
 
    // check the file contents
    auto fltBytes = ReadFileToString(pageFlt.GetPath().c_str());
-   EXPECT_EQ(fltBytes.length(), std::size(kFltBytes) - 1);
+   EXPECT_EQ(fltBytes.length(), kFltBytesLenNoChecksums);
    EXPECT_EQ(memcmp(fltBytes.data(), kFltBytes, fltBytes.length()), 0);
 
    auto vecIdxBytes = ReadFileToString(pageVecIdx.GetPath().c_str());
-   EXPECT_EQ(vecIdxBytes.length(), std::size(kVecIdxBytes) - 1);
+   EXPECT_EQ(vecIdxBytes.length(), kVecIdxBytesLenNoChecksums);
    EXPECT_EQ(memcmp(vecIdxBytes.data(), kVecIdxBytes, vecIdxBytes.length()), 0);
 
    auto vecBytes = ReadFileToString(pageVec.GetPath().c_str());
-   EXPECT_EQ(vecBytes.length(), std::size(kVecBytes) - 1);
+   EXPECT_EQ(vecBytes.length(), kVecBytesLenNoChecksums);
    EXPECT_EQ(memcmp(vecBytes.data(), kVecBytes, vecBytes.length()), 0);
 }
 
 TEST(RNTupleExporter, ExportToFilesWithChecksum)
 {
-   static const char kVecBytes[] =
-      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xfe\xff\xff\xff\x04\x00\x00\x00"
-      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x05\x00\x00\x00\x04\x00\x00\x00"
-      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
-      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
-      "\x03\x00\x00\x00\x02\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
-      "\x03\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
-      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x0b\x00\x00\x00"
-      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x0c\x00\x00\x00\x0b\x00\x00\x00"
-      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x56\x4a\xe0\x51\xf5\x0b\xfc\x61";
-   static const char kVecIdxBytes[] =
-      "\x06\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x18\x00\x00\x00"
-      "\x00\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x2a\x00\x00\x00\x00\x00\x00\x00"
-      "\x30\x00\x00\x00\x00\x00\x00\x00\x36\x00\x00\x00\x00\x00\x00\x00\x3c\x00\x00\x00\x00\x00\x00\x00\xaa\xde\x1b\xde"
-      "\xb5\xf3\xbc\x1a";
-   static const char kFltBytes[] =
-      "\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40\x00\x00\x80\x40\x00\x00\xa0\x40\x00\x00\xc0"
-      "\x40"
-      "\x00\x00\xe0\x40\x00\x00\x00\x41\x00\x00\x10\x41\x1b\xad\x67\xa6\xe6\x61\x56\x9d";
-
+   // Dump pages of a regular RNTuple with checksums. Should include checksums in the output.
    FileRaii fileGuard("ntuple_exporter_chk.root");
 
    // Create RNTuple to export
-   {
-      auto model = RNTupleModel::Create();
-      auto pFlt = model->MakeField<float>("flt");
-      auto pVec = model->MakeField<std::vector<int>>("vec");
-
-      auto opts = RNTupleWriteOptions();
-      opts.SetCompression(0);
-      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
-      for (int i = 0; i < 10; ++i) {
-         *pFlt = i;
-         pVec->clear();
-         for (int j = -3; j < 3; ++j)
-            pVec->emplace_back(i - j);
-         writer->Fill();
-      }
-   }
+   CreateExportRNTuple(fileGuard.GetPath(), kWithChecksums);
 
    // Now export the pages
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
-   auto opts = Internal::RExportPagesOptions();
-   opts.fFlags |= Internal::RExportPagesOptions::kIncludeChecksums;
+   auto opts = Internal::RNTupleExporter::RPagesOptions();
+   opts.fFlags |= Internal::RNTupleExporter::RPagesOptions::kIncludeChecksums;
    auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
 
    EXPECT_EQ(res.fExportedFileNames.size(), 3);
@@ -155,15 +147,56 @@ TEST(RNTupleExporter, ExportToFilesWithChecksum)
 
    // check the file contents
    auto fltBytes = ReadFileToString(pageFlt.GetPath().c_str());
-   EXPECT_EQ(fltBytes.length(), std::size(kFltBytes) - 1);
+   EXPECT_EQ(fltBytes.length(), kFltBytesLenChecksums);
    EXPECT_EQ(memcmp(fltBytes.data(), kFltBytes, fltBytes.length()), 0);
 
    auto vecIdxBytes = ReadFileToString(pageVecIdx.GetPath().c_str());
-   EXPECT_EQ(vecIdxBytes.length(), std::size(kVecIdxBytes) - 1);
+   EXPECT_EQ(vecIdxBytes.length(), kVecIdxBytesLenChecksums);
    EXPECT_EQ(memcmp(vecIdxBytes.data(), kVecIdxBytes, vecIdxBytes.length()), 0);
 
    auto vecBytes = ReadFileToString(pageVec.GetPath().c_str());
-   EXPECT_EQ(vecBytes.length(), std::size(kVecBytes) - 1);
+   EXPECT_EQ(vecBytes.length(), kVecBytesLenChecksums);
+   EXPECT_EQ(memcmp(vecBytes.data(), kVecBytes, vecBytes.length()), 0);
+}
+
+TEST(RNTupleExporter, ExportToFilesWithNoChecksum)
+{
+   // Try to dump pages+checksum of a RNTuple that has no checksums (should succeed)
+   FileRaii fileGuard("ntuple_exporter_no_chk.root");
+
+   // Create RNTuple to export
+   CreateExportRNTuple(fileGuard.GetPath(), kWithoutChecksums);
+
+   // Now export the pages
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto opts = Internal::RNTupleExporter::RPagesOptions();
+   opts.fFlags |= Internal::RNTupleExporter::RPagesOptions::kIncludeChecksums;
+   auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
+
+   EXPECT_EQ(res.fExportedFileNames.size(), 3);
+
+   FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_10_comp_0.page");
+   FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_60_comp_0.page");
+   FileRaii pageFlt("./cluster_0_flt-0_page_0_elems_10_comp_0.page");
+
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVec.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVecIdx.GetPath()) !=
+               res.fExportedFileNames.end());
+
+   // check the file contents
+   auto fltBytes = ReadFileToString(pageFlt.GetPath().c_str());
+   EXPECT_EQ(fltBytes.length(), kFltBytesLenNoChecksums);
+   EXPECT_EQ(memcmp(fltBytes.data(), kFltBytes, fltBytes.length()), 0);
+
+   auto vecIdxBytes = ReadFileToString(pageVecIdx.GetPath().c_str());
+   EXPECT_EQ(vecIdxBytes.length(), kVecIdxBytesLenNoChecksums);
+   EXPECT_EQ(memcmp(vecIdxBytes.data(), kVecIdxBytes, vecIdxBytes.length()), 0);
+
+   auto vecBytes = ReadFileToString(pageVec.GetPath().c_str());
+   EXPECT_EQ(vecBytes.length(), kVecBytesLenNoChecksums);
    EXPECT_EQ(memcmp(vecBytes.data(), kVecBytes, vecBytes.length()), 0);
 }
 
@@ -247,7 +280,7 @@ TEST(RNTupleExporter, ExportToFilesCustomPath)
 
    // Now export the pages
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
-   auto opts = Internal::RExportPagesOptions();
+   auto opts = Internal::RNTupleExporter::RPagesOptions();
    opts.fOutputPath = kDirName;
    auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
 

--- a/tree/ntupleutil/v7/test/ntuple_exporter.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_exporter.cxx
@@ -65,7 +65,7 @@ TEST(RNTupleExporter, ExportToFiles)
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
    auto res = Internal::RNTupleExporter::ExportPages(*source);
 
-   EXPECT_EQ(res.fNPagesExported, 3);
+   EXPECT_EQ(res.fExportedFileNames.size(), 3);
 
    FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_100_comp_505.page");
    FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
@@ -140,7 +140,7 @@ TEST(RNTupleExporter, ExportToFilesWithChecksum)
    opts.fFlags |= Internal::RExportPagesOptions::kIncludeChecksums;
    auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
 
-   EXPECT_EQ(res.fNPagesExported, 3);
+   EXPECT_EQ(res.fExportedFileNames.size(), 3);
 
    FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_10_comp_0.page");
    FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_60_comp_0.page");
@@ -192,7 +192,7 @@ TEST(RNTupleExporter, ExportToFilesManyPages)
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
    auto res = Internal::RNTupleExporter::ExportPages(*source);
 
-   EXPECT_EQ(res.fNPagesExported, 14);
+   EXPECT_EQ(res.fExportedFileNames.size(), 14);
 
    for (const auto &file : res.fExportedFileNames)
       std::remove(file.c_str());
@@ -209,7 +209,6 @@ TEST(RNTupleExporter, EmptySource)
    auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
    auto res = Internal::RNTupleExporter::ExportPages(*source);
 
-   EXPECT_EQ(res.fNPagesExported, 0);
    EXPECT_EQ(res.fExportedFileNames.size(), 0);
 }
 
@@ -252,7 +251,7 @@ TEST(RNTupleExporter, ExportToFilesCustomPath)
    opts.fOutputPath = kDirName;
    auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
 
-   EXPECT_EQ(res.fNPagesExported, 3);
+   EXPECT_EQ(res.fExportedFileNames.size(), 3);
 
    FileRaii pageVecIdx(kDirName / "cluster_0_vec-0_page_0_elems_100_comp_505.page");
    FileRaii pageVec(kDirName / "cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");

--- a/tree/ntupleutil/v7/test/ntuple_exporter.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_exporter.cxx
@@ -3,6 +3,7 @@
 #include <ROOT/RNTupleModel.hxx>
 
 #include "ntupleutil_test.hxx"
+#include <filesystem>
 
 using namespace ROOT::Experimental;
 
@@ -268,7 +269,7 @@ TEST(RNTupleExporter, ExportToFilesCustomPath)
    }
 
    // create tmp directory
-   static const std::filesystem::path kDirName = "rntuple_exporter_custom_path";
+   static const std::string kDirName = "rntuple_exporter_custom_path";
    bool ok = std::filesystem::create_directory(kDirName);
    if (!ok) {
       FAIL() << "failed to create directory " << kDirName;
@@ -286,9 +287,9 @@ TEST(RNTupleExporter, ExportToFilesCustomPath)
 
    EXPECT_EQ(res.fExportedFileNames.size(), 3);
 
-   FileRaii pageVecIdx(kDirName / "cluster_0_vec-0_page_0_elems_100_comp_505.page");
-   FileRaii pageVec(kDirName / "cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
-   FileRaii pageFlt(kDirName / "cluster_0_flt-0_page_0_elems_100_comp_505.page");
+   FileRaii pageVecIdx(kDirName + "/cluster_0_vec-0_page_0_elems_100_comp_505.page");
+   FileRaii pageVec(kDirName + "/cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
+   FileRaii pageFlt(kDirName + "/cluster_0_flt-0_page_0_elems_100_comp_505.page");
 
    EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
                res.fExportedFileNames.end());

--- a/tree/ntupleutil/v7/test/ntuple_exporter.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_exporter.cxx
@@ -1,0 +1,270 @@
+#include <ROOT/RNTupleExporter.hxx>
+
+#include <ROOT/RNTupleModel.hxx>
+
+#include "ntupleutil_test.hxx"
+
+using namespace ROOT::Experimental;
+
+static std::string ReadFileToString(const char *fname)
+{
+   FILE *f = fopen(fname, "rb");
+   if (!f) {
+      R__LOG_ERROR() << "failed to open file " << fname;
+      return "";
+   }
+   fseek(f, 0, SEEK_END);
+   size_t size = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   std::string str;
+   str.resize(size);
+   fread(str.data(), 1, size, f);
+   fclose(f);
+   return str;
+}
+
+TEST(RNTupleExporter, ExportToFiles)
+{
+   static const char kVecBytes[] =
+      "\x5a\x53\x01\x9e\x00\x00\x40\x1f\x00\x28\xb5\x2f\xfd\x60\x40\x1e\xa5\x04\x00\x84\x07\x14\x12\x10\x0e\x0c\x0a\x08"
+      "\x06\x04\x02\x00\x01\x03\x05\x07\x09\x0b\x0d\x0f\x11\x16\x18\x1a\x1c\x1e\x20\x22\x24\x26\x28\x2a\x2c\x2e\x30\x32"
+      "\x34\x36\x38\x3a\x3c\x3e\x40\x42\x44\x46\x48\x4a\x4c\x4e\x50\x52\x54\x56\x58\x5a\x5c\x5e\x60\x62\x64\x66\x68\x6a"
+      "\x6c\x6e\x70\x72\x74\x76\x78\x7a\x7c\x7e\x80\x82\x84\x86\x88\x8a\x8c\x8e\x90\x92\x94\x96\x98\x9a\x9c\x9e\xa0\xa2"
+      "\xa4\xa6\xa8\xaa\xac\xae\xb0\xb2\xb4\xb6\xb8\xba\xbc\xbe\xc0\xc2\xc4\xc6\xc8\xca\xcc\xce\xd0\xd2\xd4\xd6\xd8\xda"
+      "\x00\x64\xa8\x11\xe0\xef\x7f\x06\xf0\x85\x31\x12\xf8\x1f\xff\xfe\xff\x9f\x01\x6c\x07\xf7\x46\x27\x1a\x53\x15";
+   static const char kVecIdxBytes[] = "\x5a\x53\x01\x16\x00\x00\x20\x03\x00\x28\xb5\x2f\xfd\x60\x20\x02\x65\x00"
+                                      "\x00\x18\x14\x14\x00\x02\x00\xb8\x40\x25\x7e\x02\x58";
+   static const char kFltBytes[] =
+      "\x5a\x53\x01\x81\x00\x00\x90\x01\x00\x28\xb5\x2f\xfd\x60\x90\x00\xbd\x03\x00\xa4\x06\x00\x00\x80\x00\x40\x80\xa0"
+      "\xc0\xe0\x00\x10\x20\x30\x40\x50\x60\x70\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xd0\xd8\xe0\xe8\xf0\xf8\x00\x04"
+      "\x08\x0c\x10\x14\x18\x1c\x20\x24\x28\x2c\x30\x34\x38\x3c\x40\x44\x48\x4c\x50\x54\x58\x5c\x60\x64\x68\x6c\x70\x74"
+      "\x78\x7c\x80\x82\x84\x86\x88\x8a\x8c\x8e\x90\x92\x94\x96\x98\x9a\x9c\x9e\xa0\xa2\xa4\xa6\xa8\xaa\xac\xae\xb0\xb2"
+      "\xb4\xb6\xb8\xba\xbc\xbe\xc0\xc2\xc4\xc6\x00\x3f\x40\x41\x42\x04\x10\x00\x80\x4a\x3d\x53\x38\x44\xaa\x0d";
+
+   FileRaii fileGuard("ntuple_exporter.root");
+
+   // Create RNTuple to export
+   {
+      auto model = RNTupleModel::Create();
+      auto pFlt = model->MakeField<float>("flt");
+      auto pVec = model->MakeField<std::vector<int>>("vec");
+
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(505);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
+      for (int i = 0; i < 100; ++i) {
+         *pFlt = i;
+         pVec->clear();
+         for (int j = -10; j < 10; ++j)
+            pVec->emplace_back(i - j);
+         writer->Fill();
+      }
+   }
+
+   // Now export the pages
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto res = Internal::RNTupleExporter::ExportPages(*source);
+
+   EXPECT_EQ(res.fNPagesExported, 3);
+
+   FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_100_comp_505.page");
+   FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
+   FileRaii pageFlt("./cluster_0_flt-0_page_0_elems_100_comp_505.page");
+
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVec.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVecIdx.GetPath()) !=
+               res.fExportedFileNames.end());
+
+   // check the file contents
+   auto fltBytes = ReadFileToString(pageFlt.GetPath().c_str());
+   EXPECT_EQ(fltBytes.length(), std::size(kFltBytes) - 1);
+   EXPECT_EQ(memcmp(fltBytes.data(), kFltBytes, fltBytes.length()), 0);
+
+   auto vecIdxBytes = ReadFileToString(pageVecIdx.GetPath().c_str());
+   EXPECT_EQ(vecIdxBytes.length(), std::size(kVecIdxBytes) - 1);
+   EXPECT_EQ(memcmp(vecIdxBytes.data(), kVecIdxBytes, vecIdxBytes.length()), 0);
+
+   auto vecBytes = ReadFileToString(pageVec.GetPath().c_str());
+   EXPECT_EQ(vecBytes.length(), std::size(kVecBytes) - 1);
+   EXPECT_EQ(memcmp(vecBytes.data(), kVecBytes, vecBytes.length()), 0);
+}
+
+TEST(RNTupleExporter, ExportToFilesWithChecksum)
+{
+   static const char kVecBytes[] =
+      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xfe\xff\xff\xff\x04\x00\x00\x00"
+      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x05\x00\x00\x00\x04\x00\x00\x00"
+      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+      "\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+      "\x03\x00\x00\x00\x02\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+      "\x03\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x04\x00\x00\x00"
+      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x05\x00\x00\x00\x0b\x00\x00\x00"
+      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x06\x00\x00\x00\x0c\x00\x00\x00\x0b\x00\x00\x00"
+      "\x0a\x00\x00\x00\x09\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x56\x4a\xe0\x51\xf5\x0b\xfc\x61";
+   static const char kVecIdxBytes[] =
+      "\x06\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x18\x00\x00\x00"
+      "\x00\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x2a\x00\x00\x00\x00\x00\x00\x00"
+      "\x30\x00\x00\x00\x00\x00\x00\x00\x36\x00\x00\x00\x00\x00\x00\x00\x3c\x00\x00\x00\x00\x00\x00\x00\xaa\xde\x1b\xde"
+      "\xb5\xf3\xbc\x1a";
+   static const char kFltBytes[] =
+      "\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40\x00\x00\x80\x40\x00\x00\xa0\x40\x00\x00\xc0"
+      "\x40"
+      "\x00\x00\xe0\x40\x00\x00\x00\x41\x00\x00\x10\x41\x1b\xad\x67\xa6\xe6\x61\x56\x9d";
+
+   FileRaii fileGuard("ntuple_exporter_chk.root");
+
+   // Create RNTuple to export
+   {
+      auto model = RNTupleModel::Create();
+      auto pFlt = model->MakeField<float>("flt");
+      auto pVec = model->MakeField<std::vector<int>>("vec");
+
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
+      for (int i = 0; i < 10; ++i) {
+         *pFlt = i;
+         pVec->clear();
+         for (int j = -3; j < 3; ++j)
+            pVec->emplace_back(i - j);
+         writer->Fill();
+      }
+   }
+
+   // Now export the pages
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto opts = Internal::RExportPagesOptions();
+   opts.fFlags |= Internal::RExportPagesOptions::kIncludeChecksums;
+   auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
+
+   EXPECT_EQ(res.fNPagesExported, 3);
+
+   FileRaii pageVecIdx("./cluster_0_vec-0_page_0_elems_10_comp_0.page");
+   FileRaii pageVec("./cluster_0_vec._0-0_page_0_elems_60_comp_0.page");
+   FileRaii pageFlt("./cluster_0_flt-0_page_0_elems_10_comp_0.page");
+
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVec.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVecIdx.GetPath()) !=
+               res.fExportedFileNames.end());
+
+   // check the file contents
+   auto fltBytes = ReadFileToString(pageFlt.GetPath().c_str());
+   EXPECT_EQ(fltBytes.length(), std::size(kFltBytes) - 1);
+   EXPECT_EQ(memcmp(fltBytes.data(), kFltBytes, fltBytes.length()), 0);
+
+   auto vecIdxBytes = ReadFileToString(pageVecIdx.GetPath().c_str());
+   EXPECT_EQ(vecIdxBytes.length(), std::size(kVecIdxBytes) - 1);
+   EXPECT_EQ(memcmp(vecIdxBytes.data(), kVecIdxBytes, vecIdxBytes.length()), 0);
+
+   auto vecBytes = ReadFileToString(pageVec.GetPath().c_str());
+   EXPECT_EQ(vecBytes.length(), std::size(kVecBytes) - 1);
+   EXPECT_EQ(memcmp(vecBytes.data(), kVecBytes, vecBytes.length()), 0);
+}
+
+TEST(RNTupleExporter, ExportToFilesManyPages)
+{
+   FileRaii fileGuard("ntuple_exporter_manypages.root");
+
+   // Create RNTuple to export
+   {
+      auto model = RNTupleModel::Create();
+      auto pFlt = model->MakeField<float>("flt");
+      auto pVec = model->MakeField<std::vector<int>>("vec");
+
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
+      for (int i = 0; i < 1000; ++i) {
+         *pFlt = i;
+         for (int j = -3; j < 3; ++j)
+            pVec->emplace_back(i - j);
+         writer->Fill();
+      }
+   }
+
+   // Now export the pages
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto res = Internal::RNTupleExporter::ExportPages(*source);
+
+   EXPECT_EQ(res.fNPagesExported, 14);
+
+   for (const auto &file : res.fExportedFileNames)
+      std::remove(file.c_str());
+}
+
+TEST(RNTupleExporter, EmptySource)
+{
+   FileRaii fileGuard("ntuple_exporter_empty.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto res = Internal::RNTupleExporter::ExportPages(*source);
+
+   EXPECT_EQ(res.fNPagesExported, 0);
+   EXPECT_EQ(res.fExportedFileNames.size(), 0);
+}
+
+TEST(RNTupleExporter, ExportToFilesCustomPath)
+{
+   FileRaii fileGuard("ntuple_exporter_custom_path.root");
+
+   // Create RNTuple to export
+   {
+      auto model = RNTupleModel::Create();
+      auto pFlt = model->MakeField<float>("flt");
+      auto pVec = model->MakeField<std::vector<int>>("vec");
+
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(505);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opts);
+      for (int i = 0; i < 100; ++i) {
+         *pFlt = i;
+         pVec->clear();
+         for (int j = -10; j < 10; ++j)
+            pVec->emplace_back(i - j);
+         writer->Fill();
+      }
+   }
+
+   // create tmp directory
+   static const std::filesystem::path kDirName = "rntuple_exporter_custom_path";
+   bool ok = std::filesystem::create_directory(kDirName);
+   if (!ok) {
+      FAIL() << "failed to create directory " << kDirName;
+      return;
+   }
+   struct Defer {
+      ~Defer() { std::filesystem::remove_all(kDirName); }
+   } const defer;
+
+   // Now export the pages
+   auto source = Internal::RPageSource::Create("ntuple", fileGuard.GetPath());
+   auto opts = Internal::RExportPagesOptions();
+   opts.fOutputPath = kDirName;
+   auto res = Internal::RNTupleExporter::ExportPages(*source, opts);
+
+   EXPECT_EQ(res.fNPagesExported, 3);
+
+   FileRaii pageVecIdx(kDirName / "cluster_0_vec-0_page_0_elems_100_comp_505.page");
+   FileRaii pageVec(kDirName / "cluster_0_vec._0-0_page_0_elems_2000_comp_505.page");
+   FileRaii pageFlt(kDirName / "cluster_0_flt-0_page_0_elems_100_comp_505.page");
+
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageFlt.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVec.GetPath()) !=
+               res.fExportedFileNames.end());
+   EXPECT_TRUE(std::find(res.fExportedFileNames.begin(), res.fExportedFileNames.end(), pageVecIdx.GetPath()) !=
+               res.fExportedFileNames.end());
+
+   for (const auto &fname : res.fExportedFileNames)
+      EXPECT_TRUE(std::filesystem::exists(fname));
+}

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -9,7 +9,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
-#include <filesystem>
 
 /**
  * An RAII wrapper around an open temporary file on disk. It cleans up the
@@ -27,7 +26,7 @@ public:
    ~FileRaii()
    {
       if (!fPreserveFile)
-         std::filesystem::remove(fPath.c_str());
+         std::remove(fPath.c_str());
    }
    std::string GetPath() const { return fPath; }
 

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -9,6 +9,7 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
+#include <filesystem>
 
 /**
  * An RAII wrapper around an open temporary file on disk. It cleans up the
@@ -16,8 +17,8 @@
  */
 class FileRaii {
 private:
-   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
    std::string fPath;
+   bool fPreserveFile = false;
 
 public:
    explicit FileRaii(const std::string &path) : fPath(path) {}
@@ -25,10 +26,14 @@ public:
    FileRaii &operator=(const FileRaii &) = delete;
    ~FileRaii()
    {
-      if (!kDebug)
-         std::remove(fPath.c_str());
+      if (!fPreserveFile)
+         std::filesystem::remove(fPath.c_str());
    }
    std::string GetPath() const { return fPath; }
+
+   // Useful if you want to keep a test file after the test has finished running
+   // for debugging purposes. Should only be used locally and never pushed.
+   void PreserveFile() { fPreserveFile = true; }
 };
 
 #endif // ROOT7_RNTupleUtil_Test


### PR DESCRIPTION
This is an internal utility used to dump pages of an RNTuple. In the future it might be extended to also dump other interesting things or accept a wider range of options (e.g. customize the output file names).

Ideally it should supersede [ntuple_dump.C](https://github.com/jblomer/iotools/blob/master/ntuple_dump.C).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

