### PR TITLE
Fix dereference value-initialized vector iterator

### DIFF
--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -143,13 +143,8 @@ namespace Detail {
                *end_arena = nullptr;
                return;
             }
-            *begin_arena = &(*c->begin());
-#ifdef R__VISUAL_CPLUSPLUS
-            *end_arena = &(*(c->end()-1)) + 1; // On windows we can not dererence the end iterator at all.
-#else
-            // coverity[past_the_end] Safe on other platforms
-            *end_arena = &(*c->end());
-#endif
+            *begin_arena = c->data();
+            *end_arena = c->data() + c->size(); // We can not dereference the end iterator at all.
          }
          static void* copy(void *dest, const void *source) {
             *(void**)dest = *(void**)(const_cast<void*>(source));

--- a/io/io/inc/TVirtualCollectionIterators.h
+++ b/io/io/inc/TVirtualCollectionIterators.h
@@ -356,13 +356,8 @@ public:
          fEnd = nullptr;
          return;
       }
-      fBegin= &(*vec->begin());
-#ifdef R__VISUAL_CPLUSPLUS
-      fEnd = &(*(vec->end()-1)) + 1; // On windows we can not dererence the end iterator at all.
-#else
-      // coverity[past_the_end] Safe on other platforms
-      fEnd = &(*vec->end());
-#endif
+      fBegin= vec->data();
+      fEnd = vec->data() + vec->size(); // We can not dereference the end iterator at all.
       //fCreateIterators(collection, &fBegin, &fEnd);
    }
 };

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -364,7 +364,7 @@ void TEmulatedCollectionProxy::Shrink(UInt_t nCurr, UInt_t left, Bool_t force )
          }
    }
    c->resize(left*fValDiff,0);
-   fEnv->fStart = left>0 ? &(*c->begin()) : 0;
+   fEnv->fStart = left > 0 ? c->data() : 0;
    return;
 }
 
@@ -375,7 +375,7 @@ void TEmulatedCollectionProxy::Expand(UInt_t nCurr, UInt_t left)
    PCont_t c   = PCont_t(fEnv->fObject);
    c->resize(left*fValDiff,0);
    void *oldstart = fEnv->fStart;
-   fEnv->fStart = left>0 ? &(*c->begin()) : 0;
+   fEnv->fStart = left > 0 ? c->data() : 0;
 
    char* addr = ((char*)fEnv->fStart) + fValDiff*nCurr;
    switch ( fSTL_type )  {
@@ -454,7 +454,7 @@ void TEmulatedCollectionProxy::Resize(UInt_t left, Bool_t force)
    if ( fEnv && fEnv->fObject )   {
       size_t nCurr = Size();
       PCont_t c = PCont_t(fEnv->fObject);
-      fEnv->fStart = nCurr>0 ? &(*c->begin()) : 0;
+      fEnv->fStart = nCurr > 0 ? c->data() : 0;
       if ( left == nCurr )  {
          return;
       }
@@ -477,7 +477,7 @@ void* TEmulatedCollectionProxy::At(UInt_t idx)
       if ( idx >= (s/fValDiff) )  {
          return 0;
       }
-      return idx<(s/fValDiff) ? ((char*)&(*c->begin()))+idx*fValDiff : 0;
+      return idx < (s / fValDiff) ? c->data() + idx * fValDiff : 0;
    }
    Fatal("TEmulatedCollectionProxy","At> Logic error - no proxy object set.");
    return 0;

--- a/io/io/src/TEmulatedMapProxy.cxx
+++ b/io/io/src/TEmulatedMapProxy.cxx
@@ -71,7 +71,7 @@ void* TEmulatedMapProxy::At(UInt_t idx)
    // Return the address of the value at index 'idx'.
    if ( fEnv && fEnv->fObject )   {
       PCont_t c = PCont_t(fEnv->fObject);
-      return idx<(c->size()/fValDiff) ? ((char*)&(*c->begin())) + idx*fValDiff : 0;
+      return idx<(c->size() / fValDiff) ? c->data() + idx * fValDiff : 0;
    }
    Fatal("TEmulatedMapProxy","At> Logic error - no proxy object set.");
    return 0;

--- a/io/io/src/TEmulatedMapProxy.cxx
+++ b/io/io/src/TEmulatedMapProxy.cxx
@@ -71,7 +71,7 @@ void* TEmulatedMapProxy::At(UInt_t idx)
    // Return the address of the value at index 'idx'.
    if ( fEnv && fEnv->fObject )   {
       PCont_t c = PCont_t(fEnv->fObject);
-      return idx<(c->size() / fValDiff) ? c->data() + idx * fValDiff : 0;
+      return (idx<(c->size() / fValDiff)) ? (c->data() + idx * fValDiff) : 0;
    }
    Fatal("TEmulatedMapProxy","At> Logic error - no proxy object set.");
    return 0;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -1514,13 +1514,8 @@ void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, v
       *end_arena = 0;
       return;
    }
-   *begin_arena = &(*vec->begin());
-#ifdef R__VISUAL_CPLUSPLUS
-   *end_arena = &(*(vec->end()-1)) + 1; // On windows we can not dererence the end iterator at all.
-#else
-   // coverity[past_the_end] Safe on other platforms
-   *end_arena = &(*vec->end());
-#endif
+   *begin_arena = vec->data();
+   *end_arena = vec->data() + vec->size(); // We can not dereference the end iterator at all.
 
 }
 

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -1515,7 +1515,7 @@ void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, v
       return;
    }
    *begin_arena = vec->data();
-   *end_arena = vec->data() + vec->size(); // We can not dereference the end iterator at all.
+   *end_arena = vec->data() + vec->size();
 
 }
 

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -2241,7 +2241,7 @@ namespace TStreamerInfoActions
             return 0;
          }
 #endif
-         T *begin = &(*vec->begin());
+         T *begin = vec->data();
          buf.ReadFastArray(begin, nvalues);
 
          buf.CheckByteCount(start,count,config->fTypeName);
@@ -2260,7 +2260,7 @@ namespace TStreamerInfoActions
          Int_t nvalues = vec->size();
          buf.WriteInt(nvalues);
 
-         T *begin = &(*vec->begin());
+         T *begin = vec->data();
          buf.WriteFastArray(begin, nvalues);
 
          buf.SetByteCount(start);
@@ -2286,7 +2286,7 @@ namespace TStreamerInfoActions
             return 0;
          }
 #endif
-         float *begin = &(*vec->begin());
+         float *begin = vec->data();
          buf.ReadFastArrayFloat16(begin, nvalues);
 
          buf.CheckByteCount(start,count,config->fTypeName);
@@ -2304,7 +2304,7 @@ namespace TStreamerInfoActions
          Int_t nvalues = vec->size();
          buf.WriteInt(nvalues);
 
-         float *begin = &(*vec->begin());
+         float *begin = vec->data();
          buf.WriteFastArrayFloat16(begin, nvalues);
 
          buf.SetByteCount(start);
@@ -2330,7 +2330,7 @@ namespace TStreamerInfoActions
             return 0;
          }
 #endif
-         double *begin = &(*vec->begin());
+         double *begin = vec->data();
          buf.ReadFastArrayDouble32(begin, nvalues);
 
          buf.CheckByteCount(start,count,config->fTypeName);
@@ -2348,7 +2348,7 @@ namespace TStreamerInfoActions
          Int_t nvalues = vec->size();
          buf.WriteInt(nvalues);
 
-         double *begin = &(*vec->begin());
+         double *begin = vec->data();
          buf.WriteFastArrayDouble32(begin, nvalues);
 
          buf.SetByteCount(start);


### PR DESCRIPTION
Fix the following error on Windows:
```
Debug assertion Failed!
Can't dereference value-initialized vector iterator
```
As the standard says:
`std::vector::end()` returns an iterator to the element following the last element of the vector.
This element acts as a placeholder; attempting to access it results in undefined behavior.
See https://en.cppreference.com/w/cpp/container/vector/end 
And with empty vectors, vector.begin() == vector.end()
