### PR TITLE
[io] Set empty TKey default title

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -295,8 +295,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
 ///  WARNING: in name avoid special characters like '^','$','.' that are used
 ///  by the regular expression parser (see TRegexp).
 
-TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, TDirectory* motherDir)
-     : TNamed(name, "object title")
+TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, TDirectory *motherDir) : TNamed(name, "")
 {
    R__ASSERT(obj && cl);
 

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -40,7 +40,6 @@ TEST(TFile, WriteObjectVector)
 {
     auto filename{"tfile_writeobject_vector.root"};
     auto vec_name{"object name"}; // Decided arbitrarily
-    auto vec_title{"object title"}; // Default title for non-TObject-derived instances
 
     {
         std::vector<int> myvec{1,2,3,4,5};
@@ -62,7 +61,7 @@ TEST(TFile, WriteObjectVector)
     }
 
     EXPECT_STREQ(retkey->GetName(), vec_name);
-    EXPECT_STREQ(retkey->GetTitle(), vec_title);
+    EXPECT_STREQ(retkey->GetTitle(), ""); // Objects that don't derive from TObject have no title
 
     input.Close();
     gSystem->Unlink(filename);


### PR DESCRIPTION
Currently, the default title for a TKey is "object title". Objects that do not derive from TObject have no means to change this title. Change the default title to the empty string to save a few bytes per non-TObject object and to reduce the "noise" when listing directory contents.

Companion PR: https://github.com/root-project/roottest/pull/1242

