### PR TITLE
[ntuple] some fixes to Real32Quant

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -431,7 +431,7 @@ public:
 
    /// Sets this field to use a half precision representation, occupying half as much storage space (16 bits:
    /// 1 sign bit, 5 exponent bits, 10 mantissa bits) on disk.
-   /// This is mutually exclusive with `SetTruncated` and `SetQuantized`.
+   /// This is mutually exclusive with `SetTruncated` and `SetQuantized` and supersedes them if called after them.
    void SetHalfPrecision() { SetColumnRepresentatives({{EColumnType::kReal16}}); }
 
    /// Set the on-disk representation of this field to a single-precision float truncated to `nBits`.
@@ -439,7 +439,7 @@ public:
    /// `nBits` must be $10 <= nBits <= 31$ (this means that at least 1 bit
    /// of mantissa is always preserved). Note that this effectively rounds the number towards 0.
    /// For a double-precision field, this implies first a cast to single-precision, then the truncation.
-   /// This is mutually exclusive with `SetHalfPrecision` and `SetQuantized`.
+   /// This is mutually exclusive with `SetHalfPrecision` and `SetQuantized` and supersedes them if called after them.
    void SetTruncated(std::size_t nBits)
    {
       const auto &[minBits, maxBits] = Internal::RColumnElementBase::GetValidBitRange(EColumnType::kReal32Trunc);
@@ -454,9 +454,12 @@ public:
 
    /// Sets this field to use a quantized integer representation using `nBits` per value.
    /// It must be $1 <= nBits <= 32$.
-   /// This call promises that this field will only contain values contained in `[minValue, maxValue]` inclusive.
-   /// If a value outside this range is assigned to this field, the behavior is undefined.
-   /// This is mutually exclusive with `SetTruncated` and `SetHalfPrecision`.
+   /// `minValue` and `maxValue` must not be infinity, NaN or denormal floats, and they must be representable by the
+   /// type T.
+   /// Calling this function establishes a promise by the caller to RNTuple that this field will only contain values
+   /// contained in `[minValue, maxValue]` inclusive. If a value outside this range is assigned to this field, the
+   /// behavior is undefined.
+   /// This is mutually exclusive with `SetTruncated` and `SetHalfPrecision` and supersedes them if called after them.
    void SetQuantized(double minValue, double maxValue, std::size_t nBits)
    {
       const auto &[minBits, maxBits] = Internal::RColumnElementBase::GetValidBitRange(EColumnType::kReal32Quant);

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <limits>
 #include <type_traits>
+#include <cmath>
 
 // NOTE: some tests might define R__LITTLE_ENDIAN to simulate a different-endianness machine
 #ifndef R__LITTLE_ENDIAN
@@ -1057,8 +1058,8 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
    const double scale = (max - min) / quantMax;
    const std::size_t unusedBits = sizeof(Quantized_t) * 8 - nQuantBits;
    const double eps = std::numeric_limits<double>::epsilon();
-   const double emin = -eps * scale + min;
-   const double emax = (static_cast<double>(quantMax) + eps) * scale + min;
+   const double emin = min - std::abs(min) * eps;
+   const double emax = max + std::abs(max) * eps;
 
    int nOutOfRange = 0;
 
@@ -1101,6 +1102,9 @@ public:
    {
       R__ASSERT(min >= std::numeric_limits<T>::lowest());
       R__ASSERT(max <= std::numeric_limits<T>::max());
+      // Disallow denormal, NaN and infinity
+      R__ASSERT(std::isnormal(min) || min == 0.0);
+      R__ASSERT(std::isnormal(max) || max == 0.0);
       fValueRange = {min, max};
    }
 

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -941,12 +941,11 @@ TEST(Packing, Real32QuantFloat)
             }
          }
       } else {
-         const auto k = 0.5 * (kMax - kMin) / ((1ull << bitWidth) - 1) + kMin;
+         const auto maxErr = (kMax - kMin) / ((1ull << bitWidth) - 1);
          for (int i = 0; i < N; ++i) {
             element.Pack(packed.get(), inputs, i);
             element.Unpack(outputs, packed.get(), i);
             for (int j = 0; j < i; ++j) {
-               const float maxErr = std::abs(k) + std::abs(inputs[i]);
                EXPECT_NEAR(outputs[j], inputs[j], maxErr);
             }
          }
@@ -1067,12 +1066,11 @@ TEST(Packing, Real32QuantDouble)
             }
          }
       } else {
-         const auto k = 0.5 * (kMax - kMin) / ((1ull << bitWidth) - 1) + kMin;
+         const auto maxErr = (kMax - kMin) / ((1ull << bitWidth) - 1);
          for (int i = 0; i < N; ++i) {
             element.Pack(packed.get(), inputs, i);
             element.Unpack(outputs, packed.get(), i);
             for (int j = 0; j < i; ++j) {
-               const double maxErr = std::abs(k) + std::abs(inputs[i]);
                EXPECT_NEAR(outputs[j], inputs[j], maxErr);
             }
          }


### PR DESCRIPTION
- fix wrong calculation for maxErr in ntuple_packing
- fix wrong emin/emax adjustment in UnquantizeReals
- ensure min and max values of ValueRange are normal

## Notes
This should fix an assertion failure observed on AArch64 by @hahnjo.
These bugs do *not* have the potential of generating corrupted data (barring users that pass exotic floats as min/max values), but they can trigger false positives of the "out of range" assertion failures.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


