### PR TITLE
Add C++23 support

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveCaloData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCaloData.hxx
@@ -174,7 +174,7 @@ protected:
 
 public:
    REveCaloData(const char* n="REveCaloData", const char* t="");
-   ~REveCaloData() override {}
+   ~REveCaloData() override;
 
    void    FillImpliedSelectedSet(Set_t& impSelSet, const std::set<int>& sec_idcs) override;
 
@@ -220,7 +220,7 @@ public:
    Bool_t   GetWrapTwoPi() const { return fWrapTwoPi; }
    void     SetWrapTwoPi(Bool_t w) { fWrapTwoPi=w; }
 
-   void     SetSelector(REveCaloDataSelector* iSelector) { fSelector.reset(iSelector); }
+   void     SetSelector(REveCaloDataSelector* iSelector);
    REveCaloDataSelector* GetSelector() { return fSelector.get(); }
 
    Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;

--- a/graf3d/eve7/src/REveCaloData.cxx
+++ b/graf3d/eve7/src/REveCaloData.cxx
@@ -129,6 +129,9 @@ REveCaloData::REveCaloData(const char* n, const char* t):
    // Constructor.
 }
 
+REveCaloData::~REveCaloData() {}
+void REveCaloData::SetSelector(REveCaloDataSelector* iSelector) { fSelector.reset(iSelector); }
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Process newly selected cells with given select-record.
 

--- a/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -117,6 +117,8 @@ namespace cling {
       cppStdVersion = "-std=c++1z";
     if (langOpts.CPlusPlus20)
       cppStdVersion = "-std=c++20";
+    if (langOpts.CPlusPlus23)
+      cppStdVersion = "-std=c++23";
 
     if (cppStdVersion.empty())
       llvm::errs()

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -90,8 +90,8 @@ class ClingKernel(Kernel):
     flush_interval = Float(0.25, config=True)
 
     std = CaselessStrEnum(default_value='c++11',
-            values = ['c++11', 'c++14', 'c++1z', 'c++17', 'c++20', 'c++2b'],
-            help="C++ standard to use, either c++2b, c++20, c++17, c++1z, c++14 or c++11").tag(config=True);
+            values = ['c++11', 'c++14', 'c++1z', 'c++17', 'c++20', 'c++2b', 'c++23' ],
+            help="C++ standard to use, either c++23, c++2b, c++20, c++17, c++1z, c++14 or c++11").tag(config=True);
 
     def __init__(self, **kwargs):
         super(ClingKernel, self).__init__(**kwargs)

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistRef.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistRef.h
@@ -12,8 +12,7 @@
 #define HISTFACTORY_HISTREF_H
 
 #include <memory>
-
-class TH1;
+#include <TH1.h>
 
 namespace RooStats{
 namespace HistFactory {

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -70,8 +70,7 @@ template <class T>
 std::unique_ptr<T> compileForNormSet(T const &arg, RooArgSet const &normSet)
 {
    RooFit::Detail::CompileContext ctx{normSet};
-   std::unique_ptr<RooAbsArg> head = arg.compileForNormSet(normSet, ctx);
-   return std::unique_ptr<T>{static_cast<T *>(head.release())};
+   return std::unique_ptr<T>{static_cast<T *>(arg.compileForNormSet(normSet, ctx).release())};
 }
 
 } // namespace Detail


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

C++23 support of ROOT (see https://root-forum.cern.ch/t/enable-c-23-in-root-6-34-00-rc1/62433).

Some changes are needed for code using `std::unique_ptr`. According to C++ standards, in the context that `T` is declared but not defined, `std::unique_ptr<T>` is constructible but not destructible, thus we need to move the definitions of some functions calling `std::unique_ptr<T>::~unique_ptr` from the header file into the source file. This rule is not new in C++ 23, but it causes compile failure when `-std=c++23` is specified, so we must fix it to support C++ 23.

## Checklist:

- [x] tested changes locally  -- but I only tested these changes on 6.34.00-rc1, not on master. If test on master is mandatory, please tell me and I will do it tomorrow.
- [ ] updated the docs (if necessary)

