### PR TITLE
[textinput] add CTRL-backslash as keyboard shortcut for sigquit 

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1339,6 +1339,7 @@ void TApplication::Help(const char *line)
          Printf("   Ctrl+D           : quit ROOT (if empty line)");
          Printf("   Ctrl+C           : send kSigInt interrupt signal");
          Printf("   Ctrl+Z           : send kSigStop pause job signal");
+         Printf("   Ctrl+\\           : send kSigQuit quit job signal");
 
          Printf("   Arrow_Down       : navigate downwards in command history [Ctrl+N]");
          Printf("   Arrow_Up         : navigate upwards in command history [Ctrl+P]");

--- a/core/textinput/src/textinput/KeyBinding.cpp
+++ b/core/textinput/src/textinput/KeyBinding.cpp
@@ -81,6 +81,7 @@ namespace textinput {
       case 'y' - 0x60: return C(Editor::kCmdPaste);
       case 'z' - 0x60:
         return C(In, Editor::kCKControl);
+      case 0x1c: return C(In, Editor::kCKControl); // ctrl+backslash
       case 0x1f: return C(Editor::kCmdUndo);
       case 0x7f: // Backspace key (with Alt, or no modifier) on Unix, Del on MacOS
         if (HadEscPending) {

--- a/core/textinput/src/textinput/SignalHandler.cpp
+++ b/core/textinput/src/textinput/SignalHandler.cpp
@@ -15,7 +15,9 @@
 #include "textinput/SignalHandler.h"
 
 #include <csignal>
-#ifndef _WIN32
+#ifdef _WIN32
+#include "windows.h"
+#else
 #include <sys/signal.h> // For SIGINT when building with -fmodules
 #endif
 
@@ -30,7 +32,9 @@ namespace textinput {
   }
   void
   SignalHandler::EmitCtrlBackslash() {
-#ifndef _WIN32
+#ifdef _WIN32
+     TerminateProcess(GetCurrentProcess(), 0);
+#else
      raise(SIGQUIT);
 #endif
   }

--- a/core/textinput/src/textinput/SignalHandler.cpp
+++ b/core/textinput/src/textinput/SignalHandler.cpp
@@ -28,4 +28,10 @@ namespace textinput {
     raise(SIGTSTP);
 #endif
   }
+  void
+  SignalHandler::EmitCtrlBackslash() {
+#ifndef _WIN32
+     raise(SIGQUIT);
+#endif
+  }
 }

--- a/core/textinput/src/textinput/SignalHandler.h
+++ b/core/textinput/src/textinput/SignalHandler.h
@@ -23,6 +23,7 @@ namespace textinput {
     ~SignalHandler() {}
 
     void EmitCtrlZ();
+    void EmitCtrlBackslash();
   };
 }
 

--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -153,7 +153,7 @@ namespace textinput {
       Cmd = Editor::Command(Editor::kCmdDel);
 
     if (Cmd.GetKind() == Editor::kCKControl
-        && (Cmd.GetChar() == 3 || Cmd.GetChar() == 26)) {
+        && (Cmd.GetChar() == 3 || Cmd.GetChar() == 26 || Cmd.GetChar() == 28)) {
       // If there are modifications in the queue, process them now.
       UpdateDisplay(R);
       HandleControl(Cmd.GetChar(), R);
@@ -247,6 +247,10 @@ namespace textinput {
       ReleaseInputOutput();
       SignalHandler* Signal = fContext->GetSignalHandler();
       Signal->EmitCtrlZ();
+    } else if (C == 28) { // Control+\ (SIGQUIT)
+       ReleaseInputOutput();
+       SignalHandler* Signal = fContext->GetSignalHandler();
+       Signal->EmitCtrlBackslash();
     }
 
     GrabInputOutput();


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Finally, a way to hard-terminate ROOT with keyboard shortcut, without having to write .qqqqqqqqqq or closing the terminal.

Fixes https://its.cern.ch/jira/browse/ROOT-9906

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
