### PR TITLE
Fix invalid read in TChain

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1667,7 +1667,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
          TTree* t = fe->GetTree();
          if (!t) continue;
          if (t->GetTreeIndex()) {
-            t->GetTreeIndex()->UpdateFormulaLeaves(nullptr);
+            t->GetTreeIndex()->UpdateFormulaLeaves(GetTree());
          }
          if (t->GetTree() && t->GetTree()->GetTreeIndex()) {
             t->GetTree()->GetTreeIndex()->UpdateFormulaLeaves(GetTree());


### PR DESCRIPTION
After merging #17301 , there is no need to create the logic to suppress the TChainIndex build error presently. The invalid read found by valgrind is still there, so this PR includes a test for the global join case and fixes the memory error.