### PR TITLE
[build] Comply with CMP0175

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -200,9 +200,9 @@ endif()
 # Compile .py files
 foreach(py_source ${py_sources})
   add_custom_command(TARGET ${libname}
+                      POST_BUILD
                       COMMAND ${Python3_EXECUTABLE} -m py_compile ${localruntimedir}/${py_source}
                       COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${localruntimedir}/${py_source}
-                      DEPENDS ${localruntimedir}/${py_source}
                       COMMENT "Compiling PyROOT source ${py_source} for Python ${Python3_VERSION}")
 endforeach()
 


### PR DESCRIPTION
To fix warnings seen when building on Mac with the latest CMake 3.31 of the like

```
CMake Warning (dev) at bindings/pyroot/pythonizations/CMakeLists.txt:202 (add_custom_command):
  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
  POST_BUILD to preserve backward compatibility.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at bindings/pyroot/pythonizations/CMakeLists.txt:202 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```