### PR TITLE
[RF] new pipe operators for JSONInterface

### DIFF
--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -47,7 +47,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         # Create a data set with a derived weight
         wFunc = ROOT.RooFormulaVar("w", "event weight", "(x*x+10)", [x])
         w = data.addColumn(wFunc)
-        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar=w.GetName())
 
         self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat", "w"})
 
@@ -96,7 +96,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         w = data.addColumn(wFunc)
 
         # Instruct dataset wdata to use w as event weight and not observable
-        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar=w.GetName())
 
         np_data = wdata.to_numpy()
 

--- a/math/matrix/inc/TVectorT.h
+++ b/math/matrix/inc/TVectorT.h
@@ -24,6 +24,8 @@
 #include "TMatrixTSym.h"
 #include "TMatrixTSparse.h"
 
+#include <ROOT/RSpan.hxx>
+
 template<class Element> class TVectorT : public TObject {
 
 protected:
@@ -81,6 +83,20 @@ public:
 
    inline          Element  *data()       { return fElements; }
    inline const    Element  *data() const { return fElements; }
+
+   // Implicit conversion of TVectorT to std::span, both non-const and const
+   // version. Can be removed once the minimum C++ standard in C++20, because
+   // then it's enough to implement the contiguous_range and sized_range
+   // concepts. This should alredy be the case since data() and size() are
+   // available.
+   inline operator std::span<Element>()
+   {
+      return std::span<Element>{data(), size()};
+   }
+   inline operator std::span<const Element>() const
+   {
+      return std::span<const Element>{data(), size()};
+   }
 
    inline void     Invalidate ()       { SetBit(kStatus); }
    inline void     MakeValid  ()       { ResetBit(kStatus); }

--- a/math/matrix/inc/TVectorT.h
+++ b/math/matrix/inc/TVectorT.h
@@ -76,6 +76,12 @@ public:
    inline          Element  *GetMatrixArray  ()       { return fElements; }
    inline const    Element  *GetMatrixArray  () const { return fElements; }
 
+   // For compatibility with STL classes
+   inline          std::size_t size() const { return fNrows; }
+
+   inline          Element  *data()       { return fElements; }
+   inline const    Element  *data() const { return fElements; }
+
    inline void     Invalidate ()       { SetBit(kStatus); }
    inline void     MakeValid  ()       { ResetBit(kStatus); }
    inline Bool_t   IsValid    () const { return !TestBit(kStatus); }

--- a/roofit/jsoninterface/CMakeLists.txt
+++ b/roofit/jsoninterface/CMakeLists.txt
@@ -52,3 +52,5 @@ if(builtin_nlohmannjson)
 else()
   target_link_libraries(RooFitJSONInterface PRIVATE nlohmann_json::nlohmann_json)
 endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -13,7 +13,11 @@
 #ifndef RooFit_Detail_JSONInterface_h
 #define RooFit_Detail_JSONInterface_h
 
+#include <ROOT/RSpan.hxx>
+
 #include <iostream>
+#include <map>
+#include <unordered_map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -247,6 +251,39 @@ std::vector<T> &operator<<(std::vector<T> &v, RooFit::Detail::JSONNode const &n)
    }
    v << n.children();
    return v;
+}
+
+inline RooFit::Detail::JSONNode &operator<<(RooFit::Detail::JSONNode &n, std::span<const double> v)
+{
+   n.fill_seq(v);
+   return n;
+}
+
+inline RooFit::Detail::JSONNode &operator<<(RooFit::Detail::JSONNode &n, std::span<const float> v)
+{
+   n.fill_seq(v);
+   return n;
+}
+
+template <class Key, class T, class Hash, class KeyEqual, class Allocator>
+RooFit::Detail::JSONNode &
+operator<<(RooFit::Detail::JSONNode &n, const std::unordered_map<Key, T, Hash, KeyEqual, Allocator> &m)
+{
+   n.set_map();
+   for (const auto &it : m) {
+      n[it.first] << it.second;
+   }
+   return n;
+}
+
+template <class Key, class T, class Compare, class Allocator>
+RooFit::Detail::JSONNode &operator<<(RooFit::Detail::JSONNode &n, const std::map<Key, T, Compare, Allocator> &m)
+{
+   n.set_map();
+   for (const auto &it : m) {
+      n[it.first] << it.second;
+   }
+   return n;
 }
 
 template <>

--- a/roofit/jsoninterface/test/CMakeLists.txt
+++ b/roofit/jsoninterface/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GTEST(testJSONInterface testJSONInterface.cxx LIBRARIES RooFitJSONInterface Matrix)

--- a/roofit/jsoninterface/test/testJSONInterface.cxx
+++ b/roofit/jsoninterface/test/testJSONInterface.cxx
@@ -1,0 +1,27 @@
+// Tests for the RooFit JSON interface
+// Authors: Jonas Rembser, CERN 12/2024
+
+#include <RooFit/Detail/JSONInterface.h>
+
+#include <TVectorD.h>
+
+#include <gtest/gtest.h>
+
+TEST(JSONInterface, MapsOfTVectorD)
+{
+   using RooFit::Detail::JSONNode;
+   using RooFit::Detail::JSONTree;
+
+   std::unique_ptr<JSONTree> tree = JSONTree::create();
+   JSONNode &rootnode = tree->rootnode();
+
+   rootnode.set_map();
+
+   rootnode["map"] << std::map<std::string, TVectorD>{{"vec", TVectorD{3}}};
+   rootnode["unordered_map"] << std::unordered_map<std::string, TVectorD>{{"vec", TVectorD{3}}};
+
+   // For debugging:
+   // std::stringstream ss;
+   // rootnode.writeJSON(ss);
+   // std::cout << ss.str() << std::endl;
+}

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -45,7 +45,10 @@ public:
     // Constructor for subset of existing dataset
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
              const char *cuts=nullptr, const char* wgtVarName=nullptr)
-  R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.");
+#ifndef ROOFIT_BUILDS_ITSELF
+  R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.")
+#endif
+  ;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
              const RooFormulaVar& cutVar, const char* wgtVarName=nullptr)
   R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.");

--- a/tutorials/roostats/rs301_splot.C
+++ b/tutorials/roostats/rs301_splot.C
@@ -267,8 +267,8 @@ void MakePlots(RooWorkspace &ws)
    auto& data = static_cast<RooDataSet&>(*ws.data("dataWithSWeights"));
 
    // create weighted data sets
-   RooDataSet dataw_z{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "zYield_sw"};
-   RooDataSet dataw_qcd{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "qcdYield_sw"};
+   RooDataSet dataw_z{data.GetName(), data.GetTitle(), *data.get(), Import(data), WeightVar("zYield_sw")};
+   RooDataSet dataw_qcd{data.GetName(), data.GetTitle(), *data.get(), Import(data), WeightVar("qcdYield_sw")};
 
 
    // this shouldn't be necessary, need to fix something with workspace

--- a/tutorials/roostats/rs301_splot.py
+++ b/tutorials/roostats/rs301_splot.py
@@ -199,8 +199,8 @@ def MakePlots(wspace):
     data = wspace["dataWithSWeights"]
 
     # create weighted data sets
-    dataw_qcd = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", "qcdYield_sw")
-    dataw_z = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", "zYield_sw")
+    dataw_qcd = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar="qcdYield_sw")
+    dataw_z = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar="zYield_sw")
 
     # plot invMass for data with full model and individual components overlaid
     # cdata = TCanvas()


### PR DESCRIPTION
… TVectorD

# This Pull request:

adds new `<<` operators to the RooFit JSONInterface

## Changes or fixes:

- add a new operator that can pipe `std::vector<T>` directly into json without explicit use of `fill_seq`.
- add a new operator that can pipe `std::map<T_string,T>` directly into json (using the `set_map` method`
- add an implicit conversion for `TVectorT` to `std::vector<T>` to facilitate direct piping of `TVectorT` into json as well via the new `std::vector<T>` operator

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

