### PR TITLE
[rntuple] Fix assertion failure in RNtuple

### DIFF
--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -985,8 +985,9 @@ using Quantized_t = std::uint32_t;
 
 #ifdef _MSC_VER
    unsigned long idx = 0;
-   _BitScanForward(&idx, x);
-   return static_cast<std::size_t>(idx);
+   if (_BitScanForward(&idx, x))
+      return static_cast<std::size_t>(31 - idx);
+   return 32; // undefined behavior
 #else
    return static_cast<std::size_t>(__builtin_clzl(x));
 #endif
@@ -999,8 +1000,9 @@ using Quantized_t = std::uint32_t;
 
 #ifdef _MSC_VER
    unsigned long idx = 0;
-   _BitScanReverse(&idx, x);
-   return static_cast<std::size_t>(idx);
+   if (_BitScanForward(&idx, x))
+      return static_cast<std::size_t>(idx);
+   return 32;
 #else
    return static_cast<std::size_t>(__builtin_ctzl(x));
 #endif

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -981,7 +981,7 @@ using Quantized_t = std::uint32_t;
 [[maybe_unused]] inline std::size_t LeadingZeroes(std::uint32_t x)
 {
    if (x == 0)
-      return 64;
+      return 32;
 
 #ifdef _MSC_VER
    unsigned long idx = 0;
@@ -996,7 +996,7 @@ using Quantized_t = std::uint32_t;
 [[maybe_unused]] inline std::size_t TrailingZeroes(std::uint32_t x)
 {
    if (x == 0)
-      return 64;
+      return 32;
 
 #ifdef _MSC_VER
    unsigned long idx = 0;

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -985,9 +985,9 @@ using Quantized_t = std::uint32_t;
 
 #ifdef _MSC_VER
    unsigned long idx = 0;
-   if (_BitScanForward(&idx, x))
+   if (_BitScanReverse(&idx, x))
       return static_cast<std::size_t>(31 - idx);
-   return 32; // undefined behavior
+   return 32;
 #else
    return static_cast<std::size_t>(__builtin_clzl(x));
 #endif


### PR DESCRIPTION
Fix the following error on Windows:
```
Assertion failed: LeadingZeroes(q) >= unusedBits, file tree\ntuple\v7\src\RColumnElement.hxx, line 1038
```
`_BitScanReverse` returns the bit position of the first set bit (1) found,
so subtract it from the position of the last bit (31)
