### PR TITLE
Fix Ranges.get_clusters_and_entries in DistRDF.HeadNode.py

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -483,7 +483,7 @@ class TreeHeadNode(HeadNode):
             # Depending on the cluster setup, this may still be quite costly, so
             # we decide to pay the price only if the user explicitly requested
             # warning logging.
-            clusters, entries = Ranges.get_clusters_and_entries(self.subtreenames[0], self.inputfiles[0])
+            clusters, entries = ROOT.Internal.TreeUtils.GetClustersAndEntries(self.subtreenames[0], self.inputfiles[0])
             # The file could contain an empty tree. In that case, the estimate will not be computed.
             if entries > 0:
                 partitionsperfile = self.npartitions / len(self.inputfiles)
@@ -663,7 +663,7 @@ class RDatasetSpecHeadNode(HeadNode):
             # Depending on the cluster setup, this may still be quite costly, so
             # we decide to pay the price only if the user explicitly requested
             # warning logging.
-            clusters, entries = Ranges.get_clusters_and_entries(
+            clusters, entries = ROOT.Internal.TreeUtils.GetClustersAndEntries(
                 self.subtreenames[0], self.inputfiles[0])
             # The file could contain an empty tree. In that case, the estimate will not be computed.
             if entries > 0:


### PR DESCRIPTION
# This Pull request:

This [PR](https://github.com/root-project/root/commit/08ef067250ed06de772579cbe8cb4c9c95a4dd10#diff-49294aaf61ddd05ba43b40ae651b081a608ee7b27e3c716e9b3a2d928cbf7ebfL363) changed the ownership model of external objects in distributed RDataFrame and now the module 'DistRDF.Ranges' does not include the attribute 'get_clusters_and_entries'.
However, Ranges.get_clusters_and_entries() is still being called in  DistRDF.HeadNode.py( [line486](https://github.com/root-project/root/blob/master/bindings/experimental/distrdf/python/DistRDF/HeadNode.py#L486), [line 666](https://github.com/root-project/root/blob/master/bindings/experimental/distrdf/python/DistRDF/HeadNode.py#L666) )

This PR fixes this issue.
## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/17263

