### PR TITLE
[skip-ci][tutorials] Remove reintroduced sql group from index.md file

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -94,10 +94,6 @@ The `$ROOTSYS/tutorials` directory includes several sub-directories:
 \ingroup Tutorials
 \brief These tutorials illustrate the main features of RooStats.
 
-\defgroup tutorial_sql SQL tutorials
-\ingroup Tutorials
-\brief Examples showing the SQL classes.
-
 \defgroup tutorial_ml Machine Learning tutorials
 \ingroup Tutorials
 \brief Examples showing how to use Machine Learning from ROOT. 


### PR DESCRIPTION
By mistake (during conflict resolution) in commit: https://github.com/root-project/root/commit/0326ba02d4967beabef8613c02d6c79c72cd995e, tutorials/index.md file was wrongly edited to again include the sql tutorials group which was recently moved into tutorials/io hence is not needed here. 
