### PR TITLE
[ntuple] allow RNTuple to emulate fields of unknown types via RecordFields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
@@ -21,6 +21,9 @@ namespace ROOT::Experimental {
 struct RCreateFieldOptions {
    /// If true, failing to create a field will return a RInvalidField instead of throwing an exception.
    bool fReturnInvalidOnError = false;
+   /// If true, fields with a user defined type that have no available dictionaries will be reconstructed
+   /// as record fields from the on-disk information; otherwise, they will cause an error.
+   bool fEmulateUnknownTypes = false;
 };
 
 } // namespace ROOT::Experimental

--- a/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
@@ -1,0 +1,28 @@
+/// \file ROOT/RCreateFieldOptions.hxx
+/// \ingroup NTuple ROOT7
+/// \author Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2024-12-17
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RCreateFieldOptions
+#define ROOT7_RCreateFieldOptions
+
+namespace ROOT::Experimental {
+
+struct RCreateFieldOptions {
+   /// If true, failing to create a field will return a RInvalidField instead of throwing an exception.
+   bool fReturnInvalidOnError = false;
+};
+
+} // namespace ROOT::Experimental
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -87,6 +87,7 @@ public:
    RInvalidField(std::string_view name, std::string_view type, std::string_view error)
       : RFieldBase(name, type, ENTupleStructure::kLeaf, false /* isSimple */), fError(error)
    {
+      fTraits |= kTraitInvalidField;
    }
 
    const std::string &GetError() const { return fError; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -74,23 +74,38 @@ public:
 /// Also used when deserializing a field that contains unknown values that may come from
 /// future RNTuple versions (e.g. an unknown Structure)
 class RInvalidField final : public RFieldBase {
+public:
+   enum class RCategory {
+      /// Generic unrecoverable error
+      kGeneric,
+      /// The type given to RFieldBase::Create was invalid
+      kTypeError,
+      /// The type given to RFieldBase::Create was unknown
+      kUnknownType,
+      /// The field could not be created because its descriptor had an unknown structural role
+      kUnknownStructure
+   };
+
+private:
    std::string fError;
+   RCategory fCategory;
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RInvalidField>(newName, GetTypeName(), fError);
+      return std::make_unique<RInvalidField>(newName, GetTypeName(), fError, fCategory);
    }
    void ConstructValue(void *) const final {}
 
 public:
-   RInvalidField(std::string_view name, std::string_view type, std::string_view error)
-      : RFieldBase(name, type, ENTupleStructure::kLeaf, false /* isSimple */), fError(error)
+   RInvalidField(std::string_view name, std::string_view type, std::string_view error, RCategory category)
+      : RFieldBase(name, type, ENTupleStructure::kLeaf, false /* isSimple */), fError(error), fCategory(category)
    {
       fTraits |= kTraitInvalidField;
    }
 
    const std::string &GetError() const { return fError; }
+   RCategory GetCategory() const { return fCategory; }
 
    size_t GetValueSize() const final { return 0; }
    size_t GetAlignment() const final { return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -113,7 +113,11 @@ public:
    ~RRecordField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final { return fSize; }
+   size_t GetValueSize() const final
+   {
+      // The minimum size is 1 to support having vectors of empty records
+      return std::max<size_t>(1ul, fSize);
+   }
    size_t GetAlignment() const final { return fMaxAlignment; }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -36,10 +36,19 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+namespace Internal {
+std::unique_ptr<RFieldBase> CreateEmulatedField(std::string_view fieldName,
+                                                std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                                std::string_view emulatedFromType);
+}
+
 /// The field for an untyped record. The subfields are stored consequitively in a memory block, i.e.
 /// the memory layout is identical to one that a C++ struct would have
 class RRecordField : public RFieldBase {
-private:
+   friend std::unique_ptr<RFieldBase> Internal::CreateEmulatedField(std::string_view fieldName,
+                                                                    std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                                                    std::string_view emulatedFromType);
+
    class RRecordDeleter : public RDeleter {
    private:
       std::vector<std::unique_ptr<RDeleter>> fItemDeleters;
@@ -54,6 +63,11 @@ private:
    };
 
    RRecordField(std::string_view name, const RRecordField &source); // Used by CloneImpl()
+
+   /// If `emulatedFromType` is non-empty, this field was created as a replacement for a ClassField that we lack a
+   /// dictionary for and reconstructed from the on-disk information.
+   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                std::string_view emulatedFromType);
 
 protected:
    std::size_t fMaxAlignment = 1;

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -69,8 +69,9 @@ This is and can only be partially enforced through C++.
 */
 // clang-format on
 class RFieldBase {
-   friend class ROOT::Experimental::RClassField;                             // to mark members as artificial
-   friend class ROOT::Experimental::RNTupleJoinProcessor;                    // needs ConstuctValue
+   friend class ROOT::Experimental::RClassField;          // to mark members as artificial
+   friend class ROOT::Experimental::RNTupleJoinProcessor; // needs ConstuctValue
+   friend class ROOT::Experimental::RFieldDescriptor;
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Experimental::Internal::RFieldRepresentationModifier; // used for unit tests
    friend void Internal::CallFlushColumnsOnField(RFieldBase &);
@@ -473,9 +474,14 @@ protected:
    /// normalized type name and type alias
    /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
    /// single type name
-   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &canonicalType,
-                                                      const std::string &typeAlias,
-                                                      const RCreateFieldOptions &options = {});
+   static RResult<std::unique_ptr<RFieldBase>>
+   Create(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias,
+          const RCreateFieldOptions &options = {}, const RNTupleDescriptor *desc = nullptr,
+          DescriptorId_t fieldId = kInvalidDescriptorId);
+
+   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeAlias,
+                                                      const RCreateFieldOptions &options, const RNTupleDescriptor *desc,
+                                                      DescriptorId_t fieldId);
 
 public:
    template <bool IsConstT>
@@ -511,7 +517,8 @@ public:
    std::unique_ptr<RFieldBase> Clone(std::string_view newName) const;
 
    /// Factory method to resurrect a field from the stored on-disk type information
-   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName);
+   static RResult<std::unique_ptr<RFieldBase>>
+   Create(const std::string &fieldName, const std::string &typeName, const RCreateFieldOptions &options = {});
 
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing sub field (sub type).

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -42,11 +42,15 @@ struct RFieldCallbackInjector;
 struct RFieldRepresentationModifier;
 class RPageSink;
 class RPageSource;
-// TODO(jblomer): find a better way to not have these four methods in the RFieldBase public API
+// TODO(jblomer): find a better way to not have these methods in the RFieldBase public API
 void CallFlushColumnsOnField(RFieldBase &);
 void CallCommitClusterOnField(RFieldBase &);
 void CallConnectPageSinkOnField(RFieldBase &, RPageSink &, NTupleSize_t firstEntry = 0);
 void CallConnectPageSourceOnField(RFieldBase &, RPageSource &);
+ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
+CallFieldBaseCreate(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias,
+                    const RCreateFieldOptions &options, const RNTupleDescriptor *desc, DescriptorId_t fieldId);
+
 } // namespace Internal
 
 namespace Detail {
@@ -70,14 +74,18 @@ This is and can only be partially enforced through C++.
 // clang-format on
 class RFieldBase {
    friend class ROOT::Experimental::RClassField;                             // to mark members as artificial
-   friend class ROOT::Experimental::RNTupleJoinProcessor;                    // needs ConstuctValue
-   friend class ROOT::Experimental::RFieldDescriptor;
+   friend class ROOT::Experimental::RNTupleJoinProcessor;                    // needs ConstructValue
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Experimental::Internal::RFieldRepresentationModifier; // used for unit tests
    friend void Internal::CallFlushColumnsOnField(RFieldBase &);
    friend void Internal::CallCommitClusterOnField(RFieldBase &);
    friend void Internal::CallConnectPageSinkOnField(RFieldBase &, Internal::RPageSink &, NTupleSize_t);
    friend void Internal::CallConnectPageSourceOnField(RFieldBase &, Internal::RPageSource &);
+   friend ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
+   Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &canonicalType,
+                                 const std::string &typeAlias, const RCreateFieldOptions &options,
+                                 const RNTupleDescriptor *desc, DescriptorId_t fieldId);
+
    using ReadCallback_t = std::function<void(void *)>;
 
 protected:
@@ -480,7 +488,8 @@ protected:
           const RCreateFieldOptions &options = {}, const RNTupleDescriptor *desc = nullptr,
           DescriptorId_t fieldId = kInvalidDescriptorId);
 
-   /// Same as the above overload of Create, but infers the normalized type name and the canonical type name from `typeName`.
+   /// Same as the above overload of Create, but infers the normalized type name and the canonical type name from
+   /// `typeName`.
    static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName,
                                                       const RCreateFieldOptions &options, const RNTupleDescriptor *desc,
                                                       DescriptorId_t fieldId);

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -529,7 +529,7 @@ public:
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName, const RCreateFieldOptions &options = {});
+   Create(const std::string &fieldName, const std::string &typeName);
 
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing sub field (sub type).

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RFieldBase
 
 #include <ROOT/RColumn.hxx>
+#include <ROOT/RCreateFieldOptions.hxx>
 #include <ROOT/RNTupleRange.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
@@ -473,7 +474,8 @@ protected:
    /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
    /// single type name
    static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &canonicalType,
-                                                      const std::string &typeAlias, bool continueOnError = false);
+                                                      const std::string &typeAlias,
+                                                      const RCreateFieldOptions &options = {});
 
 public:
    template <bool IsConstT>
@@ -510,6 +512,7 @@ public:
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName);
+
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing sub field (sub type).
    static std::vector<RCheckResult> Check(const std::string &fieldName, const std::string &typeName);

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -69,8 +69,8 @@ This is and can only be partially enforced through C++.
 */
 // clang-format on
 class RFieldBase {
-   friend class ROOT::Experimental::RClassField;          // to mark members as artificial
-   friend class ROOT::Experimental::RNTupleJoinProcessor; // needs ConstuctValue
+   friend class ROOT::Experimental::RClassField;                             // to mark members as artificial
+   friend class ROOT::Experimental::RNTupleJoinProcessor;                    // needs ConstuctValue
    friend class ROOT::Experimental::RFieldDescriptor;
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Experimental::Internal::RFieldRepresentationModifier; // used for unit tests
@@ -471,7 +471,8 @@ protected:
    virtual void OnConnectPageSource() {}
 
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
-   /// normalized type name and type alias
+   /// normalized type name and type alias.
+   /// `desc` and `fieldId` must be passed if `options.fEmulateUnknownTypes` is true, otherwise they can be left blank.
    /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
    /// single type name
    static RResult<std::unique_ptr<RFieldBase>>
@@ -479,7 +480,8 @@ protected:
           const RCreateFieldOptions &options = {}, const RNTupleDescriptor *desc = nullptr,
           DescriptorId_t fieldId = kInvalidDescriptorId);
 
-   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeAlias,
+   /// Same as the above overload of Create, but infers the normalized type name and the canonical type name from `typeName`.
+   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName,
                                                       const RCreateFieldOptions &options, const RNTupleDescriptor *desc,
                                                       DescriptorId_t fieldId);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -120,7 +120,8 @@ public:
 
    /// In general, we create a field simply from the C++ type name. For untyped fields, however, we potentially need
    /// access to sub fields, which is provided by the ntuple descriptor argument.
-   std::unique_ptr<RFieldBase> CreateField(const RNTupleDescriptor &ntplDesc, const RCreateFieldOptions &options = {}) const;
+   std::unique_ptr<RFieldBase>
+   CreateField(const RNTupleDescriptor &ntplDesc, const RCreateFieldOptions &options = {}) const;
 
    DescriptorId_t GetId() const { return fFieldId; }
    std::uint32_t GetFieldVersion() const { return fFieldVersion; }
@@ -474,7 +475,10 @@ public:
 };
 
 /// Used in RExtraTypeInfoDescriptor
-enum class EExtraTypeInfoIds { kInvalid, kStreamerInfo };
+enum class EExtraTypeInfoIds {
+   kInvalid,
+   kStreamerInfo
+};
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -50,9 +50,6 @@ class RNTupleModel;
 
 namespace Internal {
 class RColumnElementBase;
-} // namespace Internal
-
-namespace Internal {
 class RColumnDescriptorBuilder;
 class RClusterDescriptorBuilder;
 class RClusterGroupDescriptorBuilder;
@@ -608,6 +605,9 @@ public:
       bool fForwardCompatible = false;
       /// If true, the model will be created without a default entry (bare model).
       bool fCreateBare = false;
+      /// If true, fields with a user defined type that have no available dictionaries will be reconstructed
+      /// as record fields from the on-disk information; otherwise, they will cause an error.
+      bool fEmulateUnknownTypes = false;
    };
 
    RNTupleDescriptor() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -17,6 +17,7 @@
 #ifndef ROOT7_RNTupleDescriptor
 #define ROOT7_RNTupleDescriptor
 
+#include <ROOT/RCreateFieldOptions.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleUtil.hxx>
@@ -116,9 +117,10 @@ public:
    bool operator==(const RFieldDescriptor &other) const;
    /// Get a copy of the descriptor
    RFieldDescriptor Clone() const;
+
    /// In general, we create a field simply from the C++ type name. For untyped fields, however, we potentially need
    /// access to sub fields, which is provided by the ntuple descriptor argument.
-   std::unique_ptr<RFieldBase> CreateField(const RNTupleDescriptor &ntplDesc, bool continueOnError = false) const;
+   std::unique_ptr<RFieldBase> CreateField(const RNTupleDescriptor &ntplDesc, const RCreateFieldOptions &options = {}) const;
 
    DescriptorId_t GetId() const { return fFieldId; }
    std::uint32_t GetFieldVersion() const { return fFieldVersion; }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -282,12 +282,13 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
 
    std::vector<RCheckResult> result;
    for (const auto &f : fieldZero) {
-      auto invalidField = dynamic_cast<const RInvalidField *>(&f);
-      if (!invalidField)
+      bool isInvalidField = f.GetTraits() & RFieldBase::kTraitInvalidField;
+      if (!isInvalidField)
          continue;
 
+      const auto &invalidField = static_cast<const RInvalidField &>(f);
       result.emplace_back(
-         RCheckResult{invalidField->GetQualifiedFieldName(), invalidField->GetTypeName(), invalidField->GetError()});
+         RCheckResult{invalidField.GetQualifiedFieldName(), invalidField.GetTypeName(), invalidField.GetError()});
    }
    return result;
 }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -302,9 +302,12 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    if (continueOnError)
       createContextGuard.SetContinueOnError(true);
 
-   auto fnFail = [&fieldName, &canonicalType](const std::string &errMsg) -> RResult<std::unique_ptr<RFieldBase>> {
+   auto fnFail = [&fieldName,
+                  &canonicalType](const std::string &errMsg,
+                                  RInvalidField::RCategory cat =
+                                     RInvalidField::RCategory::kTypeError) -> RResult<std::unique_ptr<RFieldBase>> {
       if (createContext.GetContinueOnError()) {
-         return std::unique_ptr<RFieldBase>(std::make_unique<RInvalidField>(fieldName, canonicalType, errMsg));
+         return std::unique_ptr<RFieldBase>(std::make_unique<RInvalidField>(fieldName, canonicalType, errMsg, cat));
       } else {
          return R__FAIL(errMsg);
       }
@@ -566,8 +569,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    } catch (RException &e) {
       auto error = e.GetError();
       if (createContext.GetContinueOnError()) {
-         return std::unique_ptr<RFieldBase>(
-            std::make_unique<RInvalidField>(fieldName, canonicalType, error.GetReport()));
+         return std::unique_ptr<RFieldBase>(std::make_unique<RInvalidField>(fieldName, canonicalType, error.GetReport(),
+                                                                            RInvalidField::RCategory::kGeneric));
       } else {
          return error;
       }
@@ -578,7 +581,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
          result->fTypeAlias = typeAlias;
       return result;
    }
-   return R__FORWARD_RESULT(fnFail("unknown type: " + canonicalType));
+   return R__FORWARD_RESULT(fnFail("unknown type: " + canonicalType, RInvalidField::RCategory::kUnknownType));
 }
 
 const ROOT::Experimental::RFieldBase::RColumnRepresentations &

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -272,12 +272,11 @@ std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const
 }
 
 ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::string &typeName,
-                                       const RCreateFieldOptions &options)
+ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
 {
    auto typeAlias = Internal::GetNormalizedTypeName(typeName);
    auto canonicalType = Internal::GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
-   return R__FORWARD_RESULT(RFieldBase::Create(fieldName, canonicalType, typeAlias, options));
+   return R__FORWARD_RESULT(RFieldBase::Create(fieldName, canonicalType, typeAlias, RCreateFieldOptions{}));
 }
 
 ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -278,7 +278,7 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
    auto canonicalType = Internal::GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
 
    RFieldZero fieldZero;
-   RCreateFieldOptions cfOpts {};
+   RCreateFieldOptions cfOpts{};
    cfOpts.fReturnInvalidOnError = true;
    fieldZero.Attach(RFieldBase::Create(fieldName, canonicalType, typeAlias, cfOpts).Unwrap());
 

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -278,7 +278,9 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
    auto canonicalType = Internal::GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
 
    RFieldZero fieldZero;
-   fieldZero.Attach(RFieldBase::Create(fieldName, canonicalType, typeAlias, true /* continueOnError */).Unwrap());
+   RCreateFieldOptions cfOpts {};
+   cfOpts.fReturnInvalidOnError = true;
+   fieldZero.Attach(RFieldBase::Create(fieldName, canonicalType, typeAlias, cfOpts).Unwrap());
 
    std::vector<RCheckResult> result;
    for (const auto &f : fieldZero) {
@@ -295,11 +297,11 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
 
 ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
 ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::string &canonicalType,
-                                       const std::string &typeAlias, bool continueOnError)
+                                       const std::string &typeAlias, const RCreateFieldOptions &options)
 {
    thread_local CreateContext createContext;
    CreateContextGuard createContextGuard(createContext);
-   if (continueOnError)
+   if (options.fReturnInvalidOnError)
       createContextGuard.SetContinueOnError(true);
 
    auto fnFail = [&fieldName,

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -296,7 +296,7 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
 
    std::vector<RCheckResult> result;
    for (const auto &f : fieldZero) {
-      bool isInvalidField = f.GetTraits() & RFieldBase::kTraitInvalidField;
+      const bool isInvalidField = f.GetTraits() & RFieldBase::kTraitInvalidField;
       if (!isInvalidField)
          continue;
 
@@ -333,10 +333,10 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
    std::unique_ptr<ROOT::Experimental::RFieldBase> result;
 
-   const auto maybeGetChildId = [desc, fieldId](int childIdx) {
+   const auto maybeGetChildId = [desc, fieldId](int childId) {
       if (desc) {
          const auto &fieldDesc = desc->GetFieldDescriptor(fieldId);
-         return fieldDesc.GetLinkIds()[childIdx];
+         return fieldDesc.GetLinkIds().at(childId);
       } else {
          return kInvalidDescriptorId;
       }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -97,6 +97,14 @@ void ROOT::Experimental::Internal::CallConnectPageSourceOnField(RFieldBase &fiel
    field.ConnectPageSource(source);
 }
 
+ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
+ROOT::Experimental::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &canonicalType,
+                                                  const std::string &typeAlias, const RCreateFieldOptions &options,
+                                                  const RNTupleDescriptor *desc, DescriptorId_t fieldId)
+{
+   return RFieldBase::Create(fieldName, canonicalType, typeAlias, options, desc, fieldId);
+}
+
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations()
@@ -181,7 +189,7 @@ void ROOT::Experimental::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, 
          throw RException(R__FAIL("invalid attempt to bulk read beyond the adopted buffer"));
       }
       ReleaseValues();
-      fValues = operator new(size * fValueSize);
+      fValues = operator new(size *fValueSize);
 
       if (!(fField->GetTraits() & RFieldBase::kTraitTriviallyConstructible)) {
          for (std::size_t i = 0; i < size; ++i) {
@@ -503,8 +511,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
             Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">", options, desc, maybeGetChildId(0))
                .Unwrap();
 
-         // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
-         // the inner type names are properly normalized.
+         // We use the type names of subfields of the newly created item fields to create the map's type name to
+         // ensure the inner type names are properly normalized.
          auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
          auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
 
@@ -519,8 +527,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
             Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">", options, desc, maybeGetChildId(0))
                .Unwrap();
 
-         // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
-         // the inner type names are properly normalized.
+         // We use the type names of subfields of the newly created item fields to create the map's type name to
+         // ensure the inner type names are properly normalized.
          auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
          auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
 
@@ -535,8 +543,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
             Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">", options, desc, maybeGetChildId(0))
                .Unwrap();
 
-         // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
-         // the inner type names are properly normalized.
+         // We use the type names of subfields of the newly created item fields to create the map's type name to
+         // ensure the inner type names are properly normalized.
          auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
          auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
 
@@ -552,8 +560,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
             Create("_0", "std::pair<" + innerTypes[0] + "," + innerTypes[1] + ">", options, desc, maybeGetChildId(0))
                .Unwrap();
 
-         // We use the type names of subfields of the newly created item fields to create the map's type name to ensure
-         // the inner type names are properly normalized.
+         // We use the type names of subfields of the newly created item fields to create the map's type name to
+         // ensure the inner type names are properly normalized.
          auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
          auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
 

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -546,6 +546,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 
    // See "semantics of reading non-trivial objects" in RNTuple's Architecture.md
+   R__ASSERT(fItemSize > 0);
    const auto oldNItems = typedValue->size() / fItemSize;
    const bool canRealloc = oldNItems < nItems;
    bool allDeallocated = false;

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -592,6 +592,7 @@ void ROOT::Experimental::RVectorField::RVectorDeleter::operator()(void *objPtr, 
 {
    auto vecPtr = static_cast<std::vector<char> *>(objPtr);
    if (fItemDeleter) {
+      R__ASSERT(fItemSize > 0);
       R__ASSERT((vecPtr->size() % fItemSize) == 0);
       auto nItems = vecPtr->size() / fItemSize;
       for (std::size_t i = 0; i < nItems; ++i) {
@@ -613,6 +614,7 @@ std::vector<ROOT::Experimental::RFieldBase::RValue>
 ROOT::Experimental::RVectorField::SplitValue(const RValue &value) const
 {
    auto vec = value.GetPtr<std::vector<char>>();
+   R__ASSERT(fItemSize > 0);
    R__ASSERT((vec->size() % fItemSize) == 0);
    auto nItems = vec->size() / fItemSize;
    std::vector<RValue> result;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -93,7 +93,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
          for (auto id : fLinkIds) {
             const auto &memberDesc = ntplDesc.GetFieldDescriptor(id);
             auto field = memberDesc.CreateField(ntplDesc, continueOnError);
-            if (dynamic_cast<RInvalidField *>(field.get()))
+            if (field->GetTraits() & RFieldBase::kTraitInvalidField)
                return field;
             memberFields.emplace_back(std::move(field));
          }
@@ -106,7 +106,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
             throw RException(R__FAIL("unsupported untyped collection for field \"" + GetFieldName() + "\""));
          }
          auto itemField = ntplDesc.GetFieldDescriptor(fLinkIds[0]).CreateField(ntplDesc, continueOnError);
-         if (dynamic_cast<RInvalidField *>(itemField.get()))
+         if (itemField->GetTraits() & RFieldBase::kTraitInvalidField)
             return itemField;
          auto collectionField = RVectorField::CreateUntyped(GetFieldName(), std::move(itemField));
          collectionField->SetOnDiskId(fFieldId);
@@ -628,7 +628,7 @@ ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &op
    bool continueOnError = options.fForwardCompatible;
    for (const auto &topDesc : GetTopLevelFields()) {
       auto field = topDesc.CreateField(*this, continueOnError);
-      if (dynamic_cast<RInvalidField *>(field.get()))
+      if (field->GetTraits() & RFieldBase::kTraitInvalidField)
          continue;
 
       if (options.fReconstructProjections && topDesc.IsProjectedField()) {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -125,7 +125,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       // NOTE: Unwrap() here may throw an exception, hence the try block.
       // If options.fReturnInvalidOnError is false we just rethrow it, otherwise we return an InvalidField wrapping the
       // error.
-      auto field = RFieldBase::Create(fieldName, typeName, typeName, options, &ntplDesc, fFieldId).Unwrap();
+      auto field = Internal::CallFieldBaseCreate(fieldName, typeName, typeName, options, &ntplDesc, fFieldId).Unwrap();
       field->SetOnDiskId(fFieldId);
 
       for (auto &subfield : *field) {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -125,7 +125,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       // NOTE: Unwrap() here may throw an exception, hence the try block.
       // If options.fReturnInvalidOnError is false we just rethrow it, otherwise we return an InvalidField wrapping the
       // error.
-      auto field = RFieldBase::Create(fieldName, typeName).Unwrap();
+      auto field = RFieldBase::Create(fieldName, typeName, typeName, options, &ntplDesc, fFieldId).Unwrap();
       field->SetOnDiskId(fFieldId);
 
       for (auto &subfield : *field) {
@@ -643,8 +643,9 @@ ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &op
    fieldZero->SetOnDiskId(GetFieldZeroId());
    auto model =
       options.fCreateBare ? RNTupleModel::CreateBare(std::move(fieldZero)) : RNTupleModel::Create(std::move(fieldZero));
-   RCreateFieldOptions createFieldOpts;
+   RCreateFieldOptions createFieldOpts{};
    createFieldOpts.fReturnInvalidOnError = options.fForwardCompatible;
+   createFieldOpts.fEmulateUnknownTypes = options.fEmulateUnknownTypes;
    for (const auto &topDesc : GetTopLevelFields()) {
       auto field = topDesc.CreateField(*this, createFieldOpts);
       if (field->GetTraits() & RFieldBase::kTraitInvalidField)

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -78,7 +78,8 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
    // For forward compatibility, we allow this case and return an InvalidField.
    if (GetStructure() == ENTupleStructure::kUnknown) {
       if (continueOnError) {
-         auto invalidField = std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), "");
+         auto invalidField = std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), "",
+                                                             RInvalidField::RCategory::kUnknownStructure);
          invalidField->SetOnDiskId(fFieldId);
          return invalidField;
       } else {
@@ -124,7 +125,8 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       return field;
    } catch (RException &ex) {
       if (continueOnError)
-         return std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), ex.GetError().GetReport());
+         return std::make_unique<RInvalidField>(GetFieldName(), GetTypeName(), ex.GetError().GetReport(),
+                                                RInvalidField::RCategory::kGeneric);
       else
          throw ex;
    }

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -167,8 +167,12 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       {
          auto descriptorGuard = fSource->GetSharedDescriptorGuard();
          name = descriptorGuard->GetName();
-         fullModel =
-            descriptorGuard->CreateModel(fCreateModelOptions.value_or(RNTupleDescriptor::RCreateModelOptions{}));
+         RNTupleDescriptor::RCreateModelOptions opts;
+         opts.fCreateBare = true;
+         // When printing the schema we always try to reconstruct the whole thing even when we are missing the
+         // dictionaries.
+         opts.fEmulateUnknownTypes = true;
+         fullModel = descriptorGuard->CreateModel(opts);
       }
 
       for (int i = 0; i < (width / 2 + width % 2 - 4); ++i)

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -61,6 +61,11 @@ ROOT::Experimental::RNTupleWriter::Create(std::unique_ptr<RNTupleModel> model,
    if (model->GetRegisteredSubfields().size() > 0) {
       throw RException(R__FAIL("cannot create an RNTupleWriter from a model with registered subfields"));
    }
+   for (const auto &field : model->GetConstFieldZero()) {
+      if (field.GetTraits() & RFieldBase::kTraitEmulatedField)
+         throw RException(
+            R__FAIL("creating a RNTupleWriter from a model containing emulated fields is currently unsupported."));
+   }
    if (options.GetUseBufferedWrite()) {
       sink = std::make_unique<Internal::RPageSinkBuf>(std::move(sink));
    }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -37,8 +37,9 @@ ROOT_GENERATE_DICTIONARY(RNTupleDescriptorDict ${CMAKE_CURRENT_SOURCE_DIR}/RNTup
                        DEPENDENCIES RIO CustomStruct)
 ROOT_ADD_GTEST(ntuple_endian ntuple_endian.cxx LIBRARIES ROOTNTuple)
 if(NOT MSVC)
-  # The unit test relies on fork(), which is not available on Windows.
+  # These unit tests rely on fork(), which is not available on Windows.
   ROOT_ADD_GTEST(ntuple_evolution ntuple_evolution.cxx LIBRARIES ROOTNTuple)
+  ROOT_ADD_GTEST(ntuple_emulated ntuple_emulated.cxx LIBRARIES ROOTNTuple)
 endif()
 ROOT_ADD_GTEST(ntuple_index ntuple_index.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -6,11 +6,11 @@ TEST(RFieldDescriptorBuilder, MakeDescriptorErrors)
 {
    // minimum requirements for making a field descriptor from scratch
    RFieldDescriptor fieldDesc = RFieldDescriptorBuilder()
-      .FieldId(1)
-      .Structure(ENTupleStructure::kCollection)
-      .FieldName("someField")
-      .MakeDescriptor()
-      .Unwrap();
+                                   .FieldId(1)
+                                   .Structure(ENTupleStructure::kCollection)
+                                   .FieldName("someField")
+                                   .MakeDescriptor()
+                                   .Unwrap();
 
    // MakeDescriptor() returns an RResult<RFieldDescriptor>
    // -- here we check the error cases
@@ -21,18 +21,13 @@ TEST(RFieldDescriptorBuilder, MakeDescriptorErrors)
    EXPECT_THAT(fieldDescRes.GetError()->GetReport(), testing::HasSubstr("invalid field id"));
 
    // must set field structure
-   fieldDescRes = RFieldDescriptorBuilder()
-      .FieldId(1)
-      .MakeDescriptor();
+   fieldDescRes = RFieldDescriptorBuilder().FieldId(1).MakeDescriptor();
    ASSERT_FALSE(fieldDescRes) << "field descriptors without structure should throw";
    EXPECT_THAT(fieldDescRes.GetError()->GetReport(), testing::HasSubstr("invalid field structure"));
 
    // must set field name
-   fieldDescRes = RFieldDescriptorBuilder()
-      .FieldId(1)
-      .ParentId(1)
-      .Structure(ENTupleStructure::kCollection)
-      .MakeDescriptor();
+   fieldDescRes =
+      RFieldDescriptorBuilder().FieldId(1).ParentId(1).Structure(ENTupleStructure::kCollection).MakeDescriptor();
    ASSERT_FALSE(fieldDescRes) << "unnamed field descriptors should throw";
    EXPECT_THAT(fieldDescRes.GetError()->GetReport(), testing::HasSubstr("name cannot be empty string"));
 }
@@ -40,18 +35,15 @@ TEST(RFieldDescriptorBuilder, MakeDescriptorErrors)
 TEST(RNTupleDescriptorBuilder, CatchBadLinks)
 {
    RNTupleDescriptorBuilder descBuilder;
+   descBuilder.AddField(
+      RFieldDescriptorBuilder().FieldId(0).Structure(ENTupleStructure::kRecord).MakeDescriptor().Unwrap());
    descBuilder.AddField(RFieldDescriptorBuilder()
-      .FieldId(0)
-      .Structure(ENTupleStructure::kRecord)
-      .MakeDescriptor()
-      .Unwrap());
-   descBuilder.AddField(RFieldDescriptorBuilder()
-      .FieldId(1)
-      .FieldName("field")
-      .TypeName("int32_t")
-      .Structure(ENTupleStructure::kLeaf)
-      .MakeDescriptor()
-      .Unwrap());
+                           .FieldId(1)
+                           .FieldName("field")
+                           .TypeName("int32_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
    try {
       descBuilder.AddFieldLink(1, 0);
    } catch (const ROOT::RException &err) {
@@ -374,11 +366,11 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
    auto top_level_fields = ntuple_desc.GetTopLevelFields();
 
    // iterate over child field ranges
-   const auto& float_vec_desc = *top_level_fields.begin();
+   const auto &float_vec_desc = *top_level_fields.begin();
    EXPECT_EQ(float_vec_desc.GetFieldName(), std::string("jets"));
    auto float_vec_child_range = ntuple_desc.GetFieldIterable(float_vec_desc);
    std::vector<std::string> child_names{};
-   for (auto& child_field: float_vec_child_range) {
+   for (auto &child_field : float_vec_child_range) {
       child_names.push_back(child_field.GetFieldName());
       // check the empty range
       auto float_child_range = ntuple_desc.GetFieldIterable(child_field);
@@ -390,7 +382,7 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
    // check if canonical iterator methods work
    auto iter = top_level_fields.begin();
    std::advance(iter, 2);
-   const auto& bool_vec_vec_desc = *iter;
+   const auto &bool_vec_vec_desc = *iter;
    EXPECT_EQ(bool_vec_vec_desc.GetFieldName(), std::string("bool_vec_vec"));
 
    child_names.clear();
@@ -456,7 +448,6 @@ TEST(RFieldDescriptorIterable, SortByLambda)
    EXPECT_EQ(sorted_by_typename[2], std::string("jets"));
    EXPECT_EQ(sorted_by_typename[3], std::string("bool_vec_vec"));
 }
-
 
 TEST(RColumnDescriptorIterable, IterateOverColumns)
 {

--- a/tree/ntuple/v7/test/ntuple_emulated.cxx
+++ b/tree/ntuple/v7/test/ntuple_emulated.cxx
@@ -199,3 +199,152 @@ struct Outer {
    reader = RNTupleReader::Open(cmOpts, "ntpl", fileGuard.GetPath());
    reader->LoadEntry(0);
 }
+
+TEST(RNTupleEmulated, EmulatedFields_EmptyStruct)
+{
+   // Test struct containing an empty struct
+
+   FileRaii fileGuard("test_ntuple_emulated_emptystruct.root");
+
+   ExecInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct Inner {
+   ClassDefNV(Inner, 2);
+};
+
+struct Outer {
+   Inner fInner;
+   ClassDefNV(Outer, 2);
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("f", "Outer").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      // TStreamerInfo::Build will report a warning for interpreted classes (but only for members).
+      // See also https://github.com/root-project/root/issues/9371
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                            /*matchFullMessage=*/false);
+      writer.reset();
+   });
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   const auto &desc = reader->GetDescriptor();
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = false;
+      try {
+         auto model = desc.CreateModel(opts);
+         FAIL() << "Creating a model without fEmulateUnknownTypes should fail";
+      } catch (const ROOT::RException &ex) {
+         ASSERT_THAT(ex.GetError().GetReport(), testing::HasSubstr("unknown type"));
+      }
+   }
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = true;
+      auto model = desc.CreateModel(opts);
+      ASSERT_NE(model, nullptr);
+
+      const auto &outer = model->GetConstField("f");
+      ASSERT_EQ(outer.GetTypeName(), "Outer");
+      ASSERT_EQ(outer.GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_EQ(outer.GetSubFields().size(), 1);
+
+      const auto subfields = outer.GetSubFields();
+      const auto *inner = subfields[0];
+      ASSERT_EQ(inner->GetTypeName(), "Inner");
+      ASSERT_EQ(inner->GetFieldName(), "fInner");
+      ASSERT_EQ(inner->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
+      ASSERT_EQ(inner->GetSubFields().size(), 0);
+   }
+
+   // Now test loading entries with a reader
+   RNTupleDescriptor::RCreateModelOptions cmOpts;
+   cmOpts.fEmulateUnknownTypes = true;
+   reader = RNTupleReader::Open(cmOpts, "ntpl", fileGuard.GetPath());
+   reader->LoadEntry(0);
+}
+
+TEST(RNTupleEmulated, EmulatedFields_EmptyVec)
+{
+   // Test vector of empty structs
+
+   FileRaii fileGuard("test_ntuple_emulated_emptyvec.root");
+
+   ExecInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct Inner {
+   ClassDefNV(Inner, 2);
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("f", "std::vector<Inner>").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      void *ptr = writer->GetModel().GetDefaultEntry().GetPtr<void>("f").get();
+      DeclarePointer("std::vector<Inner>", "ptrInners", ptr);
+
+      ProcessLine("ptrInners->push_back(Inner{});");
+      ProcessLine("ptrInners->push_back(Inner{});");
+      ProcessLine("ptrInners->push_back(Inner{});");
+
+      // TStreamerInfo::Build will report a warning for interpreted classes (but only for members).
+      // See also https://github.com/root-project/root/issues/9371
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                            /*matchFullMessage=*/false);
+      writer.reset();
+   });
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   const auto &desc = reader->GetDescriptor();
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = false;
+      try {
+         auto model = desc.CreateModel(opts);
+         FAIL() << "Creating a model without fEmulateUnknownTypes should fail";
+      } catch (const ROOT::RException &ex) {
+         ASSERT_THAT(ex.GetError().GetReport(), testing::HasSubstr("unknown type"));
+      }
+   }
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = true;
+      auto model = desc.CreateModel(opts);
+      ASSERT_NE(model, nullptr);
+
+      const auto &outer = model->GetConstField("f");
+      ASSERT_EQ(outer.GetTypeName(), "std::vector<Inner>");
+      ASSERT_EQ(outer.GetStructure(), ENTupleStructure::kCollection);
+      ASSERT_EQ(outer.GetSubFields().size(), 1);
+      ASSERT_EQ(outer.GetTraits() & RFieldBase::kTraitEmulatedField, 0);
+
+      const auto subfields = outer.GetSubFields();
+      const auto *inner = subfields[0];
+      ASSERT_EQ(inner->GetTypeName(), "Inner");
+      ASSERT_EQ(inner->GetFieldName(), "_0");
+      ASSERT_EQ(inner->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
+      ASSERT_EQ(inner->GetSubFields().size(), 0);
+   }
+}

--- a/tree/ntuple/v7/test/ntuple_emulated.cxx
+++ b/tree/ntuple/v7/test/ntuple_emulated.cxx
@@ -2,7 +2,7 @@
 
 #include "ntuple_fork.hxx"
 
-TEST(RNTupleEmulated, EmulatedFields)
+TEST(RNTupleEmulated, EmulatedFields_Simple)
 {
    // Write a user-defined class to RNTuple, then "forget" about it and try to load it as an emulated record field.
    // To achieve this "forgetting" we use fork() so that the parent process doesn't know about the class.
@@ -83,8 +83,114 @@ struct Outer {
       ASSERT_EQ(inner->GetTypeName(), "Inner");
       ASSERT_EQ(inner->GetFieldName(), "fInner");
       ASSERT_EQ(inner->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
       ASSERT_EQ(inner->GetSubFields().size(), 2);
       ASSERT_EQ(inner->GetSubFields()[0]->GetFieldName(), "fInt1");
+   }
+
+   // Now test loading entries with a reader
+   RNTupleDescriptor::RCreateModelOptions cmOpts;
+   cmOpts.fEmulateUnknownTypes = true;
+   reader = RNTupleReader::Open(cmOpts, "ntpl", fileGuard.GetPath());
+   reader->LoadEntry(0);
+}
+
+TEST(RNTupleEmulated, EmulatedFields_Vecs)
+{
+   // Write a user-defined class to RNTuple, then "forget" about it and try to load it as an emulated record field.
+   // To achieve this "forgetting" we use fork() so that the parent process doesn't know about the class.
+
+   FileRaii fileGuard("test_ntuple_emulated_fields_vecs.root");
+
+   ExecInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct Inner {
+   float fFlt;
+
+   ClassDefNV(Inner, 2);
+};
+
+struct Outer {
+   std::vector<Inner> fInners;
+   Inner fInner;
+   int f;
+
+   ClassDefNV(Outer, 2);
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("outers", "std::vector<Outer>").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      void *ptr = writer->GetModel().GetDefaultEntry().GetPtr<void>("outers").get();
+      DeclarePointer("std::vector<Outer>", "ptrOuters", ptr);
+
+      ProcessLine("ptrOuters->push_back(Outer{});");
+      ProcessLine("(*ptrOuters)[0].fInners.push_back(Inner{42.f});");
+      ProcessLine("(*ptrOuters)[0].fInner.fFlt = 84.f;");
+      writer->Fill();
+
+      // TStreamerInfo::Build will report a warning for interpreted classes (but only for members).
+      // See also https://github.com/root-project/root/issues/9371
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                            /*matchFullMessage=*/false);
+      writer.reset();
+   });
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   const auto &desc = reader->GetDescriptor();
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = false;
+      try {
+         auto model = desc.CreateModel(opts);
+         FAIL() << "Creating a model without fEmulateUnknownTypes should fail";
+      } catch (const ROOT::RException &ex) {
+         ASSERT_THAT(ex.GetError().GetReport(), testing::HasSubstr("unknown type"));
+      }
+   }
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = true;
+      auto model = desc.CreateModel(opts);
+      ASSERT_NE(model, nullptr);
+
+      const auto &outers = model->GetConstField("outers");
+      ASSERT_EQ(outers.GetTypeName(), "std::vector<Outer>");
+      ASSERT_EQ(outers.GetStructure(), ENTupleStructure::kCollection);
+      ASSERT_EQ(outers.GetSubFields().size(), 1);
+
+      const auto subfields = outers.GetSubFields();
+      const auto *outer = subfields[0];
+      ASSERT_EQ(outer->GetTypeName(), "Outer");
+      ASSERT_EQ(outer->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_NE(outer->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
+
+      const auto outersubfields = outer->GetSubFields();
+      ASSERT_EQ(outersubfields.size(), 3);
+
+      const auto *inners = outersubfields[0];
+      ASSERT_EQ(inners->GetTypeName(), "std::vector<Inner>");
+      ASSERT_EQ(inners->GetFieldName(), "fInners");
+      ASSERT_EQ(inners->GetStructure(), ENTupleStructure::kCollection);
+      ASSERT_EQ(inners->GetSubFields().size(), 1);
+      ASSERT_EQ(inners->GetSubFields()[0]->GetFieldName(), "_0");
+
+      const auto innersubfields = inners->GetSubFields();
+      const auto *inner = innersubfields[0];
+      ASSERT_EQ(inner->GetTypeName(), "Inner");
+      ASSERT_EQ(inner->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_EQ(inner->GetSubFields().size(), 1);
+      ASSERT_EQ(inner->GetSubFields()[0]->GetFieldName(), "fFlt");
    }
 
    // Now test loading entries with a reader

--- a/tree/ntuple/v7/test/ntuple_emulated.cxx
+++ b/tree/ntuple/v7/test/ntuple_emulated.cxx
@@ -347,4 +347,10 @@ struct Inner {
       ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
       ASSERT_EQ(inner->GetSubFields().size(), 0);
    }
+
+   // Now test loading entries with a reader
+   RNTupleDescriptor::RCreateModelOptions cmOpts;
+   cmOpts.fEmulateUnknownTypes = true;
+   reader = RNTupleReader::Open(cmOpts, "ntpl", fileGuard.GetPath());
+   reader->LoadEntry(0);
 }

--- a/tree/ntuple/v7/test/ntuple_emulated.cxx
+++ b/tree/ntuple/v7/test/ntuple_emulated.cxx
@@ -1,0 +1,95 @@
+#include "ntuple_test.hxx"
+
+#include "ntuple_fork.hxx"
+
+TEST(RNTupleEmulated, EmulatedFields)
+{
+   // Write a user-defined class to RNTuple, then "forget" about it and try to load it as an emulated record field.
+   // To achieve this "forgetting" we use fork() so that the parent process doesn't know about the class.
+
+   FileRaii fileGuard("test_ntuple_emulated_fields.root");
+
+   ExecInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct Inner {
+   int fInt1 = 1;
+   int fInt2 = 2;
+
+   ClassDefNV(Inner, 2);
+};
+
+struct Outer {
+   int fInt1 = 1;
+   Inner fInner;
+
+   ClassDefNV(Outer, 2);
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("f", "Outer").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      void *ptr = writer->GetModel().GetDefaultEntry().GetPtr<void>("f").get();
+      DeclarePointer("Outer", "ptrOuter", ptr);
+
+      ProcessLine("ptrOuter->fInner.fInt1 = 71;");
+      ProcessLine("ptrOuter->fInner.fInt2 = 82;");
+      ProcessLine("ptrOuter->fInt1 = 93;");
+      writer->Fill();
+
+      // TStreamerInfo::Build will report a warning for interpreted classes (but only for members).
+      // See also https://github.com/root-project/root/issues/9371
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                            /*matchFullMessage=*/false);
+      writer.reset();
+   });
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   const auto &desc = reader->GetDescriptor();
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = false;
+      try {
+         auto model = desc.CreateModel(opts);
+         FAIL() << "Creating a model without fEmulateUnknownTypes should fail";
+      } catch (const ROOT::RException &ex) {
+         ASSERT_THAT(ex.GetError().GetReport(), testing::HasSubstr("unknown type"));
+      }
+   }
+
+   {
+      RNTupleDescriptor::RCreateModelOptions opts;
+      opts.fEmulateUnknownTypes = true;
+      auto model = desc.CreateModel(opts);
+      ASSERT_NE(model, nullptr);
+
+      const auto &outer = model->GetConstField("f");
+      ASSERT_EQ(outer.GetTypeName(), "Outer");
+      ASSERT_EQ(outer.GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_EQ(outer.GetSubFields().size(), 2);
+
+      const auto subfields = outer.GetSubFields();
+      ASSERT_EQ(subfields[0]->GetFieldName(), "fInt1");
+
+      const auto *inner = subfields[1];
+      ASSERT_EQ(inner->GetTypeName(), "Inner");
+      ASSERT_EQ(inner->GetFieldName(), "fInner");
+      ASSERT_EQ(inner->GetStructure(), ENTupleStructure::kRecord);
+      ASSERT_EQ(inner->GetSubFields().size(), 2);
+      ASSERT_EQ(inner->GetSubFields()[0]->GetFieldName(), "fInt1");
+   }
+
+   // Now test loading entries with a reader
+   RNTupleDescriptor::RCreateModelOptions cmOpts;
+   cmOpts.fEmulateUnknownTypes = true;
+   reader = RNTupleReader::Open(cmOpts, "ntpl", fileGuard.GetPath());
+   reader->LoadEntry(0);
+}

--- a/tree/ntuple/v7/test/ntuple_fork.hxx
+++ b/tree/ntuple/v7/test/ntuple_fork.hxx
@@ -1,0 +1,77 @@
+#ifndef ROOT7_RNTuple_Test_Fork
+#define ROOT7_RNTuple_Test_Fork
+
+#include <functional>
+#include <string_view>
+#include <cstdint>
+#include <sstream>
+
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "gtest/gtest.h"
+
+#include <TInterpreter.h>
+
+// These helpers are split into an *Impl function and a macro to check for and propagate fatal failures to the caller.
+
+inline void ExecInForkImpl(std::function<void(void)> fn)
+{
+   pid_t pid = fork();
+   if (pid == -1) {
+      FAIL() << "fork() failed";
+   }
+
+   if (pid == 0) {
+      fn();
+      if (::testing::Test::HasFatalFailure())
+         exit(EXIT_FAILURE);
+      exit(EXIT_SUCCESS);
+   }
+
+   int wstatus;
+   if (waitpid(pid, &wstatus, 0) == -1) {
+      FAIL() << "waitpid() failed";
+   } else if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+      FAIL() << "child did not exit successfully";
+   }
+}
+
+inline void DeclarePointerImpl(std::string_view type, std::string_view variable, void *ptr)
+{
+   auto ptrString = std::to_string(reinterpret_cast<std::uintptr_t>(ptr));
+   std::ostringstream ptrDeclare;
+   ptrDeclare << type << " *" << variable << " = ";
+   ptrDeclare << "reinterpret_cast<" << type << " *>(" << ptrString << ");";
+   ASSERT_TRUE(gInterpreter->Declare(ptrDeclare.str().c_str()));
+}
+
+inline void ProcessLineImpl(const char *line)
+{
+   TInterpreter::EErrorCode error = TInterpreter::kNoError;
+   gInterpreter->ProcessLine(line, &error);
+   ASSERT_EQ(error, TInterpreter::kNoError);
+}
+
+#define ExecInFork(old)                       \
+   do {                                       \
+      ExecInForkImpl(old);                    \
+      if (::testing::Test::HasFatalFailure()) \
+         return;                              \
+   } while (0)
+
+#define DeclarePointer(type, variable, ptr)    \
+   do {                                        \
+      DeclarePointerImpl(type, variable, ptr); \
+      if (::testing::Test::HasFatalFailure())  \
+         return;                               \
+   } while (0)
+
+#define ProcessLine(line)                     \
+   do {                                       \
+      ProcessLineImpl(line);                  \
+      if (::testing::Test::HasFatalFailure()) \
+         return;                              \
+   } while (0)
+
+#endif // ROOT7_RNTuple_Test_Fork


### PR DESCRIPTION
# This Pull request:
adds the option to "emulate" fields of unknown user-defined types (i.e. types for which we lack dictionaries) as RecordFields whose structure is reconstructed from the on-disk information. This is off by default but can be toggled via `RCreateModelOptions`.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


