### PR TITLE
[ntuple] Improve `RNTupleProcessor` entry number bookkeeping

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -202,7 +202,7 @@ public:
       iterator operator++(int)
       {
          auto obj = *this;
-         obj.fNEntriesProcessed = fProcessor.Advance();
+         ++(*this);
          return obj;
       }
 

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -154,16 +154,14 @@ ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(const RNTuple
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleSingleProcessor::Advance()
 {
-   ++fNEntriesProcessed;
-
-   if (fNEntriesProcessed >= fPageSource->GetNEntries()) {
+   if (fLocalEntryNumber == kInvalidNTupleIndex || fLocalEntryNumber >= fPageSource->GetNEntries()) {
       return kInvalidNTupleIndex;
    }
 
-   ++fLocalEntryNumber;
    LoadEntry();
 
-   return fNEntriesProcessed;
+   fNEntriesProcessed++;
+   return fLocalEntryNumber;
 }
 
 //------------------------------------------------------------------------------
@@ -227,9 +225,10 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::Conn
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::Advance()
 {
-   ++fNEntriesProcessed;
+   if (fLocalEntryNumber == kInvalidNTupleIndex)
+      return kInvalidNTupleIndex;
 
-   if (++fLocalEntryNumber >= fPageSource->GetNEntries()) {
+   if (fLocalEntryNumber >= fPageSource->GetNEntries()) {
       do {
          if (++fCurrentNTupleNumber >= fNTuples.size()) {
             return kInvalidNTupleIndex;
@@ -240,9 +239,10 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::Adva
       fLocalEntryNumber = 0;
    }
 
-   fEntry->Read(fLocalEntryNumber);
+   LoadEntry();
 
-   return fNEntriesProcessed;
+   fNEntriesProcessed++;
+   return fLocalEntryNumber;
 }
 
 //------------------------------------------------------------------------------
@@ -389,16 +389,14 @@ void ROOT::Experimental::RNTupleJoinProcessor::ConnectFields()
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::Advance()
 {
-   ++fNEntriesProcessed;
-
-   if (fNEntriesProcessed >= fPageSource->GetNEntries()) {
+   if (fLocalEntryNumber == kInvalidNTupleIndex || fLocalEntryNumber >= fPageSource->GetNEntries()) {
       return kInvalidNTupleIndex;
    }
 
-   ++fLocalEntryNumber;
    LoadEntry();
 
-   return fNEntriesProcessed;
+   fNEntriesProcessed++;
+   return fLocalEntryNumber;
 }
 
 void ROOT::Experimental::RNTupleJoinProcessor::LoadEntry()

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -126,11 +126,6 @@ ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(const RNTuple
    fPageSource = Internal::RPageSource::Create(ntuple.fNTupleName, ntuple.fStorage);
    fPageSource->Attach();
 
-   if (fPageSource->GetNEntries() == 0) {
-      throw RException(R__FAIL("specified RNTuple \"" + ntuple.fNTupleName + "\" at path \"" + ntuple.fStorage +
-                               "\" does not contain any entries"));
-   }
-
    model.Freeze();
    fEntry = model.CreateEntry();
 

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -2,6 +2,26 @@
 
 #include <ROOT/RNTupleProcessor.hxx>
 
+TEST(RNTupleProcessor, EmptyNTuple)
+{
+   FileRaii fileGuard("test_ntuple_processor_empty.root");
+   {
+      auto model = RNTupleModel::Create();
+      model->MakeField<float>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   RNTupleOpenSpec ntuple{"ntuple", fileGuard.GetPath()};
+   auto proc = RNTupleProcessor::Create(ntuple);
+
+   int nEntries = 0;
+   for (const auto &_ : *proc) {
+      nEntries++;
+   }
+   EXPECT_EQ(0, nEntries);
+   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+}
+
 class RNTupleProcessorTest : public testing::Test {
 protected:
    const std::string fFileName = "test_ntuple_processor.root";

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -30,14 +30,13 @@ TEST_F(RNTupleProcessorTest, Base)
    int nEntries = 0;
 
    for (const auto &entry : *proc) {
-      EXPECT_FLOAT_EQ(static_cast<float>(proc->GetNEntriesProcessed()), *entry.GetPtr<float>("x"));
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
 
-      std::vector<float> yExp{static_cast<float>(proc->GetNEntriesProcessed()),
-                              static_cast<float>(proc->GetNEntriesProcessed() * 2)};
+      EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *entry.GetPtr<float>("x"));
+
+      std::vector<float> yExp{static_cast<float>(nEntries - 1), static_cast<float>((nEntries - 1) * 2)};
       EXPECT_EQ(yExp, *entry.GetPtr<std::vector<float>>("y"));
-
-      EXPECT_EQ(proc->GetNEntriesProcessed(), proc->GetLocalEntryNumber());
-      ++nEntries;
    }
    EXPECT_EQ(nEntries, 5);
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
@@ -55,8 +54,10 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
    int nEntries = 0;
 
    for (const auto &entry : *proc) {
-      EXPECT_FLOAT_EQ(static_cast<float>(proc->GetNEntriesProcessed()), *fldX);
-      EXPECT_EQ(proc->GetNEntriesProcessed(), proc->GetLocalEntryNumber());
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+
+      EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *fldX);
 
       try {
          entry.GetPtr<std::vector<float>>("y");
@@ -64,7 +65,6 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
       } catch (const RException &err) {
          EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: y"));
       }
-      ++nEntries;
    }
    EXPECT_EQ(nEntries, 5);
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
@@ -82,8 +82,10 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
    int nEntries = 0;
 
    for (const auto &entry : *proc) {
-      EXPECT_FLOAT_EQ(static_cast<float>(proc->GetNEntriesProcessed()), *entry.GetPtr<float>("x"));
-      EXPECT_EQ(proc->GetNEntriesProcessed(), proc->GetLocalEntryNumber());
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+
+      EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *entry.GetPtr<float>("x"));
 
       try {
          entry.GetPtr<std::vector<float>>("y");
@@ -91,7 +93,6 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
       } catch (const RException &err) {
          EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: y"));
       }
-      ++nEntries;
    }
    EXPECT_EQ(nEntries, 5);
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());

--- a/tree/ntuple/v7/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_join.cxx
@@ -97,7 +97,9 @@ TEST_F(RNTupleJoinProcessorTest, Basic)
 
    int nEntries = 0;
    for (const auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      ;
 
       auto i = entry.GetPtr<int>("i");
       EXPECT_EQ(proc->GetLocalEntryNumber() * 2, *i);
@@ -123,7 +125,8 @@ TEST_F(RNTupleJoinProcessorTest, Aligned)
    int nEntries = 0;
    std::vector<float> yExpected;
    for (auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
 
       auto i = entry.GetPtr<int>("i");
 


### PR DESCRIPTION
This PR improves the bookkeeping of entries in the `RNTupleProcessor`. Most importantly, a clearer distinction is made between the current entry number (relative to the currently open page source) and the number of entries processed. There was an incorrectness where this value was equal, whereas (assuming we linearly process one page source) `fNEntriesProcessed` should be higher than `fLocalEntryNumber` (e.g., after loading the first entry, `fNEntriesProcessed == 1`, and `fLocalEntryNumber == 0`).

In the process, some variables have been renamed to better capture their meaning.

As a consequence of this refactoring, the `RNTupleSingleProcessor` can now also handle empty ntuples.

Related to #17132.
