### PR TITLE
[RF] Fix parameter ordering bug in RooFormulaArgStreamer

### DIFF
--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -545,16 +545,16 @@ public:
       const RooArg_t *pdf = static_cast<const RooArg_t *>(func);
       elem["type"] << key();
       TString expression(pdf->expression());
-      std::vector<std::pair<RooAbsArg *, std::size_t>> paramsWithIndex;
+      std::vector<std::pair<std::size_t, const RooAbsArg*>> paramsWithIndex;
       paramsWithIndex.reserve(pdf->nParameters());
       for (size_t i = 0; i < pdf->nParameters(); ++i) {
-         paramsWithIndex.emplace_back(pdf->getParameter(i), i);
+	  paramsWithIndex.emplace_back(i, pdf->getParameter(i));
       }
       std::sort(paramsWithIndex.begin(), paramsWithIndex.end());
       // If the tokens follow the "x[#]" convention, the square braces enclosing each number
       // ensures that there is a unique mapping between the token and parameter name
-      for (auto [par, idx] : paramsWithIndex) {
-         expression.ReplaceAll(("x[" + std::to_string(idx) + "]").c_str(), par->GetName());
+      for (auto [idx, par] : paramsWithIndex) {
+	  expression.ReplaceAll(("x[" + std::to_string(idx) + "]").c_str(), par->GetName());
       }
       // If the tokens follow the "@#" convention, the numbers are not enclosed by braces.
       // So there may be tokens with numbers whose lower place value forms a subset string of ones with a higher place value,
@@ -562,8 +562,8 @@ public:
       // So the names of these parameters must be applied descending from the highest place value
       // in order to ensure each parameter name is uniquely applied to its token.
       for (auto it = paramsWithIndex.rbegin(); it != paramsWithIndex.rend(); ++it) {
-         RooAbsArg* par = it->first;
-         std::size_t idx = it->second;
+         const RooAbsArg* par = it->second;
+         std::size_t idx = it->first;
          expression.ReplaceAll(("@" + std::to_string(idx)).c_str(), par->GetName());
       }
       elem["expression"] << expression.Data();

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -545,25 +545,15 @@ public:
       const RooArg_t *pdf = static_cast<const RooArg_t *>(func);
       elem["type"] << key();
       TString expression(pdf->expression());
-      std::vector<std::pair<std::size_t, const RooAbsArg*>> paramsWithIndex;
-      paramsWithIndex.reserve(pdf->nParameters());
-      for (size_t i = 0; i < pdf->nParameters(); ++i) {
-	  paramsWithIndex.emplace_back(i, pdf->getParameter(i));
-      }
-      std::sort(paramsWithIndex.begin(), paramsWithIndex.end());
       // If the tokens follow the "x[#]" convention, the square braces enclosing each number
       // ensures that there is a unique mapping between the token and parameter name
-      for (auto [idx, par] : paramsWithIndex) {
-	  expression.ReplaceAll(("x[" + std::to_string(idx) + "]").c_str(), par->GetName());
-      }
       // If the tokens follow the "@#" convention, the numbers are not enclosed by braces.
-      // So there may be tokens with numbers whose lower place value forms a subset string of ones with a higher place value,
-      // e.g. "@1" is a subset of "@10".
-      // So the names of these parameters must be applied descending from the highest place value
-      // in order to ensure each parameter name is uniquely applied to its token.
-      for (auto it = paramsWithIndex.rbegin(); it != paramsWithIndex.rend(); ++it) {
-         const RooAbsArg* par = it->second;
-         std::size_t idx = it->first;
+      // So there may be tokens with numbers whose lower place value forms a subset string of ones with a higher place
+      // value, e.g. "@1" is a subset of "@10". So the names of these parameters must be applied descending from the
+      // highest place value in order to ensure each parameter name is uniquely applied to its token.
+      for (size_t idx = pdf->nParameters(); idx--;) {
+         const RooAbsArg *par = pdf->getParameter(idx);
+         expression.ReplaceAll(("x[" + std::to_string(idx) + "]").c_str(), par->GetName());
          expression.ReplaceAll(("@" + std::to_string(idx)).c_str(), par->GetName());
       }
       elem["expression"] << expression.Data();


### PR DESCRIPTION
# This Pull request fixes:

The parameter ordering bug in RooFormulaArgStreamer. I changed the code to remove the `vector< pair<RooAbsArg*, size_t> >` and just directly loop in reverse order over the parameters of the formula.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #17291 

