### PR TITLE
[RF] Follow up on RooDataSet constructor deprecation

### DIFF
--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -47,7 +47,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         # Create a data set with a derived weight
         wFunc = ROOT.RooFormulaVar("w", "event weight", "(x*x+10)", [x])
         w = data.addColumn(wFunc)
-        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar=w.GetName())
 
         self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat", "w"})
 
@@ -96,7 +96,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         w = data.addColumn(wFunc)
 
         # Instruct dataset wdata to use w as event weight and not observable
-        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar=w.GetName())
 
         np_data = wdata.to_numpy()
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -45,7 +45,10 @@ public:
     // Constructor for subset of existing dataset
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
              const char *cuts=nullptr, const char* wgtVarName=nullptr)
-  R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.");
+#ifndef ROOFIT_BUILDS_ITSELF
+  R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.")
+#endif
+  ;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
              const RooFormulaVar& cutVar, const char* wgtVarName=nullptr)
   R__DEPRECATED(6,38, "Use RooAbsData::reduce(), or if you need to change the weight column, the universal constructor with the Import(), Cut(), and WeightVar() arguments.");

--- a/tutorials/roostats/rs301_splot.C
+++ b/tutorials/roostats/rs301_splot.C
@@ -267,8 +267,8 @@ void MakePlots(RooWorkspace &ws)
    auto& data = static_cast<RooDataSet&>(*ws.data("dataWithSWeights"));
 
    // create weighted data sets
-   RooDataSet dataw_z{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "zYield_sw"};
-   RooDataSet dataw_qcd{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "qcdYield_sw"};
+   RooDataSet dataw_z{data.GetName(), data.GetTitle(), *data.get(), Import(data), WeightVar("zYield_sw")};
+   RooDataSet dataw_qcd{data.GetName(), data.GetTitle(), *data.get(), Import(data), WeightVar("qcdYield_sw")};
 
 
    // this shouldn't be necessary, need to fix something with workspace

--- a/tutorials/roostats/rs301_splot.py
+++ b/tutorials/roostats/rs301_splot.py
@@ -199,8 +199,8 @@ def MakePlots(wspace):
     data = wspace["dataWithSWeights"]
 
     # create weighted data sets
-    dataw_qcd = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", "qcdYield_sw")
-    dataw_z = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", "zYield_sw")
+    dataw_qcd = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar="qcdYield_sw")
+    dataw_z = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data.get(), Import=data, WeightVar="zYield_sw")
 
     # plot invMass for data with full model and individual components overlaid
     # cdata = TCanvas()


### PR DESCRIPTION
Follow up on cc99d62e9 by avoiding use of the deprecated constructor and avoiding an unnecessary warning that happens at ROOT build time.