### PR TITLE
Make -DCLAD_SOURCE_DIR option work

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -68,8 +68,10 @@ set(_clad_extra_settings
 # If the CLAD_SOURCE_DIR variable is defined in the CMake configuration, we're
 # skipping the download of the repository and use the passed directory.
 if (DEFINED CLAD_SOURCE_DIR)
-  list(APPEND _clad_extra_settings DOWNLOAD_COMMAND "")
   list(APPEND _clad_extra_settings SOURCE_DIR ${CLAD_SOURCE_DIR})
+else()
+  list(APPEND _clad_extra_settings GIT_REPOSITORY https://github.com/vgvassilev/clad.git)
+  list(APPEND _clad_extra_settings GIT_TAG v1.7)
 endif()
 
 #list(APPEND _clad_patches_list "patch1.patch" "patch2.patch")
@@ -82,8 +84,6 @@ endif()
 
 ExternalProject_Add(
   clad
-  GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG v1.7
   UPDATE_COMMAND ""
   PATCH_COMMAND ${_clad_patch_command}
   CMAKE_ARGS -G ${CMAKE_GENERATOR}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Using the -DCLAD_SOURCE_DIR currently does not disable the git checkout. From the cmake documentation for ExternalProject_Add:

Note: If a download method is specified, any existing contents of the source directory may be deleted. Only the URL download method checks whether this directory is either missing or empty before initiating the download, stopping with an error if it is not empty. All other download methods silently discard any previous contents of the source directory.

Currently cmake deletes the source directory defined by -DCLAD_SOURCE_DIR and then tries to recreate it using a git checkout, but fails if there is no network available:

Cloning into 'clad-1.7'...
fatal: unable to access 'https://github.com/vgvassilev/clad.git/': Could not resolve host: github.com Cloning into 'clad-1.7'...
fatal: unable to access 'https://github.com/vgvassilev/clad.git/': Could not resolve host: github.com Cloning into 'clad-1.7'...
fatal: unable to access 'https://github.com/vgvassilev/clad.git/': Could not resolve host: github.com Had to git clone more than once: 3 times.
CMake Error at redhat-linux-build/interpreter/cling/tools/plugins/clad/clad-prefix/tmp/clad-gitclone.cmake:50 (message):
  Failed to clone repository: 'https://github.com/vgvassilev/clad.git'

The attempt to disable the git checkout by setting the DOWNLOAD_COMMAND option to an empty string is not working.

This commit fixes the issue by only defining the GIT_REPOSITORY and GIT_TAG options when CLAD_SOURCE_DIR is not defined.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

