### PR TITLE
Disable run_h1analysis.C on Windows

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -421,6 +421,12 @@ set(extra_veto
   visualisation/eve7/*.C
   math/r/rootlogon.C)
 
+if(MSVC)
+  # disable run_h1analysis.C because of Endpoint Security HTTP traffic scanning,
+  # which is corrupting the data on Windows
+  list(APPEND extra_veto io/tree/run_h1analysis.C)
+endif()
+
 if(MSVC AND NOT llvm13_broken_tests)
   list(APPEND extra_veto
        math/exampleFunction.py


### PR DESCRIPTION
Disable `run_h1analysis.C` because of Endpoint Security HTTP traffic scanning, which is corrupting the data on Windows
