### PR TITLE
[DF] add validation for number of column names imposed to CSV source

### DIFF
--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -52,7 +52,8 @@ public:
       /// Note that the comment character must not be part of the data, e.g. in strings.
       char fComment = '\0';
       /// Impose column names. This can be used if a header is missing or if the header has unparsable or
-      /// unwanted column names.
+      /// unwanted column names. If this list is not empty, it must contain exactly as many elements as
+      /// the number of columns in the CSV file.
       std::vector<std::string> fColumnNames;
       /// Specify custom column types, accepts an unordered map with keys being column name, values being type alias
       /// ('O' for boolean, 'D' for double, 'L' for Long64_t, 'T' for std::string)

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -164,12 +164,18 @@ void RCsvDS::RewindToData()
 
 void RCsvDS::FillHeaders(const std::string &line)
 {
+   const auto columns = ParseColumns(line);
+
    if (!fOptions.fColumnNames.empty()) {
+      if (fOptions.fColumnNames.size() != columns.size()) {
+         auto msg = std::string("Error: passed ") + std::to_string(fOptions.fColumnNames.size()) +
+                    " column names for a CSV file containing " + std::to_string(columns.size()) + " columns!";
+         throw std::runtime_error(msg);
+      }
       std::swap(fHeaders, fOptions.fColumnNames);
       return;
    }
 
-   auto columns = ParseColumns(line);
    fHeaders.reserve(columns.size());
    for (auto &col : columns) {
       fHeaders.emplace_back(col);
@@ -222,6 +228,11 @@ void RCsvDS::FillRecord(const std::string &line, Record_t &record)
 void RCsvDS::GenerateHeaders(size_t size)
 {
    if (!fOptions.fColumnNames.empty()) {
+      if (fOptions.fColumnNames.size() != size) {
+         auto msg = std::string("Error: passed ") + std::to_string(fOptions.fColumnNames.size()) +
+                    " column names for a CSV file containing " + std::to_string(size) + " columns!";
+         throw std::runtime_error(msg);
+      }
       std::swap(fHeaders, fOptions.fColumnNames);
       return;
    }
@@ -671,6 +682,6 @@ RDataFrame FromCSV(std::string_view fileName, bool readHeaders, char delimiter, 
    return rdf;
 }
 
-} // ns RDF
+} // namespace RDF
 
-} // ns ROOT
+} // namespace ROOT

--- a/tree/dataframe/test/datasource_csv.cxx
+++ b/tree/dataframe/test/datasource_csv.cxx
@@ -8,21 +8,21 @@
 
 using namespace ROOT::RDF;
 
-auto fileName0 = "RCsvDS_test_headers.csv";
-auto fileName1 = "RCsvDS_test_noheaders.csv";
-auto fileName2 = "RCsvDS_test_empty.csv";
-auto fileName3 = "RCsvDS_test_win.csv";
-auto fileName4 = "RCsvDS_test_NaNs.csv";
-auto fileName5 = "RCsvDS_test_parsing.csv";
+static const auto fileNameHeaders = "RCsvDS_test_headers.csv";
+static const auto fileNameNoHeaders = "RCsvDS_test_noheaders.csv";
+static const auto fileNameNans = "RCsvDS_test_NaNs.csv";
+static const auto fileNameEmpty = "RCsvDS_test_empty.csv";
+static const auto fileNameWin = "RCsvDS_test_win.csv";
+static const auto fileNameParsing = "RCsvDS_test_parsing.csv";
 
 // must use http: we cannot use https on macOS until we upgrade to the newest Davix
 // and turn on the macOS SecureTransport layer.
-auto url0 = "http://root.cern/files/dataframe_test_datasource.csv";
+static const auto url0 = "http://root.cern/files/dataframe_test_datasource.csv";
 
 
 TEST(RCsvDS, ColTypeNames)
 {
-   RCsvDS tds(fileName0);
+   RCsvDS tds(fileNameHeaders);
    tds.SetNSlots(1);
 
    auto colNames = tds.GetColumnNames();
@@ -44,7 +44,7 @@ TEST(RCsvDS, ColTypeNames)
 
 TEST(RCsvDS, ColNamesNoHeaders)
 {
-   RCsvDS tds(fileName1, false);
+   RCsvDS tds(fileNameNoHeaders, false);
    tds.SetNSlots(1);
 
    auto colNames = tds.GetColumnNames();
@@ -58,20 +58,20 @@ TEST(RCsvDS, ColNamesNoHeaders)
 TEST(RCsvDS, EmptyFile)
 {
    // Cannot read headers
-   EXPECT_THROW(RCsvDS{fileName2}, std::runtime_error);
+   EXPECT_THROW(RCsvDS{fileNameEmpty}, std::runtime_error);
    // Cannot infer column types
-   EXPECT_THROW(RCsvDS(fileName2, false), std::runtime_error);
+   EXPECT_THROW(RCsvDS(fileNameEmpty, false), std::runtime_error);
 }
 
 TEST(RCsvDS, NFiles)
 {
-   RCsvDS tds(fileName1, false);
+   RCsvDS tds(fileNameNoHeaders, false);
    EXPECT_EQ(1, tds.GetNFiles());
 }
 
 TEST(RCsvDS, EntryRanges)
 {
-   RCsvDS tds(fileName0);
+   RCsvDS tds(fileNameHeaders);
    tds.SetNSlots(3U);
    tds.Initialize();
 
@@ -89,7 +89,7 @@ TEST(RCsvDS, EntryRanges)
 
 TEST(RCsvDS, ColumnReaders)
 {
-   RCsvDS tds(fileName0);
+   RCsvDS tds(fileNameHeaders);
    const auto nSlots = 3U;
    tds.SetNSlots(nSlots);
    auto vals = tds.GetColumnReaders<Long64_t>("Age");
@@ -110,7 +110,7 @@ TEST(RCsvDS, ColumnReaders)
 
 TEST(RCsvDS, ColumnReadersWrongType)
 {
-   RCsvDS tds(fileName0);
+   RCsvDS tds(fileNameHeaders);
    const auto nSlots = 3U;
    tds.SetNSlots(nSlots);
    int res = 1;
@@ -126,7 +126,7 @@ TEST(RCsvDS, ColumnReadersWrongType)
 
 TEST(RCsvDS, Snapshot)
 {
-   auto tdf = ROOT::RDF::FromCSV(fileName0);
+   auto tdf = ROOT::RDF::FromCSV(fileNameHeaders);
    auto snap = tdf.Snapshot<Long64_t>("data","csv2root.root", {"Age"});
    auto ages = *snap->Take<Long64_t>("Age");
    std::vector<Long64_t> agesRef {60LL, 50LL, 40LL, 30LL, 1LL, -1LL};
@@ -137,7 +137,7 @@ TEST(RCsvDS, Snapshot)
 
 TEST(RCsvDS, ColumnReadersString)
 {
-   RCsvDS tds(fileName0);
+   RCsvDS tds(fileNameHeaders);
    const auto nSlots = 3U;
    tds.SetNSlots(nSlots);
    auto vals = tds.GetColumnReaders<std::string>("Name");
@@ -159,7 +159,7 @@ TEST(RCsvDS, ColumnReadersString)
 TEST(RCsvDS, ProgressiveReadingEntryRanges)
 {
    auto chunkSize = 3LL;
-   RCsvDS tds(fileName0, true, ',', chunkSize);
+   RCsvDS tds(fileNameHeaders, true, ',', chunkSize);
    const auto nSlots = 3U;
    tds.SetNSlots(nSlots);
    auto vals = tds.GetColumnReaders<std::string>("Name");
@@ -193,13 +193,13 @@ TEST(RCsvDS, ProgressiveReadingRDF)
 {
    // Even chunks
    auto chunkSize = 2LL;
-   auto tdf = ROOT::RDF::FromCSV(fileName0, true, ',', chunkSize);
+   auto tdf = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', chunkSize);
    auto c = tdf.Count();
    EXPECT_EQ(6U, *c);
 
    // Uneven chunks
    chunkSize = 4LL;
-   auto tdf2 = ROOT::RDF::FromCSV(fileName0, true, ',', chunkSize);
+   auto tdf2 = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', chunkSize);
    auto c2 = tdf2.Count();
    EXPECT_EQ(6U, *c2);
 }
@@ -209,7 +209,7 @@ TEST(RCsvDS, ProgressiveReadingRDF)
 TEST(RCsvDS, SetNSlotsTwice)
 {
    auto theTest = []() {
-      RCsvDS tds(fileName0);
+      RCsvDS tds(fileNameHeaders);
       tds.SetNSlots(1);
       tds.SetNSlots(1);
    };
@@ -219,7 +219,7 @@ TEST(RCsvDS, SetNSlotsTwice)
 
 TEST(RCsvDS, FromARDF)
 {
-   std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
+   std::unique_ptr<RDataSource> tds(new RCsvDS(fileNameHeaders));
    ROOT::RDataFrame tdf(std::move(tds));
    auto max = tdf.Max<double>("Height");
    auto min = tdf.Min<double>("Height");
@@ -239,11 +239,9 @@ TEST(RCsvDS, Parsing)
    options.fSkipFirstNLines = 1;
    options.fSkipLastNLines = 2;
    options.fComment = '#';
-   options.fColumnNames = {"FirstName", "LastName"};
-
-   std::unique_ptr<RDataSource> ds(new RCsvDS(fileName5, options));
+   options.fColumnNames = {"FirstName", "LastName", "", ""};
+   std::unique_ptr<RDataSource> ds(new RCsvDS(fileNameParsing, options));
    ROOT::RDataFrame df(std::move(ds));
-
    EXPECT_EQ(1U, *df.Count());
    EXPECT_EQ(std::string("Harry"), df.Take<std::string>("FirstName")->at(0));
    EXPECT_EQ(std::string("Smith"), df.Take<std::string>("LastName")->at(0));
@@ -251,7 +249,7 @@ TEST(RCsvDS, Parsing)
 
 TEST(RCsvDS, FromARDFWithJitting)
 {
-   std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
+   std::unique_ptr<RDataSource> tds(new RCsvDS(fileNameHeaders));
    ROOT::RDataFrame tdf(std::move(tds));
    auto max = tdf.Filter("Age<40").Max("Age");
    auto min = tdf.Define("Age2", "Age").Filter("Age2>30").Min("Age2");
@@ -262,7 +260,7 @@ TEST(RCsvDS, FromARDFWithJitting)
 
 TEST(RCsvDS, MultipleEventLoops)
 {
-   auto tdf = ROOT::RDF::FromCSV(fileName0, true, ',', 2LL);
+   auto tdf = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', 2LL);
    EXPECT_EQ(6U, *tdf.Count());
    EXPECT_EQ(6U, *tdf.Count());
    EXPECT_EQ(6U, *tdf.Count());
@@ -271,7 +269,7 @@ TEST(RCsvDS, MultipleEventLoops)
 
 TEST(RCsvDS, WindowsLinebreaks)
 {
-   auto tdf = ROOT::RDF::FromCSV(fileName3);
+   auto tdf = ROOT::RDF::FromCSV(fileNameWin);
    EXPECT_EQ(6U, *tdf.Count());
 }
 
@@ -285,79 +283,19 @@ TEST(RCsvDS, Remote)
 #endif
 }
 
-// NOW MT!-------------
-#ifdef R__USE_IMT
-
-TEST(RCsvDS, DefineSlotCheckMT)
-{
-   const auto nSlots = 4U;
-   ROOT::EnableImplicitMT(nSlots);
-
-   std::vector<unsigned int> ids(nSlots, 0u);
-   std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
-   ROOT::RDataFrame d(std::move(tds));
-   auto m = d.DefineSlot("x", [&](unsigned int slot) {
-                ids[slot] = 1u;
-                return 1;
-             }).Max("x");
-   EXPECT_EQ(1, *m); // just in case
-
-   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
-   EXPECT_GT(nUsedSlots, 0u);
-   EXPECT_LE(nUsedSlots, nSlots);
-}
-
-TEST(RCsvDS, FromARDFMT)
-{
-   std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
-   ROOT::RDataFrame tdf(std::move(tds));
-   auto max = tdf.Max<double>("Height");
-   auto min = tdf.Min<double>("Height");
-   auto c = tdf.Count();
-
-   EXPECT_EQ(6U, *c);
-   EXPECT_DOUBLE_EQ(200.5, *max);
-   EXPECT_DOUBLE_EQ(.7, *min);
-}
-
-TEST(RCsvDS, FromARDFWithJittingMT)
-{
-   std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
-   ROOT::RDataFrame tdf(std::move(tds));
-   auto max = tdf.Filter("Age<40").Max("Age");
-   auto min = tdf.Define("Age2", "Age").Filter("Age2>30").Min("Age2");
-
-   EXPECT_EQ(30, *max);
-   EXPECT_EQ(40, *min);
-}
-
-TEST(RCsvDS, ProgressiveReadingRDFMT)
-{
-   // Even chunks
-   auto chunkSize = 2LL;
-   auto tdf = ROOT::RDF::FromCSV(fileName0, true, ',', chunkSize);
-   auto c = tdf.Count();
-   EXPECT_EQ(6U, *c);
-
-   // Uneven chunks
-   chunkSize = 4LL;
-   auto tdf2 = ROOT::RDF::FromCSV(fileName0, true, ',', chunkSize);
-   auto c2 = tdf2.Count();
-   EXPECT_EQ(6U, *c2);
-}
 
 TEST(RCsvDS, SpecifyColumnTypes)
 {
-   RCsvDS tds0(fileName0, true, ',', -1LL, {{"Age", 'D'}, {"Name", 'T'}}); // with headers
+   RCsvDS tds0(fileNameHeaders, true, ',', -1LL, {{"Age", 'D'}, {"Name", 'T'}}); // with headers
    EXPECT_STREQ("double", tds0.GetTypeName("Age").c_str());
    EXPECT_STREQ("std::string", tds0.GetTypeName("Name").c_str());
 
-   RCsvDS tds1(fileName1, false, ',', -1LL, {{"Col1", 'T'}}); // without headers (Col0, ...)
+   RCsvDS tds1(fileNameNoHeaders, false, ',', -1LL, {{"Col1", 'T'}}); // without headers (Col0, ...)
    EXPECT_STREQ("std::string", tds1.GetTypeName("Col1").c_str());
 
    EXPECT_THROW(
       try {
-         ROOT::RDF::FromCSV(fileName1, false, ',', -1LL, {{"Col2", 'L'}, {"wrong", 'O'}});
+         ROOT::RDF::FromCSV(fileNameNoHeaders, false, ',', -1LL, {{"Col2", 'L'}, {"wrong", 'O'}});
       } catch (const std::runtime_error &err) {
          std::string msg = "There is no column with name \"wrong\".\n";
          msg += "Since the input csv file does not contain headers, valid column names are [\"Col0\", ..., \"Col3\"].";
@@ -368,7 +306,7 @@ TEST(RCsvDS, SpecifyColumnTypes)
 
    EXPECT_THROW(
       try {
-         ROOT::RDF::FromCSV(fileName1, false, ',', -1LL, {{"Col0", 'T'}, {"Col3", 'X'}});
+         ROOT::RDF::FromCSV(fileNameNoHeaders, false, ',', -1LL, {{"Col0", 'T'}, {"Col3", 'X'}});
       } catch (const std::runtime_error &err) {
          std::string msg = "Type alias 'X' is not supported.\n";
          msg += "Supported type aliases are 'O' for boolean, 'D' for double, 'L' for Long64_t, 'T' for std::string.";
@@ -377,16 +315,79 @@ TEST(RCsvDS, SpecifyColumnTypes)
       },
       std::runtime_error);
 
-   auto df = ROOT::RDF::FromCSV(fileName0, true, ',', -1LL, {{"Age", 'L'}, {"Height", 'D'}});
+   auto df = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', -1LL, {{"Age", 'L'}, {"Height", 'D'}});
    auto maxHeight = df.Max<double>("Height");
    auto maxAge = df.Max<Long64_t>("Age");
    EXPECT_DOUBLE_EQ(maxHeight.GetValue(), 200.5);
    EXPECT_EQ(maxAge.GetValue(), 60);
 }
 
+TEST(RCsvDS, SpecifyColumnNames)
+{
+   {
+      ROOT::RDF::RCsvDS::ROptions opts;
+      // Normally: Name,Age,Height,Married
+      opts.fColumnNames = {"Surname", "Years", "Weight", "Single"};
+      opts.fColumnTypes = {{"Years", 'L'}, {"Weight", 'D'}};
+      opts.fHeaders = false;
+      auto df = ROOT::RDF::FromCSV(fileNameNoHeaders, std::move(opts));
+      auto maxWeight = df.Max<double>("Weight");
+      auto maxYears = df.Max<Long64_t>("Years");
+      EXPECT_DOUBLE_EQ(maxWeight.GetValue(), 200.5);
+      EXPECT_EQ(maxYears.GetValue(), 60);
+   }
+   {
+      ROOT::RDF::RCsvDS::ROptions opts;
+      // Normally: Name,Age,Height,Married
+      opts.fColumnNames = {"Surname", "Years", "Weight", "Single"};
+      opts.fColumnTypes = {{"Years", 'L'}, {"Weight", 'D'}};
+      // Since fHeaders is true, the first line should be skipped
+      opts.fHeaders = true;
+      auto df = ROOT::RDF::FromCSV(fileNameNoHeaders, std::move(opts));
+      auto maxWeight = df.Max<double>("Weight");
+      auto maxYears = df.Max<Long64_t>("Years");
+      EXPECT_DOUBLE_EQ(maxWeight.GetValue(), 200.5);
+      EXPECT_EQ(maxYears.GetValue(), 55);
+   }
+   {
+      // Trying to set col types with wrong names
+      ROOT::RDF::RCsvDS::ROptions opts;
+      opts.fColumnTypes = {{"Years", 'L'}, {"Weight", 'D'}};
+      EXPECT_THROW(ROOT::RDF::FromCSV(fileNameHeaders, std::move(opts)), std::runtime_error);
+   }
+   {
+      ROOT::RDF::RCsvDS::ROptions opts;
+      opts.fColumnTypes = {{"Age", 'L'}, {"Height", 'D'}};
+      auto df = ROOT::RDF::FromCSV(fileNameHeaders, std::move(opts));
+      auto maxHeight = df.Max<double>("Height");
+      auto maxAge = df.Max<Long64_t>("Age");
+      EXPECT_DOUBLE_EQ(maxHeight.GetValue(), 200.5);
+      EXPECT_EQ(maxAge.GetValue(), 60);
+   }
+   {
+      // Trying to override col names but not enough passed
+      ROOT::RDF::RCsvDS::ROptions opts;
+      opts.fColumnNames = {"Surname", "Years", "Weight"};
+      EXPECT_THROW(ROOT::RDF::FromCSV(fileNameNoHeaders, std::move(opts)), std::runtime_error);
+   }
+   {
+      // Trying to set col names but too many
+      ROOT::RDF::RCsvDS::ROptions opts;
+      opts.fColumnNames = {"Surname", "Years", "Weight", "Single", "Extra"};
+      EXPECT_THROW(ROOT::RDF::FromCSV(fileNameNoHeaders, std::move(opts)), std::runtime_error);
+   }
+   {
+      // Trying to pass col types but using original col names
+      ROOT::RDF::RCsvDS::ROptions opts;
+      opts.fColumnNames = {"Surname", "Years", "Weight", "Single"};
+      opts.fColumnTypes = {{"Age", 'L'}, {"Height", 'D'}};
+      EXPECT_THROW(ROOT::RDF::FromCSV(fileNameNoHeaders, std::move(opts)), std::runtime_error);
+   }
+}
+
 TEST(RCsvDS, NaNTypeIndentification)
 {
-   RCsvDS tds(fileName4);
+   RCsvDS tds(fileNameNans);
 
    EXPECT_STREQ("double", tds.GetTypeName("col1").c_str());
    EXPECT_STREQ("double", tds.GetTypeName("col2").c_str());
@@ -400,9 +401,7 @@ TEST(RCsvDS, NaNTypeIndentification)
 
 TEST(RCsvDS, NanWarningChecks)
 {
-   ROOT::DisableImplicitMT(); // to allow usage of display
-
-   auto rdf = ROOT::RDF::FromCSV(fileName4);
+   auto rdf = ROOT::RDF::FromCSV(fileNameNans);
    auto d = rdf.Display<double, bool, Long64_t, std::string>({"col1", "col3", "col6", "col8"}, 12);
 
    const std::string Warn =
@@ -445,6 +444,69 @@ TEST(RCsvDS, NanWarningChecks)
                                 "+-----+-----------+-------+------+----------------+\n";
 
    EXPECT_EQ(d->AsString(), AsString);
+}
+
+// ----------------------------------------------------------------------
+//                               NOW MT!
+// ----------------------------------------------------------------------
+#ifdef R__USE_IMT
+
+TEST(RCsvDS, DefineSlotCheckMT)
+{
+   const auto nSlots = 4U;
+   ROOT::EnableImplicitMT(nSlots);
+
+   std::vector<unsigned int> ids(nSlots, 0u);
+   std::unique_ptr<RDataSource> tds(new RCsvDS(fileNameHeaders));
+   ROOT::RDataFrame d(std::move(tds));
+   auto m = d.DefineSlot("x", [&](unsigned int slot) {
+                ids[slot] = 1u;
+                return 1;
+             }).Max("x");
+   EXPECT_EQ(1, *m); // just in case
+
+   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
+   EXPECT_GT(nUsedSlots, 0u);
+   EXPECT_LE(nUsedSlots, nSlots);
+}
+
+TEST(RCsvDS, FromARDFMT)
+{
+   std::unique_ptr<RDataSource> tds(new RCsvDS(fileNameHeaders));
+   ROOT::RDataFrame tdf(std::move(tds));
+   auto max = tdf.Max<double>("Height");
+   auto min = tdf.Min<double>("Height");
+   auto c = tdf.Count();
+
+   EXPECT_EQ(6U, *c);
+   EXPECT_DOUBLE_EQ(200.5, *max);
+   EXPECT_DOUBLE_EQ(.7, *min);
+}
+
+TEST(RCsvDS, FromARDFWithJittingMT)
+{
+   std::unique_ptr<RDataSource> tds(new RCsvDS(fileNameHeaders));
+   ROOT::RDataFrame tdf(std::move(tds));
+   auto max = tdf.Filter("Age<40").Max("Age");
+   auto min = tdf.Define("Age2", "Age").Filter("Age2>30").Min("Age2");
+
+   EXPECT_EQ(30, *max);
+   EXPECT_EQ(40, *min);
+}
+
+TEST(RCsvDS, ProgressiveReadingRDFMT)
+{
+   // Even chunks
+   auto chunkSize = 2LL;
+   auto tdf = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', chunkSize);
+   auto c = tdf.Count();
+   EXPECT_EQ(6U, *c);
+
+   // Uneven chunks
+   chunkSize = 4LL;
+   auto tdf2 = ROOT::RDF::FromCSV(fileNameHeaders, true, ',', chunkSize);
+   auto c2 = tdf2.Count();
+   EXPECT_EQ(6U, *c2);
 }
 
 #endif // R__USE_IMT

--- a/tree/dataframe/test/datasource_csv.py
+++ b/tree/dataframe/test/datasource_csv.py
@@ -19,7 +19,7 @@ class DataSourceCSV(unittest.TestCase):
         """Test the construction with keyword arguments"""
         df = ROOT.RDF.FromCSV('RCsvDS_test_parsing.csv', delimiter = ' ', leftTrim = True, rightTrim = True,
                               skipFirstNLines = 1, skipLastNLines = 2, comment = '#',
-                              columnNames = ['FirstName', 'LastName'])
+                              columnNames = ['FirstName', 'LastName', '', ''])
         self.assertEqual(1, df.Count().GetValue())
         self.assertEqual('Harry', df.Take['string']('FirstName').at(0))
 


### PR DESCRIPTION
# This Pull request:
adds a check that the number of items in the imposed column vector matches the number of columns in the CSV file. This avoid accessing `fHeaders` out of bounds and increases the robustness of the interface.
Also adding a test to `datasource_csv` and making sure all tests are run when needed (a couple of tests were mistakenly under the IMT ifdef guards)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

