### PR TITLE
[ntuple][python] Generalise getting and setting values of an REntry

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <variant>
 
 #include <ROOT/RError.hxx>
@@ -288,6 +289,14 @@ static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializable
 
 /// Check whether a given string is a valid name according to the RNTuple specification
 RResult<void> EnsureValidNameForRNTuple(std::string_view name, std::string_view where);
+
+/// Helper for the Python interface to perform the assignment to the pointee of a shared_ptr.
+template <typename T, typename U>
+void AssignValueToPointee(T &&value, std::shared_ptr<U> &ptr)
+{
+   static_assert(std::is_convertible_v<T, U>, "Cannot convert type of input argument to type of the pointee.");
+   *ptr = std::forward<T>(value);
+}
 
 } // namespace Internal
 

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -6,6 +6,7 @@ RNTupleModel = ROOT.Experimental.RNTupleModel
 RNTupleReader = ROOT.Experimental.RNTupleReader
 RNTupleWriter = ROOT.Experimental.RNTupleWriter
 
+
 class RNTupleBasics(unittest.TestCase):
     """Basic tests of using RNTuple from Python"""
 
@@ -14,9 +15,12 @@ class RNTupleBasics(unittest.TestCase):
 
         model = RNTupleModel.Create()
         model.MakeField["int"]("f")
+        model.MakeField["std::string"]("mystr")
+
         with RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_write_read.root") as writer:
             entry = writer.CreateEntry()
             entry["f"] = 42
+            entry["mystr"] = "string stored in RNTuple"
             writer.Fill(entry)
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
@@ -24,3 +28,18 @@ class RNTupleBasics(unittest.TestCase):
         entry = reader.GetModel().CreateEntry()
         reader.LoadEntry(0, entry)
         self.assertEqual(entry["f"], 42)
+        self.assertEqual(entry["mystr"], "string stored in RNTuple")
+
+    def test_forbid_writing_wrong_type(self):
+        """Forbid writing the wrong type into an RNTuple field."""
+
+        model = RNTupleModel.Create()
+        model.MakeField["std::string"]("mystr")
+
+        class WrongClass:
+            ...
+
+        with RNTupleWriter.Recreate(model, "ntpl", "test_ntuple_py_test_forbid_writing_wrong_type.root") as writer:
+            entry = writer.CreateEntry()
+            with self.assertRaises(TypeError):
+                entry["mystr"] = WrongClass()


### PR DESCRIPTION
The value held by an REntry for a particular field is retrieved as a shared_ptr to the underlying data. The actual type of the cppyy proxy depends on the type of the pointee. For most types, the Python proxy is exposed as a the type of the pointee: a `std::shared_ptr<std::vector>` is exposed as a `cppyy.gbl.std.vector`. For fundamental types, this does not happen: a `std::shared_ptr<int>` is exposed as `cppyy.gbl.std.shared_ptr[int]`. In the first case, we can retrieve the actual smart pointer via the `__smartptr__` method of the cppyy proxy. In the latter case, this method will return None.

For reading, it's sufficient to retrieve the smart pointer and return a read-only reference to the pointee via the `__deref__` method.

For writing, there is no automatic support for assignment to the pointee. Thus, a utility helper is introduced in C++. Since this is a very specific case, the helper is only introduced in the RNTuple library.

The test of the Python API is extended with a field of non-fundamental type.
