### PR TITLE
Text precision must be 2 in PaintText

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -10039,7 +10039,7 @@ void THistPainter::PaintText(Option_t *)
 {
 
    TLatex text;
-   text.SetTextFont(gStyle->GetTextFont());
+   text.SetTextFont(((int)gStyle->GetTextFont()/10)*10+2); // font precision must be 2
    text.SetTextColor(fH->GetMarkerColor());
    text.SetTextSize(0.02*fH->GetMarkerSize());
 


### PR DESCRIPTION
In THistPainter::PaintText the text precision must be 2 .
This problem was mention here https://root-forum.cern.ch/t/th2-option-text-not-working-with-font-43/62513
