### PR TITLE
Use legend entry's option instead of object's DrawOption when deciding endcaps

### DIFF
--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -809,14 +809,12 @@ void TLegend::PaintPrimitives()
       // bar are drawn differently.
       Int_t endcaps  = 0; // no endcaps.
       if (eobj) { // eobj == nullptr for the legend header
-         TString eobjopt = eobj->GetDrawOption();
-         eobjopt.ToLower();
-         if (eobjopt.Contains("e1") && eobj->InheritsFrom(TH1::Class())) endcaps = 1; // a bar
+         if (opt.Contains("e1") && eobj->InheritsFrom(TH1::Class())) endcaps = 1; // a bar
          if (eobj->InheritsFrom(TGraph::Class())) {
             endcaps = 1; // a bar, default for TGraph
-            if (eobjopt.Contains("z"))  endcaps = 0; // no endcaps.
-            if (eobjopt.Contains(">"))  endcaps = 2; // empty arrow.
-            if (eobjopt.Contains("|>")) endcaps = 3; // filled arrow.
+            if (opt.Contains("z"))  endcaps = 0; // no endcaps.
+            if (opt.Contains(">"))  endcaps = 2; // empty arrow.
+            if (opt.Contains("|>")) endcaps = 3; // filled arrow.
          }
       }
       float arrow_shift = 0.3;


### PR DESCRIPTION
I have encountered the case where the legend is being drawn to a separate pad from the object, which means the `GetDrawOption()` returns a blank string no matter how it was drawn in the other pad.

It would surely make most sense to have the decision about endcaps be determined from the TLegendEntry option, like all the other aspects of the drawing of the legend entry. 

This PR makes that change.

