### PR TITLE
CI: proper escaping of parentheses

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -535,7 +535,7 @@ def relatedrepo_GetClosestMatch(repo_name: str, origin: str, upstream: str):
     if current_head == "latest-stable":
       # Resolve the 'latest-stable' branch to the latest merged head/tag
       current_head = get_stdout_subprocess(f"""
-           git --git-dir={gitdir} for-each-ref --points-at=latest-stable^2 --format=%\(refname:short\)
+           git --git-dir={gitdir} for-each-ref --points-at=latest-stable^2 --format=%\\(refname:short\\)
            """, "Failed capture of lastest-stable underlying branch name")
       return fetch_url, current_head
 


### PR DESCRIPTION
Fixes:
```
/__w/root/root/.github/workflows/root-ci-config/build_root.py:539: SyntaxWarning: invalid escape sequence '\('
  """, "Failed capture of lastest-stable underlying branch name")
```