### PR TITLE
[RF] Support also `createNLL` in case of partially-extended simul. fits 

### DIFF
--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -636,7 +636,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::validateAbsMin() const
     _paramAbsMin.removeAll() ;
 
     // Only store non-constant parameters here!
-    std::unique_ptr<RooArgSet> tmp{(RooArgSet*) _par.selectByAttrib("Constant",false)};
+    std::unique_ptr<RooArgSet> tmp{_par.selectByAttrib("Constant",false)};
     _paramAbsMin.addClone(*tmp) ;
 
     _obsAbsMin.addClone(_obs) ;

--- a/roofit/roofit/inc/RooChi2MCSModule.h
+++ b/roofit/roofit/inc/RooChi2MCSModule.h
@@ -19,6 +19,8 @@
 
 #include "RooAbsMCStudyModule.h"
 
+#include <memory>
+
 class RooChi2MCSModule : public RooAbsMCStudyModule {
 public:
 
@@ -32,16 +34,13 @@ public:
   bool processAfterFit(Int_t /*sampleNum*/) override  ;
 
 private:
+   std::unique_ptr<RooDataSet> _data;    // Summary dataset to store results
+   std::unique_ptr<RooRealVar> _chi2;    // Chi^2 of function w.r.t. data
+   std::unique_ptr<RooRealVar> _ndof;    // Number of degrees of freedom
+   std::unique_ptr<RooRealVar> _chi2red; // Reduced Chi^2 w.r.t data
+   std::unique_ptr<RooRealVar> _prob;    // Probability of chi^2,nDOF combination
 
-  RooDataSet* _data = nullptr;    // Summary dataset to store results
-  RooRealVar* _chi2 = nullptr;    // Chi^2 of function w.r.t. data
-  RooRealVar* _ndof = nullptr;    // Number of degrees of freedom
-  RooRealVar* _chi2red = nullptr; // Reduced Chi^2 w.r.t data
-  RooRealVar* _prob = nullptr;    // Probability of chi^2,nDOF combination
-
-  ClassDefOverride(RooChi2MCSModule,0) // MCStudy module to calculate chi2 between binned data and fit
-} ;
-
+   ClassDefOverride(RooChi2MCSModule, 0) // MCStudy module to calculate chi2 between binned data and fit
+};
 
 #endif
-

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -120,7 +120,7 @@ bool RooChi2MCSModule::processAfterFit(Int_t /*sampleNum*/)
 
   std::unique_ptr<RooAbsReal> chi2Var{fitModel()->createChi2(*binnedData,RooFit::Extended(extendedGen()),RooFit::DataError(RooAbsData::SumW2))};
 
-  std::unique_ptr<RooArgSet> floatPars{static_cast<RooArgSet*>(fitParams()->selectByAttrib("Constant",false))};
+  std::unique_ptr<RooArgSet> floatPars{fitParams()->selectByAttrib("Constant",false)};
 
   _chi2->setVal(chi2Var->getVal()) ;
   _ndof->setVal(binnedData->numEntries()-floatPars->size()-1) ;

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -50,40 +50,24 @@ RooChi2MCSModule::RooChi2MCSModule(const RooChi2MCSModule &other) : RooAbsMCStud
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
-RooChi2MCSModule:: ~RooChi2MCSModule()
-{
-  if (_chi2) {
-    delete _chi2 ;
-  }
-  if (_ndof) {
-    delete _ndof ;
-  }
-  if (_chi2red) {
-    delete _chi2red ;
-  }
-  if (_prob) {
-    delete _prob ;
-  }
-  if (_data) {
-    delete _data ;
-  }
-}
+RooChi2MCSModule::~RooChi2MCSModule() = default;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize module after attachment to RooMCStudy object
 
 bool RooChi2MCSModule::initializeInstance()
 {
-  // Construct variable that holds -log(L) fit with null hypothesis for given parameter
-  _chi2     = new RooRealVar("chi2","chi^2",0) ;
-  _ndof     = new RooRealVar("ndof","number of degrees of freedom",0) ;
-  _chi2red  = new RooRealVar("chi2red","reduced chi^2",0) ;
-  _prob     = new RooRealVar("prob","prob(chi2,ndof)",0) ;
+   // Construct variable that holds -log(L) fit with null hypothesis for given parameter
+   _chi2 = std::make_unique<RooRealVar>("chi2", "chi^2", 0);
+   _ndof = std::make_unique<RooRealVar>("ndof", "number of degrees of freedom", 0);
+   _chi2red = std::make_unique<RooRealVar>("chi2red", "reduced chi^2", 0);
+   _prob = std::make_unique<RooRealVar>("prob", "prob(chi2,ndof)", 0);
 
-  // Create new dataset to be merged with RooMCStudy::fitParDataSet
-  _data = new RooDataSet("Chi2Data","Additional data for Chi2 study",RooArgSet(*_chi2,*_ndof,*_chi2red,*_prob)) ;
+   // Create new dataset to be merged with RooMCStudy::fitParDataSet
+   _data = std::make_unique<RooDataSet>("Chi2Data", "Additional data for Chi2 study",
+                                        RooArgSet(*_chi2, *_ndof, *_chi2red, *_prob));
 
-  return true ;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,9 +84,9 @@ bool RooChi2MCSModule::initializeRun(Int_t /*numSamples*/)
 /// calculations of this module so that it is merged with
 /// RooMCStudy::fitParDataSet() by RooMCStudy
 
-RooDataSet* RooChi2MCSModule::finalizeRun()
+RooDataSet *RooChi2MCSModule::finalizeRun()
 {
-  return _data ;
+   return _data.get();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -140,6 +140,11 @@ public:
   using RooAbsCollection::selectCommon;
   using RooAbsCollection::snapshot;
 
+  /// Use RooAbsCollection::selectByAttrib(), but return as RooArgSet.
+  RooArgSet* selectByAttrib(const char* name, bool value) const {
+    return static_cast<RooArgSet*>(RooAbsCollection::selectByAttrib(name, value));
+  }
+
   /// Use RooAbsCollection::selectByName(), but return as RooArgSet.
   inline RooArgSet* selectByName(const char* nameList, bool verbose=false) const {
     return static_cast<RooArgSet*>(RooAbsCollection::selectByName(nameList, verbose));

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -52,7 +52,7 @@ getGlobalObservables(RooAbsPdf const &pdf, RooArgSet const *globalObservables, c
 
    if (globalObservablesTag) {
       std::unique_ptr<RooArgSet> allVars{pdf.getVariables()};
-      return std::unique_ptr<RooArgSet>{static_cast<RooArgSet *>(allVars->selectByAttrib(globalObservablesTag, true))};
+      return std::unique_ptr<RooArgSet>{allVars->selectByAttrib(globalObservablesTag, true)};
    }
 
    // no global observables specified

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -107,7 +107,7 @@ int calcAsymptoticCorrectedCovariance(RooAbsReal &pdf, RooMinimizer &minimizer, 
    const RooArgList &floated = rw->floatParsFinal();
    RooArgSet allparams;
    logpdf.getParameters(data.get(), allparams);
-   std::unique_ptr<RooArgSet> floatingparams{static_cast<RooArgSet *>(allparams.selectByAttrib("Constant", false))};
+   std::unique_ptr<RooArgSet> floatingparams{allparams.selectByAttrib("Constant", false)};
 
    const double eps = 1.0e-4;
 
@@ -343,8 +343,8 @@ std::unique_ptr<RooAbsArg> createSimultaneousNLL(RooSimultaneous const &simPdf, 
 
       if (RooAbsPdf *pdf = simPdf.getPdf(catName.c_str())) {
          auto name = std::string("nll_") + pdf->GetName();
-         std::unique_ptr<RooArgSet> observables(
-            static_cast<RooArgSet *>(std::unique_ptr<RooArgSet>(pdf->getVariables())->selectByAttrib("__obs__", true)));
+         std::unique_ptr<RooArgSet> observables{
+            std::unique_ptr<RooArgSet>(pdf->getVariables())->selectByAttrib("__obs__", true)};
          // In a simultaneous fit, it is allowed that only a subset of the pdfs
          // are extended. Therefore, we have to make sure that we don't request
          // extended NLL objects for channels that can't be extended.

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -30,8 +30,6 @@ as a MIGRAD minimization step is executed for each function evaluation
 #include "RooMsgService.h"
 #include "RooRealVar.h"
 
-using std::endl;
-
 ClassImp(RooProfileLL);
 
 
@@ -121,7 +119,7 @@ RooFit::OwningPtr<RooAbsReal> RooProfileLL::createProfile(const RooArgSet& param
 
 void RooProfileLL::initializeMinimizer() const
 {
-  coutI(Minimization) << "RooProfileLL::evaluate(" << GetName() << ") Creating instance of MINUIT" << endl ;
+  coutI(Minimization) << "RooProfileLL::evaluate(" << GetName() << ") Creating instance of MINUIT" << std::endl;
 
   bool smode = RooMsgService::instance().silentMode() ;
   RooMsgService::instance().setSilentMode(true) ;
@@ -192,7 +190,7 @@ void RooProfileLL::validateAbsMin() const
       if (_paramFixed[par->GetName()] != par->isConstant()) {
    cxcoutI(Minimization) << "RooProfileLL::evaluate(" << GetName() << ") constant status of parameter " << par->GetName() << " has changed from "
             << (_paramFixed[par->GetName()]?"fixed":"floating") << " to " << (par->isConstant()?"fixed":"floating")
-            << ", recalculating absolute minimum" << endl ;
+            << ", recalculating absolute minimum" << std::endl;
    _absMinValid = false ;
    break ;
       }
@@ -203,7 +201,7 @@ void RooProfileLL::validateAbsMin() const
   // If we don't have the absolute minimum w.r.t all observables, calculate that first
   if (!_absMinValid) {
 
-    cxcoutI(Minimization) << "RooProfileLL::evaluate(" << GetName() << ") determining minimum likelihood for current configurations w.r.t all observable" << endl ;
+    cxcoutI(Minimization) << "RooProfileLL::evaluate(" << GetName() << ") determining minimum likelihood for current configurations w.r.t all observable" << std::endl;
 
 
     if (!_minimizer) {
@@ -235,7 +233,7 @@ void RooProfileLL::validateAbsMin() const
     _paramAbsMin.removeAll() ;
 
     // Only store non-constant parameters here!
-    _paramAbsMin.addClone(*std::unique_ptr<RooArgSet>{static_cast<RooArgSet*>(_par.selectByAttrib("Constant",false))});
+    _paramAbsMin.addClone(*std::unique_ptr<RooArgSet>{_par.selectByAttrib("Constant", false)});
 
     _obsAbsMin.addClone(_obs) ;
 
@@ -253,7 +251,7 @@ void RooProfileLL::validateAbsMin() const
                                << static_cast<RooAbsReal const*>(arg)->getVal() ;
         first=false ;
       }
-      ccxcoutI(Minimization) << ")" << endl ;
+      ccxcoutI(Minimization) << ")" << std::endl;
     }
 
     // Restore original parameter values

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -169,7 +169,7 @@ void RooRealMPFE::initVars()
 
   // Retrieve non-constant parameters
   auto vars = _arg->getParameters(RooArgSet());
-  //RooArgSet* ncVars = (RooArgSet*) vars->selectByAttrib("Constant",false) ;
+  // RooArgSet *ncVars = vars->selectByAttrib("Constant", false);
   RooArgList varList(*vars) ;
 
   // Save in lists

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1212,8 +1212,8 @@ RooSimultaneous::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
 
       markObs(pdfClone.get(), prefix, normSet);
 
-      std::unique_ptr<RooArgSet> pdfNormSet(
-         static_cast<RooArgSet *>(std::unique_ptr<RooArgSet>(pdfClone->getVariables())->selectByAttrib("__obs__", true)));
+      std::unique_ptr<RooArgSet> pdfNormSet{
+         std::unique_ptr<RooArgSet>(pdfClone->getVariables())->selectByAttrib("__obs__", true)};
 
       if (rangeName) {
          pdfClone->setNormRange(RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, catName).c_str());

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -953,7 +953,7 @@ void RooTreeDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet, c
 
   _cacheOwner = owner ;
 
-  std::unique_ptr<RooArgSet> constExprVarSet{static_cast<RooArgSet*>(newVarSet.selectByAttrib("ConstantExpression",true))};
+  std::unique_ptr<RooArgSet> constExprVarSet{newVarSet.selectByAttrib("ConstantExpression", true)};
 
   bool doTreeFill = (_cachedVars.empty()) ;
 

--- a/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
+++ b/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
@@ -74,7 +74,7 @@ void ConstantTermsOptimizer::enableConstantTermsOptimization(RooAbsReal *functio
          arg->setCacheAndTrackHints(trackNodes);
       }
       // Do not set CacheAndTrack on constant expressions
-      std::unique_ptr<RooArgSet> constNodes{static_cast<RooArgSet *>(trackNodes.selectByAttrib("Constant", true))};
+      std::unique_ptr<RooArgSet> constNodes{trackNodes.selectByAttrib("Constant", true)};
       trackNodes.remove(*constNodes);
 
       // Set CacheAndTrack flag on all remaining nodes
@@ -97,8 +97,7 @@ void ConstantTermsOptimizer::enableConstantTermsOptimization(RooAbsReal *functio
       cacheArg->setOperMode(RooAbsArg::AClean);
    }
 
-   std::unique_ptr<RooArgSet> constNodes{
-      static_cast<RooArgSet *>(cached_nodes.selectByAttrib("ConstantExpressionCached", true))};
+   std::unique_ptr<RooArgSet> constNodes{cached_nodes.selectByAttrib("ConstantExpressionCached", true)};
    RooArgSet actualTrackNodes(cached_nodes);
    actualTrackNodes.remove(*constNodes);
    if (!constNodes->empty()) {

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -52,7 +52,7 @@ namespace RooFit {
  *
  * The coupling of all these classes to RooMinimizer is made via the MinuitFcnGrad class, which owns the Wrappers that
  * calculate the likelihood components.
- * 
+ *
  * More extensive documentation is available at
  * https://github.com/root-project/root/blob/master/roofit/doc/developers/test_statistics.md
  */
@@ -97,7 +97,8 @@ RooArgSet getConstraintsSet(RooAbsPdf *pdf, RooAbsData *data, RooArgSet constrai
          global_observables.removeAll();
       }
       std::unique_ptr<RooArgSet> allVars{pdf->getVariables()};
-      global_observables.add(*dynamic_cast<RooArgSet *>(allVars->selectByAttrib(global_observables_tag.c_str(), true)));
+      global_observables.add(
+         *std::unique_ptr<RooArgSet>{allVars->selectByAttrib(global_observables_tag.c_str(), true)});
       oocoutI(nullptr, Minimization) << "User-defined specification of global observables definition with tag named '"
                                      << global_observables_tag << "'" << std::endl;
    } else if (global_observables.empty()) {
@@ -109,7 +110,7 @@ RooArgSet getConstraintsSet(RooAbsPdf *pdf, RooAbsData *data, RooArgSet constrai
             << "p.d.f. provides built-in specification of global observables definition with tag named '"
             << defGlobObsTag << "'" << std::endl;
          std::unique_ptr<RooArgSet> allVars{pdf->getVariables()};
-         global_observables.add(*dynamic_cast<RooArgSet *>(allVars->selectByAttrib(defGlobObsTag, true)));
+         global_observables.add(*std::unique_ptr<RooArgSet>{allVars->selectByAttrib(defGlobObsTag, true)});
       }
    }
 


### PR DESCRIPTION
Support also `createNLL` in case of partially-extended simultaneous fits
with the new default CPU backend (and hence also "codegen").

This problem was reported by @gartrog in private communication.

The fix needs to be backported to the next 6.34 patch release.

Add also a corresponding test.

Some more commits in this PR improve the `RooArgSet` interface, fix a memory leak, and avoid manual memory management.