### PR TITLE
I/O Customizaton Rules: add support for changing the input type.

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -64,6 +64,8 @@ The following people have contributed to this new version:
     [RNTupleMergeOptions](https://root.cern/doc/v634/structROOT_1_1Experimental_1_1Internal_1_1RNTupleMergeOptions.html));
   * "rntuple.ErrBehavior=(Abort|Skip)": RNTuple-specific option that specifies the behavior of the RNTupleMerger on error (see link above);
   * "rntuple.ExtraVerbose": RNTuple-specific option that tells the RNTupleMerger to emit more information during the merge process.
+* New attribute for I/O customization rules: `CanIgnore`.  When using this attribute the rule will be ignored
+if the input is missing from the schema/class-layout they apply to instead of issue a `Warning`
 
 ## RDataFrame
 

--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -64,8 +64,7 @@ The following people have contributed to this new version:
     [RNTupleMergeOptions](https://root.cern/doc/v634/structROOT_1_1Experimental_1_1Internal_1_1RNTupleMergeOptions.html));
   * "rntuple.ErrBehavior=(Abort|Skip)": RNTuple-specific option that specifies the behavior of the RNTupleMerger on error (see link above);
   * "rntuple.ExtraVerbose": RNTuple-specific option that tells the RNTupleMerger to emit more information during the merge process.
-* New attribute for I/O customization rules: `CanIgnore`.  When using this attribute the rule will be ignored
-if the input is missing from the schema/class-layout they apply to instead of issue a `Warning`
+* New attribute for I/O customization rules: `CanIgnore`.  When using this attribute the rule will be ignored if the input is missing from the schema/class-layout they apply to instead of issue a `Warning`
 
 ## RDataFrame
 

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -568,6 +568,16 @@ void WriteClassInit(std::ostream& finalString,
                     bool& needCollectionProxy);
 
 //______________________________________________________________________________
+void WriteStandaloneReadRules(std::ostream &finalString, bool rawrules,
+                              std::vector<std::string> &standaloneTargets,
+                              const cling::Interpreter &interp);
+
+//______________________________________________________________________________
+void WriteRulesRegistration(std::ostream &finalString,
+                            const std::string &dictName,
+                            const std::vector<std::string> &standaloneTargets);
+
+//______________________________________________________________________________
 bool HasCustomStreamerMemberFunction(const AnnotatedRecordDecl &cl,
                                      const clang::CXXRecordDecl* clxx,
                                      const cling::Interpreter &interp,

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -568,13 +568,11 @@ void WriteClassInit(std::ostream& finalString,
                     bool& needCollectionProxy);
 
 //______________________________________________________________________________
-void WriteStandaloneReadRules(std::ostream &finalString, bool rawrules,
-                              std::vector<std::string> &standaloneTargets,
+void WriteStandaloneReadRules(std::ostream &finalString, bool rawrules, std::vector<std::string> &standaloneTargets,
                               const cling::Interpreter &interp);
 
 //______________________________________________________________________________
-void WriteRulesRegistration(std::ostream &finalString,
-                            const std::string &dictName,
+void WriteRulesRegistration(std::ostream &finalString, const std::string &dictName,
                             const std::vector<std::string> &standaloneTargets);
 
 //______________________________________________________________________________

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1823,7 +1823,7 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
       int i = 0;
       finalString << "\n   // Schema evolution read functions\n";
       std::list<ROOT::SchemaRuleMap_t>::iterator rIt = rulesIt1->second.fRules.begin();
-      while( rIt != rulesIt1->second.fRules.end() ) {
+      while (rIt != rulesIt1->second.fRules.end()) {
 
          //--------------------------------------------------------------------
          // Check if the rules refer to valid data members
@@ -1858,7 +1858,7 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
       int i = 0;
       finalString << "\n   // Schema evolution read raw functions\n";
       std::list<ROOT::SchemaRuleMap_t>::iterator rIt = rulesIt2->second.fRules.begin();
-      while( rIt != rulesIt2->second.fRules.end() ) {
+      while (rIt != rulesIt2->second.fRules.end()) {
 
          //--------------------------------------------------------------------
          // Check if the rules refer to valid data members
@@ -2052,14 +2052,14 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
 
    if( rulesIt1 != ROOT::gReadRules.end() ) {
       finalString << "\n" << "      // the io read rules" << "\n" << "      std::vector<::ROOT::Internal::TSchemaHelper> readrules(" << rulesIt1->second.size() << ");" << "\n";
-      ROOT::WriteSchemaList( rulesIt1->second.fRules, "readrules", finalString );
+      ROOT::WriteSchemaList(rulesIt1->second.fRules, "readrules", finalString);
       finalString << "      instance.SetReadRules( readrules );" << "\n";
       rulesIt1->second.fGenerated = true;
    }
 
    if( rulesIt2 != ROOT::gReadRawRules.end() ) {
       finalString << "\n" << "      // the io read raw rules" << "\n" << "      std::vector<::ROOT::Internal::TSchemaHelper> readrawrules(" << rulesIt2->second.size() << ");" << "\n";
-      ROOT::WriteSchemaList( rulesIt2->second.fRules, "readrawrules", finalString );
+      ROOT::WriteSchemaList(rulesIt2->second.fRules, "readrawrules", finalString);
       finalString << "      instance.SetReadRawRules( readrawrules );" << "\n";
       rulesIt2->second.fGenerated = true;
    }
@@ -2193,19 +2193,17 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
 
 void ROOT::TMetaUtils::WriteStandaloneReadRules(std::ostream &finalString, bool rawrules,
                                                 std::vector<std::string> &standaloneTargets,
-                                                const cling::Interpreter& interp)
+                                                const cling::Interpreter &interp)
 {
-   for (auto &rulesIt1 : rawrules? ROOT::gReadRawRules : ROOT::gReadRules) {
+   for (auto &rulesIt1 : rawrules ? ROOT::gReadRawRules : ROOT::gReadRules) {
       if (!rulesIt1.second.fGenerated) {
          const clang::Type *typeptr = nullptr;
-         const clang::CXXRecordDecl *target
-            = ROOT::TMetaUtils::ScopeSearch(rulesIt1.first.c_str(), interp,
-                                            true /*diag*/, &typeptr);
-
+         const clang::CXXRecordDecl *target =
+            ROOT::TMetaUtils::ScopeSearch(rulesIt1.first.c_str(), interp, true /*diag*/, &typeptr);
 
          if (!target && !rulesIt1.second.fTargetDecl) {
             ROOT::TMetaUtils::Warning(nullptr, "%d Rule(s) for target class %s was not used!\n", rulesIt1.second.size(),
-                                    rulesIt1.first.c_str());
+                                      rulesIt1.first.c_str());
             continue;
          }
 
@@ -2256,8 +2254,7 @@ void ROOT::TMetaUtils::WriteStandaloneReadRules(std::ostream &finalString, bool 
    }
 }
 
-void ROOT::TMetaUtils::WriteRulesRegistration(std::ostream &finalString,
-                                              const std::string &dictName,
+void ROOT::TMetaUtils::WriteRulesRegistration(std::ostream &finalString, const std::string &dictName,
                                               const std::vector<std::string> &standaloneTargets)
 {
    std::string functionname("RecordReadRules_");
@@ -2267,27 +2264,31 @@ void ROOT::TMetaUtils::WriteRulesRegistration(std::ostream &finalString,
    finalString << "   // Registration Schema evolution read functions\n";
    finalString << "   int " << functionname << "() {" << "\n";
    if (!standaloneTargets.empty())
-      finalString << "\n" << "      ::ROOT::Internal::TSchemaHelper* rule;" << "\n";
-   for (const auto &target : standaloneTargets)
-   {
+      finalString << "\n"
+                  << "      ::ROOT::Internal::TSchemaHelper* rule;" << "\n";
+   for (const auto &target : standaloneTargets) {
       std::string name;
       TClassEdit::GetNormalizedName(name, target);
 
-      ROOT::SchemaRuleClassMap_t::iterator rulesIt1 = ROOT::gReadRules.find( target.c_str() );
+      ROOT::SchemaRuleClassMap_t::iterator rulesIt1 = ROOT::gReadRules.find(target.c_str());
       finalString << "    {\n";
       if (rulesIt1 != ROOT::gReadRules.end()) {
          finalString << "      // the io read rules for " << target << "\n";
-         finalString << "      std::vector<::ROOT::Internal::TSchemaHelper> readrules(" << rulesIt1->second.size() << ");" << "\n";
-         ROOT::WriteSchemaList( rulesIt1->second.fRules, "readrules", finalString );
-         finalString << "      TClass::RegisterReadRules(TSchemaRule::kReadRule, \"" << name << "\", std::move(readrules));\n";
+         finalString << "      std::vector<::ROOT::Internal::TSchemaHelper> readrules(" << rulesIt1->second.size()
+                     << ");" << "\n";
+         ROOT::WriteSchemaList(rulesIt1->second.fRules, "readrules", finalString);
+         finalString << "      TClass::RegisterReadRules(TSchemaRule::kReadRule, \"" << name
+                     << "\", std::move(readrules));\n";
          rulesIt1->second.fGenerated = true;
       }
-      ROOT::SchemaRuleClassMap_t::iterator rulesIt2 = ROOT::gReadRawRules.find( target.c_str() );
+      ROOT::SchemaRuleClassMap_t::iterator rulesIt2 = ROOT::gReadRawRules.find(target.c_str());
       if (rulesIt2 != ROOT::gReadRawRules.end()) {
          finalString << "\n      // the io read raw rules for " << target << "\n";
-         finalString << "      std::vector<::ROOT::Internal::TSchemaHelper> readrawrules(" << rulesIt2->second.size() << ");" << "\n";
-         ROOT::WriteSchemaList( rulesIt2->second.fRules, "readrawrules", finalString );
-         finalString << "      TClass::RegisterReadRules(TSchemaRule::kReadRawRule, \"" << name << "\", std::move(readrawrules));\n";
+         finalString << "      std::vector<::ROOT::Internal::TSchemaHelper> readrawrules(" << rulesIt2->second.size()
+                     << ");" << "\n";
+         ROOT::WriteSchemaList(rulesIt2->second.fRules, "readrawrules", finalString);
+         finalString << "      TClass::RegisterReadRules(TSchemaRule::kReadRawRule, \"" << name
+                     << "\", std::move(readrawrules));\n";
          rulesIt2->second.fGenerated = true;
       }
       finalString << "    }\n";
@@ -2295,7 +2296,7 @@ void ROOT::TMetaUtils::WriteRulesRegistration(std::ostream &finalString,
    finalString << "      return 0;\n";
    finalString << "   }\n";
    finalString << "   static int _R__UNIQUE_DICT_(ReadRules_" << dictName << ") = " << functionname << "();";
-   finalString<<  "R__UseDummy(_R__UNIQUE_DICT_(ReadRules_" << dictName << "));" << "\n";
+   finalString << "R__UseDummy(_R__UNIQUE_DICT_(ReadRules_" << dictName << "));" << "\n";
    finalString << "} // namespace ROOT" << "\n";
 }
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2649,15 +2649,9 @@ int FinalizeStreamerInfoWriting(cling::Interpreter &interp, bool writeEmptyRootP
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int GenerateFullDict(std::ostream &dictStream,
-                     std::string dictName,
-                     cling::Interpreter &interp,
-                     RScanner &scan,
-                     const ROOT::TMetaUtils::RConstructorTypes &ctorTypes,
-                     bool isSplit,
-                     bool isGenreflex,
-                     bool isSelXML,
-                     bool writeEmptyRootPCM)
+int GenerateFullDict(std::ostream &dictStream, std::string dictName, cling::Interpreter &interp, RScanner &scan,
+                     const ROOT::TMetaUtils::RConstructorTypes &ctorTypes, bool isSplit, bool isGenreflex,
+                     bool isSelXML, bool writeEmptyRootPCM)
 {
    ROOT::TMetaUtils::TNormalizedCtxt normCtxt(interp.getLookupHelper());
 
@@ -4967,15 +4961,8 @@ int RootClingMain(int argc,
          rootclingRetCode +=  FinalizeStreamerInfoWriting(interp);
       }
    } else {
-      rootclingRetCode += GenerateFullDict(*splitDictStream,
-                                 modGen.GetDictionaryName(),
-                                 interp,
-                                 scan,
-                                 constructorTypes,
-                                 gOptSplit,
-                                 isGenreflex,
-                                 isSelXML,
-                                 gOptWriteEmptyRootPCM);
+      rootclingRetCode += GenerateFullDict(*splitDictStream, modGen.GetDictionaryName(), interp, scan, constructorTypes,
+                                           gOptSplit, isGenreflex, isSelXML, gOptWriteEmptyRootPCM);
    }
 
    if (rootclingRetCode != 0) {

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2650,6 +2650,7 @@ int FinalizeStreamerInfoWriting(cling::Interpreter &interp, bool writeEmptyRootP
 ////////////////////////////////////////////////////////////////////////////////
 
 int GenerateFullDict(std::ostream &dictStream,
+                     std::string dictName,
                      cling::Interpreter &interp,
                      RScanner &scan,
                      const ROOT::TMetaUtils::RConstructorTypes &ctorTypes,
@@ -2794,6 +2795,11 @@ int GenerateFullDict(std::ostream &dictStream,
       ROOT::Internal::RStl::Instance().WriteClassInit(dictStream, interp, normCtxt, ctorTypes, needsCollectionProxy,
                                                       EmitStreamerInfo);
    }
+
+   std::vector<std::string> standaloneTargets;
+   ROOT::TMetaUtils::WriteStandaloneReadRules(dictStream, false, standaloneTargets, interp);
+   ROOT::TMetaUtils::WriteStandaloneReadRules(dictStream, true, standaloneTargets, interp);
+   ROOT::TMetaUtils::WriteRulesRegistration(dictStream, dictName, standaloneTargets);
 
    if (!gDriverConfig->fBuildingROOTStage1) {
       EmitTypedefs(scan.fSelectedTypedefs);
@@ -4962,6 +4968,7 @@ int RootClingMain(int argc,
       }
    } else {
       rootclingRetCode += GenerateFullDict(*splitDictStream,
+                                 modGen.GetDictionaryName(),
                                  interp,
                                  scan,
                                  constructorTypes,

--- a/core/foundation/res/RConversionRuleParser.h
+++ b/core/foundation/res/RConversionRuleParser.h
@@ -15,7 +15,7 @@
 #include "DllImport.h"
 
 namespace clang {
-   class CXXRecordDecl;
+class CXXRecordDecl;
 }
 
 namespace ROOT

--- a/core/foundation/res/RConversionRuleParser.h
+++ b/core/foundation/res/RConversionRuleParser.h
@@ -14,13 +14,24 @@
 #include "TSchemaType.h"
 #include "DllImport.h"
 
+namespace clang {
+   class CXXRecordDecl;
+}
+
 namespace ROOT
 {
    //---------------------------------------------------------------------------
    // Global variables
    //---------------------------------------------------------------------------
    typedef std::map<std::string, std::string> SchemaRuleMap_t;
-   typedef std::map<std::string, std::list<SchemaRuleMap_t> > SchemaRuleClassMap_t;
+   struct RRulesList {
+      bool fGenerated = false;
+      std::list<SchemaRuleMap_t> fRules;
+      const clang::CXXRecordDecl *fTargetDecl;
+
+      size_t size() const { return fRules.size(); }
+   };
+   typedef std::map<std::string, RRulesList> SchemaRuleClassMap_t;
    R__EXTERN SchemaRuleClassMap_t gReadRules;
    R__EXTERN SchemaRuleClassMap_t gReadRawRules;
 

--- a/core/foundation/src/RConversionRuleParser.cxx
+++ b/core/foundation/src/RConversionRuleParser.cxx
@@ -864,7 +864,7 @@ namespace ROOT
       //////////////////////////////////////////////////////////////////////////
 
       for( it = gReadRules.begin(); it != gReadRules.end(); ++it ) {
-         for( rule = it->second.begin(); rule != it->second.end(); ++rule ) {
+         for( rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule ) {
             attr = rule->find( "include" );
             if( attr == rule->end() ) continue;
             TSchemaRuleProcessor::SplitList( attr->second, tmp );
@@ -877,7 +877,7 @@ namespace ROOT
       //////////////////////////////////////////////////////////////////////////
 
       for( it = gReadRawRules.begin(); it != gReadRawRules.end(); ++it ) {
-         for( rule = it->second.begin(); rule != it->second.end(); ++rule ) {
+         for( rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule ) {
             attr = rule->find( "include" );
             if( attr == rule->end() ) continue;
             TSchemaRuleProcessor::SplitList( attr->second, tmp );
@@ -923,10 +923,10 @@ namespace ROOT
       if( it == gReadRules.end() ) {
          std::list<SchemaRuleMap_t> lst;
          lst.push_back( rule );
-         gReadRules[normalizedTargetName] = lst;
+         gReadRules[normalizedTargetName].fRules = lst;
       }
       else
-         it->second.push_back( rule );
+         it->second.fRules.push_back( rule );
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -958,10 +958,10 @@ namespace ROOT
       if( it == gReadRawRules.end() ) {
          std::list<SchemaRuleMap_t> lst;
          lst.push_back( rule );
-         gReadRawRules[normalizedTargetName] = lst;
+         gReadRawRules[normalizedTargetName].fRules = lst;
       }
       else
-         it->second.push_back( rule );
+         it->second.fRules.push_back( rule );
    }
 
 

--- a/core/foundation/src/RConversionRuleParser.cxx
+++ b/core/foundation/src/RConversionRuleParser.cxx
@@ -864,7 +864,7 @@ namespace ROOT
       //////////////////////////////////////////////////////////////////////////
 
       for( it = gReadRules.begin(); it != gReadRules.end(); ++it ) {
-         for( rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule ) {
+         for (rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule) {
             attr = rule->find( "include" );
             if( attr == rule->end() ) continue;
             TSchemaRuleProcessor::SplitList( attr->second, tmp );
@@ -877,7 +877,7 @@ namespace ROOT
       //////////////////////////////////////////////////////////////////////////
 
       for( it = gReadRawRules.begin(); it != gReadRawRules.end(); ++it ) {
-         for( rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule ) {
+         for (rule = it->second.fRules.begin(); rule != it->second.fRules.end(); ++rule) {
             attr = rule->find( "include" );
             if( attr == rule->end() ) continue;
             TSchemaRuleProcessor::SplitList( attr->second, tmp );
@@ -926,7 +926,7 @@ namespace ROOT
          gReadRules[normalizedTargetName].fRules = lst;
       }
       else
-         it->second.fRules.push_back( rule );
+         it->second.fRules.push_back(rule);
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -961,7 +961,7 @@ namespace ROOT
          gReadRawRules[normalizedTargetName].fRules = lst;
       }
       else
-         it->second.fRules.push_back( rule );
+         it->second.fRules.push_back(rule);
    }
 
 

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -22,6 +22,7 @@
 
 #include "TDictionary.h"
 #include "TString.h"
+#include "TSchemaRule.h"
 
 #ifdef R__LESS_INCLUDES
 class TObjArray;
@@ -36,6 +37,7 @@ class TObjArray;
 #include <cstddef>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <atomic>
@@ -72,6 +74,7 @@ namespace ROOT {
    }
    namespace Internal {
       class TCheckHashRecursiveRemoveConsistency;
+      struct TSchemaHelper;
    }
 }
 
@@ -361,6 +364,9 @@ protected:
    void GetMissingDictionariesWithRecursionCheck(TCollection &result, TCollection &visited, bool recurse);
    void GetMissingDictionariesForPairElements(TCollection &result, TCollection &visited, bool recurse);
 
+   using SchemaHelperMap_t = std::unordered_map<std::string, std::vector<ROOT::Internal::TSchemaHelper>>;
+   static SchemaHelperMap_t &GetReadRulesRegistry(ROOT::TSchemaRule::RuleType_t type);
+
 public:
    TClass();
    TClass(const char *name, Bool_t silent = kFALSE);
@@ -539,6 +545,7 @@ public:
    Long_t             Property() const override;
    Int_t              ReadBuffer(TBuffer &b, void *pointer, Int_t version, UInt_t start, UInt_t count);
    Int_t              ReadBuffer(TBuffer &b, void *pointer);
+   static void        RegisterReadRules(ROOT::TSchemaRule::RuleType_t, const char *classname, std::vector<::ROOT::Internal::TSchemaHelper> &&rules);
    void               RegisterStreamerInfo(TVirtualStreamerInfo *info);
    void               RemoveStreamerInfo(Int_t slot);
    void               ReplaceWith(TClass *newcl) const;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -545,7 +545,8 @@ public:
    Long_t             Property() const override;
    Int_t              ReadBuffer(TBuffer &b, void *pointer, Int_t version, UInt_t start, UInt_t count);
    Int_t              ReadBuffer(TBuffer &b, void *pointer);
-   static void        RegisterReadRules(ROOT::TSchemaRule::RuleType_t, const char *classname, std::vector<::ROOT::Internal::TSchemaHelper> &&rules);
+   static void        RegisterReadRules(ROOT::TSchemaRule::RuleType_t, const char *classname,
+                                        std::vector<::ROOT::Internal::TSchemaHelper> &&rules);
    void               RegisterStreamerInfo(TVirtualStreamerInfo *info);
    void               RemoveStreamerInfo(Int_t slot);
    void               ReplaceWith(TClass *newcl) const;

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -15,9 +15,9 @@ class TVirtualObject;
 class TObjArray;
 namespace ROOT {
 namespace Internal {
-   struct TSchemaHelper;
+struct TSchemaHelper;
 }
-}
+} // namespace ROOT
 
 namespace ROOT {
 
@@ -47,17 +47,14 @@ namespace ROOT {
 
             Int_t GetPointerLevel() const { return fPointerLevel; }
 
-            const char* GetUnderlyingTypeName() const
-            {
-               return fTitle;
-            }
+            const char *GetUnderlyingTypeName() const { return fTitle; }
 
             // The source can be declared with:
             //   "%s %s%s;", GetTypeForDeclaration().Data(), GetName(), GetDimensions);
             TString GetTypeForDeclaration()
             {
                TString type = fTitle;
-               for(Int_t s = 0; s < fPointerLevel; ++s)
+               for (Int_t s = 0; s < fPointerLevel; ++s)
                   type.Append('*');
                return type;
             }
@@ -81,7 +78,7 @@ namespace ROOT {
          typedef void (*ReadRawFuncPtr_t)( char*, TBuffer&);
 
          TSchemaRule();
-         TSchemaRule(RuleType_t type, const char *targetClass, const ROOT::Internal::TSchemaHelper& helper);
+         TSchemaRule(RuleType_t type, const char *targetClass, const ROOT::Internal::TSchemaHelper &helper);
          virtual ~TSchemaRule();
 
          TSchemaRule( const TSchemaRule& rhs );

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -23,13 +23,46 @@ namespace ROOT {
          class TSources : public TNamed {
          private:
             TString fDimensions;
+            Int_t fPointerLevel = 0;
+
          public:
-            TSources(const char *name = nullptr, const char *title = nullptr, const char *dims = nullptr) : TNamed(name,title), fDimensions(dims) {}
-            const char *GetDimensions() { return fDimensions; }
+            TSources(const char *name = nullptr, const char *title = nullptr, const char *dims = nullptr)
+               : TNamed(name, title), fDimensions(dims)
+            {
+               if (fTitle.Length())
+                  while (fTitle[fTitle.Length() - fPointerLevel - 1] == '*')
+                     ++fPointerLevel;
+               if (fPointerLevel)
+                  fTitle.Remove(fTitle.Length() - fPointerLevel);
+            }
 
-            const char* GetTypeName() { return GetTitle(); }
+            const char *GetDimensions() const { return fDimensions; }
 
-            ClassDefOverride(TSources,2);
+            bool IsPointer() const { return fPointerLevel > 0; }
+
+            Int_t GetPointerLevel() const { return fPointerLevel; }
+
+            const char* GetUnderlyingTypeName() const
+            {
+               return fTitle;
+            }
+
+            // The source can be declared with:
+            //   "%s %s%s;", GetTypeForDeclaration().Data(), GetName(), GetDimensions);
+            TString GetTypeForDeclaration()
+            {
+               TString type = fTitle;
+               for(Int_t s = 0; s < fPointerLevel; ++s)
+                  type.Append('*');
+               return type;
+            }
+
+            void SetTitle(const char *) override
+            {
+               Fatal("SetTitle", "Changing the type represented by a TSources is not supported.");
+            }
+
+            ClassDefOverride(TSources, 3);
          };
 
          typedef enum

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -27,6 +27,8 @@ namespace ROOT {
             TSources(const char *name = nullptr, const char *title = nullptr, const char *dims = nullptr) : TNamed(name,title), fDimensions(dims) {}
             const char *GetDimensions() { return fDimensions; }
 
+            const char* GetTypeName() { return GetTitle(); }
+
             ClassDefOverride(TSources,2);
          };
 

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -13,6 +13,11 @@
 class TBuffer;
 class TVirtualObject;
 class TObjArray;
+namespace ROOT {
+namespace Internal {
+   struct TSchemaHelper;
+}
+}
 
 namespace ROOT {
 
@@ -76,6 +81,7 @@ namespace ROOT {
          typedef void (*ReadRawFuncPtr_t)( char*, TBuffer&);
 
          TSchemaRule();
+         TSchemaRule(RuleType_t type, const char *targetClass, const ROOT::Internal::TSchemaHelper& helper);
          virtual ~TSchemaRule();
 
          TSchemaRule( const TSchemaRule& rhs );

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1719,17 +1719,19 @@ void TClass::Init(const char *name, Version_t cversion,
       // std::pairs have implicit conversions
       GetSchemaRules(kTRUE);
    }
-   for(auto ruletype : {ROOT::TSchemaRule::kReadRule, ROOT::TSchemaRule::kReadRawRule}) {
+   for (auto ruletype : {ROOT::TSchemaRule::kReadRule, ROOT::TSchemaRule::kReadRawRule}) {
       auto &registry = GetReadRulesRegistry(ruletype);
       auto rulesiter = registry.find(GetName());
       if (rulesiter != registry.end()) {
-         auto rset = GetSchemaRules( kTRUE );
-         for(const auto &helper : rulesiter->second) {
+         auto rset = GetSchemaRules(kTRUE);
+         for (const auto &helper : rulesiter->second) {
             auto rule = new ROOT::TSchemaRule(ruletype, GetName(), helper);
             TString errmsg;
-            if( !rset->AddRule( rule, ROOT::Detail::TSchemaRuleSet::kCheckAll, &errmsg ) ) {
-               Warning( "Init", "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
-                        GetName(), helper.fVersion.c_str(), helper.fTarget.c_str(), errmsg.Data() );
+            if (!rset->AddRule(rule, ROOT::Detail::TSchemaRuleSet::kCheckAll, &errmsg)) {
+               Warning(
+                  "Init",
+                  "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
+                  GetName(), helper.fVersion.c_str(), helper.fTarget.c_str(), errmsg.Data());
                delete rule;
             }
          }
@@ -3624,16 +3626,16 @@ TRealData* TClass::GetRealData(const char* name) const
    // Try ignoring the array dimensions.
    std::string::size_type firstBracket = givenName.find_first_of("[");
    std::string nameNoDim(givenName.substr(0, firstBracket));
-   TObjLink* lnk = fRealData->FirstLink();
+   TObjLink *lnk = fRealData->FirstLink();
    while (lnk) {
-      TObject* obj = lnk->GetObject();
+      TObject *obj = lnk->GetObject();
       std::string objName(obj->GetName());
       std::string::size_type pos = objName.find_first_of("[");
       if (pos != std::string::npos) {
          objName.erase(pos);
       }
       if (objName == nameNoDim) {
-         return static_cast<TRealData*>(obj);
+         return static_cast<TRealData *>(obj);
       }
       lnk = lnk->Next();
    }
@@ -6918,10 +6920,10 @@ void TClass::StreamerTObject(const TClass* pThis, void *object, TBuffer &b, cons
 ////////////////////////////////////////////////////////////////////////////////
 /// Case of TObjects when fIsOffsetStreamerSet is known to have been set.
 
-void TClass::StreamerTObjectInitialized(const TClass* pThis, void *object, TBuffer &b, const TClass *onfile_class)
+void TClass::StreamerTObjectInitialized(const TClass *pThis, void *object, TBuffer &b, const TClass *onfile_class)
 {
    if (R__likely(onfile_class == nullptr || pThis == onfile_class)) {
-      TObject *tobj = (TObject*)((Longptr_t)object + pThis->fOffsetStreamer);
+      TObject *tobj = (TObject *)((Longptr_t)object + pThis->fOffsetStreamer);
       tobj->Streamer(b);
    } else {
       // This is the case where we are reading an object of a derived class
@@ -7409,20 +7411,22 @@ TVirtualStreamerInfo *TClass::FindConversionStreamerInfo( const TClass* cl, UInt
 /// Rules will end up here if they are created in a dictionary file that does not
 /// contain the dictionary for the target class.
 
-void TClass::RegisterReadRules(ROOT::TSchemaRule::RuleType_t type,
-                               const char *classname, std::vector<::ROOT::Internal::TSchemaHelper> &&rules)
+void TClass::RegisterReadRules(ROOT::TSchemaRule::RuleType_t type, const char *classname,
+                               std::vector<::ROOT::Internal::TSchemaHelper> &&rules)
 {
    R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    auto cl = TClass::GetClass(classname, false, false);
    if (cl) {
-      auto rset = cl->GetSchemaRules( kTRUE );
-      for(const auto &it : rules) {
+      auto rset = cl->GetSchemaRules(kTRUE);
+      for (const auto &it : rules) {
          auto rule = new ROOT::TSchemaRule(type, cl->GetName(), it);
          TString errmsg;
-         if( !rset->AddRule( rule, ROOT::Detail::TSchemaRuleSet::kCheckAll, &errmsg ) ) {
-            ::Warning( "TGenericClassInfo", "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
-                        cl->GetName(), it.fVersion.c_str(), it.fTarget.c_str(), errmsg.Data() );
+         if (!rset->AddRule(rule, ROOT::Detail::TSchemaRuleSet::kCheckAll, &errmsg)) {
+            ::Warning(
+               "TGenericClassInfo",
+               "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
+               cl->GetName(), it.fVersion.c_str(), it.fTarget.c_str(), errmsg.Data());
             delete rule;
          }
       }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6918,10 +6918,17 @@ void TClass::StreamerTObject(const TClass* pThis, void *object, TBuffer &b, cons
 ////////////////////////////////////////////////////////////////////////////////
 /// Case of TObjects when fIsOffsetStreamerSet is known to have been set.
 
-void TClass::StreamerTObjectInitialized(const TClass* pThis, void *object, TBuffer &b, const TClass * /* onfile_class */)
+void TClass::StreamerTObjectInitialized(const TClass* pThis, void *object, TBuffer &b, const TClass *onfile_class)
 {
-   TObject *tobj = (TObject*)((Longptr_t)object + pThis->fOffsetStreamer);
-   tobj->Streamer(b);
+   if (R__likely(onfile_class == nullptr || pThis == onfile_class)) {
+      TObject *tobj = (TObject*)((Longptr_t)object + pThis->fOffsetStreamer);
+      tobj->Streamer(b);
+   } else {
+      // This is the case where we are reading an object of a derived class
+      // but the class is not the same as the one we are streaming.
+      // We need to call the Streamer of the base class.
+      StreamerTObjectEmulated(pThis, object, b, onfile_class);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3593,23 +3593,19 @@ TRealData* TClass::GetRealData(const char* name) const
 
    // Try ignoring the array dimensions.
    std::string::size_type firstBracket = givenName.find_first_of("[");
-   if (firstBracket != std::string::npos) {
-      // -- We are looking for an array data member.
-      std::string nameNoDim(givenName.substr(0, firstBracket));
-      TObjLink* lnk = fRealData->FirstLink();
-      while (lnk) {
-         TObject* obj = lnk->GetObject();
-         std::string objName(obj->GetName());
-         std::string::size_type pos = objName.find_first_of("[");
-         // Only match arrays to arrays for now.
-         if (pos != std::string::npos) {
-            objName.erase(pos);
-            if (objName == nameNoDim) {
-               return static_cast<TRealData*>(obj);
-            }
-         }
-         lnk = lnk->Next();
+   std::string nameNoDim(givenName.substr(0, firstBracket));
+   TObjLink* lnk = fRealData->FirstLink();
+   while (lnk) {
+      TObject* obj = lnk->GetObject();
+      std::string objName(obj->GetName());
+      std::string::size_type pos = objName.find_first_of("[");
+      if (pos != std::string::npos) {
+         objName.erase(pos);
       }
+      if (objName == nameNoDim) {
+         return static_cast<TRealData*>(obj);
+      }
+      lnk = lnk->Next();
    }
 
    // Now try it as a pointer.

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3557,7 +3557,7 @@ Longptr_t TClass::GetDataMemberOffset(const char *name) const
          return info->GetOffset(name);
       }
    }
-   return 0;
+   return TVirtualStreamerInfo::kMissing;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7403,7 +7403,7 @@ void TClass::RemoveStreamerInfo(Int_t slot)
    if (fStreamerInfo->GetSize() >= slot) {
       R__LOCKGUARD(gInterpreterMutex);
       TVirtualStreamerInfo *info = (TVirtualStreamerInfo*)fStreamerInfo->At(slot);
-      fStreamerInfo->RemoveAt(fClassVersion);
+      fStreamerInfo->RemoveAt(slot);
       if (fLastReadInfo.load() == info)
          fLastReadInfo = nullptr;
       if (fCurrentInfo.load() == info)

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -331,27 +331,10 @@ namespace Internal {
       TString errmsg;
       std::vector<Internal::TSchemaHelper>::iterator it;
       for( it = vect.begin(); it != vect.end(); ++it ) {
-         rule = new TSchemaRule();
-         rule->SetTarget( it->fTarget );
-         rule->SetTargetClass( fClass->GetName() );
-         rule->SetSourceClass( it->fSourceClass );
-         rule->SetSource( it->fSource );
-         rule->SetCode( it->fCode );
-         rule->SetVersion( it->fVersion );
-         rule->SetChecksum( it->fChecksum );
-         rule->SetEmbed( it->fEmbed );
-         rule->SetInclude( it->fInclude );
-         rule->SetAttributes( it->fAttributes );
+         rule = new TSchemaRule(ProcessReadRules ? TSchemaRule::kReadRule : TSchemaRule::kReadRawRule,
+                                fClass->GetName(), *it);
 
-         if( ProcessReadRules ) {
-            rule->SetRuleType( TSchemaRule::kReadRule );
-            rule->SetReadFunctionPointer( (TSchemaRule::ReadFuncPtr_t)it->fFunctionPtr );
-         }
-         else {
-            rule->SetRuleType( TSchemaRule::kReadRawRule );
-            rule->SetReadRawFunctionPointer( (TSchemaRule::ReadRawFuncPtr_t)it->fFunctionPtr );
-         }
-         if( !rset->AddRule( rule, TSchemaRuleSet::kCheckAll, &errmsg ) ) {
+          if( !rset->AddRule( rule, TSchemaRuleSet::kCheckAll, &errmsg ) ) {
             ::Warning( "TGenericClassInfo", "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
                         GetClassName(), it->fVersion.c_str(), it->fTarget.c_str(), errmsg.Data() );
             delete rule;

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -334,7 +334,7 @@ namespace Internal {
          rule = new TSchemaRule(ProcessReadRules ? TSchemaRule::kReadRule : TSchemaRule::kReadRawRule,
                                 fClass->GetName(), *it);
 
-          if( !rset->AddRule( rule, TSchemaRuleSet::kCheckAll, &errmsg ) ) {
+         if (!rset->AddRule(rule, TSchemaRuleSet::kCheckAll, &errmsg)) {
             ::Warning( "TGenericClassInfo", "The rule for class: \"%s\": version, \"%s\" and data members: \"%s\" has been skipped because %s.",
                         GetClassName(), it->fVersion.c_str(), it->fTarget.c_str(), errmsg.Data() );
             delete rule;

--- a/core/meta/src/TSchemaRule.cxx
+++ b/core/meta/src/TSchemaRule.cxx
@@ -10,6 +10,7 @@
 #include "TObjArray.h"
 #include "TObjString.h"
 #include "TROOT.h"
+#include "TSchemaHelper.h"
 
 #include <utility>
 #include <iostream>
@@ -93,6 +94,35 @@ TSchemaRule::TSchemaRule(): fVersionVect( nullptr ), fChecksumVect( nullptr ),
                             fRuleType( kNone )
 {
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+TSchemaRule::TSchemaRule(TSchemaRule::RuleType_t type, const char *targetClass,
+                         const ROOT::Internal::TSchemaHelper& helper) :
+                         fVersionVect( nullptr ), fChecksumVect( nullptr ),
+                         fTargetVect( nullptr ), fSourceVect( nullptr ),
+                         fIncludeVect( nullptr ), fEmbed( kTRUE ),
+                         fReadFuncPtr( nullptr ), fReadRawFuncPtr( nullptr ),
+                         fRuleType( type )
+{
+   SetTarget( helper.fTarget );
+   SetTargetClass( targetClass );
+   SetSourceClass( helper.fSourceClass );
+   SetSource( helper.fSource );
+   SetCode( helper.fCode );
+   SetVersion( helper.fVersion );
+   SetChecksum( helper.fChecksum );
+   SetEmbed( helper.fEmbed );
+   SetInclude( helper.fInclude );
+   SetAttributes( helper.fAttributes );
+
+   if( type == TSchemaRule::kReadRule ) {
+      SetReadFunctionPointer( (TSchemaRule::ReadFuncPtr_t)helper.fFunctionPtr );
+   } else {
+      SetReadRawFunctionPointer( (TSchemaRule::ReadRawFuncPtr_t)helper.fFunctionPtr );
+   }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.

--- a/core/meta/src/TSchemaRule.cxx
+++ b/core/meta/src/TSchemaRule.cxx
@@ -98,31 +98,34 @@ TSchemaRule::TSchemaRule(): fVersionVect( nullptr ), fChecksumVect( nullptr ),
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 TSchemaRule::TSchemaRule(TSchemaRule::RuleType_t type, const char *targetClass,
-                         const ROOT::Internal::TSchemaHelper& helper) :
-                         fVersionVect( nullptr ), fChecksumVect( nullptr ),
-                         fTargetVect( nullptr ), fSourceVect( nullptr ),
-                         fIncludeVect( nullptr ), fEmbed( kTRUE ),
-                         fReadFuncPtr( nullptr ), fReadRawFuncPtr( nullptr ),
-                         fRuleType( type )
+                         const ROOT::Internal::TSchemaHelper &helper)
+   : fVersionVect(nullptr),
+     fChecksumVect(nullptr),
+     fTargetVect(nullptr),
+     fSourceVect(nullptr),
+     fIncludeVect(nullptr),
+     fEmbed(kTRUE),
+     fReadFuncPtr(nullptr),
+     fReadRawFuncPtr(nullptr),
+     fRuleType(type)
 {
-   SetTarget( helper.fTarget );
-   SetTargetClass( targetClass );
-   SetSourceClass( helper.fSourceClass );
-   SetSource( helper.fSource );
-   SetCode( helper.fCode );
-   SetVersion( helper.fVersion );
-   SetChecksum( helper.fChecksum );
-   SetEmbed( helper.fEmbed );
-   SetInclude( helper.fInclude );
-   SetAttributes( helper.fAttributes );
+   SetTarget(helper.fTarget);
+   SetTargetClass(targetClass);
+   SetSourceClass(helper.fSourceClass);
+   SetSource(helper.fSource);
+   SetCode(helper.fCode);
+   SetVersion(helper.fVersion);
+   SetChecksum(helper.fChecksum);
+   SetEmbed(helper.fEmbed);
+   SetInclude(helper.fInclude);
+   SetAttributes(helper.fAttributes);
 
-   if( type == TSchemaRule::kReadRule ) {
-      SetReadFunctionPointer( (TSchemaRule::ReadFuncPtr_t)helper.fFunctionPtr );
+   if (type == TSchemaRule::kReadRule) {
+      SetReadFunctionPointer((TSchemaRule::ReadFuncPtr_t)helper.fFunctionPtr);
    } else {
-      SetReadRawFunctionPointer( (TSchemaRule::ReadRawFuncPtr_t)helper.fFunctionPtr );
+      SetReadRawFunctionPointer((TSchemaRule::ReadRawFuncPtr_t)helper.fFunctionPtr);
    }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.

--- a/core/meta/src/TSchemaRuleSet.cxx
+++ b/core/meta/src/TSchemaRuleSet.cxx
@@ -110,18 +110,26 @@ Bool_t TSchemaRuleSet::AddRule( TSchemaRule* rule, EConsistencyCheck checkConsis
 
    // Check only if we have some information about the class, otherwise we have
    // nothing to check against
-   bool streamerInfosTest;
-   {
-     R__LOCKGUARD(gInterpreterMutex);
-     streamerInfosTest = !(fClass->GetStreamerInfos()==nullptr || fClass->GetStreamerInfos()->IsEmpty());
-   }
-   if (rule->GetTarget()  && fClass->GetState() > TClass::kEmulated && streamerInfosTest)
+
+   // Do not generate/build the StreamerInfo if it is not already there.
+   TVirtualStreamerInfo *info = fClass->GetCurrentStreamerInfo();
+   if (rule->GetTarget() && (fClass->GetState() > TClass::kEmulated || info))
    {
       TObjArrayIter titer( rule->GetTarget() );
       TObject* obj;
       while( (obj = titer.Next()) ) {
          TObjString* str = (TObjString*)obj;
-         if( !fClass->GetDataMember( str->GetString() ) && !fClass->GetBaseClass( str->GetString() ) ) {
+         bool found = false;
+         // Note: an alternative would be to use the ListOfRealData which
+         // is populated in both cases but it might or might not have already
+         // been set and would make detecting if the data member is local to
+         // the current class (as opposed to a base class) more difficult.
+         if (fClass->GetState() > TClass::kEmulated) {
+            found = fClass->GetDataMember( str->GetString() ) || fClass->GetBaseClass( str->GetString() );
+         } else if (info) {
+            found = info->GetElements()->FindObject(str->GetString());
+         }
+         if (!found) {
             if (checkConsistency == kCheckAll) {
                if (errmsg) {
                   errmsg->Form("the target member (%s) is unknown",str->GetString().Data());

--- a/core/meta/src/TSchemaRuleSet.cxx
+++ b/core/meta/src/TSchemaRuleSet.cxx
@@ -113,7 +113,7 @@ Bool_t TSchemaRuleSet::AddRule( TSchemaRule* rule, EConsistencyCheck checkConsis
    bool streamerInfosTest;
    {
      R__LOCKGUARD(gInterpreterMutex);
-     streamerInfosTest = (fClass->GetStreamerInfos()==nullptr || fClass->GetStreamerInfos()->IsEmpty());
+     streamerInfosTest = !(fClass->GetStreamerInfos()==nullptr || fClass->GetStreamerInfos()->IsEmpty());
    }
    if (rule->GetTarget()  && fClass->GetState() > TClass::kEmulated && streamerInfosTest)
    {

--- a/core/meta/src/TSchemaRuleSet.cxx
+++ b/core/meta/src/TSchemaRuleSet.cxx
@@ -113,8 +113,7 @@ Bool_t TSchemaRuleSet::AddRule( TSchemaRule* rule, EConsistencyCheck checkConsis
 
    // Do not generate/build the StreamerInfo if it is not already there.
    TVirtualStreamerInfo *info = fClass->GetCurrentStreamerInfo();
-   if (rule->GetTarget() && (fClass->GetState() > TClass::kEmulated || info))
-   {
+   if (rule->GetTarget() && (fClass->GetState() > TClass::kEmulated || info)) {
       TObjArrayIter titer( rule->GetTarget() );
       TObject* obj;
       while( (obj = titer.Next()) ) {
@@ -125,7 +124,7 @@ Bool_t TSchemaRuleSet::AddRule( TSchemaRule* rule, EConsistencyCheck checkConsis
          // been set and would make detecting if the data member is local to
          // the current class (as opposed to a base class) more difficult.
          if (fClass->GetState() > TClass::kEmulated) {
-            found = fClass->GetDataMember( str->GetString() ) || fClass->GetBaseClass( str->GetString() );
+            found = fClass->GetDataMember(str->GetString()) || fClass->GetBaseClass(str->GetString());
          } else if (info) {
             found = info->GetElements()->FindObject(str->GetString());
          }

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -676,8 +676,11 @@ TClass *TStreamerBase::GetClassPointer() const
 
 Int_t TStreamerBase::GetSize() const
 {
-   TClass *cl = GetClassPointer();
-   if (cl) return cl->Size();
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
+   if (cl)
+      return cl->Size();
    return 0;
 }
 
@@ -1281,10 +1284,14 @@ const char *TStreamerObject::GetInclude() const
 
 Int_t TStreamerObject::GetSize() const
 {
-   TClass *cl = GetClassPointer();
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
    Int_t classSize = 8;
-   if (cl) classSize = cl->Size();
-   if (fArrayLength) return fArrayLength*classSize;
+   if (cl)
+      classSize = cl->Size();
+   if (fArrayLength)
+      return fArrayLength * classSize;
    return classSize;
 }
 
@@ -1374,10 +1381,14 @@ const char *TStreamerObjectAny::GetInclude() const
 
 Int_t TStreamerObjectAny::GetSize() const
 {
-   TClass *cl = GetClassPointer();
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
    Int_t classSize = 8;
-   if (cl) classSize = cl->Size();
-   if (fArrayLength) return fArrayLength*classSize;
+   if (cl)
+      classSize = cl->Size();
+   if (fArrayLength)
+      return fArrayLength * classSize;
    return classSize;
 }
 
@@ -1906,7 +1917,9 @@ Int_t TStreamerSTL::GetSize() const
    // Since the STL collection might or might not be emulated and that the
    // sizeof the object depends on this, let's just always retrieve the
    // current size!
-   TClass *cl = GetClassPointer();
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
    UInt_t size = 0;
    if (cl==nullptr) {
       if (!TestBit(kWarned)) {

--- a/etc/class.rules
+++ b/etc/class.rules
@@ -8,19 +8,19 @@
 
 # HepMC Rules
 
-HepMC::GenVertex   m_event             attributes=NotOwner
+HepMC::GenVertex   m_event             attributes=NotOwner,CanIgnore
 
-HepMC::GenParticle m_production_vertex attributes=NotOwner
-HepMC::GenParticle m_end_vertex        attributes=NotOwner
+HepMC::GenParticle m_production_vertex attributes=NotOwner,CanIgnore
+HepMC::GenParticle m_end_vertex        attributes=NotOwner,CanIgnore
 
-HepMC::Flow        m_particle_owner    attributes=NotOwner
+HepMC::Flow        m_particle_owner    attributes=NotOwner,CanIgnore
 
-HepMC::GenEvent    m_vertex_barcodes   attributes=Owner
-HepMC::GenEvent    m_particle_barcodes attributes=Owner
+HepMC::GenEvent    m_vertex_barcodes   attributes=Owner,CanIgnore
+HepMC::GenEvent    m_particle_barcodes attributes=Owner,CanIgnore
 
-HepMC::GenEvent    m_signal_process_vertex attributes=NotOwner
-HepMC::GenEvent    m_beam_particle_1       attributes=NotOwner
-HepMC::GenEvent    m_beam_particle_2       attributes=NotOwner
+HepMC::GenEvent    m_signal_process_vertex attributes=NotOwner,CanIgnore
+HepMC::GenEvent    m_beam_particle_1       attributes=NotOwner,CanIgnore
+HepMC::GenEvent    m_beam_particle_2       attributes=NotOwner,CanIgnore
 
 
 

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -3411,9 +3411,9 @@ Int_t TBufferFile::ReadClassEmulated(const TClass *cl, void *object, const TClas
    Version_t v = ReadVersion(&start,&count);
 
    TStreamerInfo *sinfo = nullptr;
-   if( onFileClass ) {
-      sinfo = (TStreamerInfo*)cl->GetConversionStreamerInfo( onFileClass, v );
-      if( !sinfo )
+   if (onFileClass) {
+      sinfo = (TStreamerInfo *)cl->GetConversionStreamerInfo(onFileClass, v);
+      if (!sinfo)
          return 0;
    }
    if (!sinfo)

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -3410,21 +3410,21 @@ Int_t TBufferFile::ReadClassEmulated(const TClass *cl, void *object, const TClas
    //We attempt to recover if a version count was not written
    Version_t v = ReadVersion(&start,&count);
 
-   if (count) {
-      TStreamerInfo *sinfo = nullptr;
-      if( onFileClass ) {
-         sinfo = (TStreamerInfo*)cl->GetConversionStreamerInfo( onFileClass, v );
-         if( !sinfo )
-            return 0;
-      }
-
+   TStreamerInfo *sinfo = nullptr;
+   if( onFileClass ) {
+      sinfo = (TStreamerInfo*)cl->GetConversionStreamerInfo( onFileClass, v );
+      if( !sinfo )
+         return 0;
+   }
+   if (!sinfo)
       sinfo = (TStreamerInfo*)cl->GetStreamerInfo(v);
+
+   if (count) {
       ApplySequence(*(sinfo->GetReadObjectWiseActions()), object);
       if (sinfo->IsRecovered()) count=0;
       CheckByteCount(start,count,cl);
    } else {
       SetBufferOffset(start);
-      TStreamerInfo *sinfo = ((TStreamerInfo*)cl->GetStreamerInfo());
       ApplySequence(*(sinfo->GetReadObjectWiseActions()), object);
    }
    return 0;

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -1071,8 +1071,9 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
          baseOffset = 0; // For now we do not support requesting from a class that is the base of one of the class for which there is transformation to ....
          clOnfile = cl;
          cl = const_cast<TClass*>(expectedClass);
-         if (gDebug >0)
-            Info("ReadObjectAny","Using Converter StreamerInfo from %s to %s",clOnfile->GetName(),expectedClass->GetName());
+         if (gDebug > 0)
+            Info("ReadObjectAny", "Using Converter StreamerInfo from %s to %s", clOnfile->GetName(),
+                 expectedClass->GetName());
       }
       if (cl->GetState() > TClass::kEmulated && expectedClass->GetState() <= TClass::kEmulated) {
          //we cannot mix a compiled class with an emulated class in the inheritance

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -1071,7 +1071,8 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
          baseOffset = 0; // For now we do not support requesting from a class that is the base of one of the class for which there is transformation to ....
          clOnfile = cl;
          cl = const_cast<TClass*>(expectedClass);
-         Info("ReadObjectAny","Using Converter StreamerInfo from %s to %s",clOnfile->GetName(),expectedClass->GetName());
+         if (gDebug >0)
+            Info("ReadObjectAny","Using Converter StreamerInfo from %s to %s",clOnfile->GetName(),expectedClass->GetName());
       }
       if (cl->GetState() > TClass::kEmulated && expectedClass->GetState() <= TClass::kEmulated) {
          //we cannot mix a compiled class with an emulated class in the inheritance

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4731,17 +4731,21 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
       {
          auto source_element = dynamic_cast<TStreamerElement *>(GetElements()->FindObject(src->GetName()));
          if (!source_element) {
-            // Missing source.
-            if (!canIgnore(rule)) {
-               TString ruleStr;
-               rule->AsString(ruleStr);
-               Warning("InsertArtificialElements",
-                       "For class %s in StreamerInfo %d is missing the source data member %s when trying to apply the "
-                       "rule:\n   %s",
-                       GetName(), GetClassVersion(), src->GetName(), ruleStr.Data());
+            // It might still be in one the base classes.
+            if (fClass->GetListOfRealData() && !fClass->GetListOfRealData()->FindObject(src->GetName()))
+            {
+               // Missing source.
+               if (!canIgnore(rule)) {
+                  TString ruleStr;
+                  rule->AsString(ruleStr);
+                  Warning("InsertArtificialElements",
+                        "For class %s in StreamerInfo %d is missing the source data member `%s` when trying to apply the "
+                        "rule:\n   %s",
+                        GetName(), GetClassVersion(), src->GetName(), ruleStr.Data());
+               }
+               rule = nullptr;
+               break;
             }
-            rule = nullptr;
-            break;
          } else {
             // The source exists, let's check if it has the expected type.
             auto [memClass, memType, datasize, dimensions, totaldim] = GetSourceType(src);

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4735,53 +4735,52 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
       // existing in this StreamerInfo.
       const TObjArray *sources = rule->GetSource();
       if (sources)
-      for(auto src : TRangeDynCast<ROOT::TSchemaRule::TSources>( *sources ))
-      {
-         auto source_element = dynamic_cast<TStreamerElement *>(GetElements()->FindObject(src->GetName()));
-         if (!source_element) {
-            // It might still be in one the base classes.
-            if (fClass->GetListOfRealData() && !fClass->GetListOfRealData()->FindObject(src->GetName()))
-            {
-               // Missing source.
-               if (!canIgnore(rule)) {
+         for (auto src : TRangeDynCast<ROOT::TSchemaRule::TSources>(*sources)) {
+            auto source_element = dynamic_cast<TStreamerElement *>(GetElements()->FindObject(src->GetName()));
+            if (!source_element) {
+               // It might still be in one the base classes.
+               if (fClass->GetListOfRealData() && !fClass->GetListOfRealData()->FindObject(src->GetName())) {
+                  // Missing source.
+                  if (!canIgnore(rule)) {
+                     TString ruleStr;
+                     rule->AsString(ruleStr);
+                     Warning("InsertArtificialElements",
+                             "For class %s in StreamerInfo %d is missing the source data member `%s` when trying to "
+                             "apply the "
+                             "rule:\n   %s",
+                             GetName(), GetClassVersion(), src->GetName(), ruleStr.Data());
+                  }
+                  rule = nullptr;
+                  break;
+               }
+            } else {
+               // The source exists, let's check if it has the expected type.
+               auto [memClass, memType, datasize, dimensions, totaldim] = GetSourceType(src, source_element);
+               if ((memClass != source_element->GetNewClass() || memType != source_element->GetNewType()) &&
+                   (memType != TVirtualStreamerInfo::kNoContextMenu && memType != TVirtualStreamerInfo::kNoType)) {
+                  const char *dim = src->GetDimensions();
                   TString ruleStr;
                   rule->AsString(ruleStr);
-                  Warning("InsertArtificialElements",
-                        "For class %s in StreamerInfo %d is missing the source data member `%s` when trying to apply the "
-                        "rule:\n   %s",
-                        GetName(), GetClassVersion(), src->GetName(), ruleStr.Data());
+                  auto cl = source_element->GetNewClass();
+                  TString classmsg;
+                  if (memClass != cl) {
+                     classmsg = "and the memory TClass is \"";
+                     classmsg += cl ? cl->GetName() : "nullptr";
+                     classmsg += "\" while the rule needed \"";
+                     classmsg += memClass ? memClass->GetName() : "nullptr";
+                     classmsg += "\"";
+                  }
+                  Error("InsertArtificialElements",
+                        "For class %s in StreamerInfo %d a rule has conflicting type for the source \"%s %s%s\",\n"
+                        "   The TStreamerElement has memory type %d (needed %d) %s:\n   %s",
+                        GetName(), GetClassVersion(), src->GetTypeForDeclaration().Data(), src->GetName(),
+                        dim && dim[0] ? dim : "", source_element->GetNewType(), memType, classmsg.Data(),
+                        ruleStr.Data());
+                  rule = nullptr;
+                  break;
                }
-               rule = nullptr;
-               break;
-            }
-         } else {
-            // The source exists, let's check if it has the expected type.
-            auto [memClass, memType, datasize, dimensions, totaldim] = GetSourceType(src, source_element);
-            if ((memClass != source_element->GetNewClass() || memType != source_element->GetNewType())
-                && (memType != TVirtualStreamerInfo::kNoContextMenu && memType != TVirtualStreamerInfo::kNoType))
-            {
-               const char *dim = src->GetDimensions();
-               TString ruleStr;
-               rule->AsString(ruleStr);
-               auto cl = source_element->GetNewClass();
-               TString classmsg;
-               if (memClass != cl) {
-                  classmsg = "and the memory TClass is \"";
-                  classmsg += cl ? cl->GetName() : "nullptr";
-                  classmsg += "\" while the rule needed \"";
-                  classmsg += memClass ? memClass->GetName() : "nullptr";
-                  classmsg += "\"";
-               }
-               Error("InsertArtificialElements",
-                     "For class %s in StreamerInfo %d a rule has conflicting type for the source \"%s %s%s\",\n"
-                     "   The TStreamerElement has memory type %d (needed %d) %s:\n   %s",
-                     GetName(), GetClassVersion(), src->GetTypeForDeclaration().Data(), src->GetName(),
-                     dim && dim[0] ? dim : "", source_element->GetNewType(), memType, classmsg.Data(), ruleStr.Data());
-               rule = nullptr;
-               break;
             }
          }
-      }
 
       if (!rule) continue;
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4981,13 +4981,16 @@ void* TStreamerInfo::New(void *obj)
 
       // Skip elements for which we do not have any class
       // information.  FIXME: Document how this could happen.
-      TClass* cle = element->GetClassPointer();
-      if (!cle) {
+      TClass* cle = element->GetNewClass();
+      if (!cle)
+         cle = element->GetClassPointer();
+      if (!cle)
          continue;
-      }
 
       char* eaddr = p + element->GetOffset();
-      Int_t etype = element->GetType();
+      Int_t etype = element->GetNewType();
+      if (etype == TStreamerInfo::kNoType)
+         etype = element->GetType();
 
       //cle->GetStreamerInfo(); //necessary in case "->" is not specified
 
@@ -5167,7 +5170,9 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
       char* eaddr = p + ele->GetOffset();
 
 
-      Int_t etype = ele->GetType();
+      Int_t etype = ele->GetNewType(); // in memory type
+      if (etype == TStreamerInfo::kNoType)
+         etype = ele->GetType();
 
       switch(etype) {
          case TStreamerInfo::kOffsetP + TStreamerInfo::kBool:   DeleteBasicPointer(eaddr,ele,Bool_t);  continue;
@@ -5190,8 +5195,11 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
 
 
 
-      TClass* cle = ele->GetClassPointer();
-      if (!cle) continue;
+      TClass* cle = ele->GetNewClass(); // in memory type
+      if (!cle)
+         cle = ele->GetClassPointer();
+      if (!cle)
+         continue;
 
 
       if (etype == kObjectp || etype == kAnyp) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4620,11 +4620,11 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
             TString newName = objstr->String();
             TString realDataName;
             if ( TDataMember* dm = fClass->GetDataMember( newName ) ) {
-               TRealData::GetName(realDataName,dm);
-               newel = new TStreamerArtificial(realDataName,"",
-                                               fClass->GetDataMemberOffset(newName),
+               TRealData::GetName(realDataName, dm);
+               newel = new TStreamerArtificial(realDataName, "",
+                                               fClass->GetDataMemberOffset(realDataName),
                                                TStreamerInfo::kArtificial,
-                                               fClass->GetDataMember( newName )->GetTypeName());
+                                               dm->GetTypeName());
                newel->SetReadFunc( rule->GetReadFunctionPointer() );
                newel->SetReadRawFunc( rule->GetReadRawFunctionPointer() );
                toAdd.push_back(newel);
@@ -4637,11 +4637,11 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
                if (objstr) {
                   newName = objstr->String();
                   if ( TDataMember* dm = fClass->GetDataMember( newName ) ) {
-                     TRealData::GetName(realDataName,dm);
-                     newel = new TStreamerArtificial(realDataName,"",
-                                                     fClass->GetDataMemberOffset(newName),
+                     TRealData::GetName(realDataName, dm);
+                     newel = new TStreamerArtificial(realDataName, "",
+                                                     fClass->GetDataMemberOffset(realDataName),
                                                      TStreamerInfo::kArtificial,
-                                                     fClass->GetDataMember( newName )->GetTypeName());
+                                                     dm->GetTypeName());
                      toAdd.push_back(newel);
                   }
                }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -662,6 +662,7 @@ void TStreamerInfo::Build(Bool_t isTransient)
          }
          cached->SetBit(TStreamerElement::kCache);
          cached->SetNewType( cached->GetType() );
+         cached->SetNewClass( nullptr );
       }
 
       fElements->Add(element);
@@ -2534,6 +2535,7 @@ void TStreamerInfo::BuildOld()
             }
             element->SetBit(TStreamerElement::kCache);
             element->SetNewType( element->GetType() );
+            element->SetNewClass( nullptr ); // Technically we could also consider setting to the type specificed in the rule
             element->SetOffset(infoalloc ? infoalloc->GetOffset(element->GetName()) : 0);
          } else if (rules.HasRuleWithTarget( element->GetName(), kTRUE ) ) {
             // The data member exist in the onfile StreamerInfo and there is a rule

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -266,11 +266,8 @@ namespace {
       if (isStdArray) {
          totaldim = 1;
          std::array<Int_t, 5> localMaxIndices;
-         TClassEdit::GetStdArrayProperties(memClass->GetName(),
-                                          localtypename,
-                                          localMaxIndices,
-                                          ndim);
-         for(Int_t i = 0; i < ndim; ++i) {
+         TClassEdit::GetStdArrayProperties(memClass->GetName(), localtypename, localMaxIndices, ndim);
+         for (Int_t i = 0; i < ndim; ++i) {
             auto d = localMaxIndices[i];
             dimensions.push_back(d);
             totaldim *= d;
@@ -278,7 +275,7 @@ namespace {
          memClass = TClass::GetClass(localtypename.c_str());
       }
       if (memClass) {
-         //cached->SetNewType( cached->GetType() );
+         // cached->SetNewType( cached->GetType() );
          if (s->GetPointerLevel()) {
             if (memClass->IsTObject()) {
                memType = TVirtualStreamerInfo::kObjectP;
@@ -290,7 +287,7 @@ namespace {
          } else {
             if (memClass->GetCollectionProxy()) {
                memType = TVirtualStreamerInfo::kSTL;
-            } else if(memClass->IsTObject() && memClass == element->GetClassPointer()) {
+            } else if (memClass->IsTObject() && memClass == element->GetClassPointer()) {
                // If there is a change in the class type, we can't use the TObject::Streamer
                // virtual function: it would streame the data using the in-memory type rather
                // than the onfile type.
@@ -300,8 +297,7 @@ namespace {
             }
          }
          if ((!s->GetPointerLevel() || memType == TVirtualStreamerInfo::kSTLp) &&
-             (isStdArray ? ndim >0 : s->GetDimensions()[0]))
-         {
+             (isStdArray ? ndim > 0 : s->GetDimensions()[0])) {
             memType += TVirtualStreamerInfo::kOffsetL;
          }
          datasize = memClass->GetClassSize();
@@ -321,7 +317,7 @@ namespace {
          if (!totaldim)
             totaldim = 1;
          auto dims = s->GetDimensions();
-         while(*dims == '[') {
+         while (*dims == '[') {
             ++dims;
             uint32_t res = 0;
             do {
@@ -339,9 +335,8 @@ namespace {
          }
       }
       if (element->GetType() == TStreamerInfo::kStreamLoop &&
-          (memType == TStreamerInfo::kAnyp || memType == TStreamerInfo::kAnyP
-          || memType == TStreamerInfo::kObjectp || memType == TStreamerInfo::kObjectP))
-      {
+          (memType == TStreamerInfo::kAnyp || memType == TStreamerInfo::kAnyP || memType == TStreamerInfo::kObjectp ||
+           memType == TStreamerInfo::kObjectP)) {
          memType = TStreamerInfo::kStreamLoop;
       }
       if (element->GetType() == TStreamerInfo::kStreamer)
@@ -352,20 +347,20 @@ namespace {
    void UpdateFromRule(const TStreamerInfo *info, const ROOT::TSchemaRule::TSources *s, TStreamerElement *element)
    {
       auto [memClass, memType, datasize, dimensions, totaldim] = GetSourceType(s, element);
-      if (element->GetType() == TVirtualStreamerInfo::kObject && memClass != element->GetClassPointer())
-      {
+      if (element->GetType() == TVirtualStreamerInfo::kObject && memClass != element->GetClassPointer()) {
          // If there is a change in the class type, we can't use the TObject::Streamer
          // virtual function: it would streame the data using the in-memory type rather
          // than the onfile type.
          element->SetType(TVirtualStreamerInfo::kAny);
       }
-      element->SetNewType( memType );
-      element->SetNewClass( memClass );
+      element->SetNewType(memType);
+      element->SetNewClass(memClass);
       // We can not change the recorded dimensions.  Let's check that
       // the total number of elements is still the same.
       if (totaldim != element->GetArrayLength()) {
          Error("UpdateFromRule",
-               "For %s::%s the number of array elements in the rule (%d) does not match the number in the StreamerElement (%d)",
+               "For %s::%s the number of array elements in the rule (%d) does not match the number in the "
+               "StreamerElement (%d)",
                info->GetName(), element->GetFullName(), totaldim, element->GetArrayLength());
       }
       element->SetSize(totaldim ? totaldim * datasize : datasize);
@@ -780,9 +775,9 @@ void TStreamerInfo::Build(Bool_t isTransient)
          cached->SetBit(TStreamerElement::kCache);
          // Get one of the potentially many rules applicable
          // We should check that we don't have a second rule
-         auto r = rules.GetRuleWithSource( element->GetName() );
+         auto r = rules.GetRuleWithSource(element->GetName());
          assert(r && r->GetSource());
-         auto s = (ROOT::TSchemaRule::TSources*)(r->GetSource()->FindObject( element->GetName() ));
+         auto s = (ROOT::TSchemaRule::TSources *)(r->GetSource()->FindObject(element->GetName()));
          assert(s);
          UpdateFromRule(this, s, cached);
       }
@@ -807,7 +802,7 @@ void TStreamerInfo::Build(Bool_t isTransient)
                if (rules.HasRuleWithSource(alloc_element->GetName(), kTRUE)) {
                   auto r = rules.GetRuleWithSource(alloc_element->GetName());
                   assert(r && r->GetSource());
-                  auto s = (ROOT::TSchemaRule::TSources*)(r->GetSource()->FindObject( alloc_element->GetName() ));
+                  auto s = (ROOT::TSchemaRule::TSources *)(r->GetSource()->FindObject(alloc_element->GetName()));
                   assert(s);
                   UpdateFromRule(this, s, alloc_element);
                }
@@ -2650,7 +2645,8 @@ void TStreamerInfo::BuildOld()
                         if (rules.HasRuleWithSource(alloc_element->GetName(), kTRUE)) {
                            auto r = rules.GetRuleWithSource(alloc_element->GetName());
                            assert(r && r->GetSource());
-                           auto s = (ROOT::TSchemaRule::TSources*)(r->GetSource()->FindObject( alloc_element->GetName() ));
+                           auto s =
+                              (ROOT::TSchemaRule::TSources *)(r->GetSource()->FindObject(alloc_element->GetName()));
                            assert(s);
                            UpdateFromRule(this, s, alloc_element);
                         }
@@ -4735,7 +4731,7 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
 
       auto canIgnore = [](const ROOT::TSchemaRule *r) {
          if (r->GetAttributes()[0] != 0) {
-            TString attr( r->GetAttributes() );
+            TString attr(r->GetAttributes());
             attr.ToLower();
             return attr.Contains("canignore");
          } else
@@ -4816,10 +4812,8 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
             TString realDataName;
             if ( TDataMember* dm = fClass->GetDataMember( newName ) ) {
                TRealData::GetName(realDataName, dm);
-               newel = new TStreamerArtificial(realDataName, "",
-                                               fClass->GetDataMemberOffset(realDataName),
-                                               TStreamerInfo::kArtificial,
-                                               dm->GetTypeName());
+               newel = new TStreamerArtificial(realDataName, "", fClass->GetDataMemberOffset(realDataName),
+                                               TStreamerInfo::kArtificial, dm->GetTypeName());
                newel->SetReadFunc( rule->GetReadFunctionPointer() );
                newel->SetReadRawFunc( rule->GetReadRawFunctionPointer() );
                toAdd.push_back(newel);
@@ -4833,10 +4827,8 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
                   newName = objstr->String();
                   if ( TDataMember* dm = fClass->GetDataMember( newName ) ) {
                      TRealData::GetName(realDataName, dm);
-                     newel = new TStreamerArtificial(realDataName, "",
-                                                     fClass->GetDataMemberOffset(realDataName),
-                                                     TStreamerInfo::kArtificial,
-                                                     dm->GetTypeName());
+                     newel = new TStreamerArtificial(realDataName, "", fClass->GetDataMemberOffset(realDataName),
+                                                     TStreamerInfo::kArtificial, dm->GetTypeName());
                      toAdd.push_back(newel);
                   }
                }
@@ -4991,7 +4983,7 @@ void* TStreamerInfo::New(void *obj)
 
       // Skip elements for which we do not have any class
       // information.  FIXME: Document how this could happen.
-      TClass* cle = element->GetNewClass();
+      TClass *cle = element->GetNewClass();
       if (!cle)
          cle = element->GetClassPointer();
       if (!cle)
@@ -5179,7 +5171,6 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
       if (ele->GetOffset() == kMissing) continue;
       char* eaddr = p + ele->GetOffset();
 
-
       Int_t etype = ele->GetNewType(); // in memory type
       if (etype == TStreamerInfo::kNoType)
          etype = ele->GetType();
@@ -5203,14 +5194,11 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
          case TStreamerInfo::kCharStar:                         DeleteBasicPointer(eaddr,ele,Char_t);  continue;
       }
 
-
-
-      TClass* cle = ele->GetNewClass(); // in memory type
+      TClass *cle = ele->GetNewClass(); // in memory type
       if (!cle)
          cle = ele->GetClassPointer();
       if (!cle)
          continue;
-
 
       if (etype == kObjectp || etype == kAnyp) {
          // Destroy an array of pre-allocated objects.

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -326,15 +326,21 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
       }
 
       // skip Class *  not derived from TObject with comment field  //->
-      case TStreamerInfo::kSkip + TStreamerInfo::kAnyp: {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyp:
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyp + TStreamerInfo::kOffsetL:
+      {
          DOLOOP {
-            b.SkipObjectAny();
+            for (Int_t j=0;j<compinfo->fLength;j++) {
+               b.SkipObjectAny();
+            }
          }
          break;
       }
 
       // skip Class*   not derived from TObject
-      case TStreamerInfo::kSkip + TStreamerInfo::kAnyP: {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyP:
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyP + TStreamerInfo::kOffsetL:
+      {
          DOLOOP {
             for (Int_t j=0;j<compinfo->fLength;j++) {
                b.SkipObjectAny();
@@ -344,9 +350,13 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
       }
 
       // skip Any Class not derived from TObject
-      case TStreamerInfo::kSkip + TStreamerInfo::kAny:    {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAny:
+      case TStreamerInfo::kSkip + TStreamerInfo::kAny + TStreamerInfo::kOffsetL:
+      {
          DOLOOP {
-            b.SkipObjectAny();
+            for (Int_t j=0;j<compinfo->fLength;j++) {
+               b.SkipObjectAny();
+            }
          }
          break;
       }
@@ -369,10 +379,13 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
       }
 
       case TStreamerInfo::kSkip + TStreamerInfo::kStreamLoop:
+      case TStreamerInfo::kSkip + TStreamerInfo::kStreamLoop + TStreamerInfo::kOffsetL:
       case TStreamerInfo::kSkip + TStreamerInfo::kStreamer: {
          DOLOOP {
-            b.SkipObjectAny();
+            for (Int_t j=0;j<compinfo->fLength;j++) {
+              b.SkipObjectAny();
             }
+         }
          break;
       }
       default:

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -1362,7 +1362,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
             continue;
 
          case TStreamerInfo::kObject: // Class derived from TObject
-            if (cle->IsStartingWithTObject() && cle->GetState() > TClass::kEmulated) {
+            if (cle == newCle && cle->IsStartingWithTObject() && cle->GetState() > TClass::kEmulated) {
                DOLOOP {((TObject*)(arr[k]+ioffset))->Streamer(b);}
                continue; // intentionally inside the if statement.
                       // if the class does not start with its TObject part (or does

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -1082,7 +1082,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
          case TStreamerInfo::kAnyP:    // Class*  not derived from TObject with no comment field NOTE:: Re-added by Phil
          case TStreamerInfo::kAnyP+TStreamerInfo::kOffsetL: {
             DOLOOP {
-               b.ReadFastArray((void**)(arr[k]+ioffset),cle,compinfo[i]->fLength,isPreAlloc,pstreamer);
+               b.ReadFastArray((void**)(arr[k]+ioffset), newCle ? newCle : cle, compinfo[i]->fLength, isPreAlloc, pstreamer, cle);
             }
          }
          continue;

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -1380,7 +1380,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
 
          case TStreamerInfo::kAny+TStreamerInfo::kOffsetL: {
             DOLOOP {
-               b.ReadFastArray((void*)(arr[k]+ioffset),cle,compinfo[i]->fLength,pstreamer);
+               b.ReadFastArray((void*)(arr[k]+ioffset), newCle ? newCle : cle, compinfo[i]->fLength, pstreamer, cle);
             }
             continue;
          }

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -327,10 +327,9 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
 
       // skip Class *  not derived from TObject with comment field  //->
       case TStreamerInfo::kSkip + TStreamerInfo::kAnyp:
-      case TStreamerInfo::kSkip + TStreamerInfo::kAnyp + TStreamerInfo::kOffsetL:
-      {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyp + TStreamerInfo::kOffsetL: {
          DOLOOP {
-            for (Int_t j=0;j<compinfo->fLength;j++) {
+            for (Int_t j = 0; j < compinfo->fLength; j++) {
                b.SkipObjectAny();
             }
          }
@@ -339,8 +338,7 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
 
       // skip Class*   not derived from TObject
       case TStreamerInfo::kSkip + TStreamerInfo::kAnyP:
-      case TStreamerInfo::kSkip + TStreamerInfo::kAnyP + TStreamerInfo::kOffsetL:
-      {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAnyP + TStreamerInfo::kOffsetL: {
          DOLOOP {
             for (Int_t j=0;j<compinfo->fLength;j++) {
                b.SkipObjectAny();
@@ -351,10 +349,9 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
 
       // skip Any Class not derived from TObject
       case TStreamerInfo::kSkip + TStreamerInfo::kAny:
-      case TStreamerInfo::kSkip + TStreamerInfo::kAny + TStreamerInfo::kOffsetL:
-      {
+      case TStreamerInfo::kSkip + TStreamerInfo::kAny + TStreamerInfo::kOffsetL: {
          DOLOOP {
-            for (Int_t j=0;j<compinfo->fLength;j++) {
+            for (Int_t j = 0; j < compinfo->fLength; j++) {
                b.SkipObjectAny();
             }
          }
@@ -382,8 +379,8 @@ Int_t TStreamerInfo::ReadBufferSkip(TBuffer &b, const T &arr, const TCompInfo *c
       case TStreamerInfo::kSkip + TStreamerInfo::kStreamLoop + TStreamerInfo::kOffsetL:
       case TStreamerInfo::kSkip + TStreamerInfo::kStreamer: {
          DOLOOP {
-            for (Int_t j=0;j<compinfo->fLength;j++) {
-              b.SkipObjectAny();
+            for (Int_t j = 0; j < compinfo->fLength; j++) {
+               b.SkipObjectAny();
             }
          }
          break;
@@ -795,17 +792,17 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
 
       if (R__TestUseCache<T>(aElement)) {
          Int_t bufpos = b.Length();
-         if (b.PeekDataCache()==0) {
+         if (b.PeekDataCache() == 0) {
             Warning("ReadBuffer","Skipping %s::%s because the cache is missing.",thisVar->GetName(),aElement->GetName());
             thisVar->ReadBufferSkip(b,arr,compinfo[i],compinfo[i]->fType+TStreamerInfo::kSkip,aElement,narr,eoffset);
          } else {
             if (gDebug > 1) {
                printf("ReadBuffer, class:%s, name=%s, fType[%d]=%d,"
-                  " %s, bufpos=%d, arr=%p, eoffset=%d, Redirect=%p\n",
-                  fClass->GetName(),aElement->GetName(),i,compinfo[i]->fType,
-                  aElement->ClassName(),b.Length(),arr[0], eoffset,b.PeekDataCache()->GetObjectAt(0));
+                      " %s, bufpos=%d, arr=%p, eoffset=%d, Redirect=%p\n",
+                      fClass->GetName(), aElement->GetName(), i, compinfo[i]->fType, aElement->ClassName(), b.Length(),
+                      arr[0], eoffset, b.PeekDataCache()->GetObjectAt(0));
             }
-            thisVar->ReadBuffer(b,*b.PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
+            thisVar->ReadBuffer(b, *b.PeekDataCache(), compinfo, i, i + 1, narr, eoffset, arrayMode);
          }
          if (aElement->TestBit(TStreamerElement::kRepeat)) { b.SetBufferOffset(bufpos); }
          continue;
@@ -1095,7 +1092,8 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
          case TStreamerInfo::kAnyP:    // Class*  not derived from TObject with no comment field NOTE:: Re-added by Phil
          case TStreamerInfo::kAnyP+TStreamerInfo::kOffsetL: {
             DOLOOP {
-               b.ReadFastArray((void**)(arr[k]+ioffset), newCle ? newCle : cle, compinfo[i]->fLength, isPreAlloc, pstreamer, cle);
+               b.ReadFastArray((void **)(arr[k] + ioffset), newCle ? newCle : cle, compinfo[i]->fLength, isPreAlloc,
+                               pstreamer, cle);
             }
          }
          continue;
@@ -1393,7 +1391,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
 
          case TStreamerInfo::kAny+TStreamerInfo::kOffsetL: {
             DOLOOP {
-               b.ReadFastArray((void*)(arr[k]+ioffset), newCle ? newCle : cle, compinfo[i]->fLength, pstreamer, cle);
+               b.ReadFastArray((void *)(arr[k] + ioffset), newCle ? newCle : cle, compinfo[i]->fLength, pstreamer, cle);
             }
             continue;
          }
@@ -1698,12 +1696,8 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
             continue;
          }
 
-         case TStreamerInfo::kCacheNew:
-            b.PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
-            continue;
-         case TStreamerInfo::kCacheDelete:
-            delete b.PopDataCache();
-            continue;
+         case TStreamerInfo::kCacheNew: b.PushDataCache(new TVirtualArray(aElement->GetClassPointer(), narr)); continue;
+         case TStreamerInfo::kCacheDelete: delete b.PopDataCache(); continue;
 
          case -1:
             // -- Skip an ignored TObject base class.

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -554,7 +554,7 @@ Int_t TStreamerInfo::ReadBufferArtificial(TBuffer &b, const T &arr,
    // Process the result
    if (readfunc) {
       TVirtualObject obj(0);
-      TVirtualArray *objarr = ((TBufferFile&)b).PeekDataCache();
+      TVirtualArray *objarr = b.PeekDataCache();
       if (objarr) {
          obj.fClass = objarr->fClass;
 
@@ -795,7 +795,7 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
 
       if (R__TestUseCache<T>(aElement)) {
          Int_t bufpos = b.Length();
-         if (((TBufferFile&)b).PeekDataCache()==0) {
+         if (b.PeekDataCache()==0) {
             Warning("ReadBuffer","Skipping %s::%s because the cache is missing.",thisVar->GetName(),aElement->GetName());
             thisVar->ReadBufferSkip(b,arr,compinfo[i],compinfo[i]->fType+TStreamerInfo::kSkip,aElement,narr,eoffset);
          } else {
@@ -803,9 +803,9 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
                printf("ReadBuffer, class:%s, name=%s, fType[%d]=%d,"
                   " %s, bufpos=%d, arr=%p, eoffset=%d, Redirect=%p\n",
                   fClass->GetName(),aElement->GetName(),i,compinfo[i]->fType,
-                  aElement->ClassName(),b.Length(),arr[0], eoffset,((TBufferFile&)b).PeekDataCache()->GetObjectAt(0));
+                  aElement->ClassName(),b.Length(),arr[0], eoffset,b.PeekDataCache()->GetObjectAt(0));
             }
-            thisVar->ReadBuffer(b,*((TBufferFile&)b).PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
+            thisVar->ReadBuffer(b,*b.PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
          }
          if (aElement->TestBit(TStreamerElement::kRepeat)) { b.SetBufferOffset(bufpos); }
          continue;
@@ -1699,10 +1699,10 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
          }
 
          case TStreamerInfo::kCacheNew:
-            ((TBufferFile&)b).PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
+            b.PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
             continue;
          case TStreamerInfo::kCacheDelete:
-            delete ((TBufferFile&)b).PopDataCache();
+            delete b.PopDataCache();
             continue;
 
          case -1:

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -146,16 +146,16 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
       if (R__TestUseCache<T>(aElement)) {
          if (aElement->TestBit(TStreamerElement::kWrite)) {
-            if (b.PeekDataCache()==0) {
+            if (b.PeekDataCache() == 0) {
                Warning("WriteBuffer","Skipping %s::%s because the cache is missing.",GetName(),aElement->GetName());
             } else {
                if (gDebug > 1) {
                   printf("WriteBuffer, class:%s, name=%s, fType[%d]=%d,"
                          " %s, bufpos=%d, arr=%p, eoffset=%d, Redirect=%p\n",
-                         fClass->GetName(),aElement->GetName(),i,compinfo[i]->fType,
-                         aElement->ClassName(),b.Length(),arr[0], eoffset,b.PeekDataCache()->GetObjectAt(0));
+                         fClass->GetName(), aElement->GetName(), i, compinfo[i]->fType, aElement->ClassName(),
+                         b.Length(), arr[0], eoffset, b.PeekDataCache()->GetObjectAt(0));
                }
-               WriteBufferAux(b,*b.PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
+               WriteBufferAux(b, *b.PeekDataCache(), compinfo, i, i + 1, narr, eoffset, arrayMode);
             }
             continue;
          } else {
@@ -800,12 +800,8 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
             continue;
          }
 
-         case TStreamerInfo::kCacheNew:
-            b.PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
-            continue;
-         case TStreamerInfo::kCacheDelete:
-            delete b.PopDataCache();
-            continue;
+         case TStreamerInfo::kCacheNew: b.PushDataCache(new TVirtualArray(aElement->GetClassPointer(), narr)); continue;
+         case TStreamerInfo::kCacheDelete: delete b.PopDataCache(); continue;
          case TStreamerInfo::kArtificial:
 #if 0
             ROOT::TSchemaRule::WriteFuncPtr_t writefunc = ((TStreamerArtificial*)aElement)->GetWriteFunc();

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -146,16 +146,16 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
       if (R__TestUseCache<T>(aElement)) {
          if (aElement->TestBit(TStreamerElement::kWrite)) {
-            if (((TBufferFile&)b).PeekDataCache()==0) {
+            if (b.PeekDataCache()==0) {
                Warning("WriteBuffer","Skipping %s::%s because the cache is missing.",GetName(),aElement->GetName());
             } else {
                if (gDebug > 1) {
                   printf("WriteBuffer, class:%s, name=%s, fType[%d]=%d,"
                          " %s, bufpos=%d, arr=%p, eoffset=%d, Redirect=%p\n",
                          fClass->GetName(),aElement->GetName(),i,compinfo[i]->fType,
-                         aElement->ClassName(),b.Length(),arr[0], eoffset,((TBufferFile&)b).PeekDataCache()->GetObjectAt(0));
+                         aElement->ClassName(),b.Length(),arr[0], eoffset,b.PeekDataCache()->GetObjectAt(0));
                }
-               WriteBufferAux(b,*((TBufferFile&)b).PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
+               WriteBufferAux(b,*b.PeekDataCache(),compinfo,i,i+1,narr,eoffset, arrayMode);
             }
             continue;
          } else {
@@ -801,10 +801,10 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
          }
 
          case TStreamerInfo::kCacheNew:
-            ((TBufferFile&)b).PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
+            b.PushDataCache( new TVirtualArray( aElement->GetClassPointer(), narr ) );
             continue;
          case TStreamerInfo::kCacheDelete:
-            delete ((TBufferFile&)b).PopDataCache();
+            delete b.PopDataCache();
             continue;
          case TStreamerInfo::kArtificial:
 #if 0

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -67,7 +67,8 @@ namespace {
       TBuffer &fBuffer;
       TVirtualArray *fOnfileObject;
 
-      R__PushCache(TBuffer &b, TVirtualArray *in, UInt_t size) : fBuffer(b), fOnfileObject(in) {
+      R__PushCache(TBuffer &b, TVirtualArray *in, UInt_t size) : fBuffer(b), fOnfileObject(in)
+      {
          if (fOnfileObject) {
             fOnfileObject->SetSize(size);
             fBuffer.PushDataCache( fOnfileObject );
@@ -2744,7 +2745,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
             if (clones->IsZombie()) {
                return -1;
             }
-            R__PushCache onfileObject(b,fOnfileObject,ndata);
+            R__PushCache onfileObject(b, fOnfileObject, ndata);
 
             char **arr = (char **)clones->GetObjectRef();
             char **end = arr + fNdata;
@@ -2757,7 +2758,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
 
             auto ndata = GetNdata();
 
-            R__PushCache onfileObject(b,fOnfileObject,ndata);
+            R__PushCache onfileObject(b, fOnfileObject, ndata);
             TVirtualCollectionProxy *proxy = GetCollectionProxy();
             TVirtualCollectionProxy::TPushPop helper(proxy, fObject);
 
@@ -2767,7 +2768,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
             // Apply the unattached rules; by definition they do not need any
             // input from a buffer.
             TBufferFile b(TBufferFile::kRead, 1);
-            R__PushCache onfileObject(b,fOnfileObject,fNdata);
+            R__PushCache onfileObject(b, fOnfileObject, fNdata);
             b.ApplySequence(*fReadActionSequence, fObject);
          }
       }
@@ -4289,7 +4290,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
    }
    fNdata = n;
 
-   R__PushCache onfileObject(b,fOnfileObject,1);
+   R__PushCache onfileObject(b, fOnfileObject, 1);
 
    // Note: Proxy-helper needs to "embrace" the entire
    //       streaming of this STL container if the container
@@ -4379,7 +4380,7 @@ void TBranchElement::ReadLeavesCollectionSplitPtrMember(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(b,fOnfileObject,fNdata);
+   R__PushCache onfileObject(b, fOnfileObject, fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4411,7 +4412,7 @@ void TBranchElement::ReadLeavesCollectionSplitVectorPtrMember(TBuffer& b)
    if (!fNdata) {
       return;
    }
-   R__PushCache onfileObject(b,fOnfileObject,fNdata);
+   R__PushCache onfileObject(b, fOnfileObject, fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4442,7 +4443,7 @@ void TBranchElement::ReadLeavesCollectionMember(TBuffer& b)
    if (!fNdata) {
       return;
    }
-   R__PushCache onfileObject(b,fOnfileObject,fNdata);
+   R__PushCache onfileObject(b, fOnfileObject, fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4522,7 +4523,7 @@ void TBranchElement::ReadLeavesClonesMember(TBuffer& b)
 
    // Note, we could (possibly) save some more, by configuring the action
    // based on the value of fOnfileObject rather than pushing in on a stack.
-   R__PushCache onfileObject(b,fOnfileObject,fNdata);
+   R__PushCache onfileObject(b, fOnfileObject, fNdata);
 
    char **arr = (char **)clones->GetObjectRef();
    char **end = arr + fNdata;
@@ -4547,7 +4548,7 @@ void TBranchElement::ReadLeavesMember(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(b,fOnfileObject,1);
+   R__PushCache onfileObject(b, fOnfileObject, 1);
    // If not a TClonesArray or STL container master branch
    // or sub-branch and branch inherits from tobject,
    // then register with the buffer so that pointers are
@@ -4599,8 +4600,9 @@ void TBranchElement::ReadLeavesMemberBranchCount(TBuffer& b)
    if (!info) {
       return;
    }
-   R__PushCache onfileObject(b,fOnfileObject,1); // Here we have a single object that contains a variable size C-style array.
-                                                                 // Since info is not null, fReadActionSequence is not null either.
+   R__PushCache onfileObject(b, fOnfileObject,
+                             1); // Here we have a single object that contains a variable size C-style array.
+                                 // Since info is not null, fReadActionSequence is not null either.
    b.ApplySequence(*fReadActionSequence, fObject);
 }
 
@@ -4634,7 +4636,7 @@ void TBranchElement::ReadLeavesMemberCounter(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(b,fOnfileObject,1);
+   R__PushCache onfileObject(b, fOnfileObject, 1);
 
    // Since info is not null, fReadActionSequence is not null either.
    b.ApplySequence(*fReadActionSequence, fObject);
@@ -4655,7 +4657,7 @@ void TBranchElement::ReadLeavesCustomStreamer(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(b,fOnfileObject,1);
+   R__PushCache onfileObject(b, fOnfileObject, 1);
    fBranchClass->Streamer(fObject,b);
 }
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -64,10 +64,10 @@ namespace {
       }
    }
    struct R__PushCache {
-      TBufferFile &fBuffer;
+      TBuffer &fBuffer;
       TVirtualArray *fOnfileObject;
 
-      R__PushCache(TBufferFile &b, TVirtualArray *in, UInt_t size) : fBuffer(b), fOnfileObject(in) {
+      R__PushCache(TBuffer &b, TVirtualArray *in, UInt_t size) : fBuffer(b), fOnfileObject(in) {
          if (fOnfileObject) {
             fOnfileObject->SetSize(size);
             fBuffer.PushDataCache( fOnfileObject );
@@ -2744,7 +2744,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
             if (clones->IsZombie()) {
                return -1;
             }
-            R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,ndata);
+            R__PushCache onfileObject(b,fOnfileObject,ndata);
 
             char **arr = (char **)clones->GetObjectRef();
             char **end = arr + fNdata;
@@ -2757,7 +2757,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
 
             auto ndata = GetNdata();
 
-            R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,ndata);
+            R__PushCache onfileObject(b,fOnfileObject,ndata);
             TVirtualCollectionProxy *proxy = GetCollectionProxy();
             TVirtualCollectionProxy::TPushPop helper(proxy, fObject);
 
@@ -2767,7 +2767,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
             // Apply the unattached rules; by definition they do not need any
             // input from a buffer.
             TBufferFile b(TBufferFile::kRead, 1);
-            R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
+            R__PushCache onfileObject(b,fOnfileObject,fNdata);
             b.ApplySequence(*fReadActionSequence, fObject);
          }
       }
@@ -4289,7 +4289,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
    }
    fNdata = n;
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1);
+   R__PushCache onfileObject(b,fOnfileObject,1);
 
    // Note: Proxy-helper needs to "embrace" the entire
    //       streaming of this STL container if the container
@@ -4379,7 +4379,7 @@ void TBranchElement::ReadLeavesCollectionSplitPtrMember(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
+   R__PushCache onfileObject(b,fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4411,7 +4411,7 @@ void TBranchElement::ReadLeavesCollectionSplitVectorPtrMember(TBuffer& b)
    if (!fNdata) {
       return;
    }
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
+   R__PushCache onfileObject(b,fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4442,7 +4442,7 @@ void TBranchElement::ReadLeavesCollectionMember(TBuffer& b)
    if (!fNdata) {
       return;
    }
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
+   R__PushCache onfileObject(b,fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
    if (info == nullptr) return;
@@ -4522,7 +4522,7 @@ void TBranchElement::ReadLeavesClonesMember(TBuffer& b)
 
    // Note, we could (possibly) save some more, by configuring the action
    // based on the value of fOnfileObject rather than pushing in on a stack.
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
+   R__PushCache onfileObject(b,fOnfileObject,fNdata);
 
    char **arr = (char **)clones->GetObjectRef();
    char **end = arr + fNdata;
@@ -4547,7 +4547,7 @@ void TBranchElement::ReadLeavesMember(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1);
+   R__PushCache onfileObject(b,fOnfileObject,1);
    // If not a TClonesArray or STL container master branch
    // or sub-branch and branch inherits from tobject,
    // then register with the buffer so that pointers are
@@ -4599,7 +4599,7 @@ void TBranchElement::ReadLeavesMemberBranchCount(TBuffer& b)
    if (!info) {
       return;
    }
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1); // Here we have a single object that contains a variable size C-style array.
+   R__PushCache onfileObject(b,fOnfileObject,1); // Here we have a single object that contains a variable size C-style array.
                                                                  // Since info is not null, fReadActionSequence is not null either.
    b.ApplySequence(*fReadActionSequence, fObject);
 }
@@ -4634,7 +4634,7 @@ void TBranchElement::ReadLeavesMemberCounter(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1);
+   R__PushCache onfileObject(b,fOnfileObject,1);
 
    // Since info is not null, fReadActionSequence is not null either.
    b.ApplySequence(*fReadActionSequence, fObject);
@@ -4655,7 +4655,7 @@ void TBranchElement::ReadLeavesCustomStreamer(TBuffer& b)
       return;
    }
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1);
+   R__PushCache onfileObject(b,fOnfileObject,1);
    fBranchClass->Streamer(fObject,b);
 }
 

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -523,9 +523,9 @@ bool ROOT::Detail::TBranchProxy::Setup()
                                   bcount?bcount->GetName():"unknown"));
                fMemberOffset = 0;
             } else if (fMemberOffset == TVirtualStreamerInfo::kMissing) {
-               Error("Setup","%s",Form("Missing data member in a TClonesArray, %s in %s and %s",
-                     fDataMember.Data(), fBranch->GetName(),
-                     bcount ? bcount->GetName() : "unknown"));
+               Error("Setup", "%s",
+                     Form("Missing data member in a TClonesArray, %s in %s and %s", fDataMember.Data(),
+                          fBranch->GetName(), bcount ? bcount->GetName() : "unknown"));
                fMemberOffset = 0;
             }
 
@@ -545,21 +545,23 @@ bool ROOT::Detail::TBranchProxy::Setup()
 
             }
             if (fMemberOffset < 0) {
-               Error("Setup","%s",Form("Negative offset %d for %s in %s, class: %s",
-                     fMemberOffset, fDataMember.Data(), fBranch->GetName(), fClass->GetName()));
+               Error("Setup", "%s",
+                     Form("Negative offset %d for %s in %s, class: %s", fMemberOffset, fDataMember.Data(),
+                          fBranch->GetName(), fClass->GetName()));
                fMemberOffset = 0;
             } else if (fMemberOffset == TVirtualStreamerInfo::kMissing) {
-               Error("Setup","%s",Form("Missing data member %s in %s, class: %s",
-                     fDataMember.Data(), fBranch->GetName(), fClass->GetName()));
+               Error("Setup", "%s",
+                     Form("Missing data member %s in %s, class: %s", fDataMember.Data(), fBranch->GetName(),
+                          fClass->GetName()));
                fMemberOffset = 0;
             }
 
          // The extra condition (fElement is not a TStreamerSTL) is to handle the case where fBranch is a
          // TBranchElement and fElement is a TStreamerSTL. Without the extra condition we get an error
          // message, although the vector (i.e. the TBranchElement) is accessible.
-         } else if (fParent && fBranch->IsA() != TBranch::Class() && fElement->IsA() != TStreamerBasicType::Class()
-                    && fElement->IsA() != TStreamerSTL::Class()) {
-            Error("Setup","%s",Form("Missing TClass object for %s",fClassName.Data()));
+         } else if (fParent && fBranch->IsA() != TBranch::Class() && fElement->IsA() != TStreamerBasicType::Class() &&
+                    fElement->IsA() != TStreamerSTL::Class()) {
+            Error("Setup", "%s", Form("Missing TClass object for %s", fClassName.Data()));
          }
 
          if ( fBranch->IsA()==TBranchElement::Class()

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -517,13 +517,19 @@ bool ROOT::Detail::TBranchProxy::Setup()
 
             fMemberOffset = fClass->GetDataMemberOffset(member);
 
-            if (fMemberOffset<0) {
+            if (fMemberOffset < 0) {
                Error("Setup","%s",Form("Negative offset %d for %s in %s",
                                   fMemberOffset,fBranch->GetName(),
                                   bcount?bcount->GetName():"unknown"));
+               fMemberOffset = 0;
+            } else if (fMemberOffset == TVirtualStreamerInfo::kMissing) {
+               Error("Setup","%s",Form("Missing data member in a TClonesArray, %s in %s and %s",
+                     fDataMember.Data(), fBranch->GetName(),
+                     bcount ? bcount->GetName() : "unknown"));
+               fMemberOffset = 0;
             }
 
-         } else if (fClass) {
+         } else if (fParent && fClass) {
 
             fElement = (TStreamerElement*)
                fClass->GetStreamerInfo()->GetElements()->FindObject(fDataMember);
@@ -538,12 +544,22 @@ bool ROOT::Detail::TBranchProxy::Setup()
                fMemberOffset = fClass->GetDataMemberOffset(member);
 
             }
+            if (fMemberOffset < 0) {
+               Error("Setup","%s",Form("Negative offset %d for %s in %s, class: %s",
+                     fMemberOffset, fDataMember.Data(), fBranch->GetName(), fClass->GetName()));
+               fMemberOffset = 0;
+            } else if (fMemberOffset == TVirtualStreamerInfo::kMissing) {
+               Error("Setup","%s",Form("Missing data member %s in %s, class: %s",
+                     fDataMember.Data(), fBranch->GetName(), fClass->GetName()));
+               fMemberOffset = 0;
+            }
+
          // The extra condition (fElement is not a TStreamerSTL) is to handle the case where fBranch is a
          // TBranchElement and fElement is a TStreamerSTL. Without the extra condition we get an error
          // message, although the vector (i.e. the TBranchElement) is accessible.
-         } else if (fBranch->IsA() != TBranch::Class() && fElement->IsA() != TStreamerBasicType::Class()
+         } else if (fParent && fBranch->IsA() != TBranch::Class() && fElement->IsA() != TStreamerBasicType::Class()
                     && fElement->IsA() != TStreamerSTL::Class()) {
-            Error("Setup","%s",Form("Missing TClass object for %s\n",fClassName.Data()));
+            Error("Setup","%s",Form("Missing TClass object for %s",fClassName.Data()));
          }
 
          if ( fBranch->IsA()==TBranchElement::Class()

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -127,8 +127,6 @@ TEST(TTreeReaderLeafs, LeafList) {
    EXPECT_EQ(6u, vec.GetSize());
    {
       using namespace ROOT::TestSupport;
-      CheckDiagsRAII diagRAII;
-      diagRAII.requiredDiag(kError, "Setup", "Missing TClass object for", false);
       EXPECT_FLOAT_EQ(13., arr[1]);
       EXPECT_DOUBLE_EQ(43., arrU[1]);
    }


### PR DESCRIPTION
With these changes, one can request the schema evolution (usually implicit) of the input data members from the on-file type to a custom type.  Example of the changes support in the test  roottest/root/io/evolution/rules/execSourceTypes.cxx added by the [companion roottest PR](https://github.com/root-project/roottest/pull/1247)

This fixes #17346 17346