### PR TITLE
[RF] Add parameter getters to RooCrystalBall

### DIFF
--- a/roofit/roofit/inc/RooCrystalBall.h
+++ b/roofit/roofit/inc/RooCrystalBall.h
@@ -8,12 +8,9 @@
 
 #include <memory>
 
-class RooRealVar;
-
 class RooCrystalBall final : public RooAbsPdf {
 public:
-
-   RooCrystalBall(){};
+   RooCrystalBall() {};
 
    RooCrystalBall(const char *name, const char *title, RooAbsReal &x, RooAbsReal &x0, RooAbsReal &sigmaL,
                   RooAbsReal &sigmaR, RooAbsReal &alphaL, RooAbsReal &nL, RooAbsReal &alphaR, RooAbsReal &nR);
@@ -31,6 +28,22 @@ public:
    // Optimized accept/reject generator support
    Int_t getMaxVal(const RooArgSet &vars) const override;
    double maxVal(Int_t code) const override;
+
+   // Getters for non-optional parameters
+   RooAbsReal const &x() const { return *x_; }
+   RooAbsReal const &x0() const { return *x0_; }
+   RooAbsReal const &sigmaL() const { return *sigmaL_; }
+   RooAbsReal const &sigmaR() const { return *sigmaR_; }
+   RooAbsReal const &alphaL() const { return *alphaL_; }
+   RooAbsReal const &nL() const { return *nL_; }
+
+   // Getters for optional parameter: return nullptr if parameter is not set
+   RooAbsReal const *alphaR() const { return alphaR_ ? &**alphaR_ : nullptr; }
+   RooAbsReal const *nR() const { return nR_ ? &**nR_ : nullptr; }
+
+   // Convenience functions to check if optional parameters are set
+   bool hasAlphaR() const { return alphaR_ != nullptr; }
+   bool hasNR() const { return nR_ != nullptr; }
 
 protected:
    double evaluate() const override;


### PR DESCRIPTION
The RooCrystalBall class didn't have getters to its parameters yet, which we generally need for all commonly-used PDFs for model inspection and IO (other than IO with ROOT files).

Requested by @VanyaBelyaev.

