### PR TITLE
[ntuple] Clean up utility definitions

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -86,7 +86,7 @@ public:
    }
    // Field is only used for reading
    void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<ClusterSize_t>(desc); }
+   void GenerateColumns(const RNTupleDescriptor &desc) final { GenerateColumnsImpl<Internal::RColumnIndex>(desc); }
 
    size_t GetValueSize() const final { return sizeof(std::size_t); }
    size_t GetAlignment() const final { return alignof(std::size_t); }

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -95,7 +95,7 @@ public:
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final
    {
       RClusterIndex collectionStart;
-      ClusterSize_t size;
+      NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
       *static_cast<std::size_t *>(to) = size;
    }
@@ -104,7 +104,7 @@ public:
    void ReadInClusterImpl(ROOT::Experimental::RClusterIndex clusterIndex, void *to) final
    {
       RClusterIndex collectionStart;
-      ClusterSize_t size;
+      NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
       *static_cast<std::size_t *>(to) = size;
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -287,17 +287,17 @@ public:
       // Try to avoid jumping back to the previous page and jumping back to the previous cluster
       if (R__likely(globalIndex > 0)) {
          if (R__likely(fReadPageRef.Get().Contains(globalIndex - 1))) {
-            idxStart = *Map<ClusterSize_t>(globalIndex - 1);
-            idxEnd = *Map<ClusterSize_t>(globalIndex);
+            idxStart = *Map<RColumnIndex>(globalIndex - 1);
+            idxEnd = *Map<RColumnIndex>(globalIndex);
             if (R__unlikely(fReadPageRef.Get().GetClusterInfo().GetIndexOffset() == globalIndex))
                idxStart = 0;
          } else {
-            idxEnd = *Map<ClusterSize_t>(globalIndex);
+            idxEnd = *Map<RColumnIndex>(globalIndex);
             auto selfOffset = fReadPageRef.Get().GetClusterInfo().GetIndexOffset();
-            idxStart = (globalIndex == selfOffset) ? 0 : *Map<ClusterSize_t>(globalIndex - 1);
+            idxStart = (globalIndex == selfOffset) ? 0 : *Map<RColumnIndex>(globalIndex - 1);
          }
       } else {
-         idxEnd = *Map<ClusterSize_t>(globalIndex);
+         idxEnd = *Map<RColumnIndex>(globalIndex);
       }
       *collectionSize = idxEnd - idxStart;
       *collectionStart = RClusterIndex(fReadPageRef.Get().GetClusterInfo().GetId(), idxStart);
@@ -306,8 +306,8 @@ public:
    void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *collectionSize)
    {
       auto index = clusterIndex.GetIndex();
-      auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t>(clusterIndex - 1);
-      auto idxEnd = *Map<ClusterSize_t>(clusterIndex);
+      auto idxStart = (index == 0) ? 0 : *Map<RColumnIndex>(clusterIndex - 1);
+      auto idxEnd = *Map<RColumnIndex>(clusterIndex);
       *collectionSize = idxEnd - idxStart;
       *collectionStart = RClusterIndex(clusterIndex.GetClusterId(), idxStart);
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -179,7 +179,7 @@ public:
       std::memcpy(to, from, elemSize);
    }
 
-   void ReadV(NTupleSize_t globalIndex, ClusterSize_t::ValueType count, void *to)
+   void ReadV(NTupleSize_t globalIndex, NTupleSize_t count, void *to)
    {
       const auto elemSize = fElement->GetSize();
       auto tail = static_cast<unsigned char *>(to);
@@ -191,7 +191,7 @@ public:
          const NTupleSize_t idxInPage = globalIndex - fReadPageRef.Get().GetGlobalRangeFirst();
 
          const void *from = static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) + idxInPage * elemSize;
-         const ClusterSize_t::ValueType nBatch = std::min(fReadPageRef.Get().GetNElements() - idxInPage, count);
+         const NTupleSize_t nBatch = std::min(fReadPageRef.Get().GetNElements() - idxInPage, count);
 
          std::memcpy(tail, from, elemSize * nBatch);
 
@@ -201,7 +201,7 @@ public:
       }
    }
 
-   void ReadV(RClusterIndex clusterIndex, ClusterSize_t::ValueType count, void *to)
+   void ReadV(RClusterIndex clusterIndex, NTupleSize_t count, void *to)
    {
       const auto elemSize = fElement->GetSize();
       auto tail = static_cast<unsigned char *>(to);
@@ -213,7 +213,7 @@ public:
          NTupleSize_t idxInPage = clusterIndex.GetIndex() - fReadPageRef.Get().GetClusterRangeFirst();
 
          const void *from = static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) + idxInPage * elemSize;
-         const ClusterSize_t::ValueType nBatch = std::min(count, fReadPageRef.Get().GetNElements() - idxInPage);
+         const NTupleSize_t nBatch = std::min(count, fReadPageRef.Get().GetNElements() - idxInPage);
 
          std::memcpy(tail, from, elemSize * nBatch);
 
@@ -280,7 +280,7 @@ public:
    }
 
    /// For offset columns only, look at the two adjacent values that define a collection's coordinates
-   void GetCollectionInfo(const NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
+   void GetCollectionInfo(const NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *collectionSize)
    {
       NTupleSize_t idxStart = 0;
       NTupleSize_t idxEnd;
@@ -303,7 +303,7 @@ public:
       *collectionStart = RClusterIndex(fReadPageRef.Get().GetClusterInfo().GetId(), idxStart);
    }
 
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *collectionSize)
    {
       auto index = clusterIndex.GetIndex();
       auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t>(clusterIndex - 1);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -270,11 +270,11 @@ class RCardinalityField : public RFieldBase {
    friend class RNTupleCollectionView; // to access GetCollectionInfo()
 
 private:
-   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size)
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *size)
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size)
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *size)
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
@@ -367,7 +367,7 @@ public:
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final
    {
       RClusterIndex collectionStart;
-      ClusterSize_t size;
+      NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
       *static_cast<RNTupleCardinality<SizeT> *>(to) = size;
    }
@@ -376,7 +376,7 @@ public:
    void ReadInClusterImpl(RClusterIndex clusterIndex, void *to) final
    {
       RClusterIndex collectionStart;
-      ClusterSize_t size;
+      NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
       *static_cast<RNTupleCardinality<SizeT> *>(to) = size;
    }
@@ -384,14 +384,14 @@ public:
    std::size_t ReadBulkImpl(const RBulkSpec &bulkSpec) final
    {
       RClusterIndex collectionStart;
-      ClusterSize_t collectionSize;
+      NTupleSize_t collectionSize;
       fPrincipalColumn->GetCollectionInfo(bulkSpec.fFirstIndex, &collectionStart, &collectionSize);
 
       auto typedValues = static_cast<RNTupleCardinality<SizeT> *>(bulkSpec.fValues);
       typedValues[0] = collectionSize;
 
       auto lastOffset = collectionStart.GetIndex() + collectionSize;
-      ClusterSize_t::ValueType nRemainingEntries = bulkSpec.fCount - 1;
+      NTupleSize_t nRemainingEntries = bulkSpec.fCount - 1;
       std::size_t nEntries = 1;
       while (nRemainingEntries > 0) {
          NTupleSize_t nItemsUntilPageEnd;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -171,7 +171,7 @@ private:
 
    TClass *fClass = nullptr;
    Internal::RNTupleSerializer::StreamerInfoMap_t fStreamerInfos; ///< streamer info records seen during writing
-   ClusterSize_t fIndex;                                          ///< number of bytes written in the current cluster
+   Internal::RColumnIndex fIndex;                                 ///< number of bytes written in the current cluster
 
 private:
    // Note that className may be different from classp->GetName(), e.g. through different canonicalization of RNTuple
@@ -395,7 +395,8 @@ public:
       std::size_t nEntries = 1;
       while (nRemainingEntries > 0) {
          NTupleSize_t nItemsUntilPageEnd;
-         auto offsets = fPrincipalColumn->MapV<ClusterSize_t>(bulkSpec.fFirstIndex + nEntries, nItemsUntilPageEnd);
+         auto offsets =
+            fPrincipalColumn->MapV<Internal::RColumnIndex>(bulkSpec.fFirstIndex + nEntries, nItemsUntilPageEnd);
          std::size_t nBatch = std::min(nRemainingEntries, nItemsUntilPageEnd);
          for (std::size_t i = 0; i < nBatch; ++i) {
             typedValues[nEntries + i] = offsets[i] - lastOffset;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -150,7 +150,7 @@ protected:
    RCollectionIterableOnce::RIteratorFuncs fIFuncsRead;
    RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;
    std::size_t fItemSize;
-   ClusterSize_t fNWritten;
+   Internal::RColumnIndex fNWritten;
 
    /// Constructor used when the value type of the collection is not known in advance, i.e. in the case of custom
    /// collections.

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -183,11 +183,11 @@ public:
    size_t GetValueSize() const final { return fProxy->Sizeof(); }
    size_t GetAlignment() const final { return alignof(std::max_align_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -166,7 +166,7 @@ public:
 /// representation.  Nullable fields use a (Split)Index[64|32] column to point to the available items.
 class RNullableField : public RFieldBase {
    /// The number of written non-null items in this cluster
-   ClusterSize_t fNWritten{0};
+   Internal::RColumnIndex fNWritten{0};
 
 protected:
    const RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
@@ -290,7 +290,7 @@ public:
 template <>
 class RField<std::string> final : public RFieldBase {
 private:
-   ClusterSize_t fIndex;
+   Internal::RColumnIndex fIndex;
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
@@ -358,7 +358,7 @@ private:
    size_t fTagOffset = 0;
    /// In the std::variant memory layout, the actual union of types may start at an offset > 0
    size_t fVariantOffset = 0;
-   std::vector<ClusterSize_t::ValueType> fNWritten;
+   std::vector<Internal::RColumnIndex::ValueType> fNWritten;
 
    static std::string GetTypeList(const std::vector<std::unique_ptr<RFieldBase>> &itemFields);
    /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -178,7 +178,7 @@ protected:
    void CommitClusterImpl() final { fNWritten = 0; }
 
    /// Given the index of the nullable field, returns the corresponding global index of the subfield or,
-   /// if it is null, returns kInvalidClusterIndex
+   /// if it is null, returns kInvalidNTupleIndex
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);
 
    RNullableField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -128,7 +128,7 @@ public:
 
 protected:
    std::size_t fItemSize;
-   ClusterSize_t fNWritten;
+   Internal::RColumnIndex fNWritten;
    std::size_t fValueSize;
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -206,7 +206,7 @@ private:
    };
 
    std::size_t fItemSize;
-   ClusterSize_t fNWritten;
+   Internal::RColumnIndex fNWritten;
    std::unique_ptr<RDeleter> fItemDeleter;
 
 protected:
@@ -263,7 +263,7 @@ public:
 template <>
 class RField<std::vector<bool>> final : public RFieldBase {
 private:
-   ClusterSize_t fNWritten{0};
+   Internal::RColumnIndex fNWritten{0};
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -157,11 +157,11 @@ public:
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
@@ -239,11 +239,11 @@ public:
    size_t GetValueSize() const final { return sizeof(std::vector<char>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
@@ -295,11 +295,11 @@ public:
    size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
    }
-   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   void GetCollectionInfo(RClusterIndex clusterIndex, RClusterIndex *collectionStart, NTupleSize_t *size) const
    {
       fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -373,7 +373,7 @@ public:
    {
       return fColumnRanges.find(physicalId) != fColumnRanges.end();
    }
-   std::uint64_t GetBytesOnStorage() const;
+   std::uint64_t GetNBytesOnStorage() const;
 };
 
 class RClusterDescriptor::RColumnRangeIterable {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -240,7 +240,7 @@ public:
       NTupleSize_t fNElements = kInvalidNTupleIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
-      int fCompressionSettings = kUnknownCompressionSettings;
+      int fCompressionSettings = kNTupleUnknownCompression;
       /// Suppressed columns have an empty page range and unknown compression settings.
       /// Their element index range, however, is aligned with the corresponding column of the
       /// primary column representation (see Section "Suppressed Columns" in the specification)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -237,7 +237,7 @@ public:
       /// The global index of the first column element in the cluster
       NTupleSize_t fFirstElementIndex = kInvalidNTupleIndex;
       /// The number of column elements in the cluster
-      ClusterSize_t fNElements = kInvalidClusterIndex;
+      NTupleSize_t fNElements = kInvalidNTupleIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
       int fCompressionSettings = kUnknownCompressionSettings;
@@ -301,12 +301,12 @@ public:
       };
       struct RPageInfoExtended : RPageInfo {
          /// Index (in cluster) of the first element in page.
-         ClusterSize_t::ValueType fFirstInPage = 0;
+         NTupleSize_t fFirstInPage = 0;
          /// Page number in the corresponding RPageRange.
          NTupleSize_t fPageNo = 0;
 
          RPageInfoExtended() = default;
-         RPageInfoExtended(const RPageInfo &pi, ClusterSize_t::ValueType i, NTupleSize_t n)
+         RPageInfoExtended(const RPageInfo &pi, NTupleSize_t i, NTupleSize_t n)
             : RPageInfo(pi), fFirstInPage(i), fPageNo(n)
          {
          }
@@ -328,7 +328,7 @@ public:
       }
 
       /// Find the page in the RPageRange that contains the given element. The element must exist.
-      RPageInfoExtended Find(ClusterSize_t::ValueType idxInCluster) const;
+      RPageInfoExtended Find(NTupleSize_t idxInCluster) const;
 
       DescriptorId_t fPhysicalColumnId = kInvalidDescriptorId;
       std::vector<RPageInfo> fPageInfos;
@@ -344,7 +344,7 @@ private:
    /// Clusters can be swapped by adjusting the entry offsets
    NTupleSize_t fFirstEntryIndex = kInvalidNTupleIndex;
    // TODO(jblomer): change to std::uint64_t
-   ClusterSize_t fNEntries = kInvalidClusterIndex;
+   NTupleSize_t fNEntries = kInvalidNTupleIndex;
 
    std::unordered_map<DescriptorId_t, RColumnRange> fColumnRanges;
    std::unordered_map<DescriptorId_t, RPageRange> fPageRanges;
@@ -364,7 +364,7 @@ public:
 
    DescriptorId_t GetId() const { return fClusterId; }
    NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
-   ClusterSize_t GetNEntries() const { return fNEntries; }
+   NTupleSize_t GetNEntries() const { return fNEntries; }
    const RColumnRange &GetColumnRange(DescriptorId_t physicalId) const { return fColumnRanges.at(physicalId); }
    const RPageRange &GetPageRange(DescriptorId_t physicalId) const { return fPageRanges.at(physicalId); }
    /// Returns an iterator over pairs { columnId, columnRange }. The iteration order is unspecified.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -56,10 +56,10 @@ struct RSealedPageMergeData;
 class RClusterPool;
 
 struct RNTupleMergeOptions {
-   /// If `fCompressionSettings == kUnknownCompressionSettings` (the default), the merger will not change the
+   /// If `fCompressionSettings == kNTupleUnknownCompression` (the default), the merger will not change the
    /// compression of any of its sources (fast merging). Otherwise, all sources will be converted to the specified
    /// compression algorithm and level.
-   int fCompressionSettings = kUnknownCompressionSettings;
+   int fCompressionSettings = kNTupleUnknownCompression;
    /// Determines how the merging treats sources with different models (\see ENTupleMergingMode).
    ENTupleMergingMode fMergingMode = ENTupleMergingMode::kFilter;
    /// Determines how the Merge function behaves upon merging errors

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -32,6 +32,15 @@
 namespace ROOT {
 namespace Experimental {
 
+/// Used to specify the underlying RNTuples in RNTupleProcessor
+struct RNTupleOpenSpec {
+   std::string fNTupleName;
+   std::string fStorage;
+   RNTupleReadOptions fOptions;
+
+   RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(s) {}
+};
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleProcessor

--- a/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
@@ -84,8 +84,8 @@ public:
 class RNTupleClusterRange {
 private:
    const DescriptorId_t fClusterId;
-   const ClusterSize_t::ValueType fStart;
-   const ClusterSize_t::ValueType fEnd;
+   const NTupleSize_t fStart;
+   const NTupleSize_t fEnd;
 
 public:
    class RIterator {
@@ -121,7 +121,7 @@ public:
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
    };
 
-   RNTupleClusterRange(DescriptorId_t clusterId, ClusterSize_t::ValueType start, ClusterSize_t::ValueType end)
+   RNTupleClusterRange(DescriptorId_t clusterId, NTupleSize_t start, NTupleSize_t end)
       : fClusterId(clusterId), fStart(start), fEnd(end)
    {
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -189,7 +189,7 @@ public:
    };
 
 private:
-   std::uint64_t fBytesOnStorage = 0;
+   std::uint64_t fNBytesOnStorage = 0;
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
    std::variant<std::uint64_t, RNTupleLocatorObject64> fPosition{};
@@ -204,14 +204,14 @@ public:
 
    bool operator==(const RNTupleLocator &other) const
    {
-      return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage && fType == other.fType;
+      return fPosition == other.fPosition && fNBytesOnStorage == other.fNBytesOnStorage && fType == other.fType;
    }
 
-   std::uint64_t GetBytesOnStorage() const { return fBytesOnStorage; }
+   std::uint64_t GetNBytesOnStorage() const { return fNBytesOnStorage; }
    ELocatorType GetType() const { return fType; }
    std::uint8_t GetReserved() const { return fReserved; }
 
-   void SetBytesOnStorage(std::uint64_t bytesOnStorage) { fBytesOnStorage = bytesOnStorage; }
+   void SetNBytesOnStorage(std::uint64_t nBytesOnStorage) { fNBytesOnStorage = nBytesOnStorage; }
    void SetType(ELocatorType type) { fType = type; }
    void SetReserved(std::uint8_t reserved) { fReserved = reserved; }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -251,15 +251,6 @@ struct RNTupleLocator {
    }
 };
 
-/// Used to specify the underlying RNTuples in RNTupleProcessor
-struct RNTupleOpenSpec {
-   std::string fNTupleName;
-   std::string fStorage;
-   RNTupleReadOptions fOptions;
-
-   RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(s) {}
-};
-
 namespace Internal {
 template <typename T>
 auto MakeAliasedSharedPtr(T *rawPtr)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -148,19 +148,6 @@ constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
 constexpr int kUnknownCompressionSettings = -1;
 
-/// Holds the index and the tag of a kSwitch column
-class RColumnSwitch {
-private:
-   ClusterSize_t fIndex;
-   std::uint32_t fTag = 0;
-
-public:
-   RColumnSwitch() = default;
-   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) {}
-   ClusterSize_t GetIndex() const { return fIndex; }
-   std::uint32_t GetTag() const { return fTag; }
-};
-
 /// Uniquely identifies a physical column within the scope of the current process, used to tag pages
 using ColumnId_t = std::int64_t;
 constexpr ColumnId_t kInvalidColumnId = -1;
@@ -252,6 +239,20 @@ struct RNTupleLocator {
 };
 
 namespace Internal {
+
+/// Holds the index and the tag of a kSwitch column
+class RColumnSwitch {
+private:
+   ClusterSize_t fIndex;
+   std::uint32_t fTag = 0;
+
+public:
+   RColumnSwitch() = default;
+   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) {}
+   ClusterSize_t GetIndex() const { return fIndex; }
+   std::uint32_t GetTag() const { return fTag; }
+};
+
 template <typename T>
 auto MakeAliasedSharedPtr(T *rawPtr)
 {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -148,10 +148,6 @@ constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
 constexpr int kUnknownCompressionSettings = -1;
 
-/// Uniquely identifies a physical column within the scope of the current process, used to tag pages
-using ColumnId_t = std::int64_t;
-constexpr ColumnId_t kInvalidColumnId = -1;
-
 /// Distriniguishes elements of the same type within a descriptor, e.g. different fields
 using DescriptorId_t = std::uint64_t;
 constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -236,13 +236,13 @@ namespace Internal {
 /// Holds the index and the tag of a kSwitch column
 class RColumnSwitch {
 private:
-   ClusterSize_t fIndex;
+   NTupleSize_t fIndex;
    std::uint32_t fTag = 0;
 
 public:
    RColumnSwitch() = default;
-   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) {}
-   ClusterSize_t GetIndex() const { return fIndex; }
+   RColumnSwitch(NTupleSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) {}
+   NTupleSize_t GetIndex() const { return fIndex; }
    std::uint32_t GetTag() const { return fTag; }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -173,8 +173,8 @@ public:
 /// Generic information about the physical location of data. Values depend on the concrete storage type.  E.g.,
 /// for a local file `fPosition` might be a 64bit file offset. Referenced objects on storage can be compressed
 /// and therefore we need to store their actual size.
-/// TODO(jblomer): consider moving this to `RNTupleDescriptor`
-struct RNTupleLocator {
+class RNTupleLocator {
+public:
    /// Values for the _Type_ field in non-disk locators.  Serializable types must have the MSb == 0; see
    /// `doc/BinaryFormatSpecification.md` for details
    enum ELocatorType : std::uint8_t {
@@ -188,6 +188,7 @@ struct RNTupleLocator {
       kTypeUnknown,
    };
 
+private:
    std::uint64_t fBytesOnStorage = 0;
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
@@ -198,14 +199,32 @@ struct RNTupleLocator {
    /// Reserved for use by concrete storage backends
    std::uint8_t fReserved = 0;
 
+public:
+   RNTupleLocator() = default;
+
    bool operator==(const RNTupleLocator &other) const
    {
       return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage && fType == other.fType;
    }
+
+   std::uint64_t GetBytesOnStorage() const { return fBytesOnStorage; }
+   ELocatorType GetType() const { return fType; }
+   std::uint8_t GetReserved() const { return fReserved; }
+
+   void SetBytesOnStorage(std::uint64_t bytesOnStorage) { fBytesOnStorage = bytesOnStorage; }
+   void SetType(ELocatorType type) { fType = type; }
+   void SetReserved(std::uint8_t reserved) { fReserved = reserved; }
+
    template <typename T>
-   const T &GetPosition() const
+   T GetPosition() const
    {
       return std::get<T>(fPosition);
+   }
+
+   template <typename T>
+   void SetPosition(T position)
+   {
+      fPosition = position;
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -117,33 +117,6 @@ enum ENTupleStructure : std::uint16_t { kInvalid, kLeaf, kCollection, kRecord, k
 /// Integer type long enough to hold the maximum number of entries in a column
 using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
-/// Wrap the integer in a struct in order to avoid template specialization clash with std::uint64_t
-struct RClusterSize {
-   using ValueType = std::uint64_t;
-
-   RClusterSize() : fValue(0) {}
-   explicit constexpr RClusterSize(ValueType value) : fValue(value) {}
-   RClusterSize &operator=(const ValueType value)
-   {
-      fValue = value;
-      return *this;
-   }
-   RClusterSize &operator+=(const ValueType value)
-   {
-      fValue += value;
-      return *this;
-   }
-   RClusterSize operator++(int)
-   {
-      auto result = *this;
-      fValue++;
-      return result;
-   }
-   operator ValueType() const { return fValue; }
-
-   ValueType fValue;
-};
-using ClusterSize_t = RClusterSize;
 
 constexpr int kUnknownCompressionSettings = -1;
 
@@ -231,6 +204,34 @@ struct RNTupleLocator {
 };
 
 namespace Internal {
+
+/// The in-memory representation of a 32bit or 64bit on-disk index column. Wraps the integer in a
+/// named type so that templates can distinguish between integer data columns and index columns.
+struct RColumnIndex {
+   using ValueType = std::uint64_t;
+
+   RColumnIndex() : fValue(0) {}
+   explicit constexpr RColumnIndex(ValueType value) : fValue(value) {}
+   RColumnIndex &operator=(const ValueType value)
+   {
+      fValue = value;
+      return *this;
+   }
+   RColumnIndex &operator+=(const ValueType value)
+   {
+      fValue += value;
+      return *this;
+   }
+   RColumnIndex operator++(int)
+   {
+      auto result = *this;
+      fValue++;
+      return result;
+   }
+   operator ValueType() const { return fValue; }
+
+   ValueType fValue;
+};
 
 /// Holds the index and the tag of a kSwitch column
 class RColumnSwitch {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -17,7 +17,6 @@
 #define ROOT7_RNTupleUtil
 
 #include <cstdint>
-
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -25,7 +24,6 @@
 
 #include <ROOT/RError.hxx>
 #include <ROOT/RLogger.hxx>
-#include <ROOT/RNTupleReadOptions.hxx>
 
 namespace ROOT {
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -207,10 +207,15 @@ namespace Internal {
 
 /// The in-memory representation of a 32bit or 64bit on-disk index column. Wraps the integer in a
 /// named type so that templates can distinguish between integer data columns and index columns.
-struct RColumnIndex {
+class RColumnIndex {
+public:
    using ValueType = std::uint64_t;
 
-   RColumnIndex() : fValue(0) {}
+private:
+   ValueType fValue = 0;
+
+public:
+   RColumnIndex() = default;
    explicit constexpr RColumnIndex(ValueType value) : fValue(value) {}
    RColumnIndex &operator=(const ValueType value)
    {
@@ -229,8 +234,6 @@ struct RColumnIndex {
       return result;
    }
    operator ValueType() const { return fValue; }
-
-   ValueType fValue;
 };
 
 /// Holds the index and the tag of a kSwitch column

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -156,19 +156,16 @@ constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);
 class RClusterIndex {
 private:
    DescriptorId_t fClusterId = kInvalidDescriptorId;
-   ClusterSize_t::ValueType fIndex = kInvalidClusterIndex;
+   NTupleSize_t fIndex = kInvalidClusterIndex;
 
 public:
    RClusterIndex() = default;
    RClusterIndex(const RClusterIndex &other) = default;
    RClusterIndex &operator=(const RClusterIndex &other) = default;
-   constexpr RClusterIndex(DescriptorId_t clusterId, ClusterSize_t::ValueType index)
-      : fClusterId(clusterId), fIndex(index)
-   {
-   }
+   constexpr RClusterIndex(DescriptorId_t clusterId, NTupleSize_t index) : fClusterId(clusterId), fIndex(index) {}
 
-   RClusterIndex operator+(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex + off); }
-   RClusterIndex operator-(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex - off); }
+   RClusterIndex operator+(NTupleSize_t off) const { return RClusterIndex(fClusterId, fIndex + off); }
+   RClusterIndex operator-(NTupleSize_t off) const { return RClusterIndex(fClusterId, fIndex - off); }
    RClusterIndex operator++(int) /* postfix */
    {
       auto r = *this;
@@ -184,7 +181,7 @@ public:
    bool operator!=(RClusterIndex other) const { return !(*this == other); }
 
    DescriptorId_t GetClusterId() const { return fClusterId; }
-   ClusterSize_t::ValueType GetIndex() const { return fIndex; }
+   NTupleSize_t GetIndex() const { return fIndex; }
 };
 
 /// RNTupleLocator payload that is common for object stores using 64bit location information.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -118,7 +118,8 @@ enum ENTupleStructure : std::uint16_t { kInvalid, kLeaf, kCollection, kRecord, k
 using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
 
-constexpr int kUnknownCompressionSettings = -1;
+/// Regular, known compression settings have the form algorithm * 100 + level, e.g. 101, 505, ...
+constexpr int kNTupleUnknownCompression = -1;
 
 /// Distriniguishes elements of the same type within a descriptor, e.g. different fields
 using DescriptorId_t = std::uint64_t;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -159,9 +159,15 @@ public:
 /// RNTupleLocator payload that is common for object stores using 64bit location information.
 /// This might not contain the full location of the content. In particular, for page locators this information may be
 /// used in conjunction with the cluster and column ID.
-struct RNTupleLocatorObject64 {
+class RNTupleLocatorObject64 {
+private:
    std::uint64_t fLocation = 0;
+
+public:
+   RNTupleLocatorObject64() = default;
+   explicit RNTupleLocatorObject64(std::uint64_t location) : fLocation(location) {}
    bool operator==(const RNTupleLocatorObject64 &other) const { return fLocation == other.fLocation; }
+   std::uint64_t GetLocation() const { return fLocation; }
 };
 
 /// Generic information about the physical location of data. Values depend on the concrete storage type.  E.g.,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -144,7 +144,6 @@ struct RClusterSize {
    ValueType fValue;
 };
 using ClusterSize_t = RClusterSize;
-constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
 constexpr int kUnknownCompressionSettings = -1;
 
@@ -156,7 +155,7 @@ constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);
 class RClusterIndex {
 private:
    DescriptorId_t fClusterId = kInvalidDescriptorId;
-   NTupleSize_t fIndex = kInvalidClusterIndex;
+   NTupleSize_t fIndex = kInvalidNTupleIndex;
 
 public:
    RClusterIndex() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -309,7 +309,7 @@ public:
    ~RNTupleCollectionView() = default;
 
    RNTupleClusterRange GetCollectionRange(NTupleSize_t globalIndex) {
-      ClusterSize_t size;
+      NTupleSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(globalIndex, &collectionStart, &size);
       return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndex(),
@@ -317,7 +317,7 @@ public:
    }
    RNTupleClusterRange GetCollectionRange(RClusterIndex clusterIndex)
    {
-      ClusterSize_t size;
+      NTupleSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(clusterIndex, &collectionStart, &size);
       return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndex(),

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -79,8 +79,7 @@ private:
 
 public:
    RPage() = default;
-   RPage(void *buffer, RPageAllocator *pageAllocator, ClusterSize_t::ValueType elementSize,
-         ClusterSize_t::ValueType maxElements)
+   RPage(void *buffer, RPageAllocator *pageAllocator, std::uint32_t elementSize, std::uint32_t maxElements)
       : fBuffer(buffer), fPageAllocator(pageAllocator), fElementSize(elementSize), fMaxElements(maxElements)
    {}
    RPage(const RPage &) = delete;
@@ -125,10 +124,8 @@ public:
    std::uint32_t GetMaxElements() const { return fMaxElements; }
    NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
-   ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
-   ClusterSize_t::ValueType GetClusterRangeLast() const {
-      return GetClusterRangeFirst() + NTupleSize_t(fNElements) - 1;
-   }
+   NTupleSize_t GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
+   NTupleSize_t GetClusterRangeLast() const { return GetClusterRangeFirst() + NTupleSize_t(fNElements) - 1; }
    const RClusterInfo& GetClusterInfo() const { return fClusterInfo; }
 
    bool Contains(NTupleSize_t globalIndex) const {
@@ -139,7 +136,7 @@ public:
    {
       if (fClusterInfo.GetId() != clusterIndex.GetClusterId())
          return false;
-      auto clusterRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetIndexOffset());
+      auto clusterRangeFirst = fRangeFirst - fClusterInfo.GetIndexOffset();
       return (clusterIndex.GetIndex() >= clusterRangeFirst) &&
              (clusterIndex.GetIndex() < clusterRangeFirst + fNElements);
    }
@@ -151,7 +148,7 @@ public:
    /// nElements in the page.
    /// When reading a page from disk, GrowUnchecked is used to set the actual number of elements. In this case, the
    /// return value is ignored.
-   void *GrowUnchecked(ClusterSize_t::ValueType nElements)
+   void *GrowUnchecked(std::uint32_t nElements)
    {
       assert(fNElements + nElements <= fMaxElements);
       auto offset = GetNBytes();

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -94,9 +94,9 @@ private:
             return fGlobalFirstElement < other.fGlobalFirstElement;
 
          assert(fClusterFirstElement.GetClusterId() != kInvalidDescriptorId &&
-                fClusterFirstElement.GetIndex() != kInvalidClusterIndex);
+                fClusterFirstElement.GetIndex() != kInvalidNTupleIndex);
          assert(other.fClusterFirstElement.GetClusterId() != kInvalidDescriptorId &&
-                other.fClusterFirstElement.GetIndex() != kInvalidClusterIndex);
+                other.fClusterFirstElement.GetIndex() != kInvalidNTupleIndex);
          if (fClusterFirstElement.GetClusterId() == other.fClusterFirstElement.GetClusterId())
             return fClusterFirstElement.GetIndex() < other.fClusterFirstElement.GetIndex();
          return fClusterFirstElement.GetClusterId() < other.fClusterFirstElement.GetClusterId();

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -187,7 +187,7 @@ public:
    /// Unregisters a column.  A page source decreases the reference counter for the corresponding active column.
    /// For a page sink, dropping columns is currently a no-op.
    virtual void DropColumn(ColumnHandle_t columnHandle) = 0;
-   ColumnId_t GetColumnId(ColumnHandle_t columnHandle) const { return columnHandle.fPhysicalId; }
+   DescriptorId_t GetColumnId(ColumnHandle_t columnHandle) const { return columnHandle.fPhysicalId; }
 
    /// Returns the default metrics object.  Subclasses might alternatively provide their own metrics object by
    /// overriding this.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -266,7 +266,7 @@ public:
 
       struct RColumnInfo {
          RClusterDescriptor::RPageRange fPageRange;
-         ClusterSize_t fNElements = kInvalidClusterIndex;
+         NTupleSize_t fNElements = kInvalidNTupleIndex;
          bool fIsSuppressed = false;
       };
 
@@ -697,8 +697,8 @@ protected:
    // Only called if a task scheduler is set. No-op be default.
    virtual void UnzipClusterImpl(RCluster *cluster);
    // Returns a page from storage if not found in the page pool. Should be able to handle zero page locators.
-   virtual RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,
-                                 ClusterSize_t::ValueType idxInCluster) = 0;
+   virtual RPageRef
+   LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, NTupleSize_t idxInCluster) = 0;
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -161,8 +161,7 @@ private:
 
    RNTupleDescriptorBuilder fDescriptorBuilder;
 
-   RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,
-                         ClusterSize_t::ValueType idxInCluster) final;
+   RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, NTupleSize_t idxInCluster) final;
 
 protected:
    void LoadStructureImpl() final {}

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -41,7 +41,7 @@ class RRawFile;
 }
 
 namespace Experimental {
-struct RNTupleLocator;
+class RNTupleLocator;
 
 namespace Internal {
 class RClusterPool;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -162,8 +162,7 @@ protected:
    /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 
-   RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,
-                         ClusterSize_t::ValueType idxInCluster) final;
+   RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, NTupleSize_t idxInCluster) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -210,9 +210,9 @@ ROOT::Experimental::Internal::RClusterPool::GetCluster(DescriptorId_t clusterId,
 
          auto cid = next;
          next = descriptorGuard->FindNextClusterId(cid);
-         if (next != kInvalidClusterIndex) {
+         if (next != kInvalidNTupleIndex) {
             if (!fPageSource.GetEntryRange().IntersectsWith(descriptorGuard->GetClusterDescriptor(next)))
-               next = kInvalidClusterIndex;
+               next = kInvalidNTupleIndex;
          }
          if (next == kInvalidDescriptorId)
             provideInfo.fFlags |= RProvides::kFlagLast;

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -111,8 +111,8 @@ std::unique_ptr<ROOT::Experimental::Internal::RColumnElementBase>
 ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType onDiskType)
 {
    switch (onDiskType) {
-   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
-   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
+   case EColumnType::kIndex64: return std::make_unique<RColumnElement<RColumnIndex, EColumnType::kIndex64>>();
+   case EColumnType::kIndex32: return std::make_unique<RColumnElement<RColumnIndex, EColumnType::kIndex32>>();
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
    case EColumnType::kByte: return std::make_unique<RColumnElement<std::byte, EColumnType::kByte>>();
    case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>();
@@ -129,10 +129,8 @@ ROOT::Experimental::Internal::RColumnElementBase::Generate<void>(EColumnType onD
    case EColumnType::kUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kUInt16>>();
    case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>();
    case EColumnType::kUInt8: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kUInt8>>();
-   case EColumnType::kSplitIndex64:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>();
-   case EColumnType::kSplitIndex32:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>();
+   case EColumnType::kSplitIndex64: return std::make_unique<RColumnElement<RColumnIndex, EColumnType::kSplitIndex64>>();
+   case EColumnType::kSplitIndex32: return std::make_unique<RColumnElement<RColumnIndex, EColumnType::kSplitIndex32>>();
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>();
    case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>();
    case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>();
@@ -181,8 +179,8 @@ ROOT::Experimental::Internal::GenerateColumnElement(std::type_index inMemoryType
       return GenerateColumnElementInternal<float>(onDiskType);
    } else if (inMemoryType == std::type_index(typeid(double))) {
       return GenerateColumnElementInternal<double>(onDiskType);
-   } else if (inMemoryType == std::type_index(typeid(ClusterSize_t))) {
-      return GenerateColumnElementInternal<ClusterSize_t>(onDiskType);
+   } else if (inMemoryType == std::type_index(typeid(RColumnIndex))) {
+      return GenerateColumnElementInternal<RColumnIndex>(onDiskType);
    } else if (inMemoryType == std::type_index(typeid(RColumnSwitch))) {
       return GenerateColumnElementInternal<RColumnSwitch>(onDiskType);
    } else if (inMemoryType == std::type_index(typeid(RTestFutureColumn))) {

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -772,8 +772,7 @@ public:
          element.fIndex = RByteSwap<8>::bswap(element.fIndex);
          element.fTag = RByteSwap<4>::bswap(element.fTag);
 #endif
-         dstArray[i] = ROOT::Experimental::Internal::RColumnSwitch(ROOT::Experimental::ClusterSize_t{element.fIndex},
-                                                                   element.fTag);
+         dstArray[i] = ROOT::Experimental::Internal::RColumnSwitch(element.fIndex, element.fTag);
       }
    }
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -717,13 +717,13 @@ public:
 };
 
 template <>
-class RColumnElement<ROOT::Experimental::RColumnSwitch, EColumnType::kUnknown> : public RColumnElementBase {
+class RColumnElement<ROOT::Experimental::Internal::RColumnSwitch, EColumnType::kUnknown> : public RColumnElementBase {
 public:
-   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::RColumnSwitch);
+   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::Internal::RColumnSwitch);
    RColumnElement() : RColumnElementBase(kSize) {}
    RIdentifier GetIdentifier() const final
    {
-      return RIdentifier{typeid(ROOT::Experimental::RColumnSwitch), EColumnType::kUnknown};
+      return RIdentifier{typeid(ROOT::Experimental::Internal::RColumnSwitch), EColumnType::kUnknown};
    }
 };
 
@@ -733,7 +733,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 template <>
-class RColumnElement<ROOT::Experimental::RColumnSwitch, EColumnType::kSwitch> : public RColumnElementBase {
+class RColumnElement<ROOT::Experimental::Internal::RColumnSwitch, EColumnType::kSwitch> : public RColumnElementBase {
 private:
    struct RSwitchElement {
       std::uint64_t fIndex;
@@ -742,14 +742,14 @@ private:
 
 public:
    static constexpr bool kIsMappable = false;
-   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::RColumnSwitch);
+   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::Internal::RColumnSwitch);
    static constexpr std::size_t kBitsOnStorage = 96;
    RColumnElement() : RColumnElementBase(kSize, kBitsOnStorage) {}
    bool IsMappable() const final { return kIsMappable; }
 
    void Pack(void *dst, const void *src, std::size_t count) const final
    {
-      auto srcArray = reinterpret_cast<const ROOT::Experimental::RColumnSwitch *>(src);
+      auto srcArray = reinterpret_cast<const ROOT::Experimental::Internal::RColumnSwitch *>(src);
       auto dstArray = reinterpret_cast<unsigned char *>(dst);
       for (std::size_t i = 0; i < count; ++i) {
          RSwitchElement element{srcArray[i].GetIndex(), srcArray[i].GetTag()};
@@ -764,7 +764,7 @@ public:
    void Unpack(void *dst, const void *src, std::size_t count) const final
    {
       auto srcArray = reinterpret_cast<const unsigned char *>(src);
-      auto dstArray = reinterpret_cast<ROOT::Experimental::RColumnSwitch *>(dst);
+      auto dstArray = reinterpret_cast<ROOT::Experimental::Internal::RColumnSwitch *>(dst);
       for (std::size_t i = 0; i < count; ++i) {
          RSwitchElement element;
          memcpy(&element, srcArray + i * 12, 12);
@@ -772,14 +772,14 @@ public:
          element.fIndex = RByteSwap<8>::bswap(element.fIndex);
          element.fTag = RByteSwap<4>::bswap(element.fTag);
 #endif
-         dstArray[i] =
-            ROOT::Experimental::RColumnSwitch(ROOT::Experimental::ClusterSize_t{element.fIndex}, element.fTag);
+         dstArray[i] = ROOT::Experimental::Internal::RColumnSwitch(ROOT::Experimental::ClusterSize_t{element.fIndex},
+                                                                   element.fTag);
       }
    }
 
    RIdentifier GetIdentifier() const final
    {
-      return RIdentifier{typeid(ROOT::Experimental::RColumnSwitch), EColumnType::kSwitch};
+      return RIdentifier{typeid(ROOT::Experimental::Internal::RColumnSwitch), EColumnType::kSwitch};
    }
 };
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -706,13 +706,13 @@ public:
 };
 
 template <>
-class RColumnElement<ROOT::Experimental::ClusterSize_t, EColumnType::kUnknown> : public RColumnElementBase {
+class RColumnElement<ROOT::Experimental::Internal::RColumnIndex, EColumnType::kUnknown> : public RColumnElementBase {
 public:
-   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::ClusterSize_t);
+   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::Internal::RColumnIndex);
    RColumnElement() : RColumnElementBase(kSize) {}
    RIdentifier GetIdentifier() const final
    {
-      return RIdentifier{typeid(ROOT::Experimental::ClusterSize_t), EColumnType::kUnknown};
+      return RIdentifier{typeid(ROOT::Experimental::Internal::RColumnIndex), EColumnType::kUnknown};
    }
 };
 
@@ -1442,13 +1442,13 @@ DECLARE_RCOLUMNELEMENT_SPEC(double, EColumnType::kSplitReal64, 64, RColumnElemen
 DECLARE_RCOLUMNELEMENT_SPEC(double, EColumnType::kReal32, 32, RColumnElementCastLE, <double, float>);
 DECLARE_RCOLUMNELEMENT_SPEC(double, EColumnType::kSplitReal32, 32, RColumnElementSplitLE, <double, float>);
 
-DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kIndex64, 64, RColumnElementLE,
+DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::Internal::RColumnIndex, EColumnType::kIndex64, 64, RColumnElementLE,
                             <std::uint64_t>);
-DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kIndex32, 32, RColumnElementCastLE,
+DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::Internal::RColumnIndex, EColumnType::kIndex32, 32, RColumnElementCastLE,
                             <std::uint64_t, std::uint32_t>);
-DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSplitIndex64, 64,
+DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::Internal::RColumnIndex, EColumnType::kSplitIndex64, 64,
                             RColumnElementDeltaSplitLE, <std::uint64_t, std::uint64_t>);
-DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::ClusterSize_t, EColumnType::kSplitIndex32, 32,
+DECLARE_RCOLUMNELEMENT_SPEC(ROOT::Experimental::Internal::RColumnIndex, EColumnType::kSplitIndex32, 32,
                             RColumnElementDeltaSplitLE, <std::uint64_t, std::uint32_t>);
 
 template <>

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -58,7 +58,7 @@ ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCardinalityField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 void ROOT::Experimental::RCardinalityField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -458,12 +458,12 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t, char>();
+   GenerateColumnsImpl<Internal::RColumnIndex, char>();
 }
 
 void ROOT::Experimental::RField<std::string>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t, char>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex, char>(desc);
 }
 
 std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const void *from)
@@ -719,18 +719,18 @@ ROOT::Experimental::RNullableField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RNullableField::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t>();
+   GenerateColumnsImpl<Internal::RColumnIndex>();
 }
 
 void ROOT::Experimental::RNullableField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 std::size_t ROOT::Experimental::RNullableField::AppendNull()
 {
    fPrincipalColumn->Append(&fNWritten);
-   return sizeof(ClusterSize_t);
+   return sizeof(Internal::RColumnIndex);
 }
 
 std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
@@ -738,7 +738,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
    auto nbytesItem = CallAppendOn(*fSubFields[0], from);
    fNWritten++;
    fPrincipalColumn->Append(&fNWritten);
-   return sizeof(ClusterSize_t) + nbytesItem;
+   return sizeof(Internal::RColumnIndex) + nbytesItem;
 }
 
 ROOT::Experimental::RClusterIndex ROOT::Experimental::RNullableField::GetItemIndex(NTupleSize_t globalIndex)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -785,7 +785,7 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(NTupleSize_t globalInde
    bool isValidValue = static_cast<bool>(*ptr);
 
    auto itemIndex = GetItemIndex(globalIndex);
-   bool isValidItem = itemIndex.GetIndex() != kInvalidClusterIndex;
+   bool isValidItem = itemIndex.GetIndex() != kInvalidNTupleIndex;
 
    void *valuePtr = nullptr;
    if (isValidValue)
@@ -874,7 +874,7 @@ void ROOT::Experimental::ROptionalField::ReadGlobalImpl(NTupleSize_t globalIndex
 {
    auto engagementPtr = GetEngagementPtr(to);
    auto itemIndex = GetItemIndex(globalIndex);
-   if (itemIndex.GetIndex() == kInvalidClusterIndex) {
+   if (itemIndex.GetIndex() == kInvalidNTupleIndex) {
       if (*engagementPtr && !(fSubFields[0]->GetTraits() & kTraitTriviallyDestructible))
          fItemDeleter->operator()(to, true /* dtorOnly */);
       *engagementPtr = false;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -480,7 +480,7 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(ROOT::Experimental:
 {
    auto typedValue = static_cast<std::string *>(to);
    RClusterIndex collectionStart;
-   ClusterSize_t nChars;
+   NTupleSize_t nChars;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nChars);
    if (nChars == 0) {
       typedValue->clear();
@@ -744,7 +744,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
 ROOT::Experimental::RClusterIndex ROOT::Experimental::RNullableField::GetItemIndex(NTupleSize_t globalIndex)
 {
    RClusterIndex collectionStart;
-   ClusterSize_t collectionSize;
+   NTupleSize_t collectionSize;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &collectionSize);
    return (collectionSize == 0) ? RClusterIndex() : collectionStart;
 }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -541,12 +541,12 @@ ROOT::Experimental::RProxiedCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t>();
+   GenerateColumnsImpl<Internal::RColumnIndex>();
 }
 
 void ROOT::Experimental::RProxiedCollectionField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 void ROOT::Experimental::RProxiedCollectionField::ConstructValue(void *where) const
@@ -706,12 +706,12 @@ ROOT::Experimental::RStreamerField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RStreamerField::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t, std::byte>();
+   GenerateColumnsImpl<Internal::RColumnIndex, std::byte>();
 }
 
 void ROOT::Experimental::RStreamerField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t, std::byte>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex, std::byte>(desc);
 }
 
 void ROOT::Experimental::RStreamerField::ConstructValue(void *where) const

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -513,7 +513,7 @@ std::size_t ROOT::Experimental::RProxiedCollectionField::AppendImpl(const void *
 
 void ROOT::Experimental::RProxiedCollectionField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
-   ClusterSize_t nItems;
+   NTupleSize_t nItems;
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
@@ -685,7 +685,7 @@ std::size_t ROOT::Experimental::RStreamerField::AppendImpl(const void *from)
 void ROOT::Experimental::RStreamerField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
    RClusterIndex collectionStart;
-   ClusterSize_t nbytes;
+   NTupleSize_t nbytes;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nbytes);
 
    TBufferFile buffer(TBuffer::kRead, nbytes);

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -1038,9 +1038,9 @@ std::size_t ROOT::Experimental::RVariantField::AppendImpl(const void *from)
       nbytes += CallAppendOn(*fSubFields[tag - 1], reinterpret_cast<const unsigned char *>(from) + fVariantOffset);
       index = fNWritten[tag - 1]++;
    }
-   RColumnSwitch varSwitch(ClusterSize_t(index), tag);
+   Internal::RColumnSwitch varSwitch(ClusterSize_t(index), tag);
    fPrincipalColumn->Append(&varSwitch);
-   return nbytes + sizeof(RColumnSwitch);
+   return nbytes + sizeof(Internal::RColumnSwitch);
 }
 
 void ROOT::Experimental::RVariantField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
@@ -1070,12 +1070,12 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVariantField::GenerateColumns()
 {
-   GenerateColumnsImpl<RColumnSwitch>();
+   GenerateColumnsImpl<Internal::RColumnSwitch>();
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<RColumnSwitch>(desc);
+   GenerateColumnsImpl<Internal::RColumnSwitch>(desc);
 }
 
 void ROOT::Experimental::RVariantField::ConstructValue(void *where) const

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -1038,7 +1038,7 @@ std::size_t ROOT::Experimental::RVariantField::AppendImpl(const void *from)
       nbytes += CallAppendOn(*fSubFields[tag - 1], reinterpret_cast<const unsigned char *>(from) + fVariantOffset);
       index = fNWritten[tag - 1]++;
    }
-   Internal::RColumnSwitch varSwitch(ClusterSize_t(index), tag);
+   Internal::RColumnSwitch varSwitch(index, tag);
    fPrincipalColumn->Append(&varSwitch);
    return nbytes + sizeof(Internal::RColumnSwitch);
 }

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -259,7 +259,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
    auto [beginPtr, sizePtr, capacityPtr] = GetRVecDataMembers(to);
 
    // Read collection info for this entry
-   ClusterSize_t nItems;
+   NTupleSize_t nItems;
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
    char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
@@ -342,7 +342,7 @@ std::size_t ROOT::Experimental::RRVecField::ReadBulkImpl(const RBulkSpec &bulkSp
 
    // Get size of the first RVec of the bulk
    RClusterIndex firstItemIndex;
-   ClusterSize_t collectionSize;
+   NTupleSize_t collectionSize;
    this->GetCollectionInfo(bulkSpec.fFirstIndex, &firstItemIndex, &collectionSize);
    *beginPtr = itemValueArray;
    *sizePtr = collectionSize;
@@ -352,7 +352,7 @@ std::size_t ROOT::Experimental::RRVecField::ReadBulkImpl(const RBulkSpec &bulkSp
    // We optimistically assume that bulkSpec.fAuxData is already large enough to hold all the item values in the
    // given range. If not, we'll fix up the pointers afterwards.
    auto lastOffset = firstItemIndex.GetIndex() + collectionSize;
-   ClusterSize_t::ValueType nRemainingValues = bulkSpec.fCount - 1;
+   NTupleSize_t nRemainingValues = bulkSpec.fCount - 1;
    std::size_t nValues = 1;
    std::size_t nItems = collectionSize;
    while (nRemainingValues > 0) {
@@ -530,7 +530,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
 {
    auto typedValue = static_cast<std::vector<char> *>(to);
 
-   ClusterSize_t nItems;
+   NTupleSize_t nItems;
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
@@ -648,7 +648,7 @@ void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t 
 {
    auto typedValue = static_cast<std::vector<bool> *>(to);
 
-   ClusterSize_t nItems;
+   NTupleSize_t nItems;
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -357,7 +357,8 @@ std::size_t ROOT::Experimental::RRVecField::ReadBulkImpl(const RBulkSpec &bulkSp
    std::size_t nItems = collectionSize;
    while (nRemainingValues > 0) {
       NTupleSize_t nElementsUntilPageEnd;
-      const auto offsets = fPrincipalColumn->MapV<ClusterSize_t>(bulkSpec.fFirstIndex + nValues, nElementsUntilPageEnd);
+      const auto offsets =
+         fPrincipalColumn->MapV<Internal::RColumnIndex>(bulkSpec.fFirstIndex + nValues, nElementsUntilPageEnd);
       const std::size_t nBatch = std::min(nRemainingValues, nElementsUntilPageEnd);
       for (std::size_t i = 0; i < nBatch; ++i) {
          const auto size = offsets[i] - lastOffset;
@@ -400,12 +401,12 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RRVecField::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t>();
+   GenerateColumnsImpl<Internal::RColumnIndex>();
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 void ROOT::Experimental::RRVecField::ConstructValue(void *where) const
@@ -574,12 +575,12 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVectorField::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t>();
+   GenerateColumnsImpl<Internal::RColumnIndex>();
 }
 
 void ROOT::Experimental::RVectorField::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 void ROOT::Experimental::RVectorField::RVectorDeleter::operator()(void *objPtr, bool dtorOnly)
@@ -671,12 +672,12 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns()
 {
-   GenerateColumnsImpl<ClusterSize_t>();
+   GenerateColumnsImpl<Internal::RColumnIndex>();
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumns(const RNTupleDescriptor &desc)
 {
-   GenerateColumnsImpl<ClusterSize_t>(desc);
+   GenerateColumnsImpl<Internal::RColumnIndex>(desc);
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -177,7 +177,7 @@ ROOT::Experimental::RColumnDescriptor ROOT::Experimental::RColumnDescriptor::Clo
 ////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfoExtended
-ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ClusterSize_t::ValueType idxInCluster) const
+ROOT::Experimental::RClusterDescriptor::RPageRange::Find(NTupleSize_t idxInCluster) const
 {
    const auto N = fCumulativeNElements.size();
    R__ASSERT(N > 0);
@@ -711,7 +711,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RClusterDescriptorBuilder::Com
       return R__FAIL("column ID mismatch");
    if (fCluster.fColumnRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
-   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, ClusterSize_t{0}};
+   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, 0};
    columnRange.fCompressionSettings = compressionSettings;
    for (const auto &pi : pageRange.fPageInfos) {
       columnRange.fNElements += pi.fNElements;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -231,7 +231,7 @@ ROOT::Experimental::RClusterDescriptor::RPageRange::ExtendToFitColumnRange(const
       RPageInfo PI;
       PI.fNElements = std::min(nElementsPerPage, nRemainingElements);
       PI.fLocator.SetType(RNTupleLocator::kTypePageZero);
-      PI.fLocator.SetBytesOnStorage(element.GetPackedSize(PI.fNElements));
+      PI.fLocator.SetNBytesOnStorage(element.GetPackedSize(PI.fNElements));
       pageInfos.emplace_back(PI);
       nRemainingElements -= PI.fNElements;
    }
@@ -248,12 +248,12 @@ bool ROOT::Experimental::RClusterDescriptor::operator==(const RClusterDescriptor
           fNEntries == other.fNEntries && fColumnRanges == other.fColumnRanges && fPageRanges == other.fPageRanges;
 }
 
-std::uint64_t ROOT::Experimental::RClusterDescriptor::GetBytesOnStorage() const
+std::uint64_t ROOT::Experimental::RClusterDescriptor::GetNBytesOnStorage() const
 {
    std::uint64_t nbytes = 0;
    for (const auto &pr : fPageRanges) {
       for (const auto &pi : pr.second.fPageInfos) {
-         nbytes += pi.fLocator.GetBytesOnStorage();
+         nbytes += pi.fLocator.GetNBytesOnStorage();
       }
    }
    return nbytes;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -729,7 +729,7 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRan
 
    RClusterDescriptor::RColumnRange columnRange;
    columnRange.fPhysicalColumnId = physicalId;
-   columnRange.fCompressionSettings = kUnknownCompressionSettings;
+   columnRange.fCompressionSettings = kNTupleUnknownCompression;
    columnRange.fIsSuppressed = true;
    fCluster.fColumnRanges[physicalId] = columnRange;
    return RResult<void>::Success();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -230,8 +230,8 @@ ROOT::Experimental::RClusterDescriptor::RPageRange::ExtendToFitColumnRange(const
    for (auto nRemainingElements = nElementsRequired - nElements; nRemainingElements > 0;) {
       RPageInfo PI;
       PI.fNElements = std::min(nElementsPerPage, nRemainingElements);
-      PI.fLocator.fType = RNTupleLocator::kTypePageZero;
-      PI.fLocator.fBytesOnStorage = element.GetPackedSize(PI.fNElements);
+      PI.fLocator.SetType(RNTupleLocator::kTypePageZero);
+      PI.fLocator.SetBytesOnStorage(element.GetPackedSize(PI.fNElements));
       pageInfos.emplace_back(PI);
       nRemainingElements -= PI.fNElements;
    }
@@ -253,7 +253,7 @@ std::uint64_t ROOT::Experimental::RClusterDescriptor::GetBytesOnStorage() const
    std::uint64_t nbytes = 0;
    for (const auto &pr : fPageRanges) {
       for (const auto &pi : pr.second.fPageInfos) {
-         nbytes += pi.fLocator.fBytesOnStorage;
+         nbytes += pi.fLocator.GetBytesOnStorage();
       }
    }
    return nbytes;

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -129,12 +129,12 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
          const auto &pageRange = cluster.second.GetPageRange(column.second.GetPhysicalId());
          auto idx = cluster2Idx[cluster.first];
          for (const auto &page : pageRange.fPageInfos) {
-            bytesOnStorage += page.fLocator.fBytesOnStorage;
+            bytesOnStorage += page.fLocator.GetBytesOnStorage();
             bytesInMemory += page.fNElements * elementSize;
-            clusters[idx].fBytesOnStorage += page.fLocator.fBytesOnStorage;
+            clusters[idx].fBytesOnStorage += page.fLocator.GetBytesOnStorage();
             clusters[idx].fBytesInMemory += page.fNElements * elementSize;
             ++clusters[idx].fNPages;
-            info.fBytesOnStorage += page.fLocator.fBytesOnStorage;
+            info.fBytesOnStorage += page.fLocator.GetBytesOnStorage();
             ++info.fNPages;
             ++nPages;
          }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -742,7 +742,7 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
 {
    if (onDiskType == EColumnType::kIndex32 || onDiskType == EColumnType::kSplitIndex32 ||
        onDiskType == EColumnType::kIndex64 || onDiskType == EColumnType::kSplitIndex64)
-      return typeid(ClusterSize_t);
+      return typeid(ROOT::Experimental::Internal::RColumnIndex);
 
    if (onDiskType == EColumnType::kSwitch)
       return typeid(ROOT::Experimental::Internal::RColumnSwitch);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -86,7 +86,7 @@ try {
          "RNTuple::Merge",
          "Passed both options \"default_compression\" and \"first_source_compression\": only the latter will apply.");
    }
-   int compression = kUnknownCompressionSettings;
+   int compression = kNTupleUnknownCompression;
    if (firstSrcComp) {
       // user passed -ff or -fk: use the same compression as the first RNTuple we find in the sources.
       // (do nothing here, the compression will be fetched below)
@@ -113,7 +113,7 @@ try {
       }
 
       auto source = RPageSourceFile::CreateFromAnchor(*anchor);
-      if (compression == kUnknownCompressionSettings) {
+      if (compression == kNTupleUnknownCompression) {
          // Get the compression of this RNTuple and use it as the output compression.
          // We currently assume all column ranges have the same compression, so we just peek at the first one.
          source->Attach();
@@ -145,7 +145,7 @@ try {
    }
 
    RNTupleWriteOptions writeOpts;
-   assert(compression != kUnknownCompressionSettings);
+   assert(compression != kNTupleUnknownCompression);
    writeOpts.SetCompression(compression);
    auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
 
@@ -886,7 +886,7 @@ RNTupleMerger::Merge(std::span<RPageSource *> sources, RPageSink &destination, c
    RNTupleMergeOptions mergeOpts = mergeOptsIn;
    {
       const auto dstCompSettings = destination.GetWriteOptions().GetCompression();
-      if (mergeOpts.fCompressionSettings == kUnknownCompressionSettings) {
+      if (mergeOpts.fCompressionSettings == kNTupleUnknownCompression) {
          mergeOpts.fCompressionSettings = dstCompSettings;
       } else if (mergeOpts.fCompressionSettings != dstCompSettings) {
          return R__FAIL(std::string("The compression given to RNTupleMergeOptions is different from that of the "

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -745,7 +745,7 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
       return typeid(ClusterSize_t);
 
    if (onDiskType == EColumnType::kSwitch)
-      return typeid(ROOT::Experimental::RColumnSwitch);
+      return typeid(ROOT::Experimental::Internal::RColumnSwitch);
 
    if (fieldType == "bool") {
       return typeid(bool);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -578,7 +578,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
          RPageStorage::RSealedPage &sealedPage = sealedPages[pageIdx];
          sealedPage.SetNElements(pageInfo.fNElements);
          sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
-         sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage + checksumSize);
+         sealedPage.SetBufferSize(pageInfo.fLocator.GetBytesOnStorage() + checksumSize);
          sealedPage.SetBuffer(onDiskPage->GetAddress());
          // TODO(gparolini): more graceful error handling (skip the page?)
          sealedPage.VerifyChecksumIfEnabled().ThrowOnError();

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -425,7 +425,7 @@ std::uint32_t SerializeLocatorPayloadObject64(const ROOT::Experimental::RNTupleL
       } else {
          RNTupleSerializer::SerializeUInt64(locator.fBytesOnStorage, buffer);
       }
-      RNTupleSerializer::SerializeUInt64(data.fLocation, buffer + sizeofBytesOnStorage);
+      RNTupleSerializer::SerializeUInt64(data.GetLocation(), buffer + sizeofBytesOnStorage);
    }
    return sizeofBytesOnStorage + sizeof(std::uint64_t);
 }
@@ -433,18 +433,19 @@ std::uint32_t SerializeLocatorPayloadObject64(const ROOT::Experimental::RNTupleL
 void DeserializeLocatorPayloadObject64(const unsigned char *buffer, std::uint32_t sizeofLocatorPayload,
                                        ROOT::Experimental::RNTupleLocator &locator)
 {
-   auto &data = locator.fPosition.emplace<ROOT::Experimental::RNTupleLocatorObject64>();
+   std::uint64_t location;
    if (sizeofLocatorPayload == 12) {
       std::uint32_t bytesOnStorage;
       RNTupleSerializer::DeserializeUInt32(buffer, bytesOnStorage);
       locator.fBytesOnStorage = bytesOnStorage;
-      RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint32_t), data.fLocation);
+      RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint32_t), location);
    } else if (sizeofLocatorPayload == 16) {
       RNTupleSerializer::DeserializeUInt64(buffer, locator.fBytesOnStorage);
-      RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint64_t), data.fLocation);
+      RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint64_t), location);
    } else {
       throw ROOT::RException(R__FAIL("invalid DAOS locator payload size: " + std::to_string(sizeofLocatorPayload)));
    }
+   locator.fPosition.emplace<ROOT::Experimental::RNTupleLocatorObject64>(location);
 }
 
 std::uint32_t SerializeAliasColumn(const ROOT::Experimental::RColumnDescriptor &columnDesc,

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -268,7 +268,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
             RSealedPage sealedPage;
             sealedPage.SetNElements(pi.fNElements);
             sealedPage.SetHasChecksum(pi.fHasChecksum);
-            sealedPage.SetBufferSize(pi.fLocator.fBytesOnStorage + pi.fHasChecksum * kNBytesPageChecksum);
+            sealedPage.SetBufferSize(pi.fLocator.GetBytesOnStorage() + pi.fHasChecksum * kNBytesPageChecksum);
             sealedPage.SetBuffer(onDiskPage->GetAddress());
             R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
 
@@ -319,10 +319,10 @@ void ROOT::Experimental::Internal::RPageSource::PrepareLoadCluster(
       const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
       NTupleSize_t pageNo = 0;
       for (const auto &pageInfo : pageRange.fPageInfos) {
-         if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
+         if (pageInfo.fLocator.GetType() == RNTupleLocator::kTypePageZero) {
             pageZeroMap.Register(
                ROnDiskPage::Key{physicalColumnId, pageNo},
-               ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.fBytesOnStorage));
+               ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.GetBytesOnStorage()));
          } else {
             perPageFunc(physicalColumnId, pageNo, pageInfo);
          }
@@ -386,7 +386,7 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 
-   if (clusterInfo.fPageInfo.fLocator.fType == RNTupleLocator::kTypeUnknown)
+   if (clusterInfo.fPageInfo.fLocator.GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
    UpdateLastUsedCluster(clusterInfo.fClusterId);
@@ -422,7 +422,7 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
       clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 
-   if (clusterInfo.fPageInfo.fLocator.fType == RNTupleLocator::kTypeUnknown)
+   if (clusterInfo.fPageInfo.fLocator.GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
    UpdateLastUsedCluster(clusterInfo.fClusterId);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -268,7 +268,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
             RSealedPage sealedPage;
             sealedPage.SetNElements(pi.fNElements);
             sealedPage.SetHasChecksum(pi.fHasChecksum);
-            sealedPage.SetBufferSize(pi.fLocator.GetBytesOnStorage() + pi.fHasChecksum * kNBytesPageChecksum);
+            sealedPage.SetBufferSize(pi.fLocator.GetNBytesOnStorage() + pi.fHasChecksum * kNBytesPageChecksum);
             sealedPage.SetBuffer(onDiskPage->GetAddress());
             R__ASSERT(onDiskPage && (onDiskPage->GetSize() == sealedPage.GetBufferSize()));
 
@@ -322,7 +322,7 @@ void ROOT::Experimental::Internal::RPageSource::PrepareLoadCluster(
          if (pageInfo.fLocator.GetType() == RNTupleLocator::kTypePageZero) {
             pageZeroMap.Register(
                ROnDiskPage::Key{physicalColumnId, pageNo},
-               ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.GetBytesOnStorage()));
+               ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.GetNBytesOnStorage()));
          } else {
             perPageFunc(physicalColumnId, pageNo, pageInfo);
          }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -589,8 +589,7 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(DescriptorId_
 
 ROOT::Experimental::Internal::RPageRef
 ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                            const RClusterInfo &clusterInfo,
-                                                            ClusterSize_t::ValueType idxInCluster)
+                                                            const RClusterInfo &clusterInfo, NTupleSize_t idxInCluster)
 {
    const auto columnId = columnHandle.fPhysicalId;
    const auto clusterId = clusterInfo.fClusterId;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -111,8 +111,8 @@ RDaosURI ParseDaosURI(std::string_view uri)
 /// the attribute key under which the cage is stored and the offset within that cage to access the page.
 std::pair<uint32_t, uint32_t> DecodeDaosPagePosition(const ROOT::Experimental::RNTupleLocatorObject64 &address)
 {
-   auto position = static_cast<uint32_t>(address.fLocation & 0xFFFFFFFF);
-   auto offset = static_cast<uint32_t>(address.fLocation >> 32);
+   auto position = static_cast<uint32_t>(address.GetLocation() & 0xFFFFFFFF);
+   auto offset = static_cast<uint32_t>(address.GetLocation() >> 32);
    return {position, offset};
 }
 
@@ -528,7 +528,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceD
       zipBuffer = MakeUninitArray<unsigned char>(cgDesc.GetPageListLocator().fBytesOnStorage);
       fDaosContainer->ReadSingleAkey(
          zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, oidPageList, kDistributionKeyDefault,
-         cgDesc.GetPageListLocator().GetPosition<RNTupleLocatorObject64>().fLocation, kCidMetadata);
+         cgDesc.GetPageListLocator().GetPosition<RNTupleLocatorObject64>().GetLocation(), kCidMetadata);
       RNTupleDecompressor::Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage,
                                  cgDesc.GetPageListLength(), buffer.get());
 
@@ -578,8 +578,9 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(DescriptorId_
       fDaosContainer->ReadSingleAkey(cageHeadBuffer.get(), bufSize, daosKey.fOid, daosKey.fDkey, daosKey.fAkey);
       memcpy(const_cast<void *>(sealedPage.GetBuffer()), cageHeadBuffer.get() + offset, sealedPage.GetBufferSize());
    } else {
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(
-         fNTupleIndex, clusterId, physicalColumnId, pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().fLocation);
+      RDaosKey daosKey =
+         GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, physicalColumnId,
+                                             pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().GetLocation());
       fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(),
                                      daosKey.fOid, daosKey.fDkey, daosKey.fAkey);
    }
@@ -621,7 +622,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
 
       directReadBuffer = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
       RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(
-         fNTupleIndex, clusterId, columnId, pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().fLocation);
+         fNTupleIndex, clusterId, columnId, pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().GetLocation());
       fDaosContainer->ReadSingleAkey(directReadBuffer.get(), sealedPage.GetBufferSize(), daosKey.fOid, daosKey.fDkey,
                                      daosKey.fAkey);
       fCounters->fNPageRead.Inc();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -87,8 +87,8 @@ ROOT::Experimental::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage:
    }
 
    RNTupleLocator result;
-   result.fPosition = offsetData;
-   result.fBytesOnStorage = sealedPage.GetDataSize();
+   result.SetPosition(offsetData);
+   result.SetBytesOnStorage(sealedPage.GetDataSize());
    fCounters->fNPageCommitted.Inc();
    fCounters->fSzWritePayload.Add(sealedPage.GetBufferSize());
    fNBytesCurrentCluster += sealedPage.GetBufferSize();
@@ -130,8 +130,8 @@ void ROOT::Experimental::Internal::RPageSinkFile::CommitBatchOfPages(CommitBatch
    for (const auto *pagePtr : batch.fSealedPages) {
       fWriter->WriteIntoReservedBlob(pagePtr->GetBuffer(), pagePtr->GetBufferSize(), offset);
       RNTupleLocator locator;
-      locator.fPosition = offset;
-      locator.fBytesOnStorage = pagePtr->GetDataSize();
+      locator.SetPosition(offset);
+      locator.SetBytesOnStorage(pagePtr->GetDataSize());
       locators.push_back(locator);
       offset += pagePtr->GetBufferSize();
    }
@@ -193,8 +193,8 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitSealedPageVImpl(std::span<RPa
             std::uint64_t offset =
                fWriter->WriteBlob(sealedPageIt->GetBuffer(), sealedPageIt->GetBufferSize(), bytesPacked);
             RNTupleLocator locator;
-            locator.fPosition = offset;
-            locator.fBytesOnStorage = sealedPageIt->GetDataSize();
+            locator.SetPosition(offset);
+            locator.SetBytesOnStorage(sealedPageIt->GetDataSize());
             locators.push_back(locator);
 
             fCounters->fNPageCommitted.Inc();
@@ -232,8 +232,8 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitClusterGroupImpl(unsigned cha
                                          RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
 
    RNTupleLocator result;
-   result.fBytesOnStorage = szPageListZip;
-   result.fPosition = fWriter->WriteBlob(bufPageListZip.get(), szPageListZip, length);
+   result.SetBytesOnStorage(szPageListZip);
+   result.SetPosition(fWriter->WriteBlob(bufPageListZip.get(), szPageListZip, length));
    return result;
 }
 
@@ -366,11 +366,11 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
    std::vector<unsigned char> buffer;
    for (const auto &cgDesc : desc.GetClusterGroupIterable()) {
       buffer.resize(
-         std::max<size_t>(buffer.size(), cgDesc.GetPageListLength() + cgDesc.GetPageListLocator().fBytesOnStorage));
+         std::max<size_t>(buffer.size(), cgDesc.GetPageListLength() + cgDesc.GetPageListLocator().GetBytesOnStorage()));
       auto *zipBuffer = buffer.data() + cgDesc.GetPageListLength();
-      fReader.ReadBuffer(zipBuffer, cgDesc.GetPageListLocator().fBytesOnStorage,
+      fReader.ReadBuffer(zipBuffer, cgDesc.GetPageListLocator().GetBytesOnStorage(),
                          cgDesc.GetPageListLocator().GetPosition<std::uint64_t>());
-      RNTupleDecompressor::Unzip(zipBuffer, cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
+      RNTupleDecompressor::Unzip(zipBuffer, cgDesc.GetPageListLocator().GetBytesOnStorage(), cgDesc.GetPageListLength(),
                                  buffer.data());
 
       RNTupleSerializer::DeserializePageList(buffer.data(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc);
@@ -394,12 +394,12 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
       pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(clusterIndex.GetIndex());
    }
 
-   sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage + pageInfo.fHasChecksum * kNBytesPageChecksum);
+   sealedPage.SetBufferSize(pageInfo.fLocator.GetBytesOnStorage() + pageInfo.fHasChecksum * kNBytesPageChecksum);
    sealedPage.SetNElements(pageInfo.fNElements);
    sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
    if (!sealedPage.GetBuffer())
       return;
-   if (pageInfo.fLocator.fType != RNTupleLocator::kTypePageZero) {
+   if (pageInfo.fLocator.GetType() != RNTupleLocator::kTypePageZero) {
       fReader.ReadBuffer(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(),
                          pageInfo.fLocator.GetPosition<std::uint64_t>());
    } else {
@@ -422,7 +422,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    const auto elementSize = element->GetSize();
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
-   if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
+   if (pageInfo.fLocator.GetType() == RNTupleLocator::kTypePageZero) {
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.fNElements);
       pageZero.GrowUnchecked(pageInfo.fNElements);
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
@@ -434,7 +434,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
    RSealedPage sealedPage;
    sealedPage.SetNElements(pageInfo.fNElements);
    sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
-   sealedPage.SetBufferSize(pageInfo.fLocator.fBytesOnStorage + pageInfo.fHasChecksum * kNBytesPageChecksum);
+   sealedPage.SetBufferSize(pageInfo.fLocator.GetBytesOnStorage() + pageInfo.fHasChecksum * kNBytesPageChecksum);
    std::unique_ptr<unsigned char[]> directReadBuffer; // only used if cluster pool is turned off
 
    if (fOptions.GetClusterCache() == RNTupleReadOptions::EClusterCache::kOff) {
@@ -505,9 +505,10 @@ ROOT::Experimental::Internal::RPageSourceFile::PrepareSingleCluster(
                       [&](DescriptorId_t physicalColumnId, NTupleSize_t pageNo,
                           const RClusterDescriptor::RPageRange::RPageInfo &pageInfo) {
                          const auto &pageLocator = pageInfo.fLocator;
-                         if (pageLocator.fType == RNTupleLocator::kTypeUnknown)
+                         if (pageLocator.GetType() == RNTupleLocator::kTypeUnknown)
                             throw RException(R__FAIL("tried to read a page with an unknown locator"));
-                         const auto nBytes = pageLocator.fBytesOnStorage + pageInfo.fHasChecksum * kNBytesPageChecksum;
+                         const auto nBytes =
+                            pageLocator.GetBytesOnStorage() + pageInfo.fHasChecksum * kNBytesPageChecksum;
                          activeSize += nBytes;
                          onDiskPages.push_back(
                             {physicalColumnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), nBytes, 0});

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -412,8 +412,7 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(DescriptorId_
 
 ROOT::Experimental::Internal::RPageRef
 ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                            const RClusterInfo &clusterInfo,
-                                                            ClusterSize_t::ValueType idxInCluster)
+                                                            const RClusterInfo &clusterInfo, NTupleSize_t idxInCluster)
 {
    const auto columnId = columnHandle.fPhysicalId;
    const auto clusterId = clusterInfo.fClusterId;

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -104,7 +104,7 @@ TEST(RNTupleChecksum, OmitPageChecksum)
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
    const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
-   EXPECT_EQ(4u, pageInfo.fLocator.GetBytesOnStorage());
+   EXPECT_EQ(4u, pageInfo.fLocator.GetNBytesOnStorage());
    EXPECT_FALSE(pageInfo.fHasChecksum);
 
    RPageStorage::RSealedPage sealedPage;

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -104,7 +104,7 @@ TEST(RNTupleChecksum, OmitPageChecksum)
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
    const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
-   EXPECT_EQ(4u, pageInfo.fLocator.fBytesOnStorage);
+   EXPECT_EQ(4u, pageInfo.fLocator.GetBytesOnStorage());
    EXPECT_FALSE(pageInfo.fHasChecksum);
 
    RPageStorage::RSealedPage sealedPage;

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-using ROOT::Experimental::ClusterSize_t;
+using ROOT::Experimental::NTupleSize_t;
 using ROOT::Experimental::RNTupleDescriptor;
 using ROOT::Experimental::Internal::RCluster;
 using ROOT::Experimental::Internal::RClusterPool;
@@ -43,7 +43,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ClusterSize_t::ValueType) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, NTupleSize_t) final { return RPageRef(); }
 
 public:
    /// Records the cluster IDs requests by LoadClusters() calls

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -371,9 +371,9 @@ class RPageSinkTestLocator : public RPageSinkFile {
    {
       auto payload = ROOT::Experimental::RNTupleLocatorObject64{0x420};
       RNTupleLocator result;
-      result.fPosition = payload;
-      result.fType = ROOT::Experimental::Internal::kTestLocatorType;
-      result.fBytesOnStorage = sealedPage.GetDataSize();
+      result.SetPosition(payload);
+      result.SetType(ROOT::Experimental::Internal::kTestLocatorType);
+      result.SetBytesOnStorage(sealedPage.GetDataSize());
       return result;
    }
 

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -373,7 +373,7 @@ class RPageSinkTestLocator : public RPageSinkFile {
       RNTupleLocator result;
       result.SetPosition(payload);
       result.SetType(ROOT::Experimental::Internal::kTestLocatorType);
-      result.SetBytesOnStorage(sealedPage.GetDataSize());
+      result.SetNBytesOnStorage(sealedPage.GetDataSize());
       return result;
    }
 

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -504,7 +504,7 @@ TEST(RColumnDescriptorIterable, IterateOverColumns)
    EXPECT_EQ(desc.GetNLogicalColumns(), counter);
 }
 
-TEST(RClusterDescriptor, GetBytesOnStorage)
+TEST(RClusterDescriptor, GetNBytesOnStorage)
 {
    auto model = RNTupleModel::Create();
    auto fldJets = model->MakeField<std::vector<float>>("jets");
@@ -526,7 +526,7 @@ TEST(RClusterDescriptor, GetBytesOnStorage)
 
    auto clusterID = desc.FindClusterId(0, 0);
    ASSERT_NE(ROOT::Experimental::kInvalidDescriptorId, clusterID);
-   EXPECT_EQ(8 + 8 + 8 + 3, desc.GetClusterDescriptor(clusterID).GetBytesOnStorage());
+   EXPECT_EQ(8 + 8 + 8 + 3, desc.GetClusterDescriptor(clusterID).GetNBytesOnStorage());
 }
 
 TEST(RNTupleDescriptor, Clone)

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -191,9 +191,7 @@ TEST(RColumnElementEndian, DeltaSplit)
 #ifndef R__BYTESWAP
    GTEST_SKIP() << "Skipping test on big endian node";
 #else
-   using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
-
-   RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element;
+   RColumnElement<ROOT::Experimental::Internal::RColumnIndex, EColumnType::kSplitIndex32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -86,7 +86,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::Experimental::ClusterSize_t::ValueType) final
+   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::Experimental::NTupleSize_t) final
    {
       return RPageRef();
    }

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -388,7 +388,7 @@ TEST(RNTuple, LargePages)
       const auto &desc = reader->GetDescriptor();
       const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(desc.FindClusterId(rndColId, 0));
-      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.GetBytesOnStorage(), kMAXZIPBUF);
+      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.GetNBytesOnStorage(), kMAXZIPBUF);
 
       auto viewRnd = reader->GetView<std::uint32_t>("rnd");
       std::mt19937 gen;

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -388,7 +388,7 @@ TEST(RNTuple, LargePages)
       const auto &desc = reader->GetDescriptor();
       const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(desc.FindClusterId(rndColId, 0));
-      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.fBytesOnStorage, kMAXZIPBUF);
+      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.GetBytesOnStorage(), kMAXZIPBUF);
 
       auto viewRnd = reader->GetView<std::uint32_t>("rnd");
       std::mt19937 gen;

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -247,7 +247,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
    EXPECT_EQ(reader->GetNEntries(), NumElements);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
    EXPECT_EQ(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos.size(), 1);
-   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].fLocator.GetBytesOnStorage(),
+   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].fLocator.GetNBytesOnStorage(),
              static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()));
 
    auto id = model.GetDefaultEntry().GetPtr<std::uint64_t>("id");

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -247,7 +247,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
    EXPECT_EQ(reader->GetNEntries(), NumElements);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
    EXPECT_EQ(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos.size(), 1);
-   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].fLocator.fBytesOnStorage,
+   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].fLocator.GetBytesOnStorage(),
              static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()));
 
    auto id = model.GetDefaultEntry().GetPtr<std::uint64_t>("id");

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -343,7 +343,7 @@ TEST(RNTuple, ModelExtensionSubFields)
    EXPECT_EQ(structFldView(7), extStructFldView(7));
 
    // Check that the column ranges for model-extended subfields are properly constructed by iterating over their view.
-   // For improper column ranges, the global field range would go until the value of kInvalidClusterIndex and result in
+   // For improper column ranges, the global field range would go until the value of kInvalidNTupleIndex and result in
    // an out-of-bounds error.
    auto vecStructElemView = ntuple->GetView<float>("structFld.v2._0._0");
    auto extVecStructElemView = ntuple->GetView<float>("extStructFld.v2._0._0");

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -2,7 +2,7 @@
 
 TEST(RNTuple, MultiColumnRepresentationSimple)
 {
-   using ROOT::Experimental::kUnknownCompressionSettings;
+   using ROOT::Experimental::kNTupleUnknownCompression;
    FileRaii fileGuard("test_ntuple_multi_column_representation_simple.root");
 
    {
@@ -53,7 +53,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
    EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
@@ -62,7 +62,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
    EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
@@ -71,7 +71,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);
@@ -142,7 +142,6 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
 
 TEST(RNTuple, MultiColumnRepresentationString)
 {
-   using ROOT::Experimental::kUnknownCompressionSettings;
    FileRaii fileGuard("test_ntuple_multi_column_representation_string.root");
 
    {
@@ -186,7 +185,6 @@ TEST(RNTuple, MultiColumnRepresentationString)
 
 TEST(RNTuple, MultiColumnRepresentationVector)
 {
-   using ROOT::Experimental::kUnknownCompressionSettings;
    FileRaii fileGuard("test_ntuple_multi_column_representation_vector.root");
 
    {
@@ -233,7 +231,6 @@ TEST(RNTuple, MultiColumnRepresentationVector)
 
 TEST(RNTuple, MultiColumnRepresentationMany)
 {
-   using ROOT::Experimental::kUnknownCompressionSettings;
    FileRaii fileGuard("test_ntuple_multi_column_representation_many.root");
 
    {

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -159,7 +159,7 @@ TEST(RNTupleParallelWriter, Staged)
 TEST(RNTupleParallelWriter, StagedMultiColumn)
 {
    // Based on MultiColumnRepresentationSimple from ntuple_multi_column.cxx
-   using ROOT::Experimental::kUnknownCompressionSettings;
+   using ROOT::Experimental::kNTupleUnknownCompression;
    FileRaii fileGuard("test_ntuple_parallel_staged_multi_column.root");
 
    {
@@ -217,7 +217,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
    EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
@@ -226,7 +226,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
    EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
@@ -235,7 +235,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kUnknownCompressionSettings, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -334,8 +334,8 @@ TEST(RNTuple, SerializeLocator)
 {
    unsigned char buffer[20];
    RNTupleLocator locator;
-   locator.fPosition = 1U;
-   locator.fBytesOnStorage = 2;
+   locator.SetPosition(1U);
+   locator.SetBytesOnStorage(2);
 
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, nullptr));
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, buffer));
@@ -355,39 +355,39 @@ TEST(RNTuple, SerializeLocator)
    }
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
    EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(2u, locator.fBytesOnStorage);
-   EXPECT_EQ(RNTupleLocator::kTypeFile, locator.fType);
+   EXPECT_EQ(2u, locator.GetBytesOnStorage());
+   EXPECT_EQ(RNTupleLocator::kTypeFile, locator.GetType());
 
-   locator.fBytesOnStorage = std::numeric_limits<std::int32_t>::max();
+   locator.SetBytesOnStorage(std::numeric_limits<std::int32_t>::max());
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, buffer));
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
-   EXPECT_EQ(std::numeric_limits<std::int32_t>::max(), locator.fBytesOnStorage);
-   locator.fBytesOnStorage = static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1;
+   EXPECT_EQ(std::numeric_limits<std::int32_t>::max(), locator.GetBytesOnStorage());
+   locator.SetBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1);
    EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer));
    EXPECT_EQ(20u, RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap());
-   EXPECT_EQ(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1, locator.fBytesOnStorage);
+   EXPECT_EQ(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1, locator.GetBytesOnStorage());
    EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(RNTupleLocator::kTypeFile, locator.fType);
+   EXPECT_EQ(RNTupleLocator::kTypeFile, locator.GetType());
 
-   locator.fType = RNTupleLocator::kTypeDAOS;
-   locator.fPosition.emplace<RNTupleLocatorObject64>(RNTupleLocatorObject64{1337U});
-   locator.fBytesOnStorage = 420420U;
-   locator.fReserved = 0x5a;
+   locator.SetType(RNTupleLocator::kTypeDAOS);
+   locator.SetPosition(RNTupleLocatorObject64{1337U});
+   locator.SetBytesOnStorage(420420U);
+   locator.SetReserved(0x5a);
    EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator = RNTupleLocator{};
    EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
-   EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
-   EXPECT_EQ(locator.fBytesOnStorage, 420420U);
-   EXPECT_EQ(locator.fReserved, 0x5a);
+   EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeDAOS);
+   EXPECT_EQ(locator.GetBytesOnStorage(), 420420U);
+   EXPECT_EQ(locator.GetReserved(), 0x5a);
    EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
-   locator.fBytesOnStorage = static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1;
+   locator.SetBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
    EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator = RNTupleLocator{};
    EXPECT_EQ(20u, RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap());
-   EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
-   EXPECT_EQ(locator.fBytesOnStorage, static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
-   EXPECT_EQ(locator.fReserved, 0x5a);
+   EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeDAOS);
+   EXPECT_EQ(locator.GetBytesOnStorage(), static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
+   EXPECT_EQ(locator.GetReserved(), 0x5a);
    EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
    std::int32_t *head = reinterpret_cast<std::int32_t *>(buffer);
@@ -398,15 +398,15 @@ TEST(RNTuple, SerializeLocator)
    *head = (0x3 << 24) | *head;
 #endif
    RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap();
-   EXPECT_EQ(locator.fType, RNTupleLocator::kTypeUnknown);
+   EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeUnknown);
 }
 
 TEST(RNTuple, SerializeEnvelopeLink)
 {
    RNTupleSerializer::REnvelopeLink link;
    link.fLength = 42;
-   link.fLocator.fPosition = 137U;
-   link.fLocator.fBytesOnStorage = 7;
+   link.fLocator.SetPosition(137U);
+   link.fLocator.SetBytesOnStorage(7);
 
    unsigned char buffer[20];
    EXPECT_EQ(20u, RNTupleSerializer::SerializeEnvelopeLink(link, nullptr));
@@ -472,8 +472,8 @@ TEST(RNTuple, SerializeClusterGroup)
    group.fEntrySpan = 84600;
    group.fNClusters = 42;
    group.fPageListEnvelopeLink.fLength = 42;
-   group.fPageListEnvelopeLink.fLocator.fPosition = 137U;
-   group.fPageListEnvelopeLink.fLocator.fBytesOnStorage = 7;
+   group.fPageListEnvelopeLink.fLocator.SetPosition(137U);
+   group.fPageListEnvelopeLink.fLocator.SetBytesOnStorage(7);
 
    unsigned char buffer[52];
    ASSERT_EQ(48u, RNTupleSerializer::SerializeClusterGroup(group, nullptr));
@@ -492,7 +492,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(group.fPageListEnvelopeLink.fLength, reco.fPageListEnvelopeLink.fLength);
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
              reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.fBytesOnStorage, reco.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetBytesOnStorage(),
+             reco.fPageListEnvelopeLink.fLocator.GetBytesOnStorage());
 
    // Test frame evolution
    auto pos = buffer;
@@ -511,7 +512,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(group.fPageListEnvelopeLink.fLength, reco.fPageListEnvelopeLink.fLength);
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
              reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.fBytesOnStorage, reco.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetBytesOnStorage(),
+             reco.fPageListEnvelopeLink.fLocator.GetBytesOnStorage());
    std::uint16_t remainder;
    RNTupleSerializer::DeserializeUInt16(buffer + 48, remainder);
    EXPECT_EQ(7u, remainder);
@@ -682,19 +684,19 @@ TEST(RNTuple, SerializeFooter)
    pageRange.fPhysicalColumnId = 17;
    // Two pages adding up to 100 elements, one with checksum one without
    pageInfo.fNElements = 40;
-   pageInfo.fLocator.fPosition = 7000U;
+   pageInfo.fLocator.SetPosition(7000U);
    pageInfo.fHasChecksum = true;
    pageRange.fPageInfos.emplace_back(pageInfo);
    pageInfo.fNElements = 60;
-   pageInfo.fLocator.fPosition = 8000U;
+   pageInfo.fLocator.SetPosition(8000U);
    pageInfo.fHasChecksum = false;
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(17, 0, 100, pageRange);
    builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
    RClusterGroupDescriptorBuilder cgBuilder;
    RNTupleLocator cgLocator;
-   cgLocator.fPosition = 1337U;
-   cgLocator.fBytesOnStorage = 42;
+   cgLocator.SetPosition(1337U);
+   cgLocator.SetBytesOnStorage(42);
    cgBuilder.ClusterGroupId(256).PageListLength(137).PageListLocator(cgLocator).NClusters(1).EntrySpan(100);
    std::vector<DescriptorId_t> clusterIds{84};
    cgBuilder.AddSortedClusters(clusterIds);
@@ -734,7 +736,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(1u, clusterGroupDesc.GetNClusters());
    EXPECT_EQ(137u, clusterGroupDesc.GetPageListLength());
    EXPECT_EQ(1337u, clusterGroupDesc.GetPageListLocator().GetPosition<std::uint64_t>());
-   EXPECT_EQ(42u, clusterGroupDesc.GetPageListLocator().fBytesOnStorage);
+   EXPECT_EQ(42u, clusterGroupDesc.GetPageListLocator().GetBytesOnStorage());
    EXPECT_EQ(1u, desc.GetNClusters());
    EXPECT_EQ(0u, desc.GetNActiveClusters());
 
@@ -745,7 +747,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(1u, verify.GetNClusters());
    EXPECT_EQ(137u, verify.GetPageListLength());
    EXPECT_EQ(1337u, verify.GetPageListLocator().GetPosition<std::uint64_t>());
-   EXPECT_EQ(42u, verify.GetPageListLocator().fBytesOnStorage);
+   EXPECT_EQ(42u, verify.GetPageListLocator().GetBytesOnStorage());
 
    EXPECT_EQ(1u, desc.GetNActiveClusters());
    const auto &clusterDesc = desc.GetClusterDescriptor(0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -379,7 +379,7 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
    EXPECT_EQ(locator.fBytesOnStorage, 420420U);
    EXPECT_EQ(locator.fReserved, 0x5a);
-   EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().fLocation);
+   EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
    locator.fBytesOnStorage = static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1;
    EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer));
@@ -388,7 +388,7 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
    EXPECT_EQ(locator.fBytesOnStorage, static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
    EXPECT_EQ(locator.fReserved, 0x5a);
-   EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().fLocation);
+   EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
    std::int32_t *head = reinterpret_cast<std::int32_t *>(buffer);
 #ifndef R__BYTESWAP

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -335,7 +335,7 @@ TEST(RNTuple, SerializeLocator)
    unsigned char buffer[20];
    RNTupleLocator locator;
    locator.SetPosition(1U);
-   locator.SetBytesOnStorage(2);
+   locator.SetNBytesOnStorage(2);
 
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, nullptr));
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, buffer));
@@ -355,38 +355,38 @@ TEST(RNTuple, SerializeLocator)
    }
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
    EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(2u, locator.GetBytesOnStorage());
+   EXPECT_EQ(2u, locator.GetNBytesOnStorage());
    EXPECT_EQ(RNTupleLocator::kTypeFile, locator.GetType());
 
-   locator.SetBytesOnStorage(std::numeric_limits<std::int32_t>::max());
+   locator.SetNBytesOnStorage(std::numeric_limits<std::int32_t>::max());
    EXPECT_EQ(12u, RNTupleSerializer::SerializeLocator(locator, buffer));
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
-   EXPECT_EQ(std::numeric_limits<std::int32_t>::max(), locator.GetBytesOnStorage());
-   locator.SetBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1);
+   EXPECT_EQ(std::numeric_limits<std::int32_t>::max(), locator.GetNBytesOnStorage());
+   locator.SetNBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1);
    EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer));
    EXPECT_EQ(20u, RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap());
-   EXPECT_EQ(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1, locator.GetBytesOnStorage());
+   EXPECT_EQ(static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1, locator.GetNBytesOnStorage());
    EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
    EXPECT_EQ(RNTupleLocator::kTypeFile, locator.GetType());
 
    locator.SetType(RNTupleLocator::kTypeDAOS);
    locator.SetPosition(RNTupleLocatorObject64{1337U});
-   locator.SetBytesOnStorage(420420U);
+   locator.SetNBytesOnStorage(420420U);
    locator.SetReserved(0x5a);
    EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator = RNTupleLocator{};
    EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
    EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeDAOS);
-   EXPECT_EQ(locator.GetBytesOnStorage(), 420420U);
+   EXPECT_EQ(locator.GetNBytesOnStorage(), 420420U);
    EXPECT_EQ(locator.GetReserved(), 0x5a);
    EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
-   locator.SetBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
+   locator.SetNBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
    EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator = RNTupleLocator{};
    EXPECT_EQ(20u, RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap());
    EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeDAOS);
-   EXPECT_EQ(locator.GetBytesOnStorage(), static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
+   EXPECT_EQ(locator.GetNBytesOnStorage(), static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
    EXPECT_EQ(locator.GetReserved(), 0x5a);
    EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
@@ -406,7 +406,7 @@ TEST(RNTuple, SerializeEnvelopeLink)
    RNTupleSerializer::REnvelopeLink link;
    link.fLength = 42;
    link.fLocator.SetPosition(137U);
-   link.fLocator.SetBytesOnStorage(7);
+   link.fLocator.SetNBytesOnStorage(7);
 
    unsigned char buffer[20];
    EXPECT_EQ(20u, RNTupleSerializer::SerializeEnvelopeLink(link, nullptr));
@@ -473,7 +473,7 @@ TEST(RNTuple, SerializeClusterGroup)
    group.fNClusters = 42;
    group.fPageListEnvelopeLink.fLength = 42;
    group.fPageListEnvelopeLink.fLocator.SetPosition(137U);
-   group.fPageListEnvelopeLink.fLocator.SetBytesOnStorage(7);
+   group.fPageListEnvelopeLink.fLocator.SetNBytesOnStorage(7);
 
    unsigned char buffer[52];
    ASSERT_EQ(48u, RNTupleSerializer::SerializeClusterGroup(group, nullptr));
@@ -492,8 +492,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(group.fPageListEnvelopeLink.fLength, reco.fPageListEnvelopeLink.fLength);
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
              reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetBytesOnStorage(),
-             reco.fPageListEnvelopeLink.fLocator.GetBytesOnStorage());
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetNBytesOnStorage(),
+             reco.fPageListEnvelopeLink.fLocator.GetNBytesOnStorage());
 
    // Test frame evolution
    auto pos = buffer;
@@ -512,8 +512,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(group.fPageListEnvelopeLink.fLength, reco.fPageListEnvelopeLink.fLength);
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
              reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetBytesOnStorage(),
-             reco.fPageListEnvelopeLink.fLocator.GetBytesOnStorage());
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetNBytesOnStorage(),
+             reco.fPageListEnvelopeLink.fLocator.GetNBytesOnStorage());
    std::uint16_t remainder;
    RNTupleSerializer::DeserializeUInt16(buffer + 48, remainder);
    EXPECT_EQ(7u, remainder);
@@ -696,7 +696,7 @@ TEST(RNTuple, SerializeFooter)
    RClusterGroupDescriptorBuilder cgBuilder;
    RNTupleLocator cgLocator;
    cgLocator.SetPosition(1337U);
-   cgLocator.SetBytesOnStorage(42);
+   cgLocator.SetNBytesOnStorage(42);
    cgBuilder.ClusterGroupId(256).PageListLength(137).PageListLocator(cgLocator).NClusters(1).EntrySpan(100);
    std::vector<DescriptorId_t> clusterIds{84};
    cgBuilder.AddSortedClusters(clusterIds);
@@ -736,7 +736,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(1u, clusterGroupDesc.GetNClusters());
    EXPECT_EQ(137u, clusterGroupDesc.GetPageListLength());
    EXPECT_EQ(1337u, clusterGroupDesc.GetPageListLocator().GetPosition<std::uint64_t>());
-   EXPECT_EQ(42u, clusterGroupDesc.GetPageListLocator().GetBytesOnStorage());
+   EXPECT_EQ(42u, clusterGroupDesc.GetPageListLocator().GetNBytesOnStorage());
    EXPECT_EQ(1u, desc.GetNClusters());
    EXPECT_EQ(0u, desc.GetNActiveClusters());
 
@@ -747,7 +747,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(1u, verify.GetNClusters());
    EXPECT_EQ(137u, verify.GetPageListLength());
    EXPECT_EQ(1337u, verify.GetPageListLocator().GetPosition<std::uint64_t>());
-   EXPECT_EQ(42u, verify.GetPageListLocator().GetBytesOnStorage());
+   EXPECT_EQ(42u, verify.GetPageListLocator().GetNBytesOnStorage());
 
    EXPECT_EQ(1u, desc.GetNActiveClusters());
    const auto &clusterDesc = desc.GetClusterDescriptor(0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -1086,10 +1086,10 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
    const auto columnRange0_2 = clusterDesc0.GetColumnRange(columnIds[2]);
    const auto columnRange0_3 = clusterDesc0.GetColumnRange(columnIds[3]);
-   RClusterDescriptor::RColumnRange expect0_0{0, 0, ClusterSize_t(1), -1, true};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, ClusterSize_t(0), -1, true};
-   RClusterDescriptor::RColumnRange expect0_2{2, 0, ClusterSize_t(1), 505, false};
-   RClusterDescriptor::RColumnRange expect0_3{3, 0, ClusterSize_t(0), 505, false};
+   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 0, -1, true};
+   RClusterDescriptor::RColumnRange expect0_2{2, 0, 1, 505, false};
+   RClusterDescriptor::RColumnRange expect0_3{3, 0, 0, 505, false};
    EXPECT_EQ(expect0_0, columnRange0_0);
    EXPECT_EQ(expect0_1, columnRange0_1);
    EXPECT_EQ(expect0_2, columnRange0_2);
@@ -1108,10 +1108,10 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
    const auto columnRange1_2 = clusterDesc1.GetColumnRange(columnIds[2]);
    const auto columnRange1_3 = clusterDesc1.GetColumnRange(columnIds[3]);
-   RClusterDescriptor::RColumnRange expect1_0{0, 1, ClusterSize_t(1), 505, false};
-   RClusterDescriptor::RColumnRange expect1_1{1, 0, ClusterSize_t(3), 505, false};
-   RClusterDescriptor::RColumnRange expect1_2{2, 1, ClusterSize_t(1), -1, true};
-   RClusterDescriptor::RColumnRange expect1_3{3, 0, ClusterSize_t(3), -1, true};
+   RClusterDescriptor::RColumnRange expect1_0{0, 1, 1, 505, false};
+   RClusterDescriptor::RColumnRange expect1_1{1, 0, 3, 505, false};
+   RClusterDescriptor::RColumnRange expect1_2{2, 1, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect1_3{3, 0, 3, -1, true};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);
    EXPECT_EQ(expect1_2, columnRange1_2);
@@ -1365,8 +1365,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    EXPECT_EQ(0u, clusterDesc0.GetFirstEntryIndex());
    const auto columnRange0_0 = clusterDesc0.GetColumnRange(columnIds[0]);
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect0_0{0, 0, ClusterSize_t(1), -1, false};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, ClusterSize_t(1), -1, true};
+   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, -1, false};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, -1, true};
    EXPECT_EQ(expect0_0, columnRange0_0);
    EXPECT_EQ(expect0_1, columnRange0_1);
 
@@ -1374,8 +1374,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    EXPECT_EQ(1u, clusterDesc1.GetFirstEntryIndex());
    const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect1_0{0, 1, ClusterSize_t(2), 505, false};
-   RClusterDescriptor::RColumnRange expect1_1{1, 1, ClusterSize_t(2), -1, true};
+   RClusterDescriptor::RColumnRange expect1_0{0, 1, 2, 505, false};
+   RClusterDescriptor::RColumnRange expect1_1{1, 1, 2, -1, true};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);
 
@@ -1383,8 +1383,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    EXPECT_EQ(3u, clusterDesc2.GetFirstEntryIndex());
    const auto columnRange2_0 = clusterDesc2.GetColumnRange(columnIds[0]);
    const auto columnRange2_1 = clusterDesc2.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect2_0{0, 3, ClusterSize_t(1), -1, true};
-   RClusterDescriptor::RColumnRange expect2_1{1, 3, ClusterSize_t(1), 505, false};
+   RClusterDescriptor::RColumnRange expect2_0{0, 3, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect2_1{1, 3, 1, 505, false};
    EXPECT_EQ(expect2_0, columnRange2_0);
    EXPECT_EQ(expect2_1, columnRange2_1);
 }
@@ -1489,8 +1489,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    EXPECT_EQ(0u, clusterDesc0.GetFirstEntryIndex());
    const auto columnRange0_0 = clusterDesc0.GetColumnRange(columnIds[0]);
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect0_0{0, 0, ClusterSize_t(1), 505, false};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, ClusterSize_t(1), -1, true};
+   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, 505, false};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, -1, true};
    EXPECT_EQ(expect0_0, columnRange0_0);
    EXPECT_EQ(expect0_1, columnRange0_1);
 
@@ -1498,8 +1498,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    EXPECT_EQ(1u, clusterDesc1.GetFirstEntryIndex());
    const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect1_0{0, 1, ClusterSize_t(1), -1, true};
-   RClusterDescriptor::RColumnRange expect1_1{1, 1, ClusterSize_t(1), 505, false};
+   RClusterDescriptor::RColumnRange expect1_0{0, 1, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect1_1{1, 1, 1, 505, false};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);
 }

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -918,12 +918,18 @@ TEST(RPageStorageFile, MultiKeyBlob_Pages)
       auto ntupleComp = RNTupleReader::Open(std::move(modelComp), "myNTuple", fileGuardComp.GetPath());
 
       // Verify that the pages are larger than maxKeySize
-      EXPECT_GT(
-         ntupleComp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.GetBytesOnStorage(),
-         kMaxKeySize);
-      EXPECT_GT(
-         ntupleUcmp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.GetBytesOnStorage(),
-         kMaxKeySize);
+      EXPECT_GT(ntupleComp->GetDescriptor()
+                   .GetClusterDescriptor(0)
+                   .GetPageRange(0)
+                   .fPageInfos[0]
+                   .fLocator.GetNBytesOnStorage(),
+                kMaxKeySize);
+      EXPECT_GT(ntupleUcmp->GetDescriptor()
+                   .GetClusterDescriptor(0)
+                   .GetPageRange(0)
+                   .fPageInfos[0]
+                   .fLocator.GetNBytesOnStorage(),
+                kMaxKeySize);
 
       TRandom3 rnd(42);
       for (int i = 0; i < 100000; ++i) {

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -919,10 +919,10 @@ TEST(RPageStorageFile, MultiKeyBlob_Pages)
 
       // Verify that the pages are larger than maxKeySize
       EXPECT_GT(
-         ntupleComp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.fBytesOnStorage,
+         ntupleComp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.GetBytesOnStorage(),
          kMaxKeySize);
       EXPECT_GT(
-         ntupleUcmp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.fBytesOnStorage,
+         ntupleUcmp->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0).fPageInfos[0].fLocator.GetBytesOnStorage(),
          kMaxKeySize);
 
       TRandom3 rnd(42);
@@ -1089,8 +1089,8 @@ TEST(RPageSink, SamePageMerging)
       const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
       const auto clusterId = desc.FindClusterId(pxColId, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
-      EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).fLocator.fPosition ==
-                           clusterDesc.GetPageRange(pyColId).Find(0).fLocator.fPosition);
+      EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).fLocator.GetPosition<std::uint64_t>() ==
+                           clusterDesc.GetPageRange(pyColId).Find(0).fLocator.GetPosition<std::uint64_t>());
 
       auto viewPx = reader->GetView<float>("px");
       auto viewPy = reader->GetView<float>("py");

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -239,8 +239,8 @@ TEST_F(RPageStorageDaos, DisabledSamePageMerging)
    const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
    const auto clusterId = desc.FindClusterId(pxColId, 0);
    const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
-   EXPECT_FALSE(clusterDesc.GetPageRange(pxColId).Find(0).fLocator.fPosition ==
-                clusterDesc.GetPageRange(pyColId).Find(0).fLocator.fPosition);
+   EXPECT_FALSE(clusterDesc.GetPageRange(pxColId).Find(0).fLocator.GetPosition<RNTupleLocatorObject64>() ==
+                clusterDesc.GetPageRange(pyColId).Find(0).fLocator.GetPosition<RNTupleLocatorObject64>());
 
    auto viewPx = reader->GetView<float>("px");
    auto viewPy = reader->GetView<float>("py");

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -65,7 +65,7 @@ using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescript
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
 using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;
 using RColumnElementBase = ROOT::Experimental::Internal::RColumnElementBase;
-using RColumnSwitch = ROOT::Experimental::RColumnSwitch;
+using RColumnSwitch = ROOT::Experimental::Internal::RColumnSwitch;
 using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
 template <class T>

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -53,7 +53,7 @@
 #include <variant>
 #include <vector>
 
-using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
+using ROOT::Experimental::Internal::RColumnIndex;
 using DescriptorId_t = ROOT::Experimental::DescriptorId_t;
 using EColumnType = ROOT::Experimental::EColumnType;
 using ROOT::Experimental::EExtraTypeInfoIds;

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -159,7 +159,7 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const void *pageBuf = onDiskPage->GetAddress();
             const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.fHasChecksum;
             const std::size_t maybeChecksumSize = incChecksum * 8;
-            const std::uint64_t pageBufSize = pageInfo.fLocator.GetBytesOnStorage() + maybeChecksumSize;
+            const std::uint64_t pageBufSize = pageInfo.fLocator.GetNBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
                << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings << ".page";

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -159,7 +159,7 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const void *pageBuf = onDiskPage->GetAddress();
             const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.fHasChecksum;
             const std::size_t maybeChecksumSize = incChecksum * 8;
-            const std::uint64_t pageBufSize = pageInfo.fLocator.fBytesOnStorage + maybeChecksumSize;
+            const std::uint64_t pageBufSize = pageInfo.fLocator.GetBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
                << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings << ".page";

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -75,7 +75,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          if (fCompressionSettings == -1) {
             fCompressionSettings = columnRange.fCompressionSettings;
          } else if (fCompressionSettings != columnRange.fCompressionSettings &&
-                    columnRange.fCompressionSettings != kUnknownCompressionSettings) {
+                    columnRange.fCompressionSettings != kNTupleUnknownCompression) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
             // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -88,7 +88,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          const auto &pageRange = clusterDescriptor.GetPageRange(colId);
 
          for (const auto &page : pageRange.fPageInfos) {
-            compressedPageSizes.emplace_back(page.fLocator.GetBytesOnStorage());
+            compressedPageSizes.emplace_back(page.fLocator.GetNBytesOnStorage());
             fUncompressedSize += page.fNElements * elemSize;
          }
       }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -88,7 +88,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          const auto &pageRange = clusterDescriptor.GetPageRange(colId);
 
          for (const auto &page : pageRange.fPageInfos) {
-            compressedPageSizes.emplace_back(page.fLocator.fBytesOnStorage);
+            compressedPageSizes.emplace_back(page.fLocator.GetBytesOnStorage());
             fUncompressedSize += page.fNElements * elemSize;
          }
       }


### PR DESCRIPTION
Preparation to move the common definitions from RNTupleUtil.h out of the experimental namespace. Some definitions are removed or moved to `ROOT::Internal`. Some API improvements for the remaining public types.

Part of the PR series to move an initial set of RNTuple APIs out of the experimental namespace.