### PR TITLE
[core] Don't crash when using a non-TObject ident in root cmdline

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1399,7 +1399,7 @@ TObject *TROOT::FindSpecialObject(const char *name, void *&where)
       if (glast) {where = glast; temp = glast->FindObject(name);}
    }
    if (!temp && gDirectory) {
-      temp  = gDirectory->Get(name);
+      gDirectory->GetObject(name, temp);
       where = gDirectory;
    }
    if (!temp && gPad) {


### PR DESCRIPTION
If you type a name in Cling that is not a valid identifier, ROOT will try to look it up into various places, including in the currently open directory.
The problem is that is wrongly assumes that, if it finds an object with that name, it must be a TObject. When that's not the case, cling will segfault as it tries to use the object as a TObject. Using TDirectory::GetObject() rather than TDirectory::Get() avoids this behavior as it returns null when the object is not a TObject.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #12673

