### PR TITLE
[Python] Avoid using `std::regex` in CPyCppyy

### DIFF
--- a/tmva/tmva/test/rbdt_xgboost.py
+++ b/tmva/tmva/test/rbdt_xgboost.py
@@ -1,12 +1,8 @@
-# XGBoost has to be imported before ROOT to avoid crashes because of clashing
-# std::regexp symbols that are exported by cppyy.
-# See also: https://github.com/wlav/cppyy/issues/227
-import xgboost
-
 import unittest
 import ROOT
 import numpy as np
 import json
+import xgboost
 
 np.random.seed(1234)
 


### PR DESCRIPTION
Using `std::regex` in CPyCppyy leads to problems in conjunction with XGBoost and PyTorch. We could previously work around these issues by importing these libraries before ROOT, but there still seem to be problems remaining as we see in the [CppInterop PR](https://github.com/root-project/root/pull/16814).

This commit tries to revert the introduction of `std::regex` in CPyCppyy and the import order hack, to see if this would also work.

https://github.com/wlav/CPyCppyy/commit/c437364950cafe06

For ROOTs CPyCppyy, `std::regex` was only introduced with the syncup in ROOT 6.32. Therefore, reverting back to the previous algorithm without `std::regex` should not affect our uses.