### PR TITLE
[Python] Remove hack to bypass `ClearProxiedObjects()` in tutorials

### DIFF
--- a/tutorials/roofit/rf615_simulation_based_inference.py
+++ b/tutorials/roofit/rf615_simulation_based_inference.py
@@ -271,8 +271,3 @@ del nll_morph
 del nllr_learned
 del nll_gauss
 del workspace
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]

--- a/tutorials/roofit/rf617_simulation_based_inference_multidimensional.py
+++ b/tutorials/roofit/rf617_simulation_based_inference_multidimensional.py
@@ -328,8 +328,3 @@ for nll in [nll_gauss, nllr_learned, nll_morph]:
     minimizer.minimize("Minuit2")
     result = minimizer.save()
     result.Print()
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]

--- a/tutorials/roofit/rf618_mixture_models.py
+++ b/tutorials/roofit/rf618_mixture_models.py
@@ -205,8 +205,3 @@ del pdf_learned_extended
 del n_pred
 del llh
 del nll_ratio
-
-import sys
-
-# Hack to bypass ClearProxiedObjects()
-del sys.modules["libROOTPythonizations"]


### PR DESCRIPTION
Since we're not calling `ClearProxiedObjects()` anymore anyway, we don't need the hack to avoid it.

