### PR TITLE
[ntuple] fix UB in SimpleCollectionProxy

### DIFF
--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -20,11 +20,11 @@ class SimpleCollectionProxy : public TVirtualCollectionProxy {
       if constexpr (CollectionKind == ROOT::kSTLvector) {
          // An iterator on an array-backed container is just a pointer; thus, it can be directly stored in `*xyz_arena`,
          // saving one dereference (see TVirtualCollectionProxy documentation)
-         *begin_arena = &(*vec.begin());
-         *end_arena = &(*vec.end());
+         *begin_arena = vec.data();
+         *end_arena = vec.data() + vec.size();
       } else {
-         static_cast<IteratorData *>(*begin_arena)->ptr = &(*vec.begin());
-         static_cast<IteratorData *>(*end_arena)->ptr = &(*vec.end());
+         static_cast<IteratorData *>(*begin_arena)->ptr = vec.data();
+         static_cast<IteratorData *>(*end_arena)->ptr = vec.data() + vec.size();
       }
    }
 


### PR DESCRIPTION
Dereferencing the end() iterator is UB, so we apply the same fix as commit 77c33187e3d678772870038e2874e803b1818619

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13568

