### PR TITLE
[ntuple] Improvements of Python interface and tests

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -60,8 +60,16 @@ def _RNTupleModel_CreateBare(*args):
     return ROOT.Experimental.RNTupleModel._CreateBare()
 
 
+def _RNTupleModel_CreateEntry(self):
+    raise RuntimeError(
+        "creating entries from model is not supported in Python, call CreateEntry on the reader or writer"
+    )
+
+
 def _RNTupleModel_GetDefaultEntry(self):
-    raise RuntimeError("default entries are not supported in Python, call CreateEntry")
+    raise RuntimeError(
+        "default entries are not supported in Python, call CreateEntry on the reader or writer"
+    )
 
 
 class _RNTupleModel_MakeField(MethodTemplateWrapper):
@@ -78,6 +86,8 @@ def pythonize_RNTupleModel(klass):
     klass._CreateBare = klass.CreateBare
     klass.CreateBare = _RNTupleModel_CreateBare
 
+    klass.CreateBareEntry = _RNTupleModel_CreateEntry
+    klass.CreateEntry = _RNTupleModel_CreateEntry
     klass.GetDefaultEntry = _RNTupleModel_GetDefaultEntry
 
     klass.MakeField = MethodTemplateGetter(klass.MakeField, _RNTupleModel_MakeField)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RNTupleReader
 
 #include <ROOT/RConfig.hxx> // for R__unlikely
+#include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
@@ -37,7 +38,6 @@ namespace ROOT {
 class RNTuple;
 
 namespace Experimental {
-class REntry;
 
 /// Listing of the different options that can be printed by RNTupleReader::GetInfo()
 enum class ENTupleInfo {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -180,6 +180,7 @@ public:
 
    NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
    const RNTupleModel &GetModel();
+   std::unique_ptr<REntry> CreateEntry();
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call
    /// to LoadEntry or to any of the views returned from the reader.

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -143,6 +143,11 @@ const ROOT::Experimental::RNTupleModel &ROOT::Experimental::RNTupleReader::GetMo
    return *fModel;
 }
 
+std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleReader::CreateEntry()
+{
+   return GetModel().CreateEntry();
+}
+
 void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output) const
 {
    // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -25,7 +25,7 @@ class RNTupleBasics(unittest.TestCase):
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
         self.assertEqual(reader.GetNEntries(), 1)
-        entry = reader.GetModel().CreateEntry()
+        entry = reader.CreateEntry()
         reader.LoadEntry(0, entry)
         self.assertEqual(entry["f"], 42)
         self.assertEqual(entry["mystr"], "string stored in RNTuple")

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -32,6 +32,63 @@ class RNTupleBasics(unittest.TestCase):
         self.assertEqual(entry["f"], 42)
         self.assertEqual(entry["mystr"], "string stored in RNTuple")
 
+    def test_write_fields(self):
+        """Can create writer with on-the-fly model"""
+
+        # FIXME: This should work without make_pair...
+        fields = [ROOT.std.make_pair("int", "f")]
+        with RNTupleWriter.Recreate(fields, "ntpl", "test_ntuple_py_write_fields.root") as writer:
+            entry = writer.CreateEntry()
+            entry["f"] = 42
+            writer.Fill(entry)
+
+        reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_fields.root")
+        self.assertEqual(reader.GetNEntries(), 1)
+        entry = reader.CreateEntry()
+        reader.LoadEntry(0, entry)
+        self.assertEqual(entry["f"], 42)
+
+    def test_append_open(self):
+        """Can append to existing TFile and open from RNTuple key."""
+
+        model = RNTupleModel.Create()
+        model.MakeField["int"]("f")
+
+        with ROOT.TFile.Open("test_ntuple_py_append.root", "RECREATE") as f:
+            with RNTupleWriter.Append(model, "ntpl", f) as writer:
+                entry = writer.CreateEntry()
+                entry["f"] = 42
+                writer.Fill(entry)
+        # The model should not have been destroyed (a clone has been used).
+        self.assertFalse(model.IsFrozen())
+
+        with ROOT.TFile.Open("test_ntuple_py_append.root") as f:
+            reader = RNTupleReader.Open(f["ntpl"])
+            self.assertEqual(reader.GetNEntries(), 1)
+            entry = reader.CreateEntry()
+            reader.LoadEntry(0, entry)
+            self.assertEqual(entry["f"], 42)
+
+    def test_read_model(self):
+        """Can impose a model when reading."""
+
+        write_model = RNTupleModel.Create()
+        write_model.MakeField["int"]("f1")
+        write_model.MakeField["int"]("f2")
+
+        with RNTupleWriter.Recreate(write_model, "ntpl", "test_ntuple_py_read_model.root") as writer:
+            entry = writer.CreateEntry()
+            writer.Fill(entry)
+
+        read_model = RNTupleModel.Create()
+        read_model.MakeField["int"]("f1")
+
+        reader = RNTupleReader.Open(read_model, "ntpl", "test_ntuple_py_read_model.root")
+        entry = reader.CreateEntry()
+        with self.assertRaises(Exception):
+            # Field f2 does not exist in imposed model
+            entry["f2"] = 42
+
     def test_forbid_writing_wrong_type(self):
         """Forbid writing the wrong type into an RNTuple field."""
 

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -22,6 +22,8 @@ class RNTupleBasics(unittest.TestCase):
             entry["f"] = 42
             entry["mystr"] = "string stored in RNTuple"
             writer.Fill(entry)
+        # The model should not have been destroyed (a clone has been used).
+        self.assertFalse(model.IsFrozen())
 
         reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
         self.assertEqual(reader.GetNEntries(), 1)


### PR DESCRIPTION
As discussed around the RNTuple workshop, forbid calling `RNTupleModel::CreateEntry()` directly from Python. This allows to clone the passed `RNTupleModel` when creating a reader or writer, and avoid destructively passing the user argument.