### PR TITLE
[ntuple] Remove redundant `RNTupleProcessor::LoadEntry` call

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -220,11 +220,7 @@ public:
          return obj;
       }
 
-      reference operator*()
-      {
-         fProcessor.LoadEntry();
-         return *fProcessor.fEntry;
-      }
+      reference operator*() { return *fProcessor.fEntry; }
 
       friend bool operator!=(const iterator &lh, const iterator &rh)
       {


### PR DESCRIPTION
When iterating over entries in the `RNTupleProcessor`, the entry is currently loaded twice: once on `RNTupleProcessor::Advance`, which is called when the iterator is incremented, and once when the iterator is dereferenced. This second call is unnecessary and only slows down the processor, so we should remove it.


