### PR TITLE
[ntuple] Simplify `REntry` pythonizations

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -13,6 +13,10 @@ from ._pyz_utils import MethodTemplateGetter, MethodTemplateWrapper
 
 
 def _REntry_GetPtr(self, key):
+    raise RuntimeError("GetPtr is not supported in Python, use indexing")
+
+
+def _REntry_CallGetPtr(self, key):
     # key can be either a RFieldToken already or a string. In the latter case, get a token to use it twice.
     if (
         not hasattr(type(key), "__cpp_name__")
@@ -24,7 +28,7 @@ def _REntry_GetPtr(self, key):
 
 
 def _REntry_getitem(self, key):
-    ptr_proxy = self.GetPtr(key)
+    ptr_proxy = self._CallGetPtr(key)
     # Most types held by a shared_ptr are exposed by cppyy as the type of the
     # pointee, so we need to get the smart pointer before dereferencing. This
     # does not happen for smart pointers to fundamental types.
@@ -33,7 +37,7 @@ def _REntry_getitem(self, key):
 
 
 def _REntry_setitem(self, key, value):
-    ptr_proxy = self.GetPtr(key)
+    ptr_proxy = self._CallGetPtr(key)
     # Most types held by a shared_ptr are exposed by cppyy as the type of the
     # pointee, so we need to get the smart pointer before dereferencing. This
     # does not happen for smart pointers to fundamental types.
@@ -47,6 +51,7 @@ def _REntry_setitem(self, key, value):
 def pythonize_REntry(klass):
     klass._GetPtr = klass.GetPtr
     klass.GetPtr = _REntry_GetPtr
+    klass._CallGetPtr = _REntry_CallGetPtr
 
     klass.__getitem__ = _REntry_getitem
     klass.__setitem__ = _REntry_setitem

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -29,11 +29,10 @@ def _REntry_CallGetPtr(self, key):
 
 def _REntry_getitem(self, key):
     ptr_proxy = self._CallGetPtr(key)
-    # Most types held by a shared_ptr are exposed by cppyy as the type of the
-    # pointee, so we need to get the smart pointer before dereferencing. This
-    # does not happen for smart pointers to fundamental types.
-    real_smartptr = ptr_proxy.__smartptr__() if ptr_proxy.__smartptr__() is not None else ptr_proxy
-    return real_smartptr.__deref__()
+    if type(ptr_proxy).__cpp_name__.startswith("std::shared_ptr"):
+        return ptr_proxy.__deref__()
+    # Otherwise, for non-fundamental types, cppyy already returns the pointee.
+    return ptr_proxy
 
 
 def _REntry_setitem(self, key, value):

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -290,14 +290,6 @@ static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializable
 /// Check whether a given string is a valid name according to the RNTuple specification
 RResult<void> EnsureValidNameForRNTuple(std::string_view name, std::string_view where);
 
-/// Helper for the Python interface to perform the assignment to the pointee of a shared_ptr.
-template <typename T, typename U>
-void AssignValueToPointee(T &&value, std::shared_ptr<U> &ptr)
-{
-   static_assert(std::is_convertible_v<T, U>, "Cannot convert type of input argument to type of the pointee.");
-   *ptr = std::forward<T>(value);
-}
-
 } // namespace Internal
 
 } // namespace Experimental


### PR DESCRIPTION
For non-fundamental types, we can avoid getting the smartptr just to deference or assign to it. Also forbid calling `REntry::GetPtr` from Python, it does not map well.