### PR TITLE
Remove limiting RNTuple factory function

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -191,7 +191,6 @@ namespace RDF {
 namespace Experimental {
 RDataFrame FromRNTuple(std::string_view ntupleName, std::string_view fileName);
 RDataFrame FromRNTuple(std::string_view ntupleName, const std::vector<std::string> &fileNames);
-RDataFrame FromRNTuple(ROOT::RNTuple *ntuple);
 } // namespace Experimental
 } // namespace RDF
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -756,8 +756,3 @@ ROOT::RDF::Experimental::FromRNTuple(std::string_view ntupleName, const std::vec
 {
    return ROOT::RDataFrame(std::make_unique<ROOT::Experimental::RNTupleDS>(ntupleName, fileNames));
 }
-
-ROOT::RDataFrame ROOT::RDF::Experimental::FromRNTuple(ROOT::RNTuple *ntuple)
-{
-   return ROOT::RDataFrame(std::make_unique<ROOT::Experimental::RNTupleDS>(ntuple));
-}


### PR DESCRIPTION
Experience with TTree processing has shown that the constructor taking an object is limited. Notably, it makes it more complicated to fully specify the input dataset in an isolated way, may be susceptible to side-effects and also complicates the logic when running distributedly. Thus, we can avoid having to suffer the same problems with RNTuple.
