### PR TITLE
[geom] Emulate Inside functionality to fix false positives in overlap checking

### DIFF
--- a/geom/geom/inc/TGeoArb8.h
+++ b/geom/geom/inc/TGeoArb8.h
@@ -42,7 +42,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    void ComputeTwist();
    Bool_t Contains(const Double_t *point) const override;

--- a/geom/geom/inc/TGeoBBox.h
+++ b/geom/geom/inc/TGeoBBox.h
@@ -39,7 +39,7 @@ public:
    
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoBoolNode.h
+++ b/geom/geom/inc/TGeoBoolNode.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_TGeoBoolNode
 #define ROOT_TGeoBoolNode
 
-#include "TObject.h"
+#include "TGeoShape.h"
 
 #include <mutex>
 #include <vector>
@@ -64,7 +64,7 @@ public:
    ~TGeoBoolNode() override;
    // methods
    virtual void ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) = 0;
-   virtual void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) = 0;
+   virtual void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const = 0;
    virtual Bool_t Contains(const Double_t *point) const = 0;
    virtual Int_t DistanceToPrimitive(Int_t px, Int_t py) = 0;
    virtual Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
@@ -72,11 +72,12 @@ public:
    virtual Double_t DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
                                     Double_t *safe = nullptr) const = 0;
    virtual EGeoBoolType GetBooleanOperator() const = 0;
-   virtual Int_t GetNpoints() = 0;
+   Int_t GetNpoints();
    TGeoMatrix *GetLeftMatrix() const { return fLeftMat; }
    TGeoMatrix *GetRightMatrix() const { return fRightMat; }
    TGeoShape *GetLeftShape() const { return fLeft; }
    TGeoShape *GetRightShape() const { return fRight; }
+   TGeoShape::EInside Inside(const Double_t *point) const;
    virtual TGeoBoolNode *MakeClone() const = 0;
    void Paint(Option_t *option) override;
    void RegisterMatrices();
@@ -108,7 +109,7 @@ public:
    ~TGeoUnion() override;
    // methods
    void ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    Bool_t Contains(const Double_t *point) const override;
    Int_t DistanceToPrimitive(Int_t px, Int_t py) override;
    Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
@@ -116,7 +117,6 @@ public:
    Double_t DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
                             Double_t *safe = nullptr) const override;
    EGeoBoolType GetBooleanOperator() const override { return kGeoUnion; }
-   Int_t GetNpoints() override;
    Double_t Safety(const Double_t *point, Bool_t in = kTRUE) const override;
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void Sizeof3D() const override;
@@ -146,7 +146,7 @@ public:
    ~TGeoIntersection() override;
    // methods
    void ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    Bool_t Contains(const Double_t *point) const override;
    Int_t DistanceToPrimitive(Int_t px, Int_t py) override;
    Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
@@ -154,7 +154,6 @@ public:
    Double_t DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
                             Double_t *safe = nullptr) const override;
    EGeoBoolType GetBooleanOperator() const override { return kGeoIntersection; }
-   Int_t GetNpoints() override;
    Double_t Safety(const Double_t *point, Bool_t in = kTRUE) const override;
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void Sizeof3D() const override;
@@ -183,7 +182,7 @@ public:
    ~TGeoSubtraction() override;
    // methods
    void ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    Bool_t Contains(const Double_t *point) const override;
    Int_t DistanceToPrimitive(Int_t px, Int_t py) override;
    Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
@@ -191,7 +190,6 @@ public:
    Double_t DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = 0,
                             Double_t *safe = nullptr) const override;
    EGeoBoolType GetBooleanOperator() const override { return kGeoSubtraction; }
-   Int_t GetNpoints() override;
    Double_t Safety(const Double_t *point, Bool_t in = kTRUE) const override;
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void Sizeof3D() const override;

--- a/geom/geom/inc/TGeoCompositeShape.h
+++ b/geom/geom/inc/TGeoCompositeShape.h
@@ -46,7 +46,7 @@ public:
    void ClearThreadData() const override;
    void CreateThreadData(Int_t nthreads) override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoCone.h
+++ b/geom/geom/inc/TGeoCone.h
@@ -39,7 +39,7 @@ public:
    Double_t Capacity() const override;
    static Double_t Capacity(Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2);
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static void ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm, Double_t dz, Double_t rmin1,
                               Double_t rmax1, Double_t rmin2, Double_t rmax2);
@@ -128,7 +128,7 @@ public:
    static Double_t
    Capacity(Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2);
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static void ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm, Double_t dz, Double_t rmin1,
                               Double_t rmax1, Double_t rmin2, Double_t rmax2, Double_t c1, Double_t s1, Double_t c2,

--- a/geom/geom/inc/TGeoEltu.h
+++ b/geom/geom/inc/TGeoEltu.h
@@ -29,7 +29,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoHalfSpace.h
+++ b/geom/geom/inc/TGeoHalfSpace.h
@@ -32,7 +32,7 @@ public:
    // methods
    Double_t Capacity() const override { return 0.; }
    void ComputeBBox() override {}
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoHype.h
+++ b/geom/geom/inc/TGeoHype.h
@@ -45,7 +45,7 @@ public:
 
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoPara.h
+++ b/geom/geom/inc/TGeoPara.h
@@ -42,7 +42,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoParaboloid.h
+++ b/geom/geom/inc/TGeoParaboloid.h
@@ -36,7 +36,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoPcon.h
+++ b/geom/geom/inc/TGeoPcon.h
@@ -51,7 +51,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoPgon.h
+++ b/geom/geom/inc/TGeoPgon.h
@@ -70,7 +70,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoScaledShape.h
+++ b/geom/geom/inc/TGeoScaledShape.h
@@ -33,7 +33,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoShape.h
+++ b/geom/geom/inc/TGeoShape.h
@@ -65,7 +65,7 @@ public:
    };
 
    enum EInside {
-      kInside  = 1,
+      kInside = 1,
       kOutside = 2,
       kSurface = 3
    };
@@ -190,7 +190,8 @@ TGeoShape::EInside Inside(const Double_t *point, Solid const *solid)
    // This function is expensive because it costs 2 * Contains + 1 * GetNormal calls
 
    // Compute the normal in the point, along a radial direction
-   constexpr TGeoShape::EInside kTable[4] = { TGeoShape::kOutside, TGeoShape::kSurface, TGeoShape::kSurface, TGeoShape::kInside };
+   constexpr TGeoShape::EInside kTable[4] = {TGeoShape::kOutside, TGeoShape::kSurface, TGeoShape::kSurface,
+                                             TGeoShape::kInside};
    constexpr double dir[3] = {1., 0., 0.};
    double pt_push[3], pt_pull[3], norm[3];
    solid->ComputeNormal(point, &dir[0], norm);

--- a/geom/geom/inc/TGeoShape.h
+++ b/geom/geom/inc/TGeoShape.h
@@ -63,6 +63,13 @@ public:
       kGeoHype = BIT(30),
       kGeoSavePrimitive = BIT(20)
    };
+
+   enum EInside {
+      kInside  = 1,
+      kOutside = 2,
+      kSurface = 3
+   };
+
    virtual void ClearThreadData() const {}
    virtual void CreateThreadData(Int_t) {}
 
@@ -126,6 +133,7 @@ public:
    const char *GetName() const override;
    virtual Int_t GetNmeshVertices() const { return 0; }
    const char *GetPointerName() const;
+   virtual EInside Inside(const Double_t *point) const;
    virtual Bool_t IsAssembly() const { return kFALSE; }
    virtual Bool_t IsComposite() const { return kFALSE; }
    virtual Bool_t IsCylType() const = 0;

--- a/geom/geom/inc/TGeoShape.h
+++ b/geom/geom/inc/TGeoShape.h
@@ -101,7 +101,7 @@ public:
    virtual Double_t Capacity() const = 0;
    void CheckShape(Int_t testNo, Int_t nsamples = 10000, Option_t *option = "");
    virtual void ComputeBBox() = 0;
-   virtual void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) = 0;
+   virtual void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const = 0;
    virtual void ComputeNormal_v(const Double_t *, const Double_t *, Double_t *, Int_t) {}
    virtual Bool_t Contains(const Double_t *point) const = 0;
    virtual void Contains_v(const Double_t *, Bool_t *, Int_t) const {}

--- a/geom/geom/inc/TGeoShapeAssembly.h
+++ b/geom/geom/inc/TGeoShapeAssembly.h
@@ -31,7 +31,7 @@ public:
    ~TGeoShapeAssembly() override;
    // methods
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoSphere.h
+++ b/geom/geom/inc/TGeoSphere.h
@@ -41,7 +41,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoTorus.h
+++ b/geom/geom/inc/TGeoTorus.h
@@ -46,7 +46,7 @@ public:
    // methods
 
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoTrd1.h
+++ b/geom/geom/inc/TGeoTrd1.h
@@ -38,7 +38,7 @@ public:
 
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoTrd2.h
+++ b/geom/geom/inc/TGeoTrd2.h
@@ -41,7 +41,7 @@ public:
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = TGeoShape::Big(),
                            Double_t *safe = nullptr) const override;

--- a/geom/geom/inc/TGeoTube.h
+++ b/geom/geom/inc/TGeoTube.h
@@ -38,7 +38,7 @@ public:
    Double_t Capacity() const override;
    static Double_t Capacity(Double_t rmin, Double_t rmax, Double_t dz);
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static void ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm, Double_t rmin, Double_t rmax,
                               Double_t dz);
@@ -120,7 +120,7 @@ public:
    Double_t Capacity() const override;
    static Double_t Capacity(Double_t rmin, Double_t rmax, Double_t dz, Double_t phi1, Double_t phi2);
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static void ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm, Double_t rmin, Double_t rmax,
                               Double_t dz, Double_t c1, Double_t s1, Double_t c2, Double_t s2);
@@ -189,7 +189,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/inc/TGeoXtru.h
+++ b/geom/geom/inc/TGeoXtru.h
@@ -74,7 +74,7 @@ public:
    // methods
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    void ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    Bool_t Contains(const Double_t *point) const override;
    void Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;

--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -462,7 +462,7 @@ Double_t TGeoArb8::GetClosestEdge(const Double_t *point, Double_t *vert, Int_t &
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoArb8::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoArb8::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t safc;
    Double_t x0, y0, z0, x1, y1, z1, x2, y2, z2;

--- a/geom/geom/src/TGeoBBox.cxx
+++ b/geom/geom/src/TGeoBBox.cxx
@@ -217,7 +217,7 @@ Double_t TGeoBBox::Capacity() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Computes normal to closest surface from POINT.
 
-void TGeoBBox::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoBBox::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    memset(norm, 0, 3 * sizeof(Double_t));
    Double_t saf[3];

--- a/geom/geom/src/TGeoBoolNode.cxx
+++ b/geom/geom/src/TGeoBoolNode.cxx
@@ -218,6 +218,58 @@ void TGeoBoolNode::AssignPoints(Int_t npoints, Double_t *points)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns number of vertices for the composite shape described by this node.
+
+Int_t TGeoBoolNode::GetNpoints()
+{
+   Int_t itot = 0;
+   Double_t point[3];
+   Double_t tolerance = TGeoShape::Tolerance();
+   if (fNpoints)
+      return fNpoints;
+   // Local points for the left shape
+   Int_t nleft = fLeft->GetNmeshVertices();
+   Double_t *points1 = new Double_t[3 * nleft];
+   fLeft->SetPoints(points1);
+   // Local points for the right shape
+   Int_t nright = fRight->GetNmeshVertices();
+   Double_t *points2 = new Double_t[3 * nright];
+   fRight->SetPoints(points2);
+   Double_t *points = new Double_t[3 * (nleft + nright)];
+   for (Int_t i = 0; i < nleft; i++) {
+      if (TMath::Abs(points1[3 * i]) < tolerance && TMath::Abs(points1[3 * i + 1]) < tolerance)
+         continue;
+      fLeftMat->LocalToMaster(&points1[3 * i], &points[3 * itot]);
+      fRightMat->MasterToLocal(&points[3 * itot], point);
+      if (Inside(point) == TGeoShape::kSurface)
+         itot++;
+   }
+   for (Int_t i = 0; i < nright; i++) {
+      if (TMath::Abs(points2[3 * i]) < tolerance && TMath::Abs(points2[3 * i + 1]) < tolerance)
+         continue;
+      fRightMat->LocalToMaster(&points2[3 * i], &points[3 * itot]);
+      fLeftMat->MasterToLocal(&points[3 * itot], point);
+      if (Inside(point) == TGeoShape::kSurface)
+         itot++;
+   }
+
+   AssignPoints(itot, points);
+
+   delete[] points1;
+   delete[] points2;
+   delete[] points;
+   return fNpoints;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Implementation of the inside function using just Contains and GetNormal
+
+TGeoShape::EInside TGeoBoolNode::Inside(const Double_t *point) const
+{
+   return tgeo_impl::Inside(point, this);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Expands the boolean expression either on left or right branch, creating
 /// component elements (composite shapes and boolean nodes). Returns true on success.
 
@@ -551,7 +603,7 @@ Bool_t TGeoUnion::Contains(const Double_t *point) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal computation in POINT. The orientation is chosen so that DIR.dot.NORM>0.
 
-void TGeoUnion::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoUnion::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    ThreadData_t &td = GetThreadData();
    norm[0] = norm[1] = 0.;
@@ -773,50 +825,6 @@ TGeoUnion::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iac
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns number of vertices for the composite shape described by this union.
-
-Int_t TGeoUnion::GetNpoints()
-{
-   Int_t itot = 0;
-   Double_t point[3];
-   Double_t tolerance = TGeoShape::Tolerance();
-   if (fNpoints)
-      return fNpoints;
-   // Local points for the left shape
-   Int_t nleft = fLeft->GetNmeshVertices();
-   Double_t *points1 = new Double_t[3 * nleft];
-   fLeft->SetPoints(points1);
-   // Local points for the right shape
-   Int_t nright = fRight->GetNmeshVertices();
-   Double_t *points2 = new Double_t[3 * nright];
-   fRight->SetPoints(points2);
-   Double_t *points = new Double_t[3 * (nleft + nright)];
-   for (Int_t i = 0; i < nleft; i++) {
-      if (TMath::Abs(points1[3 * i]) < tolerance && TMath::Abs(points1[3 * i + 1]) < tolerance)
-         continue;
-      fLeftMat->LocalToMaster(&points1[3 * i], &points[3 * itot]);
-      fRightMat->MasterToLocal(&points[3 * itot], point);
-      if (!fRight->Contains(point))
-         itot++;
-   }
-   for (Int_t i = 0; i < nright; i++) {
-      if (TMath::Abs(points2[3 * i]) < tolerance && TMath::Abs(points2[3 * i + 1]) < tolerance)
-         continue;
-      fRightMat->LocalToMaster(&points2[3 * i], &points[3 * itot]);
-      fLeftMat->MasterToLocal(&points[3 * itot], point);
-      if (!fLeft->Contains(point))
-         itot++;
-   }
-
-   AssignPoints(itot, points);
-
-   delete[] points1;
-   delete[] points2;
-   delete[] points;
-   return fNpoints;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Compute safety distance for a union node;
 
 Double_t TGeoUnion::Safety(const Double_t *point, Bool_t in) const
@@ -962,7 +970,7 @@ void TGeoSubtraction::ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Doub
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal computation in POINT. The orientation is chosen so that DIR.dot.NORM>0.
 
-void TGeoSubtraction::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoSubtraction::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    ThreadData_t &td = GetThreadData();
    norm[0] = norm[1] = 0.;
@@ -1127,48 +1135,6 @@ Double_t TGeoSubtraction::DistFromOutside(const Double_t *point, const Double_t 
       fRightMat->MasterToLocal(&master[0], &local[0]);
       inside = kTRUE;
    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Returns number of vertices for the composite shape described by this subtraction.
-
-Int_t TGeoSubtraction::GetNpoints()
-{
-   Int_t itot = 0;
-   Double_t point[3];
-   Double_t tolerance = TGeoShape::Tolerance();
-   if (fNpoints)
-      return fNpoints;
-   Int_t nleft = fLeft->GetNmeshVertices();
-   Int_t nright = fRight->GetNmeshVertices();
-   Double_t *points = new Double_t[3 * (nleft + nright)];
-   Double_t *points1 = new Double_t[3 * nleft];
-   fLeft->SetPoints(points1);
-   for (Int_t i = 0; i < nleft; i++) {
-      if (TMath::Abs(points1[3 * i]) < tolerance && TMath::Abs(points1[3 * i + 1]) < tolerance)
-         continue;
-      fLeftMat->LocalToMaster(&points1[3 * i], &points[3 * itot]);
-      fRightMat->MasterToLocal(&points[3 * itot], point);
-      if (!fRight->Contains(point))
-         itot++;
-   }
-   Double_t *points2 = new Double_t[3 * nright];
-   fRight->SetPoints(points2);
-   for (Int_t i = 0; i < nright; i++) {
-      if (TMath::Abs(points2[3 * i]) < tolerance && TMath::Abs(points2[3 * i + 1]) < tolerance)
-         continue;
-      fRightMat->LocalToMaster(&points2[3 * i], &points[3 * itot]);
-      fLeftMat->MasterToLocal(&points[3 * itot], point);
-      if (fLeft->Contains(point))
-         itot++;
-   }
-
-   AssignPoints(itot, points);
-
-   delete[] points1;
-   delete[] points2;
-   delete[] points;
-   return fNpoints;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1395,7 +1361,7 @@ void TGeoIntersection::ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Dou
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal computation in POINT. The orientation is chosen so that DIR.dot.NORM>0.
 
-void TGeoIntersection::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoIntersection::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    ThreadData_t &td = GetThreadData();
    Double_t local[3], ldir[3], lnorm[3];
@@ -1591,48 +1557,6 @@ Double_t TGeoIntersection::DistFromOutside(const Double_t *point, const Double_t
       }
    }
    return snext;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Returns number of vertices for the composite shape described by this intersection.
-
-Int_t TGeoIntersection::GetNpoints()
-{
-   Int_t itot = 0;
-   Double_t point[3];
-   Double_t tolerance = TGeoShape::Tolerance();
-   if (fNpoints)
-      return fNpoints;
-   Int_t nleft = fLeft->GetNmeshVertices();
-   Int_t nright = fRight->GetNmeshVertices();
-   Double_t *points = new Double_t[3 * (nleft + nright)];
-   Double_t *points1 = new Double_t[3 * nleft];
-   fLeft->SetPoints(points1);
-   for (Int_t i = 0; i < nleft; i++) {
-      if (TMath::Abs(points1[3 * i]) < tolerance && TMath::Abs(points1[3 * i + 1]) < tolerance)
-         continue;
-      fLeftMat->LocalToMaster(&points1[3 * i], &points[3 * itot]);
-      fRightMat->MasterToLocal(&points[3 * itot], point);
-      if (fRight->Contains(point))
-         itot++;
-   }
-   Double_t *points2 = new Double_t[3 * nright];
-   fRight->SetPoints(points2);
-   for (Int_t i = 0; i < nright; i++) {
-      if (TMath::Abs(points2[3 * i]) < tolerance && TMath::Abs(points2[3 * i + 1]) < tolerance)
-         continue;
-      fRightMat->LocalToMaster(&points2[3 * i], &points[3 * itot]);
-      fLeftMat->MasterToLocal(&points[3 * itot], point);
-      if (fLeft->Contains(point))
-         itot++;
-   }
-
-   AssignPoints(itot, points);
-
-   delete[] points1;
-   delete[] points2;
-   delete[] points;
-   return fNpoints;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoCompositeShape.cxx
+++ b/geom/geom/src/TGeoCompositeShape.cxx
@@ -311,7 +311,7 @@ void TGeoCompositeShape::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Computes normal vector in POINT to the composite shape.
 
-void TGeoCompositeShape::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoCompositeShape::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    if (fNode)
       fNode->ComputeNormal(point, dir, norm);

--- a/geom/geom/src/TGeoCone.cxx
+++ b/geom/geom/src/TGeoCone.cxx
@@ -188,7 +188,7 @@ void TGeoCone::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoCone::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoCone::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t safr, safe, phi;
    memset(norm, 0, 3 * sizeof(Double_t));
@@ -1434,7 +1434,7 @@ void TGeoConeSeg::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoConeSeg::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoConeSeg::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[3];
    Double_t ro1 = 0.5 * (fRmin1 + fRmin2);

--- a/geom/geom/src/TGeoEltu.cxx
+++ b/geom/geom/src/TGeoEltu.cxx
@@ -118,7 +118,7 @@ void TGeoEltu::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoEltu::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoEltu::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t a = fRmin;
    Double_t b = fRmax;

--- a/geom/geom/src/TGeoHalfSpace.cxx
+++ b/geom/geom/src/TGeoHalfSpace.cxx
@@ -74,7 +74,7 @@ TGeoHalfSpace::~TGeoHalfSpace() {}
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoHalfSpace::ComputeNormal(const Double_t * /*point*/, const Double_t *dir, Double_t *norm)
+void TGeoHalfSpace::ComputeNormal(const Double_t * /*point*/, const Double_t *dir, Double_t *norm) const
 {
    memcpy(norm, fN, 3 * sizeof(Double_t));
    if (norm[0] * dir[0] + norm[1] * dir[1] + norm[2] * dir[2] < 0) {

--- a/geom/geom/src/TGeoHype.cxx
+++ b/geom/geom/src/TGeoHype.cxx
@@ -179,7 +179,7 @@ void TGeoHype::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoHype::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoHype::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[3];
    Double_t rsq = point[0] * point[0] + point[1] * point[1];

--- a/geom/geom/src/TGeoPara.cxx
+++ b/geom/geom/src/TGeoPara.cxx
@@ -180,7 +180,7 @@ void TGeoPara::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoPara::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoPara::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[3];
    // distance from point to higher Z face

--- a/geom/geom/src/TGeoParaboloid.cxx
+++ b/geom/geom/src/TGeoParaboloid.cxx
@@ -141,7 +141,7 @@ void TGeoParaboloid::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoParaboloid::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoParaboloid::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    norm[0] = norm[1] = 0.0;
    if (TMath::Abs(point[2]) > fDz) {

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -363,7 +363,7 @@ void TGeoPcon::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoPcon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoPcon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    memset(norm, 0, 3 * sizeof(Double_t));
    Double_t r;

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -287,7 +287,7 @@ void TGeoPgon::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    memset(norm, 0, 3 * sizeof(Double_t));
    Double_t phi1 = 0, phi2 = 0, c1 = 0, s1 = 0, c2 = 0, s2 = 0;

--- a/geom/geom/src/TGeoScaledShape.cxx
+++ b/geom/geom/src/TGeoScaledShape.cxx
@@ -106,7 +106,7 @@ void TGeoScaledShape::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoScaledShape::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoScaledShape::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t local[3], ldir[3], lnorm[3];
    fScale->MasterToLocal(point, local);

--- a/geom/geom/src/TGeoShape.cxx
+++ b/geom/geom/src/TGeoShape.cxx
@@ -280,8 +280,7 @@ TGeoShape::EInside TGeoShape::Inside(const Double_t *point) const
    constexpr EInside kTable[4] = { kOutside, kSurface, kSurface, kInside };
    constexpr double dir[3] = {1., 0., 0.};
    double pt_push[3], pt_pull[3], norm[3];
-   // Deal with non-constness of ComputeNormal for the moment
-   ((TGeoShape *)this)->ComputeNormal(point, &dir[0], norm);
+   ComputeNormal(point, &dir[0], norm);
    // Move the point back and forth along the normal and check if the Contains changes
    for (auto i = 0; i < 3; ++i) {
       pt_push[i] = point[i] + 10. * TGeoShape::Tolerance() * norm[i];

--- a/geom/geom/src/TGeoShape.cxx
+++ b/geom/geom/src/TGeoShape.cxx
@@ -271,24 +271,7 @@ Int_t TGeoShape::ShapeDistancetoPrimitive(Int_t numpoints, Int_t px, Int_t py) c
 
 TGeoShape::EInside TGeoShape::Inside(const Double_t *point) const
 {
-   // This emulates the Inside funtionality in Geant4 and VecGeom, i.e instead of
-   // just 'inside' and 'outside', points closer to the shape surface by less than
-   // TGeoShape::Tolerance() (1.e-9 mm) are considered on surface.
-   // This function is expensive because it costs 2 * Contains + 1 * GetNormal calls
-
-   // Compute the normal in the point, along a radial direction
-   constexpr EInside kTable[4] = { kOutside, kSurface, kSurface, kInside };
-   constexpr double dir[3] = {1., 0., 0.};
-   double pt_push[3], pt_pull[3], norm[3];
-   ComputeNormal(point, &dir[0], norm);
-   // Move the point back and forth along the normal and check if the Contains changes
-   for (auto i = 0; i < 3; ++i) {
-      pt_push[i] = point[i] + 10. * TGeoShape::Tolerance() * norm[i];
-      pt_pull[i] = point[i] - 10. * TGeoShape::Tolerance() * norm[i];
-   }
-   int in_push = Contains(pt_push);
-   int in_pull = Contains(pt_pull);
-   return kTable[in_push + 2 * in_pull];
+   return tgeo_impl::Inside(point, this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoShape.cxx
+++ b/geom/geom/src/TGeoShape.cxx
@@ -267,6 +267,32 @@ Int_t TGeoShape::ShapeDistancetoPrimitive(Int_t numpoints, Int_t px, Int_t py) c
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Implementation of the inside function using just Contains and GetNormal
+
+TGeoShape::EInside TGeoShape::Inside(const Double_t *point) const
+{
+   // This emulates the Inside funtionality in Geant4 and VecGeom, i.e instead of
+   // just 'inside' and 'outside', points closer to the shape surface by less than
+   // TGeoShape::Tolerance() (1.e-9 mm) are considered on surface.
+   // This function is expensive because it costs 2 * Contains + 1 * GetNormal calls
+
+   // Compute the normal in the point, along a radial direction
+   constexpr EInside kTable[4] = { kOutside, kSurface, kSurface, kInside };
+   constexpr double dir[3] = {1., 0., 0.};
+   double pt_push[3], pt_pull[3], norm[3];
+   // Deal with non-constness of ComputeNormal for the moment
+   ((TGeoShape *)this)->ComputeNormal(point, &dir[0], norm);
+   // Move the point back and forth along the normal and check if the Contains changes
+   for (auto i = 0; i < 3; ++i) {
+      pt_push[i] = point[i] + 10. * TGeoShape::Tolerance() * norm[i];
+      pt_pull[i] = point[i] - 10. * TGeoShape::Tolerance() * norm[i];
+   }
+   int in_push = Contains(pt_push);
+   int in_pull = Contains(pt_pull);
+   return kTable[in_push + 2 * in_pull];
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// True if point is closer than epsil to one of the phi planes defined by c1,s1 or c2,s2
 
 Bool_t

--- a/geom/geom/src/TGeoShapeAssembly.cxx
+++ b/geom/geom/src/TGeoShapeAssembly.cxx
@@ -164,7 +164,7 @@ void TGeoShapeAssembly::RecomputeBoxLast()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT. Should not be called.
 
-void TGeoShapeAssembly::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoShapeAssembly::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    if (!fBBoxOK)
       ((TGeoShapeAssembly *)this)->ComputeBBox();

--- a/geom/geom/src/TGeoSphere.cxx
+++ b/geom/geom/src/TGeoSphere.cxx
@@ -229,7 +229,7 @@ void TGeoSphere::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoSphere::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoSphere::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t rxy2 = point[0] * point[0] + point[1] * point[1];
    Double_t r2 = rxy2 + point[2] * point[2];

--- a/geom/geom/src/TGeoTorus.cxx
+++ b/geom/geom/src/TGeoTorus.cxx
@@ -185,7 +185,7 @@ void TGeoTorus::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoTorus::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoTorus::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t phi = TMath::ATan2(point[1], point[0]);
    if (fDphi < 360) {

--- a/geom/geom/src/TGeoTrd1.cxx
+++ b/geom/geom/src/TGeoTrd1.cxx
@@ -139,7 +139,7 @@ void TGeoTrd1::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoTrd1::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoTrd1::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t safe, safemin;
    //--- Compute safety first

--- a/geom/geom/src/TGeoTrd2.cxx
+++ b/geom/geom/src/TGeoTrd2.cxx
@@ -138,7 +138,7 @@ void TGeoTrd2::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoTrd2::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoTrd2::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t safe, safemin;
    Double_t fx = 0.5 * (fDx1 - fDx2) / fDz;

--- a/geom/geom/src/TGeoTube.cxx
+++ b/geom/geom/src/TGeoTube.cxx
@@ -230,7 +230,7 @@ void TGeoTube::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoTube::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoTube::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[3];
    Double_t rsq = point[0] * point[0] + point[1] * point[1];
@@ -1443,7 +1443,7 @@ void TGeoTubeSeg::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoTubeSeg::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoTubeSeg::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[3];
    Double_t rsq = point[0] * point[0] + point[1] * point[1];
@@ -2771,7 +2771,7 @@ void TGeoCtub::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoCtub::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm)
+void TGeoCtub::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
 {
    Double_t saf[4];
    Bool_t isseg = kTRUE;

--- a/geom/geom/src/TGeoXtru.cxx
+++ b/geom/geom/src/TGeoXtru.cxx
@@ -355,7 +355,7 @@ void TGeoXtru::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute normal to closest surface from POINT.
 
-void TGeoXtru::ComputeNormal(const Double_t * /*point*/, const Double_t *dir, Double_t *norm)
+void TGeoXtru::ComputeNormal(const Double_t * /*point*/, const Double_t *dir, Double_t *norm) const
 {
    ThreadData_t &td = GetThreadData();
    if (td.fIz < 0) {

--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -4,6 +4,8 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
+configure_file(no_extrusion.gdml no_extrusion.gdml COPYONLY)
 ROOT_ADD_GTEST(geomTests
   test_material_units.cxx
+  test_boolean_extrusion.cxx
   LIBRARIES Geom)

--- a/geom/test/no_extrusion.gdml
+++ b/geom/test/no_extrusion.gdml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+  <define>
+    <position name="CS_1inTOPpos" x="0" y="0" z="0" unit="cm"/>
+  </define>
+    <isotope N="14" Z="7" name="Nitrogen140x7fd78af69c80">
+      <atom unit="g/mole" value="14.0031"/>
+    </isotope>
+    <isotope N="15" Z="7" name="Nitrogen150x7fd78af69cc0">
+      <atom unit="g/mole" value="15.0001"/>
+    </isotope>
+    <element name="Nitrogen0x7fd78b011ec0">
+      <fraction n="0.99632" ref="Nitrogen140x7fd78af69c80"/>
+      <fraction n="0.00368" ref="Nitrogen150x7fd78af69cc0"/>
+    </element>
+    <isotope N="16" Z="8" name="Oxygen160x7fd78af69b00">
+      <atom unit="g/mole" value="15.9949"/>
+    </isotope>
+    <isotope N="17" Z="8" name="Oxygen170x7fd78af69b80">
+      <atom unit="g/mole" value="16.9991"/>
+    </isotope>
+    <isotope N="18" Z="8" name="Oxygen180x7fd78af69bc0">
+      <atom unit="g/mole" value="17.9992"/>
+    </isotope>
+    <element name="Oxygen0x7fd78c08f4c0">
+      <fraction n="0.99757" ref="Oxygen160x7fd78af69b00"/>
+      <fraction n="0.00038" ref="Oxygen170x7fd78af69b80"/>
+      <fraction n="0.00205" ref="Oxygen180x7fd78af69bc0"/>
+    </element>
+    <isotope N="36" Z="18" name="AR360x7fd78ad67300">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="AR380x7fd78ad67340">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="AR400x7fd78ad67380">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="ARGON0x7fd78b011f80">
+      <fraction n="0.003365" ref="AR360x7fd78ad67300"/>
+      <fraction n="0.000632" ref="AR380x7fd78ad67340"/>
+      <fraction n="0.996003" ref="AR400x7fd78ad67380"/>
+    </element>
+    <isotope N="1" Z="1" name="H10x7fd78af69a80">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H20x7fd78af69ac0">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="HYDROGEN0x7fd78c08f400">
+      <fraction n="0.999885" ref="H10x7fd78af69a80"/>
+      <fraction n="0.000115" ref="H20x7fd78af69ac0"/>
+    </element>
+    <material name="materials_Air0x7fd78adb5900" state="gas">
+      <T unit="K" value="293.15"/>
+      <P unit="pascal" value="101325.009296588"/>
+      <MEE unit="eV" value="85.5379282211832"/>
+      <D unit="g/cm3" value="0.001214"/>
+      <fraction n="0.7494" ref="Nitrogen0x7fd78b011ec0"/>
+      <fraction n="0.2369" ref="Oxygen0x7fd78c08f4c0"/>
+      <fraction n="0.0129" ref="ARGON0x7fd78b011f80"/>
+      <fraction n="0.0008" ref="HYDROGEN0x7fd78c08f400"/>
+    </material>
+  <materials/>
+  <solids>
+    <box name="TOP" x="2000" y="2000" z="3000" lunit="cm"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="muonBase_MUON10x7fd78af8e9c0" rmax="8100" rmin="2950" startphi="0" z="21720"/>
+    <polycone aunit="deg" deltaphi="360" lunit="mm" name="muonBase_MUON20x7fd78af8eb80" startphi="0">
+      <zplane rmax="2950" rmin="1086" z="-10860"/>
+      <zplane rmax="2950" rmin="1086" z="-10500"/>
+      <zplane rmax="2950" rmin="1130" z="-10500"/>
+      <zplane rmax="2950" rmin="1130" z="-10165"/>
+      <zplane rmax="2950" rmin="1041.1" z="-10165"/>
+      <zplane rmax="2950" rmin="700" z="-6835"/>
+      <zplane rmax="2950" rmin="675" z="-6610"/>
+      <zplane rmax="2950" rmin="675" z="-6590"/>
+      <zplane rmax="2950" rmin="105" z="-6500"/>
+      <zplane rmax="2950" rmin="89.3" z="-5541"/>
+      <zplane rmax="2725" rmin="89.3" z="-5541"/>
+      <zplane rmax="2725" rmin="89.3" z="-5265"/>
+    </polycone>
+    <union name="muonBase_MUON00x7fd78aeaac40">
+      <first ref="muonBase_MUON10x7fd78af8e9c0"/>
+      <second ref="muonBase_MUON20x7fd78af8eb80"/>
+    </union>
+    <polycone aunit="deg" deltaphi="360" lunit="mm" name="muonBase_MUON30x7fd78af8ed40" startphi="0">
+      <zplane rmax="2725" rmin="89.3" z="5265"/>
+      <zplane rmax="2725" rmin="89.3" z="5541"/>
+      <zplane rmax="2950" rmin="89.3" z="5541"/>
+      <zplane rmax="2950" rmin="105" z="6500"/>
+      <zplane rmax="2950" rmin="675" z="6590"/>
+      <zplane rmax="2950" rmin="675" z="6610"/>
+      <zplane rmax="2950" rmin="700" z="6835"/>
+      <zplane rmax="2950" rmin="1041.1" z="10165"/>
+      <zplane rmax="2950" rmin="1130" z="10165"/>
+      <zplane rmax="2950" rmin="1130" z="10500"/>
+      <zplane rmax="2950" rmin="1086" z="10500"/>
+      <zplane rmax="2950" rmin="1086" z="10860"/>
+    </polycone>
+    <union name="muonBase_MUON_shape_0x7fd793d10b800x7fd78aeaad20">
+      <first ref="muonBase_MUON00x7fd78aeaac40"/>
+      <second ref="muonBase_MUON30x7fd78af8ed40"/>
+    </union>
+    <polycone aunit="deg" deltaphi="360" lunit="mm" name="mf_ME_shape_0x7fd793e3a7000x7fd78af76600" startphi="0">
+      <zplane rmax="2725" rmin="89.3" z="5265"/>
+      <zplane rmax="2725" rmin="89.3" z="5541"/>
+      <zplane rmax="2950" rmin="89.3" z="5541"/>
+      <zplane rmax="2950" rmin="105" z="6500"/>
+      <zplane rmax="3800" rmin="665.69" z="6500"/>
+      <zplane rmax="3800" rmin="675" z="6590"/>
+      <zplane rmax="3800" rmin="675" z="6610"/>
+      <zplane rmax="8100" rmin="675" z="6610"/>
+      <zplane rmax="8100" rmin="700" z="6835"/>
+      <zplane rmax="8100" rmin="1041.1" z="10165"/>
+      <zplane rmax="8100" rmin="1130" z="10165"/>
+      <zplane rmax="8100" rmin="1130" z="10500"/>
+      <zplane rmax="8100" rmin="1086" z="10500"/>
+      <zplane rmax="8100" rmin="1086" z="10860"/>
+    </polycone>
+  </solids>
+  <structure>
+    <volume name="mf_MEP0x7fd78b7fe840">
+      <materialref ref="materials_Air0x7fd78adb5900"/>
+      <solidref ref="mf_ME_shape_0x7fd793e3a7000x7fd78af76600"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.0153873"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.0150913"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="1"/>
+    </volume>
+    <volume name="muonBase_MUON0x7fd78b810b40">
+      <materialref ref="materials_Air0x7fd78adb5900"/>
+      <solidref ref="muonBase_MUON_shape_0x7fd793d10b800x7fd78aeaad20"/>
+      <physvol copynumber="1" name="mf_MEP_10x7fd7881a10f0">
+        <volumeref ref="mf_MEP0x7fd78b7fe840"/>
+      </physvol>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.0155647"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.0152645"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="1"/>
+    </volume>
+    <volume name="TOP">
+      <materialref ref="materials_Air0x7fd78adb5900"/>
+      <solidref ref="TOP"/>
+      <physvol name="CS_1" copynumber="1">
+        <volumeref ref="muonBase_MUON0x7fd78b810b40"/>
+        <positionref ref="CS_1inTOPpos"/>
+      </physvol>
+    </volume>
+  </structure>
+  <setup name="default" version="1.0">
+    <world ref="TOP"/>
+  </setup>
+</gdml>

--- a/geom/test/test_boolean_extrusion.cxx
+++ b/geom/test/test_boolean_extrusion.cxx
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+
+#include <TGeoManager.h>
+
+/**
+   Test to verify that child volumes spanning over more than one component of their Boolean parent
+   do not give false positives with the overlap checker
+   \author Andrei Gheata
+*/
+TEST(Geometry, NoExtrusionInUnionSpan)
+{
+   // import a GDML geometry with a policone inside a union of two polycones and a tube
+   auto geom = TGeoManager::Import("no_extrusion.gdml");
+   EXPECT_NE(geom, nullptr);
+   if (!geom) {
+      std::cout << "Could not load geometry file no_extrusion.gdml\n";
+      return;
+   }
+   geom->CheckOverlaps(0.001);
+   auto num_overlaps = gGeoManager->GetListOfOverlaps()->GetEntries();
+   EXPECT_EQ(num_overlaps, 0);
+}


### PR DESCRIPTION
# This Pull request:
This excludes solid mesh points used for overlap checking if these points are not on the surface, which can generate false positives in some Boolean cases.

## Changes or fixes:
Implemented an emulated `Inside` function in TGeoShape. This functionality exists in Geant4 and VecGeom, implemented natively by all solids, and detects points numerically on the solid surface within some tolerance. The emulation is implemented in `TGeoShape` by XOR-ing the return values given by the `Contains` function in a pushed and a pulled point along the surface normal vector. The push/pull is made using `TGeoShape::Tolerance`. 

The new `Inside` method discards mesh points on virtual surfaces inside joining Boolean solids. Previously, these points were considered on the solid surface and generated false-positive extrusions during overlap checking. I've made the `TGeoShape::ComputeNormal` interface const in the implementation process.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
- [x] Added new google test inside `gtest-geom-geomTests`

This PR fixes # 

