### PR TITLE
[ntuple] remove kNTupleUnknownCompression

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -240,7 +240,8 @@ public:
       NTupleSize_t fNElements = kInvalidNTupleIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
-      int fCompressionSettings = kNTupleUnknownCompression;
+      /// If unset, the compression settings are undefined (for suppressed columns).
+      std::optional<std::uint32_t> fCompressionSettings;
       /// Suppressed columns have an empty page range and unknown compression settings.
       /// Their element index range, however, is aligned with the corresponding column of the
       /// primary column representation (see Section "Suppressed Columns" in the specification)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -240,7 +240,7 @@ public:
       NTupleSize_t fNElements = kInvalidNTupleIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
-      /// If unset, the compression settings are undefined (for suppressed columns).
+      /// If unset, the compression settings are undefined (deferred columns, suppressed columns).
       std::optional<std::uint32_t> fCompressionSettings;
       /// Suppressed columns have an empty page range and unknown compression settings.
       /// Their element index range, however, is aligned with the corresponding column of the

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -65,10 +65,10 @@ class RClusterPool;
 ///   1. there must be no space between the separators (i.e. `:` and `=`)
 ///   2. all string matching is case insensitive
 struct RNTupleMergeOptions {
-   /// If `fCompressionSettings == kNTupleUnknownCompression` (the default), the merger will not change the
+   /// If fCompressionSettings is empty (the default), the merger will not change the
    /// compression of any of its sources (fast merging). Otherwise, all sources will be converted to the specified
    /// compression algorithm and level.
-   int fCompressionSettings = kNTupleUnknownCompression;
+   std::optional<std::uint32_t> fCompressionSettings;
    /// Determines how the merging treats sources with different models (\see ENTupleMergingMode).
    ENTupleMergingMode fMergingMode = ENTupleMergingMode::kFilter;
    /// Determines how the Merge function behaves upon merging errors

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -117,9 +117,6 @@ enum ENTupleStructure : std::uint16_t { kInvalid, kLeaf, kCollection, kRecord, k
 using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
 
-/// Regular, known compression settings have the form algorithm * 100 + level, e.g. 101, 505, ...
-constexpr int kNTupleUnknownCompression = -1;
-
 /// Distriniguishes elements of the same type within a descriptor, e.g. different fields
 using DescriptorId_t = std::uint64_t;
 constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -59,7 +59,7 @@ public:
    // clang-format on
 
 protected:
-   int fCompression{RCompressionSetting::EDefaults::kUseGeneralPurpose};
+   std::uint32_t fCompression{RCompressionSetting::EDefaults::kUseGeneralPurpose};
    /// Approximation of the target compressed cluster size
    std::size_t fApproxZippedClusterSize = 128 * 1024 * 1024;
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
@@ -103,8 +103,8 @@ public:
    virtual ~RNTupleWriteOptions() = default;
    virtual std::unique_ptr<RNTupleWriteOptions> Clone() const;
 
-   int GetCompression() const { return fCompression; }
-   void SetCompression(int val) { fCompression = val; }
+   std::uint32_t GetCompression() const { return fCompression; }
+   void SetCompression(std::uint32_t val) { fCompression = val; }
    void SetCompression(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel)
    {
       fCompression = CompressionSettings(algorithm, compressionLevel);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -709,8 +709,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RClusterDescriptorBuilder::Com
       return R__FAIL("column ID mismatch");
    if (fCluster.fColumnRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
-   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, 0};
-   columnRange.fCompressionSettings = compressionSettings;
+   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, 0, compressionSettings};
    for (const auto &pi : pageRange.fPageInfos) {
       columnRange.fNElements += pi.fNElements;
    }
@@ -727,7 +726,6 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRan
 
    RClusterDescriptor::RColumnRange columnRange;
    columnRange.fPhysicalColumnId = physicalId;
-   columnRange.fCompressionSettings = kNTupleUnknownCompression;
    columnRange.fIsSuppressed = true;
    fCluster.fColumnRanges[physicalId] = columnRange;
    return RResult<void>::Success();

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -124,7 +124,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
 
          info.fNElements += columnRange.fNElements;
          if (compression == -1) {
-            compression = columnRange.fCompressionSettings;
+            compression = columnRange.fCompressionSettings.value();
          }
          const auto &pageRange = cluster.second.GetPageRange(column.second.GetPhysicalId());
          auto idx = cluster2Idx[cluster.first];

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -123,8 +123,8 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
             continue;
 
          info.fNElements += columnRange.fNElements;
-         if (compression == -1) {
-            compression = columnRange.fCompressionSettings.value();
+         if (compression == -1 && columnRange.fCompressionSettings) {
+            compression = *columnRange.fCompressionSettings;
          }
          const auto &pageRange = cluster.second.GetPageRange(column.second.GetPhysicalId());
          auto idx = cluster2Idx[cluster.first];

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -189,8 +189,8 @@ try {
                   inFile->GetName());
             return -1;
          }
-         compression = (*firstColRange).fCompressionSettings;
-         Info("RNTuple::Merge", "Using the first RNTuple's compression: %d", compression);
+         compression = (*firstColRange).fCompressionSettings.value();
+         Info("RNTuple::Merge", "Using the first RNTuple's compression: %u", *compression);
       }
       sources.push_back(std::move(source));
    }
@@ -611,7 +611,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
       sealedPages.resize(pages.fPageInfos.size());
 
       // Each column range potentially has a distinct compression settings
-      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings;
+      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings.value();
       const bool needsCompressionChange = colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings;
       if (needsCompressionChange && mergeData.fMergeOpts.fExtraVerbose)
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -255,7 +255,7 @@ struct RChangeCompressionFunc {
       sealConf.fElement = &fDstColElement;
       sealConf.fPage = &page;
       sealConf.fBuffer = fBuffer;
-      sealConf.fCompressionSetting = fMergeOptions.fCompressionSettings.value();
+      sealConf.fCompressionSetting = *fMergeOptions.fCompressionSettings;
       sealConf.fWriteChecksum = fSealedPage.GetHasChecksum();
       auto refSealedPage = RPageSink::SealPage(sealConf);
       fSealedPage = refSealedPage;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1582,7 +1582,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
                pos += SerializeLocator(pi.fLocator, *where);
             }
             pos += SerializeInt64(columnRange.fFirstElementIndex, *where);
-            pos += SerializeUInt32(columnRange.fCompressionSettings, *where);
+            pos += SerializeUInt32(columnRange.fCompressionSettings.value(), *where);
          }
 
          pos += SerializeFramePostscript(buffer ? innerFrame : nullptr, pos - innerFrame);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -942,8 +942,8 @@ void ROOT::Experimental::Internal::RPagePersistentSink::InitFromDescriptor(const
          R__ASSERT(columnRange.fPhysicalColumnId == i);
          const auto &pageRange = cluster.GetPageRange(i);
          R__ASSERT(pageRange.fPhysicalColumnId == i);
-         clusterBuilder.CommitColumnRange(i, fOpenColumnRanges[i].fFirstElementIndex, columnRange.fCompressionSettings,
-                                          pageRange);
+         clusterBuilder.CommitColumnRange(i, fOpenColumnRanges[i].fFirstElementIndex,
+                                          columnRange.fCompressionSettings.value(), pageRange);
          fOpenColumnRanges[i].fFirstElementIndex += columnRange.fNElements;
       }
       fDescriptorBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
@@ -1111,7 +1111,8 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitStagedClusters(std
             clusterBuilder.MarkSuppressedColumnRange(colId);
          } else {
             clusterBuilder.CommitColumnRange(colId, fOpenColumnRanges[colId].fFirstElementIndex,
-                                             fOpenColumnRanges[colId].fCompressionSettings, columnInfo.fPageRange);
+                                             fOpenColumnRanges[colId].fCompressionSettings.value(),
+                                             columnInfo.fPageRange);
             fOpenColumnRanges[colId].fFirstElementIndex += columnInfo.fNElements;
          }
       }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -800,13 +800,13 @@ TEST(RNTupleMerger, MergeThroughTBufferMerger)
    EXPECT_EQ(reader->GetNEntries(), 10);
 }
 
-static bool VerifyPageCompression(const std::string_view fileName, int expectedComp)
+static bool VerifyPageCompression(const std::string_view fileName, std::uint32_t expectedComp)
 {
    // Check that the advertised compression is correct
    bool ok = true;
    {
       auto reader = RNTupleReader::Open("ntuple", fileName);
-      auto compSettings = reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).fCompressionSettings;
+      auto compSettings = *reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).fCompressionSettings;
       if (compSettings != expectedComp) {
          std::cerr << "Advertised compression is wrong: " << compSettings << " instead of " << expectedComp << "\n";
          ok = false;
@@ -826,7 +826,8 @@ static bool VerifyPageCompression(const std::string_view fileName, int expectedC
    source->LoadSealedPage(0, {0, 0}, sealedPage);
 
    // size_t uncompSize = sealedPage.GetNElements() * colElement->GetSize();
-   int compAlgo = R__getCompressionAlgorithm((const unsigned char *)sealedPage.GetBuffer(), sealedPage.GetDataSize());
+   std::uint32_t compAlgo =
+      R__getCompressionAlgorithm((const unsigned char *)sealedPage.GetBuffer(), sealedPage.GetDataSize());
    if (compAlgo == ROOT::RCompressionSetting::EAlgorithm::kUndefined)
       compAlgo = 0;
    if (compAlgo != (expectedComp / 100)) {

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -2,7 +2,6 @@
 
 TEST(RNTuple, MultiColumnRepresentationSimple)
 {
-   using ROOT::Experimental::kNTupleUnknownCompression;
    FileRaii fileGuard("test_ntuple_multi_column_representation_simple.root");
 
    {

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -53,7 +53,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
    EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
@@ -62,7 +62,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
    EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
@@ -71,7 +71,7 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -217,7 +217,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
    EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
@@ -226,7 +226,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
    EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
    EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
@@ -235,7 +235,7 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
    EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
    EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_EQ(kNTupleUnknownCompression, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -159,7 +159,6 @@ TEST(RNTupleParallelWriter, Staged)
 TEST(RNTupleParallelWriter, StagedMultiColumn)
 {
    // Based on MultiColumnRepresentationSimple from ntuple_multi_column.cxx
-   using ROOT::Experimental::kNTupleUnknownCompression;
    FileRaii fileGuard("test_ntuple_parallel_staged_multi_column.root");
 
    {

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -1088,8 +1088,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
    const auto columnRange0_2 = clusterDesc0.GetColumnRange(columnIds[2]);
    const auto columnRange0_3 = clusterDesc0.GetColumnRange(columnIds[3]);
-   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, -1, true};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, 0, -1, true};
+   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, {}, true};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 0, {}, true};
    RClusterDescriptor::RColumnRange expect0_2{2, 0, 1, 505, false};
    RClusterDescriptor::RColumnRange expect0_3{3, 0, 0, 505, false};
    EXPECT_EQ(expect0_0, columnRange0_0);
@@ -1112,8 +1112,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    const auto columnRange1_3 = clusterDesc1.GetColumnRange(columnIds[3]);
    RClusterDescriptor::RColumnRange expect1_0{0, 1, 1, 505, false};
    RClusterDescriptor::RColumnRange expect1_1{1, 0, 3, 505, false};
-   RClusterDescriptor::RColumnRange expect1_2{2, 1, 1, -1, true};
-   RClusterDescriptor::RColumnRange expect1_3{3, 0, 3, -1, true};
+   RClusterDescriptor::RColumnRange expect1_2{2, 1, 1, {}, true};
+   RClusterDescriptor::RColumnRange expect1_3{3, 0, 3, {}, true};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);
    EXPECT_EQ(expect1_2, columnRange1_2);
@@ -1367,8 +1367,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    EXPECT_EQ(0u, clusterDesc0.GetFirstEntryIndex());
    const auto columnRange0_0 = clusterDesc0.GetColumnRange(columnIds[0]);
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, -1, false};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, {}, false};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, {}, true};
    EXPECT_EQ(expect0_0, columnRange0_0);
    EXPECT_EQ(expect0_1, columnRange0_1);
 
@@ -1377,7 +1377,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
    RClusterDescriptor::RColumnRange expect1_0{0, 1, 2, 505, false};
-   RClusterDescriptor::RColumnRange expect1_1{1, 1, 2, -1, true};
+   RClusterDescriptor::RColumnRange expect1_1{1, 1, 2, {}, true};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);
 
@@ -1385,7 +1385,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    EXPECT_EQ(3u, clusterDesc2.GetFirstEntryIndex());
    const auto columnRange2_0 = clusterDesc2.GetColumnRange(columnIds[0]);
    const auto columnRange2_1 = clusterDesc2.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect2_0{0, 3, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect2_0{0, 3, 1, {}, true};
    RClusterDescriptor::RColumnRange expect2_1{1, 3, 1, 505, false};
    EXPECT_EQ(expect2_0, columnRange2_0);
    EXPECT_EQ(expect2_1, columnRange2_1);
@@ -1492,7 +1492,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    const auto columnRange0_0 = clusterDesc0.GetColumnRange(columnIds[0]);
    const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
    RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, 505, false};
-   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect0_1{1, 0, 1, {}, true};
    EXPECT_EQ(expect0_0, columnRange0_0);
    EXPECT_EQ(expect0_1, columnRange0_1);
 
@@ -1500,7 +1500,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    EXPECT_EQ(1u, clusterDesc1.GetFirstEntryIndex());
    const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
    const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
-   RClusterDescriptor::RColumnRange expect1_0{0, 1, 1, -1, true};
+   RClusterDescriptor::RColumnRange expect1_0{0, 1, 1, {}, true};
    RClusterDescriptor::RColumnRange expect1_1{1, 1, 1, 505, false};
    EXPECT_EQ(expect1_0, columnRange1_0);
    EXPECT_EQ(expect1_1, columnRange1_1);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -68,7 +68,7 @@ auto rntuple = std::unique_ptr<RNTuple>(file->Get<RNTuple>("NTupleName"));
 auto inspector = RNTupleInspector::Create(*rntuple);
 
 std::cout << "The compression factor is " << inspector->GetCompressionFactor()
-          << " using compression settings " << inspector->GetCompressionSettings()
+          << " using compression settings " << inspector->GetCompressionSettingsAsString()
           << std::endl;
 ~~~
 */
@@ -135,7 +135,7 @@ public:
 private:
    std::unique_ptr<Internal::RPageSource> fPageSource;
    std::unique_ptr<RNTupleDescriptor> fDescriptor;
-   std::optional<std::uint32_t> fCompressionSettings;
+   std::optional<std::uint32_t> fCompressionSettings; ///< The compression settings are unknown for an empty ntuple
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
 
@@ -210,10 +210,11 @@ public:
    ///
    /// \return The integer representation (\f$algorithm * 10 + level\f$, where \f$algorithm\f$ follows
    /// ROOT::RCompressionSetting::ELevel::EValues) of the compression settings used for the inspected RNTuple.
+   /// Empty for an empty ntuple.
    ///
    /// \note Here, we assume that the compression settings are consistent across all clusters and columns. If this is
    /// not the case, an exception will be thrown when RNTupleInspector::Create is called.
-   int GetCompressionSettings() const { return fCompressionSettings.value(); }
+   std::optional<std::uint32_t> GetCompressionSettings() const { return fCompressionSettings; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get a string describing compression settings of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <regex>
 #include <vector>
 
@@ -134,7 +135,7 @@ public:
 private:
    std::unique_ptr<Internal::RPageSource> fPageSource;
    std::unique_ptr<RNTupleDescriptor> fDescriptor;
-   int fCompressionSettings = -1;
+   std::optional<std::uint32_t> fCompressionSettings;
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
 
@@ -212,7 +213,7 @@ public:
    ///
    /// \note Here, we assume that the compression settings are consistent across all clusters and columns. If this is
    /// not the case, an exception will be thrown when RNTupleInspector::Create is called.
-   int GetCompressionSettings() const { return fCompressionSettings; }
+   int GetCompressionSettings() const { return fCompressionSettings.value(); }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get a string describing compression settings of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -162,7 +162,7 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const std::uint64_t pageBufSize = pageInfo.fLocator.GetNBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
-               << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings << ".page";
+               << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings.value() << ".page";
             const auto outFileName = ss.str();
             std::ofstream outFile{outFileName, std::ios_base::binary};
             outFile.write(reinterpret_cast<const char *>(pageBuf), pageBufSize);

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -161,8 +161,9 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const std::size_t maybeChecksumSize = incChecksum * 8;
             const std::uint64_t pageBufSize = pageInfo.fLocator.GetNBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
+            assert(colRange.fCompressionSettings);
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
-               << "_elems_" << pageInfo.fNElements << "_comp_" << colRange.fCompressionSettings.value() << ".page";
+               << "_elems_" << pageInfo.fNElements << "_comp_" << *colRange.fCompressionSettings << ".page";
             const auto outFileName = ss.str();
             std::ofstream outFile{outFileName, std::ios_base::binary};
             outFile.write(reinterpret_cast<const char *>(pageBuf), pageBufSize);

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -166,8 +166,11 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
 
 std::string ROOT::Experimental::RNTupleInspector::GetCompressionSettingsAsString() const
 {
-   int algorithm = fCompressionSettings.value() / 100;
-   int level = fCompressionSettings.value() - (algorithm * 100);
+   if (!fCompressionSettings)
+      return "unknown";
+
+   int algorithm = *fCompressionSettings / 100;
+   int level = *fCompressionSettings - (algorithm * 100);
 
    return RCompressionSetting::AlgorithmToString(static_cast<RCompressionSetting::EAlgorithm::EValues>(algorithm)) +
           " (level " + std::to_string(level) + ")";

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -73,15 +73,14 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          nElems += columnRange.fNElements;
 
          if (fCompressionSettings == -1) {
-            fCompressionSettings = columnRange.fCompressionSettings;
-         } else if (fCompressionSettings != columnRange.fCompressionSettings &&
-                    columnRange.fCompressionSettings != kNTupleUnknownCompression) {
+            fCompressionSettings = columnRange.fCompressionSettings.value();
+         } else if (fCompressionSettings != columnRange.fCompressionSettings.value()) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
             // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.
             throw RException(R__FAIL("compression setting mismatch between column ranges (" +
                                      std::to_string(fCompressionSettings) + " vs " +
-                                     std::to_string(columnRange.fCompressionSettings) +
+                                     std::to_string(*columnRange.fCompressionSettings) +
                                      ") for column with physical ID " + std::to_string(colId)));
          }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -72,14 +72,15 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 
          nElems += columnRange.fNElements;
 
-         if (fCompressionSettings == -1) {
-            fCompressionSettings = columnRange.fCompressionSettings.value();
-         } else if (fCompressionSettings != columnRange.fCompressionSettings.value()) {
+         if (!fCompressionSettings && columnRange.fCompressionSettings) {
+            fCompressionSettings = *columnRange.fCompressionSettings;
+         } else if (fCompressionSettings && columnRange.fCompressionSettings &&
+                    (*fCompressionSettings != *columnRange.fCompressionSettings)) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
             // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.
             throw RException(R__FAIL("compression setting mismatch between column ranges (" +
-                                     std::to_string(fCompressionSettings) + " vs " +
+                                     std::to_string(*fCompressionSettings) + " vs " +
                                      std::to_string(*columnRange.fCompressionSettings) +
                                      ") for column with physical ID " + std::to_string(colId)));
          }
@@ -165,8 +166,8 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
 
 std::string ROOT::Experimental::RNTupleInspector::GetCompressionSettingsAsString() const
 {
-   int algorithm = fCompressionSettings / 100;
-   int level = fCompressionSettings - (algorithm * 100);
+   int algorithm = fCompressionSettings.value() / 100;
+   int level = fCompressionSettings.value() - (algorithm * 100);
 
    return RCompressionSetting::AlgorithmToString(static_cast<RCompressionSetting::EAlgorithm::EValues>(algorithm)) +
           " (level " + std::to_string(level) + ")";

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -62,7 +62,7 @@ TEST(RNTupleInspector, CompressionSettings)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   EXPECT_EQ(207, inspector->GetCompressionSettings());
+   EXPECT_EQ(207, *inspector->GetCompressionSettings());
    EXPECT_EQ("LZMA (level 7)", inspector->GetCompressionSettingsAsString());
 }
 
@@ -94,7 +94,19 @@ TEST(RNTupleInspector, UnknownCompression)
    }
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(505, inspector->GetCompressionSettings());
+   EXPECT_EQ(505, *inspector->GetCompressionSettings());
+}
+
+TEST(RNTupleInspector, Empty)
+{
+   FileRaii fileGuard("test_ntuple_inspector_empty.root");
+   {
+      auto writer = RNTupleWriter::Recreate(RNTupleModel::Create(), "ntuple", fileGuard.GetPath());
+   }
+
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
+   EXPECT_FALSE(inspector->GetCompressionSettings());
+   EXPECT_EQ("unknown", inspector->GetCompressionSettingsAsString());
 }
 
 TEST(RNTupleInspector, SizeUncompressedSimple)


### PR DESCRIPTION
Instead represent undefined/unknown compression settings by std::optional<>. Also allows for representing compression settings as _unsigned_ integer.

Companion PR: https://github.com/root-project/roottest/pull/1249
