### PR TITLE
[ntuple] Make `RNTupleChainProcessor` composable

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -40,7 +40,6 @@ struct RNTupleProcessorEntryLoader;
 struct RNTupleOpenSpec {
    std::string fNTupleName;
    std::string fStorage;
-   RNTupleReadOptions fOptions;
 
    RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(s) {}
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -290,6 +290,12 @@ class RNTupleSingleProcessor : public RNTupleProcessor {
    friend class RNTupleProcessor;
 
 private:
+   bool fIsConnected = false;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connects the page source of the underlying RNTuple.
+   void Connect();
+
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Constructs a new RNTupleProcessor for processing a single RNTuple.
    ///
@@ -300,7 +306,7 @@ private:
    NTupleSize_t Advance() final;
 
 public:
-   void LoadEntry() { fEntry->Read(fLocalEntryNumber); }
+   void LoadEntry() final { fEntry->Read(fLocalEntryNumber); }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -314,6 +314,7 @@ class RNTupleSingleProcessor : public RNTupleProcessor {
    friend class RNTupleProcessor;
 
 private:
+   RNTupleOpenSpec fNTupleSpec;
    bool fIsConnected = false;
 
    /////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -46,7 +46,40 @@ std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateChain(const std::vector<RNTupleOpenSpec> &ntuples,
                                                   std::unique_ptr<RNTupleModel> model)
 {
-   return std::unique_ptr<RNTupleChainProcessor>(new RNTupleChainProcessor(ntuples, std::move(model)));
+   if (ntuples.empty())
+      throw RException(R__FAIL("at least one RNTuple must be provided"));
+
+   std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors;
+   innerProcessors.reserve(ntuples.size());
+
+   // If no model is provided, infer it from the first ntuple.
+   if (!model) {
+      auto firstPageSource = Internal::RPageSource::Create(ntuples[0].fNTupleName, ntuples[0].fStorage);
+      firstPageSource->Attach();
+      model = firstPageSource->GetSharedDescriptorGuard()->CreateModel();
+   }
+
+   for (const auto &ntuple : ntuples) {
+      innerProcessors.emplace_back(Create(ntuple, model->Clone()));
+   }
+
+   return CreateChain(std::move(innerProcessors), std::move(model));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
+ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
+                                                  std::unique_ptr<RNTupleModel> model)
+{
+   if (innerProcessors.empty())
+      throw RException(R__FAIL("at least one inner processor must be provided"));
+
+   // If no model is provided, infer it from the first inner processor.
+   if (!model) {
+      model = innerProcessors[0]->GetModel().Clone();
+   }
+
+   return std::unique_ptr<RNTupleChainProcessor>(
+      new RNTupleChainProcessor(std::move(innerProcessors), std::move(model)));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
@@ -155,6 +188,16 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleSingleProcessor::Loa
    return entryNumber;
 }
 
+void ROOT::Experimental::RNTupleSingleProcessor::SetEntryPointers(const REntry &entry)
+{
+   for (const auto &value : *fEntry) {
+      auto &field = value.GetField();
+      auto valuePtr = entry.GetPtr<void>(field.GetQualifiedFieldName());
+
+      fEntry->BindValue(field.GetQualifiedFieldName(), valuePtr);
+   }
+}
+
 void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 {
    if (fIsConnected)
@@ -171,33 +214,19 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(const std::vector<RNTupleOpenSpec> &ntuples,
-                                                                 std::unique_ptr<RNTupleModel> model)
-   : RNTupleProcessor(ntuples, std::move(model))
+ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
+   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::unique_ptr<RNTupleModel> model)
+   : RNTupleProcessor({}, std::move(model)), fInnerProcessors(std::move(processors))
 {
-   if (fNTuples.empty())
-      throw RException(R__FAIL("at least one RNTuple must be provided"));
-
-   fInnerNEntries.assign(ntuples.size(), kInvalidNTupleIndex);
-
-   fPageSource = Internal::RPageSource::Create(fNTuples[0].fNTupleName, fNTuples[0].fStorage);
-   fPageSource->Attach();
-
-   fInnerNEntries[0] = fPageSource->GetNEntries();
-
-   if (fPageSource->GetNEntries() == 0) {
-      throw RException(R__FAIL("first RNTuple does not contain any entries"));
-   }
-
-   if (!fModel)
-      fModel = fPageSource->GetSharedDescriptorGuard()->CreateModel();
+   fInnerNEntries.assign(fInnerProcessors.size(), kInvalidNTupleIndex);
+   fInnerNEntries[0] = fInnerProcessors[0]->GetNEntries();
 
    fModel->Freeze();
    fEntry = fModel->CreateEntry();
 
    for (const auto &value : *fEntry) {
       auto &field = value.GetField();
-      auto token = fEntry->GetToken(field.GetFieldName());
+      auto token = fEntry->GetToken(field.GetQualifiedFieldName());
 
       // If the model has a default entry, use the value pointers from the entry in the entry managed by the
       // processor. This way, the pointers returned by RNTupleModel::MakeField can be used in the processor loop to
@@ -206,65 +235,66 @@ ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(const std::vect
          auto valuePtr = fModel->GetDefaultEntry().GetPtr<void>(token);
          fEntry->BindValue(token, valuePtr);
       }
+   }
 
-      const auto &[fieldContext, _] =
-         fFieldContexts.try_emplace(field.GetFieldName(), field.Clone(field.GetFieldName()), token);
-      ConnectField(fieldContext->second, *fPageSource, *fEntry);
+   for (auto &innerProc : fInnerProcessors) {
+      innerProc->SetEntryPointers(*fEntry);
    }
 }
 
-ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::ConnectNTuple(std::size_t ntupleNumber)
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::GetNEntries()
 {
-   if (ntupleNumber >= fNTuples.size())
-      return kInvalidNTupleIndex;
+   NTupleSize_t nEntries = 0;
 
-   const auto &ntuple = fNTuples[ntupleNumber];
+   for (unsigned i = 0; i < fInnerProcessors.size(); ++i) {
+      if (fInnerNEntries[i] == kInvalidNTupleIndex) {
+         fInnerNEntries[i] = fInnerProcessors[i]->GetNEntries();
+      }
 
-   // Before destroying the current page source and replacing it by the new one, we need to reset the concrete fields
-   // belonging to the current page source. Otherwise, these concrete fields become invalid.
-   for (auto &[_, fieldContext] : fFieldContexts) {
-      fieldContext.ResetConcreteField();
-   }
-   // Replace the current page source with a new one, belonging to the provided ntuple.
-   fPageSource = Internal::RPageSource::Create(ntuple.fNTupleName, ntuple.fStorage);
-   fPageSource->Attach();
-
-   fInnerNEntries[ntupleNumber] = fPageSource->GetNEntries();
-
-   // Now that the new page source has been created and attached, we can create and connect the concrete fields again.
-   for (auto &[_, fieldContext] : fFieldContexts) {
-      ConnectField(fieldContext, *fPageSource, *fEntry);
+      nEntries += fInnerNEntries[i];
    }
 
-   fCurrentNTupleNumber = ntupleNumber;
+   return nEntries;
+}
 
-   return fPageSource->GetNEntries();
+void ROOT::Experimental::RNTupleChainProcessor::SetEntryPointers(const REntry &entry)
+{
+   for (const auto &value : *fEntry) {
+      auto &field = value.GetField();
+      auto valuePtr = entry.GetPtr<void>(field.GetQualifiedFieldName());
+
+      fEntry->BindValue(field.GetQualifiedFieldName(), valuePtr);
+   }
+
+   for (auto &innerProc : fInnerProcessors) {
+      innerProc->SetEntryPointers(*fEntry);
+   }
 }
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::LoadEntry(NTupleSize_t entryNumber)
 {
    NTupleSize_t localEntryNumber = entryNumber;
-   size_t currentNTuple = 0;
+   size_t currProcessor = 0;
 
-   while (localEntryNumber >= fInnerNEntries[currentNTuple]) {
-      localEntryNumber -= fInnerNEntries[currentNTuple];
+   assert(fInnerNEntries[0] != kInvalidNTupleIndex);
 
-      if (++currentNTuple >= fNTuples.size())
+   // As long as the entry fails to load from the current processor, we decrement the local entry number with the number
+   // of entries in this processor and try with the next processor until we find the correct local entry number.
+   while (fInnerProcessors[currProcessor]->LoadEntry(localEntryNumber) == kInvalidNTupleIndex) {
+      localEntryNumber -= fInnerNEntries[currProcessor];
+
+      // The provided global entry number is larger than the number of available entries.
+      if (++currProcessor >= fInnerProcessors.size())
          return kInvalidNTupleIndex;
 
-      if (fInnerNEntries[currentNTuple] == kInvalidNTupleIndex) {
-         auto tmpPageSource =
-            Internal::RPageSource::Create(fNTuples[currentNTuple].fNTupleName, fNTuples[currentNTuple].fStorage);
-         tmpPageSource->Attach();
-         fInnerNEntries[currentNTuple] = tmpPageSource->GetNEntries();
+      if (fInnerNEntries[currProcessor] == kInvalidNTupleIndex) {
+         fInnerNEntries[currProcessor] = fInnerProcessors[currProcessor]->GetNEntries();
       }
    }
 
-   if (currentNTuple != fCurrentNTupleNumber) {
-      ConnectNTuple(currentNTuple);
-   }
+   if (currProcessor != fCurrentProcessorNumber)
+      fCurrentProcessorNumber = currProcessor;
 
-   fEntry->Read(localEntryNumber);
    fNEntriesProcessed++;
    fCurrentEntryNumber = entryNumber;
    return entryNumber;
@@ -409,6 +439,18 @@ void ROOT::Experimental::RNTupleJoinProcessor::ConnectFields()
       Internal::RPageSource &pageSource =
          fieldContext.IsAuxiliary() ? *fAuxiliaryPageSources.at(fieldContext.fNTupleIdx - 1) : *fPageSource;
       ConnectField(fieldContext, pageSource, *fEntry);
+   }
+}
+
+void ROOT::Experimental::RNTupleJoinProcessor::SetEntryPointers(const REntry &entry)
+{
+   for (const auto &[_, fieldContext] : fFieldContexts) {
+      auto fieldName = fieldContext.GetProtoField().GetQualifiedFieldName();
+      if (fieldContext.IsAuxiliary()) {
+         fieldName = fNTuples[fieldContext.fNTupleIdx].fNTupleName + "." + fieldName;
+      }
+      auto valuePtr = entry.GetPtr<void>(fieldName);
+      fEntry->BindValue(fieldName, valuePtr);
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -69,7 +69,7 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
 
-   auto proc = RNTupleProcessor::Create(ntuple, *model);
+   auto proc = RNTupleProcessor::Create(ntuple, std::move(model));
 
    int nEntries = 0;
 
@@ -97,7 +97,7 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
    auto model = RNTupleModel::CreateBare();
    model->MakeField<float>("x");
 
-   auto proc = RNTupleProcessor::Create(ntuple, *model);
+   auto proc = RNTupleProcessor::Create(ntuple, std::move(model));
 
    int nEntries = 0;
 

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -51,7 +51,7 @@ TEST_F(RNTupleProcessorTest, Base)
 
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
 
       EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *entry.GetPtr<float>("x"));
 
@@ -75,7 +75,7 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
 
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
 
       EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *fldX);
 
@@ -103,7 +103,7 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
 
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
 
       EXPECT_FLOAT_EQ(static_cast<float>(nEntries - 1), *entry.GetPtr<float>("x"));
 

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -24,27 +24,43 @@ TEST(RNTupleProcessor, EmptyNTuple)
 
 class RNTupleProcessorTest : public testing::Test {
 protected:
-   const std::string fFileName = "test_ntuple_processor.root";
-   const std::string fNTupleName = "ntuple";
+   const std::array<std::string, 2> fFileNames{"test_ntuple_processor1.root", "test_ntuple_processor2.root"};
+   const std::array<std::string, 2> fNTupleNames{"ntuple", "ntuple_aux"};
 
    void SetUp() override
    {
-      auto model = RNTupleModel::Create();
-      auto fldX = model->MakeField<float>("x");
-      auto fldY = model->MakeField<std::vector<float>>("y");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), fNTupleName, fFileName);
+      {
+         auto model = RNTupleModel::Create();
+         auto fldI = model->MakeField<int>("i");
+         auto fldX = model->MakeField<float>("x");
+         auto fldY = model->MakeField<std::vector<float>>("y");
+         auto ntuple = RNTupleWriter::Recreate(std::move(model), fNTupleNames[0], fFileNames[0]);
 
-      for (unsigned i = 0; i < 5; i++) {
-         *fldX = static_cast<float>(i);
-         *fldY = {static_cast<float>(i), static_cast<float>(i * 2)};
-         ntuple->Fill();
+         for (unsigned i = 0; i < 5; i++) {
+            *fldI = i;
+            *fldX = static_cast<float>(i);
+            *fldY = {static_cast<float>(i), static_cast<float>(i * 2)};
+            ntuple->Fill();
+         }
+      }
+      {
+         auto model = RNTupleModel::Create();
+         auto fldI = model->MakeField<int>("i");
+         auto fldZ = model->MakeField<float>("z");
+         auto ntuple = RNTupleWriter::Recreate(std::move(model), fNTupleNames[1], fFileNames[1]);
+
+         for (unsigned i = 0; i < 5; ++i) {
+            *fldI = i;
+            *fldZ = i * 2.f;
+            ntuple->Fill();
+         }
       }
    }
 };
 
 TEST_F(RNTupleProcessorTest, Base)
 {
-   RNTupleOpenSpec ntuple{fNTupleName, fFileName};
+   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
    auto proc = RNTupleProcessor::Create(ntuple);
 
    int nEntries = 0;
@@ -64,7 +80,7 @@ TEST_F(RNTupleProcessorTest, Base)
 
 TEST_F(RNTupleProcessorTest, BaseWithModel)
 {
-   RNTupleOpenSpec ntuple{fNTupleName, fFileName};
+   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
 
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
@@ -92,7 +108,7 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
 
 TEST_F(RNTupleProcessorTest, BaseWithBareModel)
 {
-   RNTupleOpenSpec ntuple{fNTupleName, fFileName};
+   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
 
    auto model = RNTupleModel::CreateBare();
    model->MakeField<float>("x");
@@ -115,5 +131,53 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
       }
    }
    EXPECT_EQ(nEntries, 5);
+   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+}
+
+TEST_F(RNTupleProcessorTest, ChainedChain)
+{
+   std::vector<RNTupleOpenSpec> ntuples{{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}};
+
+   std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
+   innerProcs.push_back(RNTupleProcessor::CreateChain(ntuples));
+   innerProcs.push_back(RNTupleProcessor::Create(ntuples[0]));
+
+   auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
+
+   int nEntries = 0;
+
+   for (const auto &entry [[maybe_unused]] : *proc) {
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
+      EXPECT_EQ(*entry.GetPtr<int>("i"), proc->GetCurrentEntryNumber() % 5);
+      EXPECT_EQ(static_cast<float>(*entry.GetPtr<int>("i")), *entry.GetPtr<float>("x"));
+   }
+   EXPECT_EQ(nEntries, 15);
+   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+}
+
+TEST_F(RNTupleProcessorTest, ChainedJoin)
+{
+   std::vector<RNTupleOpenSpec> ntuples{{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}};
+
+   std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
+   innerProcs.push_back(RNTupleProcessor::CreateJoin(ntuples, {}));
+   innerProcs.push_back(RNTupleProcessor::CreateJoin(ntuples, {"i"}));
+
+   auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
+
+   int nEntries = 0;
+
+   auto x = proc->GetEntry().GetPtr<float>("x");
+
+   for (const auto &entry [[maybe_unused]] : *proc) {
+      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
+      EXPECT_EQ(*entry.GetPtr<int>("i"), proc->GetCurrentEntryNumber() % 5);
+
+      EXPECT_EQ(static_cast<float>(*entry.GetPtr<int>("i")), *x);
+      EXPECT_EQ(*x * 2, *entry.GetPtr<float>("ntuple_aux.z"));
+   }
+   EXPECT_EQ(nEntries, 10);
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
 }

--- a/tree/ntuple/v7/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_chain.cxx
@@ -103,11 +103,11 @@ TEST_F(RNTupleChainProcessorTest, Basic)
 
    std::uint64_t nEntries = 0;
    auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto x = proc->GetEntry().GetPtr<float>("x");
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
       EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
 
-      auto x = entry.GetPtr<float>("x");
       EXPECT_EQ(static_cast<float>(nEntries - 1), *x);
 
       auto y = entry.GetPtr<std::vector<float>>("y");
@@ -197,17 +197,14 @@ TEST_F(RNTupleChainProcessorTest, EmptyNTuples)
 
    std::uint64_t nEntries = 0;
 
-   try {
-      auto proc = RNTupleProcessor::CreateChain(ntuples);
-      FAIL() << "creating a processor where the first RNTuple does not contain any entries should throw";
-   } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("first RNTuple does not contain any entries"));
-   }
-
-   // Empty ntuples in the middle are just skipped (as long as their model complies)
-   ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fileGuard.GetPath()}, {fNTupleName, fFileNames[1]}};
+   // Empty ntuples are skipped (as long as their model complies)
+   ntuples = {{fNTupleName, fileGuard.GetPath()},
+              {fNTupleName, fFileNames[0]},
+              {fNTupleName, fileGuard.GetPath()},
+              {fNTupleName, fFileNames[1]}};
 
    auto proc = RNTupleProcessor::CreateChain(ntuples);
+
    for (const auto &entry : *proc) {
       auto x = entry.GetPtr<float>("x");
       EXPECT_EQ(static_cast<float>(nEntries), *x);
@@ -237,19 +234,19 @@ TEST_F(RNTupleChainProcessorTest, LoadRandomEntry)
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 3);
    EXPECT_EQ(3.f, *x);
-   EXPECT_EQ(0, proc->GetCurrentNTupleNumber());
+   EXPECT_EQ(0, proc->GetCurrentProcessorNumber());
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 7);
    EXPECT_EQ(7.f, *x);
-   EXPECT_EQ(1, proc->GetCurrentNTupleNumber());
+   EXPECT_EQ(1, proc->GetCurrentProcessorNumber());
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 6);
    EXPECT_EQ(6.f, *x);
-   EXPECT_EQ(1, proc->GetCurrentNTupleNumber());
+   EXPECT_EQ(1, proc->GetCurrentProcessorNumber());
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 2);
    EXPECT_EQ(2.f, *x);
-   EXPECT_EQ(0, proc->GetCurrentNTupleNumber());
+   EXPECT_EQ(0, proc->GetCurrentProcessorNumber());
 
    EXPECT_EQ(ROOT::Experimental::kInvalidNTupleIndex, RNTupleProcessorEntryLoader::LoadEntry(*proc, 8));
 }

--- a/tree/ntuple/v7/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_join.cxx
@@ -98,11 +98,11 @@ TEST_F(RNTupleJoinProcessorTest, Basic)
    int nEntries = 0;
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
       ;
 
       auto i = entry.GetPtr<int>("i");
-      EXPECT_EQ(proc->GetLocalEntryNumber() * 2, *i);
+      EXPECT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
    }
 
    EXPECT_EQ(5, proc->GetNEntriesProcessed());
@@ -126,7 +126,7 @@ TEST_F(RNTupleJoinProcessorTest, Aligned)
    std::vector<float> yExpected;
    for (auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetLocalEntryNumber());
+      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
 
       auto i = entry.GetPtr<int>("i");
 
@@ -166,9 +166,9 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedSingleJoinField)
    auto y = proc->GetEntry().GetPtr<std::vector<float>>("ntuple2.y");
    std::vector<float> yExpected;
    for ([[maybe_unused]] auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(proc->GetCurrentEntryNumber(), nEntries++);
 
-      EXPECT_FLOAT_EQ(proc->GetLocalEntryNumber() * 2, *i);
+      EXPECT_FLOAT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
       EXPECT_FLOAT_EQ(*i * 0.5f, *x);
 
       yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
@@ -211,9 +211,9 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
    auto x = proc->GetEntry().GetPtr<float>("x");
    auto a = proc->GetEntry().GetPtr<float>("ntuple4.a");
    for ([[maybe_unused]] auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(proc->GetCurrentEntryNumber(), nEntries++);
 
-      EXPECT_FLOAT_EQ(proc->GetLocalEntryNumber() * 2, *i);
+      EXPECT_FLOAT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
       EXPECT_FLOAT_EQ(*i * 0.5f, *x);
       EXPECT_EQ(*i * 0.1f, *a);
    }
@@ -232,9 +232,9 @@ TEST_F(RNTupleJoinProcessorTest, MissingEntries)
    auto a = proc->GetEntry().GetPtr<float>("ntuple4.a");
    std::vector<float> yExpected;
    for ([[maybe_unused]] auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(proc->GetCurrentEntryNumber(), nEntries++);
 
-      EXPECT_FLOAT_EQ(proc->GetLocalEntryNumber(), *i);
+      EXPECT_FLOAT_EQ(proc->GetCurrentEntryNumber(), *i);
 
       if (*i == 3 || *i == 9) {
          EXPECT_EQ(0.f, *a) << "entries with i=3 and i=9 are missing from ntuple4, ntuple4.a should have been "
@@ -272,9 +272,9 @@ TEST_F(RNTupleJoinProcessorTest, WithModel)
    int nEntries = 0;
    std::vector<float> yExpected;
    for (auto &entry : *proc) {
-      EXPECT_EQ(proc->GetLocalEntryNumber(), nEntries++);
+      EXPECT_EQ(proc->GetCurrentEntryNumber(), nEntries++);
 
-      EXPECT_EQ(proc->GetLocalEntryNumber() * 2, *i);
+      EXPECT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
       EXPECT_EQ(*entry.GetPtr<int>("i"), *i);
 
       EXPECT_FLOAT_EQ(*i * 0.5f, *x);

--- a/tutorials/io/ntuple/ntpl012_processor_chain.C
+++ b/tutorials/io/ntuple/ntpl012_processor_chain.C
@@ -74,12 +74,14 @@ void Read(const std::vector<RNTupleOpenSpec> &ntuples)
    // Access to the entry values in this case can be achieved through RNTupleProcessor::GetEntry() or through its
    // iterator.
    auto processor = RNTupleProcessor::CreateChain(ntuples, std::move(model));
+   int prevProcessorNumber{-1};
 
    for (const auto &entry : *processor) {
       // The RNTupleProcessor provides some additional bookkeeping information. The local entry number is reset each
       // a new ntuple in the chain is opened for processing.
-      if (processor->GetLocalEntryNumber() == 0) {
-         std::cout << "Processing " << ntuples.at(processor->GetCurrentNTupleNumber()).fNTupleName << " ("
+      if (static_cast<int>(processor->GetCurrentProcessorNumber()) > prevProcessorNumber) {
+         prevProcessorNumber = processor->GetCurrentProcessorNumber();
+         std::cout << "Processing " << ntuples.at(prevProcessorNumber).fNTupleName << " ("
                    << processor->GetNEntriesProcessed() << " total entries processed so far)" << std::endl;
       }
 


### PR DESCRIPTION
This PR introduces the possibility to create `RNTupleChainProcessor`s from other processor objects. In turn, this makes it possible to, for example, create a chain of joined ntuples.

This PR is part of a bigger set of (foreseen) changes, collected and tracked in https://github.com/root-project/root/issues/17132.
