### PR TITLE
[http] use basic sniffer if TRootSnifferFull cannot be created

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -196,13 +196,18 @@ THttpServer::THttpServer(const char *engine) : TNamed("http", "ROOT http server"
    fDrawPage = fJSROOTSYS + "/files/draw.htm";
 
    TRootSniffer *sniff = nullptr;
-   if (basic_sniffer) {
+   if (!basic_sniffer) {
+      static const TClass *snifferClass = TClass::GetClass("TRootSnifferFull");
+      if (snifferClass && snifferClass->IsLoaded())
+         sniff = (TRootSniffer *)snifferClass->New();
+      else
+         ::Warning("THttpServer::THttpServer", "Fail to load TRootSnifferFull class, use basic functionality");
+   }
+
+   if (!sniff) {
       sniff = new TRootSniffer();
       sniff->SetScanGlobalDir(kFALSE);
       sniff->CreateOwnTopFolder(); // use dedicated folder
-   } else {
-      static const TClass *snifferClass = TClass::GetClass("TRootSnifferFull");
-      sniff = (TRootSniffer *)snifferClass->New();
    }
 
    SetSniffer(sniff);


### PR DESCRIPTION
If for any reasons `libRHTTPSniff.so` library not provided, 
create at least basic sniffer instead of ROOT crash

Address https://root-forum.cern.ch/t/thttpserver-crash/62615
