### PR TITLE
[python] Pythonize `TObject::Clone()` overrides for correct ownership

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_memory_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_memory_utils.py
@@ -8,14 +8,17 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
+
 def _should_give_up_ownership(object):
     """
     Ownership of objects which automatically register to a directory should be
     left to C++, except if the object is gROOT.
     """
     import ROOT
+
     tdir = object.GetDirectory()
     return bool(tdir) and tdir is not ROOT.gROOT
+
 
 def _constructor_releasing_ownership(self, *args, **kwargs):
     """
@@ -30,9 +33,33 @@ def _constructor_releasing_ownership(self, *args, **kwargs):
     if _should_give_up_ownership(self):
         ROOT.SetOwnership(self, False)
 
+
+def _Clone_releasing_ownership(self, *args, **kwargs):
+    """
+    Analogous to _constructor_releasing_ownership, but for the TObject::Clone()
+    implementation.
+    """
+    import ROOT
+
+    out = self._Original_Clone(*args, **kwargs)
+    if _should_give_up_ownership(out):
+        ROOT.SetOwnership(out, False)
+    return out
+
+
+def inject_constructor_releasing_ownership(klass):
+    klass._cpp_constructor = klass.__init__
+    klass.__init__ = _constructor_releasing_ownership
+
+def inject_clone_releasing_ownership(klass):
+    klass._Original_Clone = klass.Clone
+    klass.Clone = _Clone_releasing_ownership
+
+
 def _SetDirectory_SetOwnership(self, dir):
     self._Original_SetDirectory(dir)
     if dir:
         # If we are actually registering with a directory, give ownership to C++
         import ROOT
+
         ROOT.SetOwnership(self, False)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -167,7 +167,7 @@ Further examples can be found in the tutorials:
 """
 
 from . import pythonization
-from ROOT._pythonization._memory_utils import _constructor_releasing_ownership, _SetDirectory_SetOwnership
+from ROOT._pythonization._memory_utils import inject_constructor_releasing_ownership, inject_clone_releasing_ownership, _SetDirectory_SetOwnership
 
 # Multiplication by constant
 
@@ -213,11 +213,6 @@ def _FillWithNumpyArray(self, *args):
         return self._Fill(*args)
 
 
-def inject_constructor_releasing_ownership(klass):
-    klass._cpp_constructor = klass.__init__
-    klass.__init__ = _constructor_releasing_ownership
-
-
 # The constructors need to be pythonized for each derived class separately:
 _th1_derived_classes_to_pythonize = [
     "TH1C",
@@ -248,3 +243,5 @@ def pythonize_th1(klass):
 
     klass._Original_SetDirectory = klass.SetDirectory
     klass.SetDirectory = _SetDirectory_SetOwnership
+
+    inject_clone_releasing_ownership(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
@@ -9,12 +9,7 @@
 ################################################################################
 
 from . import pythonization
-from ROOT._pythonization._memory_utils import _constructor_releasing_ownership
-
-
-def inject_constructor_releasing_ownership(klass):
-    klass._cpp_constructor = klass.__init__
-    klass.__init__ = _constructor_releasing_ownership
+from ROOT._pythonization._memory_utils import inject_constructor_releasing_ownership
 
 
 # The constructors need to be pythonized for each derived class separately:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th3.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th3.py
@@ -9,12 +9,7 @@
 ################################################################################
 
 from . import pythonization
-from ROOT._pythonization._memory_utils import _constructor_releasing_ownership, _SetDirectory_SetOwnership
-
-
-def inject_constructor_releasing_ownership(klass):
-    klass._cpp_constructor = klass.__init__
-    klass.__init__ = _constructor_releasing_ownership
+from ROOT._pythonization._memory_utils import inject_constructor_releasing_ownership
 
 
 # The constructors need to be pythonized for each derived class separately:

--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -95,8 +95,14 @@ class MemoryStlString(unittest.TestCase):
             with ROOT.TFile(filename, "recreate") as f:
                 f.mkdir("subdir")
                 f.cd("subdir")
+
+                # Create object by calling the constructor
                 x = klass(*args)
                 x.Write()
+
+                # Create object by using the "virtual constructor" TObject::Clone()
+                x_clone = x.Clone()
+                x_clone.Write()
         finally:
             os.remove(filename)
 


### PR DESCRIPTION
Following up on #17250, also pythonizing the `TObject::Clone()` overrides to automatically give up the ownership.

Thanks to the following forum post for noticing this problem: https://root-forum.cern.ch/t/a-question-about-root/62617