### PR TITLE
[windows] Fix root-config.bat for PowerShell

### DIFF
--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -53,6 +53,9 @@ if "@BLDCFLAGS@"=="-MDd" (
     set cflags=!cflags! -O2
     set cxxflags=!cxxflags! -O2
 )
+rem add double-quotes to allow PowerShell usage like: Invoke-Expression "cl test.cpp $(root-config --cflags --libs)"
+SET cxxflags=!cxxflags:-FIw32pragma.h=-FI"w32pragma.h"!
+SET cxxflags=!cxxflags:-FIsehmap.h=-FI"sehmap.h"!
 
 set rootglibs=libGui.lib
 set rootevelibs=libEve.lib libEG.lib libGeom.lib libGed.lib libRGL.lib

--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -54,8 +54,8 @@ if "@BLDCFLAGS@"=="-MDd" (
     set cxxflags=!cxxflags! -O2
 )
 rem add double-quotes to allow PowerShell usage like: Invoke-Expression "cl test.cpp $(root-config --cflags --libs)"
-SET cxxflags=!cxxflags:-FIw32pragma.h=-FI"w32pragma.h"!
-SET cxxflags=!cxxflags:-FIsehmap.h=-FI"sehmap.h"!
+set cxxflags=!cxxflags:-FIw32pragma.h=-FI"w32pragma.h"!
+set cxxflags=!cxxflags:-FIsehmap.h=-FI"sehmap.h"!
 
 set rootglibs=libGui.lib
 set rootevelibs=libEve.lib libEG.lib libGeom.lib libGed.lib libRGL.lib


### PR DESCRIPTION
Fix an issue with `root-config.bat` when used in PowerShell like:
`Invoke-Expression "cl test.cpp $(root-config --cflags --libs)"`
as reported [on the Forum](https://root-forum.cern.ch/t/root-6-34-windows-compilation-w32pragma-issue-cea-43597/62630)
