### PR TITLE
[skip-ci] rescue collapsed-by-default section of TFile details

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -17,6 +17,7 @@
 \sa \ref IO
 \sa \ref rootio (or `io/doc/TFile` folder in your codebase)
 
+<details>
 <summary>ROOT file data format specification</summary>
 
 A ROOT file is composed of a header, followed by consecutive data records
@@ -77,6 +78,7 @@ Begin_Macro
 End_Macro
 
 The structure of a directory is shown in TDirectoryFile::TDirectoryFile
+</details>
 */
 
 #include <ROOT/RConfig.hxx>


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

See related discussion: https://github.com/root-project/root/pull/14929
It was removed by https://github.com/ferdymercury/root/commit/41f67b698150140342e28560046266756f0570d5#comments but it shouldn't be exclusive, one can have Python interface open by default, and TFile format details closed by default.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)
