### PR TITLE
[interpreter] new function TInterpreter::SetIncludePath

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -137,6 +137,7 @@ public:
    virtual ~TInterpreter() { }
 
    virtual void     AddIncludePath(const char *path) = 0;
+   virtual void     SetIncludePath(const char *path) = 0;
    virtual void    *SetAutoLoadCallBack(void* /*cb*/) { return nullptr; }
    virtual void    *GetAutoLoadCallBack() const { return nullptr; }
    virtual Int_t    AutoLoad(const char *classname, Bool_t knowDictNotLoaded = kFALSE) = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1323,7 +1323,7 @@ static void RegisterPreIncludedHeaders(cling::Interpreter &clingInterp)
 #ifndef R__WIN32
    PreIncludes += "#include <cassert>\n";
 #endif
-         PreIncludes += "using namespace std;\n";
+   PreIncludes += "using namespace std;\n";
    clingInterp.declare(PreIncludes);
 }
 
@@ -3090,6 +3090,14 @@ void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
                                  insp, isTransient);
       }
    } // loop over bases
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Check if constructor exited correctly, ie the instance is in a valid state
+/// \return true if there is a compiler instance available, false otherwise
+bool TCling::IsValid() const
+{
+   return fInterpreter->getCI() != nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2691,7 +2691,7 @@ void TCling::AddIncludePath(const char *path)
 ///       \b NOT supported.
 /// \warning Only the path to the directory should be specified, without
 ///          prepending the \c -I prefix, i.e.
-///          <tt>gCling->AddIncludePath("/path/to/my/includes")</tt>. If the
+///          <tt>gCling->SetIncludePath("/path/to/my/includes")</tt>. If the
 ///          \c -I prefix is used it will be ignored.
 void TCling::SetIncludePath(const char *path)
 {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1323,7 +1323,7 @@ static void RegisterPreIncludedHeaders(cling::Interpreter &clingInterp)
 #ifndef R__WIN32
    PreIncludes += "#include <cassert>\n";
 #endif
-   PreIncludes += "using namespace std;\n";
+         PreIncludes += "using namespace std;\n";
    clingInterp.declare(PreIncludes);
 }
 
@@ -2684,6 +2684,23 @@ void TCling::AddIncludePath(const char *path)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// \brief Replaces current list of directories with a single path in which the
+///        interpreter looks for include files.
+/// \param[in] path The path to the directory.
+/// \note Only one path item can be specified at a time, i.e. "path1:path2" is
+///       \b NOT supported.
+/// \warning Only the path to the directory should be specified, without
+///          prepending the \c -I prefix, i.e.
+///          <tt>gCling->AddIncludePath("/path/to/my/includes")</tt>. If the
+///          \c -I prefix is used it will be ignored.
+void TCling::SetIncludePath(const char *path)
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   fInterpreter->ResetIncludePaths();
+   AddIncludePath(path);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Visit all members over members, recursing over base classes.
 
 void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
@@ -3073,14 +3090,6 @@ void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
                                  insp, isTransient);
       }
    } // loop over bases
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Check if constructor exited correctly, ie the instance is in a valid state
-/// \return true if there is a compiler instance available, false otherwise
-bool TCling::IsValid() const
-{
-   return fInterpreter->getCI() != nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -195,6 +195,7 @@ public: // Public Interface
    TCling(const char* name, const char* title, const char* const argv[], void *interpLibHandle);
 
    void    AddIncludePath(const char* path) final;
+   void    SetIncludePath(const char* path) final;
    void   *GetAutoLoadCallBack() const final { return fAutoLoadCallBack; }
    void   *SetAutoLoadCallBack(void* cb) final { void* prev = fAutoLoadCallBack; fAutoLoadCallBack = cb; return prev; }
    Int_t   AutoLoad(const char *classname, Bool_t knowDictNotLoaded = kFALSE) final;

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -438,12 +438,16 @@ namespace cling {
     ///
     bool isUniqueName(llvm::StringRef name);
 
-    ///\brief Adds multiple include paths separated by a delimter.
+    ///\brief Adds multiple include paths separated by a delimiter.
     ///
     ///\param[in] PathsStr - Path(s)
     ///\param[in] Delim - Delimiter to separate paths or NULL if a single path
     ///
     void AddIncludePaths(llvm::StringRef PathsStr, const char* Delim = ":");
+    
+    ///\brief Unsets preexisting include paths.
+    ///
+    void ResetIncludePaths();
 
     ///\brief Adds a single include path (-I).
     ///

--- a/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearch.h
+++ b/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearch.h
@@ -375,7 +375,10 @@ public:
 
   /// Add an additional search path.
   void AddSearchPath(const DirectoryLookup &dir, bool isAngled);
-
+  
+  /// Remove search path.
+  void RemoveSearchPath(const DirectoryLookup &dir, bool isAngled);
+  
   /// Add an additional system search path.
   void AddSystemSearchPath(const DirectoryLookup &dir) {
     SearchDirs.push_back(dir);

--- a/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearch.h
+++ b/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearch.h
@@ -377,7 +377,7 @@ public:
   void AddSearchPath(const DirectoryLookup &dir, bool isAngled);
   
   /// Remove search path.
-  void RemoveSearchPath(const DirectoryLookup &dir, bool isAngled);
+  void RemoveSearchPath(DirectoryLookup &dir, bool isAngled);
   
   /// Add an additional system search path.
   void AddSystemSearchPath(const DirectoryLookup &dir) {

--- a/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearchOptions.h
+++ b/interpreter/llvm-project/clang/include/clang/Lex/HeaderSearchOptions.h
@@ -284,6 +284,11 @@ public:
                bool IsFramework, bool IgnoreSysRoot) {
     UserEntries.emplace_back(Path, Group, IsFramework, IgnoreSysRoot);
   }
+  
+  /// ResetPaths - Removes all paths from the user entries list.
+  void ResetPaths() {
+    UserEntries.clear();
+  }
 
   /// AddSystemHeaderPrefix - Override whether \#include directives naming a
   /// path starting with \p Prefix should be considered as naming a system

--- a/interpreter/llvm-project/clang/lib/Lex/HeaderSearch.cpp
+++ b/interpreter/llvm-project/clang/lib/Lex/HeaderSearch.cpp
@@ -127,7 +127,7 @@ void HeaderSearch::AddSearchPath(const DirectoryLookup &dir, bool isAngled) {
   SystemDirIdx++;
 }
 
-void HeaderSearch::RemoveSearchPath(const DirectoryLookup &dir, bool isAngled) {
+void HeaderSearch::RemoveSearchPath(DirectoryLookup &dir, bool isAngled) {
   auto position = std::find(SearchDirs.begin(), SearchDirs.end(), dir);
   auto idx = std::distance(SearchDirs.begin(), position);
   SearchDirs.erase(position);

--- a/interpreter/llvm-project/clang/lib/Lex/HeaderSearch.cpp
+++ b/interpreter/llvm-project/clang/lib/Lex/HeaderSearch.cpp
@@ -127,6 +127,16 @@ void HeaderSearch::AddSearchPath(const DirectoryLookup &dir, bool isAngled) {
   SystemDirIdx++;
 }
 
+void HeaderSearch::RemoveSearchPath(const DirectoryLookup &dir, bool isAngled) {
+  auto position = std::find(SearchDirs.begin(), SearchDirs.end(), dir);
+  auto idx = std::distance(SearchDirs.begin(), position);
+  SearchDirs.erase(position);
+  SearchDirsUsage.erase(SearchDirsUsage.begin() + idx);
+  if (!isAngled)
+    AngledDirIdx--;
+  SystemDirIdx--;
+}
+
 std::vector<bool> HeaderSearch::computeUserEntryUsage() const {
   std::vector<bool> UserEntryUsage(HSOpts->UserEntries.size());
   for (unsigned I = 0, E = SearchDirsUsage.size(); I < E; ++I) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-5149

This needs a patch on top of LLVM, so maybe it's better to just close this issue as "won't fix" ?

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

