### PR TITLE
[geom][mini] Disabling (temporarily) c++20 [[unlikely]] compiler hint.

### DIFF
--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -40,10 +40,13 @@ method.
 #include <mutex>
 
 // this is for the bvh acceleration stuff
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
 
 // V2 BVH
 #include <bvh/v2/bvh.h>
@@ -1485,4 +1488,6 @@ void TGeoParallelWorld::TestVoxelGrid()
    }
 }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif

--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -40,12 +40,15 @@ method.
 #include <mutex>
 
 // this is for the bvh acceleration stuff
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wattributes"
+#if defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wall"
+#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#  pragma GCC diagnostic ignored "-Wattributes"
+#elif defined (_MSC_VER)
+#  pragma warning( push )
+#  pragma warning( disable : 5051)
 #endif
 
 // V2 BVH
@@ -1488,6 +1491,8 @@ void TGeoParallelWorld::TestVoxelGrid()
    }
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
+#if defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined (_MSC_VER)
+#  pragma warning( pop )
 #endif


### PR DESCRIPTION
# This Pull request:
Disables a c++20 [[unlikely]] hint to prevent a `-Wattributes` compilation warning

## Changes or fixes:
I just commented, not removed entirely, to disable the warning on c++17 or less mode. We have `R__unlikely`, which cannot be used in a multiple-branch statement.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

