### PR TITLE
[webgeom] correctly handle configuration change

### DIFF
--- a/geom/webviewer/inc/ROOT/RGeomData.hxx
+++ b/geom/webviewer/inc/ROOT/RGeomData.hxx
@@ -296,6 +296,13 @@ class RGeomDescription {
 
    int IsPhysNodeVisible(const std::vector<int> &stack);
 
+   /** clear drawing data without locking mutex */
+   void _ClearDrawData()
+   {
+      fDrawJson.clear();
+      fSearchJson.clear();
+   }
+
 public:
    RGeomDescription() = default;
 
@@ -311,51 +318,131 @@ public:
    TVirtualMutex *GetMutex() const { return fMutex; }
 
    /** Set maximal number of nodes which should be selected for drawing */
-   void SetMaxVisNodes(int cnt) { TLockGuard lock(fMutex); fCfg.maxnumnodes = cnt; }
+   void SetMaxVisNodes(int cnt)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.maxnumnodes = cnt;
+      _ClearDrawData();
+   }
    /** Returns maximal visible number of nodes, ignored when non-positive */
-   int GetMaxVisNodes() const { TLockGuard lock(fMutex); return fCfg.maxnumnodes; }
+   int GetMaxVisNodes() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.maxnumnodes;
+   }
 
    /** Set maximal number of faces which should be selected for drawing */
-   void SetMaxVisFaces(int cnt) { TLockGuard lock(fMutex); fCfg.maxnumfaces = cnt; }
+   void SetMaxVisFaces(int cnt)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.maxnumfaces = cnt;
+      _ClearDrawData();
+   }
    /** Returns maximal visible number of faces, ignored when non-positive */
-   int GetMaxVisFaces() const { TLockGuard lock(fMutex); return fCfg.maxnumfaces; }
+   int GetMaxVisFaces() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.maxnumfaces;
+   }
 
    /** Set maximal visible level */
-   void SetVisLevel(int lvl = 3) { TLockGuard lock(fMutex); fCfg.vislevel = lvl; }
+   void SetVisLevel(int lvl = 3)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.vislevel = lvl;
+      _ClearDrawData();
+   }
    /** Returns maximal visible level */
-   int GetVisLevel() const { TLockGuard lock(fMutex); return fCfg.vislevel; }
+   int GetVisLevel() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.vislevel;
+   }
 
    /** Set draw options as string for JSROOT TGeoPainter */
-   void SetTopVisible(bool on = true) { TLockGuard lock(fMutex); fCfg.showtop = on; }
+   void SetTopVisible(bool on = true)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.showtop = on;
+      _ClearDrawData();
+   }
    /** Returns draw options, used for JSROOT TGeoPainter */
-   bool GetTopVisible() const { TLockGuard lock(fMutex); return fCfg.showtop; }
+   bool GetTopVisible() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.showtop;
+   }
 
    /** Instruct to build binary 3D model already on the server (true) or send TGeoShape as is to client, which can build model itself */
-   void SetBuildShapes(int lvl = 1) { TLockGuard lock(fMutex); fCfg.build_shapes = lvl; }
+   void SetBuildShapes(int lvl = 1)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.build_shapes = lvl;
+      _ClearDrawData();
+   }
    /** Returns true if binary 3D model build already by C++ server (default) */
-   int IsBuildShapes() const { TLockGuard lock(fMutex); return fCfg.build_shapes; }
+   int IsBuildShapes() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.build_shapes;
+   }
 
    /** Set number of segments for cylindrical shapes, if 0 - default value will be used */
-   void SetNSegments(int n = 0) { TLockGuard lock(fMutex); fCfg.nsegm = n; }
+   void SetNSegments(int n = 0)
+   {
+      TLockGuard lock(fMutex);
+      fCfg.nsegm = n;
+      _ClearDrawData();
+   }
    /** Return of segments for cylindrical shapes, if 0 - default value will be used */
-   int GetNSegments() const { TLockGuard lock(fMutex); return fCfg.nsegm; }
+   int GetNSegments() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.nsegm;
+   }
 
    /** Set draw options as string for JSROOT TGeoPainter */
-   void SetDrawOptions(const std::string &opt = "") { TLockGuard lock(fMutex); fCfg.drawopt = opt; }
+   void SetDrawOptions(const std::string &opt = "")
+   {
+      TLockGuard lock(fMutex);
+      fCfg.drawopt = opt;
+      _ClearDrawData();
+   }
    /** Returns draw options, used for JSROOT TGeoPainter */
-   std::string GetDrawOptions() const { TLockGuard lock(fMutex); return fCfg.drawopt; }
+   std::string GetDrawOptions() const
+   {
+      TLockGuard lock(fMutex);
+      return fCfg.drawopt;
+   }
 
    /** Set JSON compression level for data transfer */
-   void SetJsonComp(int comp = 0) { TLockGuard lock(fMutex); fJsonComp = comp; }
+   void SetJsonComp(int comp = 0)
+   {
+      TLockGuard lock(fMutex);
+      fJsonComp = comp;
+      _ClearDrawData();
+   }
    /** Returns JSON compression level for data transfer */
-   int GetJsonComp() const  { TLockGuard lock(fMutex); return fJsonComp; }
+   int GetJsonComp() const
+   {
+      TLockGuard lock(fMutex);
+      return fJsonComp;
+   }
 
    /** Set preference of offline operations.
     * Server provides more info to client from the begin on to avoid communication */
-   void SetPreferredOffline(bool on) { TLockGuard lock(fMutex); fPreferredOffline = on; }
+   void SetPreferredOffline(bool on)
+   {
+      TLockGuard lock(fMutex);
+      fPreferredOffline = on;
+   }
    /** Is offline operations preferred.
     * After get full description, client can do most operations without extra requests */
-   bool IsPreferredOffline() const { TLockGuard lock(fMutex); return fPreferredOffline; }
+   bool IsPreferredOffline() const
+   {
+      TLockGuard lock(fMutex);
+      return fPreferredOffline;
+   }
 
    /** Get top node path */
    const std::vector<int>& GetSelectedStack() const { return fSelectedStack; }

--- a/geom/webviewer/src/RGeomData.cxx
+++ b/geom/webviewer/src/RGeomData.cxx
@@ -482,7 +482,7 @@ void RGeomDescription::ClearDescription()
    fDesc.clear();
    fNodes.clear();
    fSortMap.clear();
-   ClearDrawData();
+   _ClearDrawData();
    fDrawIdCut = 0;
    fDrawVolume = nullptr;
    fSelectedStack.clear();
@@ -1365,14 +1365,14 @@ void RGeomDescription::ProduceDrawData()
 }
 
 /////////////////////////////////////////////////////////////////////
-/// Clear raw data. Will be rebuild when next connection will be established
+/// Clear drawing data.
+/// Will be rebuild when next connection established or new message need to be send
 
 void RGeomDescription::ClearDrawData()
 {
    TLockGuard lock(fMutex);
 
-   fDrawJson.clear();
-   fSearchJson.clear();
+   _ClearDrawData();
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -1380,11 +1380,12 @@ void RGeomDescription::ClearDrawData()
 
 void RGeomDescription::ClearCache()
 {
-   ClearDrawData();
-
    TLockGuard lock(fMutex);
+
    fShapes.clear();
    fSearch.clear();
+
+   _ClearDrawData();
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -1887,7 +1888,7 @@ bool RGeomDescription::ChangeNodeVisibility(const std::vector<std::string> &path
          break;
       }
 
-   ClearDrawData(); // after change raw data is no longer valid
+   _ClearDrawData(); // after change raw data is no longer valid
 
    return true;
 }
@@ -1958,7 +1959,7 @@ bool RGeomDescription::SelectTop(const std::vector<std::string> &path)
 
    fSelectedStack = stack;
 
-   ClearDrawData();
+   _ClearDrawData();
 
    return true;
 }
@@ -1987,7 +1988,7 @@ bool RGeomDescription::SetPhysNodeVisibility(const std::vector<std::string> &pat
          bool changed = iter->visible != on;
          if (changed) {
             iter->visible = on;
-            ClearDrawData();
+            _ClearDrawData();
 
             // no need for custom settings if match with description
             if ((fDesc[nodeid].vis > 0) == on)
@@ -1999,13 +2000,13 @@ bool RGeomDescription::SetPhysNodeVisibility(const std::vector<std::string> &pat
 
       if (res > 0) {
          fVisibility.emplace(iter, stack, on);
-         ClearDrawData();
+         _ClearDrawData();
          return true;
       }
    }
 
    fVisibility.emplace_back(stack, on);
-   ClearDrawData();
+   _ClearDrawData();
    return true;
 }
 
@@ -2076,7 +2077,7 @@ bool RGeomDescription::ClearPhysNodeVisibility(const std::vector<std::string> &p
    for (auto iter = fVisibility.begin(); iter != fVisibility.end(); iter++)
       if (compare_stacks(iter->stack, stack) == 0) {
          fVisibility.erase(iter);
-         ClearDrawData();
+         _ClearDrawData();
          return true;
       }
 
@@ -2094,7 +2095,7 @@ bool RGeomDescription::ClearAllPhysVisibility()
       return false;
 
    fVisibility.clear();
-   ClearDrawData();
+   _ClearDrawData();
    return true;
 }
 
@@ -2118,7 +2119,7 @@ bool RGeomDescription::ChangeConfiguration(const std::string &json)
 
    fCfg = *cfg; // use assign
 
-   ClearDrawData();
+   _ClearDrawData();
 
    return true;
 }

--- a/geom/webviewer/src/RGeomViewer.cxx
+++ b/geom/webviewer/src/RGeomViewer.cxx
@@ -163,7 +163,8 @@ void RGeomViewer::Update()
    if (fWebHierarchy)
       fWebHierarchy->Update();
 
-   SendGeometry(0);
+   if (fWebWindow && (fWebWindow->NumConnections() > 0))
+      SendGeometry();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -233,8 +234,7 @@ void RGeomViewer::SetDrawOptions(const std::string &opt)
 /// In this case method executed asynchronously - it returns immediately and image will stored shortly afterwards when
 /// received from the client Height and width parameters are ignored in that case and derived from actual drawing size
 /// in the browser. Another possibility is to invoke headless browser, providing positive width and height parameter
-/// explicitely
-///
+/// explicitly
 
 void RGeomViewer::SaveImage(const std::string &fname, int width, int height)
 {


### PR DESCRIPTION
If configuration parameters are changed, drawing data need to be rebuild 

Provide internal method to clear such draw data without mutex lock. 
Do not reset/create draw data without established connection

Fix problem with `web_cms.cxx` demo where draw options was not applied