### PR TITLE
[ntuple] use MakeUninitArray when appropriate in tests

### DIFF
--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -62,7 +62,7 @@ TEST(RPageStorage, ReadSealedPages)
    ASSERT_EQ(1U, sealedPage.GetNElements());
    ASSERT_EQ(4U, sealedPage.GetDataSize());
    ASSERT_EQ(12U, sealedPage.GetBufferSize());
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+   auto buffer = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.GetNElements());
@@ -80,7 +80,7 @@ TEST(RPageStorage, ReadSealedPages)
    for (const auto &pi : pageRange.fPageInfos) {
       sealedPage.SetBuffer(nullptr);
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
-      buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+      buffer = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
       sealedPage.SetBuffer(buffer.get());
       source.LoadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage), sealedPage);
       ASSERT_GE(sealedPage.GetBufferSize(), 12U);
@@ -821,7 +821,7 @@ static bool VerifyPageCompression(const std::string_view fileName, std::uint32_t
    const auto colElement = ROOT::Experimental::Internal::RColumnElementBase::Generate(columnDesc.GetType());
    ROOT::Experimental::Internal::RPageStorage::RSealedPage sealedPage;
    source->LoadSealedPage(0, {0, 0}, sealedPage);
-   auto buffer = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+   auto buffer = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
    sealedPage.SetBuffer(buffer.get());
    source->LoadSealedPage(0, {0, 0}, sealedPage);
 

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -535,7 +535,7 @@ TEST(Packing, Real32TruncFloat)
       float f[N];
       for (int i = 0; i < N; ++i)
          f[i] = -2097176.7f;
-      auto out2 = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out2 = MakeUninitArray<unsigned char>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out2.get(), f, N);
 
       float fout[N];
@@ -556,7 +556,7 @@ TEST(Packing, Real32TruncFloat)
       for (int i = 0; i < N; ++i)
          f[i] = 2.f + (0.000001f * i);
 
-      auto out = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out = MakeUninitArray<unsigned char>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out.get(), f, N);
 
       float fout[N];
@@ -582,7 +582,7 @@ TEST(Packing, Real32TruncFloat)
          inputs[i] = dist(rng);
       }
 
-      auto packed = std::make_unique<std::uint8_t[]>(BitPacking::MinBufSize(N, bitWidth));
+      auto packed = MakeUninitArray<std::uint8_t>(BitPacking::MinBufSize(N, bitWidth));
 
       float outputs[N];
       for (int i = 0; i < N; ++i) {
@@ -694,7 +694,7 @@ TEST(Packing, Real32TruncDouble)
       double f[N];
       for (int i = 0; i < N; ++i)
          f[i] = -2097176.7f;
-      auto out2 = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out2 = MakeUninitArray<unsigned char>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out2.get(), f, N);
 
       double fout[N];
@@ -715,7 +715,7 @@ TEST(Packing, Real32TruncDouble)
       for (int i = 0; i < N; ++i)
          f[i] = 2.f + (0.000001f * i);
 
-      auto out = std::make_unique<unsigned char[]>(BitPacking::MinBufSize(N, kBitsOnStorage));
+      auto out = MakeUninitArray<unsigned char>(BitPacking::MinBufSize(N, kBitsOnStorage));
       element.Pack(out.get(), f, N);
 
       double fout[N];
@@ -741,7 +741,7 @@ TEST(Packing, Real32TruncDouble)
          inputs[i] = dist(rng);
       }
 
-      auto packed = std::make_unique<std::uint8_t[]>(BitPacking::MinBufSize(N, bitWidth));
+      auto packed = MakeUninitArray<std::uint8_t>(BitPacking::MinBufSize(N, bitWidth));
 
       double outputs[N];
       for (int i = 0; i < N; ++i) {
@@ -795,14 +795,14 @@ TEST(Packing, RealQuantize)
 
       constexpr auto N = 10000;
       constexpr auto kNbits = 20;
-      auto inputs = std::make_unique<decltype(min)[]>(N);
+      auto inputs = MakeUninitArray<decltype(min)>(N);
       for (int i = 0; i < N; ++i)
          inputs.get()[i] = dist(rng);
 
-      auto quant = std::make_unique<Quantized_t[]>(N);
+      auto quant = MakeUninitArray<Quantized_t>(N);
       QuantizeReals(quant.get(), inputs.get(), N, min, max, kNbits);
 
-      auto unquant = std::make_unique<decltype(min)[]>(N);
+      auto unquant = MakeUninitArray<decltype(min)>(N);
       UnquantizeReals(unquant.get(), quant.get(), N, min, max, kNbits);
 
       for (int i = 0; i < N; ++i)
@@ -816,14 +816,14 @@ TEST(Packing, RealQuantize)
 
       constexpr auto N = 10000;
       constexpr auto kNbits = 8;
-      auto inputs = std::make_unique<decltype(min)[]>(N);
+      auto inputs = MakeUninitArray<decltype(min)>(N);
       for (int i = 0; i < N; ++i)
          inputs.get()[i] = dist(rng);
 
-      auto quant = std::make_unique<Quantized_t[]>(N);
+      auto quant = MakeUninitArray<Quantized_t>(N);
       QuantizeReals(quant.get(), inputs.get(), N, min, max, kNbits);
 
-      auto unquant = std::make_unique<decltype(min)[]>(N);
+      auto unquant = MakeUninitArray<decltype(min)>(N);
       UnquantizeReals(unquant.get(), quant.get(), N, min, max, kNbits);
 
       for (int i = 0; i < N; ++i)
@@ -929,7 +929,7 @@ TEST(Packing, Real32QuantFloat)
          inputs[i] = dist(rng);
       }
 
-      auto packed = std::make_unique<std::uint8_t[]>(BitPacking::MinBufSize(N, bitWidth));
+      auto packed = MakeUninitArray<std::uint8_t>(BitPacking::MinBufSize(N, bitWidth));
       float outputs[N];
 
       if (bitWidth == 1) {
@@ -1054,7 +1054,7 @@ TEST(Packing, Real32QuantDouble)
          inputs[i] = dist(rng);
       }
 
-      auto packed = std::make_unique<std::uint8_t[]>(BitPacking::MinBufSize(N, bitWidth));
+      auto packed = MakeUninitArray<std::uint8_t>(BitPacking::MinBufSize(N, bitWidth));
       double outputs[N];
 
       if (bitWidth == 1) {

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -534,7 +534,7 @@ TEST(RNTuple, SerializeEmptyHeader)
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
    EXPECT_GT(context.GetHeaderSize(), 0);
-   auto buffer = std::make_unique<unsigned char []>(context.GetHeaderSize());
+   auto buffer = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(buffer.get(), desc);
 
    RNTupleSerializer::DeserializeHeader(buffer.get(), context.GetHeaderSize(), builder);
@@ -626,7 +626,7 @@ TEST(RNTuple, SerializeHeader)
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
    EXPECT_GT(context.GetHeaderSize(), 0);
-   auto buffer = std::make_unique<unsigned char []>(context.GetHeaderSize());
+   auto buffer = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(buffer.get(), desc);
 
    RNTupleSerializer::DeserializeHeader(buffer.get(), context.GetHeaderSize(), builder);
@@ -705,7 +705,7 @@ TEST(RNTuple, SerializeFooter)
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
    EXPECT_GT(context.GetHeaderSize(), 0);
-   auto bufHeader = std::make_unique<unsigned char []>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), desc);
 
    std::vector<DescriptorId_t> physClusterIDs;
@@ -717,12 +717,12 @@ TEST(RNTuple, SerializeFooter)
 
    auto sizePageList = RNTupleSerializer::SerializePageList(nullptr, desc, physClusterIDs, context);
    EXPECT_GT(sizePageList, 0);
-   auto bufPageList = std::make_unique<unsigned char []>(sizePageList);
+   auto bufPageList = MakeUninitArray<unsigned char>(sizePageList);
    EXPECT_EQ(sizePageList, RNTupleSerializer::SerializePageList(bufPageList.get(), desc, physClusterIDs, context));
 
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
    EXPECT_GT(sizeFooter, 0);
-   auto bufFooter = std::make_unique<unsigned char []>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    EXPECT_EQ(sizeFooter, RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context));
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
@@ -799,7 +799,7 @@ TEST(RNTuple, SerializeFooterXHeader)
 
    auto context = RNTupleSerializer::SerializeHeader(nullptr, builder.GetDescriptor());
    EXPECT_GT(context.GetHeaderSize(), 0);
-   auto bufHeader = std::make_unique<unsigned char[]>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), builder.GetDescriptor());
 
    builder.BeginHeaderExtension();
@@ -876,7 +876,7 @@ TEST(RNTuple, SerializeFooterXHeader)
    auto desc = builder.MoveDescriptor();
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
    EXPECT_GT(sizeFooter, 0);
-   auto bufFooter = std::make_unique<unsigned char[]>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    EXPECT_EQ(sizeFooter, RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context));
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
@@ -1033,17 +1033,17 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
-   auto bufHeader = std::make_unique<unsigned char[]>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), desc);
 
    std::vector<DescriptorId_t> physClusterIDs{context.MapClusterId(13), context.MapClusterId(17)};
    context.MapClusterGroupId(137);
    auto sizePageList = RNTupleSerializer::SerializePageList(nullptr, desc, physClusterIDs, context);
-   auto bufPageList = std::make_unique<unsigned char[]>(sizePageList);
+   auto bufPageList = MakeUninitArray<unsigned char>(sizePageList);
    RNTupleSerializer::SerializePageList(bufPageList.get(), desc, physClusterIDs, context);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
-   auto bufFooter = std::make_unique<unsigned char[]>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context);
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
@@ -1219,17 +1219,17 @@ TEST(RNTuple, SerializeMultiColumnRepresentationProjection)
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
-   auto bufHeader = std::make_unique<unsigned char[]>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), desc);
 
    std::vector<DescriptorId_t> physClusterIDs{context.MapClusterId(13), context.MapClusterId(17)};
    context.MapClusterGroupId(137);
    auto sizePageList = RNTupleSerializer::SerializePageList(nullptr, desc, physClusterIDs, context);
-   auto bufPageList = std::make_unique<unsigned char[]>(sizePageList);
+   auto bufPageList = MakeUninitArray<unsigned char>(sizePageList);
    RNTupleSerializer::SerializePageList(bufPageList.get(), desc, physClusterIDs, context);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
-   auto bufFooter = std::make_unique<unsigned char[]>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context);
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
@@ -1278,7 +1278,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
                        .Unwrap());
 
    auto context = RNTupleSerializer::SerializeHeader(nullptr, builder.GetDescriptor());
-   auto bufHeader = std::make_unique<unsigned char[]>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), builder.GetDescriptor());
 
    // First cluster
@@ -1347,11 +1347,11 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
                                               context.MapClusterId(19)};
    context.MapClusterGroupId(137);
    auto sizePageList = RNTupleSerializer::SerializePageList(nullptr, desc, physClusterIDs, context);
-   auto bufPageList = std::make_unique<unsigned char[]>(sizePageList);
+   auto bufPageList = MakeUninitArray<unsigned char>(sizePageList);
    RNTupleSerializer::SerializePageList(bufPageList.get(), desc, physClusterIDs, context);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
-   auto bufFooter = std::make_unique<unsigned char[]>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context);
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
@@ -1423,7 +1423,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
                         .Unwrap());
 
    auto context = RNTupleSerializer::SerializeHeader(nullptr, builder.GetDescriptor());
-   auto bufHeader = std::make_unique<unsigned char[]>(context.GetHeaderSize());
+   auto bufHeader = MakeUninitArray<unsigned char>(context.GetHeaderSize());
    context = RNTupleSerializer::SerializeHeader(bufHeader.get(), builder.GetDescriptor());
 
    // First cluster
@@ -1470,11 +1470,11 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    std::vector<DescriptorId_t> physClusterIDs{context.MapClusterId(13), context.MapClusterId(17)};
    context.MapClusterGroupId(137);
    auto sizePageList = RNTupleSerializer::SerializePageList(nullptr, desc, physClusterIDs, context);
-   auto bufPageList = std::make_unique<unsigned char[]>(sizePageList);
+   auto bufPageList = MakeUninitArray<unsigned char>(sizePageList);
    RNTupleSerializer::SerializePageList(bufPageList.get(), desc, physClusterIDs, context);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooter(nullptr, desc, context);
-   auto bufFooter = std::make_unique<unsigned char[]>(sizeFooter);
+   auto bufFooter = MakeUninitArray<unsigned char>(sizeFooter);
    RNTupleSerializer::SerializeFooter(bufFooter.get(), desc, context);
 
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -316,7 +316,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       RPageStorage::RSealedPage sealedPage;
       pageSource->LoadSealedPage(colId, RClusterIndex{clusterId, 0}, sealedPage);
       EXPECT_GT(sealedPage.GetNElements(), 0);
-      auto pageBuf = std::make_unique<unsigned char[]>(sealedPage.GetBufferSize());
+      auto pageBuf = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
       sealedPage.SetBuffer(pageBuf.get());
       pageSource->LoadSealedPage(colId, RClusterIndex{clusterId, 0}, sealedPage);
 

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -115,6 +115,8 @@ using RPrintSchemaVisitor = ROOT::Experimental::RPrintSchemaVisitor;
 using RRawFile = ROOT::Internal::RRawFile;
 using EContainerFormat = RNTupleFileWriter::EContainerFormat;
 
+using ROOT::Experimental::Internal::MakeUninitArray;
+
 /**
  * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
  * goes out of scope.

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -56,8 +56,8 @@ TEST(RNTupleZip, Small)
 TEST(RNTupleZip, Large)
 {
    constexpr unsigned int N = kMAXZIPBUF + 32;
-   auto zipBuffer = std::make_unique<unsigned char[]>(N);
-   auto unzipBuffer = std::make_unique<char[]>(N);
+   auto zipBuffer = MakeUninitArray<unsigned char>(N);
+   auto unzipBuffer = MakeUninitArray<char>(N);
    std::string data(N, 'x');
 
    RNTupleCompressor compressor;
@@ -88,8 +88,8 @@ TEST(RNTupleZip, Large)
 TEST(RNTupleZip, LargeWithOutputBuffer)
 {
    constexpr unsigned int N = kMAXZIPBUF + 32;
-   auto zipBuffer = std::make_unique<unsigned char[]>(N);
-   auto unzipBuffer = std::make_unique<char[]>(N);
+   auto zipBuffer = MakeUninitArray<unsigned char>(N);
+   auto unzipBuffer = MakeUninitArray<char>(N);
    std::string data(N, 'x');
 
    RNTupleCompressor compressor;


### PR DESCRIPTION
Minor optimization: use `MakeUninitArray` instead of `make_unique<T[]>` when the buffers don't need to be initialized.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


