### PR TITLE
[ntuple] Rename tutorial `ntpl012_processor` to `ntpl012_processor_chain`

### DIFF
--- a/tutorials/io/ntuple/ntpl012_processor_chain.C
+++ b/tutorials/io/ntuple/ntpl012_processor_chain.C
@@ -93,7 +93,7 @@ void Read(const std::vector<RNTupleOpenSpec> &ntuples)
    hPx.DrawCopy();
 }
 
-void ntpl012_processor()
+void ntpl012_processor_chain()
 {
    // The ntuples to generate and subsequently process. The model of the first ntuple will be used to construct the
    // entry used by the processor.


### PR DESCRIPTION
We have a separate tutorial for join-based processing. This name change better reflects the fact that we only do chain processing here.

N.B., This tutorial was already renamed previously in #17137, but this change probably got lost in the tutorial reorganization taking place around the same time.

