### PR TITLE
Fix two includes to compile with gcc-15

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -9,6 +9,7 @@
 #ifndef ROOT7_RVirtualCanvasPainter
 #define ROOT7_RVirtualCanvasPainter
 
+#include <cstdint>
 #include <memory>
 #include <functional>
 #include <string>

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cstddef>     // std::size_t
+#include <cstdint>
 #include <stdexcept>   // std::runtime_error
 #include <sstream>     // std::stringstream
 #include <memory>      // std::shared_ptr


### PR DESCRIPTION
When fixed-size integer types are in use, gcc-15 requires the inclusion of `<cstdint>`.