### PR TITLE
Implement TGraph2D::RemoveDuplicates

### DIFF
--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -147,10 +147,11 @@ public:
    virtual Int_t         GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z) const;
    Double_t              Interpolate(Double_t x, Double_t y);
    void                  Paint(Option_t *option="") override;
-   void          Print(Option_t *chopt="") const override;
+   void                  Print(Option_t *chopt="") const override;
    TH1                  *Project(Option_t *option="x") const; // *MENU*
    Int_t                 RemovePoint(Int_t ipoint); // *MENU*
-   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   Int_t                 RemoveDuplicates();
+   void                  SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void          Scale(Double_t c1=1., Option_t *option="z"); // *MENU*
    virtual void          Set(Int_t n);
    virtual void          SetDirectory(TDirectory *dir);
@@ -160,12 +161,12 @@ public:
    void                  SetMaximum(Double_t maximum=-1111); // *MENU*
    void                  SetMinimum(Double_t minimum=-1111); // *MENU*
    void                  SetMaxIter(Int_t n=100000) {fMaxIter = n;} // *MENU*
-   void          SetName(const char *name) override; // *MENU*
-   void          SetNameTitle(const char *name, const char *title) override;
+   void                  SetName(const char *name) override; // *MENU*
+   void                  SetNameTitle(const char *name, const char *title) override;
    void                  SetNpx(Int_t npx=40); // *MENU*
    void                  SetNpy(Int_t npx=40); // *MENU*
    virtual void          SetPoint(Int_t point, Double_t x, Double_t y, Double_t z); // *MENU*
-   void          SetTitle(const char *title="") override; // *MENU*
+   void                  SetTitle(const char *title="") override; // *MENU*
 
 
    ClassDefOverride(TGraph2D,1)  //Set of n x[n],y[n],z[n] points with 3-d graphics including Delaunay triangulation

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1447,26 +1447,12 @@ Int_t TGraph2D::RemovePoint(Int_t ipoint)
 {
    if (ipoint < 0) return -1;
    if (ipoint >= fNpoints) return -1;
-
-   fNpoints--;
-   Double_t *newX = new Double_t[fNpoints];
-   Double_t *newY = new Double_t[fNpoints];
-   Double_t *newZ = new Double_t[fNpoints];
-   Int_t j = -1;
-   for (Int_t i = 0; i < fNpoints + 1; i++) {
-      if (i == ipoint) continue;
-      j++;
-      newX[j] = fX[i];
-      newY[j] = fY[i];
-      newZ[j] = fZ[i];
+   for (Int_t i = ipoint; i < fNpoints - 1; i++) {
+      fX[i] = fX[i+1];
+      fY[i] = fY[i+1];
+      fZ[i] = fZ[i+1];
    }
-   delete [] fX;
-   delete [] fY;
-   delete [] fZ;
-   fX = newX;
-   fY = newY;
-   fZ = newZ;
-   fSize = fNpoints;
+   fNpoints--;
    if (fHistogram) {
       delete fHistogram;
       fHistogram = nullptr;

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -108,6 +108,11 @@ Specific drawing options can be used to paint a TGraph2D:
 | "LINE"   | Draw a 3D polyline. |
 | "CONT5"  | Draw a contour plot using Delaunay triangles.|
 
+The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
+meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
+algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates
+(see RemoveDuplicates()).
+
 A TGraph2D can be also drawn with any options valid to draw a 2D histogram
 (like `COL`, `SURF`, `LEGO`, `CONT` etc..).
 
@@ -324,15 +329,12 @@ TGraph2D::TGraph2D(TH2 *h2)
    // need to call later because sets title in ref histogram
    SetTitle(h2->GetTitle());
 
-
-
    TAxis *xaxis = h2->GetXaxis();
    TAxis *yaxis = h2->GetYaxis();
    Int_t xfirst = xaxis->GetFirst();
    Int_t xlast  = xaxis->GetLast();
    Int_t yfirst = yaxis->GetFirst();
    Int_t ylast  = yaxis->GetLast();
-
 
    Double_t x, y, z;
    Int_t k = 0;
@@ -1407,6 +1409,34 @@ TH1 *TGraph2D::Project(Option_t *option) const
    }
    h->SetEntries(entries);
    return h;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Deletes duplicated points.
+///
+/// The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
+/// meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
+/// algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates.
+/// This function provides a way to handle such duplicates.
+///
+/// Example:
+/// ~~~ {.cpp}
+/// g->RemoveDuplicates();
+/// g->Draw("TRI1");
+/// ~~~
+
+Int_t TGraph2D::RemoveDuplicates()
+{
+   for (int i=0; i<fNpoints; i++) {
+      double x = fX[i];
+      double y = fY[i];
+      for (int j=i+1; j<fNpoints; j++) {
+         if (x==fX[j] && y==fY[j]) {RemovePoint(j); j--;}
+      }
+   }
+
+   return fNpoints;
 }
 
 

--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -13,6 +13,7 @@
 
 #include "Math/Delaunay2D.h"
 #include "Rtypes.h"
+#include "TError.h"
 
 //#include <thread>
 
@@ -179,6 +180,7 @@ void Delaunay2D::DoFindTriangles() {
    std::vector<CDT::V2d<double>> points(fNpoints);
    for (i = 0; i < fNpoints; ++i) points[i] = CDT::V2d<double>::make(fXN[i], fYN[i]);
    CDT::RemoveDuplicates(points);
+   if (fNpoints-points.size() > 0) Warning("DoFindTriangles","This TGraph2D has duplicated vertices. To remove them call RemoveDuplicates before drawing");
 
    CDT::Triangulation<double> cdt;
    cdt.insertVertices(points);

--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -180,7 +180,8 @@ void Delaunay2D::DoFindTriangles() {
    std::vector<CDT::V2d<double>> points(fNpoints);
    for (i = 0; i < fNpoints; ++i) points[i] = CDT::V2d<double>::make(fXN[i], fYN[i]);
    CDT::RemoveDuplicates(points);
-   if (fNpoints-points.size() > 0) Warning("DoFindTriangles","This TGraph2D has duplicated vertices. To remove them call RemoveDuplicates before drawing");
+   if (fNpoints-points.size() > 0)
+      Warning("DoFindTriangles","This TGraph2D has duplicated vertices. To remove them call RemoveDuplicates before drawing");
 
    CDT::Triangulation<double> cdt;
    cdt.insertVertices(points);


### PR DESCRIPTION
The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates.
This function provides a way to handle such duplicates.

