### PR TITLE
[geom] Add protection for non-GCC compilers

### DIFF
--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -40,10 +40,12 @@ method.
 #include <mutex>
 
 // this is for the bvh acceleration stuff
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#endif
 
 // V2 BVH
 #include <bvh/v2/bvh.h>
@@ -1485,4 +1487,6 @@ void TGeoParallelWorld::TestVoxelGrid()
    }
 }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Add protection to avoid unknown pragma warnings on non-GCC compilers
