### PR TITLE
[RF] Support non-uniform binnings in codegen to enable AD for non-uniform template fits

### DIFF
--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -86,7 +86,7 @@ void rooHistTranslateImpl(RooAbsArg const &arg, CodegenContext &ctx, int intOrde
                                         binning.numBins(), weightArr));
       return;
    }
-   std::string const &offset = dataHist.calculateTreeIndexForCodeSquash(&arg, ctx, obs);
+   std::string const &offset = dataHist.calculateTreeIndexForCodeSquash(ctx, obs);
    std::string weightArr = dataHist.declWeightArrayForCodeSquash(ctx, correctForBinSize);
    ctx.addResult(&arg, "*(" + weightArr + " + " + offset + ")");
 }
@@ -135,7 +135,7 @@ void codegenImpl(RooFit::Detail::RooFixedProdPdf &arg, CodegenContext &ctx)
 
 void codegenImpl(ParamHistFunc &arg, CodegenContext &ctx)
 {
-   std::string const &idx = arg.dataHist().calculateTreeIndexForCodeSquash(&arg, ctx, arg.dataVars(), true);
+   std::string const &idx = arg.dataHist().calculateTreeIndexForCodeSquash(ctx, arg.dataVars(), true);
    std::string const &paramNames = ctx.buildArg(arg.paramList());
 
    ctx.addResult(&arg, paramNames + "[" + idx + "]");
@@ -190,10 +190,10 @@ void codegenImpl(PiecewiseInterpolation &arg, CodegenContext &ctx)
    std::string lowName = ctx.getTmpVarName();
    std::string highName = ctx.getTmpVarName();
    std::string nominalName = ctx.getTmpVarName();
-   code += "unsigned int " + idxName + " = " +
-           nomHist.calculateTreeIndexForCodeSquash(&arg, ctx,
-                                                   dynamic_cast<RooHistFunc const &>(*arg.nominalHist()).variables()) +
-           ";\n";
+   code +=
+      "unsigned int " + idxName + " = " +
+      nomHist.calculateTreeIndexForCodeSquash(ctx, dynamic_cast<RooHistFunc const &>(*arg.nominalHist()).variables()) +
+      ";\n";
    code += "double const* " + lowName + " = " + valsLowStr + " + " + nStr + " * " + idxName + ";\n";
    code += "double const* " + highName + " = " + valsHighStr + " + " + nStr + " * " + idxName + ";\n";
    code += "double " + nominalName + " = *(" + valsNominalStr + " + " + idxName + ");\n";
@@ -447,7 +447,7 @@ void codegenImpl(RooFit::Detail::RooNormalizedPdf &arg, CodegenContext &ctx)
 
 void codegenImpl(RooParamHistFunc &arg, CodegenContext &ctx)
 {
-   std::string const &idx = arg.dataHist().calculateTreeIndexForCodeSquash(&arg, ctx, arg.xList());
+   std::string const &idx = arg.dataHist().calculateTreeIndexForCodeSquash(ctx, arg.xList());
    std::string arrName = ctx.buildArg(arg.paramList());
    std::string result = arrName + "[" + idx + "]";
    if (arg.relParam()) {

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -711,18 +711,5 @@ INSTANTIATE_TEST_SUITE_P(HistFactory, HFFixtureFit,
                          testing::Combine(testing::Values(MakeModelMode::OverallSyst, MakeModelMode::HistoSyst,
                                                           MakeModelMode::StatSyst, MakeModelMode::ShapeSyst),
                                           testing::Values(false, true), // non-uniform bins or not
-                                          testing::Values(ROOFIT_EVAL_BACKENDS)),
+                                          testing::Values(ROOFIT_EVAL_BACKENDS_WITH_CODEGEN)),
                          getNameFromInfo);
-
-#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS) // See https://github.com/vgvassilev/clad/issues/752
-#ifdef TEST_CODEGEN_AD
-// TODO: merge with the previous HFFixtureFix test suite once the codegen AD
-// supports all of HistFactory
-INSTANTIATE_TEST_SUITE_P(HistFactoryCodeGen, HFFixtureFit,
-                         testing::Combine(testing::Values(MakeModelMode::OverallSyst, MakeModelMode::HistoSyst,
-                                                          MakeModelMode::StatSyst, MakeModelMode::ShapeSyst),
-                                          testing::Values(false), // no non-uniform bins
-                                          testing::Values(RooFit::EvalBackend::Codegen())),
-                         getNameFromInfo);
-#endif // TEST_CODEGEN_AD
-#endif // R__WIN32

--- a/roofit/roofitcore/inc/RooAbsBinning.h
+++ b/roofit/roofitcore/inc/RooAbsBinning.h
@@ -16,11 +16,19 @@
 #ifndef ROO_ABS_BINNING
 #define ROO_ABS_BINNING
 
-#include "Rtypes.h"
-#include "RooPrintable.h"
-#include "TNamed.h"
+#include <Rtypes.h>
+#include <RooPrintable.h>
+
+#include <TNamed.h>
+
 class RooAbsRealLValue ;
+class RooAbsArg ;
 class RooAbsReal ;
+namespace RooFit {
+namespace Experimental {
+class CodegenContext;
+}
+}
 
 class RooAbsBinning : public TNamed, public RooPrintable {
 public:
@@ -62,6 +70,8 @@ public:
     binNumbers(&x, &out, 1);
     return out;
   }
+
+  virtual std::string translateBinNumber(RooFit::Experimental::CodegenContext &ctx, RooAbsArg const &var, int coef) const;
 
   virtual double binCenter(Int_t bin) const = 0 ;
   virtual double binWidth(Int_t bin) const = 0 ;

--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -69,6 +69,8 @@ public:
   void addUniform(Int_t nBins, double xlo, double xhi);
   bool removeBoundary(double boundary);
 
+  std::string translateBinNumber(RooFit::Experimental::CodegenContext &ctx, RooAbsArg const &var, int coef) const override;
+
 protected:
 
   bool binEdges(Int_t bin, double& xlo, double& xhi) const;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -218,7 +218,7 @@ public:
   double const* wgtErrHiArray() const { return _errHi; }
   double const* sumW2Array()    const { return _sumw2; }
 
-  std::string calculateTreeIndexForCodeSquash(RooAbsArg const *klass, RooFit::Experimental::CodegenContext &ctx,
+  std::string calculateTreeIndexForCodeSquash(RooFit::Experimental::CodegenContext &ctx,
                                               const RooAbsCollection &coords, bool reverse = false) const;
   std::string declWeightArrayForCodeSquash(RooFit::Experimental::CodegenContext &ctx,
                                            bool correctForBinSize) const;

--- a/roofit/roofitcore/inc/RooUniformBinning.h
+++ b/roofit/roofitcore/inc/RooUniformBinning.h
@@ -44,6 +44,8 @@ public:
   double averageBinWidth() const override { return _binw ; }
   double* array() const override ;
 
+  std::string translateBinNumber(RooFit::Experimental::CodegenContext &ctx, RooAbsArg const &var, int coef) const override;
+
 protected:
    mutable std::vector<double> _array; ///<! do not persist
    double _xlo;

--- a/roofit/roofitcore/src/RooAbsBinning.cxx
+++ b/roofit/roofitcore/src/RooAbsBinning.cxx
@@ -26,6 +26,8 @@ This class defines the interface to retrieve bin boundaries, ranges etc.
 #include "RooAbsBinning.h"
 
 #include "RooAbsReal.h"
+#include "RooMsgService.h"
+
 #include "TBuffer.h"
 #include "TClass.h"
 
@@ -134,4 +136,10 @@ void RooAbsBinning::Streamer(TBuffer &R__b)
       RooPrintable::Streamer(R__b);
       R__b.SetByteCount(R__c, true);
    }
+}
+
+std::string RooAbsBinning::translateBinNumber(RooFit::Experimental::CodegenContext &, RooAbsArg const &, int) const
+{
+   oocoutE(nullptr, InputArguments) << "This binning doesn't support codegen!" << std::endl;
+   return "";
 }

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -26,15 +26,18 @@ the user to add single bin boundaries, mirrored pairs, or sets of
 uniformly spaced boundaries.
 **/
 
-#include "Riostream.h"
-#include "RooBinning.h"
-#include "RooDouble.h"
-#include "RooAbsPdf.h"
-#include "RooRealVar.h"
-#include "RooNumber.h"
-#include "RooMsgService.h"
-#include "TBuffer.h"
-#include "TList.h"
+#include <Riostream.h>
+#include <RooAbsPdf.h>
+#include <RooBinning.h>
+#include <RooDouble.h>
+#include <RooFit/CodegenContext.h>
+#include <RooFit/Detail/MathFuncs.h>
+#include <RooMsgService.h>
+#include <RooNumber.h>
+#include <RooRealVar.h>
+
+#include <TBuffer.h>
+#include <TList.h>
 
 #include <algorithm>
 #include <cmath>
@@ -101,8 +104,7 @@ RooBinning::~RooBinning()
 
 bool RooBinning::addBoundary(double boundary)
 {
-  std::vector<double>::iterator it =
-      std::lower_bound(_boundaries.begin(), _boundaries.end(), boundary);
+  auto it = std::lower_bound(_boundaries.begin(), _boundaries.end(), boundary);
   if (_boundaries.end() != it && *it == boundary) {
     // If boundary previously existed as range delimiter,
     //                    convert to regular boundary now
@@ -130,8 +132,7 @@ void RooBinning::addBoundaryPair(double boundary, double mirrorPoint)
 
 bool RooBinning::removeBoundary(double boundary)
 {
-  std::vector<double>::iterator it = std::lower_bound(_boundaries.begin(),
-      _boundaries.end(), boundary);
+  auto it = std::lower_bound(_boundaries.begin(), _boundaries.end(), boundary);
   if  (_boundaries.end() != it && *it == boundary) {
     _boundaries.erase(it);
     // if some moron deletes the boundaries corresponding to the current
@@ -161,28 +162,16 @@ void RooBinning::addUniform(Int_t nbins, double xlo, double xhi)
   }
 }
 
-namespace {
-
-inline int rawBinNumberImpl(double x, std::vector<double> const& boundaries) {
-  auto it = std::lower_bound(boundaries.begin(), boundaries.end(), x);
-  // always return valid bin number
-  while (boundaries.begin() != it &&
-     (boundaries.end() == it || boundaries.end() == it + 1 || x < *it)) --it;
-  return it - boundaries.begin();
-}
-
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Return sequential bin number that contains value x where bin
 /// zero is the first bin with an upper boundary above the lower bound
 /// of the range
 
-void RooBinning::binNumbers(double const * x, int * bins, std::size_t n, int coef) const
+void RooBinning::binNumbers(double const *x, int *bins, std::size_t n, int coef) const
 {
-  for(std::size_t i = 0; i < n; ++i) {
-    bins[i] += coef * (std::max(0, std::min(_nbins, rawBinNumberImpl(x[i], _boundaries) - _blo)));
-  }
+   for (std::size_t i = 0; i < n; ++i) {
+      bins[i] += RooFit::Detail::MathFuncs::binNumber(x[i], coef, _boundaries.data(), _boundaries.size(), _nbins, _blo);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -239,9 +228,8 @@ void RooBinning::updateBinCount()
       _nbins = -1;
       return;
   }
-  _blo = rawBinNumberImpl(_xlo, _boundaries);
-  std::vector<double>::const_iterator it = std::lower_bound(
-      _boundaries.begin(), _boundaries.end(), _xhi);
+  _blo = RooFit::Detail::MathFuncs::rawBinNumber(_xlo, _boundaries.data(), _boundaries.size());
+  auto it = std::lower_bound(_boundaries.begin(), _boundaries.end(), _xhi);
   if (_boundaries.begin() != it && (_boundaries.end() == it || _xhi < *it)) --it;
   const Int_t bhi = it - _boundaries.begin();
   _nbins = bhi - _blo;
@@ -356,4 +344,9 @@ void RooBinning::Streamer(TBuffer &R__b)
    } else {
      R__b.WriteClassBuffer(RooBinning::Class(),this);
    }
+}
+
+std::string RooBinning::translateBinNumber(RooFit::Experimental::CodegenContext &ctx, RooAbsArg const &var, int coef) const
+{
+   return ctx.buildCall("RooFit::Detail::MathFuncs::binNumber", var, coef, _boundaries, _boundaries.size(), _nbins, _blo);
 }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -996,19 +996,13 @@ std::string RooDataHist::declWeightArrayForCodeSquash(RooFit::Experimental::Code
                                                       bool correctForBinSize) const
 {
    std::vector<double> vals(_arrSize);
-   if (correctForBinSize) {
-      for (std::size_t i = 0; i < vals.size(); ++i) {
-         vals[i] = _wgt[i] / _binv[i];
-      }
-   } else {
-      for (std::size_t i = 0; i < vals.size(); ++i) {
-         vals[i] = _wgt[i];
-      }
+   for (std::size_t i = 0; i < vals.size(); ++i) {
+      vals[i] = correctForBinSize ? _wgt[i] / _binv[i] : _wgt[i];
    }
    return ctx.buildArg(vals);
 }
 
-std::string RooDataHist::calculateTreeIndexForCodeSquash(RooAbsArg const * /*klass*/, RooFit::Experimental::CodegenContext &ctx,
+std::string RooDataHist::calculateTreeIndexForCodeSquash(RooFit::Experimental::CodegenContext &ctx,
                                                          const RooAbsCollection &coords, bool reverse) const
 {
    assert(coords.size() == _vars.size());
@@ -1027,16 +1021,9 @@ std::string RooDataHist::calculateTreeIndexForCodeSquash(RooAbsArg const * /*kla
          coutE(InputArguments) << "RooHistPdf::weight(" << GetName()
                                << ") ERROR: Code Squashing currently does not support category values." << std::endl;
          return "";
-      } else if (!dynamic_cast<RooUniformBinning const *>(binning)) {
-         coutE(InputArguments) << "RooHistPdf::weight(" << GetName()
-                               << ") ERROR: Code Squashing currently only supports uniformly binned cases."
-                               << std::endl;
-         return "";
       }
 
-      std::string const &bin = ctx.buildCall("RooFit::Detail::MathFuncs::getUniformBinning", binning->lowBound(),
-                                             binning->highBound(), *theVar, binning->numBins());
-      code += " + " + std::to_string(idxMult) + " * " + bin;
+      code += " + " + binning->translateBinNumber(ctx, *theVar, idxMult);
 
       // Use RooAbsLValue here because it also generalized to categories, which
       // is useful in the future. dynamic_cast because it's a cross-cast.

--- a/roofit/roofitcore/src/RooFit/CodegenContext.cxx
+++ b/roofit/roofitcore/src/RooFit/CodegenContext.cxx
@@ -329,6 +329,9 @@ CodegenContext::buildFunction(RooAbsArg const &arg, std::map<RooFit::Detail::Dat
    static int iCodegen = 0;
    auto funcName = "roo_codegen_" + std::to_string(iCodegen++);
 
+   // Make sure the codegen implementations are known to the interpreter
+   gInterpreter->Declare("#include <RooFit/CodegenImpl.h>\n");
+
    ctx.pushScope();
    std::string funcBody = ctx.getResult(arg);
    ctx.popScope();

--- a/roofit/roofitcore/src/RooUniformBinning.cxx
+++ b/roofit/roofitcore/src/RooUniformBinning.cxx
@@ -25,10 +25,12 @@ is 'elastic': if the range changes the binning will change accordingly, unlike
 e.g. the binning of class RooBinning.
 **/
 
-#include "RooUniformBinning.h"
-#include "RooMsgService.h"
+#include <RooUniformBinning.h>
 
-#include "Riostream.h"
+#include <RooFit/CodegenContext.h>
+#include <RooMsgService.h>
+
+#include <Riostream.h>
 
 
 using std::endl;
@@ -163,4 +165,8 @@ double* RooUniformBinning::array() const
   return _array.data();
 }
 
-
+std::string
+RooUniformBinning::translateBinNumber(RooFit::Experimental::CodegenContext &ctx, RooAbsArg const &var, int coef) const
+{
+   return ctx.buildCall("RooFit::Detail::MathFuncs::uniformBinNumber", lowBound(), highBound(), var, numBins(), coef);
+}


### PR DESCRIPTION
Support the code generation also for template histograms with
non-uniform binning, to enable automatic differentiation for template
fits with non-uniform bins.

This was requested both by CMS and ATLAS users, because they use
non-uniform binnings in their Higgs combinations.