### PR TITLE
[RF] Use fully-qualified name for `std::cout` in RooFit

### DIFF
--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -31,7 +31,7 @@
 using namespace RooStats;
 using namespace HistFactory;
 
-using std::string, std::cerr, std::cout, std::endl, std::vector;
+using std::string, std::vector;
 
 namespace {
 
@@ -135,7 +135,7 @@ std::vector< RooStats::HistFactory::Measurement > ConfigParser::GetMeasurementsF
 
 
     // Read the Driver XML File
-    cxcoutIHF << "reading input : " << input << endl;
+    cxcoutIHF << "reading input : " << input << std::endl;
     TXMLDocument* xmldoc = xmlparser.GetXMLDocument();
     TXMLNode* rootNode = xmldoc->GetRootNode();
 
@@ -164,7 +164,7 @@ std::vector< RooStats::HistFactory::Measurement > ConfigParser::GetMeasurementsF
 
       else if( attrName == TString( "OutputFilePrefix" ) ) {
    OutputFilePrefix = string(curAttr->GetValue());
-   cxcoutIHF << "output file prefix is : " << OutputFilePrefix << endl;
+   cxcoutIHF << "output file prefix is : " << OutputFilePrefix << std::endl;
       }
 
       /*
@@ -204,7 +204,7 @@ std::vector< RooStats::HistFactory::Measurement > ConfigParser::GetMeasurementsF
 
     // If no channel xml files are found, exit
     if(xml_channel_files.empty()){
-      cerr << "no input channels found" << endl;
+      std::cerr << "no input channels found" << std::endl;
       throw hf_exc();
       //return measurement_list;
     }
@@ -378,7 +378,7 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
       } else if (curAttrName == "BinHigh") {
          measurement.SetBinHigh(std::stoi(curAttrValue));
       } else if (curAttrName == "Mode") {
-         cout << "\n INFO: Mode attribute is deprecated and no longer supported, will ignore\n";
+         std::cout << "\n INFO: Mode attribute is deprecated and no longer supported, will ignore\n";
       } else if (curAttrName == "ExportOnly") {
          // ignored
          cxcoutIHF << "The \"ExportOnly\" attribute is ignored it is always \"true\" for any Measurement." << std::endl;
@@ -824,7 +824,7 @@ HistFactory::StatErrorConfig ConfigParser::CreateStatErrorConfigElement( TXMLNod
       else if( IsAcceptableNode( node ) ) { ; }
 
       else {
-   cout << "Invalid Stat Constraint Type: " << curAttr->GetValue() << endl;
+   std::cout << "Invalid Stat Constraint Type: " << curAttr->GetValue() << std::endl;
    throw hf_exc();
       }
     }
@@ -1357,7 +1357,7 @@ HistFactory::ShapeSys ConfigParser::MakeShapeSys( TXMLNode* node ) {
    shapeSys.SetConstraintType( Constraint::Poisson );
       }
       else {
-   cout << "Error: Encountered unknown ShapeSys Constraint type: " << attrVal << endl;
+   std::cout << "Error: Encountered unknown ShapeSys Constraint type: " << attrVal << std::endl;
    throw hf_exc();
       }
     }
@@ -1527,7 +1527,7 @@ RooStats::HistFactory::PreprocessFunction ConfigParser::ParseFunctionConfig( TXM
 
   //std::string command = "expr::"+func.GetName()+"('"+func.GetExpression()+"',{"+func.GetDependents()+"})";
   //func.SetCommand( command );
-  // //  cout << "will pre-process this line " << ret <<endl;
+  // //  std::cout << "will pre-process this line " << ret << std::endl;
   return func;
 
 }

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -92,7 +92,7 @@ std::vector<double> histToVector(TH1 const &hist)
 
 // use this order for safety on library loading
 using namespace RooStats;
-using std::cout, std::endl, std::string, std::vector, std::make_unique, std::pair, std::unique_ptr, std::map;
+using std::string, std::vector, std::make_unique, std::pair, std::unique_ptr, std::map;
 
 using namespace RooStats::HistFactory::Detail;
 using namespace RooStats::HistFactory::Detail::MagicConstants;
@@ -144,7 +144,7 @@ namespace HistFactory{
     for(auto const& item : measurement.GetPOIList()) {
       sstream << item << " ";
     }
-    cxcoutIHF << sstream.str() << endl;
+    cxcoutIHF << sstream.str() << std::endl;
 
     RooArgSet params;
     for(auto const& poi_name : measurement.GetPOIList()) {
@@ -337,9 +337,9 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
   RooHistFunc* HistoToWorkspaceFactoryFast::MakeExpectedHistFunc(const TH1* hist,RooWorkspace &proto, string prefix,
       const RooArgList& observables) const {
     if(hist) {
-      cxcoutI(HistFactory) << "processing hist " << hist->GetName() << endl;
+      cxcoutI(HistFactory) << "processing hist " << hist->GetName() << std::endl;
     } else {
-      cxcoutF(HistFactory) << "hist is empty" << endl;
+      cxcoutF(HistFactory) << "hist is empty" << std::endl;
       R__ASSERT(hist != nullptr);
       return nullptr;
     }
@@ -466,7 +466,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         range << "[" << norm.GetVal() << "," << norm.GetLow() << "," << norm.GetHigh() << "]";
 
         if( proto.obj(varname) == nullptr) {
-          cxcoutI(HistFactory) << "making normFactor: " << norm.GetName() << endl;
+          cxcoutI(HistFactory) << "making normFactor: " << norm.GetName() << std::endl;
           // remove "doRatio" and name can be changed when ws gets imported to the combined model.
           emplace<RooRealVar>(proto, varname, norm.GetVal(), norm.GetLow(), norm.GetHigh());
           proto.var(varname)->setError(0); // ensure factor is assigned an initial error, even if its zero
@@ -492,7 +492,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         cxcoutI(HistFactory) <<"<NormFactor Name =\""<<*nit<<"\"> is duplicated for <Sample Name=\""
             << sample.GetName() << "\">, but only one factor will be included.  \n Instead, define something like"
             << "\n\t<Function Name=\""<<*nit<<"Squared\" Expression=\""<<*nit<<"*"<<*nit<<"\" Var=\""<<*nit<<rangeNames.at(rangeIndex)
-            << "\"> \nin your top-level XML's <Measurement> entry and use <NormFactor Name=\""<<*nit<<"Squared\" in your channel XML file."<< endl;
+            << "\"> \nin your top-level XML's <Measurement> entry and use <NormFactor Name=\""<<*nit<<"Squared\" in your channel XML file."<< std::endl;
       }
       ++rangeIndex;
     }
@@ -608,7 +608,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
        proto.import(interp); // params have already been imported in first loop of this function
     } else{
        // some strange behavior if params,lowVec,highVec are empty.
-       //cout << "WARNING: No OverallSyst terms" << endl;
+       //cout << "WARNING: No OverallSyst terms" << std::endl;
        emplace<RooConstVar>(proto, interpName, 1.); // params have already been imported in first loop of this function
     }
   }
@@ -696,10 +696,10 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       fprintf(covFile,"%s", myargi->GetName());
       for (auto const *myargj : static_range_cast<RooRealVar *>(*params)) {
         if(myargj->isConstant()) continue;
-        cout << myargi->GetName() << "," << myargj->GetName();
+        std::cout << myargi->GetName() << "," << myargj->GetName();
         fprintf(covFile, " & %.2f", result->correlation(*myargi, *myargj));
       }
-      cout << endl;
+      std::cout << std::endl;
       fprintf(covFile, " \\\\\n");
     }
     fclose(covFile);
@@ -774,7 +774,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
         << "\tStarting to process '"
         << channel_name << "' channel with " << fObsNameVec.size() << " observables"
-        << "\n-----------------------------------------\n" << endl;
+        << "\n-----------------------------------------\n" << std::endl;
 
     //
     // our main workspace that we are using to construct the model
@@ -786,7 +786,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     // preprocess functions
     for(auto const& func : fPreprocessFunctions){
-      cxcoutI(HistFactory) << "will preprocess this line: " << func <<endl;
+      cxcoutI(HistFactory) << "will preprocess this line: " << func << std::endl;
       proto.factory(func);
       proto.Print();
     }
@@ -873,7 +873,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
       if(sample.GetHistoSysList().empty()) {
         // If no HistoSys
-        cxcoutI(HistFactory) << sample.GetName() + "_" + channel_name + " has no variation histograms " << endl;
+        cxcoutI(HistFactory) << sample.GetName() + "_" + channel_name + " has no variation histograms " << std::endl;
 
         sampleHistFuncs.push_back(nominalHistFunc);
       } else {
@@ -1255,7 +1255,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       RooRealVar* temp = proto.var(systToFix.at(i));
       if(!temp) {
         cxcoutW(HistFactory) << "could not find variable " << systToFix.at(i)
-            << " could not set it to constant" << endl;
+            << " could not set it to constant" << std::endl;
       } else {
         // set the parameter constant
         temp->setConstant();
@@ -1306,7 +1306,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     // after observables have been made
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
         << "\timport model into workspace"
-        << "\n-----------------------------------------\n" << endl;
+        << "\n-----------------------------------------\n" << std::endl;
 
     auto model = make_unique<RooProdPdf>(
         ("model_"+channel_name).c_str(),    // MB : have changed this into conditional pdf. Much faster for toys!
@@ -1479,8 +1479,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       RooWorkspace * ch=chs[i].get();
 
       RooAbsPdf* model = ch->pdf("model_"+channel_name);
-      if(!model) cout <<"failed to find model for channel"<<endl;
-      //      cout << "int = " << model->createIntegral(*obsN)->getVal() << endl;
+      if(!model) std::cout <<"failed to find model for channel"<< std::endl;
+      //      std::cout << "int = " << model->createIntegral(*obsN)->getVal() << std::endl;
       models.push_back(model);
       globalObs.add(*ch->set("globalObservables"), /*silent=*/true); // silent because observables might exist in other channel.
 
@@ -1490,7 +1490,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
         << "\tEntering combination"
-        << "\n-----------------------------------------\n" << endl;
+        << "\n-----------------------------------------\n" << std::endl;
     auto combined = std::make_unique<RooWorkspace>("combined");
 
 
@@ -1532,7 +1532,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
             << "\tImporting combined model"
-            << "\n-----------------------------------------\n" << endl;
+            << "\n-----------------------------------------\n" << std::endl;
     combined->import(*simPdf,RooFit::RecycleConflictNodes());
 
     for(auto const& param_itr : fParamValues) {
@@ -1542,9 +1542,9 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
       if(RooRealVar* temp = combined->var( paramName )) {
         temp->setVal( paramVal );
-        cxcoutI(HistFactory) <<"setting " << paramName << " to the value: " << paramVal <<  endl;
+        cxcoutI(HistFactory) <<"setting " << paramName << " to the value: " << paramVal <<  std::endl;
       } else
-        cxcoutE(HistFactory) << "could not find variable " << paramName << " could not set its value" << endl;
+        cxcoutE(HistFactory) << "could not find variable " << paramName << " could not set its value" << std::endl;
     }
 
 
@@ -1552,9 +1552,9 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       // make sure they are fixed
       if(RooRealVar* temp = combined->var(fSystToFix[i])) {
         temp->setConstant();
-        cxcoutI(HistFactory) <<"setting " << fSystToFix.at(i) << " constant" << endl;
+        cxcoutI(HistFactory) <<"setting " << fSystToFix.at(i) << " constant" << std::endl;
       } else
-        cxcoutE(HistFactory) << "could not find variable " << fSystToFix.at(i) << " could not set it to constant" << endl;
+        cxcoutE(HistFactory) << "could not find variable " << fSystToFix.at(i) << " could not set it to constant" << std::endl;
     }
 
     ///
@@ -1574,7 +1574,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     // Make toy simultaneous dataset
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
         << "\tcreate toy data"
-        << "\n-----------------------------------------\n" << endl;
+        << "\n-----------------------------------------\n" << std::endl;
 
 
     // now with weighted datasets

--- a/roofit/histfactory/src/LinInterpVar.cxx
+++ b/roofit/histfactory/src/LinInterpVar.cxx
@@ -45,7 +45,7 @@ LinInterpVar::LinInterpVar(const char* name, const char* title,
   for (auto param : paramList) {
     if (!dynamic_cast<RooAbsReal*>(param)) {
       coutE(InputArguments) << "LinInterpVar::ctor(" << GetName() << ") ERROR: paramficient " << param->GetName()
-             << " is not of type RooAbsReal" << endl ;
+             << " is not of type RooAbsReal" << std::endl ;
       assert(0) ;
     }
     _paramList.add(*param) ;

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -58,8 +58,6 @@
 #include <cmath>
 #include <algorithm>
 
-using std::endl, std::cout;
-
 ClassImp(PiecewiseInterpolation);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,14 +92,14 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char *name, const char *tit
 {
   // KC: check both sizes
   if (lowSet.size() != highSet.size()) {
-    coutE(InputArguments) << "PiecewiseInterpolation::ctor(" << GetName() << ") ERROR: input lists should be of equal length" << endl ;
+    coutE(InputArguments) << "PiecewiseInterpolation::ctor(" << GetName() << ") ERROR: input lists should be of equal length" << std::endl ;
     RooErrorHandler::softAbort() ;
   }
 
   for (auto *comp : lowSet) {
     if (!dynamic_cast<RooAbsReal*>(comp)) {
       coutE(InputArguments) << "PiecewiseInterpolation::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " in first list is not of type RooAbsReal" << endl ;
+             << " in first list is not of type RooAbsReal" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     _lowSet.add(*comp) ;
@@ -111,7 +109,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char *name, const char *tit
   for (auto *comp : highSet) {
     if (!dynamic_cast<RooAbsReal*>(comp)) {
       coutE(InputArguments) << "PiecewiseInterpolation::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " in first list is not of type RooAbsReal" << endl ;
+             << " in first list is not of type RooAbsReal" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     _highSet.add(*comp) ;
@@ -121,7 +119,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char *name, const char *tit
   for (auto *comp : paramSet) {
     if (!dynamic_cast<RooAbsReal*>(comp)) {
       coutE(InputArguments) << "PiecewiseInterpolation::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " in first list is not of type RooAbsReal" << endl ;
+             << " in first list is not of type RooAbsReal" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     _paramSet.add(*comp) ;
@@ -185,12 +183,12 @@ double PiecewiseInterpolation::evaluate() const
 
   if(_positiveDefinite && (sum<0)){
     sum = 0;
-    //     cout <<"sum < 0 forcing  positive definite"<<endl;
+    //     std::cout <<"sum < 0 forcing  positive definite"<< std::endl;
     //     int code = 1;
     //     RooArgSet* myset = new RooArgSet();
-    //     cout << "integral = " << analyticalIntegralWN(code, myset) << endl;
+    //     std::cout << "integral = " << analyticalIntegralWN(code, myset) << std::endl;
   } else if(sum<0){
-    cxcoutD(Tracing) <<"PiecewiseInterpolation::evaluate -  sum < 0, not forcing positive definite"<<endl;
+    cxcoutD(Tracing) <<"PiecewiseInterpolation::evaluate -  sum < 0, not forcing positive definite"<< std::endl;
   }
   return sum;
 
@@ -250,7 +248,7 @@ bool PiecewiseInterpolation::setBinIntegrator(RooArgSet& allVars)
     temp->specialIntegratorConfig(true)->getConfigSection("RooBinIntegrator").setRealValue("numBins",nbins);
     return true;
   }else{
-    cout << "Currently BinIntegrator only knows how to deal with 1-d "<<endl;
+    std::cout << "Currently BinIntegrator only knows how to deal with 1-d "<< std::endl;
     return false;
   }
   return false;
@@ -263,12 +261,12 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
                         const RooArgSet* normSet, const char* /*rangeName*/) const
 {
   /*
-  cout << "---------------------------\nin PiecewiseInterpolation get analytic integral " <<endl;
-  cout << "all vars = "<<endl;
+  std::cout << "---------------------------\nin PiecewiseInterpolation get analytic integral " << std::endl;
+  std::cout << "all vars = "<< std::endl;
   allVars.Print("v");
-  cout << "anal vars = "<<endl;
+  std::cout << "anal vars = "<< std::endl;
   analVars.Print("v");
-  cout << "normset vars = "<<endl;
+  std::cout << "normset vars = "<< std::endl;
   if(normSet2)
     normSet2->Print("v");
   */
@@ -288,7 +286,7 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
   for (auto it = _paramSet.begin(); it != _paramSet.end(); ++it) {
     if (!_interpCode.empty() && _interpCode[it - _paramSet.begin()] != 0) {
         // can't factorize integral
-        cout << "can't factorize integral" << endl;
+        std::cout << "can't factorize integral" << std::endl;
         return 0;
      }
   }
@@ -336,7 +334,7 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
 double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet* /*normSet2*/,const char* /*rangeName*/) const
 {
   /*
-  cout <<"Enter analytic Integral"<<endl;
+  std::cout <<"Enter analytic Integral"<< std::endl;
   printDirty(true);
   //  _nominal.arg().setDirtyInhibit(true) ;
   _nominal.arg().setShapeDirty() ;
@@ -356,7 +354,7 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
   /*
   RooAbsArg::setDirtyInhibit(true);
   printDirty(true);
-  cout <<"done setting dirty inhibit = true"<<endl;
+  std::cout <<"done setting dirty inhibit = true"<< std::endl;
 
   // old integral, only works for linear and not positive definite
   CacheElem* cache = (CacheElem*) _normIntMgr.getObjByIndex(code-1) ;
@@ -364,7 +362,7 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
 
  std::unique_ptr<RooArgSet> vars2( getParameters(RooArgSet()) );
  std::unique_ptr<RooArgSet> iset(  _normIntMgr.nameSet2ByIndex(code-1)->select(*vars2) );
- cout <<"iset = "<<endl;
+ std::cout <<"iset = "<< std::endl;
  iset->Print("v");
 
   double sum = 0;
@@ -377,10 +375,10 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
     for(int i=0; i<obs->numBins(); ++i){
       obs->setVal( obs->getMin() + (.5+i)*(obs->getMax()-obs->getMin())/obs->numBins());
       sum+=evaluate()*(obs->getMax()-obs->getMin())/obs->numBins();
-      cout << "obs = " << obs->getVal() << " sum = " << sum << endl;
+      std::cout << "obs = " << obs->getVal() << " sum = " << sum << std::endl;
     }
   } else{
-    cout <<"only know how to deal with 1 observable right now"<<endl;
+    std::cout <<"only know how to deal with 1 observable right now"<< std::endl;
   }
   */
 
@@ -399,8 +397,8 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
   /*
   RooAbsArg::setDirtyInhibit(false);
   printDirty(true);
-  cout <<"done"<<endl;
-  cout << "sum = " <<sum<<endl;
+  std::cout <<"done"<< std::endl;
+  std::cout << "sum = " <<sum<< std::endl;
   //return sum;
   */
 
@@ -425,7 +423,7 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
     nominal = value;
     i++;
   }
-  if(i==0 || i>1) { cout << "problem, wrong number of nominal functions"<<endl; }
+  if(i==0 || i>1) { std::cout << "problem, wrong number of nominal functions"<< std::endl; }
 
   // now get low/high variations
   // KC: old interp code with new iterator
@@ -501,13 +499,13 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
 
     } else {
       coutE(InputArguments) << "PiecewiseInterpolation::analyticalIntegralWN ERROR:  " << param->GetName()
-             << " with unknown interpolation code" << endl ;
+             << " with unknown interpolation code" << std::endl ;
     }
     ++i;
   }
   */
 
-  //  cout << "value = " << value <<endl;
+  //  std::cout << "value = " << value << std::endl;
   return value;
 }
 
@@ -554,7 +552,7 @@ void PiecewiseInterpolation::setInterpCodeForParam(int iParam, int code)
 
 void PiecewiseInterpolation::printAllInterpCodes(){
   for(unsigned int i=0; i<_interpCode.size(); ++i){
-    coutI(InputArguments) <<"interp code for " << _paramSet.at(i)->GetName() << " = " << _interpCode.at(i) <<endl;
+    coutI(InputArguments) <<"interp code for " << _paramSet.at(i)->GetName() << " = " << _interpCode.at(i) << std::endl;
   }
 }
 

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -590,7 +590,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::validateAbsMin() const
       if (_paramFixed[par->GetName()] != par->isConstant()) {
    cxcoutI(Minimization) << "RooStats::HistFactory::RooBarlowBeestonLL::evaluate(" << GetName() << ") constant status of parameter " << par->GetName() << " has changed from "
             << (_paramFixed[par->GetName()]?"fixed":"floating") << " to " << (par->isConstant()?"fixed":"floating")
-            << ", recalculating absolute minimum" << endl ;
+            << ", recalculating absolute minimum" << std::endl ;
    _absMinValid = false ;
    break ;
       }
@@ -601,7 +601,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::validateAbsMin() const
   // If we don't have the absolute minimum w.r.t all observables, calculate that first
   if (!_absMinValid) {
 
-    cxcoutI(Minimization) << "RooStats::HistFactory::RooBarlowBeestonLL::evaluate(" << GetName() << ") determining minimum likelihood for current configurations w.r.t all observable" << endl ;
+    cxcoutI(Minimization) << "RooStats::HistFactory::RooBarlowBeestonLL::evaluate(" << GetName() << ") determining minimum likelihood for current configurations w.r.t all observable" << std::endl ;
 
 
     // Save current values of non-marginalized parameters
@@ -649,7 +649,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::validateAbsMin() const
    ccxcoutI(Minimization) << (first?"":", ") << arg->GetName() << "=" << arg->getVal() ;
    first=false ;
       }
-      ccxcoutI(Minimization) << ")" << endl ;
+      ccxcoutI(Minimization) << ")" << std::endl ;
     }
 
     // Restore original parameter values

--- a/roofit/multiprocess/src/ProcessTimer.cxx
+++ b/roofit/multiprocess/src/ProcessTimer.cxx
@@ -17,7 +17,7 @@
 #include <fstream>
 #include <iomanip> // setw
 
-using std::list, std::string, std::invalid_argument, std::cout, std::endl, std::to_string, std::ios;
+using std::list, std::string, std::invalid_argument, std::to_string, std::ios;
 namespace chrono = std::chrono; // alias
 
 namespace RooFit {
@@ -94,7 +94,7 @@ void ProcessTimer::end_timer(string section_name)
 
 void ProcessTimer::print_durations(string to_print)
 {
-   cout << "On PID: " << ProcessTimer::process << endl << "====================" << endl << endl;
+   std::cout << "On PID: " << ProcessTimer::process << std::endl << "====================" << std::endl << std::endl;
    ProcessTimer::duration_map_t::key_type sec_name;
    ProcessTimer::duration_map_t::mapped_type duration_list;
    for (auto const &durations_element : ProcessTimer::durations) {
@@ -104,26 +104,26 @@ void ProcessTimer::print_durations(string to_print)
 
       int i = 0;
       long total_duration = 0;
-      cout << "Section name " << sec_name << ":" << endl;
+      std::cout << "Section name " << sec_name << ":" << std::endl;
       for (auto it = duration_list.begin(); it != duration_list.end(); ++it) {
          long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
-         cout << "Duration " << i << ": " << duration << "ms +" << endl;
+         std::cout << "Duration " << i << ": " << duration << "ms +" << std::endl;
          total_duration += duration;
          i++;
       }
-      cout << "--------------------" << endl << "Total: " << total_duration << "ms" << endl << endl;
+      std::cout << "--------------------" << std::endl << "Total: " << total_duration << "ms" << std::endl << std::endl;
    }
 }
 
 void ProcessTimer::print_timestamps()
 {
-   cout << "On PID: " << ProcessTimer::process << endl;
+   std::cout << "On PID: " << ProcessTimer::process << std::endl;
    ProcessTimer::duration_map_t::key_type sec_name;
    ProcessTimer::duration_map_t::mapped_type duration_list;
    for (auto const &durations_element : ProcessTimer::durations) {
       std::tie(sec_name, duration_list) = durations_element;
       int i = 0;
-      cout << "Section name " << sec_name << ":" << endl;
+      std::cout << "Section name " << sec_name << ":" << std::endl;
       for (auto it = duration_list.begin(); it != duration_list.end(); ++it) {
          long duration_since_begin_start =
             chrono::duration_cast<chrono::milliseconds>(*it - ProcessTimer::begin).count();
@@ -131,8 +131,8 @@ void ProcessTimer::print_timestamps()
          long duration_since_begin_end =
             chrono::duration_cast<chrono::milliseconds>(*std::next(it) - ProcessTimer::begin).count();
 
-         cout << "Duration " << i << ": " << duration_since_begin_start << "ms-->" << duration_since_begin_end << "ms"
-              << endl;
+         std::cout << "Duration " << i << ": " << duration_since_begin_start << "ms-->" << duration_since_begin_end << "ms"
+              << std::endl;
          i++;
       }
    }

--- a/roofit/roofit/src/Roo2DKeysPdf.cxx
+++ b/roofit/roofit/src/Roo2DKeysPdf.cxx
@@ -29,9 +29,7 @@ Two-dimensional kernel estimation PDF.
 #include "TFile.h"
 #include "TMath.h"
 
-//#include <math.h>
-
-using std::cout, std::endl, std::ostream;
+using std::ostream;
 
 ClassImp(Roo2DKeysPdf);
 
@@ -67,7 +65,7 @@ Roo2DKeysPdf::Roo2DKeysPdf(const Roo2DKeysPdf & other, const char* name) :
   x("x", this, other.x),
   y("y", this, other.y)
 {
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::Roo2DKeysPdf copy ctor" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::Roo2DKeysPdf copy ctor" << std::endl; }
 
   _xMean   = other._xMean;
   _xSigma  = other._xSigma;
@@ -114,7 +112,7 @@ Roo2DKeysPdf::Roo2DKeysPdf(const Roo2DKeysPdf & other, const char* name) :
 /// Destructor.
 
 Roo2DKeysPdf::~Roo2DKeysPdf() {
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::Roo2KeysPdf dtor" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::Roo2KeysPdf dtor" << std::endl; }
     delete[] _x;
     delete[] _hx;
     delete[] _y;
@@ -130,18 +128,18 @@ Roo2DKeysPdf::~Roo2DKeysPdf() {
 
 Int_t Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)
 {
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::loadDataSet" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::loadDataSet" << std::endl; }
 
   setOptions(options);
 
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)" << std::endl; }
 
   _2pi       = 2.0*TMath::Pi() ;   //use pi from math.h
   _sqrt2pi   = sqrt(_2pi);
   _nEvents   = (Int_t)data.numEntries();
   if(_nEvents == 0)
   {
-    cout << "ERROR:  Roo2DKeysPdf::loadDataSet The input data set is empty.  Unable to begin generating the PDF" << endl;
+    std::cout << "ERROR:  Roo2DKeysPdf::loadDataSet The input data set is empty.  Unable to begin generating the PDF" << std::endl;
     return 1;
   }
   _n16       =  std::pow(_nEvents, -1./6.); // = (4/[n(dim(R) + 2)])^1/(dim(R)+4); dim(R) = 2
@@ -169,18 +167,18 @@ Int_t Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)
   const RooAbsReal & yy = y.arg();
   if(! static_cast<RooRealVar*>((const_cast<RooArgSet *>(data.get(0)))->find( xx.GetName() )) )
   {
-    cout << "Roo2DKeysPdf::Roo2DKeysPdf invalid RooAbsReal name: "<<xx.GetName()<<" not in the data set" <<endl;
+    std::cout << "Roo2DKeysPdf::Roo2DKeysPdf invalid RooAbsReal name: "<<xx.GetName()<<" not in the data set" << std::endl;
     bad = 1;
   }
   if(! static_cast<RooRealVar*>((const_cast<RooArgSet *>(data.get(0)))->find( yy.GetName() )) )
   {
-    cout << "Roo2DKeysPdf::Roo2DKeysPdf invalid RooAbsReal name: "<<yy.GetName()<<" not in the data set" << endl;
+    std::cout << "Roo2DKeysPdf::Roo2DKeysPdf invalid RooAbsReal name: "<<yy.GetName()<<" not in the data set" << std::endl;
     bad = 1;
   }
   if(bad)
   {
-    cout << "Roo2DKeysPdf::Roo2DKeysPdf Unable to initialize object; incompatible RooDataSet doesn't contain"<<endl;
-    cout << "                           all of the RooAbsReal arguments"<<endl;
+    std::cout << "Roo2DKeysPdf::Roo2DKeysPdf Unable to initialize object; incompatible RooDataSet doesn't contain"<< std::endl;
+    std::cout << "                           all of the RooAbsReal arguments"<< std::endl;
     return 1;
   }
 
@@ -205,7 +203,7 @@ Int_t Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)
   //==========================================//
   if(_nEvents == 0)
   {
-    cout << "Roo2DKeysPdf::Roo2DKeysPdf Empty data set was used; can't generate a PDF"<<endl;
+    std::cout << "Roo2DKeysPdf::Roo2DKeysPdf Empty data set was used; can't generate a PDF"<< std::endl;
   }
 
   _xMean  = x1/x0;
@@ -225,7 +223,7 @@ Int_t Roo2DKeysPdf::loadDataSet(RooDataSet& data, TString options)
 
 void Roo2DKeysPdf::setOptions(TString options)
 {
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::setOptions" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::setOptions" << std::endl; }
 
   options.ToLower();
   if( options.Contains("a") )   _BandWidthType    = 0;
@@ -243,12 +241,12 @@ void Roo2DKeysPdf::setOptions(TString options)
 
   if( _debug )
   {
-    cout << "Roo2DKeysPdf::setOptions(TString options)    options = "<< options << endl;
-    cout << "\t_BandWidthType    = " << _BandWidthType    << endl;
-    cout << "\t_MirrorAtBoundary = " << _MirrorAtBoundary << endl;
-    cout << "\t_debug            = " << _debug            << endl;
-    cout << "\t_verbosedebug     = " << _verbosedebug     << endl;
-    cout << "\t_vverbosedebug    = " << _vverbosedebug    << endl;
+    std::cout << "Roo2DKeysPdf::setOptions(TString options)    options = "<< options << std::endl;
+    std::cout << "\t_BandWidthType    = " << _BandWidthType    << std::endl;
+    std::cout << "\t_MirrorAtBoundary = " << _MirrorAtBoundary << std::endl;
+    std::cout << "\t_debug            = " << _debug            << std::endl;
+    std::cout << "\t_verbosedebug     = " << _verbosedebug     << std::endl;
+    std::cout << "\t_vverbosedebug    = " << _vverbosedebug    << std::endl;
   }
 }
 
@@ -257,12 +255,12 @@ void Roo2DKeysPdf::setOptions(TString options)
 
 void Roo2DKeysPdf::getOptions(void) const
 {
-  cout << "Roo2DKeysPdf::getOptions(void)" << endl;
-  cout << "\t_BandWidthType                           = " << _BandWidthType    << endl;
-  cout << "\t_MirrorAtBoundary                        = " << _MirrorAtBoundary << endl;
-  cout << "\t_debug                                   = " << _debug            << endl;
-  cout << "\t_verbosedebug                            = " << _verbosedebug     << endl;
-  cout << "\t_vverbosedebug                           = " << _vverbosedebug    << endl;
+  std::cout << "Roo2DKeysPdf::getOptions(void)" << std::endl;
+  std::cout << "\t_BandWidthType                           = " << _BandWidthType    << std::endl;
+  std::cout << "\t_MirrorAtBoundary                        = " << _MirrorAtBoundary << std::endl;
+  std::cout << "\t_debug                                   = " << _debug            << std::endl;
+  std::cout << "\t_verbosedebug                            = " << _verbosedebug     << std::endl;
+  std::cout << "\t_vverbosedebug                           = " << _vverbosedebug    << std::endl;
 }
 
 
@@ -272,7 +270,7 @@ void Roo2DKeysPdf::getOptions(void) const
 
 Int_t Roo2DKeysPdf::calculateBandWidth(Int_t kernel)
 {
-  if(_verbosedebug) { cout << "Roo2DKeysPdf::calculateBandWidth(Int_t kernel)" << endl; }
+  if(_verbosedebug) { std::cout << "Roo2DKeysPdf::calculateBandWidth(Int_t kernel)" << std::endl; }
   if(kernel != -999)
   {
     _BandWidthType = kernel;
@@ -286,7 +284,7 @@ Int_t Roo2DKeysPdf::calculateBandWidth(Int_t kernel)
   if(sigProd != 0.0)  h = _n16*sqrt( sigSum/sigProd );
   if(sqrtSum == 0)
   {
-    cout << "Roo2DKeysPdf::calculateBandWidth The sqr(variance sum) == 0.0. " << " Your dataset represents a delta function."<<endl;
+    std::cout << "Roo2DKeysPdf::calculateBandWidth The sqr(variance sum) == 0.0. " << " Your dataset represents a delta function."<< std::endl;
     return 1;
   }
 
@@ -300,8 +298,8 @@ Int_t Roo2DKeysPdf::calculateBandWidth(Int_t kernel)
   //////////////////////////////////////
   if(_BandWidthType == 1)  //calculate a trivial bandwidth
   {
-    cout << "Roo2DKeysPdf::calculateBandWidth Using a normal bandwidth (same for a given dimension) based on"<<endl;
-    cout << "                                 h_j = n^{-1/6}*sigma_j for the j^th dimension and n events * "<<_widthScaleFactor<<endl;
+    std::cout << "Roo2DKeysPdf::calculateBandWidth Using a normal bandwidth (same for a given dimension) based on"<< std::endl;
+    std::cout << "                                 h_j = n^{-1/6}*sigma_j for the j^th dimension and n events * "<<_widthScaleFactor<< std::endl;
     double hxGaussian = _n16 * _xSigma * _widthScaleFactor;
     double hyGaussian = _n16 * _ySigma * _widthScaleFactor;
     for(Int_t j=0;j<_nEvents;++j)
@@ -314,8 +312,8 @@ Int_t Roo2DKeysPdf::calculateBandWidth(Int_t kernel)
   }
   else //use an adaptive bandwidth to reduce the dependence on global data distribution
   {
-    cout << "Roo2DKeysPdf::calculateBandWidth Using an adaptive bandwidth (in general different for all events) [default]"<<endl;
-    cout << "                                 scaled by a factor of "<<_widthScaleFactor<<endl;
+    std::cout << "Roo2DKeysPdf::calculateBandWidth Using an adaptive bandwidth (in general different for all events) [default]"<< std::endl;
+    std::cout << "                                 scaled by a factor of "<<_widthScaleFactor<< std::endl;
     double xnorm   = h * std::pow(_xSigma/sqrtSum, 1.5) * _widthScaleFactor;
     double ynorm   = h * std::pow(_ySigma/sqrtSum, 1.5) * _widthScaleFactor;
     for(Int_t j=0;j<_nEvents;++j)
@@ -341,7 +339,7 @@ Int_t Roo2DKeysPdf::calculateBandWidth(Int_t kernel)
 
 double Roo2DKeysPdf::evaluate() const
 {
-  if(_vverbosedebug) { cout << "Roo2DKeysPdf::evaluate()" << endl; }
+  if(_vverbosedebug) { std::cout << "Roo2DKeysPdf::evaluate()" << std::endl; }
   return evaluateFull(x,y);
 }
 
@@ -357,7 +355,7 @@ double Roo2DKeysPdf::evaluate() const
 
 double Roo2DKeysPdf::evaluateFull(double thisX, double thisY) const
 {
-  if( _vverbosedebug ) { cout << "Roo2DKeysPdf::evaluateFull()" << endl; }
+  if( _vverbosedebug ) { std::cout << "Roo2DKeysPdf::evaluateFull()" << std::endl; }
 
   double f=0.0;
 
@@ -413,7 +411,7 @@ double Roo2DKeysPdf::evaluateFull(double thisX, double thisY) const
 
 double Roo2DKeysPdf::highBoundaryCorrection(double thisVar, double thisH, double high, double tVar) const
 {
-  if(_vverbosedebug) { cout << "Roo2DKeysPdf::highBoundaryCorrection" << endl; }
+  if(_vverbosedebug) { std::cout << "Roo2DKeysPdf::highBoundaryCorrection" << std::endl; }
 
   if(thisH == 0.0) return 0.0;
   double correction = (thisVar + tVar - 2.0* high )/thisH;
@@ -425,7 +423,7 @@ double Roo2DKeysPdf::highBoundaryCorrection(double thisVar, double thisH, double
 
 double Roo2DKeysPdf::lowBoundaryCorrection(double thisVar, double thisH, double low, double tVar) const
 {
-  if(_vverbosedebug) { cout << "Roo2DKeysPdf::lowBoundaryCorrection" << endl; }
+  if(_vverbosedebug) { std::cout << "Roo2DKeysPdf::lowBoundaryCorrection" << std::endl; }
 
   if(thisH == 0.0) return 0.0;
   double correction = (thisVar + tVar - 2.0* low )/thisH;
@@ -467,8 +465,8 @@ double Roo2DKeysPdf::g(double varMean1, double * _var1, double sigma1, double va
 
 Int_t Roo2DKeysPdf::getBandWidthType() const
 {
-  if(_BandWidthType == 1)  cout << "The Bandwidth Type selected is Trivial" << endl;
-  else                     cout << "The Bandwidth Type selected is Adaptive" << endl;
+  if(_BandWidthType == 1)  std::cout << "The Bandwidth Type selected is Trivial" << std::endl;
+  else                     std::cout << "The Bandwidth Type selected is Adaptive" << std::endl;
 
   return _BandWidthType;
 }
@@ -482,7 +480,7 @@ double Roo2DKeysPdf::getMean(const char * axis) const
   else if(!strcmp(axis,y.GetName()) || !strcmp(axis,"y") || !strcmp(axis,"Y")) return _yMean;
   else
   {
-    cout << "Roo2DKeysPdf::getMean unknown axis "<<axis<<endl;
+    std::cout << "Roo2DKeysPdf::getMean unknown axis "<<axis<< std::endl;
   }
   return 0.0;
 }
@@ -496,7 +494,7 @@ double Roo2DKeysPdf::getSigma(const char * axis) const
   else if(!strcmp(axis,y.GetName()) || !strcmp(axis,"y") || !strcmp(axis,"Y")) return _ySigma;
   else
   {
-    cout << "Roo2DKeysPdf::getSigma unknown axis "<<axis<<endl;
+    std::cout << "Roo2DKeysPdf::getSigma unknown axis "<<axis<< std::endl;
   }
   return 0.0;
 }
@@ -524,12 +522,12 @@ void Roo2DKeysPdf::writeToFile(char * outputFile, const char * name) const
 
 void Roo2DKeysPdf::writeHistToFile(char * outputFile, const char * histName) const
 {
-  cout << "Roo2DKeysPdf::writeHistToFile This member function is temporarily disabled" <<endl;
+  std::cout << "Roo2DKeysPdf::writeHistToFile This member function is temporarily disabled" << std::endl;
   //make sure that any existing file is not over written
   std::unique_ptr<TFile> file{TFile::Open(outputFile, "UPDATE")};
   if (!file)
   {
-    cout << "Roo2DKeysPdf::writeHistToFile unable to open file "<< outputFile <<endl;
+    std::cout << "Roo2DKeysPdf::writeHistToFile unable to open file "<< outputFile << std::endl;
     return;
   }
 
@@ -564,7 +562,7 @@ void Roo2DKeysPdf::writeNTupleToFile(char * outputFile, const char * name) const
   file = new TFile(outputFile, "UPDATE");
   if (!file)
   {
-    cout << "Roo2DKeysPdf::writeNTupleToFile unable to open file "<< outputFile <<endl;
+    std::cout << "Roo2DKeysPdf::writeNTupleToFile unable to open file "<< outputFile << std::endl;
     return;
   }
   RooAbsReal & xArg = (RooAbsReal&)x.arg();
@@ -576,7 +574,7 @@ void Roo2DKeysPdf::writeNTupleToFile(char * outputFile, const char * name) const
   TString label = name;
   label += " the source data for 2D Keys PDF";
   TTree * _theTree =  new TTree(name, label);
-  if(!_theTree) { cout << "Unable to get a TTree for output" << endl; return; }
+  if(!_theTree) { std::cout << "Unable to get a TTree for output" << std::endl; return; }
   _theTree->SetAutoSave(1000000000);  // autosave when 1 Gbyte written
 
   //name the TBranches the same as the RooAbsReal's
@@ -609,17 +607,17 @@ void Roo2DKeysPdf::writeNTupleToFile(char * outputFile, const char * name) const
 
 void Roo2DKeysPdf::PrintInfo(ostream & out) const
 {
-  out << "Roo2DKeysPDF instance domain information:"<<endl;
-  out << "\tX_min          = " << _lox <<endl;
-  out << "\tX_max          = " << _hix <<endl;
-  out << "\tY_min          = " << _loy <<endl;
-  out << "\tY_max          = " << _hiy <<endl;
+  out << "Roo2DKeysPDF instance domain information:"<< std::endl;
+  out << "\tX_min          = " << _lox << std::endl;
+  out << "\tX_max          = " << _hix << std::endl;
+  out << "\tY_min          = " << _loy << std::endl;
+  out << "\tY_max          = " << _hiy << std::endl;
 
-  out << "Data information:" << endl;
-  out << "\t<x>             = " << _xMean <<endl;
-  out << "\tsigma(x)       = " << _xSigma <<endl;
-  out << "\t<y>             = " << _yMean <<endl;
-  out << "\tsigma(y)       = " << _ySigma <<endl;
+  out << "Data information:" << std::endl;
+  out << "\t<x>             = " << _xMean << std::endl;
+  out << "\tsigma(x)       = " << _xSigma << std::endl;
+  out << "\t<y>             = " << _yMean << std::endl;
+  out << "\tsigma(y)       = " << _ySigma << std::endl;
 
-  out << "END of info for Roo2DKeys pdf instance"<< endl;
+  out << "END of info for Roo2DKeys pdf instance"<< std::endl;
 }

--- a/roofit/roofit/src/RooArgusBG.cxx
+++ b/roofit/roofit/src/RooArgusBG.cxx
@@ -116,7 +116,7 @@ double RooArgusBG::analyticalIntegral(Int_t code, const char* rangeName) const
     aHigh = 0.5*m0*m0*exp(c*f2)/(c*sqrt(c)) * (0.5*sqrt(pi)*(RooMath::faddeeva(sqrt(c*f2))).imag() - sqrt(c*f2));
   }
   double area = aHigh - aLow;
-  //cout << "c = " << c << "aHigh = " << aHigh << " aLow = " << aLow << " area = " << area << endl ;
+  //cout << "c = " << c << "aHigh = " << aHigh << " aLow = " << aLow << " area = " << area << std::endl ;
   return area;
 
 }

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -32,8 +32,6 @@ be analytically convolved with any RooResolutionModel implementation.
 
 #include "TError.h"
 
-using std::cout, std::endl;
-
 ClassImp(RooBDecay);
 
 /// \brief Constructor for RooBDecay.
@@ -234,16 +232,16 @@ void RooBDecay::generateEvent(Int_t code)
     double ft = std::abs(t);
     double f = exp(-ft/_tau)*(_f0*cosh(dgt)+_f1*sinh(dgt)+_f2*cos(dmt)+_f3*sin(dmt));
     if(f < 0) {
-      cout << "RooBDecay::generateEvent(" << GetName() << ") ERROR: PDF value less than zero" << endl;
+      std::cout << "RooBDecay::generateEvent(" << GetName() << ") ERROR: PDF value less than zero" << std::endl;
       ::abort();
     }
     double w = 1.001*exp(-ft*gammamin)*(std::abs(_f0)+std::abs(_f1)+sqrt(_f2*_f2+_f3*_f3));
     if(w < f) {
-      cout << "RooBDecay::generateEvent(" << GetName() << ") ERROR: Envelope function less than p.d.f. " << endl;
-      cout << _f0 << endl;
-      cout << _f1 << endl;
-      cout << _f2 << endl;
-      cout << _f3 << endl;
+      std::cout << "RooBDecay::generateEvent(" << GetName() << ") ERROR: Envelope function less than p.d.f. " << std::endl;
+      std::cout << _f0 << std::endl;
+      std::cout << _f1 << std::endl;
+      std::cout << _f2 << std::endl;
+      std::cout << _f3 << std::endl;
       ::abort();
     }
     if(w*RooRandom::uniform() > f) continue;

--- a/roofit/roofit/src/RooBMixDecay.cxx
+++ b/roofit/roofit/src/RooBMixDecay.cxx
@@ -127,7 +127,7 @@ void RooBMixDecay::doEval(RooFit::EvalContext &ctx) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///   cout << "RooBMixDecay::getCoefAI " ; allVars.Print("1") ;
+///   std::cout << "RooBMixDecay::getCoefAI " ; allVars.Print("1") ;
 
 Int_t RooBMixDecay::getCoefAnalyticalIntegral(Int_t /*code*/, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName) const
 {

--- a/roofit/roofit/src/RooBlindTools.cxx
+++ b/roofit/roofit/src/RooBlindTools.cxx
@@ -30,8 +30,6 @@
 #include <cstring>
 #include <cctype>
 
-using std::cout, std::endl;
-
 ClassImp(RooBlindTools);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -309,7 +307,7 @@ double RooBlindTools::Randomizer(const char *StringAlphabet) const{
   }
 
   if (lengthSeed<5 || ((sumSeed<1 || sumSeed>8000)&&!_s2bMode)) {
-    cout<< "RooBlindTools::Randomizer: Your String Seed is Bad: '" << _stSeed << "'" << endl ;
+    std::cout<< "RooBlindTools::Randomizer: Your String Seed is Bad: '" << _stSeed << "'" << std::endl ;
     RooErrorHandler::softAbort() ;
   }
 
@@ -332,7 +330,7 @@ double RooBlindTools::Randomizer(const char *StringAlphabet) const{
 
 double RooBlindTools::PseudoRandom(Int_t Seed) const{
   if (Seed<1 || Seed>8000 ) {
-    cout<< "RooBlindTools::PseudoRandom: Your integer Seed is Bad" <<endl;
+    std::cout<< "RooBlindTools::PseudoRandom: Your integer Seed is Bad" << std::endl;
   }
 
   Int_t ia = 8121;

--- a/roofit/roofit/src/RooFunctorBinding.cxx
+++ b/roofit/roofit/src/RooFunctorBinding.cxx
@@ -61,7 +61,7 @@ RooFunctorBinding::RooFunctorBinding(const char *name, const char *title, const 
   // Check that function dimension and number of variables match
   if (ftor.NDim()!=UInt_t(v.size())) {
     coutE(InputArguments) << "RooFunctorBinding::ctor(" << GetName() << ") ERROR number of provided variables (" << v.size()
-           << ") does not match dimensionality of function (" << ftor.NDim() << ")" << endl ;
+           << ") does not match dimensionality of function (" << ftor.NDim() << ")" << std::endl ;
     throw string("RooFunctor::ctor ERROR") ;
   }
   x = new double[func->NDim()] ;
@@ -113,7 +113,7 @@ RooFunctorPdfBinding::RooFunctorPdfBinding(const char *name, const char *title, 
   // Check that function dimension and number of variables match
   if (ftor.NDim()!=UInt_t(v.size())) {
     coutE(InputArguments) << "RooFunctorPdfBinding::ctor(" << GetName() << ") ERROR number of provided variables (" << v.size()
-           << ") does not match dimensionality of function (" << ftor.NDim() << ")" << endl ;
+           << ") does not match dimensionality of function (" << ftor.NDim() << ")" << std::endl ;
     throw string("RooFunctor::ctor ERROR") ;
   }
   x = new double[func->NDim()] ;

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -283,7 +283,7 @@ RooIntegralMorph::MorphCacheElem::~MorphCacheElem()
 double RooIntegralMorph::MorphCacheElem::calcX(double y, bool& ok)
 {
   if (y<0 || y>1) {
-    oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calcX() WARNING: requested root finding for unphysical CDF value " << y << endl ;
+    oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calcX() WARNING: requested root finding for unphysical CDF value " << y << std::endl ;
   }
   double x1;
   double x2;
@@ -385,7 +385,7 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
     if (std::abs(xOffset/binw)>1e-3) {
       double slope = (_yatX[i+1]-_yatX[i-1])/(_calcX[i+1]-_calcX[i-1]) ;
       double newY = _yatX[i] + slope*xOffset ;
-      //cout << "bin " << i << " needs to be re-centered " << xOffset/binw << " slope = " << slope << " origY = " << _yatX[i] << " newY = " << newY << endl ;
+      //cout << "bin " << i << " needs to be re-centered " << xOffset/binw << " slope = " << slope << " origY = " << _yatX[i] << " newY = " << newY << std::endl ;
       _yatX[i] = newY ;
     }
   }
@@ -434,7 +434,7 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
   pdf()->setUnitNorm(true) ;
   _self->x = xsave ;
 
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName() << ") calculation required " << _ccounter << " samplings of cdfs" << endl ;
+  oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName() << ") calculation required " << _ccounter << " samplings of cdfs" << std::endl ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -446,15 +446,15 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
 void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double splitPoint)
 {
   // CONVENTION: _yatX[ixlo] is filled, _yatX[ixhi] is filled, elements in between are empty
-  //   cout << "fillGap: gap from _yatX[" << ixlo << "]=" << _yatX[ixlo] << " to _yatX[" << ixhi << "]=" << _yatX[ixhi] << ", size = " << ixhi-ixlo << endl ;
+  //   std::cout << "fillGap: gap from _yatX[" << ixlo << "]=" << _yatX[ixlo] << " to _yatX[" << ixhi << "]=" << _yatX[ixhi] << ", size = " << ixhi-ixlo << std::endl ;
 
   if (_yatX[ixlo]<0) {
     oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap " << ixlo << " = " << ixhi
-         << " splitPoint= " << splitPoint << " _yatX[ixlo] = " << _yatX[ixlo] << endl ;
+         << " splitPoint= " << splitPoint << " _yatX[ixlo] = " << _yatX[ixlo] << std::endl ;
   }
   if (_yatX[ixhi]<0) {
     oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap " << ixlo << " = " << ixhi
-         << " splitPoint " << splitPoint << " _yatX[ixhi] = " << _yatX[ixhi] << endl ;
+         << " splitPoint " << splitPoint << " _yatX[ixhi] = " << _yatX[ixhi] << std::endl ;
   }
 
   // Determine where half-way Y value lands
@@ -463,7 +463,7 @@ void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double sp
   double Xmid = calcX(ymid,ok) ;
   if (!ok) {
     oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::fillGap(" << _self->GetName() << ") unable to calculate midpoint in gap ["
-         << ixlo << "," << ixhi << "], resorting to interpolation" << endl ;
+         << ixlo << "," << ixhi << "], resorting to interpolation" << std::endl ;
     interpolateGap(ixlo,ixhi) ;
   }
 
@@ -529,7 +529,7 @@ void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double sp
 
 void RooIntegralMorph::MorphCacheElem::interpolateGap(Int_t ixlo, Int_t ixhi)
 {
-  //cout << "filling gap with linear interpolation ixlo=" << ixlo << " ixhi=" << ixhi << endl ;
+  //cout << "filling gap with linear interpolation ixlo=" << ixlo << " ixhi=" << ixhi << std::endl ;
 
   double xmax = _x->getMax("cache") ;
   double xmin = _x->getMin("cache") ;
@@ -575,7 +575,7 @@ void RooIntegralMorph::MorphCacheElem::findRange()
   while(true) {
     ok &= _rf1->findRoot(x1,xmin,xmax,ymin) ;
     ok &= _rf2->findRoot(x2,xmin,xmax,ymin) ;
-    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMin: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << endl ;
+    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMin: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << std::endl ;
 
     // Terminate in case of non-convergence
     if (!ok) break ;
@@ -613,7 +613,7 @@ void RooIntegralMorph::MorphCacheElem::findRange()
     ok &= _rf1->findRoot(x1,xmin,xmax,1-deltaymax) ;
     ok &= _rf2->findRoot(x2,xmin,xmax,1-deltaymax) ;
 
-    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMax: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << endl ;
+    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMax: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << std::endl ;
 
     // Terminate in case of non-convergence
     if (!ok) break ;
@@ -646,8 +646,8 @@ void RooIntegralMorph::MorphCacheElem::findRange()
   // Initialize values out of range to 'out-of-range' (-2)
   for (int i=0 ; i<_yatXmin ; i++)  _yatX[i] = -2 ;
   for (int i=_yatXmax+1 ; i<nbins; i++) _yatX[i] = -2 ;
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): ymin = " << _yatX[_yatXmin] << " ymax = " << _yatX[_yatXmax] << endl;
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): xmin = " << _calcX[_yatXmin] << " xmax = " << _calcX[_yatXmax] << endl;
+  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): ymin = " << _yatX[_yatXmin] << " ymax = " << _yatX[_yatXmax] << std::endl;
+  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): xmin = " << _calcX[_yatXmin] << " xmax = " << _calcX[_yatXmax] << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooKeysPdf.cxx
+++ b/roofit/roofit/src/RooKeysPdf.cxx
@@ -280,13 +280,13 @@ double RooKeysPdf::evaluate() const {
   if (i<0) {
 //     cerr << "got point below lower bound:"
 //     << double(_x) << " < " << _lo
-//     << " -- performing linear extrapolation..." << endl;
+//     << " -- performing linear extrapolation..." << std::endl;
     i=0;
   }
   if (i>_nPoints-1) {
 //     cerr << "got point above upper bound:"
 //     << double(_x) << " > " << _hi
-//     << " -- performing linear extrapolation..." << endl;
+//     << " -- performing linear extrapolation..." << std::endl;
     i=_nPoints-1;
   }
   double dx = (double(_x)-(_lo+i*_binWidth))/_binWidth;

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -73,7 +73,7 @@ describe the same process or not.
 #include <type_traits>
 #include <typeinfo>
 
-using std::cerr, std::string, std::make_unique, std::vector;
+using std::string, std::make_unique, std::vector;
 
 ClassImp(RooLagrangianMorphFunc);
 
@@ -145,7 +145,7 @@ inline void writeMatrixToFileT(const MatrixT &matrix, const char *fname)
 {
    std::ofstream of(fname);
    if (!of.good()) {
-      cerr << "unable to read file '" << fname << "'!" << std::endl;
+      std::cerr << "unable to read file '" << fname << "'!" << std::endl;
    }
    writeMatrixToStreamT(matrix, of);
    of.close();
@@ -612,7 +612,7 @@ inline void extractServers(const RooAbsArg &coupling, T2 &operators)
 template <class T1, class T2, typename std::enable_if<!is_specialization<T1, std::vector>::value, T1>::type * = nullptr>
 inline void extractOperators(const T1 &couplings, T2 &operators)
 {
-   // coutD(InputArguments) << "extracting operators from
+   // std::coutD(InputArguments) << "extracting operators from
    // "<<couplings.size()<<" couplings" << std::endl;
    for (auto itr : couplings) {
       extractServers(*itr, operators);
@@ -638,7 +638,7 @@ inline void extractCouplings(const T1 &inCouplings, T2 &outCouplings)
 {
    for (auto itr : inCouplings) {
       if (!outCouplings.find(itr->GetName())) {
-         // coutD(InputArguments) << "adding parameter "<< obj->GetName() <<
+         // std::coutD(InputArguments) << "adding parameter "<< obj->GetName() <<
          // std::endl;
          outCouplings.add(*itr);
       }

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -30,7 +30,7 @@
 #include "TMath.h"
 #include "TH1.h"
 
-using std::cout, std::endl, std::string, std::vector;
+using std::string, std::vector;
 
 ClassImp(RooMomentMorphFunc)
 
@@ -84,12 +84,12 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
    for (auto *mref : mrefList) {
       if (!dynamic_cast<RooAbsReal *>(mref)) {
          coutE(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") ERROR: mref " << mref->GetName()
-                               << " is not of type RooAbsReal" << endl;
+                               << " is not of type RooAbsReal" << std::endl;
          throw string("RooPolyMorh::ctor() ERROR mref is not of type RooAbsReal");
       }
       if (!dynamic_cast<RooConstVar *>(mref)) {
          coutW(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") WARNING mref point " << i
-                               << " is not a constant, taking a snapshot of its value" << endl;
+                               << " is not a constant, taking a snapshot of its value" << std::endl;
       }
       (*_mref)[i] = static_cast<RooAbsReal *>(mref)->getVal();
       ++i;
@@ -132,7 +132,7 @@ void RooMomentMorphFunc::initialize()
 
    // other quantities needed
    if (nPdf != _mref->GetNrows()) {
-      coutE(InputArguments) << "RooMomentMorphFunc::initialize(" << GetName() << ") ERROR: nPdf != nRefPoints" << endl;
+      coutE(InputArguments) << "RooMomentMorphFunc::initialize(" << GetName() << ") ERROR: nPdf != nRefPoints" << std::endl;
       assert(0);
    }
 
@@ -387,7 +387,7 @@ void RooMomentMorphFunc::CacheElem::calculateFractions(const RooMomentMorphFunc 
       // fractions for rms and mean
       const_cast<RooRealVar *>(frac(nPdf + i))->setVal(ffrac);
       if (verbose) {
-         cout << ffrac << endl;
+         std::cout << ffrac << std::endl;
       }
    }
 

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -40,7 +40,7 @@
 #include <algorithm>
 #include <map>
 
-using std::cout, std::endl, std::string, std::vector;
+using std::string, std::vector;
 
 ClassImp(RooMomentMorphFuncND);
 ClassImp(RooMomentMorphFuncND::Grid2);
@@ -134,12 +134,12 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const char *name, const char *title, 
    for (auto *mref : mrefList) {
       if (!dynamic_cast<RooAbsReal *>(mref)) {
          coutE(InputArguments) << "RooMomentMorphFuncND::ctor(" << GetName() << ") ERROR: mref " << mref->GetName()
-                               << " is not of type RooAbsReal" << endl;
+                               << " is not of type RooAbsReal" << std::endl;
          throw string("RooMomentMorphFuncND::ctor() ERROR mref is not of type RooAbsReal");
       }
       if (!dynamic_cast<RooConstVar *>(mref)) {
          coutW(InputArguments) << "RooMomentMorphFuncND::ctor(" << GetName() << ") WARNING mref point " << i
-                               << " is not a constant, taking a snapshot of its value" << endl;
+                               << " is not a constant, taking a snapshot of its value" << std::endl;
       }
       mrefpoints[i] = static_cast<RooAbsReal *>(mref)->getVal();
       i++;
@@ -212,13 +212,13 @@ void RooMomentMorphFuncND::initialize()
 
    if (nPar != nDim) {
       coutE(InputArguments) << "RooMomentMorphFuncND::initialize(" << GetName() << ") ERROR: nPar != nDim"
-                            << ": " << nPar << " !=" << nDim << endl;
+                            << ": " << nPar << " !=" << nDim << std::endl;
       assert(0);
    }
 
    if (nPdf != nRef) {
       coutE(InputArguments) << "RooMomentMorphFuncND::initialize(" << GetName() << ") ERROR: nPdf != nRef"
-                            << ": " << nPdf << " !=" << nRef << endl;
+                            << ": " << nPdf << " !=" << nRef << std::endl;
       assert(0);
    }
 
@@ -621,7 +621,7 @@ void RooMomentMorphFuncND::CacheElem::calculateFractions(const RooMomentMorphFun
          const_cast<RooRealVar *>(frac(2 * nPdf + i))->setVal(ffrac); // need to add up
 
          if (verbose) {
-            cout << "NonLinear fraction " << ffrac << endl;
+            std::cout << "NonLinear fraction " << ffrac << std::endl;
             frac(i)->Print();
             frac(nPdf + i)->Print();
             frac(2 * nPdf + i)->Print();
@@ -699,7 +699,7 @@ void RooMomentMorphFuncND::CacheElem::calculateFractions(const RooMomentMorphFun
          }
 
          if (verbose) {
-            cout << "Linear fraction " << ffrac << endl;
+            std::cout << "Linear fraction " << ffrac << std::endl;
             frac(self._squareIdx[i])->Print();
             frac(nPdf + self._squareIdx[i])->Print();
             frac(2 * nPdf + self._squareIdx[i])->Print();
@@ -723,7 +723,7 @@ void RooMomentMorphFuncND::findShape(const vector<double> &x) const
    //       isEnclosed = false;
    // }
 
-   // cout << "isEnclosed = " << isEnclosed << endl;
+   // std::cout << "isEnclosed = " << isEnclosed << std::endl;
 
    int depth = std::pow(2, nPar);
 
@@ -749,15 +749,15 @@ void RooMomentMorphFuncND::findShape(const vector<double> &x) const
       }
    }
 
-   // cout << endl;
+   // std::cout << std::endl;
 
    // for (int isq = 0; isq < _squareVec.size(); isq++) {
-   //   cout << _squareIdx[isq];
-   //   cout << " (";
+   //   std::cout << _squareIdx[isq];
+   //   std::cout << " (";
    //   for (int isqq = 0; isqq < _squareVec[isq].size(); isqq++) {
-   //     cout << _squareVec[isq][isqq] << ((isqq<_squareVec[isq].size()-1)?",":"");
+   //     std::cout << _squareVec[isq][isqq] << ((isqq<_squareVec[isq].size()-1)?",":"");
    //   }
-   //   cout << ") ";
+   //   std::cout << ") ";
    // }
 
    // construct transformation matrix for linear extrapolation
@@ -801,7 +801,7 @@ bool RooMomentMorphFuncND::setBinIntegrator(RooArgSet &allVars)
       temp->specialIntegratorConfig(true)->getConfigSection("RooBinIntegrator").setRealValue("numBins", nbins);
       return true;
    } else {
-      cout << "Currently BinIntegrator only knows how to deal with 1-d " << endl;
+      std::cout << "Currently BinIntegrator only knows how to deal with 1-d " << std::endl;
       return false;
    }
    return false;

--- a/roofit/roofit/src/RooMultiBinomial.cxx
+++ b/roofit/roofit/src/RooMultiBinomial.cxx
@@ -57,7 +57,7 @@ RooMultiBinomial::RooMultiBinomial(const char *name, const char *title,
   _effFuncList.add(effFuncList);
 
   if (_catList.size() != effFuncList.size()) {
-    coutE(InputArguments) << "RooMultiBinomial::ctor(" << GetName() << ") ERROR: Wrong input, should have equal number of categories and efficiencies." << endl;
+    coutE(InputArguments) << "RooMultiBinomial::ctor(" << GetName() << ") ERROR: Wrong input, should have equal number of categories and efficiencies." << std::endl;
     throw string("RooMultiBinomial::ctor() ERROR: Wrong input, should have equal number of categories and efficiencies") ;
   }
 
@@ -94,12 +94,12 @@ double RooMultiBinomial::evaluate() const
   for (int i=0; i<effFuncListSize; ++i) {
     if (effFuncVal[i]>1) {
       coutW(Eval) << "WARNING: Efficiency >1 (equal to " << effFuncVal[i]
-        << " ), for i = " << i << "...TRUNCATED" << endl;
+        << " ), for i = " << i << "...TRUNCATED" << std::endl;
       effFuncVal[i] = 1.0 ;
     } else if (effFuncVal[i]<0) {
       effFuncVal[i] = 0.0 ;
       coutW(Eval) << "WARNING: Efficiency <0 (equal to " << effFuncVal[i]
-        << " ), for i = " << i << "...TRUNCATED" << endl;
+        << " ), for i = " << i << "...TRUNCATED" << std::endl;
     }
   }
 
@@ -117,7 +117,7 @@ double RooMultiBinomial::evaluate() const
       // Reject case
       effValue[i] = 1 - effFuncVal[i] ;
     } else {
-      coutW(Eval) << "WARNING: WRONG CATEGORY NAMES GIVEN!, label = " << (static_cast<RooAbsCategory&>(_catList[i])).getCurrentIndex() << endl;
+      coutW(Eval) << "WARNING: WRONG CATEGORY NAMES GIVEN!, label = " << (static_cast<RooAbsCategory&>(_catList[i])).getCurrentIndex() << std::endl;
       effValue[i] = 0;
     }
   }

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -42,7 +42,7 @@ in the input dataset.
 
 #include "TError.h"
 
-using std::cout, std::endl, std::string, std::vector, std::pair, std::map;
+using std::string, std::vector, std::pair, std::map;
 
 ClassImp(RooNDKeysPdf);
 
@@ -108,7 +108,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
   if(int( _varList.size()) != rho.GetNrows() ) {
      coutE(InputArguments)
         << "ERROR:  RooNDKeysPdf::RooNDKeysPdf() : The vector-size of rho is different from that of varList."
-        << "Unable to create the PDF." << endl;
+        << "Unable to create the PDF." << std::endl;
      R__ASSERT(int(_varList.size()) == rho.GetNrows());
   }
 
@@ -117,7 +117,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
   // and that _rho has already been set ...
   _rho.resize( rho.GetNrows() );
   for (Int_t j = 0; j < rho.GetNrows(); j++) {
-     _rho[j] = rho[j]; /*cout<<"RooNDKeysPdf ctor, _rho["<<j<<"]="<<_rho[j]<<endl;*/
+     _rho[j] = rho[j]; /*cout<<"RooNDKeysPdf ctor, _rho["<<j<<"]="<<_rho[j]<< std::endl;*/
   }
 
   createPdf(true, data); // calls initialize ...
@@ -141,7 +141,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
       const auto rho = rhoList.at(i);
       if (!dynamic_cast<const RooAbsReal *>(rho)) {
          coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: parameter " << rho->GetName()
-                               << " is not of type RooRealVar" << endl;
+                               << " is not of type RooRealVar" << std::endl;
          assert(0);
       }
       _rhoList.add(*rho);
@@ -151,7 +151,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
    // copy rho widths
    if ((_varList.size() != _rhoList.size())) {
       coutE(InputArguments) << "ERROR:  RooNDKeysPdf::RooNDKeysPdf() : The size of rhoList is different from varList."
-                            << "Unable to create the PDF." << endl;
+                            << "Unable to create the PDF." << std::endl;
       assert(_varList.size() == _rhoList.size());
    }
 
@@ -181,7 +181,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
       const auto rho = rhoList.at(i);
       if (!dynamic_cast<RooAbsReal *>(rho)) {
          coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: parameter " << rho->GetName()
-                               << " is not of type RooRealVar" << endl;
+                               << " is not of type RooRealVar" << std::endl;
          assert(0);
       }
       _rhoList.add(*rho);
@@ -190,7 +190,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 
    if ((_varList.size() != _rhoList.size())) {
       coutE(InputArguments) << "ERROR:  RooNDKeysPdf::RooNDKeysPdf() : The size of rhoList is different from varList."
-                            << "Unable to create the PDF." << endl;
+                            << "Unable to create the PDF." << std::endl;
       assert(_varList.size() == _rhoList.size());
    }
 
@@ -215,7 +215,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, c
    if (mirror != NoMirror) {
       if (mirror != MirrorBoth) {
          coutW(InputArguments) << "RooNDKeysPdf::RooNDKeysPdf() : Warning : asymmetric mirror(s) no longer supported."
-                               << endl;
+                               << std::endl;
       }
       _options = "m";
    }
@@ -384,12 +384,12 @@ void RooNDKeysPdf::setOptions()
          << "\n\tmirror           = " << _mirror
          << "\n\tdebug            = " << _debug
          << "\n\tverbose          = " << _verbose
-         << endl;
+         << std::endl;
 
   if (_nSigma<2.0) {
     coutW(InputArguments) << "RooNDKeysPdf::setOptions() : Warning : nSigma = " << _nSigma << " < 2.0. "
            << "Calculated normalization could be too large."
-           << endl;
+           << std::endl;
   }
 
   // number of adaptive width iterations. Default is 1.
@@ -416,13 +416,13 @@ void RooNDKeysPdf::initialize(RooDataSet const& data)
 
   if(_nDim==0) {
     coutE(InputArguments) << "ERROR:  RooNDKeysPdf::initialize() : The observable list is empty. "
-           << "Unable to begin generating the PDF." << endl;
+           << "Unable to begin generating the PDF." << std::endl;
     R__ASSERT (_nDim!=0);
   }
 
   if(_nEvents==0) {
     coutE(InputArguments) << "ERROR:  RooNDKeysPdf::initialize() : The input data set is empty. "
-           << "Unable to begin generating the PDF." << endl;
+           << "Unable to begin generating the PDF." << std::endl;
     R__ASSERT (_nEvents!=0);
   }
 
@@ -594,7 +594,7 @@ void RooNDKeysPdf::loadDataSet(bool firstCall, RooDataSet const& data)
 
   coutI(Contents) << "RooNDKeysPdf::loadDataSet(" << this << ")"
                   << "\n Number of events in dataset: " << _nEvents
-                  << "\n Weighted number of events in dataset: " << _nEventsW << endl;
+                  << "\n Weighted number of events in dataset: " << _nEventsW << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -610,8 +610,8 @@ void RooNDKeysPdf::mirrorDataSet()
      _xDatLo3s[j] = _xDatLo[j] + _nSigma * (_n * _sigma[j]);
      _xDatHi3s[j] = _xDatHi[j] - _nSigma * (_n * _sigma[j]);
 
-     // cout<<"xDatLo3s["<<j<<"]="<<_xDatLo3s[j]<<endl;
-     // cout<<"xDatHi3s["<<j<<"]="<<_xDatHi3s[j]<<endl;
+     // std::cout<<"xDatLo3s["<<j<<"]="<<_xDatLo3s[j]<< std::endl;
+     // std::cout<<"xDatHi3s["<<j<<"]="<<_xDatHi3s[j]<< std::endl;
   }
 
   vector<double> dummy(_nDim,0.);
@@ -705,7 +705,7 @@ void RooNDKeysPdf::loadWeightSet(RooDataSet const& data)
     //}
   }
 
-  coutI(Contents) << "RooNDKeysPdf::loadWeightSet(" << this << ") : Number of weighted events : " << _wMap.size() << endl;
+  coutI(Contents) << "RooNDKeysPdf::loadWeightSet(" << this << ") : Number of weighted events : " << _wMap.size() << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -725,10 +725,10 @@ void RooNDKeysPdf::calculateShell(BoxInfo* bi) const
     bi->xVarHiM3s[j] = bi->xVarHi[j] - _nSigma * (_n * _sigma[j]);
     bi->xVarHiP3s[j] = bi->xVarHi[j] + _nSigma * (_n * _sigma[j]);
 
-    //cout<<"bi->xVarLoM3s["<<j<<"]="<<bi->xVarLoM3s[j]<<endl;
-    //cout<<"bi->xVarLoP3s["<<j<<"]="<<bi->xVarLoP3s[j]<<endl;
-    //cout<<"bi->xVarHiM3s["<<j<<"]="<<bi->xVarHiM3s[j]<<endl;
-    //cout<<"bi->xVarHiM3s["<<j<<"]="<<bi->xVarHiM3s[j]<<endl;
+    //cout<<"bi->xVarLoM3s["<<j<<"]="<<bi->xVarLoM3s[j]<< std::endl;
+    //cout<<"bi->xVarLoP3s["<<j<<"]="<<bi->xVarLoP3s[j]<< std::endl;
+    //cout<<"bi->xVarHiM3s["<<j<<"]="<<bi->xVarHiM3s[j]<< std::endl;
+    //cout<<"bi->xVarHiM3s["<<j<<"]="<<bi->xVarHiM3s[j]<< std::endl;
   }
 
   //for (Int_t i=0; i<_nEventsM; i++) {
@@ -777,7 +777,7 @@ void RooNDKeysPdf::calculateShell(BoxInfo* bi) const
         << "\n Events in shell " << bi->sIdcs.size()
         << "\n Events in box " << bi->bIdcs.size()
         << "\n Events in box and shell " << bi->bpsIdcs.size()
-        << endl;
+        << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -797,7 +797,7 @@ void RooNDKeysPdf::calculatePreNorm(BoxInfo* bi) const
   cxcoutD(Eval) << "RooNDKeysPdf::calculatePreNorm() : "
          << "\n nEventsBMSW " << bi->nEventsBMSW
          << "\n nEventsBW " << bi->nEventsBW
-         << endl;
+         << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -836,7 +836,7 @@ void RooNDKeysPdf::sortDataIndices(BoxInfo* bi)
   }
 
   for (Int_t j=0; j<_nDim; j++) {
-    cxcoutD(Eval) << "RooNDKeysPdf::sortDataIndices() : Number of sorted events : " << _sortTVIdcs[j].size() << endl;
+    cxcoutD(Eval) << "RooNDKeysPdf::sortDataIndices() : Number of sorted events : " << _sortTVIdcs[j].size() << std::endl;
   }
 }
 
@@ -844,7 +844,7 @@ void RooNDKeysPdf::sortDataIndices(BoxInfo* bi)
 
 void RooNDKeysPdf::calculateBandWidth()
 {
-  cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth()" << endl;
+  cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth()" << std::endl;
 
   const bool adaptive = _options.Contains("a");
   if (_weights != &_weights1 || _weights != &_weights0) {
@@ -855,7 +855,7 @@ void RooNDKeysPdf::calculateBandWidth()
   // (default, and needed to calculate adaptive bandwidth)
 
   if(!adaptive) {
-      cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth() Using static bandwidth." << endl;
+      cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth() Using static bandwidth." << std::endl;
   }
 
   // fixed width approximation
@@ -863,13 +863,13 @@ void RooNDKeysPdf::calculateBandWidth()
     vector<double>& weight = _weights0[i];
     for (Int_t j = 0; j < _nDim; j++) {
        weight[j] = _n * (*_sigmaR)[j];
-       // cout<<"j: "<<j<<", _n: "<<_n<<", sigmaR="<<(*_sigmaR)[j]<<", weight="<<weight[j]<<endl;
+       // std::cout<<"j: "<<j<<", _n: "<<_n<<", sigmaR="<<(*_sigmaR)[j]<<", weight="<<weight[j]<< std::endl;
     }
   }
 
   // adaptive width
   if (adaptive) {
-     cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth() Using adaptive bandwidth." << endl;
+     cxcoutD(Eval) << "RooNDKeysPdf::calculateBandWidth() Using adaptive bandwidth." << std::endl;
 
      double sqrt12 = sqrt(12.);
      double sqrtSigmaAvgR = sqrt(_sigmaAvgR);
@@ -880,11 +880,11 @@ void RooNDKeysPdf::calculateBandWidth()
      std::vector<std::vector<double>> *weights_prev(nullptr);
      std::vector<std::vector<double>> *weights_new(nullptr);
 
-     // cout << "Number of adaptive iterations: " << _nAdpt << endl;
+     // std::cout << "Number of adaptive iterations: " << _nAdpt << std::endl;
 
      for (Int_t k = 1; k <= _nAdpt; ++k) {
 
-        // cout << "  Cycle: " << k << endl;
+        // std::cout << "  Cycle: " << k << std::endl;
 
         // if multiple adaptive iterations, need to swap weight sets
         if (k % 2) {
@@ -958,7 +958,7 @@ double RooNDKeysPdf::gauss(vector<double>& x, vector<vector<double> >& weights) 
         double r = (*_dx)[j]; // x[j] - point[j];
         double c = 1. / (2. * weight[j] * weight[j]);
 
-        // cout << "j = " << j << " x[j] = " << point[j] << " w = " << weight[j] << endl;
+        // std::cout << "j = " << j << " x[j] = " << point[j] << " w = " << weight[j] << std::endl;
 
         g *= exp(-c * r * r);
         g *= 1. / (sqrt2pi * weight[j]);
@@ -1091,7 +1091,7 @@ double RooNDKeysPdf::evaluate() const
    }
 
   double val = gauss(_x,*_weights);
-  //cout<<"returning "<<val<<endl;
+  //cout<<"returning "<<val<< std::endl;
 
   if (val >= 1E-20) {
      return val;
@@ -1120,7 +1120,7 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
   checkInitWeights();
 
   cxcoutD(Eval) << "Calling RooNDKeysPdf::analyticalIntegral(" << GetName() << ") with code " << code
-         << " and rangeName " << (rangeName?rangeName:"<none>") << endl;
+         << " and rangeName " << (rangeName?rangeName:"<none>") << std::endl;
 
   // determine which observables need to be integrated over ...
   Int_t nComb = 1 << (_nDim);
@@ -1153,7 +1153,7 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
 
   // reset
   if (newBounds) {
-    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Found new boundaries ... " << (rangeName?rangeName:"<none>") << endl;
+    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Found new boundaries ... " << (rangeName?rangeName:"<none>") << std::endl;
     boxInfoInit(bi,rangeName,code);
   }
 
@@ -1171,7 +1171,7 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
 
   if (_mirror && bi->netFluxZ) {
     // KEYS expression is self-normalized
-    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Using mirrored normalization : " << bi->nEventsBW << endl;
+    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Using mirrored normalization : " << bi->nEventsBW << std::endl;
     return bi->nEventsBW;
   }
   // calculate leakage in and out of variable range box
@@ -1206,7 +1206,7 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
       norm += prob * _wMap.at(_idx[bi->sIdcs[i]]);
     }
 
-    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Final normalization : " << norm << " " << bi->nEventsBW << endl;
+    cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Final normalization : " << norm << " " << bi->nEventsBW << std::endl;
     return norm;
   }
 }
@@ -1222,7 +1222,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
    for (const auto var : varList) {
       if (!dynamic_cast<RooRealVar *>(var)) {
          coutE(InputArguments) << "RooNDKeysPdf::createDatasetFromHist(" << GetName() << ") WARNING: variable "
-                               << var->GetName() << " is not of type RooRealVar. Skip." << endl;
+                               << var->GetName() << " is not of type RooRealVar. Skip." << std::endl;
          continue;
       }
       varVec.push_back(static_cast<RooRealVar *>(var)); // used for setting the variables.
@@ -1242,7 +1242,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
 
    if (histndim > 3 || histndim <= 0) {
       coutE(InputArguments) << "RooNDKeysPdf::createDatasetFromHist(" << GetName()
-                            << ") ERROR: input histogram dimension not between [1-3]: " << histndim << endl;
+                            << ") ERROR: input histogram dimension not between [1-3]: " << histndim << std::endl;
       assert(0);
    }
 
@@ -1294,7 +1294,7 @@ TMatrixD RooNDKeysPdf::getWeights(const int &k) const
 
   TMatrixD mref(_nEvents, _nDim + 1);
 
-   cxcoutD(Eval) << "RooNDKeysPdf::getWeights() Return evaluated weights." << endl;
+   cxcoutD(Eval) << "RooNDKeysPdf::getWeights() Return evaluated weights." << std::endl;
 
    for (Int_t i = 0; i < _nEvents; ++i) {
       const vector<double>& x = _dataPts[i];

--- a/roofit/roofit/src/RooNonCPEigenDecay.cxx
+++ b/roofit/roofit/src/RooNonCPEigenDecay.cxx
@@ -50,8 +50,6 @@ where Q denotes the charge of the \f$\rho\f$ meson.
 #include "TMath.h"
 #include "RooRealIntegral.h"
 
-using std::cout, std::endl;
-
 ClassImp(RooNonCPEigenDecay);
 
 #define Debug_RooNonCPEigenDecay 1
@@ -356,8 +354,8 @@ void RooNonCPEigenDecay::initGenerator( Int_t code )
     _genB0Frac = b0Int1/sumInt1;
 
     if (Debug_RooNonCPEigenDecay == 1) {
-       cout << "     o RooNonCPEigenDecay::initgenerator: genB0Frac     : " << _genB0Frac
-            << ", tag dilution: " << (1 - 2 * _avgW) << endl;
+       std::cout << "     o RooNonCPEigenDecay::initgenerator: genB0Frac     : " << _genB0Frac
+            << ", tag dilution: " << (1 - 2 * _avgW) << std::endl;
     }
   }
 
@@ -373,7 +371,7 @@ void RooNonCPEigenDecay::initGenerator( Int_t code )
     _genRhoPlusFrac = b0Int2/sumInt2;
 
     if (Debug_RooNonCPEigenDecay == 1) {
-       cout << "     o RooNonCPEigenDecay::initgenerator: genRhoPlusFrac: " << _genRhoPlusFrac << endl;
+       std::cout << "     o RooNonCPEigenDecay::initgenerator: genRhoPlusFrac: " << _genRhoPlusFrac << std::endl;
     }
   }
 }

--- a/roofit/roofit/src/RooParametricStepFunction.cxx
+++ b/roofit/roofit/src/RooParametricStepFunction.cxx
@@ -202,7 +202,7 @@ double RooParametricStepFunction::evaluate() const
      value = lastBinValue();
      if (value<=0.0){
        value = 0.000001;
-       //       cout << "RooParametricStepFunction: sum of values gt 1.0 -- beware!!" <<endl;
+       //       std::cout << "RooParametricStepFunction: sum of values gt 1.0 -- beware!!" << std::endl;
      }
      break;
    }

--- a/roofit/roofit/test/vectorisedPDFs/testCompatMode.cxx
+++ b/roofit/roofit/test/vectorisedPDFs/testCompatMode.cxx
@@ -148,7 +148,7 @@ public:
             }
          }
       } else {
-         cout << "error in RooNonVecGaussian generateEvent" << endl;
+         std::cout << "error in RooNonVecGaussian generateEvent" << std::endl;
       }
 
       return;

--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -223,7 +223,7 @@ Int_t RooCacheManager<T>::setObj(const RooArgSet* nset, const RooArgSet* iset, T
     // Found sterile slot that can should be recycled [ sterileIndex only set if isetRangeName matches ]
 
     if (sterileIdx>=_maxSize) {
-      //cout << "RooCacheManager<T>::setObj()/SI increasing object cache size from " << _maxSize << " to " << sterileIdx+4 << endl ;
+      //cout << "RooCacheManager<T>::setObj()/SI increasing object cache size from " << _maxSize << " to " << sterileIdx+4 << std::endl ;
       _maxSize = sterileIdx+4;
       _object.resize(_maxSize,nullptr) ;
       _nsetCache.resize(_maxSize) ;
@@ -239,13 +239,13 @@ Int_t RooCacheManager<T>::setObj(const RooArgSet* nset, const RooArgSet* iset, T
   }
 
   if (_size>=_maxSize-1) {
-    //cout << "RooCacheManager<T>::setObj() increasing object cache size from " << _maxSize << " to " << _maxSize*2 << endl ;
+    //cout << "RooCacheManager<T>::setObj() increasing object cache size from " << _maxSize << " to " << _maxSize*2 << std::endl ;
     _maxSize *=2 ;
     _object.resize(_maxSize,nullptr) ;
     _nsetCache.resize(_maxSize) ;
   }
 
-  //cout << "RooCacheManager::setObj<T>(" << this << ") _size = " << _size << " _maxSize = " << _maxSize << endl ;
+  //cout << "RooCacheManager::setObj<T>(" << this << ") _size = " << _size << " _maxSize = " << _maxSize << std::endl ;
   _nsetCache[_size].autoCache(_owner,nset,iset,isetRangeName,true) ;
   if (_object[_size]) {
     delete _object[_size] ;

--- a/roofit/roofitcore/src/ModelConfig.cxx
+++ b/roofit/roofitcore/src/ModelConfig.cxx
@@ -67,7 +67,7 @@ void removeConstantParameters(RooAbsCollection &coll)
 
 } // namespace
 
-using std::cout, std::endl, std::ostream;
+using std::ostream;
 
 namespace RooStats {
 
@@ -138,7 +138,7 @@ void ModelConfig::Print(Option_t *) const
 {
    ostream &os = RooPrintable::defaultPrintStream();
 
-   os << endl << "=== Using the following for " << GetName() << " ===" << endl;
+   os << std::endl << "=== Using the following for " << GetName() << " ===" << std::endl;
 
    // args
    if (GetObservables()) {
@@ -183,12 +183,12 @@ void ModelConfig::Print(Option_t *) const
    // snapshot
    const RooArgSet *snapshot = GetSnapshot();
    if (snapshot) {
-      os << "Snapshot:                " << endl;
+      os << "Snapshot:                " << std::endl;
       snapshot->Print("v");
       delete snapshot;
    }
 
-   os << endl;
+   os << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -215,7 +215,7 @@ RooWorkspace *ModelConfig::GetWS() const
 {
    RooWorkspace *ws = dynamic_cast<RooWorkspace *>(fRefWS.GetObject());
    if (!ws) {
-      coutE(ObjectHandling) << "workspace not set" << endl;
+      coutE(ObjectHandling) << "workspace not set" << std::endl;
       return nullptr;
    }
    return ws;
@@ -353,7 +353,7 @@ bool ModelConfig::SetHasOnlyParameters(const RooArgSet &set, const char *errorMs
    }
 
    if (errorMsgPrefix && !nonparams.empty()) {
-      cout << errorMsgPrefix << " ERROR: specified set contains non-parameters: " << nonparams << endl;
+      std::cout << errorMsgPrefix << " ERROR: specified set contains non-parameters: " << nonparams << std::endl;
    }
    return (nonparams.empty());
 }

--- a/roofit/roofitcore/src/Roo1DTable.cxx
+++ b/roofit/roofitcore/src/Roo1DTable.cxx
@@ -34,7 +34,7 @@ equivalent of a plot. To create a table use the RooDataSet::table() method.
 #include <iostream>
 #include <iomanip>
 
-using std::cout, std::endl, std::ostream, std::setw, std::setfill;
+using std::ostream, std::setw, std::setfill;
 
 ClassImp(Roo1DTable);
 
@@ -188,8 +188,8 @@ Int_t Roo1DTable::defaultPrintContents(Option_t* /*opt*/) const
 
 void Roo1DTable::printMultiline(ostream& os, Int_t /*contents*/, bool verbose, TString indent) const
 {
-  os << indent << endl ;
-  os << indent << "  Table " << GetName() << " : " << GetTitle() << endl ;
+  os << indent << std::endl ;
+  os << indent << "  Table " << GetName() << " : " << GetTitle() << std::endl ;
 
   // Determine maximum label and count width
   Int_t labelWidth(0) ;
@@ -213,27 +213,27 @@ void Roo1DTable::printMultiline(ostream& os, Int_t /*contents*/, bool verbose, T
 
   // Header
   Int_t countWidth=((Int_t)log10(maxCount))+1 ;
-  os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << endl ;
+  os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << std::endl ;
   os << setfill(' ') ;
 
   // Contents
   for (i=0 ; i<_types.GetEntries() ; i++) {
     RooCatType* entry = static_cast<RooCatType*>(_types.At(i)) ;
     if (_count[i]>0 || verbose) {
-      os << "  | " << setw(labelWidth) << entry->GetName() << " | " << setw(countWidth) << _count[i] << " |" << endl ;
+      os << "  | " << setw(labelWidth) << entry->GetName() << " | " << setw(countWidth) << _count[i] << " |" << std::endl ;
     }
   }
 
   // Overflow field
   if (_nOverflow) {
-    os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << endl ;
-    os << indent << "  | " << "Overflow" << " | " << setw(countWidth) << _nOverflow << " |" << endl ;
+    os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << std::endl ;
+    os << indent << "  | " << "Overflow" << " | " << setw(countWidth) << _nOverflow << " |" << std::endl ;
   }
 
   // Footer
-  os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << endl ;
+  os << indent << "  +-" << setw(labelWidth) << setfill('-') << "-" << "-+-" << setw(countWidth) << "-" << "-+" << std::endl ;
   os << setfill(' ') ;
-  os << indent << endl ;
+  os << indent << std::endl ;
 }
 
 
@@ -248,7 +248,7 @@ double Roo1DTable::get(const char* label, bool silent) const
   TObject* cat = _types.FindObject(label) ;
   if (!cat) {
     if (!silent) {
-      coutE(InputArguments) << "Roo1DTable::get: ERROR: no such entry: " << label << endl ;
+      coutE(InputArguments) << "Roo1DTable::get: ERROR: no such entry: " << label << std::endl ;
     }
     return 0 ;
   }
@@ -275,7 +275,7 @@ double Roo1DTable::get(const int index, bool silent) const
   }
   if (!cat) {
     if (!silent) {
-      coutE(InputArguments) << "Roo1DTable::get: ERROR: no such entry: " << index << endl ;
+      coutE(InputArguments) << "Roo1DTable::get: ERROR: no such entry: " << index << std::endl ;
     }
     return 0 ;
   }
@@ -304,7 +304,7 @@ double Roo1DTable::getFrac(const char* label, bool silent) const
   if (_total) {
     return get(label,silent) / _total ;
   } else {
-    if (!silent) coutW(Contents) << "Roo1DTable::getFrac: WARNING table empty, returning 0" << endl ;
+    if (!silent) coutW(Contents) << "Roo1DTable::getFrac: WARNING table empty, returning 0" << std::endl ;
     return 0. ;
   }
 }
@@ -321,7 +321,7 @@ double Roo1DTable::getFrac(const int index, bool silent) const
   if (_total) {
     return get(index, silent) / _total ;
   } else {
-    if (!silent) coutW(Contents) << "Roo1DTable::getFrac: WARNING table empty, returning 0" << endl ;
+    if (!silent) coutW(Contents) << "Roo1DTable::getFrac: WARNING table empty, returning 0" << std::endl ;
     return 0. ;
   }
 }

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -161,7 +161,7 @@ Int_t RooAbsAnaConvPdf::declareBasis(const char* expression, const RooArgList& p
   // Sanity check
   if (_isCopy) {
     coutE(InputArguments) << "RooAbsAnaConvPdf::declareBasis(" << GetName() << "): ERROR attempt to "
-           << " declare basis functions in a copied RooAbsAnaConvPdf" << endl ;
+           << " declare basis functions in a copied RooAbsAnaConvPdf" << std::endl ;
     return -1 ;
   }
 
@@ -169,7 +169,7 @@ Int_t RooAbsAnaConvPdf::declareBasis(const char* expression, const RooArgList& p
   if (!(static_cast<RooResolutionModel*>(_model.absArg()))->isBasisSupported(expression)) {
     coutE(InputArguments) << "RooAbsAnaConvPdf::declareBasis(" << GetName() << "): resolution model "
            << _model.absArg()->GetName()
-           << " doesn't support basis function " << expression << endl ;
+           << " doesn't support basis function " << expression << std::endl ;
     return -1 ;
   }
 
@@ -193,7 +193,7 @@ Int_t RooAbsAnaConvPdf::declareBasis(const char* expression, const RooArgList& p
   _basisList.addOwned(std::move(basisFunc));
   if (!conv) {
     coutE(InputArguments) << "RooAbsAnaConvPdf::declareBasis(" << GetName() << "): unable to construct convolution with basis function '"
-           << expression << "'" << endl ;
+           << expression << "'" << std::endl ;
     return -1 ;
   }
   _convSet.add(*conv) ;
@@ -276,7 +276,7 @@ RooAbsGenContext* RooAbsAnaConvPdf::genContext(const RooArgSet &vars, const RooD
     if (!pdfCanDir) reason += "PDF does not support internal generation of convolution observable. " ;
     if (!resCanDir) reason += "Resolution model does not support internal generation of convolution observable. " ;
 
-    coutI(Generation) << "RooAbsAnaConvPdf::genContext(" << GetName() << ") Using regular accept/reject generator for convolution p.d.f because: " << reason.c_str() << endl ;
+    coutI(Generation) << "RooAbsAnaConvPdf::genContext(" << GetName() << ") Using regular accept/reject generator for convolution p.d.f because: " << reason.c_str() << std::endl ;
     return new RooGenContext(*this,vars,prototype,auxProto,verbose) ;
   }
 
@@ -337,10 +337,10 @@ double RooAbsAnaConvPdf::evaluate() const
     if (coef!=0.) {
       const double c = conv->getVal(nullptr);
       cxcoutD(Eval) << "RooAbsAnaConvPdf::evaluate(" << GetName() << ") val += coef*conv [" << index-1 << "/"
-          << _convSet.size() << "] coef = " << coef << " conv = " << c << endl ;
+          << _convSet.size() << "] coef = " << coef << " conv = " << c << std::endl ;
       result += c * coef;
     } else {
-      cxcoutD(Eval) << "RooAbsAnaConvPdf::evaluate(" << GetName() << ") [" << index-1 << "/" << _convSet.size() << "] coef = 0" << endl ;
+      cxcoutD(Eval) << "RooAbsAnaConvPdf::evaluate(" << GetName() << ") [" << index-1 << "/" << _convSet.size() << "] coef = 0" << std::endl ;
     }
   }
 
@@ -546,7 +546,7 @@ Int_t RooAbsAnaConvPdf::getCoefAnalyticalIntegral(Int_t /* coef*/, RooArgSet& /*
 double RooAbsAnaConvPdf::coefAnalyticalIntegral(Int_t coef, Int_t code, const char* /*rangeName*/) const
 {
   if (code==0) return coefficient(coef) ;
-  coutE(InputArguments) << "RooAbsAnaConvPdf::coefAnalyticalIntegral(" << GetName() << ") ERROR: unrecognized integration code: " << code << endl ;
+  coutE(InputArguments) << "RooAbsAnaConvPdf::coefAnalyticalIntegral(" << GetName() << ") ERROR: unrecognized integration code: " << code << std::endl ;
   assert(0) ;
   return 1 ;
 }
@@ -646,7 +646,7 @@ void RooAbsAnaConvPdf::printMultiline(ostream& os, Int_t contents, bool verbose,
 {
   RooAbsPdf::printMultiline(os,contents,verbose,indent);
 
-  os << indent << "--- RooAbsAnaConvPdf ---" << endl;
+  os << indent << "--- RooAbsAnaConvPdf ---" << std::endl;
   for (RooAbsArg * conv : _convSet) {
     conv->printMultiline(os,contents,verbose,indent) ;
   }
@@ -660,7 +660,7 @@ void RooAbsAnaConvPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
   for (auto const* carg : static_range_cast<RooAbsArg*>(_convSet)) {
     if (carg->canNodeBeCached()==Always) {
       trackNodes.add(*carg) ;
-      //cout << "tracking node RooAddPdf component " << carg->ClassName() << "::" << carg->GetName() << endl ;
+      //cout << "tracking node RooAddPdf component " << carg->ClassName() << "::" << carg->GetName() << std::endl ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -96,7 +96,7 @@ for single nodes.
 #include <fstream>
 #include <sstream>
 
-using std::cout, std::endl, std::ostream, std::string, std::set, std::map, std::istream, std::pair, std::ofstream, std::make_pair;
+using std::ostream, std::string, std::set, std::map, std::istream, std::pair, std::ofstream, std::make_pair;
 
 ClassImp(RooAbsArg);
 
@@ -180,12 +180,12 @@ RooAbsArg::~RooAbsArg()
     if (_verboseDirty) {
 
       if (first) {
-   cxcoutD(Tracing) << "RooAbsArg::dtor(" << GetName() << "," << this << ") DeleteWatch: object is being destroyed" << endl ;
+   cxcoutD(Tracing) << "RooAbsArg::dtor(" << GetName() << "," << this << ") DeleteWatch: object is being destroyed" << std::endl ;
    first = false ;
       }
 
       cxcoutD(Tracing)  << fName << "::" << ClassName() << ":~RooAbsArg: dependent \""
-             << client->GetName() << "\" should have been deleted first" << endl ;
+             << client->GetName() << "\" should have been deleted first" << std::endl ;
     }
   }
 
@@ -329,12 +329,12 @@ void RooAbsArg::addServer(RooAbsArg& server, bool valueProp, bool shapeProp, std
   if (_prohibitServerRedirect) {
     cxcoutF(LinkStateMgmt) << "RooAbsArg::addServer(" << this << "," << GetName()
             << "): PROHIBITED SERVER ADDITION REQUESTED: adding server " << server.GetName()
-            << "(" << &server << ") for " << (valueProp?"value ":"") << (shapeProp?"shape":"") << endl ;
+            << "(" << &server << ") for " << (valueProp?"value ":"") << (shapeProp?"shape":"") << std::endl ;
     throw std::logic_error("PROHIBITED SERVER ADDITION REQUESTED in RooAbsArg::addServer");
   }
 
   cxcoutD(LinkStateMgmt) << "RooAbsArg::addServer(" << this << "," << GetName() << "): adding server " << server.GetName()
-          << "(" << &server << ") for " << (valueProp?"value ":"") << (shapeProp?"shape":"") << endl ;
+          << "(" << &server << ") for " << (valueProp?"value ":"") << (shapeProp?"shape":"") << std::endl ;
 
   if (server.operMode()==ADirty && operMode()!=ADirty && valueProp) {
     setOperMode(ADirty) ;
@@ -387,7 +387,7 @@ void RooAbsArg::removeServer(RooAbsArg& server, bool force)
 
   if (_verboseDirty) {
     cxcoutD(LinkStateMgmt) << "RooAbsArg::removeServer(" << GetName() << "): removing server "
-            << server.GetName() << "(" << &server << ")" << endl ;
+            << server.GetName() << "(" << &server << ")" << std::endl ;
   }
 
   // Remove server link to given server
@@ -439,14 +439,14 @@ void RooAbsArg::changeServer(RooAbsArg& server, bool valueProp, bool shapeProp)
 {
   if (!_serverList.containsByNamePtr(&server)) {
     coutE(LinkStateMgmt) << "RooAbsArg::changeServer(" << GetName() << "): Server "
-    << server.GetName() << " not registered" << endl ;
+    << server.GetName() << " not registered" << std::endl ;
     return ;
   }
 
   // This condition should not happen, but check anyway
   if (!server._clientList.containsByNamePtr(this)) {
     coutE(LinkStateMgmt) << "RooAbsArg::changeServer(" << GetName() << "): Server "
-          << server.GetName() << " doesn't have us registered as client" << endl ;
+          << server.GetName() << " doesn't have us registered as client" << std::endl ;
     return ;
   }
 
@@ -499,7 +499,7 @@ void RooAbsArg::branchNodeServerList(RooAbsCollection* list, const RooAbsArg* ar
 void RooAbsArg::treeNodeServerList(RooAbsCollection* list, const RooAbsArg* arg, bool doBranch, bool doLeaf, bool valueOnly, bool recurseFundamental) const
 {
 //   if (arg==0) {
-//     cout << "treeNodeServerList(" << GetName() << ") doBranch=" << (doBranch?"T":"F") << " doLeaf = " << (doLeaf?"T":"F") << " valueOnly=" << (valueOnly?"T":"F") << endl ;
+//     std::cout << "treeNodeServerList(" << GetName() << ") doBranch=" << (doBranch?"T":"F") << " doLeaf = " << (doLeaf?"T":"F") << " valueOnly=" << (valueOnly?"T":"F") << std::endl ;
 //   }
 
   if (!arg) {
@@ -813,7 +813,7 @@ bool RooAbsArg::recursiveCheckObservables(const RooArgSet* nset) const
   for(RooAbsArg * arg : nodeList) {
     if (arg->getAttribute("ServerDied")) {
       coutE(LinkStateMgmt) << "RooAbsArg::recursiveCheckObservables(" << GetName() << "): ERROR: one or more servers of node "
-            << arg->GetName() << " no longer exists!" << endl ;
+            << arg->GetName() << " no longer exists!" << std::endl ;
       arg->Print("v") ;
       ret = true ;
     }
@@ -930,7 +930,7 @@ void RooAbsArg::setValueDirty(const RooAbsArg* source)
   } else if (source==this) {
     // Cyclical dependency, abort
     coutE(LinkStateMgmt) << "RooAbsArg::setValueDirty(" << GetName()
-          << "): cyclical dependency detected, source = " << source->GetName() << endl ;
+          << "): cyclical dependency detected, source = " << source->GetName() << std::endl ;
     //assert(0) ;
     return ;
   }
@@ -938,7 +938,7 @@ void RooAbsArg::setValueDirty(const RooAbsArg* source)
   // Propagate dirty flag to all clients if this is a down->up transition
   if (_verboseDirty) {
     cxcoutD(LinkStateMgmt) << "RooAbsArg::setValueDirty(" << (source?source->GetName():"self") << "->" << GetName() << "," << this
-            << "): dirty flag " << (_valueDirty?"already ":"") << "raised" << endl ;
+            << "): dirty flag " << (_valueDirty?"already ":"") << "raised" << std::endl ;
   }
 
   _valueDirty = true ;
@@ -960,7 +960,7 @@ void RooAbsArg::setShapeDirty(const RooAbsArg* source)
 {
   if (_verboseDirty) {
     cxcoutD(LinkStateMgmt) << "RooAbsArg::setShapeDirty(" << GetName()
-            << "): dirty flag " << (_shapeDirty?"already ":"") << "raised" << endl ;
+            << "): dirty flag " << (_shapeDirty?"already ":"") << "raised" << std::endl ;
   }
 
   if (_clientListShape.empty()) {
@@ -974,7 +974,7 @@ void RooAbsArg::setShapeDirty(const RooAbsArg* source)
   } else if (source==this) {
     // Cyclical dependency, abort
     coutE(LinkStateMgmt) << "RooAbsArg::setShapeDirty(" << GetName()
-    << "): cyclical dependency detected" << endl ;
+    << "): cyclical dependency detected" << std::endl ;
     return ;
   }
 
@@ -1083,7 +1083,7 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
       auto ap = dynamic_cast<const RooArgProxy*>(p);
       coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << GetName()
               << "): ERROR, proxy '" << p->name()
-              << "' with arg '" << (ap ? ap->absArg()->GetName() : "<could not cast>") << "' could not be adjusted" << endl;
+              << "' with arg '" << (ap ? ap->absArg()->GetName() : "<could not cast>") << "' could not be adjusted" << std::endl;
       ret = true ;
     }
   }
@@ -1241,7 +1241,7 @@ bool recursiveRedirectServersImpl(RooAbsArg *arg, RooAbsCollection const &newSet
    oocxcoutD(arg, LinkStateMgmt) << "RooAbsArg::recursiveRedirectServers(" << arg << "," << arg->GetName()
                                  << ") newSet = " << newSet << " mustReplaceAll = " << (mustReplaceAll ? "T" : "F")
                                  << " nameChange = " << (nameChange ? "T" : "F")
-                                 << " recurseInNewSet = " << (recurseInNewSet ? "T" : "F") << endl;
+                                 << " recurseInNewSet = " << (recurseInNewSet ? "T" : "F") << std::endl;
 
    // Do redirect on self (identify operation as recursion step)
    ret |= arg->redirectServers(newSet, mustReplaceAll, nameChange, true);
@@ -1313,13 +1313,13 @@ void RooAbsArg::registerProxy(RooArgProxy& proxy)
   if (_proxyList.FindObject(&proxy)) {
     coutE(LinkStateMgmt) << "RooAbsArg::registerProxy(" << GetName() << "): proxy named "
           << proxy.GetName() << " for arg " << proxy.absArg()->GetName()
-          << " already registered" << endl ;
+          << " already registered" << std::endl ;
     return ;
   }
 
-//   cout << (void*)this << " " << GetName() << ": registering proxy "
+//   std::cout << (void*)this << " " << GetName() << ": registering proxy "
 //        << (void*)&proxy << " with name " << proxy.name() << " in mode "
-//        << (proxy.isValueServer()?"V":"-") << (proxy.isShapeServer()?"S":"-") << endl ;
+//        << (proxy.isValueServer()?"V":"-") << (proxy.isShapeServer()?"S":"-") << std::endl ;
 
   // Register proxied object as server
   if (proxy.absArg()) {
@@ -1356,7 +1356,7 @@ void RooAbsArg::registerProxy(RooSetProxy& proxy)
   // Every proxy can be registered only once
   if (_proxyList.FindObject(&proxy)) {
     coutE(LinkStateMgmt) << "RooAbsArg::registerProxy(" << GetName() << "): proxy named "
-          << proxy.GetName() << " already registered" << endl ;
+          << proxy.GetName() << " already registered" << std::endl ;
     return ;
   }
 
@@ -1391,7 +1391,7 @@ void RooAbsArg::registerProxy(RooListProxy& proxy)
   // Every proxy can be registered only once
   if (_proxyList.FindObject(&proxy)) {
     coutE(LinkStateMgmt) << "RooAbsArg::registerProxy(" << GetName() << "): proxy named "
-          << proxy.GetName() << " already registered" << endl ;
+          << proxy.GetName() << " already registered" << std::endl ;
     return ;
   }
 
@@ -1400,7 +1400,7 @@ void RooAbsArg::registerProxy(RooListProxy& proxy)
   _proxyList.Add(&proxy) ;
   _proxyListCache.isDirty = true;
   if (_proxyList.GetEntries()!=nProxyOld+1) {
-    cout << "RooAbsArg::registerProxy(" << GetName() << ") proxy registration failure! nold=" << nProxyOld << " nnew=" << _proxyList.GetEntries() << endl ;
+    std::cout << "RooAbsArg::registerProxy(" << GetName() << ") proxy registration failure! nold=" << nProxyOld << " nnew=" << _proxyList.GetEntries() << std::endl ;
   }
 }
 
@@ -1478,7 +1478,7 @@ void RooAbsArg::setProxyNormSet(const RooArgSet* nset)
 void RooAbsArg::attachToTree(TTree& ,Int_t)
 {
   coutE(Contents) << "RooAbsArg::attachToTree(" << GetName()
-        << "): Cannot be attached to a TTree" << endl ;
+        << "): Cannot be attached to a TTree" << std::endl ;
 }
 
 
@@ -1569,7 +1569,7 @@ Int_t RooAbsArg::defaultPrintContents(Option_t* /*opt*/) const
 
 void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/, TString indent) const
 {
-  os << indent << "--- RooAbsArg ---" << endl;
+  os << indent << "--- RooAbsArg ---" << std::endl;
   // dirty state flags
   os << indent << "  Value State: " ;
   switch(_operMode) {
@@ -1577,16 +1577,16 @@ void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/
   case AClean: os << "FORCED clean" ; break ;
   case Auto: os << (isValueDirty() ? "DIRTY":"clean") ; break ;
   }
-  os << endl
-     << indent << "  Shape State: " << (isShapeDirty() ? "DIRTY":"clean") << endl;
+  os << std::endl
+     << indent << "  Shape State: " << (isShapeDirty() ? "DIRTY":"clean") << std::endl;
   // attribute list
   os << indent << "  Attributes: " ;
   printAttribList(os) ;
-  os << endl ;
+  os << std::endl ;
   // our memory address (for x-referencing with client addresses of other args)
-  os << indent << "  Address: " << (void*)this << endl;
+  os << indent << "  Address: " << (void*)this << std::endl;
   // client list
-  os << indent << "  Clients: " << endl;
+  os << indent << "  Clients: " << std::endl;
   for (const auto client : _clientList) {
     os << indent << "    (" << (void*)client  << ","
        << (_clientListValue.containsByNamePtr(client)?"V":"-")
@@ -1596,7 +1596,7 @@ void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/
   }
 
   // server list
-  os << indent << "  Servers: " << endl;
+  os << indent << "  Servers: " << std::endl;
   for (const auto server : _serverList) {
     os << indent << "    (" << (void*)server << ","
        << (server->_clientListValue.containsByNamePtr(this)?"V":"-")
@@ -1741,13 +1741,13 @@ void RooAbsArg::printDirty(bool depth) const
     }
 
   } else {
-    cout << GetName() << " : " ;
+    std::cout << GetName() << " : " ;
     switch (_operMode) {
-    case AClean: cout << "FORCED clean" ; break ;
-    case ADirty: cout << "FORCED DIRTY" ; break ;
-    case Auto:   cout << "Auto  " << (isValueDirty()?"DIRTY":"clean") ;
+    case AClean: std::cout << "FORCED clean" ; break ;
+    case ADirty: std::cout << "FORCED DIRTY" ; break ;
+    case Auto:   std::cout << "Auto  " << (isValueDirty()?"DIRTY":"clean") ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 }
 
@@ -1767,7 +1767,7 @@ void RooAbsArg::optimizeCacheMode(const RooArgSet& observables)
   optimizeCacheMode(observables,opt,proc) ;
 
   coutI(Optimization) << "RooAbsArg::optimizeCacheMode(" << GetName() << ") nodes " << opt << " depend on observables, "
-         << "changing cache operation mode from change tracking to unconditional evaluation" << endl ;
+         << "changing cache operation mode from change tracking to unconditional evaluation" << std::endl ;
 }
 
 
@@ -1803,7 +1803,7 @@ void RooAbsArg::optimizeCacheMode(const RooArgSet& observables, RooArgSet& optim
   if (obj) {
      // here for nodes with duplicate names
      cxcoutI(Optimization) << "RooAbsArg::optimizeCacheMode(" << GetName() << " node " << this << " exists already as "
-                           << obj << " but with the SAME name !" << endl;
+                           << obj << " but with the SAME name !" << std::endl;
   }
 
   processedNodes.Add(this);
@@ -1812,7 +1812,7 @@ void RooAbsArg::optimizeCacheMode(const RooArgSet& observables, RooArgSet& optim
   if (dependsOnValue(observables)) {
 
     if (dynamic_cast<RooRealIntegral*>(this)) {
-      cxcoutI(Integration) << "RooAbsArg::optimizeCacheMode(" << GetName() << ") integral depends on value of one or more observables and will be evaluated for every event" << endl ;
+      cxcoutI(Integration) << "RooAbsArg::optimizeCacheMode(" << GetName() << ") integral depends on value of one or more observables and will be evaluated for every event" << std::endl ;
     }
     optimizedNodes.add(*this,true) ;
     if (operMode()==AClean) {
@@ -1844,7 +1844,7 @@ bool RooAbsArg::findConstantNodes(const RooArgSet& observables, RooArgSet& cache
 
   // If node can be optimized and hasn't been identified yet, add it to the list
   coutI(Optimization) << "RooAbsArg::findConstantNodes(" << GetName() << "): components "
-         << cacheList << " depend exclusively on constant parameters and will be precalculated and cached" << endl ;
+         << cacheList << " depend exclusively on constant parameters and will be precalculated and cached" << std::endl ;
 
   return ret ;
 }
@@ -1895,7 +1895,7 @@ bool RooAbsArg::findConstantNodes(const RooArgSet& observables, RooArgSet& cache
     if (!cacheList.find(*this) && dependsOnValue(observables) && !observables.find(*this) ) {
 
       // Add to cache list
-      cxcoutD(Optimization) << "RooAbsArg::findConstantNodes(" << GetName() << ") adding self to list of constant nodes" << endl ;
+      cxcoutD(Optimization) << "RooAbsArg::findConstantNodes(" << GetName() << ") adding self to list of constant nodes" << std::endl ;
 
       if (canOpt) setAttribute("ConstantExpressionCached") ;
       cacheList.add(*this,false) ;
@@ -1974,7 +1974,7 @@ void RooAbsArg::printCompactTree(const char* indent, const char* filename, const
     ofstream ofs(filename) ;
     printCompactTree(ofs,indent,namePat,client) ;
   } else {
-    printCompactTree(cout,indent,namePat,client) ;
+    printCompactTree(std::cout,indent,namePat,client) ;
   }
 }
 
@@ -2006,7 +2006,7 @@ void RooAbsArg::printCompactTree(ostream& os, const char* indent, const char* na
       case ADirty: os << " [ADIRTY] " ; break ;
       }
     }
-    os << endl ;
+    os << std::endl ;
 
     for (Int_t i=0 ;i<numCaches() ; i++) {
       getCache(i)->printCompactTreeHook(os,indent) ;
@@ -2037,7 +2037,7 @@ void RooAbsArg::printComponentTree(const char* indent, const char* namePat, Int_
   if (InheritsFrom("RooConstVar")) return ;
 
   if ( !namePat || TString(GetName()).Contains(namePat)) {
-    cout << indent ;
+    std::cout << indent ;
     Print() ;
   }
 
@@ -2151,7 +2151,7 @@ void RooAbsArg::graphVizTree(const char* fileName, const char* delimiter, bool u
 {
   ofstream ofs(fileName) ;
   if (!ofs) {
-    coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: Cannot open graphViz output file with name " << fileName << endl ;
+    coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: Cannot open graphViz output file with name " << fileName << std::endl ;
     return ;
   }
   graphVizTree(ofs, delimiter, useTitle, useLatex) ;
@@ -2168,14 +2168,14 @@ void RooAbsArg::graphVizTree(const char* fileName, const char* delimiter, bool u
 void RooAbsArg::graphVizTree(ostream& os, const char* delimiter, bool useTitle, bool useLatex)
 {
   if (!os) {
-    coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: output stream provided as input argument is in invalid state" << endl ;
+    coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: output stream provided as input argument is in invalid state" << std::endl ;
   }
 
   // silent warning messages coming when evaluating a RooAddPdf without a normalization set
   RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Eval, false);
 
   // Write header
-  os << "digraph \"" << GetName() << "\"{" << endl ;
+  os << "digraph \"" << GetName() << "\"{" << std::endl ;
 
   // First list all the tree nodes
   RooArgSet nodeSet ;
@@ -2201,7 +2201,7 @@ void RooAbsArg::graphVizTree(ostream& os, const char* delimiter, bool useTitle, 
     }
 
     os << "\"" << nodeName << "\" [ color=" << (node->isFundamental()?"blue":"red")
-       << ", label=\"" << nodeType << delimiter << nodeLabel << "\"];" << endl ;
+       << ", label=\"" << nodeType << delimiter << nodeLabel << "\"];" << std::endl ;
 
   }
 
@@ -2211,11 +2211,11 @@ void RooAbsArg::graphVizTree(ostream& os, const char* delimiter, bool useTitle, 
 
   // And write them out
   for(auto const& link : links) {
-    os << "\"" << link.first->GetName() << "\" -> \"" << link.second->GetName() << "\";" << endl ;
+    os << "\"" << link.first->GetName() << "\" -> \"" << link.second->GetName() << "\";" << std::endl ;
   }
 
   // Write trailer
-  os << "}" << endl ;
+  os << "}" << std::endl ;
 
 }
 
@@ -2350,7 +2350,7 @@ void RooAbsArg::SetName(const char* name)
   TNamed::SetName(name) ;
   auto newPtr = RooNameReg::instance().constPtr(GetName()) ;
   if (newPtr != _namePtr) {
-    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
+    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << std::endl;
     _namePtr = newPtr;
     const_cast<TNamed*>(_namePtr)->SetBit(RooNameReg::kRenamedArg);
     RooNameReg::incrementRenameCounter();

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -187,7 +187,7 @@ RooAbsCachedPdf::PdfCacheElem::PdfCacheElem(const RooAbsCachedPdf& self, const R
   _hist->removeSelfFromDir() ;
 
   //RooArgSet* observables= self.getObservables(orderedObs) ;
-  // cout << "orderedObs = " << orderedObs << " observables = " << *observables << std::endl ;
+  // std::cout << "orderedObs = " << orderedObs << " observables = " << *observables << std::endl ;
 
   // Get set of p.d.f. observable corresponding to set of histogram observables
   RooArgSet pdfObs ;

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -118,7 +118,7 @@ RooAbsCachedReal::FuncCacheElem* RooAbsCachedReal::getCache(const RooArgSet* nse
   if (cache) {
     if (cache->paramTracker()->hasChanged(true)) {
       ccoutD(Eval) << "RooAbsCachedReal::getCache(" << GetName() << ") cached function "
-        << cache->func()->GetName() << " requires recalculation as parameters changed" << endl ;
+        << cache->func()->GetName() << " requires recalculation as parameters changed" << std::endl ;
       fillCacheObject(*cache) ;
       cache->func()->setValueDirty() ;
     }
@@ -151,7 +151,7 @@ RooAbsCachedReal::FuncCacheElem* RooAbsCachedReal::getCache(const RooArgSet* nse
 
   // Store this cache configuration
   Int_t code = _cacheMgr.setObj(nset,nullptr,((RooAbsCacheElement*)cache),nullptr) ;
-  ccoutD(Caching) << "RooAbsCachedReal("<<this<<")::getCache(" << GetName() << ") creating new cache " << cache->func()->GetName() << " for nset " << (nset?*nset:RooArgSet()) << " with code " << code << endl ;
+  ccoutD(Caching) << "RooAbsCachedReal("<<this<<")::getCache(" << GetName() << ") creating new cache " << cache->func()->GetName() << " for nset " << (nset?*nset:RooArgSet()) << " with code " << code << std::endl ;
 
   return cache ;
 }
@@ -286,7 +286,7 @@ RooArgList RooAbsCachedReal::FuncCacheElem::containedArgs(Action)
 void RooAbsCachedReal::FuncCacheElem::printCompactTreeHook(ostream& os, const char* indent, Int_t curElem, Int_t maxElem)
 {
   if (curElem==0) {
-    os << indent << "--- RooAbsCachedReal begin cache ---" << endl ;
+    os << indent << "--- RooAbsCachedReal begin cache ---" << std::endl ;
   }
 
   TString indent2(indent) ;
@@ -294,7 +294,7 @@ void RooAbsCachedReal::FuncCacheElem::printCompactTreeHook(ostream& os, const ch
   func()->printCompactTree(os,indent2) ;
 
   if (curElem==maxElem) {
-    os << indent << "--- RooAbsCachedReal end cache --- " << endl ;
+    os << indent << "--- RooAbsCachedReal end cache --- " << std::endl ;
   }
 }
 

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -37,7 +37,7 @@ prototype data etc..
 #include "Riostream.h"
 
 
-using std::cout, std::endl, std::ostream;
+using std::ostream;
 
 ClassImp(RooAbsGenContext);
 
@@ -54,7 +54,7 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
 {
   // Check PDF dependents
   if (model.recursiveCheckObservables(&vars)) {
-    coutE(Generation) << "RooAbsGenContext::ctor: Error in PDF dependents" << endl ;
+    coutE(Generation) << "RooAbsGenContext::ctor: Error in PDF dependents" << std::endl ;
     _isValid = false ;
     return ;
   }
@@ -130,7 +130,7 @@ RooDataSet* RooAbsGenContext::createDataSet(const char* name, const char* title,
 RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool extendedMode)
 {
   if(!isValid()) {
-    coutE(Generation) << ClassName() << "::" << GetName() << ": context is not valid" << endl;
+    coutE(Generation) << ClassName() << "::" << GetName() << ": context is not valid" << std::endl;
     return nullptr;
   }
 
@@ -142,18 +142,18 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
     else {
       if (_extendMode == RooAbsPdf::CanNotBeExtended) {
    coutE(Generation) << ClassName() << "::" << GetName()
-        << ":generate: PDF not extendable: cannot calculate expected number of events" << endl;
+        << ":generate: PDF not extendable: cannot calculate expected number of events" << std::endl;
    return nullptr;
       }
       nEvents= _expectedEvents;
     }
     if(nEvents <= 0) {
       coutE(Generation) << ClassName() << "::" << GetName()
-         << ":generate: cannot calculate expected number of events" << endl;
+         << ":generate: cannot calculate expected number of events" << std::endl;
       return nullptr;
     }
     coutI(Generation) << ClassName() << "::" << GetName() << ":generate: will generate "
-            << nEvents << " events" << endl;
+            << nEvents << " events" << std::endl;
 
   }
 
@@ -161,7 +161,7 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
      double nExpEvents = nEvents;
      nEvents = RooRandom::randomGenerator()->Poisson(nEvents) ;
      cxcoutI(Generation) << " Extended mode active, number of events generated (" << nEvents << ") is Poisson fluctuation on "
-                         << GetName() << "::expectedEvents() = " << nExpEvents << endl ;
+                         << GetName() << "::expectedEvents() = " << nExpEvents << std::endl ;
   }
 
   // check that any prototype dataset still defines the variables we need
@@ -172,7 +172,7 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
     for (RooAbsArg * arg : _protoVars) {
       if(vars->contains(*arg)) continue;
       coutE(InputArguments) << ClassName() << "::" << GetName() << ":generate: prototype dataset is missing \""
-             << arg->GetName() << "\"" << endl;
+             << arg->GetName() << "\"" << std::endl;
 
       // WVE disable this for the moment
       // ok= false;
@@ -214,7 +214,7 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
       }
       else {
    coutE(Generation) << ClassName() << "::" << GetName() << ":generate: cannot load event "
-           << actualProtoIdx << " from prototype dataset" << endl;
+           << actualProtoIdx << " from prototype dataset" << std::endl;
    return nullptr;
       }
     }
@@ -342,7 +342,7 @@ void RooAbsGenContext::resampleData(double& ratio)
   Int_t nTarg = Int_t(nOrig*ratio+0.5) ;
   std::unique_ptr<RooAbsData> trimmedData{_genData->reduce(RooFit::EventRange(0,nTarg))};
 
-  cxcoutD(Generation) << "RooGenContext::resampleData*( existing production trimmed from " << nOrig << " to " << trimmedData->numEntries() << " events" << endl ;
+  cxcoutD(Generation) << "RooGenContext::resampleData*( existing production trimmed from " << nOrig << " to " << trimmedData->numEntries() << " events" << std::endl ;
 
   delete _genData ;
   _genData = static_cast<RooDataSet*>(trimmedData.release());

--- a/roofit/roofitcore/src/RooAbsHiddenReal.cxx
+++ b/roofit/roofitcore/src/RooAbsHiddenReal.cxx
@@ -89,7 +89,7 @@ bool RooAbsHiddenReal::readFromStream(istream& is, bool compact, bool verbose)
 {
   if (isHidden()) {
     // No-op version of readFromStream
-    coutE(InputArguments) << "RooAbsHiddenReal::readFromStream(" << GetName() << "): not allowed" << endl ;
+    coutE(InputArguments) << "RooAbsHiddenReal::readFromStream(" << GetName() << "): not allowed" << std::endl ;
     return true ;
   } else {
     return readFromStream(is,compact,verbose) ;
@@ -105,7 +105,7 @@ void RooAbsHiddenReal::writeToStream(ostream& os, bool compact) const
 {
   if (isHidden()) {
     // No-op version of writeToStream
-    coutE(InputArguments) << "RooAbsHiddenReal::writeToStream(" << GetName() << "): not allowed" << endl ;
+    coutE(InputArguments) << "RooAbsHiddenReal::writeToStream(" << GetName() << "): not allowed" << std::endl ;
   } else {
     RooAbsReal::writeToStream(os,compact) ;
   }

--- a/roofit/roofitcore/src/RooAbsIntegrator.cxx
+++ b/roofit/roofitcore/src/RooAbsIntegrator.cxx
@@ -54,7 +54,7 @@ double RooAbsIntegrator::calculate(const double *yvec)
   double ret = integral(yvec) ;
   integrand()->restoreXVec() ;
 
-  oocxcoutD(static_cast<TObject*>(nullptr), NumIntegration) << "RooAbsIntegrator::calculate(" << _function->getName() << ") number of function calls = " << integrand()->numCall()<<", result  = "<<ret << endl ;
+  oocxcoutD(static_cast<TObject*>(nullptr), NumIntegration) << "RooAbsIntegrator::calculate(" << _function->getName() << ") number of function calls = " << integrand()->numCall()<<", result  = "<<ret << std::endl ;
   return ret ;
 }
 

--- a/roofit/roofitcore/src/RooAbsNumGenerator.cxx
+++ b/roofit/roofitcore/src/RooAbsNumGenerator.cxx
@@ -56,7 +56,7 @@ RooAbsNumGenerator::RooAbsNumGenerator(const RooAbsReal &func, const RooArgSet &
   // is independent of any existing objects.
   RooArgSet nodes(func,func.GetName());
   if (nodes.snapshot(_cloneSet, true)) {
-    oocoutE(nullptr, Generation) << "RooAbsNumGenerator::RooAbsNumGenerator(" << func.GetName() << ") Couldn't deep-clone function, abort," << endl ;
+    oocoutE(nullptr, Generation) << "RooAbsNumGenerator::RooAbsNumGenerator(" << func.GetName() << ") Couldn't deep-clone function, abort," << std::endl ;
     RooErrorHandler::softAbort() ;
   }
 
@@ -72,7 +72,7 @@ RooAbsNumGenerator::RooAbsNumGenerator(const RooAbsReal &func, const RooArgSet &
   for (RooAbsArg const* arg : genVars) {
     if(!arg->isFundamental()) {
       oocoutE(nullptr, Generation) << func.GetName() << "::RooAbsNumGenerator: cannot generate values for derived \""
-         << arg->GetName() << "\"" << endl;
+         << arg->GetName() << "\"" << std::endl;
       _isValid= false;
       continue;
     }
@@ -97,18 +97,18 @@ RooAbsNumGenerator::RooAbsNumGenerator(const RooAbsReal &func, const RooArgSet &
       }
       else {
    oocoutE(nullptr, Generation) << func.GetName() << "::RooAbsNumGenerator: cannot generate values for \""
-           << realVar->GetName() << "\" with unbound range" << endl;
+           << realVar->GetName() << "\" with unbound range" << std::endl;
    _isValid= false;
       }
     }
     else {
       oocoutE(nullptr, Generation) << func.GetName() << "::RooAbsNumGenerator" << ": cannot generate values for \""
-         << arg->GetName() << "\" with unexpected type" << endl;
+         << arg->GetName() << "\" with unexpected type" << std::endl;
       _isValid= false;
     }
   }
   if(!_isValid) {
-    oocoutE(nullptr, Generation) << func.GetName() << "::RooAbsNumGenerator" << ": constructor failed with errors" << endl;
+    oocoutE(nullptr, Generation) << func.GetName() << "::RooAbsNumGenerator" << ": constructor failed with errors" << std::endl;
     return;
   }
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -208,14 +208,14 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
     if (!realReal->getBinning().lowBoundFunc() && realReal->getMin()<(datReal->getMin()-1e-6)) {
       coutE(InputArguments) << "RooAbsOptTestStatistic: ERROR minimum of FUNC observable " << arg->GetName()
                  << "(" << realReal->getMin() << ") is smaller than that of "
-                 << arg->GetName() << " in the dataset (" << datReal->getMin() << ")" << endl ;
+                 << arg->GetName() << " in the dataset (" << datReal->getMin() << ")" << std::endl ;
       RooErrorHandler::softAbort() ;
       return ;
     }
 
     if (!realReal->getBinning().highBoundFunc() && realReal->getMax()>(datReal->getMax()+1e-6)) {
       coutE(InputArguments) << "RooAbsOptTestStatistic: ERROR maximum of FUNC observable " << arg->GetName()
-                 << " is larger than that of " << arg->GetName() << " in the dataset" << endl ;
+                 << " is larger than that of " << arg->GetName() << " in the dataset" << std::endl ;
       RooErrorHandler::softAbort() ;
       return ;
     }
@@ -224,7 +224,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
   // Copy data and strip entries lost by adjusted fit range, _dataClone ranges will be copied from realDepSet ranges
   if (rangeName && strlen(rangeName)) {
     _dataClone = std::unique_ptr<RooAbsData>{indata.reduce(RooFit::SelectVars(*_funcObsSet),RooFit::CutRange(rangeName))}.release();
-    //     cout << "RooAbsOptTestStatistic: reducing dataset to fit in range named " << rangeName << " resulting dataset has " << _dataClone->sumEntries() << " events" << endl ;
+    //     std::cout << "RooAbsOptTestStatistic: reducing dataset to fit in range named " << rangeName << " resulting dataset has " << _dataClone->sumEntries() << " events" << std::endl ;
   } else {
     _dataClone = static_cast<RooAbsData*>(indata.Clone()) ;
   }
@@ -237,7 +237,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
 
   std::unique_ptr<RooArgSet> origObsSet( real.getObservables(indata) );
   if (rangeName && strlen(rangeName)) {
-    cxcoutI(Fitting) << "RooAbsOptTestStatistic::ctor(" << GetName() << ") constructing test statistic for sub-range named " << rangeName << endl ;
+    cxcoutI(Fitting) << "RooAbsOptTestStatistic::ctor(" << GetName() << ") constructing test statistic for sub-range named " << rangeName << std::endl ;
 
     if(auto pdfClone = dynamic_cast<RooAbsPdf*>(_funcClone)) {
        pdfClone->setNormRange(rangeName);
@@ -277,7 +277,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
 
     if (addCoefRangeName && strlen(addCoefRangeName)) {
       cxcoutI(Fitting) << "RooAbsOptTestStatistic::ctor(" << GetName()
-                 << ") fixing interpretation of coefficients of any RooAddPdf component to range " << addCoefRangeName << endl ;
+                 << ") fixing interpretation of coefficients of any RooAddPdf component to range " << addCoefRangeName << std::endl ;
       _funcClone->fixAddCoefRange(addCoefRangeName,false) ;
     }
   }
@@ -311,7 +311,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
 
 
   coutI(Optimization) << "RooAbsOptTestStatistic::ctor(" << GetName() << ") optimizing internal clone of p.d.f for likelihood evaluation."
-      << "Lazy evaluation and associated change tracking will disabled for all nodes that depend on observables" << endl ;
+      << "Lazy evaluation and associated change tracking will disabled for all nodes that depend on observables" << std::endl ;
 
 
   // *********************************************************************
@@ -403,7 +403,7 @@ void RooAbsOptTestStatistic::printCompactTreeHook(ostream& os, const char* inden
   TString indent2(indent) ;
   indent2 += "opt >>" ;
   _funcClone->printCompactTree(os,indent2.Data()) ;
-  os << indent2 << " dataset clone = " << _dataClone << " first obs = " << _dataClone->get()->first() << endl ;
+  os << indent2 << " dataset clone = " << _dataClone << " first obs = " << _dataClone->get()->first() << std::endl ;
 }
 
 
@@ -417,7 +417,7 @@ void RooAbsOptTestStatistic::printCompactTreeHook(ostream& os, const char* inden
 
 void RooAbsOptTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool doAlsoTrackingOpt)
 {
-  //   cout << "ROATS::constOpt(" << GetName() << ") funcClone structure dump BEFORE const-opt" << endl ;
+  //   std::cout << "ROATS::constOpt(" << GetName() << ") funcClone structure dump BEFORE const-opt" << std::endl ;
   //   _funcClone->Print("t") ;
 
   RooAbsTestStatistic::constOptimizeTestStatistic(opcode,doAlsoTrackingOpt);
@@ -426,7 +426,7 @@ void RooAbsOptTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool
   if (_dataClone->hasFilledCache() && _dataClone->store()->cacheOwner()!=this) {
     if (opcode==Activate) {
       cxcoutW(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
-             << ") dataset cache is owned by another object, no constant term optimization can be applied" << endl ;
+             << ") dataset cache is owned by another object, no constant term optimization can be applied" << std::endl ;
     }
     return ;
   }
@@ -434,7 +434,7 @@ void RooAbsOptTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool
   if (!allowFunctionCache()) {
     if (opcode==Activate) {
       cxcoutI(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
-             << ") function caching prohibited by test statistic, no constant term optimization is applied" << endl ;
+             << ") function caching prohibited by test statistic, no constant term optimization is applied" << std::endl ;
     }
     return ;
   }
@@ -447,34 +447,34 @@ void RooAbsOptTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool
   case Activate:
     cxcoutI(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
            << ") optimizing evaluation of test statistic by finding all nodes in p.d.f that depend exclusively"
-           << " on observables and constant parameters and precalculating their values" << endl ;
+           << " on observables and constant parameters and precalculating their values" << std::endl ;
     optimizeConstantTerms(true,doAlsoTrackingOpt) ;
     break ;
 
   case DeActivate:
     cxcoutI(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
-           << ") deactivating optimization of constant terms in test statistic" << endl ;
+           << ") deactivating optimization of constant terms in test statistic" << std::endl ;
     optimizeConstantTerms(false) ;
     break ;
 
   case ConfigChange:
     cxcoutI(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
            << ") one ore more parameter were changed from constant to floating or vice versa, "
-           << "re-evaluating constant term optimization" << endl ;
+           << "re-evaluating constant term optimization" << std::endl ;
     optimizeConstantTerms(false) ;
     optimizeConstantTerms(true,doAlsoTrackingOpt) ;
     break ;
 
   case ValueChange:
     cxcoutI(Optimization) << "RooAbsOptTestStatistic::constOptimize(" << GetName()
-           << ") the value of one ore more constant parameter were changed re-evaluating constant term optimization" << endl ;
+           << ") the value of one ore more constant parameter were changed re-evaluating constant term optimization" << std::endl ;
     // Request a forcible cache update of all cached nodes
     _dataClone->store()->forceCacheUpdate() ;
 
     break ;
   }
 
-//   cout << "ROATS::constOpt(" << GetName() << ") funcClone structure dump AFTER const-opt" << endl ;
+//   std::cout << "ROATS::constOpt(" << GetName() << ") funcClone structure dump AFTER const-opt" << std::endl ;
 //   _funcClone->Print("t") ;
 }
 
@@ -491,7 +491,7 @@ void RooAbsOptTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool
 
 void RooAbsOptTestStatistic::optimizeCaching()
 {
-//   cout << "RooAbsOptTestStatistic::optimizeCaching(" << GetName() << "," << this << ")" << endl ;
+//   std::cout << "RooAbsOptTestStatistic::optimizeCaching(" << GetName() << "," << this << ")" << std::endl ;
 
   // Trigger create of all object caches now in nodes that have deferred object creation
   // so that cache contents can be processed immediately
@@ -534,12 +534,12 @@ void RooAbsOptTestStatistic::optimizeConstantTerms(bool activate, bool applyTrac
     //  WVE - Patch to allow customization of optimization level per component pdf
     if (_funcClone->getAttribute("NoOptimizeLevel1")) {
       coutI(Minimization) << " Optimization customization: Level-1 constant-term optimization prohibited by attribute NoOptimizeLevel1 set on top-level pdf  "
-                          << _funcClone->ClassName() << "::" << _funcClone->GetName() << endl ;
+                          << _funcClone->ClassName() << "::" << _funcClone->GetName() << std::endl ;
       return ;
     }
     if (_funcClone->getAttribute("NoOptimizeLevel2")) {
       coutI(Minimization) << " Optimization customization: Level-2 constant-term optimization prohibited by attribute NoOptimizeLevel2 set on top-level pdf  "
-                          << _funcClone->ClassName() << "::" << _funcClone->GetName() << endl ;
+                          << _funcClone->ClassName() << "::" << _funcClone->GetName() << std::endl ;
       applyTrackingOpt=false ;
     }
 
@@ -556,7 +556,7 @@ void RooAbsOptTestStatistic::optimizeConstantTerms(bool activate, bool applyTrac
       if (!dynamic_cast<RooVectorDataStore*>(_dataClone->store())) {
         coutW(Optimization) << "RooAbsOptTestStatistic::optimizeConstantTerms(" << GetName()
                      << ") WARNING Cache-and-track optimization (Optimize level 2) is only available for datasets"
-                     << " implement in terms of RooVectorDataStore - ignoring this option for current dataset" << endl ;
+                     << " implement in terms of RooVectorDataStore - ignoring this option for current dataset" << std::endl ;
         applyTrackingOpt = false ;
       }
     }
@@ -592,16 +592,16 @@ void RooAbsOptTestStatistic::optimizeConstantTerms(bool activate, bool applyTrac
     actualTrackNodes.remove(*constNodes) ;
     if (!constNodes->empty()) {
       if (constNodes->size()<20) {
-        coutI(Minimization) << " The following expressions have been identified as constant and will be precalculated and cached: " << *constNodes << endl ;
+        coutI(Minimization) << " The following expressions have been identified as constant and will be precalculated and cached: " << *constNodes << std::endl ;
       } else {
-        coutI(Minimization) << " A total of " << constNodes->size() << " expressions have been identified as constant and will be precalculated and cached." << endl ;
+        coutI(Minimization) << " A total of " << constNodes->size() << " expressions have been identified as constant and will be precalculated and cached." << std::endl ;
       }
     }
     if (!actualTrackNodes.empty()) {
       if (actualTrackNodes.size()<20) {
-        coutI(Minimization) << " The following expressions will be evaluated in cache-and-track mode: " << actualTrackNodes << endl ;
+        coutI(Minimization) << " The following expressions will be evaluated in cache-and-track mode: " << actualTrackNodes << std::endl ;
       } else {
-        coutI(Minimization) << " A total of " << constNodes->size() << " expressions will be evaluated in cache-and-track-mode." << endl ;
+        coutI(Minimization) << " A total of " << constNodes->size() << " expressions will be evaluated in cache-and-track-mode." << std::endl ;
       }
     }
 
@@ -642,11 +642,11 @@ bool RooAbsOptTestStatistic::setDataSlave(RooAbsData& indata, bool cloneData, bo
 {
 
   if (operMode()==SimMaster) {
-    //cout << "ROATS::setDataSlave() ERROR this is SimMaster _funcClone = " << _funcClone << endl ;
+    //cout << "ROATS::setDataSlave() ERROR this is SimMaster _funcClone = " << _funcClone << std::endl ;
     return false ;
   }
 
-  //cout << "ROATS::setDataSlave() new dataset size = " << indata.numEntries() << endl ;
+  //cout << "ROATS::setDataSlave() new dataset size = " << indata.numEntries() << std::endl ;
   //indata.Print("v") ;
 
 
@@ -663,7 +663,7 @@ bool RooAbsOptTestStatistic::setDataSlave(RooAbsData& indata, bool cloneData, bo
 
   if (!cloneData && !_rangeName.empty()) {
     coutW(InputArguments) << "RooAbsOptTestStatistic::setData(" << GetName() << ") WARNING: test statistic was constructed with range selection on data, "
-          << "ignoring request to _not_ clone the input dataset" << endl ;
+          << "ignoring request to _not_ clone the input dataset" << std::endl ;
     cloneData = true ;
   }
 
@@ -720,7 +720,7 @@ RooAbsData& RooAbsOptTestStatistic::data()
     bool notice = (sealNotice() && strlen(sealNotice())) ;
     coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName()
            << ") WARNING: object sealed by creator - access to data is not permitted: "
-           << (notice?sealNotice():"<no user notice>") << endl ;
+           << (notice?sealNotice():"<no user notice>") << std::endl ;
     static RooDataSet dummy ("dummy","dummy",RooArgSet()) ;
     return dummy ;
   }
@@ -736,7 +736,7 @@ const RooAbsData& RooAbsOptTestStatistic::data() const
     bool notice = (sealNotice() && strlen(sealNotice())) ;
     coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName()
            << ") WARNING: object sealed by creator - access to data is not permitted: "
-           << (notice?sealNotice():"<no user notice>") << endl ;
+           << (notice?sealNotice():"<no user notice>") << std::endl ;
     static RooDataSet dummy ("dummy","dummy",RooArgSet()) ;
     return dummy ;
   }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -363,7 +363,7 @@ double RooAbsPdf::getValV(const RooArgSet* nset) const
 
 double RooAbsPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName) const
 {
-  cxcoutD(Eval) << "RooAbsPdf::analyticalIntegralWN(" << GetName() << ") code = " << code << " normset = " << (normSet?*normSet:RooArgSet()) << endl ;
+  cxcoutD(Eval) << "RooAbsPdf::analyticalIntegralWN(" << GetName() << ") code = " << code << " normset = " << (normSet?*normSet:RooArgSet()) << std::endl ;
 
 
   if (code==0) return getVal(normSet) ;
@@ -421,13 +421,13 @@ double RooAbsPdf::getNorm(const RooArgSet* nset) const
   if (!nset) return 1 ;
 
   syncNormalization(nset,true) ;
-  if (_verboseEval>1) cxcoutD(Tracing) << ClassName() << "::getNorm(" << GetName() << "): norm(" << _norm << ") = " << _norm->getVal() << endl ;
+  if (_verboseEval>1) cxcoutD(Tracing) << ClassName() << "::getNorm(" << GetName() << "): norm(" << _norm << ") = " << _norm->getVal() << std::endl ;
 
   double ret = _norm->getVal() ;
   if (ret==0.) {
     if(++_errorCount <= 10) {
       coutW(Eval) << "RooAbsPdf::getNorm(" << GetName() << ":: WARNING normalization is zero, nset = " ;  nset->Print("1") ;
-      if(_errorCount == 10) coutW(Eval) << "RooAbsPdf::getNorm(" << GetName() << ") INFO: no more messages will be printed " << endl ;
+      if(_errorCount == 10) coutW(Eval) << "RooAbsPdf::getNorm(" << GetName() << ") INFO: no more messages will be printed " << std::endl ;
     }
   }
 
@@ -515,10 +515,10 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
   if (_verboseEval>0) {
     if (!selfNormalized()) {
       cxcoutD(Tracing) << ClassName() << "::syncNormalization(" << GetName()
-      << ") recreating normalization integral " << endl ;
+      << ") recreating normalization integral " << std::endl ;
       depList.printStream(ccoutD(Tracing),kName|kValue|kArgs,kSingleLine) ;
     } else {
-      cxcoutD(Tracing) << ClassName() << "::syncNormalization(" << GetName() << ") selfNormalized, creating unit norm" << endl;
+      cxcoutD(Tracing) << ClassName() << "::syncNormalization(" << GetName() << ") selfNormalized, creating unit norm" << std::endl;
     }
   }
 
@@ -530,7 +530,7 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
   } else {
     const char* nr = (_normRangeOverride.Length()>0 ? _normRangeOverride.Data() : (_normRange.Length()>0 ? _normRange.Data() : nullptr)) ;
 
-//     cout << "RooAbsPdf::syncNormalization(" << GetName() << ") rangeName for normalization is " << (nr?nr:"<null>") << endl ;
+//     std::cout << "RooAbsPdf::syncNormalization(" << GetName() << ") rangeName for normalization is " << (nr?nr:"<null>") << std::endl ;
     RooAbsReal* normInt;
     {
       // Normalization is always over all pdf components. Overriding the global
@@ -541,7 +541,7 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
     }
     static_cast<RooRealIntegral*>(normInt)->setAllowComponentSelection(false);
     normInt->getVal() ;
-//     cout << "resulting normInt = " << normInt->GetName() << endl ;
+//     std::cout << "resulting normInt = " << normInt->GetName() << std::endl ;
 
     const char* cacheParamsStr = getStringAttribute("CACHEPARAMINT") ;
     if (cacheParamsStr && strlen(cacheParamsStr)) {
@@ -552,7 +552,7 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
 
       if (!cacheParams.empty()) {
    cxcoutD(Caching) << "RooAbsReal::createIntObj(" << GetName() << ") INFO: constructing " << cacheParams.size()
-          << "-dim value cache for integral over " << depList << " as a function of " << cacheParams << " in range " << (nr?nr:"<default>") <<  endl ;
+          << "-dim value cache for integral over " << depList << " as a function of " << cacheParams << " in range " << (nr?nr:"<default>") <<  std::endl ;
    string name = Form("%s_CACHE_[%s]",normInt->GetName(),cacheParams.contentsString().c_str()) ;
    RooCachedReal* cachedIntegral = new RooCachedReal(name.c_str(),name.c_str(),*normInt,cacheParams) ;
    cachedIntegral->setInterpolationOrder(2) ;
@@ -572,7 +572,7 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
   cache = new CacheElem(*_norm) ;
   _normMgr.setObj(nset,cache) ;
 
-//   cout << "making new object " << _norm->GetName() << endl ;
+//   std::cout << "making new object " << _norm->GetName() << std::endl ;
 
   return true ;
 }
@@ -1100,10 +1100,10 @@ void RooAbsPdf::printValue(ostream& os) const
 void RooAbsPdf::printMultiline(ostream& os, Int_t contents, bool verbose, TString indent) const
 {
   RooAbsReal::printMultiline(os,contents,verbose,indent);
-  os << indent << "--- RooAbsPdf ---" << endl;
-  os << indent << "Cached value = " << _value << endl ;
+  os << indent << "--- RooAbsPdf ---" << std::endl;
+  os << indent << "Cached value = " << _value << std::endl ;
   if (_norm) {
-    os << indent << " Normalization integral: " << endl ;
+    os << indent << " Normalization integral: " << std::endl ;
     auto moreIndent = std::string(indent.Data()) + "   " ;
     _norm->printStream(os,kName|kAddress|kTitle|kValue|kArgs,kSingleLine,moreIndent.c_str()) ;
   }
@@ -1257,14 +1257,14 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet& whatVars, con
      if (nEvents == 0) nEvents = expectedEvents(&whatVars);
   } else if (nEvents==0) {
     cxcoutI(Generation) << "No number of events specified , number of events generated is "
-           << GetName() << "::expectedEvents() = " << expectedEvents(&whatVars)<< endl ;
+           << GetName() << "::expectedEvents() = " << expectedEvents(&whatVars)<< std::endl ;
   }
 
   if (extended && protoData && !randProto) {
     cxcoutI(Generation) << "WARNING Using generator option Extended() (Poisson distribution of #events) together "
            << "with a prototype dataset implies incomplete sampling or oversampling of proto data. "
            << "Set randomize flag in ProtoData() option to randomize prototype dataset order and thus "
-           << "to randomize the set of over/undersampled prototype events for each generation cycle." << endl ;
+           << "to randomize the set of over/undersampled prototype events for each generation cycle." << std::endl ;
   }
 
 
@@ -1399,7 +1399,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet &whatVars, dou
      generated = std::unique_ptr<RooDataSet>{context->generate(nEvents, false, extended)};
   }
   else {
-    coutE(Generation)  << "RooAbsPdf::generate(" << GetName() << ") cannot create a valid context" << endl;
+    coutE(Generation)  << "RooAbsPdf::generate(" << GetName() << ") cannot create a valid context" << std::endl;
   }
   return RooFit::makeOwningPtr(std::move(generated));
 }
@@ -1426,7 +1426,7 @@ std::unique_ptr<RooDataSet> RooAbsPdf::generate(RooAbsGenContext& context, const
   }
 
   if (randProtoOrder && prototype && prototype->numEntries()!=nEvents) {
-    coutI(Generation) << "RooAbsPdf::generate (Re)randomizing event order in prototype dataset (Nevt=" << nEvents << ")" << endl ;
+    coutI(Generation) << "RooAbsPdf::generate (Re)randomizing event order in prototype dataset (Nevt=" << nEvents << ")" << std::endl ;
     Int_t* newOrder = randomizeProtoOrder(prototype->numEntries(),Int_t(nEvents),resampleProto) ;
     context.setProtoDataOrder(newOrder) ;
     delete[] newOrder ;
@@ -1436,7 +1436,7 @@ std::unique_ptr<RooDataSet> RooAbsPdf::generate(RooAbsGenContext& context, const
     generated = std::unique_ptr<RooDataSet>{context.generate(nEvents,skipInit,extended)};
   }
   else {
-    coutE(Generation) << "RooAbsPdf::generate(" << GetName() << ") do not have a valid generator context" << endl;
+    coutE(Generation) << "RooAbsPdf::generate(" << GetName() << ") do not have a valid generator context" << std::endl;
   }
   return generated;
 }
@@ -1473,7 +1473,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet &whatVars, con
   if (context) {
     return RooFit::makeOwningPtr(generate(*context,whatVars,&prototype,nEvents,verbose,randProtoOrder,resampleProto));
   }
-  coutE(Generation) << "RooAbsPdf::generate(" << GetName() << ") ERROR creating generator context" << endl ;
+  coutE(Generation) << "RooAbsPdf::generate(" << GetName() << ") ERROR creating generator context" << std::endl ;
   return nullptr;
 }
 
@@ -1628,14 +1628,14 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet& whatVa
      //nEvents = (nEvents==0?Int_t(expectedEvents(&whatVars)+0.5):nEvents) ;
     nEvents = (nEvents==0 ? expectedEvents(&whatVars) :nEvents) ;
     cxcoutI(Generation) << " Extended mode active, number of events generated (" << nEvents << ") is Poisson fluctuation on "
-         << GetName() << "::expectedEvents() = " << nEvents << endl ;
+         << GetName() << "::expectedEvents() = " << nEvents << std::endl ;
     // If Poisson fluctuation results in zero events, stop here
     if (nEvents==0) {
       return nullptr ;
     }
   } else if (nEvents==0) {
     cxcoutI(Generation) << "No number of events specified , number of events generated is "
-         << GetName() << "::expectedEvents() = " << expectedEvents(&whatVars)<< endl ;
+         << GetName() << "::expectedEvents() = " << expectedEvents(&whatVars)<< std::endl ;
   }
 
   // Forward to appropriate implementation
@@ -1685,7 +1685,7 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
   // Scale to number of events and introduce Poisson fluctuations
   if (nEvents<=0) {
     if (!canBeExtended()) {
-      coutE(InputArguments) << "RooAbsPdf::generateBinned(" << GetName() << ") ERROR: No event count provided and p.d.f does not provide expected number of events" << endl ;
+      coutE(InputArguments) << "RooAbsPdf::generateBinned(" << GetName() << ") ERROR: No event count provided and p.d.f does not provide expected number of events" << std::endl ;
       return nullptr;
     } else {
 
@@ -1959,7 +1959,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
           << "\n\t- Clear the automatic fit range attribute: <pdf>.removeStringAttribute(\"fitrange\");"
           << "\n\t- Explicitly specify the plotting range: Range(\"<rangeName>\")."
           << "\n\t- Explicitly specify where to compute the normalisation: NormRange(\"<rangeName>\")."
-          << "\n\tThe default (full) range can be denoted with Range(\"\") / NormRange(\"\")."<< endl ;
+          << "\n\tThe default (full) range can be denoted with Range(\"\") / NormRange(\"\")."<< std::endl ;
   }
 
   // Sanity checks
@@ -2021,7 +2021,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
   if (stype==RelativeExpected) {
     if (!canBeExtended()) {
       coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName()
-            << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << endl ;
+            << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << std::endl ;
       return frame ;
     }
     frame->updateNormVars(*frame->getPlotVar()) ;
@@ -2049,9 +2049,9 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
         coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") only plotting range ["
             << rangeLo << "," << rangeHi << "]" ;
         if (!pc.hasProcessed("NormRange")) {
-          ccoutI(Plotting) << ", curve is normalized to data in " << (adjustNorm?"given":"full") << " range" << endl ;
+          ccoutI(Plotting) << ", curve is normalized to data in " << (adjustNorm?"given":"full") << " range" << std::endl ;
         } else {
-          ccoutI(Plotting) << endl ;
+          ccoutI(Plotting) << std::endl ;
         }
 
         nameSuffix.append(Form("_Range[%f_%f]",rangeLo,rangeHi)) ;
@@ -2072,9 +2072,9 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
 
         coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") only plotting range '" << pc.getString("rangeName", "", false) << "'" ;
         if (!pc.hasProcessed("NormRange")) {
-          ccoutI(Plotting) << ", curve is normalized to data in " << (adjustNorm?"given":"full") << " range" << endl ;
+          ccoutI(Plotting) << ", curve is normalized to data in " << (adjustNorm?"given":"full") << " range" << std::endl ;
         } else {
-          ccoutI(Plotting) << endl ;
+          ccoutI(Plotting) << std::endl ;
         }
 
         nameSuffix.append("_Range[" + std::string(pc.getString("rangeName")) + "]");
@@ -2093,7 +2093,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
         }
         adjustNorm = true ;
         hasCustomRange = true ;
-        coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") p.d.f. curve is normalized using explicit choice of ranges '" << pc.getString("normRangeName", "", false) << "'" << endl ;
+        coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") p.d.f. curve is normalized using explicit choice of ranges '" << pc.getString("normRangeName", "", false) << "'" << std::endl ;
 
         nameSuffix.append("_NormRange[" + std::string(pc.getString("rangeName")) + "]");
 
@@ -2178,15 +2178,15 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
       dirSelNodes = std::unique_ptr<RooArgSet>{branchNodeSet.selectByName(compSpec)};
     }
     if (!dirSelNodes->empty()) {
-      coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") directly selected PDF components: " << *dirSelNodes << endl ;
+      coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") directly selected PDF components: " << *dirSelNodes << std::endl ;
 
       // Do indirect selection and activate both
       plotOnCompSelect(dirSelNodes.get());
     } else {
       if (compSet) {
-   coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") ERROR: component selection set " << *compSet << " does not match any components of p.d.f." << endl ;
+   coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") ERROR: component selection set " << *compSet << " does not match any components of p.d.f." << std::endl ;
       } else {
-   coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") ERROR: component selection expression '" << compSpec << "' does not select any components of p.d.f." << endl ;
+   coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") ERROR: component selection expression '" << compSpec << "' does not select any components of p.d.f." << std::endl ;
       }
       return nullptr ;
     }
@@ -2229,7 +2229,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot *frame, PlotOpt o) const
   if (o.stype==RelativeExpected) {
     if (!canBeExtended()) {
       coutE(Plotting) << "RooAbsPdf::plotOn(" << GetName()
-            << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << endl ;
+            << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << std::endl ;
       return frame ;
     }
     frame->updateNormVars(*frame->getPlotVar()) ;
@@ -2530,10 +2530,10 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createCdf(const RooArgSet& iset, const 
     Int_t isNum= !static_cast<RooRealIntegral&>(*tmp).numIntRealVars().empty();
 
     if (isNum) {
-      coutI(NumIntegration) << "RooAbsPdf::createCdf(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << endl
+      coutI(NumIntegration) << "RooAbsPdf::createCdf(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
              << "      constructing cdf though numeric integration of sampled pdf in " << numScanBins << " bins and applying order "
-             << intOrder << " interpolation on integrated histogram." << endl
-             << "      To override this choice of technique use argument ScanNone(), to change scan parameters use ScanParameters(nbins,order) argument" << endl ;
+             << intOrder << " interpolation on integrated histogram." << std::endl
+             << "      To override this choice of technique use argument ScanNone(), to change scan parameters use ScanParameters(nbins,order) argument" << std::endl ;
     }
 
     return isNum ? createScanCdf(iset,nset,numScanBins,intOrder) : createIntRI(iset,nset) ;
@@ -2591,7 +2591,7 @@ RooArgSet* RooAbsPdf::getAllConstraints(const RooArgSet& observables, RooArgSet&
     } else {
       coutI(Minimization) << "RooAbsPdf::getAllConstraints(" << GetName() << ") omitting term " << pdf->GetName()
            << " as constraint term as it does not share any parameters with the other pdfs in product. "
-           << "To force inclusion in likelihood, add an explicit Constrain() argument for the target parameter" << endl ;
+           << "To force inclusion in likelihood, add an explicit Constrain() argument for the target parameter" << std::endl ;
     }
   }
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -379,7 +379,7 @@ Int_t RooAbsReal::getAnalyticalIntegral(RooArgSet& /*integSet*/, RooArgSet& /*an
 
 double RooAbsReal::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName) const
 {
-//   cout << "RooAbsReal::analyticalIntegralWN(" << GetName() << ") code = " << code << " normSet = " << (normSet?*normSet:RooArgSet()) << std::endl ;
+//   std::cout << "RooAbsReal::analyticalIntegralWN(" << GetName() << ") code = " << code << " normSet = " << (normSet?*normSet:RooArgSet()) << std::endl ;
   if (code==0) return getVal(normSet) ;
   return analyticalIntegral(code,rangeName) ;
 }

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -152,7 +152,7 @@ bool RooAbsRealLValue::isValidReal(double value, bool verbose) const
   if (!inRange(value,nullptr)) {
     if (verbose) {
        coutI(InputArguments) << "RooRealVar::isValid(" << GetName() << "): value " << value << " out of range ("
-                             << getMin() << " - " << getMax() << ")" << endl;
+                             << getMin() << " - " << getMax() << ")" << std::endl;
     }
     return false ;
   }
@@ -350,11 +350,11 @@ RooPlot *RooAbsRealLValue::frame(Int_t nbins) const
 {
   // Plot range of variable may not be infinite or empty
   if (getMin()==getMax()) {
-    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: empty fit range, must specify plot range" << endl ;
+    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: empty fit range, must specify plot range" << std::endl ;
     return nullptr ;
   }
   if (RooNumber::isInfinite(getMin())||RooNumber::isInfinite(getMax())) {
-    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: open ended fit range, must specify plot range" << endl ;
+    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: open ended fit range, must specify plot range" << std::endl ;
     return nullptr ;
   }
 
@@ -375,11 +375,11 @@ RooPlot *RooAbsRealLValue::frame() const
 {
   // Plot range of variable may not be infinite or empty
   if (getMin()==getMax()) {
-    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: empty fit range, must specify plot range" << endl ;
+    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: empty fit range, must specify plot range" << std::endl ;
     return nullptr ;
   }
   if (RooNumber::isInfinite(getMin())||RooNumber::isInfinite(getMax())) {
-    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: open ended fit range, must specify plot range" << endl ;
+    coutE(InputArguments) << "RooAbsRealLValue::frame(" << GetName() << ") ERROR: open ended fit range, must specify plot range" << std::endl ;
     return nullptr ;
   }
 
@@ -404,7 +404,7 @@ void RooAbsRealLValue::copyCache(const RooAbsArg* source, bool valueOnly, bool s
 void RooAbsRealLValue::printMultiline(ostream& os, Int_t contents, bool verbose, TString indent) const
 {
   RooAbsReal::printMultiline(os,contents,verbose,indent);
-  os << indent << "--- RooAbsRealLValue ---" << endl;
+  os << indent << "--- RooAbsRealLValue ---" << std::endl;
   TString unit(_unit);
   if(!unit.IsNull()) unit.Prepend(' ');
   os << indent << "  Fit range is [ ";
@@ -415,10 +415,10 @@ void RooAbsRealLValue::printMultiline(ostream& os, Int_t contents, bool verbose,
     os << "-INF , ";
   }
   if(hasMax()) {
-    os << getMax() << unit << " ]" << endl;
+    os << getMax() << unit << " ]" << std::endl;
   }
   else {
-    os << "+INF ]" << endl;
+    os << "+INF ]" << std::endl;
   }
 }
 
@@ -438,7 +438,7 @@ void RooAbsRealLValue::randomize(const char* rangeName)
     setValFast(min + RooRandom::uniform()*(max-min));
   }
   else {
-    coutE(Generation) << fName << "::" << ClassName() << ":randomize: fails with unbounded fit range" << endl;
+    coutE(Generation) << fName << "::" << ClassName() << ":randomize: fails with unbounded fit range" << std::endl;
   }
 }
 
@@ -453,7 +453,7 @@ void RooAbsRealLValue::setBin(Int_t ibin, const char* rangeName)
   // Check range of plot bin index
   if (ibin<0 || ibin>=numBins(rangeName)) {
     coutE(InputArguments) << "RooAbsRealLValue::setBin(" << GetName() << ") ERROR: bin index " << ibin
-           << " is out of range (0," << getBins(rangeName)-1 << ")" << endl ;
+           << " is out of range (0," << getBins(rangeName)-1 << ")" << std::endl ;
     return ;
   }
 
@@ -689,7 +689,7 @@ TH1F *RooAbsRealLValue::createHistogram(const char *name, const char *yAxisLabel
   // Check if the fit range is usable as plot range
   if (!fitRangeOKForPlotting()) {
     coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-           << ") ERROR: fit range empty or open ended, must explicitly specify range" << endl ;
+           << ") ERROR: fit range empty or open ended, must explicitly specify range" << std::endl ;
     return nullptr ;
   }
 
@@ -747,7 +747,7 @@ TH2F *RooAbsRealLValue::createHistogram(const char *name, const RooAbsRealLValue
 {
   if ((!xlo && xhi) || (xlo && !xhi)) {
     coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-           << ") ERROR must specify either no range, or both limits" << endl ;
+           << ") ERROR must specify either no range, or both limits" << std::endl ;
     return nullptr ;
   }
 
@@ -763,12 +763,12 @@ TH2F *RooAbsRealLValue::createHistogram(const char *name, const RooAbsRealLValue
 
     if (!fitRangeOKForPlotting()) {
       coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-      << ") ERROR: fit range empty or open ended, must explicitly specify range" << endl ;
+      << ") ERROR: fit range empty or open ended, must explicitly specify range" << std::endl ;
       return nullptr ;
     }
     if (!yvar.fitRangeOKForPlotting()) {
       coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-      << ") ERROR: fit range of " << yvar.GetName() << " empty or open ended, must explicitly specify range" << endl ;
+      << ") ERROR: fit range of " << yvar.GetName() << " empty or open ended, must explicitly specify range" << std::endl ;
       return nullptr ;
     }
 
@@ -821,7 +821,7 @@ TH3F *RooAbsRealLValue::createHistogram(const char *name, const RooAbsRealLValue
 {
   if ((!xlo && xhi) || (xlo && !xhi)) {
     coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-           << ") ERROR must specify either no range, or both limits" << endl ;
+           << ") ERROR must specify either no range, or both limits" << std::endl ;
     return nullptr ;
   }
 
@@ -836,17 +836,17 @@ TH3F *RooAbsRealLValue::createHistogram(const char *name, const RooAbsRealLValue
 
     if (!fitRangeOKForPlotting()) {
       coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-             << ") ERROR: fit range empty or open ended, must explicitly specify range" << endl ;
+             << ") ERROR: fit range empty or open ended, must explicitly specify range" << std::endl ;
       return nullptr ;
     }
     if (!yvar.fitRangeOKForPlotting()) {
       coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-             << ") ERROR: fit range of " << yvar.GetName() << " empty or open ended, must explicitly specify range" << endl ;
+             << ") ERROR: fit range of " << yvar.GetName() << " empty or open ended, must explicitly specify range" << std::endl ;
       return nullptr ;
     }
     if (!zvar.fitRangeOKForPlotting()) {
       coutE(InputArguments) << "RooAbsRealLValue::createHistogram(" << GetName()
-             << ") ERROR: fit range of " << zvar.GetName() << " empty or open ended, must explicitly specify range" << endl ;
+             << ") ERROR: fit range of " << zvar.GetName() << " empty or open ended, must explicitly specify range" << std::endl ;
       return nullptr ;
     }
 
@@ -925,7 +925,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
   // Check that we have 1-3 vars
   Int_t dim= vars.size();
   if(dim < 1 || dim > 3) {
-    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: dimension not supported: " << dim << endl;
+    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: dimension not supported: " << dim << std::endl;
     return nullptr;
   }
 
@@ -939,7 +939,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
     const RooAbsArg *arg= vars.at(index);
     xyz[index]= dynamic_cast<const RooAbsRealLValue*>(arg);
     if(!xyz[index]) {
-      oocoutE(nullptr,InputArguments) << "RooAbsRealLValue::createHistogram: variable is not real lvalue: " << arg->GetName() << endl;
+      oocoutE(nullptr,InputArguments) << "RooAbsRealLValue::createHistogram: variable is not real lvalue: " << arg->GetName() << std::endl;
       return nullptr;
     }
     histName.Append("_");
@@ -986,7 +986,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
     break;
   }
   if(!histogram) {
-    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: unable to create a new histogram" << endl;
+    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: unable to create a new histogram" << std::endl;
     return nullptr;
   }
 

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -71,7 +71,7 @@ RooAbsStudy::~RooAbsStudy()
 void RooAbsStudy::registerSummaryOutput(const RooArgSet& allVars, const RooArgSet& varsWithError, const RooArgSet& varsWithAsymError)
 {
   if (_summaryData) {
-    coutW(ObjectHandling) << "RooAbsStudy::registerSummaryOutput(" << GetName() << ") WARNING summary output already registered" << endl ;
+    coutW(ObjectHandling) << "RooAbsStudy::registerSummaryOutput(" << GetName() << ") WARNING summary output already registered" << std::endl ;
     return ;
   }
 
@@ -86,7 +86,7 @@ void RooAbsStudy::registerSummaryOutput(const RooArgSet& allVars, const RooArgSe
 void RooAbsStudy::storeSummaryOutput(const RooArgSet& vars)
 {
   if (!_summaryData) {
-    coutE(ObjectHandling) << "RooAbsStudy::storeSummaryOutput(" << GetName() << ") ERROR: no summary output data configuration registered" << endl ;
+    coutE(ObjectHandling) << "RooAbsStudy::storeSummaryOutput(" << GetName() << ") ERROR: no summary output data configuration registered" << std::endl ;
     return ;
   }
   _summaryData->add(vars) ;
@@ -103,11 +103,11 @@ void RooAbsStudy::storeDetailedOutput(std::unique_ptr<TNamed> object)
     if (!_detailData) {
       _detailData = new RooLinkedList ;
       _detailData->SetName(TString::Format("%s_detailed_data_list",GetName())) ;
-      //cout << "RooAbsStudy::ctor() detailData name = " << _detailData->GetName() << endl ;
+      //cout << "RooAbsStudy::ctor() detailData name = " << _detailData->GetName() << std::endl ;
     }
 
     object->SetName(TString::Format("%s_detailed_data_%d",GetName(),_detailData->GetSize())) ;
-    //cout << "storing detailed data with name " << object.GetName() << endl ;
+    //cout << "storing detailed data with name " << object.GetName() << std::endl ;
     _detailData->Add(object.release());
 }
 
@@ -121,12 +121,12 @@ void RooAbsStudy::aggregateSummaryOutput(TList* chunkList)
 
   for(TObject * obj : *chunkList) {
 
-    //cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") processing object " << obj->GetName() << endl ;
+    //cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") processing object " << obj->GetName() << std::endl ;
 
     RooDataSet* data = dynamic_cast<RooDataSet*>(obj) ;
     if (data) {
       if (TString(data->GetName()).BeginsWith(Form("%s_summary_data",GetName()))) {
-   //cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") found summary block " << data->GetName() << endl ;
+   //cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") found summary block " << data->GetName() << std::endl ;
    if (!_summaryData) {
      _summaryData = static_cast<RooDataSet*>(data->Clone(Form("%s_summary_data",GetName()))) ;
    } else {

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -307,7 +307,7 @@ bool RooAbsTestStatistic::redirectServersHook(const RooAbsCollection& newServerL
     for (Int_t i = 0; i < _nCPU; ++i) {
       if (_mpfeArray[i]) {
    _mpfeArray[i]->recursiveRedirectServers(newServerList,mustReplaceAll,nameChange);
-//    cout << "redirecting servers on " << _mpfeArray[i]->GetName() << endl;
+//    std::cout << "redirecting servers on " << _mpfeArray[i]->GetName() << std::endl;
       }
     }
   }
@@ -324,13 +324,13 @@ void RooAbsTestStatistic::printCompactTreeHook(ostream& os, const char* indent)
 {
   if (SimMaster == _gofOpMode) {
     // Forward to slaves
-    os << indent << "RooAbsTestStatistic begin GOF contents" << endl ;
+    os << indent << "RooAbsTestStatistic begin GOF contents" << std::endl ;
     for (std::size_t i = 0; i < _gofArray.size(); ++i) {
       TString indent2(indent);
       indent2 += "[" + std::to_string(i) + "] ";
       _gofArray[i]->printCompactTreeHook(os,indent2);
     }
-    os << indent << "RooAbsTestStatistic end GOF contents" << endl;
+    os << indent << "RooAbsTestStatistic end GOF contents" << std::endl;
   } else if (MPMaster == _gofOpMode) {
     // WVE implement this
   }
@@ -415,7 +415,7 @@ void RooAbsTestStatistic::initMPMode(RooAbsReal* real, RooAbsData* data, const R
     gof->SetName(Form("%s_GOF%d",GetName(),i));
     gof->SetTitle(Form("%s_GOF%d",GetTitle(),i));
 
-    ccoutD(Eval) << "RooAbsTestStatistic::initMPMode: starting remote server process #" << i << endl;
+    ccoutD(Eval) << "RooAbsTestStatistic::initMPMode: starting remote server process #" << i << std::endl;
     _mpfeArray[i] = new RooRealMPFE(Form("%s_%zx_MPFE%d",GetName(),reinterpret_cast<size_t>(this),i),Form("%s_%zx_MPFE%d",GetTitle(),reinterpret_cast<size_t>(this),i),*gof,false);
     //_mpfeArray[i]->setVerbose(true,true);
     _mpfeArray[i]->initialize();
@@ -424,8 +424,8 @@ void RooAbsTestStatistic::initMPMode(RooAbsReal* real, RooAbsData* data, const R
     }
   }
   _mpfeArray[_nCPU - 1]->addOwnedComponents(*gof);
-  coutI(Eval) << "RooAbsTestStatistic::initMPMode: started " << _nCPU << " remote server process." << endl;
-  //cout << "initMPMode --- done" << endl ;
+  coutI(Eval) << "RooAbsTestStatistic::initMPMode: started " << _nCPU << " remote server process." << std::endl;
+  //cout << "initMPMode --- done" << std::endl ;
   return ;
 }
 
@@ -468,7 +468,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
     if (pdf && dset && (0. != dset->sumEntries() || processEmptyDataSets())) {
       ccoutI(Fitting) << "RooAbsTestStatistic::initSimMode: creating slave calculator #" << _gofArray.size() << " for state " << catName
-          << " (" << dset->numEntries() << " dataset entries)" << endl;
+          << " (" << dset->numEntries() << " dataset entries)" << std::endl;
 
 
       // *** START HERE
@@ -514,7 +514,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
   for(auto& gof : _gofArray) {
     gof->setSimCount(_gofArray.size());
   }
-  coutI(Fitting) << "RooAbsTestStatistic::initSimMode: created " << _gofArray.size() << " slave calculators." << endl;
+  coutI(Fitting) << "RooAbsTestStatistic::initSimMode: created " << _gofArray.size() << " slave calculators." << std::endl;
 
   dsetList->Delete(); // delete the content.
 }
@@ -552,7 +552,7 @@ bool RooAbsTestStatistic::setData(RooAbsData& indata, bool cloneData)
     } else {
       std::unique_ptr<TList> dlist{indata.split(*static_cast<RooSimultaneous*>(_func), processEmptyDataSets())};
       if (!dlist) {
-        coutE(Fitting) << "RooAbsTestStatistic::initSimMode(" << GetName() << ") ERROR: index category of simultaneous pdf is missing in dataset, aborting" << endl;
+        coutE(Fitting) << "RooAbsTestStatistic::initSimMode(" << GetName() << ") ERROR: index category of simultaneous pdf is missing in dataset, aborting" << std::endl;
         throw std::runtime_error("RooAbsTestStatistic::initSimMode() ERROR, index category of simultaneous pdf is missing in dataset, aborting");
       }
 
@@ -560,14 +560,14 @@ bool RooAbsTestStatistic::setData(RooAbsData& indata, bool cloneData)
         if (auto compData = static_cast<RooAbsData*>(dlist->FindObject(gof->GetName()))) {
           gof->setDataSlave(*compData,false,true);
         } else {
-          coutE(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") ERROR: Cannot find component data for state " << gof->GetName() << endl;
+          coutE(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") ERROR: Cannot find component data for state " << gof->GetName() << std::endl;
         }
       }
     }
     break;
   case MPMaster:
     // Not supported
-    coutF(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") FATAL: setData() is not supported in multi-processor mode" << endl;
+    coutF(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") FATAL: setData() is not supported in multi-processor mode" << std::endl;
     throw std::runtime_error("RooAbsTestStatistic::setData is not supported in MPMaster mode");
     break;
   }

--- a/roofit/roofitcore/src/RooAcceptReject.cxx
+++ b/roofit/roofitcore/src/RooAcceptReject.cxx
@@ -46,8 +46,6 @@ do not define internal methods
 
 #include <cassert>
 
-using std::endl, std::cerr;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register RooIntegrator1D, is parameters and capabilities with RooNumIntFactory
@@ -91,7 +89,7 @@ RooAcceptReject::RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVar
     if(_realSampleDim > 3) {
       _minTrials= _minTrialsArray[3]*_catSampleMult;
       oocoutW(nullptr, Generation) << _funcClone->GetName() << "::RooAcceptReject" << ": WARNING: generating " << _realSampleDim
-         << " variables with accept-reject may not be accurate" << endl;
+         << " variables with accept-reject may not be accurate" << std::endl;
     }
     else {
       _minTrials= _minTrialsArray[_realSampleDim]*_catSampleMult;
@@ -103,7 +101,7 @@ RooAcceptReject::RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVar
                          << "of p.d.f. Determining maximum value by taking " << _minTrials
                          << " trial samples. If p.d.f contains sharp peaks smaller than average "
                          << "distance between trial sampling points these may be missed and p.d.f. "
-                         << "may be sampled incorrectly." << endl ;
+                         << "may be sampled incorrectly." << std::endl ;
     }
   } else {
     // No trials needed if we know the maximum a priori
@@ -113,26 +111,26 @@ RooAcceptReject::RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVar
   // Need to fix some things here
   if (_minTrials>10000) {
     oocoutW(nullptr, Generation) << "RooAcceptReject::ctor(" << func.GetName() << "): WARNING: " << _minTrials << " trial samples requested by p.d.f for "
-            << _realSampleDim << "-dimensional accept/reject sampling, this may take some time" << endl ;
+            << _realSampleDim << "-dimensional accept/reject sampling, this may take some time" << std::endl ;
   }
 
   // print a verbose summary of our configuration, if requested
   if(_verbose) {
-    oocoutI(nullptr, Generation) << func.GetName() << "::RooAcceptReject" << ":" << endl
-            << "  Initializing accept-reject generator for" << endl << "    ";
+    oocoutI(nullptr, Generation) << func.GetName() << "::RooAcceptReject" << ":" << std::endl
+            << "  Initializing accept-reject generator for" << std::endl << "    ";
     _funcClone->printStream(ooccoutI(nullptr, Generation),RooPrintable::kName,RooPrintable::kSingleLine);
     if (_funcMaxVal) {
-      ooccoutI(nullptr, Generation) << "  Function maximum provided, no trial sampling performed" << endl ;
+      ooccoutI(nullptr, Generation) << "  Function maximum provided, no trial sampling performed" << std::endl ;
     } else {
-      ooccoutI(nullptr, Generation) << "  Real sampling dimension is " << _realSampleDim << endl;
-      ooccoutI(nullptr, Generation) << "  Category sampling multiplier is " << _catSampleMult << endl ;
-      ooccoutI(nullptr, Generation) << "  Min sampling trials is " << _minTrials << endl;
+      ooccoutI(nullptr, Generation) << "  Real sampling dimension is " << _realSampleDim << std::endl;
+      ooccoutI(nullptr, Generation) << "  Category sampling multiplier is " << _catSampleMult << std::endl ;
+      ooccoutI(nullptr, Generation) << "  Min sampling trials is " << _minTrials << std::endl;
     }
     if (!_catVars.empty()) {
-      ooccoutI(nullptr, Generation) << "  Will generate category vars "<< _catVars << endl ;
+      ooccoutI(nullptr, Generation) << "  Will generate category vars "<< _catVars << std::endl ;
     }
     if (!_realVars.empty()) {
-      ooccoutI(nullptr, Generation) << "  Will generate real vars " << _realVars << endl ;
+      ooccoutI(nullptr, Generation) << "  Will generate real vars " << _realVars << std::endl ;
     }
   }
 
@@ -178,7 +176,7 @@ const RooArgSet *RooAcceptReject::generateEvent(UInt_t remaining, double& resamp
       // Use any cached events first
       if (_maxFuncVal>oldMax2) {
    oocxcoutD(nullptr, Generation) << "RooAcceptReject::generateEvent maxFuncVal has changed, need to resample already accepted events by factor"
-             << oldMax2 << "/" << _maxFuncVal << "=" << oldMax2/_maxFuncVal << endl ;
+             << oldMax2 << "/" << _maxFuncVal << "=" << oldMax2/_maxFuncVal << std::endl ;
    resampleRatio=oldMax2/_maxFuncVal ;
       }
       event= nextAcceptedEvent();
@@ -190,19 +188,19 @@ const RooArgSet *RooAcceptReject::generateEvent(UInt_t remaining, double& resamp
       // Calculate how many more events to generate using our best estimate of our efficiency.
       // Always generate at least one more event so we don't get stuck.
       if(_totalEvents*_maxFuncVal <= 0) {
-   oocoutE(nullptr, Generation) << "RooAcceptReject::generateEvent: cannot estimate efficiency...giving up" << endl;
+   oocoutE(nullptr, Generation) << "RooAcceptReject::generateEvent: cannot estimate efficiency...giving up" << std::endl;
    return nullptr;
       }
 
       double eff= _funcSum/(_totalEvents*_maxFuncVal);
       Long64_t extra= 1 + (Long64_t)(1.05*remaining/eff);
-      oocxcoutD(nullptr, Generation) << "RooAcceptReject::generateEvent: adding " << extra << " events to the cache, eff = " << eff << endl;
+      oocxcoutD(nullptr, Generation) << "RooAcceptReject::generateEvent: adding " << extra << " events to the cache, eff = " << eff << std::endl;
       double oldMax(_maxFuncVal);
       while(extra--) {
    addEventToCache();
    if((_maxFuncVal > oldMax)) {
      oocxcoutD(nullptr, Generation) << "RooAcceptReject::generateEvent: estimated function maximum increased from "
-               << oldMax << " to " << _maxFuncVal << endl;
+               << oldMax << " to " << _maxFuncVal << std::endl;
      oldMax = _maxFuncVal ;
      // Trim cache here
    }
@@ -247,18 +245,18 @@ const RooArgSet *RooAcceptReject::nextAcceptedEvent()
     // accept this cached event?
     double r= RooRandom::uniform();
     if(r*_maxFuncVal > _funcValPtr->getVal()) {
-      //cout << " event number " << _eventsUsed << " has been rejected" << endl ;
+      //cout << " event number " << _eventsUsed << " has been rejected" << std::endl ;
       continue;
     }
-    //cout << " event number " << _eventsUsed << " has been accepted" << endl ;
+    //cout << " event number " << _eventsUsed << " has been accepted" << std::endl ;
     // copy this event into the output container
     if(_verbose && (_eventsUsed%1000==0)) {
-      cerr << "RooAcceptReject: accepted event (used " << _eventsUsed << " of "
-      << _cache->numEntries() << " so far)" << endl;
+      std::cerr << "RooAcceptReject: accepted event (used " << _eventsUsed << " of "
+      << _cache->numEntries() << " so far)" << std::endl;
     }
     break;
   }
-  //cout << "accepted event " << _eventsUsed << " of " << _cache->numEntries() << endl ;
+  //cout << "accepted event " << _eventsUsed << " of " << _cache->numEntries() << std::endl ;
   return event;
 }
 
@@ -291,7 +289,7 @@ void RooAcceptReject::addEventToCache()
   _totalEvents++;
 
   if (_verbose &&_totalEvents%10000==0) {
-    cerr << "RooAcceptReject: generated " << _totalEvents << " events so far." << endl ;
+    std::cerr << "RooAcceptReject: generated " << _totalEvents << " events so far." << std::endl ;
   }
 
 }
@@ -308,7 +306,7 @@ double RooAcceptReject::getFuncMax()
 
     // Limit cache size to 1M events
     if (_cache->numEntries()>1000000) {
-      oocoutI(nullptr, Generation) << "RooAcceptReject::getFuncMax: resetting event cache" << endl ;
+      oocoutI(nullptr, Generation) << "RooAcceptReject::getFuncMax: resetting event cache" << std::endl ;
       _cache->reset() ;
       _eventsUsed = 0 ;
     }

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -143,7 +143,7 @@ bool RooAdaptiveIntegratorND::checkLimits() const
 bool RooAdaptiveIntegratorND::setLimits(double *xmin, double *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr,Integration) << "RooAdaptiveIntegratorND::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooAdaptiveIntegratorND::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
   for (UInt_t i=0 ; i<_func->NDim() ; i++) {
@@ -167,11 +167,11 @@ double RooAdaptiveIntegratorND::integral(const double* /*yvec*/)
     _nError++ ;
     if (_nError<=_nWarn) {
       oocoutW(nullptr, NumIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName() << ") WARNING: target rel. precision not reached due to nEval limit of "
-             << _nmax << ", estimated rel. precision is " << Form("%3.1e",_integrator->RelError()) << endl ;
+             << _nmax << ", estimated rel. precision is " << Form("%3.1e",_integrator->RelError()) << std::endl ;
     }
     if (_nError==_nWarn) {
       oocoutW(nullptr, NumIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName()
-             << ") Further warnings on target precision are suppressed conform specification in integrator specification" << endl ;
+             << ") Further warnings on target precision are suppressed conform specification in integrator specification" << std::endl ;
     }
   }
   return ret ;

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -226,9 +226,9 @@ RooResolutionModel* RooAddModel::convolution(RooFormulaVar* inBasis, RooAbsArg* 
   // Check that primary variable of basis functions is our convolution variable
   if (inBasis->getParameter(0) != x.absArg()) {
     coutE(InputArguments) << "RooAddModel::convolution(" << GetName()
-           << ") convolution parameter of basis function and PDF don't match" << endl ;
-    ccoutE(InputArguments) << "basis->findServer(0) = " << inBasis->findServer(0) << " " << inBasis->findServer(0)->GetName() << endl ;
-    ccoutE(InputArguments) << "x.absArg()           = " << x.absArg() << " " << x.absArg()->GetName() << endl ;
+           << ") convolution parameter of basis function and PDF don't match" << std::endl ;
+    ccoutE(InputArguments) << "basis->findServer(0) = " << inBasis->findServer(0) << " " << inBasis->findServer(0)->GetName() << std::endl ;
+    ccoutE(InputArguments) << "x.absArg()           = " << x.absArg() << " " << x.absArg()->GetName() << std::endl ;
     inBasis->Print("v") ;
     return nullptr ;
   }
@@ -366,7 +366,7 @@ double RooAddModel::evaluate() const
       if (pdf->isSelectedComp()) {
    value += pdfVal*_coefCache[i]/snormVal ;
    cxcoutD(Eval) << "RooAddModel::evaluate(" << GetName() << ")  value += ["
-         << pdf->GetName() << "] " << pdfVal << " * " << _coefCache[i] << " / " << snormVal << endl ;
+         << pdf->GetName() << "] " << pdfVal << " * " << _coefCache[i] << " / " << snormVal << std::endl ;
       }
     }
     i++ ;
@@ -440,7 +440,7 @@ bool RooAddModel::checkObservables(const RooArgSet* nset) const
 
     if (pdf->observableOverlaps(nset,*coef)) {
       coutE(InputArguments) << "RooAddModel::checkObservables(" << GetName() << "): ERROR: coefficient " << coef->GetName()
-             << " and PDF " << pdf->GetName() << " have one or more dependents in common" << endl ;
+             << " and PDF " << pdf->GetName() << " have one or more dependents in common" << std::endl ;
       ret = true ;
     }
   }
@@ -551,7 +551,7 @@ double RooAddModel::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
       double intVal = pdfInt->getVal(nset) ;
       value += intVal*_coefCache[i]/snormVal ;
       cxcoutD(Eval) << "RooAddModel::evaluate(" << GetName() << ")  value += ["
-            << pdfInt->GetName() << "] " << intVal << " * " << _coefCache[i] << " / " << snormVal << endl ;
+            << pdfInt->GetName() << "] " << intVal << " * " << _coefCache[i] << " / " << snormVal << std::endl ;
     }
     i++ ;
   }

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -710,7 +710,7 @@ double RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, con
   cxcoutD(Caching) << "RooAddPdf::aiWN(" << GetName() << ") calling getProjCache with nset = " << (normSet?*normSet:RooArgSet()) << std::endl ;
 
   if ((normSet==nullptr || normSet->empty()) && !_refCoefNorm.empty()) {
-//     cout << "WVE integration of RooAddPdf without normalization, but have reference set, using ref set for normalization" << std::endl ;
+//     std::cout << "WVE integration of RooAddPdf without normalization, but have reference set, using ref set for normalization" << std::endl ;
     normSet = &_refCoefNorm ;
   }
 

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -96,7 +96,7 @@ RooArgList::RooArgList(const TCollection& tcoll, const char* name) :
   for(TObject * obj : tcoll) {
     if (!dynamic_cast<RooAbsArg*>(obj)) {
       coutW(InputArguments) << "RooArgList::RooArgList(TCollection) element " << obj->GetName()
-             << " is not a RooAbsArg, ignored" << endl ;
+             << " is not a RooAbsArg, ignored" << std::endl ;
       continue ;
     }
     add(*static_cast<RooAbsArg*>(obj)) ;
@@ -138,7 +138,7 @@ RooArgList::~RooArgList()
 void RooArgList::writeToStream(ostream& os, bool compact)
 {
   if (!compact) {
-    coutE(InputArguments) << "RooArgList::writeToStream(" << GetName() << ") non-compact mode not supported" << endl ;
+    coutE(InputArguments) << "RooArgList::writeToStream(" << GetName() << ") non-compact mode not supported" << std::endl ;
     return ;
   }
 
@@ -146,7 +146,7 @@ void RooArgList::writeToStream(ostream& os, bool compact)
     obj->writeToStream(os,true);
     os << " " ;
   }
-  os << endl ;
+  os << std::endl ;
 }
 
 
@@ -161,7 +161,7 @@ void RooArgList::writeToStream(ostream& os, bool compact)
 bool RooArgList::readFromStream(istream& is, bool compact, bool verbose)
 {
   if (!compact) {
-    coutE(InputArguments) << "RooArgList::readFromStream(" << GetName() << ") non-compact mode not supported" << endl ;
+    coutE(InputArguments) << "RooArgList::readFromStream(" << GetName() << ") non-compact mode not supported" << std::endl ;
     return true ;
   }
 
@@ -181,7 +181,7 @@ bool RooArgList::readFromStream(istream& is, bool compact, bool verbose)
     TString rest = parser.readLine() ;
     if (verbose) {
       coutW(InputArguments) << "RooArgSet::readFromStream(" << GetName()
-             << "): ignoring extra characters at end of line: '" << rest << "'" << endl ;
+             << "): ignoring extra characters at end of line: '" << rest << "'" << std::endl ;
     }
   }
 

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -144,7 +144,7 @@ RooArgSet::RooArgSet(const TCollection& tcoll, const char* name) :
   for(TObject* obj : tcoll) {
     if (!dynamic_cast<RooAbsArg*>(obj)) {
       coutW(InputArguments) << "RooArgSet::RooArgSet(TCollection) element " << obj->GetName()
-             << " is not a RooAbsArg, ignored" << endl ;
+             << " is not a RooAbsArg, ignored" << std::endl ;
       continue ;
     }
     add(*static_cast<RooAbsArg*>(obj)) ;
@@ -189,7 +189,7 @@ RooAbsArg& RooArgSet::operator[](const TString& name) const
 {
   RooAbsArg* arg = find(name) ;
   if (!arg) {
-    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named " << name << " in set" << endl ;
+    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named " << name << " in set" << std::endl ;
     throw std::invalid_argument((TString("No element named '") + name + "' in set " + GetName()).Data());
   }
   return *arg ;
@@ -208,7 +208,7 @@ bool RooArgSet::checkForDup(const RooAbsArg& var, bool silent) const
       if (!silent) {
    // print a warning if this variable is not the same one we
    // already have
-   coutE(InputArguments) << "RooArgSet::checkForDup: ERROR argument with name " << var.GetName() << " is already in this set" << endl;
+   coutE(InputArguments) << "RooArgSet::checkForDup: ERROR argument with name " << var.GetName() << " is already in this set" << std::endl;
       }
     }
     // don't add duplicates
@@ -231,7 +231,7 @@ void RooArgSet::writeToFile(const char* fileName) const
 {
   ofstream ofs(fileName) ;
   if (ofs.fail()) {
-    coutE(InputArguments) << "RooArgSet::writeToFile(" << GetName() << ") error opening file " << fileName << endl ;
+    coutE(InputArguments) << "RooArgSet::writeToFile(" << GetName() << ") error opening file " << fileName << std::endl ;
     return ;
   }
   writeToStream(ofs,false) ;
@@ -247,7 +247,7 @@ bool RooArgSet::readFromFile(const char* fileName, const char* flagReadAtt, cons
 {
   ifstream ifs(fileName) ;
   if (ifs.fail()) {
-    coutE(InputArguments) << "RooArgSet::readFromFile(" << GetName() << ") error opening file " << fileName << endl ;
+    coutE(InputArguments) << "RooArgSet::readFromFile(" << GetName() << ") error opening file " << fileName << std::endl ;
     return true ;
   }
   return readFromStream(ifs,false,flagReadAtt,section,verbose) ;
@@ -279,12 +279,12 @@ void RooArgSet::writeToStream(ostream& os, bool compact, const char* section) co
       next->writeToStream(os, true);
       os << " ";
     }
-    os << endl;
+    os << std::endl;
   } else {
     for (const auto next : _list) {
       os << next->GetName() << " = " ;
       next->writeToStream(os,false) ;
-      os << endl ;
+      os << std::endl ;
     }
   }
 }
@@ -336,7 +336,7 @@ void RooArgSet::writeToStream(ostream& os, bool compact, const char* section) co
 bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAtt, const char* section, bool verbose)
 {
   if (compact) {
-    coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << ") compact mode not supported" << endl ;
+    coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << ") compact mode not supported" << std::endl ;
     return true ;
   }
 
@@ -381,17 +381,17 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
     if (!token.CompareTo("include")) {
       if (parser.atEOL()) {
         coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName()
-                   << "): no filename found after include statement" << endl ;
+                   << "): no filename found after include statement" << std::endl ;
         return true ;
       }
       TString filename = parser.readLine() ;
       ifstream incfs(filename) ;
       if (!incfs.good()) {
-        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): cannot open include file " << filename << endl ;
+        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): cannot open include file " << filename << std::endl ;
         return true ;
       }
       coutI(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): processing include file "
-          << filename << endl ;
+          << filename << std::endl ;
       if (readFromStream(incfs,compact,flagReadAtt,inSection?nullptr:section,verbose)) return true ;
       continue ;
     }
@@ -439,7 +439,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
 
       if (verbose) {
         cxcoutD(Eval) << "RooArgSet::readFromStream(" << GetName() << "): conditional expression " << expr << " = "
-                      << (condStack[condStackLevel] ? "true" : "false") << endl;
+                      << (condStack[condStackLevel] ? "true" : "false") << std::endl;
       }
       continue ; // go to next line
     }
@@ -447,7 +447,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
     if (!token.CompareTo("else")) {
       // Must have seen an if statement before
       if (condStackLevel==0) {
-        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): unmatched 'else'" << endl ;
+        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): unmatched 'else'" << std::endl ;
       }
 
       if (parser.atEOL()) {
@@ -459,7 +459,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
         // if anything follows it should be 'if'
         token = parser.readToken() ;
         if (token.CompareTo("if")) {
-          coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): syntax error: 'else " << token << "'" << endl ;
+          coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): syntax error: 'else " << token << "'" << std::endl ;
           return true ;
         } else {
           if (anyCondTrue[condStackLevel]) {
@@ -480,7 +480,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
     if (!token.CompareTo("endif")) {
       // Must have seen an if statement before
       if (condStackLevel==0) {
-        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): unmatched 'endif'" << endl ;
+        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): unmatched 'endif'" << std::endl ;
         return true ;
       }
 
@@ -495,14 +495,14 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
       // Process echo statements
       if (!token.CompareTo("echo")) {
         TString message = parser.readLine() ;
-        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): >> " << message << endl ;
+        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): >> " << message << std::endl ;
         continue ;
       }
 
       // Process abort statements
       if (!token.CompareTo("abort")) {
         TString message = parser.readLine() ;
-        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): USER ABORT" << endl ;
+        coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): USER ABORT" << std::endl ;
         return true ;
       }
 
@@ -514,7 +514,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
           parser.zapToEnd(true) ;
           retVal=true ;
           coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName()
-                << "): missing '=' sign: " << arg << endl ;
+                << "): missing '=' sign: " << arg << std::endl ;
           continue ;
         }
         bool argRet = arg->readFromStream(is,false,verbose) ;
@@ -523,7 +523,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
       } else {
         if (verbose) {
           coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): argument "
-              << token << " not in list, ignored" << endl ;
+              << token << " not in list, ignored" << std::endl ;
         }
         parser.zapToEnd(true) ;
       }
@@ -534,7 +534,7 @@ bool RooArgSet::readFromStream(istream& is, bool compact, const char* flagReadAt
 
   // Did we fully unwind the conditional stack?
   if (condStackLevel!=0) {
-    coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): missing 'endif'" << endl ;
+    coutE(InputArguments) << "RooArgSet::readFromStream(" << GetName() << "): missing 'endif'" << std::endl ;
     return true ;
   }
 

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -86,7 +86,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc &function, int numBins)
     std::unique_ptr<list<double>> tmp{ _function->binBoundaries(i) };
     if (!tmp) {
       oocoutW(nullptr,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #"
-          << i << " substituting default binning of " << _numBins << " bins" << endl ;
+          << i << " substituting default binning of " << _numBins << " bins" << std::endl ;
       tmp = std::make_unique<list<double>>( );
       for (Int_t j=0 ; j<=_numBins ; j++) {
         tmp->push_back(_xmin[i]+j*(_xmax[i]-_xmin[i])/_numBins) ;
@@ -117,7 +117,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, const RooNumIntCo
 bool RooBinIntegrator::setLimits(double *xmin, double *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr,Integration) << "RooBinIntegrator::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooBinIntegrator::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
   _xmin[0]= *xmin;
@@ -143,7 +143,7 @@ bool RooBinIntegrator::checkLimits() const
   }
   for (UInt_t i=0 ; i<_function->getDimension() ; i++) {
     if (_xmax[i]<=_xmin[i]) {
-      oocoutE(nullptr,Integration) << "RooBinIntegrator::checkLimits: bad range with min >= max (_xmin = " << _xmin[i] << " _xmax = " << _xmax[i] << ")" << endl;
+      oocoutE(nullptr,Integration) << "RooBinIntegrator::checkLimits: bad range with min >= max (_xmin = " << _xmin[i] << " _xmax = " << _xmax[i] << ")" << std::endl;
       return false;
     }
     if (RooNumber::isInfinite(_xmin[i]) || RooNumber::isInfinite(_xmax[i])) {

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -50,7 +50,7 @@ RooBinnedGenContext::RooBinnedGenContext(const RooAbsPdf &model, const RooArgSet
          << " for generation of observable(s) " << vars ;
   if (prototype) ccxcoutI(Generation) << " with prototype data for " << *prototype->get() ;
   if (auxProto && !auxProto->empty())  ccxcoutI(Generation) << " with auxiliary prototypes " << *auxProto ;
-  ccxcoutI(Generation) << endl ;
+  ccxcoutI(Generation) << std::endl ;
 
   // Constructor. Build an array of generator contexts for each product component PDF
   RooArgSet(model).snapshot(_pdfSet, true);
@@ -120,7 +120,7 @@ RooDataSet *RooBinnedGenContext::generate(double nEvt, bool /*skipInit*/, bool e
   if (nEvents<=0) {
     if (!_pdf->canBeExtended()) {
       coutE(InputArguments) << "RooAbsPdf::generateBinned(" << GetName()
-             << ") ERROR: No event count provided and p.d.f does not provide expected number of events" << endl ;
+             << ") ERROR: No event count provided and p.d.f does not provide expected number of events" << std::endl ;
       return nullptr ;
     } else {
       // Don't round in expectedData mode
@@ -228,7 +228,7 @@ void RooBinnedGenContext::generateEvent(RooArgSet&, Int_t)
 void RooBinnedGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
 {
   RooAbsGenContext::printMultiline(os,content,verbose,indent) ;
-  os << indent << "--- RooBinnedGenContext ---" << endl ;
+  os << indent << "--- RooBinnedGenContext ---" << std::endl ;
   os << indent << "Using PDF ";
   _pdf->printStream(os,kName|kArgs|kClassName,kSingleLine,indent);
 }

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -216,7 +216,7 @@ double* RooBinning::array() const
 void RooBinning::setRange(double xlo, double xhi)
 {
   if (xlo > xhi) {
-    coutE(InputArguments) << "RooBinning::setRange: ERROR low bound > high bound" << endl;
+    coutE(InputArguments) << "RooBinning::setRange: ERROR low bound > high bound" << std::endl;
     return;
   }
   // Remove previous boundaries
@@ -254,7 +254,7 @@ void RooBinning::updateBinCount()
 bool RooBinning::binEdges(Int_t bin, double& xlo, double& xhi) const
 {
   if (0 > bin || bin >= _nbins) {
-    coutE(InputArguments) << "RooBinning::binEdges ERROR: bin number must be in range (0," << _nbins << ")" << endl;
+    coutE(InputArguments) << "RooBinning::binEdges ERROR: bin number must be in range (0," << _nbins << ")" << std::endl;
     return true;
   }
   xlo = _boundaries[bin + _blo], xhi = _boundaries[bin + _blo + 1];

--- a/roofit/roofitcore/src/RooBrentRootFinder.cxx
+++ b/roofit/roofitcore/src/RooBrentRootFinder.cxx
@@ -44,7 +44,7 @@ RooBrentRootFinder::RooBrentRootFinder(const RooAbsFunc& function) :
 {
   if(_function->getDimension() != 1) {
     oocoutE(nullptr,Eval) << "RooBrentRootFinder:: cannot find roots for function of dimension "
-               << _function->getDimension() << endl;
+               << _function->getDimension() << std::endl;
     _valid= false;
   }
 }
@@ -67,7 +67,7 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
   double fb= (*_function)(&b) - value;
   if(fb*fa > 0) {
     oocxcoutD((TObject*)nullptr,Eval) << "RooBrentRootFinder::findRoot(" << _function->getName() << "): initial interval does not bracket a root: ("
-            << a << "," << b << "), value = " << value << " f[xlo] = " << fa << " f[xhi] = " << fb << endl;
+            << a << "," << b << "), value = " << value << " f[xlo] = " << fa << " f[xhi] = " << fb << std::endl;
     return false;
   }
 
@@ -102,7 +102,7 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
 
 
     if (fb == 0 || std::abs(m) <= tol) {
-      //cout << "RooBrentRootFinder: iter = " << iter << " m = " << m << " tol = " << tol << endl ;
+      //cout << "RooBrentRootFinder: iter = " << iter << " m = " << m << " tol = " << tol << std::endl ;
       result= b;
       _function->restoreXVec() ;
       return true;
@@ -165,7 +165,7 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
 
   }
   // Return our best guess if we run out of iterations
-  oocoutE(nullptr,Eval) << "RooBrentRootFinder::findRoot(" << _function->getName() << "): maximum iterations exceeded." << endl;
+  oocoutE(nullptr,Eval) << "RooBrentRootFinder::findRoot(" << _function->getName() << "): maximum iterations exceeded." << std::endl;
   result= b;
 
   _function->restoreXVec() ;

--- a/roofit/roofitcore/src/RooCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooCachedPdf.cxx
@@ -100,7 +100,7 @@ void RooCachedPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) const
   (const_cast<RooAbsPdf &>(static_cast<RooAbsPdf const&>(pdf.arg()))).fillDataHist(cache.hist(),&cache.nset(),1.0,false,true) ;
 
   if (cache.hist()->get()->size()>1) {
-    ccoutP(Eval) << endl ;
+    ccoutP(Eval) << std::endl ;
   }
 
   cache.pdf()->setUnitNorm(true) ;

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -124,7 +124,7 @@ void RooCachedReal::fillCacheObject(RooAbsCachedReal::FuncCacheElem& cache) cons
     }
     if (nDim>nCat+1) {
         coutP(Eval) << "RooCachedReal::fillCacheObject(" << GetName() << ") filling "
-                    << nCat << " + " << nDim-nCat <<" dimensional cache (" << cache.hist()->numEntries() << " points)" <<endl;
+                    << nCat << " + " << nDim-nCat <<" dimensional cache (" << cache.hist()->numEntries() << " points)" << std::endl;
     }
   }
 

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -210,7 +210,7 @@ bool RooCategory::defineType(const std::string& label)
 {
   if (label.find(';') != std::string::npos) {
     coutE(InputArguments) << "RooCategory::defineType(" << GetName()
-        << "): semicolons not allowed in label name" << endl ;
+        << "): semicolons not allowed in label name" << std::endl ;
     return true;
   }
 
@@ -226,7 +226,7 @@ bool RooCategory::defineType(const std::string& label, Int_t index)
 {
   if (label.find(';') != std::string::npos) {
     coutE(InputArguments) << "RooCategory::defineType(" << GetName()
-         << "): semicolons not allowed in label name" << endl ;
+         << "): semicolons not allowed in label name" << std::endl ;
     return true;
   }
 
@@ -323,7 +323,7 @@ void RooCategory::clearRange(const char* name, bool silent)
   std::map<std::string, std::vector<value_type>>::iterator item = _ranges->find(name);
   if (item == _ranges->end()) {
     if (!silent)
-      coutE(InputArguments) << "RooCategory::clearRange(" << GetName() << ") ERROR: must specify valid range name" << endl ;
+      coutE(InputArguments) << "RooCategory::clearRange(" << GetName() << ") ERROR: must specify valid range name" << std::endl ;
     return;
   }
 
@@ -356,7 +356,7 @@ void RooCategory::addToRange(const char* name, RooAbsCategory::value_type stateI
 
     item = _ranges->emplace(name, std::vector<value_type>()).first;
     coutI(Contents) << "RooCategory::setRange(" << GetName()
-        << ") new range named '" << name << "' created for state " << stateIndex << endl ;
+        << ") new range named '" << name << "' created for state " << stateIndex << std::endl ;
   }
 
   item->second.push_back(stateIndex);
@@ -372,7 +372,7 @@ void RooCategory::addToRange(const char* name, RooAbsCategory::value_type stateI
 void RooCategory::addToRange(const char* name, const char* stateNameList)
 {
   if (!stateNameList) {
-    coutE(InputArguments) << "RooCategory::setRange(" << GetName() << ") ERROR: must specify valid name and state name list" << endl ;
+    coutE(InputArguments) << "RooCategory::setRange(" << GetName() << ") ERROR: must specify valid name and state name list" << std::endl ;
     return;
   }
 
@@ -383,7 +383,7 @@ void RooCategory::addToRange(const char* name, const char* stateNameList)
       addToRange(name, idx);
     } else {
       coutW(InputArguments) << "RooCategory::setRange(" << GetName() << ") WARNING: Ignoring invalid state name '"
-             << token << "' in state name list" << endl ;
+             << token << "' in state name list" << std::endl ;
     }
   }
 }
@@ -419,7 +419,7 @@ bool RooCategory::isStateInRange(const char* rangeName, const char* stateName) c
   }
 
   if (!stateName) {
-    coutE(InputArguments) << "RooCategory::isStateInRange(" << GetName() << ") ERROR: must specify valid state name" << endl ;
+    coutE(InputArguments) << "RooCategory::isStateInRange(" << GetName() << ") ERROR: must specify valid state name" << std::endl ;
     return false;
   }
 

--- a/roofit/roofitcore/src/RooChangeTracker.cxx
+++ b/roofit/roofitcore/src/RooChangeTracker.cxx
@@ -114,11 +114,11 @@ bool RooChangeTracker::hasChanged(bool clearState)
 
     if (clearState) {
       // Clear dirty flag by calling getVal()
-      //cout << "RooChangeTracker(" << GetName() << ") clearing isValueDirty" << endl ;
+      //cout << "RooChangeTracker(" << GetName() << ") clearing isValueDirty" << std::endl ;
       clearValueDirty() ;
     }
 
-    //cout << "RooChangeTracker(" << GetName() << ") isValueDirty = true, returning true" << endl ;
+    //cout << "RooChangeTracker(" << GetName() << ") isValueDirty = true, returning true" << std::endl ;
 
     return true ;
   }
@@ -132,7 +132,7 @@ bool RooChangeTracker::hasChanged(bool clearState)
     for (unsigned int i=0; i < _realSet.size(); ++i) {
       auto real = static_cast<const RooAbsReal*>(_realSet.at(i));
       if (real->getVal() != _realRef[i]) {
-        // cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << real->GetName() << " has changed from " << _realRef[i] << " to " << real->getVal() << " clearState = " << (clearState?"T":"F") << endl ;
+        // std::cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << real->GetName() << " has changed from " << _realRef[i] << " to " << real->getVal() << " clearState = " << (clearState?"T":"F") << std::endl ;
         valuesChanged = true ;
         _realRef[i] = real->getVal() ;
       }
@@ -141,7 +141,7 @@ bool RooChangeTracker::hasChanged(bool clearState)
     for (unsigned int i=0; i < _catSet.size(); ++i) {
       auto cat = static_cast<const RooAbsCategory*>(_catSet.at(i));
       if (cat->getCurrentIndex() != _catRef[i]) {
-        // cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << cat->GetName() << " has changed from " << _catRef[i-1] << " to " << cat->getIndex() << endl ;
+        // std::cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << cat->GetName() << " has changed from " << _catRef[i-1] << " to " << cat->getIndex() << std::endl ;
         valuesChanged = true ;
         _catRef[i] = cat->getCurrentIndex() ;
       }
@@ -155,7 +155,7 @@ bool RooChangeTracker::hasChanged(bool clearState)
       _init = true ;
     }
 
-    // cout << "RooChangeTracker(" << GetName() << ") returning " << (valuesChanged?"T":"F") << endl ;
+    // std::cout << "RooChangeTracker(" << GetName() << ") returning " << (valuesChanged?"T":"F") << std::endl ;
 
     return valuesChanged ;
 

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -139,7 +139,7 @@ double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEve
       return 0.;
     }
 
-//     cout << "Chi2Var[" << i << "] nData = " << nData << " nPdf = " << nPdf << " errorExt = " << eExt << " errorInt = " << eInt << " contrib = " << eExt*eExt/(eInt*eInt) << endl ;
+//     std::cout << "Chi2Var[" << i << "] nData = " << nData << " nPdf = " << nPdf << " errorExt = " << eExt << " errorInt = " << eInt << " contrib = " << eExt*eExt/(eInt*eInt) << std::endl ;
 
     double term = eExt*eExt/(eInt*eInt) ;
     double y = term - carry;

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -140,7 +140,7 @@ bool makeAndCompileClass(std::string const &baseClassName, std::string const &na
          catArgNames += arg->GetName();
       } else {
          oocoutE(nullptr, InputArguments) << "RooClassFactory ERROR input argument " << arg->GetName()
-                                          << " is neither RooAbsReal nor RooAbsCategory and is ignored" << endl;
+                                          << " is neither RooAbsReal nor RooAbsCategory and is ignored" << std::endl;
       }
    }
 
@@ -449,14 +449,14 @@ bool RooClassFactory::makeClass(std::string const &baseName, std::string const &
 
    if (realArgNames.empty() && catArgNames.empty()) {
       oocoutE(nullptr, InputArguments)
-         << "RooClassFactory::makeClass: ERROR: A list of input argument names must be given" << endl;
+         << "RooClassFactory::makeClass: ERROR: A list of input argument names must be given" << std::endl;
       return true;
    }
 
    if (!intExpression.empty() && !hasAnaInt) {
       oocoutE(nullptr, InputArguments) << "RooClassFactory::makeClass: ERROR no analytical integration code "
                                           "requestion, but expression for analytical integral provided"
-                                       << endl;
+                                       << std::endl;
       return true;
    }
 
@@ -506,9 +506,9 @@ public:
     }
     hf << alist[i] ;
     if (i==alist.size()-1) {
-      hf << ");" << endl ;
+      hf << ");" << std::endl ;
     } else {
-      hf << "," << endl ;
+      hf << "," << std::endl ;
     }
   }
 
@@ -531,14 +531,14 @@ public:
 )";
   }
 
-  hf << "" << endl ;
+  hf << "" << std::endl ;
 
   // Insert list of input arguments
   for (std::size_t i=0 ; i<alist.size() ; i++) {
     if (!isCat[i]) {
-      hf << "  RooRealProxy " << alist[i] << " ;" << endl ;
+      hf << "  RooRealProxy " << alist[i] << " ;" << std::endl ;
     } else {
-      hf << "  RooCategoryProxy " << alist[i] << " ;" << endl ;
+      hf << "  RooCategoryProxy " << alist[i] << " ;" << std::endl ;
     }
   }
 
@@ -580,9 +580,9 @@ void codegenImpl(CLASS_NAME &arg, CodegenContext &ctx);
    // ENTER EXPRESSION IN TERMS OF VARIABLE ARGUMENTS HERE
 
 )"
-     << "   return " << expression << ";" << endl
+     << "   return " << expression << ";" << std::endl
      << "}\n"
-     << endl;
+     << std::endl;
 
   hf << "\n#endif // CLASS_NAME_h";
 
@@ -623,11 +623,11 @@ CLASS_NAME::CLASS_NAME(const char *name, const char *title,
     } else {
       cf << ")" ;
     }
-    cf << endl ;
+    cf << std::endl ;
   }
 
   // Insert base class constructor
-  cf << "   : BASE_NAME(name,title)," << endl ;
+  cf << "   : BASE_NAME(name,title)," << std::endl ;
 
   // Insert list of proxy constructors
   for (std::size_t i=0 ; i<alist.size() ; i++) {
@@ -635,34 +635,34 @@ CLASS_NAME::CLASS_NAME(const char *name, const char *title,
     if (i<alist.size()-1) {
       cf << "," ;
     }
-    cf << endl ;
+    cf << std::endl ;
   }
 
-  cf << "{" << endl
-     << "}" << endl
-     << endl
+  cf << "{" << std::endl
+     << "}" << std::endl
+     << std::endl
 
-     << "CLASS_NAME::CLASS_NAME(CLASS_NAME const &other, const char *name)" << endl
-     << "   : BASE_NAME(other,name)," << endl ;
+     << "CLASS_NAME::CLASS_NAME(CLASS_NAME const &other, const char *name)" << std::endl
+     << "   : BASE_NAME(other,name)," << std::endl ;
 
   for (std::size_t i=0 ; i<alist.size() ; i++) {
     cf << "   " << alist[i] << "(\"" << alist[i] << "\",this,other." << alist[i] << ")" ;
     if (i<alist.size()-1) {
       cf << "," ;
     }
-    cf << endl ;
+    cf << std::endl ;
   }
 
   cf << "{\n"
      << "}\n"
-     << endl
+     << std::endl
      << "\n"
-     << "double CLASS_NAME::evaluate() const " << endl
+     << "double CLASS_NAME::evaluate() const " << std::endl
      << "{\n"
-     << "   return CLASS_NAME_evaluate(" << listVars(alist) << ");" << endl
+     << "   return CLASS_NAME_evaluate(" << listVars(alist) << ");" << std::endl
      << "}\n"
      << "\n"
-     << "void CLASS_NAME::doEval(RooFit::EvalContext &ctx) const" << endl
+     << "void CLASS_NAME::doEval(RooFit::EvalContext &ctx) const" << std::endl
      << "{\n"
      << declareVarSpans(alist)
      << "\n"
@@ -722,16 +722,16 @@ int CLASS_NAME::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, c
 
     if (!intObs.empty()) {
       for (std::size_t ii=0 ; ii<intObs.size() ; ii++) {
-   cf << "   if (matchArgs(allVars,analVars," << intObs[ii] << ")) return " << ii+1 << " ; " << endl ;
+   cf << "   if (matchArgs(allVars,analVars," << intObs[ii] << ")) return " << ii+1 << " ; " << std::endl ;
       }
     } else {
-      cf << "   // if (matchArgs(allVars,analVars,x)) return 1 ; " << endl ;
+      cf << "   // if (matchArgs(allVars,analVars,x)) return 1 ; " << std::endl ;
     }
 
-    cf << "   return 0 ; " << endl
-       << "} " << endl
-       << endl
-       << endl
+    cf << "   return 0 ; " << std::endl
+       << "} " << std::endl
+       << std::endl
+       << std::endl
 
        << R"(double CLASS_NAME::analyticalIntegral(int code, const char *rangeName) const
 {
@@ -743,15 +743,15 @@ int CLASS_NAME::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, c
 
     if (!intObs.empty()) {
       for (std::size_t ii=0 ; ii<intObs.size() ; ii++) {
-   cf << "   if (code==" << ii+1 << ") { return (" << intExpr[ii] << ") ; } " << endl ;
+   cf << "   if (code==" << ii+1 << ") { return (" << intExpr[ii] << ") ; } " << std::endl ;
       }
     } else {
-      cf << "   // assert(code==1) ; " << endl
-    << "   // return (x.max(rangeName)-x.min(rangeName)) ; " << endl ;
+      cf << "   // assert(code==1) ; " << std::endl
+    << "   // return (x.max(rangeName)-x.min(rangeName)) ; " << std::endl ;
     }
 
-    cf << "   return 0 ; " << endl
-       << "} " << endl;
+    cf << "   return 0 ; " << std::endl
+       << "} " << std::endl;
   }
 
   if (hasIntGen) {

--- a/roofit/roofitcore/src/RooCmdConfig.cxx
+++ b/roofit/roofitcore/src/RooCmdConfig.cxx
@@ -46,8 +46,6 @@ typename Collection::const_iterator findVar(Collection const& coll, const char *
 }
 
 
-using std::cout, std::endl;
-
 ClassImp(RooCmdConfig);
 
 
@@ -143,7 +141,7 @@ void RooCmdConfig::defineDependency(const char* refArgName, const char* neededAr
 bool RooCmdConfig::defineInt(const char* name, const char* argName, int intNum, int defVal)
 {
   if (findVar(_iList, name) != _iList.end()) {
-    coutE(InputArguments) << "RooCmdConfig::defineInt: name '" << name << "' already defined" << endl ;
+    coutE(InputArguments) << "RooCmdConfig::defineInt: name '" << name << "' already defined" << std::endl ;
     return true ;
   }
 
@@ -165,7 +163,7 @@ bool RooCmdConfig::defineInt(const char* name, const char* argName, int intNum, 
 bool RooCmdConfig::defineDouble(const char* name, const char* argName, int doubleNum, double defVal)
 {
   if (findVar(_dList, name) != _dList.end()) {
-    coutE(InputArguments) << "RooCmdConfig::defineDouble: name '" << name << "' already defined" << endl ;
+    coutE(InputArguments) << "RooCmdConfig::defineDouble: name '" << name << "' already defined" << std::endl ;
     return true ;
   }
 
@@ -189,7 +187,7 @@ bool RooCmdConfig::defineDouble(const char* name, const char* argName, int doubl
 bool RooCmdConfig::defineString(const char* name, const char* argName, int stringNum, const char* defVal, bool appendMode)
 {
   if (findVar(_sList, name) != _sList.end()) {
-    coutE(InputArguments) << "RooCmdConfig::defineString: name '" << name << "' already defined" << endl ;
+    coutE(InputArguments) << "RooCmdConfig::defineString: name '" << name << "' already defined" << std::endl ;
     return true ;
   }
 
@@ -215,7 +213,7 @@ bool RooCmdConfig::defineObject(const char* name, const char* argName, int setNu
 {
 
   if (findVar(_oList, name) != _oList.end()) {
-    coutE(InputArguments) << "RooCmdConfig::defineObject: name '" << name << "' already defined" << endl ;
+    coutE(InputArguments) << "RooCmdConfig::defineObject: name '" << name << "' already defined" << std::endl ;
     return true ;
   }
 
@@ -241,7 +239,7 @@ bool RooCmdConfig::defineSet(const char* name, const char* argName, int setNum, 
 {
 
   if (findVar(_cList, name) != _cList.end()) {
-    coutE(InputArguments) << "RooCmdConfig::defineObject: name '" << name << "' already defined" << endl ;
+    coutE(InputArguments) << "RooCmdConfig::defineObject: name '" << name << "' already defined" << std::endl ;
     return true ;
   }
 
@@ -263,28 +261,28 @@ void RooCmdConfig::print() const
 {
   // Find registered integer fields for this opcode
   for(auto const& ri : _iList) {
-    cout << ri.name << "[int] = " << ri.val << endl ;
+    std::cout << ri.name << "[int] = " << ri.val << std::endl ;
   }
 
   // Find registered double fields for this opcode
   for(auto const& rd : _dList) {
-    cout << rd.name << "[double] = " << rd.val << endl ;
+    std::cout << rd.name << "[double] = " << rd.val << std::endl ;
   }
 
   // Find registered string fields for this opcode
   for(auto const& rs : _sList) {
-    cout << rs.name << "[string] = \"" << rs.val << "\"" << endl ;
+    std::cout << rs.name << "[string] = \"" << rs.val << "\"" << std::endl ;
   }
 
   // Find registered argset fields for this opcode
   for(auto const& ro : _oList) {
-    cout << ro.name << "[TObject] = " ;
+    std::cout << ro.name << "[TObject] = " ;
     auto const * obj = ro.val.At(0);
     if (obj) {
-      cout << obj->GetName() << endl ;
+      std::cout << obj->GetName() << std::endl ;
     } else {
 
-      cout << "(null)" << endl ;
+      std::cout << "(null)" << std::endl ;
     }
   }
 }
@@ -318,7 +316,7 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
 
   // Check if not forbidden
   if (_fList.FindObject(opc)) {
-    coutE(InputArguments) << _name << " ERROR: argument " << opc << " not allowed in this context" << endl ;
+    coutE(InputArguments) << _name << " ERROR: argument " << opc << " not allowed in this context" << std::endl ;
     _error = true ;
     return true ;
   }
@@ -330,12 +328,12 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
     if (!_pList.FindObject(dep->GetTitle())) {
       _rList.Add(new TObjString(dep->GetTitle())) ;
       if (_verbose) {
-   cout << "RooCmdConfig::process: " << opc << " has unprocessed dependent " << dep->GetTitle()
-        << ", adding to required list" << endl ;
+   std::cout << "RooCmdConfig::process: " << opc << " has unprocessed dependent " << dep->GetTitle()
+        << ", adding to required list" << std::endl ;
       }
     } else {
       if (_verbose) {
-   cout << "RooCmdConfig::process: " << opc << " dependent " << dep->GetTitle() << " is already processed" << endl ;
+   std::cout << "RooCmdConfig::process: " << opc << " dependent " << dep->GetTitle() << " is already processed" << std::endl ;
       }
     }
   }
@@ -344,8 +342,8 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
   TObject * mutex = _mList.FindObject(opc) ;
   if (mutex) {
     if (_verbose) {
-      cout << "RooCmdConfig::process: " << opc << " excludes " << mutex->GetTitle()
-      << ", adding to forbidden list" << endl ;
+      std::cout << "RooCmdConfig::process: " << opc << " excludes " << mutex->GetTitle()
+      << ", adding to forbidden list" << std::endl ;
     }
     _fList.Add(new TObjString(mutex->GetTitle())) ;
   }
@@ -359,7 +357,7 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
       ri.val = arg.getInt(ri.num) ;
       anyField = true ;
       if (_verbose) {
-   cout << "RooCmdConfig::process " << ri.name << "[int]" << " set to " << ri.val << endl ;
+   std::cout << "RooCmdConfig::process " << ri.name << "[int]" << " set to " << ri.val << std::endl ;
       }
     }
   }
@@ -370,7 +368,7 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
       rd.val = arg.getDouble(rd.num) ;
       anyField = true ;
       if (_verbose) {
-   cout << "RooCmdConfig::process " << rd.name << "[double]" << " set to " << rd.val << endl ;
+   std::cout << "RooCmdConfig::process " << rd.name << "[double]" << " set to " << rd.val << std::endl ;
       }
     }
   }
@@ -402,11 +400,11 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
       os.val.Add(const_cast<TObject*>(arg.getObject(os.num)));
       anyField = true ;
       if (_verbose) {
-   cout << "RooCmdConfig::process " << os.name << "[TObject]" << " set to " ;
+   std::cout << "RooCmdConfig::process " << os.name << "[TObject]" << " set to " ;
    if (os.val.At(0)) {
-     cout << os.val.At(0)->GetName() << endl ;
+     std::cout << os.val.At(0)->GetName() << std::endl ;
    } else {
-     cout << "(null)" << endl ;
+     std::cout << "(null)" << std::endl ;
    }
       }
     }
@@ -418,11 +416,11 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
       cs.val = const_cast<RooArgSet*>(arg.getSet(cs.num));
       anyField = true ;
       if (_verbose) {
-   cout << "RooCmdConfig::process " << cs.name << "[RooArgSet]" << " set to " ;
+   std::cout << "RooCmdConfig::process " << cs.name << "[RooArgSet]" << " set to " ;
    if (cs.val) {
-     cout << cs.val->GetName() << endl ;
+     std::cout << cs.val->GetName() << std::endl ;
    } else {
-     cout << "(null)" << endl ;
+     std::cout << "(null)" << std::endl ;
    }
       }
     }
@@ -431,7 +429,7 @@ bool RooCmdConfig::process(const RooCmdArg& arg)
   bool multiArg = !TString("MultiArg").CompareTo(opc) ;
 
   if (!anyField && !_allowUndefined && !multiArg) {
-    coutE(InputArguments) << _name << " ERROR: unrecognized command: " << opc << endl ;
+    coutE(InputArguments) << _name << " ERROR: unrecognized command: " << opc << std::endl ;
   }
 
 
@@ -557,9 +555,9 @@ bool RooCmdConfig::ok(bool verbose) const
   if (verbose) {
     std::string margs = missingArgs() ;
     if (!margs.empty()) {
-      coutE(InputArguments) << _name << " ERROR: missing arguments: " << margs << endl ;
+      coutE(InputArguments) << _name << " ERROR: missing arguments: " << margs << std::endl ;
     } else {
-      coutE(InputArguments) << _name << " ERROR: illegal combination of arguments and/or missing arguments" << endl ;
+      coutE(InputArguments) << _name << " ERROR: illegal combination of arguments and/or missing arguments" << std::endl ;
     }
   }
   return false ;

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -39,7 +39,7 @@ When iterated from start to finish, datasets will be traversed in the order of t
 #include <iomanip>
 #include <iostream>
 
-using std::cout, std::endl, std::map, std::list, std::string;
+using std::map, std::list, std::string;
 
 ClassImp(RooCompositeDataStore);
 
@@ -295,7 +295,7 @@ bool RooCompositeDataStore::changeObservableName(const char* from, const char* t
 
   // Check that we found it
   if (!var) {
-    coutE(InputArguments) << "RooCompositeDataStore::changeObservableName(" << GetName() << " no observable " << from << " in this dataset" << endl ;
+    coutE(InputArguments) << "RooCompositeDataStore::changeObservableName(" << GetName() << " no observable " << from << " in this dataset" << std::endl ;
     return true ;
   }
 
@@ -457,11 +457,11 @@ void RooCompositeDataStore::resetBuffers()
 
 void RooCompositeDataStore::dump()
 {
-  cout << "RooCompositeDataStore::dump()" << endl ;
+  std::cout << "RooCompositeDataStore::dump()" << std::endl ;
   for (auto const& item : _dataMap) {
-    cout << "state number " << item.first << " has store " << item.second->ClassName() << " with variables " << *item.second->get() ;
-    if (item.second->isWeighted()) cout << " and is weighted " ;
-    cout << endl ;
+    std::cout << "state number " << item.first << " has store " << item.second->ClassName() << " with variables " << *item.second->get() ;
+    if (item.second->isWeighted()) std::cout << " and is weighted " ;
+    std::cout << std::endl ;
   }
 }
 

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -39,7 +39,7 @@ subsequently explicitly smeared with the resolution model distribution.
 #include "Riostream.h"
 
 
-using std::cout, std::endl, std::ostream;
+using std::ostream;
 
 ClassImp(RooConvGenContext);
 
@@ -59,13 +59,13 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
   RooAbsGenContext(model,vars,prototype,auxProto,verbose)
 {
   cxcoutI(Generation) << "RooConvGenContext::ctor() setting up special generator context for analytical convolution p.d.f. " << model.GetName()
-            << " for generation of observable(s) " << vars << endl ;
+            << " for generation of observable(s) " << vars << std::endl ;
 
   // Clone PDF and change model to internal truth model
   _pdfCloneSet = std::make_unique<RooArgSet>();
   RooArgSet(model).snapshot(*_pdfCloneSet, true);
   if (!_pdfCloneSet) {
-    coutE(Generation) << "RooConvGenContext::RooConvGenContext(" << GetName() << ") Couldn't deep-clone PDF, abort," << endl ;
+    coutE(Generation) << "RooConvGenContext::RooConvGenContext(" << GetName() << ") Couldn't deep-clone PDF, abort," << std::endl ;
     RooErrorHandler::softAbort() ;
   }
 
@@ -136,7 +136,7 @@ RooConvGenContext::RooConvGenContext(const RooNumConvPdf &model, const RooArgSet
   RooAbsGenContext(model,vars,prototype,auxProto,verbose)
 {
   cxcoutI(Generation) << "RooConvGenContext::ctor() setting up special generator context for numeric convolution p.d.f. " << model.GetName()
-         << " for generation of observable(s) " << vars << endl ;
+         << " for generation of observable(s) " << vars << std::endl ;
 
   // Create generator for physics X truth model
   {
@@ -185,7 +185,7 @@ RooConvGenContext::RooConvGenContext(const RooFFTConvPdf &model, const RooArgSet
   RooAbsGenContext(model,vars,prototype,auxProto,verbose)
 {
   cxcoutI(Generation) << "RooConvGenContext::ctor() setting up special generator context for fft convolution p.d.f. " << model.GetName()
-         << " for generation of observable(s) " << vars << endl ;
+         << " for generation of observable(s) " << vars << std::endl ;
 
   _convVarName = model._x.arg().GetName() ;
 
@@ -316,8 +316,8 @@ void RooConvGenContext::setProtoDataOrder(Int_t* lut)
 void RooConvGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
 {
   RooAbsGenContext::printMultiline(os,content,verbose,indent) ;
-  os << indent << "--- RooConvGenContext ---" << endl ;
-  os << indent << "List of component generators" << endl ;
+  os << indent << "--- RooConvGenContext ---" << std::endl ;
+  os << indent << "List of component generators" << std::endl ;
 
   TString indent2(indent) ;
   indent2.Append("    ") ;

--- a/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
+++ b/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
@@ -111,7 +111,7 @@ void RooConvIntegrandBinding::loadValues(const double xvector[], bool clipInvali
     if (clipInvalid && !_vars[index]->isValidReal(xvector[index])) {
       _xvecValid = false ;
     } else {
-      //cout << "RooConvBasBinding::loadValues[" << index << "] loading value " << xvector[index] << endl ;
+      //cout << "RooConvBasBinding::loadValues[" << index << "] loading value " << xvector[index] << std::endl ;
       _vars[index]->setVal(xvector[index]);
     }
   }
@@ -129,7 +129,7 @@ double RooConvIntegrandBinding::operator()(const double xvector[]) const
   // First evaluate function at x'
   loadValues(xvector);
   if (!_xvecValid) return 0 ;
-  //cout << "RooConvIntegrandBinding::operator(): evaluating f(x') at x' = " << xvector[0] << endl ;
+  //cout << "RooConvIntegrandBinding::operator(): evaluating f(x') at x' = " << xvector[0] << std::endl ;
   double f_xp = _func->getVal(_nset) ;
 
   // Next evaluate model at x-x'
@@ -138,11 +138,11 @@ double RooConvIntegrandBinding::operator()(const double xvector[]) const
   if (!_xvecValid) return 0 ;
   double g_xmxp = _model->getVal(_nset) ;
 
-  //cout << "RooConvIntegrandBinding::operator(): evaluating g(x-x') at x-x' = " << _vars[0]->getVal() << " = " << g_xmxp << endl ;
-  //cout << "RooConvIntegrandBinding::operator(): return value = " << f_xp << " * " << g_xmxp << " = " << f_xp*g_xmxp << endl ;
+  //cout << "RooConvIntegrandBinding::operator(): evaluating g(x-x') at x-x' = " << _vars[0]->getVal() << " = " << g_xmxp << std::endl ;
+  //cout << "RooConvIntegrandBinding::operator(): return value = " << f_xp << " * " << g_xmxp << " = " << f_xp*g_xmxp << std::endl ;
 
-  //cout << "_vars[0] = " << _vars[0]->getVal() << " _vars[1] = " << _vars[1]->getVal() << endl ;
-  //cout << "_xvec[0] = " <<  xvector[0]        << " _xvec[1] = " <<  xvector[1] << endl ;
+  //cout << "_vars[0] = " << _vars[0]->getVal() << " _vars[1] = " << _vars[1]->getVal() << std::endl ;
+  //cout << "_xvec[0] = " <<  xvector[0]        << " _xvec[1] = " <<  xvector[1] << std::endl ;
 
   return f_xp*g_xmxp ;
 }

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -56,7 +56,7 @@ To retrieve a RooCurve from a RooPlot, use RooPlot::getCurve().
 #include <deque>
 #include <algorithm>
 
-using std::endl, std::ostream, std::list, std::vector, std::cout, std::min;
+using std::ostream, std::list, std::vector, std::min;
 
 ClassImp(RooCurve);
 
@@ -130,7 +130,7 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, double xlo, double 
     std::unique_ptr<std::list<double>> hint{f.plotSamplingHint(x,xlo,xhi)};
     addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint.get());
     if (_showProgress) {
-      ccoutP(Plotting) << endl ;
+      ccoutP(Plotting) << std::endl ;
     }
   } else {
     // if number of bins is set to <= 0, skip any interpolation and just evaluate the pdf at the bin centers
@@ -287,11 +287,11 @@ void RooCurve::addPoints(const RooAbsFunc &func, double xlo, double xhi,
 {
   // check the inputs
   if(!func.isValid()) {
-    coutE(InputArguments) << fName << "::addPoints: input function is not valid" << endl;
+    coutE(InputArguments) << fName << "::addPoints: input function is not valid" << std::endl;
     return;
   }
   if(minPoints <= 0 || xhi <= xlo) {
-    coutE(InputArguments) << fName << "::addPoints: bad input (nothing added)" << endl;
+    coutE(InputArguments) << fName << "::addPoints: bad input (nothing added)" << std::endl;
     return;
   }
 
@@ -326,7 +326,7 @@ void RooCurve::addPoints(const RooAbsFunc &func, double xlo, double xhi,
     yval[step]= func(&xx);
     if (_showProgress) {
       ccoutP(Plotting) << "." ;
-      cout.flush() ;
+      std::cout.flush() ;
     }
 
     if (RooAbsReal::numEvalErrors()>0) {
@@ -413,7 +413,7 @@ void RooCurve::addRange(const RooAbsFunc& func, double x1, double x2,
   double ymid= func(&xmid);
   if (_showProgress) {
     ccoutP(Plotting) << "." ;
-    cout.flush() ;
+    std::cout.flush() ;
   }
 
   if (RooAbsReal::numEvalErrors()>0) {
@@ -446,7 +446,7 @@ void RooCurve::addRange(const RooAbsFunc& func, double x1, double x2,
 
 void RooCurve::addPoint(double x, double y)
 {
-//   cout << "RooCurve("<< GetName() << ") adding point at (" << x << "," << y << ")" << endl ;
+//   std::cout << "RooCurve("<< GetName() << ") adding point at (" << x << "," << y << ")" << std::endl ;
   Int_t next= GetN();
   SetPoint(next, x, y);
   updateYAxisLimits(y) ;
@@ -516,12 +516,12 @@ void RooCurve::printClassName(ostream& os) const
 
 void RooCurve::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/, TString indent) const
 {
-  os << indent << "--- RooCurve ---" << endl ;
+  os << indent << "--- RooCurve ---" << std::endl ;
   Int_t n= GetN();
-  os << indent << "  Contains " << n << " points" << endl;
-  os << indent << "  Graph points:" << endl;
+  os << indent << "  Contains " << n << " points" << std::endl;
+  os << indent << "  Graph points:" << std::endl;
   for(Int_t i= 0; i < n; i++) {
-    os << indent << std::setw(3) << i << ") x = " << fX[i] << " , y = " << fY[i] << endl;
+    os << indent << std::setw(3) << i << ") x = " << fX[i] << " , y = " << fY[i] << std::endl;
   }
 }
 
@@ -581,7 +581,7 @@ double RooCurve::average(double xFirst, double xLast) const
 {
   if (xFirst>=xLast) {
     coutE(InputArguments) << "RooCurve::average(" << GetName()
-           << ") invalid range (" << xFirst << "," << xLast << ")" << endl ;
+           << ") invalid range (" << xFirst << "," << xLast << ")" << std::endl ;
     return 0 ;
   }
 
@@ -871,8 +871,8 @@ bool RooCurve::isIdentical(const RooCurve& other, double tol, bool verbose) cons
     if (rdy>tol) {
       ret = false;
       if(!verbose) continue;
-      cout << "RooCurve::isIdentical[" << std::setw(3) << i << "] Y tolerance exceeded (" << std::setprecision(5) << std::setw(10) << rdy << ">" << tol << "),";
-      cout << "  x,y=(" << std::right << std::setw(10) << fX[i] << "," << std::setw(10) << fY[i] << ")\tref: y="
+      std::cout << "RooCurve::isIdentical[" << std::setw(3) << i << "] Y tolerance exceeded (" << std::setprecision(5) << std::setw(10) << rdy << ">" << tol << "),";
+      std::cout << "  x,y=(" << std::right << std::setw(10) << fX[i] << "," << std::setw(10) << fY[i] << ")\tref: y="
           << std::setw(10) << other.interpolate(fX[i], 1.E-15) << ". [Nearest point from ref: ";
       auto j = other.findPoint(fX[i], 1.E10);
       std::cout << "j=" << j << "\tx,y=(" << std::setw(10) << other.fX[j] << "," << std::setw(10) << other.fY[j] << ") ]" << "\trange=" << Yrange << std::endl;

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -282,7 +282,7 @@ void RooCustomizer::splitArgs(const RooArgSet& set, const RooAbsCategory& splitC
 {
   if (_sterile) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer::splitArgs(" << _name
-           << ") ERROR cannot set spitting rules on this sterile customizer" << endl ;
+           << ") ERROR cannot set spitting rules on this sterile customizer" << std::endl ;
     return ;
   }
 
@@ -305,13 +305,13 @@ void RooCustomizer::splitArg(const RooAbsArg& arg, const RooAbsCategory& splitCa
 {
   if (_splitArgList.find(arg.GetName())) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer(" << _masterPdf->GetName() << ") ERROR: multiple splitting rules defined for "
-           << arg.GetName() << " only using first rule" << endl ;
+           << arg.GetName() << " only using first rule" << std::endl ;
     return ;
   }
 
   if (_sterile) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer::splitArg(" << _name
-    << ") ERROR cannot set spitting rules on this sterile customizer" << endl ;
+    << ") ERROR cannot set spitting rules on this sterile customizer" << std::endl ;
     return ;
   }
 
@@ -328,7 +328,7 @@ void RooCustomizer::replaceArg(const RooAbsArg& orig, const RooAbsArg& subst)
 {
   if (_replaceArgList.find(orig.GetName())) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer(" << _masterPdf->GetName() << ") ERROR: multiple replacement rules defined for "
-    << orig.GetName() << " only using first rule" << endl ;
+    << orig.GetName() << " only using first rule" << std::endl ;
     return ;
   }
 
@@ -384,14 +384,14 @@ RooAbsArg* RooCustomizer::build(const char* masterCatState, bool verbose)
 {
   if (_sterile) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer::build(" << _name
-           << ") ERROR cannot use leaf spitting build() on this sterile customizer" << endl ;
+           << ") ERROR cannot use leaf spitting build() on this sterile customizer" << std::endl ;
     return nullptr ;
   }
 
   // Set masterCat to given state
   if (_masterCat->setLabel(masterCatState)) {
     oocoutE(nullptr, InputArguments) << "RooCustomizer::build(" << _masterPdf->GetName() << "): ERROR label '" << masterCatState
-           << "' not defined for master splitting category " << _masterCat->GetName() << endl ;
+           << "' not defined for master splitting category " << _masterCat->GetName() << std::endl ;
     return nullptr ;
   }
 
@@ -415,14 +415,14 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
   RooArgSet nodeList(_masterLeafList) ;
   nodeList.add(_masterBranchList) ;
 
-  //   cout << "loop over " << nodeList.size() << " nodes" << endl ;
+  //   std::cout << "loop over " << nodeList.size() << " nodes" << std::endl ;
   for (auto node : nodeList) {
     RooAbsArg* theSplitArg = !_sterile?static_cast<RooAbsArg*>(_splitArgList.find(node->GetName())):nullptr ;
     if (theSplitArg) {
       RooAbsCategory* splitCat = static_cast<RooAbsCategory*>(_splitCatList.at(_splitArgList.index(theSplitArg))) ;
       if (verbose) {
    oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName()
-               << "): tree node " << node->GetName() << " is split by category " << splitCat->GetName() << endl ;
+               << "): tree node " << node->GetName() << " is split by category " << splitCat->GetName() << std::endl ;
       }
 
       TString newName(node->GetName()) ;
@@ -439,7 +439,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
    clonedMasterNodes.add(*specNode) ;
    if (verbose) {
      oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName()
-            << ") Adding existing node specialization " << newName << " to clonedMasterNodes" << endl ;
+            << ") Adding existing node specialization " << newName << " to clonedMasterNodes" << std::endl ;
    }
 
    // Affix attribute with old name to clone to support name changing server redirect
@@ -457,7 +457,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
 
    if (node->isDerived()) {
      oocoutW(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName()
-            << "): WARNING: branch node " << node->GetName() << " is split but has no pre-defined specializations" << endl ;
+            << "): WARNING: branch node " << node->GetName() << " is split but has no pre-defined specializations" << std::endl ;
    }
 
    TString newTitle(node->GetTitle()) ;
@@ -498,7 +498,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
       RooAbsArg* substArg = static_cast<RooAbsArg*>(_replaceSubList.at(_replaceArgList.index(ReplaceArg))) ;
       if (verbose) {
    oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName()
-               << "): tree node " << node->GetName() << " will be replaced by " << substArg->GetName() << endl ;
+               << "): tree node " << node->GetName() << " will be replaced by " << substArg->GetName() << std::endl ;
       }
 
       // Affix attribute with old name to support name changing server redirect
@@ -519,13 +519,13 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
     // If branch is split itself, don't handle here
     if (masterNodesToBeSplit.find(branch->GetName())) {
       if (verbose) {
-   oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node " << branch->GetName() << " is already split" << endl ;
+   oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node " << branch->GetName() << " is already split" << std::endl ;
       }
       continue ;
     }
     if (masterNodesToBeReplaced.find(branch->GetName())) {
       if (verbose) {
-   oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node " << branch->GetName() << " is already replaced" << endl ;
+   oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node " << branch->GetName() << " is already replaced" << std::endl ;
       }
       continue ;
     }
@@ -533,13 +533,13 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
     if (branch->dependsOn(masterNodesToBeSplit)) {
       if (verbose) {
    oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node "
-               << branch->ClassName() << "::" << branch->GetName() << " cloned: depends on a split parameter" << endl ;
+               << branch->ClassName() << "::" << branch->GetName() << " cloned: depends on a split parameter" << std::endl ;
       }
       masterBranchesToBeCloned.add(*branch) ;
     } else if (branch->dependsOn(masterNodesToBeReplaced)) {
       if (verbose) {
    oocoutI(nullptr, ObjectHandling) << "RooCustomizer::build(" << _masterPdf->GetName() << ") Branch node "
-               << branch->ClassName() << "::" << branch->GetName() << " cloned: depends on a replaced parameter" << endl ;
+               << branch->ClassName() << "::" << branch->GetName() << " cloned: depends on a replaced parameter" << std::endl ;
       }
       masterBranchesToBeCloned.add(*branch) ;
     }
@@ -609,22 +609,22 @@ void RooCustomizer::printArgs(ostream& os) const
 
 void RooCustomizer::printMultiline(ostream& os, Int_t /*content*/, bool /*verbose*/, TString indent) const
 {
-  os << indent << "RooCustomizer for " << _masterPdf->GetName() << (_sterile?" (sterile)":"") << endl ;
+  os << indent << "RooCustomizer for " << _masterPdf->GetName() << (_sterile?" (sterile)":"") << std::endl ;
 
   Int_t i;
   Int_t nsplit = _splitArgList.size();
   if (nsplit>0) {
-    os << indent << "  Splitting rules:" << endl ;
+    os << indent << "  Splitting rules:" << std::endl ;
     for (i=0 ; i<nsplit ; i++) {
-      os << indent << "   " << _splitArgList.at(i)->GetName() << " is split by " << _splitCatList.at(i)->GetName() << endl ;
+      os << indent << "   " << _splitArgList.at(i)->GetName() << " is split by " << _splitCatList.at(i)->GetName() << std::endl ;
     }
   }
 
   Int_t nrepl = _replaceArgList.size() ;
   if (nrepl>0) {
-    os << indent << "  Replacement rules:" << endl ;
+    os << indent << "  Replacement rules:" << std::endl ;
     for (i=0 ; i<nrepl ; i++) {
-      os << indent << "   " << _replaceSubList.at(i)->GetName() << " replaces " << _replaceArgList.at(i)->GetName() << endl ;
+      os << indent << "   " << _replaceSubList.at(i)->GetName() << " replaces " << _replaceArgList.at(i)->GetName() << std::endl ;
     }
   }
 
@@ -701,7 +701,7 @@ std::string CustIFace::create(RooFactoryWSTool& ft, const char* typeName, const 
    char* saveptr ;
    char* tok = R__STRTOK_R(buf2,",)",&saveptr) ;
    while(tok) {
-     //cout << "$REMOVE is restricted to " << tok << endl ;
+     //cout << "$REMOVE is restricted to " << tok << std::endl ;
      subst->setAttribute(Form("REMOVE_FROM_%s",tok)) ;
      tok = R__STRTOK_R(nullptr,",)",&saveptr) ;
    }
@@ -722,7 +722,7 @@ std::string CustIFace::create(RooFactoryWSTool& ft, const char* typeName, const 
     if (orig && subst) {
       cust.replaceArg(*orig,*subst) ;
     } else {
-      oocoutW(nullptr,ObjectHandling) << "RooCustomizer::CustIFace::create() WARNING: input or replacement of a replacement operation not found, operation ignored"<< endl ;
+      oocoutW(nullptr,ObjectHandling) << "RooCustomizer::CustIFace::create() WARNING: input or replacement of a replacement operation not found, operation ignored"<< std::endl ;
     }
   }
 

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -91,7 +91,7 @@ bool RooDLLSignificanceMCSModule::initializeInstance()
 {
   // Check that parameter is also present in fit parameter list of RooMCStudy object
   if (!fitParams()->find(_parName.c_str())) {
-    coutE(InputArguments) << "RooDLLSignificanceMCSModule::initializeInstance:: ERROR: No parameter named " << _parName << " in RooMCStudy!" << endl ;
+    coutE(InputArguments) << "RooDLLSignificanceMCSModule::initializeInstance:: ERROR: No parameter named " << _parName << " in RooMCStudy!" << std::endl ;
     return false ;
   }
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -76,7 +76,7 @@ See RooAbsData::plotOn().
 #include "TMath.h"
 #include "Math/Util.h"
 
-using std::cout, std::endl, std::string, std::ostream;
+using std::string, std::ostream;
 
 ClassImp(RooDataHist);
 
@@ -514,7 +514,7 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
     // Define state labels in index category (both in provided indexCat and in internal copy in dataset)
     if (!indexCat.hasLabel(hiter.first)) {
       indexCat.defineType(hiter.first) ;
-      coutI(InputArguments) << "RooDataHist::importTH1Set(" << GetName() << ") defining state \"" << hiter.first << "\" in index category " << indexCat.GetName() << endl ;
+      coutI(InputArguments) << "RooDataHist::importTH1Set(" << GetName() << ") defining state \"" << hiter.first << "\" in index category " << indexCat.GetName() << std::endl ;
     }
     if (!icat->hasLabel(hiter.first)) {
       icat->defineType(hiter.first) ;
@@ -524,7 +524,7 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
   // Check consistency in number of dimensions
   if (histo && int(vars.size()) != histo->GetDimension()) {
     coutE(InputArguments) << "RooDataHist::importTH1Set(" << GetName() << "): dimension of input histogram must match "
-           << "number of continuous variables" << endl ;
+           << "number of continuous variables" << std::endl ;
     throw std::invalid_argument("Inputs histograms for RooDataHist are not compatible with dimensions of variables.");
   }
 
@@ -629,7 +629,7 @@ void RooDataHist::importDHistSet(const RooArgList & /*vars*/, RooCategory &index
       if (!indexCat.hasLabel(label)) {
          indexCat.defineType(label);
          coutI(InputArguments) << "RooDataHist::importDHistSet(" << GetName() << ") defining state \"" << label
-                               << "\" in index category " << indexCat.GetName() << endl;
+                               << "\" in index category " << indexCat.GetName() << std::endl;
       }
       if (!icat->hasLabel(label)) {
          icat->defineType(label);
@@ -927,7 +927,7 @@ std::unique_ptr<RooAbsData> RooDataHist::reduceEng(const RooArgSet& varSubset, c
     tmp = std::make_unique<RooArgSet>();
     // Deep clone cutVar and attach clone to this dataset
     if (RooArgSet(*cutVar).snapshot(*tmp)) {
-      coutE(DataHandling) << "RooDataHist::reduceEng(" << GetName() << ") Couldn't deep-clone cut variable, abort," << endl ;
+      coutE(DataHandling) << "RooDataHist::reduceEng(" << GetName() << ") Couldn't deep-clone cut variable, abort," << std::endl ;
       return nullptr;
     }
     cloneVar = static_cast<RooFormulaVar*>(tmp->find(*cutVar));
@@ -1116,20 +1116,20 @@ RooPlot *RooDataHist::plotOn(RooPlot *frame, PlotOpt o) const
   if (o.bins) return RooAbsData::plotOn(frame,o) ;
 
   if(!frame) {
-    coutE(InputArguments) << ClassName() << "::" << GetName() << ":plotOn: frame is null" << endl;
+    coutE(InputArguments) << ClassName() << "::" << GetName() << ":plotOn: frame is null" << std::endl;
     return nullptr;
   }
   auto var= static_cast<RooAbsRealLValue*>(frame->getPlotVar());
   if(!var) {
     coutE(InputArguments) << ClassName() << "::" << GetName()
-    << ":plotOn: frame does not specify a plot variable" << endl;
+    << ":plotOn: frame does not specify a plot variable" << std::endl;
     return nullptr;
   }
 
   auto dataVar = static_cast<RooRealVar*>(_vars.find(*var));
   if (!dataVar) {
     coutE(InputArguments) << ClassName() << "::" << GetName()
-    << ":plotOn: dataset doesn't contain plot frame variable" << endl;
+    << ":plotOn: dataset doesn't contain plot frame variable" << std::endl;
     return nullptr;
   }
 
@@ -1402,7 +1402,7 @@ double RooDataHist::weightFast(const RooArgSet& bin, Int_t intOrder, bool correc
 
   // Handle illegal intOrder values
   if (intOrder<0) {
-    coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") ERROR: interpolation order must be positive" << endl ;
+    coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") ERROR: interpolation order must be positive" << std::endl ;
     return 0 ;
   }
 
@@ -1437,7 +1437,7 @@ double RooDataHist::weight(const RooArgSet& bin, Int_t intOrder, bool correctFor
 
   // Handle illegal intOrder values
   if (intOrder<0) {
-    coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") ERROR: interpolation order must be positive" << endl ;
+    coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") ERROR: interpolation order must be positive" << std::endl ;
     return 0 ;
   }
 
@@ -1526,12 +1526,12 @@ double RooDataHist::weightInterpolated(const RooArgSet& bin, int intOrder, bool 
     }
 
     if (gDebug>7) {
-      cout << "RooDataHist interpolating data is" << endl ;
-      cout << "xarr = " ;
-      for (int q=0; q<=intOrder ; q++) cout << xarr[q] << " " ;
-      cout << " yarr = " ;
-      for (int q=0; q<=intOrder ; q++) cout << yarr[q] << " " ;
-      cout << endl ;
+      std::cout << "RooDataHist interpolating data is" << std::endl ;
+      std::cout << "xarr = " ;
+      for (int q=0; q<=intOrder ; q++) std::cout << xarr[q] << " " ;
+      std::cout << " yarr = " ;
+      for (int q=0; q<=intOrder ; q++) std::cout << yarr[q] << " " ;
+      std::cout << std::endl ;
     }
     wInt = RooMath::interpolate(xarr,yarr,intOrder+1,yval) ;
 
@@ -1539,7 +1539,7 @@ double RooDataHist::weightInterpolated(const RooArgSet& bin, int intOrder, bool 
 
     // Higher dimensional scenarios not yet implemented
     coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") interpolation in "
-                          << varInfo.nRealVars << " dimensions not yet implemented" << endl ;
+                          << varInfo.nRealVars << " dimensions not yet implemented" << std::endl ;
     return weightFast(bin,0,correctForBinSize,cdfBoundaries) ;
 
   }
@@ -1821,7 +1821,7 @@ void RooDataHist::add(const RooAbsData& dset, const RooFormulaVar* cutVar, doubl
     // Deep clone cutVar and attach clone to this dataset
     tmp = std::make_unique<RooArgSet>();
     if(RooArgSet(*cutVar).snapshot(*tmp)) {
-      coutE(DataHandling) << "RooDataHist::add(" << GetName() << ") Couldn't deep-clone cut variable, abort," << endl ;
+      coutE(DataHandling) << "RooDataHist::add(" << GetName() << ") Couldn't deep-clone cut variable, abort," << std::endl ;
       return ;
     }
 
@@ -2217,7 +2217,7 @@ TIterator* RooDataHist::sliceIterator(RooAbsArg& sliceArg, const RooArgSet& othe
 
   RooAbsArg* intArg = _vars.find(sliceArg) ;
   if (!intArg) {
-    coutE(InputArguments) << "RooDataHist::sliceIterator() variable " << sliceArg.GetName() << " is not part of this RooDataHist" << endl ;
+    coutE(InputArguments) << "RooDataHist::sliceIterator() variable " << sliceArg.GetName() << " is not part of this RooDataHist" << std::endl ;
     return nullptr ;
   }
   return new RooDataHistSliceIter(*this,*intArg) ;
@@ -2300,11 +2300,11 @@ void RooDataHist::printMultiline(ostream& os, Int_t content, bool verbose, TStri
 {
   RooAbsData::printMultiline(os,content,verbose,indent) ;
 
-  os << indent << "Binned Dataset " << GetName() << " (" << GetTitle() << ")" << endl ;
-  os << indent << "  Contains " << numEntries() << " bins with a total weight of " << sumEntries() << endl;
+  os << indent << "Binned Dataset " << GetName() << " (" << GetTitle() << ")" << std::endl ;
+  os << indent << "  Contains " << numEntries() << " bins with a total weight of " << sumEntries() << std::endl;
 
   if (!verbose) {
-    os << indent << "  Observables " << _vars << endl ;
+    os << indent << "  Observables " << _vars << std::endl ;
   } else {
     os << indent << "  Observables: " ;
     _vars.printStream(os,kName|kValue|kExtras|kTitle,kVerbose,indent+"  ") ;
@@ -2312,7 +2312,7 @@ void RooDataHist::printMultiline(ostream& os, Int_t content, bool verbose, TStri
 
   if(verbose) {
     if (!_cachedVars.empty()) {
-      os << indent << "  Caches " << _cachedVars << endl ;
+      os << indent << "  Caches " << _cachedVars << std::endl ;
     }
   }
 }
@@ -2322,7 +2322,7 @@ void RooDataHist::printDataHistogram(ostream& os, RooRealVar* obs) const
   for(Int_t i=0; i<obs->getBins(); ++i){
     this->get(i);
     obs->setBin(i);
-    os << this->weight() << " +/- " << this->weightSquared() << endl;
+    os << this->weight() << " +/- " << this->weightSquared() << std::endl;
   }
 }
 

--- a/roofit/roofitcore/src/RooDataHistSliceIter.cxx
+++ b/roofit/roofitcore/src/RooDataHistSliceIter.cxx
@@ -48,9 +48,9 @@ RooDataHistSliceIter::RooDataHistSliceIter(RooDataHist& hist, RooAbsArg& sliceAr
 
   _nStep = dynamic_cast<RooAbsLValue&>(*sliceArgInt).numBins() ;
 
-//   cout << "RooDataHistSliceIter" << endl ;
+//   std::cout << "RooDataHistSliceIter" << std::endl ;
 //   hist.Print() ;
-//   cout << "hist._iterator = " << hist._iterator << endl ;
+//   std::cout << "hist._iterator = " << hist._iterator << std::endl ;
 
   Int_t i=0 ;
   for (const auto arg : hist._vars) {

--- a/roofit/roofitcore/src/RooDataProjBinding.cxx
+++ b/roofit/roofitcore/src/RooDataProjBinding.cxx
@@ -41,8 +41,6 @@ constructed from all the categories in the dataset
 #include <iostream>
 #include <cassert>
 
-using std::cout, std::endl;
-
 ClassImp(RooDataProjBinding);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -105,11 +103,11 @@ double RooDataProjBinding::operator()(const double xvector[]) const
 
     // Procedure might be lengthy, give some progress indication
     if (_first) {
-      oocoutW(_real,Eval) << "RooDataProjBinding::operator() projecting over " << nEvt << " events" << endl ;
+      oocoutW(_real,Eval) << "RooDataProjBinding::operator() projecting over " << nEvt << " events" << std::endl ;
       _first = false ;
     } else {
       if (oodologW(_real,Eval)) {
-   ooccoutW(_real,Eval) << "." ; cout.flush() ;
+   ooccoutW(_real,Eval) << "." ; std::cout.flush() ;
       }
     }
 
@@ -126,9 +124,9 @@ double RooDataProjBinding::operator()(const double xvector[]) const
       if (wgt) {
    ret = _real->getVal(_nset) ;
    result += wgt * ret ;
-//    cout << "ret[" << i << "] = " ;
+//    std::cout << "ret[" << i << "] = " ;
 //    params->printStream(cout,RooPrintable::kName|RooPrintable::kValue,RooPrintable::kStandard) ;
-//    cout << " = " << ret << endl ;
+//    std::cout << " = " << ret << std::endl ;
    wgtSum += wgt ;
       }
     }

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -389,7 +389,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
       // Define state labels in index category (both in provided indexCat and in internal copy in dataset)
       if (indexCat && !indexCat->hasLabel(hiter->first)) {
         indexCat->defineType(hiter->first) ;
-        coutI(InputArguments) << "RooDataSet::ctor(" << GetName() << ") defining state \"" << hiter->first << "\" in index category " << indexCat->GetName() << endl ;
+        coutI(InputArguments) << "RooDataSet::ctor(" << GetName() << ") defining state \"" << hiter->first << "\" in index category " << indexCat->GetName() << std::endl ;
       }
       if (icat && !icat->hasLabel(hiter->first)) {
         icat->defineType(hiter->first) ;
@@ -661,11 +661,11 @@ void RooDataSet::initialize(const char* wgtVarName)
     RooAbsArg* wgt = _varsNoWgt.find(wgtVarName) ;
     if (!wgt) {
       coutE(DataHandling) << "RooDataSet::RooDataSet(" << GetName() << "): designated weight variable "
-           << wgtVarName << " not found in set of variables, no weighting will be assigned" << endl ;
+           << wgtVarName << " not found in set of variables, no weighting will be assigned" << std::endl ;
       throw std::invalid_argument("RooDataSet::initialize() weight variable could not be initialised.");
     } else if (!dynamic_cast<RooRealVar*>(wgt)) {
       coutE(DataHandling) << "RooDataSet::RooDataSet(" << GetName() << "): designated weight variable "
-           << wgtVarName << " is not of type RooRealVar, no weighting will be assigned" << endl ;
+           << wgtVarName << " is not of type RooRealVar, no weighting will be assigned" << std::endl ;
       throw std::invalid_argument("RooDataSet::initialize() weight variable could not be initialised.");
     } else {
       _varsNoWgt.remove(*wgt) ;
@@ -1103,7 +1103,7 @@ bool RooDataSet::merge(list<RooDataSet*>dsetList)
   // Sanity checks: data sets must have the same size
   for (list<RooDataSet*>::iterator iter = dsetList.begin() ; iter != dsetList.end() ; ++iter) {
     if (numEntries()!=(*iter)->numEntries()) {
-      coutE(InputArguments) << "RooDataSet::merge(" << GetName() << ") ERROR: datasets have different size" << endl ;
+      coutE(InputArguments) << "RooDataSet::merge(" << GetName() << ") ERROR: datasets have different size" << std::endl ;
       return true ;
     }
   }
@@ -1253,13 +1253,13 @@ RooPlot* RooDataSet::plotOnXY(RooPlot* frame, const RooCmdArg& arg1, const RooCm
 
   // Sanity check. XY plotting only applies to weighted datasets if no YVar is specified
   if (!_wgtVar && !yvar) {
-    coutE(InputArguments) << "RooDataSet::plotOnXY(" << GetName() << ") ERROR: no YVar() argument specified and dataset is not weighted" << endl ;
+    coutE(InputArguments) << "RooDataSet::plotOnXY(" << GetName() << ") ERROR: no YVar() argument specified and dataset is not weighted" << std::endl ;
     return nullptr ;
   }
 
   RooRealVar* dataY = yvar ? static_cast<RooRealVar*>(_vars.find(yvar->GetName())) : nullptr ;
   if (yvar && !dataY) {
-    coutE(InputArguments) << "RooDataSet::plotOnXY(" << GetName() << ") ERROR on YVar() argument, dataset does not contain a variable named " << yvar->GetName() << endl ;
+    coutE(InputArguments) << "RooDataSet::plotOnXY(" << GetName() << ") ERROR on YVar() argument, dataset does not contain a variable named " << yvar->GetName() << std::endl ;
     return nullptr ;
   }
 
@@ -1383,11 +1383,11 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
     ownIsBlind = false ;
     if (blindState->IsA()!=RooCategory::Class()) {
       oocoutE(nullptr,DataHandling) << "RooDataSet::read: ERROR: variable list already contains"
-          << "a non-RooCategory blindState member" << endl ;
+          << "a non-RooCategory blindState member" << std::endl ;
       return nullptr ;
     }
     oocoutW(nullptr,DataHandling) << "RooDataSet::read: WARNING: recycling existing "
-        << "blindState category in variable list" << endl ;
+        << "blindState category in variable list" << std::endl ;
   }
   RooCategory* blindCat = static_cast<RooCategory*>(blindState) ;
 
@@ -1406,7 +1406,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
   if (ownIsBlind) { variables.remove(*blindState) ; delete blindState ; }
   if(!data) {
     oocoutE(nullptr,DataHandling) << "RooDataSet::read: unable to create a new dataset"
-        << endl;
+        << std::endl;
     return nullptr;
   }
 
@@ -1421,12 +1421,12 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
     tmp = data->_vars.find(indexCatName) ;
     if (!tmp) {
       oocoutE(data.get(),DataHandling) << "RooDataSet::read: no index category named "
-          << indexCatName << " in supplied variable list" << endl ;
+          << indexCatName << " in supplied variable list" << std::endl ;
       return nullptr;
     }
     if (tmp->IsA()!=RooCategory::Class()) {
       oocoutE(data.get(),DataHandling) << "RooDataSet::read: variable " << indexCatName
-          << " is not a RooCategory" << endl ;
+          << " is not a RooCategory" << std::endl ;
       return nullptr;
     }
     indexCat = static_cast<RooCategory*>(tmp);
@@ -1465,7 +1465,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
         snprintf(newLabel,128,"file%03d",fileSeqNum) ;
         if (indexCat->defineType(newLabel,fileSeqNum)) {
           oocoutE(data.get(), DataHandling) << "RooDataSet::read: Error, cannot register automatic type name " << newLabel
-              << " in index category " << indexCat->GetName() << endl ;
+              << " in index category " << indexCat->GetName() << std::endl ;
           return nullptr ;
         }
         // Assign new category number
@@ -1473,7 +1473,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
       }
     }
 
-    oocoutI(data.get(), DataHandling) << "RooDataSet::read: reading file " << filename << endl ;
+    oocoutI(data.get(), DataHandling) << "RooDataSet::read: reading file " << filename << std::endl ;
 
     // Prefix common path
     TString fullName(commonPath) ;
@@ -1482,7 +1482,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
 
     if (!file.good()) {
       oocoutE(data.get(), DataHandling) << "RooDataSet::read: unable to open '"
-          << filename << "'. Returning nullptr now." << endl;
+          << filename << "'. Returning nullptr now." << std::endl;
       return nullptr;
     }
 
@@ -1492,11 +1492,11 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
 
     while(file.good() && !file.eof()) {
       line++;
-      if(debug) oocxcoutD(data.get(),DataHandling) << "reading line " << line << endl;
+      if(debug) oocxcoutD(data.get(),DataHandling) << "reading line " << line << std::endl;
 
       // process comment lines
       if (file.peek() == '#') {
-        if(debug) oocxcoutD(data.get(),DataHandling) << "skipping comment on line " << line << endl;
+        if(debug) oocxcoutD(data.get(),DataHandling) << "skipping comment on line " << line << std::endl;
       } else {
         // Read single line
         bool readError = variables.readFromStream(file,true,verbose) ;
@@ -1504,7 +1504,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
 
         // Stop on read error
         if(!file.good()) {
-          oocoutE(data.get(), DataHandling) << "RooDataSet::read(static): read error at line " << line << endl ;
+          oocoutE(data.get(), DataHandling) << "RooDataSet::read(static): read error at line " << line << std::endl ;
           break;
         }
 
@@ -1538,7 +1538,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
     }
   }
   oocoutI(data.get(),DataHandling) << "RooDataSet::read: read " << data->numEntries()
-                    << " events (ignored " << outOfRange << " out of range events)" << endl;
+                    << " events (ignored " << outOfRange << " out of range events)" << std::endl;
 
   return data.release();
 }
@@ -1557,12 +1557,12 @@ bool RooDataSet::write(const char* filename) const
   // Open file for writing
   ofstream ofs(filename) ;
   if (ofs.fail()) {
-    coutE(DataHandling) << "RooDataSet::write(" << GetName() << ") cannot create file " << filename << endl ;
+    coutE(DataHandling) << "RooDataSet::write(" << GetName() << ") cannot create file " << filename << std::endl ;
     return true ;
   }
 
   // Write all lines as arglist in compact mode
-  coutI(DataHandling) << "RooDataSet::write(" << GetName() << ") writing ASCII file " << filename << endl ;
+  coutI(DataHandling) << "RooDataSet::write(" << GetName() << ") writing ASCII file " << filename << std::endl ;
   return write(ofs);
 }
 
@@ -1580,7 +1580,7 @@ bool RooDataSet::write(ostream & ofs) const {
   }
 
   if (ofs.fail()) {
-    coutW(DataHandling) << "RooDataSet::write(" << GetName() << "): WARNING error(s) have occurred in writing" << endl ;
+    coutW(DataHandling) << "RooDataSet::write(" << GetName() << "): WARNING error(s) have occurred in writing" << std::endl ;
   }
 
   return ofs.fail() ;
@@ -1598,7 +1598,7 @@ void RooDataSet::printMultiline(ostream& os, Int_t contents, bool verbose, TStri
   checkInit() ;
   RooAbsData::printMultiline(os,contents,verbose,indent) ;
   if (_wgtVar) {
-    os << indent << "  Dataset variable \"" << _wgtVar->GetName() << "\" is interpreted as the event weight" << endl ;
+    os << indent << "  Dataset variable \"" << _wgtVar->GetName() << "\" is interpreted as the event weight" << std::endl ;
   }
 }
 

--- a/roofit/roofitcore/src/RooErrorVar.cxx
+++ b/roofit/roofitcore/src/RooErrorVar.cxx
@@ -119,7 +119,7 @@ RooAbsBinning& RooErrorVar::getBinning(const char* name, bool /*verbose*/, bool 
   // Create a new RooRangeBinning with this name with default range
   binning = new RooRangeBinning(getMin(),getMax(),name) ;
   coutI(Contents) << "RooErrorVar::getBinning(" << GetName() << ") new range named '"
-        << name << "' created with default bounds" << endl ;
+        << name << "' created with default bounds" << std::endl ;
 
   _altBinning.Add(binning) ;
 
@@ -200,7 +200,7 @@ void RooErrorVar::setMin(const char* name, double value)
   // Check if new limit is consistent
   if (value >= getMax()) {
     coutW(InputArguments) << "RooErrorVar::setMin(" << GetName()
-           << "): Proposed new fit min. larger than max., setting min. to max." << endl ;
+           << "): Proposed new fit min. larger than max., setting min. to max." << std::endl ;
     binning.setMin(getMax()) ;
   } else {
     binning.setMin(value) ;
@@ -230,7 +230,7 @@ void RooErrorVar::setMax(const char* name, double value)
   // Check if new limit is consistent
   if (value < getMin()) {
     coutW(InputArguments) << "RooErrorVar::setMax(" << GetName()
-           << "): Proposed new fit max. smaller than min., setting max. to min." << endl ;
+           << "): Proposed new fit max. smaller than min., setting max. to min." << std::endl ;
     binning.setMax(getMin()) ;
   } else {
     binning.setMax(value) ;
@@ -266,7 +266,7 @@ void RooErrorVar::setRange( const char* name, double min, double max)
   // Check if new limit is consistent
   if (min>max) {
     coutW(InputArguments) << "RooErrorVar::setRange(" << GetName()
-           << "): Proposed new fit max. smaller than min., setting max. to min." << endl ;
+           << "): Proposed new fit max. smaller than min., setting max. to min." << std::endl ;
     binning.setRange(min,min) ;
   } else {
     binning.setRange(min,max) ;
@@ -275,7 +275,7 @@ void RooErrorVar::setRange( const char* name, double min, double max)
   if (!exists) {
     coutI(InputArguments) << "RooErrorVar::setRange(" << GetName()
            << ") new range named '" << name << "' created with bounds ["
-           << min << "," << max << "]" << endl ;
+           << min << "," << max << "]" << std::endl ;
   }
 
   setShapeDirty() ;

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -111,7 +111,7 @@ double RooExtendPdf::expectedEvents(const RooArgSet* nset) const
 
   if (_rangeName && (!nset || nset->empty())) {
     coutW(InputArguments) << "RooExtendPdf::expectedEvents(" << GetName() << ") WARNING: RooExtendPdf needs non-null normalization set to calculate fraction in range "
-           << _rangeName << ".  Results may be nonsensical" << endl ;
+           << _rangeName << ".  Results may be nonsensical" << std::endl ;
   }
 
   double nExp = _n ;
@@ -124,7 +124,7 @@ double RooExtendPdf::expectedEvents(const RooArgSet* nset) const
 
     if ( fracInt == 0. || _n == 0.) {
       coutW(Eval) << "RooExtendPdf(" << GetName() << ") WARNING: nExpected = " << _n << " / "
-        << fracInt << " for nset = " << (nset?*nset:RooArgSet()) << endl ;
+        << fracInt << " for nset = " << (nset?*nset:RooArgSet()) << std::endl ;
     }
 
     nExp /= fracInt ;

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -492,7 +492,7 @@ void RooFFTConvPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) const
     otherObs.remove(*histArg,true,true) ;
   }
 
-  //cout << "RooFFTConvPdf::fillCacheObject() otherObs = " << otherObs << endl ;
+  //cout << "RooFFTConvPdf::fillCacheObject() otherObs = " << otherObs << std::endl ;
 
   // Handle trivial scenario -- no other observables
   if (otherObs.empty()) {
@@ -525,7 +525,7 @@ void RooFFTConvPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) const
     // Set current slice position
     for (Int_t j=0 ; j<n ; j++) { obsLV[j]->setBin(binCur[j],binningName()) ; }
 
-//     cout << "filling slice: bin of obsLV[0] = " << obsLV[0]->getBin() << endl ;
+//     std::cout << "filling slice: bin of obsLV[0] = " << obsLV[0]->getBin() << std::endl ;
 
     // Fill current slice
     fillCacheSlice(static_cast<FFTCacheElem&>(cache),otherObs) ;
@@ -876,14 +876,14 @@ RooAbsGenContext* RooFFTConvPdf::genContext(const RooArgSet &vars, const RooData
 
   if (pdfCanDir) {
     cxcoutI(Generation) << "RooFFTConvPdf::genContext() input p.d.f " << _pdf1.arg().GetName()
-         << " has internal generator that is safe to use in current context" << endl ;
+         << " has internal generator that is safe to use in current context" << std::endl ;
   }
   if (resCanDir) {
     cxcoutI(Generation) << "RooFFTConvPdf::genContext() input p.d.f. " << _pdf2.arg().GetName()
-         << " has internal generator that is safe to use in current context" << endl ;
+         << " has internal generator that is safe to use in current context" << std::endl ;
   }
   if (numAddDep>0) {
-    cxcoutI(Generation) << "RooFFTConvPdf::genContext() generation requested for observables other than the convolution observable " << _x.arg().GetName() << endl ;
+    cxcoutI(Generation) << "RooFFTConvPdf::genContext() generation requested for observables other than the convolution observable " << _x.arg().GetName() << std::endl ;
   }
 
 
@@ -892,14 +892,14 @@ RooAbsGenContext* RooFFTConvPdf::genContext(const RooArgSet &vars, const RooData
     // or pdf or resmodel do not support direct generation
     cxcoutI(Generation) << "RooFFTConvPdf::genContext() selecting accept/reject generator context because one or both of the input "
          << "p.d.f.s cannot use internal generator and/or "
-         << "observables other than the convolution variable are requested for generation" << endl ;
+         << "observables other than the convolution variable are requested for generation" << std::endl ;
     return new RooGenContext(*this,vars,prototype,auxProto,verbose) ;
   }
 
   // Any other resolution model: use specialized generator context
   cxcoutI(Generation) << "RooFFTConvPdf::genContext() selecting specialized convolution generator context as both input "
             << "p.d.fs are safe for internal generator and only "
-            << "the convolution observables is requested for generation" << endl ;
+            << "the convolution observables is requested for generation" << std::endl ;
   return new RooConvGenContext(*this,vars,prototype,auxProto,verbose) ;
 }
 
@@ -912,7 +912,7 @@ RooAbsGenContext* RooFFTConvPdf::genContext(const RooArgSet &vars, const RooData
 void RooFFTConvPdf::setBufferFraction(double frac)
 {
   if (frac<0) {
-    coutE(InputArguments) << "RooFFTConvPdf::setBufferFraction(" << GetName() << ") fraction should be greater than or equal to zero" << endl ;
+    coutE(InputArguments) << "RooFFTConvPdf::setBufferFraction(" << GetName() << ") fraction should be greater than or equal to zero" << std::endl ;
     return ;
   }
   _bufFrac = frac ;

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -127,7 +127,7 @@ RooRealVar* RooFactoryWSTool::createVariable(const char* name, double xmin, doub
 {
   // First check if variable already exists
   if (_ws->var(name)) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createFactory() ERROR: variable with name '" << name << "' already exists" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createFactory() ERROR: variable with name '" << name << "' already exists" << std::endl ;
     logError() ;
     return nullptr ;
   }
@@ -282,7 +282,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
   // Find class in ROOT class table
   TClass* tc = resolveClassName(className);
   if (!tc) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " not found in factory alias table, nor in ROOT class table" << endl;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " not found in factory alias table, nor in ROOT class table" << std::endl;
     logError();
     return nullptr;
   }
@@ -291,7 +291,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
 
   // Check that class inherits from RooAbsPdf
   if (!tc->InheritsFrom(RooAbsArg::Class())) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " does not inherit from RooAbsArg" << endl;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " does not inherit from RooAbsArg" << std::endl;
     logError();
     return nullptr;
   }
@@ -323,7 +323,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
   // Try CINT interface
   pair<list<string>,unsigned int> ca = ctorArgs(className,_args.size()+2) ;
   if (ca.first.empty()) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR no suitable constructor found for class " << className << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR no suitable constructor found for class " << className << std::endl ;
     logError() ;
     return nullptr ;
   }
@@ -333,11 +333,11 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
   if (_args.size()+2<ca.second || _args.size()+2>ca.first.size()) {
     if (ca.second==ca.first.size()) {
       coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR number of arguments provided (" << _args.size() << ") for class is invalid, " << className
-             << " expects " << ca.first.size()-2 << endl ;
+             << " expects " << ca.first.size()-2 << std::endl ;
       logError() ;
     } else {
       coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR number of arguments provided (" << _args.size() << ") for class is invalid " << className
-             << " expect number between " << ca.second-2 << " and " << ca.first.size()-2 << endl ;
+             << " expect number between " << ca.second-2 << " and " << ca.first.size()-2 << std::endl ;
       logError() ;
     }
     return nullptr ;
@@ -445,12 +445,12 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
     }
     cintExpr += ") ;" ;
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR constructing " << className << "::" << objName << ": " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR constructing " << className << "::" << objName << ": " << err << std::endl ;
     logError() ;
     return nullptr ;
   }
 
-  cxcoutD(ObjectHandling) << "RooFactoryWSTool::createArg() Construct expression is " << cintExpr << endl ;
+  cxcoutD(ObjectHandling) << "RooFactoryWSTool::createArg() Construct expression is " << cintExpr << std::endl ;
 
   // Call CINT to perform constructor call. Catch any error thrown by argument conversion method
   if (std::unique_ptr<RooAbsArg> arg{reinterpret_cast<RooAbsArg*>(gROOT->ProcessLineFast(cintExpr.c_str()))}) {
@@ -465,7 +465,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
     RooAbsArg* ret = _ws->arg(objName) ;
     return ret ;
   } else {
-    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR in CINT constructor call to create object" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR in CINT constructor call to create object" << std::endl ;
     logError() ;
     return nullptr ;
   }
@@ -501,7 +501,7 @@ RooAddPdf* RooFactoryWSTool::add(const char *objName, const char* specList, bool
     pdfList.add(pdfList2) ;
 
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooAddPdf: " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooAddPdf: " << err << std::endl ;
     logError() ;
     return nullptr;
   }
@@ -543,7 +543,7 @@ RooRealSumPdf* RooFactoryWSTool::amplAdd(const char *objName, const char* specLi
     amplList.add(amplList2) ;
 
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooRealSumPdf: " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooRealSumPdf: " << err << std::endl ;
     logError() ;
     return nullptr;
   }
@@ -585,7 +585,7 @@ RooProdPdf* RooFactoryWSTool::prod(const char *objName, const char* pdfList)
       try {
    cmdList.Add(Conditional(asSET(tok),asSET(sep),!invCond).Clone()) ;
       } catch (const string &err) {
-   coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf Conditional argument: " << err << endl ;
+   coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf Conditional argument: " << err << std::endl ;
    logError() ;
    return nullptr ;
       }
@@ -605,7 +605,7 @@ RooProdPdf* RooFactoryWSTool::prod(const char *objName, const char* pdfList)
   try {
     pdf = std::make_unique<RooProdPdf>(objName,objName,asSET(regPdfList.c_str()),cmdList);
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf input set of regular pdfs: " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf input set of regular pdfs: " << err << std::endl ;
     logError() ;
   }
   cmdList.Delete() ;
@@ -635,7 +635,7 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
     char* eq = strchr(tok,'=') ;
     if (!eq) {
       coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous::" << objName
-             << " expect mapping token of form 'state=pdfName', but found '" << tok << "'" << endl ;
+             << " expect mapping token of form 'state=pdfName', but found '" << tok << "'" << std::endl ;
       logError() ;
       return nullptr ;
     } else {
@@ -644,7 +644,7 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
       try {
    theMap[tok] = &asPDF(eq+1) ;
       } catch (const string &err ) {
-   coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous: " << err << endl ;
+   coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous: " << err << std::endl ;
    logError() ;
       }
     }
@@ -657,7 +657,7 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
   try {
     pdf = std::make_unique<RooSimultaneous>(objName,objName,theMap,asCATLV(indexCat)) ;
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous::" << objName << " " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous::" << objName << " " << err << std::endl ;
     logError() ;
     return nullptr;
   }
@@ -697,13 +697,13 @@ RooAddition* RooFactoryWSTool::addfunc(const char *objName, const char* specList
     }
 
   } catch (const string &err) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::addfunc(" << objName << ") ERROR creating RooAddition: " << err << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::addfunc(" << objName << ") ERROR creating RooAddition: " << err << std::endl ;
     logError() ;
     return nullptr ;
   }
 
   if (!sumlist2.empty() && (sumlist1.size()!=sumlist2.size())) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::addfunc(" << objName << ") ERROR creating RooAddition: syntax error: either all sum terms must be products or none" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::addfunc(" << objName << ") ERROR creating RooAddition: syntax error: either all sum terms must be products or none" << std::endl ;
     logError() ;
     return nullptr ;
   }
@@ -821,7 +821,7 @@ RooProduct* RooFactoryWSTool::prodfunc(const char *objName, const char* pdfList)
 RooAbsArg* RooFactoryWSTool::process(const char* expr)
 {
 
-//   cout << "RooFactoryWSTool::process() " << expr << endl ;
+//   std::cout << "RooFactoryWSTool::process() " << expr << std::endl ;
 
   // First perform basic syntax check
   if (checkSyntax(expr)) {
@@ -852,13 +852,13 @@ RooAbsArg* RooFactoryWSTool::process(const char* expr)
   try {
     out = processExpression(buf.data()) ;
   } catch (const string &error) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::processExpression() ERROR in parsing: " << error << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::processExpression() ERROR in parsing: " << error << std::endl ;
     logError() ;
   }
 
   // If there were no errors commit the transaction, cancel it otherwise
   if (errorCount()>0) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::processExpression() ERRORS detected, transaction to workspace aborted, no objects committed" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::processExpression() ERRORS detected, transaction to workspace aborted, no objects committed" << std::endl ;
     ws().cancelTransaction() ;
   } else {
     ws().commitTransaction() ;
@@ -1061,7 +1061,7 @@ std::string RooFactoryWSTool::processSingleExpression(const char* arg)
       // Create function argument with instance name
       ret= processCreateArg(func,args) ;
     } else {
-      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: Class::Instance must be followed by (...)" << endl ;
+      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: Class::Instance must be followed by (...)" << std::endl ;
       logError() ;
     }
   } else if (func[0]!='$'){
@@ -1090,7 +1090,7 @@ std::string RooFactoryWSTool::processSingleExpression(const char* arg)
       }
       ret= processCreateArg(autoname,args) ;
     } else {
-      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: expect either Class(...) or Instance[...]" << endl ;
+      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: expect either Class(...) or Instance[...]" << std::endl ;
       logError() ;
     }
   } else {
@@ -1098,7 +1098,7 @@ std::string RooFactoryWSTool::processSingleExpression(const char* arg)
       // Process meta function (compile arguments, but not meta-function itself)
       ret= processMetaArg(func,args) ;
     } else {
-      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: $MetaClass must be followed by (...)" << endl ;
+      coutE(ObjectHandling) << "RooFactoryWSTool::processSingleExpression(" << arg << "): ERROR: Syntax error: $MetaClass must be followed by (...)" << std::endl ;
       logError() ;
     }
   }
@@ -1186,7 +1186,7 @@ string RooFactoryWSTool::processAliasExpression(const char* token)
 {
   vector<string> args = splitFunctionArgs(token) ;
   if (args.size()!=2) {
-    coutE(ObjectHandling) << "RooFactorWSTool::processAliasExpression() ERROR $Alias() takes exactly two arguments, " << args.size() << " args found" << endl ;
+    coutE(ObjectHandling) << "RooFactorWSTool::processAliasExpression() ERROR $Alias() takes exactly two arguments, " << args.size() << " args found" << std::endl ;
     logError() ;
     return string() ;
   }
@@ -1223,7 +1223,7 @@ TClass* RooFactoryWSTool::resolveClassName(const char* className)
   if (!tc) {
     tc = TClass::GetClass(Form("Roo%s",className)) ;
     if (!tc) {
-      coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " not defined in ROOT class table" << endl ;
+      coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR class " << className << " not defined in ROOT class table" << std::endl ;
       logError() ;
       return nullptr ;
     }
@@ -1277,7 +1277,7 @@ string RooFactoryWSTool::processCreateVar(string& func, vector<string>& args)
 
       // One argument, create constant variable with given value
       double xinit = atof((ai)->c_str()) ;
-      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xinit = " << xinit << endl ;
+      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xinit = " << xinit << std::endl ;
       RooRealVar tmp(func.c_str(),func.c_str(),xinit) ;
       tmp.setStringAttribute("factory_tag",varTag(func,args).c_str()) ;
       if (_ws->import(tmp,Silence())) {
@@ -1289,7 +1289,7 @@ string RooFactoryWSTool::processCreateVar(string& func, vector<string>& args)
       // Two arguments, create variable with given range
       double xlo = atof((ai++)->c_str()) ;
       double xhi = atof(ai->c_str()) ;
-      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xlo = " << xlo << " xhi = " << xhi << endl ;
+      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xlo = " << xlo << " xhi = " << xhi << std::endl ;
       RooRealVar tmp(func.c_str(),func.c_str(),xlo,xhi) ;
       tmp.setStringAttribute("factory_tag",varTag(func,args).c_str()) ;
       if (_ws->import(tmp,Silence())) {
@@ -1302,7 +1302,7 @@ string RooFactoryWSTool::processCreateVar(string& func, vector<string>& args)
       double xinit = atof((ai++)->c_str()) ;
       double xlo = atof((ai++)->c_str()) ;
       double xhi = atof(ai->c_str()) ;
-      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xinit = " << xinit << " xlo = " << xlo << " xhi = " << xhi << endl ;
+      cxcoutD(ObjectHandling) << "CREATE variable " << func << " xinit = " << xinit << " xlo = " << xlo << " xhi = " << xhi << std::endl ;
       RooRealVar tmp(func.c_str(),func.c_str(),xinit,xlo,xhi) ;
       tmp.setStringAttribute("factory_tag",varTag(func,args).c_str()) ;
       if (_ws->import(tmp,Silence())) {
@@ -1495,15 +1495,15 @@ bool RooFactoryWSTool::checkSyntax(const char* arg)
     ptr++ ;
   }
   if (nParentheses!=0) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nParentheses>0?"(":")") << "' in expression" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nParentheses>0?"(":")") << "' in expression" << std::endl ;
     return true ;
   }
   if (nBracket!=0) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nBracket>0?"[":"]") << "' in expression" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nBracket>0?"[":"]") << "' in expression" << std::endl ;
     return true ;
   }
   if (nAccolade!=0) {
-    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nAccolade>0?"{":"}") << "' in expression" << endl ;
+    coutE(ObjectHandling) << "RooFactoryWSTool::checkSyntax ERROR non-matching '" << (nAccolade>0?"{":"}") << "' in expression" << std::endl ;
     return true ;
   }
   return false ;
@@ -1702,10 +1702,10 @@ RooArgSet RooFactoryWSTool::asSET(const char* arg)
 
   // If given object is not of {,,,} form, interpret given string as name of defined set
   if (arg[0]!='{') {
-    // cout << "asSet(arg='" << arg << "') parsing as defined set" << endl ;
+    // std::cout << "asSet(arg='" << arg << "') parsing as defined set" << std::endl ;
     const RooArgSet* defSet = ws().set(arg) ;
     if (defSet) {
-      // cout << "found defined set: " << *defSet << endl ;
+      // std::cout << "found defined set: " << *defSet << std::endl ;
       s.add(*defSet) ;
       return s ;
     }

--- a/roofit/roofitcore/src/RooFirstMoment.cxx
+++ b/roofit/roofitcore/src/RooFirstMoment.cxx
@@ -129,6 +129,6 @@ RooFirstMoment::RooFirstMoment(const RooFirstMoment& other, const char* name) :
 double RooFirstMoment::evaluate() const
 {
   double ratio = _ixf / _if ;
-  //cout << "\nRooFirstMoment::eval(" << GetName() << ") val = " << ratio << endl ;
+  //cout << "\nRooFirstMoment::eval(" << GetName() << ") val = " << ratio << std::endl ;
   return ratio ;
 }

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -54,7 +54,7 @@
 #include "RooMultiVarGaussian.h"
 
 
-using std::cout, std::endl, std::ostream, std::string, std::pair, std::vector, std::setw;
+using std::ostream, std::string, std::pair, std::vector, std::setw;
 
 ClassImp(RooFitResult);
 
@@ -189,7 +189,7 @@ Int_t RooFitResult::statusCodeHistory(UInt_t icycle) const
   if (icycle>=_statusHistory.size()) {
     coutE(InputArguments) << "RooFitResult::statusCodeHistory(" << GetName()
            << " ERROR request for status history slot "
-           << icycle << " exceeds history count of " << _statusHistory.size() << endl ;
+           << icycle << " exceeds history count of " << _statusHistory.size() << std::endl ;
   }
   return _statusHistory[icycle].second ;
 }
@@ -203,7 +203,7 @@ const char* RooFitResult::statusLabelHistory(UInt_t icycle) const
   if (icycle>=_statusHistory.size()) {
     coutE(InputArguments) << "RooFitResult::statusLabelHistory(" << GetName()
            << " ERROR request for status history slot "
-           << icycle << " exceeds history count of " << _statusHistory.size() << endl ;
+           << icycle << " exceeds history count of " << _statusHistory.size() << std::endl ;
   }
   return _statusHistory[icycle].first.c_str() ;
 }
@@ -241,12 +241,12 @@ RooPlot *RooFitResult::plotOn(RooPlot *frame, const char *parName1, const char *
   // lookup the input parameters by name: we require that they were floated in our fit
   const RooRealVar *par1= dynamic_cast<const RooRealVar*>(floatParsFinal().find(parName1));
   if(nullptr == par1) {
-    coutE(InputArguments) << "RooFitResult::correlationPlot: parameter not floated in fit: " << parName1 << endl;
+    coutE(InputArguments) << "RooFitResult::correlationPlot: parameter not floated in fit: " << parName1 << std::endl;
     return nullptr;
   }
   const RooRealVar *par2= dynamic_cast<const RooRealVar*>(floatParsFinal().find(parName2));
   if(nullptr == par2) {
-    coutE(InputArguments) << "RooFitResult::correlationPlot: parameter not floated in fit: " << parName2 << endl;
+    coutE(InputArguments) << "RooFitResult::correlationPlot: parameter not floated in fit: " << parName2 << std::endl;
     return nullptr;
   }
 
@@ -392,11 +392,11 @@ double RooFitResult::correlation(const char* parname1, const char* parname2) con
   Int_t idx1 = _finalPars->index(parname1) ;
   Int_t idx2 = _finalPars->index(parname2) ;
   if (idx1<0) {
-    coutE(InputArguments) << "RooFitResult::correlation(" << GetName() << ") parameter " << parname1 << " is not a floating fit parameter" << endl ;
+    coutE(InputArguments) << "RooFitResult::correlation(" << GetName() << ") parameter " << parname1 << " is not a floating fit parameter" << std::endl ;
     return 0 ;
   }
   if (idx2<0) {
-    coutE(InputArguments) << "RooFitResult::correlation(" << GetName() << ") parameter " << parname2 << " is not a floating fit parameter" << endl ;
+    coutE(InputArguments) << "RooFitResult::correlation(" << GetName() << ") parameter " << parname2 << " is not a floating fit parameter" << std::endl ;
     return 0 ;
   }
   return correlation(idx1,idx2) ;
@@ -416,7 +416,7 @@ const RooArgList* RooFitResult::correlation(const char* parname) const
 
   RooAbsArg* arg = _initPars->find(parname) ;
   if (!arg) {
-    coutE(InputArguments) << "RooFitResult::correlation: variable " << parname << " not a floating parameter in fit" << endl ;
+    coutE(InputArguments) << "RooFitResult::correlation: variable " << parname << " not a floating parameter in fit" << std::endl ;
     return nullptr ;
   }
   return static_cast<RooArgList*>(_corrMatrix.At(_initPars->index(arg))) ;
@@ -435,7 +435,7 @@ double RooFitResult::globalCorr(const char* parname)
 
   RooAbsArg* arg = _initPars->find(parname) ;
   if (!arg) {
-    coutE(InputArguments) << "RooFitResult::globalCorr: variable " << parname << " not a floating parameter in fit" << endl ;
+    coutE(InputArguments) << "RooFitResult::globalCorr: variable " << parname << " not a floating parameter in fit" << std::endl ;
     return 0 ;
   }
 
@@ -489,8 +489,8 @@ double RooFitResult::covariance(Int_t row, Int_t col) const
 void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose, TString indent) const
 {
 
-  os << endl
-     << indent << "  RooFitResult: minimized FCN value: " << _minNLL << ", estimated distance to minimum: " << _edm << endl
+  os << std::endl
+     << indent << "  RooFitResult: minimized FCN value: " << _minNLL << ", estimated distance to minimum: " << _edm << std::endl
      << indent << "                covariance matrix quality: " ;
   switch(_covQual) {
   case -1 : os << "Unknown, matrix was externally provided" ; break ;
@@ -499,17 +499,17 @@ void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose,
   case 2  : os << "Full matrix, but forced positive-definite" ; break ;
   case 3  : os << "Full, accurate covariance matrix" ; break ;
   }
-  os << endl ;
+  os << std::endl ;
   os << indent << "                Status : " ;
   for (vector<pair<string,int> >::const_iterator iter = _statusHistory.begin() ; iter != _statusHistory.end() ; ++iter) {
     os << iter->first << "=" << iter->second << " " ;
   }
-  os << endl << endl;
+  os << std::endl << std::endl;
 
   if (verbose) {
     if (!_constPars->empty()) {
-      os << indent << "    Constant Parameter    Value     " << endl
-    << indent << "  --------------------  ------------" << endl ;
+      os << indent << "    Constant Parameter    Value     " << std::endl
+    << indent << "  --------------------  ------------" << std::endl ;
 
       for (std::size_t i=0 ; i<_constPars->size() ; i++) {
         os << indent << "  " << setw(20) << _constPars->at(i)->GetName() << "  " << setw(12);
@@ -518,10 +518,10 @@ void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose,
         } else {
           _constPars->at(i)->printValue(os); // for anything other than RooRealVar use printValue method to print
         }
-        os << endl ;
+        os << std::endl ;
       }
 
-      os << endl ;
+      os << std::endl ;
     }
 
     // Has any parameter asymmetric errors?
@@ -534,11 +534,11 @@ void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose,
     }
 
     if (doAsymErr) {
-      os << indent << "    Floating Parameter  InitialValue    FinalValue (+HiError,-LoError)    GblCorr." << endl
-    << indent << "  --------------------  ------------  ----------------------------------  --------" << endl ;
+      os << indent << "    Floating Parameter  InitialValue    FinalValue (+HiError,-LoError)    GblCorr." << std::endl
+    << indent << "  --------------------  ------------  ----------------------------------  --------" << std::endl ;
     } else {
-      os << indent << "    Floating Parameter  InitialValue    FinalValue +/-  Error     GblCorr." << endl
-    << indent << "  --------------------  ------------  --------------------------  --------" << endl ;
+      os << indent << "    Floating Parameter  InitialValue    FinalValue +/-  Error     GblCorr." << std::endl
+    << indent << "  --------------------  ------------  --------------------------  --------" << std::endl ;
     }
 
     for (std::size_t i=0 ; i<_finalPars->size() ; i++) {
@@ -560,24 +560,24 @@ void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose,
    os << "  <none>" ;
       }
 
-      os << endl ;
+      os << std::endl ;
     }
 
   } else {
-    os << indent << "    Floating Parameter    FinalValue +/-  Error   " << endl
-       << indent << "  --------------------  --------------------------" << endl ;
+    os << indent << "    Floating Parameter    FinalValue +/-  Error   " << std::endl
+       << indent << "  --------------------  --------------------------" << std::endl ;
 
     for (std::size_t i=0 ; i<_finalPars->size() ; i++) {
       double err = (static_cast<RooRealVar*>(_finalPars->at(i)))->getError() ;
       os << indent << "  "    << setw(20) << ((RooAbsArg*)_finalPars->at(i))->GetName()
     << "  "    << setw(12) << Form("%12.4e",(static_cast<RooRealVar*>(_finalPars->at(i)))->getVal())
     << " +/- " << setw(9)  << Form("%9.2e",err)
-    << endl ;
+    << std::endl ;
     }
   }
 
 
-  os << endl ;
+  os << std::endl ;
 }
 
 
@@ -588,12 +588,12 @@ void RooFitResult::fillCorrMatrix(const std::vector<double>& globalCC, const TMa
 {
   // Sanity check
   if (globalCC.empty() || corrs.GetNoElements() < 1 || covs.GetNoElements() < 1) {
-    coutI(Minimization) << "RooFitResult::fillCorrMatrix: number of floating parameters is zero, correlation matrix not filled" << endl ;
+    coutI(Minimization) << "RooFitResult::fillCorrMatrix: number of floating parameters is zero, correlation matrix not filled" << std::endl ;
     return ;
   }
 
   if (!_initPars) {
-    coutE(Minimization) << "RooFitResult::fillCorrMatrix: ERROR: list of initial parameters must be filled first" << endl ;
+    coutE(Minimization) << "RooFitResult::fillCorrMatrix: ERROR: list of initial parameters must be filled first" << std::endl ;
     return ;
   }
 
@@ -690,12 +690,12 @@ void RooFitResult::fillCorrMatrix()
 {
   // Sanity check
   if (gMinuit->fNpar < 1) {
-    coutI(Minimization) << "RooFitResult::fillCorrMatrix: number of floating parameters is zero, correlation matrix not filled" << endl ;
+    coutI(Minimization) << "RooFitResult::fillCorrMatrix: number of floating parameters is zero, correlation matrix not filled" << std::endl ;
     return ;
   }
 
   if (!_initPars) {
-    coutE(Minimization) << "RooFitResult::fillCorrMatrix: ERROR: list of initial parameters must be filled first" << endl ;
+    coutE(Minimization) << "RooFitResult::fillCorrMatrix: ERROR: list of initial parameters must be filled first" << std::endl ;
     return ;
   }
 
@@ -813,7 +813,7 @@ bool RooFitResult::isIdenticalNoCov(const RooFitResult& other, double tol, doubl
 
       // Check in the parameter is in the other fit result
       if (!ov) {
-        if(verbose) cout << "RooFitResult::isIdentical: cannot find " << prefix << " " << tv->GetName() << " in reference" << endl ;
+        if(verbose) std::cout << "RooFitResult::isIdentical: cannot find " << prefix << " " << tv->GetName() << " in reference" << std::endl ;
         out = false;
       }
 
@@ -878,7 +878,7 @@ bool RooFitResult::isIdentical(const RooFitResult& other, double tol, double tol
       auto tv = static_cast<const RooAbsReal*>(_globalCorr->at(i));
       auto ov = static_cast<const RooAbsReal*>(other._globalCorr->find(_globalCorr->at(i)->GetName())) ;
       if (!ov) {
-        if(verbose) cout << "RooFitResult::isIdentical: cannot find global correlation coefficient " << tv->GetName() << " in reference" << endl ;
+        if(verbose) std::cout << "RooFitResult::isIdentical: cannot find global correlation coefficient " << tv->GetName() << " in reference" << std::endl ;
         ret = false ;
       }
       if (ov && deviationCorr(tv->getVal(), ov->getVal())) {
@@ -894,7 +894,7 @@ bool RooFitResult::isIdentical(const RooFitResult& other, double tol, double tol
         auto tv = static_cast<const RooAbsReal*>(row->at(i));
         auto ov = static_cast<const RooAbsReal*>(orow->find(tv->GetName())) ;
         if (!ov) {
-          if(verbose) cout << "RooFitResult::isIdentical: cannot find correlation coefficient " << tv->GetName() << " in reference" << endl ;
+          if(verbose) std::cout << "RooFitResult::isIdentical: cannot find correlation coefficient " << tv->GetName() << " in reference" << std::endl ;
           ret = false ;
         }
         if (ov && deviationCorr(tv->getVal(), ov->getVal())) {
@@ -918,15 +918,15 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
 {
   // Verify length of supplied varList
   if (!varList.empty() && int(varList.size())!=gMinuit->fNu) {
-    oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
-               << "                             or match the number of variables of the last fit (" << gMinuit->fNu << ")" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: supplied variable list must be either empty " << std::endl
+               << "                             or match the number of variables of the last fit (" << gMinuit->fNu << ")" << std::endl ;
     return nullptr;
   }
 
   // Verify that all members of varList are of type RooRealVar
   for(RooAbsArg* arg : varList) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
-      oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName() << "' is not of type RooRealVar" << endl ;
+      oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName() << "' is not of type RooRealVar" << std::endl ;
       return nullptr;
     }
   }
@@ -969,7 +969,7 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
       }
       if (varName.CompareTo(var->GetName())) {
    oocoutI(nullptr,Eval) << "RooFitResult::lastMinuitFit: fit parameter '" << varName
-              << "' stored in variable '" << var->GetName() << "'" << endl ;
+              << "' stored in variable '" << var->GetName() << "'" << std::endl ;
       }
 
     }
@@ -1014,7 +1014,7 @@ RooFitResult *RooFitResult::prefitResult(const RooArgList &paramList)
    for(RooAbsArg * arg : paramList) {
       if (!dynamic_cast<RooRealVar *>(arg)) {
          oocoutE(nullptr, InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName()
-                                               << "' is not of type RooRealVar" << endl;
+                                               << "' is not of type RooRealVar" << std::endl;
          return nullptr;
       }
    }
@@ -1133,7 +1133,7 @@ TMatrixDSym RooFitResult::reducedCovarianceMatrix(const RooArgList& params) cons
       params2.add(*arg) ;
     } else {
       coutW(InputArguments) << "RooFitResult::reducedCovarianceMatrix(" << GetName() << ") WARNING input variable "
-             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << endl ;
+             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << std::endl ;
     }
   }
 
@@ -1180,7 +1180,7 @@ TMatrixDSym RooFitResult::conditionalCovarianceMatrix(const RooArgList& params) 
 
   if (det<=0) {
     coutE(Eval) << "RooFitResult::conditionalCovarianceMatrix(" << GetName() << ") ERROR: covariance matrix is not positive definite (|V|="
-      << det << ") cannot reduce it" << endl ;
+      << det << ") cannot reduce it" << std::endl ;
     throw string("RooFitResult::conditionalCovarianceMatrix() ERROR, input covariance matrix is not positive definite") ;
   }
 
@@ -1191,7 +1191,7 @@ TMatrixDSym RooFitResult::conditionalCovarianceMatrix(const RooArgList& params) 
       params2.add(*arg) ;
     } else {
       coutW(InputArguments) << "RooFitResult::conditionalCovarianceMatrix(" << GetName() << ") WARNING input variable "
-             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << endl ;
+             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << std::endl ;
     }
   }
 
@@ -1264,7 +1264,7 @@ RooAbsPdf* RooFitResult::createHessePdf(const RooArgSet& params) const
 
   if (det<=0) {
     coutE(Eval) << "RooFitResult::createHessePdf(" << GetName() << ") ERROR: covariance matrix is not positive definite (|V|="
-      << det << ") cannot construct p.d.f" << endl ;
+      << det << ") cannot construct p.d.f" << std::endl ;
     return nullptr ;
   }
 
@@ -1275,7 +1275,7 @@ RooAbsPdf* RooFitResult::createHessePdf(const RooArgSet& params) const
       params2.add(*arg) ;
     } else {
       coutW(InputArguments) << "RooFitResult::createHessePdf(" << GetName() << ") WARNING input variable "
-             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << endl ;
+             << arg->GetName() << " was not a floating parameters in fit result and is ignored" << std::endl ;
     }
   }
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -58,7 +58,7 @@
 #include "RooChi2Var.h"
 #endif
 
-using std::cout,std::endl, std::ostream, std::istream, std::list;
+using std::ostream, std::istream, std::list;
 
 ClassImp(RooFormulaVar);
 
@@ -211,7 +211,7 @@ void RooFormulaVar::printMetaArgs(ostream& os) const
 
 bool RooFormulaVar::readFromStream(istream& /*is*/, bool /*compact*/, bool /*verbose*/)
 {
-  coutE(InputArguments) << "RooFormulaVar::readFromStream(" << GetName() << "): can't read" << endl ;
+  coutE(InputArguments) << "RooFormulaVar::readFromStream(" << GetName() << "): can't read" << std::endl ;
   return true ;
 }
 
@@ -223,7 +223,7 @@ bool RooFormulaVar::readFromStream(istream& /*is*/, bool /*compact*/, bool /*ver
 void RooFormulaVar::writeToStream(ostream& os, bool compact) const
 {
   if (compact) {
-    cout << getVal() << endl ;
+    std::cout << getVal() << std::endl ;
   } else {
     os << GetTitle() ;
   }
@@ -296,18 +296,18 @@ double RooFormulaVar::defaultErrorLevel() const
 
   if (nllArg && !chi2Arg) {
     coutI(Minimization) << "RooFormulaVar::defaultErrorLevel(" << GetName()
-         << ") Formula contains a RooNLLVar, using its error level" << endl ;
+         << ") Formula contains a RooNLLVar, using its error level" << std::endl ;
     return nllArg->defaultErrorLevel() ;
   } else if (chi2Arg && !nllArg) {
     coutI(Minimization) << "RooFormulaVar::defaultErrorLevel(" << GetName()
-    << ") Formula contains a RooChi2Var, using its error level" << endl ;
+    << ") Formula contains a RooChi2Var, using its error level" << std::endl ;
     return chi2Arg->defaultErrorLevel() ;
   } else if (!nllArg && !chi2Arg) {
     coutI(Minimization) << "RooFormulaVar::defaultErrorLevel(" << GetName() << ") WARNING: "
-            << "Formula contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0" << endl ;
+            << "Formula contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0" << std::endl ;
   } else {
     coutI(Minimization) << "RooFormulaVar::defaultErrorLevel(" << GetName() << ") WARNING: "
-         << "Formula contains BOTH RooNLLVar and RooChi2Var server, using default level of 1.0" << endl ;
+         << "Formula contains BOTH RooNLLVar and RooChi2Var server, using default level of 1.0" << std::endl ;
   }
 
   return 1.0 ;

--- a/roofit/roofitcore/src/RooFracRemainder.cxx
+++ b/roofit/roofitcore/src/RooFracRemainder.cxx
@@ -52,7 +52,7 @@ RooFracRemainder::RooFracRemainder(const char* name, const char* title, const Ro
   for(RooAbsArg * comp : sumSet) {
     if (!dynamic_cast<RooAbsReal*>(comp)) {
       coutE(InputArguments) << "RooFracRemainder::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " is not of type RooAbsReal" << endl ;
+             << " is not of type RooAbsReal" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     _set1.add(*comp) ;

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -70,14 +70,14 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   if (prototype) ccxcoutI(Generation) << " with prototype data for " << *prototype->get() ;
   if (auxProto && !auxProto->empty())  ccxcoutI(Generation) << " with auxiliary prototypes " << *auxProto ;
   if (forceDirect && !forceDirect->empty())  ccxcoutI(Generation) << " with internal generation forced for observables " << *forceDirect ;
-  ccxcoutI(Generation) << endl ;
+  ccxcoutI(Generation) << std::endl ;
 
 
   // Clone the model and all nodes that it depends on so that this context
   // is independent of any existing objects.
   RooArgSet nodes(model,model.GetName());
   if (nodes.snapshot(_cloneSet, true)) {
-    coutE(Generation) << "RooGenContext::RooGenContext(" << GetName() << ") Couldn't deep-clone PDF, abort," << endl ;
+    coutE(Generation) << "RooGenContext::RooGenContext(" << GetName() << ") Couldn't deep-clone PDF, abort," << std::endl ;
     RooErrorHandler::softAbort() ;
   }
 
@@ -100,7 +100,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 
     // is this argument derived?
     if(!tmp->isFundamental()) {
-      coutE(Generation) << "RooGenContext::ctor(): cannot generate values for derived \""  << tmp->GetName() << "\"" << endl;
+      coutE(Generation) << "RooGenContext::ctor(): cannot generate values for derived \""  << tmp->GetName() << "\"" << std::endl;
       _isValid= false;
       continue;
     }
@@ -108,7 +108,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
     arg= static_cast<RooAbsArg const*>(_cloneSet.find(tmp->GetName()));
     if(nullptr == arg) {
       coutI(Generation) << "RooGenContext::ctor() WARNING model does not depend on \"" << tmp->GetName()
-           << "\" which will have uniform distribution" << endl;
+           << "\" which will have uniform distribution" << std::endl;
       _uniformVars.add(*tmp);
     }
     else {
@@ -118,7 +118,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       const RooAbsArg *direct= arg ;
       if (forceDirect==nullptr || !forceDirect->find(direct->GetName())) {
    if (!_pdfClone->isDirectGenSafe(*arg)) {
-     cxcoutD(Generation) << "RooGenContext::ctor() observable " << arg->GetName() << " has been determined to be unsafe for internal generation" << endl;
+     cxcoutD(Generation) << "RooGenContext::ctor() observable " << arg->GetName() << " has been determined to be unsafe for internal generation" << std::endl;
      direct=nullptr ;
    }
       }
@@ -134,24 +134,24 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   }
 
   if(!isValid()) {
-    coutE(Generation) << "RooGenContext::ctor() constructor failed with errors" << endl;
+    coutE(Generation) << "RooGenContext::ctor() constructor failed with errors" << std::endl;
     return;
   }
 
   // At this point directVars are all variables that are safe to be generated directly
   //               otherVars are all variables that are _not_ safe to be generated directly
   if (!_directVars.empty()) {
-    cxcoutD(Generation) << "RooGenContext::ctor() observables " << _directVars << " are safe for internal generator (if supported by p.d.f)" << endl ;
+    cxcoutD(Generation) << "RooGenContext::ctor() observables " << _directVars << " are safe for internal generator (if supported by p.d.f)" << std::endl ;
   }
   if (!_otherVars.empty()) {
-    cxcoutD(Generation) << "RooGenContext::ctor() observables " << _otherVars << " are NOT safe for internal generator (if supported by p.d.f)" << endl ;
+    cxcoutD(Generation) << "RooGenContext::ctor() observables " << _otherVars << " are NOT safe for internal generator (if supported by p.d.f)" << std::endl ;
   }
 
   // If PDF depends on prototype data, direct generator cannot use static initialization
   // in initGenerator()
   bool staticInitOK = !_pdfClone->dependsOn(_protoVars) ;
   if (!staticInitOK) {
-    cxcoutD(Generation) << "RooGenContext::ctor() Model depends on supplied protodata observables, static initialization of internal generator will not be allowed" << endl ;
+    cxcoutD(Generation) << "RooGenContext::ctor() Model depends on supplied protodata observables, static initialization of internal generator will not be allowed" << std::endl ;
   }
 
   // Can the model generate any of the direct variables itself?
@@ -160,7 +160,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
     _code= _pdfClone->getGenerator(_directVars,generatedVars,staticInitOK);
 
     cxcoutD(Generation) << "RooGenContext::ctor() Model indicates that it can internally generate observables "
-           << generatedVars << " with configuration identifier " << _code << endl ;
+           << generatedVars << " with configuration identifier " << _code << std::endl ;
   } else {
     _code = 0 ;
   }
@@ -178,7 +178,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   if (!_directVars.empty() && !_otherVars.empty())  ccxcoutI(Generation) << " and" ;
   if (!_otherVars.empty())  ccxcoutI(Generation) << " generate variables " << _otherVars << " with accept/reject sampling" ;
   if (!_uniformVars.empty()) ccxcoutI(Generation) << ", non-observable variables " << _uniformVars << " will be generated with flat distribution" ;
-  ccxcoutI(Generation) << endl ;
+  ccxcoutI(Generation) << std::endl ;
 
   // initialize the accept-reject generator
   RooArgSet depList;
@@ -206,17 +206,17 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       Int_t maxFindCode = _pdfClone->getMaxVal(_otherVars) ;
       if (maxFindCode != 0) {
    coutI(Generation) << "RooGenContext::ctor() no prototype data provided, all observables are generated with numerically and "
-               << "model supports analytical maximum findin:, can provide analytical pdf maximum to numeric generator" << endl ;
+               << "model supports analytical maximum findin:, can provide analytical pdf maximum to numeric generator" << std::endl ;
    double maxVal = _pdfClone->maxVal(maxFindCode) / _pdfClone->getNorm(&_theEvent) ;
    _maxVar = std::make_unique<RooRealVar>("funcMax","function maximum",maxVal) ;
-   cxcoutD(Generation) << "RooGenContext::ctor() maximum value returned by RooAbsPdf::maxVal() is " << maxVal << endl ;
+   cxcoutD(Generation) << "RooGenContext::ctor() maximum value returned by RooAbsPdf::maxVal() is " << maxVal << std::endl ;
       }
     }
 
     if (!_otherVars.empty()) {
       _pdfClone->getVal(&vars) ; // WVE debug
       _acceptRejectFunc= std::make_unique<RooRealIntegral>(nname,ntitle,*_pdfClone,depList,&vars);
-      cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << endl ;
+      cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << std::endl ;
     } else {
       _acceptRejectFunc = nullptr;
     }
@@ -226,7 +226,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
     // Generation _with_ prototype variable
     depList.remove(_protoVars,true,true);
     _acceptRejectFunc= std::unique_ptr<RooAbsReal>{_pdfClone->createIntegral(depList,vars)};
-    cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << endl ;
+    cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << std::endl ;
 
     // Check if PDF supports maximum finding for the entire phase space
     RooArgSet allVars(_otherVars);
@@ -236,7 +236,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       // Special case: PDF supports max-finding in otherVars, no need to scan other+proto space for maximum
       coutI(Generation) << "RooGenContext::ctor() prototype data provided, and "
                         << "model supports analytical maximum finding in the full phase space: "
-                        << "can provide analytical pdf maximum to numeric generator" << endl ;
+                        << "can provide analytical pdf maximum to numeric generator" << std::endl ;
        double maxVal = _pdfClone->maxVal(maxFindCode) / _pdfClone->getNorm(&allVars);
       _maxVar = std::make_unique<RooRealVar>("funcMax", "function maximum", maxVal);
     } else {
@@ -246,9 +246,9 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
          coutI(Generation) << "RooGenContext::ctor() prototype data provided, and "
                            << "model supports analytical maximum finding in the variables which are not"
                            << " internally generated. Can provide analytical pdf maximum to numeric "
-                           << "generator" << endl;
+                           << "generator" << std::endl;
          cxcoutD(Generation) << "RooGenContext::ctor() maximum value must be reevaluated for each "
-                             << "event with configuration code " << maxFindCode << endl ;
+                             << "event with configuration code " << maxFindCode << std::endl ;
          _maxVar = std::make_unique<RooRealVar>("funcMax","function maximum",1) ;
       }
     }
@@ -264,7 +264,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 
    cxcoutD(Generation) << "RooGenContext::ctor() prototype data provided, observables are generated numerically no "
                << "analytical estimate of maximum function value provided by model, must determine maximum value through initial sampling space "
-               << "of accept/reject observables plus prototype observables: " << otherAndProto << endl ;
+               << "of accept/reject observables plus prototype observables: " << otherAndProto << std::endl ;
 
    // Calculate maximum in other+proto space if there are any accept/reject generated observables
    std::unique_ptr<RooAbsNumGenerator> maxFinder{RooNumGenFactory::instance().createSampler(*_acceptRejectFunc,otherAndProto,RooArgSet(_protoVars),
@@ -276,11 +276,11 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
    if (max==0) {
      oocoutE(nullptr, Generation) << "RooGenContext::ctor(" << model.GetName()
              << ") ERROR: generating conditional p.d.f. which requires prior knowledge of function maximum, "
-             << "but chosen numeric generator (" << maxFinder->generatorName() << ") does not support maximum finding" << endl ;
+             << "but chosen numeric generator (" << maxFinder->generatorName() << ") does not support maximum finding" << std::endl ;
      throw string("RooGenContext::ctor()") ;
    }
 
-   cxcoutD(Generation) << "RooGenContext::ctor() maximum function value found through initial sampling is " << max << endl ;
+   cxcoutD(Generation) << "RooGenContext::ctor() maximum function value found through initial sampling is " << max << std::endl ;
       }
     }
 
@@ -288,7 +288,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 
   if (_acceptRejectFunc && !_otherVars.empty()) {
     _generator = std::unique_ptr<RooAbsNumGenerator>{RooNumGenFactory::instance().createSampler(*_acceptRejectFunc,_otherVars,RooArgSet(_protoVars),*model.getGeneratorConfig(),_verbose,_maxVar.get())};
-    cxcoutD(Generation) << "RooGenContext::ctor() creating MC sampling generator " << _generator->generatorName() << "  from function for observables " << _otherVars << endl ;
+    cxcoutD(Generation) << "RooGenContext::ctor() creating MC sampling generator " << _generator->generatorName() << "  from function for observables " << _otherVars << std::endl ;
     //_generator= new RooAcceptReject(*_acceptRejectFunc,_otherVars,RooNumGenConfig::defaultConfig(),_verbose,_maxVar);
   } else {
     _generator = nullptr ;
@@ -334,7 +334,7 @@ void RooGenContext::initGenerator(const RooArgSet &theEvent)
 
   // Initialize the PDFs internal generator
   if (!_directVars.empty()) {
-    cxcoutD(Generation) << "RooGenContext::initGenerator() initializing internal generator of model with code " << _code << endl ;
+    cxcoutD(Generation) << "RooGenContext::initGenerator() initializing internal generator of model with code " << _code << std::endl ;
     _pdfClone->initGenerator(_code) ;
   }
 }
@@ -351,7 +351,7 @@ void RooGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
 
     if (_updateFMaxPerEvent!=0) {
       double max = _pdfClone->maxVal(_updateFMaxPerEvent)/_pdfClone->getNorm(_otherVars) ;
-      cxcoutD(Generation) << "RooGenContext::initGenerator() reevaluation of maximum function value is required for each event, new value is  " << max << endl ;
+      cxcoutD(Generation) << "RooGenContext::initGenerator() reevaluation of maximum function value is required for each event, new value is  " << max << std::endl ;
       _maxVar->setVal(max) ;
     }
 
@@ -360,11 +360,11 @@ void RooGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
       const RooArgSet *subEvent= _generator->generateEvent(remaining,resampleRatio);
       if (resampleRatio<1) {
    coutI(Generation) << "RooGenContext::generateEvent INFO: accept/reject generator requests resampling of previously produced events by factor "
-           << resampleRatio << " due to increased maximum weight" << endl ;
+           << resampleRatio << " due to increased maximum weight" << std::endl ;
    resampleData(resampleRatio) ;
       }
       if(nullptr == subEvent) {
-   coutE(Generation) << "RooGenContext::generateEvent ERROR accept/reject generator failed" << endl ;
+   coutE(Generation) << "RooGenContext::generateEvent ERROR accept/reject generator failed" << std::endl ;
    return;
       }
       theEvent.assignValueOnly(*subEvent) ;
@@ -383,7 +383,7 @@ void RooGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
   for(auto * uniVar : _uniformVars) {
     auto * arglv = dynamic_cast<RooAbsLValue*>(uniVar);
     if (!arglv) {
-      coutE(Generation) << "RooGenContext::generateEvent(" << GetName() << ") ERROR: uniform variable " << uniVar->GetName() << " is not an lvalue" << endl ;
+      coutE(Generation) << "RooGenContext::generateEvent(" << GetName() << ") ERROR: uniform variable " << uniVar->GetName() << " is not an lvalue" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     arglv->randomize() ;
@@ -399,15 +399,15 @@ void RooGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
 void RooGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
 {
   RooAbsGenContext::printMultiline(os,content,verbose,indent);
-  os << indent << " --- RooGenContext --- " << endl ;
+  os << indent << " --- RooGenContext --- " << std::endl ;
   os << indent << "Using PDF ";
   _pdfClone->printStream(os,kName|kArgs|kClassName,kSingleLine,indent);
 
   if(verbose) {
-    os << indent << "Use PDF generator for " << _directVars << endl ;
-    os << indent << "Use MC sampling generator " << (_generator ? _generator->generatorName() : "<none>") << " for " << _otherVars << endl ;
+    os << indent << "Use PDF generator for " << _directVars << std::endl ;
+    os << indent << "Use MC sampling generator " << (_generator ? _generator->generatorName() : "<none>") << " for " << _otherVars << std::endl ;
     if (!_protoVars.empty()) {
-      os << indent << "Prototype observables are " << _protoVars << endl ;
+      os << indent << "Prototype observables are " << _protoVars << std::endl ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -62,9 +62,9 @@ RooGenProdProj::RooGenProdProj(const char *name, const char *title, const RooArg
   RooAbsReal* numerator = makeIntegral("numerator",_prodSet,_intSet,*_compSetOwnedN,isetRangeName,doFactorize) ;
   RooAbsReal* denominator = makeIntegral("denominator",_prodSet,_normSet,*_compSetOwnedD,normRangeName,doFactorize) ;
 
-//   cout << "RooGenProdPdf::ctor(" << GetName() << ") numerator = " << numerator->GetName() << endl ;
+//   std::cout << "RooGenProdPdf::ctor(" << GetName() << ") numerator = " << numerator->GetName() << std::endl ;
 //   numerator->printComponentTree() ;
-//   cout << "RooGenProdPdf::ctor(" << GetName() << ") denominator = " << denominator->GetName() << endl ;
+//   std::cout << "RooGenProdPdf::ctor(" << GetName() << ") denominator = " << denominator->GetName() << std::endl ;
 //   denominator->printComponentTree() ;
 
   // Copy all components in (non-owning) set proxy
@@ -248,7 +248,7 @@ double RooGenProdProj::evaluate() const
 
   double den = static_cast<RooAbsReal*>(_intList.at(1))->getVal(nset);
 
-  //cout << "RooGenProdProj::eval(" << GetName() << ") nom = " << nom << " den = " << den << endl ;
+  //cout << "RooGenProdProj::eval(" << GetName() << ") nom = " << nom << " den = " << den << std::endl ;
 
   return nom / den ;
 }

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -159,7 +159,7 @@ void RooGenericPdf::printMultiline(ostream& os, Int_t content, bool verbose, TSt
 {
   RooAbsPdf::printMultiline(os,content,verbose,indent);
   if (verbose) {
-    os << " --- RooGenericPdf --- " << endl ;
+    os << " --- RooGenericPdf --- " << std::endl ;
     indent.Append("  ");
     os << indent ;
     formula().printMultiline(os,content,verbose,indent);
@@ -196,7 +196,7 @@ bool RooGenericPdf::readFromStream(istream& /*is*/, bool /*compact*/, bool /*ver
 void RooGenericPdf::writeToStream(ostream& os, bool compact) const
 {
   if (compact) {
-    os << getVal() << endl ;
+    os << getVal() << std::endl ;
   } else {
     os << GetTitle() ;
   }

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -97,7 +97,7 @@ bool RooHistError::getPoissonIntervalCalc(Int_t n, double &mu1, double &mu2, dou
 {
   // sanity checks
   if(n < 0) {
-    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n = " << n << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n = " << n << std::endl;
     return false;
   }
 
@@ -129,7 +129,7 @@ bool RooHistError::getBinomialIntervalAsym(Int_t n, Int_t m,
 {
   // sanity checks
   if(n < 0 || m < 0) {
-    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << std::endl;
     return false;
   }
 
@@ -192,7 +192,7 @@ bool RooHistError::getBinomialIntervalEff(Int_t n, Int_t m,
 {
   // sanity checks
   if(n < 0 || m < 0) {
-    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << std::endl;
     return false;
   }
 
@@ -296,7 +296,7 @@ bool RooHistError::getInterval(const RooAbsFunc *Qu, const RooAbsFunc *Ql, doubl
     ok= lFinder.findRoot(lo,lo,lo+stepSize,alpha+beta);
     ok|= uFinder.findRoot(hi,hi-stepSize,hi,alpha);
   }
-  if(!ok) oocoutE(nullptr,Plotting) << "RooHistError::getInterval: failed to find root(s)" << endl;
+  if(!ok) oocoutE(nullptr,Plotting) << "RooHistError::getInterval: failed to find root(s)" << std::endl;
 
   return ok;
 }

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -350,8 +350,8 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
     }
   }
 
-  // cout << "RooHistFunc::bb(" << GetName() << ") histObs = " << _histObsList << std::endl ;
-  // cout << "RooHistFunc::bb(" << GetName() << ") pdfObs = " << _depList << std::endl ;
+  // std::cout << "RooHistFunc::bb(" << GetName() << ") histObs = " << _histObsList << std::endl ;
+  // std::cout << "RooHistFunc::bb(" << GetName() << ") pdfObs = " << _depList << std::endl ;
 
   RooAbsRealLValue* transform = nullptr;
   if (!hobs) {
@@ -379,8 +379,8 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
   }
 
 
-  // cout << "hobs = " << hobs->GetName() << std::endl ;
-  // cout << "transform = " << (transform?transform->GetName():"<none>") << std::endl ;
+  // std::cout << "hobs = " << hobs->GetName() << std::endl ;
+  // std::cout << "transform = " << (transform?transform->GetName():"<none>") << std::endl ;
 
   // Check that observable is in dataset, if not no hint is generated
   RooAbsArg* xtmp = _dataHist->get()->find(hobs->GetName()) ;

--- a/roofit/roofitcore/src/RooLinearVar.cxx
+++ b/roofit/roofitcore/src/RooLinearVar.cxx
@@ -123,7 +123,7 @@ double RooLinearVar::evaluate() const
 
 void RooLinearVar::setVal(double value)
 {
-  //cout << "RooLinearVar::setVal(" << GetName() << "): new value = " << value << endl ;
+  //cout << "RooLinearVar::setVal(" << GetName() << "): new value = " << value << std::endl ;
 
   // Prevent DIV0 problems
   if (_slope == 0.) {
@@ -152,12 +152,12 @@ bool RooLinearVar::isJacobianOK(const RooArgSet& depList) const
   for(RooAbsArg* arg : depList) {
     if (arg->IsA()->InheritsFrom(RooAbsReal::Class())) {
       if (_slope->dependsOnValue(*arg)) {
-//    cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return false because slope depends on value of " << arg->GetName() << endl ;
+//    std::cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return false because slope depends on value of " << arg->GetName() << std::endl ;
    return false ;
       }
     }
   }
-  //   cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return true" << endl ;
+  //   std::cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return true" << std::endl ;
   return true ;
 }
 

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -43,8 +43,6 @@ Use RooAbsCollection derived objects for public use
 #include <memory>
 #include <vector>
 
-using std::cout, std::endl;
-
 ClassImp(RooLinkedList);
 
 /// \cond ROOFIT_INTERNAL
@@ -58,7 +56,7 @@ namespace RooLinkedListImplDetails {
    _sz(sz), _free(capacity()),
    _chunk(new RooLinkedListElem[_free]), _freelist(_chunk)
       {
-   //cout << "RLLID::Chunk ctor(" << this << ") of size " << _free << " list elements" << endl ;
+   //cout << "RLLID::Chunk ctor(" << this << ") of size " << _free << " list elements" << std::endl ;
    // initialise free list
    for (Int_t i = 0; i < _free; ++i)
      _chunk[i]._next = (i + 1 < _free) ? &_chunk[i + 1] : nullptr;
@@ -288,7 +286,7 @@ RooLinkedList::RooLinkedList(const RooLinkedList& other) :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///   cout << "RooLinkedList::createElem(" << this << ") obj = " << obj << " elem = " << elem << endl ;
+///   std::cout << "RooLinkedList::createElem(" << this << ") obj = " << obj << " elem = " << elem << std::endl ;
 
 RooLinkedListElem* RooLinkedList::createElement(TObject* obj, RooLinkedListElem* elem)
 {
@@ -331,7 +329,7 @@ RooLinkedList& RooLinkedList::operator=(const RooLinkedList& other)
 void RooLinkedList::setHashTableSize(Int_t size)
 {
   if (size<0) {
-    coutE(InputArguments) << "RooLinkedList::setHashTable() ERROR size must be positive" << endl ;
+    coutE(InputArguments) << "RooLinkedList::setHashTable() ERROR size must be positive" << std::endl ;
     return ;
   }
   if (size==0) {
@@ -432,7 +430,7 @@ void RooLinkedList::Add(TObject* arg, Int_t refCount)
   }
 
   if (_htableName){
-    //cout << "storing link " << _last << " with hash arg " << arg << endl ;
+    //cout << "storing link " << _last << " with hash arg " << arg << std::endl ;
     _htableName->insert({arg->GetName(), arg});
     _htableLink->insert({arg, reinterpret_cast<TObject *>(_last)});
   }
@@ -615,7 +613,7 @@ TObject* RooLinkedList::find(const char* name) const
     if (_useNptr) {
       // See if it might have been renamed
       const TNamed* nptr= RooNameReg::known(name);
-      //cout << "RooLinkedList::find: possibly renamed '" << name << "', kRenamedArg=" << (nptr&&nptr->TestBit(RooNameReg::kRenamedArg)) << endl;
+      //cout << "RooLinkedList::find: possibly renamed '" << name << "', kRenamedArg=" << (nptr&&nptr->TestBit(RooNameReg::kRenamedArg)) << std::endl;
       if (nptr && nptr->TestBit(RooNameReg::kRenamedArg)) {
         RooLinkedListElem* ptr = _first ;
         while(ptr) {
@@ -628,7 +626,7 @@ TObject* RooLinkedList::find(const char* name) const
       }
       return nullptr ;
     }
-    //cout << "RooLinkedList::find: possibly renamed '" << name << "'" << endl;
+    //cout << "RooLinkedList::find: possibly renamed '" << name << "'" << std::endl;
   }
 
   RooLinkedListElem* ptr = _first ;
@@ -667,7 +665,7 @@ RooAbsArg* RooLinkedList::findArg(const RooAbsArg* arg) const
   if (_htableName) {
     RooAbsArg* a = const_cast<RooAbsArg *>(static_cast<RooAbsArg const*>((*_htableName)[arg->GetName()]));
     if (a) return a;
-    //cout << "RooLinkedList::findArg: possibly renamed '" << arg->GetName() << "', kRenamedArg=" << arg->namePtr()->TestBit(RooNameReg::kRenamedArg) << endl;
+    //cout << "RooLinkedList::findArg: possibly renamed '" << arg->GetName() << "', kRenamedArg=" << arg->namePtr()->TestBit(RooNameReg::kRenamedArg) << std::endl;
     // See if it might have been renamed
     if (!arg->namePtr()->TestBit(RooNameReg::kRenamedArg)) return nullptr;
   }
@@ -723,7 +721,7 @@ void RooLinkedList::Print(const char* opt) const
 {
   RooLinkedListElem* elem = _first ;
   while(elem) {
-    cout << elem->_arg << " : " ;
+    std::cout << elem->_arg << " : " ;
     elem->_arg->Print(opt) ;
     elem = elem->_next ;
   }

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -168,7 +168,7 @@ double RooMCIntegrator::integral(const double* /*yvec*/)
 
 double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, double *absError)
 {
-  //cout << "VEGAS stage = " << stage << " calls = " << calls << " iterations = " << iterations << endl ;
+  //cout << "VEGAS stage = " << stage << " calls = " << calls << " iterations = " << iterations << std::endl ;
 
   // reset the grid to its initial state if we are starting from scratch
   if(stage == AllStages) _grid.initialize(*_function);
@@ -204,11 +204,11 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
    if(bins > RooGrid::maxBins) bins= RooGrid::maxBins;
    boxes = box_per_bin * bins;
    oocxcoutD((TObject*)nullptr,Integration) << "RooMCIntegrator: using stratified sampling with " << bins << " bins and "
-                << box_per_bin << " boxes/bin" << endl;
+                << box_per_bin << " boxes/bin" << std::endl;
       }
       else {
    oocxcoutD((TObject*)nullptr,Integration) << "RooMCIntegrator: using importance sampling with " << bins << " bins and "
-                << boxes << " boxes" << endl;
+                << boxes << " boxes" << std::endl;
       }
     }
 
@@ -286,7 +286,7 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
           sizeOfDim *= _grid.getNBoxes();
         }
         oocoutP(nullptr, Integration) << "RooMCIntegrator: still working ... iteration "
-            << it << '/' << iterations << "  box " << index << "/"<< std::pow(_grid.getNBoxes(), _grid.getDimension()) << endl;
+            << it << '/' << iterations << "  box " << index << "/"<< std::pow(_grid.getNBoxes(), _grid.getDimension()) << std::endl;
         _timer.Start(true);
       }
       else {
@@ -328,9 +328,9 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
       cum_int += (intgrl - cum_int) / (it + 1.0);
       cum_sig = 0.0;
     }
-    oocxcoutD((TObject*)nullptr,Integration) << "=== Iteration " << _it_num << " : I = " << intgrl << " +/- " << sqrt(sig) << endl
+    oocxcoutD((TObject*)nullptr,Integration) << "=== Iteration " << _it_num << " : I = " << intgrl << " +/- " << sqrt(sig) << std::endl
                  << "    Cumulative : I = " << cum_int << " +/- " << cum_sig << "( chi2 = " << _chisq
-                 << ")" << endl;
+                 << ")" << std::endl;
     // print the grid after the final iteration
     if (oodologD((TObject*)nullptr,Integration)) {
       if(it + 1 == iterations) _grid.print(std::cout, true);

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -34,7 +34,7 @@
 #include <fstream>
 #include <iomanip>
 
-using std::cout, std::endl, std::setprecision;
+using std::setprecision;
 
 namespace {
 
@@ -89,11 +89,11 @@ double RooMinimizerFcn::operator()(const double *x) const
 
    // Optional logging
    if (_logfile)
-      (*_logfile) << setprecision(15) << fvalue << setprecision(4) << endl;
+      (*_logfile) << setprecision(15) << fvalue << setprecision(4) << std::endl;
    if (cfg().verbose) {
-      cout << "\nprevFCN" << (_funct->isOffsetting() ? "-offset" : "") << " = " << setprecision(10) << fvalue
+      std::cout << "\nprevFCN" << (_funct->isOffsetting() ? "-offset" : "") << " = " << setprecision(10) << fvalue
            << setprecision(4) << "  ";
-      cout.flush();
+      std::cout.flush();
    }
 
    finishDoEval();

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -64,7 +64,7 @@ RooFit messages can be evaluated or suppressed.
 #include <fstream>
 #include <iomanip>
 
-using std::cout, std::endl, std::ofstream, std::ostream, std::string, std::vector, std::map;
+using std::ofstream, std::ostream, std::string, std::vector, std::map;
 using namespace RooFit;
 
 ClassImp(RooMsgService);
@@ -257,9 +257,9 @@ Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1, co
       os2 = new ofstream(outFile) ;
 
       if (!*os2) {
-   cout << "RooMsgService::addReportingStream ERROR: cannot open output log file " << outFile << " reverting stream to stdout" << endl ;
+   std::cout << "RooMsgService::addReportingStream ERROR: cannot open output log file " << outFile << " reverting stream to stdout" << std::endl ;
    delete os2 ;
-   newStream.os = &cout ;
+   newStream.os = &std::cout ;
       } else {
    newStream.os = os2 ;
       }
@@ -273,7 +273,7 @@ Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1, co
   } else {
 
     // To stdout
-    newStream.os = &cout ;
+    newStream.os = &std::cout ;
 
   }
 
@@ -311,7 +311,7 @@ void RooMsgService::deleteStream(Int_t id)
 void RooMsgService::setStreamStatus(Int_t id, bool flag)
 {
   if (id<0 || id>=static_cast<Int_t>(_streams.size())) {
-    cout << "RooMsgService::setStreamStatus() ERROR: invalid stream ID " << id << endl ;
+    std::cout << "RooMsgService::setStreamStatus() ERROR: invalid stream ID " << id << std::endl ;
     return ;
   }
 
@@ -331,7 +331,7 @@ void RooMsgService::setStreamStatus(Int_t id, bool flag)
 bool RooMsgService::getStreamStatus(Int_t id) const
 {
   if (id<0 || id>= static_cast<Int_t>(_streams.size())) {
-    cout << "RooMsgService::getStreamStatus() ERROR: invalid stream ID " << id << endl ;
+    std::cout << "RooMsgService::getStreamStatus() ERROR: invalid stream ID " << id << std::endl ;
     return false ;
   }
   return _streams[id].active ;
@@ -432,9 +432,9 @@ ostream& RooMsgService::log(const RooAbsArg* self, RooFit::MsgLevel level, RooFi
   // Flush any previous messages
   (*_streams[as].os).flush() ;
 
-  // Insert an endl if we switch from progress to another level
+  // Insert an std::endl if we switch from progress to another level
   if (_lastMsgLevel==PROGRESS && level!=PROGRESS) {
-    (*_streams[as].os) << endl ;
+    (*_streams[as].os) << std::endl ;
   }
   _lastMsgLevel=level ;
 
@@ -490,7 +490,7 @@ void RooMsgService::Print(Option_t *options) const
     activeOnly = false ;
   }
 
-  cout << (activeOnly?"Active Message streams":"All Message streams") << endl ;
+  std::cout << (activeOnly?"Active Message streams":"All Message streams") << std::endl ;
   for (UInt_t i=0 ; i<_streams.size() ; i++) {
 
     // Skip passive streams in active only mode
@@ -500,41 +500,41 @@ void RooMsgService::Print(Option_t *options) const
 
 
     map<int,string>::const_iterator is = _levelNames.find(_streams[i].minLevel) ;
-    cout << "[" << i << "] MinLevel = " << is->second ;
+    std::cout << "[" << i << "] MinLevel = " << is->second ;
 
-    cout << " Topic = " ;
+    std::cout << " Topic = " ;
     if (_streams[i].topic != 0xFFFFF) {
       map<int,string>::const_iterator iter = _topicNames.begin() ;
       while(iter!=_topicNames.end()) {
    if (iter->first & _streams[i].topic) {
-     cout << iter->second << " " ;
+     std::cout << iter->second << " " ;
    }
    ++iter ;
       }
     } else {
-      cout << " Any " ;
+      std::cout << " Any " ;
     }
 
 
     if (!_streams[i].objectName.empty()) {
-      cout << " ObjectName = " << _streams[i].objectName ;
+      std::cout << " ObjectName = " << _streams[i].objectName ;
     }
     if (!_streams[i].className.empty()) {
-      cout << " ClassName = " << _streams[i].className ;
+      std::cout << " ClassName = " << _streams[i].className ;
     }
     if (!_streams[i].baseClassName.empty()) {
-      cout << " BaseClassName = " << _streams[i].baseClassName ;
+      std::cout << " BaseClassName = " << _streams[i].baseClassName ;
     }
     if (!_streams[i].tagName.empty()) {
-      cout << " TagLabel = " << _streams[i].tagName ;
+      std::cout << " TagLabel = " << _streams[i].tagName ;
     }
 
     // Postfix status when printing all
     if (!activeOnly && !_streams[i].active) {
-      cout << " (NOT ACTIVE)"  ;
+      std::cout << " (NOT ACTIVE)"  ;
     }
 
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
 }

--- a/roofit/roofitcore/src/RooMultiCategory.cxx
+++ b/roofit/roofitcore/src/RooMultiCategory.cxx
@@ -59,7 +59,7 @@ RooMultiCategory::RooMultiCategory(const char *name, const char *title, const Ro
   for (const auto arg : inputCategories) {
     if (!dynamic_cast<RooAbsCategory*>(arg)) {
       coutE(InputArguments) << "RooMultiCategory::RooMultiCategory(" << GetName() << "): input argument " << arg->GetName()
-             << " is not a RooAbsCategory" << endl ;
+             << " is not a RooAbsCategory" << std::endl ;
     }
     _catSet.add(*arg) ;
   }
@@ -131,8 +131,8 @@ void RooMultiCategory::printMultiline(ostream& os, Int_t content, bool verbose, 
   RooAbsCategory::printMultiline(os,content,verbose,indent) ;
 
   if (verbose) {
-    os << indent << "--- RooMultiCategory ---" << endl;
-    os << indent << "  Input category list:" << endl ;
+    os << indent << "--- RooMultiCategory ---" << std::endl;
+    os << indent << "  Input category list:" << std::endl ;
     TString moreIndent(indent) ;
     moreIndent.Append("   ") ;
     _catSet.printStream(os,kName|kValue,kStandard,moreIndent.Data()) ;

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -35,7 +35,7 @@ Multivariate Gaussian p.d.f. with correlations
 #include "TDecompChol.h"
 #include "RooFitResult.h"
 
-using std::string, std::list, std::map, std::vector, std::cout, std::endl;
+using std::string, std::list, std::map, std::vector;
 
 ClassImp(RooMultiVarGaussian);
 
@@ -213,7 +213,7 @@ Int_t RooMultiVarGaussian::getAnalyticalIntegral(RooArgSet& allVarsIn, RooArgSet
   if (nx>127) {
     // Warn that analytical integration is only provided for the first 127 observables
     coutW(Integration) << "RooMultiVarGaussian::getAnalyticalIntegral(" << GetName() << ") WARNING: p.d.f. has " << _x.size()
-             << " observables, analytical integration is only implemented for the first 127 observables" << endl ;
+             << " observables, analytical integration is only implemented for the first 127 observables" << std::endl ;
     nx=127 ;
   }
 
@@ -230,13 +230,13 @@ Int_t RooMultiVarGaussian::getAnalyticalIntegral(RooArgSet& allVarsIn, RooArgSet
       RooRealVar* xi = static_cast<RooRealVar*>(_x.at(i)) ;
       if (xi->getMin(rangeName)<_muVec(i)-_z*sqrt(_cov(i,i)) && xi->getMax(rangeName) > _muVec(i)+_z*sqrt(_cov(i,i))) {
    cxcoutD(Integration) << "RooMultiVarGaussian::getAnalyticalIntegral(" << GetName()
-              << ") Advertising analytical integral over " << xi->GetName() << " as range is >" << _z << " sigma" << endl ;
+              << ") Advertising analytical integral over " << xi->GetName() << " as range is >" << _z << " sigma" << std::endl ;
    bits.setBit(i) ;
    anyBits = true ;
    analVars.add(*allVars.find(_x.at(i)->GetName())) ;
       } else {
    cxcoutD(Integration) << "RooMultiVarGaussian::getAnalyticalIntegral(" << GetName() << ") Range of " << xi->GetName() << " is <"
-              << _z << " sigma, relying on numeric integral" << endl ;
+              << _z << " sigma, relying on numeric integral" << std::endl ;
       }
     }
 
@@ -246,13 +246,13 @@ Int_t RooMultiVarGaussian::getAnalyticalIntegral(RooArgSet& allVarsIn, RooArgSet
       RooRealVar* pi = static_cast<RooRealVar*>(_mu.at(i)) ;
       if (pi->getMin(rangeName)<_muVec(i)-_z*sqrt(_cov(i,i)) && pi->getMax(rangeName) > _muVec(i)+_z*sqrt(_cov(i,i))) {
    cxcoutD(Integration) << "RooMultiVarGaussian::getAnalyticalIntegral(" << GetName()
-              << ") Advertising analytical integral over " << pi->GetName() << " as range is >" << _z << " sigma" << endl ;
+              << ") Advertising analytical integral over " << pi->GetName() << " as range is >" << _z << " sigma" << std::endl ;
    bits.setBit(i) ;
    anyBits = true ;
    analVars.add(*allVars.find(_mu.at(i)->GetName())) ;
       } else {
    cxcoutD(Integration) << "RooMultiVarGaussian::getAnalyticalIntegral(" << GetName() << ") Range of " << pi->GetName() << " is <"
-              << _z << " sigma, relying on numeric integral" << endl ;
+              << _z << " sigma, relying on numeric integral" << std::endl ;
       }
     }
 
@@ -379,7 +379,7 @@ Int_t RooMultiVarGaussian::getGenerator(const RooArgSet& directVars, RooArgSet &
   if (nx>127) {
     // Warn that analytical integration is only provided for the first 127 observables
     coutW(Integration) << "RooMultiVarGaussian::getGenerator(" << GetName() << ") WARNING: p.d.f. has " << _x.size()
-             << " observables, partial internal generation is only implemented for the first 127 observables" << endl ;
+             << " observables, partial internal generation is only implemented for the first 127 observables" << std::endl ;
     nx=127 ;
   }
 
@@ -597,7 +597,7 @@ RooMultiVarGaussian::GenData& RooMultiVarGaussian::genData(Int_t code) const
 void RooMultiVarGaussian::decodeCode(Int_t code, vector<int>& map1, vector<int>& map2) const
 {
   if (code<0 || code> (Int_t)_aicMap.size()) {
-    cout << "RooMultiVarGaussian::decodeCode(" << GetName() << ") ERROR don't have bit pattern for code " << code << endl ;
+    std::cout << "RooMultiVarGaussian::decodeCode(" << GetName() << ") ERROR don't have bit pattern for code " << code << std::endl ;
     throw string("RooMultiVarGaussian::decodeCode() ERROR don't have bit pattern for code") ;
   }
 

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -188,7 +188,7 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
       // Calculate log(Poisson(N|mu) for this bin
       double N = eventWeight ;
       double mu = _binnedPdf->getVal()*_binw[i] ;
-      //cout << "RooNLLVar::binnedL(" << GetName() << ") N=" << N << " mu = " << mu << endl ;
+      //cout << "RooNLLVar::binnedL(" << GetName() << ") N=" << N << " mu = " << mu << std::endl ;
 
       if (mu<=0 && N>0) {
 

--- a/roofit/roofitcore/src/RooNumConvolution.cxx
+++ b/roofit/roofitcore/src/RooNumConvolution.cxx
@@ -247,7 +247,7 @@ double RooNumConvolution::evaluate() const
     _callHist->Fill(x,_integrand->numCall()) ;
     if (_integrand->numCall()>_verboseThresh) {
       coutW(Integration) << "RooNumConvolution::evaluate(" << GetName() << ") WARNING convolution integral at x=" << x
-          << " required " << _integrand->numCall() << " function evaluations" << endl ;
+          << " required " << _integrand->numCall() << " function evaluations" << std::endl ;
     }
   }
 
@@ -302,7 +302,7 @@ void RooNumConvolution::setConvolutionWindow(RooAbsReal& centerParam, RooAbsReal
 void RooNumConvolution::setCallWarning(Int_t threshold)
 {
   if (threshold<0) {
-    coutE(InputArguments) << "RooNumConvolution::setCallWarning(" << GetName() << ") ERROR: threshold must be positive, value unchanged" << endl ;
+    coutE(InputArguments) << "RooNumConvolution::setCallWarning(" << GetName() << ") ERROR: threshold must be positive, value unchanged" << std::endl ;
     return ;
   }
   _verboseThresh = threshold ;
@@ -349,7 +349,7 @@ void RooNumConvolution::setCallProfiling(bool flag, Int_t nbinX, Int_t nbinCall,
 
 void RooNumConvolution::printCompactTreeHook(ostream& os, const char* indent)
 {
-  os << indent << "RooNumConvolution begin cache" << endl ;
+  os << indent << "RooNumConvolution begin cache" << std::endl ;
 
   if (_init) {
     _cloneVar->printCompactTree(os,Form("%s[Var]",indent)) ;
@@ -357,7 +357,7 @@ void RooNumConvolution::printCompactTreeHook(ostream& os, const char* indent)
     _cloneModel->printCompactTree(os,Form("%s[Mod]",indent)) ;
   }
 
-  os << indent << "RooNumConvolution end cache" << endl ;
+  os << indent << "RooNumConvolution end cache" << std::endl ;
 }
 
 

--- a/roofit/roofitcore/src/RooNumGenConfig.cxx
+++ b/roofit/roofitcore/src/RooNumGenConfig.cxx
@@ -290,7 +290,7 @@ const RooArgSet& RooNumGenConfig::getConfigSection(const char* name) const
   static RooArgSet dummy ;
   RooArgSet* config = static_cast<RooArgSet*>(_configSets.FindObject(name)) ;
   if (!config) {
-    oocoutE(nullptr,InputArguments) << "RooNumGenConfig::getIntegrator: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumGenConfig::getIntegrator: ERROR: no configuration stored for integrator '" << name << "'" << std::endl ;
     return dummy ;
   }
   return *config ;
@@ -321,58 +321,58 @@ RooPrintable::StyleOption RooNumGenConfig::defaultPrintStyle(Option_t* opt) cons
 
 void RooNumGenConfig::printMultiline(ostream &os, Int_t /*content*/, bool verbose, TString indent) const
 {
-  os << endl ;
-  os << indent << "1-D sampling method: " << _method1D.getCurrentLabel() << endl ;
+  os << std::endl ;
+  os << indent << "1-D sampling method: " << _method1D.getCurrentLabel() << std::endl ;
   if (_method1DCat.getCurrentIndex()!=_method1D.getCurrentIndex()) {
-    os << " (" << _method1DCat.getCurrentLabel() << " if with categories)" << endl ;
+    os << " (" << _method1DCat.getCurrentLabel() << " if with categories)" << std::endl ;
   }
   if (_method1DCond.getCurrentIndex()!=_method1D.getCurrentIndex()) {
-    os << " (" << _method1DCond.getCurrentLabel() << " if conditional)" << endl ;
+    os << " (" << _method1DCond.getCurrentLabel() << " if conditional)" << std::endl ;
   }
   if (_method1DCondCat.getCurrentIndex()!=_method1D.getCurrentIndex()) {
-    os << " (" << _method1DCondCat.getCurrentLabel() << " if conditional with categories)" << endl ;
+    os << " (" << _method1DCondCat.getCurrentLabel() << " if conditional with categories)" << std::endl ;
   }
-  os << endl ;
+  os << std::endl ;
 
-  os << indent << "2-D sampling method: " << _method2D.getCurrentLabel() << endl ;
+  os << indent << "2-D sampling method: " << _method2D.getCurrentLabel() << std::endl ;
   if (_method2DCat.getCurrentIndex()!=_method2D.getCurrentIndex()) {
-    os << " (" << _method2DCat.getCurrentLabel() << " if with categories)" << endl ;
+    os << " (" << _method2DCat.getCurrentLabel() << " if with categories)" << std::endl ;
   }
   if (_method2DCond.getCurrentIndex()!=_method2D.getCurrentIndex()) {
-    os << " (" << _method2DCond.getCurrentLabel() << " if conditional)" << endl ;
+    os << " (" << _method2DCond.getCurrentLabel() << " if conditional)" << std::endl ;
   }
   if (_method2DCondCat.getCurrentIndex()!=_method2D.getCurrentIndex()) {
-    os << " (" << _method2DCondCat.getCurrentLabel() << " if conditional with categories)" << endl ;
+    os << " (" << _method2DCondCat.getCurrentLabel() << " if conditional with categories)" << std::endl ;
   }
-  os << endl ;
+  os << std::endl ;
 
-  os << indent << "N-D sampling method: " << _methodND.getCurrentLabel() << endl ;
+  os << indent << "N-D sampling method: " << _methodND.getCurrentLabel() << std::endl ;
   if (_methodNDCat.getCurrentIndex()!=_methodND.getCurrentIndex()) {
-    os << " (" << _methodNDCat.getCurrentLabel() << " if with categories)" << endl ;
+    os << " (" << _methodNDCat.getCurrentLabel() << " if with categories)" << std::endl ;
   }
   if (_methodNDCond.getCurrentIndex()!=_methodND.getCurrentIndex()) {
-    os << " (" << _methodNDCond.getCurrentLabel() << " if conditional)" << endl ;
+    os << " (" << _methodNDCond.getCurrentLabel() << " if conditional)" << std::endl ;
   }
   if (_methodNDCondCat.getCurrentIndex()!=_methodND.getCurrentIndex()) {
-    os << " (" << _methodNDCondCat.getCurrentLabel() << " if conditional with categories)" << endl ;
+    os << " (" << _methodNDCondCat.getCurrentLabel() << " if conditional with categories)" << std::endl ;
   }
-  os << endl ;
+  os << std::endl ;
 
   if (verbose) {
 
-    os << endl << "Available sampling methods:" << endl << endl ;
+    os << std::endl << "Available sampling methods:" << std::endl << std::endl ;
     for(auto * configSet : static_range_cast<RooArgSet*>(_configSets)) {
 
-      os << indent << "*** " << configSet->GetName() << " ***" << endl ;
+      os << indent << "*** " << configSet->GetName() << " ***" << std::endl ;
       os << indent << "Capabilities: " ;
       const RooAbsNumGenerator* proto = RooNumGenFactory::instance().getProtoSampler(configSet->GetName()) ;
      if (proto->canSampleConditional()) os << "[Conditional] " ;
      if (proto->canSampleCategories()) os << "[Categories] " ;
-      os << endl ;
+      os << std::endl ;
 
-      os << "Configuration: " << endl ;
+      os << "Configuration: " << std::endl ;
       configSet->printMultiline(os,kName|kValue|kTitle) ;
-      os << endl ;
+      os << std::endl ;
 
     }
   }

--- a/roofit/roofitcore/src/RooNumGenFactory.cxx
+++ b/roofit/roofitcore/src/RooNumGenFactory.cxx
@@ -115,7 +115,7 @@ bool RooNumGenFactory::storeProtoSampler(RooAbsNumGenerator* proto, const RooArg
   TString name = proto->generatorName() ;
 
   if (getProtoSampler(name)) {
-    //cout << "RooNumGenFactory::storeSampler() ERROR: integrator '" << name << "' already registered" << endl ;
+    //cout << "RooNumGenFactory::storeSampler() ERROR: integrator '" << name << "' already registered" << std::endl ;
     return true ;
   }
 

--- a/roofit/roofitcore/src/RooNumIntConfig.cxx
+++ b/roofit/roofitcore/src/RooNumIntConfig.cxx
@@ -216,7 +216,7 @@ const RooArgSet& RooNumIntConfig::getConfigSection(const char* name) const
   static RooArgSet dummy ;
   RooArgSet* config = static_cast<RooArgSet*>(_configSets.FindObject(name)) ;
   if (!config) {
-    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::getConfigSection: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::getConfigSection: ERROR: no configuration stored for integrator '" << name << "'" << std::endl ;
     return dummy ;
   }
   return *config ;
@@ -230,7 +230,7 @@ const RooArgSet& RooNumIntConfig::getConfigSection(const char* name) const
 void RooNumIntConfig::setEpsAbs(double newEpsAbs)
 {
   if (newEpsAbs<0) {
-    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsAbs: ERROR: target absolute precision must be greater or equal than zero" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsAbs: ERROR: target absolute precision must be greater or equal than zero" << std::endl ;
     return ;
   }
   _epsAbs = newEpsAbs ;
@@ -260,7 +260,7 @@ RooPrintable::StyleOption RooNumIntConfig::defaultPrintStyle(Option_t* opt) cons
 void RooNumIntConfig::setEpsRel(double newEpsRel)
 {
   if (newEpsRel<0) {
-    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsRel: ERROR: target absolute precision must be greater or equal than zero" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsRel: ERROR: target absolute precision must be greater or equal than zero" << std::endl ;
     return ;
   }
   _epsRel = newEpsRel ;
@@ -273,53 +273,53 @@ void RooNumIntConfig::setEpsRel(double newEpsRel)
 
 void RooNumIntConfig::printMultiline(ostream &os, Int_t /*content*/, bool verbose, TString indent) const
 {
-  os << indent << "Requested precision: " << _epsAbs << " absolute, " << _epsRel << " relative" << endl << endl ;
+  os << indent << "Requested precision: " << _epsAbs << " absolute, " << _epsRel << " relative" << std::endl << std::endl ;
   if (_printEvalCounter) {
-    os << indent << "Printing of function evaluation counter for each integration enabled" << endl << endl ;
+    os << indent << "Printing of function evaluation counter for each integration enabled" << std::endl << std::endl ;
   }
 
   os << indent << "1-D integration method: " << _method1D.getCurrentLabel() ;
   if (_method1DOpen.getCurrentIndex()!=_method1D.getCurrentIndex()) {
-    os << " (" << _method1DOpen.getCurrentLabel() << " if open-ended)" << endl ;
+    os << " (" << _method1DOpen.getCurrentLabel() << " if open-ended)" << std::endl ;
   } else {
-    os << endl ;
+    os << std::endl ;
   }
   os << indent << "2-D integration method: " << _method2D.getCurrentLabel() ;
   if (_method2DOpen.getCurrentIndex()!=_method2D.getCurrentIndex()) {
-    os << " (" << _method2DOpen.getCurrentLabel() << " if open-ended)" << endl ;
+    os << " (" << _method2DOpen.getCurrentLabel() << " if open-ended)" << std::endl ;
   } else {
-    os << endl ;
+    os << std::endl ;
   }
   os << indent << "N-D integration method: " << _methodND.getCurrentLabel() ;
   if (_methodNDOpen.getCurrentIndex()!=_methodND.getCurrentIndex()) {
-    os << " (" << _methodNDOpen.getCurrentLabel() << " if open-ended)" << endl ;
+    os << " (" << _methodNDOpen.getCurrentLabel() << " if open-ended)" << std::endl ;
   } else {
-    os << endl ;
+    os << std::endl ;
   }
 
   if (verbose) {
 
-    os << endl << "Available integration methods:" << endl << endl ;
+    os << std::endl << "Available integration methods:" << std::endl << std::endl ;
     for(auto * configSet : static_range_cast<RooArgSet*>(_configSets)) {
 
       auto const& info = *RooNumIntFactory::instance().getPluginInfo(configSet->GetName());
 
-      os << indent << "*** " << configSet->GetName() << " ***" << endl ;
+      os << indent << "*** " << configSet->GetName() << " ***" << std::endl ;
       os << indent << "Capabilities: " ;
       if (info.canIntegrate1D) os << "[1-D] " ;
       if (info.canIntegrate2D) os << "[2-D] " ;
       if (info.canIntegrateND) os << "[N-D] " ;
       if (info.canIntegrateOpenEnded) os << "[OpenEnded] " ;
-      os << endl ;
+      os << std::endl ;
 
-      os << "Configuration: " << endl ;
+      os << "Configuration: " << std::endl ;
       configSet->printMultiline(os,kName|kValue) ;
       //configSet->writeToStream(os,false) ;
 
       if (!info.depName.empty()) {
-   os << indent << "(Depends on '" << info.depName << "')" << endl ;
+   os << indent << "(Depends on '" << info.depName << "')" << std::endl ;
       }
-      os << endl ;
+      os << std::endl ;
 
     }
   }

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -35,7 +35,7 @@ when any of the parameters of the input p.d.f. has changed.
 #include "RooHistPdf.h"
 #include "RooRealVar.h"
 
-using std::cout, std::endl, std::string;
+using std::string;
 
 ClassImp(RooNumRunningInt);
 
@@ -293,7 +293,7 @@ RooAbsCachedReal::FuncCacheElem* RooNumRunningInt::createCache(const RooArgSet* 
 
 double RooNumRunningInt::evaluate() const
 {
-  cout << "RooNumRunningInt::evaluate(" << GetName() << ")" << endl ;
+  std::cout << "RooNumRunningInt::evaluate(" << GetName() << ")" << std::endl ;
   return 0 ;
 }
 

--- a/roofit/roofitcore/src/RooParamBinning.cxx
+++ b/roofit/roofitcore/src/RooParamBinning.cxx
@@ -74,19 +74,19 @@ RooParamBinning::~RooParamBinning()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
-///   cout << "RooParamBinning::cctor(" << this << ") orig = " << &other << endl ;
+///   std::cout << "RooParamBinning::cctor(" << this << ") orig = " << &other << std::endl ;
 
 RooParamBinning::RooParamBinning(const RooParamBinning &other, const char *name) : RooAbsBinning(name)
 {
 
   if (other._lp) {
-//     cout << "RooParamBinning::cctor(this = " << this << ") taking addresses from orig  ListProxy" << endl ;
+//     std::cout << "RooParamBinning::cctor(this = " << this << ") taking addresses from orig  ListProxy" << std::endl ;
     _xlo = static_cast<RooAbsReal*>(other._lp->at(0)) ;
     _xhi = static_cast<RooAbsReal*>(other._lp->at(1)) ;
 
   } else {
 
-//     cout << "RooParamBinning::cctor(this = " << this << ") taking addresses from orig pointers " << other._xlo << " " << other._xhi << endl ;
+//     std::cout << "RooParamBinning::cctor(this = " << this << ") taking addresses from orig pointers " << other._xlo << " " << other._xhi << std::endl ;
 
     _xlo   = other._xlo ;
     _xhi   = other._xhi ;
@@ -95,7 +95,7 @@ RooParamBinning::RooParamBinning(const RooParamBinning &other, const char *name)
   _nbins = other._nbins ;
   _lp = nullptr ;
 
-  //cout << "RooParamBinning::cctor(this = " << this << " xlo = " << &_xlo << " xhi = " << &_xhi << " _lp = " << _lp << " owner = " << _owner << ")" << endl ;
+  //cout << "RooParamBinning::cctor(this = " << this << " xlo = " << &_xlo << " xhi = " << &_xhi << " _lp = " << _lp << " owner = " << _owner << ")" << std::endl ;
 }
 
 
@@ -111,14 +111,14 @@ void RooParamBinning::insertHook(RooAbsRealLValue& owner) const
   _owner = &owner ;
 
   // If list proxy already exists update pointers from proxy
-//   cout << "RooParamBinning::insertHook(" << this << "," << GetName() << ") _lp at beginning = " << _lp << endl ;
+//   std::cout << "RooParamBinning::insertHook(" << this << "," << GetName() << ") _lp at beginning = " << _lp << std::endl ;
   if (_lp) {
-//     cout << "updating raw pointers from list proxy contents" << endl ;
+//     std::cout << "updating raw pointers from list proxy contents" << std::endl ;
     _xlo = xlo() ;
     _xhi = xhi() ;
     delete _lp ;
   }
-//   cout << "_xlo = " << _xlo << " _xhi = " << _xhi << endl ;
+//   std::cout << "_xlo = " << _xlo << " _xhi = " << _xhi << std::endl ;
 
   // If list proxy does not exist, create it now
   _lp = new RooListProxy(Form("range::%s",GetName()),"lp",&owner,false,true) ;
@@ -158,7 +158,7 @@ void RooParamBinning::removeHook(RooAbsRealLValue& /*owner*/) const
 void RooParamBinning::setRange(double newxlo, double newxhi)
 {
   if (newxlo>newxhi) {
-    coutE(InputArguments) << "RooParamBinning::setRange: ERROR low bound > high bound" << endl ;
+    coutE(InputArguments) << "RooParamBinning::setRange: ERROR low bound > high bound" << std::endl ;
     return ;
   }
 
@@ -166,14 +166,14 @@ void RooParamBinning::setRange(double newxlo, double newxhi)
   if (xlolv) {
     xlolv->setVal(newxlo) ;
   } else {
-    coutW(InputArguments) << "RooParamBinning::setRange: WARNING lower bound not represented by lvalue, cannot set lower bound value through setRange()" << endl ;
+    coutW(InputArguments) << "RooParamBinning::setRange: WARNING lower bound not represented by lvalue, cannot set lower bound value through setRange()" << std::endl ;
   }
 
   RooAbsRealLValue* xhilv = dynamic_cast<RooAbsRealLValue*>(xhi()) ;
   if (xhilv) {
     xhilv->setVal(newxhi) ;
   } else {
-    coutW(InputArguments) << "RooParamBinning::setRange: WARNING upper bound not represented by lvalue, cannot set upper bound value through setRange()" << endl ;
+    coutW(InputArguments) << "RooParamBinning::setRange: WARNING upper bound not represented by lvalue, cannot set upper bound value through setRange()" << std::endl ;
   }
 
 }
@@ -203,7 +203,7 @@ double RooParamBinning::binCenter(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooParamBinning::binCenter ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 
@@ -230,7 +230,7 @@ double RooParamBinning::binLow(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooParamBinning::binLow ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 
@@ -246,7 +246,7 @@ double RooParamBinning::binHigh(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooParamBinning::fitBinHigh ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 
@@ -277,11 +277,11 @@ double* RooParamBinning::array() const
 
 void RooParamBinning::printMultiline(ostream &os, Int_t /*content*/, bool /*verbose*/, TString indent) const
 {
-  os << indent << "_xlo = " << _xlo << endl ;
-  os << indent << "_xhi = " << _xhi << endl ;
+  os << indent << "_xlo = " << _xlo << std::endl ;
+  os << indent << "_xhi = " << _xhi << std::endl ;
   if (_lp) {
-    os << indent << "xlo() = " << xlo() << endl ;
-    os << indent << "xhi() = " << xhi() << endl ;
+    os << indent << "xlo() = " << xlo() << std::endl ;
+    os << indent << "xhi() = " << xhi() << std::endl ;
   }
   if (xlo()) {
     xlo()->Print("t") ;

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -539,8 +539,8 @@ void RooPlot::updateFitRangeNorm(const RooPlotable* rp, bool refreshNorm)
     // scale this histogram to match that density
     _normNumEvts = rp->getFitRangeNEvt()/corFac ;
     _normObj = rp ;
-    // cout << "correction factor = " << _normBinWidth << "/" << rp->getFitRangeBinW() << std::endl ;
-    // cout << "updating numevts to " << _normNumEvts << std::endl ;
+    // std::cout << "correction factor = " << _normBinWidth << "/" << rp->getFitRangeBinW() << std::endl ;
+    // std::cout << "updating numevts to " << _normNumEvts << std::endl ;
 
   } else {
 
@@ -550,7 +550,7 @@ void RooPlot::updateFitRangeNorm(const RooPlotable* rp, bool refreshNorm)
       _normBinWidth = rp->getFitRangeBinW() ;
     }
 
-    // cout << "updating numevts to " << _normNumEvts << std::endl ;
+    // std::cout << "updating numevts to " << _normNumEvts << std::endl ;
   }
 
 }

--- a/roofit/roofitcore/src/RooPlotable.cxx
+++ b/roofit/roofitcore/src/RooPlotable.cxx
@@ -37,10 +37,10 @@ ClassImp(RooPlotable);
 /// Print detailed information
 
 void RooPlotable::printMultiline(ostream& os, Int_t /*content*/, bool /*verbose*/, TString indent) const {
-  os << indent << "--- RooPlotable ---" << endl;
-  os << indent << "  y-axis min = " << getYAxisMin() << endl
-     << indent << "  y-axis max = " << getYAxisMax() << endl
-     << indent << "  y-axis label \"" << getYAxisLabel() << "\"" << endl;
+  os << indent << "--- RooPlotable ---" << std::endl;
+  os << indent << "  y-axis min = " << getYAxisMin() << std::endl
+     << indent << "  y-axis max = " << getYAxisMax() << std::endl
+     << indent << "  y-axis label \"" << getYAxisLabel() << "\"" << std::endl;
 }
 
 

--- a/roofit/roofitcore/src/RooPolyFunc.cxx
+++ b/roofit/roofitcore/src/RooPolyFunc.cxx
@@ -115,7 +115,7 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsCollection &exponents)
    if (exponents.size() != _vars.size()) {
       coutE(InputArguments) << "RooPolyFunc::addTerm(" << GetName() << ") WARNING: number of exponents ("
                             << exponents.size() << ") provided do not match the number of variables (" << _vars.size()
-                            << ")" << endl;
+                            << ")" << std::endl;
    }
    int n_terms = _terms.size();
    std::string coeff_name = Form("%s_c%d", GetName(), n_terms);

--- a/roofit/roofitcore/src/RooPrintable.cxx
+++ b/roofit/roofitcore/src/RooPrintable.cxx
@@ -39,7 +39,7 @@ given a Print() option string.
 #include "TNamed.h"
 #include "TClass.h"
 
-using std::ostream, std::cout, std::endl, std::setw;
+using std::ostream, std::setw;
 
 ClassImp(RooPrintable);
 
@@ -139,7 +139,7 @@ void RooPrintable::printStream(ostream& os, Int_t contents, StyleOption style, T
     }
   }
 
-  if (style!=kInline) os << endl ;
+  if (style!=kInline) os << std::endl ;
 
 }
 
@@ -175,7 +175,7 @@ void RooPrintable::printMultiline(ostream& /*os*/, Int_t /*contents*/, bool /*ve
 
 void RooPrintable::printTree(ostream& /*os*/, TString /*indent*/) const
 {
-  cout << "Tree structure printing not implement for class " << IsA()->GetName() << endl ;
+  std::cout << "Tree structure printing not implement for class " << IsA()->GetName() << std::endl ;
 }
 
 
@@ -266,9 +266,9 @@ RooPrintable::StyleOption RooPrintable::defaultPrintStyle(Option_t* opt) const
 /// method allows subclasses to provide an inline implementation of
 /// Print() without pulling in iostream.h.
 
-ostream &RooPrintable::defaultPrintStream(ostream *os)
+ostream &RooPrintable::defaultPrintStream(std::ostream *os)
 {
-  static ostream *_defaultPrintStream = &cout;
+  static ostream *_defaultPrintStream = &std::cout;
 
   ostream& _oldDefault= *_defaultPrintStream;
   if(nullptr != os) _defaultPrintStream= os;

--- a/roofit/roofitcore/src/RooProdGenContext.cxx
+++ b/roofit/roofitcore/src/RooProdGenContext.cxx
@@ -54,7 +54,7 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
          << " for generation of observable(s) " << vars ;
   if (prototype) ccxcoutI(Generation) << " with prototype data for " << *prototype->get() ;
   if (auxProto && !auxProto->empty())  ccxcoutI(Generation) << " with auxiliary prototypes " << *auxProto ;
-  ccxcoutI(Generation) << endl ;
+  ccxcoutI(Generation) << std::endl ;
 
   // Make full list of dependents (generated & proto)
   RooArgSet deps(vars) ;
@@ -117,11 +117,11 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
 
       if (!neededDeps.empty()) {
    if (!anyPrevAction) {
-     cxcoutD(Generation) << "RooProdGenContext::ctor() no convergence in single term analysis loop, terminating loop and process remainder of terms as single unit " << endl ;
+     cxcoutD(Generation) << "RooProdGenContext::ctor() no convergence in single term analysis loop, terminating loop and process remainder of terms as single unit " << std::endl ;
      go=false ;
      break ;
    }
-   cxcoutD(Generation) << "RooProdGenContext::ctor() skipping this term for now because it needs imported dependents that are not generated yet" << endl ;
+   cxcoutD(Generation) << "RooProdGenContext::ctor() skipping this term for now because it needs imported dependents that are not generated yet" << std::endl ;
    ++termIter;
    ++impIter;
    ++normIter;
@@ -131,7 +131,7 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
       // Check if this component has any dependents that need to be generated
       // e.g. it can happen that there are none if all dependents of this component are prototyped
       if (termDeps->empty()) {
-   cxcoutD(Generation) << "RooProdGenContext::ctor() term has no observables requested to be generated, removing it" << endl ;
+   cxcoutD(Generation) << "RooProdGenContext::ctor() term has no observables requested to be generated, removing it" << std::endl ;
 
    // Increment the iterators first, because Removing the corresponding element
    // would invalidate them otherwise.
@@ -155,12 +155,12 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
    auto pdf = static_cast<RooAbsPdf*>((*term)[0]);
    std::unique_ptr<RooArgSet> pdfDep{pdf->getObservables(termDeps)};
    if (!pdfDep->empty()) {
-     coutI(Generation) << "RooProdGenContext::ctor() creating subcontext for generation of observables " << *pdfDep << " from model " << pdf->GetName() << endl ;
+     coutI(Generation) << "RooProdGenContext::ctor() creating subcontext for generation of observables " << *pdfDep << " from model " << pdf->GetName() << std::endl ;
      std::unique_ptr<RooArgSet> auxProto2{pdf->getObservables(impDeps)};
      _gcList.emplace_back(pdf->genContext(*pdfDep,prototype,auxProto2.get(),verbose)) ;
    }
 
-//    cout << "adding following dependents to list of generated observables: " ; pdfDep->Print("1") ;
+//    std::cout << "adding following dependents to list of generated observables: " ; pdfDep->Print("1") ;
    genDeps.add(*pdfDep) ;
 
       } else {
@@ -183,7 +183,7 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
        if (pdfnset && !pdfnset->empty()) {
          // This PDF requires a Conditional() construction
          cmdList.Add(RooFit::Conditional(*pdfSet,*pdfnset).Clone()) ;
-//          cout << "Conditional " << pdf->GetName() << " " ; pdfnset->Print("1") ;
+//          std::cout << "Conditional " << pdf->GetName() << " " ; pdfnset->Print("1") ;
        } else {
          fullPdfSet.add(*pdfSet) ;
        }
@@ -225,7 +225,7 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
   // separately due to cross dependency of observables
   if (!termList.empty()) {
 
-    cxcoutD(Generation) << "RooProdGenContext::ctor() there are left-over terms that need to be generated separately" << endl ;
+    cxcoutD(Generation) << "RooProdGenContext::ctor() there are left-over terms that need to be generated separately" << std::endl ;
 
     // Concatenate remaining terms
     auto normIter = depsList.begin();
@@ -269,7 +269,7 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
     multiPdf->useDefaultGen(true) ;
 
     cxcoutD(Generation) << "RooProdGenContext(" << model.GetName() << "): creating context for irreducible composite trailer term "
-    << multiPdf->GetName() << " that generates observables " << trailerTermDeps << endl ;
+    << multiPdf->GetName() << " that generates observables " << trailerTermDeps << std::endl ;
     _gcList.emplace_back(multiPdf->genContext(trailerTermDeps,prototype,auxProto,verbose));
 
     _ownedMultiProds.addOwned(std::move(multiPdf));
@@ -375,10 +375,10 @@ void RooProdGenContext::setProtoDataOrder(Int_t* lut)
 void RooProdGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
 {
   RooAbsGenContext::printMultiline(os,content,verbose,indent) ;
-  os << indent << "--- RooProdGenContext ---" << endl ;
+  os << indent << "--- RooProdGenContext ---" << std::endl ;
   os << indent << "Using PDF ";
   _pdf->printStream(os,kName|kArgs|kClassName,kSingleLine,indent);
-  os << indent << "List of component generators" << endl ;
+  os << indent << "List of component generators" << std::endl ;
 
   TString indent2(indent) ;
   indent2.Append("    ") ;

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -127,7 +127,7 @@ RooProdPdf::RooProdPdf(const char *name, const char *title,
       // Protect against multiple extended terms
       coutW(InputArguments) << "RooProdPdf::RooProdPdf(" << GetName()
              << ") multiple components with extended terms detected,"
-             << " product will not be extendable." << endl ;
+             << " product will not be extendable." << std::endl ;
       _extendedIndex=-1 ;
     } else {
       _extendedIndex=_pdfList.index(&pdf2) ;
@@ -327,7 +327,7 @@ void RooProdPdf::initializeFromCmdArgList(const RooArgSet& fullPdfSet, const Roo
       }
 
     } else if (0 != strlen(carg->GetName())) {
-      coutW(InputArguments) << "Unknown arg: " << carg->GetName() << endl ;
+      coutW(InputArguments) << "Unknown arg: " << carg->GetName() << std::endl ;
     }
   }
 
@@ -335,7 +335,7 @@ void RooProdPdf::initializeFromCmdArgList(const RooArgSet& fullPdfSet, const Roo
   if (numExtended>1) {
     coutW(InputArguments) << "RooProdPdf::RooProdPdf(" << GetName()
            << ") WARNING: multiple components with extended terms detected,"
-           << " product will not be extendable." << endl ;
+           << " product will not be extendable." << std::endl ;
     _extendedIndex = -1 ;
   }
 
@@ -385,9 +385,9 @@ double RooProdPdf::calculate(const RooProdPdf::CacheElem& cache, bool /*verbose*
   if (cache._isRearranged) {
     if (dologD(Eval)) {
       cxcoutD(Eval) << "RooProdPdf::calculate(" << GetName() << ") rearranged product calculation"
-                    << " calculate: num = " << cache._rearrangedNum->GetName() << " = " << cache._rearrangedNum->getVal() << endl ;
+                    << " calculate: num = " << cache._rearrangedNum->GetName() << " = " << cache._rearrangedNum->getVal() << std::endl ;
 //       cache._rearrangedNum->printComponentTree("",0,5) ;
-      cxcoutD(Eval) << "calculate: den = " << cache._rearrangedDen->GetName() << " = " << cache._rearrangedDen->getVal() << endl ;
+      cxcoutD(Eval) << "calculate: den = " << cache._rearrangedDen->GetName() << " = " << cache._rearrangedDen->getVal() << std::endl ;
 //       cache._rearrangedDen->printComponentTree("",0,5) ;
     }
 
@@ -534,7 +534,7 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
     getObservablesOfCurrentPdf(pdfAllDeps, normSet);
 
 
-//     cout << GetName() << ": pdf = " << pdf->GetName() << " pdfAllDeps = " << pdfAllDeps << " pdfNSet = " << *pdfNSet << " pdfCSet = " << *pdfCSet << endl;
+//     std::cout << GetName() << ": pdf = " << pdf->GetName() << " pdfAllDeps = " << pdfAllDeps << " pdfNSet = " << *pdfNSet << " pdfCSet = " << *pdfCSet << std::endl;
 
     // Make list of normalization dependents for this PDF;
     if (!pdfNSet.empty()) {
@@ -545,7 +545,7 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
       pdfNormDeps = pdfAllDeps;
     }
 
-//     cout << GetName() << ": pdfNormDeps for " << pdf->GetName() << " = " << pdfNormDeps << endl;
+//     std::cout << GetName() << ": pdfNormDeps for " << pdf->GetName() << " = " << pdfNormDeps << std::endl;
 
     pdfIntSet.clear();
     getObservablesOfCurrentPdf(pdfIntSet, intSet) ;
@@ -553,14 +553,14 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
     // WVE if we have no norm deps, conditional observables should be taken out of pdfIntSet
     if (pdfNormDeps.empty() && !pdfCSet.empty()) {
       removeCommon(pdfIntSet, pdfCSet);
-//       cout << GetName() << ": have no norm deps, removing conditional observables from intset" << endl;
+//       std::cout << GetName() << ": have no norm deps, removing conditional observables from intset" << std::endl;
     }
 
     pdfIntNoNormDeps.clear();
     pdfIntNoNormDeps = pdfIntSet;
     removeCommon(pdfIntNoNormDeps, pdfNormDeps);
 
-//     cout << GetName() << ": pdf = " << pdf->GetName() << " intset = " << *pdfIntSet << " pdfIntNoNormDeps = " << pdfIntNoNormDeps << endl;
+//     std::cout << GetName() << ": pdf = " << pdf->GetName() << " intset = " << *pdfIntSet << " pdfIntNoNormDeps = " << pdfIntNoNormDeps << std::endl;
 
     // Check if this PDF has dependents overlapping with one of the existing terms
     bool done = false;
@@ -580,7 +580,7 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
       //bool intOverlap =  pdfIntSet->overlaps(*termAllDeps);
 
       if (normOverlap) {
-//    cout << GetName() << ": this term overlaps with term " << (*term) << " in normalization observables" << endl;
+//    std::cout << GetName() << ": this term overlaps with term " << (*term) << " in normalization observables" << std::endl;
 
    term->add(pdf);
    termNormDeps->add(pdfNormDeps.begin(), pdfNormDeps.end(), false);
@@ -632,7 +632,7 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
     auto snap = new RooArgSet;
     impDeps.snapshot(*snap);
     impDepList.Add(snap);
-//     cout << GetName() << ": list of imported dependents for term " << (*term) << " set to " << impDeps << endl ;
+//     std::cout << GetName() << ": list of imported dependents for term " << (*term) << " set to " << impDeps << std::endl ;
 
     // Make list of cross dependents (term is self contained for these dependents,
     // but components import dependents from other components)
@@ -640,7 +640,7 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
     snap = new RooArgSet;
     crossDeps->snapshot(*snap);
     crossDepList.Add(snap);
-//     cout << GetName() << ": list of cross dependents for term " << (*term) << " set to " << *crossDeps << endl ;
+//     std::cout << GetName() << ": list of cross dependents for term " << (*term) << " set to " << *crossDeps << std::endl ;
   }
 
   return;
@@ -676,10 +676,10 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
                                                        const RooArgSet* iset,
                                                        const char* isetRangeName) const
 {
-//    cout << "   FOLKERT::RooProdPdf::getPartIntList(" << GetName() <<")  nset = " << (nset?*nset:RooArgSet()) << endl
-//         << "   _normRange = " << _normRange << endl
-//         << "   iset = " << (iset?*iset:RooArgSet()) << endl
-//         << "   isetRangeName = " << (isetRangeName?isetRangeName:"<null>") << endl ;
+//    std::cout << "   FOLKERT::RooProdPdf::getPartIntList(" << GetName() <<")  nset = " << (nset?*nset:RooArgSet()) << std::endl
+//         << "   _normRange = " << _normRange << std::endl
+//         << "   iset = " << (iset?*iset:RooArgSet()) << std::endl
+//         << "   isetRangeName = " << (isetRangeName?isetRangeName:"<null>") << std::endl ;
 
   // Create containers for partial integral components to be generated
   auto cache = std::make_unique<CacheElem>();
@@ -690,12 +690,12 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
   RooLinkedList imp;
   RooLinkedList ints;
   RooLinkedList cross;
-  //   cout << "RooProdPdf::getPIL -- now calling factorizeProduct()" << endl ;
+  //   std::cout << "RooProdPdf::getPIL -- now calling factorizeProduct()" << std::endl ;
 
 
   // Normalization set used for factorization
   RooArgSet factNset(nset ? (*nset) : _defNormSet);
-//   cout << GetName() << "factNset = " << factNset << endl ;
+//   std::cout << GetName() << "factNset = " << factNset << std::endl ;
 
   factorizeProduct(factNset, iset ? (*iset) : RooArgSet(), terms, norms, imp, cross, ints);
 
@@ -707,16 +707,16 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
   // Group irriducible terms that need to be (partially) integrated together
   std::list<std::vector<RooArgSet*>> groupedList;
   RooArgSet outerIntDeps;
-//   cout << "RooProdPdf::getPIL -- now calling groupProductTerms()" << endl;
+//   std::cout << "RooProdPdf::getPIL -- now calling groupProductTerms()" << std::endl;
   groupProductTerms(groupedList, outerIntDeps, terms, norms, imp, ints, cross);
 
   // Loop over groups
-//   cout<<"FK: pdf("<<GetName()<<") Starting selecting F(x|y)!"<<endl;
+//   std::cout<<"FK: pdf("<<GetName()<<") Starting selecting F(x|y)!"<< std::endl;
   // Find groups of type F(x|y), i.e. termImpSet!=0, construct ratio object
   std::map<std::string, RooArgSet> ratioTerms;
   for (auto const& group : groupedList) {
     if (1 == group.size()) {
-//       cout<<"FK: Starting Single Term"<<endl;
+//       std::cout<<"FK: Starting Single Term"<< std::endl;
 
       RooArgSet* term = group[0];
 
@@ -726,16 +726,16 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
       RooArgSet termNSet(*norm);
       RooArgSet termImpSet(*imps);
 
-      //       cout<<"FK: termImpSet.size()  = "<<termImpSet.size()<< " " << termImpSet << endl;
-      //       cout<<"FK: _refRangeName = "<<_refRangeName<<endl;
+      //       std::cout<<"FK: termImpSet.size()  = "<<termImpSet.size()<< " " << termImpSet << std::endl;
+      //       std::cout<<"FK: _refRangeName = "<<_refRangeName<< std::endl;
 
       if (!termImpSet.empty() && nullptr != _refRangeName) {
 
-//    cout << "WVE now here" << endl;
+//    std::cout << "WVE now here" << std::endl;
 
    // WVE we can skip this if the ref range is equal to the normalization range
    bool rangeIdentical(true);
-//    cout << "_normRange = " << _normRange << " _refRangeName = " << RooNameReg::str(_refRangeName) << endl ;
+//    std::cout << "_normRange = " << _normRange << " _refRangeName = " << RooNameReg::str(_refRangeName) << std::endl ;
    for (auto const* normObs : static_range_cast<RooRealVar*>(termNSet)) {
      //FK: Here the refRange should be compared to _normRange, if it's set, and to the normObs range if it's not set
      if (_normRange.Length() > 0) {
@@ -747,20 +747,20 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
        if (normObs->getMax() != normObs->getMax(RooNameReg::str(_refRangeName))) rangeIdentical = false;
      }
    }
-//    cout<<"FK: rangeIdentical Single = "<<(rangeIdentical ? 'T':'F')<<endl;
+//    std::cout<<"FK: rangeIdentical Single = "<<(rangeIdentical ? 'T':'F')<< std::endl;
    // coverity[CONSTANT_EXPRESSION_RESULT]
    // LM : avoid making integral ratio if range is the same. Why was not included ??? (same at line 857)
    if (!rangeIdentical ) {
-//      cout << "PREPARING RATIO HERE (SINGLE TERM)" << endl ;
+//      std::cout << "PREPARING RATIO HERE (SINGLE TERM)" << std::endl ;
      auto ratio = makeCondPdfRatioCorr(*static_cast<RooAbsReal*>(term->first()), termNSet, termImpSet, normRange(), RooNameReg::str(_refRangeName));
      std::ostringstream str; termImpSet.printValue(str);
-//      cout << GetName() << "inserting ratio term" << endl;
+//      std::cout << GetName() << "inserting ratio term" << std::endl;
      ratioTerms[str.str()].addOwned(std::move(ratio));
    }
       }
 
     } else {
-//       cout<<"FK: Starting Composite Term"<<endl;
+//       std::cout<<"FK: Starting Composite Term"<< std::endl;
 
       for (auto const& term : group) {
 
@@ -786,9 +786,9 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
          if (normObs->getMax() != normObs->getMax(RooNameReg::str(_refRangeName))) rangeIdentical = false;
        }
      }
-//      cout<<"FK: rangeIdentical Composite = "<<(rangeIdentical ? 'T':'F') <<endl;
+//      std::cout<<"FK: rangeIdentical Composite = "<<(rangeIdentical ? 'T':'F') << std::endl;
      if (!rangeIdentical ) {
-//        cout << "PREPARING RATIO HERE (COMPOSITE TERM)" << endl ;
+//        std::cout << "PREPARING RATIO HERE (COMPOSITE TERM)" << std::endl ;
        auto ratio = makeCondPdfRatioCorr(*static_cast<RooAbsReal*>(term->first()), termNSet, termImpSet, normRange(), RooNameReg::str(_refRangeName));
        std::ostringstream str; termImpSet.printValue(str);
        ratioTerms[str.str()].addOwned(std::move(ratio));
@@ -812,7 +812,7 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
    // If termNset matches index of ratioTerms, insert ratio here
    ostringstream str; termNSet.printValue(str);
    if (!ratioTerms[str.str()].empty()) {
-//      cout << "MUST INSERT RATIO OBJECT IN TERM (COMPOSITE)" << *term << endl;
+//      std::cout << "MUST INSERT RATIO OBJECT IN TERM (COMPOSITE)" << *term << std::endl;
      term->add(ratioTerms[str.str()]);
      cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
    }
@@ -820,11 +820,11 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
   }
 
   for (auto const& group : groupedList) {
-//     cout << GetName() << ":now processing group" << endl;
+//     std::cout << GetName() << ":now processing group" << std::endl;
 //      group->Print("1");
 
     if (1 == group.size()) {
-//       cout << "processing atomic item" << endl;
+//       std::cout << "processing atomic item" << std::endl;
       RooArgSet* term = group[0];
 
         Int_t termIdx = terms.IndexOf(term);
@@ -860,13 +860,13 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
           cache->_denList.addOwned(std::unique_ptr<RooAbsArg>{func[2]});
         }
       } else {
-//        cout << "processing composite item" << endl;
+//        std::cout << "processing composite item" << std::endl;
         RooArgSet compTermSet;
         RooArgSet compTermNorm;
         RooArgSet compTermNum;
         RooArgSet compTermDen;
         for (auto const &term : group) {
-          //    cout << GetName() << ": processing term " << (*term) << " of composite item" << endl ;
+          //    std::cout << GetName() << ": processing term " << (*term) << " of composite item" << std::endl ;
           Int_t termIdx = terms.IndexOf(term);
           norm = static_cast<RooArgSet *>(norms.At(termIdx));
           integ = static_cast<RooArgSet *>(ints.At(termIdx));
@@ -888,7 +888,7 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
           bool isOwned = false;
           vector<RooAbsReal *> func =
              processProductTerm(nset, iset, isetRangeName, term, termNSet, termISet, isOwned, true);
-          //       cout << GetName() << ": created composite term component " << func[0]->GetName() << endl;
+          //       std::cout << GetName() << ": created composite term component " << func[0]->GetName() << std::endl;
           if (func[0]) {
      compTermSet.add(*func[0]);
      if (isOwned) cache->_ownedList.addOwned(std::unique_ptr<RooAbsArg>{func[0]});
@@ -902,8 +902,8 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
    }
       }
 
-//       cout << GetName() << ": constructing special composite product" << endl;
-//       cout << GetName() << ": compTermSet = " ; compTermSet.Print("1");
+//       std::cout << GetName() << ": constructing special composite product" << std::endl;
+//       std::cout << GetName() << ": compTermSet = " ; compTermSet.Print("1");
 
       // WVE THIS NEEDS TO BE REARRANGED
 
@@ -1011,7 +1011,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   RooArgSet specIntDeps ;
   string specIntRange ;
 
-//   cout << "THIS IS REARRANGEPRODUCT" << endl ;
+//   std::cout << "THIS IS REARRANGEPRODUCT" << std::endl ;
 
   for (std::size_t i = 0; i < cache._partList.size(); i++) {
 
@@ -1020,9 +1020,9 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
     den = static_cast<RooAbsReal*>(cache._denList.at(i));
     i++;
 
-//     cout << "now processing part " << part->GetName() << " of type " << part->getStringAttribute("PROD_TERM_TYPE") << endl ;
-//     cout << "corresponding numerator = " << num->GetName() << endl ;
-//     cout << "corresponding denominator = " << den->GetName() << endl ;
+//     std::cout << "now processing part " << part->GetName() << " of type " << part->getStringAttribute("PROD_TERM_TYPE") << std::endl ;
+//     std::cout << "corresponding numerator = " << num->GetName() << std::endl ;
+//     std::cout << "corresponding denominator = " << den->GetName() << std::endl ;
 
 
     RooFormulaVar* ratio(nullptr) ;
@@ -1046,7 +1046,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
      RooCustomizer cust(*func,"blah") ;
      cust.replaceArg(*ratio,RooFit::RooConst(1)) ;
      RooAbsArg* funcCust = cust.build() ;
-//      cout << "customized function = " << endl ;
+//      std::cout << "customized function = " << std::endl ;
 //      funcCust->printComponentTree() ;
      nomList.add(*funcCust) ;
    } else {
@@ -1063,7 +1063,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
    func = const_cast<RooAbsReal*>(&static_cast<RooRealIntegral*>(func)->integrand());
       }
       if (func->InheritsFrom(RooProduct::Class())) {
-//    cout << "product term found: " ; func->Print() ;
+//    std::cout << "product term found: " ; func->Print() ;
    for(RooAbsArg * arg : static_cast<RooProduct*>(func)->components()) {
      if (arg->getAttribute("RATIO_TERM")) {
        ratio = static_cast<RooFormulaVar*>(arg) ;
@@ -1074,8 +1074,8 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
       }
 
       if (ratio) {
-//    cout << "Found ratio term in numerator: " << ratio->GetName() << endl ;
-//    cout << "Adding only original term to numerator: " << origNumTerm << endl ;
+//    std::cout << "Found ratio term in numerator: " << ratio->GetName() << std::endl ;
+//    std::cout << "Adding only original term to numerator: " << origNumTerm << std::endl ;
    nomList.add(origNumTerm) ;
       } else {
    nomList.add(*num) ;
@@ -1086,11 +1086,11 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
     for (list<string>::iterator iter = rangeComps.begin() ; iter != rangeComps.end() ; ++iter) {
       // If denominator is an integral, make a clone with the integration range adjusted to
       // the selected component of the normalization integral
-//       cout << "NOW PROCESSING DENOMINATOR " << den->ClassName() << "::" << den->GetName() << endl ;
+//       std::cout << "NOW PROCESSING DENOMINATOR " << den->ClassName() << "::" << den->GetName() << std::endl ;
 
       if (string("SPECINT")==part->getStringAttribute("PROD_TERM_TYPE")) {
 
-//    cout << "create integral: SPECINT case" << endl ;
+//    std::cout << "create integral: SPECINT case" << std::endl ;
    RooRealIntegral* orig = static_cast<RooRealIntegral*>(num);
    auto specRatio = static_cast<RooFormulaVar const*>(&orig->integrand()) ;
    specIntDeps.add(orig->intVars()) ;
@@ -1100,20 +1100,20 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
    //RooProduct* numtmp = (RooProduct*) specRatio->getParameter(0) ;
    RooProduct* dentmp = static_cast<RooProduct*>(specRatio->getParameter(1)) ;
 
-//    cout << "numtmp = " << numtmp->ClassName() << "::" << numtmp->GetName() << endl ;
-//    cout << "dentmp = " << dentmp->ClassName() << "::" << dentmp->GetName() << endl ;
+//    std::cout << "numtmp = " << numtmp->ClassName() << "::" << numtmp->GetName() << std::endl ;
+//    std::cout << "dentmp = " << dentmp->ClassName() << "::" << dentmp->GetName() << std::endl ;
 
-//    cout << "denominator components are " << dentmp->components() << endl ;
+//    std::cout << "denominator components are " << dentmp->components() << std::endl ;
    for (auto* parg : static_range_cast<RooAbsReal*>(dentmp->components())) {
-//      cout << "now processing denominator component " << parg->ClassName() << "::" << parg->GetName() << endl ;
+//      std::cout << "now processing denominator component " << parg->ClassName() << "::" << parg->GetName() << std::endl ;
 
      if (ratio && parg->dependsOn(*ratio)) {
-//        cout << "depends in value of ratio" << endl ;
+//        std::cout << "depends in value of ratio" << std::endl ;
 
        // Make specialize ratio instance
        std::unique_ptr<RooAbsReal> specializedRatio{specializeRatio(*(RooFormulaVar*)ratio,iter->c_str())};
 
-//        cout << "specRatio = " << endl ;
+//        std::cout << "specRatio = " << std::endl ;
 //        specializedRatio->printComponentTree() ;
 
        // Replace generic ratio with specialized ratio
@@ -1135,7 +1135,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
        }
 
        // Print customized denominator
-//        cout << "customized function = " << endl ;
+//        std::cout << "customized function = " << std::endl ;
 //        partCust->printComponentTree() ;
 
        std::unique_ptr<RooAbsReal> specializedPartCust{specializeIntegral(*static_cast<RooAbsReal*>(partCust),iter->c_str())};
@@ -1149,14 +1149,14 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
        denListList[*iter].addOwned(std::move(specIntFinal));
      } else {
 
-//        cout << "does NOT depend on value of ratio" << endl ;
+//        std::cout << "does NOT depend on value of ratio" << std::endl ;
 //        parg->Print("t") ;
 
        denListList[*iter].addOwned(specializeIntegral(*parg,iter->c_str()));
 
      }
    }
-//    cout << "end iteration over denominator components" << endl ;
+//    std::cout << "end iteration over denominator components" << std::endl ;
       } else {
 
    if (ratio) {
@@ -1164,7 +1164,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
      std::unique_ptr<RooAbsReal> specRatio{specializeRatio(*(RooFormulaVar*)ratio,iter->c_str())};
 
      // If integral is 'Int r(y)*g(y) dy ' then divide a posteriori by r(y)
-//      cout << "have ratio, orig den = " << den->GetName() << endl ;
+//      std::cout << "have ratio, orig den = " << den->GetName() << std::endl ;
 
      RooArgSet tmp(origNumTerm) ;
      tmp.add(*specRatio) ;
@@ -1210,9 +1210,9 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   std::unique_ptr<RooAbsReal> numerator = std::make_unique<RooProduct>(name.c_str(),name.c_str(),nomList) ;
 
   RooArgSet products ;
-//   cout << "nomList = " << nomList << endl ;
+//   std::cout << "nomList = " << nomList << std::endl ;
   for (map<string,RooArgSet>::iterator iter = denListList.begin() ; iter != denListList.end() ; ++iter) {
-//     cout << "denList[" << iter->first << "] = " << iter->second << endl ;
+//     std::cout << "denList[" << iter->first << "] = " << iter->second << std::endl ;
     name = Form("%s_denominator_comp_%s",GetName(),iter->first.c_str()) ;
     // WVE FIX THIS (2)
     RooProduct* prod_comp = new RooProduct(name.c_str(),name.c_str(),iter->second) ;
@@ -1237,9 +1237,9 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   }
 
 
-//   cout << "numerator" << endl ;
+//   std::cout << "numerator" << std::endl ;
 //   numerator->printComponentTree("",0,5) ;
-//   cout << "denominator" << endl ;
+//   std::cout << "denominator" << std::endl ;
 //   norm->printComponentTree("",0,5) ;
 
 
@@ -1278,7 +1278,7 @@ std::unique_ptr<RooAbsReal> RooProdPdf::specializeIntegral(RooAbsReal& input, co
 
     // If input is integral, recreate integral but override integration range to be targetRangeName
     RooRealIntegral* orig = static_cast<RooRealIntegral*>(&input) ;
-//     cout << "creating integral: integrand =  " << orig->integrand().GetName() << " vars = " << orig->intVars() << " range = " << targetRangeName << endl ;
+//     std::cout << "creating integral: integrand =  " << orig->integrand().GetName() << " vars = " << orig->intVars() << " range = " << targetRangeName << std::endl ;
     return std::unique_ptr<RooAbsReal>{orig->integrand().createIntegral(orig->intVars(),targetRangeName)};
 
   } else if (input.InheritsFrom(RooAddition::Class())) {
@@ -1286,7 +1286,7 @@ std::unique_ptr<RooAbsReal> RooProdPdf::specializeIntegral(RooAbsReal& input, co
     // If input is sum of integrals, recreate integral from first component of set, but override integration range to be targetRangeName
     RooAddition* orig = static_cast<RooAddition*>(&input) ;
     RooRealIntegral* origInt = static_cast<RooRealIntegral*>(orig->list1().first()) ;
-//     cout << "creating integral from addition: integrand =  " << origInt->integrand().GetName() << " vars = " << origInt->intVars() << " range = " << targetRangeName << endl ;
+//     std::cout << "creating integral from addition: integrand =  " << origInt->integrand().GetName() << " vars = " << origInt->intVars() << " range = " << targetRangeName << std::endl ;
     return std::unique_ptr<RooAbsReal>{origInt->integrand().createIntegral(origInt->intVars(),targetRangeName)};
   }
 
@@ -1392,7 +1392,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
   if (!termNSet.empty() && termNSet.size()==termISet.size() && isetRangeName==nullptr) {
 
 
-    //cout << "processProductTerm(" << GetName() << ") case I " << endl ;
+    //cout << "processProductTerm(" << GetName() << ") case I " << std::endl ;
 
     // Term factorizes
     return ret ;
@@ -1402,7 +1402,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
   // ------------------------------------------------------------------------------
   if (nset && termNSet.empty()) {
 
-    //cout << "processProductTerm(" << GetName() << ") case II " << endl ;
+    //cout << "processProductTerm(" << GetName() << ") case II " << std::endl ;
 
     // Drop terms that are not asked to be normalized
     return ret ;
@@ -1422,7 +1422,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
 
       isOwned=true ;
 
-      //cout << "processProductTerm(" << GetName() << ") case IIIa func = " << partInt->GetName() << endl ;
+      //cout << "processProductTerm(" << GetName() << ") case IIIa func = " << partInt->GetName() << std::endl ;
 
       ret[0] = partInt ;
 
@@ -1444,7 +1444,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       partInt->setStringAttribute("PROD_TERM_TYPE","IIIb") ;
       partInt->setOperMode(operMode()) ;
 
-      //cout << "processProductTerm(" << GetName() << ") case IIIb func = " << partInt->GetName() << endl ;
+      //cout << "processProductTerm(" << GetName() << ") case IIIb func = " << partInt->GetName() << std::endl ;
 
       isOwned=true ;
       ret[0] = partInt ;
@@ -1473,7 +1473,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
     partInt->setStringAttribute("PROD_TERM_TYPE","IVa") ;
     partInt->setOperMode(operMode()) ;
 
-    //cout << "processProductTerm(" << GetName() << ") case IVa func = " << partInt->GetName() << endl ;
+    //cout << "processProductTerm(" << GetName() << ") case IVa func = " << partInt->GetName() << std::endl ;
 
     isOwned=true ;
     ret[0] = partInt ;
@@ -1517,7 +1517,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       partInt->setStringAttribute("PROD_TERM_TYPE","IVb") ;
       isOwned=true ;
 
-      //cout << "processProductTerm(" << GetName() << ") case IVb func = " << partInt->GetName() << endl ;
+      //cout << "processProductTerm(" << GetName() << ") case IVb func = " << partInt->GetName() << std::endl ;
 
       ret[0] = partInt ;
 
@@ -1530,7 +1530,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
     } else {
       isOwned=false ;
 
-      //cout << "processProductTerm(" << GetName() << ") case IVb func = " << pdf->GetName() << endl ;
+      //cout << "processProductTerm(" << GetName() << ") case IVb func = " << pdf->GetName() << std::endl ;
 
 
       pdf->setStringAttribute("PROD_TERM_TYPE","IVb") ;
@@ -1543,7 +1543,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
     }
   }
 
-  coutE(Eval) << "RooProdPdf::processProductTerm(" << GetName() << ") unidentified term!!!" << endl ;
+  coutE(Eval) << "RooProdPdf::processProductTerm(" << GetName() << ") unidentified term!!!" << std::endl ;
   return ret ;
 }
 
@@ -1647,7 +1647,7 @@ double RooProdPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, co
   }
 
   double val = calculate(*cache,true) ;
-//   cout << "RPP::aIWN(" << GetName() << ") ,code = " << code << ", value = " << val << endl ;
+//   std::cout << "RPP::aIWN(" << GetName() << ") ,code = " << code << ", value = " << val << std::endl ;
 
   return val ;
 }
@@ -1672,7 +1672,7 @@ RooAbsPdf::ExtendMode RooProdPdf::extendMode() const
 double RooProdPdf::expectedEvents(const RooArgSet* nset) const
 {
   if (_extendedIndex<0) {
-    coutF(Generation) << "Requesting expected number of events from a RooProdPdf that does not contain an extended p.d.f" << endl ;
+    coutF(Generation) << "Requesting expected number of events from a RooProdPdf that does not contain an extended p.d.f" << std::endl ;
     throw std::logic_error(std::string("RooProdPdf ") + GetName() + " could not be extended.");
   }
 
@@ -1682,7 +1682,7 @@ double RooProdPdf::expectedEvents(const RooArgSet* nset) const
 std::unique_ptr<RooAbsReal> RooProdPdf::createExpectedEventsFunc(const RooArgSet* nset) const
 {
   if (_extendedIndex<0) {
-    coutF(Generation) << "Requesting expected number of events from a RooProdPdf that does not contain an extended p.d.f" << endl ;
+    coutF(Generation) << "Requesting expected number of events from a RooProdPdf that does not contain an extended p.d.f" << std::endl ;
     throw std::logic_error(std::string("RooProdPdf ") + GetName() + " could not be extended.");
   }
 
@@ -1804,7 +1804,7 @@ RooArgList RooProdPdf::CacheElem::containedArgs(Action)
 void RooProdPdf::CacheElem::printCompactTreeHook(ostream& os, const char* indent, Int_t curElem, Int_t maxElem)
 {
    if (curElem==0) {
-     os << indent << "RooProdPdf begin partial integral cache" << endl ;
+     os << indent << "RooProdPdf begin partial integral cache" << std::endl ;
    }
 
    auto indent2 = std::string(indent) +  "[" + std::to_string(curElem) + "]";
@@ -1813,7 +1813,7 @@ void RooProdPdf::CacheElem::printCompactTreeHook(ostream& os, const char* indent
    }
 
    if (curElem==maxElem) {
-     os << indent << "RooProdPdf end partial integral cache" << endl ;
+     os << indent << "RooProdPdf end partial integral cache" << std::endl ;
    }
 }
 
@@ -1868,7 +1868,7 @@ void RooProdPdf::addPdfs(RooAbsCollection const& pdfs)
       RooAbsPdf* pdf = dynamic_cast<RooAbsPdf*>(arg);
       if (!pdf) {
          coutW(InputArguments) << "RooProdPdf::addPdfs(" << GetName() << ") list arg "
-                               << arg->GetName() << " is not a PDF, ignored" << endl ;
+                               << arg->GetName() << " is not a PDF, ignored" << std::endl ;
          continue;
       }
       if(pdf->canBeExtended()) {
@@ -1886,7 +1886,7 @@ void RooProdPdf::addPdfs(RooAbsCollection const& pdfs)
    if (numExtended>1) {
       coutW(InputArguments) << "RooProdPdf::addPdfs(" << GetName()
                             << ") WARNING: multiple components with extended terms detected,"
-                            << " product will not be extendable." << endl ;
+                            << " product will not be extendable." << std::endl ;
       _extendedIndex = -1 ;
    }
 
@@ -2162,7 +2162,7 @@ void RooProdPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
 
     if (parg->canNodeBeCached()==Always) {
       trackNodes.add(*parg) ;
-//      cout << "tracking node RooProdPdf component " << parg << " " << parg->ClassName() << "::" << parg->GetName() << endl ;
+//      std::cout << "tracking node RooProdPdf component " << parg << " " << parg->ClassName() << "::" << parg->GetName() << std::endl ;
 
       // Additional processing to fix normalization sets in case product defines conditional observables
       if (RooArgSet* pdf_nset = findPdfNSet(static_cast<RooAbsPdf&>(*parg))) {
@@ -2175,7 +2175,7 @@ void RooProdPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
           parg->setStringAttribute("CATCondSet",getColonSeparatedNameString(*pdf_nset).c_str()) ;
         }
       } else {
-        coutW(Optimization) << "RooProdPdf::setCacheAndTrackHints(" << GetName() << ") WARNING product pdf does not specify a normalization set for component " << parg->GetName() << endl ;
+        coutW(Optimization) << "RooProdPdf::setCacheAndTrackHints(" << GetName() << ") WARNING product pdf does not specify a normalization set for component " << parg->GetName() << std::endl ;
       }
     }
   }
@@ -2222,7 +2222,7 @@ bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool
 {
   if (nameChange && _pdfList.find("REMOVAL_DUMMY")) {
 
-    cxcoutD(LinkStateMgmt) << "RooProdPdf::redirectServersHook(" << GetName() << "): removing REMOVAL_DUMMY" << endl ;
+    cxcoutD(LinkStateMgmt) << "RooProdPdf::redirectServersHook(" << GetName() << "): removing REMOVAL_DUMMY" << std::endl ;
 
     // Remove node from _pdfList proxy and remove corresponding entry from normset list
     RooAbsArg* pdfDel = _pdfList.find("REMOVAL_DUMMY") ;

--- a/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
+++ b/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
@@ -102,7 +102,7 @@ bool RooQuasiRandomGenerator::generate(UInt_t dimension, double vector[])
     else break;
   }
   if(r >= NBits) {
-    oocoutE(nullptr,Integration) << "RooQuasiRandomGenerator::generate: internal error!" << endl;
+    oocoutE(nullptr,Integration) << "RooQuasiRandomGenerator::generate: internal error!" << std::endl;
     return false;
   }
 

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -82,7 +82,7 @@ void RooRandomizeParamMCSModule::sampleUniform(RooRealVar& param, double lo, dou
   if (genParams()) {
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(param.GetName())) ;
     if (!actualPar) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       return ;
     }
   }
@@ -103,7 +103,7 @@ void RooRandomizeParamMCSModule::sampleGaussian(RooRealVar& param, double mean, 
   if (genParams()) {
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(param.GetName())) ;
     if (!actualPar) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       return ;
     }
   }
@@ -129,7 +129,7 @@ void RooRandomizeParamMCSModule::sampleSumUniform(const RooArgSet& paramSet, dou
     // Check that arg is a RooRealVar
     RooRealVar* rrv = dynamic_cast<RooRealVar*>(arg) ;
     if (!rrv) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << std::endl ;
       continue;
     }
     okset.add(*rrv) ;
@@ -142,7 +142,7 @@ void RooRandomizeParamMCSModule::sampleSumUniform(const RooArgSet& paramSet, dou
     for(RooAbsArg * arg2 : okset) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg2->GetName())) ;
       if (!actualVar) {
-   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       } else {
    okset2.add(*actualVar) ;
       }
@@ -178,7 +178,7 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, doubl
     // Check that arg is a RooRealVar
     RooRealVar* rrv = dynamic_cast<RooRealVar*>(arg) ;
     if (!rrv) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumGauss() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumGauss() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << std::endl ;
       continue;
     }
     okset.add(*rrv) ;
@@ -191,7 +191,7 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, doubl
     for(RooAbsArg * arg2 : okset) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg2->GetName())) ;
       if (!actualVar) {
-   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       } else {
    okset2.add(*actualVar) ;
       }
@@ -222,7 +222,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     // Check that listed variable is actual generator model parameter
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(uiter->_param->GetName())) ;
     if (!actualPar) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << uiter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << uiter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       uiter = _unifParams.erase(uiter) ;
       continue ;
     }
@@ -241,7 +241,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     // Check that listed variable is actual generator model parameter
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(giter->_param->GetName())) ;
     if (!actualPar) {
-      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << giter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << giter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       giter = _gausParams.erase(giter) ;
       continue ;
     }
@@ -263,7 +263,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     for(RooAbsArg * arg : usiter->_pset) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg->GetName())) ;
       if (!actualVar) {
-   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       } else {
    actualPSet.add(*actualVar) ;
       }
@@ -288,7 +288,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     for(RooAbsArg * arg : ugiter->_pset) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg->GetName())) ;
       if (!actualVar) {
-   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << std::endl ;
       } else {
    actualPSet.add(*actualVar) ;
       }
@@ -335,7 +335,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
   for (uiter= _unifParams.begin() ; uiter!= _unifParams.end() ; ++uiter) {
     double newVal = RooRandom::randomGenerator()->Uniform(uiter->_lo,uiter->_hi) ;
     oocoutE(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to generator parameter "
-    << uiter->_param->GetName() << " in range [" << uiter->_lo << "," << uiter->_hi << "], chosen value for this sample is " << newVal << endl ;
+    << uiter->_param->GetName() << " in range [" << uiter->_lo << "," << uiter->_hi << "], chosen value for this sample is " << newVal << std::endl ;
     uiter->_param->setVal(newVal) ;
 
     RooRealVar* genpar = static_cast<RooRealVar*>(_genParSet.find(Form("%s_gen",uiter->_param->GetName()))) ;
@@ -347,7 +347,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
   for (giter= _gausParams.begin() ; giter!= _gausParams.end() ; ++giter) {
     double newVal = RooRandom::randomGenerator()->Gaus(giter->_mean,giter->_sigma) ;
     oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to generator parameter "
-    << giter->_param->GetName() << " with a mean of " << giter->_mean << " and a width of " << giter->_sigma << ", chosen value for this sample is " << newVal << endl ;
+    << giter->_param->GetName() << " with a mean of " << giter->_mean << " and a width of " << giter->_sigma << ", chosen value for this sample is " << newVal << std::endl ;
     giter->_param->setVal(newVal) ;
 
     RooRealVar* genpar = static_cast<RooRealVar*>(_genParSet.find(Form("%s_gen",giter->_param->GetName()))) ;
@@ -362,7 +362,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
     double newVal = RooRandom::randomGenerator()->Uniform(usiter->_lo,usiter->_hi) ;
     oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to sum of set of generator parameters "
                 <<  usiter->_pset
-                << " in range [" << usiter->_lo << "," << usiter->_hi << "], chosen sum value for this sample is " << newVal << endl ;
+                << " in range [" << usiter->_lo << "," << usiter->_hi << "], chosen sum value for this sample is " << newVal << std::endl ;
 
     // Determine original value of sum and calculate per-component scale factor to obtain new value for sum
     RooAddition sumVal("sumVal","sumVal",usiter->_pset) ;
@@ -385,7 +385,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
     oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to sum of set of generator parameters "
                 << gsiter->_pset
                 << " with a mean of " << gsiter->_mean << " and a width of " << gsiter->_sigma
-                << ", chosen value for this sample is " << newVal << endl ;
+                << ", chosen value for this sample is " << newVal << std::endl ;
 
     // Determine original value of sum and calculate per-component scale factor to obtain new value for sum
     RooAddition sumVal("sumVal","sumVal",gsiter->_pset) ;

--- a/roofit/roofitcore/src/RooRangeBinning.cxx
+++ b/roofit/roofitcore/src/RooRangeBinning.cxx
@@ -74,7 +74,7 @@ RooRangeBinning::RooRangeBinning(const RooRangeBinning& other, const char* name)
 void RooRangeBinning::setRange(double xlo, double xhi)
 {
   if (xlo>xhi) {
-    oocoutE(nullptr,InputArguments) << "RooRangeBinning::setRange: ERROR low bound > high bound" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooRangeBinning::setRange: ERROR low bound > high bound" << std::endl ;
     return ;
   }
 

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -58,7 +58,7 @@ RooRealBinding::RooRealBinding(const RooAbsReal &func, const RooArgSet &vars, co
     _vars.push_back(dynamic_cast<RooAbsRealLValue*>(var));
     if(_vars.back() == nullptr) {
       oocoutE(nullptr,InputArguments) << "RooRealBinding: cannot bind to " << var->GetName()
-          << ". Variables need to be assignable, e.g. instances of RooRealVar." << endl ;
+          << ". Variables need to be assignable, e.g. instances of RooRealVar." << std::endl ;
       _valid= false;
     }
     if (!_func->dependsOn(*_vars[index])) {

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -339,7 +339,7 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
 
   // Choose same expensive object cache as integrand
   setExpensiveObjectCache(function.expensiveObjectCache()) ;
-//   cout << "RRI::ctor(" << GetName() << ") setting expensive object cache to " << &expensiveObjectCache() << " as taken from " << function.GetName() << std::endl ;
+//   std::cout << "RRI::ctor(" << GetName() << ") setting expensive object cache to " << &expensiveObjectCache() << " as taken from " << function.GetName() << std::endl ;
 
   // Use objects integrator configuration if none is specified
   if (!_iconfig) _iconfig = const_cast<RooNumIntConfig*>(function.getIntegratorConfig());
@@ -812,7 +812,7 @@ double RooRealIntegral::evaluate() const
 
       if (cacheVal) {
         retVal = *cacheVal ;
-   // cout << "using cached value of integral" << GetName() << std::endl ;
+   // std::cout << "using cached value of integral" << GetName() << std::endl ;
       } else {
 
 
@@ -847,7 +847,7 @@ double RooRealIntegral::evaluate() const
         if ((_cacheNum && !_intList.empty()) || int(_intList.size())>=_cacheAllNDim) {
           RooDouble* val = new RooDouble(retVal) ;
           expensiveObjectCache().registerObject(_function->GetName(),GetName(),*val,parameters())  ;
-          //     cout << "### caching value of integral" << GetName() << " in " << &expensiveObjectCache() << std::endl ;
+          //     std::cout << "### caching value of integral" << GetName() << " in " << &expensiveObjectCache() << std::endl ;
         }
 
       }

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -89,7 +89,7 @@ RooMPSentinel& RooMPSentinel::instance() {
 }
 
 
-using std::cout, std::endl, std::string, std::ostringstream, std::list;
+using std::string, std::ostringstream, std::list;
 using namespace RooFit;
 
 
@@ -220,7 +220,7 @@ void RooRealMPFE::initialize()
 
     // Kill server at end of service
     if (_verboseServer) ccoutD(Minimization) << "RooRealMPFE::initialize(" <<
-   GetName() << ") server process terminating" << endl ;
+   GetName() << ") server process terminating" << std::endl ;
 
     delete _arg.absArg();
     delete _pipe;
@@ -229,7 +229,7 @@ void RooRealMPFE::initialize()
     // Client process - fork successful
     if (_verboseClient) {
        ccoutD(Minimization) << "RooRealMPFE::initialize(" << GetName() << ") successfully forked server process "
-                            << _pipe->pidOtherEnd() << endl;
+                            << _pipe->pidOtherEnd() << std::endl;
     }
     _state = Client ;
     _calcInProgress = false ;
@@ -259,8 +259,8 @@ void RooRealMPFE::serverLoop()
   while(*_pipe && !_pipe->eof()) {
     *_pipe >> msg;
     if (Terminate == msg) {
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> Terminate" << endl;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> Terminate" << std::endl;
       // send terminate acknowledged to client
       *_pipe << msg << BidirMMapPipe::flush;
       break;
@@ -270,8 +270,8 @@ void RooRealMPFE::serverLoop()
     case SendReal:
       {
    *_pipe >> idx >> value >> isConst;
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC fromClient> SendReal [" << idx << "]=" << value << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC fromClient> SendReal [" << idx << "]=" << value << std::endl ;
    RooRealVar* rvar = static_cast<RooRealVar*>(_vars.at(idx)) ;
    rvar->setVal(value) ;
    if (rvar->isConstant() != isConst) {
@@ -283,21 +283,21 @@ void RooRealMPFE::serverLoop()
     case SendCat:
       {
    *_pipe >> idx >> index;
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC fromClient> SendCat [" << idx << "]=" << index << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC fromClient> SendCat [" << idx << "]=" << index << std::endl ;
    (static_cast<RooCategory*>(_vars.at(idx)))->setIndex(index) ;
       }
       break ;
 
     case Calculate:
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> Calculate" << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> Calculate" << std::endl ;
       _value = _arg ;
       break ;
 
     case CalculateNoOffset:
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> Calculate" << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> Calculate" << std::endl ;
 
       RooAbsReal::setHideOffset(false) ;
       _value = _arg ;
@@ -306,14 +306,14 @@ void RooRealMPFE::serverLoop()
 
     case Retrieve:
       {
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC fromClient> Retrieve" << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC fromClient> Retrieve" << std::endl ;
    msg = ReturnValue;
    numErrors = numEvalErrors();
    *_pipe << msg << _value << getCarry() << numErrors;
 
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC toClient> ReturnValue " << _value << " NumError " << numErrors << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC toClient> ReturnValue " << _value << " NumError " << numErrors << std::endl ;
 
    if (numErrors) {
      // Loop over errors
@@ -332,8 +332,8 @@ void RooRealMPFE::serverLoop()
        for (; iter->second.second.end() != iter2; ++iter2) {
          ptr = iter->first;
          *_pipe << ptr << iter2->_msg << iter2->_srvval << objidstr;
-         if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-      << ") IPC toClient> sending error log Arg " << iter->first << " Msg " << iter2->_msg << endl ;
+         if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+      << ") IPC toClient> sending error log Arg " << iter->first << " Msg " << iter2->_msg << std::endl ;
        }
      }
      // let other end know that we're done with the list of errors
@@ -351,8 +351,8 @@ void RooRealMPFE::serverLoop()
    bool doTrack ;
    int code;
    *_pipe >> code >> doTrack;
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC fromClient> ConstOpt " << code << " doTrack = " << (doTrack?"T":"F") << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC fromClient> ConstOpt " << code << " doTrack = " << (doTrack?"T":"F") << std::endl ;
    ((RooAbsReal&)_arg.arg()).constOptimizeTestStatistic(static_cast<RooAbsArg::ConstOpCode>(code),doTrack) ;
    break ;
       }
@@ -361,8 +361,8 @@ void RooRealMPFE::serverLoop()
       {
       bool flag ;
       *_pipe >> flag;
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> Verbose " << (flag?1:0) << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> Verbose " << (flag?1:0) << std::endl ;
       _verboseServer = flag ;
       }
       break ;
@@ -372,8 +372,8 @@ void RooRealMPFE::serverLoop()
       {
       bool flag ;
       *_pipe >> flag;
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> ApplyNLLW2 " << (flag?1:0) << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> ApplyNLLW2 " << (flag?1:0) << std::endl ;
 
       // Do application of weight-squared here
       doApplyNLLW2(flag) ;
@@ -384,8 +384,8 @@ void RooRealMPFE::serverLoop()
       {
       bool flag ;
       *_pipe >> flag;
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> EnableOffset " << (flag?1:0) << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> EnableOffset " << (flag?1:0) << std::endl ;
 
       // Enable likelihoof offsetting here
       ((RooAbsReal&)_arg.arg()).enableOffsetting(flag) ;
@@ -398,15 +398,15 @@ void RooRealMPFE::serverLoop()
    *_pipe >> iflag2;
    RooAbsReal::ErrorLoggingMode flag2 = static_cast<RooAbsReal::ErrorLoggingMode>(iflag2);
    RooAbsReal::setEvalErrorLoggingMode(flag2) ;
-   if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-             << ") IPC fromClient> LogEvalError flag = " << flag2 << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+             << ") IPC fromClient> LogEvalError flag = " << flag2 << std::endl ;
       }
       break ;
 
 
     default:
-      if (_verboseServer) cout << "RooRealMPFE::serverLoop(" << GetName()
-                << ") IPC fromClient> Unknown message (code = " << msg << ")" << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::serverLoop(" << GetName()
+                << ") IPC fromClient> Unknown message (code = " << msg << ")" << std::endl ;
       break ;
     }
   }
@@ -427,13 +427,13 @@ void RooRealMPFE::calculate() const
 
   // Start asynchronous calculation of arg value
   if (_state==Initialize) {
-    //     cout << "RooRealMPFE::calculate(" << GetName() << ") initializing" << endl ;
+    //     std::cout << "RooRealMPFE::calculate(" << GetName() << ") initializing" << std::endl ;
     const_cast<RooRealMPFE*>(this)->initialize() ;
   }
 
   // Inline mode -- Calculate value now
   if (_state==Inline) {
-    //     cout << "RooRealMPFE::calculate(" << GetName() << ") performing Inline calculation NOW" << endl ;
+    //     std::cout << "RooRealMPFE::calculate(" << GetName() << ") performing Inline calculation NOW" << std::endl ;
     _value = _arg ;
     clearValueDirty() ;
   }
@@ -441,7 +441,7 @@ void RooRealMPFE::calculate() const
 #ifndef _WIN32
   // Compare current value of variables with saved values and send changes to server
   if (_state==Client) {
-    //     cout << "RooRealMPFE::calculate(" << GetName() << ") state is Client trigger remote calculation" << endl ;
+    //     std::cout << "RooRealMPFE::calculate(" << GetName() << ") state is Client trigger remote calculation" << std::endl ;
     Int_t i(0) ;
 
     //for (i=0 ; i<_vars.size() ; i++) {
@@ -465,9 +465,9 @@ void RooRealMPFE::calculate() const
       }
 
       if ( valChanged || constChanged || _forceCalc) {
-   //cout << "RooRealMPFE::calculate(" << GetName() << " variable " << var->GetName() << " changed " << endl ;
-   if (_verboseClient) cout << "RooRealMPFE::calculate(" << GetName()
-             << ") variable " << _vars.at(i)->GetName() << " changed" << endl ;
+   //cout << "RooRealMPFE::calculate(" << GetName() << " variable " << var->GetName() << " changed " << std::endl ;
+   if (_verboseClient) std::cout << "RooRealMPFE::calculate(" << GetName()
+             << ") variable " << _vars.at(i)->GetName() << " changed" << std::endl ;
    if (constChanged) {
      (static_cast<RooRealVar*>(saveVar))->setConstant(var->isConstant()) ;
    }
@@ -480,14 +480,14 @@ void RooRealMPFE::calculate() const
      bool isC = var->isConstant() ;
      *_pipe << msg << i << val << isC;
 
-     if (_verboseServer) cout << "RooRealMPFE::calculate(" << GetName()
-               << ") IPC toServer> SendReal [" << i << "]=" << val << (isC?" (Constant)":"") <<  endl ;
+     if (_verboseServer) std::cout << "RooRealMPFE::calculate(" << GetName()
+               << ") IPC toServer> SendReal [" << i << "]=" << val << (isC?" (Constant)":"") <<  std::endl ;
    } else if (dynamic_cast<RooAbsCategory*>(var)) {
      int msg = SendCat ;
      UInt_t idx = (static_cast<RooAbsCategory*>(var))->getCurrentIndex() ;
      *_pipe << msg << i << idx;
-     if (_verboseServer) cout << "RooRealMPFE::calculate(" << GetName()
-               << ") IPC toServer> SendCat [" << i << "]=" << idx << endl ;
+     if (_verboseServer) std::cout << "RooRealMPFE::calculate(" << GetName()
+               << ") IPC toServer> SendCat [" << i << "]=" << idx << std::endl ;
    }
       }
       i++ ;
@@ -495,8 +495,8 @@ void RooRealMPFE::calculate() const
 
     int msg = hideOffset() ? Calculate : CalculateNoOffset;
     *_pipe << msg;
-    if (_verboseServer) cout << "RooRealMPFE::calculate(" << GetName()
-              << ") IPC toServer> Calculate " << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::calculate(" << GetName()
+              << ") IPC toServer> Calculate " << std::endl ;
 
     // Clear dirty state and mark that calculation request was dispatched
     clearValueDirty() ;
@@ -505,13 +505,13 @@ void RooRealMPFE::calculate() const
 
     msg = Retrieve ;
     *_pipe << msg << BidirMMapPipe::flush;
-    if (_verboseServer) cout << "RooRealMPFE::evaluate(" << GetName()
-              << ") IPC toServer> Retrieve " << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::evaluate(" << GetName()
+              << ") IPC toServer> Retrieve " << std::endl ;
     _retrieveDispatched = true ;
 
   } else if (_state!=Inline) {
-    cout << "RooRealMPFE::calculate(" << GetName()
-    << ") ERROR not in Client or Inline mode" << endl ;
+    std::cout << "RooRealMPFE::calculate(" << GetName()
+    << ") ERROR not in Client or Inline mode" << std::endl ;
   }
 
 
@@ -532,19 +532,19 @@ double RooRealMPFE::getValV(const RooArgSet* /*nset*/) const
 
   if (isValueDirty()) {
     // Cache is dirty, no calculation has been started yet
-    //cout << "RooRealMPFE::getValF(" << GetName() << ") cache is dirty, calling calculate and evaluate" << endl ;
+    //cout << "RooRealMPFE::getValF(" << GetName() << ") cache is dirty, calling calculate and evaluate" << std::endl ;
     calculate() ;
     _value = evaluate() ;
   } else if (_calcInProgress) {
-    //cout << "RooRealMPFE::getValF(" << GetName() << ") calculation in progress, calling evaluate" << endl ;
+    //cout << "RooRealMPFE::getValF(" << GetName() << ") calculation in progress, calling evaluate" << std::endl ;
     // Cache is clean and calculation is in progress
     _value = evaluate() ;
   } else {
-    //cout << "RooRealMPFE::getValF(" << GetName() << ") cache is clean, doing nothing" << endl ;
+    //cout << "RooRealMPFE::getValF(" << GetName() << ") cache is clean, doing nothing" << std::endl ;
     // Cache is clean and calculated value is in cache
   }
 
-//   cout << "RooRealMPFE::getValV(" << GetName() << ") value = " << Form("%5.10f",_value) << endl ;
+//   std::cout << "RooRealMPFE::getValV(" << GetName() << ") value = " << Form("%5.10f",_value) << std::endl ;
   return _value ;
 }
 
@@ -581,8 +581,8 @@ double RooRealMPFE::evaluate() const
       msg = Retrieve ;
       *_pipe << msg;
       needflush = true;
-      if (_verboseServer) cout << "RooRealMPFE::evaluate(" << GetName()
-                << ") IPC toServer> Retrieve " << endl ;
+      if (_verboseServer) std::cout << "RooRealMPFE::evaluate(" << GetName()
+                << ") IPC toServer> Retrieve " << std::endl ;
     }
     if (needflush) *_pipe << BidirMMapPipe::flush;
     _retrieveDispatched = false ;
@@ -593,15 +593,15 @@ double RooRealMPFE::evaluate() const
     *_pipe >> msg >> value >> _evalCarry >> numError;
 
     if (msg!=ReturnValue) {
-      cout << "RooRealMPFE::evaluate(" << GetName()
-      << ") ERROR: unexpected message from server process: " << msg << endl ;
+      std::cout << "RooRealMPFE::evaluate(" << GetName()
+      << ") ERROR: unexpected message from server process: " << msg << std::endl ;
       return 0 ;
     }
-    if (_verboseServer) cout << "RooRealMPFE::evaluate(" << GetName()
-              << ") IPC fromServer> ReturnValue " << value << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::evaluate(" << GetName()
+              << ") IPC fromServer> ReturnValue " << value << std::endl ;
 
-    if (_verboseServer) cout << "RooRealMPFE::evaluate(" << GetName()
-              << ") IPC fromServer> NumErrors " << numError << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::evaluate(" << GetName()
+              << ") IPC fromServer> NumErrors " << numError << std::endl ;
     if (numError) {
       // Retrieve remote errors and feed into local error queue
       char *msgbuf1 = nullptr;
@@ -612,8 +612,8 @@ double RooRealMPFE::evaluate() const
    *_pipe >> ptr;
    if (!ptr) break;
    *_pipe >> msgbuf1 >> msgbuf2 >> msgbuf3;
-   if (_verboseServer) cout << "RooRealMPFE::evaluate(" << GetName()
-     << ") IPC fromServer> retrieving error log Arg " << ptr << " Msg " << msgbuf1 << endl ;
+   if (_verboseServer) std::cout << "RooRealMPFE::evaluate(" << GetName()
+     << ") IPC fromServer> retrieving error log Arg " << ptr << " Msg " << msgbuf1 << std::endl ;
 
    logEvalError(reinterpret_cast<RooAbsReal*>(ptr),msgbuf3,msgbuf1,msgbuf2) ;
       }
@@ -644,8 +644,8 @@ void RooRealMPFE::standby()
   if (_state==Client) {
     if (_pipe->good()) {
       // Terminate server process ;
-      if (_verboseServer) cout << "RooRealMPFE::standby(" << GetName()
-   << ") IPC toServer> Terminate " << endl;
+      if (_verboseServer) std::cout << "RooRealMPFE::standby(" << GetName()
+   << ") IPC toServer> Terminate " << std::endl;
       int msg = Terminate;
       *_pipe << msg << BidirMMapPipe::flush;
       // read handshake
@@ -686,8 +686,8 @@ void RooRealMPFE::constOptimizeTestStatistic(ConstOpCode opcode, bool doAlsoTrac
     int msg = ConstOpt ;
     int op = opcode;
     *_pipe << msg << op << doAlsoTracking;
-    if (_verboseServer) cout << "RooRealMPFE::constOptimize(" << GetName()
-              << ") IPC toServer> ConstOpt " << opcode << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::constOptimize(" << GetName()
+              << ") IPC toServer> ConstOpt " << opcode << std::endl ;
 
     initVars() ;
   }
@@ -710,8 +710,8 @@ void RooRealMPFE::setVerbose(bool clientFlag, bool serverFlag)
   if (_state==Client) {
     int msg = Verbose ;
     *_pipe << msg << serverFlag;
-    if (_verboseServer) cout << "RooRealMPFE::setVerbose(" << GetName()
-              << ") IPC toServer> Verbose " << (serverFlag?1:0) << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::setVerbose(" << GetName()
+              << ") IPC toServer> Verbose " << (serverFlag?1:0) << std::endl ;
   }
 #endif // _WIN32
   _verboseClient = clientFlag ; _verboseServer = serverFlag ;
@@ -728,8 +728,8 @@ void RooRealMPFE::applyNLLWeightSquared(bool flag)
   if (_state==Client) {
     int msg = ApplyNLLW2 ;
     *_pipe << msg << flag;
-    if (_verboseServer) cout << "RooRealMPFE::applyNLLWeightSquared(" << GetName()
-              << ") IPC toServer> ApplyNLLW2 " << (flag?1:0) << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::applyNLLWeightSquared(" << GetName()
+              << ") IPC toServer> ApplyNLLW2 " << (flag?1:0) << std::endl ;
   }
 #endif // _WIN32
   doApplyNLLW2(flag) ;
@@ -757,8 +757,8 @@ void RooRealMPFE::enableOffsetting(bool flag)
   if (_state==Client) {
     int msg = EnableOffset ;
     *_pipe << msg << flag;
-    if (_verboseServer) cout << "RooRealMPFE::enableOffsetting(" << GetName()
-              << ") IPC toServer> EnableOffset " << (flag?1:0) << endl ;
+    if (_verboseServer) std::cout << "RooRealMPFE::enableOffsetting(" << GetName()
+              << ") IPC toServer> EnableOffset " << (flag?1:0) << std::endl ;
   }
 #endif // _WIN32
   ((RooAbsReal&)_arg.arg()).enableOffsetting(flag) ;

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -385,7 +385,7 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooAbsReal const& caller, RooObjCac
   Int_t sterileIdx(-1) ;
   auto* cache = static_cast<CacheElem*>(normIntMgr.getObj(normSet.get(),&analVars,&sterileIdx,RooNameReg::ptr(rangeName)));
   if (cache) {
-    //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << _normIntMgr.lastIndex()+1 << " (cached)" << endl;
+    //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << _normIntMgr.lastIndex()+1 << " (cached)" << std::endl;
     return normIntMgr.lastIndex()+1 ;
   }
 
@@ -407,7 +407,7 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooAbsReal const& caller, RooObjCac
   // Store cache element
   Int_t code = normIntMgr.setObj(normSet.get(),&analVars,(RooAbsCacheElement*)cache,RooNameReg::ptr(rangeName)) ;
 
-  //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << code+1 << endl;
+  //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << code+1 << std::endl;
   return code+1 ;
 }
 
@@ -420,9 +420,9 @@ RooRealSumPdf::getCacheElem(RooAbsReal const &caller, RooObjCacheManager &normIn
    // WVE needs adaptation for rangeName feature
    auto *cache = static_cast<CacheElem *>(normIntMgr.getObjByIndex(code - 1));
    if (cache == nullptr) { // revive the (sterilized) cache
-      // cout <<
+      // std::cout <<
       // "RooRealSumPdf("<<this<<")::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-      // << ": reviving cache "<< endl;
+      // << ": reviving cache "<< std::endl;
       RooArgSet vars;
       caller.getParameters(nullptr, vars);
       RooArgSet iset = normIntMgr.selectFromSet2(vars, code - 1);

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -334,7 +334,7 @@ RooAbsBinning& RooRealVar::getBinning(const char* name, bool verbose, bool creat
   auto binning = new RooRangeBinning(getMin(),getMax(),name) ;
   if (verbose) {
     coutI(Eval) << "RooRealVar::getBinning(" << GetName() << ") new range named '"
-      << name << "' created with default bounds" << endl ;
+      << name << "' created with default bounds" << std::endl ;
   }
   sharedProp()->_altBinning[name] = binning;
 
@@ -438,7 +438,7 @@ void RooRealVar::setMin(const char* name, double value)
   // Check if new limit is consistent
   if (value >= getMax()) {
     coutW(InputArguments) << "RooRealVar::setMin(" << GetName()
-           << "): Proposed new fit min. larger than max., setting min. to max." << endl ;
+           << "): Proposed new fit min. larger than max., setting min. to max." << std::endl ;
     binning.setMin(getMax()) ;
   } else {
     binning.setMin(value) ;
@@ -468,7 +468,7 @@ void RooRealVar::setMax(const char* name, double value)
   // Check if new limit is consistent
   if (value < getMin()) {
     coutW(InputArguments) << "RooRealVar::setMax(" << GetName()
-           << "): Proposed new fit max. smaller than min., setting max. to min." << endl ;
+           << "): Proposed new fit max. smaller than min., setting max. to min." << std::endl ;
     binning.setMax(getMin()) ;
   } else {
     binning.setMax(value) ;
@@ -505,7 +505,7 @@ void RooRealVar::setRange(const char* name, double min, double max)
   // Check if new limit is consistent
   if (min>max) {
     coutW(InputArguments) << "RooRealVar::setRange(" << GetName()
-           << "): Proposed new fit max. smaller than min., setting max. to min." << endl ;
+           << "): Proposed new fit max. smaller than min., setting max. to min." << std::endl ;
     binning.setRange(min,min) ;
   } else {
     binning.setRange(min,max) ;
@@ -514,7 +514,7 @@ void RooRealVar::setRange(const char* name, double min, double max)
   if (!exists) {
     coutI(Eval) << "RooRealVar::setRange(" << GetName()
       << ") new range named '" << name << "' created with bounds ["
-      << min << "," << max << "]" << endl ;
+      << min << "," << max << "]" << std::endl ;
   }
 
   setShapeDirty() ;
@@ -621,7 +621,7 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
        parser.expectToken(")",true)) break ;
 //    setPlotRange(plotMin,plotMax) ;
    coutW(Eval) << "RooRealVar::readFromStream(" << GetName()
-        << ") WARNING: plot range deprecated, removed P(...) token" << endl ;
+        << ") WARNING: plot range deprecated, removed P(...) token" << std::endl ;
 
       } else if (!token.CompareTo("F")) {
 
@@ -639,7 +639,7 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
    //setBins(fitBins) ;
    //setRange(fitMin,fitMax) ;
    coutW(Eval) << "RooRealVar::readFromStream(" << GetName()
-        << ") WARNING: F(lo-hi:bins) token deprecated, use L(lo-hi) B(bins)" << endl ;
+        << ") WARNING: F(lo-hi:bins) token deprecated, use L(lo-hi) B(bins)" << std::endl ;
    if (!haveConstant) setConstant(false) ;
 
       } else if (!token.CompareTo("L")) {
@@ -792,7 +792,7 @@ void RooRealVar::printExtras(ostream& os) const
   if (!_unit.IsNull())
     os << "// [" << getUnit() << "]" ;
 
-//   cout << " _value = " << &_value << " _error = " << &_error ;
+//   std::cout << " _value = " << &_value << " _error = " << &_error ;
 
 
 }
@@ -816,10 +816,10 @@ Int_t RooRealVar::defaultPrintContents(Option_t* opt) const
 void RooRealVar::printMultiline(ostream& os, Int_t contents, bool verbose, TString indent) const
 {
   RooAbsRealLValue::printMultiline(os,contents,verbose,indent);
-  os << indent << "--- RooRealVar ---" << endl;
+  os << indent << "--- RooRealVar ---" << std::endl;
   TString unit(_unit);
   if(!unit.IsNull()) unit.Prepend(' ');
-  os << indent << "  Error = " << getError() << unit << endl;
+  os << indent << "  Error = " << getError() << unit << std::endl;
 }
 
 
@@ -1081,8 +1081,8 @@ void RooRealVar::attachToTree(TTree& t, Int_t bufSize)
 {
   // Follow usual procedure for value
   RooAbsReal::attachToTree(t,bufSize) ;
-//   cout << "RooRealVar::attachToTree(" << this << ") name = " << GetName()
-//        << " StoreError = " << (getAttribute("StoreError")?"T":"F") << endl ;
+//   std::cout << "RooRealVar::attachToTree(" << this << ") name = " << GetName()
+//        << " StoreError = " << (getAttribute("StoreError")?"T":"F") << std::endl ;
 
   // Attach/create additional branch for error
   if (getAttribute("StoreError")) {
@@ -1136,7 +1136,7 @@ void RooRealVar::fillTreeBranch(TTree& t)
   TString cleanName(cleanBranchName()) ;
   TBranch* valBranch = t.GetBranch(cleanName) ;
   if (!valBranch) {
-    coutE(Eval) << "RooAbsReal::fillTreeBranch(" << GetName() << ") ERROR: not attached to tree" << endl ;
+    coutE(Eval) << "RooAbsReal::fillTreeBranch(" << GetName() << ") ERROR: not attached to tree" << std::endl ;
     assert(0) ;
   }
   valBranch->Fill() ;
@@ -1203,7 +1203,7 @@ void RooRealVar::Streamer(TBuffer &R__b)
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
     RooAbsRealLValue::Streamer(R__b);
     if (R__v==1) {
-      coutI(Eval) << "RooRealVar::Streamer(" << GetName() << ") converting version 1 data format" << endl ;
+      coutI(Eval) << "RooRealVar::Streamer(" << GetName() << ") converting version 1 data format" << std::endl ;
       double fitMin;
       double fitMax;
       Int_t fitBins ;

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -145,15 +145,15 @@ RooResolutionModel* RooResolutionModel::convolution(RooFormulaVar* inBasis, RooA
   // Check that primary variable of basis functions is our convolution variable
   if (inBasis->getParameter(0) != x.absArg()) {
     coutE(InputArguments) << "RooResolutionModel::convolution(" << GetName() << "," << this
-           << ") convolution parameter of basis function and PDF don't match" << endl
-           << "basis->findServer(0) = " << inBasis->findServer(0) << endl
-           << "x.absArg()           = " << x.absArg() << endl ;
+           << ") convolution parameter of basis function and PDF don't match" << std::endl
+           << "basis->findServer(0) = " << inBasis->findServer(0) << std::endl
+           << "x.absArg()           = " << x.absArg() << std::endl ;
     return nullptr ;
   }
 
   if (basisCode(inBasis->GetTitle())==0) {
     coutE(InputArguments) << "RooResolutionModel::convolution(" << GetName() << "," << this
-           << ") basis function '" << inBasis->GetTitle() << "' is not supported." << endl ;
+           << ") basis function '" << inBasis->GetTitle() << "' is not supported." << std::endl ;
     return nullptr ;
   }
 
@@ -234,7 +234,7 @@ double RooResolutionModel::getValV(const RooArgSet* nset) const
     _value = evaluate() ;
 
     // WVE insert traceEval traceEval
-    if (_verboseDirty) cxcoutD(Tracing) << "RooResolutionModel(" << GetName() << ") value = " << _value << endl ;
+    if (_verboseDirty) cxcoutD(Tracing) << "RooResolutionModel(" << GetName() << ") value = " << _value << std::endl ;
 
     clearValueDirty() ;
     clearShapeDirty() ;
@@ -306,7 +306,7 @@ double RooResolutionModel::getNorm(const RooArgSet* nset) const
 
   syncNormalization(nset,false) ;
   if (_verboseEval>1) cxcoutD(Tracing) << ClassName() << "::getNorm(" << GetName()
-                   << "): norm(" << _norm << ") = " << _norm->getVal() << endl ;
+                   << "): norm(" << _norm << ") = " << _norm->getVal() << std::endl ;
 
   double ret = _norm->getVal() ;
   return ret ;
@@ -326,12 +326,12 @@ void RooResolutionModel::printMultiline(ostream& os, Int_t content, bool verbose
   RooAbsPdf::printMultiline(os,content,verbose,indent) ;
 
   if(verbose) {
-    os << indent << "--- RooResolutionModel ---" << endl;
+    os << indent << "--- RooResolutionModel ---" << std::endl;
     os << indent << "basis function = " ;
     if (_basis) {
       _basis->printStream(os,kName|kAddress|kTitle,kSingleLine,indent) ;
     } else {
-      os << "<none>" << endl ;
+      os << "<none>" << std::endl ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooRombergIntegrator.cxx
+++ b/roofit/roofitcore/src/RooRombergIntegrator.cxx
@@ -186,7 +186,7 @@ std::pair<double, int> integrate1d(std::function<double(double)> func, bool doTr
             }
          }
          if (allZero) {
-            // cout << "Roo1DIntegrator(" << this << "): zero convergence at step " << j << ", value = " << 0 <<
+            // std::cout << "Roo1DIntegrator(" << this << "): zero convergence at step " << j << ", value = " << 0 <<
             // std::endl ;
             return {0, j};
          }
@@ -196,7 +196,7 @@ std::pair<double, int> integrate1d(std::function<double(double)> func, bool doTr
 
          // Fixed step mode, return result after fixed number of steps
          if (j == fixSteps) {
-            // cout << "returning result at fixed step " << j << std::endl ;
+            // std::cout << "returning result at fixed step " << j << std::endl ;
             return {sArr[j], j};
          }
 

--- a/roofit/roofitcore/src/RooSharedProperties.cxx
+++ b/roofit/roofitcore/src/RooSharedProperties.cxx
@@ -28,8 +28,6 @@ that can be stored in RooSharedPropertiesList.
 #include "RooTrace.h"
 
 #include "Riostream.h"
-using std::cout ;
-using std::endl ;
 
 ClassImp(RooSharedProperties);
 
@@ -77,5 +75,5 @@ bool RooSharedProperties::operator==(const RooSharedProperties& other) const
 
 void RooSharedProperties::Print(Option_t* /*opts*/) const
 {
-  cout << "RooSharedProperties(" << this << ") UUID = " << _uuid.AsString() << endl ;
+  std::cout << "RooSharedProperties(" << this << ") UUID = " << _uuid.AsString() << std::endl ;
 }

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -115,7 +115,7 @@
 #include "RooFracRemainder.h"
 #include "RooFactoryWSTool.h"
 
-using std::string, std::endl, std::map, std::list, std::pair, std::cout, std::vector;
+using std::string, std::map, std::list, std::pair, std::vector;
 
 namespace {
 
@@ -213,7 +213,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
     if (!obc->_masterCat) {
       oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
              << " does not contain a category named " << bc._masterCatName
-             << " that was designated as master index category in the build configuration" << endl ;
+             << " that was designated as master index category in the build configuration" << std::endl ;
       return nullptr;
     }
   } else {
@@ -228,7 +228,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
     RooAbsPdf* pdf = _ws->pdf(pdfiter->second.GetName()) ;
     if (!pdf) {
       oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
-             << " does not contain a pdf named " << pdfiter->second.GetName() << endl ;
+             << " does not contain a pdf named " << pdfiter->second.GetName() << std::endl ;
       return nullptr;
     }
 
@@ -246,14 +246,14 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
       if (!farg) {
    oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
                << " does not contain a variable named " << pariter->first.c_str()
-               << " as specified in splitting rule of parameter " << pariter->first << " of p.d.f " << pdf << endl ;
+               << " as specified in splitting rule of parameter " << pariter->first << " of p.d.f " << pdf << std::endl ;
    return nullptr;
       }
 
       // Check that given variable is indeed related to given p.d.f
       if (!pdf->dependsOn(*farg)) {
    oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: specified parameter " << pariter->first
-               << " in split is not function of p.d.f " << pdf->GetName() << endl ;
+               << " in split is not function of p.d.f " << pdf->GetName() << std::endl ;
    return nullptr;
       }
 
@@ -265,7 +265,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
    if (!cat) {
      oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
             << " does not contain a category named " << catiter->c_str()
-            << " as specified in splitting rule of parameter " << pariter->first << " of p.d.f " << pdf << endl ;
+            << " as specified in splitting rule of parameter " << pariter->first << " of p.d.f " << pdf << std::endl ;
      return nullptr;
    }
    splitCatSet.add(*cat) ;
@@ -278,7 +278,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
    if (arg->dependsOnValue(tmp)) {
      oocoutE(nullptr, InputArguments) << "RooSimWSTool::build() ERROR: Ill defined split: splitting category function " << arg->GetName()
             << " used in composite split " << splitCatSet << " of parameter " << farg->GetName() << " of pdf " << pdf->GetName()
-            << " depends on one or more of the other splitting categories in the composite split" << endl ;
+            << " depends on one or more of the other splitting categories in the composite split" << std::endl ;
      return nullptr;
    }
       }
@@ -286,7 +286,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
       // If a constrained split is specified, check that split parameter is a real-valued type
       if (!pariter->second.second.empty()) {
    if (!dynamic_cast<RooAbsReal*>(farg)) {
-     oocoutE(nullptr, InputArguments) << "RooSimWSTool::build() ERROR: Constrained split specified in non real-valued parameter " << farg->GetName() << endl ;
+     oocoutE(nullptr, InputArguments) << "RooSimWSTool::build() ERROR: Constrained split specified in non real-valued parameter " << farg->GetName() << std::endl ;
      return nullptr;
    }
       }
@@ -303,7 +303,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
      if (ctype==nullptr) {
        oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: master index category " << obc->_masterCat->GetName()
               << " does not have a state named " << *misi << " which was specified as state associated with p.d.f "
-              << sr.GetName() << endl ;
+              << sr.GetName() << std::endl ;
        return nullptr;
      }
      osr._miStateList.push_back(ctype) ;
@@ -324,7 +324,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
      if (ctype==nullptr) {
        oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: master index category " << obc->_masterCat->GetName()
               << " does not have a state named " << *misi << " which was specified as state associated with p.d.f "
-              << sr.GetName() << endl ;
+              << sr.GetName() << std::endl ;
        return nullptr;
      }
      osr._miStateList.push_back(ctype) ;
@@ -343,7 +343,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
     if (!cat) {
       oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
              << " does not contain a category named " << riter->first
-             << " for which build was requested to be restricted to states " << riter->second << endl ;
+             << " for which build was requested to be restricted to states " << riter->second << std::endl ;
       return nullptr;
     }
 
@@ -356,7 +356,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
       const RooCatType* ctype = cat->lookupType(tok,false) ;
       if (!ctype) {
    oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: restricted build category " << cat->GetName()
-               << " does not have state " << tok << " as specified in restriction list" << endl ;
+               << " does not have state " << tok << " as specified in restriction list" << std::endl ;
    return nullptr;
       }
       rlist.push_back(ctype) ;
@@ -400,7 +400,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
     ++physIter ;
   }
   if (verbose) {
-    oocoutI(nullptr, ObjectHandling) << "RooSimWSTool::executeBuild: list of prototype pdfs " << physModelSet << endl ;
+    oocoutI(nullptr, ObjectHandling) << "RooSimWSTool::executeBuild: list of prototype pdfs " << physModelSet << std::endl ;
   }
 
   RooArgSet splitCatSet(obc._usedSplitCats) ;
@@ -426,7 +426,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
     masterSplitCat = static_cast<RooAbsCategoryLValue*>(splitCatSetFund.first()) ;
   }
   if (verbose) {
-    oocoutI(nullptr, ObjectHandling) << "RooSimWSTool::executeBuild: list of splitting categories " << splitCatSet << endl ;
+    oocoutI(nullptr, ObjectHandling) << "RooSimWSTool::executeBuild: list of splitting categories " << splitCatSet << std::endl ;
   }
 
   RooArgSet splitNodeListOwned ; // owns all newly created components
@@ -436,7 +436,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
   // Loop over requested physics models and build components
   for(auto * physModel : static_range_cast<RooAbsPdf*>(physModelSet)) {
     if (verbose) {
-      oocoutI(nullptr, ObjectHandling) << "RooSimPdfBuilder::executeBuild: processing prototype pdf " << physModel->GetName() << endl ;
+      oocoutI(nullptr, ObjectHandling) << "RooSimPdfBuilder::executeBuild: processing prototype pdf " << physModel->GetName() << std::endl ;
     }
 
     customizerList.push_back(std::make_unique<RooCustomizer>(*physModel,*masterSplitCat,splitNodeListOwned,&splitNodeListAll));
@@ -466,7 +466,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
    // Check that specified split name is in fact valid
    if (!splitCat->hasLabel(splitIter->second.second)) {
      oocoutE(nullptr, InputArguments) << "RooSimWSTool::executeBuild() ERROR: name of remainder state for constrained split, '"
-            << splitIter->second.second << "' , does not match any state name of (composite) split category " << splitCat->GetName() << endl ;
+            << splitIter->second.second << "' , does not match any state name of (composite) split category " << splitCat->GetName() << std::endl ;
      return nullptr;
    }
 
@@ -510,7 +510,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
   splitNodeListAll.add(_ws->components()) ;
 
   if (verbose) {
-    oocoutI(nullptr, ObjectHandling)  << "RooSimWSTool::executeBuild: configured customizers for all prototype pdfs" << endl ;
+    oocoutI(nullptr, ObjectHandling)  << "RooSimWSTool::executeBuild: configured customizers for all prototype pdfs" << std::endl ;
   }
 
   // Create fit category from physCat and splitCatList ;
@@ -590,7 +590,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
 
     if (verbose) {
       oocoutI(nullptr, ObjectHandling) << "RooSimWSTool::executeBuild: Customizing prototype pdf " << physCustomizer->pdf().GetName()
-                   << " for mode " << fcStateName << endl ;
+                   << " for mode " << fcStateName << std::endl ;
     }
 
     // Customizer PDF for current state and add to master simPdf
@@ -850,32 +850,32 @@ void RooSimWSTool::ObjBuildConfig::print()
   // --- Dump contents of object build config ---
   map<RooAbsPdf*,ObjSplitRule>::iterator ri ;
   for (ri = _pdfmap.begin() ; ri != _pdfmap.end() ; ++ri ) {
-    cout << "Splitrule for p.d.f " << ri->first->GetName() << " with state list " ;
+    std::cout << "Splitrule for p.d.f " << ri->first->GetName() << " with state list " ;
     for (std::list<const RooCatType*>::iterator misi= ri->second._miStateList.begin() ; misi!=ri->second._miStateList.end() ; ++misi) {
-      cout << (*misi)->GetName() << " " ;
+      std::cout << (*misi)->GetName() << " " ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
 
     map<RooAbsArg*,pair<RooArgSet,string> >::iterator csi ;
     for (csi = ri->second._paramSplitMap.begin() ; csi != ri->second._paramSplitMap.end() ; ++csi ) {
       if (csi->second.second.length()>0) {
-   cout << " parameter " << csi->first->GetName() << " is split with constraint in categories " << csi->second.first
-        << " with remainder in state " << csi->second.second << endl ;
+   std::cout << " parameter " << csi->first->GetName() << " is split with constraint in categories " << csi->second.first
+        << " with remainder in state " << csi->second.second << std::endl ;
       } else {
-   cout << " parameter " << csi->first->GetName() << " is split with constraint in categories " << csi->second.first << endl ;
+   std::cout << " parameter " << csi->first->GetName() << " is split with constraint in categories " << csi->second.first << std::endl ;
       }
     }
   }
 
   map<RooAbsCategory*,list<const RooCatType*> >::iterator riter ;
   for (riter=_restr.begin() ; riter!=_restr.end() ; ++riter) {
-    cout << "Restricting build in category " << riter->first->GetName() << " to states " ;
+    std::cout << "Restricting build in category " << riter->first->GetName() << " to states " ;
     list<const RooCatType*>::iterator i ;
     for (i=riter->second.begin() ; i!=riter->second.end() ; ++i) {
-      if (i!=riter->second.begin()) cout << "," ;
-      cout << (*i)->GetName() ;
+      if (i!=riter->second.begin()) std::cout << "," ;
+      std::cout << (*i)->GetName() ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
 }

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -273,7 +273,7 @@ RooSimultaneous::initialize(std::string const& name, RooAbsCategoryLValue &inInd
         string superLabel = superIndex->getCurrentLabel() ;
         out->addPdf(*citem.second.pdf,superLabel);
         oocxcoutD(static_cast<RooAbsArg*>(nullptr), InputArguments) << msgPrefix
-                << "assigning pdf " << citem.second.pdf->GetName() << " to super label " << superLabel << endl ;
+                << "assigning pdf " << citem.second.pdf->GetName() << " to super label " << superLabel << std::endl ;
       }
     } else {
 
@@ -291,11 +291,11 @@ RooSimultaneous::initialize(std::string const& name, RooAbsCategoryLValue &inInd
             out->addPdf(*compPdf,superLabel);
             oocxcoutD(static_cast<RooAbsArg*>(nullptr), InputArguments) << msgPrefix
                     << "assigning pdf " << compPdf->GetName() << "(member of " << citem.second.pdf->GetName()
-                    << ") to super label " << superLabel << endl ;
+                    << ") to super label " << superLabel << std::endl ;
           } else {
             oocoutW(nullptr, InputArguments) << msgPrefix << "WARNING: No p.d.f. associated with label "
                 << type.second << " for component RooSimultaneous p.d.f " << citem.second.pdf->GetName()
-                << "which is associated with master index label " << citem.first << endl ;
+                << "which is associated with master index label " << citem.first << std::endl ;
           }
         }
 
@@ -317,11 +317,11 @@ RooSimultaneous::initialize(std::string const& name, RooAbsCategoryLValue &inInd
               out->addPdf(*compPdf,superLabel);
               oocxcoutD(static_cast<RooAbsArg*>(nullptr), InputArguments) << msgPrefix
                       << "assigning pdf " << compPdf->GetName() << "(member of " << citem.second.pdf->GetName()
-                      << ") to super label " << superLabel << endl ;
+                      << ") to super label " << superLabel << std::endl ;
             } else {
               oocoutW(nullptr, InputArguments) << msgPrefix << "WARNING: No p.d.f. associated with label "
                   << stype.second << " for component RooSimultaneous p.d.f " << citem.second.pdf->GetName()
-                  << "which is associated with master index label " << citem.first << endl ;
+                  << "which is associated with master index label " << citem.first << std::endl ;
             }
           }
         }
@@ -392,14 +392,14 @@ bool RooSimultaneous::addPdf(const RooAbsPdf& pdf, const char* catLabel)
   // PDFs cannot overlap with the index category
   if (pdf.dependsOn(_indexCat.arg())) {
     coutE(InputArguments) << "RooSimultaneous::addPdf(" << GetName() << "): PDF '" << pdf.GetName()
-           << "' overlaps with index category '" << _indexCat.arg().GetName() << "'."<< endl ;
+           << "' overlaps with index category '" << _indexCat.arg().GetName() << "'."<< std::endl ;
     return true ;
   }
 
   // Each index state can only have one PDF associated with it
   if (_pdfProxyList.FindObject(catLabel)) {
     coutE(InputArguments) << "RooSimultaneous::addPdf(" << GetName() << "): index state '"
-           << catLabel << "' has already an associated PDF." << endl ;
+           << catLabel << "' has already an associated PDF." << std::endl ;
     return true ;
   }
 
@@ -408,7 +408,7 @@ bool RooSimultaneous::addPdf(const RooAbsPdf& pdf, const char* catLabel)
 
     coutE(InputArguments) << "RooSimultaneous::addPdf(" << GetName()
            << ") ERROR: you cannot add a RooSimultaneous component to a RooSimultaneous using addPdf()."
-           << " Use the constructor with RooArgList if input p.d.f.s or the map<string,RooAbsPdf&> instead." << endl ;
+           << " Use the constructor with RooArgList if input p.d.f.s or the map<string,RooAbsPdf&> instead." << std::endl ;
     return true ;
 
   } else {
@@ -646,7 +646,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
   // Check if we have a projection dataset
   if (!projData) {
-    coutE(InputArguments) << "RooSimultaneous::plotOn(" << GetName() << ") ERROR: must have a projection dataset for index category" << endl ;
+    coutE(InputArguments) << "RooSimultaneous::plotOn(" << GetName() << ") ERROR: must have a projection dataset for index category" << std::endl ;
     return frame ;
   }
 
@@ -662,7 +662,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
         projectedVars.remove(*arg) ;
       } else {
         coutI(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") slice variable "
-            << sliceArg->GetName() << " was not projected anyway" << endl ;
+            << sliceArg->GetName() << " was not projected anyway" << std::endl ;
       }
     }
   } else if (projSet) {
@@ -675,12 +675,12 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
   if (!_indexCat.arg().isDerived()) {
     // *** Error checking for a fundamental index category ***
-    //cout << "RooSim::plotOn: index is fundamental" << endl ;
+    //cout << "RooSim::plotOn: index is fundamental" << std::endl ;
 
     // Check that the provided projection dataset contains our index variable
     if (!projData->get()->find(_indexCat.arg().GetName())) {
       coutE(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") ERROR: Projection over index category "
-            << "requested, but projection data set doesn't contain index category" << endl ;
+            << "requested, but projection data set doesn't contain index category" << std::endl ;
       return frame ;
     }
 
@@ -717,7 +717,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     if (!allServers) {
       coutE(Plotting) << "RooSimultaneous::plotOn(" << GetName()
           << ") ERROR: Projection dataset doesn't contain complete set of index categories to do projection."
-          << "\n\tcategory " << missing << " is missing." << endl ;
+          << "\n\tcategory " << missing << " is missing." << std::endl ;
       return frame ;
     }
 
@@ -743,7 +743,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   if (!projIndex) {
 
     coutI(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") plot on " << frame->getPlotVar()->GetName()
-          << " represents a slice in the index category ("  << _indexCat.arg().GetName() << ")" << endl ;
+          << " represents a slice in the index category ("  << _indexCat.arg().GetName() << ")" << std::endl ;
 
     // Reduce projData: take out fitCat (component) columns and entries that don't match selected slice
     // Construct cut string to only select projection data event that match the current slice
@@ -875,18 +875,18 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
   if (_indexCat.arg().isDerived() && !idxCompSliceSet->empty()) {
     coutI(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") plot on " << frame->getPlotVar()->GetName()
-          << " represents a slice in index category components " << *idxCompSliceSet << endl ;
+          << " represents a slice in index category components " << *idxCompSliceSet << std::endl ;
 
     RooArgSet idxCompProjSet;
     _indexCat.arg().getObservables(frame->getNormVars(), idxCompProjSet) ;
     idxCompProjSet.remove(*idxCompSliceSet,true,true) ;
     if (!idxCompProjSet.empty()) {
       coutI(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") plot on " << frame->getPlotVar()->GetName()
-            << " averages with data index category components " << idxCompProjSet << endl ;
+            << " averages with data index category components " << idxCompProjSet << std::endl ;
     }
   } else {
     coutI(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") plot on " << frame->getPlotVar()->GetName()
-          << " averages with data index category (" << _indexCat.arg().GetName() << ")" << endl ;
+          << " averages with data index category (" << _indexCat.arg().GetName() << ")" << std::endl ;
   }
 
 
@@ -982,7 +982,7 @@ RooAbsGenContext* RooSimultaneous::genContext(const RooArgSet &vars, const RooDa
     if (!proxy) {
       coutE(InputArguments) << "RooSimultaneous::genContext(" << GetName()
              << ") ERROR: no PDF associated with current state ("
-             << _indexCat.arg().GetName() << "=" << _indexCat.arg().getCurrentLabel() << ")" << endl ;
+             << _indexCat.arg().GetName() << "=" << _indexCat.arg().getCurrentLabel() << ")" << std::endl ;
       return nullptr;
     }
     return static_cast<RooAbsPdf*>(proxy->absArg())->genContext(vars,prototype,auxProto,verbose) ;

--- a/roofit/roofitcore/src/RooStreamParser.cxx
+++ b/roofit/roofitcore/src/RooStreamParser.cxx
@@ -148,7 +148,7 @@ TString RooStreamParser::readToken()
     // Buffer overflow protection
     if (bufptr >= 63999) {
       oocoutW(nullptr, InputArguments)
-              << "RooStreamParser::readToken: token length exceeds buffer capacity, terminating token early" << endl;
+              << "RooStreamParser::readToken: token length exceeds buffer capacity, terminating token early" << std::endl;
       break;
     }
 
@@ -192,7 +192,7 @@ TString RooStreamParser::readToken()
 
     // Check for line continuation marker
     if (c=='\\' && cnext=='\\') {
-      // Kill rest of line including endline marker
+      // Kill rest of line including std::endline marker
       zapToEnd(false) ;
       _is->get(c) ;
       lineCont=true ;
@@ -255,7 +255,7 @@ TString RooStreamParser::readToken()
 
   // Check if closing quote was encountered
   if (quotedString) {
-    oocoutW(nullptr,InputArguments) << "RooStreamParser::readToken: closing quote (\") missing" << endl ;
+    oocoutW(nullptr,InputArguments) << "RooStreamParser::readToken: closing quote (\") missing" << std::endl ;
   }
 
   // Absorb trailing white space or absorb rest of line if // is encountered
@@ -399,7 +399,7 @@ bool RooStreamParser::expectToken(const TString& expected, bool zapOnError)
   bool error=token.CompareTo(expected) ;
   if (error && !_prefix.IsNull()) {
     oocoutW(nullptr,InputArguments) << _prefix << ": parse error, expected '"
-               << expected << "'" << ", got '" << token << "'" << endl ;
+               << expected << "'" << ", got '" << token << "'" << std::endl ;
     if (zapOnError) zapToEnd(true) ;
   }
   return error ;
@@ -440,7 +440,7 @@ bool RooStreamParser::convertToDouble(const TString &token, double &value)
 
    if (error && !_prefix.IsNull()) {
       oocoutE(nullptr, InputArguments) << _prefix << ": parse error, cannot convert '" << token << "'"
-                                       << " to double precision" << endl;
+                                       << " to double precision" << std::endl;
    }
    return error;
 }
@@ -473,7 +473,7 @@ bool RooStreamParser::convertToInteger(const TString& token, Int_t& value)
 
   if (error && !_prefix.IsNull()) {
     oocoutE(nullptr,InputArguments)<< _prefix << ": parse error, cannot convert '"
-                   << token << "'" << " to integer" <<  endl ;
+                   << token << "'" << " to integer" <<  std::endl ;
   }
   return error ;
 }
@@ -505,7 +505,7 @@ bool RooStreamParser::convertToString(const TString& token, TString& string)
   strncpy(buffer, token.Data(), 63999);
   if (token.Length() >= 63999) {
     oocoutW(nullptr, InputArguments) << "RooStreamParser::convertToString: token length exceeds 63999, truncated"
-                                     << endl;
+                                     << std::endl;
     buffer[63999] = 0;
   }
   int len = strlen(buffer) ;

--- a/roofit/roofitcore/src/RooStudyManager.cxx
+++ b/roofit/roofitcore/src/RooStudyManager.cxx
@@ -101,9 +101,9 @@ void RooStudyManager::prepareBatchInput(const char* studyName, Int_t nExpPerJob,
 
     // Write header of driver script
     ofstream bdr(Form("study_driver_%s.sh",studyName)) ;
-    bdr << "#!/bin/sh" << endl
-        << Form("if [ ! -f study_data_%s.root ] ; then",studyName) << endl
-        << "uudecode <<EOR" << endl ;
+    bdr << "#!/bin/sh" << std::endl
+        << Form("if [ ! -f study_data_%s.root ] ; then",studyName) << std::endl
+        << "uudecode <<EOR" << std::endl ;
     bdr.close() ;
 
     // Write uuencoded ROOT file (base64) in driver script
@@ -111,29 +111,29 @@ void RooStudyManager::prepareBatchInput(const char* studyName, Int_t nExpPerJob,
 
     // Write remainder of driver script
     ofstream bdr2 (Form("study_driver_%s.sh",studyName),ios::app) ;
-    bdr2 << "EOR" << endl
-    << "fi" << endl
-    << "root -l -b <<EOR" << endl
-    << Form("RooStudyPackage::processFile(\"%s\",%d) ;",studyName,nExpPerJob) << endl
-    << ".q" << endl
-    << "EOR" << endl ;
+    bdr2 << "EOR" << std::endl
+    << "fi" << std::endl
+    << "root -l -b <<EOR" << std::endl
+    << Form("RooStudyPackage::processFile(\"%s\",%d) ;",studyName,nExpPerJob) << std::endl
+    << ".q" << std::endl
+    << "EOR" << std::endl ;
     // Remove binary input file
     gSystem->Unlink(Form("study_data_%s.root",studyName)) ;
 
-    coutI(DataHandling) << "RooStudyManager::prepareBatchInput batch driver file is '" << Form("study_driver_%s.sh",studyName) << "," << endl
-         << "     input data files is embedded in driver script" << endl ;
+    coutI(DataHandling) << "RooStudyManager::prepareBatchInput batch driver file is '" << Form("study_driver_%s.sh",studyName) << "," << std::endl
+         << "     input data files is embedded in driver script" << std::endl ;
 
   } else {
 
     ofstream bdr(Form("study_driver_%s.sh",studyName)) ;
-    bdr << "#!/bin/sh" << endl
-   << "root -l -b <<EOR" << endl
-   << Form("RooStudyPackage::processFile(\"%s\",%d) ;",studyName,nExpPerJob) << endl
-   << ".q" << endl
-   << "EOR" << endl ;
+    bdr << "#!/bin/sh" << std::endl
+   << "root -l -b <<EOR" << std::endl
+   << Form("RooStudyPackage::processFile(\"%s\",%d) ;",studyName,nExpPerJob) << std::endl
+   << ".q" << std::endl
+   << "EOR" << std::endl ;
 
-    coutI(DataHandling) << "RooStudyManager::prepareBatchInput batch driver file is '" << Form("study_driver_%s.sh",studyName) << "," << endl
-         << "     input data file is " << Form("study_data_%s.root",studyName) << endl ;
+    coutI(DataHandling) << "RooStudyManager::prepareBatchInput batch driver file is '" << Form("study_driver_%s.sh",studyName) << "," << std::endl
+         << "     input data file is " << Form("study_data_%s.root",studyName) << std::endl ;
 
   }
 }
@@ -151,7 +151,7 @@ void RooStudyManager::processBatchOutput(const char* filePat)
   TList olist ;
 
   for (list<string>::iterator iter = flist.begin() ; iter!=flist.end() ; ++iter) {
-    coutP(DataHandling) << "RooStudyManager::processBatchOutput() now reading file " << *iter << endl ;
+    coutP(DataHandling) << "RooStudyManager::processBatchOutput() now reading file " << *iter << std::endl ;
     TFile f(iter->c_str()) ;
 
     for(auto * key : static_range_cast<TKey*>(*f.GetListOfKeys())) {

--- a/roofit/roofitcore/src/RooStudyPackage.cxx
+++ b/roofit/roofitcore/src/RooStudyPackage.cxx
@@ -39,7 +39,7 @@ repeated applications of generate-and-fit operations on a workspace
 #include "TMath.h"
 #include "TEnv.h"
 
-using std::list, std::cout, std::endl, std::string;
+using std::list, std::string;
 
 ClassImp(RooStudyPackage);
 
@@ -104,7 +104,7 @@ void RooStudyPackage::run(Int_t nExperiments)
   Int_t prescale = nExperiments>100 ? Int_t(nExperiments/100) : 1 ;
   for (Int_t i=0 ; i<nExperiments ; i++) {
     if (i%prescale==0) {
-      coutP(Generation) << "RooStudyPackage::run(" << GetName() << ") processing experiment " << i << "/" << nExperiments << endl ;
+      coutP(Generation) << "RooStudyPackage::run(" << GetName() << ") processing experiment " << i << "/" << nExperiments << std::endl ;
     }
     runOne() ;
   }
@@ -148,7 +148,7 @@ void RooStudyPackage::exportData(TList* olist, Int_t seqno)
     RooDataSet* summaryData = (*iter)->summaryData() ;
     if (summaryData) {
       summaryData->SetName(Form("%s_%d",summaryData->GetName(),seqno)) ;
-      cout << "registering summary dataset: " ; summaryData->Print() ;
+      std::cout << "registering summary dataset: " ; summaryData->Print() ;
       olist->Add(summaryData) ;
     }
 
@@ -156,8 +156,8 @@ void RooStudyPackage::exportData(TList* olist, Int_t seqno)
     if (detailedData && detailedData->GetSize()>0) {
 
       detailedData->SetName(Form("%s_%d",detailedData->GetName(),seqno)) ;
-      cout << "registering detailed dataset " << detailedData->ClassName() << "::"
-      << detailedData->GetName() << " with " << detailedData->GetSize() << " elements" << endl ;
+      std::cout << "registering detailed dataset " << detailedData->ClassName() << "::"
+      << detailedData->GetName() << " with " << detailedData->GetSize() << " elements" << std::endl ;
       for(auto dobj : static_range_cast<TNamed*>(*detailedData)) {
         dobj->SetName(Form("%s_%d",dobj->GetName(),seqno)) ;
       }
@@ -208,13 +208,13 @@ void RooStudyPackage::processFile(const char* studyName, Int_t nexp)
   TFile fin(name_fin.c_str()) ;
   RooStudyPackage* pkg = dynamic_cast<RooStudyPackage*>(fin.Get("studypack")) ;
   if (!pkg) {
-    cout << "RooStudyPackage::processFile() ERROR input file " << name_fin << " does not contain a RooStudyPackage named 'studypack'" << endl ;
+    std::cout << "RooStudyPackage::processFile() ERROR input file " << name_fin << " does not contain a RooStudyPackage named 'studypack'" << std::endl ;
     return ;
   }
 
   // Initialize random seed
   Int_t seqno = pkg->initRandom() ;
-  cout << "RooStudyPackage::processFile() Initial random seed for this run is " << seqno << endl ;
+  std::cout << "RooStudyPackage::processFile() Initial random seed for this run is " << seqno << std::endl ;
 
   // Run study
   pkg->driver(nexp) ;

--- a/roofit/roofitcore/src/RooSuperCategory.cxx
+++ b/roofit/roofitcore/src/RooSuperCategory.cxx
@@ -61,7 +61,7 @@ RooSuperCategory::RooSuperCategory(const char *name, const char *title, const Ro
   for (const auto arg : inputCategories) {
     if (!arg->IsA()->InheritsFrom(RooAbsCategoryLValue::Class())) {
       coutE(InputArguments) << "RooSuperCategory::RooSuperCategory(" << GetName() << "): input category " << arg->GetName()
-             << " is not an lvalue. Use RooMultiCategory instead." << endl ;
+             << " is not an lvalue. Use RooMultiCategory instead." << std::endl ;
       throw std::invalid_argument("Arguments of RooSuperCategory must be lvalues.");
     }
   }

--- a/roofit/roofitcore/src/RooThresholdCategory.cxx
+++ b/roofit/roofitcore/src/RooThresholdCategory.cxx
@@ -78,7 +78,7 @@ bool RooThresholdCategory::addThreshold(double upperLimit, const char* catName, 
   for (const auto& thresh : _threshList) {
     if (thresh.first == upperLimit) {
       coutW(InputArguments) << "RooThresholdCategory::addThreshold(" << GetName()
-             << ") threshold at " << upperLimit << " already defined" << endl ;
+             << ") threshold at " << upperLimit << " already defined" << std::endl ;
       return true;
     }
   }
@@ -152,11 +152,11 @@ void RooThresholdCategory::printMultiline(ostream& os, Int_t content, bool verbo
    RooAbsCategory::printMultiline(os,content,verbose,indent);
 
    if (verbose) {
-     os << indent << "--- RooThresholdCategory ---" << endl
+     os << indent << "--- RooThresholdCategory ---" << std::endl
    << indent << "  Maps from " ;
      _inputVar.arg().printStream(os,0,kStandard);
 
-     os << indent << "  Threshold list" << endl ;
+     os << indent << "  Threshold list" << std::endl ;
      for (const auto& thresh : _threshList) {
        os << indent << "    input < " << thresh.first << " --> " ;
        os << lookupName(thresh.second) << '[' << thresh.second << "]\n";

--- a/roofit/roofitcore/src/RooTrace.cxx
+++ b/roofit/roofitcore/src/RooTrace.cxx
@@ -93,7 +93,7 @@ and there is no guarantee that this works.
 #include "TClass.h"
 
 
-using std::cout, std::endl, std::ostream, std::setw, std::hex, std::dec, std::map, std::string;
+using std::ostream, std::setw, std::hex, std::dec, std::map, std::string;
 
 ClassImp(RooTrace);
 
@@ -211,8 +211,8 @@ void RooTrace::create2(const TObject* obj)
 {
   _list.Add(const_cast<RooAbsArg *>(static_cast<RooAbsArg const*>(obj)));
   if (_verbose) {
-    cout << "RooTrace::create: object " << obj << " of type " << obj->ClassName()
-    << " created " << endl ;
+    std::cout << "RooTrace::create: object " << obj << " of type " << obj->ClassName()
+    << " created " << std::endl ;
   }
 }
 
@@ -226,8 +226,8 @@ void RooTrace::destroy2(const TObject* obj)
 {
   if (!_list.Remove(const_cast<RooAbsArg *>(static_cast<RooAbsArg const*>(obj)))) {
   } else if (_verbose) {
-    cout << "RooTrace::destroy: object " << obj << " of type " << obj->ClassName()
-    << " destroyed [" << obj->GetTitle() << "]" << endl ;
+    std::cout << "RooTrace::destroy: object " << obj << " of type " << obj->ClassName()
+    << " destroyed [" << obj->GetTitle() << "]" << std::endl ;
   }
 }
 
@@ -281,13 +281,13 @@ void RooTrace::mark3()
 
 void RooTrace::dump()
 {
-  RooTrace::instance().dump3(cout,false) ;
+  RooTrace::instance().dump3(std::cout,false) ;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooTrace::dump(ostream& os, bool sinceMarked)
+void RooTrace::dump(std::ostream& os, bool sinceMarked)
 {
   RooTrace::instance().dump3(os,sinceMarked) ;
 }
@@ -297,20 +297,20 @@ void RooTrace::dump(ostream& os, bool sinceMarked)
 /// Dump contents of object register to stream 'os'. If sinceMarked is
 /// true, only object created after the last call to mark() are shown.
 
-void RooTrace::dump3(ostream& os, bool sinceMarked)
+void RooTrace::dump3(std::ostream& os, bool sinceMarked)
 {
-  os << "List of RooFit objects allocated while trace active:" << endl ;
+  os << "List of RooFit objects allocated while trace active:" << std::endl ;
 
   Int_t i;
   Int_t nMarked(0);
   for(i=0 ; i<_list.GetSize() ; i++) {
     if (!sinceMarked || _markList.IndexOf(_list.At(i)) == -1) {
-      os << hex << setw(10) << _list.At(i) << dec << " : " << setw(20) << _list.At(i)->ClassName() << setw(0) << " - " << _list.At(i)->GetName() << endl ;
+      os << hex << setw(10) << _list.At(i) << dec << " : " << setw(20) << _list.At(i)->ClassName() << setw(0) << " - " << _list.At(i)->GetName() << std::endl ;
     } else {
       nMarked++ ;
     }
   }
-  if (sinceMarked) os << nMarked << " marked objects suppressed" << endl ;
+  if (sinceMarked) os << nMarked << " marked objects suppressed" << std::endl ;
 }
 
 
@@ -328,17 +328,17 @@ void RooTrace::printObjectCounts3()
   double total(0) ;
   for (map<TClass*,int>::iterator iter = _objectCount.begin() ; iter != _objectCount.end() ; ++iter) {
     double tot= 1.0*(iter->first->Size()*iter->second)/(1024*1024) ;
-    cout << " class " << iter->first->GetName() << " count = " << iter->second << " sizeof = " << iter->first->Size() << " total memory = " <<  Form("%5.2f",tot) << " Mb" << endl ;
+    std::cout << " class " << iter->first->GetName() << " count = " << iter->second << " sizeof = " << iter->first->Size() << " total memory = " <<  Form("%5.2f",tot) << " Mb" << std::endl ;
     total+=tot ;
   }
 
   for (map<string,int>::iterator iter = _specialCount.begin() ; iter != _specialCount.end() ; ++iter) {
     int size = _specialSize[iter->first] ;
     double tot=1.0*(size*iter->second)/(1024*1024) ;
-    cout << " speeial " << iter->first << " count = " << iter->second << " sizeof = " << size  << " total memory = " <<  Form("%5.2f",tot) << " Mb" << endl ;
+    std::cout << " speeial " << iter->first << " count = " << iter->second << " sizeof = " << size  << " total memory = " <<  Form("%5.2f",tot) << " Mb" << std::endl ;
     total+=tot ;
   }
-  cout << "Grand total memory = " << Form("%5.2f",total) << " Mb" << endl ;
+  std::cout << "Grand total memory = " << Form("%5.2f",total) << " Mb" << std::endl ;
 
 }
 
@@ -352,7 +352,7 @@ void RooTrace::printObjectCounts3()
 
 void RooTrace::callgrind_zero()
 {
-  ooccoutD((TObject*)nullptr,Tracing) << "RooTrace::callgrind_zero()" << endl ;
+  ooccoutD((TObject*)nullptr,Tracing) << "RooTrace::callgrind_zero()" << std::endl ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -364,5 +364,5 @@ void RooTrace::callgrind_zero()
 
 void RooTrace::callgrind_dump()
 {
-  ooccoutD((TObject*)nullptr,Tracing) << "RooTrace::callgrind_dump()" << endl ;
+  ooccoutD((TObject*)nullptr,Tracing) << "RooTrace::callgrind_dump()" << std::endl ;
 }

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -337,7 +337,7 @@ void RooTreeDataStore::createTree(RooStringView name, RooStringView title)
   memDir.Append(":/") ;
   bool notInMemNow= (pwd!=memDir) ;
 
-  // cout << "RooTreeData::createTree pwd=" << pwd << " memDir=" << memDir << " notInMemNow = " << (notInMemNow?"T":"F") << endl ;
+  // std::cout << "RooTreeData::createTree pwd=" << pwd << " memDir=" << memDir << " notInMemNow = " << (notInMemNow?"T":"F") << std::endl ;
 
   if (notInMemNow) {
     gDirectory->cd(memDir) ;
@@ -451,7 +451,7 @@ void RooTreeDataStore::loadValues(const TTree *t, const RooFormulaVar* select, c
   }
 
   if (numInvalid>0) {
-    coutW(DataHandling) << "RooTreeDataStore::loadValues(" << GetName() << ") Ignored " << numInvalid << " out-of-range events" << endl ;
+    coutW(DataHandling) << "RooTreeDataStore::loadValues(" << GetName() << ") Ignored " << numInvalid << " out-of-range events" << std::endl ;
   }
 
   SetTitle(t->GetTitle());
@@ -716,7 +716,7 @@ bool RooTreeDataStore::changeObservableName(const char* from, const char* to)
 
   // Check that we found it
   if (!var) {
-    coutE(InputArguments) << "RooTreeDataStore::changeObservableName(" << GetName() << " no observable " << from << " in this dataset" << endl ;
+    coutE(InputArguments) << "RooTreeDataStore::changeObservableName(" << GetName() << " no observable " << from << " in this dataset" << std::endl ;
     return true ;
   }
 
@@ -788,7 +788,7 @@ RooAbsArg* RooTreeDataStore::addColumn(RooAbsArg& newVar, bool adjustRange)
   // Sanity check that the holder really is fundamental
   if(!valHolder->isFundamental()) {
     coutE(InputArguments) << GetName() << "::addColumn: holder argument is not fundamental: \""
-    << valHolder->GetName() << "\"" << endl;
+    << valHolder->GetName() << "\"" << std::endl;
     return nullptr;
   }
 
@@ -1002,7 +1002,7 @@ void RooTreeDataStore::setArgStatus(const RooArgSet& set, bool active)
     RooAbsArg* depArg = _vars.find(arg->GetName()) ;
     if (!depArg) {
       coutE(InputArguments) << "RooTreeDataStore::setArgStatus(" << GetName()
-             << ") dataset doesn't contain variable " << arg->GetName() << endl ;
+             << ") dataset doesn't contain variable " << arg->GetName() << std::endl ;
       continue ;
     }
     depArg->setTreeBranchStatus(*_tree,active) ;

--- a/roofit/roofitcore/src/RooUniformBinning.cxx
+++ b/roofit/roofitcore/src/RooUniformBinning.cxx
@@ -62,7 +62,7 @@ RooUniformBinning::RooUniformBinning(const RooUniformBinning &other, const char 
 void RooUniformBinning::setRange(double xlo, double xhi)
 {
   if (xlo>xhi) {
-    coutE(InputArguments) << "RooUniformBinning::setRange: ERROR low bound > high bound" << endl ;
+    coutE(InputArguments) << "RooUniformBinning::setRange: ERROR low bound > high bound" << std::endl ;
     return ;
   }
 
@@ -97,7 +97,7 @@ double RooUniformBinning::binCenter(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooUniformBinning::binCenter ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 
@@ -124,7 +124,7 @@ double RooUniformBinning::binLow(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooUniformBinning::binLow ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 
@@ -140,7 +140,7 @@ double RooUniformBinning::binHigh(Int_t i) const
 {
   if (i<0 || i>=_nbins) {
     coutE(InputArguments) << "RooUniformBinning::fitBinHigh ERROR: bin index " << i
-           << " is out of range (0," << _nbins-1 << ")" << endl ;
+           << " is out of range (0," << _nbins-1 << ")" << std::endl ;
     return 0 ;
   }
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -47,7 +47,7 @@ which returns spans pointing directly to the data.
 #include "TBuffer.h"
 
 #include <iomanip>
-using std::string, std::vector, std::cout, std::endl, std::list;
+using std::string, std::vector, std::list;
 
 ClassImp(RooVectorDataStore);
 ClassImp(RooVectorDataStore::RealVector);
@@ -627,7 +627,7 @@ RooAbsArg* RooVectorDataStore::addColumn(RooAbsArg& newVar, bool /*adjustRange*/
   // Sanity check that the holder really is fundamental
   if(!valHolder->isFundamental()) {
     coutE(InputArguments) << GetName() << "::addColumn: holder argument is not fundamental: \""
-    << valHolder->GetName() << "\"" << endl;
+    << valHolder->GetName() << "\"" << std::endl;
     return nullptr;
   }
 
@@ -803,8 +803,8 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
   }
 
   // WVE need to prune tracking entries _below_ constant nodes as the're not needed
-//   cout << "Number of Cache-and-Tracked args are " << trackArgs.size() << endl ;
-//   cout << "Compound ordered cache parameters = " << endl ;
+//   std::cout << "Number of Cache-and-Tracked args are " << trackArgs.size() << std::endl ;
+//   std::cout << "Compound ordered cache parameters = " << std::endl ;
 //   orderedArgs.Print("v") ;
 
   checkInit() ;
@@ -844,7 +844,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
     RooArgSet* normSet(nullptr) ;
     const char* catNset = arg->getStringAttribute("CATNormSet") ;
     if (catNset) {
-//       cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a normalization set specification CATNormSet = " << catNset << endl ;
+//       std::cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a normalization set specification CATNormSet = " << catNset << std::endl ;
 
       RooArgSet anset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catNset);
       normSet = anset.selectCommon(*argObs);
@@ -852,7 +852,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
     }
     const char* catCset = arg->getStringAttribute("CATCondSet") ;
     if (catCset) {
-//       cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a conditional observable set specification CATCondSet = " << catCset << endl ;
+//       std::cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a conditional observable set specification CATCondSet = " << catCset << std::endl ;
 
       RooArgSet acset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catCset);
       argObs->remove(acset,true,true) ;
@@ -861,7 +861,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 
     // now construct normalization set for component from cset/nset spec
 //     if (normSet) {
-//       cout << "RooVectorDaraStore::cacheArgs() component " << arg->GetName() << " has custom normalization set " << *normSet << endl ;
+//       std::cout << "RooVectorDaraStore::cacheArgs() component " << arg->GetName() << " has custom normalization set " << *normSet << std::endl ;
 //     }
     nsetList.push_back(normSet) ;
   }
@@ -901,7 +901,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
       // find ordinal number of arg in original list
       Int_t idx = cloneSet.index(arg->GetName()) ;
 
-      coutI(Optimization) << "RooVectorDataStore::cacheArg() element " << arg->GetName() << " has change tracking enabled on parameters " << deps << endl ;
+      coutI(Optimization) << "RooVectorDataStore::cacheArg() element " << arg->GetName() << " has change tracking enabled on parameters " << deps << std::endl ;
       rv->setNset(nsetList[idx]) ;
     }
 
@@ -1065,37 +1065,37 @@ void RooVectorDataStore::resetBuffers()
 
 void RooVectorDataStore::dump()
 {
-  cout << "RooVectorDataStor::dump()" << endl ;
+  std::cout << "RooVectorDataStor::dump()" << std::endl ;
 
-  cout << "_varsww = " << endl ; _varsww.Print("v") ;
-  cout << "realVector list is" << endl ;
+  std::cout << "_varsww = " << std::endl ; _varsww.Print("v") ;
+  std::cout << "realVector list is" << std::endl ;
 
   for (const auto elm : _realStoreList) {
-    cout << "RealVector " << elm << " _nativeReal = " << elm->_nativeReal << " = " << elm->_nativeReal->GetName() << " bufptr = " << elm->_buf  << endl ;
-    cout << " values : " ;
+    std::cout << "RealVector " << elm << " _nativeReal = " << elm->_nativeReal << " = " << elm->_nativeReal->GetName() << " bufptr = " << elm->_buf  << std::endl ;
+    std::cout << " values : " ;
     Int_t imax = elm->_vec.size()>10 ? 10 : elm->_vec.size() ;
     for (Int_t i=0 ; i<imax ; i++) {
-      cout << elm->_vec[i] << " " ;
+      std::cout << elm->_vec[i] << " " ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
   for (const auto elm : _realfStoreList) {
-    cout << "RealFullVector " << elm << " _nativeReal = " << elm->_nativeReal << " = " << elm->_nativeReal->GetName()
-    << " bufptr = " << elm->_buf  << " errbufptr = " << elm->bufE() << endl ;
+    std::cout << "RealFullVector " << elm << " _nativeReal = " << elm->_nativeReal << " = " << elm->_nativeReal->GetName()
+    << " bufptr = " << elm->_buf  << " errbufptr = " << elm->bufE() << std::endl ;
 
-    cout << " values : " ;
+    std::cout << " values : " ;
     Int_t imax = elm->_vec.size()>10 ? 10 : elm->_vec.size() ;
     for (Int_t i=0 ; i<imax ; i++) {
-      cout << elm->_vec[i] << " " ;
+      std::cout << elm->_vec[i] << " " ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
     if (elm->bufE()) {
-      cout << " errors : " ;
+      std::cout << " errors : " ;
       for (Int_t i=0 ; i<imax ; i++) {
-   cout << elm->dataE()[i] << " " ;
+   std::cout << elm->dataE()[i] << " " ;
       }
-      cout << endl ;
+      std::cout << std::endl ;
 
     }
   }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -99,7 +99,7 @@ bool isCacheSet(std::string const& setName) {
 
 } // namespace
 
-using std::string, std::list, std::cout, std::endl, std::map, std::vector, std::ifstream, std::ofstream, std::fstream, std::make_unique;
+using std::string, std::list, std::map, std::vector, std::ifstream, std::ofstream, std::fstream, std::make_unique;
 
 ClassImp(RooWorkspace);
 
@@ -282,7 +282,7 @@ bool RooWorkspace::import(const char* fileSpec,
       stream << "\n\t" << token;
     }
     coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR in file specification, expecting 'filename:wsname:objname', but '" << fileSpec << "' given."
-        << "\nTokens read are:" << stream.str() << endl;
+        << "\nTokens read are:" << stream.str() << std::endl;
     return true ;
   }
 
@@ -293,7 +293,7 @@ bool RooWorkspace::import(const char* fileSpec,
   // Check that file can be opened
   std::unique_ptr<TFile> f{TFile::Open(filename.c_str())};
   if (f==nullptr) {
-    coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR opening file " << filename << endl ;
+    coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR opening file " << filename << std::endl ;
     return false;
   }
 
@@ -301,7 +301,7 @@ bool RooWorkspace::import(const char* fileSpec,
   RooWorkspace* w = dynamic_cast<RooWorkspace*>(f->Get(wsname.c_str())) ;
   if (w==nullptr) {
     coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No object named " << wsname << " in file " << filename
-           << " or object is not a RooWorkspace" << endl ;
+           << " or object is not a RooWorkspace" << std::endl ;
     return false;
   }
 
@@ -318,7 +318,7 @@ bool RooWorkspace::import(const char* fileSpec,
   }
 
   coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No RooAbsArg or RooAbsData object named " << objname
-         << " in workspace " << wsname << " in file " << filename << endl ;
+         << " in workspace " << wsname << " in file " << filename << std::endl ;
   return true ;
 }
 
@@ -474,17 +474,17 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
     if (!factoryMatch) {
       if (wsarg!=&inArg) {
         coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR importing object named " << inArg.GetName()
-                   << ": another instance with same name already in the workspace and no conflict resolution protocol specified" << endl ;
+                   << ": another instance with same name already in the workspace and no conflict resolution protocol specified" << std::endl ;
         return true ;
       } else {
         if (!silence) {
-          coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Object " << inArg.GetName() << " is already in workspace!" << endl ;
+          coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Object " << inArg.GetName() << " is already in workspace!" << std::endl ;
         }
         return true ;
       }
     } else {
       if(!silence) {
-        coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Recycling existing object " << inArg.GetName() << " created with identical factory specification" << endl ;
+        coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Recycling existing object " << inArg.GetName() << " created with identical factory specification" << std::endl ;
       }
     }
   }
@@ -508,7 +508,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
   // Terminate here if there are conflicts and no resolution protocol
   if (!conflictNodes.empty() && !suffix && !useExistingNodes) {
     coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
-        << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << endl ;
+        << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << std::endl ;
     return true ;
   }
 
@@ -547,7 +547,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
       if (!silence) {
         coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
                    << ") Resolving name conflict in workspace by changing name of imported node  "
-                   << origName << " to " << cnode2->GetName() << endl ;
+                   << origName << " to " << cnode2->GetName() << std::endl ;
       }
     }
   } else {
@@ -580,11 +580,11 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
         if (!silence) {
           coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
                 << ") Resolving name conflict in workspace by changing name of original node "
-                << origName << " to " << wsnode->GetName() << endl ;
+                << origName << " to " << wsnode->GetName() << std::endl ;
         }
       } else {
         coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Internal error: expected to find existing node "
-            << origName << " to be renamed, but didn't find it..." << endl ;
+            << origName << " to be renamed, but didn't find it..." << std::endl ;
       }
 
     }
@@ -607,7 +607,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
 
         if (!silence) {
           coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Changing name of variable "
-              << origName << " to " << cnode->GetName() << " on request" << endl ;
+              << origName << " to " << cnode->GetName() << " on request" << std::endl ;
         }
 
         if (cnode==cloneTop) {
@@ -636,7 +636,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
   // Terminate here if there are conflicts and no resolution protocol
   if (!conflictNodes2.empty()) {
     coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
-        << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << endl ;
+        << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << std::endl ;
     return true ;
   }
 
@@ -644,7 +644,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
   for (const auto node : cloneSet2) {
     if (node->importWorkspaceHook(*this)) {
       coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << node->GetName()
-                 << " has an error in importing in one or more of its auxiliary objects, aborting" << endl ;
+                 << " has an error in importing in one or more of its auxiliary objects, aborting" << std::endl ;
       return true ;
     }
   }
@@ -655,7 +655,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
     if (_autoClass) {
       if (!_classes.autoImportClass(node->IsA())) {
         coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
-            << node->ClassName() << "::" << node->GetName() << ", reading of workspace will require external definition of class" << endl ;
+            << node->ClassName() << "::" << node->GetName() << ", reading of workspace will require external definition of class" << std::endl ;
       }
     }
 
@@ -672,20 +672,20 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
       if (!silence && useExistingNodes) {
         coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") using existing copy of " << node->ClassName()
                    << "::" << node->GetName() << " for import of " << cloneTop2->ClassName() << "::"
-                   << cloneTop2->GetName() << endl ;
+                   << cloneTop2->GetName() << std::endl ;
       }
       recycledNodes.add(*_allOwnedNodes.find(node->GetName())) ;
 
       // Delete clone of incoming node
       nodesToBeDeleted.addOwned(std::unique_ptr<RooAbsArg>{node});
 
-      //cout << "WV: recycling existing node " << existingNode << " = " << existingNode->GetName() << " for imported node " << node << endl ;
+      //cout << "WV: recycling existing node " << existingNode << " = " << existingNode->GetName() << " for imported node " << node << std::endl ;
 
     } else {
       // Import node
       if (!silence) {
         coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->ClassName() << "::"
-            << node->GetName() << endl ;
+            << node->GetName() << std::endl ;
       }
       _allOwnedNodes.addOwned(std::unique_ptr<RooAbsArg>{node});
       node->setWorkspace(*this);
@@ -764,7 +764,7 @@ bool RooWorkspace::import(RooAbsData const& inData,
   Int_t silence = pc.getInt("silence") ;
 
   if (!silence)
-    coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing dataset " << inData.GetName() << endl ;
+    coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing dataset " << inData.GetName() << std::endl ;
 
   // Transform empty string into null pointer
   if (dsetName && strlen(dsetName)==0) {
@@ -779,11 +779,11 @@ bool RooWorkspace::import(RooAbsData const& inData,
 
   // Check that no dataset with target name already exists
   if (dsetName && dataList.FindObject(dsetName)) {
-    coutE(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") ERROR dataset with name " << dsetName << " already exists in workspace, import aborted" << endl ;
+    coutE(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") ERROR dataset with name " << dsetName << " already exists in workspace, import aborted" << std::endl ;
     return true ;
   }
   if (!dsetName && dataList.FindObject(inData.GetName())) {
-    coutE(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") ERROR dataset with name " << inData.GetName() << " already exists in workspace, import aborted" << endl ;
+    coutE(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") ERROR dataset with name " << inData.GetName() << " already exists in workspace, import aborted" << std::endl ;
     return true ;
   }
 
@@ -791,7 +791,7 @@ bool RooWorkspace::import(RooAbsData const& inData,
   RooAbsData* clone ;
   if (dsetName) {
     if (!silence)
-      coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") changing name of dataset from  " << inData.GetName() << " to " << dsetName << endl ;
+      coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") changing name of dataset from  " << inData.GetName() << " to " << dsetName << std::endl ;
     clone = static_cast<RooAbsData*>(inData.Clone(dsetName)) ;
   } else {
     clone = static_cast<RooAbsData*>(inData.Clone(inData.GetName())) ;
@@ -805,7 +805,7 @@ bool RooWorkspace::import(RooAbsData const& inData,
     const std::vector<std::string> tokOut = ROOT::Split(varChangeOut, ",");
     for (unsigned int i=0; i < tokIn.size(); ++i) {
       if (!silence)
-        coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") changing name of dataset observable " << tokIn[i] << " to " << tokOut[i] << endl ;
+        coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") changing name of dataset observable " << tokIn[i] << " to " << tokOut[i] << std::endl ;
       clone->changeObservableName(tokIn[i].c_str(), tokOut[i].c_str());
     }
   }
@@ -846,7 +846,7 @@ bool RooWorkspace::defineSet(const char* name, const RooArgSet& aset, bool impor
   // Check if set was previously defined, if so print warning
   map<string,RooArgSet>::iterator i = _namedSets.find(name) ;
   if (i!=_namedSets.end()) {
-    coutW(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") WARNING redefining previously defined named set " << name << endl ;
+    coutW(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") WARNING redefining previously defined named set " << name << std::endl ;
   }
 
   RooArgSet wsargs ;
@@ -859,7 +859,7 @@ bool RooWorkspace::defineSet(const char* name, const RooArgSet& aset, bool impor
    import(*sarg) ;
       } else {
    coutE(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") ERROR set constituent \"" << sarg->GetName()
-               << "\" is not in workspace and importMissing option is disabled" << endl ;
+               << "\" is not in workspace and importMissing option is disabled" << std::endl ;
    return true ;
       }
     }
@@ -885,7 +885,7 @@ bool RooWorkspace::defineSetInternal(const char *name, const RooArgSet &aset)
    map<string, RooArgSet>::iterator i = _namedSets.find(name);
    if (i != _namedSets.end()) {
       coutW(InputArguments) << "RooWorkspace::defineSet(" << GetName()
-                            << ") WARNING redefining previously defined named set " << name << endl;
+                            << ") WARNING redefining previously defined named set " << name << std::endl;
    }
 
    // Install named set
@@ -904,7 +904,7 @@ bool RooWorkspace::defineSet(const char* name, const char* contentList)
   // Check if set was previously defined, if so print warning
   map<string,RooArgSet>::iterator i = _namedSets.find(name) ;
   if (i!=_namedSets.end()) {
-    coutW(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") WARNING redefining previously defined named set " << name << endl ;
+    coutW(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") WARNING redefining previously defined named set " << name << std::endl ;
   }
 
   RooArgSet wsargs ;
@@ -914,7 +914,7 @@ bool RooWorkspace::defineSet(const char* name, const char* contentList)
     // If missing, either import or report error
     if (!arg(token.c_str())) {
       coutE(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") ERROR proposed set constituent \"" << token
-             << "\" is not in workspace" << endl ;
+             << "\" is not in workspace" << std::endl ;
       return true ;
     }
     wsargs.add(*arg(token.c_str())) ;
@@ -943,7 +943,7 @@ bool RooWorkspace::extendSet(const char* name, const char* newContents)
     // If missing, either import or report error
     if (!arg(token.c_str())) {
       coutE(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") ERROR proposed set constituent \"" << token
-             << "\" is not in workspace" << endl ;
+             << "\" is not in workspace" << std::endl ;
       return true ;
     }
     wsargs.add(*arg(token.c_str())) ;
@@ -978,14 +978,14 @@ bool RooWorkspace::renameSet(const char* name, const char* newName)
   // First check if set exists
   if (!set(name)) {
     coutE(InputArguments) << "RooWorkspace::renameSet(" << GetName() << ") ERROR a set with name " << name
-           << " does not exist" << endl ;
+           << " does not exist" << std::endl ;
     return true ;
   }
 
   // Check if no set exists with new name
   if (set(newName)) {
     coutE(InputArguments) << "RooWorkspace::renameSet(" << GetName() << ") ERROR a set with name " << newName
-           << " already exists" << endl ;
+           << " already exists" << std::endl ;
     return true ;
   }
 
@@ -1009,7 +1009,7 @@ bool RooWorkspace::removeSet(const char* name)
   // First check if set exists
   if (!set(name)) {
     coutE(InputArguments) << "RooWorkspace::removeSet(" << GetName() << ") ERROR a set with name " << name
-           << " does not exist" << endl ;
+           << " does not exist" << std::endl ;
     return true ;
   }
 
@@ -1118,7 +1118,7 @@ bool RooWorkspace::importClassCode(const char* pat, bool doReplace)
     TString className = carg->ClassName() ;
     if (className.Index(re)>=0 && !_classes.autoImportClass(carg->IsA(),doReplace)) {
       coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
-             << carg->ClassName() << "::" << carg->GetName() << ", reading of workspace will require external definition of class" << endl ;
+             << carg->ClassName() << "::" << carg->GetName() << ", reading of workspace will require external definition of class" << std::endl ;
       ret = false ;
     }
   }
@@ -1163,7 +1163,7 @@ bool RooWorkspace::saveSnapshot(RooStringView name, const RooArgSet& params, boo
   }
 
   if (std::unique_ptr<RooArgSet> oldSnap{static_cast<RooArgSet*>(_snapshots.FindObject(name.c_str()))}) {
-    coutI(ObjectHandling) << "RooWorkspace::saveSnapshot(" << GetName() << ") replacing previous snapshot with name " << name << endl ;
+    coutI(ObjectHandling) << "RooWorkspace::saveSnapshot(" << GetName() << ") replacing previous snapshot with name " << name << std::endl ;
     _snapshots.Remove(oldSnap.get()) ;
   }
 
@@ -1183,7 +1183,7 @@ bool RooWorkspace::loadSnapshot(const char* name)
 {
   RooArgSet* snap = static_cast<RooArgSet*>(_snapshots.find(name)) ;
   if (!snap) {
-    coutE(ObjectHandling) << "RooWorkspace::loadSnapshot(" << GetName() << ") no snapshot with name " << name << " is available" << endl ;
+    coutE(ObjectHandling) << "RooWorkspace::loadSnapshot(" << GetName() << ") no snapshot with name " << name << " is available" << std::endl ;
     return false ;
   }
 
@@ -1497,20 +1497,20 @@ std::list<TObject*> RooWorkspace::allGenericObjects() const
 bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
 {
 
-  oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") request to import code of class " << tc->GetName() << endl ;
+  oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") request to import code of class " << tc->GetName() << std::endl ;
 
   // *** PHASE 1 *** Check if file needs to be imported, or is in ROOT distribution, and check if it can be persisted
 
   // Check if we already have the class (i.e. it is in the classToFile map)
   if (!doReplace && _c2fmap.find(tc->GetName())!=_c2fmap.end()) {
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " already imported, skipping" << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " already imported, skipping" << std::endl ;
     return true ;
   }
 
   // Check if class is listed in a ROOTMAP file - if so we can skip it because it is in the root distribution
   const char* mapEntry = gInterpreter->GetClassSharedLibs(tc->GetName()) ;
   if (mapEntry && strlen(mapEntry)>0) {
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " is in ROOT distribution, skipping " << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " is in ROOT distribution, skipping " << std::endl ;
     return true ;
   }
 
@@ -1521,14 +1521,14 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
   // Check that file names are not empty
   if (implfile.empty() || declfile.empty()) {
     oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") ERROR: cannot retrieve code file names for class "
-               << tc->GetName() << " through ROOT TClass interface, unable to import code" << endl ;
+               << tc->GetName() << " through ROOT TClass interface, unable to import code" << std::endl ;
     return false ;
   }
 
   // Check if header filename is found in ROOT distribution, if so, do not import class
   TString rootsys = gSystem->Getenv("ROOTSYS") ;
   if (TString(implfile.c_str()).Index(rootsys)>=0) {
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " is in ROOT distribution, skipping " << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " is in ROOT distribution, skipping " << std::endl ;
     return true ;
   }
 
@@ -1537,7 +1537,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
   //  as TClass::HasDefaultCtor only returns true for callable default constructors)
   if (!(tc->Property() & kIsAbstract) && !tc->HasDefaultConstructor()) {
     oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING cannot import class "
-                << tc->GetName() << " : it cannot be persisted because it doesn't have a default constructor. Please fix " << endl ;
+                << tc->GetName() << " : it cannot be persisted because it doesn't have a default constructor. Please fix " << std::endl ;
     return false ;
   }
 
@@ -1585,7 +1585,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
    }
       }
       ooccoutW(_wspace,ObjectHandling) << ". To fix this problem, add the required directory to the search "
-                   << "path using RooWorkspace::addClassDeclImportDir(const char* dir)" << endl ;
+                   << "path using RooWorkspace::addClassDeclImportDir(const char* dir)" << std::endl ;
 
       return false ;
     }
@@ -1630,7 +1630,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
    }
       }
       ooccoutW(_wspace,ObjectHandling) << ". To fix this problem add the required directory to the search "
-                   << "path using RooWorkspace::addClassImplImportDir(const char* dir)" << endl;
+                   << "path using RooWorkspace::addClassImplImportDir(const char* dir)" << std::endl;
       return false;
     }
   }
@@ -1667,14 +1667,14 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
     // Abort import if declaration file cannot be opened
     if (!fdecl) {
       oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
-                  << ") ERROR opening declaration file " <<  declfile << endl ;
+                  << ") ERROR opening declaration file " <<  declfile << std::endl ;
       return false ;
     }
 
     oocoutI(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
                 << ") importing code of class " << tc->GetName()
                 << " from " << (!implpath.empty() ? implpath.c_str() : implfile.c_str())
-                << " and " << (!declpath.empty() ? declpath.c_str() : declfile.c_str()) << endl ;
+                << " and " << (!declpath.empty() ? declpath.c_str() : declfile.c_str()) << std::endl ;
 
 
     // Read entire file into an stl string
@@ -1701,7 +1701,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
       hpath += incfile;
       if (gSystem->AccessPathName(hpath.Data())) {
          oocoutI(_wspace, ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
-                                          << ") scheduling include file " << incfile << " for import" << endl;
+                                          << ") scheduling include file " << incfile << " for import" << std::endl;
          extraHeaders.push_back(incfile);
          extincfile = incfile;
          processedInclude = true;
@@ -1724,7 +1724,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
     // Abort import if implementation file cannot be opened
     if (!fimpl) {
       oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
-                  << ") ERROR opening implementation file " <<  implfile << endl ;
+                  << ") ERROR opening implementation file " <<  implfile << std::endl ;
       return false ;
     }
 
@@ -1760,7 +1760,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
 
       if (gSystem->AccessPathName(hpath.Data())) {
          oocoutI(_wspace, ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
-                                          << ") scheduling include file " << incfile << " for import" << endl;
+                                          << ") scheduling include file " << incfile << " for import" << std::endl;
          extraHeaders.push_back(incfile);
          extincfile = incfile;
          processedInclude = true;
@@ -1817,7 +1817,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
           if (gSystem->AccessPathName(hpath.Data())) {
              oocoutI(_wspace, ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
                                               << ") scheduling recursive include file " << incfile << " for import"
-                                              << endl;
+                                              << std::endl;
              extraHeaders.push_back(incfile);
           }
        }
@@ -1915,7 +1915,7 @@ bool RooWorkspace::import(TObject const& object, bool replaceExisting)
   std::unique_ptr<TObject> oldObj{_genObjects.FindObject(object.GetName())};
   if (oldObj && !replaceExisting) {
     coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name "
-           << object.GetName() << " is already in workspace and replaceExisting flag is set to false" << endl ;
+           << object.GetName() << " is already in workspace and replaceExisting flag is set to false" << std::endl ;
     return true ;
   }
 
@@ -1955,7 +1955,7 @@ bool RooWorkspace::import(TObject const& object, const char* aliasName, bool rep
   std::unique_ptr<TObject> oldObj{_genObjects.FindObject(aliasName)};
   if (oldObj && !replaceExisting) {
     coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name "
-           << aliasName << " is already in workspace and replaceExisting flag is set to false" << endl ;
+           << aliasName << " is already in workspace and replaceExisting flag is set to false" << std::endl ;
     return true ;
   }
 
@@ -2069,7 +2069,7 @@ RooFactoryWSTool& RooWorkspace::factory()
   if (_factory) {
     return *_factory;
   }
-  cxcoutD(ObjectHandling) << "INFO: Creating RooFactoryWSTool associated with this workspace" << endl ;
+  cxcoutD(ObjectHandling) << "INFO: Creating RooFactoryWSTool associated with this workspace" << std::endl ;
   _factory = make_unique<RooFactoryWSTool>(*this);
   return *_factory;
 }
@@ -2103,7 +2103,7 @@ void RooWorkspace::Print(Option_t* opts) const
      verbose = true;
   }
 
-  cout << endl << "RooWorkspace(" << GetName() << ") " << GetTitle() << " contents" << endl << endl  ;
+  std::cout << std::endl << "RooWorkspace(" << GetName() << ") " << GetTitle() << " contents" << std::endl << std::endl  ;
 
   RooArgSet pdfSet ;
   RooArgSet funcSet ;
@@ -2189,15 +2189,15 @@ void RooWorkspace::Print(Option_t* opts) const
 
   if (!varSet.empty()) {
     varSet.sort() ;
-    cout << "variables" << endl ;
-    cout << "---------" << endl ;
-    cout << varSet << endl ;
-    cout << endl ;
+    std::cout << "variables" << std::endl ;
+    std::cout << "---------" << std::endl ;
+    std::cout << varSet << std::endl ;
+    std::cout << std::endl ;
   }
 
   if (!pdfSet.empty()) {
-    cout << "p.d.f.s" << endl ;
-    cout << "-------" << endl ;
+    std::cout << "p.d.f.s" << std::endl ;
+    std::cout << "-------" << std::endl ;
     pdfSet.sort() ;
     for(RooAbsArg* parg : pdfSet) {
       if (treeMode) {
@@ -2206,24 +2206,24 @@ void RooWorkspace::Print(Option_t* opts) const
    parg->Print() ;
       }
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
   if (!treeMode) {
     if (!resoSet.empty()) {
-      cout << "analytical resolution models" << endl ;
-      cout << "----------------------------" << endl ;
+      std::cout << "analytical resolution models" << std::endl ;
+      std::cout << "----------------------------" << std::endl ;
       resoSet.sort() ;
       for(RooAbsArg* parg : resoSet) {
    parg->Print() ;
       }
-      cout << endl ;
+      std::cout << std::endl ;
     }
   }
 
   if (!funcSet.empty()) {
-    cout << "functions" << endl ;
-    cout << "--------" << endl ;
+    std::cout << "functions" << std::endl ;
+    std::cout << "--------" << std::endl ;
     funcSet.sort() ;
     for(RooAbsArg * parg : funcSet) {
       if (treeMode) {
@@ -2232,12 +2232,12 @@ void RooWorkspace::Print(Option_t* opts) const
    parg->Print() ;
       }
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
   if (!catfuncSet.empty()) {
-    cout << "category functions" << endl ;
-    cout << "------------------" << endl ;
+    std::cout << "category functions" << std::endl ;
+    std::cout << "------------------" << std::endl ;
     catfuncSet.sort() ;
     for(RooAbsArg* parg : catfuncSet) {
       if (treeMode) {
@@ -2246,12 +2246,12 @@ void RooWorkspace::Print(Option_t* opts) const
    parg->Print() ;
       }
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
   if (!_dataList.empty()) {
-    cout << "datasets" << endl ;
-    cout << "--------" << endl ;
+    std::cout << "datasets" << std::endl ;
+    std::cout << "--------" << std::endl ;
     for(auto * data2 : static_range_cast<RooAbsData*>(_dataList)) {
       std::cout << data2->ClassName() << "::" << data2->GetName() << *data2->get() << std::endl;
     }
@@ -2259,81 +2259,81 @@ void RooWorkspace::Print(Option_t* opts) const
   }
 
   if (!_embeddedDataList.empty()) {
-    cout << "embedded datasets (in pdfs and functions)" << endl ;
-    cout << "-----------------------------------------" << endl ;
+    std::cout << "embedded datasets (in pdfs and functions)" << std::endl ;
+    std::cout << "-----------------------------------------" << std::endl ;
     for(auto * data2 : static_range_cast<RooAbsData*>(_embeddedDataList)) {
-      cout << data2->ClassName() << "::" << data2->GetName() << *data2->get() << endl ;
+      std::cout << data2->ClassName() << "::" << data2->GetName() << *data2->get() << std::endl ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
   if (!_snapshots.empty()) {
-    cout << "parameter snapshots" << endl ;
-    cout << "-------------------" << endl ;
+    std::cout << "parameter snapshots" << std::endl ;
+    std::cout << "-------------------" << std::endl ;
     for(auto * snap : static_range_cast<RooArgSet*>(_snapshots)) {
-      cout << snap->GetName() << " = (" ;
+      std::cout << snap->GetName() << " = (" ;
       bool first(true) ;
       for(RooAbsArg* a : *snap) {
-   if (first) { first=false ; } else { cout << "," ; }
-   cout << a->GetName() << "=" ;
-   a->printValue(cout) ;
+   if (first) { first=false ; } else { std::cout << "," ; }
+   std::cout << a->GetName() << "=" ;
+   a->printValue(std::cout) ;
    if (a->isConstant()) {
-     cout << "[C]" ;
+     std::cout << "[C]" ;
    }
       }
-      cout << ")" << endl ;
+      std::cout << ")" << std::endl ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
 
   if (!_namedSets.empty()) {
-    cout << "named sets" << endl ;
-    cout << "----------" << endl ;
+    std::cout << "named sets" << std::endl ;
+    std::cout << "----------" << std::endl ;
     for (map<string,RooArgSet>::const_iterator it = _namedSets.begin() ; it != _namedSets.end() ; ++it) {
        if (verbose || !isCacheSet(it->first)) {
-          cout << it->first << ":" << it->second << endl;
+          std::cout << it->first << ":" << it->second << std::endl;
        }
     }
 
-    cout << endl ;
+    std::cout << std::endl ;
   }
 
 
   if (!_genObjects.empty()) {
-    cout << "generic objects" << endl ;
-    cout << "---------------" << endl ;
+    std::cout << "generic objects" << std::endl ;
+    std::cout << "---------------" << std::endl ;
     for(TObject* gobj : _genObjects) {
       if (gobj->IsA()==RooTObjWrap::Class()) {
-   cout << (static_cast<RooTObjWrap*>(gobj))->obj()->ClassName() << "::" << gobj->GetName() << endl ;
+   std::cout << (static_cast<RooTObjWrap*>(gobj))->obj()->ClassName() << "::" << gobj->GetName() << std::endl ;
       } else {
-   cout << gobj->ClassName() << "::" << gobj->GetName() << endl ;
+   std::cout << gobj->ClassName() << "::" << gobj->GetName() << std::endl ;
       }
     }
-    cout << endl ;
+    std::cout << std::endl ;
 
   }
 
   if (!_studyMods.empty()) {
-    cout << "study modules" << endl ;
-    cout << "-------------" << endl ;
+    std::cout << "study modules" << std::endl ;
+    std::cout << "-------------" << std::endl ;
     for(TObject* smobj : _studyMods) {
-      cout << smobj->ClassName() << "::" << smobj->GetName() << endl ;
+      std::cout << smobj->ClassName() << "::" << smobj->GetName() << std::endl ;
     }
-    cout << endl ;
+    std::cout << std::endl ;
 
   }
 
   if (!_classes.listOfClassNames().empty()) {
-    cout << "embedded class code" << endl ;
-    cout << "-------------------" << endl ;
-    cout << _classes.listOfClassNames() << endl ;
-    cout << endl ;
+    std::cout << "embedded class code" << std::endl ;
+    std::cout << "-------------------" << std::endl ;
+    std::cout << _classes.listOfClassNames() << std::endl ;
+    std::cout << std::endl ;
   }
 
   if (!_eocache.empty()) {
-    cout << "embedded precalculated expensive components" << endl ;
-    cout << "-------------------------------------------" << endl ;
+    std::cout << "embedded precalculated expensive components" << std::endl ;
+    std::cout << "-------------------------------------------" << std::endl ;
     _eocache.print() ;
   }
 
@@ -2475,8 +2475,8 @@ void RooWorkspace::Streamer(TBuffer &R__b)
          if (dynamic_cast<RooAbsOptTestStatistic *>(node)) {
             RooAbsOptTestStatistic *tmp = static_cast<RooAbsOptTestStatistic *>(node);
             if (tmp->isSealed() && tmp->sealNotice() && strlen(tmp->sealNotice()) > 0) {
-               cout << "RooWorkspace::Streamer(" << GetName() << ") " << node->ClassName() << "::" << node->GetName()
-                    << " : " << tmp->sealNotice() << endl;
+               std::cout << "RooWorkspace::Streamer(" << GetName() << ") " << node->ClassName() << "::" << node->GetName()
+                    << " : " << tmp->sealNotice() << std::endl;
             }
          }
 #endif
@@ -2511,7 +2511,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
             if (!_allOwnedNodes.containsInstance(*vclient)) {
                cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
                                        << " has external value client link to " << vclient << " (" << vclient->GetName()
-                                       << ") with ref count " << tmparg->_clientListValue.refCount(vclient) << endl;
+                                       << ") with ref count " << tmparg->_clientListValue.refCount(vclient) << std::endl;
 
                const auto refCount = tmparg->_clientListValue.refCount(vclient);
                auto &bufferVec = extValueClients[tmparg];
@@ -2527,7 +2527,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
             if (!_allOwnedNodes.containsInstance(*sclient)) {
                cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
                                        << " has external shape client link to " << sclient << " (" << sclient->GetName()
-                                       << ") with ref count " << tmparg->_clientListShape.refCount(sclient) << endl;
+                                       << ") with ref count " << tmparg->_clientListShape.refCount(sclient) << std::endl;
 
                const auto refCount = tmparg->_clientListShape.refCount(sclient);
                auto &bufferVec = extShapeClients[tmparg];
@@ -2694,12 +2694,12 @@ bool RooWorkspace::CodeRepo::compileClasses()
   map<TString,ClassRelInfo>::iterator iter = _c2fmap.begin() ;
   while(iter!=_c2fmap.end()) {
 
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() now processing class " << iter->first.Data() << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() now processing class " << iter->first.Data() << std::endl ;
 
     // If class is already known, don't load
     if (gClassTable->GetDict(iter->first.Data())) {
       oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Embedded class "
-                  << iter->first << " already in ROOT class table, skipping" << endl ;
+                  << iter->first << " already in ROOT class table, skipping" << std::endl ;
       ++iter ;
       continue ;
     }
@@ -2710,14 +2710,14 @@ bool RooWorkspace::CodeRepo::compileClasses()
       // If not, make local directory to extract files
       if (!gSystem->AccessPathName(dirName.c_str())) {
    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() reusing code export directory " << dirName.c_str()
-               << " to extract coded embedded in workspace" << endl ;
+               << " to extract coded embedded in workspace" << std::endl ;
       } else {
    if (gSystem->MakeDirectory(dirName.c_str())==0) {
      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() creating code export directory " << dirName.c_str()
-                 << " to extract coded embedded in workspace" << endl ;
+                 << " to extract coded embedded in workspace" << std::endl ;
    } else {
      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR creating code export directory " << dirName.c_str()
-                 << " to extract coded embedded in workspace" << endl ;
+                 << " to extract coded embedded in workspace" << std::endl ;
      return false ;
    }
       }
@@ -2751,7 +2751,7 @@ bool RooWorkspace::CodeRepo::compileClasses()
    // Write declaration file if required
    if (needEHWrite) {
       oocoutI(_wspace, ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting extra header file "
-                                       << fdname << endl;
+                                       << fdname << std::endl;
 
       // Extra headers may contain non-existing path - create first to be sure
       gSystem->MakeDirectory(gSystem->GetDirName(fdname.c_str()));
@@ -2759,7 +2759,7 @@ bool RooWorkspace::CodeRepo::compileClasses()
       ofstream fdecl(fdname.c_str());
       if (!fdecl) {
          oocoutE(_wspace, ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file " << fdname
-                                          << " for writing" << endl;
+                                          << " for writing" << std::endl;
          return false;
       }
       fdecl << extraIter->second._hfile.Data();
@@ -2773,12 +2773,12 @@ bool RooWorkspace::CodeRepo::compileClasses()
     // Navigate from class to file
     ClassFiles& cfinfo = _fmap[iter->second._fileBase] ;
 
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() now processing file with base " << iter->second._fileBase << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() now processing file with base " << iter->second._fileBase << std::endl ;
 
     // If file is already processed, skip to next class
     if (cfinfo._extracted) {
       oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() file with base name " << iter->second._fileBase
-                << " has already been extracted, skipping to next class" << endl ;
+                << " has already been extracted, skipping to next class" << std::endl ;
       continue ;
     }
 
@@ -2800,11 +2800,11 @@ bool RooWorkspace::CodeRepo::compileClasses()
 
     // Write declaration file if required
     if (needDeclWrite) {
-      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting declaration code of class " << iter->first << ", file " << fdname << endl ;
+      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting declaration code of class " << iter->first << ", file " << fdname << std::endl ;
       ofstream fdecl(fdname.c_str()) ;
       if (!fdecl) {
    oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file "
-               << fdname << " for writing" << endl ;
+               << fdname << " for writing" << std::endl ;
    return false ;
       }
       fdecl << cfinfo._hfile ;
@@ -2829,11 +2829,11 @@ bool RooWorkspace::CodeRepo::compileClasses()
 
     // Write implementation file if required
     if (needImplWrite) {
-      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting implementation code of class " << iter->first << ", file " << finame << endl ;
+      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting implementation code of class " << iter->first << ", file " << finame << std::endl ;
       ofstream fimpl(finame.c_str()) ;
       if (!fimpl) {
    oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file"
-               << finame << " for writing" << endl ;
+               << finame << " for writing" << std::endl ;
    return false ;
       }
       fimpl << cfinfo._cxxfile ;
@@ -2842,20 +2842,20 @@ bool RooWorkspace::CodeRepo::compileClasses()
 
     // Mark this file as extracted
     cfinfo._extracted = true ;
-    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() marking code unit  " << iter->second._fileBase << " as extracted" << endl ;
+    oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() marking code unit  " << iter->second._fileBase << " as extracted" << std::endl ;
 
     // Compile class
-    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Compiling code unit " << iter->second._fileBase.Data() << " to define class " << iter->first << endl ;
+    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Compiling code unit " << iter->second._fileBase.Data() << " to define class " << iter->first << std::endl ;
     bool ok = gSystem->CompileMacro(finame.c_str(),"k") ;
 
     if (!ok) {
-      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR compiling class " << iter->first.Data() << ", to fix this you can do the following: " << endl
-                  << "  1) Fix extracted source code files in directory " << dirName.c_str() << "/" << endl
-                  << "  2) In clean ROOT session compiled fixed classes by hand using '.x " << dirName.c_str() << "/ClassName.cxx+'" << endl
-                  << "  3) Reopen file with RooWorkspace with broken source code in UPDATE mode. Access RooWorkspace to force loading of class" << endl
-                  << "     Broken instances in workspace will _not_ be compiled, instead precompiled fixed instances will be used." << endl
-                  << "  4) Reimport fixed code in workspace using 'RooWorkspace::importClassCode(\"*\",true)' method, Write() updated workspace to file and close file" << endl
-                  << "  5) Reopen file in clean ROOT session to confirm that problems are fixed" << endl ;
+      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR compiling class " << iter->first.Data() << ", to fix this you can do the following: " << std::endl
+                  << "  1) Fix extracted source code files in directory " << dirName.c_str() << "/" << std::endl
+                  << "  2) In clean ROOT session compiled fixed classes by hand using '.x " << dirName.c_str() << "/ClassName.cxx+'" << std::endl
+                  << "  3) Reopen file with RooWorkspace with broken source code in UPDATE mode. Access RooWorkspace to force loading of class" << std::endl
+                  << "     Broken instances in workspace will _not_ be compiled, instead precompiled fixed instances will be used." << std::endl
+                  << "  4) Reimport fixed code in workspace using 'RooWorkspace::importClassCode(\"*\",true)' method, Write() updated workspace to file and close file" << std::endl
+                  << "  5) Reopen file in clean ROOT session to confirm that problems are fixed" << std::endl ;
    return false ;
     }
 
@@ -2882,7 +2882,7 @@ void RooWorkspace::WSDir::InternalAppend(TObject* obj)
 void RooWorkspace::WSDir::Add(TObject* obj,bool)
 {
   if (dynamic_cast<RooAbsArg*>(obj) || dynamic_cast<RooAbsData*>(obj)) {
-    coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << endl ;
+    coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << std::endl ;
   } else {
     InternalAppend(obj) ;
   }
@@ -2895,7 +2895,7 @@ void RooWorkspace::WSDir::Add(TObject* obj,bool)
 void RooWorkspace::WSDir::Append(TObject* obj,bool)
 {
   if (dynamic_cast<RooAbsArg*>(obj) || dynamic_cast<RooAbsData*>(obj)) {
-    coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << endl ;
+    coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << std::endl ;
   } else {
     InternalAppend(obj) ;
   }

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -226,7 +226,7 @@ double RooXYChi2Var::xErrorContribution(double ydata) const
       // Calculate slope
       double slope = (fxmax-fxmin)/(2*xerr/100.) ;
 
-//       cout << "xerrHi = " << xerrHi << " xerrLo = " << xerrLo << " slope = " << slope << std::endl ;
+//       std::cout << "xerrHi = " << xerrHi << " xerrLo = " << xerrLo << " slope = " << slope << std::endl ;
 
       // Asymmetric X error, decide which one to use
       if ((ydata>cxval && fxmax>fxmin) || (ydata<=cxval && fxmax<=fxmin)) {
@@ -254,10 +254,10 @@ double RooXYChi2Var::xErrorContribution(double ydata) const
       // Calculate slope
       double slope = (fxmax-fxmin)/(2*xerr/100.) ;
 
-//       cout << var << " " ;
+//       std::cout << var << " " ;
 //       var->Print() ;
 
-//       cout << var->GetName() << " xerr = " << xerr << " slope = " << slope << std::endl ;
+//       std::cout << var->GetName() << " xerr = " << xerr << " slope = " << slope << std::endl ;
 
       // Symmetric X error
       ret += pow(xerr*slope,2) ;
@@ -352,7 +352,7 @@ double RooXYChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
     // Add contributions due to error in x coordinates
     double eIntX2 = _integrate ? 0 : xErrorContribution(ydata) ;
 
-//     cout << "fy = " << yfunc << " eExt = " << eExt << " eInt = " << eInt << " eIntX2 = " << eIntX2 << std::endl ;
+//     std::cout << "fy = " << yfunc << " eExt = " << eExt << " eInt = " << eInt << " eIntX2 = " << eIntX2 << std::endl ;
 
     // Return 0 if eInt=0, special handling in MINUIT will follow
     if (eInt==0.) {

--- a/roofit/roofitcore/test/stressRooFit.cxx
+++ b/roofit/roofitcore/test/stressRooFit.cxx
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <cmath>
 
-using std::cout, std::endl, std::string, std::list;
+using std::string, std::list;
 using namespace RooFit;
 
 //*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*//
@@ -47,7 +47,7 @@ void StatusPrint(int id, const TString &title, int status)
    const int nch = header.Length();
    for (int i = nch; i < kMAX; i++)
       header += '.';
-   cout << header << (status > 0 ? "OK" : (status < 0 ? "SKIPPED" : "FAILED")) << endl;
+   std::cout << header << (status > 0 ? "OK" : (status < 0 ? "SKIPPED" : "FAILED")) << std::endl;
 }
 
 #include "stressRooFit_tests.h"
@@ -69,7 +69,7 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
    if (!dryRun) {
       if (TString(refFile).Contains("http:")) {
          if (writeRef) {
-            cout << "stressRooFit ERROR: reference file must be local file in writing mode" << endl;
+            std::cout << "stressRooFit ERROR: reference file must be local file in writing mode" << std::endl;
             return 1;
          }
          TFile::SetCacheFileDir(".");
@@ -80,7 +80,7 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
          // std::cout << "using file " << refFile << std::endl;
       }
       if (fref->IsZombie()) {
-         cout << "stressRooFit ERROR: cannot open reference file " << refFile << endl;
+         std::cout << "stressRooFit ERROR: cannot open reference file " << refFile << std::endl;
          return 1;
       }
    }
@@ -96,10 +96,10 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
    // Add dedicated logging stream for errors that will remain active in silent mode
    RooMsgService::instance().addStream(RooFit::ERROR);
 
-   cout << "******************************************************************" << endl;
-   cout << "*  RooFit - S T R E S S suite                                    *" << endl;
-   cout << "******************************************************************" << endl;
-   cout << "******************************************************************" << endl;
+   std::cout << "******************************************************************" << std::endl;
+   std::cout << "*  RooFit - S T R E S S suite                                    *" << std::endl;
+   std::cout << "******************************************************************" << std::endl;
+   std::cout << "******************************************************************" << std::endl;
 
    TStopwatch timer;
    timer.Start();
@@ -161,8 +161,8 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
    testList.push_back(new TestBasic803(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic804(fref, writeRef, doVerbose));
 
-   cout << "*  Starting  S T R E S S  basic suite                            *" << endl;
-   cout << "******************************************************************" << endl;
+   std::cout << "*  Starting  S T R E S S  basic suite                            *" << std::endl;
+   std::cout << "******************************************************************" << std::endl;
 
    if (doDump) {
       TFile fdbg("stressRooFit_DEBUG.root", "RECREATE");
@@ -267,50 +267,50 @@ int main(int argc, const char *argv[])
       if (arg == "-b") {
          string mode = argv[++i];
          backend = RooFit::EvalBackend(mode);
-         cout << "stressRooFit: NLL evaluation backend set to " << mode << endl;
+         std::cout << "stressRooFit: NLL evaluation backend set to " << mode << std::endl;
       } else if (arg == "-f") {
-         cout << "stressRooFit: using reference file " << argv[i + 1] << endl;
+         std::cout << "stressRooFit: using reference file " << argv[i + 1] << std::endl;
          refFileName = argv[++i];
       } else if (arg == "-w") {
-         cout << "stressRooFit: running in writing mode to updating reference file" << endl;
+         std::cout << "stressRooFit: running in writing mode to updating reference file" << std::endl;
          doWrite = true;
       } else if (arg == "-mc") {
-         cout << "stressRooFit: running in memcheck mode, no regression tests are performed" << endl;
+         std::cout << "stressRooFit: running in memcheck mode, no regression tests are performed" << std::endl;
          dryRun = true;
       } else if (arg == "-ts") {
-         cout << "stressRooFit: setting tree-based storage for datasets" << endl;
+         std::cout << "stressRooFit: setting tree-based storage for datasets" << std::endl;
          doTreeStore = true;
       } else if (arg == "-min" || arg == "-minim") {
-         cout << "stressRooFit: running using minimizer " << argv[i + 1] << endl;
+         std::cout << "stressRooFit: running using minimizer " << argv[i + 1] << std::endl;
          minimizerName = argv[++i];
       } else if (arg == "-v") {
-         cout << "stressRooFit: running in verbose mode" << endl;
+         std::cout << "stressRooFit: running in verbose mode" << std::endl;
          if (doVerbose != 0)
             throw std::runtime_error(verbosityOptionErrorMsg);
          doVerbose = 1;
       } else if (arg == "-vv") {
-         cout << "stressRooFit: running in very verbose mode" << endl;
+         std::cout << "stressRooFit: running in very verbose mode" << std::endl;
          if (doVerbose != 0)
             throw std::runtime_error(verbosityOptionErrorMsg);
          doVerbose = 2;
       } else if (arg == "-q") {
-         cout << "stressRooFit: running in quiet mode" << endl;
+         std::cout << "stressRooFit: running in quiet mode" << std::endl;
          if (doVerbose != 0)
             throw std::runtime_error(verbosityOptionErrorMsg);
          doVerbose = -1;
       } else if (arg == "-n") {
-         cout << "stressRooFit: running single test " << argv[i + 1] << endl;
+         std::cout << "stressRooFit: running single test " << argv[i + 1] << std::endl;
          oneTest = atoi(argv[++i]);
       } else if (arg == "-d") {
-         cout << "stressRooFit: setting gDebug to " << argv[i + 1] << endl;
+         std::cout << "stressRooFit: setting gDebug to " << argv[i + 1] << std::endl;
          gDebug = atoi(argv[++i]);
       } else if (arg == "-c") {
-         cout << "stressRooFit: dumping comparison file for failed tests " << endl;
+         std::cout << "stressRooFit: dumping comparison file for failed tests " << std::endl;
          doDump = true;
       }
 
       if (arg == "-h" || arg == "--help") {
-         cout << R"(usage: stressRooFit [ options ]
+         std::cout << R"(usage: stressRooFit [ options ]
 
        -b <mode>   : Perform every fit in the tests with the EvalBackend(<mode>) command argument, where <mode> is a string
        -f <file>   : use given reference file instead of default ("stressRooFit_ref.root")
@@ -341,9 +341,9 @@ int main(int argc, const char *argv[])
       refFileName = ptr + 1;
       delete[] buf;
 
-      cout
+      std::cout
          << "stressRooFit: WARNING running in write mode, but reference file is web file, writing local file instead: "
-         << refFileName << endl;
+         << refFileName << std::endl;
    }
 
    // set minimizer

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -252,7 +252,7 @@ RooAdaptiveGaussKronrodIntegrator1D::~RooAdaptiveGaussKronrodIntegrator1D()
 bool RooAdaptiveGaussKronrodIntegrator1D::setLimits(double* xmin, double* xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr, Integration) << "RooAdaptiveGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr, Integration) << "RooAdaptiveGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
 
@@ -381,7 +381,7 @@ double RooAdaptiveGaussKronrodIntegrator1D::integral(const double *yvec)
 #define GSL_ENOMEM   8  /* malloc failed */
 #define GSL_EBADTOL 13  /* user specified an invalid tolerance */
 #define GSL_ETOL    14  /* failed to reach the specified tolerance */
-#define GSL_ERROR(a,b) oocoutE(nullptr,Integration) << "RooAdaptiveGaussKronrodIntegrator1D::integral() ERROR: " << a << endl ; return b ;
+#define GSL_ERROR(a,b) oocoutE(nullptr,Integration) << "RooAdaptiveGaussKronrodIntegrator1D::integral() ERROR: " << a << std::endl ; return b ;
 #define GSL_DBL_MIN        2.2250738585072014e-308
 #define GSL_DBL_MAX        1.7976931348623157e+308
 #define GSL_DBL_EPSILON    2.2204460492503131e-16

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -154,7 +154,7 @@ bool RooGaussKronrodIntegrator1D::initialize()
 bool RooGaussKronrodIntegrator1D::setLimits(double* xmin, double* xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr,Eval) << "RooGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Eval) << "RooGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
   _xmin= *xmin;

--- a/roofit/roofitmore/src/RooNonCentralChiSquare.cxx
+++ b/roofit/roofitmore/src/RooNonCentralChiSquare.cxx
@@ -72,7 +72,7 @@ RooNonCentralChiSquare::RooNonCentralChiSquare(const char *name, const char *tit
      fHasIssuedSumWarning(false)
 {
    ccoutD(InputArguments) << "RooNonCentralChiSquare::ctor(" << GetName() <<
-      "MathMore Available, will use Bessel function expressions unless SetForceSum(true) "<< endl ;
+      "MathMore Available, will use Bessel function expressions unless SetForceSum(true) "<< std::endl ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,7 +89,7 @@ RooNonCentralChiSquare::RooNonCentralChiSquare(const RooNonCentralChiSquare &oth
      fHasIssuedSumWarning(false)
 {
    ccoutD(InputArguments) << "RooNonCentralChiSquare::ctor(" << GetName() <<
-     "MathMore Available, will use Bessel function expressions unless SetForceSum(true) "<< endl ;
+     "MathMore Available, will use Bessel function expressions unless SetForceSum(true) "<< std::endl ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -129,7 +129,7 @@ double RooNonCentralChiSquare::evaluate() const
 
    if ( fForceSum  ){
       if(!fHasIssuedSumWarning){
-         coutI(InputArguments) << "RooNonCentralChiSquare sum being forced" << endl ;
+         coutI(InputArguments) << "RooNonCentralChiSquare sum being forced" << std::endl ;
          fHasIssuedSumWarning=true;
       }
       double sum = 0;
@@ -137,14 +137,14 @@ double RooNonCentralChiSquare::evaluate() const
       double errorTol = fErrorTol;
       int MaxIters = fMaxIters;
       int iDominant = (int) std::floor(lambda/2);
-      //     cout <<"iDominant: " << iDominant << endl;
+      //     std::cout <<"iDominant: " << iDominant << std::endl;
 
       // do 0th term last
       //     if(iDominant==0) iDominant = 1;
       for(int i = iDominant; ; ++i){
          ithTerm =exp(-lambda/2.)*pow(lambda/2.,i)*ROOT::Math::chisquared_pdf(_x,k+2*i)/TMath::Gamma(i+1);
          sum+=ithTerm;
-         //       cout <<"progress: " << i << " " << ithTerm/sum << endl;
+         //       std::cout <<"progress: " << i << " " << ithTerm/sum << std::endl;
          if(ithTerm/sum < errorTol)
             break;
 
@@ -154,14 +154,14 @@ double RooNonCentralChiSquare::evaluate() const
                coutW(Eval) << "RooNonCentralChiSquare did not converge: for x=" << x <<" k="<<k
                            << ", lambda="<<lambda << " fractional error = " << ithTerm/sum
                            << "\n either adjust tolerance with SetErrorTolerance(tol) or max_iter with SetMaxIter(max_it)"
-                           << endl;
+                           << std::endl;
             }
             break;
          }
       }
 
       for(int i = iDominant - 1; i >= 0; --i){
-         //       cout <<"Progress: " << i << " " << ithTerm/sum << endl;
+         //       std::cout <<"Progress: " << i << " " << ithTerm/sum << std::endl;
          ithTerm =exp(-lambda/2.)*pow(lambda/2.,i)*ROOT::Math::chisquared_pdf(_x,k+2*i)/TMath::Gamma(i+1);
          sum+=ithTerm;
       }
@@ -188,7 +188,7 @@ Int_t RooNonCentralChiSquare::getAnalyticalIntegral(RooArgSet& allVars, RooArgSe
 double RooNonCentralChiSquare::analyticalIntegral(Int_t code, const char* rangeName) const
 {
    R__ASSERT(code==1 );
-   //  cout << "evaluating analytic integral" << endl;
+   //  std::cout << "evaluating analytic integral" << std::endl;
    double xmin = x.min(rangeName);
    double xmax = x.max(rangeName);
 
@@ -211,14 +211,14 @@ double RooNonCentralChiSquare::analyticalIntegral(Int_t code, const char* rangeN
    int MaxIters = fMaxIters; // for normalization use more terms
 
    int iDominant = (int) std::floor(lambda/2);
-   //     cout <<"iDominant: " << iDominant << endl;
+   //     std::cout <<"iDominant: " << iDominant << std::endl;
    //   iDominant=0;
    for(int i = iDominant; ; ++i){
       ithTerm =exp(-lambda/2.)*pow(lambda/2.,i)
          *( ROOT::Math::chisquared_cdf(xmax,k+2*i)/TMath::Gamma(i+1)
             - ROOT::Math::chisquared_cdf(xmin,k+2*i)/TMath::Gamma(i+1) );
       sum+=ithTerm;
-      //     cout <<"progress: " << i << " " << ithTerm << " " << sum << endl;
+      //     std::cout <<"progress: " << i << " " << ithTerm << " " << sum << std::endl;
       if(ithTerm/sum < errorTol)
          break;
 
@@ -228,7 +228,7 @@ double RooNonCentralChiSquare::analyticalIntegral(Int_t code, const char* rangeN
             coutW(Eval) << "RooNonCentralChiSquare Normalization did not converge: for k="<<k
                         << ", lambda="<<lambda << " fractional error = " << ithTerm/sum
                         << "\n either adjust tolerance with SetErrorTolerance(tol) or max_iter with SetMaxIter(max_it)"
-                        << endl;
+                        << std::endl;
          }
          break;
       }

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -96,11 +96,11 @@ public:
            break;
         } else {
            if (tries > 1) {
-         printf("    ----> Doing a re-scan first\n");
+         std::cout << "    ----> Doing a re-scan first\n";
          minim.minimize(fMinimizer,"Scan");
        }
            if (tries > 2) {
-         printf("    ----> trying with strategy = 1\n");
+              std::cout << "    ----> trying with strategy = 1\n";
               minim.setStrategy(1);
            }
         }

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -72,7 +72,7 @@ The calculator can generate Asimov datasets from two kinds of PDFs:
 #include <ROOT/RSpan.hxx>
 
 using namespace RooStats;
-using std::cout, std::endl, std::string, std::unique_ptr;
+using std::string, std::unique_ptr;
 
 ClassImp(RooStats::AsymptoticCalculator);
 
@@ -166,7 +166,7 @@ bool AsymptoticCalculator::Initialize() const {
 
    const RooArgSet * poi = GetNullModel()->GetParametersOfInterest();
    if (!poi || poi->empty()) {
-      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize -  ModelConfig has not POI defined." << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize -  ModelConfig has not POI defined." << std::endl;
       return false;
    }
    if (poi->size() > 1) {
@@ -179,7 +179,7 @@ bool AsymptoticCalculator::Initialize() const {
    // This will set the poi value to the null snapshot value in the ModelConfig
    const RooArgSet * nullSnapshot = GetNullModel()->GetSnapshot();
    if(nullSnapshot == nullptr || nullSnapshot->empty()) {
-      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << std::endl;
       return false;
    }
 
@@ -202,7 +202,7 @@ bool AsymptoticCalculator::Initialize() const {
 
    // evaluate the unconditional nll for the full model on the  observed data
    if (verbose >= 0)
-      oocoutP(nullptr,Eval) << "AsymptoticCalculator::Initialize - Find  best unconditional NLL on observed data" << endl;
+      oocoutP(nullptr,Eval) << "AsymptoticCalculator::Initialize - Find  best unconditional NLL on observed data" << std::endl;
    fNLLObs = EvaluateNLL(*GetNullModel(), data);
    // fill also snapshot of best poi
    poi->snapshot(fBestFitPoi);
@@ -216,13 +216,13 @@ bool AsymptoticCalculator::Initialize() const {
    // compute Asimov data set for the background (alt poi ) value
    const RooArgSet * altSnapshot = GetAlternateModel()->GetSnapshot();
    if(altSnapshot == nullptr || altSnapshot->empty()) {
-      oocoutE(nullptr,InputArguments) << "Alt (Background)  model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,InputArguments) << "Alt (Background)  model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << std::endl;
       return false;
    }
 
    RooArgSet poiAlt(*altSnapshot);  // this is the poi snapshot of B (i.e. for mu=0)
 
-   oocoutP(nullptr,Eval) << "AsymptoticCalculator: Building Asimov data Set" << endl;
+   oocoutP(nullptr,Eval) << "AsymptoticCalculator: Building Asimov data Set" << std::endl;
 
    // check that in case of binned models the n number of bins of the observables are consistent
    // with the number of bins  in the observed data
@@ -245,7 +245,7 @@ bool AsymptoticCalculator::Initialize() const {
 
    if (!fNominalAsimov) {
       if (verbose >= 0)
-         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimov data will be generated using fitted nuisance parameter values" << endl;
+         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimov data will be generated using fitted nuisance parameter values" << std::endl;
       RooArgSet * tmp = (RooArgSet*) poiAlt.snapshot();
       fAsimovData = MakeAsimovData( data, *GetNullModel(), poiAlt, fAsimovGlobObs,tmp);
    }
@@ -253,13 +253,13 @@ bool AsymptoticCalculator::Initialize() const {
    else {
       // assume use current value of nuisance as nominal ones
       if (verbose >= 0)
-         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimovdata set will be generated using nominal (current) nuisance parameter values" << endl;
+         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimovdata set will be generated using nominal (current) nuisance parameter values" << std::endl;
       nominalParams.assign(poiAlt); // set poi to alt value but keep nuisance at the nominal one
       fAsimovData = MakeAsimovData( *GetNullModel(), nominalParams, fAsimovGlobObs);
    }
 
    if (!fAsimovData) {
-      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator: Error : Asimov data set could not be generated " << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator: Error : Asimov data set could not be generated " << std::endl;
       return false;
    }
 
@@ -484,13 +484,13 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    // re-initialized the calculator in case it is needed (pdf or data modified)
    if (!fIsInitialized) {
       if (!Initialize() ) {
-         oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Error initializing Asymptotic calculator - return nullptr result " << endl;
+         oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Error initializing Asymptotic calculator - return nullptr result " << std::endl;
          return nullptr;
       }
    }
 
    if (!fAsimovData) {
-       oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Asimov data set has not been generated - return nullptr result " << endl;
+       oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Asimov data set has not been generated - return nullptr result " << std::endl;
        return nullptr;
    }
 
@@ -743,9 +743,9 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       // for one-sided PL (q_mu : equations 56,57)
       if (verbose>2) {
          if (fOneSided) {
-            oocoutI(nullptr,Eval) << "Using one-sided limit asymptotic formula (qmu)" << endl;
+            oocoutI(nullptr,Eval) << "Using one-sided limit asymptotic formula (qmu)" << std::endl;
          } else {
-            oocoutI(nullptr, Eval) << "Using one-sided discovery asymptotic formula (q0)" << endl;
+            oocoutI(nullptr, Eval) << "Using one-sided discovery asymptotic formula (q0)" << std::endl;
          }
       }
       pnull = ROOT::Math::normal_cdf_c( sqrtqmu, 1.);
@@ -753,7 +753,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    }
    else  {
       // for 2-sided PL (t_mu : equations 35,36 in asymptotic paper)
-      if (verbose > 2) oocoutI(nullptr,Eval) << "Using two-sided asymptotic  formula (tmu)" << endl;
+      if (verbose > 2) oocoutI(nullptr,Eval) << "Using two-sided asymptotic  formula (tmu)" << std::endl;
       pnull = 2.*ROOT::Math::normal_cdf_c( sqrtqmu, 1.);
       palt = ROOT::Math::normal_cdf_c( sqrtqmu + sqrtqmu_A, 1.) +
          ROOT::Math::normal_cdf_c( sqrtqmu - sqrtqmu_A, 1.);
@@ -764,7 +764,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       if (fOneSided) {
          // for bounded one-sided (q_mu_tilde: equations 64,65)
          if ( qmu > qmu_A && (qmu_A > 0 || qmu > tol) ) { // to avoid case 0/0
-            if (verbose > 2) oocoutI(nullptr,Eval) << "Using qmu_tilde (qmu is greater than qmu_A)" << endl;
+            if (verbose > 2) oocoutI(nullptr,Eval) << "Using qmu_tilde (qmu is greater than qmu_A)" << std::endl;
             pnull = ROOT::Math::normal_cdf_c( (qmu + qmu_A)/(2 * sqrtqmu_A), 1.);
             palt = ROOT::Math::normal_cdf_c( (qmu - qmu_A)/(2 * sqrtqmu_A), 1.);
          }
@@ -773,7 +773,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
          // for 2 sided bounded test statistic  (N.B there is no one sided discovery qtilde)
          // t_mu_tilde: equations 43,44 in asymptotic paper
          if ( qmu >  qmu_A  && (qmu_A > 0 || qmu > tol)  ) {
-            if (verbose > 2) oocoutI(nullptr,Eval) << "Using tmu_tilde (qmu is greater than qmu_A)" << endl;
+            if (verbose > 2) oocoutI(nullptr,Eval) << "Using tmu_tilde (qmu is greater than qmu_A)" << std::endl;
             pnull = ROOT::Math::normal_cdf_c(sqrtqmu,1.) +
                     ROOT::Math::normal_cdf_c( (qmu + qmu_A)/(2 * sqrtqmu_A), 1.);
             palt = ROOT::Math::normal_cdf_c( sqrtqmu_A + sqrtqmu, 1.) +
@@ -890,12 +890,12 @@ void FillBins(const RooAbsPdf & pdf, const RooArgList &obs, RooAbsData & data, i
             if (fval*expectedEvents < 0) {
                oocoutW(nullptr,InputArguments)
                    << "AsymptoticCalculator::" << __func__
-                   << "(): Bin " << i << " of " << v->GetName() << " has negative expected events! Please check your inputs." << endl;
+                   << "(): Bin " << i << " of " << v->GetName() << " has negative expected events! Please check your inputs." << std::endl;
             }
             else {
                oocoutW(nullptr,InputArguments)
                    << "AsymptoticCalculator::" << __func__
-                   << "(): Bin " << i << " of " << v->GetName() << " has zero expected events - skip it" << endl;
+                   << "(): Bin " << i << " of " << v->GetName() << " has zero expected events - skip it" << std::endl;
             }
          }
          // have a cut off for overflows ??
@@ -1028,7 +1028,7 @@ bool setObsToExpectedProdPdf(RooProdPdf &prod, const RooArgSet &obs)
         oocoutE(nullptr, InputArguments)
            << "Illegal term in counting model: "
            << "the PDF " << a->GetName() << " depends on the observables, but is not a Poisson, Gaussian or Product"
-           << endl;
+           << std::endl;
         return false;
         }
     }
@@ -1063,7 +1063,7 @@ RooAbsData *GenerateCountingAsimovData(RooAbsPdf & pdf, const RooArgSet & observ
     } else if ((mvgauss = dynamic_cast<RooMultiVarGaussian *>(&pdf)) != nullptr) {
         r = setObsToExpectedMultiVarGauss(*mvgauss, observables);
     } else {
-       oocoutE(nullptr,InputArguments) << "A counting model pdf must be either a RooProdPdf or a RooPoisson or a RooGaussian" << endl;
+       oocoutE(nullptr,InputArguments) << "A counting model pdf must be either a RooProdPdf or a RooPoisson or a RooGaussian" << std::endl;
     }
     if (!r) return nullptr;
     int icat = 0;
@@ -1115,8 +1115,8 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
 
     // loop on observables and on the bins
     if (printLevel >= 2) {
-       cout << "Generating Asimov data for pdf " << pdf.GetName() << endl;
-       cout << "list of observables  " << endl;
+       std::cout << "Generating Asimov data for pdf " << pdf.GetName() << std::endl;
+       std::cout << "list of observables  " << std::endl;
        obsList.Print();
     }
 
@@ -1125,7 +1125,7 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
     int nbins = 0;
     FillBins(pdf, obsList, *asimovData, obsIndex, binVolume, nbins);
     if (printLevel >= 2)
-       cout << "filled from " << pdf.GetName() << "   " << nbins << " nbins " << " volume is " << binVolume << endl;
+       std::cout << "filled from " << pdf.GetName() << "   " << nbins << " nbins " << " volume is " << binVolume << std::endl;
 
     // for (int iobs = 0; iobs < obsList.size(); ++iobs) {
     //    RooRealVar * thisObs = dynamic_cast<RooRealVar*> &obsList[i];
@@ -1137,7 +1137,7 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
     //   thisNorm=pdftmp->getVal(obstmp)*thisObs->getBinWidth(jj);
     //   if (thisNorm*expectedEvents <= 0)
     //   {
-    //     cout << "WARNING::Detected bin with zero expected events! Please check your inputs." << endl;
+    //     std::cout << "WARNING::Detected bin with zero expected events! Please check your inputs." << std::endl;
     //   }
     //   // have a cut off for overflows ??
     //   obsDataUnbinned->add(*mc->GetObservables(), thisNorm*expectedEvents);
@@ -1148,7 +1148,7 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
       asimovData->Print();
     }
     if( TMath::IsNaN(asimovData->sumEntries()) ){
-      cout << "sum entries is nan"<<endl;
+      std::cout << "sum entries is nan"<< std::endl;
       assert(0);
       asimovData = nullptr;
     }
@@ -1169,7 +1169,7 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
    RooRealVar weightVar{"binWeightAsimov", "binWeightAsimov", 1, 0, 1.e30};
 
-   if (printLevel > 1) cout <<" Generate Asimov data for observables"<<endl;
+   if (printLevel > 1) std::cout <<" Generate Asimov data for observables"<< std::endl;
   //RooDataSet* simData=nullptr;
    const RooSimultaneous* simPdf = dynamic_cast<const RooSimultaneous*>(&pdf);
    if (!simPdf) {
@@ -1183,7 +1183,7 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
   RooCategory& channelCat = const_cast<RooCategory&>(dynamic_cast<const RooCategory&>(simPdf->indexCat()));
   int nrIndices = channelCat.numTypes();
   if( nrIndices == 0 ) {
-    oocoutW(nullptr,Generation) << "Simultaneous pdf does not contain any categories." << endl;
+    oocoutW(nullptr,Generation) << "Simultaneous pdf does not contain any categories." << std::endl;
   }
   for (int i=0;i<nrIndices;i++){
     channelCat.setIndex(i);
@@ -1194,26 +1194,26 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
     if (printLevel > 1)
     {
-      cout << "on type " << channelCat.getCurrentLabel() << " " << channelCat.getCurrentIndex() << endl;
+      std::cout << "on type " << channelCat.getCurrentLabel() << " " << channelCat.getCurrentIndex() << std::endl;
     }
 
     std::unique_ptr<RooDataSet> dataSinglePdf{static_cast<RooDataSet*>(GenerateAsimovDataSinglePdf( *pdftmp, observables, weightVar, &channelCat))};
     if (!dataSinglePdf) {
-       oocoutE(nullptr,Generation) << "Error generating an Asimov data set for pdf " << pdftmp->GetName() << endl;
+       oocoutE(nullptr,Generation) << "Error generating an Asimov data set for pdf " << pdftmp->GetName() << std::endl;
        return nullptr;
     }
 
     if (asimovDataMap.count(string(channelCat.getCurrentLabel())) != 0) {
       oocoutE(nullptr,Generation) << "AsymptoticCalculator::GenerateAsimovData(): The PDF for " << channelCat.getCurrentLabel()
-          << " was already defined. It will be overridden. The faulty category definitions follow:" << endl;
+          << " was already defined. It will be overridden. The faulty category definitions follow:" << std::endl;
       channelCat.Print("V");
     }
 
     if (printLevel > 1)
     {
-      cout << "channel: " << channelCat.getCurrentLabel() << ", data: ";
+      std::cout << "channel: " << channelCat.getCurrentLabel() << ", data: ";
       dataSinglePdf->Print();
-      cout << endl;
+      std::cout << std::endl;
     }
 
     asimovDataMap[string(channelCat.getCurrentLabel())] = std::move(dataSinglePdf);
@@ -1408,7 +1408,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       if (model.GetNuisanceParameters()) nuis.add(*model.GetNuisanceParameters());
       if (nuis.empty()) {
             oocoutW(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData: model does not have nuisance parameters but has global observables"
-                                            << " set global observables to model values " << endl;
+                                            << " set global observables to model values " << std::endl;
             asimovGlobObs.assign(gobs);
             return asimov;
       }

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -184,9 +184,9 @@ bool AsymptoticCalculator::Initialize() const {
    }
 
    // GetNullModel()->Print();
-   // printf("ASymptotic calc: null snapshot\n");
+   // std::cout << "ASymptotic calc: null snapshot\n";
    // nullSnapshot->Print("v");
-   // printf("PDF  variables " );
+   // std::cout << "PDF  variables ";
    // nullPdf->getVariables()->Print("v");
 
    // keep snapshot for the initial parameter values (need for nominal Asimov)
@@ -399,19 +399,19 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
              break;
           } else {
              if (tries == 1) {
-                printf("    ----> Doing a re-scan first\n");
+                std::cout << "    ----> Doing a re-scan first\n";
                 minim.minimize(minimizer,"Scan");
              }
              if (tries == 2) {
                 if (ROOT::Math::MinimizerOptions::DefaultStrategy() == 0 ) {
-                   printf("    ----> trying with strategy = 1\n");
+                   std::cout << "    ----> trying with strategy = 1\n";
                    minim.setStrategy(1);
                 }
                 else
                    tries++; // skip this trial if strategy is already 1
              }
              if (tries == 3) {
-                printf("    ----> trying with improve\n");
+                std::cout << "    ----> trying with improve\n";
                 minimizer = "Minuit";
                 algorithm = "migradimproved";
              }

--- a/roofit/roostats/src/BernsteinCorrection.cxx
+++ b/roofit/roostats/src/BernsteinCorrection.cxx
@@ -72,7 +72,7 @@ ClassImp(RooStats::BernsteinCorrection);
 
 using namespace RooFit;
 using namespace RooStats;
-using std::cout, std::endl, std::vector;
+using std::vector;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -94,7 +94,7 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
   RooAbsData* data = wks->data(dataName);
 
   if (!x || !nominal || !data) {
-     cout << "Error:  wrong name for pdf or variable or dataset - return -1 " << std::endl;
+     std::cout << "Error:  wrong name for pdf or variable or dataset - return -1 " << std::endl;
      return -1;
   }
 
@@ -113,7 +113,7 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
 
   // setup a log
   std::stringstream log;
-  log << "------ Begin Bernstein Correction Log --------" << endl;
+  log << "------ Begin Bernstein Correction Log --------" << std::endl;
 
   // Local variables that we want to keep in scope after loop
   RooArgList coeff;
@@ -181,15 +181,15 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
      << " -log L("<<degree-1<<") = " << lastNll
      << " -log L(" << degree <<") = " << result->minNll()
      << " q = " << q
-     << " P(chi^2_1 > q) = " << TMath::Prob(q,1) << endl;
+     << " P(chi^2_1 > q) = " << TMath::Prob(q,1) << std::endl;
     }
 
     // update last result for next iteration in loop
     lastNll = result->minNll();
   }
 
-  log << "------ End Bernstein Correction Log --------" << endl;
-  cout << log.str();
+  log << "------ End Bernstein Correction Log --------" << std::endl;
+  std::cout << log.str();
 
   return degree;
 }
@@ -212,13 +212,13 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
   RooAbsData* data = wks->data(dataName);
 
   if (!x || !nominal || !data) {
-     cout << "Error:  wrong name for pdf or variable or dataset ! " << std::endl;
+     std::cout << "Error:  wrong name for pdf or variable or dataset ! " << std::endl;
      return;
   }
 
   // setup a log
   std::stringstream log;
-  log << "------ Begin Bernstein Correction Log --------" << endl;
+  log << "------ Begin Bernstein Correction Log --------" << std::endl;
 
   // Local variables that we want to keep in scope after loop
   RooArgList coeff; // n-th degree correction
@@ -226,7 +226,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
   RooArgList coeffExtra; // n+1 correction
   vector<RooRealVar*> coefficients;
 
-  //cout << "make coefs" << endl;
+  //cout << "make coefs" << std::endl;
   for(int i = 0; i<=degree+1; ++i) {
     // we need to generate names for vars on the fly
     std::stringstream str;
@@ -266,7 +266,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
     = new RooEffProd("correctedExtra","",*nominal,*polyExtra);
 
 
-  cout << "made pdfs, make toy generator" << endl;
+  std::cout << "made pdfs, make toy generator" << std::endl;
 
   // make a PDF to generate the toys
   RooDataHist dataHist("dataHist","",*x,*data);
@@ -285,7 +285,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
     double qExtra = 0;
     // do toys
     for (int i = 0; i < nToys; ++i) {
-       cout << "on toy " << i << endl;
+       std::cout << "on toy " << i << std::endl;
 
        std::unique_ptr<RooDataSet> tmpData{toyGen.generate(*x, data->numEntries())};
        // check to see how well this correction fits
@@ -307,8 +307,8 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
        samplingDist->Fill(q);
        samplingDistExtra->Fill(qExtra);
        if (printLevel > 0) {
-      cout << "NLL Results: null " << resultNull->minNll() << " ref = " << result->minNll() << " extra"
-           << resultExtra->minNll() << endl;
+      std::cout << "NLL Results: null " << resultNull->minNll() << " ref = " << result->minNll() << " extra"
+           << resultExtra->minNll() << std::endl;
        }
   }
 

--- a/roofit/roostats/src/ConfidenceBelt.cxx
+++ b/roofit/roostats/src/ConfidenceBelt.cxx
@@ -41,7 +41,7 @@ store the interval.
 ClassImp(RooStats::ConfidenceBelt);
 
 using namespace RooStats;
-using std::cout, std::endl, std::vector;
+using std::vector;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Alternate constructor
@@ -78,7 +78,7 @@ ConfidenceBelt::ConfidenceBelt(const char* name, const char* title, RooAbsData& 
 ////////////////////////////////////////////////////////////////////////////////
 
 double ConfidenceBelt::GetAcceptanceRegionMin(RooArgSet& parameterPoint, double cl, double leftside) {
-  if(cl>0 || leftside > 0) cout <<"using default cl, leftside for now" <<endl;
+  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
   AcceptanceRegion * region = GetAcceptanceRegion(parameterPoint, cl,leftside);
   return (region) ? region->GetLowerLimit() : TMath::QuietNaN();
 }
@@ -86,7 +86,7 @@ double ConfidenceBelt::GetAcceptanceRegionMin(RooArgSet& parameterPoint, double 
 ////////////////////////////////////////////////////////////////////////////////
 
 double ConfidenceBelt::GetAcceptanceRegionMax(RooArgSet& parameterPoint, double cl, double leftside) {
-  if(cl>0 || leftside > 0) cout <<"using default cl, leftside for now" <<endl;
+  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
   AcceptanceRegion * region = GetAcceptanceRegion(parameterPoint, cl,leftside);
   return (region) ? region->GetUpperLimit() : TMath::QuietNaN();
 }
@@ -103,22 +103,22 @@ vector<double> ConfidenceBelt::ConfidenceLevels() const {
 void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsIndex,
                 double lower, double upper,
                 double cl, double leftside){
-  if(cl>0 || leftside > 0) cout <<"using default cl, leftside for now" <<endl;
+  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );
 
-  //  cout << "add: " << tree << " " << hist << endl;
+  //  std::cout << "add: " << tree << " " << hist << std::endl;
 
   if( !this->CheckParameters(parameterPoint) )
     std::cout << "problem with parameters" << std::endl;
 
   Int_t luIndex = fSamplingSummaryLookup.GetLookupIndex(cl, leftside);
-  //  cout << "lookup index = " << luIndex << endl;
+  //  std::cout << "lookup index = " << luIndex << std::endl;
   if(luIndex <0 ) {
     fSamplingSummaryLookup.Add(cl,leftside);
     luIndex = fSamplingSummaryLookup.GetLookupIndex(cl, leftside);
-    cout << "lookup index = " << luIndex << endl;
+    std::cout << "lookup index = " << luIndex << std::endl;
   }
   AcceptanceRegion* thisRegion = new AcceptanceRegion(luIndex, lower, upper);
 
@@ -129,7 +129,7 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsInde
     //    RooStats::SetParameters(&parameterPoint, const_cast<RooArgSet*>(hist->get()));
     //    int index = hist->calcTreeIndex(); // get index
     int index = hist->getIndex(parameterPoint); // get index
-    //    cout << "hist index = " << index << endl;
+    //    std::cout << "hist index = " << index << std::endl;
 
     // allocate memory if necessary.  numEntries is overkill?
     if((Int_t)fSamplingSummaries.size() <= index) {
@@ -143,7 +143,7 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsInde
   else if( tree ){
     //    int index = tree->getIndex(parameterPoint);
     int index = dsIndex;
-    //    cout << "tree index = " << index << endl;
+    //    std::cout << "tree index = " << index << std::endl;
 
     // allocate memory if necessary.  numEntries is overkill?
     if((Int_t)fSamplingSummaries.size() <= index){
@@ -160,7 +160,7 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsInde
 
 void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, AcceptanceRegion region,
                 double cl, double leftside){
-  if(cl>0 || leftside > 0) cout <<"using default cl, leftside for now" <<endl;
+  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );
@@ -199,7 +199,7 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, AcceptanceRe
 
 AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint, double cl, double leftside)
 {
-  if(cl>0 || leftside > 0) cout <<"using default cl, leftside for now" <<endl;
+  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );

--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -89,7 +89,7 @@ namespace RooStats {
 
       if (aset == nullptr) {
          // silently ignore
-         //std::cout << "Attempted to append nullptr" << endl;
+         //std::cout << "Attempted to append nullptr" << std::endl;
          return;
       }
       if (fBuiltSet == nullptr) {

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -119,14 +119,14 @@ void FeldmanCousins::CreateTestStatSampler() const{
   fTestStatSampler->SetPdf(*fModel.GetPdf());
 
   if(!fAdaptiveSampling){
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: ntoys per point = " << (int) (fAdditionalNToysFactor*50./fSize) << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: ntoys per point = " << (int) (fAdditionalNToysFactor*50./fSize) << std::endl;
   } else{
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: ntoys per point: adaptive" << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: ntoys per point: adaptive" << std::endl;
   }
   if(fFluctuateData){
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: nEvents per toy will fluctuate about  expectation" << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: nEvents per toy will fluctuate about  expectation" << std::endl;
   } else{
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: nEvents per toy will not fluctuate, will always be " << fData.numEntries() << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: nEvents per toy will not fluctuate, will always be " << fData.numEntries() << std::endl;
     fTestStatSampler->SetNEventsPerToy(fData.numEntries());
   }
 }
@@ -139,7 +139,7 @@ void FeldmanCousins::CreateParameterPoints() const{
   // get ingredients
   RooAbsPdf* pdf   = fModel.GetPdf();
   if (!pdf ){
-    ooccoutE(&fModel,Generation) << "FeldmanCousins: ModelConfig has no PDF" << endl;
+    ooccoutE(&fModel,Generation) << "FeldmanCousins: ModelConfig has no PDF" << std::endl;
     return;
   }
 
@@ -151,7 +151,7 @@ void FeldmanCousins::CreateParameterPoints() const{
 
   if( fModel.GetNuisanceParameters() && ! fModel.GetParametersOfInterest()->equals(*parameters) && fDoProfileConstruction) {
     // if parameters include nuisance parameters, do profile construction
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: Model has nuisance parameters, will do profile construction" << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: Model has nuisance parameters, will do profile construction" << std::endl;
 
     // set nbins for the POI
     for (auto *myarg2 : static_range_cast<RooRealVar *>(*fModel.GetParametersOfInterest())){
@@ -167,7 +167,7 @@ void FeldmanCousins::CreateParameterPoints() const{
       parameterScan = new RooDataHist("parameterScan", "", *fModel.GetParametersOfInterest());
     }
 
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: # points to test = " << parameterScan->numEntries() << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: # points to test = " << parameterScan->numEntries() << std::endl;
     // make profile construction
     RooFit::MsgLevel previous  = RooMsgService::instance().globalKillBelow();
     RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL) ;
@@ -193,14 +193,14 @@ void FeldmanCousins::CreateParameterPoints() const{
 
   } else{
     // Do full construction
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: Model has no nuisance parameters" << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: Model has no nuisance parameters" << std::endl;
 
     for (auto *myarg : static_range_cast<RooRealVar *>(*parameters)){
       myarg->setBins(fNbins);
     }
 
     RooDataHist* parameterScan = new RooDataHist("parameterScan", "", *parameters);
-    ooccoutP(&fModel,Generation) << "FeldmanCousins: # points to test = " << parameterScan->numEntries() << endl;
+    ooccoutP(&fModel,Generation) << "FeldmanCousins: # points to test = " << parameterScan->numEntries() << std::endl;
 
     fPointsToTest = parameterScan;
   }

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -70,7 +70,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    if( fNullModel->GetNuisanceParameters() ) {
       allButNuisance.remove(*fNullModel->GetNuisanceParameters());
       if( fConditionalMLEsNull ) {
-         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Null." << endl;
+         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Null." << std::endl;
          allParams->assign(*fConditionalMLEsNull);
          // LM: fConditionalMLEsNull must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsNull );
@@ -84,7 +84,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       doProfile = false;
    }
    if (doProfile) {
-      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Null." << std::endl;
       RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
       RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
@@ -135,7 +135,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << std::endl;
 
       // variable number of toys
       if(fNToysNull >= 0) toymcs->SetNToys(fNToysNull);
@@ -145,7 +145,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
 
       // adaptive sampling
       if(fNToysNullTail) {
-         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << std::endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysRightTail(fNToysNullTail, obsTestStat);
          }else{
@@ -176,7 +176,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    if( fAltModel->GetNuisanceParameters() ) {
       allButNuisance.remove(*fAltModel->GetNuisanceParameters());
       if( fConditionalMLEsAlt ) {
-         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Alt." << endl;
+         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Alt." << std::endl;
          allParams->assign(*fConditionalMLEsAlt);
          // LM: fConditionalMLEsAlt must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsAlt );
@@ -190,7 +190,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       doProfile = false;
    }
    if (doProfile) {
-      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Alt." << std::endl;
       RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
       RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
@@ -241,7 +241,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << std::endl;
 
       // variable number of toys
       if(fNToysAlt >= 0) toymcs->SetNToys(fNToysAlt);
@@ -251,7 +251,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
 
       // adaptive sampling
       if(fNToysAltTail) {
-         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << std::endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysLeftTail(fNToysAltTail, obsTestStat);
          }else{

--- a/roofit/roostats/src/HybridCalculator.cxx
+++ b/roofit/roostats/src/HybridCalculator.cxx
@@ -37,11 +37,11 @@ using std::endl;
 int HybridCalculator::CheckHook(void) const {
 
    if( fPriorNuisanceNull && (!fNullModel->GetNuisanceParameters() || fNullModel->GetNuisanceParameters()->empty()) ) {
-      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Null ModelConfig." << endl;
+      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Null ModelConfig." << std::endl;
       return -1; // error
    }
    if( fPriorNuisanceAlt && (!fAltModel->GetNuisanceParameters() || fAltModel->GetNuisanceParameters()->empty()) ) {
-      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Alt ModelConfig" << endl;
+      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Alt ModelConfig" << std::endl;
       return -1; // error
    }
 
@@ -64,9 +64,9 @@ int HybridCalculator::PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestS
    ) {
       oocoutI(nullptr,InputArguments)
        << "HybridCalculator - No nuisance parameters specified for Null model and no prior forced. "
-       << "Case is reduced to simple hypothesis testing with no uncertainty." << endl;
+       << "Case is reduced to simple hypothesis testing with no uncertainty." << std::endl;
    } else {
-      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Null model)." << endl;
+      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Null model)." << std::endl;
    }
 
 
@@ -75,14 +75,14 @@ int HybridCalculator::PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestS
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << std::endl;
 
       // variable number of toys
       if(fNToysNull >= 0) toymcs->SetNToys(fNToysNull);
 
       // adaptive sampling
       if(fNToysNullTail) {
-         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << std::endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysRightTail(fNToysNullTail, obsTestStat);
          }else{
@@ -113,9 +113,9 @@ int HybridCalculator::PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestSt
    ) {
       oocoutI(nullptr,InputArguments)
        << "HybridCalculator - No nuisance parameters specified for Alt model and no prior forced. "
-       << "Case is reduced to simple hypothesis testing with no uncertainty." << endl;
+       << "Case is reduced to simple hypothesis testing with no uncertainty." << std::endl;
    } else {
-      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Alt model)." << endl;
+      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Alt model)." << std::endl;
    }
 
 
@@ -124,14 +124,14 @@ int HybridCalculator::PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestSt
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << std::endl;
 
       // variable number of toys
       if(fNToysAlt >= 0) toymcs->SetNToys(fNToysAlt);
 
       // adaptive sampling
       if(fNToysAltTail) {
-         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << std::endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysLeftTail(fNToysAltTail, obsTestStat);
          }else{

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -112,18 +112,18 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    std::unique_ptr<const RooArgSet> nullSnapshot {fNullModel->GetSnapshot()};
    if(nullSnapshot == nullptr) {
-      oocoutE(nullptr,Generation) << "Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,Generation) << "Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << std::endl;
       return nullptr;
    }
 
    // CheckHook
    if(CheckHook() != 0) {
-      oocoutE(nullptr,Generation) << "There was an error in CheckHook(). Stop." << endl;
+      oocoutE(nullptr,Generation) << "There was an error in CheckHook(). Stop." << std::endl;
       return nullptr;
    }
 
    if (!fTestStatSampler  || !fTestStatSampler->GetTestStatistic() ) {
-      oocoutE(nullptr,InputArguments) << "Test Statistic Sampler or Test Statistics not defined. Stop." << endl;
+      oocoutE(nullptr,InputArguments) << "Test Statistic Sampler or Test Statistics not defined. Stop." << std::endl;
       return nullptr;
    }
 
@@ -146,7 +146,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    if( toymcs ) {
       allTS = std::unique_ptr<RooArgList>{toymcs->EvaluateAllTestStatistics(*const_cast<RooAbsData*>(fData), nullP)};
       if (!allTS) return nullptr;
-      //oocoutP(nullptr,Generation) << "All Test Statistics on data: " << endl;
+      //oocoutP(nullptr,Generation) << "All Test Statistics on data: " << std::endl;
       //allTS->Print("v");
       RooRealVar* firstTS = static_cast<RooRealVar*>(allTS->at(0));
       obsTestStat = firstTS->getVal();
@@ -156,7 +156,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }else{
       obsTestStat = fTestStatSampler->EvaluateTestStatistic(*const_cast<RooAbsData*>(fData), nullP);
    }
-   oocoutP(nullptr,Generation) << "Test Statistic on data: " << obsTestStat << endl;
+   oocoutP(nullptr,Generation) << "Test Statistic on data: " << obsTestStat << std::endl;
 
    // set parameters back ... in case the evaluation of the test statistic
    // modified something (e.g. a nuisance parameter that is not randomized
@@ -169,7 +169,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    SetupSampler(*fNullModel);
    RooArgSet paramPointNull(*fNullModel->GetParametersOfInterest());
    if(PreNullHook(&paramPointNull, obsTestStat) != 0) {
-      oocoutE(nullptr,Generation) << "PreNullHook did not return 0." << endl;
+      oocoutE(nullptr,Generation) << "PreNullHook did not return 0." << std::endl;
    }
    SamplingDistribution* samp_null = nullptr;
    RooDataSet* detOut_null = nullptr;
@@ -191,7 +191,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    SetupSampler(*fAltModel);
    RooArgSet paramPointAlt(*fAltModel->GetParametersOfInterest());
    if(PreAltHook(&paramPointAlt, obsTestStat) != 0) {
-      oocoutE(nullptr,Generation) << "PreAltHook did not return 0." << endl;
+      oocoutE(nullptr,Generation) << "PreAltHook did not return 0." << std::endl;
    }
    SamplingDistribution* samp_alt = nullptr;
    RooDataSet* detOut_alt = nullptr;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -1205,7 +1205,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
                                        << nToys << std::endl;
 
 
-      printf("\n\nshnapshot of s+b model \n");
+      std::cout << "\n\nshnapshot of s+b model \n";
       sbModel->GetSnapshot()->Print("v");
 
       // reset parameters to initial values to be sure in case they are not reset

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -144,7 +144,7 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
           (static_cast<RooRealVar *>(poiB->find(scanVariable.GetName())))->getVal() != 0) {
          oocoutW(nullptr, InputArguments)
             << "HypoTestInverter - using a B model  with POI " << scanVariable.GetName() << " not equal to zero "
-            << " user must check input model configurations " << endl;
+            << " user must check input model configurations " << std::endl;
       }
       if (poiB) delete poiB;
    }
@@ -696,13 +696,13 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    const_cast<ModelConfig*>(sbModel)->SetSnapshot(poi);
 
    if (fVerbose > 0)
-      oocoutP(nullptr,Eval) << "Running for " << fScannedVariable->GetName() << " = " << fScannedVariable->getVal() << endl;
+      oocoutP(nullptr,Eval) << "Running for " << fScannedVariable->GetName() << " = " << fScannedVariable->getVal() << std::endl;
 
    // compute the results
    std::unique_ptr<HypoTestResult> result( Eval(*fCalculator0,adaptive,clTarget) );
    if (!result) {
       oocoutE(nullptr,Eval) << "HypoTestInverter - Error running point " << fScannedVariable->GetName() << " = " <<
-   fScannedVariable->getVal() << endl;
+   fScannedVariable->getVal() << std::endl;
       return false;
    }
    // in case of a dummy result
@@ -710,7 +710,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    const double altPV = result->AlternatePValue();
    if (!std::isfinite(nullPV) || nullPV < 0. || nullPV > 1. || !std::isfinite(altPV) || altPV < 0. || altPV > 1.) {
       oocoutW(nullptr,Eval) << "HypoTestInverter - Skipping invalid result for  point " << fScannedVariable->GetName() << " = " <<
-         fScannedVariable->getVal() << ". null p-value=" << nullPV << ", alternate p-value=" << altPV << endl;
+         fScannedVariable->getVal() << ". null p-value=" << nullPV << ", alternate p-value=" << altPV << std::endl;
       return false;
    }
 

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -821,7 +821,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
    }
 
 #ifdef DO_DEBUG
-   std::cout << "finding " << lowSearch << " limit between " << xmin << "  " << xmax << endl;
+   std::cout << "finding " << lowSearch << " limit between " << xmin << "  " << xmax << std::endl;
 #endif
 
    // compute now the limit using the TGraph interpolations routine
@@ -938,7 +938,7 @@ int HypoTestInverterResult::FindClosestPointIndex(double target, int mode, doubl
 double HypoTestInverterResult::LowerLimit()
 {
   if (fFittedLowerLimit) return fLowerLimit;
-  //std::cout << "finding point with cl = " << 1-(1-ConfidenceLevel())/2 << endl;
+  //std::cout << "finding point with cl = " << 1-(1-ConfidenceLevel())/2 << std::endl;
   if ( fInterpolateLowerLimit ) {
      // find both lower/upper limit
      if (TMath::IsNaN(fLowerLimit) )  FindInterpolatedLimit(1-ConfidenceLevel(),true);
@@ -953,7 +953,7 @@ double HypoTestInverterResult::LowerLimit()
 
 double HypoTestInverterResult::UpperLimit()
 {
-   //std::cout << "finding point with cl = " << (1-ConfidenceLevel())/2 << endl;
+   //std::cout << "finding point with cl = " << (1-ConfidenceLevel())/2 << std::endl;
   if (fFittedUpperLimit) return fUpperLimit;
   if ( fInterpolateUpperLimit ) {
      if (TMath::IsNaN(fUpperLimit) )  FindInterpolatedLimit(1-ConfidenceLevel(),false);

--- a/roofit/roostats/src/HypoTestResult.cxx
+++ b/roofit/roostats/src/HypoTestResult.cxx
@@ -334,7 +334,7 @@ void HypoTestResult::Print(Option_t * ) const
 {
    bool fromToys = (fAltDistr || fNullDistr);
 
-   std::cout << std::endl << "Results " << GetName() << ": " << endl;
+   std::cout << std::endl << "Results " << GetName() << ": " << std::endl;
    std::cout << " - Null p-value = " << NullPValue();
    if (fromToys) std::cout << " +/- " << NullPValueError();
    std::cout << std::endl;

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -125,7 +125,7 @@ void MCMCCalculator::SetLeftSideTailFraction(double a)
    if (a < 0 || a > 1) {
       coutE(InputArguments) << "MCMCCalculator::SetLeftSideTailFraction: "
          << "Fraction must be in the range [0, 1].  "
-         << a << "is not allowed." << endl;
+         << a << "is not allowed." << std::endl;
       return;
    }
 
@@ -144,7 +144,7 @@ MCMCInterval* MCMCCalculator::GetInterval() const
 
    if (fSize < 0) {
       coutE(InputArguments) << "MCMCCalculator::GetInterval: "
-         << "Test size/Confidence level not set.  Returning nullptr." << endl;
+         << "Test size/Confidence level not set.  Returning nullptr." << std::endl;
       return nullptr;
    }
 

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -217,7 +217,7 @@ bool MCMCInterval::IsInInterval(const RooArgSet& point) const
    }
 
    coutE(InputArguments) << "Error in MCMCInterval::IsInInterval: "
-      << "Interval type not set.  Returning false." << endl;
+      << "Interval type not set.  Returning false." << std::endl;
    return false;
 }
 
@@ -242,7 +242,7 @@ void MCMCInterval::SetConfidenceLevel(double cl)
 //   }
 //   else {
 //      coutE(Eval) << "* Error in MCMCInterval::SetNumBins: " <<
-//                     "Negative number of bins given: " << numBins << endl;
+//                     "Negative number of bins given: " << numBins << std::endl;
 //      return;
 //   }
 //
@@ -260,7 +260,7 @@ void MCMCInterval::SetAxes(RooArgList& axes)
       coutE(InputArguments) << "* Error in MCMCInterval::SetAxes: " <<
                                "number of variables in axes (" << size <<
                                ") doesn't match number of parameters ("
-                               << fDimension << ")" << endl;
+                               << fDimension << ")" << std::endl;
       return;
    }
    for (Int_t i = 0; i < size; i++)
@@ -276,7 +276,7 @@ void MCMCInterval::CreateKeysPdf()
    // also check for memory leak from chain, does RooNDKeysPdf clone that?
    if (fAxes == nullptr || fParameters.empty()) {
       coutE(InputArguments) << "Error in MCMCInterval::CreateKeysPdf: "
-         << "parameters have not been set." << endl;
+         << "parameters have not been set." << std::endl;
       return;
    }
 
@@ -284,7 +284,7 @@ void MCMCInterval::CreateKeysPdf()
       coutE(InputArguments) <<
          "MCMCInterval::CreateKeysPdf: creation of Keys PDF failed: " <<
          "Number of burn-in steps (num steps to ignore) >= number of steps " <<
-         "in Markov chain." << endl;
+         "in Markov chain." << std::endl;
       delete fKeysPdf;
       delete fCutoffVar;
       delete fHeaviside;
@@ -315,8 +315,8 @@ void MCMCInterval::CreateHist()
 {
    if (fAxes == nullptr || fChain == nullptr) {
       coutE(Eval) << "* Error in MCMCInterval::CreateHist(): " <<
-                     "Crucial data member was nullptr." << endl;
-      coutE(Eval) << "Make sure to fully construct/initialize." << endl;
+                     "Crucial data member was nullptr." << std::endl;
+      coutE(Eval) << "Make sure to fully construct/initialize." << std::endl;
       return;
    }
    if (fHist != nullptr) {
@@ -328,7 +328,7 @@ void MCMCInterval::CreateHist()
       coutE(InputArguments) <<
          "MCMCInterval::CreateHist: creation of histogram failed: " <<
          "Number of burn-in steps (num steps to ignore) >= number of steps " <<
-         "in Markov chain." << endl;
+         "in Markov chain." << std::endl;
       return;
    }
 
@@ -349,7 +349,7 @@ void MCMCInterval::CreateHist()
 
    } else {
       coutE(Eval) << "* Error in MCMCInterval::CreateHist() : " <<
-                     "TH1* couldn't handle dimension: " << fDimension << endl;
+                     "TH1* couldn't handle dimension: " << fDimension << std::endl;
       return;
    }
 
@@ -386,9 +386,9 @@ void MCMCInterval::CreateSparseHist()
 {
    if (fAxes == nullptr || fChain == nullptr) {
       coutE(InputArguments) << "* Error in MCMCInterval::CreateSparseHist(): "
-                            << "Crucial data member was nullptr." << endl;
+                            << "Crucial data member was nullptr." << std::endl;
       coutE(InputArguments) << "Make sure to fully construct/initialize."
-                            << endl;
+                            << std::endl;
       return;
    }
    if (fSparseHist != nullptr)
@@ -414,7 +414,7 @@ void MCMCInterval::CreateSparseHist()
       coutE(InputArguments) <<
          "MCMCInterval::CreateSparseHist: creation of histogram failed: " <<
          "Number of burn-in steps (num steps to ignore) >= number of steps " <<
-         "in Markov chain." << endl;
+         "in Markov chain." << std::endl;
    }
 
    // Fill histogram
@@ -435,8 +435,8 @@ void MCMCInterval::CreateDataHist()
 {
    if (fParameters.empty() || fChain == nullptr) {
       coutE(Eval) << "* Error in MCMCInterval::CreateDataHist(): " <<
-                     "Crucial data member was nullptr or empty." << endl;
-      coutE(Eval) << "Make sure to fully construct/initialize." << endl;
+                     "Crucial data member was nullptr or empty." << std::endl;
+      coutE(Eval) << "Make sure to fully construct/initialize." << std::endl;
       return;
    }
 
@@ -444,7 +444,7 @@ void MCMCInterval::CreateDataHist()
       coutE(InputArguments) <<
          "MCMCInterval::CreateDataHist: creation of histogram failed: " <<
          "Number of burn-in steps (num steps to ignore) >= number of steps " <<
-         "in Markov chain." << endl;
+         "in Markov chain." << std::endl;
       fDataHist = nullptr;
       return;
    }
@@ -462,9 +462,9 @@ void MCMCInterval::CreateVector(RooRealVar* param)
 
    if (fChain == nullptr) {
       coutE(InputArguments) << "* Error in MCMCInterval::CreateVector(): " <<
-                     "Crucial data member (Markov chain) was nullptr." << endl;
+                     "Crucial data member (Markov chain) was nullptr." << std::endl;
       coutE(InputArguments) << "Make sure to fully construct/initialize."
-                            << endl;
+                            << std::endl;
       return;
    }
 
@@ -472,7 +472,7 @@ void MCMCInterval::CreateVector(RooRealVar* param)
       coutE(InputArguments) <<
          "MCMCInterval::CreateVector: creation of vector failed: " <<
          "Number of burn-in steps (num steps to ignore) >= number of steps " <<
-         "in Markov chain." << endl;
+         "in Markov chain." << std::endl;
    }
 
    // Fill vector
@@ -525,7 +525,7 @@ void MCMCInterval::DetermineInterval()
          break;
       default:
          coutE(InputArguments) << "MCMCInterval::DetermineInterval(): " <<
-            "Error: Interval type not set" << endl;
+            "Error: Interval type not set" << std::endl;
          break;
    }
 }
@@ -548,22 +548,22 @@ void MCMCInterval::DetermineTailFractionInterval()
    if (fLeftSideTF < 0 || fLeftSideTF > 1) {
       coutE(InputArguments) << "MCMCInterval::DetermineTailFractionInterval: "
          << "Fraction must be in the range [0, 1].  "
-         << fLeftSideTF << "is not allowed." << endl;
+         << fLeftSideTF << "is not allowed." << std::endl;
       return;
    }
 
    if (fDimension != 1) {
       coutE(InputArguments) << "MCMCInterval::DetermineTailFractionInterval(): "
          << "Error: Can only find a tail-fraction interval for 1-D intervals"
-         << endl;
+         << std::endl;
       return;
    }
 
    if (fAxes == nullptr) {
       coutE(InputArguments) << "MCMCInterval::DetermineTailFractionInterval(): "
-                            << "Crucial data member was nullptr." << endl;
+                            << "Crucial data member was nullptr." << std::endl;
       coutE(InputArguments) << "Make sure to fully construct/initialize."
-                            << endl;
+                            << std::endl;
       return;
    }
 
@@ -669,7 +669,7 @@ void MCMCInterval::DetermineByKeys()
    if (full < 0.98) {
       coutW(Eval) << "Warning: Integral of Keys PDF came out to " << full
          << " instead of expected value 1.  Will continue using this "
-         << "factor to normalize further integrals of this PDF." << endl;
+         << "factor to normalize further integrals of this PDF." << std::endl;
    }
 
    // kbelasco: Is there a better way to set the search range?
@@ -728,7 +728,7 @@ void MCMCInterval::DetermineByKeys()
    }
 
    coutI(Eval) << "range set: [" << bottomCutoff << ", " << topCutoff << "]"
-               << endl;
+               << std::endl;
 
    cutoff = (topCutoff + bottomCutoff) / 2.0;
    confLevel = CalcConfLevel(cutoff, full);
@@ -748,7 +748,7 @@ void MCMCInterval::DetermineByKeys()
       }
       cutoff = (topCutoff + bottomCutoff) / 2.0;
       coutI(Eval) << "cutoff range: [" << bottomCutoff << ", "
-                  << topCutoff << "]" << endl;
+                  << topCutoff << "]" << std::endl;
       confLevel = CalcConfLevel(cutoff, full);
    }
 
@@ -928,7 +928,7 @@ double MCMCInterval::GetActualConfidenceLevel()
       return fTFConfLevel;
    } else {
       coutE(InputArguments) << "MCMCInterval::GetActualConfidenceLevel: "
-         << "not implemented for this type of interval.  Returning 0." << endl;
+         << "not implemented for this type of interval.  Returning 0." << std::endl;
       return 0;
    }
 }
@@ -944,7 +944,7 @@ double MCMCInterval::LowerLimit(RooRealVar& param)
          return LowerLimitTailFraction(param);
       default:
          coutE(InputArguments) << "MCMCInterval::LowerLimit(): " <<
-            "Error: Interval type not set" << endl;
+            "Error: Interval type not set" << std::endl;
          return RooNumber::infinity();
    }
 }
@@ -960,7 +960,7 @@ double MCMCInterval::UpperLimit(RooRealVar& param)
          return UpperLimitTailFraction(param);
       default:
          coutE(InputArguments) << "MCMCInterval::UpperLimit(): " <<
-            "Error: Interval type not set" << endl;
+            "Error: Interval type not set" << std::endl;
          return RooNumber::infinity();
    }
 }
@@ -1041,7 +1041,7 @@ double MCMCInterval::LowerLimitBySparseHist(RooRealVar& param)
 {
    if (fDimension != 1) {
       coutE(InputArguments) << "In MCMCInterval::LowerLimitBySparseHist: "
-         << "Sorry, will not compute lower limit unless dimension == 1" << endl;
+         << "Sorry, will not compute lower limit unless dimension == 1" << std::endl;
       return param.getMin();
    }
    if (fHistCutoff < 0)
@@ -1051,7 +1051,7 @@ double MCMCInterval::LowerLimitBySparseHist(RooRealVar& param)
       // if fHistCutoff < 0 still, then determination of interval failed
       coutE(Eval) << "In MCMCInterval::LowerLimitBySparseHist: "
          << "couldn't determine cutoff.  Check that num burn in steps < num "
-         << "steps in the Markov chain.  Returning param.getMin()." << endl;
+         << "steps in the Markov chain.  Returning param.getMin()." << std::endl;
       return param.getMin();
    }
 
@@ -1087,7 +1087,7 @@ double MCMCInterval::LowerLimitByDataHist(RooRealVar& param)
       // if fHistCutoff < 0 still, then determination of interval failed
       coutE(Eval) << "In MCMCInterval::LowerLimitByDataHist: "
          << "couldn't determine cutoff.  Check that num burn in steps < num "
-         << "steps in the Markov chain.  Returning param.getMin()." << endl;
+         << "steps in the Markov chain.  Returning param.getMin()." << std::endl;
       return param.getMin();
    }
 
@@ -1118,7 +1118,7 @@ double MCMCInterval::UpperLimitBySparseHist(RooRealVar& param)
 {
    if (fDimension != 1) {
       coutE(InputArguments) << "In MCMCInterval::UpperLimitBySparseHist: "
-         << "Sorry, will not compute upper limit unless dimension == 1" << endl;
+         << "Sorry, will not compute upper limit unless dimension == 1" << std::endl;
       return param.getMax();
    }
    if (fHistCutoff < 0)
@@ -1128,7 +1128,7 @@ double MCMCInterval::UpperLimitBySparseHist(RooRealVar& param)
       // if fHistCutoff < 0 still, then determination of interval failed
       coutE(Eval) << "In MCMCInterval::UpperLimitBySparseHist: "
          << "couldn't determine cutoff.  Check that num burn in steps < num "
-         << "steps in the Markov chain.  Returning param.getMax()." << endl;
+         << "steps in the Markov chain.  Returning param.getMax()." << std::endl;
       return param.getMax();
    }
 
@@ -1164,7 +1164,7 @@ double MCMCInterval::UpperLimitByDataHist(RooRealVar& param)
       // if fHistCutoff < 0 still, then determination of interval failed
       coutE(Eval) << "In MCMCInterval::UpperLimitByDataHist: "
          << "couldn't determine cutoff.  Check that num burn in steps < num "
-         << "steps in the Markov chain.  Returning param.getMax()." << endl;
+         << "steps in the Markov chain.  Returning param.getMax()." << std::endl;
       return param.getMax();
    }
 
@@ -1204,7 +1204,7 @@ double MCMCInterval::LowerLimitByKeys(RooRealVar& param)
       coutE(Eval) << "in MCMCInterval::LowerLimitByKeys(): "
          << "couldn't find lower limit, check that the number of burn in "
          << "steps < number of total steps in the Markov chain.  Returning "
-         << "param.getMin()" << endl;
+         << "param.getMin()" << std::endl;
       return param.getMin();
    }
 
@@ -1244,7 +1244,7 @@ double MCMCInterval::UpperLimitByKeys(RooRealVar& param)
       coutE(Eval) << "in MCMCInterval::UpperLimitByKeys(): "
          << "couldn't find upper limit, check that the number of burn in "
          << "steps < number of total steps in the Markov chain.  Returning "
-         << "param.getMax()" << endl;
+         << "param.getMax()" << std::endl;
       return param.getMax();
    }
 
@@ -1283,7 +1283,7 @@ double MCMCInterval::GetKeysMax()
       coutE(Eval) << "in MCMCInterval::KeysMax(): "
          << "couldn't find Keys max value, check that the number of burn in "
          << "steps < number of total steps in the Markov chain.  Returning 0"
-         << endl;
+         << std::endl;
       return 0;
    }
 
@@ -1331,7 +1331,7 @@ double MCMCInterval::CalcConfLevel(double cutoff, double full)
    fCutoffVar->setVal(cutoff);
    std::unique_ptr<RooAbsReal> integral{fProduct->createIntegral(fParameters, NormSet(fParameters))};
    double confLevel = integral->getVal(fParameters) / full;
-   coutI(Eval) << "cutoff = " << cutoff << ", conf = " << confLevel << endl;
+   coutI(Eval) << "cutoff = " << cutoff << ", conf = " << confLevel << std::endl;
    return confLevel;
 }
 
@@ -1341,7 +1341,7 @@ TH1* MCMCInterval::GetPosteriorHist()
 {
    if (fConfidenceLevel == 0) {
       coutE(InputArguments) << "Error in MCMCInterval::GetPosteriorHist: "
-                            << "confidence level not set " << endl;
+                            << "confidence level not set " << std::endl;
    }
   if (fHist == nullptr)
      CreateHist();
@@ -1360,7 +1360,7 @@ RooNDKeysPdf* MCMCInterval::GetPosteriorKeysPdf()
 {
   if (fConfidenceLevel == 0) {
      coutE(InputArguments) << "Error in MCMCInterval::GetPosteriorKeysPdf: "
-                           << "confidence level not set " << endl;
+                           << "confidence level not set " << std::endl;
   }
    if (fKeysPdf == nullptr)
       CreateKeysPdf();
@@ -1379,7 +1379,7 @@ RooProduct* MCMCInterval::GetPosteriorKeysProduct()
 {
    if (fConfidenceLevel == 0) {
       coutE(InputArguments) << "MCMCInterval::GetPosteriorKeysProduct: "
-                            << "confidence level not set " << endl;
+                            << "confidence level not set " << std::endl;
    }
    if (fProduct == nullptr) {
       CreateKeysPdf();

--- a/roofit/roostats/src/MCMCIntervalPlot.cxx
+++ b/roofit/roostats/src/MCMCIntervalPlot.cxx
@@ -130,7 +130,7 @@ void* MCMCIntervalPlot::DrawPosteriorHist(const Option_t* /*options*/,
 
    if (fPosteriorHist == nullptr) {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawPosteriorHist: "
-         << "Couldn't get posterior histogram." << endl;
+         << "Couldn't get posterior histogram." << std::endl;
       return nullptr;
    }
 
@@ -168,7 +168,7 @@ void* MCMCIntervalPlot::DrawPosteriorKeysPdf(const Option_t* options)
 
    if (fPosteriorKeysPdf == nullptr) {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawPosteriorKeysPdf: "
-         << "Couldn't get posterior Keys PDF." << endl;
+         << "Couldn't get posterior Keys PDF." << std::endl;
       return nullptr;
    }
 
@@ -180,7 +180,7 @@ void* MCMCIntervalPlot::DrawPosteriorKeysPdf(const Option_t* options)
       RooPlot* frame = v->frame();
       if (frame == nullptr) {
          coutE(InputArguments) << "MCMCIntervalPlot::DrawPosteriorKeysPdf: "
-                               << "Invalid parameter" << endl;
+                               << "Invalid parameter" << std::endl;
          return nullptr;
       }
       if (isEmpty) {
@@ -227,7 +227,7 @@ void MCMCIntervalPlot::DrawInterval(const Option_t* options)
          break;
       default:
          coutE(InputArguments) << "MCMCIntervalPlot::DrawInterval(): " <<
-            "Interval type not supported" << endl;
+            "Interval type not supported" << std::endl;
          break;
    }
 }
@@ -304,7 +304,7 @@ void MCMCIntervalPlot::DrawKeysPdfInterval(const Option_t* options)
 
       if (fPosteriorKeysPdf == nullptr) {
          coutE(InputArguments) << "MCMCIntervalPlot::DrawKeysPdfInterval: "
-            << "Couldn't get posterior Keys PDF." << endl;
+            << "Couldn't get posterior Keys PDF." << std::endl;
          return;
       }
 
@@ -337,7 +337,7 @@ void MCMCIntervalPlot::DrawKeysPdfInterval(const Option_t* options)
       delete axes;
    } else {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawKeysPdfInterval: "
-         << " Sorry: " << fDimension << "-D plots not currently supported" << endl;
+         << " Sorry: " << fDimension << "-D plots not currently supported" << std::endl;
    }
 }
 
@@ -407,7 +407,7 @@ void MCMCIntervalPlot::DrawHistInterval(const Option_t* options)
 
       if (fPosteriorHist == nullptr) {
          coutE(InputArguments) << "MCMCIntervalPlot::DrawHistInterval: "
-            << "Couldn't get posterior histogram." << endl;
+            << "Couldn't get posterior histogram." << std::endl;
          return;
       }
 
@@ -437,7 +437,7 @@ void MCMCIntervalPlot::DrawHistInterval(const Option_t* options)
       fPosteriorHist->Draw(tmpOpt.Data());
    } else {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawHistInterval: "
-         << " Sorry: " << fDimension << "-D plots not currently supported" << endl;
+         << " Sorry: " << fDimension << "-D plots not currently supported" << std::endl;
    }
 }
 
@@ -499,7 +499,7 @@ void MCMCIntervalPlot::DrawTailFractionInterval(const Option_t* options)
    } else {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawTailFractionInterval: "
          << " Sorry: " << fDimension << "-D plots not currently supported"
-         << endl;
+         << std::endl;
    }
 }
 
@@ -512,7 +512,7 @@ void* MCMCIntervalPlot::DrawPosteriorKeysProduct(const Option_t* options)
 
    if (fPosteriorKeysProduct == nullptr) {
       coutE(InputArguments) << "MCMCIntervalPlot::DrawPosteriorKeysProduct: "
-         << "Couldn't get posterior Keys product." << endl;
+         << "Couldn't get posterior Keys product." << std::endl;
       return nullptr;
    }
 

--- a/roofit/roostats/src/MetropolisHastings.cxx
+++ b/roofit/roostats/src/MetropolisHastings.cxx
@@ -79,13 +79,13 @@ MarkovChain* MetropolisHastings::ConstructChain()
 {
    if (fParameters.empty() || !fPropFunc || !fFunction) {
       coutE(Eval) << "Critical members uninitialized: parameters, proposal " <<
-                     " function, or (log) likelihood function" << endl;
+                     " function, or (log) likelihood function" << std::endl;
          return nullptr;
    }
    if (fSign == kSignUnset || fType == kTypeUnset) {
       coutE(Eval) << "Please set type and sign of your function using "
          << "MetropolisHastings::SetType() and MetropolisHastings::SetSign()" <<
-         endl;
+         std::endl;
       return nullptr;
    }
 
@@ -158,7 +158,7 @@ MarkovChain* MetropolisHastings::ConstructChain()
 
    if(hadEvalError) {
       coutE(Eval) << "Problem finding a good starting point in " <<
-                     "MetropolisHastings::ConstructChain() " << endl;
+                     "MetropolisHastings::ConstructChain() " << std::endl;
    }
 
 
@@ -230,14 +230,14 @@ MarkovChain* MetropolisHastings::ConstructChain()
    // make sure to add the last point
    if (weight != 0.0)
       chain->Add(x, CalcNLL(xL), (double)weight);
-   ooccoutP((TObject *)nullptr, Generation) << endl;
+   ooccoutP((TObject *)nullptr, Generation) << std::endl;
 
    RooMsgService::instance().setGlobalKillBelow(oldMsgLevel);
 
    Int_t numAccepted = chain->Size();
    coutI(Eval) << "Proposal acceptance rate: " <<
-                   numAccepted/(Float_t)fNumIters * 100 << "%" << endl;
-   coutI(Eval) << "Number of steps in chain: " << numAccepted << endl;
+                   numAccepted/(Float_t)fNumIters * 100 << "%" << std::endl;
+   coutI(Eval) << "Number of steps in chain: " << numAccepted << std::endl;
 
    //TFile chainDataFile("chainData.root", "recreate");
    //chain->GetDataSet()->Write();

--- a/roofit/roostats/src/NeymanConstruction.cxx
+++ b/roofit/roostats/src/NeymanConstruction.cxx
@@ -113,7 +113,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
   TFile* f=nullptr;
   if(fSaveBeltToFile){
     //coverity[FORWARD_NULL]
-    oocoutI(f,Contents) << "NeymanConstruction saving ConfidenceBelt to file SamplingDistributions.root" << endl;
+    oocoutI(f,Contents) << "NeymanConstruction saving ConfidenceBelt to file SamplingDistributions.root" << std::endl;
     f = new TFile("SamplingDistributions.root","recreate");
   }
 
@@ -142,11 +142,11 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
      // get the value of the test statistic for this data set
     double thisTestStatistic = fTestStatSampler->EvaluateTestStatistic(fData, *fPOI );
     /*
-    cout << "NC CHECK: " << i << endl;
+    std::cout << "NC CHECK: " << i << std::endl;
     point->Print();
     fPOI->Print("v");
     fData.Print();
-    cout <<"thisTestStatistic = " << thisTestStatistic << endl;
+    std::cout <<"thisTestStatistic = " << thisTestStatistic << std::endl;
     */
 
     // find the lower & upper thresholds on the test statistic that
@@ -194,13 +194,13 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
                      samplingDist,
                      additionalMC);
         if (!samplingDist) {
-           oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
+           oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << std::endl;
            return nullptr;
         }
    totalMC=samplingDist->GetSize();
 
    //cout << "without sigma upper = " <<
-   //samplingDist->InverseCDF( 1. - ((1.-fLeftSideFraction) * fSize) ) << endl;
+   //samplingDist->InverseCDF( 1. - ((1.-fLeftSideFraction) * fSize) ) << std::endl;
 
    sigma = 1;
    upperEdgeOfAcceptance =
@@ -220,13 +220,13 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
 
    ooccoutD(samplingDist,Eval) << "NeymanConstruction: "
         << "total MC = " << totalMC
-        << " this test stat = " << thisTestStatistic << endl
+        << " this test stat = " << thisTestStatistic << std::endl
         << " upper edge -1sigma = " << upperEdgeMinusSigma
         << ", upperEdge = "<<upperEdgeOfAcceptance
-        << ", upper edge +1sigma = " << upperEdgePlusSigma << endl
+        << ", upper edge +1sigma = " << upperEdgePlusSigma << std::endl
         << " lower edge -1sigma = " << lowerEdgeMinusSigma
         << ", lowerEdge = "<<lowerEdgeOfAcceptance
-        << ", lower edge +1sigma = " << lowerEdgePlusSigma << endl;
+        << ", lower edge +1sigma = " << lowerEdgePlusSigma << std::endl;
       } while((
          (thisTestStatistic <= upperEdgeOfAcceptance &&
           thisTestStatistic > upperEdgeMinusSigma)
@@ -243,7 +243,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
       // generating the sampling dist of the test statistic.
       samplingDist = fTestStatSampler->GetSamplingDistribution(*point);
       if (!samplingDist) {
-         oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
+         oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << std::endl;
          return nullptr;
       }
 
@@ -255,7 +255,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
 
     // add acceptance region to ConfidenceBelt
     if(fConfBelt && fCreateBelt){
-      //      cout << "conf belt set " << fConfBelt << endl;
+      //      std::cout << "conf belt set " << fConfBelt << std::endl;
       fConfBelt->AddAcceptanceRegion(*point, i,
                  lowerEdgeOfAcceptance,
                  upperEdgeOfAcceptance);
@@ -264,7 +264,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
     // printout some debug info
     ooccoutP(samplingDist,Eval) << "NeymanConstruction: Prog: "<< i+1<<"/"<<fPointsToTest->numEntries()
             << " total MC = " << samplingDist->GetSize()
-            << " this test stat = " << thisTestStatistic << endl;
+            << " this test stat = " << thisTestStatistic << std::endl;
     ooccoutP(samplingDist,Eval) << " ";
     for (auto const *myarg : static_range_cast<RooRealVar *> (*point)){
       ooccoutP(samplingDist,Eval) << myarg->GetName() << "=" << myarg->getVal() << " ";
@@ -272,7 +272,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
     ooccoutP(samplingDist,Eval) << "[" << lowerEdgeOfAcceptance << ", "
              << upperEdgeOfAcceptance << "] " << " in interval = " <<
       (thisTestStatistic >= lowerEdgeOfAcceptance && thisTestStatistic <= upperEdgeOfAcceptance)
-         << endl << endl;
+         << std::endl << std::endl;
 
     // Check if this data is in the acceptance region
     if(thisTestStatistic >= lowerEdgeOfAcceptance && thisTestStatistic <= upperEdgeOfAcceptance) {
@@ -297,7 +297,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
     delete samplingDist;
     //    delete point; // from dataset
   }
-  oocoutI(pointsInInterval,Eval) << npass << " points in interval" << endl;
+  oocoutI(pointsInInterval,Eval) << npass << " points in interval" << std::endl;
 
   // create an interval based pointsInInterval
   PointSetInterval* interval

--- a/roofit/roostats/src/ProfileInspector.cxx
+++ b/roofit/roostats/src/ProfileInspector.cxx
@@ -34,7 +34,7 @@ Utility class to plot conditional MLE of nuisance parameters vs. Parameters of I
 ClassImp(RooStats::ProfileInspector);
 
 using namespace RooStats;
-using std::cout, std::endl, std::string, std::map;
+using std::string, std::map;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -72,24 +72,24 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
 
 
   if(!poi_set){
-    cout << "no parameters of interest" << endl;
+    std::cout << "no parameters of interest" << std::endl;
     return nullptr;
   }
 
   if(poi_set->size()!=1){
-    cout << "only one parameter of interest is supported currently" << endl;
+    std::cout << "only one parameter of interest is supported currently" << std::endl;
     return nullptr;
   }
   RooRealVar* poi = static_cast<RooRealVar*>(poi_set->first());
 
 
   if(!nuis_params){
-    cout << "no nuisance parameters" << endl;
+    std::cout << "no nuisance parameters" << std::endl;
     return nullptr;
   }
 
   if(!pdf){
-    cout << "pdf not set" << endl;
+    std::cout << "pdf not set" << std::endl;
     return nullptr;
   }
 

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -66,9 +66,6 @@ AsymptoticCalculator, which can compute in addition the expected
 
 #include "Math/MinimizerOptions.h"
 #include "RooMinimizer.h"
-//#include "RooProdPdf.h"
-
-using std::cout, std::endl;
 
 ClassImp(RooStats::ProfileLikelihoodCalculator);
 
@@ -185,18 +182,18 @@ RooFit::OwningPtr<RooFitResult> ProfileLikelihoodCalculator::DoMinimizeNLL(RooAb
       if (status%1000 == 0) {  // ignore errors from Improve
          break;
       } else if (tries < maxtries) {
-         cout << "    ----> Doing a re-scan first" << endl;
+         std::cout << "    ----> Doing a re-scan first" << std::endl;
          minim.minimize(minimType,"Scan");
          if (tries == 2) {
             if (strategy == 0 ) {
-               cout << "    ----> trying with strategy = 1" << endl;
+               std::cout << "    ----> trying with strategy = 1" << std::endl;
                minim.setStrategy(1);
             }
             else
                tries++; // skip this trial if strategy is already 1
          }
          if (tries == 3) {
-            cout << "    ----> trying with improve" << endl;
+            std::cout << "    ----> trying with improve" << std::endl;
             minimType = "Minuit";
             minimAlgo = "migradimproved";
          }

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -39,8 +39,6 @@ either use:
 
 #include "RooStats/RooStatsUtils.h"
 
-using std::cout, std::endl;
-
 bool RooStats::ProfileLikelihoodTestStat::fgAlwaysReuseNll = true ;
 
 void RooStats::ProfileLikelihoodTestStat::SetAlwaysReuseNLL(bool flag) { fgAlwaysReuseNll = flag ; }
@@ -68,7 +66,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        if (firstPOI) initial_mu_value = firstPOI->getVal();
        //paramsOfInterest.getRealValue(firstPOI->GetName());
        if (fPrintLevel > 1) {
-            cout << "POIs: " << endl;
+            std::cout << "POIs: " << std::endl;
             paramsOfInterest.Print("v");
        }
 
@@ -87,13 +85,13 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           fNll = std::unique_ptr<RooAbsReal>{fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),
                                  RooFit::GlobalObservables(fGlobalObs), RooFit::ConditionalObservables(fConditionalObs), RooFit::Offset(fLOffset))};
 
-          if (fPrintLevel > 0 && fLOffset) cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << endl ;
+          if (fPrintLevel > 0 && fLOffset) std::cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << std::endl ;
 
           created = true ;
-          if (fPrintLevel > 1) cout << "creating NLL " << &*fNll << " with data = " << &data << endl ;
+          if (fPrintLevel > 1) std::cout << "creating NLL " << &*fNll << " with data = " << &data << std::endl ;
        }
        if (reuse && !created) {
-         if (fPrintLevel > 1) cout << "reusing NLL " << &*fNll << " new data = " << &data << endl ;
+         if (fPrintLevel > 1) std::cout << "reusing NLL " << &*fNll << " new data = " << &data << std::endl ;
          fNll->setData(data,false) ;
        }
        // print data in case of number counting (simple data sets)
@@ -174,7 +172,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           if (fPrintLevel>1) std::cout << "Do conditional fit " << std::endl;
 
 
-          //       cout <<" reestablish snapshot"<<endl;
+          //       std::cout <<" reestablish snapshot"<< std::endl;
           attachedSet->assign(*snap);
 
 
@@ -307,18 +305,18 @@ std::unique_ptr<RooFitResult> RooStats::ProfileLikelihoodTestStat::GetMinNLL() {
       if (status%1000 == 0) {  // ignore errors from Improve
          break;
       } else if (tries < maxtries) {
-         cout << "    ----> Doing a re-scan first" << endl;
+         std::cout << "    ----> Doing a re-scan first" << std::endl;
          minim.minimize(minimizer,"Scan");
          if (tries == 2) {
             if (fStrategy == 0 ) {
-               cout << "    ----> trying with strategy = 1" << endl;
+               std::cout << "    ----> trying with strategy = 1" << std::endl;
                minim.setStrategy(1);
             }
             else
                tries++; // skip this trial if strategy is already 1
          }
          if (tries == 3) {
-            cout << "    ----> trying with improve" << endl;
+            std::cout << "    ----> trying with improve" << std::endl;
             minimizer = "Minuit";
             algorithm = "migradimproved";
          }

--- a/roofit/roostats/src/ProposalHelper.cxx
+++ b/roofit/roostats/src/ProposalHelper.cxx
@@ -63,10 +63,10 @@ ProposalFunction* ProposalHelper::GetProposalFunction()
    if (fCluesPdf == nullptr)
       CreateCluesPdf();
    if (fCluesPdf != nullptr) {
-      if (fCluesFrac < 0)
+      if (fCluesFrac < 0) {
          fCluesFrac = DEFAULT_CLUES_FRAC;
-      printf("added clues from dataset %s with fraction %g\n",
-            fClues->GetName(), fCluesFrac);
+      }
+      std::cout << "added clues from dataset " << fClues->GetName() << " with fraction " << fCluesFrac << std::endl;
       components.add(*fCluesPdf);
       coeffs.add(RooConst(fCluesFrac));
    }

--- a/roofit/roostats/src/ProposalHelper.cxx
+++ b/roofit/roostats/src/ProposalHelper.cxx
@@ -92,7 +92,7 @@ void ProposalHelper::CreatePdf()
 {
    if (fVars == nullptr) {
       coutE(InputArguments) << "ProposalHelper::CreatePdf(): " <<
-         "Variables to create proposal function for are not set." << endl;
+         "Variables to create proposal function for are not set." << std::endl;
       return;
    }
    RooArgList xVec{};

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -125,7 +125,7 @@ namespace RooStats {
       // utility function to factorize constraint terms from a pdf
       // (from G. Petrucciani)
       if (!model.GetObservables() ) {
-         oocoutE(nullptr,InputArguments) << "RooStatsUtils::FactorizePdf - invalid input model: missing observables" << endl;
+         oocoutE(nullptr,InputArguments) << "RooStatsUtils::FactorizePdf - invalid input model: missing observables" << std::endl;
          return;
       }
       return FactorizePdf(*model.GetObservables(), pdf, obsTerms, constraints);
@@ -138,7 +138,7 @@ namespace RooStats {
       RooArgList constraints;
       FactorizePdf(observables, pdf, obsTerms, constraints);
       if(constraints.empty()) {
-         oocoutW(nullptr, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;
+         oocoutW(nullptr, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << std::endl;
          return nullptr;
       }
       return new RooProdPdf(name,"", constraints);
@@ -147,7 +147,7 @@ namespace RooStats {
    RooAbsPdf * MakeNuisancePdf(const RooStats::ModelConfig &model, const char *name) {
       // make a nuisance pdf by factorizing out all constraint terms in a common pdf
       if (!model.GetPdf() || !model.GetObservables() ) {
-         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeNuisancePdf - invalid input model: missing pdf and/or observables" << endl;
+         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeNuisancePdf - invalid input model: missing pdf and/or observables" << std::endl;
          return nullptr;
       }
       return MakeNuisancePdf(*model.GetPdf(), *model.GetObservables(), name);
@@ -221,7 +221,7 @@ namespace RooStats {
       // make a clone pdf without all constraint terms in a common pdf
       RooAbsPdf * unconstrainedPdf = StripConstraints(pdf, observables);
       if(!unconstrainedPdf) {
-         oocoutE(nullptr, InputArguments) << "RooStats::MakeUnconstrainedPdf - invalid observable list passed (observables not found in original pdf) or invalid pdf passed (without observables)" << endl;
+         oocoutE(nullptr, InputArguments) << "RooStats::MakeUnconstrainedPdf - invalid observable list passed (observables not found in original pdf) or invalid pdf passed (without observables)" << std::endl;
          return nullptr;
       }
       if(name != nullptr) unconstrainedPdf->SetName(name);
@@ -231,7 +231,7 @@ namespace RooStats {
    RooAbsPdf * MakeUnconstrainedPdf(const RooStats::ModelConfig &model, const char *name) {
       // make a clone pdf without all constraint terms in a common pdf
       if(!model.GetPdf() || !model.GetObservables()) {
-         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeUnconstrainedPdf - invalid input model: missing pdf and/or observables" << endl;
+         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeUnconstrainedPdf - invalid input model: missing pdf and/or observables" << std::endl;
          return nullptr;
       }
       return MakeUnconstrainedPdf(*model.GetPdf(), *model.GetObservables(), name);

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -198,7 +198,7 @@ SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* p
     if (!dynamic_cast<const RooAbsRealLValue*>(arg)) {
       coutE(InputArguments) << "SPlot::SPlot(" << GetName() << ") input argument "
              << arg->GetName() << " is not of type RooRealVar (or RooLinearVar)."
-             << "\nRooStats must be able to set it to 0 and to 1 to probe the PDF." << endl ;
+             << "\nRooStats must be able to set it to 0 and to 1 to probe the PDF." << std::endl ;
       throw std::invalid_argument(Form("SPlot::SPlot(%s) input argument %s is not of type RooRealVar/RooLinearVar",GetName(),arg->GetName())) ;
     }
   }
@@ -237,13 +237,13 @@ double SPlot::GetSWeight(Int_t numEvent, const char* sVariable) const
 {
   if(numEvent > fSData->numEntries() )
     {
-      coutE(InputArguments)  << "Invalid Entry Number" << endl;
+      coutE(InputArguments)  << "Invalid Entry Number" << std::endl;
       return -1;
     }
 
   if(numEvent < 0)
     {
-      coutE(InputArguments)  << "Invalid Entry Number" << endl;
+      coutE(InputArguments)  << "Invalid Entry Number" << std::endl;
       return -1;
     }
 
@@ -271,7 +271,7 @@ double SPlot::GetSWeight(Int_t numEvent, const char* sVariable) const
     }
 
   else
-    coutE(InputArguments) << "InputVariable not in list of sWeighted variables" << endl;
+    coutE(InputArguments) << "InputVariable not in list of sWeighted variables" << std::endl;
 
   return -1;
 }
@@ -286,13 +286,13 @@ double SPlot::GetSumOfEventSWeight(Int_t numEvent) const
 {
   if(numEvent > fSData->numEntries() )
     {
-      coutE(InputArguments)  << "Invalid Entry Number" << endl;
+      coutE(InputArguments)  << "Invalid Entry Number" << std::endl;
       return -1;
     }
 
   if(numEvent < 0)
     {
-      coutE(InputArguments)  << "Invalid Entry Number" << endl;
+      coutE(InputArguments)  << "Invalid Entry Number" << std::endl;
       return -1;
     }
 
@@ -345,7 +345,7 @@ double SPlot::GetYieldFromSWeight(const char* sVariable) const
     }
 
   else
-    coutE(InputArguments) << "InputVariable not in list of sWeighted variables" << endl;
+    coutE(InputArguments) << "InputVariable not in list of sWeighted variables" << std::endl;
 
   return -1;
 }
@@ -453,7 +453,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
   RooArgList yields = *static_cast<RooArgList*>(yieldsTmp.snapshot(false));
 
   if (RooMsgService::instance().isActive(this, RooFit::InputArguments, RooFit::DEBUG)) {
-    coutI(InputArguments) << "Printing Yields" << endl;
+    coutI(InputArguments) << "Printing Yields" << std::endl;
     yields.Print();
   }
 
@@ -470,7 +470,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
     assert(pdf->dependsOn(*yieldinpdf));
 
     if (yieldinpdf) {
-      coutI(InputArguments)<< "yield in pdf: " << yieldinpdf->GetName() << " " << thisyield->getVal(&vars) << endl;
+      coutI(InputArguments)<< "yield in pdf: " << yieldinpdf->GetName() << " " << thisyield->getVal(&vars) << std::endl;
 
       yieldvars.push_back(yieldinpdf) ;
       yieldvalues.push_back(thisyield->getVal(&vars)) ;
@@ -613,7 +613,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
       for(Int_t m=0; m<nspec; ++m) covnorm += covInv[k][m]*yieldvalues[m] ;
       double sumrow(0) ;
       for(Int_t m = 0; m < nspec; ++m) sumrow += covMatrix[k][m] ;
-      coutI(Eval)  << yieldvalues[k] << " " << sumrow << " " << covnorm << endl ;
+      coutI(Eval)  << yieldvalues[k] << " " << sumrow << " " << covnorm << std::endl ;
     }
   }
 
@@ -674,7 +674,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
      if( !(std::abs(nsum/dsum)>=0 ) )
        {
-         coutE(Contents) << "error: " << nsum/dsum << endl ;
+         coutE(Contents) << "error: " << nsum/dsum << std::endl ;
          return;
        }
    }

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -37,7 +37,7 @@ objects.
 ClassImp(RooStats::SamplingDistPlot);
 
 using namespace RooStats;
-using std::cout, std::endl, std::string;
+using std::string;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// SamplingDistPlot default constructor with bin size
@@ -69,7 +69,7 @@ SamplingDistPlot::~SamplingDistPlot()
 double SamplingDistPlot::AddSamplingDistribution(const SamplingDistribution *samplingDist, Option_t *drawOptions) {
    fSamplingDistr = samplingDist->GetSamplingDistribution();
    if( fSamplingDistr.empty() ) {
-      coutW(Plotting) << "Empty sampling distribution given to plot. Skipping." << endl;
+      coutW(Plotting) << "Empty sampling distribution given to plot. Skipping." << std::endl;
       return 0.0;
    }
    SetSampleWeights(samplingDist);
@@ -89,7 +89,7 @@ double SamplingDistPlot::AddSamplingDistribution(const SamplingDistribution *sam
       }
    }
    if( xmin >= xmax ) {
-      coutW(Plotting) << "Could not determine xmin and xmax of sampling distribution that was given to plot." << endl;
+      coutW(Plotting) << "Could not determine xmin and xmax of sampling distribution that was given to plot." << std::endl;
       xmin = -1.0;
       xmax = 1.0;
    }
@@ -150,7 +150,7 @@ double SamplingDistPlot::AddSamplingDistribution(const SamplingDistribution *sam
 
 double SamplingDistPlot::AddSamplingDistributionShaded(const SamplingDistribution *samplingDist, double minShaded, double maxShaded, Option_t *drawOptions) {
    if( samplingDist->GetSamplingDistribution().empty() ) {
-      coutW(Plotting) << "Empty sampling distribution given to plot. Skipping." << endl;
+      coutW(Plotting) << "Empty sampling distribution given to plot. Skipping." << std::endl;
       return 0.0;
    }
    double scaleFactor = AddSamplingDistribution(samplingDist, drawOptions);
@@ -289,11 +289,11 @@ void SamplingDistPlot::Draw(Option_t * /*options */) {
    }
    fRooPlot->SetTitle("");
    if( !TMath::IsNaN(theYMax) ) {
-      //coutI(InputArguments) << "Setting maximum to " << theYMax << endl;
+      //coutI(InputArguments) << "Setting maximum to " << theYMax << std::endl;
       fRooPlot->SetMaximum(theYMax);
    }
    if( !TMath::IsNaN(theYMin) ) {
-      //coutI(InputArguments) << "Setting minimum to " << theYMin << endl;
+      //coutI(InputArguments) << "Setting minimum to " << theYMin << std::endl;
       fRooPlot->SetMinimum(theYMin);
    }
 
@@ -302,11 +302,11 @@ void SamplingDistPlot::Draw(Option_t * /*options */) {
       // add cloned objects to avoid mem leaks
       TH1 * cloneObj = static_cast<TH1*>(obj->Clone());
       if( !TMath::IsNaN(theYMax) ) {
-         //coutI(InputArguments) << "Setting maximum of TH1 to " << theYMax << endl;
+         //coutI(InputArguments) << "Setting maximum of TH1 to " << theYMax << std::endl;
          cloneObj->SetMaximum(theYMax);
       }
       if( !TMath::IsNaN(theYMin) ) {
-         //coutI(InputArguments) << "Setting minimum of TH1 to " << theYMin << endl;
+         //coutI(InputArguments) << "Setting minimum of TH1 to " << theYMin << std::endl;
          cloneObj->SetMinimum(theYMin);
       }
       cloneObj->SetDirectory(nullptr);  // transfer ownership of the object
@@ -322,11 +322,11 @@ void SamplingDistPlot::Draw(Option_t * /*options */) {
    if(fLegend) fRooPlot->addObject(fLegend);
 
    if(bool(gStyle->GetOptLogx()) != fLogXaxis) {
-      if(!fApplyStyle) coutW(Plotting) << "gStyle will be changed to adjust SetOptLogx(...)" << endl;
+      if(!fApplyStyle) coutW(Plotting) << "gStyle will be changed to adjust SetOptLogx(...)" << std::endl;
       gStyle->SetOptLogx(fLogXaxis);
    }
    if(bool(gStyle->GetOptLogy()) != fLogYaxis) {
-      if(!fApplyStyle) coutW(Plotting) << "gStyle will be changed to adjust SetOptLogy(...)" << endl;
+      if(!fApplyStyle) coutW(Plotting) << "gStyle will be changed to adjust SetOptLogy(...)" << std::endl;
       gStyle->SetOptLogy(fLogYaxis);
    }
    fRooPlot->Draw();
@@ -562,7 +562,7 @@ void SamplingDistPlot::DumpToFile(const char* RootFileName, Option_t *option, co
    // All the objects are written to rootfile
 
    if(!fRooPlot) {
-      cout << "Plot was not drawn yet. Dump can only be saved after it was drawn with Draw()." << endl;
+      std::cout << "Plot was not drawn yet. Dump can only be saved after it was drawn with Draw()." << std::endl;
       return;
    }
 

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -69,10 +69,10 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
    for( int i = -1; i < (int)fImportanceDensities.size(); i++ ) {
       if( i < 0 ) {
          // generate null toys
-         oocoutP(nullptr,Generation) << endl << endl << "   GENERATING FROM nullptr DENSITY " << endl << endl;
+         oocoutP(nullptr,Generation) << std::endl << std::endl << "   GENERATING FROM nullptr DENSITY " << std::endl << std::endl;
          SetDensityToGenerateFromByIndex( 0, true ); // true = generate from null
       }else{
-         oocoutP(nullptr,Generation) << endl << endl << "   GENERATING IMP DENS/SNAP "<<i+1<<"  OUT OF "<<fImportanceDensities.size()<<endl<<endl;
+         oocoutP(nullptr,Generation) << std::endl << std::endl << "   GENERATING IMP DENS/SNAP "<<i+1<<"  OUT OF "<<fImportanceDensities.size()<< std::endl<< std::endl;
          SetDensityToGenerateFromByIndex( i, false ); // false = generate not from null
       }
 
@@ -90,8 +90,8 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
          reweight.setVal( ((double)largestNToys) / fNToys );
       }
 
-      ooccoutI(nullptr,InputArguments) << "Generating " << fNToys << " toys for this density." << endl;
-      ooccoutI(nullptr,InputArguments) << "Reweight is " << reweight.getVal() << endl;
+      ooccoutI(nullptr,InputArguments) << "Generating " << fNToys << " toys for this density." << std::endl;
+      ooccoutI(nullptr,InputArguments) << "Reweight is " << reweight.getVal() << std::endl;
 
 
       RooDataSet* result = ToyMCSampler::GetSamplingDistributionsSingleWorker( paramPoint );
@@ -108,10 +108,10 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
       }
 
       for( int j=0; j < result->numEntries(); j++ ) {
-//          cout << "entry: " << j << endl;
+//          std::cout << "entry: " << j << std::endl;
 //          result->get(j)->Print();
-//          cout << "weight: " << result->weight() << endl;
-//          cout << "reweight: " << reweight.getVal() << endl;
+//          std::cout << "weight: " << result->weight() << std::endl;
+//          std::cout << "reweight: " << reweight.getVal() << std::endl;
          const RooArgSet* row = result->get(j);
          fullResult->add( *row, result->weight()*reweight.getVal() );
       }
@@ -131,23 +131,23 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    double& weight
 ) const {
    if( fNullDensities.size() > 1 ) {
-      ooccoutI(nullptr,InputArguments) << "Null Densities:" << endl;
+      ooccoutI(nullptr,InputArguments) << "Null Densities:" << std::endl;
       for( unsigned int i=0; i < fNullDensities.size(); i++) {
-         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
+         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << std::endl;
       }
-      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight." << endl;
+      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight." << std::endl;
       return nullptr;
    }
 
    if( fNullDensities.empty()  &&  fPdf ) {
-      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
+      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << std::endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
    // do not do anything if the given parameter point if fNullSnapshots[0]
    // ... which is the most common case
    if( fNullSnapshots[0] != &paramPoint ) {
-      ooccoutD(nullptr,InputArguments) << "Using given parameter point. Replaces snapshot for the only null currently defined." << endl;
+      ooccoutD(nullptr,InputArguments) << "Using given parameter point. Replaces snapshot for the only null currently defined." << std::endl;
       if(fNullSnapshots[0]) delete fNullSnapshots[0];
       fNullSnapshots.clear();
       fNullSnapshots.push_back( (RooArgSet*)paramPoint.snapshot() );
@@ -175,20 +175,20 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    double& nullNLL
 ) const {
    if( fNullDensities.size() > 1 ) {
-      ooccoutI(nullptr,InputArguments) << "Null Densities:" << endl;
+      ooccoutI(nullptr,InputArguments) << "Null Densities:" << std::endl;
       for( unsigned int i=0; i < fNullDensities.size(); i++) {
-         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
+         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << std::endl;
       }
-      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight and NLL." << endl;
+      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight and NLL." << std::endl;
       return nullptr;
    }
 
    if( fNullDensities.empty()  &&  fPdf ) {
-      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
+      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << std::endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
-   ooccoutI(nullptr,InputArguments) << "Using given parameter point. Overwrites snapshot for the only null currently defined." << endl;
+   ooccoutI(nullptr,InputArguments) << "Using given parameter point. Overwrites snapshot for the only null currently defined." << std::endl;
    if(fNullSnapshots[0]) delete fNullSnapshots[0];
    fNullSnapshots.clear();
    fNullSnapshots.push_back( (const RooArgSet*)paramPoint.snapshot() );
@@ -211,7 +211,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    vector<double>& weights
 ) const {
    if( fNullDensities.size() != weights.size() ) {
-      ooccoutI(nullptr,InputArguments) << "weights.size() != nullDesnities.size(). You need to provide a vector with the correct size." << endl;
+      ooccoutI(nullptr,InputArguments) << "weights.size() != nullDesnities.size(). You need to provide a vector with the correct size." << std::endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
@@ -238,16 +238,16 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 ) const {
 
 
-   ooccoutD(nullptr,InputArguments) << endl;
-   ooccoutD(nullptr,InputArguments) << "GenerateToyDataImportanceSampling" << endl;
+   ooccoutD(nullptr,InputArguments) << std::endl;
+   ooccoutD(nullptr,InputArguments) << "GenerateToyDataImportanceSampling" << std::endl;
 
    if(!fObservables) {
-      ooccoutE(nullptr,InputArguments) << "Observables not set." << endl;
+      ooccoutE(nullptr,InputArguments) << "Observables not set." << std::endl;
       return nullptr;
    }
 
    if( fNullDensities.empty() ) {
-      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Need to specify the null density explicitly." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Need to specify the null density explicitly." << std::endl;
       return nullptr;
    }
 
@@ -260,14 +260,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    }
 
    if( fNullDensities.size() != fNullNLLs.size() ) {
-      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Something wrong. NullNLLs must be of same size as null densities." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Something wrong. NullNLLs must be of same size as null densities." << std::endl;
       return nullptr;
    }
 
    if( (!fGenerateFromNull  &&  fIndexGenDensity >= fImportanceDensities.size()) ||
        (fGenerateFromNull   &&  fIndexGenDensity >= fNullDensities.size())
    ) {
-      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: no importance density given or index out of range." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: no importance density given or index out of range." << std::endl;
       return nullptr;
    }
 
@@ -276,7 +276,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    // situation is clear when there is only one null.
    // WHAT TO DO FOR MANY nullptr DENSITIES?
    RooArgSet paramPoint( *fNullSnapshots[0] );
-   //cout << "paramPoint: " << endl;
+   //cout << "paramPoint: " << std::endl;
    //paramPoint.Print("v");
 
 
@@ -326,22 +326,22 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
    RooAbsData* data = nullptr;
    if( fGenerateFromNull ) {
-      //cout << "gen from null" << endl;
+      //cout << "gen from null" << std::endl;
       allVars->assign(*fNullSnapshots[fIndexGenDensity]);
       data = Generate(*fNullDensities[fIndexGenDensity], observables).release();
    }else{
       // need to be careful here not to overwrite the current state of the
       // nuisance parameters, ie they must not be part of the snapshot
-      //cout << "gen from imp" << endl;
+      //cout << "gen from imp" << std::endl;
       if(fImportanceSnapshots[fIndexGenDensity]) {
         allVars->assign(*fImportanceSnapshots[fIndexGenDensity]);
       }
       data = Generate(*fImportanceDensities[fIndexGenDensity], observables).release();
    }
-   //cout << "data generated: " << data << endl;
+   //cout << "data generated: " << data << std::endl;
 
    if (!data) {
-      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: error generating data" << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: error generating data" << std::endl;
       return nullptr;
    }
 
@@ -350,9 +350,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    // Importance Sampling: adjust weight
    // Sources: Alex Read, presentation by Michael Woodroofe
 
-   ooccoutD(nullptr,InputArguments) << "About to create/calculate all nullNLLs." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to create/calculate all nullNLLs." << std::endl;
    for( unsigned int i=0; i < fNullDensities.size(); i++ ) {
-      //oocoutI(nullptr,InputArguments) << "Setting variables to nullSnapshot["<<i<<"]"<<endl;
+      //oocoutI(nullptr,InputArguments) << "Setting variables to nullSnapshot["<<i<<"]"<< std::endl;
       //fNullSnapshots[i]->Print("v");
 
       allVars->assign(*fNullSnapshots[i]);
@@ -370,12 +370,12 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    // for each null: find minNLLVal of null and all imp densities
-   ooccoutD(nullptr,InputArguments) << "About to find the minimum NLLs." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to find the minimum NLLs." << std::endl;
    vector<double> minNLLVals;
    for( unsigned int i=0; i < nullNLLVals.size(); i++ ) minNLLVals.push_back( nullNLLVals[i] );
 
    for( unsigned int i=0; i < fImportanceDensities.size(); i++ ) {
-      //oocoutI(nullptr,InputArguments) << "Setting variables to impSnapshot["<<i<<"]"<<endl;
+      //oocoutI(nullptr,InputArguments) << "Setting variables to impSnapshot["<<i<<"]"<< std::endl;
       //fImportanceSnapshots[i]->Print("v");
 
       if( fImportanceSnapshots[i] ) {
@@ -394,13 +394,13 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
       for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
          if( impNLLVals[i] < minNLLVals[j] ) minNLLVals[j] = impNLLVals[i];
-         ooccoutD(nullptr,InputArguments) << "minNLLVals["<<j<<"]: " << minNLLVals[j] << "  nullNLLVals["<<j<<"]: " << nullNLLVals[j] << "    impNLLVals["<<i<<"]: " << impNLLVals[i] << endl;
+         ooccoutD(nullptr,InputArguments) << "minNLLVals["<<j<<"]: " << minNLLVals[j] << "  nullNLLVals["<<j<<"]: " << nullNLLVals[j] << "    impNLLVals["<<i<<"]: " << impNLLVals[i] << std::endl;
       }
    }
 
    // veto toys: this is a sort of "overlap removal" of the various distributions
    // if not vetoed: apply weight
-   ooccoutD(nullptr,InputArguments) << "About to apply vetos and calculate weights." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to apply vetos and calculate weights." << std::endl;
    for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
       if     ( fApplyVeto  &&  fGenerateFromNull  &&  minNLLVals[j] != nullNLLVals[j] ) weights[j] = 0.0;
       else if( fApplyVeto  &&  !fGenerateFromNull  &&  minNLLVals[j] != impNLLVals[fIndexGenDensity] ) weights[j] = 0.0;
@@ -411,7 +411,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
          weights[j] *= exp(minNLLVals[j] - nullNLLVals[j]);
       }
 
-      ooccoutD(nullptr,InputArguments) << "weights["<<j<<"]: " << weights[j] << endl;
+      ooccoutD(nullptr,InputArguments) << "weights["<<j<<"]: " << weights[j] << std::endl;
    }
 
 
@@ -435,10 +435,10 @@ int ToyMCImportanceSampler::CreateImpDensitiesForOnePOIAdaptively( RooAbsPdf& pd
    // check whether error is trustworthy
    if( poi.getError() > 0.01  &&  poi.getError() < 5.0 ) {
       n = TMath::CeilNint( poi.getVal() / (2.*nStdDevOverlap*poi.getError()) ); // round up
-      oocoutI(nullptr,InputArguments) << "Using fitFavoredMu and error to set the number of imp points" << endl;
-      oocoutI(nullptr,InputArguments) << "muhat: " << poi.getVal() << "    optimize for distance: " << 2.*nStdDevOverlap*poi.getError() << endl;
-      oocoutI(nullptr,InputArguments) << "n = " << n << endl;
-      oocoutI(nullptr,InputArguments) << "This results in a distance of: " << impMaxMu / n << endl;
+      oocoutI(nullptr,InputArguments) << "Using fitFavoredMu and error to set the number of imp points" << std::endl;
+      oocoutI(nullptr,InputArguments) << "muhat: " << poi.getVal() << "    optimize for distance: " << 2.*nStdDevOverlap*poi.getError() << std::endl;
+      oocoutI(nullptr,InputArguments) << "n = " << n << std::endl;
+      oocoutI(nullptr,InputArguments) << "This results in a distance of: " << impMaxMu / n << std::endl;
    }
 
    // exclude the null, just return the number of importance snapshots
@@ -457,7 +457,7 @@ int ToyMCImportanceSampler::CreateNImpDensitiesForOnePOI( RooAbsPdf& pdf, const 
    if( impMaxMu > poiValueForBackground  &&  n > 0 ) {
       for( int i=1; i <= n; i++ ) {
          poi.setVal( poiValueForBackground + (double)i/(n)*(impMaxMu - poiValueForBackground) );
-         oocoutI(nullptr,InputArguments) << endl << "create point with poi: " << endl;
+         oocoutI(nullptr,InputArguments) << std::endl << "create point with poi: " << std::endl;
          poi.Print();
 
          // impSnaps without first snapshot because that is null hypothesis

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -73,7 +73,7 @@ void NuisanceParametersSampler::NextPoint(RooArgSet& nuisPoint, double& weight) 
 
    // check whether result will have any influence
    if(fPoints->weight() == 0.0) {
-      oocoutI(nullptr,Generation) << "Weight 0 encountered. Skipping." << endl;
+      oocoutI(nullptr,Generation) << "Weight 0 encountered. Skipping." << std::endl;
       NextPoint(nuisPoint, weight);
    }
 }
@@ -90,7 +90,7 @@ void NuisanceParametersSampler::Refresh() {
 
    if (fExpected) {
       // UNDER CONSTRUCTION
-      oocoutI(nullptr,InputArguments) << "Using expected nuisance parameters." << endl;
+      oocoutI(nullptr,InputArguments) << "Using expected nuisance parameters." << std::endl;
 
       int nBins = fNToys;
 
@@ -110,7 +110,7 @@ void NuisanceParametersSampler::Refresh() {
       if(fPoints->numEntries() != fNToys) {
          fNToys = fPoints->numEntries();
          oocoutI(nullptr,InputArguments) <<
-            "Adjusted number of toys to number of bins of nuisance parameters: " << fNToys << endl;
+            "Adjusted number of toys to number of bins of nuisance parameters: " << fNToys << std::endl;
       }
 
 /*
@@ -121,12 +121,12 @@ void NuisanceParametersSampler::Refresh() {
       p->Draw();
       for(int x=0; x < fPoints->numEntries(); x++) {
          fPoints->get(x)->Print("v");
-         cout << fPoints->weight() << endl;
+         std::cout << fPoints->weight() << std::endl;
       }
 */
 
    }else{
-      oocoutI(nullptr,InputArguments) << "Using randomized nuisance parameters." << endl;
+      oocoutI(nullptr,InputArguments) << "Using randomized nuisance parameters." << std::endl;
 
       fPoints = std::unique_ptr<RooDataSet>{fPrior->generate(*fParams, fNToys)};
    }
@@ -183,10 +183,10 @@ ToyMCSampler::~ToyMCSampler() {
 bool ToyMCSampler::CheckConfig(void) {
    bool goodConfig = true;
 
-   if(fTestStatistics.empty() || fTestStatistics[0] == nullptr) { ooccoutE(nullptr,InputArguments) << "Test statistic not set." << endl; goodConfig = false; }
-   if(!fObservables) { ooccoutE(nullptr,InputArguments) << "Observables not set." << endl; goodConfig = false; }
-   if(!fParametersForTestStat) { ooccoutE(nullptr,InputArguments) << "Parameter values used to evaluate the test statistic are not set." << endl; goodConfig = false; }
-   if(!fPdf) { ooccoutE(nullptr,InputArguments) << "Pdf not set." << endl; goodConfig = false; }
+   if(fTestStatistics.empty() || fTestStatistics[0] == nullptr) { ooccoutE(nullptr,InputArguments) << "Test statistic not set." << std::endl; goodConfig = false; }
+   if(!fObservables) { ooccoutE(nullptr,InputArguments) << "Observables not set." << std::endl; goodConfig = false; }
+   if(!fParametersForTestStat) { ooccoutE(nullptr,InputArguments) << "Parameter values used to evaluate the test statistic are not set." << std::endl; goodConfig = false; }
+   if(!fPdf) { ooccoutE(nullptr,InputArguments) << "Pdf not set." << std::endl; goodConfig = false; }
 
    return goodConfig;
 }
@@ -240,15 +240,15 @@ const RooArgList* ToyMCSampler::EvaluateAllTestStatistics(RooAbsData& data, cons
 
 SamplingDistribution* ToyMCSampler::GetSamplingDistribution(RooArgSet& paramPointIn) {
    if(fTestStatistics.size() > 1) {
-      oocoutW(nullptr, InputArguments) << "Multiple test statistics defined, but only one distribution will be returned." << endl;
+      oocoutW(nullptr, InputArguments) << "Multiple test statistics defined, but only one distribution will be returned." << std::endl;
       for( unsigned int i=0; i < fTestStatistics.size(); i++ ) {
-         oocoutW(nullptr, InputArguments) << " \t test statistic: " << fTestStatistics[i] << endl;
+         oocoutW(nullptr, InputArguments) << " \t test statistic: " << fTestStatistics[i] << std::endl;
       }
    }
 
    std::unique_ptr<RooDataSet> r{GetSamplingDistributions(paramPointIn)};
    if(r == nullptr || r->numEntries() == 0) {
-      oocoutW(nullptr, Generation) << "no sampling distribution generated" << endl;
+      oocoutW(nullptr, Generation) << "no sampling distribution generated" << std::endl;
       return nullptr;
    }
 
@@ -278,7 +278,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
    if (!CheckConfig()){
       oocoutE(nullptr, InputArguments)
          << "Bad COnfiguration in ToyMCSampler "
-         << endl;
+         << std::endl;
       return nullptr;
    }
 
@@ -303,7 +303,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
       if ( i% 500 == 0 && i>0 ) {
          oocoutP(nullptr,Generation) << "generated toys: " << i << " / " << fNToys;
          if (fToysInTails) ooccoutP(nullptr,Generation) << " (tails: " << toysInTails << " / " << fToysInTails << ")" << std::endl;
-         else ooccoutP(nullptr,Generation) << endl;
+         else ooccoutP(nullptr,Generation) << std::endl;
       }
 
       // TODO: change this treatment to keep track of all values so that the threshold
@@ -338,7 +338,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
 
       // check for nan
       if(valueFirst != valueFirst) {
-         oocoutW(nullptr, Generation) << "skip: " << valueFirst << ", " << weight << endl;
+         oocoutW(nullptr, Generation) << "skip: " << valueFirst << ", " << weight << std::endl;
          continue;
       }
 
@@ -363,7 +363,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
 
 
    if(!fGlobalObservables  ||  fGlobalObservables->empty()) {
-      ooccoutE(nullptr,InputArguments) << "Global Observables not set." << endl;
+      ooccoutE(nullptr,InputArguments) << "Global Observables not set." << std::endl;
       return;
    }
 
@@ -428,7 +428,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
 RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight, RooAbsPdf& pdf) const {
 
    if(!fObservables) {
-      ooccoutE(nullptr,InputArguments) << "Observables not set." << endl;
+      ooccoutE(nullptr,InputArguments) << "Observables not set." << std::endl;
       return nullptr;
    }
 
@@ -441,7 +441,7 @@ RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight,
    if(!fNuisanceParametersSampler && fPriorNuisance && fNuisancePars) {
       fNuisanceParametersSampler = new NuisanceParametersSampler(fPriorNuisance, fNuisancePars, fNToys, fExpectedNuisancePar);
       if ((fUseMultiGen || fgAlwaysUseMultiGen) &&  fNuisanceParametersSampler )
-         oocoutI(nullptr,InputArguments) << "Cannot use multigen when nuisance parameters vary for every toy" << endl;
+         oocoutI(nullptr,InputArguments) << "Cannot use multigen when nuisance parameters vary for every toy" << std::endl;
    }
 
    // generate global observables
@@ -531,7 +531,7 @@ std::unique_ptr<RooAbsData> ToyMCSampler::Generate(RooAbsPdf &pdf, RooArgSet &ob
     } else {
       oocoutE(nullptr,InputArguments)
                 << "ToyMCSampler: Error : pdf is not extended and number of events per toy is zero"
-                << endl;
+                << std::endl;
     }
   } else {
     if (fGenerateBinned) {

--- a/roofit/roostats/test/stressRooStats.cxx
+++ b/roofit/roostats/test/stressRooStats.cxx
@@ -34,7 +34,7 @@
 // Tests file
 #include "stressRooStats_tests.h"
 
-using std::cout, std::endl, std::string, std::list, std::setw, std::setfill, std::left;
+using std::string, std::list, std::setw, std::setfill, std::left;
 using namespace RooFit;
 
 //*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*//
@@ -50,8 +50,8 @@ using namespace RooFit;
 void StatusPrint(const int id, const TString &title, const int status, const int lineWidth)
 {
    TString header = TString::Format("Test %d : %s ", id, title.Data());
-   cout << left << setw(lineWidth) << setfill('.') << header << " "
-        << (status > 0 ? "OK" : (status < 0 ? "SKIPPED" : "FAILED")) << endl;
+   std::cout << left << setw(lineWidth) << setfill('.') << header << " "
+        << (status > 0 ? "OK" : (status < 0 ? "SKIPPED" : "FAILED")) << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +74,7 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
    if (!dryRun) {
       if (TString(refFile).Contains("http:")) {
          if (writeRef) {
-            cout << "stressRooStats ERROR: reference file must be local file in writing mode" << endl;
+            std::cout << "stressRooStats ERROR: reference file must be local file in writing mode" << std::endl;
             return -1;
          }
          fref = new TWebFile(refFile);
@@ -82,7 +82,7 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
          fref = new TFile(refFile, writeRef ? "RECREATE" : "");
       }
       if (fref->IsZombie()) {
-         cout << "stressRooStats ERROR: cannot open reference file " << refFile << endl;
+         std::cout << "stressRooStats ERROR: cannot open reference file " << refFile << std::endl;
          return -1;
       }
    }
@@ -98,11 +98,11 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
    // Add dedicated logging stream for errors that will remain active in silent mode
    RooMsgService::instance().addStream(RooFit::ERROR);
 
-   cout << left << setw(lineWidth) << setfill('*') << "" << endl;
-   cout << "*" << setw(lineWidth - 2) << setfill(' ') << " RooStats S.T.R.E.S.S. suite "
-        << "*" << endl;
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
+   std::cout << left << setw(lineWidth) << setfill('*') << "" << std::endl;
+   std::cout << "*" << setw(lineWidth - 2) << setfill(' ') << " RooStats S.T.R.E.S.S. suite "
+        << "*" << std::endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
 
    TStopwatch timer;
    timer.Start();
@@ -195,8 +195,8 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
       " Starting S.T.R.E.S.S. %s",
       allTests ? "full suite" : (oneTest ? TString::Format("test %d", testNumber).Data() : "basic suite"));
 
-   cout << "*" << setw(lineWidth - 3) << setfill(' ') << suiteType << " *" << endl;
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
+   std::cout << "*" << setw(lineWidth - 3) << setfill(' ') << suiteType << " *" << std::endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
 
    if (doDump) {
       TFile fdbg("stressRooStats_DEBUG.root", "RECREATE");
@@ -210,7 +210,7 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
       list<RooUnitTest *>::iterator iter;
 
       if (oneTest && (testNumber <= 0 || (UInt_t)testNumber > testList.size())) {
-         cout << "Tests are numbered from 1 to " << testList.size() << endl;
+         std::cout << "Tests are numbered from 1 to " << testList.size() << std::endl;
       } else {
          for (iter = testList.begin(), i = 1; iter != testList.end(); iter++, i++) {
             if (!oneTest || testNumber == i) {
@@ -235,25 +235,25 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
 
    // Print table with results
    bool UNIX = strcmp(gSystem->GetName(), "Unix") == 0;
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
    if (UNIX) {
       TString sp = gSystem->GetFromPipe("uname -a");
-      cout << "* SYS: " << sp << endl;
+      std::cout << "* SYS: " << sp << std::endl;
       if (strstr(gSystem->GetBuildNode(), "Darwin")) {
          sp = gSystem->GetFromPipe("sw_vers -productVersion");
          sp += " Mac OS X ";
-         cout << "* SYS: " << sp << endl;
+         std::cout << "* SYS: " << sp << std::endl;
       }
    } else {
       const Char_t *os = gSystem->Getenv("OS");
       if (!os) {
-         cout << "*  SYS: Windows 95" << endl;
+         std::cout << "*  SYS: Windows 95" << std::endl;
       } else {
-         cout << "*  SYS: " << os << " " << gSystem->Getenv("PROCESSOR_IDENTIFIER") << endl;
+         std::cout << "*  SYS: " << os << " " << gSystem->Getenv("PROCESSOR_IDENTIFIER") << std::endl;
       }
    }
 
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
    gBenchmark->Print("stressRooStats");
 #ifdef __CINT__
    Double_t reftime = 186.34; // pcbrun4 interpreted
@@ -262,15 +262,15 @@ int stressRooStats(const char *refFile, bool writeRef, int verbose, bool allTest
 #endif
    const Double_t rootmarks = 860 * reftime / gBenchmark->GetCpuTime("stressRooStats");
 
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
-   cout << TString::Format("*  ROOTMARKS = %6.1f  *  Root %-8s %d/%d", rootmarks, gROOT->GetVersion(),
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
+   std::cout << TString::Format("*  ROOTMARKS = %6.1f  *  Root %-8s %d/%d", rootmarks, gROOT->GetVersion(),
                            gROOT->GetVersionDate(), gROOT->GetVersionTime())
-        << endl;
-   cout << setw(lineWidth) << setfill('*') << "" << endl;
+        << std::endl;
+   std::cout << setw(lineWidth) << setfill('*') << "" << std::endl;
 
    // NOTE: The function TStopwatch::CpuTime() calls Tstopwatch::Stop(), so you do not need to stop the timer
    // separately.
-   cout << "Time at the end of job = " << timer.CpuTime() << " seconds" << endl;
+   std::cout << "Time at the end of job = " << timer.CpuTime() << " seconds" << std::endl;
 
    if (fref) {
       fref->Close();
@@ -324,44 +324,44 @@ int main(int argc, const char *argv[])
          backend = RooFit::EvalBackend(mode);
          std::cout << "stressRooStats: NLL evaluation backend set to " << mode << std::endl;
       } else if (arg == "-f") {
-         cout << "stressRooStats: using reference file " << argv[i + 1] << endl;
+         std::cout << "stressRooStats: using reference file " << argv[i + 1] << std::endl;
          refFileName = argv[++i];
       } else if (arg == "-w") {
-         cout << "stressRooStats: running in writing mode to update reference file" << endl;
+         std::cout << "stressRooStats: running in writing mode to update reference file" << std::endl;
          doWrite = true;
       } else if (arg == "-mc") {
-         cout << "stressRooStats: running in memcheck mode, no regression tests are performed" << endl;
+         std::cout << "stressRooStats: running in memcheck mode, no regression tests are performed" << std::endl;
          dryRun = true;
       } else if (arg == "-min" || arg == "-minim") {
-         cout << "stressRooStats: running using minimizer " << argv[i + 1] << endl;
+         std::cout << "stressRooStats: running using minimizer " << argv[i + 1] << std::endl;
          minimizerName = argv[++i];
       } else if (arg == "-ts") {
-         cout << "stressRooStats: setting tree-based storage for datasets" << endl;
+         std::cout << "stressRooStats: setting tree-based storage for datasets" << std::endl;
          doTreeStore = true;
       } else if (arg == "-v") {
-         cout << "stressRooStats: running in verbose mode" << endl;
+         std::cout << "stressRooStats: running in verbose mode" << std::endl;
          verbose = 1;
       } else if (arg == "-vv") {
-         cout << "stressRooStats: running in very verbose mode" << endl;
+         std::cout << "stressRooStats: running in very verbose mode" << std::endl;
          verbose = 2;
       } else if (arg == "-vvv") {
-         cout << "stressRooStats: running in very very verbose mode" << endl;
+         std::cout << "stressRooStats: running in very very verbose mode" << std::endl;
          verbose = 3;
       } else if (arg == "-a") {
-         cout << "stressRooStats: deploying full suite of tests" << endl;
+         std::cout << "stressRooStats: deploying full suite of tests" << std::endl;
          allTests = true;
       } else if (arg == "-n") {
-         cout << "stressRooStats: running single test" << endl;
+         std::cout << "stressRooStats: running single test" << std::endl;
          oneTest = true;
          testNumber = atoi(argv[++i]);
       } else if (arg == "-d") {
-         cout << "stressRooStats: setting gDebug to " << argv[i + 1] << endl;
+         std::cout << "stressRooStats: setting gDebug to " << argv[i + 1] << std::endl;
          gDebug = atoi(argv[++i]);
       } else if (arg == "-c") {
-         cout << "stressRooStats: dumping comparison file for failed tests " << endl;
+         std::cout << "stressRooStats: dumping comparison file for failed tests " << std::endl;
          doDump = true;
       } else if (arg == "-h" || arg == "--help") {
-         cout << R"(usage: stressRooStats [ options ]
+         std::cout << R"(usage: stressRooStats [ options ]
 
        -b <mode>   : Perform every fit in the tests with the EvalBackend(<mode>) command argument, where <mode> is a string
        -f <file>   : use given reference file instead of default ("stressRooStats_ref.root")
@@ -389,9 +389,9 @@ int main(int argc, const char *argv[])
    //       refFileName = ptr + 1;
    //       delete[] buf;
 
-   //       cout << "stressRooStats: WARNING running in write mode, but reference file is web file, writing local file
+   //       std::cout << "stressRooStats: WARNING running in write mode, but reference file is web file, writing local file
    //       instead: "
-   //            << refFileName << endl;
+   //            << refFileName << std::endl;
    //    }
 
    // set minimizer


### PR DESCRIPTION
This makes is easier to find occurrences of `std::cout` in the code, becuase `cout` is also a substring of the names of the RooFit printing functions (like `coutE`, `coutI`, etc.).

Like this, we can better distinguish RooFit printing from standard output printing, which helps to work on this GitHub issue:
   * https://github.com/root-project/root/issues/17429