### PR TITLE
Fixes for compiling with GCC 15 (Fedora 42)

### DIFF
--- a/misc/minicern/src/cernlib.c
+++ b/misc/minicern/src/cernlib.c
@@ -172,8 +172,8 @@ int cfstati_(char *fname, int *info, int *lgname)
 #endif
 {
    struct stat buf;
-   char *ptname, *fchtak();
-   int istat=-1, stat();
+   char *ptname;
+   int istat = -1;
    ptname = fchtak(fname,*lgname);
    if (ptname == ((void *)0)) return -1;
    istat = stat(ptname, &buf);
@@ -226,7 +226,7 @@ void cfopei_(int *lundes, int *medium, int *nwrec, int *mode, int *nbuf,
              char *ftext, int *astat, int *lgtx)
 #endif
 {
-   char *pttext, *fchtak();
+   char *pttext;
    int flags = 0;
    int fildes;
    int perm;


### PR DESCRIPTION
# This Pull request:

These changes make it possible to compile root 6.34.02 using gcc 15 on Fedora 42.

Also the following commits need to be backported from master:

commit 2884f67f5a145ef5d2ba1f8050b2b1a543d97881
commit cfc922131c8a977e14c6611ed991f0889b0c47c8

... and the following commits from LLVM:

commit llvm/llvm-project@7e44305041d96b064c197216b931ae3917a34ac1
commit llvm/llvm-project@7abf44069aec61eee147ca67a6333fc34583b524 (see PR llvm/llvm-project#123320)
