### PR TITLE
[webgui] properly configure usage of current dir [6.34]

### DIFF
--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -854,6 +854,11 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
       InformListener(std::string("win:") + winurl + "\n");
    }
 
+   auto server = GetServer();
+
+   if (win.IsUseCurrentDir() && server)
+      server->AddLocation("currentdir/", ".");
+
    if (!args.IsHeadless() && ((args.GetBrowserKind() == RWebDisplayArgs::kServer) || gROOT->IsWebDisplayBatch()) /*&& (RWebWindowWSHandler::GetBoolEnv("WebGui.OnetimeKey") != 1)*/) {
       std::cout << "New web window: " << args.GetUrl() << std::endl;
       return 0;
@@ -880,11 +885,6 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
       }
    }
 #endif
-
-   auto server = GetServer();
-
-   if (win.IsUseCurrentDir())
-      server->AddLocation("currentdir/", ".");
 
    if (!normal_http)
       args.SetHttpServer(server);


### PR DESCRIPTION
If web window requires usage of current directory, configure it earlier. 

Fix problem that `webpanel.cxx` example not working with `--web=server` mode

Fixes https://root-forum.cern.ch/t/webpanel-tutorial-error/62704

Backport of  #17457 
