### PR TITLE
[RF] Address Clang compiler warning

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -781,7 +781,7 @@ namespace MathFuncs {
 // custom dummy pullback that does nothing.
 
 template <class... Types>
-void binNumber_pullback(Types... args)
+void binNumber_pullback(Types...)
 {
 }
 


### PR DESCRIPTION
Building ROOT with Clang 18 currently warns:
```
MathFuncs.h:784:34: warning: unused parameter 'args' [-Wunused-parameter]
```