### PR TITLE
[RF] Don't override `TObject::Clone()` in TH2Poly

### DIFF
--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -81,7 +81,6 @@ public:
    Bool_t Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1) override;
    Bool_t Add(TF1 *h1, Double_t c1=1, Option_t *option="") override;
    void          ClearBinContents();                 // Clears the content of all bins
-   TObject      *Clone(const char* newname = "") const override;
    void          Copy(TObject & newth2p) const override;
    void          ChangePartition(Int_t n, Int_t m);  // Sets the number of partition cells to another value
    using TH2::Multiply;

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -548,19 +548,6 @@ void TH2Poly::ChangePartition(Int_t n, Int_t m)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Make a complete copy of the underlying object.  If 'newname' is set,
-/// the copy's name will be set to that name.
-
-TObject* TH2Poly::Clone(const char* newname) const
-{
-   // TH1::Clone relies on ::Copy to implemented by the derived class.
-   // Until this is implemented, revert to the much slower default version
-   // (and possibly non-thread safe).
-
-   return TNamed::Clone(newname);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Clears the contents of all bins in the histogram.
 
 void TH2Poly::ClearBinContents()


### PR DESCRIPTION
The `TH1` base class already implements the `Clone()` method in such a way that no TH1-derived class needs to re-implement it, also cloning the fit functions correctly:
https://github.com/root-project/root/blob/master/hist/hist/src/TH1.cxx

However, there is one TH1-derived class that again overrides `Clone()` with a fallback to `TNamed::Clone()`, falling back to the wrong base class.

This is one of the blockers for #17399, where such crashes appeared in the newly added tests.

One might also consider marking `TH1::Clone()` as `final` to avoid these kind of mistakes in the future.

