### PR TITLE
[hist] Make abstract TH1,2,3 methods truly abstract and add missing implementations

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -200,8 +200,12 @@ public:
    virtual Bool_t   Add(TF1 *h1, Double_t c1=1, Option_t *option="");
    virtual Bool_t   Add(const TH1 *h1, Double_t c1=1);
    virtual Bool_t   Add(const TH1 *h, const TH1 *h2, Double_t c1=1, Double_t c2=1);
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
+   /// Increment bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t bin) = 0;
+   /// Increment bin content by a weight w.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t bin, Double_t w) = 0;
    static  void     AddDirectory(Bool_t add=kTRUE);
    static  Bool_t   AddDirectoryStatus();
            void     Browse(TBrowser *b) override;
@@ -456,8 +460,15 @@ public:
    ClassDefOverride(TH1,8)  //1-Dim histogram base class
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const;
-   virtual void     UpdateBinContent(Int_t bin, Double_t content);
+
+   /// Raw retrieval of bin content on internal data structure
+   /// see convention for numbering bins in TH1::GetBin
+   virtual Double_t RetrieveBinContent(Int_t bin) const = 0;
+
+   /// Raw update of bin content on internal data structure
+   /// see convention for numbering bins in TH1::GetBin
+   virtual void     UpdateBinContent(Int_t bin, Double_t content) = 0;
+
    virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const { return fSumw2.fN ? fSumw2.fArray[bin] : RetrieveBinContent(bin); }
 };
 

--- a/hist/hist/inc/TH1K.h
+++ b/hist/hist/inc/TH1K.h
@@ -28,17 +28,26 @@ class TH1K : public TH1, public TArrayF {
 private:
    void Sort();
 protected:
-   Int_t fReady;  //!
-   Int_t fNIn;
-   Int_t fKOrd;   //!
-   Int_t fKCur;   //!
+   Int_t fReady = 0;  //!
+   Int_t fNIn = 0;
+   Int_t fKOrd = 3;   //!
+   Int_t fKCur = 0;   //!
 
    Double_t RetrieveBinContent(Int_t bin) const override { return GetBinContent(bin); }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Float_t (content); }
 
 public:
    TH1K();
    TH1K(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup,Int_t k=0);
-   ~TH1K() override;
+
+   /// Increment bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
+   void     AddBinContent(Int_t bin) override {++fArray[bin];}
+   /// Increment bin content by a weight w.
+   /// \warning The value of w is cast to `Float_t` before being added.
+   /// Passing an out-of-range bin leads to undefined behavior
+   void     AddBinContent(Int_t bin, Double_t w) override
+                          { fArray[bin] += Float_t (w); }
 
    void      Copy(TObject &obj) const override;
    Int_t     Fill(Double_t x) override;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -71,12 +71,12 @@ private:
 public:
    ~TH2() override;
    using TH1::AddBinContent;
-   /// Increment 2D bin content by 1.
-   /// Passing an out-of-range bin leads to undefined behavior
-   virtual void     AddBinContent(Int_t binx, Int_t biny) = 0;
-   /// Increment 2D bin content by a weight w.
-   /// Passing an out-of-range bin leads to undefined behavior
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Double_t w) = 0;
+           /// Increment 2D bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
+           void     AddBinContent(Int_t binx, Int_t biny) { AddBinContent(GetBin(binx, biny)); }
+           /// Increment 2D bin content by a weight w.
+           /// Passing an out-of-range bin leads to undefined behavior
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) { AddBinContent(GetBin(binx, biny), w); }
            Int_t    BufferEmpty(Int_t action=0) override;
            void     Copy(TObject &hnew) const override;
            Int_t    Fill(Double_t x, Double_t y) override;
@@ -159,8 +159,6 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
-           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -202,8 +200,6 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
-           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -245,8 +241,6 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
-           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -286,8 +280,6 @@ public:
    ~TH2L() override;
    void     AddBinContent(Int_t bin) override;
    void     AddBinContent(Int_t bin, Double_t w) override;
-   void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-   void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
    void     Copy(TObject &hnew) const override;
    void     Reset(Option_t *option="") override;
    void     SetBinsLength(Int_t n=-1) override;
@@ -334,8 +326,6 @@ public:
            /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
-           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -383,8 +373,6 @@ public:
            /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
-           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
-           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -70,10 +70,13 @@ private:
 
 public:
    ~TH2() override;
-           void     AddBinContent(Int_t bin) override;
-           void     AddBinContent(Int_t bin, Double_t w) override;
-   virtual void     AddBinContent(Int_t binx, Int_t biny);
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Double_t w);
+   using TH1::AddBinContent;
+   /// Increment 2D bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t binx, Int_t biny) = 0;
+   /// Increment 2D bin content by a weight w.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Double_t w) = 0;
            Int_t    BufferEmpty(Int_t action=0) override;
            void     Copy(TObject &hnew) const override;
            Int_t    Fill(Double_t x, Double_t y) override;

--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -130,6 +130,9 @@ protected:
 
    //functions not to be used for TH2Poly
 
+   void AddBinContent(Int_t) override;           ///< NOT IMPLEMENTED for TH2Poly
+   void AddBinContent(Int_t, Double_t) override; ///< NOT IMPLEMENTED for TH2Poly
+
    Int_t        Fill(Double_t) override{return -1;}                              ///< NOT IMPLEMENTED for TH2Poly
    Int_t        Fill(Double_t , const char *, Double_t) override{return -1;}     ///< NOT IMPLEMENTED for TH2Poly
    Int_t        Fill(const char *, Double_t , Double_t ) override{return -1;}    ///< NOT IMPLEMENTED for TH2Poly

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -75,10 +75,13 @@ private:
 
 public:
    ~TH3() override;
-           void     AddBinContent(Int_t bin) override;
-           void     AddBinContent(Int_t bin, Double_t w) override;
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz);
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w);
+   using TH1::AddBinContent;
+   /// Increment 3D bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz) = 0;
+   /// Increment 3D bin content by a weight w.
+   /// Passing an out-of-range bin leads to undefined behavior
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) = 0;
            Int_t    BufferEmpty(Int_t action = 0) override;
            void     Copy(TObject &hnew) const override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z);

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -76,12 +76,12 @@ private:
 public:
    ~TH3() override;
    using TH1::AddBinContent;
-   /// Increment 3D bin content by 1.
-   /// Passing an out-of-range bin leads to undefined behavior
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz) = 0;
-   /// Increment 3D bin content by a weight w.
-   /// Passing an out-of-range bin leads to undefined behavior
-   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) = 0;
+           /// Increment 3D bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
+           void     AddBinContent(Int_t binx, Int_t biny, Int_t binz) { AddBinContent(GetBin(binx, biny, binz)); }
+           /// Increment 3D bin content by a weight w.
+           /// Passing an out-of-range bin leads to undefined behavior
+           void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) { AddBinContent(GetBin(binx, biny, binz), w); }
            Int_t    BufferEmpty(Int_t action = 0) override;
            void     Copy(TObject &hnew) const override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z);
@@ -175,8 +175,6 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -215,8 +213,6 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -255,8 +251,6 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -295,8 +289,6 @@ public:
    ~TH3L() override;
    void      AddBinContent(Int_t bin) override;
    void      AddBinContent(Int_t bin, Double_t w) override;
-   void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-   void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
    void      Copy(TObject &hnew) const override;
    void      Reset(Option_t *option="") override;
    void      SetBinsLength(Int_t n=-1) override;
@@ -341,8 +333,6 @@ public:
            /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -386,8 +376,6 @@ public:
            /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
-           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -1249,24 +1249,6 @@ Bool_t TH1::Add(const TH1 *h1, const TH1 *h2, Double_t c1, Double_t c2)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by 1.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH1::AddBinContent(Int_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by a weight w.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH1::AddBinContent(Int_t, Double_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Sets the flag controlling the automatic add of histograms in memory
 ///
 /// By default (fAddDirectory = kTRUE), histograms are automatically added
@@ -9452,25 +9434,6 @@ TH1* TH1::TransformHisto(TVirtualFFT *fft, TH1* h_output,  Option_t *option)
    }
 
    return hout;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Raw retrieval of bin content on internal data structure
-/// see convention for numbering bins in TH1::GetBin
-
-Double_t TH1::RetrieveBinContent(Int_t) const
-{
-   AbstractMethod("RetrieveBinContent");
-   return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Raw update of bin content on internal data structure
-/// see convention for numbering bins in TH1::GetBin
-
-void TH1::UpdateBinContent(Int_t, Double_t)
-{
-   AbstractMethod("UpdateBinContent");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH1K.cxx
+++ b/hist/hist/src/TH1K.cxx
@@ -39,10 +39,6 @@ ClassImp(TH1K);
 TH1K::TH1K()
 {
    fDimension = 1;
-   fNIn   = 0;
-   fReady = 0;
-   fKOrd  = 3;
-   fKCur  = 0;
 }
 
 
@@ -54,18 +50,7 @@ TH1K::TH1K(const char *name,const char *title,Int_t nbins,Double_t xlow,Double_t
      : TH1(name,title,nbins,xlow,xup), TArrayF(100)
 {
    fDimension = 1;
-   fNIn   = 0;
-   fReady = 0;
    fKOrd  = k;
-   fKCur  = 0;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor.
-
-TH1K::~TH1K()
-{
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -232,42 +232,6 @@ TH2::~TH2()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by 1.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH2::AddBinContent(Int_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by a weight w.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH2::AddBinContent(Int_t, Double_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment 2D bin content by 1.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH2::AddBinContent(Int_t, Int_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment 2D bin content by a weight w.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH2::AddBinContent(Int_t, Int_t, Double_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram with all entries in the buffer.
 ///  - action = -1 histogram is reset and refilled from the buffer (called by THistPainter::Paint)
 ///  - action =  0 histogram is filled from the buffer

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -1751,3 +1751,15 @@ Double_t TH2Poly::Interpolate(Double_t, Double_t)
    Error("Interpolate", "Not implemented for TH2Poly");
    return TMath::QuietNaN();
 }
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+void TH2Poly::AddBinContent(Int_t)
+{
+   Error("AddBinContent", "Not implemented for TH2Poly");
+}
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+void TH2Poly::AddBinContent(Int_t, Double_t)
+{
+   Error("AddBinContent", "Not implemented for TH2Poly");
+}

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -218,42 +218,6 @@ void TH3::Copy(TObject &obj) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by 1.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH3::AddBinContent(Int_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by a weight w.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH3::AddBinContent(Int_t, Double_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment 3D bin content by 1.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH3::AddBinContent(Int_t, Int_t, Int_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Increment 3D bin content by a weight w.
-/// Passing an out-of-range bin leads to undefined behavior
-
-void TH3::AddBinContent(Int_t, Int_t, Int_t, Double_t)
-{
-   AbstractMethod("AddBinContent");
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram with all entries in the buffer.
 /// action = -1 histogram is reset and refilled from the buffer (called by THistPainter::Paint)
 /// action =  0 histogram is filled from the buffer


### PR DESCRIPTION
The TH1K class implementation forgot to implement some abstract methods
from the TH1 class that need to be implemented.

As the TH1K is almost identical to TH1F (besides the KDE algorithm in
the bin lookup), the TH1F implementations are copy-pasted.

The incomplete implementation was noticed thanks to the test in #17399.

To make sure that these mistakes can't happen anymore, the virtual methods of `TH1` are made truly virtual in the sense of the C++ language standard. So far, the implementation was only telling you at runtime that the method should be overridden.