### PR TITLE
[v634] [PyROOT] Add executors and converters for `std::byte`

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -3513,8 +3513,11 @@ public:
         gf["const signed char&"] =          gf["const char&"];
 #if __cplusplus > 201402L
         gf["std::byte"] =                   gf["uint8_t"];
+        gf["byte"] =                        gf["uint8_t"];
         gf["const std::byte&"] =            gf["const uint8_t&"];
+        gf["const byte&"] =                 gf["const uint8_t&"];
         gf["std::byte&"] =                  gf["uint8_t&"];
+        gf["byte&"] =                       gf["uint8_t&"];
 #endif
         gf["std::int8_t"] =                 gf["int8_t"];
         gf["const std::int8_t&"] =          gf["const int8_t&"];

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
@@ -1036,6 +1036,8 @@ public:
 #if __cplusplus > 201402L
         gf["std::byte ptr"] =               (ef_t)+[](cdims_t d) { return new ByteArrayExecutor{d};     };
         gf["const std::byte ptr"] =         gf["std::byte ptr"];
+        gf["byte ptr"] =                    gf["std::byte ptr"];
+        gf["const byte ptr"] =              gf["std::byte ptr"];
 #endif
         gf["int8_t ptr"] =                  (ef_t)+[](cdims_t d) { return new Int8ArrayExecutor{d};    };
         gf["uint8_t ptr"] =                 (ef_t)+[](cdims_t d) { return new UInt8ArrayExecutor{d};   };
@@ -1060,8 +1062,11 @@ public:
         gf["internal_enum_type_t ptr"] =    gf["int ptr"];
 #if __cplusplus > 201402L
         gf["std::byte"] =                   gf["uint8_t"];
+        gf["byte"] =                        gf["uint8_t"];
         gf["std::byte&"] =                  gf["uint8_t&"];
+        gf["byte&"] =                       gf["uint8_t&"];
         gf["const std::byte&"] =            gf["const uint8_t&"];
+        gf["const byte&"] =                 gf["const uint8_t&"];
 #endif
         gf["std::int8_t"] =                 gf["int8_t"];
         gf["std::int8_t&"] =                gf["int8_t&"];

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Adapt-to-no-std-in-ROOT.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Adapt-to-no-std-in-ROOT.patch
@@ -1,7 +1,7 @@
 From 24b94cde0a5fa6b46be05359b7218af9bb295d87 Mon Sep 17 00:00:00 2001
 From: Jonas Rembser <jonas.rembser@cern.ch>
 Date: Tue, 12 Mar 2024 01:59:37 +0100
-Subject: [PATCH] [CPyCppyy] Adapt to no `std::` in ROOT
+Subject: [PATCH 1/2] [CPyCppyy] Adapt to no `std::` in ROOT
 
 ---
  .../pyroot/cppyy/CPyCppyy/src/Converters.cxx  | 20 +++++++++++--------
@@ -126,4 +126,59 @@ index c1720cf3f2..ae0e31cac8 100644
          Utility::AddToClass(pyclass, "__bytes__", (PyCFunction)STLWStringBytes,      METH_NOARGS);
 -- 
 2.44.0
+
+From ef0836c23c850ce3113d5a7ff5787dee9e094099 Mon Sep 17 00:00:00 2001
+From: Aaron Jomy <aaron.jomy@cern.ch>
+Date: Tue, 21 Jan 2025 14:09:03 +0100
+Subject: [PATCH 2/2] [PyROOT] Add executors and converters for `std::byte`
+
+Fixes issue: https://github.com/root-project/root/issues/17442
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx | 3 +++
+ bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx  | 5 +++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+index c127604a6e..21d3d4aa73 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+@@ -3522,8 +3522,11 @@ public:
+         gf["const signed char&"] =          gf["const char&"];
+ #if __cplusplus > 201402L
+         gf["std::byte"] =                   gf["uint8_t"];
++        gf["byte"] =                        gf["uint8_t"];
+         gf["const std::byte&"] =            gf["const uint8_t&"];
++        gf["const byte&"] =                 gf["const uint8_t&"];
+         gf["std::byte&"] =                  gf["uint8_t&"];
++        gf["byte&"] =                       gf["uint8_t&"];
+ #endif
+         gf["std::int8_t"] =                 gf["int8_t"];
+         gf["const std::int8_t&"] =          gf["const int8_t&"];
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
+index 5e94846771..edefcf5b5b 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
+@@ -1022,6 +1022,8 @@ public:
+ #if __cplusplus > 201402L
+         gf["std::byte ptr"] =               (ef_t)+[](cdims_t d) { return new ByteArrayExecutor{d};     };
+         gf["const std::byte ptr"] =         gf["std::byte ptr"];
++        gf["byte ptr"] =                    gf["std::byte ptr"];
++        gf["const byte ptr"] =              gf["std::byte ptr"];
+ #endif
+         gf["int8_t ptr"] =                  (ef_t)+[](cdims_t d) { return new Int8ArrayExecutor{d};    };
+         gf["uint8_t ptr"] =                 (ef_t)+[](cdims_t d) { return new UInt8ArrayExecutor{d};   };
+@@ -1046,8 +1048,11 @@ public:
+         gf["internal_enum_type_t ptr"] =    gf["int ptr"];
+ #if __cplusplus > 201402L
+         gf["std::byte"] =                   gf["uint8_t"];
++        gf["byte"] =                        gf["uint8_t"];
+         gf["std::byte&"] =                  gf["uint8_t&"];
++        gf["byte&"] =                       gf["uint8_t&"];
+         gf["const std::byte&"] =            gf["const uint8_t&"];
++        gf["const byte&"] =                 gf["const uint8_t&"];
+ #endif
+         gf["std::int8_t"] =                 gf["int8_t"];
+         gf["std::int8_t&"] =                gf["int8_t&"];
+-- 
+2.43.0
 


### PR DESCRIPTION
Backport changes from #17469 to the 6.34 branch. This is required to fix #17442
