### PR TITLE
[RF] Deprecate `RooAbsPdf::generateSimGlobal()`

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -38,6 +38,7 @@ The following people have contributed to this new version:
 * The ROOT splash screen was removed for Linux and macOS
 * Proof support has been completely removed form RooFit and RooStats, after it was already not working anymore for several releases
 * The build options `mysql`, `odbc`, `pgsql` and `qt5web` have been deprecated. Please complain with root-dev@cern.ch should you still need one!
+* The `RooAbsPdf::generateSimGlobal()` method is deprecated and will be removed in ROOT 6.38. It only contains some workarounds that are not necessary anymore. One can just use the regular `RooAbsPdf::generate()` function.
 
 ## Python Interface
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -23,6 +23,8 @@
 #include <RooGlobalFunc.h>
 #include <RooObjCacheManager.h>
 
+#include <ROOT/RConfig.hxx> // for R__DEPRECATED
+
 class RooArgSet ;
 class RooAbsGenContext ;
 class RooFitResult ;
@@ -118,7 +120,8 @@ public:
                const RooCmdArg& arg5={},const RooCmdArg& arg6={}) const;
   virtual RooFit::OwningPtr<RooDataHist> generateBinned(const RooArgSet &whatVars, double nEvents, bool expectedData=false, bool extended=false) const;
 
-  virtual RooFit::OwningPtr<RooDataSet> generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) ;
+  virtual RooFit::OwningPtr<RooDataSet> generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents)
+  R__DEPRECATED(6,38, "Use RooAbsPdf::generate() instead. The RooAbsPdf::generateSimGlobal() only contains some workarounds that are not necessary anymore");
 
   ///Helper calling plotOn(RooPlot*, RooLinkedList&) const
   RooPlot* plotOn(RooPlot* frame,

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -26,6 +26,8 @@
 #include <RooRealProxy.h>
 #include <RooSetProxy.h>
 
+#include <ROOT/RConfig.hxx> // for R__DEPRECATED
+
 #include <TList.h>
 
 #include <map>
@@ -91,7 +93,8 @@ public:
   const RooAbsCategoryLValue& indexCat() const { return (RooAbsCategoryLValue&) _indexCat.arg() ; }
 
 
-  RooFit::OwningPtr<RooDataSet> generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) override ;
+  RooFit::OwningPtr<RooDataSet> generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) override
+  R__DEPRECATED(6,38, "Use RooAbsPdf::generate() instead. The RooAbsPdf::generateSimGlobal() only contains some workarounds that are not necessary anymore");
 
   virtual RooDataHist* fillDataHist(RooDataHist *hist, const RooArgSet* nset, double scaleFactor,
                 bool correctForBinVolume=false, bool showProgress=false) const ;

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -410,7 +410,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
    } else {
 
       // not using multigen for global observables
-      std::unique_ptr<RooDataSet> one{pdf.generateSimGlobal( *fGlobalObservables, 1 )};
+      std::unique_ptr<RooDataSet> one{pdf.generate( *fGlobalObservables, 1 )};
       const RooArgSet *values = one->get(0);
       std::unique_ptr<RooArgSet> allVars{pdf.getVariables()};
       allVars->assign(*values);

--- a/tutorials/roofit/roostats/TwoSidedFrequentistUpperLimitWithBands.C
+++ b/tutorials/roofit/roostats/TwoSidedFrequentistUpperLimitWithBands.C
@@ -317,24 +317,10 @@ void TwoSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
       }
 
       // generate global observables
-      // need to be careful for simpdf.
-      // In ROOT 5.28 there is a problem with generating global observables
-      // with a simultaneous PDF.  In 5.29 there is a solution with
-      // RooSimultaneous::generateSimGlobal, but this may change to
-      // the standard generate interface in 5.30.
-
-      RooSimultaneous *simPdf = dynamic_cast<RooSimultaneous *>(mc->GetPdf());
-      if (!simPdf) {
-         std::unique_ptr<RooDataSet> one{mc->GetPdf()->generate(*mc->GetGlobalObservables(), 1)};
-         const RooArgSet *values = one->get();
-         std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
-         allVars->assign(*values);
-      } else {
-         std::unique_ptr<RooDataSet> one{simPdf->generateSimGlobal(*mc->GetGlobalObservables(), 1)};
-         const RooArgSet *values = one->get();
-         std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
-         allVars->assign(*values);
-      }
+      std::unique_ptr<RooDataSet> one{mc->GetPdf()->generate(*mc->GetGlobalObservables(), 1)};
+      const RooArgSet *values = one->get();
+      std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
+      allVars->assign(*values);
 
       // get test stat at observed UL in observed data
       firstPOI->setVal(observedUL);

--- a/tutorials/roofit/roostats/TwoSidedFrequentistUpperLimitWithBands.py
+++ b/tutorials/roofit/roostats/TwoSidedFrequentistUpperLimitWithBands.py
@@ -293,23 +293,10 @@ for imc in range(nToyMC):
         toyData = mc.GetPdf().generate(mc.GetObservables(), Extended=True)
 
     # generate global observables
-    # need to be careful for simpdf.
-    # In ROOT 5.28 there is a problem with generating global observables
-    # with a simultaneous PDF.  In 5.29 there is a solution with
-    # RooSimultaneous::generateSimGlobal, but this may change to
-    # the standard generate interface in 5.30.
-
-    simPdf = ROOT.RooSimultaneous(mc.GetPdf())
-    if not simPdf:
-        one = mc.GetPdf().generate(mc.GetGlobalObservables(), 1)
-        values = one.get()
-        allVars = mc.GetPdf().getVariables()
-        allVars.assign(values)
-    else:
-        one = simPdf.generateSimGlobal(mc.GetGlobalObservables(), 1)
-        values = one.get()
-        allVars = mc.GetPdf().getVariables()
-        allVars.assign(values)
+    one = mc.GetPdf().generate(mc.GetGlobalObservables(), 1)
+    values = one.get()
+    allVars = mc.GetPdf().getVariables()
+    allVars.assign(values)
 
     # get test stat at observed UL in observed data
     firstPOI.setVal(observedUL)


### PR DESCRIPTION
The `RooAbsPdf::generateSimGlobal()` method is deprecated and will be removed in ROOT 6.38. It only contains some workarounds that are not necessary anymore. One can just use the regular `RooAbsPdf::generate()` function.

Getting rid of these redundant functions will avoid user confusion.