### PR TITLE
[ntuple] Make RNTupleDescriptor::Clone() return it by value

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDataSource.hxx>
 #include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
 #include <string_view>
 
 #include <condition_variable>
@@ -36,7 +37,6 @@ class RNTuple;
 
 namespace Experimental {
 class RFieldBase;
-class RNTupleDescriptor;
 
 namespace Internal {
 class RNTupleColumnReader;
@@ -57,7 +57,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    };
 
    /// A clone of the first pages source's descriptor.
-   std::unique_ptr<RNTupleDescriptor> fPrincipalDescriptor;
+   RNTupleDescriptor fPrincipalDescriptor;
 
    /// The data source may be constructed with an ntuple name and a list of files
    std::string fNTupleName;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -377,7 +377,7 @@ RNTupleDS::RNTupleDS(std::unique_ptr<Internal::RPageSource> pageSource)
    fPrincipalDescriptor = pageSource->GetSharedDescriptorGuard()->Clone();
    fStagingArea.emplace_back(std::move(pageSource));
 
-   AddField(*fPrincipalDescriptor, "", fPrincipalDescriptor->GetFieldZeroId(),
+   AddField(fPrincipalDescriptor, "", fPrincipalDescriptor.GetFieldZeroId(),
             std::vector<ROOT::Experimental::RNTupleDS::RFieldInfo>());
 }
 
@@ -442,9 +442,9 @@ RNTupleDS::GetColumnReaders(unsigned int slot, std::string_view name, const std:
 
    // Map the field's and subfields' IDs to qualified names so that we can later connect the fields to
    // other page sources from the chain
-   fFieldId2QualifiedName[field->GetOnDiskId()] = fPrincipalDescriptor->GetQualifiedFieldName(field->GetOnDiskId());
+   fFieldId2QualifiedName[field->GetOnDiskId()] = fPrincipalDescriptor.GetQualifiedFieldName(field->GetOnDiskId());
    for (const auto &s : *field) {
-      fFieldId2QualifiedName[s.GetOnDiskId()] = fPrincipalDescriptor->GetQualifiedFieldName(s.GetOnDiskId());
+      fFieldId2QualifiedName[s.GetOnDiskId()] = fPrincipalDescriptor.GetQualifiedFieldName(s.GetOnDiskId());
    }
 
    auto reader = std::make_unique<Internal::RNTupleColumnReader>(this, field);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -65,7 +65,7 @@ class RNTupleDescriptorBuilder;
 \brief Meta-data stored for every field of an ntuple
 */
 // clang-format on
-class RFieldDescriptor {
+class RFieldDescriptor final {
    friend class Internal::RNTupleDescriptorBuilder;
    friend class Internal::RFieldDescriptorBuilder;
 
@@ -149,7 +149,7 @@ public:
 \brief Meta-data stored for every column of an ntuple
 */
 // clang-format on
-class RColumnDescriptor {
+class RColumnDescriptor final {
    friend class Internal::RColumnDescriptorBuilder;
    friend class Internal::RNTupleDescriptorBuilder;
 
@@ -227,7 +227,7 @@ Clusters usually span across all available columns but in some cases they can de
 for instance when describing friend ntuples.
 */
 // clang-format on
-class RClusterDescriptor {
+class RClusterDescriptor final {
    friend class Internal::RClusterDescriptorBuilder;
 
 public:
@@ -427,7 +427,7 @@ Every ntuple has at least one cluster group.  The clusters in a cluster group ar
 the order of page locations in the page list envelope that belongs to the cluster group (see format specification)
 */
 // clang-format on
-class RClusterGroupDescriptor {
+class RClusterGroupDescriptor final {
    friend class Internal::RClusterGroupDescriptorBuilder;
 
 private:
@@ -486,7 +486,7 @@ enum class EExtraTypeInfoIds {
 Currently only used by streamer fields to store RNTuple-wide list of streamer info records.
 */
 // clang-format on
-class RExtraTypeInfoDescriptor {
+class RExtraTypeInfoDescriptor final {
    friend class Internal::RExtraTypeInfoDescriptorBuilder;
 
 private:
@@ -536,7 +536,7 @@ the concept of frames: header, footer, and substructures have a preamble with ve
 writte struct. This allows for forward and backward compatibility when the meta-data evolves.
 */
 // clang-format on
-class RNTupleDescriptor {
+class RNTupleDescriptor final {
    friend class Internal::RNTupleDescriptorBuilder;
 
 public:
@@ -616,7 +616,7 @@ public:
    RNTupleDescriptor(RNTupleDescriptor &&other) = default;
    RNTupleDescriptor &operator=(RNTupleDescriptor &&other) = default;
 
-   std::unique_ptr<RNTupleDescriptor> Clone() const;
+   RNTupleDescriptor Clone() const;
 
    bool operator==(const RNTupleDescriptor &other) const;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -86,7 +86,7 @@ private:
    /// descriptor.  Using the descriptor's generation number, we know if the cached descriptor is stale.
    /// Retrieving descriptor data from an RNTupleReader is supposed to be for testing and information purposes,
    /// not on a hot code path.
-   std::unique_ptr<RNTupleDescriptor> fCachedDescriptor;
+   std::optional<RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
    /// If not nullopt, these will used when creating the model
    std::optional<RNTupleDescriptor::RCreateModelOptions> fCreateModelOptions;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -602,7 +602,7 @@ public:
          fLock.unlock();
       }
       RNTupleDescriptor *operator->() const { return &fDescriptor; }
-      void MoveIn(RNTupleDescriptor &&desc) { fDescriptor = std::move(desc); }
+      void MoveIn(RNTupleDescriptor desc) { fDescriptor = std::move(desc); }
    };
 
 private:

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -663,32 +663,32 @@ ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &op
    return model;
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTupleDescriptor::Clone() const
+ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clone() const
 {
-   auto clone = std::make_unique<RNTupleDescriptor>();
-   clone->fName = fName;
-   clone->fDescription = fDescription;
-   clone->fOnDiskHeaderXxHash3 = fOnDiskHeaderXxHash3;
-   clone->fOnDiskHeaderSize = fOnDiskHeaderSize;
-   clone->fOnDiskFooterSize = fOnDiskFooterSize;
-   clone->fNEntries = fNEntries;
-   clone->fNClusters = fNClusters;
-   clone->fNPhysicalColumns = fNPhysicalColumns;
-   clone->fFieldZeroId = fFieldZeroId;
-   clone->fGeneration = fGeneration;
+   RNTupleDescriptor clone;
+   clone.fName = fName;
+   clone.fDescription = fDescription;
+   clone.fOnDiskHeaderXxHash3 = fOnDiskHeaderXxHash3;
+   clone.fOnDiskHeaderSize = fOnDiskHeaderSize;
+   clone.fOnDiskFooterSize = fOnDiskFooterSize;
+   clone.fNEntries = fNEntries;
+   clone.fNClusters = fNClusters;
+   clone.fNPhysicalColumns = fNPhysicalColumns;
+   clone.fFieldZeroId = fFieldZeroId;
+   clone.fGeneration = fGeneration;
    for (const auto &d : fFieldDescriptors)
-      clone->fFieldDescriptors.emplace(d.first, d.second.Clone());
+      clone.fFieldDescriptors.emplace(d.first, d.second.Clone());
    for (const auto &d : fColumnDescriptors)
-      clone->fColumnDescriptors.emplace(d.first, d.second.Clone());
+      clone.fColumnDescriptors.emplace(d.first, d.second.Clone());
    for (const auto &d : fClusterGroupDescriptors)
-      clone->fClusterGroupDescriptors.emplace(d.first, d.second.Clone());
-   clone->fSortedClusterGroupIds = fSortedClusterGroupIds;
+      clone.fClusterGroupDescriptors.emplace(d.first, d.second.Clone());
+   clone.fSortedClusterGroupIds = fSortedClusterGroupIds;
    for (const auto &d : fClusterDescriptors)
-      clone->fClusterDescriptors.emplace(d.first, d.second.Clone());
+      clone.fClusterDescriptors.emplace(d.first, d.second.Clone());
    for (const auto &d : fExtraTypeInfoDescriptors)
-      clone->fExtraTypeInfoDescriptors.emplace_back(d.Clone());
+      clone.fExtraTypeInfoDescriptors.emplace_back(d.Clone());
    if (fHeaderExtension)
-      clone->fHeaderExtension = std::make_unique<RHeaderExtension>(*fHeaderExtension);
+      clone.fHeaderExtension = std::make_unique<RHeaderExtension>(*fHeaderExtension);
    return clone;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -212,7 +212,7 @@ std::unique_ptr<ROOT::Experimental::Internal::RPageSource> ROOT::Experimental::I
 {
    auto clone = CloneImpl();
    if (fIsAttached) {
-      clone->GetExclDescriptorGuard().MoveIn(std::move(*GetSharedDescriptorGuard()->Clone()));
+      clone->GetExclDescriptorGuard().MoveIn(GetSharedDescriptorGuard()->Clone());
       clone->fHasStructure = true;
       clone->fIsAttached = true;
    }

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -537,7 +537,7 @@ TEST(RNTupleDescriptor, Clone)
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    const auto &desc = ntuple->GetDescriptor();
    auto clone = desc.Clone();
-   EXPECT_EQ(desc, *clone);
+   EXPECT_EQ(desc, clone);
 }
 
 TEST(RNTupleDescriptor, BuildStreamerInfos)

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -310,8 +310,8 @@ TEST_F(RPageStorageDaos, CagedPages)
       auto pageSource = RPageSource::Create(ntupleName, daosUri, options);
       pageSource->Attach();
       const auto &desc = pageSource->GetSharedDescriptorGuard()->Clone();
-      const auto colId = desc->FindPhysicalColumnId(desc->FindFieldId("cnt"), 0, 0);
-      const auto clusterId = desc->FindClusterId(colId, 0);
+      const auto colId = desc.FindPhysicalColumnId(desc.FindFieldId("cnt"), 0, 0);
+      const auto clusterId = desc.FindClusterId(colId, 0);
 
       RPageStorage::RSealedPage sealedPage;
       pageSource->LoadSealedPage(colId, RNTupleLocalIndex{clusterId, 0}, sealedPage);
@@ -320,7 +320,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       sealedPage.SetBuffer(pageBuf.get());
       pageSource->LoadSealedPage(colId, RNTupleLocalIndex{clusterId, 0}, sealedPage);
 
-      auto colType = desc->GetColumnDescriptor(colId).GetType();
+      auto colType = desc.GetColumnDescriptor(colId).GetType();
       auto elem = ROOT::Experimental::Internal::RColumnElementBase::Generate<std::uint32_t>(colType);
       auto page = pageSource->UnsealPage(sealedPage, *elem).Unwrap();
       EXPECT_GT(page.GetNElements(), 0);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -134,7 +134,7 @@ public:
 
 private:
    std::unique_ptr<Internal::RPageSource> fPageSource;
-   std::unique_ptr<RNTupleDescriptor> fDescriptor;
+   RNTupleDescriptor fDescriptor;
    std::optional<std::uint32_t> fCompressionSettings; ///< The compression settings are unknown for an empty ntuple
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
@@ -203,7 +203,7 @@ public:
    /// \brief Get the descriptor for the RNTuple being inspected.
    ///
    /// \return A static copy of the RNTupleDescriptor belonging to the inspected RNTuple.
-   RNTupleDescriptor *GetDescriptor() const { return fDescriptor.get(); }
+   const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the compression settings of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -38,7 +38,7 @@ ROOT::Experimental::RNTupleInspector::RNTupleInspector(
    fDescriptor = descriptorGuard->Clone();
 
    CollectColumnInfo();
-   CollectFieldTreeInfo(fDescriptor->GetFieldZeroId());
+   CollectFieldTreeInfo(fDescriptor.GetFieldZeroId());
 }
 
 // NOTE: outlined to avoid including RPageStorage in the header
@@ -49,7 +49,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
    fCompressedSize = 0;
    fUncompressedSize = 0;
 
-   for (const auto &colDesc : fDescriptor->GetColumnIterable()) {
+   for (const auto &colDesc : fDescriptor.GetColumnIterable()) {
       if (colDesc.IsAliasColumn())
          continue;
 
@@ -61,7 +61,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
       std::uint64_t nElems = 0;
       std::vector<std::uint64_t> compressedPageSizes{};
 
-      for (const auto &clusterDescriptor : fDescriptor->GetClusterIterable()) {
+      for (const auto &clusterDescriptor : fDescriptor.GetClusterIterable()) {
          if (!clusterDescriptor.ContainsColumn(colId)) {
             continue;
          }
@@ -104,13 +104,13 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldI
    std::uint64_t compressedSize = 0;
    std::uint64_t uncompressedSize = 0;
 
-   for (const auto &colDescriptor : fDescriptor->GetColumnIterable(fieldId)) {
+   for (const auto &colDescriptor : fDescriptor.GetColumnIterable(fieldId)) {
       auto colInfo = GetColumnInspector(colDescriptor.GetPhysicalId());
       compressedSize += colInfo.GetCompressedSize();
       uncompressedSize += colInfo.GetUncompressedSize();
    }
 
-   for (const auto &subFieldDescriptor : fDescriptor->GetFieldIterable(fieldId)) {
+   for (const auto &subFieldDescriptor : fDescriptor.GetFieldIterable(fieldId)) {
       DescriptorId_t subFieldId = subFieldDescriptor.GetId();
 
       auto subFieldInfo = CollectFieldTreeInfo(subFieldId);
@@ -119,7 +119,7 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldI
       uncompressedSize += subFieldInfo.GetUncompressedSize();
    }
 
-   auto fieldInfo = RFieldTreeInspector(fDescriptor->GetFieldDescriptor(fieldId), compressedSize, uncompressedSize);
+   auto fieldInfo = RFieldTreeInspector(fDescriptor.GetFieldDescriptor(fieldId), compressedSize, uncompressedSize);
    fFieldTreeInfo.emplace(fieldId, fieldInfo);
    return fieldInfo;
 }
@@ -134,7 +134,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(DescriptorId_t fieldId
       auto currId = fieldIdQueue.front();
       fieldIdQueue.pop_front();
 
-      for (const auto &col : fDescriptor->GetColumnIterable(currId)) {
+      for (const auto &col : fDescriptor.GetColumnIterable(currId)) {
          if (col.IsAliasColumn()) {
             continue;
          }
@@ -142,7 +142,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(DescriptorId_t fieldId
          colIds.emplace_back(col.GetPhysicalId());
       }
 
-      for (const auto &fld : fDescriptor->GetFieldIterable(currId)) {
+      for (const auto &fld : fDescriptor.GetFieldIterable(currId)) {
          fieldIdQueue.push_back(fld.GetId());
       }
    }
@@ -181,7 +181,7 @@ std::string ROOT::Experimental::RNTupleInspector::GetCompressionSettingsAsString
 const ROOT::Experimental::RNTupleInspector::RColumnInspector &
 ROOT::Experimental::RNTupleInspector::GetColumnInspector(DescriptorId_t physicalColumnId) const
 {
-   if (physicalColumnId > fDescriptor->GetNPhysicalColumns()) {
+   if (physicalColumnId > fDescriptor.GetNPhysicalColumns()) {
       throw RException(R__FAIL("No column with physical ID " + std::to_string(physicalColumnId) + " present"));
    }
 
@@ -437,7 +437,7 @@ std::unique_ptr<THStack> ROOT::Experimental::RNTupleInspector::GetPageSizeDistri
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInspector &
 ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(DescriptorId_t fieldId) const
 {
-   if (fieldId >= fDescriptor->GetNFields()) {
+   if (fieldId >= fDescriptor.GetNFields()) {
       throw RException(R__FAIL("No field with ID " + std::to_string(fieldId) + " present"));
    }
 
@@ -447,7 +447,7 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(DescriptorId_t field
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInspector &
 ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(std::string_view fieldName) const
 {
-   DescriptorId_t fieldId = fDescriptor->FindFieldId(fieldName);
+   DescriptorId_t fieldId = fDescriptor.FindFieldId(fieldName);
 
    if (fieldId == kInvalidDescriptorId) {
       throw RException(R__FAIL("Could not find field `" + std::string(fieldName) + "`"));
@@ -462,7 +462,7 @@ size_t ROOT::Experimental::RNTupleInspector::GetFieldCountByType(const std::rege
    size_t typeCount = 0;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
-      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
          continue;
       }
 
@@ -481,7 +481,7 @@ ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNam
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
 
-      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
          continue;
       }
 


### PR DESCRIPTION
It doesn't make much sense to return the descriptor by unique_ptr, because it's not polymorphic and it's not copyable, so value+move semantics do a better job (and they are consistent with the other descriptors).

Also marked all descriptor classes final because they're not meant to be overridden by users.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


