### PR TITLE
[RDF] Add option to not clone histograms in MT-RDF

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -345,6 +345,39 @@ public:
    }
 };
 
+// class which wraps a pointer and implements a no-op increment operator
+template <typename T>
+class ScalarConstIterator {
+   const T *obj_;
+
+public:
+   ScalarConstIterator(const T *obj) : obj_(obj) {}
+   const T &operator*() const { return *obj_; }
+   ScalarConstIterator<T> &operator++() { return *this; }
+};
+
+// return unchanged value for scalar
+template <typename T>
+auto MakeBegin(const T &val)
+{
+   if constexpr (IsDataContainer<T>::value) {
+      return std::begin(val);
+   } else {
+      return ScalarConstIterator<T>(&val);
+   }
+}
+
+// return container size for containers, and 1 for scalars
+template <typename T>
+std::size_t GetSize(const T &val)
+{
+   if constexpr (IsDataContainer<T>::value) {
+      return std::size(val);
+   } else {
+      return 1;
+   }
+}
+
 /// The generic Fill helper: it calls Fill on per-thread objects and then Merge to produce a final result.
 /// For one-dimensional histograms, if no axes are specified, RDataFrame uses BufferedFillHelper instead.
 template <typename HIST = Hist_t>
@@ -410,42 +443,6 @@ class R__CLING_PTRCHECK(off) FillHelper : public RActionImpl<FillHelper<HIST>> {
       const T &operator*() const { return *obj_; }
       ScalarConstIterator<T> &operator++() { return *this; }
    };
-
-   // helper functions which provide one implementation for scalar types and another for containers
-   // TODO these could probably all be replaced by inlined lambdas and/or constexpr if statements
-   // in c++17 or later
-
-   // return unchanged value for scalar
-   template <typename T, std::enable_if_t<!IsDataContainer<T>::value, int> = 0>
-   ScalarConstIterator<T> MakeBegin(const T &val)
-   {
-      return ScalarConstIterator<T>(&val);
-   }
-
-   // return iterator to beginning of container
-   template <typename T, std::enable_if_t<IsDataContainer<T>::value, int> = 0>
-   auto MakeBegin(const T &val)
-   {
-      return std::begin(val);
-   }
-
-   // return 1 for scalars
-   template <typename T, std::enable_if_t<!IsDataContainer<T>::value, int> = 0>
-   std::size_t GetSize(const T &)
-   {
-      return 1;
-   }
-
-   // return container size
-   template <typename T, std::enable_if_t<IsDataContainer<T>::value, int> = 0>
-   std::size_t GetSize(const T &val)
-   {
-#if __cplusplus >= 201703L
-      return std::size(val);
-#else
-      return val.size();
-#endif
-   }
 
    template <std::size_t ColIdx, typename End_t, typename... Its>
    void ExecLoop(unsigned int slot, End_t end, Its... its)

--- a/tree/dataframe/inc/ROOT/RDF/BufferedFillWrapper.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/BufferedFillWrapper.hxx
@@ -1,0 +1,211 @@
+// Author: Stephan Hageboeck CERN  10/2024
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_BUFFERED_FILL
+#define ROOT_BUFFERED_FILL
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
+namespace ROOT::Internal::RDF {
+
+/**
+ * Wrapper for any kind of thread-unsafe object that has a Fill function.
+ *
+ * This wrapper uses thread-safe queues to protect the Fill function of the underlying object.
+ * Instead of having to clone the object, a single instance can be used, saving lots or RAM.
+ * The use of multiple fill queues enables other threads to make progress while the managed
+ * object is being filled under lock.
+ *
+ * \tparam Payload_t Object with a fill function.
+ * \tparam FillArgs Argument type(s) of the fill function.
+ */
+template <typename Payload_t, typename... FillArgs>
+class BufferedFillWrapper {
+   using Tuple_t = std::tuple<FillArgs...>;
+   /// This struct represents all data that is needed to queue up fills.
+   /// We align to a typical cache line to avoid false sharing.
+   struct alignas(64) FillQueue {
+      std::vector<Tuple_t> data;
+      std::atomic_uint requestedSlots = 0;
+      std::atomic_uint refCount = 0;
+      std::atomic_bool acceptsNewData = true;
+   };
+
+   std::array<FillQueue, 2> fQueues;
+   std::atomic<FillQueue *> fActiveQueue;
+
+   std::shared_ptr<Payload_t> fManagedObject;
+   std::mutex fManagedObjectMutex;
+
+public:
+   class LockedHandle {
+      std::unique_lock<std::mutex> fLock;
+      std::shared_ptr<Payload_t> fPayload;
+
+   public:
+      LockedHandle(std::mutex &mutex, std::shared_ptr<Payload_t> payload) : fLock{mutex}, fPayload{std::move(payload)}
+      {
+      }
+
+      Payload_t *operator->() const { return fPayload.get(); }
+   };
+
+   /// @brief Create a thread-safe wrapper around an object to be filled.
+   /// @param objectToFill Object to fill, e.g. TH3D or similar.
+   /// @param queueSize Size of the fill buffers in case the object is unavailable.
+   /// If no value is passed, the queue will be set to 4K.
+   BufferedFillWrapper(std::shared_ptr<Payload_t> objectToFill, unsigned int queueSize = 0)
+      : fActiveQueue(fQueues.begin()), fManagedObject(std::move(objectToFill))
+   {
+      if (fManagedObject == nullptr)
+         throw std::invalid_argument{"BufferedFillWrapper: No object to fill provided."};
+
+      if (queueSize == 0) {
+         queueSize = std::max(32ul, 4096 / sizeof(Tuple_t));
+      }
+      for (auto &queue : fQueues) {
+         queue.data.resize(queueSize);
+         queue.requestedSlots = 0;
+      }
+   }
+   BufferedFillWrapper(const BufferedFillWrapper &) = delete;
+   BufferedFillWrapper(BufferedFillWrapper &&) = default;
+
+   struct RefCountGuard {
+      RefCountGuard(FillQueue &slotData) : fSlotData{slotData}
+      {
+         fSlotData.refCount.fetch_add(1, std::memory_order_release);
+      }
+      ~RefCountGuard() { fSlotData.refCount.fetch_sub(1, std::memory_order_release); }
+      FillQueue &fSlotData;
+   };
+
+   /// @brief Fill the managed object under a lock, or (if the lock is unavailable) place the arguments
+   /// into a buffer for later filling.
+   /// @param ...args Arguments of the fill function.
+   void Fill(FillArgs... args)
+   {
+      bool dataFilled = false;
+      do {
+         FillQueue *const activeQueue = fActiveQueue.load();
+         if (activeQueue == nullptr) {
+            throw std::logic_error("BufferedFillWrapper::Fill() called after the object has been retrieved.");
+         }
+
+         if (std::unique_lock objectLock{fManagedObjectMutex, std::try_to_lock}; objectLock.owns_lock()) {
+            FillQueue *queueToFlush = nullptr;
+            if (activeQueue->requestedSlots > 0)
+               queueToFlush = &CycleQueues();
+
+            fManagedObject->Fill(args...);
+            dataFilled = true;
+
+            if (queueToFlush)
+               FlushQueue(*queueToFlush);
+         } else {
+            RefCountGuard refCountGuard{*activeQueue};
+
+            if (!activeQueue->acceptsNewData)
+               continue;
+
+            const auto ourSlot = activeQueue->requestedSlots.fetch_add(1);
+            if (ourSlot < activeQueue->data.size()) {
+               activeQueue->data[ourSlot] = Tuple_t{args...};
+               dataFilled = true;
+            }
+         }
+      } while (!dataFilled);
+   }
+
+   /// @brief Lock the underlying object and return a handle to it.
+   /// All fill queues are flushed before the object is returned, and the lock is held
+   /// as long as the LockedHandle is alive, so Fill threads cannot make progress.
+   /// @return Handle to the object. While the handle is alive, the object is locked.
+   LockedHandle Get()
+   {
+      LockedHandle handle{fManagedObjectMutex, fManagedObject};
+
+      for (auto &queue : fQueues) {
+         FlushQueue(queue);
+      }
+
+      return std::move(handle);
+   }
+
+   /// Flush all queues, and release the underlying object.
+   std::shared_ptr<Payload_t> Release()
+   {
+      fActiveQueue = nullptr;
+      std::scoped_lock lock{fManagedObjectMutex};
+
+      for (auto &queue : fQueues) {
+         FlushQueue(queue);
+      }
+
+      auto ret = fManagedObject;
+      fManagedObject = nullptr;
+
+      return ret;
+   }
+
+private:
+   /// @brief Move over to the next fill queue.
+   /// Returns the queue that should be flushed.
+   FillQueue &CycleQueues()
+   {
+      auto activeQueue = fActiveQueue.load();
+
+      auto it = fQueues.begin();
+      while (it != activeQueue)
+         ++it;
+      fActiveQueue = (++it) == fQueues.end() ? fQueues.begin() : it;
+
+      activeQueue->acceptsNewData = false;
+      return *activeQueue;
+   }
+
+   /// @brief Flush a queue by filling all items into the managed object.
+   /// @param queueToFlush Queue of arguments to be filled into the managed object.
+   void FlushQueue(FillQueue &queueToFlush)
+   {
+      queueToFlush.acceptsNewData = false;
+
+      if (!fManagedObject)
+         throw std::logic_error{"BufferedFillWrapper: The managed object has already been retrieved."};
+
+      // Wait until all write operations have completed
+      while (queueToFlush.refCount.load(std::memory_order_acquire) > 0)
+         ;
+
+      const auto nFilled =
+         std::min<unsigned int>(queueToFlush.data.size(), queueToFlush.requestedSlots.load(std::memory_order_acquire));
+
+      auto &toFill = *fManagedObject;
+      auto callFill = [&toFill](FillArgs... args) { toFill.Fill(args...); };
+
+      for (unsigned int i = 0; i < nFilled; ++i) {
+         std::apply(callFill, queueToFlush.data[i]);
+      }
+
+      queueToFlush.requestedSlots = 0;
+      queueToFlush.acceptsNewData = true;
+   }
+};
+
+} // namespace ROOT::Internal::RDF
+
+#endif // ROOT_BUFFERED_FILL

--- a/tree/dataframe/inc/ROOT/RDF/HistoModels.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/HistoModels.hxx
@@ -85,6 +85,7 @@ struct TH3DModel {
    std::vector<double> fBinXEdges;
    std::vector<double> fBinYEdges;
    std::vector<double> fBinZEdges;
+   bool fCloneHistogram = true;
 
    TH3DModel() = default;
    TH3DModel(const TH3DModel &) = default;

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -92,6 +92,7 @@ namespace ActionTags {
 struct Histo1D{};
 struct Histo2D{};
 struct Histo3D{};
+struct Histo3DNoClone{};
 struct HistoND{};
 struct Graph{};
 struct GraphAsymmErrors{};
@@ -134,6 +135,17 @@ BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h,
    using Helper_t = FillHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
    return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
+}
+
+// Filling of histograms without cloning of the object
+template <typename... ColTypes, typename ActionResultType, typename PrevNodeType>
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h, const unsigned int /*nSlots*/,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Histo3DNoClone, const RColumnRegister &colRegister)
+{
+   using Helper_t = FillThreadSafeHistogramHelper<ActionResultType, typename ValueType<ColTypes>::value_type...>;
+   using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
+   return std::make_unique<Action_t>(Helper_t{h}, bl, std::move(prevNode), colRegister);
 }
 
 // Histo1D filling (must handle the special case of distinguishing FillHelper and BufferedFillHelper

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2063,7 +2063,11 @@ public:
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
-      return CreateAction<RDFInternal::ActionTags::Histo3D, V1, V2, V3>(userColumns, h, h, fProxiedPtr);
+      if (model.fCloneHistogram) {
+         return CreateAction<RDFInternal::ActionTags::Histo3D, V1, V2, V3>(userColumns, h, h, fProxiedPtr);
+      } else {
+         return CreateAction<RDFInternal::ActionTags::Histo3DNoClone, V1, V2, V3>(userColumns, h, h, fProxiedPtr);
+      }
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -2112,7 +2116,11 @@ public:
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
-      return CreateAction<RDFInternal::ActionTags::Histo3D, V1, V2, V3, W>(userColumns, h, h, fProxiedPtr);
+      if (model.fCloneHistogram) {
+         return CreateAction<RDFInternal::ActionTags::Histo3D, V1, V2, V3, W>(userColumns, h, h, fProxiedPtr);
+      } else {
+         return CreateAction<RDFInternal::ActionTags::Histo3DNoClone, V1, V2, V3, W>(userColumns, h, h, fProxiedPtr);
+      }
    }
 
    template <typename V1, typename V2, typename V3, typename W>

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -878,7 +878,7 @@ public:
    ///            return an RVec of varied values, one for each variation tag, in the same order as the tags.
    /// \param[in] inputColumns the names of the columns to be passed to the callable.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///            colName is used if none is provided.
    ///
@@ -984,7 +984,7 @@ public:
    ///            return an RVec of varied values, one for each variation tag, in the same order as the tags.
    /// \param[in] inputColumns the names of the columns to be passed to the callable.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///            colName is used if none is provided.
    ///
@@ -1032,7 +1032,7 @@ public:
    /// \param[in] inputColumns the names of the columns to be passed to the callable.
    /// \param[in] inputColumns the names of the columns to be passed to the callable.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///            colName is used if none is provided.
    ///
@@ -1087,7 +1087,7 @@ public:
    /// \param[in] expression a string containing valid C++ code that evaluates to an RVec containing the varied
    ///            values for the specified column.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///            colName is used if none is provided.
    ///
@@ -1122,7 +1122,7 @@ public:
    /// \param[in] expression a string containing valid C++ code that evaluates to an RVec or RVecs containing the varied
    ///            values for the specified columns.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///
    /// This overload adds the possibility for the expression used to evaluate the varied values to be just-in-time
@@ -1159,7 +1159,7 @@ public:
    /// \param[in] expression a string containing valid C++ code that evaluates to an RVec containing the varied
    ///            values for the specified column.
    /// \param[in] nVariations number of variations returned by the expression. The corresponding tags will be `"0"`,
-   /// `"1"`, etc. 
+   /// `"1"`, etc.
    /// \param[in] variationName a generic name for this set of varied values, e.g. `"ptvariation"`.
    ///            colName is used if none is provided.
    ///
@@ -2088,7 +2088,7 @@ public:
    ///
    /// ### Example usage:
    /// ~~~{.cpp}
-   /// // Deduce column types (this invocation needs jitting internally)
+   /// // Deduce column types (this invocation leads to just-in-time compilation)
    /// auto myHist1 = myDf.Histo3D({"name", "title", 64u, 0., 128., 32u, -4., 4., 8u, -2., 2.},
    ///                             "myValueX", "myValueY", "myValueZ", "myWeight");
    /// // Explicit column types

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics R
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_report dataframe_report.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_incomplete_entries dataframe_incomplete_entries.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_bufferedFill dataframe_bufferedFill.cxx LIBRARIES ROOTDataFrame REPEATS 20)
 
 
 if(MSVC)

--- a/tree/dataframe/test/dataframe_bufferedFill.cxx
+++ b/tree/dataframe/test/dataframe_bufferedFill.cxx
@@ -1,0 +1,55 @@
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDF/BufferedFillWrapper.hxx"
+#include "TH2D.h"
+
+#include "gtest/gtest.h"
+
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+TEST(RDataFrameUtils, BufferedFillWrapper)
+{
+   using ROOT::Internal::RDF::BufferedFillWrapper;
+
+   constexpr int nThread = 20;
+   constexpr int nFill = 100;
+   constexpr double fillWeight = 0.5;
+
+   auto histo = std::make_shared<TH2D>("histo", "Histo;x;y", 10, 0., 10., 10, 0., 10.);
+   BufferedFillWrapper<TH2D, double, int> bufferedFill(std::move(histo), 10);
+
+   auto histo2 = std::make_shared<TH2D>("histo2", "Histo;x;y", 10, 0., 10., 10, 0., 10.);
+   BufferedFillWrapper<TH2D, double, double, double> bufferedFillWeight(std::move(histo2), 10000);
+
+   auto filler = [&bufferedFill, &bufferedFillWeight](std::size_t N, double valx, double valy, double weight) {
+      for (unsigned int i = 0; i < N; ++i) {
+         bufferedFill.Fill(valx, valy /*, weight*/);
+         bufferedFillWeight.Fill(valx, valy, weight);
+      }
+   };
+
+   {
+      std::vector<std::thread> threads;
+      threads.reserve(nThread);
+      for (unsigned int i = 0; i < nThread; ++i) {
+         threads.emplace_back(filler, nFill, 1, i, fillWeight);
+      }
+      for (auto &thread : threads)
+         thread.join();
+   }
+
+   auto histoHandle = bufferedFill.Get();
+   EXPECT_FLOAT_EQ(histoHandle->GetEntries(), nThread * nFill);
+   EXPECT_FLOAT_EQ(histoHandle->GetBinContent(histoHandle->GetBin(0, 0)), 0.);
+   EXPECT_FLOAT_EQ(histoHandle->GetBinContent(histoHandle->GetBin(1, 1)), 0.);
+   EXPECT_FLOAT_EQ(histoHandle->GetBinContent(histoHandle->GetBin(2, 1)), nFill);
+   EXPECT_FLOAT_EQ(histoHandle->GetBinContent(histoHandle->GetBin(2, 12)), (nThread - 10.) * nFill);
+
+   histo2 = bufferedFillWeight.Release();
+   EXPECT_FLOAT_EQ(histo2->GetEntries(), nThread * nFill);
+   EXPECT_FLOAT_EQ(histo2->GetBinContent(histo2->GetBin(0, 0)), 0.);
+   EXPECT_FLOAT_EQ(histo2->GetBinContent(histo2->GetBin(1, 1)), 0.);
+   EXPECT_FLOAT_EQ(histo2->GetBinContent(histo2->GetBin(2, 1)), nFill * fillWeight);
+   EXPECT_FLOAT_EQ(histo2->GetBinContent(histo2->GetBin(2, 12)), (nThread - 10.) * nFill * fillWeight);
+}


### PR DESCRIPTION
- Add a wrapper for objects which are not thread safe
- Write an RDF action that uses TH3D without cloning them

TODOs:
- [ ] Document the feature
- [ ] Converge on how to enable the interface
  - [ ] Extend to 1D, 2D, ND?
  - [ ] Provide clone = Auto option?