### PR TITLE
[RF] Consistently use universal `RooAbsData::reduce()` overload

### DIFF
--- a/roofit/roofitcore/res/RooFitImplHelpers.h
+++ b/roofit/roofitcore/res/RooFitImplHelpers.h
@@ -103,6 +103,8 @@ std::string makeValidVarName(std::string const &in);
 
 void replaceAll(std::string &inOut, std::string_view what, std::string_view with);
 
+std::string makeSliceCutString(RooArgSet const &sliceDataSet);
+
 } // namespace Detail
 } // namespace RooFit
 

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1891,7 +1891,7 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
   RooAbsRealLValue* dataVar = static_cast<RooAbsRealLValue*>(_vars.find(var->GetName())) ;
   double nEnt(sumEntries()) ;
   if (dataVar->getMin()<var->getMin() || dataVar->getMax()>var->getMax()) {
-    std::unique_ptr<RooAbsData> tmp{const_cast<RooAbsData*>(this)->reduce(*var)};
+    std::unique_ptr<RooAbsData> tmp{const_cast<RooAbsData*>(this)->reduce(RooFit::SelectVars(*var))};
     nEnt = tmp->sumEntries() ;
   }
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -64,7 +64,7 @@ parallelized calculation of test statistics.
 
 #include "ROOT/StringUtils.hxx"
 
-using std::endl, std::ostream;
+using std::ostream;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a test statistic, and optimise its calculation.
@@ -669,11 +669,7 @@ bool RooAbsOptTestStatistic::setDataSlave(RooAbsData& indata, bool cloneData, bo
 
   if (cloneData) {
     // Cloning input dataset
-    if (_rangeName.empty()) {
-      _dataClone = std::unique_ptr<RooAbsData>{indata.reduce(*indata.get())}.release();
-    } else {
-      _dataClone = std::unique_ptr<RooAbsData>{indata.reduce(RooFit::SelectVars(*indata.get()),RooFit::CutRange(_rangeName.c_str()))}.release();
-    }
+    _dataClone = std::unique_ptr<RooAbsData>{indata.reduce(RooFit::SelectVars(*indata.get()),RooFit::CutRange(_rangeName.c_str()))}.release();
     _ownData = true ;
 
   } else {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2009,31 +2009,14 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     if (projDataNeededVars->size() < o.projData->get()->size()) {
 
       // Determine if there are any slice variables in the projection set
-        std::unique_ptr<RooArgSet> sliceDataSet{sliceSet.selectCommon(*o.projData->get())};
-      TString cutString ;
-      if (!sliceDataSet->empty()) {
-   bool first(true) ;
-   for(RooAbsArg * sliceVar : *sliceDataSet) {
-     if (!first) {
-       cutString.Append("&&") ;
-     } else {
-       first=false ;
-     }
+      RooArgSet sliceDataSet;
+      sliceSet.selectCommon(*o.projData->get(), sliceDataSet);
+      std::string cutString = RooFit::Detail::makeSliceCutString(sliceDataSet);
 
-     RooAbsRealLValue* real ;
-     RooAbsCategoryLValue* cat ;
-     if ((real = dynamic_cast<RooAbsRealLValue*>(sliceVar))) {
-       cutString.Append(Form("%s==%f",real->GetName(),real->getVal())) ;
-     } else if ((cat = dynamic_cast<RooAbsCategoryLValue*>(sliceVar))) {
-       cutString.Append(Form("%s==%d",cat->GetName(),cat->getCurrentIndex())) ;
-     }
-   }
-      }
-
-      if (!cutString.IsNull()) {
+      if (!cutString.empty()) {
        coutI(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") reducing given projection dataset to entries with " << cutString << std::endl ;
       }
-      projDataSelOwned = std::unique_ptr<RooAbsData>{const_cast<RooAbsData*>(o.projData)->reduce(*projDataNeededVars, cutString.IsNull() ? nullptr : cutString)};
+      projDataSelOwned = std::unique_ptr<RooAbsData>{projDataSel->reduce(RooFit::SelectVars(*projDataNeededVars), RooFit::Cut(cutString.c_str()))};
       projDataSel = projDataSelOwned.get();
       coutI(Plotting) << "RooAbsReal::plotOn(" << GetName()
             << ") only the following components of the projection data will be used: " << *projDataNeededVars << std::endl ;
@@ -2348,31 +2331,13 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
       // Determine if there are any slice variables in the projection set
       RooArgSet sliceDataSet;
       sliceSet.selectCommon(*o.projData->get(), sliceDataSet);
-      TString cutString ;
-      if (!sliceDataSet.empty()) {
-   bool first(true) ;
-   for(RooAbsArg * sliceVar : sliceDataSet) {
-     if (!first) {
-       cutString.Append("&&") ;
-     } else {
-       first=false ;
-     }
+      std::string cutString = RooFit::Detail::makeSliceCutString(sliceDataSet);
 
-     RooAbsRealLValue* real ;
-     RooAbsCategoryLValue* cat ;
-     if ((real = dynamic_cast<RooAbsRealLValue*>(sliceVar))) {
-       cutString.Append(Form("%s==%f",real->GetName(),real->getVal())) ;
-     } else if ((cat = dynamic_cast<RooAbsCategoryLValue*>(sliceVar))) {
-       cutString.Append(Form("%s==%d",cat->GetName(),cat->getCurrentIndex())) ;
-     }
-   }
-      }
-
-      if (!cutString.IsNull()) {
+      if (!cutString.empty()) {
    coutI(Plotting) << "RooAbsReal::plotAsymOn(" << GetName()
          << ") reducing given projection dataset to entries with " << cutString << std::endl ;
       }
-      projDataSelOwned = std::unique_ptr<RooAbsData>{const_cast<RooAbsData*>(o.projData)->reduce(*projDataNeededVars,cutString.IsNull() ? nullptr : cutString)};
+      projDataSelOwned = std::unique_ptr<RooAbsData>{projDataSel->reduce(RooFit::SelectVars(*projDataNeededVars),RooFit::Cut(cutString.c_str()))};
       projDataSel = projDataSelOwned.get();
       coutI(Plotting) << "RooAbsReal::plotAsymOn(" << GetName()
             << ") only the following components of the projection data will be used: " << *projDataNeededVars << std::endl ;

--- a/roofit/roofitcore/src/RooFitImplHelpers.cxx
+++ b/roofit/roofitcore/src/RooFitImplHelpers.cxx
@@ -315,6 +315,26 @@ void replaceAll(std::string &inOut, std::string_view what, std::string_view with
    }
 }
 
+std::string makeSliceCutString(RooArgSet const &sliceDataSet)
+{
+   std::stringstream cutString;
+   bool first = true;
+   for (RooAbsArg *sliceVar : sliceDataSet) {
+      if (!first) {
+         cutString << "&&";
+      } else {
+         first = false;
+      }
+
+      if (auto *real = dynamic_cast<RooAbsRealLValue *>(sliceVar)) {
+         cutString << real->GetName() << "==" << real->getVal();
+      } else if (auto *cat = dynamic_cast<RooAbsCategoryLValue *>(sliceVar)) {
+         cutString << cat->GetName() << "==" << cat->getCurrentIndex();
+      }
+   }
+   return cutString.str();
+}
+
 } // namespace Detail
 } // namespace RooFit
 

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -1496,7 +1496,7 @@ public:
       // ---------------------------------------------------------------------------------------------
 
       // Make subset of experimental data with only y values
-      std::unique_ptr<RooAbsData> expDataY{expDataXY->reduce(y)};
+      std::unique_ptr<RooAbsData> expDataY{expDataXY->reduce(RooFit::SelectVars(y))};
 
       // Generate 10000 events in x obtained from _conditional_ model(x|y) with y values taken from experimental data
       std::unique_ptr<RooDataSet> data{model.generate(x, ProtoData(static_cast<RooDataSet &>(*expDataY)))};
@@ -2453,10 +2453,10 @@ public:
       // -------------------------------------------------------------
 
       // The reduce() function returns a new dataset which is a subset of the original
-      std::unique_ptr<RooAbsData> d1{d.reduce(RooArgSet(x, c))};
-      std::unique_ptr<RooAbsData> d2{d.reduce(RooArgSet(y))};
-      std::unique_ptr<RooAbsData> d3{d.reduce("y>5.17")};
-      std::unique_ptr<RooAbsData> d4{d.reduce(RooArgSet(x, c), "y>5.17")};
+      std::unique_ptr<RooAbsData> d1{d.reduce(SelectVars({x, c}))};
+      std::unique_ptr<RooAbsData> d2{d.reduce(SelectVars(y))};
+      std::unique_ptr<RooAbsData> d3{d.reduce(Cut("y>5.17"))};
+      std::unique_ptr<RooAbsData> d4{d.reduce(SelectVars({x, c}), Cut("y>5.17"))};
 
       regValue(d3->numEntries(), "rf403_nd3");
       regValue(d4->numEntries(), "rf403_nd4");
@@ -2489,7 +2489,7 @@ public:
       //
       // All reduce() methods are interfaced in RooAbsData. All reduction techniques
       // demonstrated on unbinned datasets can be applied to binned datasets as well.
-      std::unique_ptr<RooAbsData> dh2{dh.reduce(y, "x>0")};
+      std::unique_ptr<RooAbsData> dh2{dh.reduce(SelectVars(y), Cut("x>0"))};
 
       // Add dh2 to yframe and redraw
       dh2->plotOn(yframe, LineColor(kRed), MarkerColor(kRed), Name("dh2"));

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -305,7 +305,7 @@ TEST(RooDataSet, ReduceWithCompositeDataStore)
                                RooFit::Link({{"physics", &dataSetWeighted}}));
 
    // Reduce the dataset with the RooCompositeDataStore
-   std::unique_ptr<RooAbsData> dataSetReducedPtr{dataSetComposite.reduce("true")};
+   std::unique_ptr<RooAbsData> dataSetReducedPtr{dataSetComposite.reduce(RooFit::Cut("true"))};
    auto &dataSetReduced = static_cast<RooDataSet &>(*dataSetReducedPtr);
 
    // Get the first row of all datasets

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -22,6 +22,7 @@ MarkovChain.
 
 #include "TNamed.h"
 #include "RooStats/MarkovChain.h"
+#include "RooGlobalFunc.h"
 #include "RooDataSet.h"
 #include "RooArgSet.h"
 #include "RooRealVar.h"
@@ -136,7 +137,7 @@ RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(RooArgSet* whichVars) co
       args.add(*whichVars);
    }
 
-   return RooFit::makeOwningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
+   return RooFit::makeOwningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(RooFit::SelectVars(args))});
 }
 
 RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) const
@@ -150,7 +151,7 @@ RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) 
       args.add(*whichVars);
    }
 
-   std::unique_ptr<RooAbsData> data{fChain->reduce(args)};
+   std::unique_ptr<RooAbsData> data{fChain->reduce(RooFit::SelectVars(args))};
    return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
 }
 


### PR DESCRIPTION
Consistently use `RooAbsData::reduce()` overload that takes RooFit command arguments in the RooFit code.

This allows us to deprecate all the other overloads one day, in the spirit of avoiding duplicate interfaces and user confusion.

Also, avoid some code repetition in setting up the cut expressions for slicing in RooAbsReal.cxx and RooSimultaneous.cxx.