### PR TITLE
[RF] Include any fundamental args as variables of RooFit::Evaluator

### DIFF
--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -663,7 +663,7 @@ RooArgSet Evaluator::getParameters() const
 {
    RooArgSet parameters;
    for (auto &nodeInfo : _nodes) {
-      if (nodeInfo.isVariable) {
+      if (nodeInfo.absArg->isFundamental()) {
          parameters.add(*nodeInfo.absArg);
       }
    }


### PR DESCRIPTION
This change is needed to also consider categorical parameters.

Closes #15701.