### PR TITLE
[skip-ci][df][doc] Enhance GraphAssymErrors description.

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2270,6 +2270,18 @@ public:
    /// auto myGAE2 = myDf.GraphAsymmErrors<f, f, f, f, f, f>("xValues", "yValues", "exl", "exh", "eyl", "eyh");
    /// ~~~
    ///
+   /// `GraphAssymErrors` should also be used for the cases in which values associated only with 
+   /// one of the axes have associated errors. For example, only `ey` exist and `ex` are equal to zero. 
+   /// In such cases, user should do the following: 
+   /// ~~~{.cpp}
+   /// // Create a column of zeros in RDataFrame
+   /// auto rdf_withzeros = rdf.Define("zero", "0"); 
+   /// // or alternatively: 
+   /// auto rdf_withzeros = rdf.Define("zero", []() -> double { return 0.;});
+   /// // Create the graph with y errors only
+   /// auto rdf_errorsOnYOnly = rdf_withzeros.GraphAsymmErrors("xValues", "yValues", "zero", "zero", "eyl", "eyh");
+   /// ~~~
+   ///
    /// \note Differently from other ROOT interfaces, the returned TGraphAsymmErrors is not associated to gDirectory
    /// and the caller is responsible for its lifetime (in particular, a typical source of confusion is that
    /// if result histograms go out of scope before the end of the program, ROOT might display a blank canvas).

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -131,7 +131,7 @@ produce many different results in one event loop. Instant actions trigger the ev
 | Display() | Provides a printable representation of the dataset contents. The method returns a ROOT::RDF::RDisplay() instance which can print a tabular representation of the data or return it as a string. |
 | Fill() | Fill a user-defined object with the values of the specified columns, as if by calling `Obj.Fill(col1, col2, ...)`. |
 | Graph() | Fills a TGraph with the two columns provided. If multi-threading is enabled, the order of the points may not be the one expected, it is therefore suggested to sort if before drawing. |
-| GraphAsymmErrors() | Fills a TGraphAsymmErrors. If multi-threading is enabled, the order of the points may not be the one expected, it is therefore suggested to sort if before drawing. |
+| GraphAsymmErrors() | Fills a TGraphAsymmErrors. Should be used for any type of graph with errors, including cases with errors on one of the axes only. If multi-threading is enabled, the order of the points may not be the one expected, it is therefore suggested to sort if before drawing. |
 | Histo1D(), Histo2D(), Histo3D() | Fill a one-, two-, three-dimensional histogram with the processed column values. |
 | HistoND() | Fill an N-dimensional histogram with the processed column values. |
 | Max() | Return the maximum of processed column values. If the type of the column is inferred, the return type is `double`, the type of the column otherwise.|


### PR DESCRIPTION
An action that fixes #11959. 

It was decided that we will refrain from adding another action to RDataFrame as the existing one already covers the functionality required. This PR enhances the documentation of GraphAssymErrors which should solve doubts of the users. 
