### PR TITLE
[RF] Avoid unneeded cached projection integrals in RooAddPdf

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/RooNormalizedPdf.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/RooNormalizedPdf.h
@@ -32,6 +32,7 @@ public:
       auto name = std::string(pdf.GetName()) + "_over_" + _normIntegral->GetName();
       SetName(name.c_str());
       SetTitle(name.c_str());
+      _normRange = pdf.normRange(); // so that e.g. RooAddPdf can query over what we are normalized
    }
 
    RooNormalizedPdf(const RooNormalizedPdf &other, const char *name)

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -8,7 +8,7 @@
 # @author Patrick Bos, NL eScience Center, 2018
 
 ROOT_ADD_GTEST(testSimple testSimple.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooAddPdf testRooAddPdf.cxx LIBRARIES RooFitCore RooStats)
+ROOT_ADD_GTEST(testRooAddPdf testRooAddPdf.cxx LIBRARIES RooFitCore RooFit RooStats)
 ROOT_ADD_GTEST(testRooCacheManager testRooCacheManager.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooCategory testRooCategory.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooStats)


### PR DESCRIPTION
By already normalizing the pdf components integrals to the right fit range, one can elide some potentially expensive numeric correction factor integrals.

The code that calculates the predicted number of events was updated accordingly, since it containts also some integrals that depend on the components normalization range.

Closes #12645.

A unit test that validates that there are no superfluous integrals in the case of the GitHub reproducer was also added.