### PR TITLE
io rules: Prevent dimensions from spilling.

### DIFF
--- a/core/foundation/res/TSchemaRuleProcessor.h
+++ b/core/foundation/res/TSchemaRuleProcessor.h
@@ -83,6 +83,7 @@ namespace Internal {
                elem = Trim( source.substr( last, size ) );
                if( !elem.empty() ) {
                   unsigned int level = 0;
+                  dims.clear();
 
                   // Split between the typename and the membername
                   // Take in consideration template names.


### PR DESCRIPTION
This solves part 1 at https://github.com/cms-sw/cmsdist/pull/9627#issuecomment-2609571193.

without this path all inputs following an array input were wrongly marked as an array.

