### PR TITLE
[RF] Account for cuts over the index category inside RooCompositeDataStore::reduce

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -18,6 +18,7 @@ The following people have contributed to this new version:
  Mattias Ellert, Uppsala University,\
  Florine de Geus, CERN/University of Twente,\
  Fernando Hueso Gonzalez, University of Valencia,\
+ Enrico Lusiani, INFN Padova,\
  Alberto Mecca, University of Turin,\
  Lorenzo Moneta, CERN/EP-SFT,\
  Mark Owen, University of Glasgow,\


### PR DESCRIPTION
The `reduce` implementation for `RooCompositeDataStore` currently delegates all of its logic to the children datastores. 
The index category, however, is not contained inside the children and should be handled by the composite datastore itself.

This PR also adds a unit test that validates that the cut is correctly applied.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #15744

