### PR TITLE
[TMVA][SOFIE] Memory Optimization for Intermediate tensors - v1

### DIFF
--- a/tmva/pymva/test/scale_by_2_op.hxx
+++ b/tmva/pymva/test/scale_by_2_op.hxx
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include <span>
+#include "ROOT/RSpan.hxx"
 
 namespace Scale_by_2 {
 void Compute(std::span<const float> input, std::span<float> output) {

--- a/tmva/pymva/test/scale_by_2_op.hxx
+++ b/tmva/pymva/test/scale_by_2_op.hxx
@@ -1,10 +1,10 @@
-#include <vector>
 #include <algorithm>
-#include <iostream>
-namespace Scale_by_2{
-void Compute(const std::vector<float>& input, std::vector<float>& output){
-    for(size_t i=0; i<input.size(); ++i){
-        output[i]=input[i]*2;
+#include <span>
+
+namespace Scale_by_2 {
+void Compute(std::span<const float> input, std::span<float> output) {
+    for (size_t i = 0; i < input.size(); ++i) {
+        output[i] = input[i] * 2;
     }
 }
-} //Scale_by_2 operator
+}

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -35,6 +35,10 @@ private:
 
    const std::string SP = "   ";
 
+   // memory pool information for intermediate tensors
+   MemoryPoolInfo fIntermediateMemoryInfo;
+   std::unordered_map<std::string, std::pair<size_t, size_t>> fIntermediateTensorFrequencyLookup;
+
 public:
    // Rule of five: explicitly define move semantics, disallow copy
    RModel(RModel &&other);
@@ -142,6 +146,10 @@ public:
    // used to infer the sub-graphs
    std::string GenerateInferSignature(bool isdecl = true);
 
+   void EvaluateIntermediateMemory(const std::vector<std::string>& op_input_tensors, const size_t& current_op_idx, size_t& total_memory, std::vector<size_t>& available_memory);
+   std::string CheckAndAllocateIntermediateMemory(const std::vector<std::string>& op_output_tensors);
+   void CheckAndFlushIntermediateMemory(const std::vector<std::string>& op_output_tensors);
+
 protected:
    // internal functions
    // generate code for the initialized tensors
@@ -154,6 +162,8 @@ protected:
    void GenerateOperatorDeclarations();
    // generate code for inference
    void GenerateOutput();
+   // generate code for initializing memory pool for intermediate tensors
+   void GenerateIntermediateMemoryPool();
    // Generate all session code
    void GenerateSessionCode();
 

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -36,8 +36,9 @@ private:
    const std::string SP = "   ";
 
    // memory pool information for intermediate tensors
+   size_t fTotalIntermediateMemory;
    MemoryPoolInfo fIntermediateMemoryInfo;
-   std::unordered_map<std::string, std::pair<size_t, size_t>> fIntermediateTensorFrequencyLookup;
+   std::unordered_map<std::string_view, std::pair<size_t, size_t>> fIntermediateTensorFrequencyLookup;
 
 public:
    // Rule of five: explicitly define move semantics, disallow copy
@@ -146,9 +147,9 @@ public:
    // used to infer the sub-graphs
    std::string GenerateInferSignature(bool isdecl = true);
 
-   void EvaluateIntermediateMemory(const std::vector<std::string>& op_input_tensors, const size_t& current_op_idx, size_t& total_memory, std::vector<size_t>& available_memory);
-   std::string CheckAndAllocateIntermediateMemory(const std::vector<std::string>& op_output_tensors);
-   void CheckAndFlushIntermediateMemory(const std::vector<std::string>& op_output_tensors);
+   void EvaluateIntermediateMemory(std::span<const std::string_view> op_input_tensors, const size_t& current_op_idx, size_t& total_memory, std::vector<size_t>& available_memory);
+   std::string AllocateIntermediateMemory(std::span<const std::string_view> op_output_tensors);
+   void CheckAndFlushIntermediateMemory(std::span<const std::string_view> op_output_tensors, const size_t& op_idx);
 
 protected:
    // internal functions

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -36,9 +36,8 @@ private:
    const std::string SP = "   ";
 
    // memory pool information for intermediate tensors
-   size_t fTotalIntermediateMemory = 0;
-   MemoryPoolInfo fIntermediateMemoryInfo;
-   std::unordered_map<std::string_view, size_t> fIntermediateTensorFrequencyLookup;
+   MemoryPoolInfo fIntermediateMemoryInfo;    ///<!  intermediate memory info (transient)
+   std::unordered_map<std::string_view, size_t> fIntermediateTensorFrequencyLookup;    ///<!  lookup table for intermediate tensor frequency (transient)
 
 public:
    // Rule of five: explicitly define move semantics, disallow copy

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -36,7 +36,7 @@ private:
    const std::string SP = "   ";
 
    // memory pool information for intermediate tensors
-   size_t fTotalIntermediateMemory;
+   size_t fTotalIntermediateMemory = 0;
    MemoryPoolInfo fIntermediateMemoryInfo;
    std::unordered_map<std::string_view, std::pair<size_t, size_t>> fIntermediateTensorFrequencyLookup;
 
@@ -147,8 +147,8 @@ public:
    // used to infer the sub-graphs
    std::string GenerateInferSignature(bool isdecl = true);
 
-   void EvaluateIntermediateMemory(std::span<const std::string_view> op_input_tensors, const size_t& current_op_idx, size_t& total_memory, std::vector<size_t>& available_memory);
-   std::string AllocateIntermediateMemory(std::span<const std::string_view> op_output_tensors);
+   void EvaluateIntermediateMemory(std::span<const std::string_view> op_input_tensors, std::span<const std::string_view> op_output_tensors, const size_t& current_op_idx, std::vector<size_t>& available_memory);
+   std::string AllocateIntermediateMemory(std::span<const std::string_view> op_output_tensors, size_t& total_intermediate_capacity);
    void CheckAndFlushIntermediateMemory(std::span<const std::string_view> op_output_tensors, const size_t& op_idx);
 
 protected:

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -38,7 +38,7 @@ private:
    // memory pool information for intermediate tensors
    size_t fTotalIntermediateMemory = 0;
    MemoryPoolInfo fIntermediateMemoryInfo;
-   std::unordered_map<std::string_view, std::pair<size_t, size_t>> fIntermediateTensorFrequencyLookup;
+   std::unordered_map<std::string_view, size_t> fIntermediateTensorFrequencyLookup;
 
 public:
    // Rule of five: explicitly define move semantics, disallow copy
@@ -147,8 +147,8 @@ public:
    // used to infer the sub-graphs
    std::string GenerateInferSignature(bool isdecl = true);
 
-   void EvaluateIntermediateMemory(std::span<const std::string_view> op_input_tensors, std::span<const std::string_view> op_output_tensors, const size_t& current_op_idx, std::vector<size_t>& available_memory);
-   std::string AllocateIntermediateMemory(std::span<const std::string_view> op_output_tensors, size_t& total_intermediate_capacity);
+   // calculate total intermediate memory and position intermediate tensor addresses
+   std::string AllocateIntermediateMemory(std::span<const std::string_view> op_output_tensors);
    void CheckAndFlushIntermediateMemory(std::span<const std::string_view> op_output_tensors, const size_t& op_idx);
 
 protected:

--- a/tmva/sofie/inc/TMVA/RModel_Base.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_Base.hxx
@@ -43,7 +43,7 @@ protected:
 
    std::unordered_set<std::string> fNeededBlasRoutines;
 
-   const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath","memory"};
+   const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath", "memory", "span"};
    std::unordered_set<std::string> fNeededStdLib = {"vector"};
    std::unordered_set<std::string> fCustomOpHeaders;
 

--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -21,6 +21,14 @@ class ROperator{
 public:
    virtual std::vector<std::string> GetBlasRoutines() { return {}; }
    virtual std::vector<std::string> GetStdLibs() { return {}; }
+   virtual const std::vector<std::string>& GetOpInputTensors() {
+      static const std::vector<std::string> defaultTensors;
+      return defaultTensors;
+   }
+   virtual const std::vector<std::string>& GetOpOutputTensors() {
+      static const std::vector<std::string> defaultTensors;
+      return defaultTensors;
+   }      
    virtual std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) = 0;
    virtual std::vector<ETensorType> TypeInference(std::vector<ETensorType>) = 0;
    virtual void Initialize(RModel&) = 0;
@@ -32,7 +40,6 @@ public:
    // generate session data members specific to operator
    virtual std::string GenerateSessionMembersCode(std::string /*opName*/) { return ""; }
    virtual std::string Header() { return "";}
-
 
    //virtual void Forward_reference() = 0;
    //virtual void Forward_blas() = 0;

--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -21,14 +21,6 @@ class ROperator{
 public:
    virtual std::vector<std::string> GetBlasRoutines() { return {}; }
    virtual std::vector<std::string> GetStdLibs() { return {}; }
-   virtual const std::vector<std::string>& GetOpInputTensors() {
-      static const std::vector<std::string> defaultTensors;
-      return defaultTensors;
-   }
-   virtual const std::vector<std::string>& GetOpOutputTensors() {
-      static const std::vector<std::string> defaultTensors;
-      return defaultTensors;
-   }      
    virtual std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) = 0;
    virtual std::vector<ETensorType> TypeInference(std::vector<ETensorType>) = 0;
    virtual void Initialize(RModel&) = 0;
@@ -50,6 +42,19 @@ protected:
    const std::string SP = "   ";    ///< space used to correctly indent the generated C++ code
    bool fUseSession = false;        ///< flag to identify if using the session class
    bool fIsOutputConstant = false;  ///< flag to identify if operator has a constant output (no need to generate code)
+   
+   mutable std::vector<std::string_view> fInputTensorNames;
+   mutable std::vector<std::string_view> fOutputTensorNames;
+
+public:
+   std::span<const std::string_view> GetOpInputTensors() const {
+      return fInputTensorNames;
+   }
+
+   std::span<const std::string_view> GetOpOutputTensors() const {
+      return fOutputTensorNames;
+   }
+   
 };
 
 

--- a/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
@@ -85,7 +85,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNA)){
          throw std::runtime_error(std::string("TMVA SOFIE Binary Op Input Tensor ") + fNA + "is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
@@ -68,7 +68,10 @@ private:
 public:
    ROperator_BasicBinary(){}
    ROperator_BasicBinary(std::string nameA, std::string nameB, std::string nameY):
-      fNA(UTILITY::Clean_name(nameA)), fNB(UTILITY::Clean_name(nameB)), fNY(UTILITY::Clean_name(nameY)){}
+      fNA(UTILITY::Clean_name(nameA)), fNB(UTILITY::Clean_name(nameB)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNA, fNB };
+         fOutputTensorNames = { fNY };
+      }
 
    // type of output given input
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {

--- a/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
@@ -82,7 +82,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) override {
+   void Initialize(RModel& model){
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNA)){
          throw std::runtime_error(std::string("TMVA SOFIE Binary Op Input Tensor ") + fNA + "is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
@@ -100,6 +100,11 @@ public:
       fNInputs.reserve(inputNames.size());
       for (auto & name : inputNames)
          fNInputs.push_back(UTILITY::Clean_name(name));
+
+      fInputTensorNames.resize(fNInputs.size());
+      std::transform(fNInputs.begin(), fNInputs.end(), fInputTensorNames.begin(),
+                  [](const std::string& s) -> std::string_view { return s; });
+      fOutputTensorNames = { fNY };
    }
 
    // type of output given input

--- a/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
@@ -118,7 +118,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       for (auto &it : fNInputs) {
          if (!model.CheckIfTensorAlreadyExist(it)) {
             throw std::runtime_error("TMVA SOFIE BasicNary Op Input Tensor " + it + " is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
@@ -80,7 +80,7 @@ public:
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override { return input; }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA::SOFIE - Tensor " + fNX + " not found.");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
@@ -71,7 +71,10 @@ public:
 
    ROperator_BasicUnary(std::string nameX, std::string nameY)
       : fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY))
-   {}
+   {
+         fInputTensorNames =  { fNX };
+         fOutputTensorNames = { fNY };   
+   }
 
    std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input) override { return input; }
 

--- a/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
@@ -77,8 +77,7 @@ public:
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override { return input; }
 
-   void Initialize(RModel &model) override
-   {
+   void Initialize(RModel& model){
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA::SOFIE - Tensor " + fNX + " not found.");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
@@ -30,6 +30,7 @@ private:
    std::string fNMean;
    std::string fNVar;
    std::string fNY;
+   EActivationType fActivation;
 
    std::vector<size_t> fShapeX;
    std::vector<size_t> fShapeScale;
@@ -46,11 +47,11 @@ public:
    /* Constructor */
    ROperator_BatchNormalization( float epsilon, float momentum, std::size_t training_mode,
    std::string nameX, std::string nameScale, std::string nameB,
-   std::string nameMean, std::string nameVar, std::string nameY):
+   std::string nameMean, std::string nameVar, std::string nameY, EActivationType activation=EActivationType::UNDEFINED):
    fepsilon(epsilon), fmomentum(momentum), ftraining_mode(training_mode),
    fNX(UTILITY::Clean_name(nameX)), fNScale(UTILITY::Clean_name(nameScale)),
    fNB(UTILITY::Clean_name(nameB)), fNMean(UTILITY::Clean_name(nameMean)),
-   fNVar(UTILITY::Clean_name(nameVar)), fNY(UTILITY::Clean_name(nameY))
+   fNVar(UTILITY::Clean_name(nameVar)), fNY(UTILITY::Clean_name(nameY)), fActivation(activation)
    {  
       fInputTensorNames = { fNX };
       fOutputTensorNames = { fNY };
@@ -86,7 +87,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw
             std::runtime_error("TMVA SOFIE BatchNormalization op Input Tensor " + fNX + " fnx is not found in model");
@@ -220,6 +221,11 @@ public:
       out << SP << "BLAS::saxpy_(&" << OpName << "_N, &" << OpName << "_alpha, " << "tensor_" << fNB << ", &" << OpName << "_incx, "
          << "tensor_" << fNY << ", &" << OpName << "_incy);\n\n";
 
+      if(fActivation == EActivationType::RELU){
+         out << SP << "for (int id = 0; id < " << ConvertShapeToLength(fShapeY) << " ; id++){\n";
+         out << SP << SP << "tensor_" << fNY << "[id] = ((tensor_" << fNY << "[id] > 0 )? tensor_" << fNY << "[id] : 0);\n";
+         out << SP << "}\n";
+      }
       return out.str();
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
@@ -51,7 +51,10 @@ public:
    fNX(UTILITY::Clean_name(nameX)), fNScale(UTILITY::Clean_name(nameScale)),
    fNB(UTILITY::Clean_name(nameB)), fNMean(UTILITY::Clean_name(nameMean)),
    fNVar(UTILITY::Clean_name(nameVar)), fNY(UTILITY::Clean_name(nameY))
-   {
+   {  
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
+
       if(std::is_same<T, float>::value){
       fType = "float";
       }
@@ -195,6 +198,7 @@ public:
       size_t n = batchSize * channels * height * width;
 
       //// copy X into Y
+      out << "\n\n//---- BatchNorm\n";
       out << SP << "constexpr int " << OpName << "_N =" << batchSize * channels * height * width << ";\n";
       out << SP << "constexpr int "<<OpName<< "_incx = 1;\n";
       out << SP << "constexpr int "<<OpName<< "_incy = 1;\n";

--- a/tmva/sofie/inc/TMVA/ROperator_Cast.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Cast.hxx
@@ -26,7 +26,10 @@ public:
    ROperator_Cast(){}
    ROperator_Cast(std::string attr_type,std::string nameX, std::string nameY):
    fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)),
-   fAttrType(attr_type) {}
+   fAttrType(attr_type) {
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
+   }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Cast.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Cast.hxx
@@ -40,7 +40,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       if (model.CheckIfTensorAlreadyExist(fNX) == false){
         throw std::runtime_error("TMVA SOFIE Cast Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
@@ -91,7 +91,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNX1)){
          throw std::runtime_error(std::string("TMVA SOFIE Comparision Op Input Tensor ") + fNX1 + "is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
@@ -73,7 +73,12 @@ private:
 public:
    ROperator_Comparision(){}
    ROperator_Comparision(const std::string & nameX1, const std::string & nameX2, const std::string & nameY):
-      fNX1(UTILITY::Clean_name(nameX1)), fNX2(UTILITY::Clean_name(nameX2)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX1(UTILITY::Clean_name(nameX1)), fNX2(UTILITY::Clean_name(nameX2)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX1, fNX2 };
+         
+         // output will be a boolean vector so should not be considered for memory optimized pool
+         fOutputTensorNames = { fNY };
+      }
 
    // type of output given input
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {

--- a/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
@@ -86,7 +86,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) override {
+   void Initialize(RModel& model){
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNX1)){
          throw std::runtime_error(std::string("TMVA SOFIE Comparision Op Input Tensor ") + fNX1 + "is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
@@ -138,8 +138,7 @@
             return ret;
          }
 
-         void Initialize(RModel &model)
-         {
+      void Initialize(RModel& model){
             for (auto &it : fInputs) {
                if (model.CheckIfTensorAlreadyExist(it) == false) {
                   throw std::runtime_error("TMVA SOFIE Concat Op Input Tensor " + it + " is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
@@ -143,7 +143,7 @@
             return ret;
          }
 
-      void Initialize(RModel& model){
+      void Initialize(RModel& model) override {
             for (auto &it : fInputs) {
                if (model.CheckIfTensorAlreadyExist(it) == false) {
                   throw std::runtime_error("TMVA SOFIE Concat Op Input Tensor " + it + " is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
@@ -33,6 +33,11 @@
             fInputs.reserve(inputs.size());
             for (auto & name : inputs)
                fInputs.push_back(UTILITY::Clean_name(name));
+
+         fInputTensorNames.resize(fInputs.size());
+         std::transform(fInputs.begin(), fInputs.end(), fInputTensorNames.begin(),
+                   [](const std::string& s) -> std::string_view { return s; });
+         fOutputTensorNames = { fOutput };
          }
 
          std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
@@ -47,7 +47,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       size_t length = 1;
       if (!fNX.empty()) {

--- a/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
@@ -33,7 +33,10 @@ public:
       fShape(shape),
       fValues(values),
       fAttrType(type)
-      { }
+      {
+         fInputTensorNames = { };
+         fOutputTensorNames = { };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -63,7 +63,7 @@ public:
             std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a Conv operator");
       }
       fInputTensorNames = { fNX, fNB };
-      fOutputTensorNames = { fNY, fNB2 };
+      fOutputTensorNames = { fNY };
    }
 
    ROperator_Conv(std::string autopad, std::vector<size_t> dilations,

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -194,7 +194,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) {
+   void Initialize(RModel& model){
       fUseSession = model.UseSession();
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw
@@ -257,6 +257,7 @@ public:
             }
          }
       }
+
    }
 
    std::string GenerateInitCode() {
@@ -539,6 +540,16 @@ public:
    /*! \brief Returns the blas routines needed to compile the generated code
     */
    std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
+
+   const std::vector<std::string>& GetOpInputTensors() {
+      static const std::vector<std::string> op_input_tensors = { fNX, fNB };
+      return op_input_tensors;
+   }
+   const std::vector<std::string>& GetOpOutputTensors() {
+      static const std::vector<std::string> op_output_tensors = { fNY, fNB2 };
+      return op_output_tensors;
+   }   
+
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -62,6 +62,8 @@ public:
          throw
             std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a Conv operator");
       }
+      fInputTensorNames = { fNX, fNB };
+      fOutputTensorNames = { fNY, fNB2 };
    }
 
    ROperator_Conv(std::string autopad, std::vector<size_t> dilations,
@@ -78,6 +80,8 @@ public:
          throw
             std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a Conv operator");
       }
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) {
@@ -194,7 +198,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) {
       fUseSession = model.UseSession();
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw
@@ -257,7 +261,6 @@ public:
             }
          }
       }
-
    }
 
    std::string GenerateInitCode() {
@@ -540,16 +543,6 @@ public:
    /*! \brief Returns the blas routines needed to compile the generated code
     */
    std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
-
-   const std::vector<std::string>& GetOpInputTensors() {
-      static const std::vector<std::string> op_input_tensors = { fNX, fNB };
-      return op_input_tensors;
-   }
-   const std::vector<std::string>& GetOpOutputTensors() {
-      static const std::vector<std::string> op_output_tensors = { fNY, fNB2 };
-      return op_output_tensors;
-   }   
-
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -201,7 +201,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) {
+   void Initialize(RModel& model) override {
       fUseSession = model.UseSession();
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -33,6 +33,9 @@ private:
    std::string fNB2; // bias tensor name after broadcasting
    std::string fNY;
 
+   std::string convK;
+   std::string imcol;
+
    std::vector<size_t> fShapeX;
    std::vector<size_t> fShapeW;
    std::vector<size_t> fShapeB;
@@ -261,6 +264,22 @@ public:
             }
          }
       }
+
+      size_t outputChannelSize = fShapeY[2];  // size/channel = D * H * W
+      size_t kernelSize = fAttrKernelShape[0];
+      for (size_t i = 1; i < fDim; i++) {
+         outputChannelSize *= fShapeY[2 + i];
+         kernelSize *= fAttrKernelShape[i];
+      }
+
+      std::vector<size_t> shape1 = {fShapeW[0], fShapeW[1], kernelSize};
+      std::vector<size_t> shape2 = {fShapeW[1], kernelSize, outputChannelSize};
+      model.AddIntermediateTensor(fNX +"_f", ConvertStringToType(fType), shape1 );
+      model.AddIntermediateTensor(fNX +"_xcol", ConvertStringToType(fType), shape2 );
+      convK = fNX +"_f";
+      imcol = fNX +"_xcol";
+      fOutputTensorNames.emplace_back(convK);
+      fOutputTensorNames.emplace_back(imcol);
    }
 
    std::string GenerateInitCode() {
@@ -294,12 +313,12 @@ public:
       opName = "op_" + opName;
       std::stringstream out;
       // matrix with convolution kernels
-      out << "std::vector<" << fType << "> fVec_" << opName << "_f = std::vector<" << fType << ">("
-          << fShapeW[0] * fShapeW[1] * kernelSize << ");\n";
-      // output matrix of im2col
-      out << "std::vector<" << fType << "> fVec_" << opName << "_xcol = std::vector<" << fType << ">("
-          << fShapeW[1] * kernelSize * outputChannelSize << ");\n";
-      out << "\n";
+      // out << "std::vector<" << fType << "> fVec_" << opName << "_f = std::vector<" << fType << ">("
+      //     << fShapeW[0] * fShapeW[1] * kernelSize << ");\n";
+      // // output matrix of im2col
+      // out << "std::vector<" << fType << "> fVec_" << opName << "_xcol = std::vector<" << fType << ">("
+      //     << fShapeW[1] * kernelSize * outputChannelSize << ");\n";
+      // out << "\n";
 
       return out.str();
    }
@@ -327,10 +346,8 @@ public:
       out << "\n//----  operator Conv " << OpName << "\n";
 
       // create first matrix with convolution kernels
-      if (fUseSession)
-         out << SP << fType << " * " << OpName << "_f = fVec_" << OpName << "_f.data();\n";
-      else
-         out << SP << fType << " " << OpName << "_f[" << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] << "] = {0};\n";
+      if (!fUseSession)
+         out << SP << fType << " tensor_" << fNX << "_f[" << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] << "] = {0};\n";
 
       // vectorize the (dilated)convolution kernels into a matrix
       // no need to transpose the matrix
@@ -358,7 +375,7 @@ public:
          out << SP << SP << SP << "for (std::size_t kh = 0; kh < " << kHeight << "; kh++) {\n";
       out << SP << SP << SP << SP << "for (std::size_t kw = 0; kw < " << kWidth << "; kw++) {\n";
 
-      out << SP << SP << SP << SP << SP << OpName <<  "_f[oc * "
+      out << SP << SP << SP << SP << SP << "tensor_" <<fNX <<  "_f[oc * "
           << ocstrideDil << " + ic * " << icstrideDil;
       if (fDim > 2) out << " + kd * " << dstrideDil;
       if (fDim > 1) out << " + kh * " << hstrideDil;
@@ -384,11 +401,8 @@ public:
       out << SP << "float " << OpName << "_alpha = 1.0;\n";
       out << SP << "float " << OpName << "_beta = 0.0;\n";
 
-      if (fUseSession) {
-         out << SP << fType << " * " << OpName << "_xcol = fVec_" << OpName << "_xcol.data();\n";
-      }
-      else {
-         out << SP << fType << " " << OpName << "_xcol["
+      if (!fUseSession) {
+         out << SP << fType << " tensor_" << fNX << "_xcol["
              << fShapeX[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] * oDepth * oHeight * oWidth
              << "] = {0};\n";
       }
@@ -447,7 +461,7 @@ public:
                out << fAttrKernelShape[0] << "," << fAttrKernelShape[1] << "," << fAttrPads[0] << "," << fAttrPads[1]
                    << "," << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrDilations[0] << ","
                    << fAttrDilations[1];
-            out << "," << OpName << "_xcol);\n\n ";
+            out << "," << "tensor_" <<fNX << "_xcol);\n\n ";
          } else {
             // 3d im2col
             out << SP << SP << "TMVA::Experimental::SOFIE::UTILITY::Im2col_3d<float>(tensor_" << fNX
@@ -460,13 +474,13 @@ public:
                 << fAttrPads[0] << "," << fAttrPads[1] << "," << fAttrPads[2] << ","
                 << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrStrides[2] << ","
                 << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << ","
-                << OpName << "_xcol);\n\n ";
+                << "tensor_" << fNX << "_xcol);\n\n ";
          }
          // BLAS
          out << SP << SP << "BLAS::sgemm_(&" << OpName << "_transA, &" << OpName << "_transB, &" << OpName << "_m, &"
-             << OpName << "_n, &" << OpName << "_k, &" << OpName << "_alpha, " << OpName << "_xcol, &" << OpName
+             << OpName << "_n, &" << OpName << "_k, &" << OpName << "_alpha, " << "tensor_" << fNX << "_xcol, &" << OpName
              << "_m,\n"; // use m if op_xcol is not transpose , otherwise k
-         out << SP << SP << SP << OpName << "_f, &" << OpName << "_k, &" << OpName << "_beta, tensor_" << fNY
+         out << SP << SP << SP << "tensor_" << fNX << "_f, &" << OpName << "_k, &" << OpName << "_beta, tensor_" << fNY
              << " + out_offset, &" << OpName << "_m);\n";
       } else {
          // case of group convolution
@@ -493,7 +507,7 @@ public:
                out << fAttrKernelShape[0] << "," << fAttrKernelShape[1] << "," << fAttrPads[0] << "," << fAttrPads[1]
                    << "," << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrDilations[0] << ","
                    << fAttrDilations[1];
-            out << "," << OpName << "_xcol);\n\n ";
+            out << ", tensor_" << fNX << "_xcol);\n\n ";
          } else {
             // 3d im2col
             out << SP << SP << "TMVA::Experimental::SOFIE::UTILITY::Im2col_3d<float>(tensor_" << fNX
@@ -504,7 +518,7 @@ public:
                 << fShapeW[1] << "," << iDepth << "," << iHeight << "," << iWidth << "," << fAttrKernelShape[0] << ","
                 << fAttrKernelShape[1] << "," << fAttrKernelShape[2] << "," << fAttrPads[0] << "," << fAttrPads[1]
                 << "," << fAttrPads[2] << "," << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrStrides[2]
-                << "," << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << "," << OpName
+                << "," << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << ",tensor_" << fNX
                 << "_xcol);\n\n ";
          }
 
@@ -516,9 +530,9 @@ public:
              << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] / fAttrGroup
              << ";\n";
          out << SP << SP << "BLAS::sgemm_(&" << OpName << "_transA, &" << OpName << "_transB, &" << OpName << "_m, &"
-             << OpName << "_n, &" << OpName << "_k, &" << OpName << "_alpha, " << OpName << "_xcol, &" << OpName
+             << OpName << "_n, &" << OpName << "_k, &" << OpName << "_alpha, tensor_" << fNX << "_xcol, &" << OpName
              << "_m,\n"; // use m if op_xcol is not transpose , otherwise k
-         out << SP << SP << SP << OpName << "_f + offset_f, &" << OpName << "_k, &" << OpName << "_beta, tensor_" << fNY
+         out << SP << SP << SP << "tensor_" << fNX << "_f + offset_f, &" << OpName << "_k, &" << OpName << "_beta, tensor_" << fNY
              << " + out_offset"
              << ", &" << OpName << "_m);\n";
 

--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
@@ -101,7 +101,7 @@ public:
    /*! \brief Initialize the model
     * \param model Model
     */
-   void Initialize(RModel & /*model*/) override;
+   void Initialize(RModel &) override;
 
    /*! \brief Generate code for initializing the op
     */

--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
@@ -77,6 +77,12 @@ public:
         fNX(UTILITY::Clean_name(nameX)), fNW(UTILITY::Clean_name(nameW)), fNB(UTILITY::Clean_name(nameB)),
         fNY(UTILITY::Clean_name(nameY))
    {
+      fInputTensorNames = { fNX, fNW };
+      fOutputTensorNames = { fNY };
+      if (!fNB.empty()) {
+         fInputTensorNames.emplace_back(fNB);
+      }
+
       if (std::is_same<T, float>::value) {
          fType = "float";
       } else {

--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.icc
@@ -103,8 +103,8 @@ auto ROperator_ConvTranspose<T>::ShapeInference(std::vector<std::vector<size_t>>
 }
 
 template <typename T>
-void ROperator_ConvTranspose<T>::Initialize(RModel &model)
-{
+void ROperator_ConvTranspose<T>::Initialize(RModel& model){
+
    fUseSession = model.UseSession();
    if (!model.CheckIfTensorAlreadyExist(fNX)) {
       throw std::runtime_error("TMVA SOFIE Conv Transpose op Input Tensor " + fNX + " is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
@@ -39,7 +39,7 @@ public:
     std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) {return {{}};};
     std::vector<ETensorType> TypeInference(std::vector<ETensorType>){ return {};};
 
-    void Initialize(RModel& model){
+   void Initialize(RModel& model){
       model.AddNeededCustomHeader(fHeaderName);
       for(auto& it:fInputNames){
         if (model.CheckIfTensorAlreadyExist(it) == false){

--- a/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
@@ -72,6 +72,7 @@ public:
          for (auto & i : fOutputNames) std::cout << " " << i;
          std::cout << "\n";
       }
+      model.AddNeededCustomHeader("ROOT/RSpan.hxx");
    }
 
     std::string Generate(std::string OpName){
@@ -80,11 +81,11 @@ public:
       out << "\n//------ "<<fOpName<<" \n";
       std::string args;
       for(long unsigned int i = 0; i<fInputNames.size(); ++i){
-        args+="std::span<"+ConvertTypeToString(fInputType)+">(tensor_"+std::string(fInputNames[i])+", "+fInputSizes[i]+"),";
+        args+="std::span<const "+ConvertTypeToString(fInputType)+">(tensor_"+std::string(fInputNames[i])+", "+fInputSizes[i]+"),";
       }
 
       for(long unsigned int i = 0; i<fOutputNames.size(); ++i){
-        args+="std::span<float>(tensor_"+std::string(fOutputNames[i])+", "+ConvertShapeToLength(fOutputShapes[i])+"),";
+        args+="std::span<"+TensorType<T>::Name()+">(tensor_"+std::string(fOutputNames[i])+", "+ConvertShapeToLength(fOutputShapes[i])+"),";
       }
       args.pop_back();
       out << SP << fOpName<<"::Compute("+args+");\n";

--- a/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Custom.hxx
@@ -43,7 +43,7 @@ public:
     std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) {return {{}};};
     std::vector<ETensorType> TypeInference(std::vector<ETensorType>){ return {};};
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       model.AddNeededCustomHeader(fHeaderName);
       fInputType = model.GetTensorType(fInputNames[0]);
 

--- a/tmva/sofie/inc/TMVA/ROperator_Einsum.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Einsum.hxx
@@ -48,6 +48,11 @@ public:
       // parse teh equations to find labels
       if (!ParseEquation(equation))
          throw std::runtime_error("TMVA SOFIE Einsum Op: Error parsing the equation " + equation);
+
+      fInputTensorNames.resize(fNInputs.size());
+      std::transform(fNInputs.begin(), fNInputs.end(), fInputTensorNames.begin(),
+                  [](const std::string& s) -> std::string_view { return s; });
+      fOutputTensorNames = { fNY };
    }
 
    bool ParseEquation(const std::string & input_equation) {
@@ -183,7 +188,7 @@ public:
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNInputs[0]), fShapeY);
 
       if (model.Verbose()) {
-         std::cout << "Einstein op ";
+         std::cout << "Einsum op ";
          for (i = 0; i < fNInputs.size(); i++) {
             if (i > 0) std::cout << ", ";
             std::cout << fNInputs[i] << " " << ConvertShapeToString(fShapeInputs[i]) << " " << fInputLabels[i];

--- a/tmva/sofie/inc/TMVA/ROperator_Elu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Elu.hxx
@@ -29,6 +29,9 @@ public:
    ROperator_Elu(float alpha,std::string nameX, std::string nameY):
    falpha(alpha),fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY))
    {
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
+      
       if(std::is_same<T, float>::value){
          fType = "float";
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Erf(){}
    ROperator_Erf(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;
@@ -60,15 +63,6 @@ public:
    }
 
    std::vector<std::string> GetStdLibs() { return { std::string("cmath") };}
-
-   const std::vector<std::string>& GetOpInputTensors() {
-      static const std::vector<std::string> op_input_tensors = { fNX };
-      return op_input_tensors;
-   }
-   const std::vector<std::string>& GetOpOutputTensors() {
-      static const std::vector<std::string> op_output_tensors = { fNY };
-      return op_output_tensors;
-   }
    
 };
 

--- a/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
@@ -42,7 +42,6 @@ public:
       }
       fShape = model.GetTensorShape(fNX);
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShape);
-
    }
 
 
@@ -61,6 +60,16 @@ public:
    }
 
    std::vector<std::string> GetStdLibs() { return { std::string("cmath") };}
+
+   const std::vector<std::string>& GetOpInputTensors() {
+      static const std::vector<std::string> op_input_tensors = { fNX };
+      return op_input_tensors;
+   }
+   const std::vector<std::string>& GetOpOutputTensors() {
+      static const std::vector<std::string> op_output_tensors = { fNY };
+      return op_output_tensors;
+   }
+   
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Erf.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       if (model.CheckIfTensorAlreadyExist(fNX) == false){
         throw std::runtime_error("TMVA SOFIE Erf Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
@@ -29,7 +29,10 @@ private:
 public:
    ROperator_Expand(){}
    ROperator_Expand(std::string nameX, std::string nameShape, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNShape(UTILITY::Clean_name(nameShape)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNShape(UTILITY::Clean_name(nameShape)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    // type of output given input
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {
@@ -117,15 +120,6 @@ public:
                    << ", fTensor_" << fNY << ");\n";
       }
       return out.str();
-   }
-   
-   const std::vector<std::string>& GetOpInputTensors() {
-      static const std::vector<std::string> op_input_tensors = { fNX };
-      return op_input_tensors;
-   }
-   const std::vector<std::string>& GetOpOutputTensors() {
-      static const std::vector<std::string> op_output_tensors = { fNY };
-      return op_output_tensors;
    }
 
 };

--- a/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
@@ -43,7 +43,7 @@ public:
       return input;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
         throw std::runtime_error("TMVA SOFIE Expand Op Input Tensor " + fNX + " is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
@@ -83,6 +83,7 @@ public:
          if (broadcast || model.IsConstantTensor(fNX)) {
             fIsOutputConstant = true; // constant output in this case
             model.AddConstantTensor(fNY, model.GetTensorType(fNX), fShapeY, data);
+            fOutputTensorNames.pop_back();
          } else {
             model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShapeY);
          }
@@ -117,7 +118,7 @@ public:
       if (!fInitialized && fShapeX != fShapeY) {
          out << SP << "// Broadcasting uninitialized tensor " << fNX << "\n";
          out << SP << "TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast<" << fType << ">(tensor_" << fNX << ", " << ConvertShapeToString(fShapeX) << ", " << ConvertShapeToString(fShapeY)
-                   << ", fTensor_" << fNY << ");\n";
+                   << ", std::span<"<<fType<<">(tensor_"<<fNY<<", "<<ConvertShapeToLength(fShapeY)<<"));\n";                   
       }
       return out.str();
    }

--- a/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
@@ -40,7 +40,7 @@ public:
       return input;
    }
 
-   void Initialize(RModel& model) override {
+   void Initialize(RModel& model){
       // input must be a graph input, or already initialized intermediate tensor
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
         throw std::runtime_error("TMVA SOFIE Expand Op Input Tensor " + fNX + " is not found in model");
@@ -89,7 +89,7 @@ public:
       }
       fType = ConvertTypeToString(model.GetTensorType(fNX));
       if (model.Verbose())
-         std::cout << "Expand - output is with shape " << ConvertShapeToString(fShapeY) << std::endl;
+         std::cout << "Expand - output is with shape " << ConvertShapeToString(fShapeY) << std::endl;      
    }
 
    std::string GenerateInitCode() override {
@@ -117,6 +117,15 @@ public:
                    << ", fTensor_" << fNY << ");\n";
       }
       return out.str();
+   }
+   
+   const std::vector<std::string>& GetOpInputTensors() {
+      static const std::vector<std::string> op_input_tensors = { fNX };
+      return op_input_tensors;
+   }
+   const std::vector<std::string>& GetOpOutputTensors() {
+      static const std::vector<std::string> op_output_tensors = { fNY };
+      return op_output_tensors;
    }
 
 };

--- a/tmva/sofie/inc/TMVA/ROperator_EyeLike.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_EyeLike.hxx
@@ -39,7 +39,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE EyeLike Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_EyeLike.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_EyeLike.hxx
@@ -25,7 +25,10 @@ private:
 public:
    ROperator_EyeLike(){}
    ROperator_EyeLike(int dtype, int k, std::string nameX, std::string nameY):
-      fdtype(dtype), fk(k), fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fdtype(dtype), fk(k), fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;
@@ -66,7 +69,8 @@ public:
       // add a dummy statement to avoid warning for unused input
       out << SP << "(void) tensor_" << fNX << ";\n";
 
-      out << SP << "fTensor_" << fNY << ".assign(" << length << ", 0);\n";
+      out << SP << "std::fill(tensor_" << fNY << ", tensor_" << fNY << " + " << length << ","
+          << 0 << ");\n";
       out << SP << "for (int i = 0; i < " << fShape[0] << "; i++) {\n";
       out << SP << SP << "int j = i +" << fk << ";\n";
       out << SP << SP << "if (j >= 0 && j < " << fShape[1] << ")\n";

--- a/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
@@ -116,7 +116,7 @@ template <typename T> class ROperator_GRU final : public ROperator {
     *
     * \param model Model
     */
-   void Initialize(RModel & /*model*/);
+   void Initialize(RModel &);
 
    /*! \brief Generate the inference code
     *

--- a/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
@@ -92,6 +92,26 @@ template <typename T> class ROperator_GRU final : public ROperator {
          fNSequence_lens(UTILITY::Clean_name(nameSequence_lens)),
          fNInitial_h(UTILITY::Clean_name(nameInitial_h)),
          fNY(UTILITY::Clean_name(nameY)), fNY_h(UTILITY::Clean_name(nameY_h)) {
+      
+      fInputTensorNames = { fNX, fNW, fNR };
+      if (!fNB.empty()){
+        fInputTensorNames.emplace_back(fNB);
+      }
+      if (!fNSequence_lens.empty()){
+        fInputTensorNames.emplace_back(fNSequence_lens);
+      }
+      if (!fNInitial_h.empty()){
+        fInputTensorNames.emplace_back(fNInitial_h);
+      }
+
+      fOutputTensorNames = { };
+      if (!fNY.empty()){
+        fOutputTensorNames.emplace_back(fNY);
+      }
+      if (!fNY_h.empty()){
+        fOutputTensorNames.emplace_back(fNY_h);
+      }
+
       if (std::is_same<T, float>::value) {
          fType = "float";
       } else {

--- a/tmva/sofie/inc/TMVA/ROperator_GRU.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_GRU.icc
@@ -35,7 +35,8 @@ auto ROperator_GRU<T>::ShapeInference(std::vector<std::vector<size_t>> input)
 }
 
 template<typename T>
-void ROperator_GRU<T>::Initialize(RModel &model) {
+void ROperator_GRU<T>::Initialize(RModel& model){
+
    fUseSession = model.UseSession();
    // Check the input and output tensors
    if (!model.CheckIfTensorAlreadyExist(fNX)) {

--- a/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
@@ -46,7 +46,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) {
+   void Initialize(RModel& model){
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA SOFIE Gather Op Input Tensor " + fNX + " is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
@@ -48,7 +48,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA SOFIE Gather Op Input Tensor " + fNX + " is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
@@ -35,6 +35,8 @@ public:
    ROperator_Gather(){}
    ROperator_Gather(int64_t attrAxis, std::string nameX, std::string nameIndices, std::string nameY):
       fAttrAxis(attrAxis), fNX(UTILITY::Clean_name(nameX)), fNIndices(UTILITY::Clean_name(nameIndices)), fNY(UTILITY::Clean_name(nameY)) {
+         fInputTensorNames = { fNX, fNIndices };
+         fOutputTensorNames = { fNY };
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -36,6 +36,7 @@ namespace SOFIE{
       std::string fNC2; // bias tensor name after broadcasting
       std::string fNY;
       std::string fType;
+      EActivationType fActivation;
       std::vector<Dim> fShapeA;
       std::vector<Dim> fShapeB;
       std::vector<size_t> fShapeC;
@@ -44,10 +45,11 @@ namespace SOFIE{
    public:
 
       ROperator_Gemm(){}
-      ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameY):
+      ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameY, EActivationType activation=EActivationType::UNDEFINED):
          fAttrAlpha(alpha), fAttrBeta(beta), fAttrTransA(transA), fAttrTransB(transB), fNA(UTILITY::Clean_name(nameA)),
          fNB(UTILITY::Clean_name(nameB)), fNY(UTILITY::Clean_name(nameY))
-      {
+      {  
+         fActivation = activation;
          fType = "float";
          static_assert(std::is_same_v<T, float>,
                   "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
@@ -55,14 +57,13 @@ namespace SOFIE{
          fOutputTensorNames = { fNY };
       }
 
-      ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameC, std::string nameY):
+      ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameC, std::string nameY, EActivationType activation=EActivationType::UNDEFINED):
          fAttrAlpha(alpha), fAttrBeta(beta), fAttrTransA(transA), fAttrTransB(transB), fNA(UTILITY::Clean_name(nameA)),
-         fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY))
+         fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY)), fActivation(activation)
       {
+         fActivation = activation;
          fType = "float";
-         static_assert(std::is_same_v<T, float>,
-                  "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
-         fInputTensorNames = { fNA, fNB, fNC };
+
          fOutputTensorNames = { fNY };
       }
 
@@ -136,7 +137,7 @@ namespace SOFIE{
 
 
 
-      void Initialize(RModel& model){
+      void Initialize(RModel& model) override {
          //TODO: propagate A or B as specified by ONNX standard
 
          if ((model.CheckIfTensorAlreadyExist(fNA) == false) || (model.CheckIfTensorAlreadyExist(fNB) == false) ){   //input must be a graph input, or already initialized intermediate tensor
@@ -374,6 +375,12 @@ namespace SOFIE{
              << "tensor_" << fNY;
              if (doStackMul) out << " + " << opName << "_yoffset";
              out << ", &" << opName << "_n);\n";
+
+            if(fActivation == EActivationType::RELU){
+               out << SP << "for (int id = 0; id < " << TMVA::Experimental::SOFIE::ConvertDynamicShapeToLength(fShapeY) << " ; id++){\n";
+               out << SP << SP << "tensor_" << fNY << "[id] = ((tensor_" << fNY << "[id] > 0 )? tensor_" << fNY << "[id] : 0);\n";
+               out << SP << "}\n";
+            }
          }
 
          if (doStackMul) {

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -40,7 +40,7 @@ namespace SOFIE{
       std::vector<Dim> fShapeB;
       std::vector<size_t> fShapeC;
       std::vector<Dim> fShapeY;
-
+      
    public:
 
       ROperator_Gemm(){}
@@ -51,6 +51,8 @@ namespace SOFIE{
          fType = "float";
          static_assert(std::is_same_v<T, float>,
                   "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
+         fInputTensorNames = { fNA, fNB };
+         fOutputTensorNames = { fNY };
       }
 
       ROperator_Gemm(float alpha, float beta, int_t transA, int_t transB, std::string nameA, std::string nameB, std::string nameC, std::string nameY):
@@ -60,6 +62,8 @@ namespace SOFIE{
          fType = "float";
          static_assert(std::is_same_v<T, float>,
                   "TMVA::SOFIE - Unsupported type parsing a Gemm operator");
+         fInputTensorNames = { fNA, fNB, fNC };
+         fOutputTensorNames = { fNY };
       }
 
       std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
@@ -381,15 +385,6 @@ namespace SOFIE{
       }
 
       std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Gemv") }; }
-
-      const std::vector<std::string>& GetOpInputTensors() {
-         static const std::vector<std::string> op_input_tensors = { fNA, fNB, fNC };
-         return op_input_tensors;
-      }
-      const std::vector<std::string>& GetOpOutputTensors() {
-         static const std::vector<std::string> op_output_tensors = { fNY, fNC2 };
-         return op_output_tensors;
-      }      
       
    };
 

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -262,7 +262,6 @@ namespace SOFIE{
          }
 
          model.AddNeededStdLib("algorithm");
-
       }
 
       std::string GenerateInitCode()
@@ -383,6 +382,15 @@ namespace SOFIE{
 
       std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Gemv") }; }
 
+      const std::vector<std::string>& GetOpInputTensors() {
+         static const std::vector<std::string> op_input_tensors = { fNA, fNB, fNC };
+         return op_input_tensors;
+      }
+      const std::vector<std::string>& GetOpOutputTensors() {
+         static const std::vector<std::string> op_output_tensors = { fNY, fNC2 };
+         return op_output_tensors;
+      }      
+      
    };
 
 

--- a/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
@@ -25,7 +25,10 @@ private:
 public:
    ROperator_Identity(){}
    ROperator_Identity(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
@@ -109,6 +109,34 @@ template <typename T> class ROperator_LSTM final : public ROperator {
          throw std::runtime_error(
              "TMVA SOFIE Encountered unsupported type parsing a LSTM operator");
       }
+      
+      fInputTensorNames = { fNX, fNW, fNR };
+      if (!fNB.empty()){
+         fInputTensorNames.emplace_back(fNB);
+      }
+      if (!fNSequence_lens.empty()){
+         fInputTensorNames.emplace_back(fNSequence_lens);
+      }
+      if (!fNInitial_h.empty()){
+         fInputTensorNames.emplace_back(fNInitial_h);
+      }
+      if (!fNInitial_c.empty()){
+         fInputTensorNames.emplace_back(fNInitial_c);
+      }
+      if (!fNP.empty()){
+         fInputTensorNames.emplace_back(fNP);
+      }
+
+      fOutputTensorNames = { };
+      if (!fNY.empty()){
+         fOutputTensorNames.emplace_back(fNY);
+      }
+      if (!fNY_h.empty()){
+         fOutputTensorNames.emplace_back(fNY_h);
+      }
+      if (!fNY_c.empty()){
+         fOutputTensorNames.emplace_back(fNY_c);
+      }
    }
 
    /*! \brief Infers the type of the output tensors

--- a/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
@@ -128,7 +128,7 @@ template <typename T> class ROperator_LSTM final : public ROperator {
     *
     * \param model Model
     */
-   void Initialize(RModel &model);
+   void Initialize(RModel &);
 
    /*! \brief Generate the inference code
     *

--- a/tmva/sofie/inc/TMVA/ROperator_LSTM.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_LSTM.icc
@@ -37,7 +37,7 @@ auto ROperator_LSTM<T>::ShapeInference(std::vector<std::vector<size_t>> input)
 }
 
 template<typename T>
-auto ROperator_LSTM<T>::Initialize(RModel &model)
+auto ROperator_LSTM<T>::Initialize(RModel& model)
 -> void {
    fUseSession = model.UseSession();
    // Check the input and output tensors

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -65,8 +65,7 @@ public:
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override { return input; }
 
-   void Initialize(RModel &model) override
-   {
+   void Initialize(RModel& model) override {
       if (!model.CheckIfTensorAlreadyExist(fNX)) {
          throw std::runtime_error("TMVA::SOFIE - Tensor " + fNX + " not found.");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -59,6 +59,18 @@ public:
         fNScale(UTILITY::Clean_name(nameScale)), fNB(UTILITY::Clean_name(nameB)),
         fNY(UTILITY::Clean_name(nameY)), fNMean(UTILITY::Clean_name(nameMean)), fNInvStdDev(UTILITY::Clean_name(nameInvStdDev))
    {
+         fInputTensorNames = { fNX, fNScale };
+         if (!fNB.empty()){
+            fInputTensorNames.emplace_back(fNB);
+         }
+
+         fOutputTensorNames = { fNY };
+         if (!fNMean.empty()){
+            fOutputTensorNames.emplace_back(fNMean);
+         }
+         if (!fNInvStdDev.empty()){
+            fOutputTensorNames.emplace_back(fNInvStdDev);
+         }
    }
 
    std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input) override { return input; }

--- a/tmva/sofie/inc/TMVA/ROperator_LeakyRelu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LeakyRelu.hxx
@@ -50,7 +50,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Leaky Relu Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_LeakyRelu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LeakyRelu.hxx
@@ -36,6 +36,9 @@ public:
 			throw
 				std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a Leaky Relu operator");
 		}
+
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Pad.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pad.hxx
@@ -61,7 +61,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Pad Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Pad.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pad.hxx
@@ -47,6 +47,9 @@ public:
             fMode = kEdge;
          else if (mode == "wrap")
             fMode = kWrap;
+         
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
       }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -198,7 +198,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model) {
+   void Initialize(RModel& model){
 
       fUseSession = model.UseSession();
 

--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -200,7 +200,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
 
       fUseSession = model.UseSession();
 

--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -80,6 +80,8 @@ public:
          throw
             std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a Pool operator");
       }
+      fInputTensorNames = { fNX };
+      fOutputTensorNames = { fNY };
    }
 
    // return input type (defined abstract in ROperator class )

--- a/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
@@ -94,6 +94,25 @@ template <typename T> class ROperator_RNN final : public ROperator {
          throw std::runtime_error(
              "TMVA SOFIE Encountered unsupported type parsing a RNN operator");
       }
+
+      fInputTensorNames = { fNX, fNW, fNR };
+      if(!fNB.empty()){
+         fInputTensorNames.emplace_back(fNB);
+      }
+      if(!fNSequence_lens.empty()){
+         fInputTensorNames.emplace_back(fNSequence_lens);
+      }
+      if(!fNInitial_h.empty()){
+         fInputTensorNames.emplace_back(fNInitial_h);
+      }
+
+      fOutputTensorNames = { };
+      if(!fNY.empty()){
+         fOutputTensorNames.emplace_back(fNY);
+      }
+      if(!fNY_h.empty()){
+         fOutputTensorNames.emplace_back(fNY_h);
+      }
    }
 
    /*! \brief Infers the type of the output tensors

--- a/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
@@ -113,7 +113,7 @@ template <typename T> class ROperator_RNN final : public ROperator {
     *
     * \param model Model
     */
-   void Initialize(RModel &model);
+   void Initialize(RModel &);
 
    /*! \brief Generates the inference code
     *

--- a/tmva/sofie/inc/TMVA/ROperator_RNN.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_RNN.icc
@@ -35,7 +35,7 @@ auto ROperator_RNN<T>::ShapeInference(std::vector<std::vector<size_t>> input)
 }
 
 template <typename T>
-auto ROperator_RNN<T>::Initialize(RModel &model)
+auto ROperator_RNN<T>::Initialize(RModel& model)
 -> void {
    fUseSession = model.UseSession();
    // Check the input and output tensors

--- a/tmva/sofie/inc/TMVA/ROperator_Random.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Random.hxx
@@ -43,7 +43,10 @@ public:
       fSeed(seed),
       fShapeY(shape),
       fParams(params)
-      {}
+      {
+         fInputTensorNames = {  };
+         fOutputTensorNames = { fNY };
+      }
 
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override  {

--- a/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
@@ -82,7 +82,7 @@ public:
       }
       return ret;
    }
-   void Initialize(RModel &model) {
+   void Initialize(RModel& model){
 
       fUseSession = model.UseSession();
 

--- a/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
@@ -89,7 +89,7 @@ public:
       }
       return ret;
    }
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
 
       fUseSession = model.UseSession();
 

--- a/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
@@ -48,6 +48,13 @@ public:
    ROperator_Reduce(int keepdims, std::vector<int64_t> attrAxes, std::string nameX, std::string nameAxes, std::string nameY):
    fkeepdims(keepdims), fAttrAxes(attrAxes), fNX(UTILITY::Clean_name(nameX)), fNAxes(UTILITY::Clean_name(nameAxes)), fNY(UTILITY::Clean_name(nameY)) {
       fReduceOpMode = Op;
+      
+      fInputTensorNames = { fNX };
+      if(!fNAxes.empty()){
+         fInputTensorNames.emplace_back(fNAxes);
+      }
+
+      fOutputTensorNames = { fNY };
    }
 
    // type of output given input
@@ -110,6 +117,7 @@ public:
       if (model.Verbose()){
          std::cout << Name() << " : " << fNX << " -> " << fNY << " shape " << ConvertShapeToString(fShapeY) << std::endl;
       }
+      model.AddNeededStdLib("algorithm");
    }
 
    std::string Generate(std::string opName){
@@ -188,9 +196,9 @@ public:
          // case reduction is at beginning
          // reset output tensors
          if (fReduceOpMode == ReduceProd)
-            out << SP << "fTensor_" << fNY << ".assign(" << outputLength << ",1);\n";
+            out << SP << "std::fill(tensor_" << fNY <<", tensor_"<< fNY <<" + "<< outputLength << ", 1);\n";
          else
-            out << SP << "fTensor_" << fNY << ".assign(" << outputLength << ",0);\n";
+            out << SP << "std::fill(tensor_" << fNY <<", tensor_"<< fNY <<" + "<< outputLength << ", 0);\n";
 
          out << SP << "for (size_t i = 0; i < " << reducedLength << "; i++) {\n";
          out << SP << SP << "for (size_t j = 0; j < " << outputLength << "; j++) {\n";
@@ -215,9 +223,9 @@ public:
          //std::cout << "reduction for operator " << opName << " is middle" << std::endl;
          // reset output tensors
          if (fReduceOpMode == ReduceProd)
-            out << SP << "fTensor_" << fNY << ".assign(" << outputLength << ",1);\n";
+            out << SP << "std::fill(tensor_" << fNY <<", tensor_"<< fNY <<" + "<< outputLength << ", 1);\n";
          else
-            out << SP << "fTensor_" << fNY << ".assign(" << outputLength << ",0);\n";
+            out << SP << "std::fill(tensor_" << fNY <<", tensor_"<< fNY <<" + "<< outputLength << ",0);\n";
 
          out << SP << "for (size_t i = 0; i < " << inputLength << "; i++) {\n";
 

--- a/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Relu Op Input Tensor " + fNX + " is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
@@ -63,6 +63,15 @@ public:
       return out.str();
    }
 
+      const std::vector<std::string>& GetOpInputTensors() {
+      static const std::vector<std::string> op_input_tensors = { fNX };
+      return op_input_tensors;
+   }
+   const std::vector<std::string>& GetOpOutputTensors() {
+      static const std::vector<std::string> op_output_tensors = { fNY };
+      return op_output_tensors;
+   }     
+   
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Relu(){}
    ROperator_Relu(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;
@@ -63,15 +66,6 @@ public:
       return out.str();
    }
 
-      const std::vector<std::string>& GetOpInputTensors() {
-      static const std::vector<std::string> op_input_tensors = { fNX };
-      return op_input_tensors;
-   }
-   const std::vector<std::string>& GetOpOutputTensors() {
-      static const std::vector<std::string> op_output_tensors = { fNY };
-      return op_output_tensors;
-   }     
-   
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -166,7 +166,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       
       fVerbose = model.Verbose();
       if (model.CheckIfTensorAlreadyExist(fNData) == false) {

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -160,8 +160,8 @@ public:
       return ret;
    }
 
-   void Initialize(RModel &model)
-   {
+   void Initialize(RModel& model){
+      
       fVerbose = model.Verbose();
       if (model.CheckIfTensorAlreadyExist(fNData) == false) {
           // input must be a graph input, or already initialized intermediate tensor

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -50,6 +50,12 @@ public:
    {
       if (opMode == Reshape) fAllowZero = attr_value;
       if (opMode == Flatten) fAxis = attr_value;
+
+      fInputTensorNames = { fNData };
+      if(!fNShape.empty()){
+         fInputTensorNames.emplace_back(fNShape);
+      }
+      fOutputTensorNames = { fNOutput };
    }
 
    // for squeeze/unsqueezed operators following old ONNX version (< 10)

--- a/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Selu(){}
    ROperator_Selu(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Selu Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
@@ -45,7 +45,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Shape Op Input Tensor " + fNX + " is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
@@ -56,7 +56,7 @@ public:
       if (fEnd < 0) fEnd += length;
       if (fEnd > fStart)
          fOutput_shape = { size_t(fEnd - fStart) };
-      // in case input tensor is not a dynamic tensor we should register the output as a Constant tensor since we know
+      // in case the input tensor is not a dynamic tensor we should register the output as a Constant tensor since we know
       // its content
       if (!model.IsDynamicTensor(fNX) && !fOutput_shape.empty()) {
          std::shared_ptr<void> data(malloc(length * sizeof(int64_t)), free);
@@ -69,6 +69,7 @@ public:
                std::cout << shape_values[i] << "  ";
             std::cout << std::endl;
          }
+         fIsOutputConstant = true;
       }
       else
          model.AddIntermediateTensor(fNY, ETensorType::INT64, fOutput_shape);
@@ -77,6 +78,9 @@ public:
    }
 
    std::string Generate(std::string OpName){
+      // no need to generate code if the output is constant
+      if (fIsOutputConstant) return "";
+
       OpName = "op_" + OpName;
       if (fShape.empty()) {
          throw std::runtime_error("TMVA SOFIE Shape op called to Generate without being initialized first");

--- a/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
@@ -30,7 +30,10 @@ private:
 public:
    ROperator_Shape(){}
    ROperator_Shape(int start, int end, std::string nameX, std::string nameY):
-   fStart(start) ,fEnd(end), fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+   fStart(start) ,fEnd(end), fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+   }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;
@@ -63,6 +66,7 @@ public:
          auto shape_values = std::vector<int64_t>(fShape.begin()+fStart, fShape.begin() + fEnd );
          std::memcpy(data.get(), (void*) shape_values.data(), length * sizeof(int64_t));
          model.AddConstantTensor(fNY, ETensorType::INT64, fOutput_shape, data);
+         fOutputTensorNames.pop_back();
          if (model.Verbose()) {
             std::cout << "Output of Shape is constant tensor with shape " << ConvertShapeToString(fOutput_shape) << " and values ";
             for (size_t i = 0; i < shape_values.size(); i++)

--- a/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Sigmoid(){}
    ROperator_Sigmoid(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Sigmoid Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
@@ -50,6 +50,8 @@ public:
         fNames[i] = UTILITY::Clean_name(names[i]);
     }
 
+    fInputTensorNames = { fNData };
+    fOutputTensorNames = { fNOutput };
    }
    // ctor for versions < 10
    ROperator_Slice(std::string nameData, std::vector<IType> starts, std::vector<IType> ends, std::vector<IType> axes, std::string nameOutput)

--- a/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
@@ -82,7 +82,7 @@ public:
    }
 
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNData) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA Slice Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
@@ -28,6 +28,8 @@ public:
    ROperator_Softmax(int64_t attr_axis, std::string nameX, std::string nameY)
       : fAttrAxis(attr_axis), fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY))
    {
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) { return input; }

--- a/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
@@ -38,8 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel &model)
-   {
+   void Initialize(RModel& model){
       if (model.CheckIfTensorAlreadyExist(fNX) ==
           false) { // input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Softmax Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
@@ -40,7 +40,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) ==
           false) { // input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Softmax Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Split.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Split.hxx
@@ -34,6 +34,11 @@ public:
          fNYs.reserve(namesY.size());
          for (auto & name : namesY)
             fNYs.push_back(UTILITY::Clean_name(name));
+      
+         fInputTensorNames = { fNX };
+         fOutputTensorNames.resize(fNYs.size());
+         std::transform(fNYs.begin(), fNYs.end(), fOutputTensorNames.begin(),
+                   [](const std::string& s) -> std::string_view { return s; });
       }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Split.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Split.hxx
@@ -50,7 +50,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Split Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_SubGraph.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_SubGraph.hxx
@@ -48,7 +48,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       if (model.CheckIfTensorAlreadyExist(fNX) == false){
         throw std::runtime_error("TMVA SOFIE If Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_SubGraph.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_SubGraph.hxx
@@ -33,6 +33,10 @@ public:
       {
          for (auto & n : fNYs)
             n = UTILITY::Clean_name(n);
+
+         fInputTensorNames = { fNX };
+         std::transform(fNYs.begin(), fNYs.end(), fOutputTensorNames.begin(),
+                   [](const std::string& s) -> std::string_view { return s; });
       }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){

--- a/tmva/sofie/inc/TMVA/ROperator_Swish.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Swish.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false){   //input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE Swish Op Input Tensor is not found in model");
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Swish.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Swish.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Swish(){}
    ROperator_Swish(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
@@ -38,7 +38,7 @@ public:
       return ret;
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       if (model.CheckIfTensorAlreadyExist(fNX) == false){
         throw std::runtime_error("TMVA SOFIE Tanh Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
@@ -24,7 +24,10 @@ private:
 public:
    ROperator_Tanh(){}
    ROperator_Tanh(std::string nameX, std::string nameY):
-      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){}
+      fNX(UTILITY::Clean_name(nameX)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNX };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Tile.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Tile.hxx
@@ -26,7 +26,10 @@ private:
 public:
    ROperator_Tile(){}
    ROperator_Tile(std::string nameRepeat, std::string nameInput, std::string nameY):
-      fNRepeats(UTILITY::Clean_name(nameRepeat)),fNInput(UTILITY::Clean_name(nameInput)), fNY(UTILITY::Clean_name(nameY)){}
+      fNRepeats(UTILITY::Clean_name(nameRepeat)),fNInput(UTILITY::Clean_name(nameInput)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNRepeats, fNInput };
+         fOutputTensorNames = { fNY };
+      }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;

--- a/tmva/sofie/inc/TMVA/ROperator_Tile.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Tile.hxx
@@ -44,7 +44,7 @@ public:
       return {ret};
    }
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
        //input must be a graph input, or already initialized intermediate tensor
       if (model.CheckIfTensorAlreadyExist(fNInput) == false){
         throw std::runtime_error("TMVA SOFIE Tile Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -57,8 +57,7 @@ public:
    }
 
 
-   void Initialize(RModel &model)
-   {
+   void Initialize(RModel& model){
       if (model.CheckIfTensorAlreadyExist(fNX) == false) {
          // input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE TopK Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -126,7 +126,7 @@ public:
       // [m,n,o,k,p] => boundary's size = length/(m*n*o)
       size_t groupSize = length/bound; //final search space for topK elements
 
-      size_t jump= groupSize/fShapeX[fAttrAxis];
+      size_t jump= groupSize/fShapeX[axis]; /// this is stride[axis]
       //candidates to check in group
       size_t numOfChecksInGrp=groupSize/jump;
       size_t numOfCheckersInGrp=groupSize/numOfChecksInGrp;
@@ -148,13 +148,13 @@ public:
       out<<SP<<SP<<"}\n";
       if (fAttrSorted) {
          if (fAttrLargest) {
-            out<<SP<<SP << "std::sort(elements.begin(),elements.end(),[](std::pair<float,int>a,std::pair<float,int>b){return "
+            out<<SP<<SP << "std::partial_sort(elements.begin(),elements.begin()+" << fK << ",elements.end(),[](std::pair<float,int>a,std::pair<float,int>b){return "
                    "a.first>b.first;});\n";
          } else
-            out<<SP<<SP << "std::sort(elements.begin(),elements.end(),[](std::pair<float,int>a,std::pair<float,int>b){return "
+            out<<SP<<SP << "std::partial_sort(elements.begin(),elements.begin()+" << fK << ",elements.end(),[](std::pair<float,int>a,std::pair<float,int>b){return "
                    "a.first<b.first;});\n";
       } else
-         out<<SP<<SP << "std::sort(elements.begin(),elements.end());\n";
+         out<<SP<<SP << "std::partial_sort(elements.begin(),elements.begin()+" << fK << ",elements.end());\n";
 
       out<<SP<<SP<<"itr++;\n";
       out<<SP<<SP<<"std::vector<std::pair<float,int>>kelems;\n";

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -37,7 +37,10 @@ public:
         fNK(UTILITY::Clean_name(nameK)),
         fNX(UTILITY::Clean_name(nameX)),
         fNVal(UTILITY::Clean_name(nameVal)),
-        fNInd(UTILITY::Clean_name(nameInd)){}
+        fNInd(UTILITY::Clean_name(nameInd)){
+            fInputTensorNames = { fNX, fNK };
+            fOutputTensorNames = { fNVal, fNInd };
+        }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) {
          ETensorType ret = input[0];

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -60,7 +60,7 @@ public:
    }
 
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNX) == false) {
          // input must be a graph input, or already initialized intermediate tensor
          throw std::runtime_error("TMVA SOFIE TopK Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
@@ -62,7 +62,7 @@ public:
    }
 
 
-   void Initialize(RModel& model){
+   void Initialize(RModel& model) override {
       if (model.CheckIfTensorAlreadyExist(fNData) == false){   //input must be a graph input, or already initialized intermediate tensor
          std::cout<<"Input tensor for transpose: "<<fNData<<'\n';
          throw std::runtime_error("TMVA SOFIE Tranpose Op Input Tensor is not found in model");

--- a/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
@@ -32,10 +32,14 @@ public:
    ROperator_Transpose(){}
    ROperator_Transpose(std::vector<int_t> attr_perm, std::string nameData, std::string nameOutput):
       fAttrPerm(attr_perm), fNData(UTILITY::Clean_name(nameData)), fNOutput(UTILITY::Clean_name(nameOutput)) {
+            fInputTensorNames = { fNData };
+            fOutputTensorNames = { fNOutput };
    }
 
    ROperator_Transpose(std::string nameData, std::string nameOutput):
       fNData(UTILITY::Clean_name(nameData)), fNOutput(UTILITY::Clean_name(nameOutput)) {
+         fInputTensorNames = { fNData };
+         fOutputTensorNames = { fNOutput };
    }
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
@@ -60,7 +64,7 @@ public:
 
    void Initialize(RModel& model){
       if (model.CheckIfTensorAlreadyExist(fNData) == false){   //input must be a graph input, or already initialized intermediate tensor
-         std::cout<<"Input tensor for transspose: "<<fNData<<'\n';
+         std::cout<<"Input tensor for transpose: "<<fNData<<'\n';
          throw std::runtime_error("TMVA SOFIE Tranpose Op Input Tensor is not found in model");
       }
       fShapeData = model.GetTensorShape(fNData);

--- a/tmva/sofie/inc/TMVA/ROperator_Where.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Where.hxx
@@ -38,7 +38,10 @@ private:
 public:
    ROperator_Where(){}
    ROperator_Where(const std::string & nameA, const std::string & nameB, const std::string & nameC, const std::string & nameY):
-      fNA(UTILITY::Clean_name(nameA)), fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY)){}
+      fNA(UTILITY::Clean_name(nameA)), fNB(UTILITY::Clean_name(nameB)), fNC(UTILITY::Clean_name(nameC)), fNY(UTILITY::Clean_name(nameY)){
+         fInputTensorNames = { fNA, fNB, fNC };
+         fOutputTensorNames = { fNY };
+      }
 
    // type of output given input
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) override {
@@ -168,6 +171,9 @@ public:
          if (model.Verbose())
             std::cout << "Where op ---> " << fNY << "  " << ConvertShapeToString(fShapeY) << " : "
                << ConvertValuesToString(dataY) << std::endl;
+         
+         // output is a constant tensor
+         fOutputTensorNames.pop_back();
       }
       else {
         model.AddIntermediateTensor(fNY, model.GetTensorType(fNA), fShapeY);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -121,13 +121,29 @@ struct TensorType<uint64_t> {
 
 struct TensorMemoryInfo {
    std::string tensor_name;
-   size_t chunk_idx;
    size_t tensor_size;
+
+   TensorMemoryInfo split(const std::string& new_name, size_t new_size) {
+        if (new_size > tensor_size) {
+            throw std::invalid_argument("New size exceeds available tensor size.");
+        }
+        tensor_size -= new_size;
+        return TensorMemoryInfo{new_name, new_size};
+   }
+
+    // Method to merge another struct into this one
+   void merge(const TensorMemoryInfo& other) {
+        tensor_size += other.tensor_size;
+   }
 };
 
 struct MemoryPoolInfo {
-   std::vector<TensorMemoryInfo> total_memory;
-   std::vector<std::pair<size_t, size_t>> available_memory;
+
+   // ordered map with chunk_idx as key and TensorMemoryInfo as value
+   std::map<size_t, TensorMemoryInfo> total_stack;
+
+   // ordered map with chunk_idx as key and chunk_size as value
+   std::map<size_t, size_t> available_stack;
 };
 
 std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -100,22 +100,13 @@ struct TensorType<uint64_t> {
 
 struct TensorMemoryInfo {
    std::string tensor_name;
-   unsigned int chunk_idx;
+   size_t chunk_idx;
    size_t tensor_size;
 };
 
-struct AvailableChunkInfo {
-   unsigned int chunk_idx;
-   size_t chunk_size;
-};
 struct MemoryPoolInfo {
    std::vector<TensorMemoryInfo> total_memory;
-   std::map<unsigned int, size_t> available_memory;
-};
-
-struct TensorCounter {
-   bool check_flag;
-   unsigned int frequency;
+   std::vector<std::pair<size_t, size_t>> available_memory;
 };
 
 std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -32,6 +32,10 @@ enum class ETensorType{
     FLOAT16 = 10, DOUBLE = 11, UINT32 = 12, UINT64 = 13, COMPLEX64 = 14, COMPLEX28 = 15, BFLOAT16 = 16
 };
 
+enum class EActivationType{
+   UNDEFINED = 0, RELU = 1, SOFTMAX = 2, SIGMOID = 3, LEAKYRELU = 4, TANH = 5, ELU = 6
+};
+
 constexpr size_t GetTypeSize(ETensorType type) {
     switch (type) {
         case ETensorType::FLOAT:     return sizeof(float);

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -98,6 +98,25 @@ struct TensorType<uint64_t> {
    static const std::string Name() { return "uint64_t"; }
 };
 
+struct TensorMemoryInfo {
+   std::string tensor_name;
+   unsigned int chunk_idx;
+   size_t tensor_size;
+};
+
+struct AvailableChunkInfo {
+   unsigned int chunk_idx;
+   size_t chunk_size;
+};
+struct MemoryPoolInfo {
+   std::vector<TensorMemoryInfo> total_memory;
+   std::map<unsigned int, size_t> available_memory;
+};
+
+struct TensorCounter {
+   bool check_flag;
+   unsigned int frequency;
+};
 
 std::vector<Dim> ConvertShapeToDim(std::vector<size_t> shape);
 

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <cstdint>
 #include <cstring>
+#include <complex>
 #include <string>
 #include <vector>
 #include <memory>
@@ -29,6 +30,26 @@ enum class ETensorType{
    UNDEFINED = 0, FLOAT = 1, UNINT8 = 2, INT8 = 3, UINT16 = 4, INT16 = 5, INT32 = 6, INT64 = 7, STRING = 8, BOOL = 9, //order sensitive
     FLOAT16 = 10, DOUBLE = 11, UINT32 = 12, UINT64 = 13, COMPLEX64 = 14, COMPLEX28 = 15, BFLOAT16 = 16
 };
+
+constexpr size_t GetTypeSize(ETensorType type) {
+    switch (type) {
+        case ETensorType::FLOAT:     return sizeof(float);
+        case ETensorType::DOUBLE:    return sizeof(double);
+        case ETensorType::UNINT8:     return sizeof(uint8_t);
+        case ETensorType::INT8:      return sizeof(int8_t);
+        case ETensorType::UINT16:    return sizeof(uint16_t);
+        case ETensorType::INT16:     return sizeof(int16_t);
+        case ETensorType::INT32:     return sizeof(int32_t);
+        case ETensorType::INT64:     return sizeof(int64_t);
+        case ETensorType::UINT32:    return sizeof(uint32_t);
+        case ETensorType::UINT64:    return sizeof(uint64_t);
+        case ETensorType::BOOL:      return sizeof(bool);
+        case ETensorType::STRING:    return sizeof(std::string);
+        case ETensorType::COMPLEX64: return sizeof(std::complex<float>);
+        case ETensorType::COMPLEX28: return sizeof(std::complex<double>);
+        default: return 0;
+    }
+}
 
 typedef std::int64_t int_t;
 

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -12,6 +12,7 @@
 #include <complex>
 #include <string>
 #include <vector>
+#include <map>
 #include <memory>
 #include <regex>
 #include <sstream>
@@ -45,8 +46,6 @@ constexpr size_t GetTypeSize(ETensorType type) {
         case ETensorType::UINT64:    return sizeof(uint64_t);
         case ETensorType::BOOL:      return sizeof(bool);
         case ETensorType::STRING:    return sizeof(std::string);
-        case ETensorType::COMPLEX64: return sizeof(std::complex<float>);
-        case ETensorType::COMPLEX28: return sizeof(std::complex<double>);
         default: return 0;
     }
 }
@@ -120,10 +119,10 @@ struct TensorType<uint64_t> {
 };
 
 struct TensorMemoryInfo {
-   std::string tensor_name;
+   std::string_view tensor_name;
    size_t tensor_size;
 
-   TensorMemoryInfo split(const std::string& new_name, size_t new_size) {
+   TensorMemoryInfo split(const std::string_view new_name, size_t new_size) {
         if (new_size > tensor_size) {
             throw std::invalid_argument("New size exceeds available tensor size.");
         }

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -819,7 +819,7 @@ void RModel::GenerateSessionCode()
 
    // generate code for declaring the initialized tensors
    GenerateInitializedTensorInfo();
-   
+
    // evaluate total intermediate memory and position intermediate tensor addresses
    std::string intermediate_memory_alloc_string = "";
    intermediate_memory_alloc_string += "\n// --- Positioning intermediate tensor memory --";
@@ -828,10 +828,10 @@ void RModel::GenerateSessionCode()
       CheckAndFlushIntermediateMemory(fOperators[op_idx]->GetOpInputTensors(), op_idx);
    }
 
-   std::cout<<"Still in available memory: ";
-   for (const auto &it: fIntermediateMemoryInfo.available_stack){
-      std::cout<<"chunk_idx: "<<it.first<<", chunk_size: "<<it.second<<"\n";
-   }
+   // to check remaining unused fragments after memory allocation (lesser the better)
+   // for (const auto &it: fIntermediateMemoryInfo.available_stack){
+   //    std::cout<<"chunk_idx: "<<it.first<<", chunk_size: "<<it.second<<"\n";
+   // }
    
    // generate the memory pool to be used by intermediate tensors
    GenerateIntermediateMemoryPool();

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -827,6 +827,11 @@ void RModel::GenerateSessionCode()
       intermediate_memory_alloc_string += AllocateIntermediateMemory(fOperators[op_idx]->GetOpOutputTensors());
       CheckAndFlushIntermediateMemory(fOperators[op_idx]->GetOpInputTensors(), op_idx);
    }
+
+   std::cout<<"Still in available memory: ";
+   for (const auto &it: fIntermediateMemoryInfo.available_stack){
+      std::cout<<"chunk_idx: "<<it.first<<", chunk_size: "<<it.second<<"\n";
+   }
    
    // generate the memory pool to be used by intermediate tensors
    GenerateIntermediateMemoryPool();

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -387,9 +387,9 @@ void UTILITY::UnidirectionalBroadcast(const std::vector<bool> & data, const std:
       std::vector<size_t> newShape(targetSize, 1);
       size_t offset = targetSize - shape.size();
       std::copy(shape.begin(), shape.end(), newShape.begin() + offset);
-      UTILITY::BroadcastTensor<bool, std::vector<bool> &>(ncdata, newShape, targetShape, broadcastedData);
+      UTILITY::BroadcastTensor<bool, const std::vector<bool> &, std::vector<bool> &>(ncdata, newShape, targetShape, broadcastedData);
    }
-   UTILITY::BroadcastTensor<bool, std::vector<bool> &>(ncdata, shape, targetShape, broadcastedData);
+   UTILITY::BroadcastTensor<bool, const std::vector<bool> &, std::vector<bool> &>(ncdata, shape, targetShape, broadcastedData);
 }
 
 std::string UTILITY::Clean_name(std::string input_tensor_name){

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -56,6 +56,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser
     src/ParseElu.cxx
     src/ParseFuseConvAdd.cxx
     src/ParseFuseConvTransposeAdd.cxx
+    src/ParseFuseGemmRelu.cxx
+    src/ParseFuseBatchnormRelu.cxx
     src/ParseFuseMatMulAdd.cxx
     src/ParseMatMul.cxx
     src/ParseComparision.cxx

--- a/tmva/sofie_parsers/src/ParseFuseBatchnormRelu.cxx
+++ b/tmva/sofie_parsers/src/ParseFuseBatchnormRelu.cxx
@@ -1,0 +1,49 @@
+#include "TMVA/RModelParser_ONNX.hxx"
+#include "TMVA/ROperator_BatchNormalization.hxx"
+#include "onnx_proto3.pb.h"
+
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+ParserFuseFuncSignature ParseFuseBatchnormRelu = [](RModelParser_ONNX &parser, const onnx::NodeProto &batchnormnode,
+                                                const onnx::NodeProto &relunode) {
+        ETensorType input_type;
+
+        auto input_name = batchnormnode.input(0);
+        if (parser.IsRegisteredTensorType(input_name)) {
+            input_type = parser.GetTensorType(input_name);
+        } else {
+            throw std::runtime_error("TMVA::SOFIE ONNX Parser BatchNorm op has input tensor " + input_name +
+                                    " but its type is not yet registered");
+        }
+        
+        std::unique_ptr<ROperator> op;
+        std::string output_name = relunode.output(0);
+        float fepsilon = 1e-05;
+        float fmomentum = 0.9;
+        std::size_t ftraining_mode = 0;
+        
+        switch (input_type) {
+        case ETensorType::FLOAT:
+            if (batchnormnode.input_size() == 5) {
+                op.reset(new ROperator_BatchNormalization<float>(fepsilon, fmomentum, ftraining_mode, batchnormnode.input(0),
+                                                                batchnormnode.input(1), batchnormnode.input(2), batchnormnode.input(3),
+                                                                batchnormnode.input(4), output_name, EActivationType::RELU));
+            }
+            break;
+        default:
+            throw std::runtime_error("TMVA::SOFIE - Unsupported - Operator BatchNorm does not yet support input type " +
+                                    std::to_string(static_cast<int>(input_type)));
+        }
+        
+        if (!parser.IsRegisteredTensorType(output_name)) {
+            parser.RegisterTensorType(output_name, input_type);
+        }
+        
+        return op;
+};
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA

--- a/tmva/sofie_parsers/src/ParseFuseGemmRelu.cxx
+++ b/tmva/sofie_parsers/src/ParseFuseGemmRelu.cxx
@@ -1,0 +1,73 @@
+#include "TMVA/RModelParser_ONNX.hxx"
+#include "TMVA/ROperator_Gemm.hxx"
+#include "onnx_proto3.pb.h"
+
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+ParserFuseFuncSignature ParseFuseGemmRelu = [](RModelParser_ONNX &parser, const onnx::NodeProto &gemmnode,
+                                                const onnx::NodeProto &relunode) -> std::unique_ptr<ROperator> {
+   ETensorType input_type = ETensorType::UNDEFINED;
+   // check input type - only first input from Gemm
+   auto input_name = gemmnode.input(0);
+   if (parser.IsRegisteredTensorType(input_name)) {
+      input_type = parser.GetTensorType(input_name);
+   } else {
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser MatMul op has input tensor " + input_name +
+                               " but its type is not yet registered");
+   }
+
+   // we don't check input type of ADD since it is not be registered
+   std::unique_ptr<ROperator> op;
+
+   float attr_alpha = 1.0;
+   float attr_beta = 1.0;
+   int_t attr_transA = 0;
+   int_t attr_transB = 0;
+
+   for (int i = 0; i < gemmnode.attribute_size(); i++) {
+      std::string attribute_name = gemmnode.attribute(i).name();
+      if (attribute_name == "alpha") {
+         attr_alpha = gemmnode.attribute(i).f();
+      } else if (attribute_name == "beta") {
+         attr_beta = gemmnode.attribute(i).f();
+      } else if (attribute_name == "transA") {
+         attr_transA = gemmnode.attribute(i).i();
+         if (attr_transA != 0 && attr_transA != 1)
+            throw std::runtime_error("TMVA::SOFIE Error - Model Loading - attribute transA in Operator Gemm not 0/1");
+      } else if (attribute_name == "transB") {
+         attr_transB = gemmnode.attribute(i).i();
+         if (attr_transB != 0 && attr_transB != 1)
+            throw std::runtime_error("TMVA::SOFIE Error - Model Loading - attribute transB in Operator Gemm not 0/1");
+      } else {
+         std::cout << "TMVA::SOFIE Warning - Model Loading - Attribute " << attribute_name << " in OperatorNode "
+                   << gemmnode.name() << " is not defined in ONNX IR and not applied!\n";
+      }
+   }
+   switch (input_type) {
+   case ETensorType::FLOAT:
+      if (gemmnode.input_size() == 2) {
+         op.reset(new ROperator_Gemm<float>(attr_alpha, attr_beta, attr_transA, attr_transB, gemmnode.input(0),
+                                            gemmnode.input(1), relunode.output(0), EActivationType::RELU));
+      } else {
+         op.reset(new ROperator_Gemm<float>(attr_alpha, attr_beta, attr_transA, attr_transB, gemmnode.input(0),
+                                            gemmnode.input(1), gemmnode.input(2), relunode.output(0), EActivationType::RELU));
+      }
+      break;
+   default:
+      throw std::runtime_error("TMVA::SOFIE - Unsupported - Operator Gemm does not yet support input type " +
+                               std::to_string(static_cast<int>(input_type)));
+   }
+
+   std::string output_name = relunode.output(0);
+   if (!parser.IsRegisteredTensorType(output_name)) {
+      parser.RegisterTensorType(output_name, input_type);
+   }
+
+   return op;
+};
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -688,7 +688,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
          // for skipping the fused nodes like Add after MatMul
          continue;
       }
-      rmodel.AddOperator(std::move(op));
+      rmodel.AddOperator(std::move(op), i);
    }
 
    std::vector<std::string> outputnames;

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -608,7 +608,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
          bool existInputs = true;
          int input_size = graph.node(i).input_size();
          // special case for Reshape where shape is input and not a weight tensor
-         if (fVerbose )
+         if (fVerbose)
             std::cout << "Checking input of  Node " << i << " : " << graph.node(i).name() << std::endl;
          for (int j = 0; j < input_size; j++) {
             std::string name = graph.node(i).input(j);
@@ -616,7 +616,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
             if (!name.empty()) {
                existInputs &= (allInputs.find(name) != allInputs.end() ||
                                allInitializedTensors.find(name) != allInitializedTensors.end());
-               if (fVerbose ) {
+               if (fVerbose) {
                   std::cout << "\t\t input " << name << " "
                      << bool(allInputs.find(name) != allInputs.end()) << "  " <<
                      bool(allInitializedTensors.find(name) != allInitializedTensors.end()) <<


### PR DESCRIPTION
This PR brings the first version for the memory optimization for intermediate tensors.

Currently, in the inference code, all the intermediate tensors are initialized at first and are allocated memory, thus no memory reuse takes place. Since not all the intermediate tensors are required till the end, we can flush some of them, and reuse the memory that they release. 

This first edition of memory optimization for intermediate tensors uses a simple mechanism, where the total memory required is first calculated along with the count of operators who need a particular intermediate tensor as their input. 

While adding a operator into the RModel during the Parsing stage, its input operators are taken into account into an unordered map (added as a new key-value pair if not already present, otherwise frequency is incremented). During the initialize phase, we calculate the total memory required by the tensors. We keep two separate containers - total memory (for calculating the total memory required by all the tensors) and available memory (for accounting all the reusable memory - memory that was flushed and can be reused). During the generate phase, we Initialize the intermediate tensors when a particular operator needs it as an output, and flush them when no operator no longer needs it as an input.