### PR TITLE
[skip-ci] remove warning: multiple use of section label 'python' 

### DIFF
--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -201,7 +201,6 @@ void FilterPythonBox()
                                     "<b>Python interface</b></summary>\n"
                                     "<div class=\"pyrootbox\">\n"
                                     "\\endhtmlonly\n"
-                                    "\\anchor python\n"
                                     "\\ingroup Pythonizations", class_name.c_str());
       }
       if (gLineString.find("\\endpythondoc") != string::npos)


### PR DESCRIPTION
remove warning while generating the doc
