### PR TITLE
[ntuple] Fix handling of I/O rules' inputs

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -157,7 +157,7 @@ protected:
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final;
    void BeforeConnectPageSource(Internal::RPageSource &pageSource) final;
-   void OnConnectPageSource() final;
+   void AfterConnectPageSource() final;
 
 public:
    RClassField(std::string_view fieldName, std::string_view className);
@@ -448,7 +448,7 @@ protected:
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
 
-   void OnConnectPageSource() final;
+   void AfterConnectPageSource() final;
 
 public:
    static std::string TypeName() { return "TObject"; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -143,9 +143,13 @@ private:
    RClassField(std::string_view fieldName, const RClassField &source); ///< Used by CloneImpl
    RClassField(std::string_view fieldName, TClass *classp);
    void Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo info);
-   /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
-   /// fill the `TVirtualObject` instance passed to the user function.
-   void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
+   /// Register post-read callback corresponding to a ROOT I/O customization rules.
+   void AddReadCallbacksFromIORule(const TSchemaRule *rule);
+   /// Given the on-disk information from the page source, find all the I/O customization rules that apply
+   /// to the class field at hand, to which the fieldDesc descriptor, if provided, must correspond.
+   /// Fields may not have an on-disk representation (e.g., when inserted by schema evolution), in which case the passed
+   /// field descriptor is nullptr.
+   std::vector<const TSchemaRule *> FindRules(const RFieldDescriptor *fieldDesc);
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -157,7 +161,6 @@ protected:
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final;
    void BeforeConnectPageSource(Internal::RPageSource &pageSource) final;
-   void AfterConnectPageSource() final;
 
 public:
    RClassField(std::string_view fieldName, std::string_view className);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -149,6 +149,11 @@ private:
    /// The staging area stores inputs to I/O rules according to the offsets given by the streamer info of
    /// "TypeName@@Version". The area is allocated depending on I/O rules resp. the source members of the I/O rules.
    std::unique_ptr<unsigned char[]> fStagingArea;
+   /// The TClass instance that corresponds to the staging area.
+   /// The staging class exists as <class name>@@<on-disk version> if the on-disk version is different from the
+   /// current in-memory version, or it can be accessed by the first @@alloc streamer element of the current streamer
+   /// info.
+   TClass *fStagingClass = nullptr;
    std::unordered_map<std::string, RStagingItem> fStagingItems; ///< Lookup staging items by member name
 
 private:
@@ -160,6 +165,8 @@ private:
    /// member exist. Looks recursively in base classes.
    ROOT::DescriptorId_t
    LookupMember(const RNTupleDescriptor &desc, std::string_view memberName, ROOT::DescriptorId_t classFieldId);
+   /// Sets fStagingClass according to the given name and version
+   void SetStagingClass(const std::string &className, unsigned int classVersion);
    /// If there are rules with inputs (source members), create the staging area according to the TClass instance
    /// that corresponds to the on-disk field.
    void PrepareStagingArea(const std::vector<const TSchemaRule *> &rules, const RNTupleDescriptor &desc,

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -476,7 +476,7 @@ protected:
    virtual void BeforeConnectPageSource(Internal::RPageSource &) {}
 
    /// Called by `ConnectPageSource()` once connected; derived classes may override this as appropriate
-   virtual void OnConnectPageSource() {}
+   virtual void AfterConnectPageSource() {}
 
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
    /// normalized type name and type alias.

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -1014,7 +1014,8 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
    }
    for (auto &column : fAvailableColumns)
       column->ConnectPageSource(fOnDiskId, pageSource);
-   OnConnectPageSource();
+
+   AfterConnectPageSource();
 
    fState = EState::kConnectedToSource;
 }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -208,7 +208,8 @@ std::vector<const ROOT::TSchemaRule *> ROOT::Experimental::RClassField::FindRule
    // Erase unknown rule types
    auto hasUnknownType = [](const ROOT::TSchemaRule *rule) {
       if (rule->GetRuleType() != ROOT::TSchemaRule::kReadRule) {
-         R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "ignoring I/O customization rule with unsupported type";
+         R__LOG_WARNING(ROOT::Internal::NTupleLog())
+            << "ignoring I/O customization rule with unsupported type: " << rule->GetRuleType();
          return true;
       }
       return false;

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -247,7 +247,7 @@ void ROOT::Experimental::RClassField::BeforeConnectPageSource(Internal::RPageSou
    }
 }
 
-void ROOT::Experimental::RClassField::OnConnectPageSource()
+void ROOT::Experimental::RClassField::AfterConnectPageSource()
 {
    // Add post-read callbacks for I/O customization rules; only rules that target transient members are allowed for now
    // TODO(jalopezg): revise after supporting schema evolution
@@ -844,7 +844,7 @@ void ROOT::Experimental::RField<TObject>::ReadGlobalImpl(ROOT::NTupleSize_t glob
    *reinterpret_cast<UInt_t *>(reinterpret_cast<unsigned char *>(to) + GetOffsetBits()) = bits;
 }
 
-void ROOT::Experimental::RField<TObject>::OnConnectPageSource()
+void ROOT::Experimental::RField<TObject>::AfterConnectPageSource()
 {
    if (GetTypeVersion() != 1) {
       throw RException(R__FAIL("unsupported on-disk version of TObject: " + std::to_string(GetTypeVersion())));

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -362,11 +362,11 @@ void ROOT::Experimental::RClassField::AddReadCallbacksFromIORule(const TSchemaRu
    auto func = rule->GetReadFunctionPointer();
    R__ASSERT(func != nullptr);
    fReadCallbacks.emplace_back([func, stagingClass = fStagingClass, stagingArea = fStagingArea.get()](void *target) {
-      TVirtualObject oldObj{nullptr};
-      oldObj.fClass = stagingClass;
-      oldObj.fObject = stagingArea;
-      func(static_cast<char *>(target), &oldObj);
-      oldObj.fClass = nullptr; // TVirtualObject does not own the value
+      TVirtualObject onfileObj{nullptr};
+      onfileObj.fClass = stagingClass;
+      onfileObj.fObject = stagingArea;
+      func(static_cast<char *>(target), &onfileObj);
+      onfileObj.fObject = nullptr; // TVirtualObject does not own the value
    });
 }
 

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -401,9 +401,9 @@ void ROOT::Experimental::RClassField::BeforeConnectPageSource(Internal::RPageSou
       if (!rules.empty()) {
          SetStagingClass(fieldDesc.GetTypeName(), fieldDesc.GetTypeVersion());
          PrepareStagingArea(rules, desc, fieldDesc);
+         for (auto &[_, si] : fStagingItems)
+            Internal::CallConnectPageSourceOnField(*si.fField, pageSource);
       }
-      for (auto &[_, si] : fStagingItems)
-         Internal::CallConnectPageSourceOnField(*si.fField, pageSource);
    }
 
    for (const auto rule : rules) {

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -846,7 +846,7 @@ void ROOT::Experimental::RField<TObject>::ReadGlobalImpl(ROOT::NTupleSize_t glob
 
 void ROOT::Experimental::RField<TObject>::AfterConnectPageSource()
 {
-   if (GetTypeVersion() != 1) {
+   if (GetOnDiskTypeVersion() != 1) {
       throw RException(R__FAIL("unsupported on-disk version of TObject: " + std::to_string(GetTypeVersion())));
    }
 }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -321,6 +321,9 @@ void ROOT::Experimental::RClassField::PrepareStagingArea(const std::vector<const
          stagingItem.fField->SetOnDiskId(memberFieldDesc.GetId());
 
          stagingItem.fOffset = cl->GetDataMemberOffset(source->GetName());
+         // Since we successfully looked up the source member in the RNTuple on-disk meta-data, we expect it
+         // to be present in the TClass instance, too.
+         R__ASSERT(stagingItem.fOffset != TVirtualStreamerInfo::kMissing);
          stagingAreaSize = std::max(stagingAreaSize, stagingItem.fOffset + stagingItem.fField->GetValueSize());
          R__ASSERT(stagingAreaSize > 0);
       }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -190,7 +190,7 @@ std::vector<const ROOT::TSchemaRule *> ROOT::Experimental::RClassField::FindRule
    }
 
    // For the time being, we only support rules targeting transient members
-   auto referencesNonTransientMembers = [classp = fClass](const ROOT::TSchemaRule *rule) {
+   auto targetsNonTransientMembers = [classp = fClass](const ROOT::TSchemaRule *rule) {
       if (rule->GetTarget() == nullptr)
          return false;
       for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
@@ -203,7 +203,7 @@ std::vector<const ROOT::TSchemaRule *> ROOT::Experimental::RClassField::FindRule
       }
       return false;
    };
-   rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
+   rules.erase(std::remove_if(rules.begin(), rules.end(), targetsNonTransientMembers), rules.end());
 
    // Erase unknown rule types
    auto hasUnknownType = [](const ROOT::TSchemaRule *rule) {

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -225,6 +225,13 @@ struct StructWithIORules : StructWithIORulesBase {
    StructWithIORules(float _a, char _c[4]) : StructWithIORulesBase{_a, 0.0f}, s{{_c[0], _c[1], _c[2], _c[3]}, {}} {}
 };
 
+struct CoordinatesWithIORules {
+   float fX;
+   float fY;
+   float fR;   //!
+   float fPhi; //!
+};
+
 struct Cyclic {
    std::vector<Cyclic> fMember;
 };

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -217,6 +217,7 @@ struct StructWithTransientString {
 struct StructWithIORules : StructWithIORulesBase {
    StructWithTransientString s;
    float c = 0.0f; //! transient member
+   float cDerived = 0.0f;    //! should become 2*c after rules for c applied
    float checksumA = 0.0f;   //! transient member, edited by checksum based rule
    float checksumB = 137.0f; //! transient member, skipped by checksum based rule due to checksum mismatch
 

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -90,6 +90,12 @@
 #pragma read sourceClass = "StructWithIORules" source = "" checksum = "[1]" targetClass = "StructWithIORules" target = \
    "checksumB" code = "{ checksumB = 0.0; }"
 
+#pragma link C++ options = version(3) class CoordinatesWithIORules + ;
+
+#pragma read sourceClass = "CoordinatesWithIORules" source = "float fX; float fY" version = "[3]" targetClass = \
+   "CoordinatesWithIORules" target = "fPhi,fR" include = "cmath" code =                                         \
+      "{ fR = sqrt(onfile.fX * onfile.fX + onfile.fY * onfile.fY); fPhi = atan2(onfile.fY, onfile.fX); }"
+
 #pragma link C++ class Cyclic + ;
 #pragma link C++ class CyclicCollectionProxy + ;
 #pragma link C++ class Unsupported + ;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -73,8 +73,10 @@
    "StructWithTransientString" target = "str" include = "string" code = "{ str = std::string{onfile.chars, 4}; }"
 
 // Whole object rule (without target member) listed first but should be executed last
-#pragma read sourceClass = "StructWithIORules" version = "[1-]" targetClass = "StructWithIORules" source = "" target = \
-   "" code = "{ newObj->cDerived = 2 * newObj->c; }"
+// clang-format off
+#pragma read sourceClass="StructWithIORules" version="[1-]" targetClass="StructWithIORules" source="" target="" \
+   code="{ newObj->cDerived = 2 * newObj->c; }"
+// clang-format on
 
 #pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
    "StructWithIORules" target = "c" code = "{ c = onfile.a + newObj->b; }"

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -72,6 +72,10 @@
 #pragma read sourceClass = "StructWithTransientString" source = "char chars[4]" version = "[1-]" targetClass = \
    "StructWithTransientString" target = "str" include = "string" code = "{ str = std::string{onfile.chars, 4}; }"
 
+// Whole object rule (without target member) listed first but should be executed last
+#pragma read sourceClass = "StructWithIORules" version = "[1-]" targetClass = "StructWithIORules" source = "" target = \
+   "" code = "{ newObj->cDerived = 2 * newObj->c; }"
+
 #pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
    "StructWithIORules" target = "c" code = "{ c = onfile.a + newObj->b; }"
 

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -79,6 +79,10 @@
 #pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
    "StructWithIORules" target = "c" code = "{ c = onfile.a + newObj->b; }"
 
+// Conflicting type for source member
+#pragma read sourceClass = "StructWithIORules" source = "double a" version = "[1-]" targetClass = \
+   "StructWithIORules" target = "" code = "{ }"
+
 // This rule uses a checksum to identify the source class
 #pragma read sourceClass = "StructWithIORules" source = "" checksum = "[3494027874]" targetClass = \
    "StructWithIORules" target = "checksumA" code = "{ checksumA = 42.0; }"

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -69,32 +69,18 @@
 #pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[100-]" targetClass = \
    "StructWithIORulesBase" target = "b" code = "{ b = 0.0f; }"
 
-// Note: This rule has been modified to work around ROOT bug #15877.
-// The original rule was `str = std::string{onfile.chars, 4};`
-//
-// This bug is triggered by the TClassReadRules unit test (in rfield_class.cxx) in the following way:
-//   1. Upon write, RNTuple calls TClass::GetStreamerInfo() to store the streamer info of StructWithTransientString
-//   2. The read rule calls TClass::GetDataMemberOffset("chars") to fill the `onfile` variable
-//   3. The class doesn't find "chars" among its real data members (it's "chars[4]" in this list)
-//   4. The class therefore tries to get the offset from the streamer info; the streamer info exists in
-//      GetCurrentStreamerInfo() because we called TClass::GetStreamerInfo() in step 1.
-//      Otherwise GetDataMemberOffset() would return 0 which happens to be correct.
-//   5. Now we enter the bug:
-//      - The streamer info has two elements for "chars", one with the correct offset (0),
-//        one cached, with a wrong one (8)
-//      - The streamer info returns the offset of the wrong data member
 #pragma read sourceClass = "StructWithTransientString" source = "char chars[4]" version = "[1-]" targetClass = \
-   "StructWithTransientString" target = "str" include = "string" code = "{ str = \"ROOT\"; }"
+   "StructWithTransientString" target = "str" include = "string" code = "{ str = std::string{onfile.chars, 4}; }"
 
-#pragma read sourceClass = "StructWithIORules" source = "float a;float b" version = "[1-]" targetClass = \
-   "StructWithIORules" target = "c" code = "{ c = onfile.a + onfile.b; }"
+#pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
+   "StructWithIORules" target = "c" code = "{ c = onfile.a + newObj->b; }"
 
 // This rule uses a checksum to identify the source class
-#pragma read sourceClass = "StructWithIORules" source = "float checksumA" checksum = "[3494027874]" targetClass = \
+#pragma read sourceClass = "StructWithIORules" source = "" checksum = "[3494027874]" targetClass = \
    "StructWithIORules" target = "checksumA" code = "{ checksumA = 42.0; }"
 // This rule will be ignored due to a checksum mismatch
-#pragma read sourceClass = "StructWithIORules" source = "float checksumB" checksum = "[1]" targetClass = \
-   "StructWithIORules" target = "checksumB" code = "{ checksumB = 0.0; }"
+#pragma read sourceClass = "StructWithIORules" source = "" checksum = "[1]" targetClass = "StructWithIORules" target = \
+   "checksumB" code = "{ checksumB = 0.0; }"
 
 #pragma link C++ class Cyclic + ;
 #pragma link C++ class CyclicCollectionProxy + ;

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -243,6 +243,9 @@ TEST(RNTuple, TClassReadRules)
    {
       auto model = RNTupleModel::Create();
       auto ptrClass = model->MakeField<StructWithIORules>("class");
+      auto ptrCoord = model->MakeField<CoordinatesWithIORules>("coord");
+      ptrCoord->fX = 1.0;
+      ptrCoord->fY = 1.0;
       auto writer = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       for (int i = 0; i < 5; i++) {
          *ptrClass = StructWithIORules{/*a=*/static_cast<float>(i), /*chars=*/c};
@@ -271,4 +274,10 @@ TEST(RNTuple, TClassReadRules)
       // The following member is not touched by a rule due to a checksum mismatch
       EXPECT_FLOAT_EQ(137.0, viewKlass(i).checksumB);
    }
+
+   auto viewCoord = reader->GetView<CoordinatesWithIORules>("coord");
+   EXPECT_FLOAT_EQ(1.0, viewCoord(0).fX);
+   EXPECT_FLOAT_EQ(1.0, viewCoord(0).fY);
+   EXPECT_FLOAT_EQ(sqrt(2), viewCoord(0).fR);
+   EXPECT_FLOAT_EQ(M_PI / 4., viewCoord(0).fPhi);
 }

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -257,8 +257,9 @@ TEST(RNTuple, TClassReadRules)
       EXPECT_TRUE(0 == memcmp(c, viewKlass(i).s.chars, sizeof(c)));
 
       // The following values are set from a read rule; see CustomStructLinkDef.h
-      EXPECT_EQ(fi + 1.0f, viewKlass(i).b);
-      EXPECT_EQ(viewKlass(i).a + viewKlass(i).b, viewKlass(i).c);
+      EXPECT_FLOAT_EQ(fi + 1.0f, viewKlass(i).b);
+      EXPECT_FLOAT_EQ(viewKlass(i).a + viewKlass(i).b, viewKlass(i).c);
+      EXPECT_FLOAT_EQ(2 * (viewKlass(i).a + viewKlass(i).b), viewKlass(i).cDerived);
       EXPECT_STREQ("ROOT", viewKlass(i).s.str.c_str());
 
       // The following member is set by a checksum based rule

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -233,6 +233,10 @@ TEST(RNTuple, TClassReadRules)
 {
    ROOT::TestSupport::CheckDiagsRAII diags;
    diags.requiredDiag(kWarning, "[ROOT.NTuple]", "ignoring I/O customization rule with non-transient member: a", false);
+   diags.requiredDiag(kWarning, "[ROOT.NTuple]",
+                      "ignoring I/O customization rule due to conflicting source member type: float vs. double "
+                      "for member a",
+                      false);
 
    FileRaii fileGuard("test_ntuple_tclassrules.root");
    char c[4] = {'R', 'O', 'O', 'T'};


### PR DESCRIPTION
Fix execution of I/O customization rules that have on-disk data member sources (inputs). Previously, `TVirtualObject::fObject` pointed to the target object, which is plain wrong (but happens to work in some cases). Now, rule inputs are examined, fields are created according to the provided input's type, and the data is read in a staging area that follows the memory layout of the on-disk class given by TClass. This staging area is now what `TVirtualObject::fObject` points to. 

Note that the target still has to be a transient member. This restriction is going to be lifted in a second PR.

