### PR TITLE
[RF] Refactor RooProdPdf for more concise code

### DIFF
--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -155,9 +155,16 @@ private:
 
   Int_t getPartIntList(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName=nullptr) const ;
 
-  std::vector<RooAbsReal*> processProductTerm(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName,
+  struct ProcessProductTermOutput {
+    bool isOwned = false;
+    RooAbsReal* x0 = nullptr;
+    std::unique_ptr<RooAbsReal> x1;
+    std::unique_ptr<RooAbsReal> x2;
+  };
+
+  ProcessProductTermOutput processProductTerm(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName,
                      const RooArgSet* term,const RooArgSet& termNSet, const RooArgSet& termISet,
-                     bool& isOwned, bool forceWrap=false) const ;
+                     bool forceWrap=false) const ;
 
 
   CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -27,9 +27,6 @@
 #include <list>
 #include <string>
 
-typedef RooArgList* pRooArgList ;
-typedef RooLinkedList* pRooLinkedList ;
-
 namespace RooFit {
 namespace Detail {
 class RooFixedProdPdf;
@@ -135,14 +132,24 @@ private:
 
   void initializeFromCmdArgList(const RooArgSet& fullPdfSet, const RooLinkedList& l) ;
 
-  void factorizeProduct(const RooArgSet& normSet, const RooArgSet& intSet,
-                        RooLinkedList& termList,   RooLinkedList& normList,
-                        RooLinkedList& impDepList, RooLinkedList& crossDepList,
-                        RooLinkedList& intList) const;
+  struct Factorized {
+     ~Factorized();
+
+     RooArgSet *termNormDeps(int i) const { return static_cast<RooArgSet*>(norms.At(i)); }
+     RooArgSet *termIntDeps(int i) const { return static_cast<RooArgSet*>(ints.At(i)); }
+     RooArgSet *termImpDeps(int i) const { return static_cast<RooArgSet*>(imps.At(i)); }
+     RooArgSet *termCrossDeps(int i) const { return static_cast<RooArgSet*>(cross.At(i)); }
+
+     RooLinkedList terms;
+     RooLinkedList norms;
+     RooLinkedList imps;
+     RooLinkedList ints;
+     RooLinkedList cross;
+  };
+
+  void factorizeProduct(const RooArgSet& normSet, const RooArgSet& intSet, Factorized &factorized) const;
   std::string makeRGPPName(const char* pfx, const RooArgSet& term, const RooArgSet& iset, const RooArgSet& nset, const char* isetRangeName) const ;
-  void groupProductTerms(std::list<std::vector<RooArgSet*>>& groupedTerms, RooArgSet& outerIntDeps,
-                         const RooLinkedList& terms, const RooLinkedList& norms,
-                         const RooLinkedList& imps, const RooLinkedList& ints, const RooLinkedList& cross) const ;
+  void groupProductTerms(std::list<std::vector<RooArgSet*>>& groupedTerms, RooArgSet& outerIntDeps, Factorized const &factorized) const;
 
 
 


### PR DESCRIPTION
While trying to address the several GitHub issues related to
integrals of RooProdPdfs, I saw some opportunities to refactor the code
to avoid duplication, especially in `RooProdPdf::processProductTerm()`.

Besides refactoring to avoid code repetition, this PR includes commits that remove unnecessary commented-out lines with `std::cout`, and to introduce proper datastructures to move data around the `RooProdPdf` helper functions.