### PR TITLE
[ntuple] add different modes of descriptor loading to RNTupleSerializer

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -60,6 +60,10 @@ Deserialization errors throw exceptions. Only when indicated or when passed as a
 */
 // clang-format on
 class RNTupleSerializer {
+   static RResult<std::vector<RClusterDescriptorBuilder>>
+   DeserializePageListRaw(const void *buffer, std::uint64_t bufSize, DescriptorId_t clusterGroupId,
+                          const RNTupleDescriptor &desc);
+
 public:
    static constexpr std::uint16_t kEnvelopeTypeHeader = 0x01;
    static constexpr std::uint16_t kEnvelopeTypeFooter = 0x02;
@@ -275,9 +279,21 @@ public:
    DeserializeHeader(const void *buffer, std::uint64_t bufSize, RNTupleDescriptorBuilder &descBuilder);
    static RResult<void>
    DeserializeFooter(const void *buffer, std::uint64_t bufSize, RNTupleDescriptorBuilder &descBuilder);
+
+   enum class EDescriptorDeserializeMode {
+      /// Deserializes the descriptor as-is without performing any additional fixup. The produced descriptor is
+      /// unsuitable for reading or writing, but it's a faithful representation of the on-disk information.
+      kRaw,
+      /// Deserializes the descriptor and performs fixup on the suppressed column ranges. This produces a descriptor
+      /// that is suitable for writing, but not reading.
+      kForWriting,
+      /// Deserializes the descriptor and performs fixup on the suppressed column ranges and on clusters, taking
+      /// into account the header extension. This produces a descriptor that is suitable for reading.
+      kForReading,
+   };
    // The clusters vector must be initialized with the cluster summaries corresponding to the page list
    static RResult<void> DeserializePageList(const void *buffer, std::uint64_t bufSize, DescriptorId_t clusterGroupId,
-                                            RNTupleDescriptor &desc);
+                                            RNTupleDescriptor &desc, EDescriptorDeserializeMode mode);
 
    // Helper functions to (de-)serialize the streamer info type extra information
    static std::string SerializeStreamerInfos(const StreamerInfoMap_t &infos);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -695,7 +695,7 @@ protected:
 
    virtual void LoadStructureImpl() = 0;
    /// `LoadStructureImpl()` has been called before `AttachImpl()` is called
-   virtual RNTupleDescriptor AttachImpl() = 0;
+   virtual RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) = 0;
    /// Returns a new, unattached page source for the same data set
    virtual std::unique_ptr<RPageSource> CloneImpl() const = 0;
    // Only called if a task scheduler is set. No-op be default.
@@ -766,7 +766,8 @@ public:
    /// Therefore, `LoadStructure()` may do nothing and defer loading the meta-data to `Attach()`.
    void LoadStructure();
    /// Open the physical storage container and deserialize header and footer
-   void Attach();
+   void Attach(
+      RNTupleSerializer::EDescriptorDeserializeMode mode = RNTupleSerializer::EDescriptorDeserializeMode::kForReading);
    NTupleSize_t GetNEntries();
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -165,7 +165,7 @@ private:
 
 protected:
    void LoadStructureImpl() final {}
-   RNTupleDescriptor AttachImpl() final;
+   RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
    /// The cloned page source creates a new connection to the pool/container.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -158,7 +158,7 @@ private:
 
 protected:
    void LoadStructureImpl() final;
-   RNTupleDescriptor AttachImpl() final;
+   RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
    /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -200,11 +200,11 @@ void ROOT::Experimental::Internal::RPageSource::LoadStructure()
    fHasStructure = true;
 }
 
-void ROOT::Experimental::Internal::RPageSource::Attach()
+void ROOT::Experimental::Internal::RPageSource::Attach(RNTupleSerializer::EDescriptorDeserializeMode mode)
 {
    LoadStructure();
    if (!fIsAttached)
-      GetExclDescriptorGuard().MoveIn(AttachImpl());
+      GetExclDescriptorGuard().MoveIn(AttachImpl(mode));
    fIsAttached = true;
 }
 
@@ -297,7 +297,7 @@ void ROOT::Experimental::Internal::RPageSource::UnzipClusterImpl(RCluster *clust
 
          fCounters->fNPageUnsealed.Add(pageNo);
       } // for all in-memory types of the column
-   }    // for all columns in cluster
+   } // for all columns in cluster
 
    fTaskScheduler->Wait();
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -503,7 +503,8 @@ ROOT::Experimental::Internal::RPageSourceDaos::RPageSourceDaos(std::string_view 
 
 ROOT::Experimental::Internal::RPageSourceDaos::~RPageSourceDaos() = default;
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceDaos::AttachImpl()
+ROOT::Experimental::RNTupleDescriptor
+ROOT::Experimental::Internal::RPageSourceDaos::AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode)
 {
    ROOT::Experimental::RNTupleDescriptor ntplDesc;
    std::unique_ptr<unsigned char[]> buffer, zipBuffer;
@@ -532,7 +533,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceD
       RNTupleDecompressor::Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().GetNBytesOnStorage(),
                                  cgDesc.GetPageListLength(), buffer.get());
 
-      RNTupleSerializer::DeserializePageList(buffer.get(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc);
+      RNTupleSerializer::DeserializePageList(buffer.get(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc, mode);
    }
 
    return desc;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -349,7 +349,8 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadStructureImpl()
    }
 }
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceFile::AttachImpl()
+ROOT::Experimental::RNTupleDescriptor
+ROOT::Experimental::Internal::RPageSourceFile::AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode)
 {
    auto unzipBuf = reinterpret_cast<unsigned char *>(fStructureBuffer.fPtrFooter) + fAnchor->GetNBytesFooter();
 
@@ -373,7 +374,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RPageSourceF
       RNTupleDecompressor::Unzip(zipBuffer, cgDesc.GetPageListLocator().GetNBytesOnStorage(),
                                  cgDesc.GetPageListLength(), buffer.data());
 
-      RNTupleSerializer::DeserializePageList(buffer.data(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc);
+      RNTupleSerializer::DeserializePageList(buffer.data(), cgDesc.GetPageListLength(), cgDesc.GetId(), desc, mode);
    }
 
    // For the page reads, we rely on the I/O scheduler to define the read requests

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -41,7 +41,7 @@ namespace {
 class RPageSourceMock : public RPageSource {
 protected:
    void LoadStructureImpl() final {}
-   RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
+   RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, NTupleSize_t) final { return RPageRef(); }
 

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -86,7 +86,10 @@ protected:
    const std::vector<RPageStorage::RSealedPage> &fPages;
 
    void LoadStructureImpl() final {}
-   RNTupleDescriptor AttachImpl() final { return RNTupleDescriptor(); }
+   RNTupleDescriptor AttachImpl(ROOT::Experimental::Internal::RNTupleSerializer::EDescriptorDeserializeMode) final
+   {
+      return RNTupleDescriptor();
+   }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::Experimental::NTupleSize_t) final
    {

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -5,6 +5,8 @@
 
 #include <limits>
 
+using EDeserializeMode = RNTupleSerializer::EDescriptorDeserializeMode;
+
 TEST(RNTuple, SerializeInt)
 {
    std::int32_t value;
@@ -526,11 +528,11 @@ TEST(RNTuple, SerializeEmptyHeader)
    RNTupleDescriptorBuilder builder;
    builder.SetNTuple("ntpl", "");
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(0)
-      .FieldName("")
-      .Structure(ENTupleStructure::kRecord)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(0)
+                       .FieldName("")
+                       .Structure(ENTupleStructure::kRecord)
+                       .MakeDescriptor()
+                       .Unwrap());
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
    EXPECT_GT(context.GetHeaderSize(), 0);
@@ -540,23 +542,22 @@ TEST(RNTuple, SerializeEmptyHeader)
    RNTupleSerializer::DeserializeHeader(buffer.get(), context.GetHeaderSize(), builder);
 }
 
-
 TEST(RNTuple, SerializeHeader)
 {
    RNTupleDescriptorBuilder builder;
    builder.SetNTuple("ntpl", "");
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(0)
-      .FieldName("")
-      .Structure(ENTupleStructure::kRecord)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(0)
+                       .FieldName("")
+                       .Structure(ENTupleStructure::kRecord)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(42)
-      .FieldName("pt")
-      .Structure(ENTupleStructure::kLeaf)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(42)
+                       .FieldName("pt")
+                       .Structure(ENTupleStructure::kLeaf)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
                        .FieldId(24)
                        .FieldName("ptAlias")
@@ -565,17 +566,17 @@ TEST(RNTuple, SerializeHeader)
                        .MakeDescriptor()
                        .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(137)
-      .FieldName("jet")
-      .Structure(ENTupleStructure::kRecord)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(137)
+                       .FieldName("jet")
+                       .Structure(ENTupleStructure::kRecord)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(13)
-      .FieldName("eta")
-      .Structure(ENTupleStructure::kLeaf)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(13)
+                       .FieldName("eta")
+                       .Structure(ENTupleStructure::kLeaf)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddFieldLink(0, 42);
    builder.AddFieldLink(0, 24);
    builder.AddFieldLink(0, 137);
@@ -648,23 +649,22 @@ TEST(RNTuple, SerializeHeader)
    EXPECT_STREQ("xyz", extraTypeInfoDesc.GetContent().c_str());
 }
 
-
 TEST(RNTuple, SerializeFooter)
 {
    RNTupleDescriptorBuilder builder;
    builder.SetNTuple("ntpl", "");
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(0)
-      .FieldName("")
-      .Structure(ENTupleStructure::kRecord)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(0)
+                       .FieldName("")
+                       .Structure(ENTupleStructure::kRecord)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
-      .FieldId(42)
-      .FieldName("tag")
-      .Structure(ENTupleStructure::kLeaf)
-      .MakeDescriptor()
-      .Unwrap());
+                       .FieldId(42)
+                       .FieldName("tag")
+                       .Structure(ENTupleStructure::kLeaf)
+                       .MakeDescriptor()
+                       .Unwrap());
    builder.AddFieldLink(0, 42);
    builder.AddColumn(RColumnDescriptorBuilder()
                         .LogicalColumnId(17)
@@ -740,7 +740,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(1u, desc.GetNClusters());
    EXPECT_EQ(0u, desc.GetNActiveClusters());
 
-   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc);
+   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc, EDeserializeMode::kForReading);
    const auto &verify = desc.GetClusterGroupDescriptor(0);
    EXPECT_EQ(0u, verify.GetMinEntry());
    EXPECT_EQ(100u, verify.GetEntrySpan());
@@ -1049,7 +1049,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
    RNTupleSerializer::DeserializeFooter(bufFooter.get(), sizeFooter, builder);
    desc = builder.MoveDescriptor();
-   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc);
+   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc, EDeserializeMode::kForReading);
 
    EXPECT_EQ(2u, desc.GetNClusters());
    const auto &fieldDesc = desc.GetFieldDescriptor(desc.FindFieldId("str"));
@@ -1235,7 +1235,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationProjection)
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
    RNTupleSerializer::DeserializeFooter(bufFooter.get(), sizeFooter, builder);
    desc = builder.MoveDescriptor();
-   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc);
+   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc, EDeserializeMode::kForReading);
 
    EXPECT_EQ(2u, desc.GetNClusters());
    const auto &aliasDesc = desc.GetFieldDescriptor(desc.FindFieldId("ptAlias"));
@@ -1357,7 +1357,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
    RNTupleSerializer::DeserializeFooter(bufFooter.get(), sizeFooter, builder);
    desc = builder.MoveDescriptor();
-   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc);
+   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc, EDeserializeMode::kForReading);
 
    EXPECT_EQ(3u, desc.GetNClusters());
    const auto &fieldDesc = desc.GetFieldDescriptor(desc.FindFieldId("pt"));
@@ -1480,7 +1480,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    RNTupleSerializer::DeserializeHeader(bufHeader.get(), context.GetHeaderSize(), builder);
    RNTupleSerializer::DeserializeFooter(bufFooter.get(), sizeFooter, builder);
    desc = builder.MoveDescriptor();
-   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc);
+   RNTupleSerializer::DeserializePageList(bufPageList.get(), sizePageList, 0, desc, EDeserializeMode::kForReading);
 
    EXPECT_EQ(2u, desc.GetNClusters());
    const auto &fieldDesc = desc.GetFieldDescriptor(desc.FindFieldId("pt"));


### PR DESCRIPTION
The default mode - the same we did so far - is "for reading": this means that we not only load the on-disk information into the in-memory descriptor, but we also fixup the suppressed column ranges and the clusters with the info coming from the header extension (deferred columns); this is a required step for reading the rntuple correctly.
We then add two additional modes: "for writing" and "raw". "for writing" is the same as "for reading" except it doesn't do the header extension fixup - this mode will be used by the RNTupleMerger to properly write out an incrementally-merged RNTuple. "raw" simply deserializes the on-disk information without doing any fixup.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
