### PR TITLE
[io] Apply TFile::k630forwardCompatibility when creating new file if set in rootrc

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -664,6 +664,11 @@ void TFile::Init(Bool_t create)
       fEND         = fBEGIN;    //Pointer to end of file
       new TFree(fFree, fBEGIN, Long64_t(kStartBigFile));  //Create new free list
 
+      //*-* -------------Check if we need to enable forward compatible with version
+      //*-* -------------prior to v6.30
+      if (gEnv->GetValue("TFile.v630forwardCompatibility", 0) == 1)
+         SetBit(k630forwardCompatibility);
+
       //*-* Write Directory info
       Int_t namelen= TNamed::Sizeof();
       Int_t nbytes = namelen + TDirectoryFile::Sizeof();

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -136,7 +136,7 @@ TEST(TFile, ReadWithoutGlobalRegistrationNet)
    TestReadWithoutGlobalRegistrationIfPossible(netFile);
 }
 
-https://github.com/root-project/root/issues/16189
+// https://github.com/root-project/root/issues/16189
 TEST(TFile, k630forwardCompatibility)
 {
    gEnv->SetValue("TFile.v630forwardCompatibility", 1);

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -149,5 +149,5 @@ TEST(TFile, k630forwardCompatibility)
    TFile fileu{filename.c_str(),"UPDATE"};
    ASSERT_EQ(fileu.TestBit(TFile::k630forwardCompatibility), true);  
    fileu.Close();
-   gSystem->Unlink(filename);
+   gSystem->Unlink(filename.c_str());
 }

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -8,7 +8,7 @@
 #include "TNamed.h"
 #include "TPluginManager.h"
 #include "TROOT.h" // gROOT
-#include "TSystem.h"
+#include "TEnv.h" // gEnv
 
 TEST(TFile, WriteObjectTObject)
 {
@@ -133,4 +133,21 @@ TEST(TFile, ReadWithoutGlobalRegistrationNet)
 {
    const auto netFile = "root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root";
    TestReadWithoutGlobalRegistrationIfPossible(netFile);
+}
+
+https://github.com/root-project/root/issues/16189
+TEST(TFile, k630forwardCompatibility)
+{
+   gEnv->SetValue("TFile.v630forwardCompatibility", 1);
+   const std::string filename{std::tmpnam(nullptr)};
+   TFile filec{filename.c_str(),"CREATE"};
+   ASSERT_EQ(filec.TestBit(TFile::k630forwardCompatibility), true);  
+   filec.Close();
+   TFile filer{filename.c_str(),"READ"};
+   ASSERT_EQ(filer.TestBit(TFile::k630forwardCompatibility), true);  
+   filer.Close();
+   TFile fileu{filename.c_str(),"UPDATE"};
+   ASSERT_EQ(fileu.TestBit(TFile::k630forwardCompatibility), true);  
+   fileu.Close();
+   gSystem->Unlink(filename);
 }

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -8,6 +8,7 @@
 #include "TNamed.h"
 #include "TPluginManager.h"
 #include "TROOT.h" // gROOT
+#include "TSystem.h"
 #include "TEnv.h" // gEnv
 
 TEST(TFile, WriteObjectTObject)

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -140,7 +140,7 @@ TEST(TFile, ReadWithoutGlobalRegistrationNet)
 TEST(TFile, k630forwardCompatibility)
 {
    gEnv->SetValue("TFile.v630forwardCompatibility", 1);
-   const std::string filename{std::tmpnam(nullptr)};
+   const std::string filename{"filek30.root"};
    TFile filec{filename.c_str(),"CREATE"};
    ASSERT_EQ(filec.TestBit(TFile::k630forwardCompatibility), true);  
    filec.Close();

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -141,6 +141,7 @@ TEST(TFile, k630forwardCompatibility)
 {
    gEnv->SetValue("TFile.v630forwardCompatibility", 1);
    const std::string filename{"filek30.root"};
+   // Testing that the flag is also set when creating the file from scratch (as opposed to "UPDATE")
    TFile filec{filename.c_str(),"RECREATE"};
    ASSERT_EQ(filec.TestBit(TFile::k630forwardCompatibility), true);  
    filec.Close();

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -141,7 +141,7 @@ TEST(TFile, k630forwardCompatibility)
 {
    gEnv->SetValue("TFile.v630forwardCompatibility", 1);
    const std::string filename{"filek30.root"};
-   TFile filec{filename.c_str(),"CREATE"};
+   TFile filec{filename.c_str(),"RECREATE"};
    ASSERT_EQ(filec.TestBit(TFile::k630forwardCompatibility), true);  
    filec.Close();
    TFile filer{filename.c_str(),"READ"};


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/16189

