### PR TITLE
[tree] Apply clang-format to TTreeReader[,Value,Array].[h,cxx]

### DIFF
--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -13,7 +13,6 @@
 #ifndef ROOT_TTreeReader
 #define ROOT_TTreeReader
 
-
 ////////////////////////////////////////////////////////////////////////////
 //                                                                        //
 // TTreeReader                                                            //
@@ -38,14 +37,13 @@ class TFileCollection;
 
 namespace ROOT {
 namespace Internal {
-   class TBranchProxyDirector;
-   class TFriendProxy;
-}
-}
+class TBranchProxyDirector;
+class TFriendProxy;
+} // namespace Internal
+} // namespace ROOT
 
-class TTreeReader: public TObject {
+class TTreeReader : public TObject {
 public:
-
    ///\class TTreeReader::Iterator_t
    /// Iterate through the entries of a TTree.
    ///
@@ -57,8 +55,8 @@ public:
    /// is reached).
    class Iterator_t {
    private:
-      Long64_t fEntry; ///< Entry number of the tree referenced by this iterator; -1 is invalid.
-      TTreeReader* fReader; ///< The reader we select the entries on.
+      Long64_t fEntry;      ///< Entry number of the tree referenced by this iterator; -1 is invalid.
+      TTreeReader *fReader; ///< The reader we select the entries on.
 
       /// Whether the iterator points to a valid entry.
       bool IsValid() const { return fEntry >= 0; }
@@ -72,12 +70,11 @@ public:
       using reference = const Long64_t &;
 
       /// Default-initialize the iterator as "past the end".
-      Iterator_t(): fEntry(-1), fReader(nullptr) {}
+      Iterator_t() : fEntry(-1), fReader(nullptr) {}
 
       /// Initialize the iterator with the reader it steers and a
       /// tree entry number; -1 is invalid.
-      Iterator_t(TTreeReader& reader, Long64_t entry):
-         fEntry(entry), fReader(&reader) {}
+      Iterator_t(TTreeReader &reader, Long64_t entry) : fEntry(entry), fReader(&reader) {}
 
       /// Compare two iterators for equality.
       bool operator==(const Iterator_t &lhs) const
@@ -106,19 +103,19 @@ public:
       }
 
       /// Compare two iterators for inequality.
-      bool operator!=(const Iterator_t& lhs) const {
-         return !(*this == lhs);
-      }
+      bool operator!=(const Iterator_t &lhs) const { return !(*this == lhs); }
 
       /// Increment the iterator (postfix i++).
-      Iterator_t operator++(int) {
+      Iterator_t operator++(int)
+      {
          Iterator_t ret = *this;
          this->operator++();
          return ret;
       }
 
       /// Increment the iterator (prefix ++i).
-      Iterator_t& operator++() {
+      Iterator_t &operator++()
+      {
          if (IsValid()) {
             ++fEntry;
             // Force validity check of new fEntry.
@@ -131,7 +128,8 @@ public:
       }
 
       /// Set the entry number in the reader and return it.
-      const Long64_t& operator*() {
+      const Long64_t &operator*()
+      {
          if (IsValid()) {
             // If we cannot access that entry, mark the iterator invalid.
             if (fReader->SetEntry(fEntry) != kEntryValid) {
@@ -142,9 +140,7 @@ public:
          return fEntry;
       }
 
-      const Long64_t& operator*() const {
-         return **const_cast<Iterator_t*>(this);
-      }
+      const Long64_t &operator*() const { return **const_cast<Iterator_t *>(this); }
    };
 
    typedef Iterator_t iterator;
@@ -189,23 +185,21 @@ public:
 
    TTreeReader(TTree *tree, TEntryList *entryList = nullptr, bool warnAboutLongerFriends = true,
                const std::vector<std::string> &suppressErrorsForMissingBranches = {});
-   TTreeReader(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
+   TTreeReader(const char *keyname, TDirectory *dir, TEntryList *entryList = nullptr);
    TTreeReader(const char *keyname, TEntryList *entryList = nullptr) : TTreeReader(keyname, nullptr, entryList) {}
 
    ~TTreeReader() override;
 
-   void SetTree(TTree* tree, TEntryList* entryList = nullptr);
-   void SetTree(const char* keyname, TEntryList* entryList = nullptr) {
-      SetTree(keyname, nullptr, entryList);
-   }
-   void SetTree(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
+   void SetTree(TTree *tree, TEntryList *entryList = nullptr);
+   void SetTree(const char *keyname, TEntryList *entryList = nullptr) { SetTree(keyname, nullptr, entryList); }
+   void SetTree(const char *keyname, TDirectory *dir, TEntryList *entryList = nullptr);
 
    bool IsChain() const { return TestBit(kBitIsChain); }
 
    bool IsInvalid() const { return fLoadTreeStatus == kNoTree; }
 
-   TTree* GetTree() const { return fTree; }
-   TEntryList* GetEntryList() const { return fEntryList; }
+   TTree *GetTree() const { return fTree; }
+   TEntryList *GetEntryList() const { return fEntryList; }
 
    ///\{ \name Entry setters
 
@@ -213,9 +207,7 @@ public:
    ///
    /// \return false if the previous entry was already the last entry. This allows
    ///   the function to be used in `while (reader.Next()) { ... }`
-   bool Next() {
-      return SetEntry(GetCurrentEntry() + 1) == kEntryValid;
-   }
+   bool Next() { return SetEntry(GetCurrentEntry() + 1) == kEntryValid; }
 
    /// Set the next entry (or index of the TEntryList if that is set).
    ///
@@ -263,16 +255,14 @@ public:
    bool Notify() override;
 
    /// Return an iterator to the 0th TTree entry.
-   Iterator_t begin() {
-      return Iterator_t(*this, 0);
-   }
+   Iterator_t begin() { return Iterator_t(*this, 0); }
    /// Return an iterator beyond the last TTree entry.
    Iterator_t end() { return Iterator_t(*this, -1); }
 
 protected:
    using NamedProxies_t = std::unordered_map<std::string, std::unique_ptr<ROOT::Internal::TNamedBranchProxy>>;
    void Initialize();
-   ROOT::Internal::TNamedBranchProxy* FindProxy(const char* branchname) const
+   ROOT::Internal::TNamedBranchProxy *FindProxy(const char *branchname) const
    {
       const auto proxyIt = fProxies.find(branchname);
       return fProxies.end() != proxyIt ? proxyIt->second.get() : nullptr;
@@ -293,8 +283,8 @@ protected:
 
    ROOT::Internal::TFriendProxy &AddFriendProxy(std::size_t friendIdx);
 
-   bool RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
-   void DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
+   bool RegisterValueReader(ROOT::Internal::TTreeReaderValueBase *reader);
+   void DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase *reader);
 
    EEntryStatus SetEntryBase(Long64_t entry, bool local);
 
@@ -304,19 +294,20 @@ private:
    std::string GetProxyKey(const char *branchname)
    {
       std::string key(branchname);
-      //key += reinterpret_cast<std::uintptr_t>(fTree);
+      // key += reinterpret_cast<std::uintptr_t>(fTree);
       return key;
    }
 
    enum EStatusBits {
       kBitIsChain = BIT(14), ///< our tree is a chain
-      kBitHaveWarnedAboutEntryListAttachedToTTree = BIT(15), ///< the tree had a TEntryList and we have warned about that
+      kBitHaveWarnedAboutEntryListAttachedToTTree =
+         BIT(15),                                ///< the tree had a TEntryList and we have warned about that
       kBitSetEntryBaseCallingLoadTree = BIT(16), ///< SetEntryBase is in the process of calling TChain/TTree::%LoadTree.
-      kBitIsExternalTree = BIT(17)  ///< we do not own the tree
+      kBitIsExternalTree = BIT(17)               ///< we do not own the tree
    };
 
-   TTree* fTree = nullptr; ///< tree that's read
-   TEntryList* fEntryList = nullptr; ///< entry list to be used
+   TTree *fTree = nullptr;                      ///< tree that's read
+   TEntryList *fEntryList = nullptr;            ///< entry list to be used
    EEntryStatus fEntryStatus = kEntryNotLoaded; ///< status of most recent read request
    ELoadTreeStatus fLoadTreeStatus = kNoTree;   ///< Indicator on how LoadTree was called 'last' time.
    /// TTree and TChain will notify this object upon LoadTree, leading to a call to TTreeReader::Notify().
@@ -324,8 +315,8 @@ private:
    std::unique_ptr<ROOT::Internal::TBranchProxyDirector> fDirector{nullptr}; ///< proxying director
    /// Proxies to friend trees, created in TTreeReader[Value,Array]::CreateProxy
    std::vector<std::unique_ptr<ROOT::Internal::TFriendProxy>> fFriendProxies;
-   std::deque<ROOT::Internal::TTreeReaderValueBase*> fValues; ///< readers that use our director
-   NamedProxies_t fProxies; ///< attached ROOT::TNamedBranchProxies; owned
+   std::deque<ROOT::Internal::TTreeReaderValueBase *> fValues; ///< readers that use our director
+   NamedProxies_t fProxies;                                    ///< attached ROOT::TNamedBranchProxies; owned
 
    Long64_t fEntry = -1; ///< Current (non-local) entry of fTree or of fEntryList if set.
 
@@ -333,8 +324,8 @@ private:
    /// to stop looping over the TTree when we reach a certain entry: Next()
    /// returns false when GetCurrentEntry() reaches fEndEntry.
    Long64_t fEndEntry = -1LL;
-   Long64_t fBeginEntry = 0LL; ///< This allows us to propagate the range to the TTreeCache
-   bool fProxiesSet = false; ///< True if the proxies have been set, false otherwise
+   Long64_t fBeginEntry = 0LL;                ///< This allows us to propagate the range to the TTreeCache
+   bool fProxiesSet = false;                  ///< True if the proxies have been set, false otherwise
    bool fSetEntryBaseCallingLoadTree = false; ///< True if during the LoadTree execution triggered by SetEntryBase.
 
    // Flag to activate or deactivate warnings in case the friend trees have

--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -12,9 +12,6 @@
 #ifndef ROOT_TTreeReaderArray
 #define ROOT_TTreeReaderArray
 
-
-
-
 #include "TTreeReaderValue.h"
 #include "TTreeReaderUtils.h"
 #include <type_traits>
@@ -26,32 +23,31 @@ namespace Internal {
 Base class of TTreeReaderArray.
 */
 
-   class TTreeReaderArrayBase: public TTreeReaderValueBase {
-   public:
-      TTreeReaderArrayBase(TTreeReader* reader, const char* branchname,
-                           TDictionary* dict):
-         TTreeReaderValueBase(reader, branchname, dict) {}
+class TTreeReaderArrayBase : public TTreeReaderValueBase {
+public:
+   TTreeReaderArrayBase(TTreeReader *reader, const char *branchname, TDictionary *dict)
+      : TTreeReaderValueBase(reader, branchname, dict)
+   {
+   }
 
-      std::size_t GetSize() const { return fImpl ? fImpl->GetSize(GetProxy()) : 0; }
-      bool IsEmpty() const { return !GetSize(); }
+   std::size_t GetSize() const { return fImpl ? fImpl->GetSize(GetProxy()) : 0; }
+   bool IsEmpty() const { return !GetSize(); }
 
-      EReadStatus GetReadStatus() const override { return fImpl ? fImpl->fReadStatus : kReadError; }
+   EReadStatus GetReadStatus() const override { return fImpl ? fImpl->fReadStatus : kReadError; }
 
-   protected:
-      void *UntypedAt(std::size_t idx) const { return fImpl->At(GetProxy(), idx); }
-      void CreateProxy() override;
-      bool GetBranchAndLeaf(TBranch *&branch, TLeaf *&myLeaf, TDictionary *&branchActualType,
-                            bool suppressErrorsForMissingBranch = false);
-      void SetImpl(TBranch* branch, TLeaf* myLeaf);
-      const char* GetBranchContentDataType(TBranch* branch,
-                                           TString& contentTypeName,
-                                           TDictionary* &dict);
+protected:
+   void *UntypedAt(std::size_t idx) const { return fImpl->At(GetProxy(), idx); }
+   void CreateProxy() override;
+   bool GetBranchAndLeaf(TBranch *&branch, TLeaf *&myLeaf, TDictionary *&branchActualType,
+                         bool suppressErrorsForMissingBranch = false);
+   void SetImpl(TBranch *branch, TLeaf *myLeaf);
+   const char *GetBranchContentDataType(TBranch *branch, TString &contentTypeName, TDictionary *&dict);
 
-      std::unique_ptr<TVirtualCollectionReader> fImpl; // Common interface to collections
+   std::unique_ptr<TVirtualCollectionReader> fImpl; // Common interface to collections
 
-      // FIXME: re-introduce once we have ClassDefInline!
-      //ClassDefOverride(TTreeReaderArrayBase, 0);//Accessor to member of an object stored in a collection
-   };
+   // FIXME: re-introduce once we have ClassDefInline!
+   // ClassDefOverride(TTreeReaderArrayBase, 0);//Accessor to member of an object stored in a collection
+};
 
 } // namespace Internal
 } // namespace ROOT
@@ -73,7 +69,7 @@ Base class of TTreeReaderArray.
 
 template <typename T>
 class R__CLING_PTRCHECK(off) TTreeReaderArray final : public ROOT::Internal::TTreeReaderArrayBase {
-// R__CLING_PTRCHECK is disabled because pointer / types are checked by CreateProxy().
+   // R__CLING_PTRCHECK is disabled because pointer / types are checked by CreateProxy().
 
 public:
    /// Random access iterator to the elements of a TTreeReaderArray.
@@ -106,7 +102,9 @@ public:
 
       /// Construct iterator from a const TTreeReaderArray
       Iterator_t(std::size_t index, const TTreeReaderArray *array)
-         : Iterator_t(index, const_cast<TTreeReaderArray *>(array)) {}
+         : Iterator_t(index, const_cast<TTreeReaderArray *>(array))
+      {
+      }
 
       Iterator_t(Iterator_t &&) = default;
       Iterator_t(const Iterator_t &) = default;
@@ -200,7 +198,9 @@ public:
 
    /// Create an array reader of branch "branchname" for TTreeReader "tr".
    TTreeReaderArray(TTreeReader &tr, const char *branchname)
-      : TTreeReaderArrayBase(&tr, branchname, TDictionary::GetDictionary(typeid(T))) {}
+      : TTreeReaderArrayBase(&tr, branchname, TDictionary::GetDictionary(typeid(T)))
+   {
+   }
 
    T &At(std::size_t idx) { return *static_cast<T *>(UntypedAt(idx)); }
    const T &At(std::size_t idx) const { return *static_cast<T *>(UntypedAt(idx)); }

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -42,144 +42,149 @@ namespace Internal {
 Base class of TTreeReaderValue.
 */
 
-   class TTreeReaderValueBase {
-   public:
-
-      /// Status flags, 0 is good
-      enum ESetupStatus {
-         kSetupNotSetup = -7,              ///< No initialization has happened yet.
-         kSetupTreeDestructed = -8,        ///< The TTreeReader has been destructed / not set.
-         kSetupMakeClassModeMismatch = -9, ///< readers disagree on whether TTree::SetMakeBranch() should be on
-         kSetupMissingCounterBranch = -6,  ///< The array cannot find its counter branch: Array[CounterBranch]
-         kSetupMissingBranch = -5,         ///< The specified branch cannot be found.
-         kSetupInternalError = -4,         ///< Some other error - hopefully the error message helps.
-         kSetupMissingDictionary = -3,     ///< To read this branch, we need a dictionary.
-         kSetupMismatch = -2,              ///< Mismatch of branch type and reader template type.
-         kSetupNotACollection = -1,        ///< The branch class type is not a collection.
-         kSetupMatch = 0,                  ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
-         kSetupMatchBranch = 7,            ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
-         //kSetupMatchConversion = 1, /// This branch has been set up, the branch data type can be converted to the reader template type, reading should succeed.
-         //kSetupMatchConversionCollection = 2, /// This branch has been set up, the data type of the branch's collection elements can be converted to the reader template type, reading should succeed.
-         //kSetupMakeClass = 3, /// This branch has been set up, enabling MakeClass mode for it, reading should succeed.
-         // kSetupVoidPtr = 4,
-         kSetupNoCheck = 5,
-         kSetupMatchLeaf = 6               ///< This branch (or TLeaf, really) has been set up, reading should succeed.
-      };
-      enum EReadStatus {
-         kReadSuccess = 0,                 ///< Data read okay
-         kReadNothingYet,                  ///< Data now yet accessed
-         kReadError                        ///< Problem reading data
-      };
-
-      EReadStatus ProxyRead() { return (this->*fProxyReadFunc)(); }
-
-      EReadStatus ProxyReadDefaultImpl();
-
-      typedef bool (ROOT::Detail::TBranchProxy::*BranchProxyRead_t)();
-      template <BranchProxyRead_t Func>
-      ROOT::Internal::TTreeReaderValueBase::EReadStatus ProxyReadTemplate();
-
-      /// Return true if the branch was setup \em and \em read correctly.
-      /// Use GetSetupStatus() to only check the setup status.
-      bool IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
-      /// Return this TTreeReaderValue's setup status.
-      /// Use this method to check e.g. whether the TTreeReaderValue is correctly setup and ready for reading.
-      ESetupStatus GetSetupStatus() const { return fSetupStatus; }
-      virtual EReadStatus GetReadStatus() const { return fReadStatus; }
-
-      /// If we are reading a leaf, return the corresponding TLeaf.
-      TLeaf* GetLeaf() { return fLeaf; }
-
-      void* GetAddress();
-
-      const char* GetBranchName() const { return fBranchName; }
-
-      virtual ~TTreeReaderValueBase();
-
-   protected:
-      TTreeReaderValueBase(TTreeReader *reader, const char *branchname, TDictionary *dict, bool opaqueRead = false);
-      TTreeReaderValueBase(const TTreeReaderValueBase&);
-      TTreeReaderValueBase& operator=(const TTreeReaderValueBase&);
-
-      void RegisterWithTreeReader();
-      void NotifyNewTree(TTree* newTree);
-
-      TBranch* SearchBranchWithCompositeName(TLeaf *&myleaf, TDictionary *&branchActualType, std::string &err);
-      virtual void CreateProxy();
-      static const char* GetBranchDataType(TBranch* branch,
-                                           TDictionary* &dict,
-                                           TDictionary const *curDict);
-
-      virtual const char* GetDerivedTypeName() const = 0;
-
-      Detail::TBranchProxy* GetProxy() const { return fProxy; }
-
-      void MarkTreeReaderUnavailable() { fTreeReader = nullptr; fSetupStatus = kSetupTreeDestructed; }
-
-      /// Stringify the template argument.
-      static std::string GetElementTypeName(const std::type_info& ti);
-
-      void ErrorAboutMissingProxyIfNeeded();
-
-      bool         fHaveLeaf : 1;                 ///< Whether the data is in a leaf
-      bool         fHaveStaticClassOffsets : 1;   ///< Whether !fStaticClassOffsets.empty()
-      EReadStatus  fReadStatus : 2;               ///< Read status of this data access
-      ESetupStatus fSetupStatus = kSetupNotSetup; ///< Setup status of this data access
-      TString      fBranchName;                   ///< Name of the branch to read data from.
-      TString      fLeafName;
-      TTreeReader* fTreeReader;                   ///< Tree reader we belong to
-      TDictionary* fDict;                         ///< Type that the branch should contain
-      Detail::TBranchProxy* fProxy = nullptr;     ///< Proxy for this branch, owned by TTreeReader
-      TLeaf*       fLeaf = nullptr;
-      std::vector<Long64_t> fStaticClassOffsets;
-      typedef EReadStatus (TTreeReaderValueBase::*Read_t)();
-      Read_t fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;      ///<! Pointer to the Read implementation to use.
-      /**
-       * If true, the reader will not do any type-checking against the actual
-       * type held by the branch. Useful to just check if the current entry can
-       * be read or not without caring about its value.
-       * \note Only used by TTreeReaderOpaqueValue.
-       */
-      bool fOpaqueRead{false};
-
-      // FIXME: re-introduce once we have ClassDefInline!
-      //ClassDefOverride(TTreeReaderValueBase, 0);//Base class for accessors to data via TTreeReader
-
-      friend class ::TTreeReader;
+class TTreeReaderValueBase {
+public:
+   /// Status flags, 0 is good
+   enum ESetupStatus {
+      kSetupNotSetup = -7,              ///< No initialization has happened yet.
+      kSetupTreeDestructed = -8,        ///< The TTreeReader has been destructed / not set.
+      kSetupMakeClassModeMismatch = -9, ///< readers disagree on whether TTree::SetMakeBranch() should be on
+      kSetupMissingCounterBranch = -6,  ///< The array cannot find its counter branch: Array[CounterBranch]
+      kSetupMissingBranch = -5,         ///< The specified branch cannot be found.
+      kSetupInternalError = -4,         ///< Some other error - hopefully the error message helps.
+      kSetupMissingDictionary = -3,     ///< To read this branch, we need a dictionary.
+      kSetupMismatch = -2,              ///< Mismatch of branch type and reader template type.
+      kSetupNotACollection = -1,        ///< The branch class type is not a collection.
+      kSetupMatch =
+         0, ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
+      kSetupMatchBranch =
+         7, ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
+      // kSetupMatchConversion = 1, /// This branch has been set up, the branch data type can be converted to the reader
+      // template type, reading should succeed. kSetupMatchConversionCollection = 2, /// This branch has been set up,
+      // the data type of the branch's collection elements can be converted to the reader template type, reading should
+      // succeed. kSetupMakeClass = 3, /// This branch has been set up, enabling MakeClass mode for it, reading should
+      // succeed.
+      //  kSetupVoidPtr = 4,
+      kSetupNoCheck = 5,
+      kSetupMatchLeaf = 6 ///< This branch (or TLeaf, really) has been set up, reading should succeed.
+   };
+   enum EReadStatus {
+      kReadSuccess = 0, ///< Data read okay
+      kReadNothingYet,  ///< Data now yet accessed
+      kReadError        ///< Problem reading data
    };
 
+   EReadStatus ProxyRead() { return (this->*fProxyReadFunc)(); }
+
+   EReadStatus ProxyReadDefaultImpl();
+
+   typedef bool (ROOT::Detail::TBranchProxy::*BranchProxyRead_t)();
+   template <BranchProxyRead_t Func>
+   ROOT::Internal::TTreeReaderValueBase::EReadStatus ProxyReadTemplate();
+
+   /// Return true if the branch was setup \em and \em read correctly.
+   /// Use GetSetupStatus() to only check the setup status.
+   bool IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
+   /// Return this TTreeReaderValue's setup status.
+   /// Use this method to check e.g. whether the TTreeReaderValue is correctly setup and ready for reading.
+   ESetupStatus GetSetupStatus() const { return fSetupStatus; }
+   virtual EReadStatus GetReadStatus() const { return fReadStatus; }
+
+   /// If we are reading a leaf, return the corresponding TLeaf.
+   TLeaf *GetLeaf() { return fLeaf; }
+
+   void *GetAddress();
+
+   const char *GetBranchName() const { return fBranchName; }
+
+   virtual ~TTreeReaderValueBase();
+
+protected:
+   TTreeReaderValueBase(TTreeReader *reader, const char *branchname, TDictionary *dict, bool opaqueRead = false);
+   TTreeReaderValueBase(const TTreeReaderValueBase &);
+   TTreeReaderValueBase &operator=(const TTreeReaderValueBase &);
+
+   void RegisterWithTreeReader();
+   void NotifyNewTree(TTree *newTree);
+
+   TBranch *SearchBranchWithCompositeName(TLeaf *&myleaf, TDictionary *&branchActualType, std::string &err);
+   virtual void CreateProxy();
+   static const char *GetBranchDataType(TBranch *branch, TDictionary *&dict, TDictionary const *curDict);
+
+   virtual const char *GetDerivedTypeName() const = 0;
+
+   Detail::TBranchProxy *GetProxy() const { return fProxy; }
+
+   void MarkTreeReaderUnavailable()
+   {
+      fTreeReader = nullptr;
+      fSetupStatus = kSetupTreeDestructed;
+   }
+
+   /// Stringify the template argument.
+   static std::string GetElementTypeName(const std::type_info &ti);
+
+   void ErrorAboutMissingProxyIfNeeded();
+
+   bool fHaveLeaf : 1;                         ///< Whether the data is in a leaf
+   bool fHaveStaticClassOffsets : 1;           ///< Whether !fStaticClassOffsets.empty()
+   EReadStatus fReadStatus : 2;                ///< Read status of this data access
+   ESetupStatus fSetupStatus = kSetupNotSetup; ///< Setup status of this data access
+   TString fBranchName;                        ///< Name of the branch to read data from.
+   TString fLeafName;
+   TTreeReader *fTreeReader;               ///< Tree reader we belong to
+   TDictionary *fDict;                     ///< Type that the branch should contain
+   Detail::TBranchProxy *fProxy = nullptr; ///< Proxy for this branch, owned by TTreeReader
+   TLeaf *fLeaf = nullptr;
+   std::vector<Long64_t> fStaticClassOffsets;
+   typedef EReadStatus (TTreeReaderValueBase::*Read_t)();
+   Read_t fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl; ///<! Pointer to the Read implementation to use.
    /**
-    * \brief Read a value in a branch without knowledge of its type
-    *
-    * This class is helpful in situations where the actual contents of the branch
-    * at the current entry are not relevant and one only wants to know whether
-    * the entry can be read.
+    * If true, the reader will not do any type-checking against the actual
+    * type held by the branch. Useful to just check if the current entry can
+    * be read or not without caring about its value.
+    * \note Only used by TTreeReaderOpaqueValue.
     */
-   class R__CLING_PTRCHECK(off) TTreeReaderOpaqueValue final : public ROOT::Internal::TTreeReaderValueBase {
-   public:
-      TTreeReaderOpaqueValue(TTreeReader &tr, const char *branchname)
-         : TTreeReaderValueBase(&tr, branchname, /*dict*/ nullptr, /*opaqueRead*/ true)
-      {
-      }
+   bool fOpaqueRead{false};
 
-   protected:
-      const char *GetDerivedTypeName() const { return ""; }
-   };
+   // FIXME: re-introduce once we have ClassDefInline!
+   // ClassDefOverride(TTreeReaderValueBase, 0);//Base class for accessors to data via TTreeReader
+
+   friend class ::TTreeReader;
+};
+
+/**
+ * \brief Read a value in a branch without knowledge of its type
+ *
+ * This class is helpful in situations where the actual contents of the branch
+ * at the current entry are not relevant and one only wants to know whether
+ * the entry can be read.
+ */
+class R__CLING_PTRCHECK(off) TTreeReaderOpaqueValue final : public ROOT::Internal::TTreeReaderValueBase {
+public:
+   TTreeReaderOpaqueValue(TTreeReader &tr, const char *branchname)
+      : TTreeReaderValueBase(&tr, branchname, /*dict*/ nullptr, /*opaqueRead*/ true)
+   {
+   }
+
+protected:
+   const char *GetDerivedTypeName() const { return ""; }
+};
 
 } // namespace Internal
 } // namespace ROOT
 
-
 template <typename T>
-class R__CLING_PTRCHECK(off) TTreeReaderValue final: public ROOT::Internal::TTreeReaderValueBase {
-// R__CLING_PTRCHECK is disabled because pointer / types are checked by CreateProxy().
+class R__CLING_PTRCHECK(off) TTreeReaderValue final : public ROOT::Internal::TTreeReaderValueBase {
+   // R__CLING_PTRCHECK is disabled because pointer / types are checked by CreateProxy().
 
 public:
    using NonConstT_t = typename std::remove_const<T>::type;
    TTreeReaderValue() = delete;
-   TTreeReaderValue(TTreeReader& tr, const char* branchname):
-      TTreeReaderValueBase(&tr, branchname,
-                           TDictionary::GetDictionary(typeid(NonConstT_t))) {}
+   TTreeReaderValue(TTreeReader &tr, const char *branchname)
+      : TTreeReaderValueBase(&tr, branchname, TDictionary::GetDictionary(typeid(NonConstT_t)))
+   {
+   }
 
    /// Return a pointer to the value of the current entry.
    /// Return a nullptr and print an error if no entry has been loaded yet.
@@ -198,23 +203,24 @@ public:
 
    /// Return a pointer to the value of the current entry.
    /// Equivalent to Get().
-   T* operator->() { return Get(); }
+   T *operator->() { return Get(); }
 
    /// Return a reference to the value of the current entry.
    /// Equivalent to dereferencing the pointer returned by Get(). Behavior is undefined if no entry has been loaded yet.
    /// Most likely a crash will occur.
-   T& operator*() { return *Get(); }
+   T &operator*() { return *Get(); }
 
 protected:
    // FIXME: use IsA() instead once we have ClassDefTInline
    /// Get the template argument as a string.
-   const char* GetDerivedTypeName() const override {
+   const char *GetDerivedTypeName() const override
+   {
       static const std::string sElementTypeName = GetElementTypeName(typeid(T));
       return sElementTypeName.data();
    }
 
    // FIXME: re-introduce once we have ClassDefTInline!
-   //ClassDefT(TTreeReaderValue, 0);//Accessor to data via TTreeReader
+   // ClassDefT(TTreeReaderValue, 0);//Accessor to data via TTreeReader
 };
 
 namespace cling {

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -183,7 +183,7 @@ ClassImp(TTreeReader);
 using namespace ROOT::Internal;
 
 // Provide some storage for the poor little symbol.
-constexpr const char * const TTreeReader::fgEntryStatusText[TTreeReader::kEntryUnknownError + 1];
+constexpr const char *const TTreeReader::fgEntryStatusText[TTreeReader::kEntryUnknownError + 1];
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.  Call SetTree to connect to a TTree.
@@ -234,7 +234,8 @@ TTreeReader::TTreeReader(TTree *tree, TEntryList *entryList /*= nullptr*/, bool 
 TTreeReader::TTreeReader(const char *keyname, TDirectory *dir, TEntryList *entryList /*= nullptr*/)
    : fEntryList(entryList), fNotify(this), fFriendProxies()
 {
-   if (!dir) dir = gDirectory;
+   if (!dir)
+      dir = gDirectory;
    dir->GetObject(keyname, fTree);
    if (!fTree) {
       std::string msg = "No TTree called ";
@@ -250,8 +251,8 @@ TTreeReader::TTreeReader(const char *keyname, TDirectory *dir, TEntryList *entry
 
 TTreeReader::~TTreeReader()
 {
-   for (std::deque<ROOT::Internal::TTreeReaderValueBase*>::const_iterator
-           i = fValues.begin(), e = fValues.end(); i != e; ++i) {
+   for (std::deque<ROOT::Internal::TTreeReaderValueBase *>::const_iterator i = fValues.begin(), e = fValues.end();
+        i != e; ++i) {
       (*i)->MarkTreeReaderUnavailable();
    }
    if (fTree && fNotify.IsLinked())
@@ -335,10 +336,10 @@ bool TTreeReader::Notify()
          // This means that "local" should be set!
          // There are two entities switching trees which is bad.
          Warning("SetEntryBase()",
-                  "The current tree in the TChain %s has changed (e.g. by TTree::Process) "
-                  "even though TTreeReader::SetEntry() was called, which switched the tree "
-                  "again. Did you mean to call TTreeReader::SetLocalEntry()?",
-                  fTree->GetName());
+                 "The current tree in the TChain %s has changed (e.g. by TTree::Process) "
+                 "even though TTreeReader::SetEntry() was called, which switched the tree "
+                 "again. Did you mean to call TTreeReader::SetLocalEntry()?",
+                 fTree->GetName());
       }
       fLoadTreeStatus = kInternalLoadTree;
    } else {
@@ -360,7 +361,7 @@ bool TTreeReader::Notify()
    }
 
    if (fProxiesSet) {
-      for (auto value: fValues) {
+      for (auto value : fValues) {
          value->NotifyNewTree(fTree->GetTree());
       }
    }
@@ -559,8 +560,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long
       // thus adding all the branches to the cache and triggering the learning phase.
       EEntryStatus es = SetEntry(beginEntry - 1);
       if (es != kEntryValid) {
-         Error("SetEntriesRange()", "Error setting first entry %lld: %s",
-               beginEntry, fgEntryStatusText[(int)es]);
+         Error("SetEntriesRange()", "Error setting first entry %lld: %s", beginEntry, fgEntryStatusText[(int)es]);
          return es;
       }
    }
@@ -568,7 +568,8 @@ TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long
    return kEntryValid;
 }
 
-void TTreeReader::Restart() {
+void TTreeReader::Restart()
+{
    fDirector->SetReadEntry(-1);
    fProxiesSet = false; // we might get more value readers, meaning new proxies.
    fEntry = -1;
@@ -585,15 +586,14 @@ void TTreeReader::Restart() {
 /// of the TTree / TChain, independent of a range set by SetEntriesRange()
 /// by calling TTree/TChain::%GetEntriesFast.
 
-
-Long64_t TTreeReader::GetEntries() const {
+Long64_t TTreeReader::GetEntries() const
+{
    if (fEntryList)
       return fEntryList->GetN();
    if (!fTree)
       return -1;
    return fTree->GetEntriesFast();
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns the number of entries of the TEntryList if one is provided, else
@@ -603,7 +603,8 @@ Long64_t TTreeReader::GetEntries() const {
 ///   this TChain should be opened to determine the exact number of entries
 /// of the TChain. If `!IsChain()`, `force` is ignored.
 
-Long64_t TTreeReader::GetEntries(bool force)  {
+Long64_t TTreeReader::GetEntries(bool force)
+{
    if (fEntryList)
       return fEntryList->GetN();
    if (!fTree)
@@ -618,8 +619,6 @@ Long64_t TTreeReader::GetEntries(bool force)  {
    }
    return fTree->GetEntriesFast();
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Load an entry into the tree, return the status of the read.
@@ -663,7 +662,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
       }
    }
 
-   TTree* treeToCallLoadOn = local ? fTree->GetTree() : fTree;
+   TTree *treeToCallLoadOn = local ? fTree->GetTree() : fTree;
 
    fSetEntryBaseCallingLoadTree = true;
    const Long64_t loadResult = treeToCallLoadOn->LoadTree(entryAfterList);
@@ -679,13 +678,12 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
       if (loadResult == -3 && TestBit(kBitIsChain) && !fTree->GetTree()) {
          fDirector->Notify();
          if (fProxiesSet) {
-            for (auto value: fValues) {
+            for (auto value : fValues) {
                value->NotifyNewTree(fTree->GetTree());
             }
          }
-         Warning("SetEntryBase()",
-               "There was an issue opening the last file associated to the TChain "
-               "being processed.");
+         Warning("SetEntryBase()", "There was an issue opening the last file associated to the TChain "
+                                   "being processed.");
          fEntryStatus = kEntryChainFileError;
          return fEntryStatus;
       }
@@ -693,7 +691,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
       if (loadResult == -2) {
          fDirector->Notify();
          if (fProxiesSet) {
-            for (auto value: fValues) {
+            for (auto value : fValues) {
                value->NotifyNewTree(fTree->GetTree());
             }
          }
@@ -723,7 +721,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
          // the TTree is missing from the file.
          fDirector->Notify();
          if (fProxiesSet) {
-            for (auto value: fValues) {
+            for (auto value : fValues) {
                value->NotifyNewTree(fTree->GetTree());
             }
          }
@@ -749,8 +747,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
          return fEntryStatus;
       }
 
-      Warning("SetEntryBase()",
-              "Unexpected error '%lld' in %s::LoadTree", loadResult,
+      Warning("SetEntryBase()", "Unexpected error '%lld' in %s::LoadTree", loadResult,
               treeToCallLoadOn->IsA()->GetName());
 
       fEntryStatus = kEntryUnknownError;
@@ -813,7 +810,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
 /// Set (or update) the which tree to read from. `tree` can be
 /// a TTree or a TChain.
 
-void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
+void TTreeReader::SetTree(TTree *tree, TEntryList *entryList /*= nullptr*/)
 {
    if (fEntryStatus != kEntryNoTree && !TestBit(kBitIsExternalTree)) {
       // a plain TTree is automatically added to the current directory,
@@ -838,8 +835,7 @@ void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
 
    if (!fDirector) {
       Initialize();
-   }
-   else {
+   } else {
       fDirector->SetTree(fTree);
       fDirector->SetReadEntry(-1);
    }
@@ -853,9 +849,9 @@ void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
 /// \param dir - the `TDirectory` to load `keyname` from (or gDirectory if `nullptr`)
 /// \param entryList - the `TEntryList` to attach to the `TTreeReader`.
 
-void TTreeReader::SetTree(const char* keyname, TDirectory* dir, TEntryList* entryList /*= nullptr*/)
+void TTreeReader::SetTree(const char *keyname, TDirectory *dir, TEntryList *entryList /*= nullptr*/)
 {
-   TTree* tree = nullptr;
+   TTree *tree = nullptr;
    if (!dir)
       dir = gDirectory;
    dir->GetObject(keyname, tree);
@@ -865,11 +861,12 @@ void TTreeReader::SetTree(const char* keyname, TDirectory* dir, TEntryList* entr
 ////////////////////////////////////////////////////////////////////////////////
 /// Add a value reader for this tree.
 
-bool TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader)
+bool TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase *reader)
 {
    if (fProxiesSet) {
       Error("RegisterValueReader",
-            "Error registering reader for %s: TTreeReaderValue/Array objects must be created before the call to Next() / SetEntry() / SetLocalEntry(), or after TTreeReader::Restart()!",
+            "Error registering reader for %s: TTreeReaderValue/Array objects must be created before the call to Next() "
+            "/ SetEntry() / SetLocalEntry(), or after TTreeReader::Restart()!",
             reader->GetBranchName());
       return false;
    }
@@ -880,12 +877,13 @@ bool TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* read
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove a value reader for this tree.
 
-void TTreeReader::DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader)
+void TTreeReader::DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase *reader)
 {
-   std::deque<ROOT::Internal::TTreeReaderValueBase*>::iterator iReader
-      = std::find(fValues.begin(), fValues.end(), reader);
+   std::deque<ROOT::Internal::TTreeReaderValueBase *>::iterator iReader =
+      std::find(fValues.begin(), fValues.end(), reader);
    if (iReader == fValues.end()) {
-      Error("DeregisterValueReader", "Cannot find reader of type %s for branch %s", reader->GetDerivedTypeName(), reader->fBranchName.Data());
+      Error("DeregisterValueReader", "Cannot find reader of type %s for branch %s", reader->GetDerivedTypeName(),
+            reader->fBranchName.Data());
       return;
    }
    fValues.erase(iReader);

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -70,18 +70,18 @@ ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(TTreeReader *reader /
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy-construct.
 
-ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(const TTreeReaderValueBase& rhs):
-   fHaveLeaf(rhs.fHaveLeaf),
-   fHaveStaticClassOffsets(rhs.fHaveStaticClassOffsets),
-   fReadStatus(rhs.fReadStatus),
-   fSetupStatus(rhs.fSetupStatus),
-   fBranchName(rhs.fBranchName),
-   fLeafName(rhs.fLeafName),
-   fTreeReader(rhs.fTreeReader),
-   fDict(rhs.fDict),
-   fProxy(rhs.fProxy),
-   fLeaf(rhs.fLeaf),
-   fStaticClassOffsets(rhs.fStaticClassOffsets)
+ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(const TTreeReaderValueBase &rhs)
+   : fHaveLeaf(rhs.fHaveLeaf),
+     fHaveStaticClassOffsets(rhs.fHaveStaticClassOffsets),
+     fReadStatus(rhs.fReadStatus),
+     fSetupStatus(rhs.fSetupStatus),
+     fBranchName(rhs.fBranchName),
+     fLeafName(rhs.fLeafName),
+     fTreeReader(rhs.fTreeReader),
+     fDict(rhs.fDict),
+     fProxy(rhs.fProxy),
+     fLeaf(rhs.fLeaf),
+     fStaticClassOffsets(rhs.fStaticClassOffsets)
 {
    RegisterWithTreeReader();
 }
@@ -89,8 +89,8 @@ ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(const TTreeReaderValu
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy-assign.
 
-ROOT::Internal::TTreeReaderValueBase&
-ROOT::Internal::TTreeReaderValueBase::operator=(const TTreeReaderValueBase& rhs) {
+ROOT::Internal::TTreeReaderValueBase &ROOT::Internal::TTreeReaderValueBase::operator=(const TTreeReaderValueBase &rhs)
+{
    if (&rhs != this) {
       fHaveLeaf = rhs.fHaveLeaf;
       fHaveStaticClassOffsets = rhs.fHaveStaticClassOffsets;
@@ -117,17 +117,17 @@ ROOT::Internal::TTreeReaderValueBase::operator=(const TTreeReaderValueBase& rhs)
 
 ROOT::Internal::TTreeReaderValueBase::~TTreeReaderValueBase()
 {
-   if (fTreeReader) fTreeReader->DeregisterValueReader(this);
-   R__ASSERT((fLeafName.Length() == 0 ) == !fHaveLeaf
-          && "leafness disagreement");
-   R__ASSERT(fStaticClassOffsets.empty() == !fHaveStaticClassOffsets
-          && "static class offset disagreement");
+   if (fTreeReader)
+      fTreeReader->DeregisterValueReader(this);
+   R__ASSERT((fLeafName.Length() == 0) == !fHaveLeaf && "leafness disagreement");
+   R__ASSERT(fStaticClassOffsets.empty() == !fHaveStaticClassOffsets && "static class offset disagreement");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register with tree reader.
 
-void ROOT::Internal::TTreeReaderValueBase::RegisterWithTreeReader() {
+void ROOT::Internal::TTreeReaderValueBase::RegisterWithTreeReader()
+{
    if (fTreeReader) {
       if (!fTreeReader->RegisterValueReader(this)) {
          fTreeReader = nullptr;
@@ -138,8 +138,6 @@ void ROOT::Internal::TTreeReaderValueBase::RegisterWithTreeReader() {
 ////////////////////////////////////////////////////////////////////////////////
 /// Try to read the value from the TBranchProxy, returns
 /// the status of the read.
-
-
 
 template <ROOT::Internal::TTreeReaderValueBase::BranchProxyRead_t Func>
 ROOT::Internal::TTreeReaderValueBase::EReadStatus ROOT::Internal::TTreeReaderValueBase::ProxyReadTemplate()
@@ -152,51 +150,57 @@ ROOT::Internal::TTreeReaderValueBase::EReadStatus ROOT::Internal::TTreeReaderVal
    return fReadStatus;
 }
 
-ROOT::Internal::TTreeReaderValueBase::EReadStatus
-ROOT::Internal::TTreeReaderValueBase::ProxyReadDefaultImpl() {
-   if (!fProxy) return kReadNothingYet;
+ROOT::Internal::TTreeReaderValueBase::EReadStatus ROOT::Internal::TTreeReaderValueBase::ProxyReadDefaultImpl()
+{
+   if (!fProxy)
+      return kReadNothingYet;
    if (fProxy->IsInitialized() || fProxy->Setup()) {
 
       using EReadType = ROOT::Detail::TBranchProxy::EReadType;
       using TBranchPoxy = ROOT::Detail::TBranchProxy;
 
       EReadType readtype = EReadType::kNoDirector;
-      if (fProxy) readtype = fProxy->GetReadType();
+      if (fProxy)
+         readtype = fProxy->GetReadType();
 
       switch (readtype) {
-         case EReadType::kNoDirector:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoDirector>;
-            break;
-         case EReadType::kReadParentNoCollection:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentNoCollection>;
-            break;
-         case EReadType::kReadParentCollectionNoPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentCollectionNoPointer>;
-            break;
-         case EReadType::kReadParentCollectionPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentCollectionPointer>;
-            break;
-         case EReadType::kReadNoParentNoBranchCountCollectionPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountCollectionPointer>;
-            break;
-         case EReadType::kReadNoParentNoBranchCountCollectionNoPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountCollectionNoPointer>;
-            break;
-         case EReadType::kReadNoParentNoBranchCountNoCollection:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountNoCollection>;
-            break;
-         case EReadType::kReadNoParentBranchCountCollectionPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountCollectionPointer>;
-            break;
-         case EReadType::kReadNoParentBranchCountCollectionNoPointer:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountCollectionNoPointer>;
-            break;
-         case EReadType::kReadNoParentBranchCountNoCollection:
-            fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountNoCollection>;
-            break;
-         case EReadType::kDefault:
-            // intentional fall through.
-         default: fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;
+      case EReadType::kNoDirector:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoDirector>;
+         break;
+      case EReadType::kReadParentNoCollection:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentNoCollection>;
+         break;
+      case EReadType::kReadParentCollectionNoPointer:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentCollectionNoPointer>;
+         break;
+      case EReadType::kReadParentCollectionPointer:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadParentCollectionPointer>;
+         break;
+      case EReadType::kReadNoParentNoBranchCountCollectionPointer:
+         fProxyReadFunc =
+            &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountCollectionPointer>;
+         break;
+      case EReadType::kReadNoParentNoBranchCountCollectionNoPointer:
+         fProxyReadFunc =
+            &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountCollectionNoPointer>;
+         break;
+      case EReadType::kReadNoParentNoBranchCountNoCollection:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentNoBranchCountNoCollection>;
+         break;
+      case EReadType::kReadNoParentBranchCountCollectionPointer:
+         fProxyReadFunc =
+            &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountCollectionPointer>;
+         break;
+      case EReadType::kReadNoParentBranchCountCollectionNoPointer:
+         fProxyReadFunc =
+            &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountCollectionNoPointer>;
+         break;
+      case EReadType::kReadNoParentBranchCountNoCollection:
+         fProxyReadFunc = &TTreeReaderValueBase::ProxyReadTemplate<&TBranchPoxy::ReadNoParentBranchCountNoCollection>;
+         break;
+      case EReadType::kDefault:
+         // intentional fall through.
+      default: fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;
       }
       return (this->*fProxyReadFunc)();
    }
@@ -214,9 +218,10 @@ ROOT::Internal::TTreeReaderValueBase::ProxyReadDefaultImpl() {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Stringify the template argument.
-std::string ROOT::Internal::TTreeReaderValueBase::GetElementTypeName(const std::type_info& ti) {
+std::string ROOT::Internal::TTreeReaderValueBase::GetElementTypeName(const std::type_info &ti)
+{
    int err;
-   char* buf = TClassEdit::DemangleTypeIdName(ti, err);
+   char *buf = TClassEdit::DemangleTypeIdName(ti, err);
    std::string ret = buf;
    free(buf);
    return ret;
@@ -225,7 +230,8 @@ std::string ROOT::Internal::TTreeReaderValueBase::GetElementTypeName(const std::
 ////////////////////////////////////////////////////////////////////////////////
 /// The TTreeReader has switched to a new TTree. Update the leaf.
 
-void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
+void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree *newTree)
+{
    // Since the TTree structure might have change, let's make sure we
    // use the right reading function.
    fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;
@@ -252,7 +258,8 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns the memory address of the object being read.
 
-void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
+void *ROOT::Internal::TTreeReaderValueBase::GetAddress()
+{
 
    // If an indexed friend did not match the current entry and if this reader
    // is associated with that friend (i.e. its active read entry is -1), avoid
@@ -261,28 +268,28 @@ void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
        fProxy->fDirector->GetReadEntry() == -1)
       return nullptr;
 
-   if (ProxyRead() != kReadSuccess) return nullptr;
+   if (ProxyRead() != kReadSuccess)
+      return nullptr;
 
-   if (fHaveLeaf){
-      if (GetLeaf()){
+   if (fHaveLeaf) {
+      if (GetLeaf()) {
          return fLeaf->GetValuePointer();
-      }
-      else {
+      } else {
          fReadStatus = kReadError;
          Error("TTreeReaderValueBase::GetAddress()", "Unable to get the leaf");
          return nullptr;
       }
    }
-   if (fHaveStaticClassOffsets){ // Follow all the pointers
-      Byte_t *address = (Byte_t*)fProxy->GetWhere();
+   if (fHaveStaticClassOffsets) { // Follow all the pointers
+      Byte_t *address = (Byte_t *)fProxy->GetWhere();
 
-      for (unsigned int i = 0; i < fStaticClassOffsets.size() - 1; ++i){
-         address = *(Byte_t**)(address + fStaticClassOffsets[i]);
+      for (unsigned int i = 0; i < fStaticClassOffsets.size() - 1; ++i) {
+         address = *(Byte_t **)(address + fStaticClassOffsets[i]);
       }
 
       return address + fStaticClassOffsets.back();
    }
-   return (Byte_t*)fProxy->GetWhere();
+   return (Byte_t *)fProxy->GetWhere();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -300,33 +307,38 @@ void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
 /// ```
 /// The method has some side effects, namely it can modify fSetupStatus, fProxy
 /// and fStaticClassOffsets/fHaveStaticClassOffsets.
-TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLeaf *&myLeaf, TDictionary *&branchActualType, std::string &errMsg)
+TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLeaf *&myLeaf,
+                                                                             TDictionary *&branchActualType,
+                                                                             std::string &errMsg)
 {
-   TRegexp leafNameExpression ("\\.[a-zA-Z0-9_]+$");
-   TString leafName (fBranchName(leafNameExpression));
+   TRegexp leafNameExpression("\\.[a-zA-Z0-9_]+$");
+   TString leafName(fBranchName(leafNameExpression));
    TString branchName = fBranchName(0, fBranchName.Length() - leafName.Length());
    auto branch = fTreeReader->GetTree()->GetBranch(branchName);
-   if (!branch){
+   if (!branch) {
       std::vector<TString> nameStack;
-      nameStack.push_back(TString()); //Trust me
+      nameStack.push_back(TString()); // Trust me
       nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
       leafName = branchName(leafNameExpression);
       branchName = branchName(0, branchName.Length() - leafName.Length());
 
       branch = fTreeReader->GetTree()->GetBranch(branchName);
-      if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
-      if (leafName.Length()) nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
+      if (!branch)
+         branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
+      if (leafName.Length())
+         nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
 
-      while (!branch && branchName.Contains(".")){
+      while (!branch && branchName.Contains(".")) {
          leafName = branchName(leafNameExpression);
          branchName = branchName(0, branchName.Length() - leafName.Length());
          branch = fTreeReader->GetTree()->GetBranch(branchName);
-         if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
+         if (!branch)
+            branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
          nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
       }
 
-      if (branch && branch->IsA() == TBranchElement::Class()){
-         TBranchElement *myBranchElement = (TBranchElement*)branch;
+      if (branch && branch->IsA() == TBranchElement::Class()) {
+         TBranchElement *myBranchElement = (TBranchElement *)branch;
 
          TString traversingBranch = nameStack.back();
          nameStack.pop_back();
@@ -342,14 +354,14 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          TObjArray *myObjArray = myBranchElement->GetInfo()->GetElements();
          TVirtualStreamerInfo *myInfo = myBranchElement->GetInfo();
 
-         while (!nameStack.empty() && found){
+         while (!nameStack.empty() && found) {
             found = false;
 
-            for (int i = 0; i < myObjArray->GetEntries(); ++i){
+            for (int i = 0; i < myObjArray->GetEntries(); ++i) {
 
-               TStreamerElement *tempStreamerElement = (TStreamerElement*)myObjArray->At(i);
+               TStreamerElement *tempStreamerElement = (TStreamerElement *)myObjArray->At(i);
 
-               if (!strcmp(tempStreamerElement->GetName(), traversingBranch.Data())){
+               if (!strcmp(tempStreamerElement->GetName(), traversingBranch.Data())) {
                   offset += myInfo->GetElementOffset(i);
 
                   traversingBranch = nameStack.back();
@@ -360,18 +372,17 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
                      myInfo = elementClass->GetStreamerInfo(0);
                      myObjArray = myInfo->GetElements();
                      // FIXME: this is odd, why is 'i' not also reset????
-                  }
-                  else {
+                  } else {
                      finalDataType = TDataType::GetDataType((EDataType)tempStreamerElement->GetType());
                      if (!finalDataType) {
-                        TDictionary* seType = TDictionary::GetDictionary(tempStreamerElement->GetTypeName());
+                        TDictionary *seType = TDictionary::GetDictionary(tempStreamerElement->GetTypeName());
                         if (seType && seType->IsA() == TDataType::Class()) {
-                           finalDataType = TDataType::GetDataType((EDataType)((TDataType*)seType)->GetType());
+                           finalDataType = TDataType::GetDataType((EDataType)((TDataType *)seType)->GetType());
                         }
                      }
                   }
 
-                  if (tempStreamerElement->IsaPointer()){
+                  if (tempStreamerElement->IsaPointer()) {
                      offsets.push_back(offset);
                      offset = 0;
                   }
@@ -384,11 +395,11 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
 
          offsets.push_back(offset);
 
-         if (found){
+         if (found) {
             fStaticClassOffsets = offsets;
             fHaveStaticClassOffsets = true;
 
-            if (fDict != finalDataType && fDict != elementClass){
+            if (fDict != finalDataType && fDict != elementClass) {
                errMsg = "Wrong data type ";
                errMsg += finalDataType ? finalDataType->GetName() : elementClass ? elementClass->GetName() : "UNKNOWN";
                fSetupStatus = kSetupMismatch;
@@ -398,7 +409,6 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          }
       }
 
-
       if (!fHaveStaticClassOffsets) {
          errMsg = "The tree does not have a branch called ";
          errMsg += fBranchName;
@@ -407,29 +417,26 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          fProxy = nullptr;
          return nullptr;
       }
-   }
-   else {
+   } else {
       myLeaf = branch->GetLeaf(TString(leafName(1, leafName.Length())));
-      if (!myLeaf){
+      if (!myLeaf) {
          errMsg = "The tree does not have a branch, nor a sub-branch called ";
          errMsg += fBranchName;
          errMsg += ". You could check with TTree::Print() for available branches.";
          fSetupStatus = kSetupMissingBranch;
          fProxy = nullptr;
          return nullptr;
-      }
-      else {
+      } else {
          TDataType *tempDict = gROOT->GetType(myLeaf->GetTypeName());
-         if (tempDict && fDict->IsA() == TDataType::Class() && tempDict->GetType() == ((TDataType*)fDict)->GetType()) {
-            //fLeafOffset = myLeaf->GetOffset() / 4;
+         if (tempDict && fDict->IsA() == TDataType::Class() && tempDict->GetType() == ((TDataType *)fDict)->GetType()) {
+            // fLeafOffset = myLeaf->GetOffset() / 4;
             branchActualType = fDict;
             fLeaf = myLeaf;
             fBranchName = branchName;
             fLeafName = leafName(1, leafName.Length());
             fHaveLeaf = fLeafName.Length() > 0;
             fSetupStatus = kSetupMatchLeaf;
-         }
-         else {
+         } else {
             errMsg = "Leaf of type ";
             errMsg += myLeaf->GetTypeName();
             errMsg += " cannot be read by TTreeReaderValue<";
@@ -447,9 +454,10 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
 ////////////////////////////////////////////////////////////////////////////////
 /// Create the proxy object for our branch.
 
-void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
+void ROOT::Internal::TTreeReaderValueBase::CreateProxy()
+{
 
-   constexpr const char* errPrefix = "TTreeReaderValueBase::CreateProxy()";
+   constexpr const char *errPrefix = "TTreeReaderValueBase::CreateProxy()";
 
    if (fProxy) {
       return;
@@ -457,8 +465,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
 
    fSetupStatus = kSetupInternalError; // Fallback; set to something concrete below.
    if (!fTreeReader) {
-      Error(errPrefix, "TTreeReader object not set / available for branch %s!",
-            fBranchName.Data());
+      Error(errPrefix, "TTreeReader object not set / available for branch %s!", fBranchName.Data());
       fSetupStatus = kSetupTreeDestructed;
       return;
    }
@@ -492,7 +499,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
    // Search for the branchname, determine what it contains, and wire the
    // TBranchProxy representing it to us so we can access its data.
 
-   TNamedBranchProxy* namedProxy = fTreeReader->FindProxy(fBranchName);
+   TNamedBranchProxy *namedProxy = fTreeReader->FindProxy(fBranchName);
    if (namedProxy && namedProxy->GetDict() == fDict) {
       fProxy = namedProxy->GetProxy();
       // But go on: we need to set fLeaf etc!
@@ -501,7 +508,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
    const std::string originalBranchName = fBranchName.Data();
 
    TLeaf *myLeaf = nullptr;
-   TDictionary* branchActualType = nullptr;
+   TDictionary *branchActualType = nullptr;
    std::string errMsg;
 
    TBranch *branch = nullptr;
@@ -520,10 +527,10 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       // For these cases, we do not have to give priority to the previously
       // identified branch since we are in a different situation.
       // This behaviour is described in ROOT-9757.
-      if (branch && branch->IsA() == TBranchElement::Class() && branchFromFullName){
-        branch = branchFromFullName;
-        fStaticClassOffsets = {};
-        fHaveStaticClassOffsets = false;
+      if (branch && branch->IsA() == TBranchElement::Class() && branchFromFullName) {
+         branch = branchFromFullName;
+         fStaticClassOffsets = {};
+         fHaveStaticClassOffsets = false;
       }
    }
 
@@ -580,7 +587,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
    if (!myLeaf && !fHaveStaticClassOffsets) {
       // The following two lines cannot be swapped. The GetBranchDataType can
       // change the value of branchActualType
-      const char* branchActualTypeName = GetBranchDataType(branch, branchActualType, fDict);
+      const char *branchActualTypeName = GetBranchDataType(branch, branchActualType, fDict);
       if (!branchActualType) {
          Error(errPrefix, "The branch %s contains data of type %s, which does not have a dictionary.",
                fBranchName.Data(), branchActualTypeName ? branchActualTypeName : "{UNDETERMINED TYPE}");
@@ -590,37 +597,36 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
 
       // Check if the dictionaries are TClass instances and if there is inheritance
       // because in this case, we can read the values.
-      auto dictAsClass = dynamic_cast<TClass*>(fDict);
-      auto branchActualTypeAsClass = dynamic_cast<TClass*>(branchActualType);
+      auto dictAsClass = dynamic_cast<TClass *>(fDict);
+      auto branchActualTypeAsClass = dynamic_cast<TClass *>(branchActualType);
       auto inheritance = dictAsClass && branchActualTypeAsClass && branchActualTypeAsClass->InheritsFrom(dictAsClass);
-      bool typeinfoMatch = dictAsClass && dictAsClass->GetTypeInfo() && dictAsClass->GetTypeInfo() == branchActualTypeAsClass->GetTypeInfo();
+      bool typeinfoMatch = dictAsClass && dictAsClass->GetTypeInfo() &&
+                           dictAsClass->GetTypeInfo() == branchActualTypeAsClass->GetTypeInfo();
 
       if (!inheritance && !typeinfoMatch && fDict != branchActualType) {
-         TDataType *dictdt = dynamic_cast<TDataType*>(fDict);
-         TDataType *actualdt = dynamic_cast<TDataType*>(branchActualType);
-         TEnum *dictenum = dynamic_cast<TEnum*>(fDict);
-         TEnum *actualenum = dynamic_cast<TEnum*>(branchActualType);
+         TDataType *dictdt = dynamic_cast<TDataType *>(fDict);
+         TDataType *actualdt = dynamic_cast<TDataType *>(branchActualType);
+         TEnum *dictenum = dynamic_cast<TEnum *>(fDict);
+         TEnum *actualenum = dynamic_cast<TEnum *>(branchActualType);
          bool complainAboutMismatch = true;
          if (dictdt && actualdt) {
             if (dictdt->GetType() > 0 && dictdt->GetType() == actualdt->GetType()) {
                // Same numerical type but different TDataType, likely Long64_t
                complainAboutMismatch = false;
-            } else if ((actualdt->GetType() == kDouble32_t && dictdt->GetType() == kDouble_t)
-                       || (actualdt->GetType() == kFloat16_t && dictdt->GetType() == kFloat_t)) {
+            } else if ((actualdt->GetType() == kDouble32_t && dictdt->GetType() == kDouble_t) ||
+                       (actualdt->GetType() == kFloat16_t && dictdt->GetType() == kFloat_t)) {
                // Double32_t and Float16_t never "decay" to their underlying type;
                // we need to identify them manually here (ROOT-8731).
                complainAboutMismatch = false;
             }
-         } else if ( (dictdt || dictenum) && (actualdt || actualenum) ) {
-            if ((dictdt && dictdt->GetType() == kInt_t && actualenum)
-                ||(actualdt && actualdt->GetType() == kInt_t && dictenum))
+         } else if ((dictdt || dictenum) && (actualdt || actualenum)) {
+            if ((dictdt && dictdt->GetType() == kInt_t && actualenum) ||
+                (actualdt && actualdt->GetType() == kInt_t && dictenum))
                complainAboutMismatch = false;
          }
          if (complainAboutMismatch) {
-            Error(errPrefix,
-                  "The branch %s contains data of type %s. It cannot be accessed by a TTreeReaderValue<%s>",
-                  fBranchName.Data(), branchActualType->GetName(),
-                  fDict->GetName());
+            Error(errPrefix, "The branch %s contains data of type %s. It cannot be accessed by a TTreeReaderValue<%s>",
+                  fBranchName.Data(), branchActualType->GetName(), fDict->GetName());
             return;
          }
       }
@@ -690,19 +696,18 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
 /// dict, return its type name. If no dictionary is available, at least
 /// its type name should be returned.
 
-const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* branch,
-                                           TDictionary* &dict,
-                                           TDictionary const *curDict)
+const char *
+ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch *branch, TDictionary *&dict, TDictionary const *curDict)
 {
    dict = nullptr;
    if (branch->IsA() == TBranchElement::Class()) {
-      TBranchElement* brElement = (TBranchElement*)branch;
+      TBranchElement *brElement = (TBranchElement *)branch;
 
       auto ResolveTypedef = [&]() -> void {
          if (dict->IsA() != TDataType::Class())
             return;
          // Resolve the typedef.
-         dict = TDictionary::GetDictionary(((TDataType*)dict)->GetTypeName());
+         dict = TDictionary::GetDictionary(((TDataType *)dict)->GetTypeName());
          if (dict->IsA() != TDataType::Class()) {
             // Might be a class.
             if (dict != curDict) {
@@ -714,17 +719,16 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
          }
       };
 
-      if (brElement->GetType() == TBranchElement::kSTLNode ||
-            brElement->GetType() == TBranchElement::kLeafNode ||
-            brElement->GetType() == TBranchElement::kObjectNode) {
+      if (brElement->GetType() == TBranchElement::kSTLNode || brElement->GetType() == TBranchElement::kLeafNode ||
+          brElement->GetType() == TBranchElement::kObjectNode) {
 
          TStreamerInfo *streamerInfo = brElement->GetInfo();
          Int_t id = brElement->GetID();
 
-         if (id >= 0){
-            TStreamerElement *element = (TStreamerElement*)streamerInfo->GetElements()->At(id);
-            if (element->IsA() == TStreamerSTL::Class()){
-               TStreamerSTL *myStl = (TStreamerSTL*)element;
+         if (id >= 0) {
+            TStreamerElement *element = (TStreamerElement *)streamerInfo->GetElements()->At(id);
+            if (element->IsA() == TStreamerSTL::Class()) {
+               TStreamerSTL *myStl = (TStreamerSTL *)element;
                dict = myStl->GetClass();
                return nullptr;
             }
@@ -747,28 +751,27 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
       } else if (brElement->GetType() == TBranchElement::kClonesNode) {
          dict = TClonesArray::Class();
          return "TClonesArray";
-      } else if (brElement->GetType() == 31
-                 || brElement->GetType() == 41) {
+      } else if (brElement->GetType() == 31 || brElement->GetType() == 41) {
          // it's a member, extract from GetClass()'s streamer info
-         Error("TTreeReaderValueBase::GetBranchDataType()", "Must use TTreeReaderArray to access a member of an object that is stored in a collection.");
+         Error("TTreeReaderValueBase::GetBranchDataType()",
+               "Must use TTreeReaderArray to access a member of an object that is stored in a collection.");
       } else if (brElement->GetType() == -1 && brElement->GetTypeName()) {
          dict = TDictionary::GetDictionary(brElement->GetTypeName());
          ResolveTypedef();
          return brElement->GetTypeName();
       } else {
-         Error("TTreeReaderValueBase::GetBranchDataType()", "Unknown type and class combination: %i, %s", brElement->GetType(), brElement->GetClassName());
+         Error("TTreeReaderValueBase::GetBranchDataType()", "Unknown type and class combination: %i, %s",
+               brElement->GetType(), brElement->GetClassName());
       }
       return nullptr;
-   } else if (branch->IsA() == TBranch::Class()
-              || branch->IsA() == TBranchObject::Class()
-              || branch->IsA() == TBranchSTL::Class()) {
-      if (branch->GetTree()->IsA() == TNtuple::Class()){
+   } else if (branch->IsA() == TBranch::Class() || branch->IsA() == TBranchObject::Class() ||
+              branch->IsA() == TBranchSTL::Class()) {
+      if (branch->GetTree()->IsA() == TNtuple::Class()) {
          dict = TDataType::GetDataType(kFloat_t);
          return dict->GetName();
       }
-      const char* dataTypeName = branch->GetClassName();
-      if ((!dataTypeName || !dataTypeName[0])
-          && branch->IsA() == TBranch::Class()) {
+      const char *dataTypeName = branch->GetClassName();
+      if ((!dataTypeName || !dataTypeName[0]) && branch->IsA() == TBranch::Class()) {
          TLeaf *myLeaf = branch->GetLeaf(branch->GetName());
          if (!myLeaf) {
             myLeaf = branch->FindLeaf(branch->GetName());
@@ -776,38 +779,47 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
          if (!myLeaf && branch->GetListOfLeaves()->GetEntries() == 1) {
             myLeaf = static_cast<TLeaf *>(branch->GetListOfLeaves()->UncheckedAt(0));
          }
-         if (myLeaf){
+         if (myLeaf) {
             TDictionary *myDataType = TDictionary::GetDictionary(myLeaf->GetTypeName());
-            if (myDataType && myDataType->IsA() == TDataType::Class()){
+            if (myDataType && myDataType->IsA() == TDataType::Class()) {
                if (myLeaf->GetLeafCount() != nullptr || myLeaf->GetLenStatic() > 1) {
-                  Error("TTreeReaderValueBase::GetBranchDataType()", "Must use TTreeReaderArray to read branch %s: it contains an array or a collection.", branch->GetName());
+                  Error("TTreeReaderValueBase::GetBranchDataType()",
+                        "Must use TTreeReaderArray to read branch %s: it contains an array or a collection.",
+                        branch->GetName());
                   return nullptr;
                }
-               dict = TDataType::GetDataType((EDataType)((TDataType*)myDataType)->GetType());
+               dict = TDataType::GetDataType((EDataType)((TDataType *)myDataType)->GetType());
                return myLeaf->GetTypeName();
             }
          }
 
          // leaflist. Can't represent.
-         Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s was created using a leaf list and cannot be represented as a C++ type. Please access one of its siblings using a TTreeReaderArray:", branch->GetName());
+         Error("TTreeReaderValueBase::GetBranchDataType()",
+               "The branch %s was created using a leaf list and cannot be represented as a C++ type. Please access one "
+               "of its siblings using a TTreeReaderArray:",
+               branch->GetName());
          TIter iLeaves(branch->GetListOfLeaves());
-         TLeaf* leaf = nullptr;
-         while ((leaf = (TLeaf*) iLeaves())) {
+         TLeaf *leaf = nullptr;
+         while ((leaf = (TLeaf *)iLeaves())) {
             Error("TTreeReaderValueBase::GetBranchDataType()", "   %s.%s", branch->GetName(), leaf->GetName());
          }
          return nullptr;
       }
-      if (dataTypeName) dict = TDictionary::GetDictionary(dataTypeName);
+      if (dataTypeName)
+         dict = TDictionary::GetDictionary(dataTypeName);
       return dataTypeName;
    } else if (branch->IsA() == TBranchClones::Class()) {
       dict = TClonesArray::Class();
       return "TClonesArray";
    } else if (branch->IsA() == TBranchRef::Class()) {
       // Can't represent.
-      Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s is a TBranchRef and cannot be represented as a C++ type.", branch->GetName());
+      Error("TTreeReaderValueBase::GetBranchDataType()",
+            "The branch %s is a TBranchRef and cannot be represented as a C++ type.", branch->GetName());
       return nullptr;
    } else {
-      Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s is of type %s - something that is not handled yet.", branch->GetName(), branch->IsA()->GetName());
+      Error("TTreeReaderValueBase::GetBranchDataType()",
+            "The branch %s is of type %s - something that is not handled yet.", branch->GetName(),
+            branch->IsA()->GetName());
       return nullptr;
    }
 


### PR DESCRIPTION
This is just  running `clang-format -i filename`, also done in preparation for more changes needed by TTree-based processing in RDataFrame.