### PR TITLE
[hist] paint TH2 even if nEntries==0, as already happens for TH1

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -9663,7 +9663,7 @@ void THistPainter::PaintTable(Option_t *option)
          if (Hoption.Text)         PaintTH2PolyText(option);
          if (Hoption.Line)         PaintTH2PolyBins("l");
          if (Hoption.Mark)         PaintTH2PolyBins("P");
-      } else if (fH->GetEntries() != 0 && Hoption.Axis<=0) {
+      } else if (Hoption.Axis<=0) {
          if (Hoption.Scat)         PaintScatterPlot(option);
          if (Hoption.Arrow)        PaintArrows(option);
          if (Hoption.Box)          PaintBoxes(option);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

If you fill a TH1 using only AddBinContent, the resulting nEntries=0, and call Draw(), it works. If you fill a TH2 using only AddBinContent, the resulting nEntries=0, and call Draw("COLZ"), it does not work. This commit tries to fix it so that it also works for the 2D case, for consistency.

Fixes https://github.com/root-project/root/issues/14153

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
