### PR TITLE
ACLiC: use user provided library name for dependency filename

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2976,6 +2976,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       if (! IsAbsoluteFileName(library) ) {
          AssignAndDelete( library , ConcatFileName( WorkingDirectory(), library ) );
       }
+      libname_noext = library_specified;
       library = TString(library) + "." + fSoExt;
    }
    library = gSystem->UnixPathName(library);


### PR DESCRIPTION
This might address the instability in roottest-root-io-evolution.

The companion roottest PR is https://github.com/root-project/roottest/pull/1254