### PR TITLE
Fix out-of-bounds error in pyroot

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Utility.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Utility.cxx
@@ -645,7 +645,7 @@ void CPyCppyy::Utility::ConstructCallbackPreamble(const std::string& retType,
              << retType << "\"), CPyCppyy::DestroyConverter};\n";
     std::vector<bool> arg_is_ptr;
     if (nArgs) {
-        arg_is_ptr.reserve(nArgs);
+        arg_is_ptr.resize(nArgs);
         code << "    CPYCPPYY_STATIC std::vector<std::unique_ptr<CPyCppyy::Converter, std::function<void(CPyCppyy::Converter*)>>> argcvs;\n"
              << "    if (argcvs.empty()) {\n"
              << "      argcvs.reserve(" << nArgs << ");\n";


### PR DESCRIPTION
```
 526/1416 Test   #63: pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-tf-pycallables ..........................***Failed   75.51 sec
test_callable (tf_pycallables.TF1.test_callable)
Test function provided as callable ... /usr/include/c++/15/bits/stl_bvector.h:1134: std::vector<bool, _Alloc>::reference std::vector<bool, _Alloc>::operator[](size_type) [with _Alloc = std::allocator<bool>; reference = std::vector<bool>::reference; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
 *** Break *** abort

=========================================================== The lines below might hint at the cause of the crash. If you see question marks as part of the stack trace, try to recompile with debugging information enabled and export CLING_DEBUG=1 environment variable before running. You may get help by asking at the ROOT forum https://root.cern/forum preferably using the command (.forum bug) in the ROOT prompt. Only if you are really convinced it is a bug in ROOT then please submit a report at https://root.cern/bugs or (preferably) using the command (.gh bug) in the ROOT prompt. Please post the ENTIRE stack trace from above as an attachment in addition to anything else that might help us fixing this issue.
===========================================================
 #10 0x00007f6bcac7fea4 in __pthread_kill_implementation () from /lib64/libc.so.6
 #11 0x00007f6bcac264de in raise () from /lib64/libc.so.6
 #12 0x00007f6bcac0e350 in abort () from /lib64/libc.so.6
 #13 0x00007f6bc9a0be02 in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /lib64/libstdc++.so.6
 #14 0x00007f6bb9b15257 in std::vector<bool, std::allocator<bool> >::operator[](unsigned long) [clone .part.0] [clone .lto_priv.0] (__n=<optimized out>, this=<optimized out>) at /usr/include/c++/15/bits/stl_bvector.h:1134
 #15 0x00007f6bb9bab976 in std::vector<bool, std::allocator<bool> >::operator[] (this=<synthetic pointer>, __n=0) at /usr/include/c++/15/bits/stl_bvector.h:201
 #16 CPyCppyy::Utility::ConstructCallbackPreamble (retType="Double_t", argtypes=..., code=Python Exception <class 'IndexError'>: list index out of range
 #17 0x00007f6bb9b389e0 in PyFunction_AsCPointer (pyobject=<optimized out>, pyobject
entry=0x7f6bb8f838c0, rettype="Double_t", signature="(Double_t*,Double_t*)") at /builddir/build/BUILD/root-6.34.02-build/root-6.34.02/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx:2713
 #18 0x00007f6bb9b39851 in CPyCppyy::(anonymous namespace)::FunctionPointerConverter::SetArg (this=0x55eb25d61d40, pyobject=0x7f6bb8f838c0, para=..., ctxt=0x7ffc484855c0) at /builddir/build/BUILD/root-6.34.02-build/root-6.34.02/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx:2768
```
