### PR TITLE
[graf] Warn user about automatic overwrite of TCutG if same name

### DIFF
--- a/graf2d/graf/src/TCutG.cxx
+++ b/graf2d/graf/src/TCutG.cxx
@@ -123,7 +123,12 @@ TCutG::TCutG(const char *name, Int_t n)
    fObjectX  = nullptr;
    fObjectY  = nullptr;
    SetName(name);
-   delete gROOT->GetListOfSpecials()->FindObject(name);
+   auto obj = gROOT->GetListOfSpecials()->FindObject(name);
+   if (obj) {
+      Warning("TCutG","Replacing existing %s: %s (Potential memory leak).",
+                 obj->IsA()->GetName(),obj->GetName()); 
+      delete obj;
+   }
    gROOT->GetListOfSpecials()->Add(this);
 
    // Take name of cut variables from pad title if title contains ":"
@@ -164,7 +169,12 @@ TCutG::TCutG(const char *name, Int_t n, const Float_t *x, const Float_t *y)
    fObjectX  = nullptr;
    fObjectY  = nullptr;
    SetName(name);
-   delete gROOT->GetListOfSpecials()->FindObject(name);
+   auto obj = gROOT->GetListOfSpecials()->FindObject(name);
+   if (obj) {
+      Warning("TCutG","Replacing existing %s: %s (Potential memory leak).",
+                 obj->IsA()->GetName(),obj->GetName()); 
+      delete obj;
+   }
    gROOT->GetListOfSpecials()->Add(this);
 
    // Take name of cut variables from pad title if title contains ":"
@@ -205,7 +215,12 @@ TCutG::TCutG(const char *name, Int_t n, const Double_t *x, const Double_t *y)
    fObjectX  = nullptr;
    fObjectY  = nullptr;
    SetName(name);
-   delete gROOT->GetListOfSpecials()->FindObject(name);
+   auto obj = gROOT->GetListOfSpecials()->FindObject(name);
+   if (obj) {
+      Warning("TCutG","Replacing existing %s: %s (Potential memory leak).",
+                 obj->IsA()->GetName(),obj->GetName()); 
+      delete obj;
+   }
    gROOT->GetListOfSpecials()->Add(this);
 
    // Take name of cut variables from pad title if title contains ":"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Warn user about automatic overwrite of TCutG if same name

As done also in TDirectory::Append or when constructing a TH1

Suggested by https://root-forum.cern.ch/t/resolved-report-bug-lack-of-warning-with-crash-for-multiple-tcutg-object-having-the-same-name/62774/5

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

