### PR TITLE
[math][minuit2] Add new version of Fumili algorithm using trust region method

### DIFF
--- a/etc/plugins/ROOT@@Math@@Minimizer/P040_GSLNLSMinimizer.C
+++ b/etc/plugins/ROOT@@Math@@Minimizer/P040_GSLNLSMinimizer.C
@@ -1,5 +1,5 @@
 void P040_GSLNLSMinimizer()
 {
    gPluginMgr->AddHandler("ROOT::Math::Minimizer", "GSLMultiFit", "ROOT::Math::GSLNLSMinimizer",
-      "MathMore", "GSLNLSMinimizer(int)");
+      "MathMore", "GSLNLSMinimizer(const char * )");
 }

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -310,7 +310,7 @@ TFitResultPtr HFit::Fit(FitObject * h1, TF1 *f1 , Foption_t & fitOption , const 
    fitConfig.SetMinimizerOptions(minOption);
 
    // specific  print level options
-   if (fitOption.Verbose) fitConfig.MinimizerOptions().SetPrintLevel(3);
+   if (fitOption.Verbose)  fitConfig.MinimizerOptions().SetPrintLevel(fitOption.Verbose + 1);
    if (fitOption.Quiet)    fitConfig.MinimizerOptions().SetPrintLevel(0);
 
    // specific minimizer options depending on minimizer
@@ -789,6 +789,8 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
    }
    if (opt.Contains("Q")) fitOption.Quiet   = 1;
    if (opt.Contains("V")) {fitOption.Verbose = 1; fitOption.Quiet   = 0;}
+   if (opt.Contains("VV")) {fitOption.Verbose = 2; }
+    if (opt.Contains("VVV") || opt.Contains("DEBUG")) {fitOption.Verbose = 3; }
 
 
    if (opt.Contains("E")) fitOption.Errors  = 1;
@@ -895,7 +897,7 @@ TFitResultPtr ROOT::Fit::UnBinFit(ROOT::Fit::UnBinData * data, TF1 * fitfunc, Fo
 
    fitConfig.SetMinimizerOptions(minOption);
 
-   if (fitOption.Verbose)   fitConfig.MinimizerOptions().SetPrintLevel(3);
+   if (fitOption.Verbose)   fitConfig.MinimizerOptions().SetPrintLevel(fitOption.Verbose+1);
    if (fitOption.Quiet)     fitConfig.MinimizerOptions().SetPrintLevel(0);
 
    // more

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -787,10 +787,12 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
          fitOption.User = 0;
       }
    }
-   if (opt.Contains("Q")) fitOption.Quiet   = 1;
-   if (opt.Contains("V")) {fitOption.Verbose = 1; fitOption.Quiet   = 0;}
-   if (opt.Contains("VV")) {fitOption.Verbose = 2; }
-    if (opt.Contains("VVV") || opt.Contains("DEBUG")) {fitOption.Verbose = 3; }
+
+   // in case of Q and V options V has precedence
+   if (opt.Contains("VVV") || opt.Contains("DEBUG")) { fitOption.Verbose = 3; }
+   else if (opt.Contains("VV")) {fitOption.Verbose = 2; }
+   else if (opt.Contains("V")) {fitOption.Verbose = 1; }
+   else if (opt.Contains("Q")) {fitOption.Quiet   = 1; }
 
 
    if (opt.Contains("E")) fitOption.Errors  = 1;

--- a/hist/hist/src/TF1Convolution.cxx
+++ b/hist/hist/src/TF1Convolution.cxx
@@ -329,7 +329,9 @@ void TF1Convolution::MakeFFTConv()
 
 Double_t TF1Convolution::EvalFFTConv(Double_t t)
 {
-   if (!fFlagGraph)  MakeFFTConv();
+   if (!fFlagGraph) {
+      MakeFFTConv();
+   }
    // if cannot make FFT use numconv
    if (fGraphConv)
       return  fGraphConv -> Eval(t);
@@ -430,10 +432,10 @@ void TF1Convolution::SetParameters(Double_t p0, Double_t p1, Double_t p2, Double
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set the fraction of extra range used when doing an FFT convolution.
+/// Set the fraction of extra range used when doing an convolution.
 /// The extra range is often needed to avoid mirroring effect of the resulting convolution
 /// function at the borders.
-/// By default an extra range of 0.1 is used.
+/// By default an extra range of 0.1 is used when doing FFT and it is not use for numerical convolution
 
 void TF1Convolution::SetExtraRange(Double_t percentage)
 {

--- a/math/fumili/src/TFumili.cxx
+++ b/math/fumili/src/TFumili.cxx
@@ -110,6 +110,8 @@ function argument.
 #include "TList.h"
 #include "TVirtualFitter.h"
 
+#include <iostream>
+
 
 extern void H1FitChisquareFumili(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
 extern void H1FitLikelihoodFumili(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
@@ -1067,6 +1069,27 @@ Bool_t TFumili::IsFixed(Int_t ipar) const
    else                return kFALSE;
 }
 
+void PrintVector(const char * name, int n, double * x) {
+   // print vector data
+   std::cout << name << " : {";
+   for (int i  = 0; i < n; i++)
+      std::cout << "  " << x[i];
+   std::cout << " }\n";
+}
+void PrintMatrix(const char * name, int n, double * x) {
+   // print matrix data
+   std::cout << name << " : \n";
+   int index = 0;
+   for (int i  = 0; i < n; i++) {
+      for (int j  = 0; j <= i; j++) {
+         std::cout << "  " << x[index];
+         index++;
+      }
+      std::cout << std::endl;
+   }
+   std::cout << "\n";
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Main minimization procedure
 ///
@@ -1092,6 +1115,8 @@ Int_t TFumili::Minimize()
    //
    Int_t parn;
 
+   // I think this funciton call is needed for getting fA and fNpar
+   // and fAMX fAMN ?
    if(fFCN) {
       Eval(parn,fGr,fS,fA,9); fNfcn++;
    }
@@ -1102,7 +1127,7 @@ Int_t TFumili::Minimize()
 
    Int_t nn2, n, fixFLG,  ifix1, fi, nn3, nn1, n0;
    Double_t t1;
-   Double_t sp, t, olds=0;
+   Double_t sp, t = 0, olds=0;
    Double_t bi, aiMAX=0, amb;
    Double_t afix, sigi, akap;
    Double_t alambd, al, bm, abi, abm;
@@ -1135,7 +1160,17 @@ L3: // Start Iteration
    nn1 = 1;
    t1 = 1.;
 
+
+
+//perform iteration
 L4: // New iteration
+
+   if (fDEBUG) {
+      std::cout << "New iteration - nfcn " << fNfcn << " nn1 = " << nn1 << " fGT " << fGT << "\n";
+      PrintVector("Parameter",n,fA);
+      PrintVector("PL ",n,fPL);
+      PrintVector("Step ",n,fDA);
+   }
 
    // fS - objective function value - zero first
    fS = 0.;
@@ -1143,7 +1178,7 @@ L4: // New iteration
    n0 = 0;
    for( i = 0; i < n; i++) {
       fGr[i]=0.; // zero gradients
-      if (fPL0[i] > .0) {
+      if (fPL0[i] > .0) {   // fLO is negstive foa fixed parameters
          n0=n0+1;
          // new iteration - new parallelepiped
          if (fPL[i] > .0) fPL0[i]=fPL[i];
@@ -1170,15 +1205,18 @@ L4: // New iteration
    if (ijkl == -1) fINDFLG[0]=1;
 
    // sp - scaled on fS machine precision
+   // compute precision epsilon (fRP is 1.E-15)
    sp=fRP*TMath::Abs(fS);
 
    // save fZ-matrix
    for( i=0; i < nn0; i++) fZ0[i] = fZ[i];
    if (nn3 > 0) {
       if (nn1 <= fNstepDec) {
+         // conditions on next step point
          t=2.*(fS-olds-fGT);
          if (fINDFLG[0] == 0) {
             if (TMath::Abs(fS-olds) <= sp && -fGT <= sp) goto L19;
+            if (fDEBUG) std::cout << " factor t is " << -fGT/t << std::endl;
             if(        0.59*t < -fGT) goto L19;
             t = -fGT/t;
             if (t < 0.25 ) t = 0.25;
@@ -1187,6 +1225,8 @@ L4: // New iteration
          fGT = fGT*t;
          t1 = t1*t;
          nn2=0;
+         // loop on parameter
+         // change parameter value using step  fPL and fDA
          for( i = 0; i < n; i++) {
             if (fPL[i] > 0.) {
                fA[i]=fA[i]-fDA[i];
@@ -1196,12 +1236,19 @@ L4: // New iteration
             }
          }
          nn1=nn1+1;
+         if (fDEBUG) {
+            std::cout << "change all PL and steps by factor t " << t << std::endl;
+         }
          goto L4;
       }
    }
 
 L19:
 
+   if (fDEBUG)
+      std::cout << "exit iteration (L19) t = " << t << " fGT = " << fGT << std::endl;
+
+   // flag here should be equal to zero
    if(fINDFLG[0] != 0) {
       fENDFLG=-4;
       printf("trying to execute an illegal jump at L85\n");
@@ -1224,6 +1271,8 @@ L19:
             // or vice versa then fix parameter again and increment k1 by i1
             if ((fA[i] >= fAMX[i] && fGr[i] < 0.) ||
                    (fA[i] <= fAMN[i] && fGr[i] > 0.)) {
+               if (fDEBUG)
+                  std::cout << "Fix parameters with values outside boundary and negative derivative " << std::endl;
                fPL[i] = 0.;
                k1 = k1 + i1; // i1 stands for fZ-matrix row-number multiplier
                ///  - skip this row
@@ -1248,6 +1297,7 @@ L19:
    }
 
    // INVERT fZ-matrix (mconvd() procedure)
+   // fZ stores lower diagonal part of symmetrix matrix
    i1 = 1;
    l  = 1;
    for( i = 0; i < n; i++) {// extract diagonal elements to fR-vector
@@ -1259,16 +1309,27 @@ L19:
    }
 
    n0 = i1 - 1;
+   if (fDEBUG)
+      PrintMatrix("Approximate Hessian matrix  ",n0,fZ);
+
    InvertZ(n0);
 
    // fZ matrix now is inverted
    if (fINDFLG[0] != 0) { // problems
+      if (fDEBUG)
+         std::cout << "Some problems inverting the matrix - go back and try reducing again" << std::endl;
       // some PLs now have negative values, try to reduce fZ-matrix again
       fINDFLG[0] = 0;
       fINDFLG[1] = 1; // errors can be infinite
       fixFLG = fixFLG + 1;
       fi = 0;
       goto L19;
+   }
+
+   if (fDEBUG) {
+      PrintMatrix("Approximate Covariance matrix (inverse of Hessian ) ",n0,fZ);
+      PrintVector("Current gradient",n,fGr);
+      PrintVector("Current step",n,fDA);
    }
 
    // ... CALCULATE THEORETICAL STEP TO MINIMUM
@@ -1291,6 +1352,9 @@ L19:
          i1=i1+1;
       }
    }
+   if (fDEBUG)
+      PrintVector("theoretical step (Newton)",n,fDA);
+
    //          ... CHECK FOR PARAMETERS ON BOUNDARY
 
    afix=0.;
@@ -1300,6 +1364,7 @@ L19:
    for( i = 0; i < n; i++)
       if (fPL[i] > .0) {
          sigi = TMath::Sqrt(TMath::Abs(fZ[l - 1])); // calculate \sqrt{Z^{-1}_{ii}}
+         // original fR is diagonal of Hessian (not inverted matrix)
          fR[i] = fR[i]*fZ[l - 1];      // Z_ii * Z^-1_ii
          if (fEPS > .0) fParamError[i]=sigi;
          if ((fA[i] >= fAMX[i] && fDA[i] > 0.) || (fA[i] <= fAMN[i]
@@ -1313,6 +1378,9 @@ L19:
                ifix=i;
                ifix1=i;
             }
+            if (fDEBUG)
+               std::cout << "Parameter " << i << " is outside bounds "
+                         << akap << "  " << afix << "  " << ifix << std::endl;
          }
          i1=i1+1;
          l=l+i1;
@@ -1323,6 +1391,10 @@ L19:
       fPL[ifix] = -1.;
       fixFLG = fixFLG + 1;
       fi = 0;
+
+      if (fDEBUG) {
+         std::cout << "Parameter " << ifix << " is the worst - fix it and repeat step calculation " << std::endl;
+      }
       //.. REPEAT CALCULATION OF THEORETICAL STEP AFTER fiXING EACH PARAMETER
       goto L19;
    }
@@ -1351,11 +1423,17 @@ L19:
          if ( bi > bm) {
             bi = bm;
             abi = abm;
+            if (fDEBUG)
+               std::cout << "Reduce parallelepide for "
+                        << i << " from " << fPL[i] << " to " << bi << std::endl;
          }
          // if calculated step is out of bounds
          if ( TMath::Abs(fDA[i]) > bi) {
             // decrease step splitter alambdA if needed
+            // by definition al is less than 1
             al = TMath::Abs(bi/fDA[i]);
+            if (fDEBUG)
+               std::cout << "step out of bound for  " << i <<  " reduce to " << al << std::endl;
             if (alambd > al) {
                imax=i;
                aiMAX=abi;
@@ -1367,6 +1445,9 @@ L19:
          if (akap > fAKAPPA) fAKAPPA=akap;
       }
    }
+
+   if (fDEBUG)
+      std::cout << "Compute now corrected step - min found correction factor " << alambd << " max of akappa " << fAKAPPA << " nn2 " << nn2 << std::endl;
    //... CALCULATE NEW CORRECTED STEP
    fGT = 0.;
    amb = 1.e18;
@@ -1376,6 +1457,8 @@ L19:
       if (fPL[i] > .0) {
          if (nn2 > fNlimMul ) {
             if (TMath::Abs(fDA[i]/fPL[i]) > amb ) {
+               if (fDEBUG)
+                  std::cout << "increase parallelipid 4-times for " << i << std::endl;
                fPL[i] = 4.*fPL[i]; // increase parallelepiped
                t1=4.; // flag - that fPL was increased
             }
@@ -1385,6 +1468,10 @@ L19:
          // expected function value change in next iteration
          fGT = fGT + fDA[i]*fGr[i];
       }
+   }
+   if (fDEBUG) {
+      PrintVector("Reduced step",n,fDA);
+      std::cout << "after applying step reduction of " << alambd << " expected function change is " << fGT << std::endl;
    }
 
    //.. CHECK IF MINIMUM ATTAINED AND SET EXIT MODE
@@ -1406,6 +1493,8 @@ L19:
                for( i = 0; i < fNpar; i++) fPL[i] = fPL0[i];
                fINDFLG[1] = 0;
                // and repeat iteration
+               if (fDEBUG)
+                  std::cout << "We have fixed some params - released and repeat " << std::endl;
                goto L19;
             } else {
                if( ifix1 >= 0) {
@@ -1466,6 +1555,8 @@ L19:
       }
       return fENDFLG - 1;
    }
+   if (fDEBUG)
+      std::cout << "Continue and repeat iteration " << std::endl;
    goto L3;
 }
 

--- a/math/fumili/src/TFumili.cxx
+++ b/math/fumili/src/TFumili.cxx
@@ -1178,7 +1178,7 @@ L4: // New iteration
    n0 = 0;
    for( i = 0; i < n; i++) {
       fGr[i]=0.; // zero gradients
-      if (fPL0[i] > .0) {   // fLO is negstive foa fixed parameters
+      if (fPL0[i] > .0) {   // fLO is negative for fixed parameters
          n0=n0+1;
          // new iteration - new parallelepiped
          if (fPL[i] > .0) fPL0[i]=fPL[i];

--- a/math/mathcore/inc/Math/MinimizerOptions.h
+++ b/math/mathcore/inc/Math/MinimizerOptions.h
@@ -201,6 +201,7 @@ public:
 
    /// return extra options (NULL pointer if they are not present)
    const IOptions * ExtraOptions() const { return fExtraOptions; }
+   IOptions * ExtraOptions() { return fExtraOptions; }
 
    /// type of minimizer
    const std::string & MinimizerType() const { return fMinimType; }

--- a/math/mathcore/src/FitConfig.cxx
+++ b/math/mathcore/src/FitConfig.cxx
@@ -241,8 +241,8 @@ std::string FitConfig::MinimizerName() const
    // set minimizer type
    std::string name = MinimizerType();
 
-   // append algorithm name for minimizer that support it
-   if ((name.find("Fumili") == std::string::npos) && (name.find("GSLMultiFit") == std::string::npos)) {
+   // append algorithm name for minimizer that support it (all except Fumili)
+   if ((name.find("Fumili") == std::string::npos)) {
       if (!MinimizerAlgoType().empty())
          name += " / " + MinimizerAlgoType();
    }

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -72,9 +72,8 @@ FitResult::FitResult(const FitConfig & fconfig) :
    // set minimizer type and algorithm
    fMinimType = fconfig.MinimizerType();
    // append algorithm name for minimizer that support it
-   if ( (fMinimType.find("Fumili") == std::string::npos) &&
-        (fMinimType.find("GSLMultiFit") == std::string::npos)
-      ) {
+   if ( (fMinimType.find("Fumili") == std::string::npos) )
+   {
       if (!fconfig.MinimizerAlgoType().empty()) fMinimType += " / " + fconfig.MinimizerAlgoType();
    }
 

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -46,6 +46,7 @@ namespace ROOT {
    namespace Math {
 
       class GSLMultiFit;
+      class GSLMultiFit2;
 
 //_____________________________________________________________________________________________________
 /**
@@ -61,9 +62,14 @@ class GSLNLSMinimizer : public  ROOT::Math::BasicMinimizer {
 public:
 
    /**
-      Default constructor
+      Constructor from a type
    */
-   GSLNLSMinimizer (int type = 0);
+   explicit GSLNLSMinimizer (int type);
+   /**
+      Constructor from name
+   */
+   explicit GSLNLSMinimizer (const char * = nullptr);
+
 
    /**
       Destructor (no operations)
@@ -116,8 +122,8 @@ protected:
 
    /// Internal method to perform minimization
    /// template on the type of method function
-   template<class Func>
-   bool DoMinimize(const Func & f);
+   template<class Func, class FitterType>
+   bool DoMinimize(const Func & f, FitterType * fitter);
 
 
 private:
@@ -126,7 +132,8 @@ private:
    unsigned int fNFree;      // dimension of the internal function to be minimized
    unsigned int fNCalls;        // number of function calls
 
-   ROOT::Math::GSLMultiFit * fGSLMultiFit;        // pointer to GSL multi fit solver
+   ROOT::Math::GSLMultiFit * fGSLMultiFit = nullptr;        // pointer to old GSL multi fit solver
+   ROOT::Math::GSLMultiFit2 * fGSLMultiFit2 = nullptr;       // pointer to new GSL multi fit driver
 
    double fEdm;                                   // edm value
    double fLSTolerance;                           // Line Search Tolerance

--- a/math/mathmore/src/GSLMultiFit.h
+++ b/math/mathmore/src/GSLMultiFit.h
@@ -115,6 +115,7 @@ public:
       if (npts == 0) return -1;
 
       unsigned int npar = funcVec[0].NDim();
+
       // Remove unused typedef to remove warning in GCC48
       // http://gcc.gnu.org/gcc-4.8/porting_to.html
       // typedef typename std::vector<Func>  FuncVec;
@@ -150,8 +151,7 @@ public:
    /// parameter values at the minimum
    const double * X() const {
       if (fSolver == nullptr) return nullptr;
-      gsl_vector * x =  gsl_multifit_fdfsolver_position(fSolver);
-      return x->data;
+      return fSolver->x->data;
    }
 
    /// gradient value at the minimum

--- a/math/mathmore/src/GSLMultiFit2.h
+++ b/math/mathmore/src/GSLMultiFit2.h
@@ -1,0 +1,388 @@
+// @(#)root/mathmore:$Id$
+// Author: L. Moneta Wed Dec 20 17:26:06 2006
+
+/**********************************************************************
+ *                                                                    *
+ * Copyright (c) 2006  LCG ROOT Math Team, CERN/PH-SFT                *
+ *                                                                    *
+ * This library is free software; you can redistribute it and/or      *
+ * modify it under the terms of the GNU General Public License        *
+ * as published by the Free Software Foundation; either version 2     *
+ * of the License, or (at your option) any later version.             *
+ *                                                                    *
+ * This library is distributed in the hope that it will be useful,    *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU   *
+ * General Public License for more details.                           *
+ *                                                                    *
+ * You should have received a copy of the GNU General Public License  *
+ * along with this library (see file COPYING); if not, write          *
+ * to the Free Software Foundation, Inc., 59 Temple Place, Suite      *
+ * 330, Boston, MA 02111-1307 USA, or contact the author.             *
+ *                                                                    *
+ **********************************************************************/
+
+// Header file for class GSLMultiFit
+
+#ifndef ROOT_Math_GSLMultiFit2
+#define ROOT_Math_GSLMultiFit2
+
+#include "gsl/gsl_vector.h"
+#include "gsl/gsl_matrix.h"
+#include "gsl/gsl_multifit_nlinear.h"
+#include "gsl/gsl_blas.h"
+#include "gsl/gsl_version.h"
+#include "GSLMultiFitFunctionWrapper.h"
+
+#include "Math/IFunction.h"
+#include "Math/MinimizerOptions.h"
+#include "Math/GenAlgoOptions.h"
+#include <string>
+#include <vector>
+#include <cassert>
+
+//#if GSL_MAJOR_VERSION > 1
+
+namespace ROOT {
+
+   namespace Math {
+
+
+/**
+   GSLMultiFit2, internal class for implementing GSL non linear least square GSL fitting
+   New class implementing new GSL non linear fitting methods introduced in GSL 2.2
+
+   @ingroup MultiMin
+*/
+class GSLMultiFit2 {
+
+
+public:
+
+   /**
+      Default constructor
+      No need to specify the type so far since only one solver exists so far
+   */
+   GSLMultiFit2 (int type = 0) :
+      //fSolver(0),
+      fVec(0),
+      //fTmp(0),
+      fCov(0)
+      //fJac(0)
+   {
+      fType = gsl_multifit_nlinear_trust; // default value (unique for the moment)
+      fParams = gsl_multifit_nlinear_default_parameters();
+      if (type == 1)  // lm
+         fParams.trs =  gsl_multifit_nlinear_trs_lm;
+      else if (type == 2)
+         fParams.trs =  gsl_multifit_nlinear_trs_lmaccel;
+      else if (type == 3)
+         fParams.trs =  gsl_multifit_nlinear_trs_dogleg;
+      else if (type == 4)
+         fParams.trs =  gsl_multifit_nlinear_trs_ddogleg;
+      else if (type == 5)
+         fParams.trs =  gsl_multifit_nlinear_trs_subspace2D;
+
+   }
+
+   ROOT::Math::GenAlgoOptions GetDefaultOptions() const
+   {
+      // set the extra minimizer options from GSLMultiFit
+      ROOT::Math::GenAlgoOptions opt;
+      opt.SetValue("scale", fParams.scale->name);
+      opt.SetValue("solver", fParams.solver->name);
+      opt.SetValue("fdtype", fParams.fdtype);
+      opt.SetValue("factor_up", fParams.factor_up);
+      opt.SetValue("factor_down", fParams.factor_down);
+      opt.SetValue("avmax", fParams.avmax);
+      opt.SetValue("h_df", fParams.h_df);
+      opt.SetValue("h_fvv", fParams.h_fvv);
+
+      return opt;
+   }
+
+   void SetParameters(const ROOT::Math::MinimizerOptions & minimOptions)
+   {
+      // set the parameters from the minimizer options
+      fPrintLevel = minimOptions.PrintLevel();
+      if (minimOptions.Tolerance() > 0) fTolerance = minimOptions.Tolerance();
+      if (minimOptions.MaxIterations() > 0) fMaxIter = minimOptions.MaxIterations();
+      // now specific options to set the specific GSL parameters
+      const ROOT::Math::IOptions  * opt = minimOptions.ExtraOptions();
+      if (!opt)
+         return;
+      std::string sval;
+      opt->GetValue("scale",sval);
+      if (sval == "more")
+         fParams.scale = gsl_multifit_nlinear_scale_more;
+      else if (sval == "levenberg")
+         fParams.scale = gsl_multifit_nlinear_scale_levenberg;
+      else if (sval == "marquardt")
+         fParams.scale = gsl_multifit_nlinear_scale_marquardt;
+      else {
+         if (fPrintLevel > 0)
+            std::cout << "GSLMultiFit2::SetParameters use default scale : "
+                  << fParams.scale->name << std::endl;
+      }
+      opt->GetValue("solver",sval);
+      if (sval == "qr")
+         fParams.solver = gsl_multifit_nlinear_solver_qr;
+      else if (sval == "cholesky")
+         fParams.solver = gsl_multifit_nlinear_solver_cholesky;
+#if ((GSL_MAJOR_VERSION >= 2) && (GSL_MINOR_VERSION > 5))
+      else if (sval == "mcholesky")
+         fParams.solver = gsl_multifit_nlinear_solver_mcholesky;
+#endif
+      else if (sval == "svd")
+         fParams.solver = gsl_multifit_nlinear_solver_svd;
+      else {
+          if (fPrintLevel > 0)
+            std::cout << "GSLMultiFit2::SetParameters use default solver : "
+                  << fParams.solver->name << std::endl;
+      }
+      double val;
+      opt->GetValue("factor_up",val);
+      fParams.factor_up = val;
+      opt->GetValue("factor_down",val);
+      fParams.factor_down = val;
+
+
+   }
+
+   /**
+      Destructor (no operations)
+   */
+   ~GSLMultiFit2 ()  {
+      if (fWs) gsl_multifit_nlinear_free(fWs);
+      if (fVec != 0) gsl_vector_free(fVec);
+      if (fCov != 0) gsl_matrix_free(fCov);
+   }
+
+   void PrintOptions() const {
+      std::cout << "GSLMultiFit: Parameters used for solving the non-linear fit problem" << std::endl;
+      std::cout << "\t\t Solver for trust region   : " << fParams.trs->name << std::endl;
+      std::cout << "\t\t Scaling method            : " << fParams.scale->name << std::endl;
+      std::cout << "\t\t Solver method for GN step : " << fParams.solver->name << std::endl;
+      std::cout << "\t\t Finite difference type    : " << fParams.fdtype << std::endl;
+      std::cout << "\t\t Factor TR up              : " << fParams.factor_up << std::endl;
+      std::cout << "\t\t Factor TR down            : " << fParams.factor_down << std::endl;
+      std::cout << "\t\t Max allowed |a|/|v|       : " << fParams.avmax << std::endl;
+      std::cout << "\t\t Step size for deriv       : " << fParams.h_df << std::endl;
+      std::cout << "\t\t Step size for fvv         : " << fParams.h_fvv << std::endl;
+      std::cout << "\t\t Max number of iterations  : " << fMaxIter << std::endl;
+      std::cout << "\t\t Tolerance                 : " << fTolerance << std::endl;
+   }
+
+private:
+   // usually copying is non trivial, so we make this unaccessible
+
+   /**
+      Copy constructor
+   */
+   GSLMultiFit2(const GSLMultiFit &) {}
+
+   /**
+      Assignment operator
+   */
+   GSLMultiFit2 & operator = (const GSLMultiFit2 & rhs)  {
+      if (this == &rhs) return *this;  // time saving self-test
+      return *this;
+   }
+
+
+public:
+
+
+   /// set the solver parameters
+   template<class Func>
+   int Set(const std::vector<Func> & funcVec, const double * x) {
+      // create a vector of the fit contributions
+      // create function wrapper from an iterator of functions
+      unsigned int npts = funcVec.size();
+      if (npts == 0) return -1;
+
+      unsigned int npar = funcVec[0].NDim();
+
+      // Remove unused typedef to remove warning in GCC48
+      // http://gcc.gnu.org/gcc-4.8/porting_to.html
+      // typedef typename std::vector<Func>  FuncVec;
+      //FuncIt funcIter = funcVec.begin();
+      SetFunction(funcVec, npts, npar);
+
+       // set initial values
+      if (fVec != 0) gsl_vector_free(fVec);
+      fVec = gsl_vector_alloc( npar );
+      std::copy(x,x+npar, fVec->data);
+
+      if (fCov != 0) gsl_matrix_free(fCov);
+      fCov = gsl_matrix_alloc( npar, npar );
+      return 0;
+   }
+
+   std::string Name() const {
+      if (fWs == nullptr) return "undefined";
+      return std::string(gsl_multifit_nlinear_name(fWs) );
+   }
+
+   int Iterate() {
+      return -1;
+   }
+
+
+   int Solve() {
+      int npts = fFunc.n;
+      int npar = fFunc.p;
+
+      if (fPrintLevel > 0)
+         PrintOptions();
+
+      /* allocate workspace with default parameters */
+      fWs = gsl_multifit_nlinear_alloc (fType, &fParams, npts, npar);
+
+      /* initialize solver with starting point and weights */
+      gsl_multifit_nlinear_init (fVec, &fFunc, fWs);
+      // in case of weights
+      //gsl_multifit_nlinear_winit (&x.vector, &wts.vector, &fdf, w);
+
+      /* compute initial cost function */
+      gsl_vector * f = gsl_multifit_nlinear_residual(fWs);
+      double chisq0;
+      gsl_blas_ddot(f, f, &chisq0);
+
+      // use slightly larger tolerance for gradient
+      const double xtol = fTolerance;
+      const double gtol = 10*fTolerance;
+      const double ftol = 0.0;
+
+      /* solve the system with a maximum of 100 iterations */
+      int info = 0;
+      void * callback_params = (fPrintLevel > 0) ? &fPrintLevel : nullptr;
+      int status = gsl_multifit_nlinear_driver(fMaxIter, xtol, gtol, ftol,
+                                       GSLMultiFit2::Callback, callback_params , &info, fWs);
+
+      /* compute covariance of best fit parameters */
+      fJac = gsl_multifit_nlinear_jac (fWs);
+      gsl_multifit_nlinear_covar (fJac, 0.0, fCov);
+
+     /* compute final cost */
+     double chisq;
+     gsl_blas_ddot(f, f, &chisq);
+
+      return status;
+
+   }
+
+   static void Callback(const size_t iter, void * params , const gsl_multifit_nlinear_workspace *w) {
+      // return in case of printLevel=0
+      if (params == nullptr) return;
+
+      gsl_vector *f = gsl_multifit_nlinear_residual(w);
+      gsl_vector *x = gsl_multifit_nlinear_position(w);
+      double rcond = 0;
+
+     /* compute reciprocal condition number of J(x) */
+      gsl_multifit_nlinear_rcond(&rcond, w);
+
+      printf("iter %2zu: x = {",iter);
+      for (unsigned int i = 0; i < x->size; i++)
+         printf(" %.4f,",gsl_vector_get(x, i));
+      printf(" } cond(J) = %8.4f, |f(x)| = %.4f\n",1.0 / rcond, gsl_blas_dnrm2(f));
+
+      // trust state is not accessible
+      //gsl_multifit_nlinear_trust_state * state = (gsl_multifit_nlinear_trust_state *) w->state;
+      printf("        step  :  = {");
+      for (unsigned int i = 0; i < w->dx->size; i++)
+         printf(" %.4f,",gsl_vector_get(w->dx, i));
+      printf("\n");
+      printf("        gradient  :  = {");
+      for (unsigned int i = 0; i < w->g->size; i++)
+         printf(" %.4f,",gsl_vector_get(w->g, i));
+      printf("\n");
+      //if (state) {
+      // printf("   diagonal : D = {");
+      // for (unsigned int i = 0; i < state->diag->size; i++)
+      //    printf(" %.4f,",gsl_vector_get(state->diag, i));
+      // }
+
+   }
+
+   int NIter() const {
+      return gsl_multifit_nlinear_niter(fWs);
+   }
+
+   /// parameter values at the minimum
+   const double * X() const {
+      if (!fWs) return nullptr;
+      gsl_vector * x =  gsl_multifit_nlinear_position(fWs);
+      return x->data;
+   }
+
+    /// return covariance matrix of the parameters
+   const double * CovarMatrix() const {
+      return (fCov) ? fCov->data : nullptr;
+   }
+
+   /// gradient value at the minimum
+   const double * Gradient() const {
+      return nullptr;
+   }
+
+   // this functions are not used (kept for keeping same interface as old GSLMultiFit class )
+   /// test gradient (ask from solver gradient vector)
+   int TestGradient(double /* absTol */ ) const {
+      return -1;
+   }
+
+   /// test using abs and relative tolerance
+   ///  |dx| < absTol + relTol*|x| for every component
+   int TestDelta(double /* absTol */, double /* relTol */) const {
+      return -1;
+   }
+
+   // calculate edm  1/2 * ( grad^T * Cov * grad )
+   double Edm() const {
+      return -1;
+   }
+
+protected:
+
+   template<class FuncVector>
+   void SetFunction(const FuncVector & f, unsigned int nres, unsigned int npar  ) {
+      const void * p = &f;
+      assert (p != 0);
+      fFunc.f   = &GSLMultiFitFunctionAdapter<FuncVector >::F;
+      // set to null for internal finite diff
+      fFunc.df  = &GSLMultiFitFunctionAdapter<FuncVector >::Df;
+      //fFunc.fdf = &GSLMultiFitFunctionAdapter<FuncVector >::FDf;
+      fFunc.fvv = NULL;     /* not using geodesic acceleration */
+      fFunc.n = nres;
+      fFunc.p = npar;
+      fFunc.params =  const_cast<void *>(p);
+   }
+
+private:
+
+   int fPrintLevel = 0;
+   int fMaxIter = 100;
+   double fTolerance = 1.E-6;
+   gsl_multifit_nlinear_fdf fFunc;
+   gsl_multifit_nlinear_workspace * fWs;
+   //gsl_multifit_fdfsolver * fSolver;
+   // cached vector to avoid re-allocating every time a new one
+   mutable gsl_vector * fVec;
+   //mutable gsl_vector * fTmp;
+   mutable gsl_matrix * fCov;
+   mutable gsl_matrix * fJac;
+
+   const gsl_multifit_nlinear_type * fType;
+   gsl_multifit_nlinear_parameters fParams;
+
+
+};
+
+   } // end namespace Math
+
+} // end namespace ROOT
+
+
+#endif /* ROOT_Math_GSLMultiFit2 */

--- a/math/mathmore/src/GSLMultiFitFunctionAdapter.h
+++ b/math/mathmore/src/GSLMultiFitFunctionAdapter.h
@@ -36,6 +36,7 @@
 
 #include "gsl/gsl_vector.h"
 #include "gsl/gsl_matrix.h"
+#include "gsl/gsl_matrix.h"
 
 #include <cassert>
 
@@ -109,12 +110,12 @@ public:
       if (npar == 0) return -2;
       FuncVector  & funcVec = *( reinterpret_cast< FuncVector *> (p) );
       assert ( f->size == n);
-      for (unsigned int i = 0; i < n ; ++i) {
-         assert ( npar == (funcVec[i]).NDim() );
+      for (unsigned int i = 0; i < n; ++i) {
+         assert(npar == (funcVec[i]).NDim());
          double fval = 0;
-         double * g = (h->data)+i*npar;   //pointer to start  of i-th row
+         double *g = (h->data) + i * npar; // pointer to start  of i-th row
          (funcVec[i]).FdF(x->data, fval, g);
-         gsl_vector_set(f, i, fval  );
+         gsl_vector_set(f, i, fval);
       }
       return 0;
    }

--- a/math/mathmore/src/GSLMultiFitFunctionWrapper.h
+++ b/math/mathmore/src/GSLMultiFitFunctionWrapper.h
@@ -49,7 +49,7 @@ namespace Math {
 
 
 /**
-   wrapper to a multi-dim function withtout  derivatives for multi-dimensional
+   wrapper to a multi-dim function without  derivatives for multi-dimensional
    minimization algorithm
 
    @ingroup MultiMin

--- a/math/mathmore/src/GSLNLSMinimizer.cxx
+++ b/math/mathmore/src/GSLNLSMinimizer.cxx
@@ -14,14 +14,15 @@
 
 #include "Math/MinimTransformFunction.h"
 #include "Math/MultiNumGradFunction.h"
+#include "Math/GenAlgoOptions.h"
 
 #include "Math/Error.h"
 #include "GSLMultiFit.h"
+#include "GSLMultiFit2.h"
 #include "gsl/gsl_errno.h"
 
-
 #include "Math/FitMethodFunction.h"
-//#include "Math/Derivator.h"
+// #include "Math/Derivator.h"
 
 #include <iostream>
 #include <iomanip>
@@ -29,94 +30,93 @@
 
 namespace ROOT {
 
-   namespace Math {
-
+namespace Math {
 
 /// Internal class used by GSLNLSMinimizer to implement the transformation of the chi2
 /// function used by GSL Non-linear Least-square fitting
 /// The class is template on the FitMethodFunction type to support both gradient and non
 /// gradient functions
-template<class FMFunc>
+template <class FMFunc>
 class FitTransformFunction : public FMFunc {
 
 public:
-
-   FitTransformFunction(const FMFunc & f, std::unique_ptr<MinimTransformFunction> transFunc ) :
-      FMFunc( f.NDim(), f.NPoints() ),
-      fFunc(f),
-      fTransform(std::move(transFunc)),
-      fGrad( std::vector<double>(f.NDim() ) )
+   FitTransformFunction(const FMFunc &f, std::unique_ptr<MinimTransformFunction> transFunc)
+      : FMFunc(f.NDim(), f.NPoints()), fFunc(f), fTransform(std::move(transFunc)), fGrad(std::vector<double>(f.NDim()))
    {
       // constructor from a given FitMethodFunction and  Transformation object.
       // Ownership of the transformation object is passed to this class
    }
 
-   virtual ~FitTransformFunction()  {
-   }
+   virtual ~FitTransformFunction() {}
 
    // re-implement data element
-   virtual double DataElement(const double *  x, unsigned i, double * g = nullptr, double * = nullptr, bool = false) const  {
+   virtual double DataElement(const double *x, unsigned i, double *g = nullptr, double * = nullptr, bool = false) const
+   {
       // transform from x internal to x external
-      const double * xExt = fTransform->Transformation(x);
-      if ( g == nullptr) return fFunc.DataElement( xExt, i );
+      const double *xExt = fTransform->Transformation(x);
+      if (g == nullptr)
+         return fFunc.DataElement(xExt, i);
       // use gradient
-      double val =  fFunc.DataElement( xExt, i, &fGrad[0]);
+      double val = fFunc.DataElement(xExt, i, &fGrad[0]);
       // transform gradient
-      fTransform->GradientTransformation( x, &fGrad.front(), g);
+      fTransform->GradientTransformation(x, &fGrad.front(), g);
       return val;
    }
 
-
-   virtual IMultiGenFunction * Clone() const {
+   virtual IMultiGenFunction *Clone() const
+   {
       // not supported
       return nullptr;
    }
 
    // dimension (this is number of free dimensions)
-   virtual unsigned int NDim() const  {
-      return fTransform->NDim();
-   }
+   virtual unsigned int NDim() const { return fTransform->NDim(); }
 
-   unsigned int NTot() const {
-      return fTransform->NTot();
-   }
+   unsigned int NTot() const { return fTransform->NTot(); }
+
+   virtual typename FMFunc::Type_t Type() const { return fFunc.Type(); }
 
    // forward of transformation functions
-   const double * Transformation( const double * x) const { return fTransform->Transformation(x); }
-
+   const double *Transformation(const double *x) const { return fTransform->Transformation(x); }
 
    /// inverse transformation (external -> internal)
-   void  InvTransformation(const double * xext,  double * xint) const { fTransform->InvTransformation(xext,xint); }
+   void InvTransformation(const double *xext, double *xint) const { fTransform->InvTransformation(xext, xint); }
 
    /// inverse transformation for steps (external -> internal) at external point x
-   void  InvStepTransformation(const double * x, const double * sext,  double * sint) const { fTransform->InvStepTransformation(x,sext,sint); }
-
-   ///transform gradient vector (external -> internal) at internal point x
-   void GradientTransformation(const double * x, const double *gext, double * gint) const   { fTransform->GradientTransformation(x,gext,gint); }
-
-   void MatrixTransformation(const double * x, const double *cint, double * cext) const { fTransform->MatrixTransformation(x,cint,cext); }
-
-private:
-
-   // objects of this class are not meant for copying or assignment
-   FitTransformFunction(const FitTransformFunction& rhs) = delete;
-   FitTransformFunction& operator=(const FitTransformFunction& rhs) = delete;
-
-   virtual double DoEval(const double * x) const  {
-      return fFunc( fTransform->Transformation(x) );
+   void InvStepTransformation(const double *x, const double *sext, double *sint) const
+   {
+      fTransform->InvStepTransformation(x, sext, sint);
    }
 
-   virtual double DoDerivative(const double * /* x */, unsigned int /*icoord*/) const  {
+   /// transform gradient vector (external -> internal) at internal point x
+   void GradientTransformation(const double *x, const double *gext, double *gint) const
+   {
+      fTransform->GradientTransformation(x, gext, gint);
+   }
+
+   void MatrixTransformation(const double *x, const double *cint, double *cext) const
+   {
+      fTransform->MatrixTransformation(x, cint, cext);
+   }
+
+private:
+   // objects of this class are not meant for copying or assignment
+   FitTransformFunction(const FitTransformFunction &rhs) = delete;
+   FitTransformFunction &operator=(const FitTransformFunction &rhs) = delete;
+
+   virtual double DoEval(const double *x) const { return fFunc(fTransform->Transformation(x)); }
+
+   virtual double DoDerivative(const double * /* x */, unsigned int /*icoord*/) const
+   {
       // not used
       throw std::runtime_error("FitTransformFunction::DoDerivative");
       return 0;
    }
 
    bool fOwnTransformation;
-   const FMFunc & fFunc;                  // pointer to original fit method function
-   std::unique_ptr<MinimTransformFunction> fTransform;        // pointer to transformation function
-   mutable std::vector<double> fGrad;          // cached vector of gradient values
-
+   const FMFunc &fFunc;                                // pointer to original fit method function
+   std::unique_ptr<MinimTransformFunction> fTransform; // pointer to transformation function
+   mutable std::vector<double> fGrad;                  // cached vector of gradient values
 };
 
 //________________________________________________________________________________
@@ -131,111 +131,133 @@ private:
 
     @ingroup MultiMin
 */
-template<class Func>
+template <class Func>
 class LSResidualFunc : public IMultiGradFunction {
 public:
+   // default ctor (required by CINT)
+   LSResidualFunc() : fIndex(0), fChi2(0) {}
 
-   //default ctor (required by CINT)
-   LSResidualFunc() : fIndex(0), fChi2(0)
-   {}
-
-
-   LSResidualFunc(const Func & func, unsigned int i) :
-      fIndex(i),
-      fChi2(&func)
-   {}
-
+   LSResidualFunc(const Func &func, unsigned int i) : fIndex(i), fChi2(&func) {}
 
    // copy ctor
-   LSResidualFunc(const LSResidualFunc<Func> & rhs) :
-      IMultiGenFunction(),
-      IMultiGradFunction()
-   {
-      operator=(rhs);
-   }
+   LSResidualFunc(const LSResidualFunc<Func> &rhs) : IMultiGenFunction(), IMultiGradFunction() { operator=(rhs); }
 
    // assignment
-   LSResidualFunc<Func> & operator= (const LSResidualFunc<Func> & rhs)
+   LSResidualFunc<Func> &operator=(const LSResidualFunc<Func> &rhs)
    {
       fIndex = rhs.fIndex;
       fChi2 = rhs.fChi2;
       return *this;
    }
 
-   IMultiGenFunction * Clone() const override {
-      return new LSResidualFunc<Func>(*fChi2,fIndex);
-   }
+   IMultiGenFunction *Clone() const override { return new LSResidualFunc<Func>(*fChi2, fIndex); }
 
    unsigned int NDim() const override { return fChi2->NDim(); }
 
-   void Gradient( const double * x, double * g) const override {
+   void Gradient(const double *x, double *g) const override
+   {
       double f0 = 0;
-      FdF(x,f0,g);
+      FdF(x, f0, g);
    }
 
-   void FdF (const double * x, double & f, double * g) const override {
-      f = fChi2->DataElement(x,fIndex,g);
-      // for likelihood fits need to rescale g ??
-      // if (fChi2->Type() == Func::kPoissonLikelihood) {
-      //    f *= -1;
-      //    for (unsigned int i = 0; i < NDim(); i++)
-      //       g[i] *= -1.; // /= f;
-      // }
-   }
+   bool IsLSType() const { return fChi2->Type() == fChi2->kLeastSquare; }
 
+   void FdF(const double *x, double &f, double *g) const override { f = fChi2->DataElement(x, fIndex, g); }
 
 private:
+   double DoEval(const double *x) const override { return fChi2->DataElement(x, fIndex, nullptr); }
 
-   double DoEval (const double * x) const override {
-      return fChi2->DataElement(x, fIndex, nullptr);
-   }
-
-   double DoDerivative(const double * /* x */, unsigned int /* icoord */) const override {
-      //this function should not be called by GSL
+   double DoDerivative(const double * /* x */, unsigned int /* icoord */) const override
+   {
+      // this function should not be called by GSL
       throw std::runtime_error("LSRESidualFunc::DoDerivative");
       return 0;
    }
 
    unsigned int fIndex;
-   const Func * fChi2;
+   const Func *fChi2;
 };
 
+int GetTypeFromName(const char *name)
+{
+   std::string tName(name);
+   if (tName.empty())
+      return 0;
+   if (tName == "lms_old")
+      return 1;
+   if (tName == "lm_old")
+      return 2;
+   if (tName == "trust")
+      return 3;
+   if (tName == "trust_lm")
+      return 4;
+   if (tName == "trust_lmaccel")
+      return 5;
+   if (tName == "trust_dogleg")
+      return 6;
+   if (tName == "trust_ddogleg")
+      return 7;
+   if (tName == "trust_subspace2D" || tName == "trust_2D")
+      return 8;
+   return 0;
+}
 
 // GSLNLSMinimizer implementation
+GSLNLSMinimizer::GSLNLSMinimizer(const char *name) : GSLNLSMinimizer(GetTypeFromName(name)) {}
 
-GSLNLSMinimizer::GSLNLSMinimizer( int type )
+GSLNLSMinimizer::GSLNLSMinimizer(int type)
 {
    // Constructor implementation : create GSLMultiFit wrapper object
-   const gsl_multifit_fdfsolver_type * gsl_type = nullptr; // use default type defined in GSLMultiFit
-   if (type == 1) gsl_type =   gsl_multifit_fdfsolver_lmsder; // scaled lmder version
-   if (type == 2) gsl_type =   gsl_multifit_fdfsolver_lmder; // unscaled version
+   const gsl_multifit_fdfsolver_type *gsl_old_type = nullptr; // use default type defined in GSLMultiFit
+   if (type == 1)
+      gsl_old_type = gsl_multifit_fdfsolver_lmsder; // scaled lmder version
+   if (type == 2)
+      gsl_old_type = gsl_multifit_fdfsolver_lmder; // unscaled version
 
-   fGSLMultiFit = new GSLMultiFit( gsl_type );
+   // const gsl_multifit_nlinear_type * gsl_new_type = nullptr; //
+   // if (type == 3) gsl_new_type =   gsl_multifit_nlinear_trust; // trust region default
+
+   if (gsl_old_type)
+      fGSLMultiFit = new GSLMultiFit(gsl_old_type);
+   else
+      fGSLMultiFit2 = new GSLMultiFit2(type - 3);
 
    fEdm = -1;
 
    // default tolerance and max iterations
    int niter = ROOT::Math::MinimizerOptions::DefaultMaxIterations();
-   if (niter <= 0) niter = 100;
+   if (niter <= 0)
+      niter = 100;
    SetMaxIterations(niter);
 
    fLSTolerance = ROOT::Math::MinimizerOptions::DefaultTolerance();
-   if (fLSTolerance <=0) fLSTolerance = 0.0001; // default internal value
+   if (fLSTolerance <= 0)
+      fLSTolerance = 0.0001; // default internal value
 
    SetPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel());
+
+   // set the default options
+   if (fGSLMultiFit2) {
+      fOptions.SetExtraOptions(fGSLMultiFit2->GetDefaultOptions());
+      if (type == 0 || type == 3)
+         fOptions.SetMinimizerAlgorithm("trust_lm");
+
+      fOptions.ExtraOptions()->SetValue("scale", "marquardt");
+   }
 }
 
-GSLNLSMinimizer::~GSLNLSMinimizer () {
-   assert(fGSLMultiFit != nullptr);
-   delete fGSLMultiFit;
+GSLNLSMinimizer::~GSLNLSMinimizer()
+{
+   if (fGSLMultiFit)
+      delete fGSLMultiFit;
+   if (fGSLMultiFit2)
+      delete fGSLMultiFit2;
 }
 
-
-
-void GSLNLSMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction & func) {
+void GSLNLSMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction &func)
+{
    // set the function to minimizer
    // need to create vector of functions to be passed to GSL multifit
-   // support now only CHi2 implementation
 
    // call base class method. It will clone the function and set number of dimensions
    BasicMinimizer::SetFunction(func);
@@ -243,32 +265,57 @@ void GSLNLSMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction & func) {
    fUseGradFunction = func.HasGradient();
 }
 
-
-bool GSLNLSMinimizer::Minimize() {
+bool GSLNLSMinimizer::Minimize()
+{
 
    if (ObjFunction() == nullptr) {
-      MATH_ERROR_MSG("GSLNLSMinimizer::Minimize","Function has not been  set");
+      MATH_ERROR_MSG("GSLNLSMinimizer::Minimize", "Function has not been  set");
       return false;
    }
    // check type of function (if it provides gradient)
    auto fitFunc = (!fUseGradFunction) ? dynamic_cast<const ROOT::Math::FitMethodFunction *>(ObjFunction()) : nullptr;
-   auto fitGradFunc = (fUseGradFunction) ? dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(ObjFunction()) : nullptr;
+   auto fitGradFunc =
+      (fUseGradFunction) ? dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(ObjFunction()) : nullptr;
    if (fitFunc == nullptr && fitGradFunc == nullptr) {
-      if (PrintLevel() > 0) std::cout << "GSLNLSMinimizer: Invalid function set - only FitMethodFunction types are supported" << std::endl;
+      if (PrintLevel() > 0)
+         std::cout << "GSLNLSMinimizer: Invalid function set - only FitMethodFunction types are supported" << std::endl;
       return false;
    }
 
-   if (fitGradFunc)
-      return DoMinimize<ROOT::Math::FitMethodGradFunction>(*fitGradFunc);
-   else
-      return DoMinimize<ROOT::Math::FitMethodFunction>(*fitFunc);
+   if (fGSLMultiFit) {
+
+      if (PrintLevel() > 0)
+         std::cout << "GLSNLSMinimizer::Minimize - Using old GSLMultiFit with method " << fOptions.MinimizerAlgorithm()
+                << std::endl;
+
+      if (fitGradFunc)
+         return DoMinimize<ROOT::Math::FitMethodGradFunction, GSLMultiFit>(*fitGradFunc, fGSLMultiFit);
+      else
+         return DoMinimize<ROOT::Math::FitMethodFunction, GSLMultiFit>(*fitFunc, fGSLMultiFit);
+   }
+   if (fGSLMultiFit2) {
+
+      // set specific minimizer parameters
+      fGSLMultiFit2->SetParameters(fOptions);
+
+      if (PrintLevel() > 0)
+         std::cout << "GLSNLSMinimizer::Minimize - Using new GSLMultiFit with trs method " << fOptions.MinimizerAlgorithm()
+                << std::endl;
+
+      if (fitGradFunc)
+         return DoMinimize<ROOT::Math::FitMethodGradFunction, GSLMultiFit2>(*fitGradFunc, fGSLMultiFit2);
+      else
+         return DoMinimize<ROOT::Math::FitMethodFunction, GSLMultiFit2>(*fitFunc, fGSLMultiFit2);
+   }
+   return false;
 }
 
-template<class Func>
-bool GSLNLSMinimizer::DoMinimize(const Func & fitFunc) {
+template <class Func, class FitterType>
+bool GSLNLSMinimizer::DoMinimize(const Func &fitFunc, FitterType *fitter)
+{
 
    unsigned int size = fitFunc.NPoints();
-   fNCalls = 0;  // reset number of function calls
+   fNCalls = 0; // reset number of function calls
 
    std::vector<LSResidualFunc<Func>> residualFuncs;
    residualFuncs.reserve(size);
@@ -276,13 +323,11 @@ bool GSLNLSMinimizer::DoMinimize(const Func & fitFunc) {
    // set initial parameters of the minimizer
    int debugLevel = PrintLevel();
 
-   assert (fGSLMultiFit != nullptr);
-
    unsigned int npar = NPar();
    unsigned int ndim = NDim();
    if (npar == 0 || npar < ndim) {
-       MATH_ERROR_MSGVAL("GSLNLSMinimizer::Minimize","Wrong number of parameters",npar);
-       return false;
+      MATH_ERROR_MSGVAL("GSLNLSMinimizer::Minimize", "Wrong number of parameters", npar);
+      return false;
    }
 
    // set residual functions and check if a transformation is needed
@@ -294,152 +339,167 @@ bool GSLNLSMinimizer::DoMinimize(const Func & fitFunc) {
    if (!fUseGradFunction) {
       gradFunction = std::make_unique<MultiNumGradFunction>(fitFunc);
       trFuncRaw.reset(CreateTransformation(startValues, gradFunction.get()));
-   }
-   else {
+   } else {
       // use pointer stored in BasicMinimizer
       trFuncRaw.reset(CreateTransformation(startValues));
    }
    // need to transform in a FitTransformFunction which is set in the residual functions
    std::unique_ptr<FitTransformFunction<Func>> trFunc;
    if (trFuncRaw) {
-      //pass ownership of trFuncRaw to FitTransformFunction
+      // pass ownership of trFuncRaw to FitTransformFunction
       trFunc = std::make_unique<FitTransformFunction<Func>>(fitFunc, std::move(trFuncRaw));
-      assert(npar == trFunc->NTot() );
+      assert(npar == trFunc->NTot());
       for (unsigned int ires = 0; ires < size; ++ires) {
          residualFuncs.emplace_back(LSResidualFunc<Func>(*trFunc, ires));
       }
-   }  else {
+   } else {
       for (unsigned int ires = 0; ires < size; ++ires) {
-        residualFuncs.emplace_back( LSResidualFunc<Func>(fitFunc, ires) );
+         residualFuncs.emplace_back(LSResidualFunc<Func>(fitFunc, ires));
       }
    }
 
-   if (debugLevel >=1 ) std::cout <<"Minimize using GSLNLSMinimizer "  << std::endl;
+   if (debugLevel >= 1)
+      std::cout << "Minimize using GSLNLSMinimizer " << std::endl;
 
-
-   int iret = fGSLMultiFit->Set( residualFuncs, &startValues.front() );
+   int iret = fitter->Set(residualFuncs, &startValues.front());
 
    if (iret) {
-      MATH_ERROR_MSGVAL("GSLNLSMinimizer::Minimize","Error setting the residual functions ",iret);
+      MATH_ERROR_MSGVAL("GSLNLSMinimizer::Minimize", "Error setting the residual functions ", iret);
       return false;
    }
 
-   if (debugLevel >=1 ) std::cout <<"GSLNLSMinimizer: " << fGSLMultiFit->Name() << " - start iterating......... "  << std::endl;
-
-   // start iteration
-   unsigned  int iter = 0;
-   int status;
+   int status = 0;
    bool minFound = false;
-   do {
-      status = fGSLMultiFit->Iterate();
+   unsigned int iter = 0;
+   if (fGSLMultiFit) {
+      // case of using old solver
 
-      if (debugLevel >=1) {
-         std::cout << "----------> Iteration " << iter << " / " << MaxIterations() << " status " << gsl_strerror(status)  << std::endl;
-         const double * x = fGSLMultiFit->X();
-         if (trFunc) x = trFunc->Transformation(x);
-         int pr = std::cout.precision(18);
-         std::cout << "            FVAL = " << (fitFunc)(x) << std::endl;
-         std::cout.precision(pr);
-         std::cout << "            X Values : ";
-         for (unsigned int i = 0; i < NDim(); ++i)
-            std::cout << " " << VariableName(i) << " = " << X()[i];
-         std::cout << std::endl;
-      }
+      if (debugLevel >= 1)
+         std::cout << "GSLNLSMinimizer: " << fGSLMultiFit->Name() << " - start iterating......... " << std::endl;
 
-      if (status) break;
+      // start iteration
+      do {
+         status = fitter->Iterate();
 
-      // check also the delta in X()
-      status = fGSLMultiFit->TestDelta( Tolerance(), Tolerance() );
-      if (status == GSL_SUCCESS) {
+         if (debugLevel >= 1) {
+            std::cout << "----------> Iteration " << iter << " / " << MaxIterations() << " status "
+                      << gsl_strerror(status) << std::endl;
+            const double *x = fitter->X();
+            if (trFunc)
+               x = trFunc->Transformation(x);
+            int pr = std::cout.precision(18);
+            std::cout << "            FVAL = " << (fitFunc)(x) << std::endl;
+            std::cout.precision(pr);
+            std::cout << "            X Values : ";
+            for (unsigned int i = 0; i < NDim(); ++i)
+               std::cout << " " << VariableName(i) << " = " << x[i];
+            std::cout << std::endl;
+         }
+
+         if (status)
+            break;
+
+         // check also the delta in X()
+         status = fitter->TestDelta(Tolerance(), Tolerance());
+         if (status == GSL_SUCCESS) {
+            minFound = true;
+         }
+
+         // double-check with the gradient
+         int status2 = fitter->TestGradient(Tolerance());
+         if (minFound && status2 != GSL_SUCCESS) {
+            // check now edm
+            fEdm = fitter->Edm();
+            if (fEdm > Tolerance()) {
+               // continue the iteration
+               status = status2;
+               minFound = false;
+            }
+         }
+
+         if (debugLevel >= 1) {
+            std::cout << "          after Gradient and Delta tests:  " << gsl_strerror(status);
+            if (fEdm > 0)
+               std::cout << ", edm is:  " << fEdm;
+            std::cout << std::endl;
+         }
+
+         iter++;
+
+      } while (status == GSL_CONTINUE && iter < MaxIterations());
+
+      // check edm
+      fEdm = fitter->Edm();
+      if (fEdm < Tolerance()) {
          minFound = true;
       }
 
-      // double-check with the gradient
-      int status2 = fGSLMultiFit->TestGradient( Tolerance() );
-      if ( minFound && status2 != GSL_SUCCESS) {
-         // check now edm
-         fEdm = fGSLMultiFit->Edm();
-         if (fEdm > Tolerance() ) {
-            // continue the iteration
-            status = status2;
-            minFound = false;
-         }
-      }
-
-      if (debugLevel >=1) {
-         std::cout  << "          after Gradient and Delta tests:  " << gsl_strerror(status);
-         if (fEdm > 0) std::cout << ", edm is:  " << fEdm;
-         std::cout << std::endl;
-      }
-
-      iter++;
-
-   }
-   while (status == GSL_CONTINUE && iter < MaxIterations() );
-
-   // check edm
-   fEdm = fGSLMultiFit->Edm();
-   if ( fEdm < Tolerance() ) {
-      minFound = true;
+   } else if (fGSLMultiFit2) {
+      // case using new solver and given driver
+      status = fGSLMultiFit2->Solve();
+      if (status == GSL_SUCCESS)
+         minFound = true;
+      iter = fGSLMultiFit2->NIter();
    }
 
    // save state with values and function value
-   const double * x = fGSLMultiFit->X();
-   if (x == nullptr) return false;
+   const double *x = fitter->X();
+   if (x == nullptr)
+      return false;
    // apply transformation outside SetFinalValues(..)
    // because trFunc is not a MinimTransformFunction but a FitTransFormFunction
-   if (trFunc)  x = trFunc->Transformation(x);
+   if (trFunc)
+      x = trFunc->Transformation(x);
    SetFinalValues(x);
 
-   SetMinValue( (fitFunc)(x) );
+   SetMinValue((fitFunc)(x));
    fStatus = status;
    fNCalls = fitFunc.NCalls();
    fErrors.resize(NDim());
 
    // get errors from cov matrix
-   const double * cov =  fGSLMultiFit->CovarMatrix();
+   const double *cov = fitter->CovarMatrix();
    if (cov) {
 
-      fCovMatrix.resize(ndim*ndim);
+      fCovMatrix.resize(ndim * ndim);
 
       if (trFunc) {
-         trFunc->MatrixTransformation(x, fGSLMultiFit->CovarMatrix(), fCovMatrix.data() );
-      }
-      else {
-         std::copy(cov, cov + fCovMatrix.size(), fCovMatrix.begin() );
+         trFunc->MatrixTransformation(x, fitter->CovarMatrix(), fCovMatrix.data());
+      } else {
+         std::copy(cov, cov + fCovMatrix.size(), fCovMatrix.begin());
       }
 
       for (unsigned int i = 0; i < ndim; ++i)
-         fErrors[i] = std::sqrt(fCovMatrix[i*ndim + i]);
+         fErrors[i] = std::sqrt(fCovMatrix[i * ndim + i]);
    }
 
    if (minFound) {
 
-      if (debugLevel >=1 ) {
+      if (debugLevel >= 1) {
          std::cout << "GSLNLSMinimizer: Minimum Found" << std::endl;
          int pr = std::cout.precision(18);
          std::cout << "FVAL         = " << MinValue() << std::endl;
-         std::cout << "Edm          = " << fEdm    << std::endl;
+         std::cout << "Edm          = " << fEdm << std::endl;
          std::cout.precision(pr);
          std::cout << "NIterations  = " << iter << std::endl;
          std::cout << "NFuncCalls   = " << fitFunc.NCalls() << std::endl;
          for (unsigned int i = 0; i < NDim(); ++i)
-            std::cout << std::setw(12) <<  VariableName(i) << " = " << std::setw(12) << X()[i] << "   +/-   " << std::setw(12) << fErrors[i] << std::endl;
+            std::cout << std::setw(12) << VariableName(i) << " = " << std::setw(12) << X()[i] << "   +/-   "
+                      << std::setw(12) << fErrors[i] << std::endl;
       }
 
       return true;
-   }
-   else {
-      if (debugLevel >=0 ) {
+   } else {
+      if (debugLevel >= 0) {
          std::cout << "GSLNLSMinimizer: Minimization did not converge: " << std::endl;
          if (status == GSL_ENOPROG) // case status 27
             std::cout << "\t iteration is not making progress towards solution" << std::endl;
          else
             std::cout << "\t failed with status " << status << std::endl;
       }
-      if (debugLevel >=1 ) {
+      if (debugLevel >= 1) {
          std::cout << "FVAL         = " << MinValue() << std::endl;
-         std::cout << "Edm   = " << fGSLMultiFit->Edm() << std::endl;
+         std::cout << "Edm   = " << fitter->Edm() << std::endl;
          std::cout << "Niterations  = " << iter << std::endl;
       }
       return false;
@@ -447,31 +507,35 @@ bool GSLNLSMinimizer::DoMinimize(const Func & fitFunc) {
    return false;
 }
 
-const double * GSLNLSMinimizer::MinGradient() const {
-   // return gradient (internal values)
-   return fGSLMultiFit->Gradient();
+const double *GSLNLSMinimizer::MinGradient() const
+{
+   // return gradient (internal values) - only when using old fitter
+   return (fGSLMultiFit) ? fGSLMultiFit->Gradient() : nullptr;
 }
 
-
-double GSLNLSMinimizer::CovMatrix(unsigned int i , unsigned int j ) const {
+double GSLNLSMinimizer::CovMatrix(unsigned int i, unsigned int j) const
+{
    // return covariance matrix element
    unsigned int ndim = NDim();
-   if ( fCovMatrix.empty()) return 0;
-   if (i > ndim || j > ndim) return 0;
-   return fCovMatrix[i*ndim + j];
+   if (fCovMatrix.empty())
+      return 0;
+   if (i > ndim || j > ndim)
+      return 0;
+   return fCovMatrix[i * ndim + j];
 }
 
-int GSLNLSMinimizer::CovMatrixStatus( ) const {
+int GSLNLSMinimizer::CovMatrixStatus() const
+{
    // return covariance  matrix status = 0 not computed,
    // 1 computed but is approximate because minimum is not valid, 3 is fine
-   if ( fCovMatrix.empty()) return 0;
+   if (fCovMatrix.empty())
+      return 0;
    // case minimization did not finished correctly
-   if (fStatus != GSL_SUCCESS) return 1;
+   if (fStatus != GSL_SUCCESS)
+      return 1;
    return 3;
 }
 
-
-   } // end namespace Math
+} // end namespace Math
 
 } // end namespace ROOT
-

--- a/math/minuit2/inc/Minuit2/FumiliBuilder.h
+++ b/math/minuit2/inc/Minuit2/FumiliBuilder.h
@@ -40,9 +40,15 @@ section 5
 class FumiliBuilder : public MinimumBuilder {
 
 public:
+
+   enum FumiliMethodType { kLineSearch = 0, kTrustRegion = 1, kTrustRegionScaled = 2};
+
+
    FumiliBuilder() : fEstimator(VariableMetricEDMEstimator()), fErrorUpdator(FumiliErrorUpdator()) {}
 
    ~FumiliBuilder() override {}
+
+   void SetMethod(FumiliMethodType type) { fMethodType = type;}
 
    /**
 
@@ -131,6 +137,7 @@ public:
 private:
    VariableMetricEDMEstimator fEstimator;
    FumiliErrorUpdator fErrorUpdator;
+   FumiliMethodType fMethodType;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FumiliBuilder.h
+++ b/math/minuit2/inc/Minuit2/FumiliBuilder.h
@@ -137,7 +137,7 @@ public:
 private:
    VariableMetricEDMEstimator fEstimator;
    FumiliErrorUpdator fErrorUpdator;
-   FumiliMethodType fMethodType;
+   FumiliMethodType fMethodType = kTrustRegion;   // use Trust region as default method
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FumiliFCNAdapter.h
+++ b/math/minuit2/inc/Minuit2/FumiliFCNAdapter.h
@@ -54,13 +54,9 @@ public:
 
    void SetErrorDef(double up) override { fUp = up; }
 
-   // virtual std::vector<double> Gradient(std::vector<double> const &) const;
-
-   // forward interface
-   // virtual double operator()(int npar, double* params,int iflag = 4) const;
 
    /**
-       evaluate gradient hessian and function value needed by fumili
+       evaluate gradient hessian and function value needed by Fumili
      */
    void EvaluateAll(std::vector<double> const &v) override;
 
@@ -130,7 +126,7 @@ void FumiliFCNAdapter<Function>::EvaluateAll(std::vector<double> const &v)
    } else if (fFunc.Type() == Function::kPoissonLikelihood) {
       print.Debug("Poisson Likelihood FCN: Evaluate gradient and Hessian");
       // for Poisson need Hessian computed in DataElement since one needs the bin expected value ad bin observed value
-     for (unsigned int i = 0; i < ndata; ++i) {
+      for (unsigned int i = 0; i < ndata; ++i) {
          // calculate data element and gradient
          fFunc.DataElement(&v.front(), i, gf.data(), h.data());
          for (size_t j = 0; j < npar; ++j) {
@@ -140,7 +136,7 @@ void FumiliFCNAdapter<Function>::EvaluateAll(std::vector<double> const &v)
                hess[idx] += h[idx];
             }
          }
-     }
+      }
    } else {
       print.Error("Type of fit method is not supported, it must be chi2 or log-likelihood or Poisson Likelihood");
    }

--- a/math/minuit2/inc/Minuit2/FumiliFCNBase.h
+++ b/math/minuit2/inc/Minuit2/FumiliFCNBase.h
@@ -70,7 +70,6 @@ public:
    {
    }
 
-   //   FumiliFCNBase(const ParametricFunction& modelFCN) { fModelFunction = &modelFCN; }
 
    ~FumiliFCNBase() override {}
 

--- a/math/minuit2/inc/Minuit2/FumiliMinimizer.h
+++ b/math/minuit2/inc/Minuit2/FumiliMinimizer.h
@@ -86,6 +86,13 @@ public:
    FunctionMinimum Minimize(const FCNBase &, const MnUserParameterState &, const MnStrategy &, unsigned int maxfcn = 0,
                             double toler = 0.1) const override;
 
+   // set the type of Fumili method to use, possible values are:
+   //  LineSearch based : method  = "ls"
+   //  Trust region : method = "tr"
+   //  Scaled trust region: method  = "trs"
+   void SetMethod(const std::string & method);
+
+
    using ModularFunctionMinimizer::Minimize;
 
 private:

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -38,20 +38,24 @@ public:
    };
 
 public:
-   MinimumError(unsigned int n) : fPtr{new Data{{n}, 1.0, MnUnset}} {}
+   MinimumError(unsigned int n) : fPtr{new Data{{n}, {0}, 1.0, MnUnset}} {}
 
-   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, dcov, MnPosDef}} {}
+   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, {0}, dcov, MnPosDef}} {}
 
-   MinimumError(const MnAlgebraicSymMatrix &mat, Status status) : fPtr{new Data{mat, 1.0, status}} {}
+   MinimumError(const MnAlgebraicSymMatrix &mat, const MnAlgebraicSymMatrix &hess, double dcov) : fPtr{new Data{mat, hess, dcov, MnPosDef}} {}
+
+   MinimumError(const MnAlgebraicSymMatrix &mat, Status status) : fPtr{new Data{mat, {0}, 1.0, status}} {}
 
    MnAlgebraicSymMatrix Matrix() const { return 2. * fPtr->fMatrix; } // why *2 ?
 
    const MnAlgebraicSymMatrix &InvHessian() const { return fPtr->fMatrix; }
 
    // calculate invert of matrix. Used to compute Hessian  by inverting matrix
-   MnAlgebraicSymMatrix Hessian() const
+   const MnAlgebraicSymMatrix & Hessian() const
    {
-      return InvertMatrix(fPtr->fMatrix);
+      if (fPtr->fHessian.size() == 0)
+         fPtr->fHessian = InvertMatrix(fPtr->fMatrix);
+      return fPtr->fHessian;
    }
 
    static MnAlgebraicSymMatrix InvertMatrix(const MnAlgebraicSymMatrix & matrix, int & ifail) {
@@ -89,6 +93,7 @@ public:
 private:
    struct Data {
       MnAlgebraicSymMatrix fMatrix;
+      MnAlgebraicSymMatrix fHessian;  // optional stored also Hessian (used in Fumili)
       double fDCovar;
       Status fStatus;
    };

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -90,7 +90,7 @@ public:
    bool HasReachedCallLimit() const { return GetStatus() == MnReachedCallLimit; }
    bool IsAvailable() const { return GetStatus() != MnUnset; }
 
-private:
+public:
    struct Data {
       MnAlgebraicSymMatrix fMatrix;
       MnAlgebraicSymMatrix fHessian;  // optional stored also Hessian (used in Fumili)

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -90,7 +90,7 @@ public:
    bool HasReachedCallLimit() const { return GetStatus() == MnReachedCallLimit; }
    bool IsAvailable() const { return GetStatus() != MnUnset; }
 
-public:
+private:
    struct Data {
       MnAlgebraicSymMatrix fMatrix;
       MnAlgebraicSymMatrix fHessian;  // optional stored also Hessian (used in Fumili)

--- a/math/minuit2/inc/Minuit2/MinimumSeed.h
+++ b/math/minuit2/inc/Minuit2/MinimumSeed.h
@@ -23,6 +23,7 @@ namespace Minuit2 {
 class MinimumSeed {
 
 public:
+
    MinimumSeed(const MinimumState &state, const MnUserTransformation &trafo) : fPtr{new Data{state, trafo, true}} {}
 
    const MinimumState &State() const { return fPtr->fState; }

--- a/math/minuit2/src/FumiliBuilder.cxx
+++ b/math/minuit2/src/FumiliBuilder.cxx
@@ -96,6 +96,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
 
       // call always Hesse (error matrix from Fumili is never accurate since is approximate)
 
+      if (strategy.Strategy() > 0) {
       print.Debug("FumiliBuilder will verify convergence and Error matrix; "
                   "dcov",
                   min.Error().Dcovar());
@@ -117,6 +118,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
       edm = st.Edm();
 
       print.Debug("Edm", edm, "State", st);
+      }
 
       // break the loop if edm is NOT getting smaller
       if (ipass > 0 && edm >= edmprev) {
@@ -204,7 +206,22 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
    MnAlgebraicVector step(initialState.Gradient().Vec().size());
 
    // initial lambda Value
-   double lambda = 0.001;
+
+
+   bool doLineSearch = false;
+   bool doTrustRegion = true;
+   // trust region parameter
+   // use as initial value 0.3 * || x0 ||
+   auto & x0 = initialState.Vec();
+   double normX0 = std::sqrt(inner_product(x0,x0));
+   double delta = 0.3 * std::max(1.0 , normX0);
+   double eta = 0.1;
+   // use GSL defaults
+   double tr_factor_up = 3;
+   double tr_factor_down = 0.5;
+   bool acceptNewPoint = true;
+
+   double lambda = (doLineSearch) ? 0.001 : 0;
 
    do {
 
@@ -217,6 +234,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
                   "\n  Internal Parameter values", s0.Vec(), "\n  Newton step", step);
 
       double gdel = inner_product(step, s0.Gradient().Grad());
+      //not sure if this is needed ??
       if (gdel > 0.) {
          print.Warn("Matrix not pos.def, gdel =", gdel, " > 0");
 
@@ -233,24 +251,17 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
          }
       }
 
-      //     MnParabolaPoint pp = lsearch(fcn, s0.Parameters(), step, gdel, prec);
-
-      //     if(std::fabs(pp.Y() - s0.Fval()) < prec.Eps()) {
-      //       std::cout<<"FumiliBuilder: no improvement"<<std::endl;
-      //       break; //no improvement
-      //     }
-
-      //     MinimumParameters p(s0.Vec() + pp.X()*step, pp.Y());
-
-      // if taking a full step
 
       // take a full step
 
-      MinimumParameters p(s0.Vec() + step, fcn(s0.Vec() + step));
+      //evaluate function only if doing a line search
+      double fval2 = (doLineSearch) ? fcn(s0.Vec() + step) : 0;
+      MinimumParameters p(s0.Vec() + step, fval2);
 
       // check that taking the full step does not deteriorate minimum
       // in that case do a line search
-      if (p.Fval() >= s0.Fval()) {
+      if (doLineSearch && p.Fval() >= s0.Fval()) {
+         print.Debug("Do a line search", fcn.NumOfCalls());
          MnLineSearch lsearch;
          MnParabolaPoint pp = lsearch(fcn, s0.Parameters(), step, gdel, prec);
 
@@ -259,19 +270,133 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
             break; // no improvement
          }
          p = MinimumParameters(s0.Vec() + pp.X() * step, pp.Y());
+         print.Debug("New point after Line Search :", "\n  FVAL     ", p.Fval(), "\n  Parameter", p.Vec());
       }
+
+      if (doTrustRegion) {
+         // do simple trust region using some control delta and eta
+         // compute norm of Newton step
+         double norm = sqrt(inner_product(step,step));
+         // some conditions
+         double tr_radius = norm;
+         if (norm < 0.1 * delta) tr_radius = 0.1*delta;
+         else if (norm > delta) tr_radius = delta;
+
+         // update new point using reduced step
+         //step = (tr_radius/norm) * step;
+
+         // if the proposed point (newton step) is inside the trust region radius accept it
+         if (norm <= delta) {
+            p = MinimumParameters(s0.Vec() + step, fcn(s0.Vec() + step));
+            print.Debug("Accept full Newton step - it inside TR ",delta);
+         } else {
+            //step = - (delta/norm) * step;
+
+            // if Newton step  is outside try to use the Cauchy point ?
+            double normGrad2 = inner_product(s0.Gradient().Grad(),s0.Gradient().Grad());
+            double normGrad = sqrt(normGrad2);
+            // need to compute gTHg :
+            double gHg = similarity(s0.Gradient().Grad(), s0.Error().Hessian());
+
+            print.Debug("computed gdel gHg and normGN",gdel,gHg,norm*norm, normGrad2);
+            if (gHg <= 0.) {
+               // Cauchy point is at the trust region boundary)
+               step = - (delta/ normGrad) * s0.Gradient().Grad();
+               print.Debug("Use as new point the Cauchy  point - along gradient with norm=delta ", delta);
+            } else {
+               // Cauchy point can be inside the trust region
+               double tau = std::min( (normGrad2*normGrad)/(gHg*delta), 1.0);
+               if (tau == 1.0) {
+                  // Cauchy is at the boundary
+                  step = - (delta/ normGrad) * s0.Gradient().Grad();
+                  print.Debug("tau=1. - Use as new point the Cauchy  point - along gradient with norm=delta ", delta);
+               } else {
+                  MnAlgebraicVector stepC(step.size());
+                  stepC = - tau * (delta/ normGrad) * s0.Gradient().Grad();
+                  print.Debug("Use as new point the Cauchy  point - along gradient with tau ", tau, "delta = ", delta);
+
+                  // compute dog -leg step solving quadratic equation a * t^2 + b * t + c = 0
+                  // where a = ||p_n - P_c ||^2
+                  //       b  = 2 * p_c * (P_n - P_c)
+                  //       c = || pc ||^2 - ||Delta||^2
+                  auto diffP = step - stepC;
+                  double a = inner_product(diffP, diffP);
+                  double b = 2. * inner_product(stepC, diffP);
+                  // norm cauchy point is tau*delta
+                  double c = delta*delta * (tau * tau  - 1.);
+                  print.Debug(" dogleg equation", a, b, c);
+                  // solution is
+                  double t = 0;
+                  // a cannot be negative or zero, otherwise point was accepted
+                  assert( a> 0);
+                  double t1 = (-b + sqrt(b * b - 4. * a * c)) / (2.0 * a);
+                  double t2 = (-b - sqrt(b * b - 4. * a * c)) / (2.0 * a);
+                  // if b is positive solution is
+                  print.Debug(" solution dogleg equation", t1, t2);
+                  if (t1 >= 0 && t1 <= 1.)
+                     t = t1;
+                  else
+                     t = t2;
+                  step = stepC + t * diffP;
+                  print.Debug("New dogleg point is t = ", t);
+               }
+            }
+            print.Debug("New accepted step is ",step);
+
+            p = MinimumParameters(s0.Vec() + step, fcn(s0.Vec() + step));
+            norm = delta;
+            gdel = inner_product(step, s0.Gradient().Grad());
+         }
+
+         // compute real changes (require an evaluation)
+
+         // expected change is gdel (I could correct for Hessian term but I have only INvHessian stored)
+         //double fcexp =  (-gdel - 0.5 * dot(step, hess(x) * step)
+         //double fcexp = -gdel;
+         double svs = 0.5 * similarity(step, s0.Error().Hessian());
+         double rho = (p.Fval()-s0.Fval())/(gdel+svs);
+         if (rho < 0.25) {
+            delta = tr_factor_down * delta;
+         } else {
+            if (rho > 0.75 && norm == delta) {
+                delta = std::min(tr_factor_up * delta, 100.*norm);  // 1000. is the delta max
+            }
+         }
+         print.Debug("New point after Trust region :", "norm tr ",tr_radius/norm," rho ", rho," delta ", delta,
+           "  FVAL    ", p.Fval(), "\n  Parameter", p.Vec());
+
+      // check if we need to accept the point ?
+         acceptNewPoint = (rho > eta);
+         if (acceptNewPoint) {
+               // we accept the point
+               // we have already p = s0 + step
+               print.Debug("Trust region: accept new point p = x + step since rho is larger than eta");
+           }
+           else {
+             // we keep old point
+             print.Debug("Trust region reject new point and repeat since rho is smaller than eta");
+             p = MinimumParameters(s0.Vec(), s0.Fval());
+           }
+
+      }
+
+      FunctionGradient g = s0.Gradient();
+
+      if (acceptNewPoint || result.size() == 1) {
 
       print.Debug("Before Gradient - NCalls = ", fcn.NumOfCalls());
 
-      FunctionGradient g = gc(p, s0.Gradient());
+      g = gc(p, s0.Gradient());
 
       print.Debug("After Gradient - NCalls = ", fcn.NumOfCalls());
 
+      }
 
       // move Error updator after Gradient since the Value is cached inside
 
       MinimumError e = ErrorUpdator().Update(s0, p, gc, lambda);
 
+      // should I use here new error instead of old one (so.Error) ?
       edm = Estimator().Estimate(g, s0.Error());
 
       print.Debug("Updated new point:", "\n  FVAL     ", p.Fval(), "\n  Parameter", p.Vec(), "\n  Gradient", g.Vec(),
@@ -292,6 +417,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
       }
 
       // check lambda according to step
+      if (doLineSearch) {
       if (p.Fval() < s0.Fval())
          // fcn is decreasing along the step
          lambda *= 0.1;
@@ -300,6 +426,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
          // if close to minimum stop to avoid oscillations around minimum value
          if (edm < 0.1)
             break;
+      }
       }
 
       print.Debug("finish iteration -", result.size(), "lambda =", lambda, "f1 =", p.Fval(), "f0 =", s0.Fval(),
@@ -312,6 +439,9 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
       print.Info(MnPrint::Oneline(result.back(), result.size()));
 
       edm *= (1. + 3. * e.Dcovar());
+
+      //}  // endif on acceptNewPoint
+
 
    } while (edm > edmval && fcn.NumOfCalls() < maxfcn);
 

--- a/math/minuit2/src/FumiliBuilder.cxx
+++ b/math/minuit2/src/FumiliBuilder.cxx
@@ -210,6 +210,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
 
    bool doLineSearch = false;
    bool doTrustRegion = true;
+   bool scaleTR = false;
    // trust region parameter
    // use as initial value 0.3 * || x0 ||
    auto & x0 = initialState.Vec();
@@ -272,15 +273,38 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
          p = MinimumParameters(s0.Vec() + pp.X() * step, pp.Y());
          print.Debug("New point after Line Search :", "\n  FVAL     ", p.Fval(), "\n  Parameter", p.Vec());
       }
+      // use as scaling matrix diagonal of Hessian
+      auto & H = s0.Error().Hessian();
+      unsigned int n = (scaleTR) ?   H.Nrow() : 0;
+
+      MnAlgebraicSymMatrix D(n);
+      MnAlgebraicSymMatrix Dinv(n);
+      MnAlgebraicSymMatrix Dinv2(n);
+      MnAlgebraicVector stepScaled(n);
+      // set the scaling matrix to the sqrt(diagoinal hessian)
+      for (unsigned int i = 0; i < n; i++){
+         double d  = std::sqrt(H(i,i));
+         D(i,i) = d;
+         Dinv(i,i) = 1./d;
+         Dinv2(i,i) = 1./(d*d);
+      }
 
       if (doTrustRegion) {
          // do simple trust region using some control delta and eta
          // compute norm of Newton step
-         double norm = sqrt(inner_product(step,step));
+         double norm = 0;
+         if (scaleTR) {
+            print.Debug("scaling Trust region with diagonal matrix D ",D);
+            stepScaled = D * step;
+            norm = sqrt(inner_product(stepScaled, stepScaled) );
+         }
+         else
+            norm = sqrt(inner_product(step,step));
          // some conditions
-         double tr_radius = norm;
-         if (norm < 0.1 * delta) tr_radius = 0.1*delta;
-         else if (norm > delta) tr_radius = delta;
+
+         // double tr_radius = norm;
+         // if (norm < 0.1 * delta) tr_radius = 0.1*delta;
+         // else if (norm > delta) tr_radius = delta;
 
          // update new point using reduced step
          //step = (tr_radius/norm) * step;
@@ -293,15 +317,32 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
             //step = - (delta/norm) * step;
 
             // if Newton step  is outside try to use the Cauchy point ?
-            double normGrad2 = inner_product(s0.Gradient().Grad(),s0.Gradient().Grad());
+            double normGrad2 = 0;
+            double gHg = 0;
+            if (scaleTR) {
+               auto gScaled = Dinv * s0.Gradient().Grad();
+               normGrad2 = inner_product(gScaled, gScaled);
+               // compute D-1 H D-1 = H(i,j) * D(i,i) * D(j,j)
+               MnAlgebraicSymMatrix Hscaled(n);
+               for (unsigned int i = 0; i < n; i++) {
+                  for (unsigned int j = 0; j <=i; j++) {
+                     Hscaled(i,j) = H(i,j) * Dinv(i,i) * Dinv(j,j);
+                  }
+               }
+               gHg = similarity(gScaled, Hscaled);
+            } else {
+               normGrad2 = inner_product(s0.Gradient().Grad(),s0.Gradient().Grad());
+               gHg = similarity(s0.Gradient().Grad(), s0.Error().Hessian());
+            }
             double normGrad = sqrt(normGrad2);
             // need to compute gTHg :
-            double gHg = similarity(s0.Gradient().Grad(), s0.Error().Hessian());
+
 
             print.Debug("computed gdel gHg and normGN",gdel,gHg,norm*norm, normGrad2);
             if (gHg <= 0.) {
                // Cauchy point is at the trust region boundary)
                step = - (delta/ normGrad) * s0.Gradient().Grad();
+               if (scaleTR) step = Dinv2 * step;
                print.Debug("Use as new point the Cauchy  point - along gradient with norm=delta ", delta);
             } else {
                // Cauchy point can be inside the trust region
@@ -309,10 +350,17 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
                if (tau == 1.0) {
                   // Cauchy is at the boundary
                   step = - (delta/ normGrad) * s0.Gradient().Grad();
+                  if (scaleTR)
+                    step = Dinv2 * step;
+
+
                   print.Debug("tau=1. - Use as new point the Cauchy  point - along gradient with norm=delta ", delta);
                } else {
                   MnAlgebraicVector stepC(step.size());
                   stepC = - tau * (delta/ normGrad) * s0.Gradient().Grad();
+                  if (scaleTR)
+                    stepC = Dinv2 * stepC;
+
                   print.Debug("Use as new point the Cauchy  point - along gradient with tau ", tau, "delta = ", delta);
 
                   // compute dog -leg step solving quadratic equation a * t^2 + b * t + c = 0
@@ -323,7 +371,8 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
                   double a = inner_product(diffP, diffP);
                   double b = 2. * inner_product(stepC, diffP);
                   // norm cauchy point is tau*delta
-                  double c = delta*delta * (tau * tau  - 1.);
+                  double c =  (scaleTR) ? inner_product(stepC,stepC) - delta*delta : delta*delta * (tau*tau - 1.);
+
                   print.Debug(" dogleg equation", a, b, c);
                   // solution is
                   double t = 0;
@@ -338,6 +387,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
                   else
                      t = t2;
                   step = stepC + t * diffP;
+                  // need to rescale point per D^-1 >
                   print.Debug("New dogleg point is t = ", t);
                }
             }
@@ -362,7 +412,7 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
                 delta = std::min(tr_factor_up * delta, 100.*norm);  // 1000. is the delta max
             }
          }
-         print.Debug("New point after Trust region :", "norm tr ",tr_radius/norm," rho ", rho," delta ", delta,
+         print.Debug("New point after Trust region :", "norm tr ",norm," rho ", rho," delta ", delta,
            "  FVAL    ", p.Fval(), "\n  Parameter", p.Vec());
 
       // check if we need to accept the point ?

--- a/math/minuit2/src/FumiliBuilder.cxx
+++ b/math/minuit2/src/FumiliBuilder.cxx
@@ -208,9 +208,9 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
    // initial lambda Value
 
 
-   bool doLineSearch = false;
-   bool doTrustRegion = true;
-   bool scaleTR = false;
+   bool doLineSearch = (fMethodType == kLineSearch);
+   bool doTrustRegion = (fMethodType == kTrustRegion || fMethodType == kTrustRegionScaled);
+   bool scaleTR = (fMethodType == kTrustRegionScaled);
    // trust region parameter
    // use as initial value 0.3 * || x0 ||
    auto & x0 = initialState.Vec();
@@ -221,6 +221,14 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn &fcn, const GradientCalculato
    double tr_factor_up = 3;
    double tr_factor_down = 0.5;
    bool acceptNewPoint = true;
+
+   if (doLineSearch)
+      print.Info("Using Fumili with a line search algorithm");
+   else if (doTrustRegion && scaleTR)
+      print.Info("Using Fumili with a scaled trust region algorithm with factors up/down",tr_factor_up,tr_factor_down);
+   else
+      print.Info("Using Fumili with a trust region algorithm with factors up/down",tr_factor_up,tr_factor_down);
+
 
    double lambda = (doLineSearch) ? 0.001 : 0;
 

--- a/math/minuit2/src/FumiliErrorUpdator.cxx
+++ b/math/minuit2/src/FumiliErrorUpdator.cxx
@@ -46,11 +46,13 @@ MinimumError FumiliErrorUpdator::Update(const MinimumState &s0, const MinimumPar
    // we apply also the Marquard lambda factor to increase weight of diagonal term
    // as suggester in Numerical Receipt for Marquard method
 
+   MnPrint print("FumiliErrorUpdator");
+   print.Debug("Compute covariance matrix using Fumili method");
+
    // need to downcast to FumiliGradientCalculator
    FumiliGradientCalculator *fgc = dynamic_cast<FumiliGradientCalculator *>(const_cast<GradientCalculator *>(&gc));
    assert(fgc != nullptr);
 
-   MnPrint print("FumiliErrorUpdator");
 
    // get Hessian from Gradient calculator
 
@@ -80,6 +82,9 @@ MinimumError FumiliErrorUpdator::Update(const MinimumState &s0, const MinimumPar
       for (unsigned int i = 0; i < cov.Nrow(); i++) {
          cov(i, i) = 1. / cov(i, i);
       }
+
+      // shiould we return the Hessian in addition to cov in this case?
+      return MinimumError(cov, MinimumError::MnInvertFailed);
    }
 
    double dcov = -1;

--- a/math/minuit2/src/FumiliErrorUpdator.cxx
+++ b/math/minuit2/src/FumiliErrorUpdator.cxx
@@ -72,12 +72,13 @@ MinimumError FumiliErrorUpdator::Update(const MinimumState &s0, const MinimumPar
       }
    }
 
-   int ifail = Invert(h);
+   MnAlgebraicSymMatrix cov(h);
+   int ifail = Invert(cov);
    if (ifail != 0) {
       print.Warn("inversion fails; return diagonal matrix");
 
-      for (unsigned int i = 0; i < h.Nrow(); i++) {
-         h(i, i) = 1. / h(i, i);
+      for (unsigned int i = 0; i < cov.Nrow(); i++) {
+         cov(i, i) = 1. / cov(i, i);
       }
    }
 
@@ -89,10 +90,10 @@ MinimumError FumiliErrorUpdator::Update(const MinimumState &s0, const MinimumPar
    // calculate by how much did the covariance matrix changed
    // (if it changed a lot since the last step, probably we
    // are not yet near the Minimum)
-      dcov = 0.5 * (s0.Error().Dcovar() + sum_of_elements(h - v0) / sum_of_elements(h));
+      dcov = 0.5 * (s0.Error().Dcovar() + sum_of_elements(cov - v0) / sum_of_elements(cov));
    }
 
-   return MinimumError(h, dcov);
+   return MinimumError(cov, h, dcov);
 }
 
 } // namespace Minuit2

--- a/math/minuit2/src/FumiliErrorUpdator.cxx
+++ b/math/minuit2/src/FumiliErrorUpdator.cxx
@@ -81,12 +81,16 @@ MinimumError FumiliErrorUpdator::Update(const MinimumState &s0, const MinimumPar
       }
    }
 
-   const MnAlgebraicSymMatrix &v0 = s0.Error().InvHessian();
+   double dcov = -1;
+   if (s0.IsValid()) {
+
+      const MnAlgebraicSymMatrix &v0 = s0.Error().InvHessian();
 
    // calculate by how much did the covariance matrix changed
    // (if it changed a lot since the last step, probably we
    // are not yet near the Minimum)
-   double dcov = 0.5 * (s0.Error().Dcovar() + sum_of_elements(h - v0) / sum_of_elements(h));
+      dcov = 0.5 * (s0.Error().Dcovar() + sum_of_elements(h - v0) / sum_of_elements(h));
+   }
 
    return MinimumError(h, dcov);
 }

--- a/math/minuit2/src/FumiliGradientCalculator.cxx
+++ b/math/minuit2/src/FumiliGradientCalculator.cxx
@@ -39,13 +39,14 @@ FunctionGradient FumiliGradientCalculator::operator()(const MinimumParameters &p
    // Need to apply internal to external for parameters and the external to int transformation
    // for the return gradient and Hessian
 
+   MnPrint print("FumiliGradientCalculator");
+
    int nvar = par.Vec().size();
    std::vector<double> extParam = fTransformation(par.Vec());
 
    // eval Gradient
    FumiliFCNBase &fcn = const_cast<FumiliFCNBase &>(fFcn);
 
-   // evaluate gradient and Hessian
    fcn.EvaluateAll(extParam);
 
    MnAlgebraicVector v(nvar);
@@ -70,14 +71,16 @@ FunctionGradient FumiliGradientCalculator::operator()(const MinimumParameters &p
       }
    }
 
-   MnPrint print("FumiliGradientCalculator");
+
    print.Debug([&](std::ostream &os) {
       // compare Fumili with Minuit gradient
+      os << "Comparison of Fumili Gradient and standard (numerical) Minuit Gradient (done only when debugging enabled)" << std::endl;
       int plevel = MnPrint::SetGlobalLevel(MnPrint::GlobalLevel()-1);
       Numerical2PGradientCalculator gc(MnUserFcn(fFcn, fTransformation), fTransformation, MnStrategy(1));
       FunctionGradient grd2 = gc(par);
-      os << "Fumili Gradient:" << v << "\nMinuit Gradient" << grd2.Vec();
-      os << "\nFumili Hessian:  " << h << std::endl;
+      os << "Fumili Gradient:" << v << std::endl;
+      os << "Minuit Gradient" << grd2.Vec() << std::endl;
+      os << "Fumili Hessian:  " << h << std::endl;
       os << "Numerical g2 " << grd2.G2() << std::endl;
       MnPrint::SetGlobalLevel(plevel);
    });

--- a/math/minuit2/src/FumiliMinimizer.cxx
+++ b/math/minuit2/src/FumiliMinimizer.cxx
@@ -83,6 +83,16 @@ FunctionMinimum FumiliMinimizer::Minimize(const FCNBase &fcn, const MnUserParame
 }
 
 
+void FumiliMinimizer::SetMethod(const std::string & method) {
+   if (method == "tr")
+      fMinBuilder.SetMethod(FumiliBuilder::kTrustRegion);
+   else if (method == "ls")
+      fMinBuilder.SetMethod(FumiliBuilder::kLineSearch);
+   else if (method == "trs")
+      fMinBuilder.SetMethod(FumiliBuilder::kTrustRegionScaled);
+}
+
+
 } // namespace Minuit2
 
 } // namespace ROOT

--- a/math/minuit2/src/FumiliMinimizer.cxx
+++ b/math/minuit2/src/FumiliMinimizer.cxx
@@ -41,19 +41,15 @@ FunctionMinimum FumiliMinimizer::Minimize(const FCNBase &fcn, const MnUserParame
    // The FCNBase passed must be a FumiliFCNBase type otherwise method will fail !
 
    MnUserFcn mfcn(fcn, st.Trafo());
-   //  Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
+
 
    unsigned int npar = st.VariableParameters();
    if (maxfcn == 0)
       maxfcn = 200 + 100 * npar + 5 * npar * npar;
    // FUMILI needs much less function calls
-   maxfcn = int(0.1 * maxfcn);
+   //maxfcn = int(0.1 * maxfcn);
 
-   // MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
-
-   // std::cout << "FCN type " << typeid(&fcn).Name() << std::endl;
-
-   // Minimize using Fumili. Case of interface is a function with gradient.
+   // Minimize using Fumili - function interface must be a FumiliFCNBase type
    FumiliFCNBase *fumiliFcn = dynamic_cast<FumiliFCNBase *>(const_cast<FCNBase *>(&fcn));
    if (!fumiliFcn) {
       print.Error("Wrong FCN type; try to use default minimizer");
@@ -77,7 +73,8 @@ FunctionMinimum FumiliMinimizer::Minimize(const FCNBase &fcn, const MnUserParame
    FunctionGradient grad = fgc(pa);
    FumiliErrorUpdator errUpdator;
    MinimumError err = errUpdator.Update(MinimumState(0), pa, fgc, 0.);
-   MinimumSeed mnseeds(MinimumState(pa, err, grad, -1., 1), st.Trafo());
+   // set an arbitrary large initial edm (1.E10)
+   MinimumSeed mnseeds(MinimumState(pa, err, grad, 1.E10, 1), st.Trafo());
 
    return ModularFunctionMinimizer::Minimize(mfcn, fgc, mnseeds, strategy, maxfcn, toler);
 }

--- a/math/minuit2/src/FumiliMinimizer.cxx
+++ b/math/minuit2/src/FumiliMinimizer.cxx
@@ -11,6 +11,7 @@
 #include "Minuit2/FumiliMinimizer.h"
 #include "Minuit2/MinimumSeedGenerator.h"
 #include "Minuit2/FumiliGradientCalculator.h"
+#include "Minuit2/FumiliErrorUpdator.h"
 #include "Minuit2/Numerical2PGradientCalculator.h"
 #include "Minuit2/AnalyticalGradientCalculator.h"
 #include "Minuit2/MinimumBuilder.h"
@@ -39,60 +40,48 @@ FunctionMinimum FumiliMinimizer::Minimize(const FCNBase &fcn, const MnUserParame
    // Minimize using Fumili. Create seed and Fumili gradient calculator.
    // The FCNBase passed must be a FumiliFCNBase type otherwise method will fail !
 
-   if (fcn.HasGradient()) {
-      MnUserFcn mfcn(fcn, st.Trafo());
-      Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
-
-      unsigned int npar = st.VariableParameters();
-      if (maxfcn == 0)
-         maxfcn = 200 + 100 * npar + 5 * npar * npar;
-      // FUMILI needs much less function calls
-      maxfcn = int(0.1 * maxfcn);
-
-      MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
-
-      // downcast fcn
-
-      // std::cout << "FCN type " << typeid(&fcn).Name() << std::endl;
-
-      FumiliFCNBase *fumiliFcn = dynamic_cast<FumiliFCNBase *>(const_cast<FCNBase *>(&fcn));
-      if (!fumiliFcn) {
-         print.Error("Wrong FCN type; try to use default minimizer");
-         return FunctionMinimum(mnseeds, fcn.Up());
-      }
-
-      FumiliGradientCalculator fgc(*fumiliFcn, st.Trafo(), npar);
-      print.Debug("Using FumiliMinimizer");
-
-      return ModularFunctionMinimizer::Minimize(mfcn, fgc, mnseeds, strategy, maxfcn, toler);
-   }
-
-   // Minimize using Fumili. Case of interface is a function with gradient.
-   // Normally other method is used  - probably this could be removed (t.b.i.)
-
-   // need MnUserFcn
    MnUserFcn mfcn(fcn, st.Trafo());
-   AnalyticalGradientCalculator gc(fcn, st.Trafo());
+   //  Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
 
    unsigned int npar = st.VariableParameters();
    if (maxfcn == 0)
       maxfcn = 200 + 100 * npar + 5 * npar * npar;
+   // FUMILI needs much less function calls
+   maxfcn = int(0.1 * maxfcn);
 
-   MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
+   // MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
 
-   // downcast fcn
+   // std::cout << "FCN type " << typeid(&fcn).Name() << std::endl;
 
+   // Minimize using Fumili. Case of interface is a function with gradient.
    FumiliFCNBase *fumiliFcn = dynamic_cast<FumiliFCNBase *>(const_cast<FCNBase *>(&fcn));
    if (!fumiliFcn) {
       print.Error("Wrong FCN type; try to use default minimizer");
-      return FunctionMinimum(mnseeds, fcn.Up());
+      return FunctionMinimum(MinimumSeed(MinimumState(0), st.Trafo()), fcn.Up());
    }
 
    FumiliGradientCalculator fgc(*fumiliFcn, st.Trafo(), npar);
-   print.Debug("Using FumiliMinimizer");
+   if (fcn.HasGradient()) {
+      print.Debug("Using FumiliMinimizer with analytical gradients");
+   } else {
+      print.Debug("Using FumiliMinimizer with numerical gradients");
+   }
+
+   // compute initial values;
+   const unsigned int n = st.VariableParameters();
+   MnAlgebraicVector x(n);
+   for (unsigned int i = 0; i < n; i++)
+      x(i) = st.IntParameters()[i];
+   double fcnmin = mfcn(x);
+   MinimumParameters pa(x, fcnmin);
+   FunctionGradient grad = fgc(pa);
+   FumiliErrorUpdator errUpdator;
+   MinimumError err = errUpdator.Update(MinimumState(0), pa, fgc, 0.);
+   MinimumSeed mnseeds(MinimumState(pa, err, grad, -1., 1), st.Trafo());
 
    return ModularFunctionMinimizer::Minimize(mfcn, fgc, mnseeds, strategy, maxfcn, toler);
 }
+
 
 } // namespace Minuit2
 

--- a/math/minuit2/src/InitialGradientCalculator.cxx
+++ b/math/minuit2/src/InitialGradientCalculator.cxx
@@ -71,7 +71,7 @@ FunctionGradient InitialGradientCalculator::operator()(const MinimumParameters &
       gr2(i) = g2;
       gst(i) = gstep;
 
-      print.Debug("Computed initial gradient for parameter", Trafo().Name(exOfIn), "value", var, "[", vmin, ",", vplu,
+      print.Trace("Computed initial gradient for parameter", Trafo().Name(exOfIn), "value", var, "[", vmin, ",", vplu,
                   "]", "dirin", dirin, "grd", grd, "g2", g2);
    }
 

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -520,6 +520,17 @@ bool Minuit2Minimizer::Minimize()
       if (ret)
          SetStorageLevel(storageLevel);
 
+      // fumili options
+      if (fUseFumili) {
+         std::string fumiliMethod;
+         ret = minuit2Opt->GetValue("FumiliMethod", fumiliMethod);
+         if (ret) {
+            auto fumiliMinimizer = dynamic_cast<ROOT::Minuit2::FumiliMinimizer*>(fMinimizer);
+            if (fumiliMinimizer)
+               fumiliMinimizer->SetMethod(fumiliMethod);
+         }
+      }
+
       if (printLevel > 0) {
          std::cout << "Minuit2Minimizer::Minuit  - Changing default options" << std::endl;
          minuit2Opt->Print();

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -486,6 +486,7 @@ bool Minuit2Minimizer::Minimize()
    fMinuitFCN->SetErrorDef(ErrorDef());
 
    const int printLevel = PrintLevel();
+   print.Debug("Minuit print level is", printLevel);
    if (PrintLevel() >= 1) {
       // print the real number of maxfcn used (defined in ModularFunctionMinimizer)
       int maxfcn_used = maxfcn;

--- a/math/minuit2/src/MnLineSearch.cxx
+++ b/math/minuit2/src/MnLineSearch.cxx
@@ -57,7 +57,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
 
    MnPrint print("MnLineSearch");
 
-   print.Debug("gdel", gdel, "step", step);
+   print.Debug("doing line search along given step and gdel = s^t*g = ", gdel);
 
    double overall = 1000.;
    double undral = -100.;
@@ -107,7 +107,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
       iterate = false;
       // MnParabola pb = MnParabolaFactory()(p0, gdel, p1);
 
-      print.Debug("flast", flast, "f0", f0, "flast-f0", flast - f0, "slam", slam);
+      print.Trace("flast", flast, "f0", f0, "flast-f0", flast - f0, "slam", slam);
       //     double df = flast-f0;
       //     if(std::fabs(df) < prec.Eps2()) {
       //       if(flast-f0 < 0.) df = -prec.Eps2();
@@ -117,14 +117,14 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
       //     double denom = 2.*(df-gdel*slam)/(slam*slam);
       double denom = 2. * (flast - f0 - gdel * slam) / (slam * slam);
 
-      print.Debug("denom", denom);
+      print.Trace("denom", denom);
       if (denom != 0) {
          slam = -gdel / denom;
       } else {
          denom = -0.1 * gdel;
          slam = 1.;
       }
-      print.Debug("new slam", slam);
+      print.Trace("new slam", slam);
 
 #ifdef TRY_OPPOSIT_DIR
       // if is less than zero indicates maximum position. Use then slamax or x = x0 - 2slam + 1
@@ -133,27 +133,25 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
 #endif
 
       if (slam < 0.) {
-         print.Debug("slam is negative - set to", slamax);
+         print.Trace("slam is negative - set to", slamax);
 #ifdef TRY_OPPOSITE_DIR
          slamNeg = 2 * slam - 1;
          slamIsNeg = true;
-         print.Debug("slam is negative - compare values between", slamNeg, "and", slamax);
+         print.Trace("slam is negative - compare values between", slamNeg, "and", slamax);
 #endif
          slam = slamax;
       }
-      //     std::cout<<"slam= "<<slam<<std::endl;
       if (slam > slamax) {
          slam = slamax;
-         print.Debug("slam larger than mac value - set to", slamax);
+         print.Trace("slam larger than max value - set to", slamax);
       }
 
       if (slam < toler8) {
-         print.Debug("slam too small - set to", toler8);
+         print.Trace("slam too small - set to", toler8);
          slam = toler8;
       }
-      //     std::cout<<"slam= "<<slam<<std::endl;
       if (slam < slamin) {
-         print.Debug("slam smaller than", slamin, "return");
+         print.Trace("slam smaller than", slamin, "return");
          //       std::cout<<"f1, f2= "<<p0.Y()<<", "<<p1.Y()<<std::endl;
          //       std::cout<<"x1, x2= "<<p0.X()<<", "<<p1.X()<<std::endl;
          //       std::cout<<"x, f= "<<xvmin<<", "<<fvmin<<std::endl;
@@ -209,7 +207,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
       return MnParabolaPoint(xvmin, fvmin);
    }
 
-   print.Debug("after initial 2-point iter:", '\n', " x0, x1, x2:", p0.X(), p1.X(), slam, '\n', " f0, f1, f2:", p0.Y(),
+   print.Trace("after initial 2-point iter:", '\n', " x0, x1, x2:", p0.X(), p1.X(), slam, '\n', " f0, f1, f2:", p0.Y(),
                p1.Y(), f2);
 
    MnParabolaPoint p2(slam, f2);
@@ -218,7 +216,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
    do {
       slamax = std::max(slamax, alpha * std::fabs(xvmin));
       MnParabola pb = MnParabolaFactory()(p0, p1, p2);
-      print.Debug("Iteration", niter, '\n', " x0, x1, x2:", p0.X(), p1.X(), p2.X(), '\n', " f0, f1, f2:", p0.Y(),
+      print.Trace("Iteration", niter, '\n', " x0, x1, x2:", p0.X(), p1.X(), p2.X(), '\n', " f0, f1, f2:", p0.Y(),
                   p1.Y(), p2.Y(), '\n', " slamax    :", slamax, '\n', " p2-p0,p1  :", p2.Y() - p0.Y(), p2.Y() - p1.Y(),
                   '\n', " a, b, c   :", pb.A(), pb.B(), pb.C());
       if (pb.A() < prec.Eps2()) {
@@ -227,7 +225,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
             slam = xvmin + slamax;
          else
             slam = xvmin - slamax;
-         print.Debug("xvmin", xvmin, "slopem", slopem, "slam", slam);
+         print.Trace("xvmin", xvmin, "slopem", slopem, "slam", slam);
       } else {
          slam = pb.Min();
          //      std::cout<<"pb.Min() slam= "<<slam<<std::endl;
@@ -249,7 +247,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
       double f3 = 0.;
       do {
 
-         print.Debug("iterate on f3- slam", niter, "slam", slam, "xvmin", xvmin);
+         print.Trace("iterate on f3- slam", niter, "slam", slam, "xvmin", xvmin);
 
          iterate = false;
          double toler9 = std::max(toler8, std::fabs(toler8 * slam));
@@ -266,22 +264,23 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
          //       MnAlgebraicVector tmp = step;
          //       tmp *= slam;
          f3 = fcn(st.Vec() + slam * step);
-         print.Debug("f3", f3, "f3-p(2-0).Y()", f3 - p2.Y(), f3 - p1.Y(), f3 - p0.Y());
+         print.Trace("f3", f3, "f3-p(2-0).Y()", f3 - p2.Y(), f3 - p1.Y(), f3 - p0.Y());
          // if latest point worse than all three previous, cut step
          if (f3 > p0.Y() && f3 > p1.Y() && f3 > p2.Y()) {
-            print.Debug("f3 worse than all three previous");
+            print.Trace("f3 worse than all three previous");
             if (slam > xvmin)
                overall = std::min(overall, slam - toler8);
             if (slam < xvmin)
                undral = std::max(undral, slam + toler8);
             slam = 0.5 * (slam + xvmin);
-            print.Debug("new slam", slam);
+            print.Trace("new slam", slam);
             iterate = true;
             niter++;
          }
       } while (iterate && niter < maxiter);
       if (niter >= maxiter) {
          // exhausted max number of iterations
+         print.Debug("Exhausted max number of iterations ",maxiter," return");
          return MnParabolaPoint(xvmin, fvmin);
       }
 
@@ -293,7 +292,7 @@ MnParabolaPoint MnLineSearch::operator()(const MnFcn &fcn, const MinimumParamete
          p1 = p3;
       else
          p2 = p3;
-      print.Debug("f3", f3, "fvmin", fvmin, "xvmin", xvmin);
+      print.Trace("f3", f3, "fvmin", fvmin, "xvmin", xvmin);
       if (f3 < fvmin) {
          fvmin = f3;
          xvmin = slam;
@@ -322,7 +321,7 @@ MnParabolaPoint MnLineSearch::CubicSearch(const MnFcn &fcn, const MinimumParamet
 {
    MnPrint print("MnLineSearch::CubicSearch");
 
-   print.Debug("gdel", gdel, "g2del", g2del, "step", step);
+   print.Trace("gdel", gdel, "g2del", g2del, "step", step);
 
    // change of large values
    double overall = 100.;

--- a/math/minuit2/src/MnPosDef.cxx
+++ b/math/minuit2/src/MnPosDef.cxx
@@ -13,6 +13,7 @@
 #include "Minuit2/MnPrint.h"
 
 #include <algorithm>
+#include <iostream>
 
 namespace ROOT {
 
@@ -98,7 +99,9 @@ MinimumError MnPosDef::operator()(const MinimumError &e, const MnMachinePrecisio
 
    print.Warn("Matrix forced pos-def by adding to diagonal", pAdd);
 
-   return MinimumError(err, MinimumError::MnMadePosDef);
+   MinimumError epdf(err, MinimumError::MnMadePosDef);
+   std::cout << epdf.Hessian().size() << "  " << epdf.Hessian().Nrow() << std::endl;
+   return epdf;
 }
 
 } // namespace Minuit2

--- a/math/minuit2/src/MnPosDef.cxx
+++ b/math/minuit2/src/MnPosDef.cxx
@@ -99,9 +99,7 @@ MinimumError MnPosDef::operator()(const MinimumError &e, const MnMachinePrecisio
 
    print.Warn("Matrix forced pos-def by adding to diagonal", pAdd);
 
-   MinimumError epdf(err, MinimumError::MnMadePosDef);
-   std::cout << epdf.Hessian().size() << "  " << epdf.Hessian().Nrow() << std::endl;
-   return epdf;
+   return MinimumError(err, MinimumError::MnMadePosDef);
 }
 
 } // namespace Minuit2


### PR DESCRIPTION
Implement a new version of the Fumili algorithm for minimization in Minuit2 using trust-region instead of line search for finding the next step. See this [presentation](https://indico.jlab.org/event/459/contributions/11597/attachments/9469/13862/Minuit2_CHEP2023.pdf). 

This PR implements also: 
-  the possibility to change the verbosity in fitting histograms. In addition to option `V`, the fitting options `VV` and `VVV` have been added
- a new version of gsl non-linear multidimensional fit algorithm. New classes were impelmented in GSL  versions 2, and now this PR impelments a new wrapper for the new GSL routines. Various different solver can be used for the `GSLMultiFit` minimization algorith, when fitting histograms. 