### PR TITLE
[ntuple] Remove RContext::fHeaderExtensionOffset

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -117,7 +117,6 @@ public:
       std::vector<DescriptorId_t> fOnDisk2MemColumnIDs;
       std::vector<DescriptorId_t> fOnDisk2MemClusterIDs;
       std::vector<DescriptorId_t> fOnDisk2MemClusterGroupIDs;
-      std::size_t fHeaderExtensionOffset = -1U;
 
    public:
       void SetHeaderSize(std::uint64_t size) { fHeaderSize = size; }
@@ -184,10 +183,6 @@ public:
       /// Return a vector containing the in-memory field ID for each on-disk counterpart, in order, i.e. the `i`-th
       /// value corresponds to the in-memory field ID for `i`-th on-disk ID
       const std::vector<DescriptorId_t> &GetOnDiskFieldList() const { return fOnDisk2MemFieldIDs; }
-      /// Mark the first on-disk field ID that is part of the schema extension
-      void BeginHeaderExtension() { fHeaderExtensionOffset = fOnDisk2MemFieldIDs.size(); }
-      /// Return the offset of the first element in `fOnDisk2MemFieldIDs` that is part of the schema extension
-      std::size_t GetHeaderExtensionOffset() const { return fHeaderExtensionOffset; }
    };
 
    /// Writes a XxHash-3 64bit checksum of the byte range given by data and length.

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1247,7 +1247,7 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
 
    R__ASSERT(desc.GetNFields() > 0); // we must have at least a zero field
    if (!forHeaderExtension)
-      R__ASSERT(GetHeaderExtensionOffset() == -1U);
+      R__ASSERT(!desc.GetHeaderExtension());
 
    std::vector<DescriptorId_t> fieldTrees;
    if (!forHeaderExtension) {
@@ -1273,9 +1273,6 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
             MapPhysicalColumnId(columnDesc.GetPhysicalId());
          }
       }
-   } else {
-      // Anything added after this point is accounted for the header extension
-      BeginHeaderExtension();
    }
 }
 
@@ -1298,7 +1295,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
          nFields = xHeader->GetNFields();
          nColumns = xHeader->GetNPhysicalColumns();
          nAliasColumns = xHeader->GetNLogicalColumns() - xHeader->GetNPhysicalColumns();
-         fieldListOffset = context.GetHeaderExtensionOffset();
+         fieldListOffset = desc.GetNFields() - nFields - 1;
 
          extraColumns.reserve(xHeader->GetExtendedColumnRepresentations().size());
          for (auto columnId : xHeader->GetExtendedColumnRepresentations()) {


### PR DESCRIPTION
The offset can be easily derived without the need to store it.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


