### PR TITLE
[ntuple] rename RHeaderExtension::AddExtended* to MarkExtended*

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1002,13 +1002,19 @@ private:
    std::uint32_t fNLogicalColumns = 0;
    std::uint32_t fNPhysicalColumns = 0;
 
-   void AddExtendedField(const RFieldDescriptor &fieldDesc)
+   /// Marks `fieldDesc` as an extended field, i.e. a field that appears in the Header Extension (e.g. having been added
+   /// through late model extension). Note that the field descriptor should also have been added to the RNTuple
+   /// Descriptor alongside non-extended fields.
+   void MarkExtendedField(const RFieldDescriptor &fieldDesc)
    {
       fFieldIdsOrder.emplace_back(fieldDesc.GetId());
       fFieldIdsLookup.insert(fieldDesc.GetId());
    }
 
-   void AddExtendedColumn(const RColumnDescriptor &columnDesc)
+   /// Marks `columnDesc` as an extended column, i.e. a column that appears in the Header Extension (e.g. having been
+   /// added through late model extension as an additional representation of an existing column). Note that the column
+   /// descriptor should also have been added to the RNTuple Descriptor alongside non-extended columns.
+   void MarkExtendedColumn(const RColumnDescriptor &columnDesc)
    {
       fNLogicalColumns++;
       if (!columnDesc.IsAliasColumn())

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -1063,7 +1063,7 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddField(const RFie
 {
    fDescriptor.fFieldDescriptors.emplace(fieldDesc.GetId(), fieldDesc.Clone());
    if (fDescriptor.fHeaderExtension)
-      fDescriptor.fHeaderExtension->AddExtendedField(fieldDesc);
+      fDescriptor.fHeaderExtension->MarkExtendedField(fieldDesc);
    if (fieldDesc.GetFieldName().empty() && fieldDesc.GetParentId() == kInvalidDescriptorId) {
       fDescriptor.fFieldZeroId = fieldDesc.GetId();
    }
@@ -1171,7 +1171,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddC
       fDescriptor.fNPhysicalColumns++;
    fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(columnDesc));
    if (fDescriptor.fHeaderExtension)
-      fDescriptor.fHeaderExtension->AddExtendedColumn(columnDesc);
+      fDescriptor.fHeaderExtension->MarkExtendedColumn(columnDesc);
 
    return RResult<void>::Success();
 }


### PR DESCRIPTION
Resulted from an offline discussion with Jakob: the word "add" is a bit ambiguous because we already Add the extended columns/fields to the descriptor, but we also mark them as extended if we're extending the header.