### PR TITLE
math: Remove commented out code for PtEtaPhiMSystem EEtaPhiMSystem.

### DIFF
--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -11,7 +11,7 @@
 // Header file for class PtEtaPhiM4D
 //
 // Created by: fischler at Wed Jul 21 2005
-//   Similar to PtEtaPhiMSystem by moneta
+//   Successor to PtEtaPhiMSystem by moneta
 //
 // Last update: $Id$
 //

--- a/math/genvector/inc/Math/LinkDef_GenVector.h
+++ b/math/genvector/inc/Math/LinkDef_GenVector.h
@@ -274,23 +274,6 @@
 #pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Float16_t>"  \
              targetClass="ROOT::Math::PtEtaPhiM4D<double>";
 
-//#pragma link C++ class    ROOT::Math::EEtaPhiMSystem<double>+;
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Double32_t>" \
-             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<float>"      \
-             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Float16_t>"  \
-             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
-
-//#pragma link C++ class    ROOT::Math::PtEtaPhiMSystem<double>+;
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Double32_t>" \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<float>"      \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Float16_t>"  \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
-
-
 #pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >+;
 #pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >" \
              targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >";
@@ -582,23 +565,6 @@
              targetClass="ROOT::Math::PtEtaPhiM4D<float>";
 #pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Float16_t>"  \
              targetClass="ROOT::Math::PtEtaPhiM4D<float>";
-
-//#pragma link C++ class    ROOT::Math::EEtaPhiMSystem<float>+;
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<double>"     \
-             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Double32_t>" \
-             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
-#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Float16_t>"  \
-             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
-
-//#pragma link C++ class    ROOT::Math::PtEtaPhiMSystem<float>+;
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<double>"     \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Double32_t>" \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
-#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Float16_t>"  \
-             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
-
 
 #pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >+;
 #pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >"     \

--- a/math/genvector/inc/Math/Vector4D.h
+++ b/math/genvector/inc/Math/Vector4D.h
@@ -7,20 +7,14 @@
 // defines typedefs to specific vectors and forward declarations
 // define additional (to Cartesian) coordinate system types
 #include "Math/Vector4Dfwd.h"
-// generic LorentzVector class definition
 
+// generic LorentzVector class definition
 #include "Math/GenVector/PxPyPzE4D.h"
 #include "Math/GenVector/PtEtaPhiE4D.h"
 #include "Math/GenVector/PxPyPzM4D.h"
 #include "Math/GenVector/PtEtaPhiM4D.h"
 
-
 #include "Math/GenVector/LorentzVector.h"
-
-//#include "Math/GenVector/PtEtaPhiMSystem.h"
-//#include "Math/GenVector/EEtaPhiMSystem.h"
-
-
 
 #endif
 

--- a/math/genvector/inc/Math/Vector4Dfwd.h
+++ b/math/genvector/inc/Math/Vector4Dfwd.h
@@ -31,8 +31,6 @@ namespace ROOT {
     template<typename T> class PtEtaPhiE4D;
     template<typename T> class PxPyPzM4D;
     template<typename T> class PtEtaPhiM4D;
-//     template<typename T> class EEtaPhiMSystem;
-
 
     // for LorentzVector have only double classes (define the vector in the global ref frame)
 
@@ -84,13 +82,6 @@ namespace ROOT {
        See the documentation on the LorentzVector page.
     */
     typedef LorentzVector<PtEtaPhiM4D<double> > PtEtaPhiMVector;
-
-//     /**
-//        LorentzVector based on the coordinates E, Eta, Phi and Mass in double precision. These coordinates are normally used to represents a cluster objects in a calorimeter at a collider experiment.
-//     */
-//     typedef BasicLorentzVector<EEtaPhiMSystem<double> > LorentzVectorEEtaPhiM;
-
-
 
   } // end namespace Math
 


### PR DESCRIPTION
This finishes their removal started by commit 7a2f77140ae715dde292d842c680525d4f64ce47 in 2005

