### PR TITLE
[ntuple] properly support incremental merging with Union mode

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -551,7 +551,7 @@ private:
    DescriptorId_t fFieldZeroId = kInvalidDescriptorId; ///< Set by the descriptor builder
 
    std::uint64_t fNPhysicalColumns = 0; ///< Updated by the descriptor builder when columns are added
-   std::uint64_t fOnDiskHeaderSize = 0;    ///< Set by the descriptor builder when deserialized
+   std::uint64_t fOnDiskHeaderSize = 0; ///< Set by the descriptor builder when deserialized
 
    std::set<unsigned int> fFeatureFlags;
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
@@ -566,8 +566,8 @@ private:
    std::uint64_t fOnDiskHeaderXxHash3 = 0; ///< Set by the descriptor builder when deserialized
    std::uint64_t fOnDiskFooterSize = 0; ///< Like fOnDiskHeaderSize, contains both cluster summaries and page locations
 
-   std::uint64_t fNEntries = 0;         ///< Updated by the descriptor builder when the cluster groups are added
-   std::uint64_t fNClusters = 0;        ///< Updated by the descriptor builder when the cluster groups are added
+   std::uint64_t fNEntries = 0;  ///< Updated by the descriptor builder when the cluster groups are added
+   std::uint64_t fNClusters = 0; ///< Updated by the descriptor builder when the cluster groups are added
 
    /**
     * Once constructed by an RNTupleDescriptorBuilder, the descriptor is mostly immutable except for set of
@@ -1048,6 +1048,8 @@ public:
    /// We cannot create this vector when building the fFields because at the time when AddExtendedField is called,
    /// the field is not yet linked into the schema tree.
    std::vector<DescriptorId_t> GetTopLevelFields(const RNTupleDescriptor &desc) const;
+
+   bool ContainsField(DescriptorId_t fieldId) const { return fFieldIdsLookup.find(fieldId) != fFieldIdsLookup.end(); }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1412,7 +1412,7 @@ public:
    const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
    RNTupleDescriptor MoveDescriptor();
 
-   void CreateFromSchema(const RNTupleDescriptor &descriptor);
+   void SetSchemaFromExisting(const RNTupleDescriptor &descriptor);
 
    void SetNTuple(const std::string_view name, const std::string_view description);
    void SetFeature(unsigned int flag);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -89,6 +89,7 @@ class RNTupleMerger final {
    std::unique_ptr<RPageSink> fDestination;
    std::unique_ptr<RPageAllocator> fPageAlloc;
    std::optional<TTaskGroup> fTaskGroup;
+   std::unique_ptr<RNTupleModel> fModel;
 
    void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
                            std::span<RColumnMergeInfo> commonColumns, const RCluster::ColumnSet_t &commonColumnSet,
@@ -99,7 +100,9 @@ class RNTupleMerger final {
 
 public:
    /// Creates a RNTupleMerger with the given destination.
-   explicit RNTupleMerger(std::unique_ptr<RPageSink> destination);
+   /// The model must be given if and only if `destination` has been initialized with that model
+   /// (i.e. in case of incremental merging).
+   RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique_ptr<RNTupleModel> model = nullptr);
 
    /// Merge a given set of sources into the destination.
    RResult<void> Merge(std::span<RPageSource *> sources, const RNTupleMergeOptions &mergeOpts = RNTupleMergeOptions());

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -281,6 +281,9 @@ protected:
    /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
+   /// Flag if sink was initialized
+   bool fIsInitialized = false;
+
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable and not checksummed, the returned sealed page
    /// will point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
@@ -289,8 +292,6 @@ protected:
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
 private:
-   /// Flag if sink was initialized
-   bool fIsInitialized = false;
    std::vector<Callback_t> fOnDatasetCommitCallbacks;
    std::vector<unsigned char> fSealPageBuffer; ///< Used as destination buffer in the simple SealPage overload
 
@@ -529,7 +530,7 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
    /// Initialize sink based on an existing descriptor and fill into the descriptor builder.
-   void InitFromDescriptor(const RNTupleDescriptor &descriptor);
+   [[nodiscard]] std::unique_ptr<RNTupleModel> InitFromDescriptor(const RNTupleDescriptor &descriptor);
 
    void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -1210,7 +1210,7 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::Reset()
    fDescriptor.fHeaderExtension.reset();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::CreateFromSchema(const RNTupleDescriptor &descriptor)
+void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::SetSchemaFromExisting(const RNTupleDescriptor &descriptor)
 {
    fDescriptor = descriptor.CloneSchema();
 }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -167,7 +167,7 @@ try {
       if (!compression) {
          // Get the compression of this RNTuple and use it as the output compression.
          // We currently assume all column ranges have the same compression, so we just peek at the first one.
-         source->Attach();
+         source->Attach(RNTupleSerializer::EDescriptorDeserializeMode::kRaw);
          auto descriptor = source->GetSharedDescriptorGuard();
          auto clusterIter = descriptor->GetClusterIterable();
          auto firstCluster = clusterIter.begin();
@@ -203,7 +203,7 @@ try {
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
       auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
-      outSource->Attach();
+      outSource->Attach(RNTupleSerializer::EDescriptorDeserializeMode::kForWriting);
       auto desc = outSource->GetSharedDescriptorGuard();
       model = destination->InitFromDescriptor(desc.GetRef());
    }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -949,8 +949,9 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
 
    // we should have a model if and only if the destination is initialized.
    if (!!fModel != fDestination->IsInitialized()) {
-      return R__FAIL("Passing an already-initialized destination to RNTupleMerger (i.e. trying to do incremental "
-                     "merging) can only be done if you provided a valid RNTupleModel");
+      return R__FAIL(
+         "passing an already-initialized destination to RNTupleMerger::Merge (i.e. trying to do incremental "
+         "merging) can only be done if you provided a valid RNTupleModel when constructing the RNTupleMerger.");
    }
 
    RNTupleMergeData mergeData{sources, *fDestination, mergeOpts};

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -862,6 +862,9 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
 
       auto srcColumnId = srcFieldDesc.GetLogicalColumnIds()[i];
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
+      if (srcColumn.IsDeferredColumn())
+         continue;
+
       RColumnMergeInfo info{};
       info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex());
       info.fInputId = srcColumn.GetPhysicalId();
@@ -994,7 +997,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       auto descCmpRes = CompareDescriptorStructure(mergeData.fDstDescriptor, srcDescriptor.GetRef());
       if (!descCmpRes) {
          SKIP_OR_ABORT(
-            std::string("Source RNTuple will be skipped due to incompatible schema with the fDestination:\n") +
+            std::string("Source RNTuple has an incompatible schema with the destination:\n") +
             descCmpRes.GetError()->GetReport());
       }
       auto descCmp = descCmpRes.Unwrap();
@@ -1016,7 +1019,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
             ExtendDestinationModel(descCmp.fExtraSrcFields, *model, mergeData, descCmp.fCommonFields);
          } else if (mergeOpts.fMergingMode == ENTupleMergingMode::kStrict) {
             // If the current source has extra fields and we're in Strict mode, error
-            std::string msg = "Source RNTuple has extra fields that the fDestination RNTuple doesn't have:";
+            std::string msg = "Source RNTuple has extra fields that the destination RNTuple doesn't have:";
             for (const auto *field : descCmp.fExtraSrcFields) {
                msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -802,34 +802,22 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
    if (onDiskType == ENTupleColumnType::kSwitch)
       return typeid(ROOT::Experimental::Internal::RColumnSwitch);
 
-   if (fieldType == "bool") {
-      return typeid(bool);
-   } else if (fieldType == "std::byte") {
-      return typeid(std::byte);
-   } else if (fieldType == "char") {
-      return typeid(char);
-   } else if (fieldType == "std::int8_t") {
-      return typeid(std::int8_t);
-   } else if (fieldType == "std::uint8_t") {
-      return typeid(std::uint8_t);
-   } else if (fieldType == "std::int16_t") {
-      return typeid(std::int16_t);
-   } else if (fieldType == "std::uint16_t") {
-      return typeid(std::uint16_t);
-   } else if (fieldType == "std::int32_t") {
-      return typeid(std::int32_t);
-   } else if (fieldType == "std::uint32_t") {
-      return typeid(std::uint32_t);
-   } else if (fieldType == "std::int64_t") {
-      return typeid(std::int64_t);
-   } else if (fieldType == "std::uint64_t") {
-      return typeid(std::uint64_t);
-   } else if (fieldType == "float") {
-      return typeid(float);
-   } else if (fieldType == "double") {
-      return typeid(double);
-   }
-
+   // clang-format off
+   if (fieldType == "bool")          return typeid(bool);
+   if (fieldType == "std::byte")     return typeid(std::byte);
+   if (fieldType == "char")          return typeid(char);
+   if (fieldType == "std::int8_t")   return typeid(std::int8_t);
+   if (fieldType == "std::uint8_t")  return typeid(std::uint8_t);
+   if (fieldType == "std::int16_t")  return typeid(std::int16_t);
+   if (fieldType == "std::uint16_t") return typeid(std::uint16_t);
+   if (fieldType == "std::int32_t")  return typeid(std::int32_t);
+   if (fieldType == "std::uint32_t") return typeid(std::uint32_t);
+   if (fieldType == "std::int64_t")  return typeid(std::int64_t);
+   if (fieldType == "std::uint64_t") return typeid(std::uint64_t);
+   if (fieldType == "float")         return typeid(float);
+   if (fieldType == "double")        return typeid(double);
+   // clang-format on
+   
    // if the type is not one of those above, we use the default in-memory type.
    return std::nullopt;
 }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -247,13 +247,21 @@ std::uint32_t SerializePhysicalColumn(const ROOT::Experimental::RColumnDescripto
 std::uint32_t SerializeColumnsOfFields(const ROOT::Experimental::RNTupleDescriptor &desc,
                                        std::span<const ROOT::Experimental::DescriptorId_t> fieldList,
                                        const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
-                                       void *buffer)
+                                       void *buffer, bool forHeaderExtension)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
    void **where = (buffer == nullptr) ? &buffer : reinterpret_cast<void **>(&pos);
 
+   const auto *xHeader = !forHeaderExtension ? desc.GetHeaderExtension() : nullptr;
+
    for (auto parentId : fieldList) {
+      // If we're serializing the non-extended header and we already have a header extension (which may happen if
+      // we load an RNTuple for incremental merging), we need to skip all the extended fields, as they need to be
+      // written in the header extension, not in the regular header.
+      if (xHeader && xHeader->ContainsField(parentId))
+         continue;
+
       for (const auto &c : desc.GetColumnIterable(parentId)) {
          if (c.IsAliasColumn())
             continue;
@@ -476,13 +484,18 @@ std::uint32_t SerializeAliasColumn(const ROOT::Experimental::RColumnDescriptor &
 std::uint32_t SerializeAliasColumnsOfFields(const ROOT::Experimental::RNTupleDescriptor &desc,
                                             std::span<const ROOT::Experimental::DescriptorId_t> fieldList,
                                             const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
-                                            void *buffer)
+                                            void *buffer, bool forHeaderExtension)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
    void **where = (buffer == nullptr) ? &buffer : reinterpret_cast<void **>(&pos);
 
+   const auto *xHeader = !forHeaderExtension ? desc.GetHeaderExtension() : nullptr;
+
    for (auto parentId : fieldList) {
+      if (xHeader && xHeader->ContainsField(parentId))
+         continue;
+
       for (const auto &c : desc.GetColumnIterable(parentId)) {
          if (!c.IsAliasColumn())
             continue;
@@ -1246,8 +1259,6 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
    };
 
    R__ASSERT(desc.GetNFields() > 0); // we must have at least a zero field
-   if (!forHeaderExtension)
-      R__ASSERT(!desc.GetHeaderExtension());
 
    std::vector<DescriptorId_t> fieldTrees;
    if (!forHeaderExtension) {
@@ -1303,9 +1314,16 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
          }
       }
    } else {
-      nFields = desc.GetNFields() - 1;
-      nColumns = desc.GetNPhysicalColumns();
-      nAliasColumns = desc.GetNLogicalColumns() - desc.GetNPhysicalColumns();
+      if (auto xHeader = desc.GetHeaderExtension()) {
+         nFields = desc.GetNFields() - xHeader->GetNFields() - 1;
+         nColumns = desc.GetNPhysicalColumns() - xHeader->GetNPhysicalColumns();
+         nAliasColumns = desc.GetNLogicalColumns() - desc.GetNPhysicalColumns() -
+                         (xHeader->GetNLogicalColumns() - xHeader->GetNPhysicalColumns());
+      } else {
+         nFields = desc.GetNFields() - 1;
+         nColumns = desc.GetNPhysicalColumns();
+         nAliasColumns = desc.GetNLogicalColumns() - desc.GetNPhysicalColumns();
+      }
    }
    const auto nExtraTypeInfos = desc.GetNExtraTypeInfos();
    const auto &onDiskFields = context.GetOnDiskFieldList();
@@ -1320,7 +1338,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
 
    frame = pos;
    pos += SerializeListFramePreamble(nColumns, *where);
-   pos += SerializeColumnsOfFields(desc, fieldList, context, *where);
+   pos += SerializeColumnsOfFields(desc, fieldList, context, *where, forHeaderExtension);
    for (const auto &c : extraColumns) {
       if (!c.get().IsAliasColumn()) {
          pos += SerializePhysicalColumn(c.get(), context, *where);
@@ -1330,7 +1348,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
 
    frame = pos;
    pos += SerializeListFramePreamble(nAliasColumns, *where);
-   pos += SerializeAliasColumnsOfFields(desc, fieldList, context, *where);
+   pos += SerializeAliasColumnsOfFields(desc, fieldList, context, *where, forHeaderExtension);
    for (const auto &c : extraColumns) {
       if (c.get().IsAliasColumn()) {
          pos += SerializeAliasColumn(c.get(), context, *where);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -922,7 +922,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel>
 ROOT::Experimental::Internal::RPagePersistentSink::InitFromDescriptor(const RNTupleDescriptor &srcDescriptor)
 {
    // Create new descriptor
-   fDescriptorBuilder.CreateFromSchema(srcDescriptor);
+   fDescriptorBuilder.SetSchemaFromExisting(srcDescriptor);
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
    // Create column/page ranges

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -129,7 +129,9 @@ private:
 public:
    explicit FileRaii(const std::string &path) : fPath(path) {}
    FileRaii(const FileRaii &) = delete;
+   FileRaii(FileRaii &&) = default;
    FileRaii &operator=(const FileRaii &) = delete;
+   FileRaii &operator=(FileRaii &&) = default;
    ~FileRaii()
    {
       if (!fPreserveFile)

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -114,6 +114,8 @@ using RPrepareVisitor = ROOT::Experimental::RPrepareVisitor;
 using RPrintSchemaVisitor = ROOT::Experimental::RPrintSchemaVisitor;
 using RRawFile = ROOT::Internal::RRawFile;
 using EContainerFormat = RNTupleFileWriter::EContainerFormat;
+template <typename T>
+using RNTupleView = ROOT::Experimental::RNTupleView<T>;
 
 using ROOT::Experimental::Internal::MakeUninitArray;
 


### PR DESCRIPTION
Based on #17559. Opening as a draft because I'd like to add some more unit tests.

This is the last(*) PR of a series that adds proper support for incremental merging with Union mode, i.e. proper handling of deferred columns in the Merger.
With this change we should be able to support [ATLAS-like workflows](https://gitlab.cern.ch/amete/rootparallelmerger/-/blob/master/src/ParallelFileMerger.cpp?ref_type=heads) where the TFileMerger is used to incrementally construct an RNTuple from a sequence of files that may contain additional fields compared to the already-merged ones.

(*) at least for a minimal working case - more edge cases remain to be tested and likely fixed.

## A brief overview
When Union-merging files containing compatible-but-different models (e.g. the second file contains an additional field), we resort to Late Model Extension in the RNTupleMerger and therefore produce a merged RNTuple containing deferred columns in the header extension.
When we incrementally merge a new file, we need to read the metadata from the existing RNTuple, preserve the header extension as-is and possibly Late Model Extend again the new model created from this metadata. This requires some care because we need to explicitly keep all the extended fields and columns in the header extension when writing the file back (rather than merging them in the regular header).
This requires dropping the implicit assumption in our serializer API that assumes that no header extension is present when serializing the header the first time.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


cc @amete who is probably interested, as he provided the ParallelFileMerger example linked above