### PR TITLE
[ntuple] RMiniFile: write StreamerInfo with the correct compression

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RSpan.hxx>
+#include <Compression.h>
 #include <string_view>
 
 #include <cstdint>
@@ -202,7 +203,7 @@ private:
    /// Write the TList with the RNTuple key
    void WriteTFileKeysList();
    /// Write the compressed streamer info record with the description of the RNTuple class
-   void WriteTFileStreamerInfo();
+   void WriteTFileStreamerInfo(int compression);
    /// Last record in the file
    void WriteTFileFreeList();
    /// For a bare file, which is necessarily written by a C file stream, write file header
@@ -245,7 +246,7 @@ public:
    /// Ensures that the streamer info records passed as argument are written to the file
    void UpdateStreamerInfos(const RNTupleSerializer::StreamerInfoMap_t &streamerInfos);
    /// Writes the RNTuple key to the file so that the header and footer keys can be found
-   void Commit();
+   void Commit(int compression = RCompressionSetting::EDefaults::kUseGeneralPurpose);
 };
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -199,9 +199,10 @@ private:
    /// For a TFile container written by a C file stream, write the header and TFile object
    void WriteTFileSkeleton(int defaultCompression);
    /// The only key that will be visible in file->ls()
-   void WriteTFileNTupleKey();
+   /// Returns the size on disk of the anchor object
+   std::uint64_t WriteTFileNTupleKey(int compression);
    /// Write the TList with the RNTuple key
-   void WriteTFileKeysList();
+   void WriteTFileKeysList(std::uint64_t anchorSize);
    /// Write the compressed streamer info record with the description of the RNTuple class
    void WriteTFileStreamerInfo(int compression);
    /// Last record in the file

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1188,7 +1188,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::UpdateStreamerInfos(
    fStreamerInfoMap.insert(streamerInfos.cbegin(), streamerInfos.cend());
 }
 
-void ROOT::Experimental::Internal::RNTupleFileWriter::Commit()
+void ROOT::Experimental::Internal::RNTupleFileWriter::Commit(int compression)
 {
    if (fFileProper) {
       // Easy case, the ROOT file header and the RNTuple streaming is taken care of by TFile
@@ -1220,7 +1220,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::Commit()
 
    WriteTFileNTupleKey();
    WriteTFileKeysList();
-   WriteTFileStreamerInfo();
+   WriteTFileStreamerInfo(compression);
    WriteTFileFreeList();
 
    // Update header and TFile record
@@ -1365,7 +1365,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::WriteBareFileSkeleton(int 
    fFileSimple.fKeyOffset = fFileSimple.fFilePos;
 }
 
-void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileStreamerInfo()
+void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileStreamerInfo(int compression)
 {
    // The streamer info record is a TList of TStreamerInfo object.  We cannot use
    // RNTupleSerializer::SerializeStreamerInfos because that uses TBufferIO::WriteObject.
@@ -1400,7 +1400,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileStreamerInfo()
 
    RNTupleCompressor compressor;
    auto zipStreamerInfos = MakeUninitArray<unsigned char>(lenPayload);
-   auto szZipStreamerInfos = compressor.Zip(bufPayload, lenPayload, 1, zipStreamerInfos.get());
+   auto szZipStreamerInfos = compressor.Zip(bufPayload, lenPayload, compression, zipStreamerInfos.get());
 
    fFileSimple.WriteKey(zipStreamerInfos.get(), szZipStreamerInfos, lenPayload,
                         fFileSimple.fControlBlock->fHeader.GetSeekInfo(), RTFHeader::kBEGIN, "TList", "StreamerInfo",

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -245,7 +245,7 @@ void ROOT::Experimental::Internal::RPageSinkFile::CommitDatasetImpl(unsigned cha
    auto szFooterZip = fCompressor->Zip(serializedFooter, length, GetWriteOptions().GetCompression(),
                                        RNTupleCompressor::MakeMemCopyWriter(bufFooterZip.get()));
    fWriter->WriteNTupleFooter(bufFooterZip.get(), szFooterZip, length);
-   fWriter->Commit();
+   fWriter->Commit(GetWriteOptions().GetCompression());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently RMiniFile doesn't honor the compression settings set in the RNTupleWriteOptions when writing out the StreamerInfo, but instead it always ZLIB-compresses it.
With this change, it will use the same compression as it was specified in the options (or 505 if unspecified).
This makes the behavior more consistent with the TFile, where the TFile compression determines also the StreamerInfo's compression (whereas now RNTuple may export a compressed StreamerInfo even if the TFile's compression is 0).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


