### PR TITLE
[ntuple] RMiniFile: properly write the free slot's nbytes

### DIFF
--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -305,4 +305,8 @@ struct ThrowForVariant {
    ThrowForVariant &operator=(const ThrowForVariant &) = default;
 };
 
+struct RelativelyLargeStruct {
+   char fDummy[250];
+};
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -105,4 +105,6 @@
 
 #pragma link C++ class ThrowForVariant + ;
 
+#pragma link C++ class RelativelyLargeStruct + ;
+
 #endif


### PR DESCRIPTION
# This Pull request:
depends on https://github.com/root-project/root/pull/17575.

Fixes the case in RMiniFileWriter where a RBlob is allocated inside a free slot that is bigger than the blob itself. In that case allocating the TKey also needs to update the header of the remaining free slot after the space for the blob was reserved (see [TKey::Create](https://github.com/root-project/root/blob/master/io/io/src/TKey.cxx#L510-L516)). This is normally done by `TKey::WriteFile`, but since RMiniFile bypasses that it needs to write the updated nbytes to disk manually.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


