### PR TITLE
[skip-ci] disable minimal=on

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Apply option overrides
       env:
-        OVERRIDES: "testing=Off roottest=Off minimal=On"
+        OVERRIDES: "testing=Off roottest=Off"
         CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma9.txt'
       shell: bash
       run: |


### PR DESCRIPTION
When building ROOT for the doc, `minimal=on` was set. this prevented to build `geom`.

