### PR TITLE
[ntuple] Detect mismatch between entry and model in `RNTupleReader::LoadEntry`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -234,7 +234,13 @@ public:
       LoadEntry(index, fModel->GetDefaultEntry());
    }
    /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
-   void LoadEntry(NTupleSize_t index, REntry &entry) { entry.Read(index); }
+   void LoadEntry(NTupleSize_t index, REntry &entry)
+   {
+      if (R__unlikely(entry.GetModelId() != fModel->GetModelId()))
+         throw RException(R__FAIL("mismatch between entry and model"));
+
+      entry.Read(index);
+   }
 
    /// Returns an iterator over the entry indices of the RNTuple.
    ///


### PR DESCRIPTION
Mirroring the behavior for `RNTupleWriter::Fill`, with this PR, calling `RNTupleReader::LoadEntry` with an entry that does not belong to the model of that `RNTupleReader` now properly throws an exception.

Fixes #16841.

