### PR TITLE
[skip-ci] use tcanvas_js

### DIFF
--- a/tutorials/hist/hist048_Graphics_candle_hist.C
+++ b/tutorials/hist/hist048_Graphics_candle_hist.C
@@ -3,7 +3,7 @@
 /// \notebook
 /// Example showing how to combine the various candle plot options.
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \date December 2017

--- a/tutorials/hist/hist049_Graphics_candle_plot.C
+++ b/tutorials/hist/hist049_Graphics_candle_plot.C
@@ -3,7 +3,7 @@
 /// \notebook
 /// Example of candle plot with 2-D histograms.
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \date May 2024

--- a/tutorials/hist/hist050_Graphics_candle_plot_options.C
+++ b/tutorials/hist/hist050_Graphics_candle_plot_options.C
@@ -3,7 +3,7 @@
 /// \notebook
 /// Example showing how to combine the various candle plot options.
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \date December 2017
@@ -26,8 +26,7 @@ void hist050_Graphics_candle_plot_options()
    }
    for (int i = 1; i < 7; i++) {
       c1->cd(i);
-      char str[16];
-      sprintf(str, "candlex%d", i);
+      TString str = TString::Format("candlex%d", i);
       TH2I *myhist = (TH2I *)h1->DrawCopy(str);
       myhist->SetTitle(str);
    }
@@ -38,8 +37,7 @@ void hist050_Graphics_candle_plot_options()
                         "301", "1111", "2321", "12111", "112111", "212111", "312111"};
    for (int i = 0; i < 15; i++) {
       c2->cd(i + 1);
-      char str[16];
-      sprintf(str, "candlex(%s)", myopt[i]);
+      TString str = TString::Format("candlex(%s)", myopt[i]);
       TH2I *myhist = (TH2I *)h1->DrawCopy(str);
       myhist->SetTitle(str);
    }

--- a/tutorials/hist/hist051_Graphics_candle_plot_stack.C
+++ b/tutorials/hist/hist051_Graphics_candle_plot_stack.C
@@ -3,7 +3,7 @@
 /// \notebook
 /// Example showing how a THStack with candle plot option.
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \date May 2024

--- a/tutorials/hist/hist052_Graphics_candle_plot_whiskers.C
+++ b/tutorials/hist/hist052_Graphics_candle_plot_whiskers.C
@@ -3,7 +3,7 @@
 /// \notebook
 /// Example of candle plot showing the whiskers definition.
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_output
 /// \macro_code
 ///

--- a/tutorials/hist/hist053_Graphics_candle_scaled.C
+++ b/tutorials/hist/hist053_Graphics_candle_scaled.C
@@ -4,7 +4,7 @@
 /// Candle Scaled, illustrates what scaling does on candle and violin charts.
 /// Please try to modify the static functions SetScaledCandle and SetScaledViolin
 ///
-/// \macro_image
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \date February 2023


### PR DESCRIPTION
Use tcanvas_js to display candle plot examples.
Remove sprintf

