### PR TITLE
io: Allow implicit conversion from  vector<pair<A<B> > to map<A,B>

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -717,8 +717,10 @@ TString TBufferJSON::StoreObject(const void *obj, const TClass *cl)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Converts selected data member into json
-/// Parameter ptr specifies address in memory, where data member is located
-/// compact parameter defines compactness of produced JSON (from 0 to 3)
+/// Parameter ptr specifies address in memory, where data member is located.
+/// Note; if data member described by 'member'is pointer, `ptr` should be the
+/// value of the pointer, not the address of the pointer.
+/// compact parameter defines compactness of produced JSON (from 0 to 3).
 /// arraylen (when specified) is array length for this data member,  //[fN] case
 
 TString TBufferJSON::ConvertToJSON(const void *ptr, TDataMember *member, Int_t compact, Int_t arraylen)
@@ -1002,6 +1004,8 @@ void *TBufferJSON::ConvertFromJSONChecked(const char *str, const TClass *expecte
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Convert single data member to JSON structures
+/// Note; if data member described by 'member'is pointer, `ptr` should be the
+/// value of the pointer, not the address of the pointer.
 /// Returns string with converted member
 
 TString TBufferJSON::JsonWriteMember(const void *ptr, TDataMember *member, TClass *memberClass, Int_t arraylen)

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1038,7 +1038,13 @@ TString TBufferJSON::JsonWriteMember(const void *ptr, TDataMember *member, TClas
       if (indx.IsArray() && (tid == kChar_t))
          shift = indx.ReduceDimension();
 
+      auto unitSize = member->GetUnitSize();
       char *ppp = (char *)ptr;
+      if (member->IsaPointer()) {
+         // UnitSize was the sizeof(void*)
+         assert(member->GetDataType());
+         unitSize = member->GetDataType()->Size();
+      }
 
       if (indx.IsArray())
          fOutBuffer.Append(indx.GetBegin());
@@ -1079,7 +1085,7 @@ TString TBufferJSON::JsonWriteMember(const void *ptr, TDataMember *member, TClas
          if (indx.IsArray())
             fOutBuffer.Append(indx.NextSeparator());
 
-         ppp += shift * member->GetUnitSize();
+         ppp += shift * unitSize;
 
       } while (!indx.IsDone());
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2459,7 +2459,9 @@ void TStreamerInfo::BuildOld()
 
                } else if ( (newkind==ROOT::kSTLmap || newkind==ROOT::kSTLmultimap) &&
                            (oldkind!=ROOT::kSTLmap && oldkind!=ROOT::kSTLmultimap) ) {
-                  element->SetNewType(TVirtualStreamerInfo::kUnsupportedConversion);
+                  // This case was not previously not supported, however it is unclear
+                  // why so we keep it as a separate case for the time behind.
+                  element->Update(oldClass, newClass.GetClass());
                } else {
                   element->Update(oldClass, newClass.GetClass());
                }


### PR DESCRIPTION
The roottest companion PR is https://github.com/root-project/roottest/pull/1255