### PR TITLE
[RF] Make Offset("bin") usable for CLs method

### DIFF
--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -512,13 +512,11 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const c
 
    fitRes->setConstParList(_fcn->constParams());
 
-   double removeOffset = 0.;
    fitRes->setNumInvalidNLL(_fcn->GetNumInvalidNLL());
-   removeOffset = -_fcn->getOffset();
 
    fitRes->setStatus(_status);
    fitRes->setCovQual(_minimizer->CovMatrixStatus());
-   fitRes->setMinNLL(_result->fVal + removeOffset);
+   fitRes->setMinNLL(_result->fVal -_fcn->getOffset());
    fitRes->setEDM(_result->fEdm);
 
    fitRes->setInitParList(_fcn->initFloatParams());

--- a/roofit/roofitcore/test/TestStatistics/testInterface.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testInterface.cxx
@@ -70,7 +70,7 @@ TEST(Interface, createNLLModularLAndOffset)
 
    RooHelpers::HijackMessageStream hijack(RooFit::ERROR, RooFit::InputArguments);
 
-   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::Offset(true), RooFit::ModularL(true))};
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::Offset("initial"), RooFit::ModularL(true))};
 
    EXPECT_NE(hijack.str().find("ERROR"), std::string::npos) << "Stream contents: " << hijack.str();
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -477,15 +477,17 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
+   using namespace RooFit;
+
    // A variation to test some additional parameters (ConstrainedParameters and offsetting)
 
    // The reference likelihood is using the legacy evaluation backend, because
    // the multiprocess test statistics classes were designed to give values
    // that are bit-by-bit identical with the old test statistics based on
    // RooAbsTestStatistic.
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_A")),
-                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")),
+                                                    GlobalObservables(*w.var("alpha_bkg_obs_B")), Offset("initial"),
+                                                    EvalBackend::Legacy())};
 
    // --------
 
@@ -555,15 +557,17 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
 TEST_P(LikelihoodJobSplitStrategies, DISABLED_SimBinnedConstrainedAndOffset)
 #endif
 {
+   using namespace RooFit;
+
    // Based on ConstrainedAndOffset, this test tests different parallelization strategies
 
    // The reference likelihood is using the legacy evaluation backend, because
    // the multiprocess test statistics classes were designed to give values
    // that are bit-by-bit identical with the old test statistics based on
    // RooAbsTestStatistic.
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_A")),
-                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")),
+                                                    GlobalObservables(*w.var("alpha_bkg_obs_B")), Offset("initial"),
+                                                    EvalBackend::Legacy())};
 
    // --------
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -417,15 +417,17 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
+   using namespace RooFit;
+
    // A variation to test some additional parameters (ConstrainedParameters and offsetting)
 
    // The reference likelihood is using the legacy evaluation backend, because
    // the multiprocess test statistics classes were designed to give values
    // that are bit-by-bit identical with the old test statistics based on
    // RooAbsTestStatistic.
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_A"))),
-                                                    RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))),
-                                                    RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")),
+                                                    GlobalObservables(*w.var("alpha_bkg_obs_B")), Offset("initial"),
+                                                    EvalBackend::Legacy())};
 
    // --------
 

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -32,15 +32,6 @@ namespace RooStats {
      enum LimitType {twoSided, oneSided, oneSidedDiscovery};
 
    public:
-      /// Proof constructor. Do not use.
-      ProfileLikelihoodTestStat()
-         : fStrategy(::ROOT::Math::MinimizerOptions::DefaultStrategy()),
-           fTolerance(std::max(1., ::ROOT::Math::MinimizerOptions::DefaultTolerance())),
-           fPrintLevel(::ROOT::Math::MinimizerOptions::DefaultPrintLevel()),
-           fLOffset(RooStats::IsNLLOffset())
-      {
-      }
-
       ProfileLikelihoodTestStat(RooAbsPdf &pdf)
          : fPdf(&pdf),
            fStrategy(::ROOT::Math::MinimizerOptions::DefaultStrategy()),
@@ -137,9 +128,7 @@ namespace RooStats {
       Int_t fPrintLevel;
       bool fLOffset ;
 
-   protected:
-
-      ClassDefOverride(ProfileLikelihoodTestStat,10)   // implements the profile likelihood ratio as a test statistic to be used with several tools
+      ClassDefOverride(ProfileLikelihoodTestStat,0)   // implements the profile likelihood ratio as a test statistic to be used with several tools
    };
 }
 

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -37,7 +37,7 @@ namespace RooStats {
            fStrategy(::ROOT::Math::MinimizerOptions::DefaultStrategy()),
            fTolerance(std::max(1., ::ROOT::Math::MinimizerOptions::DefaultTolerance())),
            fPrintLevel(::ROOT::Math::MinimizerOptions::DefaultPrintLevel()),
-           fLOffset(RooStats::IsNLLOffset())
+           fLOffset(RooStats::NLLOffsetMode())
       {
          // avoid default tolerance to be too small (1. is default in RooMinimizer)
       }
@@ -56,7 +56,8 @@ namespace RooStats {
      static void SetAlwaysReuseNLL(bool flag);
 
      void SetReuseNLL(bool flag) { fReuseNll = flag ; }
-     void SetLOffset(bool flag=true) { fLOffset = flag ; }
+     void SetLOffset(bool flag=true) { fLOffset = flag ? "initial" : "none"; }
+     void SetLOffset(std::string const &mode) { fLOffset = mode; }
 
      void SetMinimizer(const char* minimizer){ fMinimizer=minimizer;}
      void SetStrategy(Int_t strategy){fStrategy=strategy;}
@@ -126,7 +127,7 @@ namespace RooStats {
       Int_t fStrategy;
       double fTolerance;
       Int_t fPrintLevel;
-      bool fLOffset ;
+      std::string fLOffset;
 
       ClassDefOverride(ProfileLikelihoodTestStat,0)   // implements the profile likelihood ratio as a test statistic to be used with several tools
    };

--- a/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
+++ b/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
@@ -24,16 +24,6 @@ namespace RooStats {
    class RatioOfProfiledLikelihoodsTestStat: public TestStatistic {
 
    public:
-      RatioOfProfiledLikelihoodsTestStat()
-         :
-
-           fAltPOI(nullptr),
-           fSubtractMLE(true),
-           fDetailedOutputEnabled(false),
-           fDetailedOutput(nullptr)
-      {
-         // Proof constructor. Don't use.
-      }
 
       RatioOfProfiledLikelihoodsTestStat(RooAbsPdf& nullPdf, RooAbsPdf& altPdf,
                                          const RooArgSet* altPOI=nullptr) :
@@ -141,9 +131,7 @@ namespace RooStats {
       bool fDetailedOutputEnabled;
       RooArgSet* fDetailedOutput;
 
-
-   protected:
-      ClassDefOverride(RatioOfProfiledLikelihoodsTestStat,3)  // implements the ratio of profiled likelihood as test statistic
+      ClassDefOverride(RatioOfProfiledLikelihoodsTestStat,0)  // implements the ratio of profiled likelihood as test statistic
    };
 
 }

--- a/roofit/roostats/inc/RooStats/RooStatsUtils.h
+++ b/roofit/roostats/inc/RooStats/RooStatsUtils.h
@@ -37,7 +37,7 @@ In addition the namespace contain a set of utility functions.
 
 namespace RooStats {
    struct RooStatsConfig {
-      bool useLikelihoodOffset{false}; ///< Offset the likelihood by passing RooFit::Offset to fitTo().
+      std::string useLikelihoodOffset = "none"; ///< Offset the likelihood by passing RooFit::Offset to fitTo().
       bool useEvalErrorWall{true};     ///< Use the error wall RooFit::EvalErrorWall to drive the fitter away from disallowed parameter values.
    };
 
@@ -131,12 +131,31 @@ namespace RooStats {
    /// useful function to print in one line the content of a set with their values
    void PrintListContent(const RooArgList & l, std::ostream & os = std::cout);
 
-   /// function to set a global flag in RooStats to use NLL offset when performing nll computations
-   /// Note that not all ROoStats tools implement this capabilities
-   void UseNLLOffset(bool on);
+   /// Use an offset in NLL calculations.
+   /// \deprecated Use SetNLLOffsetMode().
+   inline void UseNLLOffset(bool on) {
+      GetGlobalRooStatsConfig().useLikelihoodOffset = on ? "initial" : "none";
+   }
 
-   /// function returning if the flag to check if the flag to use  NLLOffset is set
-   bool IsNLLOffset();
+   /// Function returning if the flag to check if the flag to use  NLLOffset is
+   /// set.
+   /// \deprecated Use NLLOffsetMode().
+   inline bool IsNLLOffset() {
+      return GetGlobalRooStatsConfig().useLikelihoodOffset == "initial";
+   }
+
+   /// Function to set a global flag in RooStats to use NLL offset when
+   /// performing nll computations.
+   /// \note Not all RooStats tools implement this capabilities.
+   inline void SetNLLOffsetMode(std::string const& mode) {
+      GetGlobalRooStatsConfig().useLikelihoodOffset = mode;
+   }
+
+   /// Test what offsetting mode RooStats should use by default.
+   inline std::string const &NLLOffsetMode() {
+      return GetGlobalRooStatsConfig().useLikelihoodOffset;
+   }
+
 
    /// function that clones a workspace, copying all needed components and discarding all others
    RooWorkspace* MakeReducedWorkspace(RooWorkspace *oldWS, const char *newName, bool copySnapshots,

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -22,9 +22,6 @@ enum toysStrategies { EQUALTOYSPERDENSITY, EXPONENTIALTOYDISTRIBUTION };
 class ToyMCImportanceSampler: public ToyMCSampler {
 
    public:
-      /// Proof constructor. Do not use.
-      ToyMCImportanceSampler() = default;
-
       ToyMCImportanceSampler(TestStatistic &ts, Int_t ntoys) : ToyMCSampler(ts, ntoys) {}
 
       ~ToyMCImportanceSampler() override;
@@ -177,8 +174,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
       mutable std::vector<std::unique_ptr<RooAbsReal>> fNullNLLs;    ///<!
       mutable std::vector<std::unique_ptr<RooAbsReal>> fImpNLLs;     ///<!
 
-   protected:
-   ClassDefOverride(ToyMCImportanceSampler,2) // An implementation of importance sampling
+   ClassDefOverride(ToyMCImportanceSampler,0) // An implementation of importance sampling
 };
 }
 

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -67,7 +67,6 @@ class ToyMCSampler: public TestStatSampler {
 
    public:
 
-      ToyMCSampler();
       ToyMCSampler(TestStatistic &ts, Int_t ntoys);
       ~ToyMCSampler() override;
 
@@ -285,8 +284,7 @@ class ToyMCSampler: public TestStatSampler {
       static bool fgAlwaysUseMultiGen ;  ///< Use PrepareMultiGen always
       bool fUseMultiGen = false;         ///< Use PrepareMultiGen?
 
-   protected:
-   ClassDefOverride(ToyMCSampler, 4) // A simple implementation of the TestStatSampler interface
+   ClassDefOverride(ToyMCSampler, 0) // A simple implementation of the TestStatSampler interface
 };
 }
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -425,7 +425,7 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
           result = std::unique_ptr<RooFitResult>{minim.save()};
        }
        if (result){
-          if (!RooStats::IsNLLOffset()) {
+          if (RooStats::NLLOffsetMode() != "initial") {
              val = result->minNll();
           } else {
              bool previous = RooAbsReal::hideOffset();

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -247,8 +247,8 @@ bool LikelihoodInterval::CreateMinimizer() {
    const auto& config = GetGlobalRooStatsConfig();
 
    // now do binding of NLL with a functor for Minimizer
-   if (config.useLikelihoodOffset) {
-      ccoutI(InputArguments) << "LikelihoodInterval: using nll offset - set all RooAbsReal to hide the offset  " << std::endl;
+   if (config.useLikelihoodOffset == "initial") {
+      ccoutI(InputArguments) << "LikelihoodInterval: using nll offset \"initial\" - set all RooAbsReal to hide the offset  " << std::endl;
       RooAbsReal::setHideOffset(false); // need to keep this false
    }
    fFunctor = std::make_shared<RooFunctor>(nll, RooArgSet(), params);

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -312,7 +312,7 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
 
    double nLLatMLE = fFitResult->minNll();
    // in case of using offset need to save offset value
-   double nlloffset = (RooStats::IsNLLOffset() ) ? nll->getVal() - nLLatMLE : 0;
+   double nlloffset = RooStats::NLLOffsetMode() == "initial" ? nll->getVal() - nLLatMLE : 0;
 
    // set POI to given values, set constant, calculate conditional MLE
    std::vector<double> oldValues(poiList.size() );
@@ -364,7 +364,7 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
       // get just the likelihood value (no need to do a fit since the likelihood is a constant function)
       nLLatCondMLE = nll->getVal();
       // this value contains the offset
-      if (RooStats::IsNLLOffset() ) nLLatCondMLE -= nlloffset;
+      if (RooStats::NLLOffsetMode() == "initial") nLLatCondMLE -= nlloffset;
    }
 
    // Use Wilks' theorem to translate -2 log lambda into a significance/p-value

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -85,7 +85,10 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           fNll = std::unique_ptr<RooAbsReal>{fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),
                                  RooFit::GlobalObservables(fGlobalObs), RooFit::ConditionalObservables(fConditionalObs), RooFit::Offset(fLOffset))};
 
-          if (fPrintLevel > 0 && fLOffset) std::cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << std::endl ;
+          if (fPrintLevel > 0) {
+             std::cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset mode \""
+                 << fLOffset << "\" in creating NLL" << std::endl;
+          }
 
           created = true ;
           if (fPrintLevel > 1) std::cout << "creating NLL " << &*fNll << " with data = " << &data << std::endl ;
@@ -191,9 +194,9 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           // no need to minimize just evaluate the nll
           if (allParams.empty() ) {
              // be sure to evaluate with offsets
-             if (fLOffset) RooAbsReal::setHideOffset(false);
+             if (fLOffset == "initial") RooAbsReal::setHideOffset(false);
              condML = fNll->getVal();
-             if (fLOffset) RooAbsReal::setHideOffset(true);
+             if (fLOffset == "initial") RooAbsReal::setHideOffset(true);
           }
           else {
             fNll->clearEvalErrorLog();
@@ -221,7 +224,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        if (type != 0)  {
           // for conditional only or unconditional fits
           // need to compute nll value without the offset
-          if (fLOffset) {
+          if (fLOffset == "initial") {
              RooAbsReal::setHideOffset(false) ;
              pll = fNll->getVal();
           }

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -78,16 +78,6 @@ namespace RooStats {
       return std::sqrt(za2);
    }
 
-   /// Use an offset in NLL calculations.
-   void UseNLLOffset(bool on) {
-      GetGlobalRooStatsConfig().useLikelihoodOffset = on;
-   }
-
-   /// Test of RooStats should by default offset NLL calculations.
-   bool IsNLLOffset() {
-      return GetGlobalRooStatsConfig().useLikelihoodOffset;
-   }
-
    void FactorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, RooArgList &obsTerms, RooArgList &constraints) {
    // utility function to factorize constraint terms from a pdf
    // (from G. Petrucciani)

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -139,20 +139,6 @@ bool ToyMCSampler::fgAlwaysUseMultiGen = false ;
 void ToyMCSampler::SetAlwaysUseMultiGen(bool flag) { fgAlwaysUseMultiGen = flag ; }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Proof constructor. Do not use.
-
-ToyMCSampler::ToyMCSampler()
-   : fSamplingDistName("SD"),
-     fNToys(1),
-     fMaxToys(RooNumber::infinity()),
-     fAdaptiveLowLimit(-RooNumber::infinity()),
-     fAdaptiveHighLimit(RooNumber::infinity())
-{
-   //suppress messages for num integration of Roofit
-   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 ToyMCSampler::ToyMCSampler(TestStatistic &ts, Int_t ntoys)
    : fSamplingDistName(ts.GetVarName().Data()),

--- a/tutorials/roofit/roostats/HybridInstructional.py
+++ b/tutorials/roofit/roostats/HybridInstructional.py
@@ -292,7 +292,6 @@ w.factory("Lognormal::lognorm_prior(b,y, expr::kappa('1+1./sqrt(y)',y))")
 # -------------------------------------------------------
 
 hc1 = ROOT.RooStats.HybridCalculator(data, sb_model, b_model)
-toymcs1 = ROOT.RooStats.ToyMCSampler()
 toymcs1 = hc1.GetTestStatSampler()
 toymcs1.SetNEventsPerToy(1)
 # because the model is in number counting form
@@ -345,7 +344,6 @@ slrts.SetAltParameters(sb_model.GetSnapshot())
 
 # HYBRID CALCULATOR
 hc2 = ROOT.RooStats.HybridCalculator(data, sb_model, b_model)
-toymcs2 = ROOT.RooStats.ToyMCSampler()
 toymcs2 = hc2.GetTestStatSampler()
 toymcs2.SetNEventsPerToy(1)
 toymcs2.SetTestStatistic(slrts)
@@ -455,7 +453,6 @@ w.factory("Gaussian::gauss_prior_y0(b,y0, expr::sqrty0('sqrt(y0)',y0))")
 
 # HYBRID CALCULATOR
 hc3 = ROOT.RooStats.HybridCalculator(dataXY, sb_modelXY, b_modelXY)
-toymcs3 = ROOT.RooStats.ToyMCSampler()
 toymcs3 = hc3.GetTestStatSampler()
 toymcs3.SetNEventsPerToy(1)
 toymcs3.SetTestStatistic(slrts)

--- a/tutorials/roofit/roostats/HybridStandardForm.py
+++ b/tutorials/roofit/roostats/HybridStandardForm.py
@@ -277,7 +277,6 @@ w.factory("Lognormal::lognorm_prior(b,y, expr::kappa('1+1./sqrt(y)',y))")
 # -------------------------------------------------------
 
 hc1 = ROOT.RooStats.HybridCalculator(data, sb_model, b_model)
-toymcs1 = ROOT.RooStats.ToyMCSampler()
 toymcs1 = hc1.GetTestStatSampler()
 #  toymcs1.SetNEventsPerToy(1) # because the model is in number counting form
 toymcs1.SetTestStatistic(eventCount)  # set the test statistic

--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.C
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.C
@@ -357,7 +357,7 @@ void StandardHypoTestInvDemo(const char *infile = nullptr, const char *wsName = 
 
    // enable offset for all roostats
    if (optHTInv.useNLLOffset)
-      RooStats::UseNLLOffset(true);
+      RooStats::SetNLLOffsetMode("initial");
 
    RooWorkspace *w = dynamic_cast<RooWorkspace *>(file->Get(wsName));
    HypoTestInverterResult *r = nullptr;
@@ -672,13 +672,13 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
       tw.Start();
       std::unique_ptr<RooFitResult> fitres{sbModel->GetPdf()->fitTo(
          *data, InitialHesse(false), Hesse(false), Minimizer(mMinimizerType.c_str(), "Migrad"), Strategy(0),
-         PrintLevel(mPrintLevel), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()))};
+         PrintLevel(mPrintLevel), Constrain(constrainParams), Save(true), Offset(RooStats::NLLOffsetMode()))};
       if (fitres->status() != 0) {
          Warning("StandardHypoTestInvDemo",
                  "Fit to the model failed - try with strategy 1 and perform first an Hesse computation");
          fitres = std::unique_ptr<RooFitResult>{sbModel->GetPdf()->fitTo(
             *data, InitialHesse(true), Hesse(false), Minimizer(mMinimizerType.c_str(), "Migrad"), Strategy(1),
-            PrintLevel(mPrintLevel + 1), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()))};
+            PrintLevel(mPrintLevel + 1), Constrain(constrainParams), Save(true), Offset(RooStats::NLLOffsetMode()))};
       }
       if (fitres->status() != 0)
          Warning("StandardHypoTestInvDemo", " Fit still failed - continue anyway.....");
@@ -979,7 +979,7 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
 
             sbModel->GetPdf()->fitTo(*data, InitialHesse(false), Hesse(false),
                                      Minimizer(mMinimizerType.c_str(), "Migrad"), Strategy(0), PrintLevel(mPrintLevel),
-                                     Constrain(constrainParams), Offset(RooStats::IsNLLOffset()));
+                                     Constrain(constrainParams), Offset(RooStats::NLLOffsetMode()));
 
             std::cout << "rebuild using fitted parameter value for B-model snapshot" << std::endl;
             constrainParams.Print("v");

--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
@@ -561,7 +561,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
                 PrintLevel(self.mPrintLevel),
                 Constrain(constrainParams),
                 Save(True),
-                Offset(RooStats.IsNLLOffset()),
+                Offset(RooStats.NLLOffsetMode()),
             )
 
             if fitres.status() != 0:
@@ -578,7 +578,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
                     PrintLevel(self.mPrintLevel + 1),
                     Constrain(constrainParams),
                     Save(True),
-                    Offset(RooStats.IsNLLOffset()),
+                    Offset(RooStats.NLLOffsetMode()),
                 )
 
             if fitres.status() != 0:
@@ -1098,7 +1098,7 @@ def StandardHypoTestInvDemo(
 
     # enable offset for all roostats
     if optHTInv.useNLLOffset:
-        RooStats.UseNLLOffset(True)
+        RooStats.SetNLLOffsetMode("initial")
 
     w = file.Get(wsName)
     r = 0


### PR DESCRIPTION
Turn the relevant variables for the likelihood offsetting mode from type
`bool` to `std::string`. Like this, any offsetting mode can be set
("none", "initial", and "bin").

Closes https://github.com/root-project/root/issues/15959.

Note that the issue also requested to support setting `Offset("bin")` at the level of the RooMinimizer, but this is not intended: this offsetting strategy is only changing the mathematical definition of the likelihood function, which the minimizer interface should not change. For the existing offsetting by subtracting the initial evaluation value, this was as different story, because to subtract the initial evaluation value one doesn't need to look inside the function.