### PR TITLE
Changing auto to double in ROOT::VecOps::Var definition

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2107,7 +2107,7 @@ double Var(const RVec<T> &v)
    auto pred = [&sum_squares, &squared_sum](const T& x) {sum_squares+=x*x; squared_sum+=x;};
    std::for_each(v.begin(), v.end(), pred);
    squared_sum *= squared_sum;
-   const auto dsize = (double) size;
+   const double dsize = (double) size;
    return 1. / (dsize - 1.) * (sum_squares - squared_sum / dsize );
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Changing auto to double in `ROOT::VecOps::Var` definition

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

