### PR TITLE
[ntuple] remove wrong assert in RNTupleSerialize.cxx

### DIFF
--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1246,8 +1246,6 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
    };
 
    R__ASSERT(desc.GetNFields() > 0); // we must have at least a zero field
-   if (!forHeaderExtension)
-      R__ASSERT(!desc.GetHeaderExtension());
 
    std::vector<DescriptorId_t> fieldTrees;
    if (!forHeaderExtension) {


### PR DESCRIPTION
This assert was introduced in da99545d831, but it is wrong (it may be the case that we call MapSchema when a header extension is already there). This code path will be exercised (and tested) in an upcoming PR about incremental merging (https://github.com/root-project/root/pull/17563/commits/9469b920c31be9fb03500b633946d83a1ea1c657)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)