### PR TITLE
[ntuple] Fix serialization when a header extension is already present

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1051,6 +1051,13 @@ public:
    /// We cannot create this vector when building the fFields because at the time when AddExtendedField is called,
    /// the field is not yet linked into the schema tree.
    std::vector<DescriptorId_t> GetTopLevelFields(const RNTupleDescriptor &desc) const;
+
+   bool ContainsField(DescriptorId_t fieldId) const { return fFieldIdsLookup.find(fieldId) != fFieldIdsLookup.end(); }
+   bool ContainsExtendedColumnRepresentation(DescriptorId_t columnId) const
+   {
+      return std::find(fExtendedColumnRepresentations.begin(), fExtendedColumnRepresentations.end(), columnId) !=
+             fExtendedColumnRepresentations.end();
+   }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -281,6 +281,9 @@ protected:
    /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
+   /// Flag if sink was initialized
+   bool fIsInitialized = false;
+
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable and not checksummed, the returned sealed page
    /// will point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
@@ -289,8 +292,6 @@ protected:
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
 private:
-   /// Flag if sink was initialized
-   bool fIsInitialized = false;
    std::vector<Callback_t> fOnDatasetCommitCallbacks;
    std::vector<unsigned char> fSealPageBuffer; ///< Used as destination buffer in the simple SealPage overload
 
@@ -529,7 +530,9 @@ public:
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
    /// Initialize sink based on an existing descriptor and fill into the descriptor builder.
-   void InitFromDescriptor(const RNTupleDescriptor &descriptor);
+   /// \return The model created from the new sink's descriptor. This model should be kept alive
+   /// for at least as long as the sink.
+   [[nodiscard]] std::unique_ptr<RNTupleModel> InitFromDescriptor(const RNTupleDescriptor &descriptor);
 
    void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -663,32 +663,46 @@ ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &op
    return model;
 }
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clone() const
+ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::CloneSchema() const
 {
    RNTupleDescriptor clone;
    clone.fName = fName;
    clone.fDescription = fDescription;
-   clone.fOnDiskHeaderXxHash3 = fOnDiskHeaderXxHash3;
-   clone.fOnDiskHeaderSize = fOnDiskHeaderSize;
-   clone.fOnDiskFooterSize = fOnDiskFooterSize;
-   clone.fNEntries = fNEntries;
-   clone.fNClusters = fNClusters;
    clone.fNPhysicalColumns = fNPhysicalColumns;
    clone.fFieldZeroId = fFieldZeroId;
-   clone.fGeneration = fGeneration;
+   clone.fFeatureFlags = fFeatureFlags;
+   // OnDiskHeaderSize, OnDiskHeaderXxHash3 not copied because they may come from a merged header + extension header
+   // and therefore not represent the actual sources's header.
+   // OnDiskFooterSize not copied because it contains information beyond the schema, for example the clustering.
+
    for (const auto &d : fFieldDescriptors)
       clone.fFieldDescriptors.emplace(d.first, d.second.Clone());
    for (const auto &d : fColumnDescriptors)
       clone.fColumnDescriptors.emplace(d.first, d.second.Clone());
+
+   for (const auto &d : fExtraTypeInfoDescriptors)
+      clone.fExtraTypeInfoDescriptors.emplace_back(d.Clone());
+   if (fHeaderExtension)
+      clone.fHeaderExtension = std::make_unique<RHeaderExtension>(*fHeaderExtension);
+
+   return clone;
+}
+
+ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clone() const
+{
+   RNTupleDescriptor clone = CloneSchema();
+
+   clone.fOnDiskHeaderSize = fOnDiskHeaderSize;
+   clone.fOnDiskHeaderXxHash3 = fOnDiskHeaderXxHash3;
+   clone.fOnDiskFooterSize = fOnDiskFooterSize;
+   clone.fNEntries = fNEntries;
+   clone.fNClusters = fNClusters;
+   clone.fGeneration = fGeneration;
    for (const auto &d : fClusterGroupDescriptors)
       clone.fClusterGroupDescriptors.emplace(d.first, d.second.Clone());
    clone.fSortedClusterGroupIds = fSortedClusterGroupIds;
    for (const auto &d : fClusterDescriptors)
       clone.fClusterDescriptors.emplace(d.first, d.second.Clone());
-   for (const auto &d : fExtraTypeInfoDescriptors)
-      clone.fExtraTypeInfoDescriptors.emplace_back(d.Clone());
-   if (fHeaderExtension)
-      clone.fHeaderExtension = std::make_unique<RHeaderExtension>(*fHeaderExtension);
    return clone;
 }
 
@@ -1197,6 +1211,11 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::Reset()
    fDescriptor.fClusterDescriptors.clear();
    fDescriptor.fClusterGroupDescriptors.clear();
    fDescriptor.fHeaderExtension.reset();
+}
+
+void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::SetSchemaFromExisting(const RNTupleDescriptor &descriptor)
+{
+   fDescriptor = descriptor.CloneSchema();
 }
 
 void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::BeginHeaderExtension()

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -199,13 +199,15 @@ try {
    assert(compression);
    writeOpts.SetCompression(*compression);
    auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
+   // TODO: currently unused, will be used by the merger in a future change.
+   std::unique_ptr<RNTupleModel> model;
 
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
       auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
       outSource->Attach();
       auto desc = outSource->GetSharedDescriptorGuard();
-      destination->InitFromDescriptor(desc.GetRef());
+      model = destination->InitFromDescriptor(desc.GetRef());
    }
 
    // Interface conversion

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -919,39 +919,68 @@ void ROOT::Experimental::Internal::RPagePersistentSink::InitImpl(RNTupleModel &m
    fDescriptorBuilder.BeginHeaderExtension();
 }
 
-void ROOT::Experimental::Internal::RPagePersistentSink::InitFromDescriptor(const RNTupleDescriptor &descriptor)
+std::unique_ptr<ROOT::Experimental::RNTupleModel>
+ROOT::Experimental::Internal::RPagePersistentSink::InitFromDescriptor(const RNTupleDescriptor &srcDescriptor)
 {
-   {
-      auto model = descriptor.CreateModel();
-      Init(*model.get());
+   // Create new descriptor
+   fDescriptorBuilder.SetSchemaFromExisting(srcDescriptor);
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+
+   // Create column/page ranges
+   const auto nColumns = descriptor.GetNPhysicalColumns();
+   R__ASSERT(fOpenColumnRanges.empty() && fOpenPageRanges.empty());
+   fOpenColumnRanges.reserve(nColumns);
+   fOpenPageRanges.reserve(nColumns);
+   for (DescriptorId_t i = 0; i < nColumns; ++i) {
+      const auto &column = descriptor.GetColumnDescriptor(i);
+      RClusterDescriptor::RColumnRange columnRange;
+      columnRange.fPhysicalColumnId = i;
+      columnRange.fFirstElementIndex = column.GetFirstElementIndex();
+      columnRange.fNElements = 0;
+      columnRange.fCompressionSettings = GetWriteOptions().GetCompression();
+      fOpenColumnRanges.emplace_back(columnRange);
+      RClusterDescriptor::RPageRange pageRange;
+      pageRange.fPhysicalColumnId = i;
+      fOpenPageRanges.emplace_back(std::move(pageRange));
    }
 
-   auto clusterId = descriptor.FindClusterId(0, 0);
-
+   // Clone and add all cluster descriptors
+   auto clusterId = srcDescriptor.FindClusterId(0, 0);
    while (clusterId != ROOT::Experimental::kInvalidDescriptorId) {
-      auto &cluster = descriptor.GetClusterDescriptor(clusterId);
+      auto &cluster = srcDescriptor.GetClusterDescriptor(clusterId);
       auto nEntries = cluster.GetNEntries();
-
-      RClusterDescriptorBuilder clusterBuilder;
-      clusterBuilder.ClusterId(fDescriptorBuilder.GetDescriptor().GetNActiveClusters())
-         .FirstEntryIndex(fPrevClusterNEntries)
-         .NEntries(nEntries);
-
       for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
          R__ASSERT(fOpenColumnRanges[i].fPhysicalColumnId == i);
+         if (!cluster.ContainsColumn(i)) // a cluster may not contain a column if that column is deferred
+            break;
          const auto &columnRange = cluster.GetColumnRange(i);
          R__ASSERT(columnRange.fPhysicalColumnId == i);
-         const auto &pageRange = cluster.GetPageRange(i);
-         R__ASSERT(pageRange.fPhysicalColumnId == i);
-         clusterBuilder.CommitColumnRange(i, fOpenColumnRanges[i].fFirstElementIndex,
-                                          columnRange.fCompressionSettings.value(), pageRange);
+         // TODO: properly handle suppressed columns (check MarkSuppressedColumnRange())
          fOpenColumnRanges[i].fFirstElementIndex += columnRange.fNElements;
       }
-      fDescriptorBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
+      fDescriptorBuilder.AddCluster(cluster.Clone());
       fPrevClusterNEntries += nEntries;
 
-      clusterId = descriptor.FindNextClusterId(clusterId);
+      clusterId = srcDescriptor.FindNextClusterId(clusterId);
    }
+
+   // Create model
+   auto modelOpts = RNTupleDescriptor::RCreateModelOptions();
+   modelOpts.fReconstructProjections = true;
+   auto model = descriptor.CreateModel(modelOpts);
+
+   // Serialize header and init from it
+   fSerializationContext = RNTupleSerializer::SerializeHeader(nullptr, descriptor);
+   auto buffer = MakeUninitArray<unsigned char>(fSerializationContext.GetHeaderSize());
+   fSerializationContext = RNTupleSerializer::SerializeHeader(buffer.get(), descriptor);
+   InitImpl(buffer.get(), fSerializationContext.GetHeaderSize());
+
+   fDescriptorBuilder.BeginHeaderExtension();
+
+   // mark this sink as initialized
+   fIsInitialized = true;
+
+   return model;
 }
 
 void ROOT::Experimental::Internal::RPagePersistentSink::CommitSuppressedColumn(ColumnHandle_t columnHandle)


### PR DESCRIPTION
Based on #17596, derived from #17563.
Introduces a new method in RNTupleDescriptor/Builder to allow cloning only the "schema" part of a descriptor, then uses this new method to fix `RPagePersistentSink::InitFromDescriptor` in the general case where the given descriptor already contains a header extension.
The RNTupleSerializer also needs a couple of changes to cope with this case, because we don't want to move the fields and columns from the header extension to the regular header (which would hinder the Merger's capability of doing incremental merging).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


