### PR TITLE
[ntuple] properly support incremental merging with Union mode

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -25,11 +25,12 @@
 
 #include <memory>
 #include <optional>
-#include <string>
-#include <vector>
-#include <unordered_map>
 
-namespace ROOT::Experimental::Internal {
+namespace ROOT {
+
+class RNTuple;
+
+namespace Experimental::Internal {
 
 enum class ENTupleMergingMode {
    /// The merger will discard all columns that aren't present in the prototype model (i.e. the model of the first
@@ -86,6 +87,8 @@ struct RNTupleMergeOptions {
  */
 // clang-format on
 class RNTupleMerger final {
+   friend class ROOT::RNTuple;
+
    std::unique_ptr<RPageSink> fDestination;
    std::unique_ptr<RPageAllocator> fPageAlloc;
    std::optional<TTaskGroup> fTaskGroup;
@@ -98,17 +101,21 @@ class RNTupleMerger final {
    void MergeSourceClusters(RPageSource &source, std::span<RColumnMergeInfo> commonColumns,
                             std::span<RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData);
 
-public:
    /// Creates a RNTupleMerger with the given destination.
    /// The model must be given if and only if `destination` has been initialized with that model
    /// (i.e. in case of incremental merging).
-   RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique_ptr<RNTupleModel> model = nullptr);
+   RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique_ptr<RNTupleModel> model);
+
+public:
+   /// Creates a RNTupleMerger with the given destination.
+   explicit RNTupleMerger(std::unique_ptr<RPageSink> destination);
 
    /// Merge a given set of sources into the destination.
    RResult<void> Merge(std::span<RPageSource *> sources, const RNTupleMergeOptions &mergeOpts = RNTupleMergeOptions());
 
 }; // end of class RNTupleMerger
 
-} // namespace ROOT::Experimental::Internal
+} // namespace Experimental::Internal
+} // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -89,6 +89,7 @@ class RNTupleMerger final {
    std::unique_ptr<RPageSink> fDestination;
    std::unique_ptr<RPageAllocator> fPageAlloc;
    std::optional<TTaskGroup> fTaskGroup;
+   std::unique_ptr<RNTupleModel> fModel;
 
    void MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t clusterId,
                            std::span<RColumnMergeInfo> commonColumns, const RCluster::ColumnSet_t &commonColumnSet,
@@ -99,7 +100,9 @@ class RNTupleMerger final {
 
 public:
    /// Creates a RNTupleMerger with the given destination.
-   explicit RNTupleMerger(std::unique_ptr<RPageSink> destination);
+   /// The model must be given if and only if `destination` has been initialized with that model
+   /// (i.e. in case of incremental merging).
+   RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique_ptr<RNTupleModel> model = nullptr);
 
    /// Merge a given set of sources into the destination.
    RResult<void> Merge(std::span<RPageSource *> sources, const RNTupleMergeOptions &mergeOpts = RNTupleMergeOptions());

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -198,9 +198,7 @@ try {
    assert(compression);
    writeOpts.SetCompression(*compression);
    auto destination = std::make_unique<RPageSinkFile>(ntupleName, *outFile, writeOpts);
-   // TODO: currently unused, will be used by the merger in a future change.
    std::unique_ptr<RNTupleModel> model;
-
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
       auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
@@ -216,7 +214,7 @@ try {
    }
 
    // Now merge
-   RNTupleMerger merger{std::move(destination)};
+   RNTupleMerger merger{std::move(destination), std::move(model)};
    RNTupleMergeOptions mergerOpts;
    mergerOpts.fCompressionSettings = *compression;
    mergerOpts.fExtraVerbose = extraVerbose;
@@ -233,7 +231,7 @@ try {
    *this = *outFile->Get<ROOT::RNTuple>(ntupleName.c_str());
 
    return 0;
-} catch (const RException &ex) {
+} catch (const std::exception &ex) {
    Error("RNTuple::Merge", "Exception thrown while merging: %s", ex.what());
    return -1;
 }
@@ -615,6 +613,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
       const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings.value();
       const bool needsCompressionChange =
          colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings.value();
+
       if (needsCompressionChange && mergeData.fMergeOpts.fExtraVerbose)
          Info("RNTuple::Merge", "Column %s: changing source compression from %d to %d", column.fColumnName.c_str(),
               colRangeCompressionSettings, mergeData.fMergeOpts.fCompressionSettings.value());
@@ -630,6 +629,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, DescriptorId_t
       for (const auto &pageInfo : pages.fPageInfos) {
          assert(pageIdx < sealedPages.size());
          assert(sealedPageData.fBuffers.size() == 0 || pageIdx < sealedPageData.fBuffers.size());
+         assert(pageInfo.fLocator.GetType() != RNTupleLocator::kTypePageZero);
 
          ROnDiskPage::Key key{columnId, pageIdx};
          auto onDiskPage = cluster->GetOnDiskPage(key);
@@ -772,14 +772,8 @@ void RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<RColumnMe
       R__ASSERT(nClusterEntries > 0);
 
       RSealedPageMergeData sealedPageData;
-
-      if (!commonColumnSet.empty()) {
-         MergeCommonColumns(clusterPool, clusterId, commonColumns, commonColumnSet, sealedPageData, mergeData);
-      }
-
-      if (!extraDstColumnSet.empty()) {
-         GenerateExtraDstColumns(nClusterEntries, extraDstColumns, sealedPageData, mergeData);
-      }
+      MergeCommonColumns(clusterPool, clusterId, commonColumns, commonColumnSet, sealedPageData, mergeData);
+      GenerateExtraDstColumns(nClusterEntries, extraDstColumns, sealedPageData, mergeData);
 
       // Commit the pages and the clusters
       mergeData.fDestination.CommitSealedPageV(sealedPageData.fGroups);
@@ -839,13 +833,12 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
    return std::nullopt;
 }
 
-// Given a field, fill `columns` and `colIdMap` with information about all columns belonging to it and its subfields.
-// `colIdMap` is used to map matching columns from different sources to the same output column in the destination.
-// We match columns by their "fully qualified name", which is the concatenation of their ancestor fields' names
-// and the column index.
-// By this point, since we called `CompareDescriptorStructure()` earlier, we should be guaranteed that two matching
-// columns will have at least compatible representations.
-// NOTE: srcFieldDesc and dstFieldDesc may alias.
+// Given a field, fill `columns` and `mergeData.fColumnIdMap` with information about all columns belonging to it and its
+// subfields. `mergeData.fColumnIdMap` is used to map matching columns from different sources to the same output column
+// in the destination. We match columns by their "fully qualified name", which is the concatenation of their ancestor
+// fields' names and the column index. By this point, since we called `CompareDescriptorStructure()` earlier, we should
+// be guaranteed that two matching columns will have at least compatible representations. NOTE: srcFieldDesc and
+// dstFieldDesc may alias.
 static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RNTupleDescriptor &srcDesc,
                                 RNTupleMergeData &mergeData, const RFieldDescriptor &srcFieldDesc,
                                 const RFieldDescriptor &dstFieldDesc, const std::string &prefix = "")
@@ -915,8 +908,8 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
 }
 
 // Converts the fields comparison data to the corresponding column information.
-// While doing so, it collects such information in `colIdMap`, which is used by later calls to this function
-// to map already-seen column names to their chosen outputId, type and so on.
+// While doing so, it collects such information in `mergeData.fColumnIdMap`, which is used by later calls to this
+// function to map already-seen column names to their chosen outputId, type and so on.
 static RColumnInfoGroup
 GatherColumnInfos(const RDescriptorsComparison &descCmp, const RNTupleDescriptor &srcDesc, RNTupleMergeData &mergeData)
 {
@@ -927,13 +920,14 @@ GatherColumnInfos(const RDescriptorsComparison &descCmp, const RNTupleDescriptor
    for (const auto &[srcField, dstField] : descCmp.fCommonFields) {
       AddColumnsFromField(res.fCommonColumns, srcDesc, mergeData, *srcField, *dstField);
    }
+
    return res;
 }
 
-RNTupleMerger::RNTupleMerger(std::unique_ptr<RPageSink> destination)
+RNTupleMerger::RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique_ptr<RNTupleModel> model)
    // TODO(gparolini): consider using an arena allocator instead, since we know the precise lifetime
    // of the RNTuples we are going to handle (e.g. we can reset the arena at every source)
-   : fDestination(std::move(destination)), fPageAlloc(std::make_unique<RPageAllocatorHeap>())
+   : fDestination(std::move(destination)), fPageAlloc(std::make_unique<RPageAllocatorHeap>()), fModel(std::move(model))
 {
    R__ASSERT(fDestination);
 
@@ -962,9 +956,15 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       }
    }
 
-   RNTupleMergeData mergeData{sources, *fDestination, mergeOpts};
+   // we should have a model if and only if the destination is initialized.
+   if (!!fModel != fDestination->IsInitialized()) {
+      return R__FAIL(
+         "passing an already-initialized destination to RNTupleMerger::Merge (i.e. trying to do incremental "
+         "merging) can only be done by providing a valid RNTupleModel when constructing the RNTupleMerger.");
+   }
 
-   std::unique_ptr<RNTupleModel> model; // used to initialize the schema of the output RNTuple
+   RNTupleMergeData mergeData{sources, *fDestination, mergeOpts};
+   mergeData.fNumDstEntries = mergeData.fDestination.GetNEntries();
 
 #define SKIP_OR_ABORT(errMsg)                                                        \
    do {                                                                              \
@@ -983,11 +983,11 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       mergeData.fSrcDescriptor = &srcDescriptor.GetRef();
 
       // Create sink from the input model if not initialized
-      if (!fDestination->IsInitialized()) {
+      if (!fModel) {
          auto opts = RNTupleDescriptor::RCreateModelOptions();
          opts.fReconstructProjections = true;
-         model = srcDescriptor->CreateModel(opts);
-         fDestination->Init(*model);
+         fModel = srcDescriptor->CreateModel(opts);
+         fDestination->Init(*fModel);
       }
 
       for (const auto &extraTypeInfoDesc : srcDescriptor->GetExtraTypeInfoIterable())
@@ -995,9 +995,8 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
 
       auto descCmpRes = CompareDescriptorStructure(mergeData.fDstDescriptor, srcDescriptor.GetRef());
       if (!descCmpRes) {
-         SKIP_OR_ABORT(
-            std::string("Source RNTuple has an incompatible schema with the destination:\n") +
-            descCmpRes.GetError()->GetReport());
+         SKIP_OR_ABORT(std::string("Source RNTuple has an incompatible schema with the destination:\n") +
+                       descCmpRes.GetError()->GetReport());
       }
       auto descCmp = descCmpRes.Unwrap();
 
@@ -1015,7 +1014,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       if (descCmp.fExtraSrcFields.size()) {
          if (mergeOpts.fMergingMode == ENTupleMergingMode::kUnion) {
             // late model extension for all fExtraSrcFields in Union mode
-            ExtendDestinationModel(descCmp.fExtraSrcFields, *model, mergeData, descCmp.fCommonFields);
+            ExtendDestinationModel(descCmp.fExtraSrcFields, *fModel, mergeData, descCmp.fCommonFields);
          } else if (mergeOpts.fMergingMode == ENTupleMergingMode::kStrict) {
             // If the current source has extra fields and we're in Strict mode, error
             std::string msg = "Source RNTuple has extra fields that the destination RNTuple doesn't have:";

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -166,7 +166,7 @@ try {
       if (!compression) {
          // Get the compression of this RNTuple and use it as the output compression.
          // We currently assume all column ranges have the same compression, so we just peek at the first one.
-         source->Attach();
+         source->Attach(RNTupleSerializer::EDescriptorDeserializeMode::kRaw);
          auto descriptor = source->GetSharedDescriptorGuard();
          auto clusterIter = descriptor->GetClusterIterable();
          auto firstCluster = clusterIter.begin();
@@ -202,7 +202,7 @@ try {
    // If we already have an existing RNTuple, copy over its descriptor to support incremental merging
    if (outNTuple) {
       auto outSource = RPageSourceFile::CreateFromAnchor(*outNTuple);
-      outSource->Attach();
+      outSource->Attach(RNTupleSerializer::EDescriptorDeserializeMode::kForWriting);
       auto desc = outSource->GetSharedDescriptorGuard();
       model = destination->InitFromDescriptor(desc.GetRef());
    }
@@ -978,7 +978,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
 
    // Merge main loop
    for (RPageSource *source : sources) {
-      source->Attach();
+      source->Attach(RNTupleSerializer::EDescriptorDeserializeMode::kRaw);
       auto srcDescriptor = source->GetSharedDescriptorGuard();
       mergeData.fSrcDescriptor = &srcDescriptor.GetRef();
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -925,6 +925,8 @@ RNTupleMerger::RNTupleMerger(std::unique_ptr<RPageSink> destination, std::unique
 #endif
 }
 
+RNTupleMerger::RNTupleMerger(std::unique_ptr<RPageSink> destination) : RNTupleMerger(std::move(destination), nullptr) {}
+
 ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const RNTupleMergeOptions &mergeOptsIn)
 {
    RNTupleMergeOptions mergeOpts = mergeOptsIn;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -801,33 +801,21 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
    if (onDiskType == ENTupleColumnType::kSwitch)
       return typeid(ROOT::Experimental::Internal::RColumnSwitch);
 
-   if (fieldType == "bool") {
-      return typeid(bool);
-   } else if (fieldType == "std::byte") {
-      return typeid(std::byte);
-   } else if (fieldType == "char") {
-      return typeid(char);
-   } else if (fieldType == "std::int8_t") {
-      return typeid(std::int8_t);
-   } else if (fieldType == "std::uint8_t") {
-      return typeid(std::uint8_t);
-   } else if (fieldType == "std::int16_t") {
-      return typeid(std::int16_t);
-   } else if (fieldType == "std::uint16_t") {
-      return typeid(std::uint16_t);
-   } else if (fieldType == "std::int32_t") {
-      return typeid(std::int32_t);
-   } else if (fieldType == "std::uint32_t") {
-      return typeid(std::uint32_t);
-   } else if (fieldType == "std::int64_t") {
-      return typeid(std::int64_t);
-   } else if (fieldType == "std::uint64_t") {
-      return typeid(std::uint64_t);
-   } else if (fieldType == "float") {
-      return typeid(float);
-   } else if (fieldType == "double") {
-      return typeid(double);
-   }
+   // clang-format off
+   if (fieldType == "bool")          return typeid(bool);
+   if (fieldType == "std::byte")     return typeid(std::byte);
+   if (fieldType == "char")          return typeid(char);
+   if (fieldType == "std::int8_t")   return typeid(std::int8_t);
+   if (fieldType == "std::uint8_t")  return typeid(std::uint8_t);
+   if (fieldType == "std::int16_t")  return typeid(std::int16_t);
+   if (fieldType == "std::uint16_t") return typeid(std::uint16_t);
+   if (fieldType == "std::int32_t")  return typeid(std::int32_t);
+   if (fieldType == "std::uint32_t") return typeid(std::uint32_t);
+   if (fieldType == "std::int64_t")  return typeid(std::int64_t);
+   if (fieldType == "std::uint64_t") return typeid(std::uint64_t);
+   if (fieldType == "float")         return typeid(float);
+   if (fieldType == "double")        return typeid(double);
+   // clang-format on
 
    // if the type is not one of those above, we use the default in-memory type.
    return std::nullopt;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -863,6 +863,7 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RN
 
       auto srcColumnId = srcFieldDesc.GetLogicalColumnIds()[i];
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
+
       RColumnMergeInfo info{};
       info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex());
       info.fInputId = srcColumn.GetPhysicalId();
@@ -995,7 +996,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       auto descCmpRes = CompareDescriptorStructure(mergeData.fDstDescriptor, srcDescriptor.GetRef());
       if (!descCmpRes) {
          SKIP_OR_ABORT(
-            std::string("Source RNTuple will be skipped due to incompatible schema with the fDestination:\n") +
+            std::string("Source RNTuple has an incompatible schema with the destination:\n") +
             descCmpRes.GetError()->GetReport());
       }
       auto descCmp = descCmpRes.Unwrap();
@@ -1017,7 +1018,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
             ExtendDestinationModel(descCmp.fExtraSrcFields, *model, mergeData, descCmp.fCommonFields);
          } else if (mergeOpts.fMergingMode == ENTupleMergingMode::kStrict) {
             // If the current source has extra fields and we're in Strict mode, error
-            std::string msg = "Source RNTuple has extra fields that the fDestination RNTuple doesn't have:";
+            std::string msg = "Source RNTuple has extra fields that the destination RNTuple doesn't have:";
             for (const auto *field : descCmp.fExtraSrcFields) {
                msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -1644,3 +1644,118 @@ TEST(RNTupleMerger, SkipMissing)
    bool ok = merger.PartialMerge();
    EXPECT_TRUE(ok);
 }
+
+TEST(RNTupleMerger, MergeIncrementalLMExt)
+{
+   // Create the input files:
+   // File 0: f_0: int
+   // File 1: f_0: int, f_1: float
+   // File 2: f_0: int, f_1: float, f_2: string
+   // File 3: f_0: int, f_1: float, f_2: string, f_3: int
+   // ...
+   // each file has 5 entries.
+   std::vector<FileRaii> inputFiles;
+   const auto nInputs = 12;
+   auto model = RNTupleModel::Create();
+   for (int fileIdx = 0; fileIdx < nInputs; ++fileIdx) {
+      auto &fileGuard =
+         inputFiles.emplace_back(std::string("test_ntuple_merge_incr_lmext_in_") + std::to_string(fileIdx) + ".root");
+
+      // Each input gets a different model, so we can exercise the late model extension.
+      // Just to have some variation, use different types depending on the field index
+      const auto fieldName = std::string("f_") + std::to_string(fileIdx);
+      switch (fileIdx % 3) {
+      case 0: model->MakeField<int>(fieldName); break;
+      case 1: model->MakeField<float>(fieldName); break;
+      default: model->MakeField<std::string>(fieldName);
+      }
+
+      auto writer = RNTupleWriter::Recreate(model->Clone(), "ntpl", fileGuard.GetPath());
+
+      // Fill the RNTuple with nFills per field
+      const auto nFills = 5;
+      const auto &entry = writer->GetModel().GetDefaultEntry();
+      for (int fillIdx = 0; fillIdx < nFills; ++fillIdx) {
+         for (int fieldIdx = 0; fieldIdx < fileIdx + 1; ++fieldIdx) {
+            const auto fldName = std::string("f_") + std::to_string(fieldIdx);
+            switch (fieldIdx % 3) {
+            case 0: *entry.GetPtr<int>(fldName) = fileIdx + fillIdx + fieldIdx; break;
+            case 1: *entry.GetPtr<float>(fldName) = fileIdx + fillIdx + fieldIdx; break;
+            default: *entry.GetPtr<std::string>(fldName) = std::to_string(fileIdx + fillIdx + fieldIdx);
+            }
+         }
+         writer->Fill();
+      }
+   }
+
+   // Incrementally merge the inputs
+   FileRaii fileGuard("test_ntuple_merge_incr_lmext.root");
+   const auto compression = 0;
+
+   {
+      TFileMerger merger(kFALSE, kFALSE);
+      merger.OutputFile(fileGuard.GetPath().c_str(), "RECREATE", compression);
+      merger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+
+      for (int i = 0; i < nInputs; ++i) {
+         auto tfile = std::unique_ptr<TFile>(TFile::Open(inputFiles[i].GetPath().c_str(), "READ"));
+         merger.AddFile(tfile.get());
+         bool result =
+            merger.PartialMerge(TFileMerger::kIncremental | TFileMerger::kNonResetable | TFileMerger::kKeepCompression);
+         ASSERT_TRUE(result);
+      }
+   }
+
+   // Now verify that the output file contains all the expected data.
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      const auto &desc = reader->GetDescriptor();
+      for (int i = 0; i < nInputs; ++i) {
+         const auto fieldId = desc.FindFieldId(std::string("f_") + std::to_string(i));
+         EXPECT_NE(fieldId, ROOT::Experimental::kInvalidDescriptorId);
+         const auto &fdesc = desc.GetFieldDescriptor(fieldId);
+         for (const auto &colId : fdesc.GetLogicalColumnIds()) {
+            const auto &cdesc = desc.GetColumnDescriptor(colId);
+            EXPECT_EQ(cdesc.GetFirstElementIndex(), (cdesc.GetIndex() == 0) * i * 5);
+         }
+      }
+
+      RNTupleView<int> v_int[] = {
+         reader->GetView<int>("f_0"),
+         reader->GetView<int>("f_3"),
+         reader->GetView<int>("f_6"),
+         reader->GetView<int>("f_9"),
+      };
+      RNTupleView<float> v_float[] = {
+         reader->GetView<float>("f_1"),
+         reader->GetView<float>("f_4"),
+         reader->GetView<float>("f_7"),
+         reader->GetView<float>("f_10"),
+      };
+      RNTupleView<std::string> v_string[] = {
+         reader->GetView<std::string>("f_2"),
+         reader->GetView<std::string>("f_5"),
+         reader->GetView<std::string>("f_8"),
+         reader->GetView<std::string>("f_11"),
+      };
+      for (auto entryId : reader->GetEntryRange()) {
+         int fileIdx = entryId / 5;
+         int localEntryId = entryId % 5;
+
+         for (int i = 0; i < nInputs / 3; ++i) {
+            auto x0 = v_int[i](entryId);
+            int expected_x0 = (entryId >= 15u * i) * (fileIdx + localEntryId + i * 3);
+            EXPECT_EQ(x0, expected_x0);
+
+            auto x1 = v_float[i](entryId);
+            float expected_x1 = (entryId >= 5 + 15u * i) * (fileIdx + localEntryId + i * 3 + 1);
+            EXPECT_FLOAT_EQ(x1, expected_x1);
+
+            auto x2 = v_string[i](entryId);
+            std::string expected_x2 =
+               (entryId >= 10 + 15u * i) ? std::to_string(fileIdx + localEntryId + i * 3 + 2) : "";
+            EXPECT_EQ(x2, expected_x2);
+         }
+      }
+   }
+}

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -114,6 +114,8 @@ using RPrepareVisitor = ROOT::Experimental::RPrepareVisitor;
 using RPrintSchemaVisitor = ROOT::Experimental::RPrintSchemaVisitor;
 using RRawFile = ROOT::Internal::RRawFile;
 using EContainerFormat = RNTupleFileWriter::EContainerFormat;
+template <typename T>
+using RNTupleView = ROOT::Experimental::RNTupleView<T>;
 
 using ROOT::Experimental::Internal::MakeUninitArray;
 


### PR DESCRIPTION
# This Pull request:
depends on #17597 and it's the other half of #17563. 

Copy-pasted text from it:

This is the last(*) PR of a series that adds proper support for incremental merging with Union mode, i.e. proper handling of deferred columns in the Merger.
With this change we should be able to support [ATLAS-like workflows](https://gitlab.cern.ch/amete/rootparallelmerger/-/blob/master/src/ParallelFileMerger.cpp?ref_type=heads) where the TFileMerger is used to incrementally construct an RNTuple from a sequence of files that may contain additional fields compared to the already-merged ones.

(*) at least for a minimal working case - more edge cases remain to be tested and likely fixed.

## A brief overview
When Union-merging files containing compatible-but-different models (e.g. the second file contains an additional field), we resort to Late Model Extension in the RNTupleMerger and therefore produce a merged RNTuple containing deferred columns in the header extension.
When we incrementally merge a new file, we need to read the metadata from the existing RNTuple, preserve the header extension as-is and possibly Late Model Extend again the new model created from this metadata. This requires some care because we need to explicitly keep all the extended fields and columns in the header extension when writing the file back (rather than merging them in the regular header).
This requires dropping the implicit assumption in our serializer API that assumes that no header extension is present when serializing the header the first time.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
