### PR TITLE
[net] Allow users to specify binding options when opening sockets

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -38,6 +38,16 @@ class TSeqCollection;
 class TFdSet;
 class TVirtualMutex;
 
+/*! \enum ESocketBindOption
+    \brief Options for binging the sockets created
+
+    These values can be used to configure the binding of the opened sockets.
+*/
+enum ESocketBindOption {
+   kInaddrAny = 0,      ///< Any address for socket binding
+   kInaddrLoopback = 1, ///< Refers to the local host via the loopback device
+};
+
 enum EAccessMode {
    kFileExists        = 0,
    kExecutePermission = 1,
@@ -501,8 +511,9 @@ public:
    virtual int             GetServiceByName(const char *service);
    virtual char           *GetServiceByPort(int port);
    virtual int             OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp");
-   virtual int             AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1);
-   virtual int             AnnounceUdpService(int port, int backlog);
+   virtual int AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1,
+                                  ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny);
+   virtual int AnnounceUdpService(int port, int backlog, ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny);
    virtual int             AnnounceUnixService(int port, int backlog);
    virtual int             AnnounceUnixService(const char *sockpath, int backlog);
    virtual int             AcceptConnection(int sock);

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2342,7 +2342,7 @@ int TSystem::OpenConnection(const char *, int, int, const char *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Announce TCP/IP service.
 
-int TSystem::AnnounceTcpService(int, Bool_t, int, int)
+int TSystem::AnnounceTcpService(int, Bool_t, int, int, ESocketBindOption)
 {
    AbstractMethod("AnnounceTcpService");
    return -1;
@@ -2351,7 +2351,7 @@ int TSystem::AnnounceTcpService(int, Bool_t, int, int)
 ////////////////////////////////////////////////////////////////////////////////
 /// Announce UDP service.
 
-int TSystem::AnnounceUdpService(int, int)
+int TSystem::AnnounceUdpService(int, int, ESocketBindOption)
 {
    AbstractMethod("AnnounceUdpService");
    return -1;

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -62,8 +62,8 @@ protected:
    static int          UnixUnixConnect(int port);
    static int          UnixUnixConnect(const char *path);
    static int          UnixTcpService(int port, Bool_t reuse, int backlog,
-                                      int tcpwindowsize);
-   static int          UnixUdpService(int port, int backlog);
+                                      int tcpwindowsize, ESocketBindOption socketBindOption);
+   static int          UnixUdpService(int port, int backlog, ESocketBindOption socketBindOption);
    static int          UnixUnixService(int port, int backlog);
    static int          UnixUnixService(const char *sockpath, int backlog);
    static int          UnixRecv(int sock, void *buf, int len, int flag);
@@ -197,8 +197,8 @@ public:
    char             *GetServiceByPort(int port) override;
    int               ConnectService(const char *server, int port, int tcpwindowsize, const char *protocol = "tcp");
    int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp") override;
-   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1) override;
-   int               AnnounceUdpService(int port, int backlog) override;
+   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1, ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny) override;
+   int               AnnounceUdpService(int port, int backlog, ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny) override;
    int               AnnounceUnixService(int port, int backlog) override;
    int               AnnounceUnixService(const char *sockpath, int backlog) override;
    int               AcceptConnection(int sock) override;

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -232,8 +232,8 @@ public:
    int               GetServiceByName(const char *service) override;
    char              *GetServiceByPort(int port) override;
    int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp") override;
-   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1) override;
-   int               AnnounceUdpService(int port, int backlog) override;
+   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1, ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny) override;
+   int               AnnounceUdpService(int port, int backlog, ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny) override;
    int               AnnounceUnixService(int port, int backlog) override;
    int               AnnounceUnixService(const char *sockpath, int backlog) override;
    int               AcceptConnection(int sock) override;

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -5384,11 +5384,13 @@ int TWinNTSystem::OpenConnection(const char *server, int port, int tcpwindowsize
 /// Use tcpwindowsize to specify the size of the receive buffer, it has
 /// to be specified here to make sure the window scale option is set (for
 /// tcpwindowsize > 65KB and for platforms supporting window scaling).
+/// The socketBindOption parameter allows to specify how the socket will be 
+/// bound. See the documentation of ESocketBindOption for the details.
 /// Returns socket fd or -1 if socket() failed, -2 if bind() failed
 /// or -3 if listen() failed.
 
 int TWinNTSystem::AnnounceTcpService(int port, Bool_t reuse, int backlog,
-                                     int tcpwindowsize)
+                                     int tcpwindowsize, ESocketBindOption socketBindOption)
 {
    short  sport;
    struct servent *sp;
@@ -5431,7 +5433,7 @@ int TWinNTSystem::AnnounceTcpService(int port, Bool_t reuse, int backlog,
    struct sockaddr_in inserver;
    memset(&inserver, 0, sizeof(inserver));
    inserver.sin_family = AF_INET;
-   inserver.sin_addr.s_addr = ::htonl(INADDR_ANY);
+   inserver.sin_addr.s_addr = socketBindOption == ESocketBindOption::kInaddrAny ? ::htonl(INADDR_ANY) : ::htonl(INADDR_LOOPBACK);
    inserver.sin_port = sport;
 
    // Bind socket
@@ -5465,13 +5467,15 @@ int TWinNTSystem::AnnounceTcpService(int port, Bool_t reuse, int backlog,
 ////////////////////////////////////////////////////////////////////////////////
 /// Announce UDP service.
 
-int TWinNTSystem::AnnounceUdpService(int port, int backlog)
+int TWinNTSystem::AnnounceUdpService(int port, int backlog, ESocketBindOption socketBindOption)
 {
    // Open a socket, bind to it and start listening for UDP connections
    // on the port. If reuse is true reuse the address, backlog specifies
    // how many sockets can be waiting to be accepted. If port is 0 a port
    // scan will be done to find a free port. This option is mutual exlusive
    // with the reuse option.
+   // The socketBindOption parameter allows to specify how the socket will be 
+   // bound. See the documentation of ESocketBindOption for the details.
 
    const short kSOCKET_MINPORT = 5000, kSOCKET_MAXPORT = 15000;
    short  sport, tryport = kSOCKET_MINPORT;
@@ -5492,7 +5496,7 @@ int TWinNTSystem::AnnounceUdpService(int port, int backlog)
    struct sockaddr_in inserver;
    memset(&inserver, 0, sizeof(inserver));
    inserver.sin_family = AF_INET;
-   inserver.sin_addr.s_addr = htonl(INADDR_ANY);
+   inserver.sin_addr.s_addr = socketBindOption == ESocketBindOption::kInaddrAny ? htonl(INADDR_ANY) : htonl(INADDR_LOOPBACK);
    inserver.sin_port = sport;
 
    // Bind socket

--- a/net/net/CMakeLists.txt
+++ b/net/net/CMakeLists.txt
@@ -108,3 +108,5 @@ if(ssl)
   target_include_directories(Net PRIVATE ${OPENSSL_INCLUDE_DIR})
   target_link_libraries(Net PRIVATE ${OPENSSL_LIBRARIES})
 endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/net/net/inc/TServerSocket.h
+++ b/net/net/inc/TServerSocket.h
@@ -55,8 +55,8 @@ private:
 public:
    enum { kDefaultBacklog = 10 };
 
-   TServerSocket(Int_t port, Bool_t reuse = kFALSE, Int_t backlog = kDefaultBacklog,
-                 Int_t tcpwindowsize = -1);
+   TServerSocket(Int_t port, Bool_t reuse = kFALSE, Int_t backlog = kDefaultBacklog, Int_t tcpwindowsize = -1,
+                 ESocketBindOption socketBindOption = ESocketBindOption::kInaddrAny);
    TServerSocket(const char *service, Bool_t reuse = kFALSE,
                  Int_t backlog = kDefaultBacklog, Int_t tcpwindowsize = -1);
    virtual ~TServerSocket();

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -72,7 +72,7 @@ protected:
    TBits         fBitsInfo;       // bits array to mark TStreamerInfo classes already sent
    TList        *fUUIDs;          // list of TProcessIDs already sent through the socket
 
-   TVirtualMutex *fLastUsageMtx;   // Protect last usage setting / reading
+   TVirtualMutex *fLastUsageMtx;  // Protect last usage setting / reading
    TTimeStamp    fLastUsage;      // Time stamp of last usage
 
    static ULong64_t fgBytesRecv;  // total bytes received by all socket objects

--- a/net/net/src/TServerSocket.cxx
+++ b/net/net/src/TServerSocket.cxx
@@ -62,6 +62,8 @@ static void SetAuthOpt(UChar_t &opt, UChar_t mod)
 /// Use tcpwindowsize to specify the size of the receive buffer, it has
 /// to be specified here to make sure the window scale option is set (for
 /// tcpwindowsize > 65KB and for platforms supporting window scaling).
+/// The socketBindOption parameter allows to specify how the socket will be 
+/// bound. See the documentation of ESocketBindOption for the details.
 /// Use IsValid() to check the validity of the
 /// server socket. In case server socket is not valid use GetErrorCode()
 /// to obtain the specific error value. These values are:
@@ -105,7 +107,7 @@ TServerSocket::TServerSocket(const char *service, Bool_t reuse, Int_t backlog,
       fService = service;
       int port = gSystem->GetServiceByName(service);
       if (port != -1) {
-         fSocket = gSystem->AnnounceTcpService(port, reuse, backlog, tcpwindowsize);
+         fSocket = gSystem->AnnounceTcpService(port, reuse, backlog, tcpwindowsize, ESocketBindOption::kInaddrLoopback);
          if (fSocket >= 0) {
             R__LOCKGUARD(gROOTMutex);
             gROOT->GetListOfSockets()->Add(this);
@@ -125,6 +127,8 @@ TServerSocket::TServerSocket(const char *service, Bool_t reuse, Int_t backlog,
 /// Use tcpwindowsize to specify the size of the receive buffer, it has
 /// to be specified here to make sure the window scale option is set (for
 /// tcpwindowsize > 65KB and for platforms supporting window scaling).
+/// The socketBindOption parameter allows to specify how the socket will be 
+/// bound. See the documentation of ESocketBindOption for the details.
 /// Use IsValid() to check the validity of the
 /// server socket. In case server socket is not valid use GetErrorCode()
 /// to obtain the specific error value. These values are:
@@ -136,8 +140,8 @@ TServerSocket::TServerSocket(const char *service, Bool_t reuse, Int_t backlog,
 /// will make sure that any open sockets are properly closed on
 /// program termination.
 
-TServerSocket::TServerSocket(Int_t port, Bool_t reuse, Int_t backlog,
-                             Int_t tcpwindowsize)
+TServerSocket::TServerSocket(Int_t port, Bool_t reuse, Int_t backlog, Int_t tcpwindowsize,
+                             ESocketBindOption socketBindOption)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -149,7 +153,7 @@ TServerSocket::TServerSocket(Int_t port, Bool_t reuse, Int_t backlog,
    fService = gSystem->GetServiceByPort(port);
    SetTitle(fService);
 
-   fSocket = gSystem->AnnounceTcpService(port, reuse, backlog, tcpwindowsize);
+   fSocket = gSystem->AnnounceTcpService(port, reuse, backlog, tcpwindowsize, socketBindOption);
    if (fSocket >= 0) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfSockets()->Add(this);

--- a/net/net/test/CMakeLists.txt
+++ b/net/net/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+ROOT_ADD_GTEST(nettests nettests.cxx LIBRARIES Net)

--- a/net/net/test/nettests.cxx
+++ b/net/net/test/nettests.cxx
@@ -1,0 +1,13 @@
+#include "TServerSocket.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+TEST(TServerSocket, SocketBinding)
+{
+   TServerSocket theSocket(2020, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const auto addr = theSocket.GetLocalInetAddress().GetHostAddress();
+   const auto expectedAddr = "0.0.0.0";
+   ASSERT_THAT(addr, ::testing::StrNe(expectedAddr))
+      << "The address is " << addr << " while the expected one must be different from " << expectedAddr;
+}


### PR DESCRIPTION
in a backwards compatible way. An enumerator, ESocketBindOption, is introduced to specify the option.


