### PR TITLE
TMessage honour kIsOwner bit when compression is used

### DIFF
--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -59,6 +59,9 @@ private:
    Bool_t TestBitNumber(UInt_t bitnumber) const { return fBitsPIDs.TestBitNumber(bitnumber); }
 
 protected:
+   enum EStatusBits {
+     kIsOwnerComp = BIT(18) // if TMessage owns fBufComp
+   };
    TMessage(void *buf, Int_t bufsize);   // only called by T(P)Socket::Recv()
    void SetLength() const;               // only called by T(P)Socket::Send()
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

(Checking gganis solution)

Fixes https://github.com/root-project/root/issues/14557

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

