### PR TITLE
[skip-ci] convert old THtml class comments to doxygen format

### DIFF
--- a/bindings/pyroot/pythonizations/inc/TPyDispatcher.h
+++ b/bindings/pyroot/pythonizations/inc/TPyDispatcher.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TPyDispatcher
 #define ROOT_TPyDispatcher
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TPyDispatcher                                                            //
-//                                                                          //
-// Dispatcher for C++ callbacks into Python code.                           //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
 // ROOT
 #include "TObject.h"
 
@@ -51,6 +43,7 @@ struct Event_t;
 struct _object;
 typedef _object PyObject;
 
+/// Dispatcher for C++ callbacks into Python code.
 class TPyDispatcher : public TObject {
 public:
    TPyDispatcher(PyObject *callable);

--- a/bindings/tpython/inc/TPyArg.h
+++ b/bindings/tpython/inc/TPyArg.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TPyArg
 #define ROOT_TPyArg
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TPyArg                                                                   //
-//                                                                          //
-// Morphing argument type from evaluating python expressions.               //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
 // ROOT
 #include "Rtypes.h"
 
@@ -30,6 +22,7 @@ typedef _object PyObject;
 // Standard
 #include <vector>
 
+/// Morphing argument type from evaluating python expressions.
 class TPyArg {
 public:
    // converting constructors

--- a/bindings/tpython/inc/TPyReturn.h
+++ b/bindings/tpython/inc/TPyReturn.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TPyReturn
 #define ROOT_TPyReturn
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TPyReturn                                                                //
-//                                                                          //
-// Morphing return type from evaluating python expressions.                 //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
 // ROOT
 #include "Rtypes.h"
 
@@ -27,6 +19,7 @@
 struct _object;
 typedef _object PyObject;
 
+/// Morphing return type from evaluating python expressions. 
 class TPyReturn {
 public:
    TPyReturn();

--- a/bindings/tpython/inc/TPython.h
+++ b/bindings/tpython/inc/TPython.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TPython
 #define ROOT_TPython
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TPython                                                                  //
-//                                                                          //
-// Access to the python interpreter and API onto PyROOT.                    //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
 // ROOT
 #include "TObject.h"
 
@@ -40,6 +32,7 @@ inline void SwapWithObjAtAddr(T &a, std::intptr_t b) { std::swap(a, *reinterpret
 }
 }
 
+// Access to the python interpreter and API onto PyROOT.
 class TPython {
 
 private:

--- a/core/gui/inc/TContextMenu.h
+++ b/core/gui/inc/TContextMenu.h
@@ -13,16 +13,6 @@
 #define ROOT_TContextMenu
 
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// TContextMenu                                                               //
-//                                                                            //
-// This class provides an interface to  context sensitive popup menus.        //
-// These menus pop up when the user hits  the right mouse button,  and        //
-// are destroyed when the menu pops downs.                                    //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
 #include "TNamed.h"
 
 #ifdef R__LESS_INCLUDES

--- a/core/gui/inc/TContextMenuImp.h
+++ b/core/gui/inc/TContextMenuImp.h
@@ -12,16 +12,6 @@
 #ifndef ROOT_TContextMenuImp
 #define ROOT_TContextMenuImp
 
-
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// TContextMenuImp                                                            //
-//                                                                            //
-// This class provides an interface to GUI independent                        //
-// context sensitive popup menus.                                             //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
 #include "Rtypes.h"
 
 class TContextMenu;
@@ -29,7 +19,7 @@ class TObject;
 class TMethod;
 class TFunction;
 
-
+// interface to GUI independent context sensitive popup menus.
 class TContextMenuImp {
 
 protected:

--- a/core/gui/inc/TControlBarImp.h
+++ b/core/gui/inc/TControlBarImp.h
@@ -13,20 +13,13 @@
 #define ROOT_TControlBarImp
 
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// TControlBarImp                                                             //
-//                                                                            //
-// ABC describing GUI independent control bar (see TControlBar)               //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
 #include "Rtypes.h"
 
 
 class TControlBar;
 class TControlBarButton;
 
+/// @see TControlBar
 class TControlBarImp {
 
 protected:

--- a/core/gui/inc/TInspectorImp.h
+++ b/core/gui/inc/TInspectorImp.h
@@ -12,16 +12,6 @@
 #ifndef ROOT_TInspectorImp
 #define ROOT_TInspectorImp
 
-
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// TInspectorImp                                                              //
-//                                                                            //
-// ABC describing GUI independent object inspector (abstration mainly needed  //
-// for Win32. On X11 systems it currently uses a standard TCanvas).           //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
 #include "Rtypes.h"
 
 class TObject;

--- a/core/meta/inc/TInterpreterValue.h
+++ b/core/meta/inc/TInterpreterValue.h
@@ -9,17 +9,17 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.                   *
  ******************************************************************************/
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-//  Class representing a value coming from the interpreter. Its main use case //
-//  is to TCallFunc. When TCallFunc returns by-value, i.e. a temporary        //
-//  variable, its lifetime has to be extended. TInterpreterValue provides a   //
-//  way to extend the temporaries lifetime and gives the user to control it.  //
-//                                                                            //
-//  The class needs to be derived from for the actual interpreter,            //
-//  see TClingValue.                                                          //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////
+///                                                                            //
+///  Class representing a value coming from the interpreter. Its main use case //
+///  is to TCallFunc. When TCallFunc returns by-value, i.e. a temporary        //
+///  variable, its lifetime has to be extended. TInterpreterValue provides a   //
+///  way to extend the temporaries lifetime and gives the user to control it.  //
+///                                                                            //
+///  The class needs to be derived from for the actual interpreter,            //
+///  see TClingValue.                                                          //
+///                                                                            //
+/////////////////////////////////////////////////////////////////////////////////
 
 #ifndef ROOT_TInterpreterValue
 #define ROOT_TInterpreterValue

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TStreamerElement
 #define ROOT_TStreamerElement
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TStreamerElement                                                     //
-//                                                                      //
-// Describe one element (data member) to be Streamed                    //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TNamed.h"
 
 #include "ESTLType.h"
@@ -29,6 +21,7 @@ class TClass;
 class TStreamerBasicType;
 class TVirtualStreamerInfo;
 
+/// Describe one element (data member) to be Streamed
 class TStreamerElement : public TNamed {
 
 private:

--- a/core/metacling/src/TClingValue.h
+++ b/core/metacling/src/TClingValue.h
@@ -9,17 +9,17 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.                   *
  ******************************************************************************/
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-//  Class representing a value coming from cling. Its main use case           //
-//  is to TCallFunc. When TCallFunc returns by-value, i.e. a temporary        //
-//  variable, its lifetime has to be extended. TClingValue provides a         //
-//  way to extend the temporaries lifetime and gives the user to control it.  //
-//                                                                            //
-//  The class is used to hide the implementation details of                   //
-//  cling::Value.                                                             //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////
+///                                                                            //
+///  Class representing a value coming from cling. Its main use case           //
+///  is to TCallFunc. When TCallFunc returns by-value, i.e. a temporary        //
+///  variable, its lifetime has to be extended. TClingValue provides a         //
+///  way to extend the temporaries lifetime and gives the user to control it.  //
+///                                                                            //
+///  The class is used to hide the implementation details of                   //
+///  cling::Value.                                                             //
+///                                                                            //
+/////////////////////////////////////////////////////////////////////////////////
 
 #ifndef ROOT_TClingValue
 #define ROOT_TClingValue

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -13,14 +13,6 @@
 #ifndef ROOT_TWinNTSystem
 #define ROOT_TWinNTSystem
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TWinNTSystem                                                         //
-//                                                                      //
-// Class providing an interface to the Windows NT Operating System.     //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TSystem.h"
 #include <string>
 
@@ -54,7 +46,7 @@ struct group {
    char   **gr_mem;     // group members
 };
 
-
+/// Class providing an interface to the Windows NT Operating System.
 class TWinNTSystem : public TSystem {
 public:
    // pointer to message handler func

--- a/geom/geom/inc/TGeoBoolNode.h
+++ b/geom/geom/inc/TGeoBoolNode.h
@@ -92,12 +92,7 @@ public:
    ClassDefOverride(TGeoBoolNode, 1) // a boolean node
 };
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TGeoUnion - Boolean node representing a union between two components.    //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
+/// Boolean node representing a union between two components.
 class TGeoUnion : public TGeoBoolNode {
 public:
    // constructors
@@ -128,13 +123,7 @@ public:
    ClassDefOverride(TGeoUnion, 1) // union node
 };
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TGeoIntersection - Boolean node representing an intersection between two //
-// components.                                                              //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
+/// Boolean node representing an intersection between two components.
 class TGeoIntersection : public TGeoBoolNode {
 public:
    // constructors
@@ -165,12 +154,7 @@ public:
    ClassDefOverride(TGeoIntersection, 1) // intersection node
 };
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TGeoSubtraction - Boolean node representing a subtraction.               //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
+/// Boolean node representing a subtraction
 class TGeoSubtraction : public TGeoBoolNode {
 public:
    // constructors

--- a/geom/geom/inc/TGeoCompositeShape.h
+++ b/geom/geom/inc/TGeoCompositeShape.h
@@ -14,16 +14,11 @@
 
 #include "TGeoBBox.h"
 
-/////////////////////////////////////////////////////////////////////////////
-//                                                                         //
-// TGeoCompositeShape - composite shape class. A composite shape contains  //
-//   a list of primitive shapes, the list of corresponding transformations //
-//   and a boolean finder handling boolean operations among components.    //
-//                                                                         //
-/////////////////////////////////////////////////////////////////////////////
-
 class TGeoBoolNode;
 
+/// @details A composite shape contains
+/// a list of primitive shapes, the list of corresponding transformations
+/// and a boolean finder handling boolean operations among components.
 class TGeoCompositeShape : public TGeoBBox {
 private:
    // data members

--- a/geom/geom/inc/TGeoElement.h
+++ b/geom/geom/inc/TGeoElement.h
@@ -27,12 +27,7 @@
 class TGeoElementTable;
 class TGeoIsotope;
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoElement - a chemical element                                       //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+// a chemical element
 class TGeoElement : public TNamed {
 protected:
    enum EGeoElement { kElemUsed = BIT(17), kElemDefined = BIT(18), kElementChecked = BIT(19) };
@@ -93,13 +88,7 @@ public:
    ClassDefOverride(TGeoElement, 3) // base element class
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoIsotope - a isotope defined by the atomic number, number of        //
-// nucleons and atomic weight (g/mole)                                    //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// an isotope defined by the atomic number, number of nucleons and atomic weight (g/mole)
 class TGeoIsotope : public TNamed {
 protected:
    Int_t fZ;    // atomic number
@@ -120,15 +109,10 @@ public:
    ClassDefOverride(TGeoIsotope, 1) // Isotope class defined by Z,N,A
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoElementRN - a radionuclide.                                        //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
 class TGeoDecayChannel;
 class TGeoBatemanSol;
 
+/// a radionuclide
 class TGeoElementRN : public TGeoElement {
 protected:
    Int_t fENDFcode;        // ENDF element code
@@ -198,12 +182,7 @@ public:
    ClassDefOverride(TGeoElementRN, 2) // radionuclides class
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoDecayChannel - decay channel utility class.                        //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// decay channel utility class.
 class TGeoDecayChannel : public TObject {
 private:
    UInt_t fDecay;            // Decay mode
@@ -277,12 +256,7 @@ public:
    ClassDefOverride(TGeoDecayChannel, 1) // Decay channel for Elements
 };
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// TGeoBatemanSol -Class representing the Bateman solution for a decay branch //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
+/// Class representing the Bateman solution for a decay branch
 class TGeoBatemanSol : public TObject, public TAttLine, public TAttFill, public TAttMarker {
 private:
    typedef struct {
@@ -349,12 +323,7 @@ public:
    ClassDefOverride(TGeoBatemanSol, 1) // Solution for the Bateman equation
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoElemIter - iterator for decay chains.                              //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// iterator for decay chains.
 class TGeoElemIter {
 private:
    const TGeoElementRN *fTop;  // Top element of the iteration
@@ -389,12 +358,7 @@ public:
    ClassDef(TGeoElemIter, 0) // Iterator for radionuclide chains.
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoElementTable - table of elements                                   //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// table of elements
 class TGeoElementTable : public TObject {
 private:
    // data members

--- a/geom/geom/inc/TGeoPatternFinder.h
+++ b/geom/geom/inc/TGeoPatternFinder.h
@@ -21,13 +21,7 @@
 
 class TGeoMatrix;
 
-/////////////////////////////////////////////////////////////////////////////////
-//                                                                             //
-// TGeoPatternFinder - base finder class for patterns. A pattern is specifying //
-// a division type                                                             //
-//                                                                             //
-/////////////////////////////////////////////////////////////////////////////////
-
+/// base finder class for patterns. A pattern is specifying a division type
 class TGeoPatternFinder : public TObject {
 public:
    struct ThreadData_t {
@@ -101,12 +95,7 @@ public:
    ClassDefOverride(TGeoPatternFinder, 4) // patterns to divide volumes
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternX - a X axis divison pattern                                //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a X axis divison pattern
 class TGeoTranslation;
 
 class TGeoPatternX : public TGeoPatternFinder {
@@ -136,12 +125,7 @@ public:
    ClassDefOverride(TGeoPatternX, 1) // X division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternY - a Y axis divison pattern                                //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a Y axis divison pattern
 class TGeoPatternY : public TGeoPatternFinder {
 public:
    // constructors
@@ -168,12 +152,7 @@ public:
    ClassDefOverride(TGeoPatternY, 1) // Y division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternZ - a Z axis divison pattern                                //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a Z axis divison pattern
 class TGeoPatternZ : public TGeoPatternFinder {
 public:
    // constructors
@@ -200,12 +179,7 @@ public:
    ClassDefOverride(TGeoPatternZ, 1) // Z division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternParaX - a X axis divison pattern for PARA shapes            //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a X axis divison pattern for PARA shapes
 class TGeoPatternParaX : public TGeoPatternFinder {
 public:
    // constructors
@@ -232,12 +206,7 @@ public:
    ClassDefOverride(TGeoPatternParaX, 1) // Para X division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternParaY - a Y axis divison pattern for PARA shapes            //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a Y axis divison pattern for PARA shapes
 class TGeoPatternParaY : public TGeoPatternFinder {
 private:
    // data members
@@ -267,12 +236,7 @@ public:
    ClassDefOverride(TGeoPatternParaY, 1) // Para Y division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternParaZ - a Z axis divison pattern for PARA shapes            //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a Z axis divison pattern for PARA shapes
 class TGeoPatternParaZ : public TGeoPatternFinder {
 private:
    // data members
@@ -303,12 +267,7 @@ public:
    ClassDefOverride(TGeoPatternParaZ, 1) // Para Z division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternTrapZ - a Z axis divison pattern for TRAP or GTRA shapes    //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a Z axis divison pattern for TRAP or GTRA shapes
 class TGeoPatternTrapZ : public TGeoPatternFinder {
 private:
    // data members
@@ -341,12 +300,7 @@ public:
    ClassDefOverride(TGeoPatternTrapZ, 1) // Trap od Gtra Z division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternCylR - a cylindrical R divison pattern                      //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a cylindrical R divison pattern
 class TGeoPatternCylR : public TGeoPatternFinder {
 public:
    // constructors
@@ -372,12 +326,7 @@ public:
    ClassDefOverride(TGeoPatternCylR, 1) // Cylindrical R division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternCylPhi - a cylindrical phi divison pattern                  //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a cylindrical phi divison pattern
 class TGeoPatternCylPhi : public TGeoPatternFinder {
 private:
    // data members
@@ -420,12 +369,7 @@ public:
    ClassDefOverride(TGeoPatternCylPhi, 1) // Cylindrical phi division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternSphR - a spherical R divison pattern                        //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a spherical R divison pattern
 class TGeoPatternSphR : public TGeoPatternFinder {
 public:
    // constructors
@@ -450,12 +394,7 @@ public:
    ClassDefOverride(TGeoPatternSphR, 1) // spherical R division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternSphTheta - a spherical theta divison pattern                //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a spherical theta divison pattern
 class TGeoPatternSphTheta : public TGeoPatternFinder {
 public:
    // constructors
@@ -480,12 +419,7 @@ public:
    ClassDefOverride(TGeoPatternSphTheta, 1) // spherical theta division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternSphPhi - a spherical phi divison pattern                    //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a spherical phi divison pattern
 class TGeoPatternSphPhi : public TGeoPatternFinder {
 private:
    Double_t *fSinCos = nullptr; //! Sincos table
@@ -517,12 +451,7 @@ public:
    ClassDefOverride(TGeoPatternSphPhi, 1) // Spherical phi division pattern
 };
 
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// TGeoPatternHoneycomb - a divison pattern specialized for honeycombs    //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
-
+/// a divison pattern specialized for honeycombs
 class TGeoPatternHoneycomb : public TGeoPatternFinder {
 private:
    // data members

--- a/geom/geom/inc/TGeoPhysicalNode.h
+++ b/geom/geom/inc/TGeoPhysicalNode.h
@@ -25,13 +25,7 @@ class TGeoShape;
 class TGeoNavigator;
 class TObjArray;
 
-//////////////////////////////////////////////////////////////////////////////
-//                                                                          //
-// TGeoPhysicalNode - class representing an unique object associated with a //
-//   path.                                                                  //
-//                                                                          //
-//////////////////////////////////////////////////////////////////////////////
-
+/// @details class representing an unique object associated with a path.
 class TGeoPhysicalNode : public TNamed, public TAttLine {
 protected:
    Int_t fLevel;             // depth in the geometry tree
@@ -90,13 +84,7 @@ public:
    ClassDefOverride(TGeoPhysicalNode, 1) // base class for physical nodes
 };
 
-///////////////////////////////////////////////////////////////////////////////
-//                                                                           //
-// TGeoPNEntry - class representing physical node entry having a unique name //
-//   associated to a path.                                                   //
-//                                                                           //
-///////////////////////////////////////////////////////////////////////////////
-
+/// @details class representing physical node entry having a unique name associated to a path.
 class TGeoPNEntry : public TNamed {
 private:
    enum EPNEntryFlags { kPNEntryOwnMatrix = BIT(14) };

--- a/math/physics/inc/TGenPhaseSpace.h
+++ b/math/physics/inc/TGenPhaseSpace.h
@@ -1,17 +1,12 @@
 // @(#)root/physics:$Id$
 // Author: Rene Brun , Valerio Filippini  06/09/2000
 
-///////////////////////////////////////////////////////////////////////////////
-//                                                                           //
-//   Phase Space Generator, based on the GENBOD routine of CERNLIB           //
-//                                                                           //
-///////////////////////////////////////////////////////////////////////////////
-
 #ifndef ROOT_TGenPhaseSpace
 #define ROOT_TGenPhaseSpace
 
 #include "TLorentzVector.h"
 
+/// Phase Space Generator, based on the GENBOD routine of CERNLIB
 class TGenPhaseSpace : public TObject {
 private:
    Int_t        fNt;             // number of decay particles

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -17,8 +17,6 @@
 // Authors: Justin Salmon, Lukasz Janyst                                      //
 //          CERN, 2013                                                        //
 //                                                                            //
-// Enables access to XRootD files using the new client.                       //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "TFile.h"
@@ -30,6 +28,8 @@ namespace XrdCl {
 }
 class XrdSysCondVar;
 
+
+/// Enables access to XRootD files using the new client.
 class TNetXNGFile: public TFile {
 private:
    XrdCl::File            *fFile;        // Underlying XRootD file

--- a/net/netxng/inc/TNetXNGFileStager.h
+++ b/net/netxng/inc/TNetXNGFileStager.h
@@ -17,8 +17,6 @@
 // Authors: Lukasz Janyst, Justin Salmon                                      //
 //          CERN, 2013                                                        //
 //                                                                            //
-// Enables access to XRootD staging capabilities using the new client.        //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "TFileStager.h"
@@ -27,6 +25,7 @@ class TCollection;
 class TNetXNGSystem;
 class TFileCollection;
 
+/// Enables access to XRootD staging capabilities using the new client
 class TNetXNGFileStager: public TFileStager {
 
 private:

--- a/net/netxng/inc/TNetXNGSystem.h
+++ b/net/netxng/inc/TNetXNGSystem.h
@@ -17,8 +17,6 @@
 // Authors: Justin Salmon, Lukasz Janyst                                      //
 //          CERN, 2013                                                        //
 //                                                                            //
-// Enables access to XRootD filesystem interface using the new client.        //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "TSystem.h"
@@ -33,6 +31,7 @@ namespace XrdCl {
    class DirectoryList;
 }
 
+/// Enables access to XRootD filesystem interface using the new client.
 class TNetXNGSystem: public TSystem {
 
 private:

--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -15,13 +15,6 @@
 #ifndef ROOT_TMVA_PyMethodBase
 #define ROOT_TMVA_PyMethodBase
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// PyMethodBase                                                               //
-//                                                                            //
-// Virtual base class for all TMVA method based on Python                     //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
 
 #include "TMVA/MethodBase.h"
 #include "TMVA/Types.h"
@@ -58,6 +51,7 @@ namespace TMVA {
    /// If "Python3" is installed, return "python3"
    TString Python_Executable();
 
+   /// Virtual base class for all TMVA method based on Python
    class PyMethodBase : public MethodBase {
 
       friend class Factory;

--- a/tree/treeviewer/inc/TTVSession.h
+++ b/tree/treeviewer/inc/TTVSession.h
@@ -12,12 +12,8 @@
 #ifndef ROOT_TTVSession
 #define ROOT_TTVSession
 
-///////////////////////////////////////////////////////////////////////////////
-//                                                                           //
-// TTVSession and TTVRecord - I/O classes for TreeViewer session handling    //
-//     TTreeViewer                                                           //
-//                                                                           //
-///////////////////////////////////////////////////////////////////////////////
+/// @file
+/// @brief TTVSession and TTVRecord - I/O classes for TreeViewer session handling
 
 #include "TObject.h"
 #include "TString.h"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Many classes have a proper web documentation in ROOT5 and 'lost' it in ROOT6.

See e.g.:
https://root.cern/root/html534/TMessage.html

vs
https://root.cern/doc/master/classTMessage.html

See also a lot of classes with no 'brief' description:
https://root.cern.ch/doc/master/annotated.html

This PR tries to fix 'some of these occurrences', not all cause it'll take some time to doxygenize all these.


## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)
