### PR TITLE
[tree] Clarify ownership of TBranchProxy data member

### DIFF
--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <string>
 #include <iostream>
+#include <memory>
 
 class TBranch;
 class TStreamerElement;
@@ -106,7 +107,7 @@ namespace Detail {
       Long64_t fRead;     // Last entry read
 
       void    *fWhere;    // memory location of the data
-      TVirtualCollectionProxy *fCollection; // Handle to the collection containing the data chunk.
+      std::unique_ptr<TVirtualCollectionProxy> fCollection; // Handle to the collection containing the data chunk.
 
    public:
       virtual void Print();
@@ -440,7 +441,7 @@ public:
          return nullptr;
       }
 
-      TVirtualCollectionProxy *GetCollection() { return fCollection; }
+      TVirtualCollectionProxy *GetCollection() { return fCollection.get(); }
 
       // protected:
       virtual  void *GetStart(UInt_t /*i*/=0) {

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -221,8 +221,6 @@ void ROOT::Detail::TBranchProxy::Reset()
    fIsClone = false;
    fInitialized = false;
    fHasLeafCount = false;
-   delete fCollection;
-   fCollection = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -278,8 +276,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
       } else if (pcl->GetCollectionProxy()) {
          // We always skip the collections.
 
-         if (fCollection) delete fCollection;
-         fCollection = pcl->GetCollectionProxy()->Generate();
+         fCollection.reset(pcl->GetCollectionProxy()->Generate());
          pcl = fCollection->GetValueClass();
          if (pcl == nullptr) {
             // coverity[dereference] fparent is checked jus a bit earlier and can not be null here
@@ -412,8 +409,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
                   if (!fIsMember) fIsClone = true;
                   fClass = clones->GetClass();
                } else if (fClass && fClass->GetCollectionProxy()) {
-                  delete fCollection;
-                  fCollection = fClass->GetCollectionProxy()->Generate();
+                  fCollection.reset(fClass->GetCollectionProxy()->Generate());
                   fClass = fCollection->GetValueClass();
                }
 
@@ -434,7 +430,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
          } else if (be->GetType()==4) {
             // top level TClonesArray
 
-            fCollection = be->GetCollectionProxy()->Generate();
+            fCollection.reset(be->GetCollectionProxy()->Generate());
             fIsaPointer = false;
             fWhere = be->GetObject();
 
@@ -446,7 +442,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
 
          } else if (be->GetType()==41) {
 
-            fCollection = be->GetCollectionProxy()->Generate();
+            fCollection.reset(be->GetCollectionProxy()->Generate());
             fWhere   = be->GetObject();
             fOffset += be->GetOffset();
 


### PR DESCRIPTION
The fCollection data member is an owning pointer to a TVirtualCollectionProxy. Its lifetime was not properly tracked in the class, leaving space for memory leaks. Change the data member to unique_ptr so the memory management is done automatically.

The memory leaks were found via asan, running the `imt_parTreeProcessing.C` tutorial which has recently started failing in the CI.

Note that this is only fixing *some* of the memory leaks I found, not all. The fix for the rest seems to be non-trivial, but I believe it is still worth checking these changes in isolation.

Related to https://github.com/root-project/root/pull/17594 . I still believe we should use TTreeReaderArray for the tutorial, but let's see how this looks.