### PR TITLE
io: in UpdateFromRule properly handle case of std::string and alias without dictionary

### DIFF
--- a/core/foundation/src/RConversionRuleParser.cxx
+++ b/core/foundation/src/RConversionRuleParser.cxx
@@ -803,7 +803,17 @@ namespace ROOT
          }
 
          if( it->find( "source" ) != it->end() ) {
-            output << "      rule->fSource      = \"" << (*it)["source"];
+            // Normalize the type name first, in particular we need to remove the
+            // aliases.
+            SourceTypeList_t source;
+            TSchemaRuleProcessor::SplitDeclaration( (*it)["source"], source );
+            std::string norm_sources;
+            std::string norm_type;
+            for(auto it2 = source.begin(); it2 != source.end(); ++it2 ) {
+               TClassEdit::GetNormalizedName(norm_type, it2->first.fType);
+               norm_sources += norm_type + " " + it2->second + it2->first.fDimensions + "; ";
+            }
+            output << "      rule->fSource      = \"" << norm_sources;
             output << "\";" << std::endl;
          }
 

--- a/core/meta/inc/TClassRef.h
+++ b/core/meta/inc/TClassRef.h
@@ -24,12 +24,13 @@
 #include "TClass.h"
 
 #include <string>
+#include <atomic>
 
 class TClassRef {
 
 private:
-   std::string   fClassName; //Name of referenced class
-   TClass *const*fClassPtr;  //! Ptr to the permanent TClass ptr/reference
+   std::string                 fClassName; //Name of referenced class
+   std::atomic<TClass *const*> fClassPtr;  //! Ptr to the permanent TClass ptr/reference
 
    friend class TClass;
 

--- a/core/meta/src/TClassRef.cxx
+++ b/core/meta/src/TClassRef.cxx
@@ -28,7 +28,7 @@ TClass::fRefStart.
 /// Copy ctor, increases reference count to original TClass object.
 
 TClassRef::TClassRef(const TClassRef &org) :
-   fClassName(org.fClassName), fClassPtr(org.fClassPtr)
+   fClassName(org.fClassName), fClassPtr(org.fClassPtr.load())
 {
 }
 
@@ -59,7 +59,7 @@ TClassRef::TClassRef(TClass *cl) : fClassPtr(nullptr)
 void TClassRef::Assign(const TClassRef &rhs)
 {
    fClassName = rhs.fClassName;
-   fClassPtr  = rhs.fClassPtr;
+   fClassPtr  = rhs.fClassPtr.load();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -262,6 +262,7 @@ namespace {
       Int_t datasize = 1;
       auto memClass = TClass::GetClass(localtypename.c_str());
       std::vector<Int_t> dimensions;
+      static TClassRef string_classref("string");
       bool isStdArray = memClass && TClassEdit::IsStdArray(memClass->GetName());
       if (isStdArray) {
          totaldim = 1;
@@ -279,13 +280,13 @@ namespace {
          if (s->GetPointerLevel()) {
             if (memClass->IsTObject()) {
                memType = TVirtualStreamerInfo::kObjectP;
-            } else if (memClass->GetCollectionProxy()) {
+            } else if (memClass->GetCollectionProxy() || memClass == string_classref) {
                memType = TVirtualStreamerInfo::kSTLp;
             } else {
                memType = TVirtualStreamerInfo::kAnyP;
             }
          } else {
-            if (memClass->GetCollectionProxy()) {
+            if (memClass->GetCollectionProxy() || memClass == string_classref) {
                memType = TVirtualStreamerInfo::kSTL;
             } else if (memClass->IsTObject() && memClass == element->GetClassPointer()) {
                // If there is a change in the class type, we can't use the TObject::Streamer


### PR DESCRIPTION
This fixes the issue seen in https://github.com/cms-sw/cmsdist/pull/9643#issuecomment-2632063998
and is the companion PR of https://github.com/root-project/roottest/pull/1256
