### PR TITLE
[gui] avoid loading of `TStyleManager` for quit ROOT

### DIFF
--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -950,7 +950,7 @@ again:
                      }
                      if (TVirtualPadEditor::GetPadEditor(kFALSE) != 0)
                         TVirtualPadEditor::Terminate();
-                     if (TClass::GetClass("TStyleManager"))
+                     if (TClass::GetClass("TStyleManager", kFALSE, kTRUE))
                         gROOT->ProcessLine("TStyleManager::Terminate()");
                      gApplication->Terminate(0);
                      break;


### PR DESCRIPTION
When selecting "Quit ROOT" menu item in canvas, 
do not load `TStyleManager` class. 

Only if it was loaded before - execute `Terminate()` method

