### PR TITLE
[davix] Fix problems with locks and mutexes in `TDavixFile` classes

### DIFF
--- a/net/davix/inc/TDavixFile.h
+++ b/net/davix/inc/TDavixFile.h
@@ -69,8 +69,7 @@ private:
     TDavixFileInternal* d_ptr;
 
     void Init(Bool_t init);
-    Long64_t DavixReadBuffer(Davix_fd *fd, char *buf, Int_t len);
-    Long64_t DavixPReadBuffer(Davix_fd *fd, char *buf, Long64_t pos, Int_t len);
+    Long64_t DavixReadBuffer(Davix_fd *fd, char *buf, Long64_t pos, Int_t len);
     Long64_t DavixReadBuffers(Davix_fd *fd, char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
     Long64_t DavixWriteBuffer(Davix_fd *fd, const char *buf, Int_t len);
     Int_t DavixStat(struct stat *st) const;

--- a/net/davix/src/TDavixFile.cxx
+++ b/net/davix/src/TDavixFile.cxx
@@ -737,7 +737,6 @@ void TDavixFile::Seek(Long64_t offset, ERelativeTo pos)
 
 Bool_t TDavixFile::ReadBuffer(char *buf, Int_t len)
 {
-   TLockGuard guard(&davixLock);
    Davix_fd *fd;
    if ((fd = d_ptr->getDavixFileInstance()) == NULL)
       return kTRUE;
@@ -912,7 +911,12 @@ Long64_t TDavixFile::DavixReadBuffer(Davix_fd *fd, char *buf, Long64_t pos, Int_
    DavixError *davixErr = NULL;
    Double_t start_time = eventStart();
 
-   Long64_t ret = d_ptr->davixPosix->pread(fd, buf, len, pos, &davixErr);
+   Long64_t ret;
+   {
+      TLockGuard guard(&davixLock);
+      ret = d_ptr->davixPosix->pread(fd, buf, len, pos, &davixErr);
+   }
+
    if (ret < 0) {
       Error("DavixReadBuffer", "can not read data with davix: %s (%d)",
             davixErr->getErrMsg().c_str(), davixErr->getStatus());

--- a/net/davix/src/TDavixFileInternal.h
+++ b/net/davix/src/TDavixFileInternal.h
@@ -56,42 +56,20 @@ class TDavixFileInternal {
 
 private:
    TDavixFileInternal(const TUrl & mUrl, Option_t* mopt) :
-      positionLock(),
-      openLock(),
       davixContext(getDavixInstance()),
-      davixParam(nullptr),
-      davixPosix(nullptr),
-      davixFd(nullptr),
       fUrl(mUrl),
       opt(mopt),
-      oflags(0),
       dirdVec() { }
 
    TDavixFileInternal(const char* url, Option_t* mopt) :
-      positionLock(),
-      openLock(),
       davixContext(getDavixInstance()),
-      davixParam(nullptr),
-      davixPosix(nullptr),
-      davixFd(nullptr),
       fUrl(url),
       opt(mopt),
-      oflags(0),
       dirdVec() { }
 
    ~TDavixFileInternal();
 
-   Davix_fd *getDavixFileInstance()
-   {
-      // singleton init
-      if (davixFd == nullptr) {
-         TLockGuard l(&(openLock));
-         if (davixFd == nullptr) {
-            davixFd = this->Open();
-         }
-      }
-      return davixFd;
-   }
+   Davix_fd *getDavixFileInstance();
 
    Davix_fd * Open();
 
@@ -123,19 +101,16 @@ private:
      return replicas;
    }
 
-   TMutex positionLock;
-   TMutex openLock;
-
    std::vector<std::string> replicas;
 
    // DAVIX
    Davix::Context *davixContext;
-   Davix::RequestParams *davixParam;
-   Davix::DavPosix *davixPosix;
-   Davix_fd *davixFd;
+   Davix::RequestParams *davixParam = nullptr;
+   Davix::DavPosix *davixPosix = nullptr;
+   Davix_fd *davixFd = nullptr;
    TUrl fUrl;
    Option_t* opt;
-   int oflags;
+   int oflags = 0;
    std::vector<void*> dirdVec;
 
 public:


### PR DESCRIPTION
See the commit descriptions for more detail.

Closes https://github.com/root-project/root/issues/17611, verified by running the reproducer 200 times in the
Fedora 40 container with this PR, without a single crash.

The new davix version seems to be more prone to concurrency issues.