### PR TITLE
[DF] Check if column exists on `GetTypeName`

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -684,7 +684,14 @@ void RNTupleDS::FinalizeSlot(unsigned int slot)
 
 std::string RNTupleDS::GetTypeName(std::string_view colName) const
 {
-   const auto index = std::distance(fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), colName));
+   auto colNamePos = std::find(fColumnNames.begin(), fColumnNames.end(), colName);
+
+   if (colNamePos == fColumnNames.end()) {
+      auto msg = std::string("RNTupleDS: There is no column with name \"") + std::string(colName) + "\"";
+      throw std::runtime_error(msg);
+   }
+
+   const auto index = std::distance(fColumnNames.begin(), colNamePos);
    return fColumnTypes[index];
 }
 

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -9,6 +9,7 @@
 #include <NTupleStruct.hxx>
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "ClassWithArrays.h"
 
@@ -99,6 +100,13 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    EXPECT_STREQ("float", ds.GetTypeName("energy").c_str());
    EXPECT_STREQ("std::size_t", ds.GetTypeName("R_rdf_sizeof_jets").c_str());
    EXPECT_STREQ("ROOT::VecOps::RVec<std::int32_t>", ds.GetTypeName("rvec").c_str());
+
+   try {
+      ds.GetTypeName("Address");
+      FAIL() << "should not be able to get a type for a non-existent column";
+   } catch (const std::runtime_error &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("RNTupleDS: There is no column with name \"Address\""));
+   }
 }
 
 TEST_F(RNTupleDSTest, NFiles)


### PR DESCRIPTION
This PR adds a check to `RNTupleDS::GetTypeName` for the existence of the provided column name, and throws a `std::runtime_error` if this is not the case.

To simplify, we could also use `RNTupleDS::HasColumn`, but that would mean calling `std::find` on `fColumnNames` twice, so I opted for this slightly duplicated approach instead.

