### PR TITLE
ci: improvement of clang-format step

### DIFF
--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
 clang-format --version
 COMMIT_FILES=$(git diff --name-status $BASE_COMMIT | grep -i -v '.mjs$' | grep -i -v LinkDef | grep -v -E '^D +' | sed -E 's,^.[[:space:]]+,,')

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -x
 
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
 clang-format --version

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -28,7 +28,7 @@ else
   echo -e "\n\nPlease apply the code formatting changes without bloating the history."
   echo -e "\tConsider running:"
   echo -e "\t\tgit checkout $TRAVIS_PULL_REQUEST_BRANCH"
-  echo -e "\t\tgit rebase -i -x \"git-clang-format-7 master && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/master"
+  echo -e "\t\tgit rebase -i -x \"git-clang-format master && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/master"
   echo -e "\t Then inspect the results with git log --oneline"
   echo -e "\t Then squash without poluting the history with: git rebase --autosquash -i master"
 

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -3,6 +3,7 @@
 set -ex
 
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
+clang-format --version
 COMMIT_FILES=$(git diff --name-status $BASE_COMMIT | grep -i -v '.mjs$' | grep -i -v LinkDef | grep -v -E '^D +' | sed -E 's,^.[[:space:]]+,,')
 
 RESULT_OUTPUT="no modified files to format"

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -17,14 +17,14 @@ if [ "$RESULT_OUTPUT" == "no modified files to format" ] \
   echo "clang-format passed."
   exit 0
 else
-  echo "clang-format failed."
-  echo "To reproduce it locally please run"
-  echo -e "\tgit checkout $TRAVIS_PULL_REQUEST_BRANCH"
-  echo -e "\tgit-clang-format --commit $BASE_COMMIT --diff --binary $(which clang-format)"
+  echo  -e "clang-format failed with the following diff:\n"
   echo "$RESULT_OUTPUT"
 
-  echo -e "\n\nPlease apply the code formatting changes without bloating the history."
-  echo -e "\tConsider running:"
+  echo -e "\nTo reproduce it locally please run"
+  echo -e "\tgit checkout $TRAVIS_PULL_REQUEST_BRANCH"
+  echo -e "\tgit-clang-format --commit $BASE_COMMIT --diff --binary $(which clang-format) # adjust to point to the local clang-format"
+
+  echo -e "\nConsider running the following to apply the code formatting changes without bloating the history."
   echo -e "\t\tgit checkout $TRAVIS_PULL_REQUEST_BRANCH"
   echo -e "\t\tgit rebase -i -x \"git-clang-format master && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/master"
   echo -e "\t Then inspect the results with git log --oneline"


### PR DESCRIPTION
The main purpose of this PR is to expose directly the version number of the clang-format used by the CI.

The secondary purpose is to shorten and clarify the output.

NOTE: An intentional formatting error is introduced to show the error output and will (of course) be removed before merging.
