### PR TITLE
Properly delete 3dview in TPaletteAxis::UnZoom

### DIFF
--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -662,12 +662,11 @@ void TPaletteAxis::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
 void TPaletteAxis::UnZoom()
 {
-   if (!fH) return;
-   TView *view = gPad ? gPad->GetView() : nullptr;
-   if (view) {
-      delete view;
+   if (!fH)
+      return;
+   // if view exists - it will be deleted
+   if (gPad)
       gPad->SetView(nullptr);
-   }
    fH->GetZaxis()->SetRange(0, 0);
    if (fH->GetDimension() == 2) {
       fH->SetMinimum();


### PR DESCRIPTION
View automatically deleted when `gPad->SetView(nullptr)` called 
Therefore there is no need to to call destructor
