### PR TITLE
[TFormula] TFormula: Pol functions do not accept variable name as arguments 

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -998,67 +998,140 @@ void TFormula::FillVecFunctionsShurtCuts() {
 ///    eg.
 ///    varpol2(5) will be replaced with: [5] + [6]*var + [7]*var^2
 ///    Empty name is treated like variable x.
+///    Extended format also supports direct variable specification: pol2(x, 0) or pol(x, [A])
+///    Traditional Syntax: polN - Polynomial of degree N
+///          ypol1             [p0]+[p1]*y
+///          pol1(x, 0)        [p0]+[p1]*x
+///          pol2(y, 1)        [p1]+[p2]*y+[p3]*TMath::Sq(y)
 
 void TFormula::HandlePolN(TString &formula)
 {
+   
+   
    Int_t polPos = formula.Index("pol");
    while (polPos != kNPOS && !IsAParameterName(formula, polPos)) {
-
       Bool_t defaultVariable = false;
       TString variable;
       Int_t openingBracketPos = formula.Index('(', polPos);
       Bool_t defaultCounter = openingBracketPos == kNPOS;
       Bool_t defaultDegree = true;
-      Int_t degree, counter;
+      Int_t degree = 1, counter = 0;
       TString sdegree;
+      std::vector<TString> paramNames;
+
+      // check for extended format
+      Bool_t isNewFormat = false;
       if (!defaultCounter) {
-         // verify first of opening parenthesis belongs to pol expression
-         // character between 'pol' and '(' must all be digits
-         sdegree = formula(polPos + 3, openingBracketPos - polPos - 3);
-         if (!sdegree.IsDigit())
-            defaultCounter = true;
-      }
-      if (!defaultCounter) {
-         degree = sdegree.Atoi();
-         counter = TString(formula(openingBracketPos + 1, formula.Index(')', polPos) - openingBracketPos)).Atoi();
-      } else {
-         Int_t temp = polPos + 3;
-         while (temp < formula.Length() && isdigit(formula[temp])) {
-            defaultDegree = false;
-            temp++;
+         TString args = formula(openingBracketPos + 1, formula.Index(')', polPos) - openingBracketPos - 1);
+         if (args.Contains(",")) {
+            isNewFormat = true;
+            sdegree = formula(polPos + 3, openingBracketPos - polPos - 3);
+            if (!sdegree.IsDigit()) sdegree = "1";
+            degree = sdegree.Atoi();
+            
+            std::vector<TString> tokens;
+            std::stringstream ss(args.Data());
+            std::string token;
+            while (std::getline(ss, token, ',')) {    // spliting string at ,
+               tokens.push_back(TString(token));
+            }
+            
+            if (!tokens.empty()) {
+               variable = tokens[0];
+               variable.Strip(TString::kBoth);
+               
+               // extract counter if provided as a numeric value, without this it was not working with [A], [B]
+               if (tokens.size() > 1) {
+                  TString counterStr = tokens[1];
+                  counterStr.Strip(TString::kBoth);
+                  if (counterStr.IsDigit()) {
+                     counter = counterStr.Atoi();
+                  }
+               }
+
+               // store parameter names for later use
+               for (size_t i = 1; i < tokens.size(); i++) {
+                  TString paramStr = tokens[i];
+                  paramStr.Strip(TString::kBoth);
+                  if (paramStr.BeginsWith("[") && paramStr.EndsWith("]")) {
+                     paramStr = paramStr(1, paramStr.Length() - 2);
+                     paramNames.push_back(paramStr);
+                     
+                     if (fParams.find(paramStr) == fParams.end()) {
+                        fParams[paramStr] = fNpar;
+                        fClingParameters.push_back(0.0);
+                        fNpar++;
+                     }
+                  }
+               }
+            }
          }
-         degree = TString(formula(polPos + 3, temp - polPos - 3)).Atoi();
-         counter = 0;
       }
 
-      TString replacement = TString::Format("[%d]", counter);
-      if (polPos - 1 < 0 || !IsFunctionNameChar(formula[polPos - 1]) || formula[polPos - 1] == ':') {
-         variable = "x";
-         defaultVariable = true;
-      } else {
-         Int_t tmp = polPos - 1;
-         while (tmp >= 0 && IsFunctionNameChar(formula[tmp]) && formula[tmp] != ':') {
-            tmp--;
+      // handle original format if not new format
+      if (!isNewFormat) {
+         if (!defaultCounter) {
+            sdegree = formula(polPos + 3, openingBracketPos - polPos - 3);
+            if (!sdegree.IsDigit())
+               defaultCounter = true;
          }
-         variable = formula(tmp + 1, polPos - (tmp + 1));
+         if (!defaultCounter) {
+            degree = sdegree.Atoi();
+            counter = TString(formula(openingBracketPos + 1, formula.Index(')', polPos) - openingBracketPos)).Atoi();
+         } else {
+            Int_t temp = polPos + 3;
+            while (temp < formula.Length() && isdigit(formula[temp])) {
+               defaultDegree = false;
+               temp++;
+            }
+            degree = TString(formula(polPos + 3, temp - polPos - 3)).Atoi();
+         }
+
+         if (polPos - 1 < 0 || !IsFunctionNameChar(formula[polPos - 1]) || formula[polPos - 1] == ':') {
+            variable = "x";
+            defaultVariable = true;
+         } else {
+            Int_t tmp = polPos - 1;
+            while (tmp >= 0 && IsFunctionNameChar(formula[tmp]) && formula[tmp] != ':') {
+               tmp--;
+            }
+            variable = formula(tmp + 1, polPos - (tmp + 1));
+         }
       }
-      Int_t param = counter + 1;
-      Int_t tmp = 1;
-      while (tmp <= degree) {
-         if (tmp > 1)
-            replacement.Append(TString::Format("+[%d]*%s^%d", param, variable.Data(), tmp));
-         else
-            replacement.Append(TString::Format("+[%d]*%s", param, variable.Data()));
-         param++;
-         tmp++;
+
+      // build replacement string (modified)
+      TString replacement;
+      if (isNewFormat && !paramNames.empty()) {
+         for (size_t i = 0; i <= degree && i < paramNames.size(); i++) {
+            if (i == 0) {
+               replacement = TString::Format("[%s]", paramNames[i].Data());
+            } else if (i == 1) {
+               replacement.Append(TString::Format("+[%s]*%s", paramNames[i].Data(), variable.Data()));
+            } else {
+               replacement.Append(TString::Format("+[%s]*%s^%d", paramNames[i].Data(), variable.Data(), i));
+            }
+         }
+      } else {
+         replacement = TString::Format("[%d]", counter);
+         for (Int_t i = 1; i <= degree; i++) {
+            if (i == 1) {
+               replacement.Append(TString::Format("+[%d]*%s", counter + i, variable.Data()));
+            } else {
+               replacement.Append(TString::Format("+[%d]*%s^%d", counter + i, variable.Data(), i));
+            }
+         }
       }
-      // add parenthesis before and after
+
       if (degree > 0) {
          replacement.Insert(0, '(');
          replacement.Append(')');
       }
+
+      // create patern based on format either new or old
       TString pattern;
-      if (defaultCounter && !defaultDegree) {
+      if (isNewFormat) {
+         pattern = formula(polPos, formula.Index(')', polPos) - polPos + 1);
+      } else if (defaultCounter && !defaultDegree) {
          pattern = TString::Format("%spol%d", (defaultVariable ? "" : variable.Data()), degree);
       } else if (defaultCounter && defaultDegree) {
          pattern = TString::Format("%spol", (defaultVariable ? "" : variable.Data()));
@@ -1071,11 +1144,12 @@ void TFormula::HandlePolN(TString &formula)
                formula.Data(), pattern.Data(), replacement.Data());
          break;
       }
+      
       if (formula == pattern) {
-         // case of single polynomial
          SetBit(kLinear, true);
          fNumber = 300 + degree;
       }
+      
       formula.ReplaceAll(pattern, replacement);
       polPos = formula.Index("pol");
    }

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -991,7 +991,6 @@ void TFormula::FillVecFunctionsShurtCuts() {
    // do nothing in case Veccore is not enabled
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 ///    Handling polN
 ///    If before 'pol' exist any name, this name will be treated as variable used in polynomial
@@ -1006,8 +1005,7 @@ void TFormula::FillVecFunctionsShurtCuts() {
 
 void TFormula::HandlePolN(TString &formula)
 {
-   
-   
+
    Int_t polPos = formula.Index("pol");
    while (polPos != kNPOS && !IsAParameterName(formula, polPos)) {
       Bool_t defaultVariable = false;
@@ -1026,20 +1024,21 @@ void TFormula::HandlePolN(TString &formula)
          if (args.Contains(",")) {
             isNewFormat = true;
             sdegree = formula(polPos + 3, openingBracketPos - polPos - 3);
-            if (!sdegree.IsDigit()) sdegree = "1";
+            if (!sdegree.IsDigit())
+               sdegree = "1";
             degree = sdegree.Atoi();
-            
+
             std::vector<TString> tokens;
             std::stringstream ss(args.Data());
             std::string token;
-            while (std::getline(ss, token, ',')) {    // spliting string at ,
+            while (std::getline(ss, token, ',')) { // spliting string at ,
                tokens.push_back(TString(token));
             }
-            
+
             if (!tokens.empty()) {
                variable = tokens[0];
                variable.Strip(TString::kBoth);
-               
+
                // extract counter if provided as a numeric value, without this it was not working with [A], [B]
                if (tokens.size() > 1) {
                   TString counterStr = tokens[1];
@@ -1056,7 +1055,7 @@ void TFormula::HandlePolN(TString &formula)
                   if (paramStr.BeginsWith("[") && paramStr.EndsWith("]")) {
                      paramStr = paramStr(1, paramStr.Length() - 2);
                      paramNames.push_back(paramStr);
-                     
+
                      if (fParams.find(paramStr) == fParams.end()) {
                         fParams[paramStr] = fNpar;
                         fClingParameters.push_back(0.0);
@@ -1144,12 +1143,12 @@ void TFormula::HandlePolN(TString &formula)
                formula.Data(), pattern.Data(), replacement.Data());
          break;
       }
-      
+
       if (formula == pattern) {
          SetBit(kLinear, true);
          fNumber = 300 + degree;
       }
-      
+
       formula.ReplaceAll(pattern, replacement);
       polPos = formula.Index("pol");
    }

--- a/hist/hist/test/test_TFormula.cxx
+++ b/hist/hist/test/test_TFormula.cxx
@@ -1,9 +1,84 @@
 #include "gtest/gtest.h"
+#include "TF1.h"
+#include "ROOT/TestSupport.hxx"
+#include <cmath>
 
 #include "TFormula.h"
+
+using namespace ROOT;
 
 // Test that autoloading works (ROOT-9840)
 TEST(TFormula, Interp)
 {
   TFormula f("func", "TGeoBBox::DeclFileLine()");
+}
+
+// Test for TFormula Extended syntax support
+TEST(TFormulaPolTest, BasicPolynomialConstruction) {
+    
+    TFormula f1("f1", "pol1");
+    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)"));
+    
+    TFormula f2("f2", "pol2");
+    EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*x+[p2]*TMath::Sq(x))"));
+}
+
+TEST(TFormulaPolTest, VariablePolynomials) {
+    
+    TFormula f1("f1", "pol1(y,0)");
+    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*y)"));
+    
+    TFormula f2("f2", "pol2(z,0)");
+    EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*z+[p2]*TMath::Sq(z))"));
+}
+
+TEST(TFormulaPolTest, ParameterPlaceholders) {
+    
+    TFormula f1("f1", "pol1(x,[A], [B])");
+    EXPECT_EQ(f1.GetExpFormula(), TString("([A]+[B]*x)"));
+    f1.SetParameter("A", -1.234);
+    EXPECT_EQ(f1.GetParameter("A"), -1.234);
+    EXPECT_EQ(f1.GetParameter(0), -1.234);
+    f1.SetParameter(0, -1.2345);
+    EXPECT_EQ(f1.GetParameter("A"), -1.2345);
+    EXPECT_EQ(f1.GetParameter(0), -1.2345);
+}
+
+TEST(TFormulaPolTest, NumericEvaluation) {
+    
+    TF1 f1("f1", "pol1(x,0)");
+    f1.SetParameters(1.0, 2.0);  // f(x) = 1 + 2x
+    
+    EXPECT_NEAR(f1.Eval(0.0), 1.0, 1e-10);
+    EXPECT_NEAR(f1.Eval(1.0), 3.0, 1e-10);
+}
+
+TEST(TFormulaPolTest, Parameters) {
+    
+    TFormula f2("f2", "pol2(x, [A], [B], [C])");
+    EXPECT_EQ(f2.GetExpFormula(), TString("([A]+[B]*x+[C]*TMath::Sq(x))"));
+    f2.SetParameter("A", -1.234);
+    EXPECT_EQ(f2.GetParameter("A"), -1.234);
+    EXPECT_EQ(f2.GetParameter(0), -1.234);
+    f2.SetParameter(0, -1.234);
+    EXPECT_EQ(f2.GetParameter("A"), -1.234);
+    EXPECT_EQ(f2.GetParameter(0), -1.234);
+    f2.SetParameter("B", -1.235);
+    EXPECT_EQ(f2.GetParameter("B"), -1.235);
+    EXPECT_EQ(f2.GetParameter(1), -1.235);
+    f2.SetParameter(1, -1.235);
+    EXPECT_EQ(f2.GetParameter("B"), -1.235);
+    EXPECT_EQ(f2.GetParameter(1), -1.235);
+    f2.SetParameter("C", -1.236);
+    EXPECT_EQ(f2.GetParameter("C"), -1.236);
+    EXPECT_EQ(f2.GetParameter(2), -1.236);
+    f2.SetParameter(2, -1.236);
+    EXPECT_EQ(f2.GetParameter("C"), -1.236);
+    EXPECT_EQ(f2.GetParameter(2), -1.236);
+}
+
+TEST(TFormulaPolTest, CompoundExpressions) {
+    
+    TFormula f1("f1", "pol1(x,0) + pol1(y,2)");
+    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)+([p2]+[p3]*y)"));
 }

--- a/hist/hist/test/test_TFormula.cxx
+++ b/hist/hist/test/test_TFormula.cxx
@@ -14,71 +14,77 @@ TEST(TFormula, Interp)
 }
 
 // Test for TFormula Extended syntax support
-TEST(TFormulaPolTest, BasicPolynomialConstruction) {
-    
-    TFormula f1("f1", "pol1");
-    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)"));
-    
-    TFormula f2("f2", "pol2");
-    EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*x+[p2]*TMath::Sq(x))"));
+TEST(TFormulaPolTest, BasicPolynomialConstruction)
+{
+
+   TFormula f1("f1", "pol1");
+   EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)"));
+
+   TFormula f2("f2", "pol2");
+   EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*x+[p2]*TMath::Sq(x))"));
 }
 
-TEST(TFormulaPolTest, VariablePolynomials) {
-    
-    TFormula f1("f1", "pol1(y,0)");
-    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*y)"));
-    
-    TFormula f2("f2", "pol2(z,0)");
-    EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*z+[p2]*TMath::Sq(z))"));
+TEST(TFormulaPolTest, VariablePolynomials)
+{
+
+   TFormula f1("f1", "pol1(y,0)");
+   EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*y)"));
+
+   TFormula f2("f2", "pol2(z,0)");
+   EXPECT_EQ(f2.GetExpFormula(), TString("([p0]+[p1]*z+[p2]*TMath::Sq(z))"));
 }
 
-TEST(TFormulaPolTest, ParameterPlaceholders) {
-    
-    TFormula f1("f1", "pol1(x,[A], [B])");
-    EXPECT_EQ(f1.GetExpFormula(), TString("([A]+[B]*x)"));
-    f1.SetParameter("A", -1.234);
-    EXPECT_EQ(f1.GetParameter("A"), -1.234);
-    EXPECT_EQ(f1.GetParameter(0), -1.234);
-    f1.SetParameter(0, -1.2345);
-    EXPECT_EQ(f1.GetParameter("A"), -1.2345);
-    EXPECT_EQ(f1.GetParameter(0), -1.2345);
+TEST(TFormulaPolTest, ParameterPlaceholders)
+{
+
+   TFormula f1("f1", "pol1(x,[A], [B])");
+   EXPECT_EQ(f1.GetExpFormula(), TString("([A]+[B]*x)"));
+   f1.SetParameter("A", -1.234);
+   EXPECT_EQ(f1.GetParameter("A"), -1.234);
+   EXPECT_EQ(f1.GetParameter(0), -1.234);
+   f1.SetParameter(0, -1.2345);
+   EXPECT_EQ(f1.GetParameter("A"), -1.2345);
+   EXPECT_EQ(f1.GetParameter(0), -1.2345);
 }
 
-TEST(TFormulaPolTest, NumericEvaluation) {
-    
-    TF1 f1("f1", "pol1(x,0)");
-    f1.SetParameters(1.0, 2.0);  // f(x) = 1 + 2x
-    
-    EXPECT_NEAR(f1.Eval(0.0), 1.0, 1e-10);
-    EXPECT_NEAR(f1.Eval(1.0), 3.0, 1e-10);
+TEST(TFormulaPolTest, NumericEvaluation)
+{
+
+   TF1 f1("f1", "pol1(x,0)");
+   f1.SetParameters(1.0, 2.0); // f(x) = 1 + 2x
+
+   EXPECT_NEAR(f1.Eval(0.0), 1.0, 1e-10);
+   EXPECT_NEAR(f1.Eval(1.0), 3.0, 1e-10);
 }
 
-TEST(TFormulaPolTest, Parameters) {
-    
-    TFormula f2("f2", "pol2(x, [A], [B], [C])");
-    EXPECT_EQ(f2.GetExpFormula(), TString("([A]+[B]*x+[C]*TMath::Sq(x))"));
-    f2.SetParameter("A", -1.234);
-    EXPECT_EQ(f2.GetParameter("A"), -1.234);
-    EXPECT_EQ(f2.GetParameter(0), -1.234);
-    f2.SetParameter(0, -1.234);
-    EXPECT_EQ(f2.GetParameter("A"), -1.234);
-    EXPECT_EQ(f2.GetParameter(0), -1.234);
-    f2.SetParameter("B", -1.235);
-    EXPECT_EQ(f2.GetParameter("B"), -1.235);
-    EXPECT_EQ(f2.GetParameter(1), -1.235);
-    f2.SetParameter(1, -1.235);
-    EXPECT_EQ(f2.GetParameter("B"), -1.235);
-    EXPECT_EQ(f2.GetParameter(1), -1.235);
-    f2.SetParameter("C", -1.236);
-    EXPECT_EQ(f2.GetParameter("C"), -1.236);
-    EXPECT_EQ(f2.GetParameter(2), -1.236);
-    f2.SetParameter(2, -1.236);
-    EXPECT_EQ(f2.GetParameter("C"), -1.236);
-    EXPECT_EQ(f2.GetParameter(2), -1.236);
+TEST(TFormulaPolTest, Parameters)
+{
+
+   TFormula f2("f2", "pol2(x, [A], [B], [C])");
+   EXPECT_EQ(f2.GetExpFormula(), TString("([A]+[B]*x+[C]*TMath::Sq(x))"));
+   f2.SetParameter("A", -1.234);
+   EXPECT_EQ(f2.GetParameter("A"), -1.234);
+   EXPECT_EQ(f2.GetParameter(0), -1.234);
+   f2.SetParameter(0, -1.234);
+   EXPECT_EQ(f2.GetParameter("A"), -1.234);
+   EXPECT_EQ(f2.GetParameter(0), -1.234);
+   f2.SetParameter("B", -1.235);
+   EXPECT_EQ(f2.GetParameter("B"), -1.235);
+   EXPECT_EQ(f2.GetParameter(1), -1.235);
+   f2.SetParameter(1, -1.235);
+   EXPECT_EQ(f2.GetParameter("B"), -1.235);
+   EXPECT_EQ(f2.GetParameter(1), -1.235);
+   f2.SetParameter("C", -1.236);
+   EXPECT_EQ(f2.GetParameter("C"), -1.236);
+   EXPECT_EQ(f2.GetParameter(2), -1.236);
+   f2.SetParameter(2, -1.236);
+   EXPECT_EQ(f2.GetParameter("C"), -1.236);
+   EXPECT_EQ(f2.GetParameter(2), -1.236);
 }
 
-TEST(TFormulaPolTest, CompoundExpressions) {
-    
-    TFormula f1("f1", "pol1(x,0) + pol1(y,2)");
-    EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)+([p2]+[p3]*y)"));
+TEST(TFormulaPolTest, CompoundExpressions)
+{
+
+   TFormula f1("f1", "pol1(x,0) + pol1(y,2)");
+   EXPECT_EQ(f1.GetExpFormula(), TString("([p0]+[p1]*x)+([p2]+[p3]*y)"));
 }


### PR DESCRIPTION
# This Pull request:
Extend TFormula's syntax for polynomials
1. Modified HandlePolN to accept named parameters and variables
2. Modified the HandlePolN to use modern c++ functions like std::getline
3. Added tests for the same in test_TFormula.cxx
## Changes or fixes:
Allow variables in TFormula Pol functions like
`TF1 f1("f1", "pol1(x, 0)");`
`TF1 f1("f1", "pol1(x, [A], [B])");`

## Checklist:

- [✅] tested changes locally
- [❌] updated the docs (if necessary)

This PR fixes #16794 

