### PR TITLE
[skip-ci] fix doxygen warnings

### DIFF
--- a/math/foam/src/TFoam.cxx
+++ b/math/foam/src/TFoam.cxx
@@ -42,7 +42,7 @@ See [full version of FOAM](http://jadach.home.cern.ch/jadach/Foam/Index.html)
 ### Simple example of the use of FOAM:
 
 Begin_Macro(source)
-../../../tutorials/foam/foam_kanwa.C
+../../../tutorials/math/foam/foam_kanwa.C
 End_Macro
 
 ### Canonical nine steering parameters of FOAM

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -61,12 +61,12 @@ You can directly see RDataFrame in action in our [tutorials](https://root.cern/d
 
 ## Table of Contents
 - [Cheat sheet](\ref cheatsheet)
-- [Introduction](\ref introduction)
+- [Introduction](\ref rdf_intro)
 - [Crash course](\ref crash-course)
 - [Working with collections](\ref collections)
 - [Transformations: manipulating data](\ref transformations)
 - [Actions: getting results](\ref actions)
-- [Distributed execution in Python](classROOT_1_1RDataFrame.html#distrdf)
+- [Distributed execution in Python](rdf_distrdf)
 - [Performance tips and parallel execution](\ref parallel-execution)
 - [More features](\ref more-features)
    - [Systematic variations](\ref systematics)
@@ -168,7 +168,7 @@ These operations do not modify the dataframe or book computations but simply ret
 | GetNSlots() | Return the number of processing slots that RDataFrame will use during the event loop (i.e. the concurrency level). |
 | SaveGraph() | Store the computation graph of an RDataFrame in [DOT format (graphviz)](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) for easy inspection. See the [relevant section](\ref representgraph) for details. |
 
-\anchor introduction
+\anchor rdf_intro
 ## Introduction
 Users define their analysis as a sequence of operations to be performed on the dataframe object; the framework
 takes care of the management of the loop over entries as well as low-level details such as I/O and parallelization.
@@ -670,7 +670,7 @@ auto graph = df2.Graph<int, int>("x","y");
 The `Graph` action is going to request first the value from column "x", then that of column "y". Specifically, the order
 of execution of the operations of nodes in this branch of the computation graph is guaranteed to be top to bottom.
 
-\anchor distrdf
+\anchor rdf_distrdf
 ## Distributed execution
 
 RDataFrame applications can be executed in parallel through distributed computing frameworks on a set of remote machines

--- a/tutorials/analysis/dataframe/index.md
+++ b/tutorials/analysis/dataframe/index.md
@@ -20,18 +20,18 @@ histoB->Draw(); // HistoB has already been filled, no event loop is run here
 Explore the examples below or go to [RDataFrame's user guide](classROOT_1_1RDataFrame.html). A list of all the RDataFrame tutorials can be found [here](\ref alltutorials).
 
 ## Table of contents
-- [Introduction](\ref introduction)
+- [Introduction](\ref df_intro)
 - [Processing your data](\ref processingdata)
 - [Write and read from many sources](\ref readwrite)
 - [Interface with Numpy and Pandas](\ref numpypanda)
-- [Distributed execution in Python](\ref distrdf)
+- [Distributed execution in Python](\ref df_distrdf)
 - [Know more about your analysis](\ref analysisinfo)
 - [Example HEP analyses tutorials](\ref hepanalysis)
 - [List of all the tutorials](\ref alltutorials)
 
 
 
-\anchor introduction
+\anchor df_intro
 ## Introduction
 
 To get started these examples show how to create a simple RDataFrame, how to process the data in a simple analyses and how to plot distributions.
@@ -96,7 +96,7 @@ From Python, NumPy arrays can be imported into RDataFrame and columns from RData
 | df032_RDFFromNumpy.py | Read data from Numpy arrays. |
 | df035_RDFFromPandas.py | Read data from Pandas DataFrame. |
 
-\anchor distrdf
+\anchor df_distrdf
 ##Distributed execution in Python
 
 RDataFrame applications can be executed in parallel through distributed computing frameworks on a set of remote machines via Apache Spark or Dask.

--- a/tutorials/hist/index.md
+++ b/tutorials/hist/index.md
@@ -37,7 +37,7 @@ Explore the examples below for [different histogram classes](group__Histograms.h
 
 ## Tutorials sorted after groups
 
-- [Introduction](\ref introduction)
+- [Introduction](\ref hist_intro)
 - [TH1 Histograms](\ref th1)
 - [TH2 Histograms](\ref th2)
 - [THnSparse](\ref thnsparse)
@@ -48,7 +48,7 @@ Explore the examples below for [different histogram classes](group__Histograms.h
 - [TExec](\ref texec)
 
 [List of all tutorials](\ref alltutorials)
-\anchor introduction
+\anchor hist_intro
 
 ## Introduction
 


### PR DESCRIPTION
fix doxygen warnings,: anchors were defined several times
foam_kanwa.C moved

