### PR TITLE
TMessage honour kIsOwner bit when compression is used

### DIFF
--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -60,13 +60,13 @@ private:
 
 protected:
    enum EStatusBits {
-     kIsOwnerComp = BIT(18) // if TMessage owns fBufComp
+     kIsOwnerComp = BIT(19) // if TMessage owns fBufComp
    };
    TMessage(void *buf, Int_t bufsize);   // only called by T(P)Socket::Recv()
    void SetLength() const;               // only called by T(P)Socket::Send()
 
 public:
-   TMessage(UInt_t what = kMESS_ANY, Int_t bufsiz = TBuffer::kInitialSize);
+   TMessage(UInt_t what = kMESS_ANY, Int_t bufsiz = TBuffer::kInitialSize, Bool_t adopt = kTRUE);
    virtual ~TMessage();
 
    void     ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force) override;

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -59,6 +59,9 @@ private:
    Bool_t TestBitNumber(UInt_t bitnumber) const { return fBitsPIDs.TestBitNumber(bitnumber); }
 
 protected:
+   enum EStatusBits {
+     kIsOwnerComp = BIT(18) // if TMessage owns fBufComp
+   };
    TMessage(void *buf, Int_t bufsize);   // only called by T(P)Socket::Recv()
    void SetLength() const;               // only called by T(P)Socket::Send()
 

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -62,11 +62,11 @@ protected:
    enum EStatusBits {
      kIsOwnerComp = BIT(19) // if TMessage owns fBufComp
    };
-   TMessage(void *buf, Int_t bufsize);   // only called by T(P)Socket::Recv()
+   TMessage(void *buf, Int_t bufsize, Bool_t adopt = kTRUE);   // only called by T(P)Socket::Recv()
    void SetLength() const;               // only called by T(P)Socket::Send()
 
 public:
-   TMessage(UInt_t what = kMESS_ANY, Int_t bufsiz = TBuffer::kInitialSize, Bool_t adopt = kTRUE);
+   TMessage(UInt_t what = kMESS_ANY, Int_t bufsiz = TBuffer::kInitialSize);
    virtual ~TMessage();
 
    void     ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force) override;

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -111,7 +111,8 @@ TMessage::TMessage(void *buf, Int_t bufsize, Bool_t adopt) : TBufferFile(TBuffer
 TMessage::~TMessage()
 {
    // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-   if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+   if (TestBit(kIsOwnerComp))
+      delete [] fBufComp;
    delete fInfos;
 }
 
@@ -189,7 +190,8 @@ void TMessage::Reset()
 
    if (fBufComp) {
       // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-      if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+      if (TestBit(kIsOwnerComp))
+         delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
       fCompPos    = nullptr;
@@ -258,7 +260,8 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
    }
    if (newCompress != fCompress && fBufComp) {
       // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-      if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+      if (TestBit(kIsOwnerComp))
+         delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
       fCompPos    = nullptr;
@@ -283,7 +286,8 @@ void TMessage::SetCompressionLevel(Int_t level)
    }
    if (newCompress != fCompress && fBufComp) {
       // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-      if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+      if (TestBit(kIsOwnerComp))
+         delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
       fCompPos    = nullptr;
@@ -298,7 +302,8 @@ void TMessage::SetCompressionSettings(Int_t settings)
 {
    if (settings != fCompress && fBufComp) {
       // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-      if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+      if (TestBit(kIsOwnerComp))
+         delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
       fCompPos    = nullptr;
@@ -321,7 +326,8 @@ Int_t TMessage::Compress()
       // no compression specified
       if (fBufComp) {
          // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-         if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+         if (TestBit(kIsOwnerComp))
+            delete [] fBufComp;
          fBufComp    = nullptr;
          fBufCompCur = nullptr;
          fCompPos    = nullptr;
@@ -337,7 +343,8 @@ Int_t TMessage::Compress()
    // remove any existing compressed buffer before compressing modified message
    if (fBufComp) {
       // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
-      if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+      if (TestBit(kIsOwnerComp))
+         delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
       fCompPos    = nullptr;
@@ -373,7 +380,8 @@ Int_t TMessage::Compress()
                               static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(compressionAlgorithm));
       if (nout == 0 || nout >= messlen) {
          //this happens when the buffer cannot be compressed
-         if (TestBit(kIsOwnerComp)) delete [] fBufComp;
+         if (TestBit(kIsOwnerComp))
+            delete [] fBufComp;
          fBufComp    = nullptr;
          fBufCompCur = nullptr;
          fCompPos    = nullptr;

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -110,7 +110,7 @@ TMessage::TMessage(void *buf, Int_t bufsize, Bool_t adopt) : TBufferFile(TBuffer
 
 TMessage::~TMessage()
 {
-   // We only own fBufComp when we explictly created it
+   // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
    if (TestBit(kIsOwnerComp)) delete [] fBufComp;
    delete fInfos;
 }
@@ -188,7 +188,7 @@ void TMessage::Reset()
    ResetMap();
 
    if (fBufComp) {
-      // We only own fBufComp when we explictly created it
+      // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
       if (TestBit(kIsOwnerComp)) delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
@@ -257,7 +257,7 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
       newCompress = 100 * algorithm + level;
    }
    if (newCompress != fCompress && fBufComp) {
-      // We only own fBufComp when we explictly created it
+      // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
       if (TestBit(kIsOwnerComp)) delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
@@ -282,7 +282,7 @@ void TMessage::SetCompressionLevel(Int_t level)
       newCompress = 100 * algorithm + level;
    }
    if (newCompress != fCompress && fBufComp) {
-      // We only own fBufComp when we explictly created it
+      // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
       if (TestBit(kIsOwnerComp)) delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
@@ -297,7 +297,7 @@ void TMessage::SetCompressionLevel(Int_t level)
 void TMessage::SetCompressionSettings(Int_t settings)
 {
    if (settings != fCompress && fBufComp) {
-      // We only own fBufComp when we explictly created it
+      // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
       if (TestBit(kIsOwnerComp)) delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;
@@ -320,7 +320,7 @@ Int_t TMessage::Compress()
    if (compressionLevel <= 0) {
       // no compression specified
       if (fBufComp) {
-         // We only own fBufComp when we explictly created it
+         // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
          if (TestBit(kIsOwnerComp)) delete [] fBufComp;
          fBufComp    = nullptr;
          fBufCompCur = nullptr;
@@ -336,7 +336,7 @@ Int_t TMessage::Compress()
 
    // remove any existing compressed buffer before compressing modified message
    if (fBufComp) {
-      // We only own fBufComp when we explictly created it
+      // We only own fBufComp when we explictly created it or adopt and kMESS_ZIP were true
       if (TestBit(kIsOwnerComp)) delete [] fBufComp;
       fBufComp    = nullptr;
       fBufCompCur = nullptr;

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -82,7 +82,6 @@ TMessage::TMessage(void *buf, Int_t bufsize, Bool_t adopt) : TBufferFile(TBuffer
    fInfos      = nullptr;
    fEvolution  = kFALSE;
 
-
    if (fWhat & kMESS_ZIP) {
       // if buffer has kMESS_ZIP set, move it to fBufComp and uncompress
       fBufComp    = fBuffer;

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -91,8 +91,6 @@ TMessage::TMessage(void *buf, Int_t bufsize, Bool_t adopt) : TBufferFile(TBuffer
       if (adopt) {
          SetBit(kIsOwnerComp); // bufcomp points to the original buf
       }
-      // Force being owner of the newly created buffer (inside Uncompress)
-      SetBit(kIsOwner);
    }
 
    if (fWhat == kMESS_OBJECT) {
@@ -430,6 +428,9 @@ Int_t TMessage::Uncompress()
    fBufCur  = fBuffer + sizeof(UInt_t) + sizeof(fWhat);
    fBufMax  = fBuffer + fBufSize;
    char *messbuf = fBuffer + hdrlen;
+   
+   // Force being owner of the newly created buffer
+   SetBit(kIsOwner);
 
    Int_t nout;
    Int_t noutot = 0;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Rebased version of https://github.com/root-project/root/pull/17601

Fixes https://github.com/root-project/root/issues/14557 reported by @cpulvermacher 

