### PR TITLE
Fix drawing of `TMultiGraph` axes

### DIFF
--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1308,16 +1308,20 @@ void TMultiGraph::Paint(Option_t *choptin)
          fHistogram->SetMaximum(rwymax);
          fHistogram->GetYaxis()->SetLimits(rwymin,rwymax);
          fHistogram->SetDirectory(nullptr);
+         fHistogram->Sumw2(kFALSE);
          if (!xtitle.empty()) fHistogram->GetXaxis()->SetTitle(xtitle.c_str());
          if (!ytitle.empty()) fHistogram->GetYaxis()->SetTitle(ytitle.c_str());
          if (firstx != lastx) fHistogram->GetXaxis()->SetRange(firstx,lastx);
          if (timedisplay) {fHistogram->GetXaxis()->SetTimeDisplay(timedisplay);}
          if (!timeformat.empty()) fHistogram->GetXaxis()->SetTimeFormat(timeformat.c_str());
       }
-      TString chopth = "0";
-      if (strstr(chopt.Data(),"X+")) chopth.Append("X+");
-      if (strstr(chopt.Data(),"Y+")) chopth.Append("Y+");
-      if (strstr(chopt.Data(),"I"))  chopth.Append("A");
+      TString chopth("0");
+      if (strstr(chopt.Data(),"X+"))
+         chopth.Append("X+");
+      if (strstr(chopt.Data(),"Y+"))
+         chopth.Append("Y+");
+      if (strstr(chopt.Data(),"I"))
+         chopth.Append("A");
       fHistogram->Paint(chopth.Data());
    }
 

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1316,11 +1316,11 @@ void TMultiGraph::Paint(Option_t *choptin)
          if (!timeformat.empty()) fHistogram->GetXaxis()->SetTimeFormat(timeformat.c_str());
       }
       TString chopth("0");
-      if (strstr(chopt.Data(),"X+"))
+      if (chopt.Contains("X+"))
          chopth.Append("X+");
-      if (strstr(chopt.Data(),"Y+"))
+      if (chopt.Contains("Y+"))
          chopth.Append("Y+");
-      if (strstr(chopt.Data(),"I"))
+      if (chopt.Contains("I"))
          chopth.Append("A");
       fHistogram->Paint(chopth.Data());
    }


### PR DESCRIPTION
Reset Sumw2 array of histogram to avoid baseline drawing at position 0.

Solves #17470 