### PR TITLE
[ntuple] fix type name normalization

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -141,7 +141,7 @@ private:
 
 private:
    RClassField(std::string_view fieldName, const RClassField &source); ///< Used by CloneImpl
-   RClassField(std::string_view fieldName, std::string_view className, TClass *classp);
+   RClassField(std::string_view fieldName, TClass *classp);
    void Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo info);
    /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
    /// fill the `TVirtualObject` instance passed to the user function.
@@ -190,9 +190,7 @@ private:
    Internal::RColumnIndex fIndex;                                 ///< number of bytes written in the current cluster
 
 private:
-   // Note that className may be different from classp->GetName(), e.g. through different canonicalization of RNTuple
-   // vs. TClass. Also, classp may be nullptr for types unsupported by the ROOT I/O.
-   RStreamerField(std::string_view fieldName, std::string_view className, TClass *classp);
+   RStreamerField(std::string_view fieldName, TClass *classp);
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -229,7 +227,7 @@ public:
 /// The field for an unscoped or scoped enum with dictionary
 class REnumField : public RFieldBase {
 private:
-   REnumField(std::string_view fieldName, std::string_view enumName, TEnum *enump);
+   REnumField(std::string_view fieldName, TEnum *enump);
    REnumField(std::string_view fieldName, std::string_view enumName, std::unique_ptr<RFieldBase> intField);
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -154,7 +154,7 @@ protected:
 
    /// Constructor used when the value type of the collection is not known in advance, i.e. in the case of custom
    /// collections.
-   RProxiedCollectionField(std::string_view fieldName, std::string_view typeName, TClass *classp);
+   RProxiedCollectionField(std::string_view fieldName, TClass *classp);
    /// Constructor used when the value type of the collection is known in advance, e.g. in `RSetField`.
    RProxiedCollectionField(std::string_view fieldName, std::string_view typeName,
                            std::unique_ptr<RFieldBase> itemField);

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -48,8 +48,8 @@ void CallCommitClusterOnField(RFieldBase &);
 void CallConnectPageSinkOnField(RFieldBase &, RPageSink &, ROOT::NTupleSize_t firstEntry = 0);
 void CallConnectPageSourceOnField(RFieldBase &, RPageSource &);
 ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-CallFieldBaseCreate(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias,
-                    const RCreateFieldOptions &options, const RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
+CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName, const RCreateFieldOptions &options,
+                    const RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 } // namespace Internal
 
@@ -82,9 +82,9 @@ class RFieldBase {
    friend void Internal::CallConnectPageSinkOnField(RFieldBase &, Internal::RPageSink &, ROOT::NTupleSize_t);
    friend void Internal::CallConnectPageSourceOnField(RFieldBase &, Internal::RPageSource &);
    friend ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-   Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &canonicalType,
-                                 const std::string &typeAlias, const RCreateFieldOptions &options,
-                                 const RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
+   Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
+                                 const RCreateFieldOptions &options, const RNTupleDescriptor *desc,
+                                 ROOT::DescriptorId_t fieldId);
 
    using ReadCallback_t = std::function<void(void *)>;
 
@@ -481,15 +481,6 @@ protected:
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
    /// normalized type name and type alias.
    /// `desc` and `fieldId` must be passed if `options.fEmulateUnknownTypes` is true, otherwise they can be left blank.
-   /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
-   /// single type name
-   static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias,
-          const RCreateFieldOptions &options = {}, const RNTupleDescriptor *desc = nullptr,
-          ROOT::DescriptorId_t fieldId = ROOT::kInvalidDescriptorId);
-
-   /// Same as the above overload of Create, but infers the normalized type name and the canonical type name from
-   /// `typeName`.
    static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName,
                                                       const RCreateFieldOptions &options, const RNTupleDescriptor *desc,
                                                       ROOT::DescriptorId_t fieldId);

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -518,7 +518,9 @@ public:
    /// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
    std::unique_ptr<RFieldBase> Clone(std::string_view newName) const;
 
-   /// Factory method to resurrect a field from the stored on-disk type information
+   /// Factory method to create a field from a certain type given as string.
+   /// Note that the provided type name must be a valid C++ type name. Template arguments of templated types
+   /// must be type names or integers (e.g., no expressions).
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &typeName);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -79,7 +79,7 @@ public:
    static constexpr std::uint16_t kVersionEpoch = 1;
    static constexpr std::uint16_t kVersionMajor = 0;
    static constexpr std::uint16_t kVersionMinor = 0;
-   static constexpr std::uint16_t kVersionPatch = 0;
+   static constexpr std::uint16_t kVersionPatch = 1;
 
 private:
    /// Version of the RNTuple binary format that the writer supports (see specification).

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -593,12 +593,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    }
 
    if (result) {
-      const TClassEdit::EModType modType = static_cast<TClassEdit::EModType>(
-         TClassEdit::kDropStlDefault | TClassEdit::kDropComparator | TClassEdit::kDropHash);
-      std::string normOrigType{typeName};
-      TClassEdit::TSplitType splitname(normOrigType.c_str(), modType);
-      splitname.ShortType(normOrigType, modType);
-      normOrigType = Internal::GetRenormalizedTypeName(normOrigType);
+      const auto normOrigType = Internal::GetNormalizedUnresolvedTypeName(typeName);
       if (normOrigType != result->GetTypeName()) {
          result->fTypeAlias = normOrigType;
       }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -597,10 +597,6 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
       std::string normOrigType{typeName};
       TClassEdit::TSplitType splitname(normOrigType.c_str(), modType);
       splitname.ShortType(normOrigType, modType);
-      // See TClassEdit::GetNormalizedName
-      if (normOrigType.length() > 2 && normOrigType[0] == ':' && normOrigType[1] == ':') {
-         normOrigType.erase(0, 2);
-      }
       normOrigType = Internal::GetRenormalizedTypeName(normOrigType);
       if (normOrigType != result->GetTypeName()) {
          result->fTypeAlias = normOrigType;

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -125,9 +125,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
          continue;
       }
 
-      std::string typeName{Internal::GetNormalizedTypeName(dataMember->GetTrueTypeName())};
-      std::string typeAlias{Internal::GetNormalizedTypeName(dataMember->GetFullTypeName())};
-
+      std::string typeName{dataMember->GetFullTypeName()};
       // For C-style arrays, complete the type name with the size for each dimension, e.g. `int[4][2]`
       if (dataMember->Property() & kIsArray) {
          for (int dim = 0, n = dataMember->GetArrayDim(); dim < n; ++dim)
@@ -136,7 +134,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
 
       std::unique_ptr<RFieldBase> subField;
 
-      subField = RFieldBase::Create(dataMember->GetName(), typeName, typeAlias).Unwrap();
+      subField = RFieldBase::Create(dataMember->GetName(), typeName).Unwrap();
       fTraits &= subField->GetTraits();
       Attach(std::move(subField), RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -433,8 +433,9 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
    if (fProxy->HasPointers())
       throw RException(R__FAIL("collection proxies whose value type is a pointer are not supported"));
    if (!fProxy->GetCollectionClass()->HasDictionary()) {
+      // TODO(jblomer): Use GetRenormalizedTypeName() once available
       throw RException(R__FAIL("dictionary not available for type " +
-                               Internal::GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
+                               Internal::GetCanonicalTypePrefix(fProxy->GetCollectionClass()->GetName())));
    }
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -8,6 +8,7 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RFieldVisitor.hxx>
+#include "RFieldUtils.hxx"
 
 #include <cstdlib> // for malloc, free
 #include <memory>
@@ -16,7 +17,9 @@
 ROOT::Experimental::RArrayField::RArrayField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
                                              std::size_t arrayLength)
    : ROOT::Experimental::RFieldBase(fieldName,
-                                    "std::array<" + itemField->GetTypeName() + "," + std::to_string(arrayLength) + ">",
+                                    "std::array<" + itemField->GetTypeName() + "," +
+                                       Internal::GetNormalizedInteger(static_cast<unsigned long long>(arrayLength)) +
+                                       ">",
                                     ROOT::ENTupleStructure::kLeaf, false /* isSimple */, arrayLength),
      fItemSize(itemField->GetValueSize()),
      fArrayLength(arrayLength)

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -63,6 +63,11 @@ const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
 std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::string &typeName)
 {
    std::string canonicalType{TClassEdit::CleanType(typeName.c_str(), /*mode=*/1)};
+   if (canonicalType.substr(0, 7) == "struct ") {
+      canonicalType.erase(0, 7);
+   } else if (canonicalType.substr(0, 5) == "enum ") {
+      canonicalType.erase(0, 5);
+   }
 
    if (canonicalType.substr(0, 6) == "array<") {
       canonicalType = "std::" + canonicalType;

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -67,6 +67,8 @@ std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::stri
       canonicalType.erase(0, 7);
    } else if (canonicalType.substr(0, 5) == "enum ") {
       canonicalType.erase(0, 5);
+   } else if (canonicalType.substr(0, 2) == "::") {
+      canonicalType.erase(0, 2);
    }
 
    if (canonicalType.substr(0, 6) == "array<") {

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -178,6 +178,10 @@ std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::stri
 std::string ROOT::Experimental::Internal::GetRenormalizedTypeName(const std::string &metaNormalizedName)
 {
    std::string normName{GetCanonicalTypePrefix(metaNormalizedName)};
+   // RNTuple resolves Double32_t for the normalized type name but keeps Double32_t for the type alias
+   // (also in template parameters)
+   if (normName == "Double32_t")
+      return "double";
 
    const auto [typePrefix, argList] = SplitTypePrefixFromTemplateArgs(normName);
    if (argList.empty())

--- a/tree/ntuple/v7/src/RFieldUtils.hxx
+++ b/tree/ntuple/v7/src/RFieldUtils.hxx
@@ -40,7 +40,8 @@ ERNTupleSerializationMode GetRNTupleSerializationMode(TClass *cl);
 std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typeName);
 
 /// Used in RFieldBase::Create() in order to get the comma-separated list of template types
-/// E.g., gets {"int", "std::variant<double,int>"} from "int,std::variant<double,int>"
+/// E.g., gets {"int", "std::variant<double,int>"} from "int,std::variant<double,int>".
+/// TODO(jblomer): Try to merge with TClassEdit::TSplitType
 std::vector<std::string> TokenizeTypeList(std::string_view templateType);
 
 } // namespace Internal

--- a/tree/ntuple/v7/src/RFieldUtils.hxx
+++ b/tree/ntuple/v7/src/RFieldUtils.hxx
@@ -24,6 +24,9 @@ namespace Internal {
 /// template arguments (hence "Prefix").
 std::string GetCanonicalTypePrefix(const std::string &typeName);
 
+/// Given a type name normalized by ROOT meta, renormalize it for RNTuple. E.g., insert std::prefix.
+std::string GetRenormalizedTypeName(const std::string &metaNormalizedName);
+
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode { kForceNativeMode, kForceStreamerMode, kUnset };
 

--- a/tree/ntuple/v7/src/RFieldUtils.hxx
+++ b/tree/ntuple/v7/src/RFieldUtils.hxx
@@ -27,6 +27,9 @@ std::string GetCanonicalTypePrefix(const std::string &typeName);
 /// Given a type name normalized by ROOT meta, renormalize it for RNTuple. E.g., insert std::prefix.
 std::string GetRenormalizedTypeName(const std::string &metaNormalizedName);
 
+/// Applies all RNTuple type normalization rules except typedef resolution.
+std::string GetNormalizedUnresolvedTypeName(const std::string &origName);
+
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode { kForceNativeMode, kForceStreamerMode, kUnset };
 

--- a/tree/ntuple/v7/src/RFieldUtils.hxx
+++ b/tree/ntuple/v7/src/RFieldUtils.hxx
@@ -30,6 +30,13 @@ std::string GetRenormalizedTypeName(const std::string &metaNormalizedName);
 /// Applies all RNTuple type normalization rules except typedef resolution.
 std::string GetNormalizedUnresolvedTypeName(const std::string &origName);
 
+/// Appends 'll' or 'ull' to the where necessary and strips the suffix if not needed.
+std::string GetNormalizedInteger(const std::string &intTemplateArg);
+std::string GetNormalizedInteger(long long val);
+std::string GetNormalizedInteger(unsigned long long val);
+long long ParseIntTypeToken(const std::string &intToken);
+unsigned long long ParseUIntTypeToken(const std::string &uintToken);
+
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode { kForceNativeMode, kForceStreamerMode, kUnset };
 
@@ -40,7 +47,7 @@ ERNTupleSerializationMode GetRNTupleSerializationMode(TClass *cl);
 /// `{"unsigned char", {1, 2, 3}}`. Extra whitespace in `typeName` should be removed before calling this function.
 ///
 /// If `typeName` is not an array type, it returns a tuple `{T, {}}`. On error, it returns a default-constructed tuple.
-std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typeName);
+std::tuple<std::string, std::vector<std::size_t>> ParseArrayType(const std::string &typeName);
 
 /// Used in RFieldBase::Create() in order to get the comma-separated list of template types
 /// E.g., gets {"int", "std::variant<double,int>"} from "int,std::variant<double,int>".

--- a/tree/ntuple/v7/src/RFieldUtils.hxx
+++ b/tree/ntuple/v7/src/RFieldUtils.hxx
@@ -19,11 +19,10 @@ namespace ROOT {
 namespace Experimental {
 namespace Internal {
 
-/// Applies type name normalization rules that lead to the final name used to create a RField, e.g. transforms
-/// `const vector<T>` to `std::vector<T>`.  Specifically, `const` / `volatile` qualifiers are removed and `std::` is
-/// added to fully qualify known types in the `std` namespace.  The same happens to `ROOT::RVec` which is normalized to
-/// `ROOT::VecOps::RVec`.
-std::string GetNormalizedTypeName(const std::string &typeName);
+/// Applies RNTuple specific type name normalization rules (see specs) that help the string parsing in
+/// RFieldBase::Create(). The normalization of templated types does not include full normalization of the
+/// template arguments (hence "Prefix").
+std::string GetCanonicalTypePrefix(const std::string &typeName);
 
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode { kForceNativeMode, kForceStreamerMode, kUnset };

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -125,7 +125,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       // NOTE: Unwrap() here may throw an exception, hence the try block.
       // If options.fReturnInvalidOnError is false we just rethrow it, otherwise we return an InvalidField wrapping the
       // error.
-      auto field = Internal::CallFieldBaseCreate(fieldName, typeName, typeName, options, &ntplDesc, fFieldId).Unwrap();
+      auto field = Internal::CallFieldBaseCreate(fieldName, typeName, options, &ntplDesc, fFieldId).Unwrap();
       field->SetOnDiskId(fFieldId);
 
       for (auto &subfield : *field) {

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -55,6 +55,7 @@ ROOT_ADD_GTEST(ntuple_processor_join ntuple_processor_join.cxx LIBRARIES ROOTNTu
 ROOT_ADD_GTEST(ntuple_project ntuple_project.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_modelext ntuple_modelext.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_serialize ntuple_serialize.cxx LIBRARIES ROOTNTuple CustomStruct)
+ROOT_ADD_GTEST(ntuple_type_name ntuple_type_name.cxx LIBRARIES ROOTNTuple CustomStruct)
 if(NOT MSVC OR llvm13_broken_tests)
   ROOT_ADD_GTEST(ntuple_types ntuple_types.cxx LIBRARIES ROOTNTuple CustomStruct)
   ROOT_GENERATE_DICTIONARY(ProxiedSTLContainerDict ${CMAKE_CURRENT_SOURCE_DIR}/ProxiedSTLContainer.hxx

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -96,6 +96,9 @@ public:
 template <typename T1, typename T2, typename T3, typename T4>
 class InnerCV {};
 
+template <long long TLL, unsigned long long TULL>
+class IntegerTemplates {};
+
 class IOConstructor {
 public:
    IOConstructor() = delete;

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -86,6 +86,16 @@ public:
    T fMember;
 };
 
+template <typename FirstT, typename SecondT = double>
+class DataVector {
+public:
+   FirstT fFirst;
+   SecondT fSecond;
+};
+
+template <typename T1, typename T2, typename T3, typename T4>
+class InnerCV {};
+
 class IOConstructor {
 public:
    IOConstructor() = delete;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -23,6 +23,11 @@
 
 #pragma link C++ class EdmWrapper<CustomStruct> +;
 
+#pragma link C++ class DataVector < int, double> + ;
+#pragma link C++ class DataVector < int, float> + ;
+#pragma link C++ class DataVector < bool, std::vector < unsigned int>> + ;
+#pragma link C++ class InnerCV < const int, const volatile int, volatile const int, volatile int> + ;
+
 #pragma link C++ class IAuxSetOption+;
 #pragma link C++ class PackedParameters+;
 #pragma link C++ class PackedContainer<int>+;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -27,6 +27,9 @@
 #pragma link C++ class DataVector < int, float> + ;
 #pragma link C++ class DataVector < bool, std::vector < unsigned int>> + ;
 #pragma link C++ class InnerCV < const int, const volatile int, volatile const int, volatile int> + ;
+#pragma link C++ class IntegerTemplates < 0, 0> + ;
+#pragma link C++ class IntegerTemplates < -1, 1> + ;
+#pragma link C++ class IntegerTemplates < -2147483650ll, 9223372036854775810ull> + ;
 
 #pragma link C++ class IAuxSetOption+;
 #pragma link C++ class PackedParameters+;

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -76,6 +76,10 @@ TEST(MiniFile, Stream)
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
    auto ntuple = reader.GetNTuple("MyNTuple").Inspect();
+   EXPECT_EQ(1u, ntuple.GetVersionEpoch());
+   EXPECT_EQ(0u, ntuple.GetVersionMajor());
+   EXPECT_EQ(0u, ntuple.GetVersionMinor());
+   EXPECT_EQ(1u, ntuple.GetVersionPatch());
    EXPECT_EQ(offHeader, ntuple.GetSeekHeader());
    EXPECT_EQ(offFooter, ntuple.GetSeekFooter());
 
@@ -111,6 +115,10 @@ TEST(MiniFile, Proper)
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
    auto ntuple = reader.GetNTuple("MyNTuple").Inspect();
+   EXPECT_EQ(1u, ntuple.GetVersionEpoch());
+   EXPECT_EQ(0u, ntuple.GetVersionMajor());
+   EXPECT_EQ(0u, ntuple.GetVersionMinor());
+   EXPECT_EQ(1u, ntuple.GetVersionPatch());
    EXPECT_EQ(offHeader, ntuple.GetSeekHeader());
    EXPECT_EQ(offFooter, ntuple.GetSeekFooter());
 

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -68,6 +68,8 @@ TEST(RNTuple, TClassDefaultTemplateParameter)
       model->MakeField<DataVector<int, float>>("f2");
       model->AddField(RFieldBase::Create("f3", "DataVector<int>").Unwrap());
       model->AddField(RFieldBase::Create("f4", "struct DataVector<bool,vector<unsigned>>").Unwrap());
+      model->AddField(RFieldBase::Create("f5", "DataVector<Double32_t>").Unwrap());
+      model->AddField(RFieldBase::Create("f6", "DataVector<int, double>").Unwrap());
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
    }
 
@@ -77,12 +79,22 @@ TEST(RNTuple, TClassDefaultTemplateParameter)
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeName());
    EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeAlias());
+
    EXPECT_EQ("DataVector<std::int32_t,float>", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeName());
    EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeAlias());
+
    EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeName());
    EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeAlias());
+
    EXPECT_EQ("DataVector<bool,std::vector<std::uint32_t>>",
              desc.GetFieldDescriptor(desc.FindFieldId("f4")).GetTypeName());
+   EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f4")).GetTypeAlias());
+
+   EXPECT_EQ("DataVector<double,double>", desc.GetFieldDescriptor(desc.FindFieldId("f5")).GetTypeName());
+   EXPECT_EQ("DataVector<Double32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f5")).GetTypeAlias());
+
+   EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f6")).GetTypeName());
+   EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f6")).GetTypeAlias());
 
    auto v1 = reader->GetView<DataVector<int>>("f1");
    auto v3 = reader->GetView<DataVector<int>>("f3");

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -76,8 +76,11 @@ TEST(RNTuple, TClassDefaultTemplateParameter)
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeName());
+   EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeAlias());
    EXPECT_EQ("DataVector<std::int32_t,float>", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeName());
+   EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeAlias());
    EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeName());
+   EXPECT_EQ("", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeAlias());
    EXPECT_EQ("DataVector<bool,std::vector<std::uint32_t>>",
              desc.GetFieldDescriptor(desc.FindFieldId("f4")).GetTypeName());
 

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -1,0 +1,83 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTuple, TypeNameBasics)
+{
+   EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
+   EXPECT_STREQ("std::vector<std::string>", ROOT::Experimental::RField<std::vector<std::string>>::TypeName().c_str());
+   EXPECT_STREQ("CustomStruct", ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
+   EXPECT_STREQ("DerivedB", ROOT::Experimental::RField<DerivedB>::TypeName().c_str());
+
+   auto field = RField<DerivedB>("derived");
+   EXPECT_EQ(sizeof(DerivedB), field.GetValueSize());
+
+   EXPECT_STREQ("std::pair<std::pair<float,CustomStruct>,std::int32_t>",
+                (ROOT::Experimental::RField<std::pair<std::pair<float, CustomStruct>, int>>::TypeName().c_str()));
+   EXPECT_STREQ(
+      "std::tuple<std::tuple<char,CustomStruct,char>,std::int32_t>",
+      (ROOT::Experimental::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
+}
+
+TEST(RNTuple, TypeNameNormalization)
+{
+   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("CustomEnum", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "signed").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("std::uint32_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeName());
+   EXPECT_EQ("SG::sgkey_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeAlias());
+
+   const std::string innerCV = "class InnerCV<const int, const volatile int, volatile const int, volatile int>";
+   const std::string normInnerCV =
+      "InnerCV<const std::int32_t,const volatile std::int32_t,const volatile std::int32_t,volatile std::int32_t>";
+   EXPECT_EQ(normInnerCV, RFieldBase::Create("f", innerCV).Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", innerCV).Unwrap()->GetTypeAlias());
+
+   const std::string example = "const pair<size_t, array<class CustomStruct, 6>>";
+   std::string normExample;
+   if (sizeof(std::size_t) == 4) {
+      normExample = "std::pair<std::uint32_t,std::array<CustomStruct,6>>";
+   } else {
+      normExample = "std::pair<std::uint64_t,std::array<CustomStruct,6>>";
+   }
+   EXPECT_EQ(normExample, RFieldBase::Create("f", example).Unwrap()->GetTypeName());
+   EXPECT_EQ("std::pair<size_t,std::array<CustomStruct,6>>", RFieldBase::Create("f", example).Unwrap()->GetTypeAlias());
+}
+
+TEST(RNTuple, TClassDefaultTemplateParameter)
+{
+   FileRaii fileGuard("test_ntuple_default_template_parameter.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      model->MakeField<DataVector<int>>("f1"); // default second template parameter is double
+      model->MakeField<DataVector<int, float>>("f2");
+      model->AddField(RFieldBase::Create("f3", "DataVector<int>").Unwrap());
+      model->AddField(RFieldBase::Create("f4", "struct DataVector<bool,vector<unsigned>>").Unwrap());
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(0u, reader->GetNEntries());
+
+   const auto &desc = reader->GetDescriptor();
+   EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeName());
+   EXPECT_EQ("DataVector<std::int32_t,float>", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeName());
+   EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeName());
+   EXPECT_EQ("DataVector<bool,std::vector<std::uint32_t>>",
+             desc.GetFieldDescriptor(desc.FindFieldId("f4")).GetTypeName());
+
+   auto v1 = reader->GetView<DataVector<int>>("f1");
+   auto v3 = reader->GetView<DataVector<int>>("f3");
+   EXPECT_THROW(reader->GetView<DataVector<int>>("f2"), ROOT::RException);
+}

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -30,6 +30,7 @@ TEST(RNTuple, TypeNameNormalization)
 
    EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
    EXPECT_EQ("", RFieldBase::Create("f", "signed").Unwrap()->GetTypeAlias());
+   EXPECT_TRUE(RFieldBase::Create("f", "std::int32_t").Unwrap()->GetTypeAlias().empty());
 
    EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
    EXPECT_EQ("", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeAlias());

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -100,3 +100,20 @@ TEST(RNTuple, TClassDefaultTemplateParameter)
    auto v3 = reader->GetView<DataVector<int>>("f3");
    EXPECT_THROW(reader->GetView<DataVector<int>>("f2"), ROOT::RException);
 }
+
+TEST(RNTuple, TemplateArgIntegerNormalization)
+{
+   EXPECT_EQ("IntegerTemplates<0,0>", RFieldBase::Create("f", "IntegerTemplates<0ll,0ull>").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "IntegerTemplates<0ll,0ull>").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("IntegerTemplates<-1,1>", RFieldBase::Create("f", "IntegerTemplates<-1LL,1ULL>").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "IntegerTemplates<-1LL,1ULL>").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("IntegerTemplates<-2147483650,9223372036854775810u>",
+             RFieldBase::Create("f", "IntegerTemplates<-2147483650ll,9223372036854775810>").Unwrap()->GetTypeName());
+   EXPECT_EQ("",
+             RFieldBase::Create("f", "IntegerTemplates<-2147483650ll,9223372036854775810>").Unwrap()->GetTypeAlias());
+
+   EXPECT_THROW(RFieldBase::Create("f", "IntegerTemplates<-1u,0u>").Unwrap(), ROOT::RException);
+   EXPECT_THROW(RFieldBase::Create("f", "IntegerTemplates<1u,0x>").Unwrap(), ROOT::RException);
+}

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -52,6 +52,10 @@ TEST(RNTuple, TypeNameNormalization)
    }
    EXPECT_EQ(normExample, RFieldBase::Create("f", example).Unwrap()->GetTypeName());
    EXPECT_EQ("std::pair<size_t,std::array<CustomStruct,6>>", RFieldBase::Create("f", example).Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("std::vector<CustomStruct>",
+             RFieldBase::Create("f", "::std::vector<::CustomStruct>").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "::std::vector<::CustomStruct>").Unwrap()->GetTypeAlias());
 }
 
 TEST(RNTuple, TClassDefaultTemplateParameter)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -10,62 +10,6 @@
 #include <type_traits>
 #include <utility>
 
-TEST(RNTuple, TypeName) {
-   EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
-   EXPECT_STREQ("std::vector<std::string>",
-                ROOT::Experimental::RField<std::vector<std::string>>::TypeName().c_str());
-   EXPECT_STREQ("CustomStruct",
-                ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
-   EXPECT_STREQ("DerivedB",
-                ROOT::Experimental::RField<DerivedB>::TypeName().c_str());
-
-   auto field = RField<DerivedB>("derived");
-   EXPECT_EQ(sizeof(DerivedB), field.GetValueSize());
-
-   EXPECT_STREQ("std::pair<std::pair<float,CustomStruct>,std::int32_t>", (ROOT::Experimental::RField<
-                 std::pair<std::pair<float,CustomStruct>,int>>::TypeName().c_str()));
-   EXPECT_STREQ(
-      "std::tuple<std::tuple<char,CustomStruct,char>,std::int32_t>",
-      (ROOT::Experimental::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
-}
-
-TEST(RNTuple, TypeNameNormalization)
-{
-   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeAlias());
-
-   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeAlias());
-
-   EXPECT_EQ("CustomEnum", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeAlias());
-
-   EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", "signed").Unwrap()->GetTypeAlias());
-
-   EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeAlias());
-
-   EXPECT_EQ("std::uint32_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeName());
-   EXPECT_EQ("SG::sgkey_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeAlias());
-
-   const std::string innerCV = "class InnerCV<const int, const volatile int, volatile const int, volatile int>";
-   const std::string normInnerCV =
-      "InnerCV<const std::int32_t,const volatile std::int32_t,const volatile std::int32_t,volatile std::int32_t>";
-   EXPECT_EQ(normInnerCV, RFieldBase::Create("f", innerCV).Unwrap()->GetTypeName());
-   EXPECT_EQ("", RFieldBase::Create("f", innerCV).Unwrap()->GetTypeAlias());
-
-   const std::string example = "const pair<size_t, array<class CustomStruct, 6>>";
-   std::string normExample;
-   if (sizeof(std::size_t) == 4) {
-      normExample = "std::pair<std::uint32_t,std::array<CustomStruct,6>>";
-   } else {
-      normExample = "std::pair<std::uint64_t,std::array<CustomStruct,6>>";
-   }
-   EXPECT_EQ(normExample, RFieldBase::Create("f", example).Unwrap()->GetTypeName());
-   EXPECT_EQ("std::pair<size_t,std::array<CustomStruct,6>>", RFieldBase::Create("f", example).Unwrap()->GetTypeAlias());
-}
-
 TEST(RNTuple, EnumBasics)
 {
    // Needs fix of TEnum

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -37,7 +37,10 @@ TEST(RNTuple, TypeNameNormalization)
    EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
    EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
 
-   EXPECT_TRUE(RFieldBase::Create("f", "std::int32_t").Unwrap()->GetTypeAlias().empty());
+   const std::string innerCV = "class InnerCV<const int, const volatile int, volatile const int, volatile int>";
+   const std::string normInnerCV =
+      "InnerCV<const std::int32_t,const volatile std::int32_t,const volatile std::int32_t,volatile std::int32_t>";
+   EXPECT_EQ(normInnerCV, RFieldBase::Create("f", innerCV).Unwrap()->GetTypeName());
 }
 
 TEST(RNTuple, EnumBasics)
@@ -1642,16 +1645,16 @@ TEST(RNTuple, Optional)
 TEST(RNTuple, UnsupportedStdTypes)
 {
    try {
-      auto field = RField<std::weak_ptr<int>>("myWeakPtr");
+      auto field = RField<std::weak_ptr<float>>("myWeakPtr");
       FAIL() << "should not be able to make a std::weak_ptr field";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<float> is not supported"));
    }
    try {
-      auto field = RField<std::vector<std::weak_ptr<int>>>("weak_ptr_vec");
+      auto field = RField<std::vector<std::weak_ptr<float>>>("weak_ptr_vec");
       FAIL() << "should not be able to make a std::vector<std::weak_ptr> field";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<float> is not supported"));
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -29,6 +29,17 @@ TEST(RNTuple, TypeName) {
       (ROOT::Experimental::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
 }
 
+TEST(RNTuple, TypeNameNormalization)
+{
+   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("CustomEnum", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeName());
+   EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
+   EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
+
+   EXPECT_TRUE(RFieldBase::Create("f", "std::int32_t").Unwrap()->GetTypeAlias().empty());
+}
+
 TEST(RNTuple, EnumBasics)
 {
    // Needs fix of TEnum

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -32,15 +32,38 @@ TEST(RNTuple, TypeName) {
 TEST(RNTuple, TypeNameNormalization)
 {
    EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "class CustomStruct").Unwrap()->GetTypeAlias());
+
    EXPECT_EQ("CustomStruct", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "struct CustomStruct").Unwrap()->GetTypeAlias());
+
    EXPECT_EQ("CustomEnum", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "enum CustomEnum").Unwrap()->GetTypeAlias());
+
    EXPECT_EQ("std::int32_t", RFieldBase::Create("f", "signed").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "signed").Unwrap()->GetTypeAlias());
+
    EXPECT_EQ("std::map<std::int32_t,std::int32_t>", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", "map<int, int>").Unwrap()->GetTypeAlias());
+
+   EXPECT_EQ("std::uint32_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeName());
+   EXPECT_EQ("SG::sgkey_t", RFieldBase::Create("f", "SG::sgkey_t").Unwrap()->GetTypeAlias());
 
    const std::string innerCV = "class InnerCV<const int, const volatile int, volatile const int, volatile int>";
    const std::string normInnerCV =
       "InnerCV<const std::int32_t,const volatile std::int32_t,const volatile std::int32_t,volatile std::int32_t>";
    EXPECT_EQ(normInnerCV, RFieldBase::Create("f", innerCV).Unwrap()->GetTypeName());
+   EXPECT_EQ("", RFieldBase::Create("f", innerCV).Unwrap()->GetTypeAlias());
+
+   const std::string example = "const pair<size_t, array<class CustomStruct, 6>>";
+   std::string normExample;
+   if (sizeof(std::size_t) == 4) {
+      normExample = "std::pair<std::uint32_t,std::array<CustomStruct,6>>";
+   } else {
+      normExample = "std::pair<std::uint64_t,std::array<CustomStruct,6>>";
+   }
+   EXPECT_EQ(normExample, RFieldBase::Create("f", example).Unwrap()->GetTypeName());
+   EXPECT_EQ("std::pair<size_t,std::array<CustomStruct,6>>", RFieldBase::Create("f", example).Unwrap()->GetTypeAlias());
 }
 
 TEST(RNTuple, EnumBasics)

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -267,31 +267,3 @@ TEST(RNTuple, TClassReadRules)
       EXPECT_FLOAT_EQ(137.0, viewKlass(i).checksumB);
    }
 }
-
-TEST(RNTuple, TClassDefaultTemplateParameter)
-{
-   FileRaii fileGuard("test_ntuple_default_template_parameter.root");
-
-   {
-      auto model = RNTupleModel::Create();
-      model->MakeField<DataVector<int>>("f1"); // default second template parameter is double
-      model->MakeField<DataVector<int, float>>("f2");
-      model->AddField(RFieldBase::Create("f3", "DataVector<int>").Unwrap());
-      model->AddField(RFieldBase::Create("f4", "struct DataVector<bool,vector<unsigned>>").Unwrap());
-      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
-   }
-
-   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   EXPECT_EQ(0u, reader->GetNEntries());
-
-   const auto &desc = reader->GetDescriptor();
-   EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f1")).GetTypeName());
-   EXPECT_EQ("DataVector<std::int32_t,float>", desc.GetFieldDescriptor(desc.FindFieldId("f2")).GetTypeName());
-   EXPECT_EQ("DataVector<std::int32_t,double>", desc.GetFieldDescriptor(desc.FindFieldId("f3")).GetTypeName());
-   EXPECT_EQ("DataVector<bool,std::vector<std::uint32_t>>",
-             desc.GetFieldDescriptor(desc.FindFieldId("f4")).GetTypeName());
-
-   auto v1 = reader->GetView<DataVector<int>>("f1");
-   auto v3 = reader->GetView<DataVector<int>>("f3");
-   EXPECT_THROW(reader->GetView<DataVector<int>>("f2"), ROOT::RException);
-}


### PR DESCRIPTION
Fixes type name and type alias normalization, especially for types that involve meta (TClass etc.). Introduces patch version 1.0.0.1 of the specification.

Fixes #17570