### PR TITLE
[tut] Avoid races caused by Davix 0.8.8

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -257,6 +257,8 @@ endif()
 if(MSVC)
   #---Multiproc is not supported on Windows
   set(imt_veto ${imt_veto} analysis/mp*.C io/tree/mp*.C legacy/multicore/mp*.C  multicore/mp*.C ./analysis/mtbb_parallelHistoFill.C)
+  #---XRootD is not supported on Windows
+  set(imt_veto ${imt_veto} io/tree/imt_parTreeProcessing.C)
 endif()
 
 if(ROOT_CLASSIC_BUILD)

--- a/tutorials/io/tree/imt_parTreeProcessing.C
+++ b/tutorials/io/tree/imt_parTreeProcessing.C
@@ -29,7 +29,7 @@ int imt_parTreeProcessing()
    ROOT::TThreadedObject<TH2F> pxpyHist("px_py", "p_{X} vs p_{Y} Distribution;p_{X};p_{Y}", 100, -5., 5., 100, -5., 5.);
 
    // Create a TTreeProcessorMT: specify the file and the tree in it
-   ROOT::TTreeProcessorMT tp("http://root.cern/files/tp_process_imt.root", "events");
+   ROOT::TTreeProcessorMT tp("root://eospublic.cern.ch//eos/root-eos/testfiles/tp_process_imt.root", "events");
 
    // Define the function that will process a subrange of the tree.
    // The function must receive only one parameter, a TTreeReader,


### PR DESCRIPTION
by using xrootd and reading from EOS Opendata

