### PR TITLE
[BP][634][tut] Avoid races caused by Davix 0.8.8

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -259,6 +259,8 @@ endif()
 if(MSVC)
   #---Multiproc is not supported on Windows
   set(imt_veto ${imt_veto} multicore/mp*.C multicore/mtbb201_parallelHistoFill.C)
+  #---XRootD is not supported on Windows
+  set(imt_veto ${imt_veto} multicore/imt101_parTreeProcessing.C)
 endif()
 
 if(ROOT_CLASSIC_BUILD)
@@ -376,7 +378,7 @@ if(root7)
     list(APPEND root7_veto rcanvas/df105.py)
   endif()
   if(MSVC AND NOT win_broken_tests)
-    #---EOS is not supported on Windows
+    #---XRootD is not supported on Windows
     list(APPEND root7_veto rcanvas/df104.py)
     list(APPEND root7_veto rcanvas/df105.py)
     list(APPEND root7_veto rcanvas/rbox.py)

--- a/tutorials/multicore/imt101_parTreeProcessing.C
+++ b/tutorials/multicore/imt101_parTreeProcessing.C
@@ -29,7 +29,7 @@ int imt101_parTreeProcessing()
    ROOT::TThreadedObject<TH2F> pxpyHist("px_py", "p_{X} vs p_{Y} Distribution;p_{X};p_{Y}", 100, -5., 5., 100, -5., 5.);
 
    // Create a TTreeProcessorMT: specify the file and the tree in it
-   ROOT::TTreeProcessorMT tp("http://root.cern/files/tp_process_imt.root", "events");
+   ROOT::TTreeProcessorMT tp("root://eospublic.cern.ch//eos/root-eos/testfiles/tp_process_imt.root", "events");
 
    // Define the function that will process a subrange of the tree.
    // The function must receive only one parameter, a TTreeReader,


### PR DESCRIPTION
by using xrootd and reading from EOS Opendata
BP of https://github.com/root-project/root/pull/17640 , adapted to the old tutorials structure

