### PR TITLE
Always remove Sumw2 in object painting

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3126,6 +3126,7 @@ TH1   *TF1::DoCreateHistogram(Double_t xmin, Double_t  xmax, Bool_t recreate)
 
    // Copy Function attributes to histogram attributes.
    histogram->SetBit(TH1::kNoStats);
+   histogram->Sumw2(kFALSE);
    histogram->SetLineColor(GetLineColor());
    histogram->SetLineStyle(GetLineStyle());
    histogram->SetLineWidth(GetLineWidth());

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -782,6 +782,7 @@ void TF2::Paint(Option_t *option)
    fHistogram->SetMarkerStyle(GetMarkerStyle());
    fHistogram->SetMarkerSize(GetMarkerSize());
    fHistogram->SetStats(false);
+   fHistogram->Sumw2(kFALSE);
 
 //-  Draw the histogram
    if (!gPad) return;

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1081,6 +1081,7 @@ TH2D *TGraph2D::GetHistogram(Option_t *option)
          CreateInterpolator(oldInterp);
       }
       fHistogram->SetBit(TH1::kNoStats);
+      fHistogram->Sumw2(kFALSE);
    } else {
       hxmin = fHistogram->GetXaxis()->GetXmin();
       hymin = fHistogram->GetYaxis()->GetXmin();

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -878,6 +878,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stac
          }
       }
       fHistogram->SetStats(false);
+      fHistogram->Sumw2(kFALSE);
       TH1::AddDirectory(add);
    } else {
       fHistogram->SetTitle(GetTitle());


### PR DESCRIPTION
In classes like `THStack`, `TGraph2D`, `TF1`, `TF2` created histogram may have Sumw2 array - 
if  `TH1::SetDefaultSumw2();` was activated before. Always remove such array to save memory and 
to avoid paint artifacts as in #17470