### PR TITLE
[skip-ci] tutorial_histfactory was defined twice

### DIFF
--- a/tutorials/roofit/index.md
+++ b/tutorials/roofit/index.md
@@ -1,11 +1,7 @@
 \defgroup tutorial_roofit_main RooFit
 \ingroup tutorial_roofit
-\brief These tutorials illustrate the main features of RooFit. A more indepth description of the codes can be found at [RooFit User Manual](https://root.cern/download/doc/RooFit_Users_Manual_2.91-33.pdf) 
+\brief These tutorials illustrate the main features of RooFit. A more indepth description of the codes can be found at [RooFit User Manual](https://root.cern/download/doc/RooFit_Users_Manual_2.91-33.pdf)
 
 \defgroup tutorial_roostats RooStats
 \ingroup tutorial_roofit
 \brief These tutorials illustrate the main features of RooStats.
-
-\defgroup tutorial_histfactory HistFactory
-\ingroup tutorial_roofit
-\brief These tutorials illustrate the usage of the HistFactory.


### PR DESCRIPTION
`tutorial_histfactory` was defined twice

