### PR TITLE
[ntuple] don't try to construct an Emulated TClass as a RClassField

### DIFF
--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -552,7 +552,11 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
       if (!result) {
          auto cl = TClass::GetClass(typeName.c_str());
-         if (cl != nullptr) {
+         // NOTE: if the class is not at least "Interpreted" we currently don't try to construct
+         // the RClassField, as in that case we'd need to fetch the information from the StreamerInfo
+         // rather than from TClass. This might be desirable in the future, but for now in this
+         // situation we rely on field emulation instead.
+         if (cl != nullptr && cl->GetState() >= TClass::kInterpreted) {
             createContextGuard.AddClassToStack(resolvedType);
             if (cl->GetCollectionProxy()) {
                result = std::make_unique<RProxiedCollectionField>(fieldName, typeName);


### PR DESCRIPTION
When constructing a RClassField we now require that the TClass is at least Interpreted. If not, we follow the same logic as when we have no TClass at all (i.e. either create an emulated field or fail, depending on the user options).


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #17648

