### PR TITLE
[skip-ci] replace False by false

### DIFF
--- a/tutorials/roofit/roostats/ModelInspector.C
+++ b/tutorials/roofit/roostats/ModelInspector.C
@@ -218,7 +218,7 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
       TGLabel *hlabel =
          new TGLabel(hframek, Form("%s = %.3f +%.3f", param->GetName(), param->getVal(), param->getError()));
       TGTripleHSlider *hsliderk = new TGTripleHSlider(hframek, 190, kDoubleScaleBoth, HSId1, kHorizontalFrame,
-                                                      GetDefaultFrameBackground(), False, False, False, False);
+                                                      GetDefaultFrameBackground(), false, false, false, false);
       hsliderk->Connect("PointerPositionChanged()", "ModelInspectorGUI", this, "DoSlider()");
       hsliderk->Connect("PositionChanged()", "ModelInspectorGUI", this, "DoSlider()");
       hsliderk->SetRange(param->getMin(), param->getMax());


### PR DESCRIPTION
Correct an error where `kFALSE` was changed to `false`. This instance was missed and remains as `False`, but it should be `false`. This issue doesn't appear in the Doxygen log because the macro isn't executed because no image is generated for it since there's no `\macro_image` directive; only the code is displayed. The error was discovered using a `grep` search.

