### PR TITLE
[DF][ntuple] Only create `RVec`-type columns for vectors, arrays and `RVec` fields

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -138,8 +138,11 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    ///    float eta;
    /// };
    /// AddField will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
+   ///
+   /// In case the field is a collection of type `ROOT::VecOps::RVec`, `std::vector` or `std::array`, its corresponding
+   /// column is added as a `ROOT::VecOps::RVec`. Otherwise, the field's on-disk type is used.
    void AddField(const RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
-                 std::vector<RFieldInfo> fieldInfos);
+                 std::vector<RFieldInfo> fieldInfos, bool convertToRVec = false);
 
    /// The main function of the fThreadStaging background thread
    void ExecStaging();

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -143,9 +143,11 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// each.
    ///
    /// In case the field is a collection of type `ROOT::VecOps::RVec`, `std::vector` or `std::array`, its corresponding
-   /// column is added as a `ROOT::VecOps::RVec`. Otherwise, the field's on-disk type is used.
+   /// column is added as a `ROOT::VecOps::RVec`. Otherwise, the collection field's on-disk type is used. Note, however,
+   /// that inner record members of such collections will still be added as `ROOT::VecOps::RVec` (e.g., `std::set<Jet>
+   /// will be added as a `std::set`, but `Jet.[pt|eta] will be added as `ROOT::VecOps::RVec<float>).
    void AddField(const RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
-                 std::vector<RFieldInfo> fieldInfos, bool convertToRVec = false);
+                 std::vector<RFieldInfo> fieldInfos, bool convertToRVec = true);
 
    /// The main function of the fThreadStaging background thread
    void ExecStaging();

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -133,11 +133,14 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// AddField recurses into the sub fields. The fieldInfos argument is a list of objects holding info
    /// about the fields of the outer collection(s) (w.r.t. fieldId). For instance, if fieldId refers to an
    /// `std::vector<Jet>`, with
+   /// ~~~{.cpp}
    /// struct Jet {
    ///    float pt;
    ///    float eta;
    /// };
-   /// AddField will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
+   /// ~~~
+   /// AddField will recurse into `Jet.pt` and `Jet.eta` and provide the two inner fields as `ROOT::VecOps::RVec<float>`
+   /// each.
    ///
    /// In case the field is a collection of type `ROOT::VecOps::RVec`, `std::vector` or `std::array`, its corresponding
    /// column is added as a `ROOT::VecOps::RVec`. Otherwise, the field's on-disk type is used.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -68,9 +68,8 @@ protected:
    void ConstructValue(void *where) const final { *static_cast<std::size_t *>(where) = 0; }
 
 public:
-   static std::string TypeName() { return "std::size_t"; }
    RRDFCardinalityField()
-      : ROOT::Experimental::RFieldBase("", TypeName(), ROOT::ENTupleStructure::kLeaf, false /* isSimple */)
+      : ROOT::Experimental::RFieldBase("", "std::size_t", ROOT::ENTupleStructure::kLeaf, false /* isSimple */)
    {
    }
    RRDFCardinalityField(RRDFCardinalityField &&other) = default;

--- a/tree/dataframe/test/NTupleStruct.hxx
+++ b/tree/dataframe/test/NTupleStruct.hxx
@@ -1,11 +1,15 @@
 #ifndef ROOT7_RDataFrame_Test_NTupleStruct
 #define ROOT7_RDataFrame_Test_NTupleStruct
 
+#include <set>
+
 /**
  * Used to test serialization and deserialization of classes in RNTuple with TClass
  */
 struct Electron {
    float pt;
+
+   friend bool operator<(const Electron &left, const Electron &right) { return left.pt < right.pt; }
 };
 
 #endif

--- a/tree/dataframe/test/NTupleStructLinkDef.h
+++ b/tree/dataframe/test/NTupleStructLinkDef.h
@@ -5,5 +5,8 @@
 #pragma link off all functions;
 
 #pragma link C++ class Electron + ;
+#pragma link C++ class std::set < Electron> + ;
+#pragma link C++ class std::set < std::set < Electron>> + ;
+#pragma link C++ class std::set < std::vector < Electron>> + ;
 
 #endif


### PR DESCRIPTION
Not all collection-type fields should be read as RVecs, given that some collection types have different semantic meaning (e.g., sets). With this change, only `std::vector`, `std::array` and `ROOT::RVec` collection fields are added to the data source as RVecs.

The implemented change corresponds to the way collection column types are determined in TTree-based RDFs.

