### PR TITLE
[tutorials] Don't rely on conversion of Python tuple to TColorNumber

### DIFF
--- a/tutorials/analysis/dataframe/df105_WBosonAnalysis.py
+++ b/tutorials/analysis/dataframe/df105_WBosonAnalysis.py
@@ -173,7 +173,9 @@ for h, color in zip(
         [(0.82, 0.94, 0.76), (0.76, 0.54, 0.57), (0.61, 0.6, 0.8), (0.97, 0.81, 0.41), (0.87, 0.35, 0.42)]):
     h.SetLineWidth(1)
     h.SetLineColor("black")
-    h.SetFillColor(color)
+    h.SetFillColor(ROOT.TColor.GetColor(*color))
+    # From Python 3.11 onward, implicit conversion of the tuple works too:
+    # h.SetFillColor(color)
     stack.Add(h)
 stack.Draw("HIST")
 stack.GetXaxis().SetLabelSize(0.04)

--- a/tutorials/analysis/dataframe/df107_SingleTopAnalysis.py
+++ b/tutorials/analysis/dataframe/df107_SingleTopAnalysis.py
@@ -212,7 +212,9 @@ for h, color in zip(
         [(0.87, 0.35, 0.42), (0.61, 0.6, 0.8), (0.82, 0.94, 0.76)]):
     h.SetLineWidth(1)
     h.SetLineColor("black")
-    h.SetFillColor(color)
+    h.SetFillColor(ROOT.TColor.GetColor(*color))
+    # From Python 3.11 onward, implicit conversion of the tuple works too:
+    # h.SetFillColor(color)
     stack.Add(h)
 stack.Draw("HIST")
 stack.GetXaxis().SetTitle("m_{W(l#nu)+b} [GeV]")

--- a/tutorials/experimental/rcanvas/df105.py
+++ b/tutorials/experimental/rcanvas/df105.py
@@ -194,7 +194,9 @@ for h, color in zip(
         [(0.82, 0.94, 0.76), (0.76, 0.54, 0.57), (0.61, 0.6, 0.8), (0.97, 0.81, 0.41), (0.87, 0.35, 0.42)]):
     h.SetLineWidth(1)
     h.SetLineColor("black")
-    h.SetFillColor(color)
+    h.SetFillColor(ROOT.TColor.GetColor(*color))
+    # From Python 3.11 onward, implicit conversion of the tuple works too:
+    # h.SetFillColor(color)
     stack.Add(h)
 c.Add[TObjectDrawable]().Set(stack, "HIST SAME")
 


### PR DESCRIPTION
The conversion of Python tuples to TColorNumber doesn't work for older Python versions. Therefore, `TColor::GetColor()` is brought back to the tutorials, following up on 8eefabd.

The underlying problem is a wrong overload resolution because of implicit conversion from double to integer, see also the error that one gets for example with Python 3.9:
```txt
/Users/couet/git/couet-root/tutorials/analysis/dataframe/df105_WBosonAnalysis.py:176: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  h.SetFillColor(color)
```

Comments are added to clarify that this would not be needed with Python 3.11 onwards, reminding us that we have the option to revert this commit once the minimum Python version is 3.11.