### PR TITLE
RDataFrame fix broken link in documentation

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -66,7 +66,7 @@ You can directly see RDataFrame in action in our [tutorials](https://root.cern/d
 - [Working with collections](\ref working_with_collections)
 - [Transformations: manipulating data](\ref transformations)
 - [Actions: getting results](\ref actions)
-- [Distributed execution in Python](rdf_distrdf)
+- [Distributed execution in Python](\ref rdf_distrdf)
 - [Performance tips and parallel execution](\ref parallel-execution)
 - [More features](\ref more-features)
    - [Systematic variations](\ref systematics)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Should fix the doc from looking like this
![image](https://github.com/user-attachments/assets/891442c5-c50e-4c48-8a94-79b9f2d85659)

I did not test this, though (and from what I heard about building the documentation I will also not do it...)

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

