### PR TITLE
[geompainter] correctly handle drawing on the pad [6.34]

### DIFF
--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -2916,9 +2916,15 @@ Int_t TGeoManager::GetByteCount(Option_t * /*option*/)
 TVirtualGeoPainter *TGeoManager::GetGeomPainter()
 {
    if (!fPainter) {
-      const char *kind = gEnv->GetValue("GeomPainter.Name", "");
+      const char *kind = nullptr;
+      if (gPad)
+         kind = gPad->IsWeb() ? "web" : "root";
+      else
+         kind = gEnv->GetValue("GeomPainter.Name", "");
+
       if (!kind || !*kind)
          kind = (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch()) ? "web" : "root";
+
       if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualGeoPainter", kind)) {
          if (h->LoadPlugin() == -1) {
             Error("GetGeomPainter", "could not load plugin for %s geo_painter", kind);


### PR DESCRIPTION
In this case do not use stored "GeomPainter.Name" value, but directly check configured web display for pad

Should behaves like TCanvas when web mode checked if batch flag enabled.

Backport of https://github.com/root-project/root/pull/17680