### PR TITLE
[ntuple] Store number of entries in the `RNTupleProcessor`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -130,6 +130,10 @@ protected:
 
    std::unique_ptr<RNTupleModel> fModel;
 
+   /// Total number of entries. Only to be used internally by the processor, not meant to be exposed in the public
+   /// interface.
+   ROOT::NTupleSize_t fNEntries = kInvalidNTupleIndex;
+
    ROOT::NTupleSize_t fNEntriesProcessed = 0;  //< Total number of entries processed so far
    ROOT::NTupleSize_t fCurrentEntryNumber = 0; //< Current processor entry number
    std::size_t fCurrentProcessorNumber = 0;    //< Number of the currently open inner processor
@@ -336,7 +340,7 @@ private:
    ROOT::NTupleSize_t GetNEntries() final
    {
       Connect();
-      return fPageSource->GetNEntries();
+      return fNEntries;
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -421,7 +425,7 @@ private:
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
-   ROOT::NTupleSize_t GetNEntries() final { return fPageSource->GetNEntries(); }
+   ROOT::NTupleSize_t GetNEntries() final { return fNEntries; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Constructs a new RNTupleJoinProcessor.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -318,7 +318,6 @@ class RNTupleSingleProcessor : public RNTupleProcessor {
 
 private:
    RNTupleOpenSpec fNTupleSpec;
-   bool fIsConnected = false;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Connects the page source of the underlying RNTuple.

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -199,7 +199,8 @@ void ROOT::Experimental::RNTupleSingleProcessor::SetEntryPointers(const REntry &
 
 void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 {
-   if (fIsConnected)
+   // The processor has already been connected.
+   if (fNEntries != kInvalidNTupleIndex)
       return;
 
    if (!fPageSource)
@@ -210,8 +211,6 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
    for (auto &[_, fieldContext] : fFieldContexts) {
       ConnectField(fieldContext, *fPageSource, *fEntry);
    }
-
-   fIsConnected = true;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Calling `GetNEntries` on the page source each time is expensive, so instead we store this as a member of the processor.

Mostly relevant for the `RNTupleSingleProcesor`, because the chain processor already is composed of other processors, and the join processor will do the same soon.

