### PR TITLE
[ntuple] Remove superfluous `GetNEntries` call in `RNTupleChainProcessor::LoadEntry`

### DIFF
--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -220,7 +220,6 @@ ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
    : RNTupleProcessor({}, std::move(model)), fInnerProcessors(std::move(processors))
 {
    fInnerNEntries.assign(fInnerProcessors.size(), kInvalidNTupleIndex);
-   fInnerNEntries[0] = fInnerProcessors[0]->GetNEntries();
 
    fModel->Freeze();
    fEntry = fModel->CreateEntry();
@@ -277,20 +276,18 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::Load
    NTupleSize_t localEntryNumber = entryNumber;
    size_t currProcessor = 0;
 
-   assert(fInnerNEntries[0] != kInvalidNTupleIndex);
-
    // As long as the entry fails to load from the current processor, we decrement the local entry number with the number
    // of entries in this processor and try with the next processor until we find the correct local entry number.
    while (fInnerProcessors[currProcessor]->LoadEntry(localEntryNumber) == kInvalidNTupleIndex) {
+      if (fInnerNEntries[currProcessor] == kInvalidNTupleIndex) {
+         fInnerNEntries[currProcessor] = fInnerProcessors[currProcessor]->GetNEntries();
+      }
+
       localEntryNumber -= fInnerNEntries[currProcessor];
 
       // The provided global entry number is larger than the number of available entries.
       if (++currProcessor >= fInnerProcessors.size())
          return kInvalidNTupleIndex;
-
-      if (fInnerNEntries[currProcessor] == kInvalidNTupleIndex) {
-         fInnerNEntries[currProcessor] = fInnerProcessors[currProcessor]->GetNEntries();
-      }
    }
 
    if (currProcessor != fCurrentProcessorNumber)


### PR DESCRIPTION
The current implementation loads the number of entries in the *next* processor in the loop, if this is not known yet, which might not be necessary. This change instead only loads the number of entries in the loop's current processor.

It also removes the requirement to load the number of entries in the first processor on construction (even though this will get loaded in the first iteration of the `LoadEntry` loop anyways, so in the end it won't make much difference).

