### PR TITLE
[ntuple] Assign names to `RNTupleProcessor`s 

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -271,6 +271,14 @@ public:
    RIterator begin() { return RIterator(*this, 0); }
    RIterator end() { return RIterator(*this, ROOT::kInvalidNTupleIndex); }
 
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Create an `RNTupleProcessor` for a single RNTuple.
+   ///
+   /// \param[in] ntuple The name and storage location of the RNTuple to process.
+   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
+   /// one will be created based on the descriptor of the first ntuple specified.
+   ///
+   /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
    Create(const RNTupleOpenSpec &ntuple, std::unique_ptr<RNTupleModel> model = nullptr);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -168,10 +168,7 @@ protected:
    ///
    /// \note Before processing, a model *must* exist. However, this is handled downstream by the RNTupleProcessor's
    /// factory functions (CreateSingle, CreateChain and CreateJoin) and constructors.
-   RNTupleProcessor(const std::vector<RNTupleOpenSpec> &ntuples, std::unique_ptr<RNTupleModel> model)
-      : fNTuples(ntuples), fModel(std::move(model))
-   {
-   }
+   RNTupleProcessor(std::unique_ptr<RNTupleModel> model) : fModel(std::move(model)) {}
 
 public:
    RNTupleProcessor(const RNTupleProcessor &) = delete;

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -145,7 +145,7 @@ void ROOT::Experimental::RNTupleProcessor::ConnectField(RFieldContext &fieldCont
 
 ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(const RNTupleOpenSpec &ntuple,
                                                                    std::unique_ptr<RNTupleModel> model)
-   : RNTupleProcessor({ntuple}, std::move(model)), fNTupleSpec(ntuple)
+   : RNTupleProcessor(std::move(model)), fNTupleSpec(ntuple)
 {
    if (!fModel) {
       fPageSource = Internal::RPageSource::Create(fNTupleSpec.fNTupleName, fNTupleSpec.fStorage);
@@ -217,7 +217,7 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 
 ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
    std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::unique_ptr<RNTupleModel> model)
-   : RNTupleProcessor({}, std::move(model)), fInnerProcessors(std::move(processors))
+   : RNTupleProcessor(std::move(model)), fInnerProcessors(std::move(processors))
 {
    fInnerNEntries.assign(fInnerProcessors.size(), kInvalidNTupleIndex);
 
@@ -304,8 +304,9 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::LoadEntry(ROOT::NT
 
 ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(const RNTupleOpenSpec &mainNTuple,
                                                                std::unique_ptr<RNTupleModel> model)
-   : RNTupleProcessor({mainNTuple}, nullptr)
+   : RNTupleProcessor(nullptr)
 {
+   fNTuples.emplace_back(mainNTuple);
    fPageSource = Internal::RPageSource::Create(mainNTuple.fNTupleName, mainNTuple.fStorage);
    fPageSource->Attach();
 

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -115,6 +115,13 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
 
    auto proc = RNTupleProcessor::Create(ntuple, std::move(model));
 
+   EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
+
+   {
+      auto namedProc = RNTupleProcessor::Create(ntuple, "my_ntuple");
+      EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
+   }
+
    int nEntries = 0;
 
    for (const auto &entry : *proc) {

--- a/tree/ntuple/v7/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_chain.cxx
@@ -103,6 +103,14 @@ TEST_F(RNTupleChainProcessorTest, Basic)
 
    std::uint64_t nEntries = 0;
    auto proc = RNTupleProcessor::CreateChain(ntuples);
+
+   EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
+
+   {
+      auto namedProc = RNTupleProcessor::CreateChain(ntuples, "my_ntuple");
+      EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
+   }
+
    auto x = proc->GetEntry().GetPtr<float>("x");
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());

--- a/tree/ntuple/v7/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_join.cxx
@@ -94,6 +94,12 @@ TEST_F(RNTupleJoinProcessorTest, Basic)
    ntuples = {{fNTupleNames[0], fFileNames[0]}};
 
    auto proc = RNTupleProcessor::CreateJoin(ntuples, {});
+   EXPECT_STREQ("ntuple1", proc->GetProcessorName().c_str());
+
+   {
+      auto namedProc = RNTupleProcessor::CreateJoin(ntuples, {}, "my_ntuple");
+      EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
+   }
 
    int nEntries = 0;
    for (const auto &entry : *proc) {


### PR DESCRIPTION
Naming `RNTupleProcessors` is necessary to make the `RNTupleJoinProcessor` composable. Currently, we use the name of the auxiliary ntuple as prefix to the field names, but when this is abstracted to another processor, we need something else to identify these fields. Adding names to processors also fixes the current issue where two RNTuples with the same name cannot be joined. 

Providing a name is optional; by default, for single processors the name of the ntuple is used. For chain processors, the name of the first ntuple/inner processor in the chain is used. For join processors, the name of the primary ntuple is used.
