### PR TITLE
[hist] in TTree::Draw, last bin should include vmax values

### DIFF
--- a/hist/hist/src/THLimitsFinder.cxx
+++ b/hist/hist/src/THLimitsFinder.cxx
@@ -401,5 +401,12 @@ void THLimitsFinder::OptimizeLimits(Int_t nbins, Int_t &newbins, Double_t &xmin,
       if (xmin +nbins*bw < umax) {nbins++; xmax = xmin +nbins*bw;}
       if (xmin > umin)           {nbins++; xmin = xmax -nbins*bw;}
    }
+   else {
+      xmax = std::max(xmax + 1e-12, std::nextafter(xmax,INFINITY));
+      // If we put the upper bin limit directly at xmax, then all values at xmax will go into the overflow and will be invisible.
+      // So shift it slightly to the right, by at least 1e-12.
+      // Otherwise, it still does not plot the max data it with the reproducer at https://root-forum.cern.ch/t/bug-or-feature-in-ttree-draw/62862
+      // probably due to some extra double rounding precision loss in subsequent operations.
+   }
    newbins = nbins;
 }

--- a/hist/hist/src/THLimitsFinder.cxx
+++ b/hist/hist/src/THLimitsFinder.cxx
@@ -402,11 +402,11 @@ void THLimitsFinder::OptimizeLimits(Int_t nbins, Int_t &newbins, Double_t &xmin,
       if (xmin > umin)           {nbins++; xmin = xmax -nbins*bw;}
    }
    else {
-      xmax = std::max(xmax + 1e-12, std::nextafter(xmax,INFINITY));
+      xmax = std::max(xmax + 1e-15*(xmax - xmin), std::nextafter(xmax,INFINITY));
       // If we put the upper bin limit directly at xmax, then all values at xmax will go into the overflow and will be invisible.
-      // So shift it slightly to the right, by at least 1e-12.
+      // So shift it slightly to the right, by at least 1e-12 when hist_xlow=-1000, hist_xup=0 and nbins = 100.
       // Otherwise, it still does not plot the max data it with the reproducer at https://root-forum.cern.ch/t/bug-or-feature-in-ttree-draw/62862
-      // probably due to some extra double rounding precision loss in subsequent operations.
+      // due to the rounding in TAxis::FindBin line: bin = 1 + int (fNbins*(x-fXmin)/(fXmax-fXmin) );.
    }
    newbins = nbins;
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://root-forum.cern.ch/t/bug-or-feature-in-ttree-draw/62862

Rounding issue reproducer::

`TH1F h("h","h", 100, -1000, 1e31*std::nextafter(float(0),INFINITY));  h.Fill(-999); h.Fill(0);  h.GetBinContent(100)`

changing to 1e32 makes it work.

It comes down to this line in TAxis:

`bin = 1 + int (fNbins*(x-fXmin)/(fXmax-fXmin) );`

so:

`int(100*1000./(1000.+1e-13)) is 99`
whereas
`int(100*1000./(1000.+1e-14)) is 100`

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
