### PR TITLE
Speed up the copy of artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,29 +310,33 @@ add_custom_command(OUTPUT ${stamp_file}
                    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
                    COMMENT "Copying directories such as etc, icons, fonts, js, ui5, etc. to build area")
 
+
+#---Copy files to the build area at build time---------------------------------
+set(directories_to_copy etc test icons fonts macros tutorials)
 if(http)
-set(jsroot_files js/*)
+  list(APPEND directories_to_copy js)
 endif()
 if(webgui)
-set(openui5_files ui5/*)
+  list(APPEND directories_to_copy ui5)
 endif()
 
-#---Copy files to the build area, with dependency---------------------------------
-file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/* etc/* test/* icons/* fonts/* macros/* ${jsroot_files} ${openui5_files})
-set(artifact_files_builddir)
-foreach(artifact_file ${artifact_files})
-  # Filter out hsimple.root; someone might have created it in the src dir, and the hsimple.root
-  # target below will interfere.
-  if (NOT (artifact_file STREQUAL "tutorials/hsimple.root"))
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMENT "Copying ${CMAKE_SOURCE_DIR}/${artifact_file}"
-      DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
-    list(APPEND artifact_files_builddir ${CMAKE_BINARY_DIR}/${artifact_file})
-  endif()
-endforeach()
-add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir})
+foreach(dir_to_copy ${directories_to_copy})
+  # For target dependencies:
+  file(GLOB_RECURSE artifacts_in ${dir_to_copy}/*)
+  set(artifacts_out ${artifacts_in})
+  list(TRANSFORM artifacts_out REPLACE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  list(APPEND all_artifacts ${artifacts_out})
 
+  add_custom_command(OUTPUT ${artifacts_out}
+      COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${dir_to_copy} ${CMAKE_BINARY_DIR}/${dir_to_copy}
+      COMMENT "Copy ${dir_to_copy}"
+      DEPENDS ${artifacts_in})
+endforeach()
+
+add_custom_target(move_artifacts DEPENDS ${stamp_file} ${all_artifacts})
+
+
+#---Add the main sources ---------------------------------
 add_subdirectory (interpreter)
 
 # Update etc/gitinfo.txt for every build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,10 +532,10 @@ add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
 add_dependencies(hsimple onepcm)
 if(WIN32)
   set(hsimple_cmd COMMAND ${CMAKE_COMMAND} -E env PATH="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\\\;%PATH%"
-                          ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x hsimple.C -e return)
+                          ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C -e return)
 else()
   set(hsimple_cmd COMMAND ${MODULES_ROOT_INCPATH} ${ld_library_path}=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{${ld_library_path}}
-                          ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x hsimple.C -e return)
+                          ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C -e return)
 endif()
 add_custom_command(OUTPUT tutorials/hsimple.root
                    ${hsimple_cmd}


### PR DESCRIPTION
This was factored out of #17607.

In contrast to the initial proposal in #17607, I managed to keep the artifact copy at build time. This should alleviate all problems where an out-of-date file might surprise developers.
I used `cmake -E copy_directory` instead of going file-by-file, which again significantly reduces build targets and makes the initial copy much faster. We don't gain on the second invocation of make, and when tutorials are touched, one pays a 5s penalty, but I think the 15s saved on first invocation and the reduced number of targets make this worthwhile.

| `make -j6 move_artifacts` | Old | New |
|--------|--------|--------|
| 1st invocation | 25.5 | 10.4 |
| 2nd invocation | 2.5 | 2.6 |
| Touch a RooFit tutorial | 2.5 | 7.8 | 

### For the people who wonder why we do this at all
- Although all tutorials that run as part of ctest are invoked with a path to the source directory, 77 tutorials break because they call `gROOT->GetTutorialDir()`, which points to the path where the `root.exe` is.
- Users might be used to finding the tutorials next to their `root.exe`, and we didn't yet have a discussion on whether or not and how this should be changed. 

Fix #14953.