### PR TITLE
[ntuple] Properly late-model extend projected fields in the merger

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -34,7 +34,8 @@ namespace Experimental::Internal {
 
 enum class ENTupleMergingMode {
    /// The merger will discard all columns that aren't present in the prototype model (i.e. the model of the first
-   /// source)
+   /// source); also all subsequent RNTuples must contain at least all the columns that are present in the prototype
+   /// model
    kFilter,
    /// The merger will refuse to merge any 2 RNTuples whose schema doesn't match exactly
    kStrict,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -246,8 +246,8 @@ private:
    RNTupleModel(std::unique_ptr<RFieldZero> fieldZero);
 
 public:
-   RNTupleModel(const RNTupleModel&) = delete;
-   RNTupleModel& operator =(const RNTupleModel&) = delete;
+   RNTupleModel(const RNTupleModel &) = delete;
+   RNTupleModel &operator=(const RNTupleModel &) = delete;
    ~RNTupleModel() = default;
 
    std::unique_ptr<RNTupleModel> Clone() const;

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -240,7 +240,8 @@ void ROOT::Experimental::RNTupleModel::EnsureNotBare() const
 
 ROOT::Experimental::RNTupleModel::RNTupleModel(std::unique_ptr<RFieldZero> fieldZero)
    : fFieldZero(std::move(fieldZero)), fModelId(GetNewModelId()), fSchemaId(fModelId)
-{}
+{
+}
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::CreateBare()
 {


### PR DESCRIPTION
The RNTupleMerger needs to bypass RUpdater and directly use RNTupleModelChangeset because it doesn't interface with a RNTupleWriter. So far it was duplicating the functionality of RUpdater::AddField() and RUpdater::AddProjectedField(), but the latter was incomplete and therefore late-model extending a projected field was broken. This PR moved the functionality of Add*Field() from RUpdater to RNTupleModelChangeset and has the Merger call those methods instead of duplicating their functionality. This fixes the bug. In addition, two unit tests are added related to projected fields, one of which covers this feature.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


