### PR TITLE
[ntuple] Add compression settings to RStagedCluster::RColumnInfo

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -268,6 +268,7 @@ public:
       struct RColumnInfo {
          RClusterDescriptor::RPageRange fPageRange;
          ROOT::NTupleSize_t fNElements = ROOT::kInvalidNTupleIndex;
+         int fCompressionSettings;
          bool fIsSuppressed = false;
       };
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -1108,6 +1108,7 @@ ROOT::Experimental::Internal::RPagePersistentSink::StageCluster(ROOT::NTupleSize
 
    for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RStagedCluster::RColumnInfo columnInfo;
+      columnInfo.fCompressionSettings = fOpenColumnRanges[i].fCompressionSettings.value();
       if (fOpenColumnRanges[i].fIsSuppressed) {
          assert(fOpenPageRanges[i].fPageInfos.empty());
          columnInfo.fPageRange.fPhysicalColumnId = i;
@@ -1142,7 +1143,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitStagedClusters(std
             clusterBuilder.MarkSuppressedColumnRange(colId);
          } else {
             clusterBuilder.CommitColumnRange(colId, fOpenColumnRanges[colId].fFirstElementIndex,
-                                             fOpenColumnRanges[colId].fCompressionSettings.value(),
+                                             columnInfo.fCompressionSettings,
                                              columnInfo.fPageRange);
             fOpenColumnRanges[colId].fFirstElementIndex += columnInfo.fNElements;
          }


### PR DESCRIPTION
The compression of a column range is fixed when we call StageCluster(), so we should use the same one when committing the cluster, rather than reading it from `fOpenColumnRanges` (since it may in principle have changed in the meantime).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


