### PR TITLE
[PyROOT] Add __hash_not_enabled to names from std namespace.

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -275,7 +275,8 @@ public:
             "slice_array", "slice", "stack", "string", "strstream", "strstreambuf",
             "time_get_byname", "time_get", "time_put_byname", "time_put", "unary_function",
             "unary_negate", "unique_ptr", "underflow_error", "unordered_map", "unordered_multimap",
-            "unordered_multiset", "unordered_set", "valarray", "vector", "weak_ptr", "wstring"};
+            "unordered_multiset", "unordered_set", "valarray", "vector", "weak_ptr", "wstring",
+            "__hash_not_enabled"};
         for (auto& name : stl_names)
             gSTLNames.insert(name);
 


### PR DESCRIPTION
With gcc-15, the lookups of `std::hash<xxx>` lead to the following error:
```
input_line_50:1:16: error: explicit instantiation of 'std::__hash_not_enabled' must occur in namespace 'std'
template class __hash_not_enabled<RooRealVar>;
```
Adding this class to the list of names that require "std::" fixes the error.

Fix #17456.
