### PR TITLE
[DF] Avoid unnecessary `std::vector` in RDisplay.hxx to fix warnings

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -83,8 +83,6 @@ private:
    static constexpr unsigned fgMaxWidth = 100; ///< Maximum width of the table that Print() displays
 
    VecStr_t fTypes; ///< This attribute stores the type of each column. It is needed by the interpreter to print it.
-   std::vector<bool> fIsCollection; ///< True if the column contains a collection. Collections are treated differently
-                                    ///< during the printing.
    std::vector<std::vector<DElement_t>> fTable; ///< String representation of the data to be printed.
    std::vector<unsigned short> fWidths; ///< Tracks the maximum width of each column, based on the largest element.
 
@@ -281,7 +279,7 @@ private:
       std::stringstream calc; // JITted code
       int columnIndex = 0;
       // Unwrapping the parameters to create the JITted code.
-      fIsCollection = {AddInterpreterString(calc, columns, columnIndex++)...};
+      bool isCollection [] {AddInterpreterString(calc, columns, columnIndex++)...};
 
       // Let cling::printValue handle the conversion. This can be done only through cling-compiled code.
       const std::string toJit = calc.str();
@@ -290,7 +288,7 @@ private:
 
       // Populate the fTable using the results of the JITted code.
       for (size_t i = 0; i < fNColumns; ++i) {
-         if (fIsCollection[i]) {
+         if (isCollection[i]) {
             AddCollectionToRow(fCollectionsRepresentations[i]);
          } else {
             AddToRow(fRepresentations[i]);


### PR DESCRIPTION
When compiling ROOT `master`, I saw the following kind of warnings [1].

While I don't understand exactly why these happen, then can be prevented by directly putting the return values of the function on the stack.

I guess this is worth doing anyway, to avoid manual memory allocation.

Like this, we also don't need to carry around the `fIsCollection` data member just for the sake of heap memory reuse.

[1] :

```txt
In file included from /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/string:51,
                 from /home/rembserj/code/root/core/meta/inc/TSchemaHelper.h:17,
                 from /home/rembserj/code/root/core/meta/inc/TGenericClassInfo.h:21,
                 from /home/rembserj/code/root/core/base/inc/Rtypes.h:198,
                 from /home/rembserj/code/root/core/base/inc/TObject.h:17,
                 from /home/rembserj/code/root/core/base/inc/TNamed.h:25,
                 from /home/rembserj/code/root/core/base/inc/TDirectory.h:24,
                 from /home/rembserj/code/root/core/base/inc/TROOT.h:28,
                 from /home/rembserj/code/root/tree/dataframe/inc/ROOT/RDataFrame.hxx:19,
                 from /home/rembserj/code/root/tree/dataframe/test/dataframe_vary.cxx:1:
In static member function ‘static constexpr _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = long unsigned int; _Up = long unsigned int; bool _IsMove = false]’,
    inlined from ‘constexpr _OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_algobase.h:521:30,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_algobase.h:548:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_algobase.h:555:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_algobase.h:651:7,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::_M_copy_aligned(const_iterator, const_iterator, iterator) [with _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_bvector.h:1342:28,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_insert_range(iterator, _ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/vector.tcc:1124:33,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::insert(const_iterator, _InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_bvector.h:1219:19,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_bvector.h:1479:14,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::assign(_InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_bvector.h:974:17,
    inlined from ‘constexpr std::vector<bool, _Alloc>& std::vector<bool, _Alloc>::operator=(std::initializer_list<bool>) [with _Alloc = std::allocator<bool>]’ at /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_bvector.h:954:14,
    inlined from ‘void ROOT::RDF::RDisplay::AddRow(Columns& ...) [with Columns = {long long unsigned int, int}]’ at /home/rembserj/code/root/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx:284:21:
/nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/bits/stl_algobase.h:452:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] [-Warray-bounds=]
  452 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```