### PR TITLE
[tree] reserve use of default TTreeFormula constructor only for ROOT I/O

### DIFF
--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -170,7 +170,8 @@ private:
    template<typename T> T GetConstant(Int_t k);
 
 public:
-   TTreeFormula();
+   TTreeFormula() = delete;
+   TTreeFormula(TRootIOCtor*);
    TTreeFormula(const char *name,const char *formula, TTree *tree);
      ~TTreeFormula() override;
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -120,13 +120,12 @@ public:
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+/// TreeFormula constructor only valid for ROOT I/O purposes.
 
-TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(false), fNeedLoading(true),
+TTreeFormula::TTreeFormula(TRootIOCtor*): ROOT::v5::TFormula(), fQuickLoad(false), fNeedLoading(true),
    fDidBooleanOptimization(false), fDimensionSetup(nullptr)
 
 {
-   // Tree Formula default constructor
-
    fTree         = nullptr;
    fLookupType   = nullptr;
    fNindex       = 0;


### PR DESCRIPTION
since fManager is null and could lead to crashes if object is used later on

See https://github.com/root-project/root/pull/17707#discussion_r1953453947

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
