### PR TITLE
[RF][HF] Remove LinkDef entry for HistFactory ConfigParser

### DIFF
--- a/roofit/histfactory/inc/LinkDef.h
+++ b/roofit/histfactory/inc/LinkDef.h
@@ -22,7 +22,6 @@
 #pragma link C++ class RooStats::HistFactory::RooBarlowBeestonLL+ ;
 #pragma link C++ class RooStats::HistFactory::HistFactoryNavigation+ ;
 
-#pragma link C++ class RooStats::HistFactory::ConfigParser+ ;
 #pragma link C++ class RooStats::HistFactory::Measurement+ ;
 #pragma read sourceClass="RooStats::HistFactory::Measurement" targetClass="RooStats::HistFactory::Measurement" checksum="[973506941]" source="std::string fPOI" target="fPOI"  code="{ fPOI.push_back(onfile.fPOI) ; }"
 


### PR DESCRIPTION
The ConfigParser parses XML to HistFactory measurements and is only built when `xml=ON`. To avoid unused class rule warnings for `xml=OFF`, this commit suggests to remove the LinkDef entry, which is not necessary anyway. The `ConfigParser` is a helper class for this `hist2workspace` tool.