### PR TITLE
Prevent a race condition in fStreamerImpl value

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -307,7 +307,7 @@ private:
    void               SetClassSize(Int_t sizof) { fSizeof = sizof; }
    TVirtualStreamerInfo* DetermineCurrentStreamerInfo();
 
-   void SetStreamerImpl();
+   void SetStreamerImpl(Int_t streamerType);
 
    void SetRuntimeProperties();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6180,6 +6180,14 @@ Long_t TClass::Property() const
    // Avoid asking about the class when it is still building
    if (TestBit(kLoading)) return fProperty;
 
+   if (fStreamerType != kDefault && !HasInterpreterInfo()) {
+      // We have no interpreter information but we already set the streamer type
+      // so we have already been here and have no new information, then let's
+      // give up.  See the code at this end of this routine (else branch of the
+      // `if (HasInterpreterInfo()` for the path we took before.
+      return 0;
+   }
+
    // When called via TMapFile (e.g. Update()) make sure that the dictionary
    // gets allocated on the heap and not in the mapped file.
    TMmallocDescTemp setreset;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6229,6 +6229,8 @@ Long_t TClass::Property() const
          kl->SetBit(kHasLocalHashMember);
       }
 
+      kl->SetStreamerImpl(streamerType);
+
       if (GetClassInfo()) {
          // In the case where the TClass for one of ROOT's core class
          // (eg TClonesArray for map<int,TClonesArray*>) is requested
@@ -6244,7 +6246,6 @@ Long_t TClass::Property() const
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
 
-      kl->SetStreamerImpl(streamerType);
    } else {
 
       if (fStreamer) {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6186,7 +6186,7 @@ Long_t TClass::Property() const
 
    TClass *kl = const_cast<TClass*>(this);
 
-   kl->fStreamerType = TClass::kDefault;
+   Int_t streamerType = TClass::kDefault;
 
    if (InheritsFrom(TObject::Class())) {
       kl->SetBit(kIsTObject);
@@ -6195,7 +6195,7 @@ Long_t TClass::Property() const
       Int_t delta = kl->GetBaseClassOffsetRecurse(TObject::Class());
       if (delta==0) kl->SetBit(kStartWithTObject);
 
-      kl->fStreamerType  = kTObject;
+      streamerType = kTObject;
    }
 
    if (HasInterpreterInfo()) {
@@ -6207,22 +6207,22 @@ Long_t TClass::Property() const
       if (!const_cast<TClass*>(this)->GetClassMethodWithPrototype("Streamer","TBuffer&",kFALSE)) {
 
          kl->SetBit(kIsForeign);
-         kl->fStreamerType  = kForeign;
+         streamerType = kForeign;
 
-      } else if ( kl->fStreamerType == TClass::kDefault ) {
+      } else if (streamerType == TClass::kDefault) {
          if (kl->fConvStreamerFunc) {
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          } else if (kl->fStreamerFunc) {
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          } else {
             // We have an automatic streamer using the StreamerInfo .. no need to go through the
             // Streamer method function itself.
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          }
       }
 
       if (fStreamer) {
-         kl->fStreamerType  = kExternal;
+         streamerType = kExternal;
       }
 
       if (const_cast<TClass *>(this)->GetClassMethodWithPrototype("Hash", "", kTRUE)) {
@@ -6244,15 +6244,16 @@ Long_t TClass::Property() const
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
 
-      kl->SetStreamerImpl();
+      kl->SetStreamerImpl(streamerType);
    } else {
 
       if (fStreamer) {
-         kl->fStreamerType  = kExternal;
+         streamerType = kExternal;
       }
 
-      kl->fStreamerType |= kEmulatedStreamer;
-      kl->SetStreamerImpl();
+      streamerType |= kEmulatedStreamer;
+
+      kl->SetStreamerImpl(streamerType);
       // fProperty was *not* set so that it can be forced to be recalculated
       // next time.
       return 0;
@@ -6287,8 +6288,9 @@ void TClass::SetRuntimeProperties()
 /// Internal routine to set fStreamerImpl based on the value of
 /// fStreamerType.
 
-void TClass::SetStreamerImpl()
+void TClass::SetStreamerImpl(Int_t StreamerType)
 {
+   fStreamerType = StreamerType;
    switch (fStreamerType) {
       case kTObject:  fStreamerImpl  = &TClass::StreamerTObject; break;
       case kForeign:  fStreamerImpl  = &TClass::StreamerStreamerInfo; break;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6187,7 +6187,6 @@ Long_t TClass::Property() const
    TClass *kl = const_cast<TClass*>(this);
 
    kl->fStreamerType = TClass::kDefault;
-   kl->fStreamerImpl = &TClass::StreamerDefault;
 
    if (InheritsFrom(TObject::Class())) {
       kl->SetBit(kIsTObject);
@@ -6197,7 +6196,6 @@ Long_t TClass::Property() const
       if (delta==0) kl->SetBit(kStartWithTObject);
 
       kl->fStreamerType  = kTObject;
-      kl->fStreamerImpl  = &TClass::StreamerTObject;
    }
 
    if (HasInterpreterInfo()) {
@@ -6210,26 +6208,21 @@ Long_t TClass::Property() const
 
          kl->SetBit(kIsForeign);
          kl->fStreamerType  = kForeign;
-         kl->fStreamerImpl  = &TClass::StreamerStreamerInfo;
 
       } else if ( kl->fStreamerType == TClass::kDefault ) {
          if (kl->fConvStreamerFunc) {
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::ConvStreamerInstrumented;
          } else if (kl->fStreamerFunc) {
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::StreamerInstrumented;
          } else {
             // We have an automatic streamer using the StreamerInfo .. no need to go through the
             // Streamer method function itself.
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::StreamerStreamerInfo;
          }
       }
 
       if (fStreamer) {
          kl->fStreamerType  = kExternal;
-         kl->fStreamerImpl  = &TClass::StreamerExternal;
       }
 
       if (const_cast<TClass *>(this)->GetClassMethodWithPrototype("Hash", "", kTRUE)) {
@@ -6250,11 +6243,12 @@ Long_t TClass::Property() const
          // and think all test bits have been properly set.
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
+
+      kl->SetStreamerImpl();
    } else {
 
       if (fStreamer) {
          kl->fStreamerType  = kExternal;
-         kl->fStreamerImpl  = &TClass::StreamerExternal;
       }
 
       kl->fStreamerType |= kEmulatedStreamer;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5014,8 +5014,8 @@ const void *TClass::DynamicCast(const TClass *cl, const void *obj, Bool_t up)
 /// If quiet is true, do not issue a message via Error in case
 /// of problems, just return `nullptr`.
 ///
-/// This method is also used by the I/O subsystem to allocate the right amount 
-/// of memory for the objects. If a default constructor is not defined for a 
+/// This method is also used by the I/O subsystem to allocate the right amount
+/// of memory for the objects. If a default constructor is not defined for a
 /// certain class, some options are available.
 /// The simplest is to define the default I/O constructor, for example
 /// ~~~{.cpp}
@@ -5032,7 +5032,7 @@ const void *TClass::DynamicCast(const TClass *cl, const void *obj, Bool_t up)
 /// ~~~ {.cpp}
 ///    #pragma link C++ ioctortype UserClass;
 /// ~~~
-/// `TClass::New` will then look for a constructor (for a class `MyClass` in the 
+/// `TClass::New` will then look for a constructor (for a class `MyClass` in the
 /// following example) in the following order, constructing the object using the
 /// first one in the list that exists and is declared public:
 /// ~~~ {.cpp}

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -304,7 +304,6 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
    cl->fCanSplit = fCanSplit;
    cl->fProperty = fProperty;
    cl->fClassProperty = fClassProperty;
-   cl->fStreamerType = fStreamerType;
 
    // Update pointers to TClass
    if (cl->fBase.load()) {
@@ -405,7 +404,7 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
       cl->fRealData = new TList(); // FIXME: this should really become a THashList!
    }
 
-   cl->SetStreamerImpl();
+   cl->SetStreamerImpl(fStreamerType);
 
    // set to zero in order not to delete when protoclass is deleted
    fBase = nullptr;


### PR DESCRIPTION
`TClass` objects that do not have a dictionary and do not have interpreter info (this happens forwarded classes and in some cases STL collection) do not have enough information for a final value of their "Properties" and thus `TClass::Property` is set for them to re-run at each invocations.  In addition the start of the `Property` calculation was to reset `fStreamerImpl` to the default.  Consequently if 1 thread execute `Property` while the other is reading `fStreamerImpl`, the 2nd one will get an incorrect value.

This fixes the problem seen at https://github.com/cms-sw/cmssw/issues/47287#issuecomment-2657729709

The companion roottest PR is https://github.com/root-project/roottest/pull/1262

This fixes #17753