### PR TITLE
[skip-ci] Clean namespaces

### DIFF
--- a/documentation/doxygen/modifyNamespacesWebpage.sh
+++ b/documentation/doxygen/modifyNamespacesWebpage.sh
@@ -1,17 +1,42 @@
 #!/bin/bash
 # The Python tutorials appear in the Namespaces page. This script removes them from Namespaces.
 
+# defime HTMLPATH
 HTMLPATH=$DOXYGEN_OUTPUT_DIRECTORY/html
 if [ ! -d "$HTMLPATH" ]; then
    echo "Error: DOXYGEN_OUTPUT_DIRECTORY is not exported."
    exit 1
 fi
 
-sed -i -e /namespace$1.html/d $HTMLPATH/namespaces_dup.js
-sed -i -e /namespace$1.html/d $HTMLPATH/namespaces.html
-sed -i -e "/memberdecls/,+5d" $HTMLPATH/$1_8py.html
+# change __ to _ in the input parameter
+u=${1//__/_}
 
-FILE=$HTMLPATH/namespace$1.html
-if test -f "$FILE"; then
-   rm $FILE
+# clean namespaces in $HTMLPATH and in $HTMLPATH/search
+echo "Clean namespace for" $u
+s="namespace$1.html"
+find "$HTMLPATH" -type f | xargs -P 12 -n 100 grep -s -l "$s" | while IFS= read -r file; do
+  if test -e "$file"; then
+	 echo "   Patching:" $file
+	 # Remove the links to the namespace
+	 sed -e "s/<a href=.$s.>$u<\/a>/$u/" "$file" > "$HTMLPATH/TMP_FILE"
+	 mv "$HTMLPATH/TMP_FILE" "$file"
+	 sed -e "s/<a c.*href=.$s.>$u<\/a>/$u/" "$file" > "$HTMLPATH/TMP_FILE"
+	 mv "$HTMLPATH/TMP_FILE" "$file"
+	 # Remove the line containing the namespace
+	 sed -e "/$s/d" "$file" > "$HTMLPATH/TMP_FILE"
+	 mv "$HTMLPATH/TMP_FILE" "$file"
+  fi
+done
+
+# clean memberdecls in the python file
+file="$HTMLPATH/$1_8py.html"
+if test -e "$file"; then
+   sed -e "/memberdecls/,+5d" "$file" > "$HTMLPATH/TMP_FILE"
+   mv "$HTMLPATH/TMP_FILE" "$file"
+fi
+
+# remove the faulty namespace file
+file=$HTMLPATH/namespace$1.html
+if test -e "$file"; then
+   rm $file
 fi


### PR DESCRIPTION
ROOT combines C++ and Python code. However, Doxygen incorrectly treats Python tutorials as namespaces. To address this, Doxygen developers suggested creating separate documentation for C++ and Python. This approach, however, does not align with ROOT's preference to integrate both languages in a single documentation.

The preferred solution is to post-process the documentation to remove incorrect namespaces. The script modifyNamespacesWebpage.sh was designed for this purpose. However, the script was incomplete, and some incorrect references remained, particularly in the search functionality. This new version of the script performs a more thorough cleanup.
