### PR TITLE
[CI] Disable `pythia8` on alma9 gcc configuration

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,5 +1,6 @@
-builtin_nlohmannjson=ON
-builtin_vdt=On
-tmva-sofie=On
 BLA_VENDOR=OpenBLAS
-ccache=On
+builtin_nlohmannjson=ON
+builtin_vdt=ON
+ccache=ON
+pythia8=OFF
+tmva-sofie=ON


### PR DESCRIPTION
The new Pythia version 8.313 is missing to add the `inline` keyword to some functions in header files, resulting in linker errors like below.

This commit suggest to disable the Pythia8 interfaces until this regression is fixed upstream.

It was validated in the `alma9` docker container that adding the `inline` keywords indeed fixes the problem.

```
/usr/bin/ld: CMakeFiles/EGPythia8.dir/src/TPythia8.cxx.o: in function `TPythia8::ReadString(char const*) const':
/github/home/ROOT-CI/src/montecarlo/pythia8/src/TPythia8.cxx:302: undefined reference to `Pythia8::Pythia::readString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, int)'
/usr/bin/ld: CMakeFiles/EGPythia8.dir/src/TPythia8.cxx.o: in function `TPythia8::ReadConfigFile(char const*) const':
/github/home/ROOT-CI/src/montecarlo/pythia8/src/TPythia8.cxx:310: undefined reference to `Pythia8::Pythia::readFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, int)'
/usr/bin/ld: CMakeFiles/EGPythia8.dir/src/TPythia8Decayer.cxx.o: in function `TPythia8Decayer::TPythia8Decayer()':
/github/home/ROOT-CI/src/montecarlo/pythia8/src/TPythia8Decayer.cxx:33: undefined reference to `Pythia8::Pythia::readString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, int)'
collect2: error: ld returned 1 exit status
gmake[2]: *** [montecarlo/pythia8/CMakeFiles/EGPythia8.dir/build.make:131: lib/libEGPythia8.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:58046: montecarlo/pythia8/CMakeFiles/EGPythia8.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

The diff that needs to be applied to `Pythia8/Pythia.h`:
```diff
98c98
<   bool readString(string line, bool warn = true, int subrun = SUBRUNDEFAULT) {
---
>   inline bool readString(string line, bool warn = true, int subrun = SUBRUNDEFAULT) {
102c102
<   bool readFile(string fileName, bool warn = true,
---
>   inline bool readFile(string fileName, bool warn = true,
105c105
<   bool readFile(string fileName, int subrun) {
---
>   inline bool readFile(string fileName, int subrun) {
107c107
<   bool readFile(istream& is = cin, bool warn = true,
---
>   inline bool readFile(istream& is = cin, bool warn = true,
110c110
<   bool readFile(istream& is, int subrun) {
---
>   inline bool readFile(istream& is, int subrun) {
```

