### PR TITLE
Some cleanups of CMake options

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -39,7 +39,6 @@ clingtest=OFF
 cocoa=OFF
 coverage=OFF
 cuda=OFF
-cxxmodules=OFF
 daos=OFF
 dataframe=ON
 davix=ON

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -386,7 +386,7 @@ endif()
 #---Removed options------------------------------------------------------------
 # Please notify SPI when adding to this list
 foreach(opt afdsmgrd afs alien bonjour builtin_afterimage castor chirp cxx11 cxx14 cxx17
-        exceptions geocad gfal glite globus gsl_shared hdfs html ios jemalloc krb5
+        cxxmodules exceptions geocad gfal glite globus gsl_shared hdfs html ios jemalloc krb5
         ldap memstat minuit2 monalisa oracle pyroot-python2 pyroot_legacy
         pythia6 pythia6_nolink python qt qtgsi rfio ruby sapdb srp table
         tcmalloc vmc xproofd)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -409,11 +409,6 @@ foreach(opt minuit2_omp minuit2_mpi)
   endif()
 endforeach()
 
-#---Replaced options--------------------------------------------------------------------------
-if(python)
-  message(STATUS ">>> INFO: 'python' option was removed. Instead, please check, that it was enabled a 'pyroot' option (by default it is ON).")
-endif()
-
 #---Avoid creating dependencies to 'non-standard' header files -------------------------------
 include_regular_expression("^[^.]+$|[.]h$|[.]icc$|[.]hxx$|[.]hpp$")
 

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -605,15 +605,6 @@ if(MSVC)
   string(REPLACE "-I${CMAKE_SOURCE_DIR}/cmake/win" "" __cflags "${__cflags}")
 endif()
 
-if (cxxmodules)
-  # Re-add the -Wno-module-import-in-extern-c which we just filtered out.
-  # We want it because it changes the module cache hash and causes modules to be
-  # rebuilt.
-  # FIXME: We should review how we do the regex.
-  set(ROOT_CXX_FLAGS "${ROOT_CXX_FLAGS} -Wno-module-import-in-extern-c")
-  set(ROOT_C_FLAGS "${ROOT_C_FLAGS} -Wno-module-import-in-extern-c")
-endif()
-
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __fflags "${CMAKE_Fortran_FLAGS}")
 string(REGEX MATCHALL "(-Wp,)?-(D|U)[^ ]*" __defs "${CMAKE_CXX_FLAGS}")
 set(ROOT_COMPILER_FLAG_HINTS "#

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -319,7 +319,6 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
        endforeach()
     endif()
 
-    # if (cxxmodules OR runtime_cxxmodules)
     # Comments from Vassil:
     # FIXME: We prepend ROOTSYS/include because if we have built a module
     # and try to resolve the 'same' header from a different location we will
@@ -335,7 +334,6 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     list(FILTER incdirs EXCLUDE REGEX "^${CMAKE_BINARY_DIR}/externals")
     list(FILTER incdirs EXCLUDE REGEX "^${CMAKE_BINARY_DIR}/builtins")
     list(INSERT incdirs 0 ${CMAKE_BINARY_DIR}/include)
-    # endif()
 
     # this instruct rootcling do not store such paths in dictionary
     set(excludepaths ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/ginclude ${CMAKE_BINARY_DIR}/externals ${CMAKE_BINARY_DIR}/builtins)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -101,7 +101,6 @@ IOSSDK         := @iossdk@
 
 CXX11          := @c++11@
 CXX14          := @c++14@
-CXXMODULES     := @cxxmodules@
 LIBCXX         := @libc++@
 
 ENABLETHREAD   := @enable_thread@

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -99,10 +99,6 @@ OSXSDK         := @osxsdk@
 IOSVERS        := @iosvers@
 IOSSDK         := @iossdk@
 
-CXX11          := @c++11@
-CXX14          := @c++14@
-LIBCXX         := @libc++@
-
 ENABLETHREAD   := @enable_thread@
 OSTHREADFLAG   := @threadflag@
 OSTHREADLIBDIR := @threadlibdir@

--- a/graf3d/CMakeLists.txt
+++ b/graf3d/CMakeLists.txt
@@ -4,14 +4,6 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-if(cxxmodules AND APPLE)
-  # FIXME: Any header of graf3d can trigger building of the OSX OpenGL module.
-  # It looks like our glew infrastructure combined with the OpenGL modulemap
-  # cannot be compiled with -fmodules-local-submodule-visibility yet.
-  # Strip out that flag.
-  string(REPLACE "-Xclang -fmodules-local-submodule-visibility" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-endif()
-
 add_subdirectory(g3d) # special CMakeLists.txt
 if(NOT WIN32 AND x11)
   add_subdirectory(x3d) # special CMakeLists.txt

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -136,19 +136,6 @@ if (NOT MSVC AND NOT APPLE)
 endif()
 set(CMAKE_VISIBILITY_INLINES_HIDDEN "ON")
 
-#--- Build LLVM/Clang with modules -----------------------------------------------------------------
-if(cxxmodules)
-  # LLVM knows how to configure its modules builds. We cannot just add the flags
-  # because the cxxmodules builds in llvm have different build dependency order.
-  string(REPLACE "${ROOT_CXXMODULES_CXXFLAGS}" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-  string(REPLACE "${ROOT_CXXMODULES_CFLAGS}" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
-  if(libcxx)
-    # FIXME: We cannot build LLVM/clang with modules on with libstdc++, yet.
-    # FIXME: We cannot build LLVM/clang with modules on with libc++, too.
-    #set (LLVM_ENABLE_MODULES ON CACHE BOOL "Override the default LLVM_ENABLE_MODULES option value." )
-  endif(libcxx)
-endif(cxxmodules)
-
 if(gcctoolchain)
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS --gcc-toolchain=${gcctoolchain})
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,43 +370,27 @@ if(TARGET g2root)
 endif()
 
 #--periodic----------------------------------------------------------------------------------------
-if (NOT cxxmodules)
-  # There are two problems with this test and cxxmodules. First, it picks up a
-  # header files from $ROOTSYS/include and builds a library. Naturally, we should
-  # build pcm files, however, building module MathCore requires specific -I to
-  # build the needed VecCore and Vc components. This test does not have access
-  # to the include relevant include paths. Secondly, if we want to reuse the
-  # modules from ROOT which makes most sense we can't because we get a hard
-  # error such as: fatal error: malformed or corrupted AST file:
-  # 'SourceLocation remap refers to unknown module, cannot find include/pcms/1WYSNQV9VBZK7/stl-2OZGQN92C38MI.pcm
-  #
-  # FIXME: We can fix the first point by moving out all VecCore-related headers
-  # such as Math/Types.h and all of its includers in a separate module. Thus,
-  # the current test will not require the VecCore (as in the textual case).
-  # Alternatively, we can trace the origin of the fatal error and try to remap
-  # the source locations.
-  if(MSVC)
-    set(build_generator_args --build-generator ${CMAKE_GENERATOR})
-    if(CMAKE_GENERATOR_PLATFORM)
-      list(APPEND build_generator_args --build-generator-platform ${CMAKE_GENERATOR_PLATFORM})
-    endif()
-    if(CMAKE_GENERATOR_TOOLSET)
-      list(APPEND build_generator_args --build-generator-toolset ${CMAKE_GENERATOR_TOOLSET})
-    endif()
-    ROOT_ADD_TEST(test-periodic-build
-      COMMAND ${CMAKE_CTEST_COMMAND} ${build_generator_args}
-        --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
-        --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
-    )
-  else()
-    ROOT_ADD_TEST(test-periodic-build
-      COMMAND
-        env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
-        ${CMAKE_CTEST_COMMAND} --build-generator ${CMAKE_GENERATOR}
-        --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
-        --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
-    )
+if(MSVC)
+  set(build_generator_args --build-generator ${CMAKE_GENERATOR})
+  if(CMAKE_GENERATOR_PLATFORM)
+    list(APPEND build_generator_args --build-generator-platform ${CMAKE_GENERATOR_PLATFORM})
   endif()
+  if(CMAKE_GENERATOR_TOOLSET)
+    list(APPEND build_generator_args --build-generator-toolset ${CMAKE_GENERATOR_TOOLSET})
+  endif()
+  ROOT_ADD_TEST(test-periodic-build
+    COMMAND ${CMAKE_CTEST_COMMAND} ${build_generator_args}
+      --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
+      --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
+  )
+else()
+  ROOT_ADD_TEST(test-periodic-build
+    COMMAND
+      env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+      ${CMAKE_CTEST_COMMAND} --build-generator ${CMAKE_GENERATOR}
+      --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
+      --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
+  )
 endif()
 
 #--canary tests------------------------------------------------------------------------------------


### PR DESCRIPTION
`cxxmodules` was deprecated at https://github.com/root-project/root/pull/12746