### PR TITLE
[cling][NFC] Replace use of deprecated `AddFileDependencies`

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -346,8 +346,9 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
                    MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
                    COMMENT "Updating cling-compiledata.h")
 
-add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
-                      ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
+             APPEND PROPERTY OBJECT_DEPENDS
+             ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
 
 # If LLVM is external, but Clang is builtin, we must use some files
 # from patched (builtin) version of LLVM


### PR DESCRIPTION
This was deprecated in CMake version 3.20.0
https://cmake.org/cmake/help/latest/module/AddFileDependencies.html

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

