### PR TITLE
[df] Extend lifetime of Python-bound TTree dataset

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_namespace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_namespace.py
@@ -77,9 +77,20 @@ def _rdataframe(local_rdf, distributed_rdf):
     """
 
     def rdataframe(*args, **kwargs):
+        import ROOT
+        from libROOTPythonizations import PyObjRefCounterAsStdAny
+
         if kwargs.get("executor", None) is not None:
-            return distributed_rdf(*args, **kwargs)
+            rdf = distributed_rdf(*args, **kwargs)
+            rnode = ROOT.RDF.AsRNode(rdf._headnode.rdf_node)
         else:
-            return local_rdf(*args, **kwargs)
+            rdf = local_rdf(*args, **kwargs)
+            rnode = ROOT.RDF.AsRNode(rdf)
+
+        if args and isinstance(args[0], ROOT.TTree):
+            ROOT.Internal.RDF.SetTTreeLifeline(
+                rnode, PyObjRefCounterAsStdAny(args[0]))
+
+        return rdf
 
     return rdataframe

--- a/bindings/pyroot/pythonizations/test/rdataframe_misc.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_misc.py
@@ -1,9 +1,50 @@
 import cppyy
 import platform
 import unittest
+import numpy
+import os
 
 import ROOT
 
+class DatasetContext:
+    """A helper class to create the dataset for the tutorial below."""
+
+    filenames = [
+        "rdataframe_misc_1.root",
+        "rdataframe_misc_2.root",
+        "rdataframe_misc_3.root"
+    ]
+    treename = "dataset"
+    nentries = 5
+
+    def __init__(self):
+        for filename in self.filenames:
+            with ROOT.TFile(filename, "RECREATE") as f:
+                t = ROOT.TTree(self.treename, self.treename)
+
+                x = numpy.array([0], dtype=int)
+                y = numpy.array([0], dtype=int)
+                t.Branch("x", x, "x/I")
+                t.Branch("y", y, "y/I")
+
+                for i in range(1, self.nentries + 1):
+                    x[0] = i
+                    y[0] = 2 * i
+                    t.Fill()
+
+                f.Write()
+
+    def __enter__(self):
+        """Enable using the class as a context manager."""
+        return self
+
+    def __exit__(self, *_):
+        """
+        Enable using the class as a context manager. At the end of the context,
+        remove the files created.
+        """
+        for filename in self.filenames:
+            os.remove(filename)
 
 class RDataFrameMisc(unittest.TestCase):
     """Miscellaneous RDataFrame tests"""
@@ -33,6 +74,60 @@ class RDataFrameMisc(unittest.TestCase):
 
             with self.assertRaisesRegex(TypeError, "RDataFrame: empty list of input files."):
                 ROOT.RDataFrame("events", ())
+
+    def _get_rdf(self, dataset):
+        chain = ROOT.TChain(dataset.treename)
+        for filename in dataset.filenames:
+            chain.Add(filename)
+
+        return ROOT.RDataFrame(chain)
+    
+    def _get_chain(self, dataset):
+        chain = ROOT.TChain(dataset.treename)
+        for filename in dataset.filenames:
+            chain.Add(filename)
+        return chain
+
+    def _define_col(self, rdf):
+        return rdf.Define("z", "42")
+
+    def _filter_x(self, rdf):
+        return rdf.Filter("x > 2")
+    
+    def _test_rdf_in_function(self, chain):
+
+        rdf = ROOT.RDataFrame(chain)
+        meanx = rdf.Mean("x")
+        meany = rdf.Mean("y")
+        self.assertLess(meanx.GetValue(), meany.GetValue())
+
+    def test_ttree_ownership(self):
+        """
+        Regression tests for https://github.com/root-project/root/issues/17691
+        """
+        # Issues on windows with contention on file deletion
+        if platform.system() == "Windows":
+            return
+
+        with DatasetContext() as dataset:
+            rdf = self._get_rdf(dataset)
+
+            npy_dict = rdf.AsNumpy()
+            self.assertIsNone(numpy.testing.assert_array_equal(npy_dict["x"], numpy.array([1,2,3,4,5]*3)))
+            self.assertIsNone(numpy.testing.assert_array_equal(npy_dict["y"], numpy.array([2,4,6,8,10]*3)))
+
+            chain = self._get_chain(dataset)
+
+            rdf = ROOT.RDataFrame(chain)
+
+            self._test_rdf_in_function(chain)
+
+            rdf = self._define_col(rdf)
+            rdf = self._filter_x(rdf)
+
+            self.assertEqual(rdf.Count().GetValue(), 9)
+
+
 
 
 if __name__ == '__main__':

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -59,6 +59,7 @@
 #include <unordered_set>
 #include <utility> // std::index_sequence
 #include <vector>
+#include <any>
 
 class TGraph;
 
@@ -93,6 +94,7 @@ void ChangeBeginAndEndEntries(const RNode &node, Long64_t begin, Long64_t end);
 void ChangeSpec(const ROOT::RDF::RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
 void TriggerRun(ROOT::RDF::RNode node);
 std::string GetDataSourceLabel(const ROOT::RDF::RNode &node);
+void SetTTreeLifeline(ROOT::RDF::RNode &node, std::any lifeline);
 } // namespace RDF
 } // namespace Internal
 
@@ -127,6 +129,7 @@ class RInterface : public RInterfaceBase {
    friend void RDFInternal::ChangeBeginAndEndEntries(const RNode &node, Long64_t start, Long64_t end);
    friend void RDFInternal::ChangeSpec(const RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
    friend std::string ROOT::Internal::RDF::GetDataSourceLabel(const RNode &node);
+   friend void ROOT::Internal::RDF::SetTTreeLifeline(ROOT::RDF::RNode &node, std::any lifeline);
    std::shared_ptr<Proxied> fProxiedPtr; ///< Smart pointer to the graph node encapsulated by this RInterface.
 
 public:

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <any>
 
 // forward declarations
 class TTree;
@@ -192,6 +193,10 @@ class RLoopManager : public RNodeBase {
    std::set<std::pair<std::string_view, std::unique_ptr<ROOT::Internal::RDF::RVariationsWithReaders>>>
       fUniqueVariationsWithReaders;
 
+   /// A wrapped reference to a TTree dataset that can be shared by many computation graphs. Ensures lifetime
+   /// management.
+   std::any fTTreeLifeline{};
+
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
    RLoopManager(std::unique_ptr<TTree> tree, const ColumnNames_t &defaultBranches);
@@ -282,6 +287,8 @@ public:
    {
       return fSuppressErrorsForMissingBranches;
    }
+
+   void SetTTreeLifeline(std::any lifeline);
 };
 
 /// \brief Create an RLoopManager that reads a TChain.

--- a/tree/dataframe/src/RInterface.cxx
+++ b/tree/dataframe/src/RInterface.cxx
@@ -56,3 +56,8 @@ std::string ROOT::Internal::RDF::GetDataSourceLabel(const ROOT::RDF::RNode &node
       return "EmptyDS";
    }
 }
+
+void ROOT::Internal::RDF::SetTTreeLifeline(ROOT::RDF::RNode &node, std::any lifeline)
+{
+   node.GetLoopManager()->SetTTreeLifeline(std::move(lifeline));
+}

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1245,6 +1245,11 @@ void RLoopManager::ChangeBeginAndEndEntries(Long64_t begin, Long64_t end)
    fEndEntry = end;
 }
 
+void ROOT::Detail::RDF::RLoopManager::SetTTreeLifeline(std::any lifeline)
+{
+   fTTreeLifeline = std::move(lifeline);
+}
+
 /**
  * \brief Helper function to open a file (or the first file from a glob).
  * This function is used at construction time of an RDataFrame, to check the


### PR DESCRIPTION
If a TTree dataset is created in a Python application and the RDataFrame constructor that takes in a `TTree &` parameter is used, the ownership of the TTree might result ambiguous for the user. Specifically, a Python user might expect the following to work out of the box:
```py
def foo():
    ch = ROOT.TChain()
    return ROOT.RDataFrame(ch)
```
Whereas it won't since the chain will become a dangling reference by the end of the function scope.

To cope with this unfortunate interaction of the C++ API and Python, we introduce an internal mechanism to keep track of the shared ownership of the *Python* proxy object. The implementation features a C++ wrapper in the ROOT CPython extension, which increases/decreases the Python reference count of a `PyObject *` data member. If this Python object is carefully given, i.e. if it is always pointing to the same underlying C++ object, then the reference counting will work correctly and destroy the C++ object only when there are no more Python objects referencing it. In order to keep the wrapper alive, a `std::any` data member is added to RLoopManager which represents the C++ counterpart of the Python lifeline. Within the same computation graph, different nodes share the same RLoopManager, so the Python object will stay alive as long as at least one node of the computation graph is still alive. If the same TTree is used (via a reference) by multiple computation graphs, then the wrapper mechanism will ensure that reference counting is correct across the different RDataFrame objects.

This PR fixes #17691