### PR TITLE
Implement `TBrowser::Draw()` method

### DIFF
--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -105,6 +105,7 @@ public:
    void          Show()                        { if (fImp) fImp->Show(); }
    void          SetDrawOption(Option_t *option="") override { if (fImp) fImp->SetDrawOption(option); }
    Option_t     *GetDrawOption() const override { return  (fImp) ? fImp->GetDrawOption() : nullptr; }
+   void          Draw(Option_t *option="") override;
 
    Longptr_t     ExecPlugin(const char *name = nullptr, const char *fname = nullptr,
                             const char *cmd = nullptr, Int_t pos = 1, Int_t subpos = -1) {

--- a/core/gui/inc/TBrowserImp.h
+++ b/core/gui/inc/TBrowserImp.h
@@ -39,7 +39,7 @@ public:
    TBrowserImp(TBrowser *b = nullptr);
    TBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt = "");
    TBrowserImp(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");
-   virtual ~TBrowserImp() = default;
+   virtual ~TBrowserImp();
 
    virtual void      Add(TObject *, const char *, Int_t) { }
    virtual void      AddCheckBox(TObject *, Bool_t = kFALSE) { }

--- a/core/gui/src/TBrowser.cxx
+++ b/core/gui/src/TBrowser.cxx
@@ -393,6 +393,25 @@ void TBrowser::Create(TObject *obj)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw browser again if it was closed before
+/// If browser exists - just call Show method
+
+void TBrowser::Draw(Option_t *)
+{
+   if (fImp) {
+      fImp->Show();
+   } else {
+      Float_t cx = gStyle->GetScreenFactor();
+      UInt_t w = UInt_t(cx*800);
+      UInt_t h = UInt_t(cx*500);
+      fImp = gGuiFactory->CreateBrowserImp(this, "ROOT Object Browser", w, h, "");
+      if (fImp)
+         fImp->BrowseObj(gROOT);
+   }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Execute default action for selected object (action is specified
 /// in the `$HOME/.root.mimes` or `$ROOTSYS/etc/root.mimes file`).
 

--- a/core/gui/src/TBrowserImp.cxx
+++ b/core/gui/src/TBrowserImp.cxx
@@ -16,6 +16,7 @@ ABC describing GUI independent browser implementation protocol.
 */
 
 #include "TBrowserImp.h"
+#include "TBrowser.h"
 
 ClassImp(TBrowserImp);
 
@@ -41,4 +42,13 @@ TBrowserImp::TBrowserImp(TBrowser *, const char *, UInt_t, UInt_t, Option_t *) :
 TBrowserImp::TBrowserImp(TBrowser *, const char *, Int_t, Int_t, UInt_t, UInt_t, Option_t *)
    : fBrowser(nullptr), fShowCycles(kFALSE)
 {
+}
+
+///////////////////////////////////////////////////////////////////
+/// Destructor
+
+TBrowserImp::~TBrowserImp()
+{
+   if (fBrowser && fBrowser->GetBrowserImp() == this)
+      fBrowser->SetBrowserImp(nullptr);
 }

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -510,8 +510,6 @@ void RBrowser::Show(const RWebDisplayArgs &args, bool always_start_new_browser)
 {
    if (!fWebWindow->NumConnections() || always_start_new_browser) {
       fWebWindow->Show(args);
-   } else {
-      SendInitMsg(0);
    }
 }
 


### PR DESCRIPTION
Now dummy canvas is drawn. 
Instead create browser implementation again if it was deleted before

Correctly reset `TBrowser::fImp` pointer when 'normal' TRootBrowser is closed and deleted.
Up to now TBrowser was using no-longer-valid pointer

Small fix in `RBrowser::Show()` method - which is invoked by `TBrowser::Draw()` now
