### PR TITLE
[ntuple] Allow for alternative column types in `RNTupleDS`

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -86,6 +86,12 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// Only the clone connects to the backing page store and acquires I/O resources.
    /// The field IDs are set in the context of the first source and used as keys in fFieldId2QualifiedName.
    std::vector<std::unique_ptr<ROOT::Experimental::RFieldBase>> fProtoFields;
+   /// Columns may be requested with types other than with which they were initially added as proto fields. For example,
+   /// a column with a `ROOT::RVec<float>` proto field may instead be requested as a `std::vector<float>`. In case this
+   /// happens, we create an alternative proto field and store it here, with the original index in `fProtoFields` as
+   /// key. A single column can have more than one alternative proto fields.
+   std::unordered_map<std::size_t, std::vector<std::unique_ptr<ROOT::Experimental::RFieldBase>>>
+      fAlternativeProtoFields;
    /// Connects the IDs of active proto fields and their subfields to their fully qualified name (a.b.c.d).
    /// This enables the column reader to rewire the field IDs when the file changes (chain),
    /// using the fully qualified name as a search key in the descriptor of the other page sources.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -194,7 +194,15 @@ public:
          }
       }
 
-      ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fField, source);
+      try {
+         ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fField, source);
+      } catch (const ROOT::RException &err) {
+         auto onDiskType = source.GetSharedDescriptorGuard()->GetFieldDescriptor(fField->GetOnDiskId()).GetTypeName();
+         std::string msg = "RNTupleDS: invalid type \"" + fField->GetTypeName() + "\" for column \"" +
+                           fDataSource->fFieldId2QualifiedName[fField->GetOnDiskId()] + "\" with on-disk type \"" +
+                           onDiskType + "\"";
+         throw std::runtime_error(msg);
+      }
 
       if (fValuePtr) {
          // When the reader reconnects to a new file, the fValuePtr is already set

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -339,8 +339,9 @@ TEST_F(RNTupleDSTest, AlternativeColumnTypes)
          .Take<std::size_t, ROOT::RVec<std::size_t>>("firstJet")
          .GetValue();
       FAIL() << "specifying templated actions with incompatible column types should throw";
-   } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk field information for `jets._1`"));
+   } catch (const std::runtime_error &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("RNTupleDS: invalid type \"std::pair<float,float>\" for column "
+                                                 "\"jets\" with on-disk type \"std::vector<float>\""));
    }
 
    try {
@@ -350,9 +351,9 @@ TEST_F(RNTupleDSTest, AlternativeColumnTypes)
          .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
          .GetValue();
       FAIL() << "specifying templated actions with incompatible column types should throw";
-   } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("On-disk column types {`SplitReal32`} for field `jets._0` cannot be "
-                                                 "matched to its in-memory type `std::uint64_t`"));
+   } catch (const std::runtime_error &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("RNTupleDS: invalid type \"std::vector<std::uint64_t>\" for column "
+                                                 "\"jets\" with on-disk type \"std::vector<float>\""));
    }
 }
 

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -267,6 +267,95 @@ TEST_F(RNTupleDSTest, ChainMT)
    ChainTest(fNtplName, fFileName);
 }
 
+TEST_F(RNTupleDSTest, AlternativeColumnTypes)
+{
+   auto df = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+
+   // Alternative inner type
+   auto usingDouble = df.Define("nJets", [](const ROOT::RVec<double> &jets) { return jets.size(); }, {"jets"})
+                         .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
+                         .GetValue();
+   EXPECT_EQ(2ull, ROOT::VecOps::Sum(usingDouble));
+
+   // Alternative outer type (original on-disk type)
+   auto asStdVec = df.Define("nJets", [](const std::vector<float> &jets) { return jets.size(); }, {"jets"})
+                      .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
+                      .GetValue();
+   EXPECT_EQ(2ull, ROOT::VecOps::Sum(asStdVec));
+
+   // Original datasource protofield type
+   auto asRVec = df.Define("nJets", [](const ROOT::RVec<float> &jets) { return jets.size(); }, {"jets"})
+                    .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
+                    .GetValue();
+   EXPECT_EQ(2ull, ROOT::VecOps::Sum(asRVec));
+
+   auto multipleAlternativeTypes =
+      df.Define("nJets", [](const std::vector<float> &jets) { return jets.size(); }, {"jets"})
+         .Define("smallestJet", [](const std::set<float> &jets) { return *(jets.begin()); }, {"jets"})
+         .Min<float>("smallestJet")
+         .GetValue();
+   EXPECT_FLOAT_EQ(1.f, multipleAlternativeTypes);
+
+   auto jitted = df.Define("jetsType", "ROOT::Internal::RDF::TypeID2TypeName(typeid(jets))")
+                    .Take<std::string>("jetsType")
+                    .GetValue();
+   EXPECT_EQ("ROOT::VecOps::RVec<float>", jitted[0]);
+
+   // Original protofield type of ROOT::RVec<ROOT::RVec<float>>, test with different ROOT::RVec/std::vector combinations
+   auto nestedStdVecStdVec =
+      df.Define("nNnlo", [](const std::vector<std::vector<float>> &nnlo) { return nnlo.size(); }, {"nnlo"})
+         .Take<std::size_t, ROOT::RVec<std::size_t>>("nNnlo")
+         .GetValue();
+   EXPECT_EQ(3ull, ROOT::VecOps::Sum(nestedStdVecStdVec));
+
+   auto nestedStdVecRVec =
+      df.Define("nNnlo", [](const std::vector<ROOT::RVec<float>> &nnlo) { return nnlo.size(); }, {"nnlo"})
+         .Take<std::size_t, ROOT::RVec<std::size_t>>("nNnlo")
+         .GetValue();
+   EXPECT_EQ(3ull, ROOT::VecOps::Sum(nestedStdVecRVec));
+
+   auto nestedRVecStdVec =
+      df.Define("nNnlo", [](const ROOT::RVec<std::vector<float>> &nnlo) { return nnlo.size(); }, {"nnlo"})
+         .Take<std::size_t, ROOT::RVec<std::size_t>>("nNnlo")
+         .GetValue();
+   EXPECT_EQ(3ull, ROOT::VecOps::Sum(nestedRVecStdVec));
+
+   // Check that the ROOT RtypesCore typedefs are handled properly
+   auto usingTypeAlias1 = df.Define("nJets", [](const std::vector<Float_t> &jets) { return jets.size(); }, {"jets"})
+                             .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
+                             .GetValue();
+   EXPECT_EQ(2ull, ROOT::VecOps::Sum(usingTypeAlias1));
+
+   auto usingTypeAlias2 =
+      df.Define("vecSum", [](const ROOT::RVec<Int_t> &rvec) { return ROOT::VecOps::Sum(rvec); }, {"rvec"})
+         .Take<std::int32_t>("vecSum")
+         .GetValue();
+   EXPECT_EQ(6, usingTypeAlias2[0]);
+
+   try {
+      // Invalid outer field type
+      auto dfInvalid = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+      dfInvalid.Define("firstJet", [](const std::pair<float, float> &jets) { return jets.first; }, {"jets"})
+         .Take<std::size_t, ROOT::RVec<std::size_t>>("firstJet")
+         .GetValue();
+      FAIL() << "specifying templated actions with incompatible column types should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk field information for `jets._1`"));
+   }
+
+   try {
+      // Invalid inner field types
+      auto dfInvalid = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+      dfInvalid.Define("nJets", [](const std::vector<std::uint64_t> &jets) { return jets.size(); }, {"jets"})
+         .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
+         .GetValue();
+      FAIL() << "specifying templated actions with incompatible column types should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("On-disk column types {`SplitReal32`} for field `jets._0` cannot be "
+                                                 "matched to its in-memory type `std::uint64_t`"));
+   }
+}
+
 TEST_F(RNTupleDSTest, ChainTailScheduling)
 {
    IMTRAII _;

--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -22,6 +22,7 @@ HEADERS
   ROOT/REntry.hxx
   ROOT/RField.hxx
   ROOT/RFieldBase.hxx
+  ROOT/RFieldUtils.hxx
   ROOT/RFieldVisitor.hxx
   ROOT/RMiniFile.hxx
   ROOT/RNTuple.hxx

--- a/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
@@ -38,7 +38,11 @@ long long ParseIntTypeToken(const std::string &intToken);
 unsigned long long ParseUIntTypeToken(const std::string &uintToken);
 
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
-enum class ERNTupleSerializationMode { kForceNativeMode, kForceStreamerMode, kUnset };
+enum class ERNTupleSerializationMode {
+   kForceNativeMode,
+   kForceStreamerMode,
+   kUnset
+};
 
 ERNTupleSerializationMode GetRNTupleSerializationMode(TClass *cl);
 

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -9,7 +9,7 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RFieldVisitor.hxx>
-#include "RFieldUtils.hxx"
+#include <ROOT/RFieldUtils.hxx>
 
 #include <TClass.h>
 #include <TClassEdit.h>

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -19,7 +19,7 @@
 
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
-#include "RFieldUtils.hxx"
+#include <ROOT/RFieldUtils.hxx>
 #include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RSpan.hxx>
 

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -8,7 +8,7 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RFieldVisitor.hxx>
-#include "RFieldUtils.hxx"
+#include <ROOT/RFieldUtils.hxx>
 
 #include <cstdlib> // for malloc, free
 #include <memory>

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -5,7 +5,7 @@
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
-#include "RFieldUtils.hxx"
+#include <ROOT/RFieldUtils.hxx>
 
 #include <ROOT/RField.hxx>
 #include <ROOT/RLogger.hxx>


### PR DESCRIPTION
This PR adds the possibility of using different (valid) types for RDF columns in the `RNTupleDS`. A notable example is the interchangeable use of `std::vector<T>` and `ROOT::RVec<T>`. We enable this by introducing *alternative prototype fields*, which are created on-demand when a column reader is requested for a type other than the original prototype field that was added when the datasource was constructed. 

An error is thrown in `RNTupleColumnReader` in case the alternative column type is incompatible with the on-disk type of the corresponding field.

Fixes #16034 and #10749.