### PR TITLE
Introduce `RWebWindow::Reset()` method

### DIFF
--- a/geom/webviewer/src/RGeomHierarchy.cxx
+++ b/geom/webviewer/src/RGeomHierarchy.cxx
@@ -48,6 +48,8 @@ RGeomHierarchy::RGeomHierarchy(RGeomDescription &desc, bool use_server_threads) 
 RGeomHierarchy::~RGeomHierarchy()
 {
    fDesc.RemoveSignalHandler(this);
+   if (fWebWindow)
+      fWebWindow->Reset();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/geom/webviewer/src/RGeomViewer.cxx
+++ b/geom/webviewer/src/RGeomViewer.cxx
@@ -71,6 +71,9 @@ RGeomViewer::RGeomViewer(TGeoManager *mgr, const std::string &volname)
 RGeomViewer::~RGeomViewer()
 {
    fDesc.RemoveSignalHandler(this);
+
+   if (fWebWindow)
+      fWebWindow->Reset();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -344,6 +344,7 @@ RBrowser::~RBrowser()
    if (fWebWindow) {
       fWebWindow->GetManager()->SetShowCallback(nullptr);
       fWebWindow->GetManager()->SetDeleteCallback(nullptr);
+      fWebWindow->Reset();
    }
 }
 

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -233,7 +233,7 @@ RCanvasPainter::~RCanvasPainter()
    CancelCommands();
    CancelUpdates();
    if (fWindow)
-      fWindow->CloseConnections();
+      fWindow->Reset();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -394,6 +394,8 @@ public:
 
    void SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn = nullptr);
 
+   void Reset();
+
    void SetConnectCallBack(WebWindowConnectCallback_t func);
 
    void SetDataCallBack(WebWindowDataCallback_t func);

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1838,6 +1838,22 @@ void RWebWindow::SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCall
 }
 
 /////////////////////////////////////////////////////////////////////////////////
+/// Reset window call-backs and close connections
+/// Should be invoked in widget destructor to simplify cleanup process
+
+void RWebWindow::Reset()
+{
+   CloseConnections();
+
+   fConnCallback = nullptr;
+   fDataCallback = nullptr;
+   fDisconnCallback = nullptr;
+
+   if (fWSHandler)
+      fWSHandler->SetDisabled();
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 /// Waits until provided check function or lambdas returns non-zero value
 /// Check function has following signature: int func(double spent_tm)
 /// Waiting will be continued, if function returns zero.

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -215,9 +215,11 @@ TWebCanvas::TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t wi
 
 TWebCanvas::~TWebCanvas()
 {
+   if(fWindow)
+      fWindow->Reset();
+
    delete fTimer;
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Add font to static list of fonts supported by the canvas

--- a/tree/webviewer/src/RTreeViewer.cxx
+++ b/tree/webviewer/src/RTreeViewer.cxx
@@ -134,7 +134,8 @@ RTreeViewer::RTreeViewer(TTree *tree)
 
 RTreeViewer::~RTreeViewer()
 {
-
+   if (fWebWindow)
+      fWebWindow->Reset();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Usage of `Reset()` method allows to avoid complex invocation tree 
during "trivial" cleanup of all sub-widgets of the `RBrowser`. 
Without such method "close connection callback" may try to invoke directly widget methods
at the moment when widgets were already destroyed.

Resolve problem with simple use case:
```
auto br = new TBrowser();
delete br;
```

Use in `TWebCanvas`, `RCanvasPainter`, `RGeomViewer`, `RTreeViewer`, `RBrowser`.
All these widgets used together in `RBrowser` and may affect destructor calling sequence.

Method has no effect for standalone widgets while there `RWebWindow` destructor 
called directly in context of widget (aka `TCanvas` or `RGeomViewer`) destructor.

