### PR TITLE
 [hist] Add TH1::Normalize()

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -363,6 +363,7 @@ public:
    virtual Bool_t   Multiply(TF1 *f1, Double_t c1=1);
    virtual Bool_t   Multiply(const TH1 *h1);
    virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="");
+   virtual void     Normalize(Option_t *option=""); // *MENU*
            void     Paint(Option_t *option = "") override;
            void     Print(Option_t *option = "") const override;
    virtual void     PutStats(Double_t *stats);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -363,7 +363,7 @@ public:
    virtual Bool_t   Multiply(TF1 *f1, Double_t c1=1);
    virtual Bool_t   Multiply(const TH1 *h1);
    virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="");
-   virtual void     Normalize(Option_t *option=""); // *MENU*
+   virtual void     Normalize(Option_t *option="width"); // *MENU*
            void     Paint(Option_t *option = "") override;
            void     Print(Option_t *option = "") const override;
    virtual void     PutStats(Double_t *stats);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6200,20 +6200,23 @@ Bool_t TH1::Multiply(const TH1 *h1, const TH1 *h2, Double_t c1, Double_t c2, Opt
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief Normalize a histogram to its maximum value or integral.
 /// @note Works for TH1, TH2, TH3, ...
-/// @param option `"max"`, `"width"` or `""` (default)
+/// @param option`"width"` (default) or `"max"` or `""`
 /// If it contains `max`, this histogram is normalized by 1/GetMaximum()
-/// else it is normalized by `1/Integral(option)`, ie it is normalized by `1/sum`
-/// in the default case or by `1/(sum*bin_width)` if option is "width".
+/// else it is normalized by `1/(sum*bin_width)`
+/// in the default case ("width") or by `1/(sum)` if option is "".
 /// In case the norm is zero, it raises an error.
+/// @sa https://root-forum.cern.ch/t/different-ways-of-normalizing-histograms/15582/
 
 void TH1::Normalize(Option_t *option)
 {
-   const Double_t norm = TString(option).Contains("max", TString::kIgnoreCase) ? GetMaximum() : this->Integral(option);
+   const Double_t norm = TString(option).Contains("max", TString::kIgnoreCase) ? GetMaximum() : this->Integral();
 
    if (norm == 0) {
       Error("Normalize", "Attempt to normalize histogram with zero integral");
    } else {
       Scale(1.0 / norm, option);
+      // An alternative could have been to call Integral(option) and Scale(1/norm, "").
+      // Instead, doing simultaneously Integral(option) and Scale(1/norm, option) leads to an error since you are dividing twice by bin width.
    }
 }
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6198,6 +6198,26 @@ Bool_t TH1::Multiply(const TH1 *h1, const TH1 *h2, Double_t c1, Double_t c2, Opt
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief Normalize a histogram to its maximum value or integral.
+/// @note Works for TH1, TH2, TH3, ...
+/// @param option `"max"`, `"width"` or `""` (default)
+/// If it contains `max`, this histogram is normalized by 1/GetMaximum()
+/// else it is normalized by `1/Integral(option)`, ie it is normalized by `1/sum`
+/// in the default case or by `1/(sum*bin_width)` if option is "width".
+/// In case the norm is zero, it raises an error.
+
+void TH1::Normalize(Option_t *option)
+{
+   const Double_t norm = TString(option).Contains("max", TString::kIgnoreCase) ? GetMaximum() : this->Integral(option);
+
+   if (norm == 0) {
+      Error("Normalize", "Attempt to normalize histogram with zero integral");
+   } else {
+      Scale(1.0 / norm, option);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Control routine to paint any kind of histograms.
 ///
 /// This function is automatically called by TCanvas::Update.

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6198,7 +6198,7 @@ Bool_t TH1::Multiply(const TH1 *h1, const TH1 *h2, Double_t c1, Double_t c2, Opt
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief Normalize a histogram to its maximum value or integral.
+/// @brief Normalize a histogram to its integral or to its maximum.
 /// @note Works for TH1, TH2, TH3, ...
 /// @param option`"width"` (default) or `"max"` or `""`
 /// If it contains `max`, this histogram is normalized by 1/GetMaximum()

--- a/hist/hist/test/test_TH1.cxx
+++ b/hist/hist/test/test_TH1.cxx
@@ -92,3 +92,60 @@ TEST(TH1, AddBinContent)
    h3.AddBinContent(1,1,1,1.);
    EXPECT_FLOAT_EQ(h3.GetBinContent(1,1,1),1.);
 }
+
+// https://github.com/root-project/root/pull/17751
+// https://root-forum.cern.ch/t/different-ways-of-normalizing-histograms/15582
+TEST(TH1, Normalize)
+{
+   TH1F h1("h1", "h1", 10, 0, 1);
+   h1.SetBinContent(1,1.);
+   h1.SetBinContent(3,5.);
+   h1.SetBinContent(5,10.);
+   h1.SetBinContent(7,-1.);
+   h1.SetBinContent(10,3.);
+   EXPECT_FLOAT_EQ(h1.GetEntries(), 5.);
+   EXPECT_FLOAT_EQ(h1.GetSumOfWeights(), 18.);
+   EXPECT_FLOAT_EQ(h1.Integral(), 18.);
+   EXPECT_FLOAT_EQ(h1.Integral("width"), 1.8);
+   EXPECT_FLOAT_EQ(h1.GetMaximum(), 10.);
+   TH1F h2(h1);
+   h2.Normalize();
+   EXPECT_FLOAT_EQ(h2.GetEntries(), 16.2);
+   EXPECT_FLOAT_EQ(h2.GetSumOfWeights(), 10.);
+   EXPECT_FLOAT_EQ(h2.Integral(), 10.);   
+   EXPECT_FLOAT_EQ(h2.Integral("width"), 1.);
+   EXPECT_FLOAT_EQ(h2.GetMaximum(), 50./9);
+   TH1F h3(h1);
+   h3.Normalize("max");
+   EXPECT_FLOAT_EQ(h3.GetEntries(), 5.);
+   EXPECT_FLOAT_EQ(h3.GetSumOfWeights(), 1.8);
+   EXPECT_FLOAT_EQ(h3.Integral(), 1.8);   
+   EXPECT_FLOAT_EQ(h3.Integral("width"), 0.18);
+   EXPECT_FLOAT_EQ(h3.GetMaximum(), 1.);
+   TH1F h4(h1);
+   h4.Normalize("");
+   EXPECT_FLOAT_EQ(h4.GetEntries(), 5.);
+   EXPECT_FLOAT_EQ(h4.GetSumOfWeights(), 1);
+   EXPECT_FLOAT_EQ(h4.Integral(), 1);   
+   EXPECT_FLOAT_EQ(h4.Integral("width"), 0.1);
+   EXPECT_FLOAT_EQ(h4.GetMaximum(), 5./9);
+   const Float_t xbins[10+1] {0.,0.05,0.1,0.15,0.2,0.3,0.5,0.7,0.8,0.95,1.}
+   TH1F v1("v1","vbw", 10, xbins);
+   v1.SetBinContent(1,1.);
+   v1.SetBinContent(3,5.);
+   v1.SetBinContent(5,10.);
+   v1.SetBinContent(7,-1.);
+   v1.SetBinContent(10,3.);
+   EXPECT_FLOAT_EQ(v1.GetEntries(), 5.);
+   EXPECT_FLOAT_EQ(v1.GetSumOfWeights(), 18.);
+   EXPECT_FLOAT_EQ(v1.Integral(), 18.);
+   EXPECT_FLOAT_EQ(v1.Integral("width"), 1.25);
+   EXPECT_FLOAT_EQ(v1.GetMaximum(), 10.);
+   TH1F v2(v1);
+   v2.Normalize();
+   EXPECT_FLOAT_EQ(v2.GetEntries(), 16.35135);
+   EXPECT_FLOAT_EQ(v2.GetSumOfWeights(), 15.277776);
+   EXPECT_FLOAT_EQ(v2.Integral(), 15.277776);   
+   EXPECT_FLOAT_EQ(v2.Integral("width"), 1.);
+   EXPECT_FLOAT_EQ(v2.GetMaximum(), 50./9);
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Add a helper function to normalize TH1/TH2/TH3 objects to maximum or integral.

Sibling roottest PR: https://github.com/root-project/roottest/pull/1263

All credit goes to @dvotaw

Supersedes/rebases https://github.com/root-project/root/pull/5241

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

