### PR TITLE
[skip-ci][math][nfc] Do not use doxy \see special command

### DIFF
--- a/math/minuit/src/TLinearMinimizer.cxx
+++ b/math/minuit/src/TLinearMinimizer.cxx
@@ -53,7 +53,7 @@ struct BasisFunction {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \class TLinearMinimizer
-/// \see Minuit2 for a newer version of this class
+/// See Minuit2 for a newer version of this class.
 ///
 /// TLinearMinimizer, simple class implementing the ROOT::Math::Minimizer
 /// interface usingTLinearFitter. This class uses TLinearFitter to find directly


### PR DESCRIPTION
since the verb see is what we meant to use.
Fixes #17754
