### PR TITLE
[v632] Prevent a race condition in fStreamerImpl value

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -307,7 +307,7 @@ private:
    void               SetClassSize(Int_t sizof) { fSizeof = sizof; }
    TVirtualStreamerInfo* DetermineCurrentStreamerInfo();
 
-   void SetStreamerImpl();
+   void SetStreamerImpl(Int_t streamerType);
 
    void SetRuntimeProperties();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6148,6 +6148,8 @@ Long_t TClass::Property() const
          kl->SetBit(kHasLocalHashMember);
       }
 
+      kl->SetStreamerImpl(streamerType);
+
       if (GetClassInfo()) {
          // In the case where the TClass for one of ROOT's core class
          // (eg TClonesArray for map<int,TClonesArray*>) is requested
@@ -6163,7 +6165,6 @@ Long_t TClass::Property() const
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
 
-      kl->SetStreamerImpl(streamerType);
    } else {
 
       if (fStreamer) {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6099,6 +6099,14 @@ Long_t TClass::Property() const
    // Avoid asking about the class when it is still building
    if (TestBit(kLoading)) return fProperty;
 
+   if (fStreamerType != kDefault && !HasInterpreterInfo()) {
+      // We have no interpreter information but we already set the streamer type
+      // so we have already been here and have no new information, then let's
+      // give up.  See the code at this end of this routine (else branch of the
+      // `if (HasInterpreterInfo()` for the path we took before.
+      return 0;
+   }
+
    // When called via TMapFile (e.g. Update()) make sure that the dictionary
    // gets allocated on the heap and not in the mapped file.
    TMmallocDescTemp setreset;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6106,7 +6106,6 @@ Long_t TClass::Property() const
    TClass *kl = const_cast<TClass*>(this);
 
    kl->fStreamerType = TClass::kDefault;
-   kl->fStreamerImpl = &TClass::StreamerDefault;
 
    if (InheritsFrom(TObject::Class())) {
       kl->SetBit(kIsTObject);
@@ -6116,7 +6115,6 @@ Long_t TClass::Property() const
       if (delta==0) kl->SetBit(kStartWithTObject);
 
       kl->fStreamerType  = kTObject;
-      kl->fStreamerImpl  = &TClass::StreamerTObject;
    }
 
    if (HasInterpreterInfo()) {
@@ -6129,26 +6127,21 @@ Long_t TClass::Property() const
 
          kl->SetBit(kIsForeign);
          kl->fStreamerType  = kForeign;
-         kl->fStreamerImpl  = &TClass::StreamerStreamerInfo;
 
       } else if ( kl->fStreamerType == TClass::kDefault ) {
          if (kl->fConvStreamerFunc) {
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::ConvStreamerInstrumented;
          } else if (kl->fStreamerFunc) {
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::StreamerInstrumented;
          } else {
             // We have an automatic streamer using the StreamerInfo .. no need to go through the
             // Streamer method function itself.
             kl->fStreamerType  = kInstrumented;
-            kl->fStreamerImpl  = &TClass::StreamerStreamerInfo;
          }
       }
 
       if (fStreamer) {
          kl->fStreamerType  = kExternal;
-         kl->fStreamerImpl  = &TClass::StreamerExternal;
       }
 
       if (const_cast<TClass *>(this)->GetClassMethodWithPrototype("Hash", "", kTRUE)) {
@@ -6169,11 +6162,12 @@ Long_t TClass::Property() const
          // and think all test bits have been properly set.
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
+
+      kl->SetStreamerImpl();
    } else {
 
       if (fStreamer) {
          kl->fStreamerType  = kExternal;
-         kl->fStreamerImpl  = &TClass::StreamerExternal;
       }
 
       kl->fStreamerType |= kEmulatedStreamer;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6105,7 +6105,7 @@ Long_t TClass::Property() const
 
    TClass *kl = const_cast<TClass*>(this);
 
-   kl->fStreamerType = TClass::kDefault;
+   Int_t streamerType = TClass::kDefault;
 
    if (InheritsFrom(TObject::Class())) {
       kl->SetBit(kIsTObject);
@@ -6114,7 +6114,7 @@ Long_t TClass::Property() const
       Int_t delta = kl->GetBaseClassOffsetRecurse(TObject::Class());
       if (delta==0) kl->SetBit(kStartWithTObject);
 
-      kl->fStreamerType  = kTObject;
+      streamerType = kTObject;
    }
 
    if (HasInterpreterInfo()) {
@@ -6126,22 +6126,22 @@ Long_t TClass::Property() const
       if (!const_cast<TClass*>(this)->GetClassMethodWithPrototype("Streamer","TBuffer&",kFALSE)) {
 
          kl->SetBit(kIsForeign);
-         kl->fStreamerType  = kForeign;
+         streamerType = kForeign;
 
-      } else if ( kl->fStreamerType == TClass::kDefault ) {
+      } else if (streamerType == TClass::kDefault) {
          if (kl->fConvStreamerFunc) {
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          } else if (kl->fStreamerFunc) {
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          } else {
             // We have an automatic streamer using the StreamerInfo .. no need to go through the
             // Streamer method function itself.
-            kl->fStreamerType  = kInstrumented;
+            streamerType = kInstrumented;
          }
       }
 
       if (fStreamer) {
-         kl->fStreamerType  = kExternal;
+         streamerType = kExternal;
       }
 
       if (const_cast<TClass *>(this)->GetClassMethodWithPrototype("Hash", "", kTRUE)) {
@@ -6163,15 +6163,16 @@ Long_t TClass::Property() const
          kl->fProperty = gCling->ClassInfo_Property(fClassInfo);
       }
 
-      kl->SetStreamerImpl();
+      kl->SetStreamerImpl(streamerType);
    } else {
 
       if (fStreamer) {
-         kl->fStreamerType  = kExternal;
+         streamerType = kExternal;
       }
 
-      kl->fStreamerType |= kEmulatedStreamer;
-      kl->SetStreamerImpl();
+      streamerType |= kEmulatedStreamer;
+
+      kl->SetStreamerImpl(streamerType);
       // fProperty was *not* set so that it can be forced to be recalculated
       // next time.
       return 0;
@@ -6206,8 +6207,9 @@ void TClass::SetRuntimeProperties()
 /// Internal routine to set fStreamerImpl based on the value of
 /// fStreamerType.
 
-void TClass::SetStreamerImpl()
+void TClass::SetStreamerImpl(Int_t StreamerType)
 {
+   fStreamerType = StreamerType;
    switch (fStreamerType) {
       case kTObject:  fStreamerImpl  = &TClass::StreamerTObject; break;
       case kForeign:  fStreamerImpl  = &TClass::StreamerStreamerInfo; break;

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -304,7 +304,6 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
    cl->fCanSplit = fCanSplit;
    cl->fProperty = fProperty;
    cl->fClassProperty = fClassProperty;
-   cl->fStreamerType = fStreamerType;
 
    // Update pointers to TClass
    if (cl->fBase.load()) {
@@ -405,7 +404,7 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
       cl->fRealData = new TList(); // FIXME: this should really become a THashList!
    }
 
-   cl->SetStreamerImpl();
+   cl->SetStreamerImpl(fStreamerType);
 
    // set to zero in order not to delete when protoclass is deleted
    fBase = nullptr;


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/17714.

`TClass` objects that do not have a dictionary and do not have interpreter info (this happens forwarded classes and in some cases STL collection) do not have enough information for a final value of their "Properties" and thus `TClass::Property` is set for them to re-run at each invocations.  In addition the start of the `Property` calculation was to reset `fStreamerImpl` to the default.  Consequently if 1 thread execute `Property` while the other is reading `fStreamerImpl`, the 2nd one will get an incorrect value.

This fixes the problem seen at https://github.com/cms-sw/cmssw/issues/47287#issuecomment-2657729709

This fixes #17753 for v6-32-00-patches.