### PR TITLE
[windows] Fix compilation with OpenSSL on Windows

### DIFF
--- a/net/net/src/TS3HTTPRequest.cxx
+++ b/net/net/src/TS3HTTPRequest.cxx
@@ -160,8 +160,13 @@ TS3HTTPRequest& TS3HTTPRequest::SetTimeStamp()
    time_t now = time(NULL);
    char result[128];
    struct tm dateFormat;
+#ifdef R__WIN32
+   gmtime_s(&dateFormat, &now);
+   strftime(result, sizeof(result), "%a, %d %b %Y %H:%M:%S GMT", &dateFormat);
+#else
    strftime(result, sizeof(result), "%a, %d %b %Y %H:%M:%S GMT",
       gmtime_r(&now, &dateFormat));
+#endif
    fTimeStamp = result;
    return *this;
 }


### PR DESCRIPTION
- Fix use of posix functions in `TS3HTTPRequest.cxx`
- Add SSL debug info in `TSSLSocket.cxx`
- Make `TWebFile` working with OpenSSL on Windows and simplify the code
