### PR TITLE
fix broken ninja builds with cppinterop

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -120,7 +120,7 @@ ROOT_LINKER_LIBRARY(Cling
 add_dependencies(Cling rootcling_stage1)
 
 if(testing)
-  add_dependencies(Cling CppInterOpUnitTests)
+  set_target_properties(CppInterOpUnitTests PROPERTIES EXCLUDE_FROM_ALL OFF)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
No longer force `CppInterOpUnitTests` to build in metacling by adding a dependency to libCling (a bad hack). This target is not built since it is excluded from the build tree. Setting the property to off, triggers the `check-cppinterop` target, so ninja no longer complains about not finding the executables while building dictionaries

