### PR TITLE
[math] remove copy constr and assign operator for `TVirtualFitter`

### DIFF
--- a/hist/hist/inc/TBackCompFitter.h
+++ b/hist/hist/inc/TBackCompFitter.h
@@ -36,9 +36,12 @@ namespace ROOT {
 
 class TBackCompFitter : public TVirtualFitter {
 
+private:
+
+   TBackCompFitter(const TBackCompFitter &) = delete;
+   TBackCompFitter& operator=(const TBackCompFitter &) = delete;
+
 public:
-
-
 
    TBackCompFitter();
 
@@ -46,8 +49,6 @@ public:
    TBackCompFitter( const std::shared_ptr<ROOT::Fit::Fitter> & fitter, const std::shared_ptr<ROOT::Fit::FitData> & data  );
 
    ~TBackCompFitter() override;
-
-public:
 
    enum EStatusBits {
       kCanDeleteLast = BIT(9)  // object can be deleted before creating a new one

--- a/hist/hist/inc/TVirtualFitter.h
+++ b/hist/hist/inc/TVirtualFitter.h
@@ -52,8 +52,8 @@ protected:
 //   static Double_t        fgPrecision; //maximum precision
 //   static TString         fgDefault;   //name of the default fitter ("Minuit","Fumili",etc)
 
-   TVirtualFitter(const TVirtualFitter& tvf);
-   TVirtualFitter& operator=(const TVirtualFitter& tvf);
+   TVirtualFitter(const TVirtualFitter &) = delete;
+   TVirtualFitter& operator=(const TVirtualFitter &) = delete;
 
 public:
    TVirtualFitter();

--- a/hist/hist/src/TVirtualFitter.cxx
+++ b/hist/hist/src/TVirtualFitter.cxx
@@ -88,55 +88,6 @@ TVirtualFitter::TVirtualFitter() :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///copy constructor
-
-TVirtualFitter::TVirtualFitter(const TVirtualFitter& tvf) :
-  TNamed(tvf),
-  fOption(tvf.fOption),
-  fXfirst(tvf.fXfirst),
-  fXlast(tvf.fXlast),
-  fYfirst(tvf.fYfirst),
-  fYlast(tvf.fYlast),
-  fZfirst(tvf.fZfirst),
-  fZlast(tvf.fZlast),
-  fNpoints(tvf.fNpoints),
-  fPointSize(tvf.fPointSize),
-  fCacheSize(tvf.fCacheSize),
-  fCache(tvf.fCache),
-  fObjectFit(tvf.fObjectFit),
-  fUserFunc(tvf.fUserFunc),
-  fMethodCall(tvf.fMethodCall),
-  fFCN(tvf.fFCN)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///assignment operator
-
-TVirtualFitter& TVirtualFitter::operator=(const TVirtualFitter& tvf)
-{
-   if(this!=&tvf) {
-      TNamed::operator=(tvf);
-      fOption=tvf.fOption;
-      fXfirst=tvf.fXfirst;
-      fXlast=tvf.fXlast;
-      fYfirst=tvf.fYfirst;
-      fYlast=tvf.fYlast;
-      fZfirst=tvf.fZfirst;
-      fZlast=tvf.fZlast;
-      fNpoints=tvf.fNpoints;
-      fPointSize=tvf.fPointSize;
-      fCacheSize=tvf.fCacheSize;
-      fCache=tvf.fCache;
-      fObjectFit=tvf.fObjectFit;
-      fUserFunc=tvf.fUserFunc;
-      fMethodCall=tvf.fMethodCall;
-      fFCN=tvf.fFCN;
-   }
-   return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Cleanup virtual fitter.
 
 TVirtualFitter::~TVirtualFitter()

--- a/math/minuit/inc/TFitter.h
+++ b/math/minuit/inc/TFitter.h
@@ -24,8 +24,8 @@ private:
    Double_t  *fSumLog;     //Sum of logs (array of fNlog elements)
    TMinuit   *fMinuit;     //pointer to the TMinuit object
 
-   TFitter(const TFitter&); // Not implemented
-   TFitter& operator=(const TFitter&); // Not implemented
+   TFitter(const TFitter &) = delete;
+   TFitter& operator=(const TFitter &) = delete;
 
 public:
    TFitter(Int_t maxpar = 25);

--- a/math/minuit/inc/TLinearFitter.h
+++ b/math/minuit/inc/TLinearFitter.h
@@ -210,15 +210,16 @@ private:
    Double_t  CStep(Int_t step, Int_t h, Double_t *residuals, Int_t *index, Int_t *subdat, Int_t start, Int_t end);
    Bool_t    Linf();
 
+   TLinearFitter(const TLinearFitter &) = delete;
+   TLinearFitter& operator=(const TLinearFitter &) = delete;
+
 public:
    TLinearFitter();
    TLinearFitter(Int_t ndim, const char *formula, Option_t *opt="D");
    TLinearFitter(Int_t ndim);
    TLinearFitter(TFormula *function, Option_t *opt="D");
-   TLinearFitter(const TLinearFitter& tlf);
    ~TLinearFitter() override;
 
-   TLinearFitter& operator=(const TLinearFitter& tlf);
    virtual void       Add(TLinearFitter *tlf);
    virtual void       AddPoint(Double_t *x, Double_t y, Double_t e=1);
    virtual void       AddTempMatrices();

--- a/math/minuit/src/TLinearFitter.cxx
+++ b/math/minuit/src/TLinearFitter.cxx
@@ -344,61 +344,6 @@ TLinearFitter::TLinearFitter(TFormula *function, Option_t *opt)
    SetFormula(function);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Copy ctor
-
-TLinearFitter::TLinearFitter(const TLinearFitter& tlf) :
-   TVirtualFitter(tlf),
-   fParams(tlf.fParams),
-   fParCovar(tlf.fParCovar),
-   fTValues(tlf.fTValues),
-   fParSign(tlf.fParSign),
-   fDesign(tlf.fDesign),
-   fDesignTemp(tlf.fDesignTemp),
-   fDesignTemp2(tlf.fDesignTemp2),
-   fDesignTemp3(tlf.fDesignTemp3),
-   fAtb(tlf.fAtb),
-   fAtbTemp(tlf.fAtbTemp),
-   fAtbTemp2(tlf.fAtbTemp2),
-   fAtbTemp3(tlf.fAtbTemp3),
-   fFunctions( * (TObjArray *)tlf.fFunctions.Clone()),
-   fY(tlf.fY),
-   fY2(tlf.fY2),
-   fY2Temp(tlf.fY2Temp),
-   fX(tlf.fX),
-   fE(tlf.fE),
-   fInputFunction(tlf.fInputFunction),
-   fVal(),
-   fNpoints(tlf.fNpoints),
-   fNfunctions(tlf.fNfunctions),
-   fFormulaSize(tlf.fFormulaSize),
-   fNdim(tlf.fNdim),
-   fNfixed(tlf.fNfixed),
-   fSpecial(tlf.fSpecial),
-   fFormula(nullptr),
-   fIsSet(tlf.fIsSet),
-   fStoreData(tlf.fStoreData),
-   fChisquare(tlf.fChisquare),
-   fH(tlf.fH),
-   fRobust(tlf.fRobust),
-   fFitsample(tlf.fFitsample),
-   fFixedParams(nullptr)
-{
-   // make a deep  copy of managed objects
-   // fFormula, fFixedParams and fFunctions
-
-   if ( tlf.fFixedParams && fNfixed > 0 ) {
-      fFixedParams=new Bool_t[fNfixed];
-      for(Int_t i=0; i<fNfixed; ++i)
-         fFixedParams[i]=tlf.fFixedParams[i];
-   }
-   if (tlf.fFormula) {
-      fFormula = new char[fFormulaSize+1];
-      strlcpy(fFormula,tlf.fFormula,fFormulaSize+1);
-   }
-
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Linear fitter cleanup.
@@ -418,75 +363,6 @@ TLinearFitter::~TLinearFitter()
    //fFunctions.Delete();
    fFunctions.Clear();
 
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Assignment operator
-
-TLinearFitter& TLinearFitter::operator=(const TLinearFitter& tlf)
-{
-   if(this!=&tlf) {
-
-      TVirtualFitter::operator=(tlf);
-      fParams.ResizeTo(tlf.fParams);      fParams=tlf.fParams;
-      fParCovar.ResizeTo(tlf.fParCovar);  fParCovar=tlf.fParCovar;
-      fTValues.ResizeTo(tlf.fTValues);    fTValues=tlf.fTValues;
-      fParSign.ResizeTo(tlf.fParSign);    fParSign=tlf.fParSign;
-      fDesign.ResizeTo(tlf.fDesign);                fDesign=tlf.fDesign;
-      fDesignTemp.ResizeTo(tlf.fDesignTemp);        fDesignTemp=tlf.fDesignTemp;
-      fDesignTemp2.ResizeTo(tlf.fDesignTemp2);      fDesignTemp2=tlf.fDesignTemp2;
-      fDesignTemp3.ResizeTo(tlf.fDesignTemp3);      fDesignTemp3=tlf.fDesignTemp3;
-
-      fAtb.ResizeTo(tlf.fAtb);            fAtb=tlf.fAtb;
-      fAtbTemp.ResizeTo(tlf.fAtbTemp);    fAtbTemp=tlf.fAtbTemp;
-      fAtbTemp2.ResizeTo(tlf.fAtbTemp2);    fAtbTemp2=tlf.fAtbTemp2;
-      fAtbTemp3.ResizeTo(tlf.fAtbTemp3);    fAtbTemp3=tlf.fAtbTemp3;
-
-      // use clear instead of delete
-      fFunctions.Clear();
-      fFunctions= *(TObjArray*) tlf.fFunctions.Clone();
-
-      fY.ResizeTo(tlf.fY);    fY = tlf.fY;
-      fX.ResizeTo(tlf.fX);    fX = tlf.fX;
-      fE.ResizeTo(tlf.fE);    fE = tlf.fE;
-
-      fY2 = tlf.fY2;
-      fY2Temp = tlf.fY2Temp;
-      for(Int_t i = 0; i < 1000; i++) fVal[i] = tlf.fVal[i];
-
-      if(fInputFunction) { delete fInputFunction; fInputFunction = nullptr; }
-      if(tlf.fInputFunction) fInputFunction = new TFormula(*tlf.fInputFunction);
-
-      fNpoints=tlf.fNpoints;
-      fNfunctions=tlf.fNfunctions;
-      fFormulaSize=tlf.fFormulaSize;
-      fNdim=tlf.fNdim;
-      fNfixed=tlf.fNfixed;
-      fSpecial=tlf.fSpecial;
-
-      if(fFormula) { delete [] fFormula; fFormula = nullptr; }
-      if (tlf.fFormula) {
-         fFormula = new char[fFormulaSize+1];
-         strlcpy(fFormula,tlf.fFormula,fFormulaSize+1);
-      }
-
-      fIsSet=tlf.fIsSet;
-      fStoreData=tlf.fStoreData;
-      fChisquare=tlf.fChisquare;
-
-      fH=tlf.fH;
-      fRobust=tlf.fRobust;
-      fFitsample=tlf.fFitsample;
-
-      if(fFixedParams) { delete [] fFixedParams; fFixedParams = nullptr; }
-      if ( tlf.fFixedParams && fNfixed > 0 ) {
-         fFixedParams=new Bool_t[fNfixed];
-         for(Int_t i=0; i< fNfixed; ++i)
-            fFixedParams[i]=tlf.fFixedParams[i];
-      }
-
-   }
-   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Provided implementation was wrong while
include pointer copy for `fCache` and `fMethodCall`
Plus copy/assign was forbidden for `TFitter` anyway, do it now for all fitter classes
