### PR TITLE
[skip-ci] Add preview to the tutorials

### DIFF
--- a/tutorials/hist/hist001_TH1_fillrandom.C
+++ b/tutorials/hist/hist001_TH1_fillrandom.C
@@ -3,7 +3,6 @@
 /// \notebook
 /// Fill a 1D histogram with random values using predefined functions
 ///
-/// \macro_image
 /// \macro_code
 ///
 /// \date November 2024

--- a/tutorials/hist/hist002_TH1_fillrandom_userfunc.C
+++ b/tutorials/hist/hist002_TH1_fillrandom_userfunc.C
@@ -3,7 +3,6 @@
 /// \notebook
 /// Fill a 1D histogram from a user-defined parametric function.
 ///
-/// \macro_image
 /// \macro_code
 ///
 /// \date November 2024

--- a/tutorials/hist/hist003_TH1_draw.C
+++ b/tutorials/hist/hist003_TH1_draw.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Draw a 1D histogram to a canvas.
+/// \preview Draw a 1D histogram to a canvas.
 ///
 /// \note When using graphics inside a ROOT macro the objects must be created with `new`.
 ///

--- a/tutorials/hist/hist004_TH1_labels.C
+++ b/tutorials/hist/hist004_TH1_labels.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// 1D histograms with alphanumeric labels.
+/// \preview 1D histograms with alphanumeric labels.
 ///
 /// A TH1 can have named bins that are filled with the method overload TH1::Fill(const char*, double)
 ///

--- a/tutorials/hist/hist005_TH1_palettecolor.C
+++ b/tutorials/hist/hist005_TH1_palettecolor.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Palette coloring for TH1
+/// \preview Palette coloring for TH1
 ///
 /// Palette coloring for histogram is activated thanks to the options `PFC`
 /// (Palette Fill Color), `PLC` (Palette Line Color) and `PMC` (Palette Marker Color).

--- a/tutorials/hist/hist006_TH1_bar_charts.C
+++ b/tutorials/hist/hist006_TH1_bar_charts.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Draw 1D histograms as bar charts
+/// \preview Draw 1D histograms as bar charts
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist007_TH1_liveupdate.C
+++ b/tutorials/hist/hist007_TH1_liveupdate.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Histograms filled and drawn in a loop.
+/// \preview Histograms filled and drawn in a loop.
 /// Simple example illustrating how to use the C++ interpreter
 /// to fill histograms in a loop and show the graphics results
 ///

--- a/tutorials/hist/hist008_TH1_zoom.C
+++ b/tutorials/hist/hist008_TH1_zoom.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Changing the Range on the X-Axis of a Histogram
+/// \preview Changing the Range on the X-Axis of a Histogram
 ///
 /// Image produced by `.x ZoomHistogram.C`
 ///

--- a/tutorials/hist/hist009_TH1_normalize.C
+++ b/tutorials/hist/hist009_TH1_normalize.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Normalizing a Histogram
+/// \preview Normalizing a Histogram
 ///
 /// Image produced by `.x NormalizeHistogram.C`
 /// Two different methods of normalizing histograms

--- a/tutorials/hist/hist010_TH1_two_scales.C
+++ b/tutorials/hist/hist010_TH1_two_scales.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of macro illustrating how to superimpose two histograms
+/// \preview Example of macro illustrating how to superimpose two histograms
 /// with different scales in the "same" pad.
 ///
 /// \macro_image

--- a/tutorials/hist/hist011_TH1_legend_autoplaced.C
+++ b/tutorials/hist/hist011_TH1_legend_autoplaced.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// The legend can be placed automatically in the current pad in an empty space
+/// \preview The legend can be placed automatically in the current pad in an empty space
 /// found at painting time.
 ///
 /// The following example illustrate this facility. Only the width and height of the

--- a/tutorials/hist/hist012_TH1_hksimple.C
+++ b/tutorials/hist/hist012_TH1_hksimple.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Illustrates the advantages of a TH1K histogram
+/// \preview  Illustrates the advantages of a TH1K histogram
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist013_TH1_rebin.C
+++ b/tutorials/hist/hist013_TH1_rebin.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Rebin a variable bin-width histogram.
+/// \preview Rebin a variable bin-width histogram.
 ///
 /// This tutorial illustrates how to:
 ///   - create a variable bin-width histogram with a binning such

--- a/tutorials/hist/hist014_TH1_cumulative.C
+++ b/tutorials/hist/hist014_TH1_cumulative.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Illustrate use of the TH1::GetCumulative method.
+/// \preview Illustrate use of the TH1::GetCumulative method.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist015_TH1_read_and_draw.C
+++ b/tutorials/hist/hist015_TH1_read_and_draw.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Read a 1-D histogram from a ROOT File and draw it.
+/// \preview  Read a 1-D histogram from a ROOT File and draw it.
 /// We attach (or generate) the ROOT file in `$ROOTSYS/tutorials/hsimple.root`
 /// or `$PWD/hsimple.root`
 /// We draw one histogram in different formats.

--- a/tutorials/hist/hist016_TH1_different_scales_canvas.C
+++ b/tutorials/hist/hist016_TH1_different_scales_canvas.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of a canvas showing two histograms with different scales.
+/// \preview Example of a canvas showing two histograms with different scales.
 /// The second histogram is drawn in a transparent pad
 ///
 /// \macro_image

--- a/tutorials/hist/hist017_TH1_smooth.C
+++ b/tutorials/hist/hist017_TH1_smooth.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Histogram smoothing.
+/// \preview Histogram smoothing.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist018_TH2_cutg.C
+++ b/tutorials/hist/hist018_TH2_cutg.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// This example demonstrates how to display a 2D histogram and
+/// \preview This example demonstrates how to display a 2D histogram and
 /// use TCutG object to select bins for drawing.
 /// Moving TCutG object one can change displayed region of histogram
 ///

--- a/tutorials/hist/hist019_TH2_projection.C
+++ b/tutorials/hist/hist019_TH2_projection.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// This example demonstrates how to display a histogram and its two projections.
+/// \preview This example demonstrates how to display a histogram and its two projections.
 /// A TExec allows to redraw automatically the projections when a zoom is performed
 /// on the 2D histogram.
 ///

--- a/tutorials/hist/hist020_TH2_draw.C
+++ b/tutorials/hist/hist020_TH2_draw.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Display the various 2-d drawing options
+/// \preview  Display the various 2-d drawing options
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist021_TH2_reverse_axis.C
+++ b/tutorials/hist/hist021_TH2_reverse_axis.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example showing an histogram with reverse axis.
+/// \preview Example showing an histogram with reverse axis.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist022_TH2_palette.C
+++ b/tutorials/hist/hist022_TH2_palette.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// When an histogram is drawn with the option `COLZ`, a palette is automatically drawn
+/// \preview When an histogram is drawn with the option `COLZ`, a palette is automatically drawn
 /// vertically on the right side of the plot. It is possible to move and resize this
 /// vertical palette as shown on the left plot. The right plot demonstrates that, when the
 /// width of the palette is larger than its height, the palette is automatically drawn

--- a/tutorials/hist/hist023_THStack_simple.C
+++ b/tutorials/hist/hist023_THStack_simple.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of stacked histograms: class THStack.
+/// \preview Example of stacked histograms: class THStack.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist024_THStack_pads.C
+++ b/tutorials/hist/hist024_THStack_pads.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Drawing stack histograms on subpads.
+/// \preview Drawing stack histograms on subpads.
 ///
 /// In this example three histograms are displayed on separate pads.
 /// If canvas divided in advance - provided subpads will be used by the THStack.

--- a/tutorials/hist/hist025_THStack_2d_palette_color.C
+++ b/tutorials/hist/hist025_THStack_2d_palette_color.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Palette coloring for 2D histograms' stack is activated thanks to the option `PFC`
+/// \preview Palette coloring for 2D histograms' stack is activated thanks to the option `PFC`
 /// (Palette Fill Color).
 /// When this option is given to `THStack::Draw` the histograms  in the
 /// `THStack` get their color from the current color palette defined by

--- a/tutorials/hist/hist026_THStack_color_scheme.C
+++ b/tutorials/hist/hist026_THStack_color_scheme.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// This example demonstrates how to use the accessible color schemes with THStack.
+/// \preview This example demonstrates how to use the accessible color schemes with THStack.
 /// In this example, the color scheme with six colors is used.
 /// It also shows that the grayscale version is an acceptable alternative.
 ///

--- a/tutorials/hist/hist027_THStack_palette_color.C
+++ b/tutorials/hist/hist027_THStack_palette_color.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Palette coloring for histograms' stack is activated thanks to the options `PFC`
+/// \preview Palette coloring for histograms' stack is activated thanks to the options `PFC`
 /// (Palette Fill Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color).
 /// When one of these options is given to `THStack::Draw` the histograms  in the
 /// `THStack` get their color from the current color palette defined by

--- a/tutorials/hist/hist028_THStack_multicolor.C
+++ b/tutorials/hist/hist028_THStack_multicolor.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Use a THStack to show a 2-D hist with cells with different colors.
+/// \preview Use a THStack to show a 2-D hist with cells with different colors.
 /// ~~~{.cpp}
 ///  root > .x multicolor.C
 ///  root > .x multicolor.C(1)

--- a/tutorials/hist/hist029_TRatioPlot_simple.C
+++ b/tutorials/hist/hist029_TRatioPlot_simple.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example creating a simple ratio plot of two histograms using the `pois` division option.
+/// \preview Example creating a simple ratio plot of two histograms using the `pois` division option.
 /// Two histograms are set up and filled with random numbers. The constructor of `TRatioPlot`
 /// takes the two histograms, name and title for the object, drawing options for the histograms
 /// (`hist` and `E` in this case) and a drawing option for the output graph.

--- a/tutorials/hist/hist030_TRatioPlot_residual.C
+++ b/tutorials/hist/hist030_TRatioPlot_residual.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of a fit residual plot.
+/// \preview Example of a fit residual plot.
 ///
 /// Creates a histogram filled with random numbers from a gaussian distribution
 /// and fits it with a standard gaussian function. The result is passed to the `TRatioPlot`

--- a/tutorials/hist/hist031_TRatioPlot_residual_fit.C
+++ b/tutorials/hist/hist031_TRatioPlot_residual_fit.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example which shows how you can get the graph of the lower plot and set the y axis range for it.
+/// \preview Example which shows how you can get the graph of the lower plot and set the y axis range for it.
 ///
 /// Since the lower plot is not created until `TRatioPlot::Draw` is called, you can only use the method
 /// afterwards.

--- a/tutorials/hist/hist032_TRatioPlot_fit_lines.C
+++ b/tutorials/hist/hist032_TRatioPlot_fit_lines.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example that shows custom dashed lines on the lower plot, specified by a vector of floats.
+/// \preview Example that shows custom dashed lines on the lower plot, specified by a vector of floats.
 ///
 /// By default, dashed lines are drawn at certain points. You can either disable them, or specify
 /// where you want them to appear.

--- a/tutorials/hist/hist033_TRatioPlot_fit_confidence.C
+++ b/tutorials/hist/hist033_TRatioPlot_fit_confidence.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example that shows how you can set the colors of the confidence interval bands by using
+/// \preview Example that shows how you can set the colors of the confidence interval bands by using
 /// the method `TRatioPlot::SetConfidenceIntervalColors`.
 ///
 /// \macro_image

--- a/tutorials/hist/hist034_TRatioPlot_fit_margin.C
+++ b/tutorials/hist/hist034_TRatioPlot_fit_margin.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example showing a fit residual plot, where the separation margin has been set to 0.
+/// \preview Example showing a fit residual plot, where the separation margin has been set to 0.
 /// The last label of the lower plot's y axis is hidden automatically.
 ///
 /// \macro_image

--- a/tutorials/hist/hist036_TH2_labels.C
+++ b/tutorials/hist/hist036_TH2_labels.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// 2-D histograms with alphanumeric labels.
+/// \preview 2-D histograms with alphanumeric labels.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist038_TH2Poly_honeycomb.C
+++ b/tutorials/hist/hist038_TH2Poly_honeycomb.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// This tutorial illustrates how to create an histogram with hexagonal
+/// \preview This tutorial illustrates how to create an histogram with hexagonal
 /// bins (TH2Poly). The method TH2Poly::Honeycomb allows to build automatically
 /// an honeycomb binning.
 ///

--- a/tutorials/hist/hist039_TH2Poly_usa.C
+++ b/tutorials/hist/hist039_TH2Poly_usa.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// This tutorial illustrates how to create an histogram with polygonal
+/// \preview This tutorial illustrates how to create an histogram with polygonal
 /// bins (TH2Poly), fill it and draw it using the `col` option. The initial data
 /// are stored in TMultiGraphs. They represent the USA map. Such histograms can
 /// be rendered in 3D using the option `legogl`.

--- a/tutorials/hist/hist041_TProfile2Poly_realistic.C
+++ b/tutorials/hist/hist041_TProfile2Poly_realistic.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Different charges depending on region
+/// \preview Different charges depending on region
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist042_TProfile2Poly_module_error.C
+++ b/tutorials/hist/hist042_TProfile2Poly_module_error.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Simulate faulty detector panel w.r.t. particle charge
+/// \preview Simulate faulty detector panel w.r.t. particle charge
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist047_Graphics_candle_decay.C
+++ b/tutorials/hist/hist047_Graphics_candle_decay.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Candle Decay, illustrate a time development of a certain value.
+/// \preview Candle Decay, illustrate a time development of a certain value.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/hist/hist048_Graphics_candle_hist.C
+++ b/tutorials/hist/hist048_Graphics_candle_hist.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example showing how to combine the various candle plot options.
+/// \preview Example showing how to combine the various candle plot options.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/hist/hist049_Graphics_candle_plot.C
+++ b/tutorials/hist/hist049_Graphics_candle_plot.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of candle plot with 2-D histograms.
+/// \preview Example of candle plot with 2-D histograms.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/hist/hist050_Graphics_candle_plot_options.C
+++ b/tutorials/hist/hist050_Graphics_candle_plot_options.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example showing how to combine the various candle plot options.
+/// \preview Example showing how to combine the various candle plot options.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/hist/hist051_Graphics_candle_plot_stack.C
+++ b/tutorials/hist/hist051_Graphics_candle_plot_stack.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example showing how a THStack with candle plot option.
+/// \preview Example showing how a THStack with candle plot option.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code

--- a/tutorials/hist/hist052_Graphics_candle_plot_whiskers.C
+++ b/tutorials/hist/hist052_Graphics_candle_plot_whiskers.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Example of candle plot showing the whiskers definition.
+/// \preview Example of candle plot showing the whiskers definition.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_output

--- a/tutorials/hist/hist053_Graphics_candle_scaled.C
+++ b/tutorials/hist/hist053_Graphics_candle_scaled.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Candle Scaled, illustrates what scaling does on candle and violin charts.
+/// \preview Candle Scaled, illustrates what scaling does on candle and violin charts.
 /// Please try to modify the static functions SetScaledCandle and SetScaledViolin
 ///
 /// \macro_image (tcanvas_js)

--- a/tutorials/hist/hist060_TH1_stats.C
+++ b/tutorials/hist/hist060_TH1_stats.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Edit statistics box.
+/// \preview Edit statistics box.
 ///
 /// This example shows:
 ///  - how to remove a stat element from the stat box

--- a/tutorials/hist/hist061_TH1_timeonaxis.C
+++ b/tutorials/hist/hist061_TH1_timeonaxis.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// This macro illustrates the use of the time mode on the axis
+/// \preview This macro illustrates the use of the time mode on the axis
 /// with different time intervals and time formats.
 /// Through all this script, the time is expressed in UTC. some
 /// information about this format (and others like GPS) may be found at

--- a/tutorials/hist/hist062_TH1_timeonaxis2.C
+++ b/tutorials/hist/hist062_TH1_timeonaxis2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Define the time offset as 2003, January 1st.
+/// \preview Define the time offset as 2003, January 1st.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist063_TH1_seism.C
+++ b/tutorials/hist/hist063_TH1_seism.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Strip chart example.
+/// \preview Strip chart example.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist101_TH1_autobinning.C
+++ b/tutorials/hist/hist101_TH1_autobinning.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_hist
-/// Fill multiple histograms with different functions and automatic binning.
+/// \preview Fill multiple histograms with different functions and automatic binning.
 /// Illustrates merging with the power-of-two autobin algorithm
 ///
 /// \macro_output

--- a/tutorials/hist/hist102_TH2_contour_list.C
+++ b/tutorials/hist/hist102_TH2_contour_list.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Getting Contours From TH2D.
+/// \preview Getting Contours From TH2D.
 ///
 /// #### Image produced by `.x ContourList.C`
 /// The contours values are drawn next to each contour.

--- a/tutorials/hist/hist104_TH2Poly_fibonacci.C
+++ b/tutorials/hist/hist104_TH2Poly_fibonacci.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// A TH2Poly build with Fibonacci numbers.
+/// \preview A TH2Poly build with Fibonacci numbers.
 ///
 /// In mathematics, the Fibonacci sequence is a suite of integer in which
 /// every number is the sum of the two preceding one.

--- a/tutorials/hist/hist105_TExec_dynamic_slice.C
+++ b/tutorials/hist/hist105_TExec_dynamic_slice.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// Show the slice of a TH2 following the mouse position.
+/// \preview Show the slice of a TH2 following the mouse position.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/analyze.C
+++ b/tutorials/visualisation/graphics/analyze.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// This macro produces the flowchart of TFormula::Analyze.
+///  \preview This macro produces the flowchart of TFormula::Analyze.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/annotation3d.C
+++ b/tutorials/visualisation/graphics/annotation3d.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This example show how to put some annotation on a 3D plot using 3D
+/// \preview This example show how to put some annotation on a 3D plot using 3D
 /// polylines. It also demonstrates how the axis labels can be modified.
 /// It was created for the book:
 /// [Statistical Methods for Data Analysis in Particle Physics](http://www.springer.com/la/book/9783319201757)

--- a/tutorials/visualisation/graphics/basic3d.C
+++ b/tutorials/visualisation/graphics/basic3d.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Show 3-D polylines and markers.
+/// \preview Show 3-D polylines and markers.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/compile.C
+++ b/tutorials/visualisation/graphics/compile.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// This macro produces the flowchart of TFormula::Compile
+/// \preview This macro produces the flowchart of TFormula::Compile
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/crown.C
+++ b/tutorials/visualisation/graphics/crown.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw crowns.
+/// \preview Draw crowns.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/diamond.C
+++ b/tutorials/visualisation/graphics/diamond.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw a diamond.
+/// \preview Draw a diamond.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/earth.C
+++ b/tutorials/visualisation/graphics/earth.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This tutorial illustrates the special contour options.
+/// \preview This tutorial illustrates the special contour options.
 ///
 ///   - "AITOFF"     : Draw a contour via an AITOFF projection
 ///   - "MERCATOR"   : Draw a contour via an Mercator projection

--- a/tutorials/visualisation/graphics/eval.C
+++ b/tutorials/visualisation/graphics/eval.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// This macro produces the flowchart of TFormula::Eval.
+/// \preview This macro produces the flowchart of TFormula::Eval.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/event.C
+++ b/tutorials/visualisation/graphics/event.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Illustrate some basic primitives.
+/// \preview Illustrate some basic primitives.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/feynman.C
+++ b/tutorials/visualisation/graphics/feynman.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw Feynman diagrams.
+/// \preview Draw Feynman diagrams.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/first.C
+++ b/tutorials/visualisation/graphics/first.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Show some basic primitives.
+/// \preview Show some basic primitives.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/formula1.C
+++ b/tutorials/visualisation/graphics/formula1.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// Display interpreted functions.
+/// \preview Display interpreted functions.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/framework.C
+++ b/tutorials/visualisation/graphics/framework.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// An example with basic graphics illustrating the Object Oriented User Interface of ROOT.
+/// \preview An example with basic graphics illustrating the Object Oriented User Interface of ROOT.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/gaxis.C
+++ b/tutorials/visualisation/graphics/gaxis.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Simple example illustrating how to draw TGaxis objects in various formats.
+/// \preview Simple example illustrating how to draw TGaxis objects in various formats.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/gaxis2.C
+++ b/tutorials/visualisation/graphics/gaxis2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example illustrating how to draw TGaxis with labels defined by a function.
+/// \preview Example illustrating how to draw TGaxis with labels defined by a function.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/gaxis3.C
+++ b/tutorials/visualisation/graphics/gaxis3.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example illustrating how to modify individual labels of a TGaxis. The method
+/// \preview Example illustrating how to modify individual labels of a TGaxis. The method
 /// `ChangeLabel` allows to do that.
 ///
 /// The first parameter of this method is the label number to be modified. If

--- a/tutorials/visualisation/graphics/greyscale.C
+++ b/tutorials/visualisation/graphics/greyscale.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Create grey scale of `200 x 200` boxes.
+/// \preview Create grey scale of 200x200 boxes.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/latex.C
+++ b/tutorials/visualisation/graphics/latex.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro draws 5 Latex-style formula in a canvas and prints the canvas as a Postscript file.
+/// \preview This macro draws 5 Latex-style formula in a canvas and prints the canvas as a Postscript file.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/latex2.C
+++ b/tutorials/visualisation/graphics/latex2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro draws 4 Latex-style formula in a canvas and prints the canvas as a Postscript file.
+/// \preview This macro draws 4 Latex-style formula in a canvas and prints the canvas as a Postscript file.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/latex3.C
+++ b/tutorials/visualisation/graphics/latex3.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example illustrating a TPaveText with Latex inside.
+/// \preview Example illustrating a TPaveText with Latex inside.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/latex4.C
+++ b/tutorials/visualisation/graphics/latex4.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw the Greek letters as a table and save the result as GIF, PS, PDF
+/// \preview Draw the Greek letters as a table and save the result as GIF, PS, PDF
 /// and SVG files.
 /// Lowercase Greek letters are obtained by adding a # to the name of the letter.
 /// For an uppercase Greek letter, just capitalize the first letter of the

--- a/tutorials/visualisation/graphics/latex5.C
+++ b/tutorials/visualisation/graphics/latex5.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This draws the Mathematical Symbols letters as a table and save the result
+/// \preview This draws the Mathematical Symbols letters as a table and save the result
 /// as GIF, PS, PDF and SVG files.
 ///
 /// ### png output:

--- a/tutorials/visualisation/graphics/logscales.C
+++ b/tutorials/visualisation/graphics/logscales.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw parametric functions with log scales.
+/// \preview Draw parametric functions with log scales.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/markerwarning.C
+++ b/tutorials/visualisation/graphics/markerwarning.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This script illustrates the danger of using asymmetric symbols.
+/// \preview This script illustrates the danger of using asymmetric symbols.
 ///
 /// \macro_image
 ///

--- a/tutorials/visualisation/graphics/mass_spectrum.C
+++ b/tutorials/visualisation/graphics/mass_spectrum.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro makes use of some basic graphics primitives such as line, arrow
+/// \preview This macro makes use of some basic graphics primitives such as line, arrow
 /// and text. It has been written using the TCanvas ToolBar to produce a first
 /// draft and was then modified for fine adjustments. Note also the use
 /// of C functions. They allow to simplify the macro reading and editing by

--- a/tutorials/visualisation/graphics/multipalette.C
+++ b/tutorials/visualisation/graphics/multipalette.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw color plots using different color palettes.
+/// \preview Draw color plots using different color palettes.
 ///
 /// As only one palette is active, one need to use `TExec` to be able to
 /// display plots using different palettes on the same pad.

--- a/tutorials/visualisation/graphics/palettes.C
+++ b/tutorials/visualisation/graphics/palettes.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro draws all the high definition palettes available in ROOT.
+/// \preview This macro draws all the high definition palettes available in ROOT.
 /// It generates a png file for each palette and one pdf file, with a table of
 /// content, containing all the palettes.
 ///

--- a/tutorials/visualisation/graphics/pavetext.C
+++ b/tutorials/visualisation/graphics/pavetext.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw a pave text.
+/// \preview Draw a pave text.
 /// The text lines are added in order using the AddText method
 /// Line separator can be added using AddLine.
 ///

--- a/tutorials/visualisation/graphics/perceptualcolormap.C
+++ b/tutorials/visualisation/graphics/perceptualcolormap.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// A “Perceptual” colormap explicitly identifies a fixed value in the data
+/// \preview A “Perceptual” colormap explicitly identifies a fixed value in the data
 ///
 /// On geographical plot this fixed point can, for instance, the "sea level". A perceptual
 /// colormap provides a monotonic luminance variations above and below this fixed value.

--- a/tutorials/visualisation/graphics/piechart.C
+++ b/tutorials/visualisation/graphics/piechart.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Pie chart example.
+/// \preview Pie chart example.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/pstable.C
+++ b/tutorials/visualisation/graphics/pstable.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Display all possible types of ROOT/Postscript characters.
+/// \preview Display all possible types of ROOT/Postscript characters.
 ///
 /// \macro_code
 ///

--- a/tutorials/visualisation/graphics/quarks.C
+++ b/tutorials/visualisation/graphics/quarks.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example illustrating divided pads and Latex.
+/// \preview Example illustrating divided pads and Latex.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/splines_test.C
+++ b/tutorials/visualisation/graphics/splines_test.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Examples of use of the spline classes.
+/// \preview Examples of use of the spline classes.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/surfaces.C
+++ b/tutorials/visualisation/graphics/surfaces.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Draw 2-Dim functions.
+/// \preview Draw 2-Dim functions.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/timeonaxis3.C
+++ b/tutorials/visualisation/graphics/timeonaxis3.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This example compares what the system time function gmtime and localtime give
+/// \preview This example compares what the system time function gmtime and localtime give
 /// with what gives TGaxis. It can be used as referenced test to check if TGaxis
 /// is working properly.
 /// The original code was developed by Philippe Gras (CEA Saclay. IRFU/SEDI)

--- a/tutorials/visualisation/graphics/tmathtext.C
+++ b/tutorials/visualisation/graphics/tmathtext.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_graphics
-/// This macro draws various formula in a canvas.
+/// \preview This macro draws various formula in a canvas.
 /// It also prints the canvas as a Postscript file using TMathText.
 ///
 /// \macro_image

--- a/tutorials/visualisation/graphics/tmathtext2.C
+++ b/tutorials/visualisation/graphics/tmathtext2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro draw all possible symbols provided by TMathtext.
+/// \preview This macro draw all possible symbols provided by TMathtext.
 /// \macro_image
 /// \author Olivier Couet
 

--- a/tutorials/visualisation/graphics/tornado.C
+++ b/tutorials/visualisation/graphics/tornado.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Show 3-d polymarker.
+/// \preview Show 3-d polymarker.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/transparency.C
+++ b/tutorials/visualisation/graphics/transparency.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// This macro demonstrates the use of color transparency.
+/// \preview This macro demonstrates the use of color transparency.
 ///
 /// It is done by specifying the alpha value of a given color.
 /// For instance

--- a/tutorials/visualisation/graphics/triangles.C
+++ b/tutorials/visualisation/graphics/triangles.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Create small triangles at random positions on the canvas.
+///  \preview Create small triangles at random positions on the canvas.
 /// Assign a unique ID to each triangle, and give each one a random color from the color palette.
 ///
 /// ~~~{.cpp}

--- a/tutorials/visualisation/graphics/xyplot.C
+++ b/tutorials/visualisation/graphics/xyplot.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// Example showing how to produce a plot with an orthogonal axis system
+/// \preview Example showing how to produce a plot with an orthogonal axis system
 /// centered at (0,0).
 ///
 /// \macro_image

--- a/tutorials/visualisation/graphs/gr001_simple.C
+++ b/tutorials/visualisation/graphs/gr001_simple.C
@@ -1,8 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-///
-/// This tutorial demonstrates how to create simple graphs in ROOT. The example is divided into two sections:
+/// \preview This tutorial demonstrates how to create simple graphs in ROOT. The example is divided into two sections:
 /// - The first section plots data generated from arrays.
 /// - The second section plots data read from a text file.
 ///

--- a/tutorials/visualisation/graphs/gr002_errors.C
+++ b/tutorials/visualisation/graphs/gr002_errors.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// Create and draw a graph with error bars. If more graphs are needed, see the
+/// \preview Create and draw a graph with error bars. If more graphs are needed, see the
 /// [gr03_err2gr.C](https://root.cern/doc/master/gerrors2_8C.html) tutorial
 ///
 /// See the [TGraphErrors documentation](https://root.cern/doc/master/classTGraphErrors.html)

--- a/tutorials/visualisation/graphs/gr003_errors2.C
+++ b/tutorials/visualisation/graphs/gr003_errors2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// Create and draw two graphs with error bars, superposed on the same canvas
+/// \preview Create and draw two graphs with error bars, superposed on the same canvas
 ///
 /// We first draw an empty frame with the axes, then draw the graphs on top of it
 /// Note that the graphs should have the same or very close ranges (in both axis),

--- a/tutorials/visualisation/graphs/gr004_errors_asym.C
+++ b/tutorials/visualisation/graphs/gr004_errors_asym.C
@@ -1,8 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-///
-/// This tutorial demonstrates the use of TGraphAsymmErrors to plot a graph with asymmetrical errors on both the x and y axes.
+/// \preview This tutorial demonstrates the use of TGraphAsymmErrors to plot a graph with asymmetrical errors on both the x and y axes.
 /// The errors for the x values are divided into low (left side of the marker) and high (right side of the marker) errors.
 /// Similarly, for the y values, there are low (lower side of the marker) and high (upper side of the marker) errors.
 ///

--- a/tutorials/visualisation/graphs/gr005_apply.C
+++ b/tutorials/visualisation/graphs/gr005_apply.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// A macro to demonstrate the functionality of TGraph::Apply() method.
+/// \preview A macro to demonstrate the functionality of TGraph::Apply() method.
 /// TGraph::Apply applies a function `f` to all the data TGraph points, `f` may be a 1-D function TF1 or 2-d function TF2.
 /// The Y values of the graph are replaced by the new values computed using the function.
 ///

--- a/tutorials/visualisation/graphs/gr006_scatter.C
+++ b/tutorials/visualisation/graphs/gr006_scatter.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Draw a scatter plot for 4 variables, mapped to: x, y, marker colour and marker size.
+/// \preview Draw a scatter plot for 4 variables, mapped to: x, y, marker colour and marker size.
 ///
 /// TScatter is available since ROOT v.6.30. See the [TScatter documentation](https://root.cern/doc/master/classTScatter.html)
 ///

--- a/tutorials/visualisation/graphs/gr007_multigraph.C
+++ b/tutorials/visualisation/graphs/gr007_multigraph.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// TMultiGraph is used to combine multiple graphs into one plot. 
+/// \preview TMultiGraph is used to combine multiple graphs into one plot. 
 /// Allowing to overlay different graphs can be useful for comparing different datasets
 /// or for plotting multiple related graphs on the same canvas.
 ///

--- a/tutorials/visualisation/graphs/gr008_multierrors.C
+++ b/tutorials/visualisation/graphs/gr008_multierrors.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// Draw a graph with multiple errors. Multi errors can be usefull for distinguishing different type of errors,
+/// \preview Draw a graph with multiple errors. Multi errors can be usefull for distinguishing different type of errors,
 /// for example statistical and systematic errors.
 ///
 /// \macro_image

--- a/tutorials/visualisation/graphs/gr009_bent_err.C
+++ b/tutorials/visualisation/graphs/gr009_bent_err.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// Graph with bent error bars. See the [TGraphBentErrors documentation](https://root.cern/doc/master/classTGraphBentErrors.html)
+/// \preview Graph with bent error bars. See the [TGraphBentErrors documentation](https://root.cern/doc/master/classTGraphBentErrors.html)
 ///
 /// exl / exh: low and high (left/right) errors in x; similar for y
 /// e*d: delta, in axis units, to be added/subtracted (if >0 or <0) in x or y from

--- a/tutorials/visualisation/graphs/gr010_approx_smooth.C
+++ b/tutorials/visualisation/graphs/gr010_approx_smooth.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// Create a TGraphSmooth and show the usage of the interpolation function Approx
+/// \preview Create a TGraphSmooth and show the usage of the interpolation function Approx
 ///
 /// See the [TGraphSmooth documentation](https://root.cern/doc/master/classTGraphSmooth.html)
 ///

--- a/tutorials/visualisation/graphs/gr011_graph2d_errorsfit.C
+++ b/tutorials/visualisation/graphs/gr011_graph2d_errorsfit.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Create, draw and fit a TGraph2DErrors. See the [TGraph2DErrors documentation](https://root.cern/doc/master/classTGraph2DErrors.html)
+/// \preview Create, draw and fit a TGraph2DErrors. See the [TGraph2DErrors documentation](https://root.cern/doc/master/classTGraph2DErrors.html)
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr012_polar.C
+++ b/tutorials/visualisation/graphs/gr012_polar.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Create and draw a polar graph. See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
+/// \preview Create and draw a polar graph. See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
 ///
 /// Since TGraphPolar is a TGraphErrors, it is painted with
 /// [TGraphPainter](https://root.cern/doc/master/classTGraphPainter.html) options.

--- a/tutorials/visualisation/graphs/gr013_polar2.C
+++ b/tutorials/visualisation/graphs/gr013_polar2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Create and draw a polar graph with errors and polar axis in radians (PI fractions).
+/// \preview Create and draw a polar graph with errors and polar axis in radians (PI fractions).
 /// See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
 ///
 /// Since TGraphPolar is a TGraphErrors, it is painted with

--- a/tutorials/visualisation/graphs/gr014_polar3.C
+++ b/tutorials/visualisation/graphs/gr014_polar3.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Create a polar graph using a TF1 and draw it with PI axis.
+/// \preview Create a polar graph using a TF1 and draw it with PI axis.
 /// See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
 ///
 /// Since TGraphPolar is a TGraphErrors, it is painted with

--- a/tutorials/visualisation/graphs/gr015_smooth.C
+++ b/tutorials/visualisation/graphs/gr015_smooth.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Show scatter plot smoothers: ksmooth, lowess, supsmu,
+/// \preview Show scatter plot smoothers: ksmooth, lowess, supsmu,
 /// as described in:
 ///
 ///      Modern Applied Statistics with S-Plus, 3rd Edition

--- a/tutorials/visualisation/graphs/gr017_time.C
+++ b/tutorials/visualisation/graphs/gr017_time.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Example of TGraphTime. See the [TGraphTime documentation](https://root.cern/doc/master/classTGraphTime.html)
+/// \preview Example of TGraphTime. See the [TGraphTime documentation](https://root.cern/doc/master/classTGraphTime.html)
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr018_time2.C
+++ b/tutorials/visualisation/graphs/gr018_time2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Example of TGraphTime showing how the class could be used to visualize
+/// \preview Example of TGraphTime showing how the class could be used to visualize
 /// a set of particles with their time stamp in a MonteCarlo program.
 ///
 /// See the [TGraphTime documentation](https://root.cern/doc/master/classTGraphTime.html)

--- a/tutorials/visualisation/graphs/gr101_shade_area.C
+++ b/tutorials/visualisation/graphs/gr101_shade_area.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Show how to shade an area between two graphs.
+/// \preview Show how to shade an area between two graphs.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr102_reverse_graph.C
+++ b/tutorials/visualisation/graphs/gr102_reverse_graph.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// This example tests the reverse graphs obtained with Draw("a  pl rx ry ") on a TGraph, where rx and ry refere to the reversing of x and y axis.
+/// \preview This example tests the reverse graphs obtained with Draw("a  pl rx ry ") on a TGraph, where rx and ry refere to the reversing of x and y axis.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr103_zones.C
+++ b/tutorials/visualisation/graphs/gr103_zones.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Example of script showing how to divide a canvas
+/// \preview Example of script showing how to divide a canvas
 /// into adjacent subpads + axis labels on the top and right side
 /// of the pads.
 ///

--- a/tutorials/visualisation/graphs/gr104_palettecolor.C
+++ b/tutorials/visualisation/graphs/gr104_palettecolor.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Palette coloring for graphs is activated thanks to the options `PFC` (Palette Fill
+/// \preview Palette coloring for graphs is activated thanks to the options PFC (Palette Fill
 /// Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color). When
 /// one of these options is given to `TGraph::Draw` the `TGraph` get its color
 /// from the current color palette defined by `gStyle->SetPalette(...)`. The color

--- a/tutorials/visualisation/graphs/gr105_multigraphpalettecolor.C
+++ b/tutorials/visualisation/graphs/gr105_multigraphpalettecolor.C
@@ -1,15 +1,15 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Palette coloring for multi-graphs is activated thanks to the options `PFC`
-/// (Palette Fill Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color).
-/// When one of these options is given to `TMultiGraph::Draw` the `TGraph`s  in the
-/// `TMultiGraph` get their color from the current color palette defined by
-/// `gStyle->SetPalette(...)`. The color is determined according to the number of
-/// `TGraph`s.
+/// \preview Palette coloring for multi-graphs is activated thanks to the options PFC
+/// (Palette Fill Color), PLC (Palette Line Color) and AMC (Palette Marker Color).
+/// When one of these options is given to TMultiGraph::Draw the TGraphs  in the
+/// TMultiGraph get their color from the current color palette defined by
+/// gStyle->SetPalette(...). The color is determined according to the number of
+/// TGraphs.
 ///
 /// In this example four graphs are displayed with palette coloring for lines and
-/// and markers. The color of each graph is picked inside the default palette `kBird`.
+/// and markers. The color of each graph is picked inside the default palette kBird.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr106_exclusiongraph.C
+++ b/tutorials/visualisation/graphs/gr106_exclusiongraph.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Draw three graphs with an exclusion zone.
+/// \preview Draw three graphs with an exclusion zone.
 ///
 /// The shaded areas are obtained with a fill for the graph and controlled with `SetLineWidth`.
 /// `SetLineWidth` for exclusion graphs is explained in the [TGraphPainter documentation](https://root.cern/doc/master/classTGraphPainter.html#GrP2)

--- a/tutorials/visualisation/graphs/gr107_exclusiongraph2.C
+++ b/tutorials/visualisation/graphs/gr107_exclusiongraph2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Draw several graphs with exclusion zones.
+/// \preview Draw several graphs with exclusion zones.
 /// The shaded areas are obtained with a fill for the graph and controlled with `SetLineWidth`.
 /// `SetLineWidth` for exclusion graphs is explained in the [TGraphPainter documentation](https://root.cern/doc/master/classTGraphPainter.html#GrP2)
 ///

--- a/tutorials/visualisation/graphs/gr108_timeSeriesFromCSV.C
+++ b/tutorials/visualisation/graphs/gr108_timeSeriesFromCSV.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// This macro illustrates the use of the time axis on a TGraph
+/// \preview This macro illustrates the use of the time axis on a TGraph
 /// with data read from a text file containing the SWAN usage
 /// statistics during July 2017.
 ///

--- a/tutorials/visualisation/graphs/gr109_timeSeriesFromCSV_RDF.C
+++ b/tutorials/visualisation/graphs/gr109_timeSeriesFromCSV_RDF.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// This macro illustrates the use of the time axis on a TGraph
+/// \preview This macro illustrates the use of the time axis on a TGraph
 /// with data read from a text file containing the SWAN usage
 /// statistics during July 2017.
 /// We exploit the TDataFrame for reading from the file. See the [RDataFrame documentation](https://root.cern/doc/master/classROOT_1_1RDataFrame.html) and [RDataFrame tutorials](https://root.cern/doc/master/group__tutorial__dataframe.html)

--- a/tutorials/visualisation/graphs/gr110_logscale.C
+++ b/tutorials/visualisation/graphs/gr110_logscale.C
@@ -1,8 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-///  
-/// This tutorial demonstrates how to set a logarithmic scale for the axes of a graph using the `SetLogScale()` method.
+/// \preview This tutorial demonstrates how to set a logarithmic scale for the axes of a graph using the `SetLogScale()` method.
 /// The logarithmic scale can be applied to either the x-axis, the y-axis, or both axes at the same time.
 /// When using a logarithmic scale, the data must be positive since the logarithm is undefined for non-positive values and zero.
 ///

--- a/tutorials/visualisation/graphs/gr111_legend.C
+++ b/tutorials/visualisation/graphs/gr111_legend.C
@@ -1,9 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
-/// \notebook
-///  
-/// Simple graph with legend. For more details on TLegend [see documentation](https://root.cern/doc/master/classTLegend.html)
-///
+/// \notebook  
+/// \preview Simple graph with legend. For more details on TLegend [see documentation](https://root.cern/doc/master/classTLegend.html)
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr112_reverse_graph_and_errors.C
+++ b/tutorials/visualisation/graphs/gr112_reverse_graph_and_errors.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// This example tests all the various cases of reverse graphs obtained with Draw("a  pl rx ry "), where rx and ry refer to the reversing of x and y axis.
+/// \preview This example tests all the various cases of reverse graphs obtained with Draw("a  pl rx ry "), where rx and ry refer to the reversing of x and y axis.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphs/gr201_waves.C
+++ b/tutorials/visualisation/graphs/gr201_waves.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Draw spherical waves interference. Two closed TGraphs filled with white are used
+/// \preview Draw spherical waves interference. Two closed TGraphs filled with white are used
 /// here to draw triangles on top of a 2D function in order to hide parts of it.
 ///
 /// \macro_image

--- a/tutorials/visualisation/graphs/gr202_textmarkers.C
+++ b/tutorials/visualisation/graphs/gr202_textmarkers.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// Draw a graph with text attached to each point.
+/// \preview Draw a graph with text attached to each point.
 /// The text is drawn in a TExec function attached to the TGraph,
 /// therefore if the a graph's point is
 /// moved interactively, the text will be automatically updated.

--- a/tutorials/visualisation/graphs/gr301_highlight1.C
+++ b/tutorials/visualisation/graphs/gr301_highlight1.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 ///
-/// This tutorial demonstrates how to use the highlight mode on graph, thanks to the TCanvas [HighlightConnect](https://root.cern/doc/master/classTCanvas.html#a462b8dc286a2d29152fefa9b31f89920) method.
+/// \preview This tutorial demonstrates how to use the highlight mode on graph, thanks to the TCanvas [HighlightConnect](https://root.cern/doc/master/classTCanvas.html#a462b8dc286a2d29152fefa9b31f89920) method.
 ///
 /// \macro_code
 /// \date March 2018

--- a/tutorials/visualisation/graphs/gr302_highlight2.C
+++ b/tutorials/visualisation/graphs/gr302_highlight2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 ///
-/// This tutorial demonstrates how to use the highlight mode on graph, thanks to the TCanvas [HighlightConnect](https://root.cern/doc/master/classTCanvas.html#a462b8dc286a2d29152fefa9b31f89920) method.
+/// \preview This tutorial demonstrates how to use the highlight mode on graph, thanks to the TCanvas [HighlightConnect](https://root.cern/doc/master/classTCanvas.html#a462b8dc286a2d29152fefa9b31f89920) method.
 ///
 /// \macro_code
 /// \date March 2018

--- a/tutorials/visualisation/graphs/gr303_zdemo.C
+++ b/tutorials/visualisation/graphs/gr303_zdemo.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// This macro is an example of graphs in log scales with annotations.
+/// \preview This macro is an example of graphs in log scales with annotations.
 ///
 /// The presented results are predictions of invariant cross-section
 /// of Direct Photons produced at RHIC energies, based on the universality of


### PR DESCRIPTION
- Add the `\preview` keyword to the tutorials producing graphics (in its and visualization)
- Remove `\macro_image` for some tutorials not generating graphics
