### PR TITLE
Improve THStack pads painting

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -787,8 +787,12 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stac
       while (lnk) {
          auto subpad = padsav->GetPad(i++);
          if (!subpad) break;
-         subpad->Clear();
-         subpad->Add(lnk->GetObject(), lnk->GetOption());
+         // check if histogram already drawn on the pad
+         if (!subpad->FindObject(lnk->GetObject())) {
+            subpad->Clear();
+            subpad->Add(lnk->GetObject(), lnk->GetOption());
+            subpad->Paint(); // need to re-paint subpad immediately
+         }
          lnk = lnk->Next();
       }
       padsav->cd();


### PR DESCRIPTION
Only when hstack painted for the first time, create subpads and
paint them immediately. Also check if histogram
was already painted on the pad - to avoid permanent repainting of subpads
