### PR TITLE
Revert "[cmake] Silence Clang8 shadow warnings"

### DIFF
--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -93,13 +93,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   endif()
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe ${FP_MATH_FLAGS} -Wall -W -Woverloaded-virtual -fsigned-char")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe ${FP_MATH_FLAGS} -Wshadow -Wall -W -Woverloaded-virtual -fsigned-char")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Wall -W")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")
-
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-  endif()
 
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 

--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -46,12 +46,8 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
      set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -m64")
 
   elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wall -Woverloaded-virtual -fsigned-char -fno-common -Qunused-arguments")
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wshadow -Wall -Woverloaded-virtual -fsigned-char -fno-common -Qunused-arguments")
      SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -fsigned-char -fno-common -Qunused-arguments")
-     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
-       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-     endif()
-
      SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")
 
      SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -Wl,-dead_strip_dylibs")

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -16,10 +16,20 @@
 #include "TEnum.h"
 #include "TError.h"
 #include "TFile.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+// Shadowing warnings can not be fixed without breaking backward compatibility
+// so just silence them. see https://github.com/root-project/root/pull/15379#issuecomment-2083159907
 #include "TProtoClass.h"
+#pragma clang diagnostic pop
 #include "TDataMember.h"
 #include "TROOT.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+// Shadowing warnings can not be fixed without breaking backward compatibility
+// so just silence them. see https://github.com/root-project/root/pull/15379#issuecomment-2083159907
 #include "TStreamerInfo.h"
+#pragma clang diagnostic pop
 #include "TClassEdit.h"
 #include <memory>
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Closes:
https://its.cern.ch/jira/browse/ROOT-9763

A new look on https://github.com/root-project/root/pull/15379

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

