### PR TITLE
Expose contiguousness from TTreeReaderArray and use it

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -35,6 +35,8 @@ public:
 
    EReadStatus GetReadStatus() const override { return fImpl ? fImpl->fReadStatus : kReadError; }
 
+   bool IsContiguous() const { return fImpl->IsContiguous(GetProxy()); }
+
 protected:
    void *UntypedAt(std::size_t idx) const { return fImpl->At(GetProxy(), idx); }
    void CreateProxy() override;

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -88,6 +88,7 @@ namespace Internal {
       virtual ~TVirtualCollectionReader();
       virtual size_t GetSize(Detail::TBranchProxy*) = 0;
       virtual void* At(Detail::TBranchProxy*, size_t /*idx*/) = 0;
+      virtual bool IsContiguous(Detail::TBranchProxy *) = 0;
    };
 
 }


### PR DESCRIPTION
TTreeReaderArray now exposes information on whether the underlying array type uses contiguous memory. This info is in turn used by RDataFrame to optimise reading collections as RVec.

Fixes https://its.cern.ch/jira/browse/ROOT-10823
