### PR TITLE
[ntuple] Decouple `RPageSource` from `RNTupleJoinTable`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
@@ -73,9 +73,9 @@ private:
    /// Names of the join fields used for the mapping to their respective entry numbers.
    std::vector<std::string> fJoinFieldNames;
 
-   /// The fields for which the join table is built, corresponding to `fJoinFieldNames`. Used to compute the hashes for
-   /// each entry value.
-   std::vector<std::unique_ptr<RFieldBase>> fJoinFields;
+   /// The size (in bytes) for each join field, corresponding to `fJoinFieldNames`. This information is stored to be
+   /// able to properly cast incoming void pointers to the join field values in `GetAllEntryNumbers`.
+   std::vector<std::size_t> fJoinFieldValueSizes;
 
    /// Only built join tables can be queried.
    bool fIsBuilt = false;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
@@ -106,12 +106,10 @@ public:
    /// \param[in] fieldNames The names of the join fields to use for the join table. Only integral-type fields are
    /// allowed.
    /// \param[in] pageSource The page source.
-   /// \param[in] deferBuild When set to `true`, an empty join table will be created. A call to RNTupleJoinTable::Build
-   /// is required before the join table can actually be used.
    ///
    /// \return A pointer to the newly-created join table.
    static std::unique_ptr<RNTupleJoinTable>
-   Create(const std::vector<std::string> &fieldNames, const RPageSource &pageSource, bool deferBuild = false);
+   Create(const std::vector<std::string> &fieldNames, const RPageSource &pageSource);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Build the join table.

--- a/tree/ntuple/v7/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/v7/src/RNTupleJoinTable.cxx
@@ -65,12 +65,9 @@ void ROOT::Experimental::Internal::RNTupleJoinTable::EnsureBuilt() const
 
 std::unique_ptr<ROOT::Experimental::Internal::RNTupleJoinTable>
 ROOT::Experimental::Internal::RNTupleJoinTable::Create(const std::vector<std::string> &fieldNames,
-                                                       const RPageSource &pageSource, bool deferBuild)
+                                                       const RPageSource &pageSource)
 {
    auto joinTable = std::unique_ptr<RNTupleJoinTable>(new RNTupleJoinTable(fieldNames, pageSource));
-
-   if (!deferBuild)
-      joinTable->Build();
 
    return joinTable;
 }

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -474,7 +474,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::AddAuxiliary(const RNTupleOpenSpe
 
    // If no join fields have been specified, an aligned join is assumed and an join table won't be created.
    if (joinFields.size() > 0)
-      fJoinTables.emplace_back(Internal::RNTupleJoinTable::Create(joinFields, *pageSource));
+      fJoinTables.emplace_back(Internal::RNTupleJoinTable::Create(joinFields));
 
    fAuxiliaryPageSources.emplace_back(std::move(pageSource));
 }
@@ -535,7 +535,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
    for (unsigned i = 0; i < fJoinTables.size(); ++i) {
       auto &joinTable = fJoinTables[i];
       if (!joinTable->IsBuilt())
-         joinTable->Build();
+         joinTable->Build(*fAuxiliaryPageSources[i]);
 
       auxEntryIdxs.push_back(joinTable->GetFirstEntryNumber(valPtrs));
    }

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -474,7 +474,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::AddAuxiliary(const RNTupleOpenSpe
 
    // If no join fields have been specified, an aligned join is assumed and an join table won't be created.
    if (joinFields.size() > 0)
-      fJoinTables.emplace_back(Internal::RNTupleJoinTable::Create(joinFields, *pageSource, true /* deferBuild */));
+      fJoinTables.emplace_back(Internal::RNTupleJoinTable::Create(joinFields, *pageSource));
 
    fAuxiliaryPageSources.emplace_back(std::move(pageSource));
 }

--- a/tree/ntuple/v7/test/ntuple_join_table.cxx
+++ b/tree/ntuple/v7/test/ntuple_join_table.cxx
@@ -17,7 +17,7 @@ TEST(RNTupleJoinTable, Basic)
    }
 
    auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
-   auto joinTable = RNTupleJoinTable::Create({"fld"}, *pageSource);
+   auto joinTable = RNTupleJoinTable::Create({"fld"});
    EXPECT_FALSE(joinTable->IsBuilt());
 
    try {
@@ -27,7 +27,7 @@ TEST(RNTupleJoinTable, Basic)
       EXPECT_THAT(err.what(), testing::HasSubstr("join table has not been built yet"));
    }
 
-   joinTable->Build();
+   joinTable->Build(*pageSource);
    EXPECT_TRUE(joinTable->IsBuilt());
 
    EXPECT_EQ(10UL, joinTable->GetSize());
@@ -59,12 +59,12 @@ TEST(RNTupleJoinTable, InvalidTypes)
 
    auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
 
-   auto joinTable = RNTupleJoinTable::Create({"fldInt"}, *pageSource);
-   joinTable->Build();
+   auto joinTable = RNTupleJoinTable::Create({"fldInt"});
+   joinTable->Build(*pageSource);
    EXPECT_EQ(1UL, joinTable->GetSize());
 
    try {
-      RNTupleJoinTable::Create({"fldFloat"}, *pageSource)->Build();
+      RNTupleJoinTable::Create({"fldFloat"})->Build(*pageSource);
       FAIL() << "non-integral-type field should not be allowed as join fields";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(
@@ -74,7 +74,7 @@ TEST(RNTupleJoinTable, InvalidTypes)
    }
 
    try {
-      RNTupleJoinTable::Create({"fldString"}, *pageSource)->Build();
+      RNTupleJoinTable::Create({"fldString"})->Build(*pageSource);
       FAIL() << "non-integral-type field should not be allowed as join fields";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(
@@ -84,7 +84,7 @@ TEST(RNTupleJoinTable, InvalidTypes)
    }
 
    try {
-      RNTupleJoinTable::Create({"fldStruct"}, *pageSource)->Build();
+      RNTupleJoinTable::Create({"fldStruct"})->Build(*pageSource);
       FAIL() << "non-integral-type field should not be allowed as join fields";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("cannot use field \"fldStruct\" with type \"CustomStruct\" in "
@@ -126,8 +126,8 @@ TEST(RNTupleJoinTable, SparseSecondary)
    auto fldEvent = mainNtuple->GetView<std::uint64_t>("event");
 
    auto secondaryPageSource = RPageSource::Create("secondary", fileGuardSecondary.GetPath());
-   auto joinTable = RNTupleJoinTable::Create({"event"}, *secondaryPageSource);
-   joinTable->Build();
+   auto joinTable = RNTupleJoinTable::Create({"event"});
+   joinTable->Build(*secondaryPageSource);
 
    auto secondaryNTuple = RNTupleReader::Open("secondary", fileGuardSecondary.GetPath());
    auto fldX = secondaryNTuple->GetView<float>("x");
@@ -168,8 +168,8 @@ TEST(RNTupleJoinTable, MultipleFields)
    }
 
    auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
-   auto joinTable = RNTupleJoinTable::Create({"run", "event"}, *pageSource);
-   joinTable->Build();
+   auto joinTable = RNTupleJoinTable::Create({"run", "event"});
+   joinTable->Build(*pageSource);
 
    EXPECT_EQ(15ULL, joinTable->GetSize());
 
@@ -224,8 +224,8 @@ TEST(RNTupleJoinTable, MultipleMatches)
    }
 
    auto pageSource = RPageSource::Create("ntuple", fileGuard.GetPath());
-   auto joinTable = RNTupleJoinTable::Create({"run"}, *pageSource);
-   joinTable->Build();
+   auto joinTable = RNTupleJoinTable::Create({"run"});
+   joinTable->Build(*pageSource);
 
    EXPECT_EQ(3ULL, joinTable->GetSize());
 

--- a/tree/ntuple/v7/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_join.cxx
@@ -204,8 +204,9 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
 
    try {
       std::vector<RNTupleOpenSpec> unfitNTuples = {{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}};
-      RNTupleProcessor::CreateJoin(unfitNTuples, {"i", "j", "k"});
-      FAIL() << "trying to create a join processor where not all join fields are present should throw";
+      auto proc = RNTupleProcessor::CreateJoin(unfitNTuples, {"i", "j", "k"});
+      proc->begin();
+      FAIL() << "trying to use a join processor where not all join fields are present should throw";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("could not find join field \"j\" in RNTuple \"ntuple2\""));
    }


### PR DESCRIPTION
This is the first PR (out of a yet unknown number) related to the refactoring and extension of the `RNTupleJoinTable` to enable more complex join table structures which may contain entries from more than one RNTuple. This is necessary to make the `RNTupleJoinProcessor` fully composable (see also #17132).

The changes in this PR are twofold:
1. Join tables have to now be build explicitly through a call to `RNTupleJoinTable::Build`.
2. The `RNTupleJoinTable` doesn't store the page source as a data member anymore. Instead, this page source is passed to `RNTupleJoinTable::Build`.

