### PR TITLE
[ntuple] use raw strings in ntuple_show for ease of reading

### DIFF
--- a/tree/ntuple/test/ntuple_show.cxx
+++ b/tree/ntuple/test/ntuple_show.cxx
@@ -84,44 +84,46 @@ TEST(RNTupleShow, BasicTypes)
    std::ostringstream os;
    ntuple2->Show(0, os);
    // clang-format off
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"pt\": 5,\n"
-      + "  \"db\": 9.99,\n"
-      + "  \"byte\": 0x89,\n"
-      + "  \"int\": -4,\n"
-      + "  \"uint\": 3,\n"
-      + "  \"uint64\": 44444444444,\n"
-      + "  \"string\": \"TestString\",\n"
-      + "  \"boolean\": true,\n"
-      + "  \"uint8\": 97,\n"
-      + "  \"int8\": 97,\n"
-      + "  \"bitset\": \"10000000000000000000000000000010000000000000000000000000000010010\",\n"
-      + "  \"pstring\": \"abc\",\n"
-      + "  \"atomic\": false\n"
-      + "}\n" };
+   std::string fString{
+R"({
+  "pt": 5,
+  "db": 9.99,
+  "byte": 0x89,
+  "int": -4,
+  "uint": 3,
+  "uint64": 44444444444,
+  "string": "TestString",
+  "boolean": true,
+  "uint8": 97,
+  "int8": 97,
+  "bitset": "10000000000000000000000000000010000000000000000000000000000010010",
+  "pstring": "abc",
+  "atomic": false
+}
+)" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, os1);
    // clang-format off
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"pt\": 8.5,\n"
-      + "  \"db\": 9.998,\n"
-      + "  \"byte\": 0x2a,\n"
-      + "  \"int\": -94,\n"
-      + "  \"uint\": 4294967266,\n"
-      + "  \"uint64\": 2299994967294,\n"
-      + "  \"string\": \"TestString2\",\n"
-      + "  \"boolean\": false,\n"
-      + "  \"uint8\": 98,\n"
-      + "  \"int8\": 98,\n"
-      + "  \"bitset\": \"01111111111111111111111111111101111111111111111111111111111101101\",\n"
-      + "  \"pstring\": null,\n"
-      + "  \"atomic\": true\n"
-      + "}\n" };
+   std::string fString1{
+R"({
+  "pt": 8.5,
+  "db": 9.998,
+  "byte": 0x2a,
+  "int": -94,
+  "uint": 4294967266,
+  "uint64": 2299994967294,
+  "string": "TestString2",
+  "boolean": false,
+  "uint8": 98,
+  "int8": 98,
+  "bitset": "01111111111111111111111111111101111111111111111111111111111101101",
+  "pstring": null,
+  "atomic": true
+}
+)" };
    // clang-format on
    EXPECT_EQ(fString1, os1.str());
 
@@ -165,24 +167,26 @@ TEST(RNTupleShow, Vectors)
    std::ostringstream os;
    ntuple2->Show(0, os);
    // clang-format off
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"intVec\": [4, 5, 6],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false]]\n"
-      + "}\n" };
+   std::string fString{ 
+R"({
+  "intVec": [4, 5, 6],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2]],
+  "booleanVecVec": [[false, true, false], [false, true], [true, false, false]]
+}
+)" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, os1);
    // clang-format off
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"intVec\": [4, 5, 6, 7],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],\n"
-      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false], [false, true]]\n"
-      + "}\n" };
+   std::string fString1{
+R"({
+  "intVec": [4, 5, 6, 7],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],
+  "booleanVecVec": [[false, true, false], [false, true], [true, false, false], [false, true]]
+}
+)" };
    // clang-format on
    EXPECT_EQ(fString1, os1.str());
 }
@@ -234,30 +238,32 @@ TEST(RNTupleShow, Arrays)
    std::ostringstream os;
    ntuple2->Show(0, os);
    // clang-format off
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"IntArray\": [1, 3],\n"
-      + "  \"FloatArray\": [3.5, 4.6, 5.7],\n"
-      + "  \"ArrayOfVec\": [[1, 2], [4, 5], [7, 8, 9], [11]],\n"
-      + "  \"stringArray\": [\"First\", \"Second\"],\n"
-      + "  \"ArrayOfArray\": [[true, false], [false, true], [false, false]],\n"
-      + "  \"VecOfArray\": [[0, 1], [2, 3], [4, 5]]\n"
-      + "}\n"};
+   std::string fString{
+R"({
+  "IntArray": [1, 3],
+  "FloatArray": [3.5, 4.6, 5.7],
+  "ArrayOfVec": [[1, 2], [4, 5], [7, 8, 9], [11]],
+  "stringArray": ["First", "Second"],
+  "ArrayOfArray": [[true, false], [false, true], [false, false]],
+  "VecOfArray": [[0, 1], [2, 3], [4, 5]]
+}
+)"};
    // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, os1);
    // clang-format off
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"IntArray\": [2, 5],\n"
-      + "  \"FloatArray\": [2.3, 5.7, 11.13],\n"
-      + "  \"ArrayOfVec\": [[17, 19], [23, 29], [31, 37, 41], [43]],\n"
-      + "  \"stringArray\": [\"Third\", \"Fourth\"],\n"
-      + "  \"ArrayOfArray\": [[true, true], [false, true], [true, true]],\n"
-      + "  \"VecOfArray\": [[6, 7], [8, 9]]\n"
-      + "}\n"};
+   std::string fString1{
+R"({
+  "IntArray": [2, 5],
+  "FloatArray": [2.3, 5.7, 11.13],
+  "ArrayOfVec": [[17, 19], [23, 29], [31, 37, 41], [43]],
+  "stringArray": ["Third", "Fourth"],
+  "ArrayOfArray": [[true, true], [false, true], [true, true]],
+  "VecOfArray": [[6, 7], [8, 9]]
+}
+)"};
    // clang-format on
    EXPECT_EQ(fString1, os1.str());
 }
@@ -275,21 +281,24 @@ TEST(RNTupleShow, Objects)
       auto derivedAfield = model->MakeField<DerivedA>("DerivedA");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
-      *customStructfield =
-         CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example1String", std::byte{0}};
-      *customStructVec = {
-         CustomStruct{4.2f, std::vector<float>{0.1f, 0.2f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example2String", std::byte{0}},
-         CustomStruct{4.3f, std::vector<float>{0.1f, 0.2f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "Example3String", std::byte{0}},
-         CustomStruct{4.4f, std::vector<float>{0.1f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example4String", std::byte{0}}};
-      *customStructArray = {
-         CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "AnotherString1", std::byte{0}},
-         CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f},
-                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString2", std::byte{0}}};
+      *customStructfield = CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                                        std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}},
+                                        "Example1String", std::byte{0}};
+      *customStructVec = {CustomStruct{4.2f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                                       std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}},
+                                       "Example2String", std::byte{0}},
+                          CustomStruct{4.3f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                                       std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}},
+                                       "Example3String", std::byte{0}},
+                          CustomStruct{4.4f, std::vector<float>{0.1f, 0.3f},
+                                       std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}},
+                                       "Example4String", std::byte{0}}};
+      *customStructArray = {CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                                         std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}},
+                                         "AnotherString1", std::byte{0}},
+                            CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                                         std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}},
+                                         "AnotherString2", std::byte{0}}};
       *derivedAfield = DerivedA();
       ntuple->Fill();
    }
@@ -303,35 +312,35 @@ TEST(RNTupleShow, Objects)
    std::ostringstream os;
    ntuple2->Show(0, os);
    // clang-format off
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"CustomStruct\": {\n"
-      + "    \"a\": 4.1,\n"
-      + "    \"v1\": [0.1, 0.2, 0.3],\n"
-      + "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n"
-      + "    \"s\": \"Example1String\",\n"
-      + "    \"b\": 0x00\n"
-      + "  },\n"
-      + "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example2String\", \"b\": 0x00}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\", \"b\": 0x00}, "
-      +      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example4String\", \"b\": 0x00}],\n"
-      + "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"AnotherString1\", \"b\": 0x00}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\", \"b\": 0x00}],\n"
-      + "  \"DerivedA\": {\n"
-      + "    \":_0\": {\n"
-      + "      \"a\": 0,\n"
-      + "      \"v1\": [],\n"
-      + "      \"v2\": [],\n"
-      + "      \"s\": \"\",\n"
-      + "      \"b\": 0x00\n"
-      + "    },\n"
-      + "    \"a_v\": [],\n"
-      + "    \"a_s\": \"\"\n"
-      + "  }\n"
-      + "}\n" };
+   std::string fString{ 
+R"({
+  "CustomStruct": {
+    "a": 4.1,
+    "v1": [0.1, 0.2, 0.3],
+    "v2": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],
+    "s": "Example1String",
+    "b": 0x00
+  },
+  "CustomStructVec": [)"
+     R"({"a": 4.2, "v1": [0.1, 0.2, 0.3], "v2": [[1.1, 1.3], [2.1, 2.2, 2.3]], "s": "Example2String", "b": 0x00}, )"
+     R"({"a": 4.3, "v1": [0.1, 0.2, 0.3], "v2": [[1.1, 1.2, 1.3], [2.1, 2.3]], "s": "Example3String", "b": 0x00}, )"
+     R"({"a": 4.4, "v1": [0.1, 0.3], "v2": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], "s": "Example4String", "b": 0x00}],)" R"(
+  "CustomStructArray": [)"
+     R"({"a": 4.5, "v1": [0.1, 0.2, 0.3], "v2": [[1.1, 1.3], [2.1, 2.2, 2.3]], "s": "AnotherString1", "b": 0x00}, )"
+     R"({"a": 4.6, "v1": [0.1, 0.2, 0.3], "v2": [[1.1, 1.2, 1.3], [2.1, 2.3]], "s": "AnotherString2", "b": 0x00}],)" R"(
+  "DerivedA": {
+    ":_0": {
+      "a": 0,
+      "v1": [],
+      "v2": [],
+      "s": "",
+      "b": 0x00
+    },
+    "a_v": [],
+    "a_s": ""
+  }
+}
+)" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
 }
@@ -374,26 +383,27 @@ TEST(RNTupleShow, Collections)
    std::ostringstream osData;
    reader->Show(0, osData);
    // clang-format off
-   std::string outputData{ std::string("")
-      + "{\n"
-      + "  \"myCollection\": [{\"myShort\": 1, \"myFloat\": 10}, {\"myShort\": 2, \"myFloat\": 20}]\n"
-      + "}\n" };
+   std::string outputData{
+R"({
+  "myCollection": [{"myShort": 1, "myFloat": 10}, {"myShort": 2, "myFloat": 20}]
+}
+)" };
    // clang-format on
    EXPECT_EQ(outputData, osData.str());
 
    std::ostringstream osFields;
    reader->PrintInfo(ROOT::ENTupleInfo::kSummary, osFields);
    // clang-format off
-   std::string outputFields{ std::string("")
-      + "************************************ NTUPLE ************************************\n"
-      + "* N-Tuple : Collections                                                        *\n"
-      + "* Entries : 1                                                                  *\n"
-      + "********************************************************************************\n"
-      + "* Field 1           : myCollection                                             *\n"
-      + "*   Field 1.1       : _0                                                       *\n"
-      + "*     Field 1.1.1   : myShort (std::int16_t)                                   *\n"
-      + "*     Field 1.1.2   : myFloat (float)                                          *\n"
-      + "********************************************************************************\n" };
+   std::string outputFields{
+      "************************************ NTUPLE ************************************\n"
+      "* N-Tuple : Collections                                                        *\n"
+      "* Entries : 1                                                                  *\n"
+      "********************************************************************************\n"
+      "* Field 1           : myCollection                                             *\n"
+      "*   Field 1.1       : _0                                                       *\n"
+      "*     Field 1.1.1   : myShort (std::int16_t)                                   *\n"
+      "*     Field 1.1.2   : myFloat (float)                                          *\n"
+      "********************************************************************************\n" };
    // clang-format on
    EXPECT_EQ(outputFields, osFields.str());
 }
@@ -415,7 +425,8 @@ TEST(RNTupleShow, RVec)
 
       *fieldIntVec = ROOT::RVec<int>{1, 2, 3};
       *fieldFloatVecVec = ROOT::RVec<ROOT::RVec<float>>{ROOT::RVec<float>{0.1, 0.2}, ROOT::RVec<float>{1.1, 1.2}};
-      *fieldCustomStructVec = ROOT::RVec<CustomStruct>{CustomStruct(), {1.f, {2.f, 3.f}, {{4.f}, {5.f}}, "foo", std::byte{0}}};
+      *fieldCustomStructVec =
+         ROOT::RVec<CustomStruct>{CustomStruct(), {1.f, {2.f, 3.f}, {{4.f}, {5.f}}, "foo", std::byte{0}}};
       ntuple->Fill();
 
       fieldIntVec->emplace_back(4);
@@ -429,27 +440,29 @@ TEST(RNTupleShow, RVec)
    std::ostringstream os;
    r->Show(0, os);
    // clang-format off
-   std::string expected1{std::string("")
-      + "{\n"
-      + "  \"intVec\": [1, 2, 3],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00}]\n"
-      + "}\n"};
+   std::string expected1{
+R"({
+  "intVec": [1, 2, 3],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2]],
+  "customStructVec": [{"a": 0, "v1": [], "v2": [], "s": "", "b": 0x00}, {"a": 1, "v1": [2, 3], "v2": [[4], [5]], "s": "foo", "b": 0x00}]
+}
+)"};
    // clang-format on
    EXPECT_EQ(os.str(), expected1);
 
    std::ostringstream os2;
    r->Show(1, os2);
    // clang-format off
-   std::string expected2{std::string("")
-      + "{\n"
-      + "  \"intVec\": [1, 2, 3, 4],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00},"
-      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\", \"b\": 0x00}]\n"
-      + "}\n"};
+   std::string expected2{
+R"({
+  "intVec": [1, 2, 3, 4],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],
+  "customStructVec": [)"
+     R"({"a": 0, "v1": [], "v2": [], "s": "", "b": 0x00}, )"
+     R"({"a": 1, "v1": [2, 3], "v2": [[4], [5]], "s": "foo", "b": 0x00}, )"
+     R"({"a": 6, "v1": [7, 8], "v2": [[9], [10]], "s": "bar", "b": 0x00}])" R"(
+}
+)"};
    // clang-format on
    EXPECT_EQ(os2.str(), expected2);
 }
@@ -496,27 +509,29 @@ TEST(RNTupleShow, RVecTypeErased)
    std::ostringstream os;
    ntuple->Show(0, os);
    // clang-format off
-   std::string fString{std::string("")
-      + "{\n"
-      + "  \"intVec\": [1, 2, 3],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00}]\n"
-      + "}\n"};
+   std::string fString{
+R"({
+  "intVec": [1, 2, 3],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2]],
+  "customStructVec": [{"a": 0, "v1": [], "v2": [], "s": "", "b": 0x00}, {"a": 1, "v1": [2, 3], "v2": [[4], [5]], "s": "foo", "b": 0x00}]
+}
+)"};
    // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple->Show(1, os1);
    // clang-format off
-   std::string fString1{std::string("")
-      + "{\n"
-      + "  \"intVec\": [1, 2, 3, 4],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00},"
-      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\", \"b\": 0x00}]\n"
-      + "}\n"};
+   std::string fString1{
+R"({
+  "intVec": [1, 2, 3, 4],
+  "floatVecVec": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],
+  "customStructVec": [)"
+     R"({"a": 0, "v1": [], "v2": [], "s": "", "b": 0x00}, )"
+     R"({"a": 1, "v1": [2, 3], "v2": [[4], [5]], "s": "foo", "b": 0x00}, )"
+     R"({"a": 6, "v1": [7, 8], "v2": [[9], [10]], "s": "bar", "b": 0x00}]
+}
+)"};
    // clang-format off
    EXPECT_EQ(fString1, os1.str());
 }
@@ -550,11 +565,12 @@ TEST(RNTupleShow, CollectionProxy)
       std::ostringstream os;
       ntuple->Show(0, os);
       // clang-format off
-      std::string expected{std::string("")
-         + "{\n"
-         + "  \"proxyF\": [42, 24],\n"
-         + "  \"vecProxyF\": [[1, 2], [1, 2]]\n"
-         + "}\n"};
+      std::string expected{
+R"({
+  "proxyF": [42, 24],
+  "vecProxyF": [[1, 2], [1, 2]]
+}
+)"};
       // clang-format on
       EXPECT_EQ(os.str(), expected);
    }
@@ -578,10 +594,11 @@ TEST(RNTupleShow, Map)
    std::ostringstream os;
    ntuple->Show(0, os);
    // clang-format off
-   std::string expected{std::string("")
-      + "{\n"
-      + "  \"mapF\": [{\"_0\": \"bar\", \"_1\": 2.72}, {\"_0\": \"foo\", \"_1\": 3.14}]\n"
-      + "}\n"};
+   std::string expected{
+R"({
+  "mapF": [{"_0": "bar", "_1": 2.72}, {"_0": "foo", "_1": 3.14}]
+}
+)"};
    // clang-format on
    EXPECT_EQ(os.str(), expected);
 }
@@ -606,20 +623,22 @@ TEST(RNTupleShow, Enum)
    std::ostringstream os0;
    ntuple->Show(0, os0);
    // clang-format off
-   std::string expected{std::string("")
-      + "{\n"
-      + "  \"enum\": 7\n"
-      + "}\n"};
+   std::string expected{
+R"({
+  "enum": 7
+}
+)"};
    // clang-format on
    EXPECT_EQ(os0.str(), expected);
 
    std::ostringstream os1;
    ntuple->Show(1, os1);
    // clang-format off
-   expected = std::string("")
-      + "{\n"
-      + "  \"enum\": 137\n"
-      + "}\n";
+   expected = std::string(
+R"({
+  "enum": 137
+}
+)");
    // clang-format on
    EXPECT_EQ(os1.str(), expected);
 }


### PR DESCRIPTION
Aesthetic-only change: use raw strings instead of string concatenation for the expected values in ntuple_show.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


