### PR TITLE
[skip-ci] Improve preview display

### DIFF
--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -505,7 +505,7 @@ void FilterTutorial()
          string name = gMacroName;
          int width = 150;
          ReplaceAll(name,".C","_8C.html");
-         ReplaceAll(gLineString, "\\preview", StringFormat("\\htmlonly <a href=\"%s\"><img src=\"pict1_%s.png\" valign=\"middle\" width=\"%d\"/></a>\\endhtmlonly",name.c_str(),gMacroName.c_str(),width));
+         ReplaceAll(gLineString, "\\preview", StringFormat("\\htmlonly <a href=\"%s\"><img src=\"pict1_%s.png\" style=\"float: left; margin-right: 10px;\" width=\"%d\"/></a>\\endhtmlonly",name.c_str(),gMacroName.c_str(),width));
       }
 
       // \macro_output found

--- a/tutorials/hist/hist001_TH1_fillrandom.C
+++ b/tutorials/hist/hist001_TH1_fillrandom.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// Fill a 1D histogram with random values using predefined functions
+/// Fill a 1D histogram with random values using predefined functions.
 ///
 /// \macro_code
 ///

--- a/tutorials/hist/hist001_TH1_fillrandom.py
+++ b/tutorials/hist/hist001_TH1_fillrandom.py
@@ -1,7 +1,7 @@
 ## \file
 ## \ingroup tutorial_hist
 ## \notebook
-## Fill a 1D histogram with random values using predefined functions
+## Fill a 1D histogram with random values using predefined functions.
 ##
 ## \macro_image
 ## \macro_code

--- a/tutorials/hist/hist005_TH1_palettecolor.C
+++ b/tutorials/hist/hist005_TH1_palettecolor.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Palette coloring for TH1
+/// \preview Palette coloring for TH1.
 ///
 /// Palette coloring for histogram is activated thanks to the options `PFC`
 /// (Palette Fill Color), `PLC` (Palette Line Color) and `PMC` (Palette Marker Color).

--- a/tutorials/hist/hist006_TH1_bar_charts.C
+++ b/tutorials/hist/hist006_TH1_bar_charts.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Draw 1D histograms as bar charts
+/// \preview Draw 1D histograms as bar charts.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist007_TH1_liveupdate.py
+++ b/tutorials/hist/hist007_TH1_liveupdate.py
@@ -1,7 +1,7 @@
 ## \file
 ## \ingroup tutorial_hist
 ## \notebook -js
-## Simple example illustrating how to use the C++ interpreter
+## Simple example illustrating how to use the C++ interpreter.
 ##
 ## \macro_image
 ## \macro_code

--- a/tutorials/hist/hist008_TH1_zoom.C
+++ b/tutorials/hist/hist008_TH1_zoom.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// \preview Changing the Range on the X-Axis of a Histogram
+/// \preview Changing the Range on the X-Axis of a Histogram.
 ///
 /// Image produced by `.x ZoomHistogram.C`
 ///

--- a/tutorials/hist/hist009_TH1_normalize.C
+++ b/tutorials/hist/hist009_TH1_normalize.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook -js
-/// \preview Normalizing a Histogram
+/// \preview Normalizing a Histogram.
 ///
 /// Image produced by `.x NormalizeHistogram.C`
 /// Two different methods of normalizing histograms

--- a/tutorials/hist/hist012_TH1_hksimple.C
+++ b/tutorials/hist/hist012_TH1_hksimple.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview  Illustrates the advantages of a TH1K histogram
+/// \preview  Illustrates the advantages of a TH1K histogram.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist015_TH1_read_and_draw.py
+++ b/tutorials/hist/hist015_TH1_read_and_draw.py
@@ -1,7 +1,7 @@
 ## \file
 ## \ingroup tutorial_hist
 ## \notebook -js
-## A Simple histogram drawing example
+## A Simple histogram drawing example.
 ##
 ## \macro_image
 ## \macro_output

--- a/tutorials/hist/hist020_TH2_draw.C
+++ b/tutorials/hist/hist020_TH2_draw.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview  Display the various 2-d drawing options
+/// \preview  Display the various 2-d drawing options.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/hist/hist022_TH2_palette.C
+++ b/tutorials/hist/hist022_TH2_palette.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview When an histogram is drawn with the option `COLZ`, a palette is automatically drawn
+/// \preview When an histogram is drawn with the option COLZ, a palette is automatically drawn
 /// vertically on the right side of the plot. It is possible to move and resize this
 /// vertical palette as shown on the left plot. The right plot demonstrates that, when the
 /// width of the palette is larger than its height, the palette is automatically drawn

--- a/tutorials/hist/hist025_THStack_2d_palette_color.C
+++ b/tutorials/hist/hist025_THStack_2d_palette_color.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Palette coloring for 2D histograms' stack is activated thanks to the option `PFC`
+/// \preview Palette coloring for 2D histograms' stack is activated thanks to the option PFC
 /// (Palette Fill Color).
 /// When this option is given to `THStack::Draw` the histograms  in the
 /// `THStack` get their color from the current color palette defined by

--- a/tutorials/hist/hist027_THStack_palette_color.C
+++ b/tutorials/hist/hist027_THStack_palette_color.C
@@ -1,8 +1,8 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Palette coloring for histograms' stack is activated thanks to the options `PFC`
-/// (Palette Fill Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color).
+/// \preview Palette coloring for histograms' stack is activated thanks to the options PFC
+/// (Palette Fill Color), PLC (Palette Line Color) and AMC (Palette Marker Color).
 /// When one of these options is given to `THStack::Draw` the histograms  in the
 /// `THStack` get their color from the current color palette defined by
 /// `gStyle->SetPalette(...)`. The color is determined according to the number of

--- a/tutorials/hist/hist029_TRatioPlot_simple.C
+++ b/tutorials/hist/hist029_TRatioPlot_simple.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Example creating a simple ratio plot of two histograms using the `pois` division option.
+/// \preview Example creating a simple ratio plot of two histograms using the "pois" division option.
 /// Two histograms are set up and filled with random numbers. The constructor of `TRatioPlot`
 /// takes the two histograms, name and title for the object, drawing options for the histograms
 /// (`hist` and `E` in this case) and a drawing option for the output graph.

--- a/tutorials/hist/hist041_TProfile2Poly_realistic.C
+++ b/tutorials/hist/hist041_TProfile2Poly_realistic.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_hist
 /// \notebook
-/// \preview Different charges depending on region
+/// \preview Different charges depending on region.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/compile.C
+++ b/tutorials/visualisation/graphics/compile.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook -js
-/// \preview This macro produces the flowchart of TFormula::Compile
+/// \preview This macro produces the flowchart of TFormula::Compile.
 ///
 /// \macro_image
 /// \macro_code

--- a/tutorials/visualisation/graphics/perceptualcolormap.C
+++ b/tutorials/visualisation/graphics/perceptualcolormap.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// \notebook
-/// \preview A “Perceptual” colormap explicitly identifies a fixed value in the data
+/// \preview A “Perceptual” colormap explicitly identifies a fixed value in the data.
 ///
 /// On geographical plot this fixed point can, for instance, the "sea level". A perceptual
 /// colormap provides a monotonic luminance variations above and below this fixed value.

--- a/tutorials/visualisation/graphs/gr010_approx_smooth.C
+++ b/tutorials/visualisation/graphs/gr010_approx_smooth.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook -js
-/// \preview Create a TGraphSmooth and show the usage of the interpolation function Approx
+/// \preview Create a TGraphSmooth and show the usage of the interpolation function Approx.
 ///
 /// See the [TGraphSmooth documentation](https://root.cern/doc/master/classTGraphSmooth.html)
 ///

--- a/tutorials/visualisation/graphs/gr015_smooth.C
+++ b/tutorials/visualisation/graphs/gr015_smooth.C
@@ -3,10 +3,9 @@
 /// \notebook
 /// \preview Show scatter plot smoothers: ksmooth, lowess, supsmu,
 /// as described in:
-///
-///      Modern Applied Statistics with S-Plus, 3rd Edition
-///      W.N. Venables and B.D. Ripley
-///      Chapter 9: Smooth Regression, Figure 9.1
+///  Modern Applied Statistics with S-Plus, 3rd Edition
+///  W.N. Venables and B.D. Ripley
+///  Chapter 9: Smooth Regression, Figure 9.1
 ///
 /// Example is a set of data on 133 observations of acceleration against time
 /// for a simulated motorcycle accident, taken from Silverman (1985). The data

--- a/tutorials/visualisation/graphs/gr104_palettecolor.C
+++ b/tutorials/visualisation/graphs/gr104_palettecolor.C
@@ -1,9 +1,9 @@
 /// \file
 /// \ingroup tutorial_graphs
 /// \notebook
-/// \preview Palette coloring for graphs is activated thanks to the options PFC (Palette Fill
-/// Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color). When
-/// one of these options is given to `TGraph::Draw` the `TGraph` get its color
+/// \preview Palette coloring for graphs is activated thanks to the options PFC (Palette Fill Color), 
+/// PLC (Palette Line Color) and AMC (Palette Marker Color). 
+/// When one of these options is given to `TGraph::Draw` the `TGraph` get its color
 /// from the current color palette defined by `gStyle->SetPalette(...)`. The color
 /// is determined according to the number of objects having palette coloring in
 /// the current pad.


### PR DESCRIPTION
- Improve the preview display. The text was not wrapped correctly around the icon
- format some tutorials (missing dot)
