### PR TITLE
[tmva] Use local input files instead of downloading them from root.cern.ch for tmva tests and tutorials

### DIFF
--- a/tmva/pymva/test/Classification.C
+++ b/tmva/pymva/test/Classification.C
@@ -34,17 +34,13 @@ void Classification()
    factory->AddSpectator("spec1 := var1*2",  "Spectator 1", "units", 'F');
    factory->AddSpectator("spec2 := var1*3",  "Spectator 2", "units", 'F');
 
-   TFile *input(0);
-   TString fname = "./tmva_class_example.root";
+   TFile *input(nullptr);
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
    }
-   else {
-      TFile::SetCacheFileDir(".");
-      input = TFile::Open("http://root.cern/files/tmva_class_example.root", "CACHEREAD");
-   }
    if (!input) {
-      std::cout << "ERROR: could not open data file" << std::endl;
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
       exit(1);
    }
 

--- a/tmva/pymva/test/testPyAdaBoostClassification.C
+++ b/tmva/pymva/test/testPyAdaBoostClassification.C
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TSystem.h"
+#include "TROOT.h"
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
 #include "TMVA/DataLoader.h"
@@ -12,12 +13,12 @@
 int testPyAdaBoostClassification(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_class_example.root";
-   if (gSystem->AccessPathName(fname)) {
-      // file does not exist in local directory
-      gSystem->Exec("curl -L -O http://root.cern/files/tmva_class_example.root");
-   }
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    TFile *input = TFile::Open(fname);
+   if (!input) {
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
+      return 1;
+   }
 
    // Setup PyMVA and factory
    std::cout << "Setup TMVA..." << std::endl;

--- a/tmva/pymva/test/testPyGTBClassification.C
+++ b/tmva/pymva/test/testPyGTBClassification.C
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TSystem.h"
+#include "TROOT.h"
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
 #include "TMVA/DataLoader.h"
@@ -12,12 +13,12 @@
 int testPyGTBClassification(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_class_example.root";
-   if (gSystem->AccessPathName(fname)) {
-      // file does not exist in local directory
-      gSystem->Exec("curl -L -O http://root.cern/files/tmva_class_example.root");
-   }
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    TFile *input = TFile::Open(fname);
+   if (!input) {
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
+      return 1;
+   }
 
    // Setup PyMVA and factory
    std::cout << "Setup TMVA..." << std::endl;

--- a/tmva/pymva/test/testPyKerasClassification.C
+++ b/tmva/pymva/test/testPyKerasClassification.C
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TSystem.h"
+#include "TROOT.h"
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
 #include "TMVA/DataLoader.h"
@@ -24,12 +25,12 @@ int testPyKerasClassification(){
 
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_class_example.root";
-   if (gSystem->AccessPathName(fname)) {
-      // file does not exist in local directory
-      gSystem->Exec("curl -L -O http://root.cern/files/tmva_class_example.root");
-   }
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    TFile *input = TFile::Open(fname);
+   if (!input) {
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
+      return 1;
+   }
 
    // Build model from python file
    if (gSystem->AccessPathName("kerasModelClassification.h5")) {

--- a/tmva/pymva/test/testPyKerasRegression.C
+++ b/tmva/pymva/test/testPyKerasRegression.C
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TSystem.h"
+#include "TROOT.h"
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
 #include "TMVA/DataLoader.h"
@@ -23,12 +24,12 @@ model.save(\"kerasModelRegression.h5\")\n";
 int testPyKerasRegression(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_reg_example.root";
-   if (gSystem->AccessPathName(fname)) {
-      // file does not exist in local directory
-      gSystem->Exec("curl -L -O http://root.cern/files/tmva_reg_example.root");
-   }
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_reg_example.root";
    TFile *input = TFile::Open(fname);
+   if (!input) {
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
+      return 1;
+   }
 
    // Build model from python file
    std::cout << "Generate keras model..." << std::endl;

--- a/tmva/pymva/test/testPyRandomForestClassification.C
+++ b/tmva/pymva/test/testPyRandomForestClassification.C
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TSystem.h"
+#include "TROOT.h"
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
 #include "TMVA/DataLoader.h"
@@ -12,12 +13,12 @@
 int testPyRandomForestClassification(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_class_example.root";
-   if (gSystem->AccessPathName(fname)) {
-      // file does not exist in local directory
-      gSystem->Exec("curl -L -O http://root.cern/files/tmva_class_example.root");
-   }
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    TFile *input = TFile::Open(fname);
+   if (!input) {
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
+      return 1;
+   }
 
    // Setup PyMVA and factory
    std::cout << "Setup TMVA..." << std::endl;

--- a/tmva/rmva/test/Classification.C
+++ b/tmva/rmva/test/Classification.C
@@ -39,16 +39,12 @@ void Classification()
    dataloader->AddSpectator("spec2 := var1*3",  "Spectator 2", "units", 'F');
 
    TFile *input(0);
-   TString fname = "./tmva_class_example.root";
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
    }
-   else {
-      TFile::SetCacheFileDir(".");
-      input = TFile::Open("http://root.cern/files/tmva_class_example.root", "CACHEREAD");
-   }
    if (!input) {
-      std::cout << "ERROR: could not open data file" << std::endl;
+      std::cout << "ERROR: could not open data file " << fname << std::endl;
       exit(1);
    }
 

--- a/tmva/tmva/inc/TMVA/Classification.h
+++ b/tmva/tmva/inc/TMVA/Classification.h
@@ -57,12 +57,9 @@ void classification(UInt_t jobs = 2)
    TMVA::Tools::Instance();
 
    TFile *input(0);
-   TString fname = "./tmva_class_example.root";
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    if (!gSystem->AccessPathName(fname)) {
       input = TFile::Open(fname); // check if file in local directory exists
-   } else {
-      TFile::SetCacheFileDir(".");
-      input = TFile::Open("http://root.cern/files/tmva_class_example.root", "CACHEREAD");
    }
    if (!input) {
       std::cout << "ERROR: could not open data file" << std::endl;

--- a/tmva/tmva/test/rreader.cxx
+++ b/tmva/tmva/test/rreader.cxx
@@ -35,7 +35,7 @@ void TrainClassificationModel()
            output, "Silent:!V:!DrawProgressBar:AnalysisType=Classification");
 
    // Open trees with signal and background events
-   const std::string filename = "http://root.cern/files/tmva_class_example.root";
+   const std::string filename = filenameClassification;
    std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto signal = (TTree *)data->Get("TreeS");
    auto background = (TTree *)data->Get("TreeB");
@@ -58,7 +58,7 @@ void TrainClassificationModel()
 
 // Regression
 static const std::string modelRegression = "RReaderRegression/weights/RReaderRegression_BDTG.weights.xml";
-static const std::string filenameRegression = "http://root.cern/files/tmva_reg_example.root";
+static const std::string filenameRegression = std::string(gROOT->GetTutorialDir()) + "/machine_learning/data/tmva_reg_example.root";
 static const std::vector<std::string> variablesRegression = {"var1", "var2"};
 
 void TrainRegressionModel()
@@ -77,7 +77,7 @@ void TrainRegressionModel()
            output, "Silent:!V:!DrawProgressBar:AnalysisType=Regression");
 
    // Open trees with signal and background events
-   const std::string filename = "http://root.cern/files/tmva_reg_example.root";
+   const std::string filename = filenameRegression;
    std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto tree = (TTree *)data->Get("TreeR");
 
@@ -97,7 +97,7 @@ void TrainRegressionModel()
 
 // Multiclass
 static const std::string modelMulticlass = "RReaderMulticlass/weights/RReaderMulticlass_BDT.weights.xml";
-static const std::string filenameMulticlass = "http://root.cern/files/tmva_multiclass_example.root";
+static const std::string filenameMulticlass = std::string(gROOT->GetTutorialDir()) + "/machine_learning/data/tmva_multiclass_example.root";
 static const std::vector<std::string> variablesMulticlass = variablesClassification;
 
 void TrainMulticlassModel()
@@ -116,7 +116,7 @@ void TrainMulticlassModel()
            output, "Silent:!V:!DrawProgressBar:AnalysisType=Multiclass");
 
    // Open trees with signal and background events
-   const std::string filename = "http://root.cern/files/tmva_multiclass_example.root";
+   const std::string filename = filenameMulticlass;
    std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto signal = (TTree *)data->Get("TreeS");
    auto background0 = (TTree *)data->Get("TreeB0");

--- a/tutorials/machine_learning/RBatchGenerator_NumPy.py
+++ b/tutorials/machine_learning/RBatchGenerator_NumPy.py
@@ -11,7 +11,7 @@
 import ROOT
 
 tree_name = "sig_tree"
-file_name = "http://root.cern/files/Higgs_data.root"
+file_name = str(ROOT.gROOT.GetTutorialDir()) + "/machine_learning/data/Higgs_data.root"
 
 batch_size = 128
 chunk_size = 5_000

--- a/tutorials/machine_learning/RBatchGenerator_PyTorch.py
+++ b/tutorials/machine_learning/RBatchGenerator_PyTorch.py
@@ -12,7 +12,7 @@ import torch
 import ROOT
 
 tree_name = "sig_tree"
-file_name = "http://root.cern/files/Higgs_data.root"
+file_name = str(ROOT.gROOT.GetTutorialDir()) + "/machine_learning/data/Higgs_data.root"
 
 batch_size = 128
 chunk_size = 5_000

--- a/tutorials/machine_learning/RBatchGenerator_TensorFlow.py
+++ b/tutorials/machine_learning/RBatchGenerator_TensorFlow.py
@@ -12,7 +12,7 @@ import tensorflow as tf
 import ROOT
 
 tree_name = "sig_tree"
-file_name = "http://root.cern/files/Higgs_data.root"
+file_name = str(ROOT.gROOT.GetTutorialDir()) + "/machine_learning/data/Higgs_data.root"
 
 batch_size = 128
 chunk_size = 5_000
@@ -50,7 +50,7 @@ num_features = len(input_columns)
 
 # Define TensorFlow model
 model = tf.keras.Sequential(
-    [   
+    [
         tf.keras.layers.Input(shape=(num_features,)),
         tf.keras.layers.Dense(300, activation=tf.nn.tanh),
         tf.keras.layers.Dense(300, activation=tf.nn.tanh),

--- a/tutorials/machine_learning/TMVACrossValidationRegression.C
+++ b/tutorials/machine_learning/TMVACrossValidationRegression.C
@@ -75,14 +75,10 @@
 #include "TMVA/CrossValidation.h"
 
 TFile * getDataFile(TString fname) {
-   TFile *input(0);
+   TFile *input(nullptr);
 
    if (!gSystem->AccessPathName(fname)) {
       input = TFile::Open(fname); // check if file in local directory exists
-   } else {
-      // if not: download from ROOT server
-      TFile::SetCacheFileDir(".");
-      input = TFile::Open("http://root.cern/files/tmva_reg_example.root", "CACHEREAD");
    }
 
    if (!input) {
@@ -104,7 +100,7 @@ int TMVACrossValidationRegression()
    TString outfileName("TMVARegCv.root");
    TFile * outputFile = TFile::Open(outfileName, "RECREATE");
 
-   TString infileName("./files/tmva_reg_example.root");
+   TString infileName = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_reg_example.root";
    TFile * inputFile = getDataFile(infileName);
 
    TMVA::DataLoader *dataloader=new TMVA::DataLoader("datasetcvreg");

--- a/tutorials/machine_learning/TMVAMinimalClassification.C
+++ b/tutorials/machine_learning/TMVAMinimalClassification.C
@@ -6,9 +6,10 @@
 ///
 /// This is intended as a simple foundation to build on. It assumes you are
 /// familiar with TMVA already. As such concepts like the Factory, the DataLoader
-/// and others are not explained. For descriptions and tutorials use the TMVA
-/// User's Guide (https://root.cern/root-user-guides-and-manuals under TMVA)
-/// or the more detailed examples provided with TMVA e.g. TMVAClassification.C.
+/// and others are not explained. For descriptions and tutorials use the TMVA online manual
+/// https://root.cern/manual/tmva/ or the more detailed examples provided with TMVA
+///  e.g. TMVAClassification.C. or the TMVA Users Guide
+/// https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf
 ///
 /// Sets up a minimal binary classification example with two slightly overlapping
 /// 2-D gaussian distributions and trains a BDT classifier to discriminate the

--- a/tutorials/machine_learning/envelope/classification.C
+++ b/tutorials/machine_learning/envelope/classification.C
@@ -9,22 +9,20 @@
 #include "TMVA/Factory.h"
 #include "TMVA/DataLoader.h"
 #include "TMVA/Tools.h"
+#include "TROOT.h"
 #include "TMVA/Classification.h"
 
 void classification(UInt_t jobs = 4)
 {
    TMVA::Tools::Instance();
 
-   TFile *input(0);
-   TString fname = "./tmva_class_example.root";
+   TFile *input(nullptr);
+   TString fname = gROOT->GetTutorialDir() + "/machine_learning/data/tmva_class_example.root";
    if (!gSystem->AccessPathName(fname)) {
       input = TFile::Open(fname); // check if file in local directory exists
-   } else {
-      TFile::SetCacheFileDir(".");
-      input = TFile::Open("http://root.cern/files/tmva_class_example.root", "CACHEREAD");
    }
    if (!input) {
-      std::cout << "ERROR: could not open data file" << std::endl;
+      std::cout << "ERROR: could not open data file" << fname << std::endl;
       exit(1);
    }
 

--- a/tutorials/machine_learning/keras/ApplicationClassificationKeras.py
+++ b/tutorials/machine_learning/keras/ApplicationClassificationKeras.py
@@ -20,7 +20,7 @@ TMVA.PyMethodBase.PyInitialize()
 reader = TMVA.Reader("Color:!Silent")
 
 # Load data
-data = TFile.Open(gROOT.GetTutorialDir() + "/machine_learning/data/tmva_class_example.root")
+data = TFile.Open(str(gROOT.GetTutorialDir()) + "/machine_learning/data/tmva_class_example.root")
 signal = data.Get('TreeS')
 background = data.Get('TreeB')
 

--- a/tutorials/machine_learning/keras/ApplicationRegressionKeras.py
+++ b/tutorials/machine_learning/keras/ApplicationRegressionKeras.py
@@ -20,10 +20,7 @@ TMVA.PyMethodBase.PyInitialize()
 reader = TMVA.Reader("Color:!Silent")
 
 # Load data
-if not isfile('tmva_reg_example.root'):
-    call(['curl', '-L', '-O', 'http://root.cern/files/tmva_reg_example.root'])
-
-data = TFile.Open(gROOT.GetTutorialDir() + '/machine_learning/data/tmva_reg_example.root')
+data = TFile.Open(str(gROOT.GetTutorialDir()) + '/machine_learning/data/tmva_reg_example.root')
 tree = data.Get('TreeR')
 
 branches = {}

--- a/tutorials/machine_learning/keras/ClassificationKeras.py
+++ b/tutorials/machine_learning/keras/ClassificationKeras.py
@@ -10,7 +10,7 @@
 # \date 2017
 # \author TMVA Team
 
-from ROOT import TMVA, TFile, TCut
+from ROOT import TMVA, TFile, TCut, gROOT
 from subprocess import call
 from os.path import isfile
 
@@ -37,7 +37,7 @@ def create_model():
 
 
 def run():
-    with TFile.Open('TMVA_Classification_Keras.root', 'RECREATE') as output, TFile.Open(gROOT.GetTutorialDir() + '/machine_learning/data/tmva_class_example.root') as data:
+    with TFile.Open('TMVA_Classification_Keras.root', 'RECREATE') as output, TFile.Open(str(gROOT.GetTutorialDir()) + '/machine_learning/data/tmva_class_example.root') as data:
         factory = TMVA.Factory('TMVAClassification', output,
                                '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
 

--- a/tutorials/machine_learning/keras/RegressionKeras.py
+++ b/tutorials/machine_learning/keras/RegressionKeras.py
@@ -10,7 +10,7 @@
 # \date 2017
 # \author TMVA Team
 
-from ROOT import TMVA, TFile, TCut
+from ROOT import TMVA, TFile, TCut, gROOT
 from subprocess import call
 from os.path import isfile
 
@@ -36,7 +36,7 @@ def create_model():
 
 def run():
 
-    with TFile.Open('TMVA_Regression_Keras.root', 'RECREATE') as output, TFile.Open(gROOT.GetTutorialDir() + '/machine_learning/data/tmva_reg_example.root') as data:
+    with TFile.Open('TMVA_Regression_Keras.root', 'RECREATE') as output, TFile.Open(str(gROOT.GetTutorialDir()) + '/machine_learning/data/tmva_reg_example.root') as data:
         factory = TMVA.Factory('TMVARegression', output,
                                '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Regression')
 
@@ -70,10 +70,6 @@ if __name__ == "__main__":
     # Setup TMVA
     TMVA.Tools.Instance()
     TMVA.PyMethodBase.PyInitialize()
-
-    # Load data
-    if not isfile('tmva_reg_example.root'):
-        call(['curl', '-L', '-O', 'http://root.cern/files/tmva_reg_example.root'])
 
     # Generate model
     create_model()


### PR DESCRIPTION


Use as input to TMVA tutorials and tests local files uploaded in github in the tutorials/machine_learning/data directory instead of getting them from root.cern.ch



