### PR TITLE
Add YXRatio paramater for `TCrown`

### DIFF
--- a/graf2d/graf/inc/TCrown.h
+++ b/graf2d/graf/inc/TCrown.h
@@ -17,6 +17,7 @@
 
 
 class TCrown : public TEllipse {
+   Double_t fYXRatio = 1;  // ratio between Y and X axis
 
 public:
    TCrown();
@@ -24,6 +25,9 @@ public:
           Double_t phimin=0,Double_t phimax=360);
    TCrown(const TCrown &crown);
    ~TCrown() override;
+
+   void SetYXRatio(Double_t v = 1) { fYXRatio = v; }
+   Double_t GetYXRatio() const { return fYXRatio; }
 
    void Copy(TObject &crown) const override;
    Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
@@ -34,7 +38,7 @@ public:
    void    Paint(Option_t *option="") override;
    void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDefOverride(TCrown,1)  //A crown or segment of crown
+   ClassDefOverride(TCrown,2)  //A crown or segment of crown
 };
 
 #endif

--- a/graf2d/graf/src/TCrown.cxx
+++ b/graf2d/graf/src/TCrown.cxx
@@ -31,22 +31,22 @@ Example:
 Begin_Macro(source)
 {
    TCanvas *c1 = new TCanvas("c1","c1",400,400);
-   TCrown cr1(.5,.5,.3,.4);
-   cr1.SetLineStyle(2);
-   cr1.SetLineWidth(4);
-   cr1.Draw();
-   TCrown cr2(.5,.5,.2,.3,45,315);
-   cr2.SetFillColor(38);
-   cr2.SetFillStyle(3010);
-   cr2.Draw();
-   TCrown cr3(.5,.5,.2,.3,-45,45);
-   cr3.SetFillColor(50);
-   cr3.SetFillStyle(3025);
-   cr3.Draw();
-   TCrown cr4(.5,.5,.0,.2);
-   cr4.SetFillColor(4);
-   cr4.SetFillStyle(3008);
-   cr4.Draw();
+   auto cr1 = new TCrown(.5,.5,.3,.4);
+   cr1->SetLineStyle(2);
+   cr1->SetLineWidth(4);
+   cr1->Draw();
+   auto cr2 = new TCrown(.5,.5,.2,.3,45,315);
+   cr2->SetFillColor(38);
+   cr2->SetFillStyle(3010);
+   cr2->Draw();
+   auto cr3 = new TCrown(.5,.5,.2,.3,-45,45);
+   cr3->SetFillColor(50);
+   cr3->SetFillStyle(3025);
+   cr3->Draw();
+   auto cr4 = new TCrown(.5,.5,.0,.2);
+   cr4->SetFillColor(4);
+   cr4->SetFillStyle(3008);
+   cr4->Draw();
    return c1;
 }
 End_Macro

--- a/graf2d/graf/src/TCrown.cxx
+++ b/graf2d/graf/src/TCrown.cxx
@@ -98,6 +98,7 @@ TCrown::~TCrown()
 void TCrown::Copy(TObject &crown) const
 {
    TEllipse::Copy(crown);
+   static_cast<TCrown &>(crown).fYXRatio = fYXRatio;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,7 +112,7 @@ Int_t TCrown::DistancetoPrimitive(Int_t px, Int_t py)
    if (!gPad) return 9999;
    const Double_t kPI = TMath::Pi();
    Double_t x = gPad->PadtoX(gPad->AbsPixeltoX(px)) - fX1;
-   Double_t y = gPad->PadtoY(gPad->AbsPixeltoY(py)) - fY1;
+   Double_t y = (gPad->PadtoY(gPad->AbsPixeltoY(py)) - fY1) / fYXRatio;
 
    Double_t r1 = fR1;
    Double_t r2 = fR2;
@@ -157,6 +158,7 @@ TCrown *TCrown::DrawCrown(Double_t x1, Double_t y1,Double_t radin,Double_t radou
    TCrown *newcrown = new TCrown(x1, y1, radin, radout, phimin, phimax);
    TAttLine::Copy(*newcrown);
    TAttFill::Copy(*newcrown);
+   newcrown->SetYXRatio(GetYXRatio());
    newcrown->SetBit(kCanDelete);
    newcrown->AppendPad(option);
    return newcrown;
@@ -169,8 +171,7 @@ TCrown *TCrown::DrawCrown(Double_t x1, Double_t y1,Double_t radin,Double_t radou
 
 void TCrown::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 {
-
-   TEllipse::ExecuteEvent(event,px,py);
+   TEllipse::ExecuteEvent(event, px, py);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -179,10 +180,9 @@ void TCrown::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
 Int_t TCrown::IsInside(Double_t x, Double_t y) const
 {
-
    const Double_t kPI = TMath::Pi();
    const Int_t np = 40;
-   static Double_t xc[2 * np + 3], yc[2 * np +3];
+   static Double_t xc[2 * np + 3], yc[2 * np + 3];
 
    Double_t angle, dx, dy;
    Double_t dphi = (fPhimax - fPhimin) * kPI / (180 * np);
@@ -194,7 +194,7 @@ Int_t TCrown::IsInside(Double_t x, Double_t y) const
    for (i = 0; i <= np; i++) {
       angle = fPhimin * kPI / 180 + Double_t(i) * dphi;
       dx = fR2 * TMath::Cos(angle);
-      dy = fR2 * TMath::Sin(angle);
+      dy = fR2 * fYXRatio * TMath::Sin(angle);
       xc[i] = fX1 + dx * ct - dy * st;
       yc[i] = fY1 + dx * st + dy * ct;
    }
@@ -202,7 +202,7 @@ Int_t TCrown::IsInside(Double_t x, Double_t y) const
    for (i = 0; i <= np; i++) {
       angle = fPhimin * kPI / 180 + Double_t(i) * dphi;
       dx = fR1 * TMath::Cos(angle);
-      dy = fR1 * TMath::Sin(angle);
+      dy = fR1 * fYXRatio * TMath::Sin(angle);
       xc[2 * np - i + 1]  = fX1 + dx * ct - dy * st;
       yc[2 * np - i + 1]  = fY1 + dx * st + dy * ct;
    }
@@ -225,7 +225,7 @@ void TCrown::Paint(Option_t *)
    TAttLine::Modify();
    TAttFill::Modify();
 
-   Double_t angle,dx,dy;
+   Double_t angle, dx, dy;
    Double_t dphi = (fPhimax - fPhimin) * kPI / (180 * np);
    Double_t ct = TMath::Cos(kPI * fTheta / 180);
    Double_t st = TMath::Sin(kPI * fTheta / 180);
@@ -234,7 +234,7 @@ void TCrown::Paint(Option_t *)
    for (i = 0; i <= np; i++) {
       angle = fPhimin * kPI / 180 + Double_t(i) * dphi;
       dx = fR2 * TMath::Cos(angle);
-      dy = fR2 * TMath::Sin(angle);
+      dy = fR2 * fYXRatio * TMath::Sin(angle);
       x[i] = fX1 + dx * ct - dy * st;
       y[i] = fY1 + dx * st + dy * ct;
    }
@@ -242,7 +242,7 @@ void TCrown::Paint(Option_t *)
    for (i = 0; i <= np; i++) {
       angle = fPhimin * kPI / 180 + Double_t(i) * dphi;
       dx = fR1 * TMath::Cos(angle);
-      dy = fR1 * TMath::Sin(angle);
+      dy = fR1 * fYXRatio * TMath::Sin(angle);
       x[2 * np - i + 1]  = fX1 + dx * ct - dy * st;
       y[2 * np - i + 1]  = fY1 + dx * st + dy * ct;
    }
@@ -270,7 +270,6 @@ void TCrown::Paint(Option_t *)
 
 void TCrown::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-
    out<<"   "<<std::endl;
    if (gROOT->ClassSaved(TCrown::Class())) {
       out<<"   ";
@@ -283,7 +282,11 @@ void TCrown::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    SaveFillAttributes(out,"crown",0,1001);
    SaveLineAttributes(out,"crown",1,1,1);
 
-   if (GetNoEdges()) out<<"   crown->SetNoEdges();"<<std::endl;
+   if (GetNoEdges())
+      out << "   crown->SetNoEdges();" << std::endl;
+
+   if (fYXRatio != 1)
+      out << "   crown->SetYXRatio(" << fYXRatio << ");" << std::endl;
 
    out<<"   crown->Draw();"<<std::endl;
 }

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -5912,11 +5912,13 @@ void THistPainter::PaintColorLevels(Option_t*)
                      midy = (gPad->GetUymin() + gPad->GetUymax()) / 2,
                      a1 = (xlow - gPad->GetUxmin()) / (gPad->GetUxmax() - gPad->GetUxmin()) * 360,
                      a2 = (xup - gPad->GetUxmin()) / (gPad->GetUxmax() - gPad->GetUxmin()) * 360,
-                     r0 = TMath::Min(gPad->GetUxmax() - gPad->GetUxmin(), gPad->GetUymax() - gPad->GetUymin()),
-                     r1 = (ylow - gPad->GetUymin()) / (gPad->GetUymax() - gPad->GetUymin()) * r0 / 2,
-                     r2 = (yup - gPad->GetUymin()) / (gPad->GetUymax() - gPad->GetUymin()) * r0 / 2;
+                     rx = gPad->GetUxmax() - gPad->GetUxmin(),
+                     ry = gPad->GetUymax() - gPad->GetUymin(),
+                     r1 = (ylow - gPad->GetUymin()) / (gPad->GetUymax() - gPad->GetUymin()) * rx / 2,
+                     r2 = (yup - gPad->GetUymin()) / (gPad->GetUymax() - gPad->GetUymin()) * rx / 2;
 
             TCrown crown(midx, midy, r1, r2, a1, a2);
+            crown.SetYXRatio(rx > 0 ? ry / rx : 1);
             crown.SetFillColor(fillColor);
             crown.SetLineColor(fH->GetLineColor());
             crown.SetLineWidth(fH->GetLineWidth());

--- a/js/modules/draw/more.mjs
+++ b/js/modules/draw/more.mjs
@@ -146,13 +146,15 @@ function drawEllipse() {
          x = funcs.x(ellipse.fX1),
          y = funcs.y(ellipse.fY1),
          rx = is_crown && (ellipse.fR1 <= 0) ? (funcs.x(ellipse.fX1 + ellipse.fR2) - x) : (funcs.x(ellipse.fX1 + ellipse.fR1) - x),
-         ry = y - funcs.y(ellipse.fY1 + ellipse.fR2);
+         ry = y - funcs.y(ellipse.fY1 + ellipse.fR2),
+         dr = Math.PI/180;
 
    let path = '';
 
    if (is_crown && (ellipse.fR1 > 0)) {
-      const rx1 = rx, ry2 = ry,
-            ry1 = y - funcs.y(ellipse.fY1 + ellipse.fR1),
+      const ratio = ellipse.fYXRatio ?? 1,
+            rx1 = rx, ry2 = ratio * ry,
+            ry1 = ratio * (y - funcs.y(ellipse.fY1 + ellipse.fR1)),
             rx2 = funcs.x(ellipse.fX1 + ellipse.fR2) - x;
 
       if (closed_ellipse) {
@@ -160,7 +162,7 @@ function drawEllipse() {
                 `M${-rx2},0A${rx2},${ry2},0,1,0,${rx2},0A${rx2},${ry2},0,1,0,${-rx2},0`;
       } else {
          const large_arc = (ellipse.fPhimax-ellipse.fPhimin>=180) ? 1 : 0,
-               a1 = ellipse.fPhimin*Math.PI/180, a2 = ellipse.fPhimax*Math.PI/180,
+               a1 = ellipse.fPhimin*dr, a2 = ellipse.fPhimax*dr,
                dx1 = Math.round(rx1*Math.cos(a1)), dy1 = Math.round(ry1*Math.sin(a1)),
                dx2 = Math.round(rx1*Math.cos(a2)), dy2 = Math.round(ry1*Math.sin(a2)),
                dx3 = Math.round(rx2*Math.cos(a1)), dy3 = Math.round(ry2*Math.sin(a1)),
@@ -173,22 +175,22 @@ function drawEllipse() {
       if (closed_ellipse)
          path = `M${-rx},0A${rx},${ry},0,1,0,${rx},0A${rx},${ry},0,1,0,${-rx},0Z`;
       else {
-         const x1 = Math.round(rx * Math.cos(ellipse.fPhimin*Math.PI/180)),
-               y1 = Math.round(ry * Math.sin(ellipse.fPhimin*Math.PI/180)),
-               x2 = Math.round(rx * Math.cos(ellipse.fPhimax*Math.PI/180)),
-               y2 = Math.round(ry * Math.sin(ellipse.fPhimax*Math.PI/180));
+         const x1 = Math.round(rx * Math.cos(ellipse.fPhimin*dr)),
+               y1 = Math.round(ry * Math.sin(ellipse.fPhimin*dr)),
+               x2 = Math.round(rx * Math.cos(ellipse.fPhimax*dr)),
+               y2 = Math.round(ry * Math.sin(ellipse.fPhimax*dr));
          path = `M0,0L${x1},${y1}A${rx},${ry},0,1,1,${x2},${y2}Z`;
       }
    } else {
-     const ct = Math.cos(ellipse.fTheta*Math.PI/180),
-           st = Math.sin(ellipse.fTheta*Math.PI/180),
-           phi1 = ellipse.fPhimin*Math.PI/180,
-           phi2 = ellipse.fPhimax*Math.PI/180,
-           np = 200,
-           dphi = (phi2-phi1) / (np - (closed_ellipse ? 0 : 1));
-     let lastx = 0, lasty = 0;
-     if (!closed_ellipse) path = 'M0,0';
-     for (let n = 0; n < np; ++n) {
+      const ct = Math.cos(ellipse.fTheta*dr),
+            st = Math.sin(ellipse.fTheta*dr),
+            phi1 = ellipse.fPhimin*dr,
+            phi2 = ellipse.fPhimax*dr,
+            np = 200,
+            dphi = (phi2-phi1) / (np - (closed_ellipse ? 0 : 1));
+      let lastx = 0, lasty = 0;
+      if (!closed_ellipse) path = 'M0,0';
+      for (let n = 0; n < np; ++n) {
          const angle = phi1 + n*dphi,
                dx = ellipse.fR1 * Math.cos(angle),
                dy = ellipse.fR2 * Math.sin(angle),
@@ -203,8 +205,8 @@ function drawEllipse() {
          else
             path += `l${px-lastx},${py-lasty}`;
          lastx = px; lasty = py;
-     }
-     path += 'Z';
+      }
+      path += 'Z';
    }
 
    this.x = x;

--- a/js/modules/geom/geobase.mjs
+++ b/js/modules/geom/geobase.mjs
@@ -919,9 +919,9 @@ function createTubeBuffer(shape, faces_limit) {
    if (faces_limit < 0) return numfaces;
 
    const phi0 = thetaStart*Math.PI/180,
-       dphi = thetaLength/radiusSegments*Math.PI/180,
-       _sin = new Float32Array(radiusSegments+1),
-       _cos = new Float32Array(radiusSegments+1);
+         dphi = thetaLength/radiusSegments*Math.PI/180,
+         _sin = new Float32Array(radiusSegments+1),
+         _cos = new Float32Array(radiusSegments+1);
 
    for (let seg = 0; seg <= radiusSegments; ++seg) {
       _cos[seg] = Math.cos(phi0+seg*dphi);


### PR DESCRIPTION
Allows to draw ellipse segments with arbitrary Y to X ratio
Default is 1, can be optionally changed after object is created
Required for THistPainter, when `TCrown` used for 'col pol' drawing
Add support in JSROOT as well.