### PR TITLE
[ntuple] Reflect `RNTupleJoinTable` name change in `RNTupleJoinProcessor`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -499,9 +499,9 @@ private:
    std::vector<std::unique_ptr<Internal::RPageSource>> fAuxiliaryPageSources;
    /// Tokens representing the join fields present in the main RNTuple
    std::vector<REntry::RFieldToken> fJoinFieldTokens;
-   std::vector<std::unique_ptr<Internal::RNTupleJoinTable>> fJoinIndices;
+   std::vector<std::unique_ptr<Internal::RNTupleJoinTable>> fJoinTables;
 
-   bool IsUsingIndex() const { return fJoinIndices.size() > 0; }
+   bool HasJoinTable() const { return fJoinTables.size() > 0; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided entry number of the primary RNTuple.


### PR DESCRIPTION
The `RNTupleJoinProcessor` still referred to "index" in its member, method and variable names, as well as some comments. This PR renames them to properly reflect the new naming.

