### PR TITLE
[ci] Point Davix to the curl CA bundle on macOS

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -153,6 +153,9 @@ jobs:
         with:
           build-directory: /Users/sftnight/ROOT-CI/src/
 
+      - name: Set up curl CA bundle for Davix to work with https
+        run: 'echo SSL_CERT_FILE=/opt/local/share/curl/curl-ca-bundle.crt >> $GITHUB_ENV'
+
       - name: Pull Request Build
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
in order for Davix to be able to read through https


