### PR TITLE
[ntuple] Fix remaining issues with deferred columns in RNTupleMerger

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1467,6 +1467,7 @@ public:
    RResult<void> AddCluster(RClusterDescriptor &&clusterDesc);
 
    RResult<void> AddExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc);
+   void ReplaceExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc);
 
    /// Clears so-far stored clusters, fields, and columns and return to a pristine ntuple descriptor
    void Reset();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -95,10 +95,10 @@ class RNTupleMerger final {
    std::optional<TTaskGroup> fTaskGroup;
    std::unique_ptr<RNTupleModel> fModel;
 
-   void MergeCommonColumns(RClusterPool &clusterPool, ROOT::DescriptorId_t clusterId,
+   void MergeCommonColumns(RClusterPool &clusterPool, const RClusterDescriptor &clusterDesc,
                            std::span<const RColumnMergeInfo> commonColumns,
-                           const RCluster::ColumnSet_t &commonColumnSet, RSealedPageMergeData &sealedPageData,
-                           const RNTupleMergeData &mergeData);
+                           const RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
+                           RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData);
 
    void MergeSourceClusters(RPageSource &source, std::span<const RColumnMergeInfo> commonColumns,
                             std::span<const RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -532,10 +532,12 @@ public:
    void UpdateSchema(const RNTupleModelChangeset &changeset, ROOT::NTupleSize_t firstEntry) final;
    void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
-   /// Initialize sink based on an existing descriptor and fill into the descriptor builder.
+   /// Initialize sink based on an existing descriptor and fill into the descriptor builder, optionally copying over
+   /// the descriptor's clusters to this sink's descriptor.
    /// \return The model created from the new sink's descriptor. This model should be kept alive
    /// for at least as long as the sink.
-   [[nodiscard]] std::unique_ptr<RNTupleModel> InitFromDescriptor(const RNTupleDescriptor &descriptor);
+   [[nodiscard]] std::unique_ptr<RNTupleModel>
+   InitFromDescriptor(const RNTupleDescriptor &descriptor, bool copyClusters);
 
    void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -1266,6 +1266,17 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddExtraTypeInfo(RExtraT
    return RResult<void>::Success();
 }
 
+void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::ReplaceExtraTypeInfo(
+   RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
+{
+   auto it = std::find(fDescriptor.fExtraTypeInfoDescriptors.begin(), fDescriptor.fExtraTypeInfoDescriptors.end(),
+                       extraTypeInfoDesc);
+   if (it != fDescriptor.fExtraTypeInfoDescriptors.end())
+      *it = std::move(extraTypeInfoDesc);
+   else
+      fDescriptor.fExtraTypeInfoDescriptors.emplace_back(std::move(extraTypeInfoDesc));
+}
+
 ROOT::Experimental::Internal::RNTupleSerializer::StreamerInfoMap_t
 ROOT::Experimental::Internal::RNTupleDescriptorBuilder::BuildStreamerInfos() const
 {

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -545,15 +545,17 @@ static void ExtendDestinationModel(std::span<const RFieldDescriptor *> newFields
    dstModel.Unfreeze();
    RNTupleModelChangeset changeset{dstModel};
 
-   std::string msg = "destination doesn't contain field";
-   if (newFields.size() > 1)
-      msg += 's';
-   msg += ' ';
-   msg += std::accumulate(newFields.begin(), newFields.end(), std::string{}, [](const auto &acc, const auto *field) {
-      return acc + (acc.length() ? ", " : "") + '`' + field->GetFieldName() + '`';
-   });
-   Info("RNTuple::Merge", "%s: adding %s to the destination model (entry #%" PRIu64 ").", msg.c_str(),
-        (newFields.size() > 1 ? "them" : "it"), mergeData.fNumDstEntries);
+   if (mergeData.fMergeOpts.fExtraVerbose) {
+      std::string msg = "destination doesn't contain field";
+      if (newFields.size() > 1)
+         msg += 's';
+      msg += ' ';
+      msg += std::accumulate(newFields.begin(), newFields.end(), std::string{}, [](const auto &acc, const auto *field) {
+         return acc + (acc.length() ? ", " : "") + '`' + field->GetFieldName() + '`';
+      });
+      Info("RNTuple::Merge", "%s: adding %s to the destination model (entry #%" PRIu64 ").", msg.c_str(),
+           (newFields.size() > 1 ? "them" : "it"), mergeData.fNumDstEntries);
+   }
 
    changeset.fAddedFields.reserve(newFields.size());
    // First add all non-projected fields...

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1352,8 +1352,13 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    frame = pos;
-   pos += SerializeListFramePreamble(nExtraTypeInfos, *where);
-   pos += SerializeExtraTypeInfoList(desc, *where);
+   // We only serialize the extra type info list in the header extension.
+   if (forHeaderExtension) {
+      pos += SerializeListFramePreamble(nExtraTypeInfos, *where);
+      pos += SerializeExtraTypeInfoList(desc, *where);
+   } else {
+      pos += SerializeListFramePreamble(0, *where);
+   }
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    return static_cast<std::uint32_t>(pos - base);

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -838,17 +838,17 @@ static bool VerifyPageCompression(const std::string_view fileName, std::uint32_t
       R__getCompressionAlgorithm((const unsigned char *)sealedPage.GetBuffer(), sealedPage.GetDataSize());
    if (compAlgo == ROOT::RCompressionSetting::EAlgorithm::kUndefined)
       compAlgo = 0;
-   if (compAlgo == 0) {
-      // This page might be uncompressed because compressing it wouldn't have saved space: check if that's the case.
-      const auto nbytesComp =
-         RNTupleCompressor::Zip(sealedPage.GetBuffer(), sealedPage.GetDataSize(), expectedComp, buffer.get());
-      if (nbytesComp == sealedPage.GetDataSize()) {
-         // Yep, the page was uncompressible. Accept that and return true.
-         return true;
-      }
-      // Not good, the page should have been compressed! Fall through and follow the usual error flow.
-   }
    if (compAlgo != (expectedComp / 100)) {
+      if (compAlgo == 0) {
+         // This page might be uncompressed because compressing it wouldn't have saved space: check if that's the case.
+         const auto nbytesComp =
+            RNTupleCompressor::Zip(sealedPage.GetBuffer(), sealedPage.GetDataSize(), expectedComp, buffer.get());
+         if (nbytesComp == sealedPage.GetDataSize()) {
+            // Yep, the page was uncompressible. Accept that and return true.
+            return true;
+         }
+         // Not good, the page should have been compressed! Fall through and follow the usual error flow.
+      }
       std::cerr << "Actual compression is wrong: " << compAlgo << " instead of " << (expectedComp / 100) << "\n";
       ok = false;
    }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -1979,7 +1979,7 @@ TEST_P(RNTupleMergerDeferred, MergeSecondDeferred)
    // Second RNTuple with deferred field "flt"
    {
       auto model = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model->MakeField<int>("int");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
@@ -2056,7 +2056,7 @@ TEST_P(RNTupleMergerDeferred, MergeSecondDeferredTwoClusters)
    // Second RNTuple with deferred field "flt"
    {
       auto model = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model->MakeField<int>("int");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
@@ -2138,7 +2138,7 @@ TEST_P(RNTupleMergerDeferred, MergeSecondDeferredTwoClustersUnaligned)
    // Second RNTuple with deferred field "flt"
    {
       auto model = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model->MakeField<int>("int");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
@@ -2199,8 +2199,8 @@ TEST_P(RNTupleMergerDeferred, MergeSecondDeferredTwoClustersUnaligned)
 
 TEST_P(RNTupleMergerDeferred, MergeFirstDeferred)
 {
-   // Try merging 2 RNTuples, the first having a deferred column "flt" and the second having a regular column "flt".
-   // Verify that the merged file contains the expected values.
+   // Try merging 2 RNTuples, the first having a late model extended field "flt" (with a deferred column) and the second
+   // having a regular field "flt". Verify that the merged file contains the expected values.
    FileRaii fileGuard1("test_ntuple_merge_deferred_in_1.root");
    FileRaii fileGuard2("test_ntuple_merge_deferred_in_2.root");
 
@@ -2211,7 +2211,7 @@ TEST_P(RNTupleMergerDeferred, MergeFirstDeferred)
    // First RNTuple with deferred field "flt"
    {
       auto model1 = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model1->MakeField<int>("int");
       auto wopts = RNTupleWriteOptions();
@@ -2290,7 +2290,7 @@ TEST_P(RNTupleMergerDeferred, MergeFirstDeferredTwoClusters)
    // First RNTuple with deferred field "flt"
    {
       auto model1 = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model1->MakeField<int>("int");
       auto wopts = RNTupleWriteOptions();
@@ -2368,10 +2368,10 @@ TEST_P(RNTupleMergerDeferred, MergeFirstDeferredTwoClustersUnaligned)
    constexpr auto firstDeferredIdx = 5;
    assert(nEntriesPerFile > firstDeferredIdx);
 
-   // First RNTuple with deferred field "flt"
+   // First RNTuple with late model extended field "flt"
    {
       auto model1 = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model1->MakeField<int>("int");
       auto wopts = RNTupleWriteOptions();
@@ -2452,8 +2452,8 @@ INSTANTIATE_TEST_SUITE_P(Seq, RNTupleMergerDeferred,
 
 TEST(RNTupleMerger, MergeDeferredAdvanced)
 {
-   // Try merging 3 RNTuples, the first 2 having a deferred column "flt" and the third having a regular column "flt".
-   // Verify that the merged file contains the expected values.
+   // Try merging 3 RNTuples, the first 2 having a late-model extended field "flt" (where the second one has a deferred
+   // column) and the third having a regular field "flt". Verify that the merged file contains the expected values.
    FileRaii fileGuard1("test_ntuple_merge_deferred_adv_in_1.root");
    FileRaii fileGuard2("test_ntuple_merge_deferred_adv_in_2.root");
    FileRaii fileGuard3("test_ntuple_merge_deferred_adv_in_3.root");
@@ -2475,10 +2475,10 @@ TEST(RNTupleMerger, MergeDeferredAdvanced)
       }
    }
 
-   // Second RNTuple with deferred field "flt"
+   // Second RNTuple with late model extended field "flt"
    {
       auto model2 = RNTupleModel::Create();
-      // Add a non-deferred field so we can write some entries before we extend the model and obtain
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
       // actual deferred columns in the extension header.
       auto pInt = model2->MakeField<int>("int");
       auto wopts = RNTupleWriteOptions();

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -618,11 +618,6 @@ TEST(RNTuple, SerializeHeader)
                         .Index(1)
                         .MakeDescriptor()
                         .Unwrap());
-   builder.AddExtraTypeInfo(RExtraTypeInfoDescriptorBuilder()
-                               .ContentId(EExtraTypeInfoIds::kStreamerInfo)
-                               .Content("xyz")
-                               .MoveDescriptor()
-                               .Unwrap());
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeader(nullptr, desc);
@@ -641,12 +636,6 @@ TEST(RNTuple, SerializeHeader)
    EXPECT_TRUE(desc.GetFieldDescriptor(ptAliasFieldId).IsProjectedField());
    EXPECT_EQ(ptFieldId, desc.GetFieldDescriptor(ptAliasFieldId).GetProjectionSourceId());
    EXPECT_FALSE(desc.GetFieldDescriptor(ptFieldId).IsProjectedField());
-   EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
-   const auto &extraTypeInfoDesc = *desc.GetExtraTypeInfoIterable().begin();
-   EXPECT_EQ(EExtraTypeInfoIds::kStreamerInfo, extraTypeInfoDesc.GetContentId());
-   EXPECT_EQ(0u, extraTypeInfoDesc.GetTypeVersion());
-   EXPECT_TRUE(extraTypeInfoDesc.GetTypeName().empty());
-   EXPECT_STREQ("xyz", extraTypeInfoDesc.GetContent().c_str());
 }
 
 TEST(RNTuple, SerializeFooter)

--- a/tree/ntuple/v7/test/rfield_streamer.cxx
+++ b/tree/ntuple/v7/test/rfield_streamer.cxx
@@ -2,6 +2,7 @@
 
 #include <TDictAttributeMap.h>
 #include <TVirtualStreamerInfo.h>
+#include <TFileMerger.h>
 
 #include "StreamerField.hxx"
 #include "StreamerFieldXML.h"
@@ -206,6 +207,81 @@ TEST(RField, StreamerMerge)
    reader->LoadEntry(1);
    EXPECT_EQ(2, ptrPoly->fPoly->x);
    EXPECT_EQ(200, dynamic_cast<PolyB *>(ptrPoly->fPoly.get())->b);
+
+   const auto &desc = reader->GetDescriptor();
+   EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
+   const auto &typeInfo = *desc.GetExtraTypeInfoIterable().begin();
+   EXPECT_EQ(ROOT::Experimental::EExtraTypeInfoIds::kStreamerInfo, typeInfo.GetContentId());
+   auto streamerInfoMap = RNTupleSerializer::DeserializeStreamerInfos(typeInfo.GetContent()).Unwrap();
+   EXPECT_EQ(4u, streamerInfoMap.size());
+   std::array<bool, 4> seenStreamerInfos{false, false, false, false};
+   for (const auto &[_, streamerInfo] : streamerInfoMap) {
+      if (strcmp(streamerInfo->GetName(), "PolyContainer") == 0)
+         seenStreamerInfos[0] = true;
+      else if (strcmp(streamerInfo->GetName(), "PolyBase") == 0)
+         seenStreamerInfos[1] = true;
+      else if (strcmp(streamerInfo->GetName(), "PolyA") == 0)
+         seenStreamerInfos[2] = true;
+      else if (strcmp(streamerInfo->GetName(), "PolyB") == 0)
+         seenStreamerInfos[3] = true;
+   }
+   EXPECT_TRUE(seenStreamerInfos[0]);
+   EXPECT_TRUE(seenStreamerInfos[1]);
+   EXPECT_TRUE(seenStreamerInfos[2]);
+   EXPECT_TRUE(seenStreamerInfos[3]);
+}
+
+TEST(RField, StreamerMergeIncremental)
+{
+   FileRaii fileGuard1("test_ntuple_merge_streamer_incr_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("p", "PolyContainer").Unwrap());
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard1.GetPath());
+      auto ptrPoly = writer->GetModel().GetDefaultEntry().GetPtr<PolyContainer>("p");
+      ptrPoly->fPoly = std::make_unique<PolyA>();
+      ptrPoly->fPoly->x = 1;
+      static_cast<PolyA &>(*ptrPoly->fPoly).a = 100;
+      writer->Fill();
+   }
+
+   FileRaii fileGuard2("test_ntuple_merge_streamer_incr_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("p", "PolyContainer").Unwrap());
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard2.GetPath());
+      auto ptrPoly = writer->GetModel().GetDefaultEntry().GetPtr<PolyContainer>("p");
+      ptrPoly->fPoly = std::make_unique<PolyB>();
+      ptrPoly->fPoly->x = 2;
+      static_cast<PolyB &>(*ptrPoly->fPoly).b = 200;
+      writer->Fill();
+   }
+
+   // Now merge the inputs
+   FileRaii fileGuard3("test_ntuple_merge_streamer_incr_out.root");
+
+   TFileMerger merger(kFALSE, kFALSE);
+   merger.OutputFile(fileGuard3.GetPath().c_str(), "RECREATE", 505);
+
+   const FileRaii inputFiles[] = {std::move(fileGuard1), std::move(fileGuard2)};
+
+   for (auto i = 0u; i < std::size(inputFiles); ++i) {
+      auto tfile = std::unique_ptr<TFile>(TFile::Open(inputFiles[i].GetPath().c_str(), "READ"));
+      merger.AddFile(tfile.get());
+      bool result =
+         merger.PartialMerge(TFileMerger::kIncremental | TFileMerger::kNonResetable | TFileMerger::kKeepCompression);
+      ASSERT_TRUE(result);
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard3.GetPath());
+   EXPECT_EQ(2u, reader->GetNEntries());
+   auto ptrPoly = reader->GetModel().GetDefaultEntry().GetPtr<PolyContainer>("p");
+   reader->LoadEntry(0);
+   EXPECT_EQ(1, ptrPoly->fPoly->x);
+   EXPECT_EQ(100, static_cast<PolyA &>(*ptrPoly->fPoly).a);
+   reader->LoadEntry(1);
+   EXPECT_EQ(2, ptrPoly->fPoly->x);
+   EXPECT_EQ(200, static_cast<PolyB &>(*ptrPoly->fPoly).b);
 
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(1u, desc.GetNExtraTypeInfos());


### PR DESCRIPTION
# This Pull request:
fixes all remaining known cases of mishandling of deferred columns in the RNTupleMerger, most notably the inability of merging a file with a deferred column in the first source and mishandling of sources with a deferred column unaligned with cluster boundaries.
Several tests are added to cover those cases.

## Optimizations left to do
- properly compress synthesized zero pages
- don't generate leading zero pages for columns when not needed (use the deferred column machinery instead).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

