### PR TITLE
[cling][NFC] Use StringRef::operator== instead of StringRef::equals

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -5033,7 +5033,10 @@ ROOT::ESTLType ROOT::TMetaUtils::STLKind(const llvm::StringRef type)
        ROOT::kNotSTL
       };
    //              kind of stl container
-   for(int k=1;stls[k];k++) {if (type.equals(stls[k])) return values[k];}
+   for (int k = 1; stls[k]; k++) {
+      if (type == stls[k])
+         return values[k];
+   }
    return ROOT::kNotSTL;
 }
 

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -787,7 +787,7 @@ bool TClingCallbacks::tryResolveAtRuntimeInternal(LookupResult &R, Scope *S) {
    // Prevent redundant declarations for control statements (e.g., for, if, while)
    // that have already been annotated.
    if (auto annot = Wrapper->getAttr<AnnotateAttr>())
-      if (annot->getAnnotation().equals("__ResolveAtRuntime") && S->isControlScope())
+      if (annot->getAnnotation() == "__ResolveAtRuntime" && S->isControlScope())
          return false;
 
    VarDecl* Result = VarDecl::Create(C, TU, Loc, Loc, II, C.DependentTy,

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -261,9 +261,9 @@ const FunctionTemplateDecl *TClingClassInfo::GetFunctionTemplate(const char *fna
       const TypedefType *TT = llvm::dyn_cast<TypedefType>(fType);
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
-         if (tname.equals(fname)) {
+         if (tname == fname) {
             const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
-            if (ndecl && !ndecl->getName().equals(fname)) {
+            if (ndecl && ndecl->getName() != fname) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetFunctionTemplate(ndecl->getName().str().c_str());
             }
@@ -308,9 +308,9 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname) const
       const TypedefType *TT = llvm::dyn_cast<TypedefType>(fType);
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
-         if (tname.equals(fname)) {
+         if (tname == fname) {
             const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
-            if (ndecl && !ndecl->getName().equals(fname)) {
+            if (ndecl && ndecl->getName() != fname) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str());
             }
@@ -359,9 +359,9 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       const TypedefType *TT = llvm::dyn_cast<TypedefType>(fType);
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
-         if (tname.equals(fname)) {
+         if (tname == fname) {
             const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
-            if (ndecl && !ndecl->getName().equals(fname)) {
+            if (ndecl && ndecl->getName() != fname) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),proto,
                                 objectIsConst,poffset,
@@ -453,9 +453,9 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       const TypedefType *TT = llvm::dyn_cast<TypedefType>(fType);
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
-         if (tname.equals(fname)) {
+         if (tname == fname) {
             const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
-            if (ndecl && !ndecl->getName().equals(fname)) {
+            if (ndecl && ndecl->getName() != fname) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),proto,objectIsConst,poffset,
                                 mode,imode);
@@ -519,9 +519,9 @@ TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
       const TypedefType *TT = llvm::dyn_cast<TypedefType>(fType);
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
-         if (tname.equals(fname)) {
+         if (tname == fname) {
             const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
-            if (ndecl && !ndecl->getName().equals(fname)) {
+            if (ndecl && ndecl->getName() != fname) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),arglist,
                                 objectIsConst,poffset

--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -124,7 +124,8 @@ namespace cling {
                        bool prepend = false) {
        if (!dir.empty()) {
           for (auto & item : m_SearchPaths)
-            if (dir.equals(item.Path)) return;
+            if (dir == item.Path)
+              return;
           auto pos = prepend ? m_SearchPaths.begin() : m_SearchPaths.end();
           m_SearchPaths.insert(pos, SearchPathInfo{dir.str(), isUser});
        }

--- a/interpreter/cling/lib/Interpreter/AutoSynthesizer.cpp
+++ b/interpreter/cling/lib/Interpreter/AutoSynthesizer.cpp
@@ -82,7 +82,7 @@ namespace cling {
     bool VisitDeclRefExpr(DeclRefExpr* DRE) {
       const Decl* D = DRE->getDecl();
       if (const AnnotateAttr* A = D->getAttr<AnnotateAttr>())
-        if (A->getAnnotation().equals("__Auto")) {
+        if (A->getAnnotation() == "__Auto") {
           m_FoundDRE = DRE;
           return false; // we abort on the first found candidate.
         }

--- a/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
+++ b/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
@@ -116,9 +116,9 @@ namespace cling {
         ConstSearchDirIterator* CurDir = nullptr;
         bool needCacheUpdate = false;
 
-        if (FileName.equals(m_PrevFileName.first))
+        if (FileName == m_PrevFileName.first)
           FE = m_PrevFE.first;
-        else if (FileName.equals(m_PrevFileName.second))
+        else if (FileName == m_PrevFileName.second)
           FE = m_PrevFE.second;
         else if (auto FERef = m_PP->LookupFile(fileNameLoc, FileName, isAngled,
                                                FromDir, FromFile, CurDir,
@@ -374,9 +374,9 @@ namespace cling {
         if (isa<EmptyDecl>(D))
           continue;
         else if (auto VD = dyn_cast<VarDecl>(D)) {
-          HaveAutoLoadingMapMarker
-            = VD->hasExternalStorage() && VD->getIdentifier()
-              && VD->getName().equals("__Cling_AutoLoading_Map");
+          HaveAutoLoadingMapMarker = VD->hasExternalStorage() &&
+                                     VD->getIdentifier() &&
+                                     VD->getName() == "__Cling_AutoLoading_Map";
           if (!HaveAutoLoadingMapMarker)
             return;
           break;

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -307,8 +307,8 @@ namespace {
       if (!GV.hasName())
         return false;
 
-      if (GV.getName().equals("__cuda_fatbin_wrapper") ||
-          GV.getName().equals("__cuda_gpubin_handle")) {
+      if (GV.getName() == "__cuda_fatbin_wrapper" ||
+          GV.getName() == "__cuda_gpubin_handle") {
         GV.setName(add_module_suffix(GV.getName(), ModuleName));
         return true;
       }
@@ -318,9 +318,9 @@ namespace {
 
     // make CUDA specific functions unique
     bool runOnFunction(Function& F, const StringRef ModuleName) {
-      if (F.hasName() && (F.getName().equals("__cuda_module_ctor") ||
-                          F.getName().equals("__cuda_module_dtor") ||
-                          F.getName().equals("__cuda_register_globals"))) {
+      if (F.hasName() && (F.getName() == "__cuda_module_ctor" ||
+                          F.getName() == "__cuda_module_dtor" ||
+                          F.getName() == "__cuda_register_globals")) {
         F.setName(add_module_suffix(F.getName(), ModuleName));
         return true;
       }
@@ -486,25 +486,23 @@ void BackendPasses::CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
 
     // Register a callback for disabling all other inliner passes.
     PIC.registerShouldRunOptionalPassCallback([](StringRef P, Any) {
-      if (P.equals("ModuleInlinerWrapperPass") ||
-          P.equals("InlineAdvisorAnalysisPrinterPass") ||
-          P.equals("PartialInlinerPass") || P.equals("buildInlinerPipeline") ||
-          P.equals("ModuleInlinerPass") || P.equals("InlinerPass") ||
-          P.equals("InlineAdvisorAnalysis") ||
-          P.equals("PartiallyInlineLibCallsPass") ||
-          P.equals("RelLookupTableConverterPass") ||
-          P.equals("InlineCostAnnotationPrinterPass") ||
-          P.equals("InlineSizeEstimatorAnalysisPrinterPass") ||
-          P.equals("InlineSizeEstimatorAnalysis"))
+      if (P == "ModuleInlinerWrapperPass" ||
+          P == "InlineAdvisorAnalysisPrinterPass" ||
+          P == "PartialInlinerPass" || P == "buildInlinerPipeline" ||
+          P == "ModuleInlinerPass" || P == "InlinerPass" ||
+          P == "InlineAdvisorAnalysis" || P == "PartiallyInlineLibCallsPass" ||
+          P == "RelLookupTableConverterPass" ||
+          P == "InlineCostAnnotationPrinterPass" ||
+          P == "InlineSizeEstimatorAnalysisPrinterPass" ||
+          P == "InlineSizeEstimatorAnalysis")
         return false;
 
       return true;
     });
   } else {
     // Register a callback for disabling RelLookupTableConverterPass.
-    PIC.registerShouldRunOptionalPassCallback([](StringRef P, Any) {
-      return !P.equals("RelLookupTableConverterPass");
-    });
+    PIC.registerShouldRunOptionalPassCallback(
+        [](StringRef P, Any) { return P != "RelLookupTableConverterPass"; });
   }
 
   SI.registerCallbacks(PIC, &MAM);

--- a/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
@@ -206,7 +206,7 @@ namespace {
             continue;
 
           // Required by ::DwarfEHPrepare::InsertUnwindResumeCalls (in the JIT)
-          if ((*I)->getName().equals("_Unwind_Resume"))
+          if ((*I)->getName() == "_Unwind_Resume")
             continue;
 
           m_CodeGen->forgetGlobal(*I);

--- a/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
@@ -910,7 +910,7 @@ namespace cling {
   bool EvaluateTSynthesizer::ShouldVisit(FunctionDecl* D) {
     // FIXME: Here we should have our custom attribute.
     if (AnnotateAttr* A = D->getAttr<AnnotateAttr>())
-      if (A->getAnnotation().equals("__ResolveAtRuntime"))
+      if (A->getAnnotation() == "__ResolveAtRuntime")
         return true;
     return false;
   }

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -672,7 +672,7 @@ namespace cling {
     llvm::raw_ostream &where = cling::log();
     // `.stats decl' and `.stats asttree FILTER' cause deserialization; force transaction
     PushTransactionRAII RAII(this);
-    if (what.equals("asttree")) {
+    if (what == "asttree") {
       std::unique_ptr<clang::ASTConsumer> printer =
         clang::CreateASTDumper(nullptr /*Dump to stdout.*/,
                                filter, true  /*DumpDecls*/,
@@ -681,11 +681,11 @@ namespace cling {
                                false /*DumpDeclTypes*/,
                                ADOF_Default /*DumpFormat*/);
       printer->HandleTranslationUnit(getSema().getASTContext());
-    } else if (what.equals("ast"))
+    } else if (what == "ast")
       getSema().getASTContext().PrintStats();
-    else if (what.equals("decl"))
+    else if (what == "decl")
       ClangInternalState::printLookupTables(where, getSema().getASTContext());
-    else if (what.equals("undo"))
+    else if (what == "undo")
       m_IncrParser->printTransactionStructure();
   }
 

--- a/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
+++ b/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
@@ -234,7 +234,7 @@ InvocationOptions::InvocationOptions(int argc, const char* const* argv) :
       case Option::UnknownClass:
       case Option::InputClass:
         // prune "-" we need to control where it appears when invoking clang
-        if (!arg->getSpelling().equals("-")) {
+        if (arg->getSpelling() != "-") {
           if (const char* Arg = argv[arg->getIndex()]) {
 #ifdef CLING_TRANSLATE_NOSTDINCxx
             if (!::strcmp(Arg, "-nostdinc++"))

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -121,7 +121,7 @@ namespace cling {
       // Compare the contents of the cached buffer and the string we should
       // process. If there are hash collisions this assert should trigger
       // making it easier to debug.
-      CacheIsValid = FIDContents.equals(llvm::StringRef(code.str() + "\n"));
+      CacheIsValid = FIDContents == llvm::StringRef(code.str() + "\n");
       assert(CacheIsValid && "Hash collision!");
       if (CacheIsValid) {
         // We have already included this file once. Reuse the include loc.
@@ -319,35 +319,42 @@ namespace cling {
       isunsigned = true;
       typeName = StringRef(typeName.data()+9, typeName.size()-9);
     }
-    if (typeName.equals("char")) {
+    if (typeName == "char") {
       if (isunsigned) return Context.UnsignedCharTy;
       return Context.SignedCharTy;
     }
-    if (typeName.equals("short")) {
+    if (typeName == "short") {
       if (isunsigned) return Context.UnsignedShortTy;
       return Context.ShortTy;
     }
-    if (typeName.equals("int")) {
+    if (typeName == "int") {
       if (isunsigned) return Context.UnsignedIntTy;
       return Context.IntTy;
     }
-    if (typeName.equals("long")) {
+    if (typeName == "long") {
       if (isunsigned) return Context.UnsignedLongTy;
       return Context.LongTy;
     }
-    if (typeName.equals("long long")) {
+    if (typeName == "long long") {
       if (isunsigned) return Context.UnsignedLongLongTy;
       return Context.LongLongTy;
     }
     if (!issigned && !isunsigned) {
-      if (typeName.equals("bool")) return Context.BoolTy;
-      if (typeName.equals("float")) return Context.FloatTy;
-      if (typeName.equals("double")) return Context.DoubleTy;
-      if (typeName.equals("long double")) return Context.LongDoubleTy;
+      if (typeName == "bool")
+        return Context.BoolTy;
+      if (typeName == "float")
+        return Context.FloatTy;
+      if (typeName == "double")
+        return Context.DoubleTy;
+      if (typeName == "long double")
+        return Context.LongDoubleTy;
 
-      if (typeName.equals("wchar_t")) return Context.WCharTy;
-      if (typeName.equals("char16_t")) return Context.Char16Ty;
-      if (typeName.equals("char32_t")) return Context.Char32Ty;
+      if (typeName == "wchar_t")
+        return Context.WCharTy;
+      if (typeName == "char16_t")
+        return Context.Char16Ty;
+      if (typeName == "char32_t")
+        return Context.Char32Ty;
     }
     /* Missing
    CanQualType WideCharTy; // Same as WCharTy in C++, integer type in C99.
@@ -1320,12 +1327,12 @@ namespace cling {
        TagDecl *decl = llvm::dyn_cast<TagDecl>(foundDC);
        if (decl) {
           // We have a class or struct or something.
-          if (funcName.substr(1).equals(decl->getName())) {
-             ParsedType PT;
-             QualType QT( decl->getTypeForDecl(), 0 );
-             PT.set(QT);
-             FuncId.setDestructorName(SourceLocation(),PT,SourceLocation());
-             return true;
+          if (funcName.substr(1) == decl->getName()) {
+            ParsedType PT;
+            QualType QT(decl->getTypeForDecl(), 0);
+            PT.set(QT);
+            FuncId.setDestructorName(SourceLocation(), PT, SourceLocation());
+            return true;
           }
        }
        // So it starts with ~ but is not followed by the name of
@@ -1336,14 +1343,14 @@ namespace cling {
        TagDecl *decl = llvm::dyn_cast<TagDecl>(foundDC);
        if (decl) {
           // We have a class or struct or something.
-          if (funcName.equals(decl->getName())) {
-             ParsedType PT;
-             QualType QT( decl->getTypeForDecl(), 0 );
-             PT.set(QT);
-             FuncId.setConstructorName(PT,SourceLocation(),SourceLocation());
+          if (funcName == decl->getName()) {
+            ParsedType PT;
+            QualType QT(decl->getTypeForDecl(), 0);
+            PT.set(QT);
+            FuncId.setConstructorName(PT, SourceLocation(), SourceLocation());
           } else {
-             IdentifierInfo *TypeInfoII = &PP.getIdentifierTable().get(funcName);
-             FuncId.setIdentifier (TypeInfoII, SourceLocation() );
+            IdentifierInfo* TypeInfoII = &PP.getIdentifierTable().get(funcName);
+            FuncId.setIdentifier(TypeInfoII, SourceLocation());
           }
           return true;
        } else {

--- a/interpreter/cling/lib/Interpreter/Transaction.cpp
+++ b/interpreter/cling/lib/Interpreter/Transaction.cpp
@@ -73,7 +73,7 @@ namespace cling {
     for (auto I = decls_begin(), E = decls_end(); I != E; ++I) {
       for (auto DI : I->m_DGR) {
         if (NamedDecl* ND = dyn_cast<NamedDecl>(DI)) {
-          if (name.equals(ND->getNameAsString()))
+          if (name == ND->getNameAsString())
             return ND;
         }
       }
@@ -84,7 +84,7 @@ namespace cling {
         if (LinkageSpecDecl* LSD = dyn_cast<LinkageSpecDecl>(DI)) {
           for (Decl* DI : LSD->decls()) {
             if (NamedDecl* ND = dyn_cast<NamedDecl>(DI)) {
-              if (name.equals(ND->getNameAsString()))
+              if (name == ND->getNameAsString())
                 return ND;
             }
           }

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -134,7 +134,7 @@ namespace cling {
   // FilePath := AnyString
   // AnyString := .*^('\t' Comment)
   bool MetaParser::isLCommand(MetaSema::ActionResult& actionResult) {
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("L")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "L") {
       consumeAnyStringToken(tok::comment);
       llvm::StringRef filePath;
       if (getCurTok().is(tok::raw_ident)) {
@@ -157,7 +157,7 @@ namespace cling {
   // AnyString := .*^('\t' Comment)
   bool MetaParser::isTCommand(MetaSema::ActionResult& actionResult) {
     bool result = false;
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("T")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "T") {
       consumeAnyStringToken();
       if (getCurTok().is(tok::raw_ident)) {
         std::string inputFile = getCurTok().getIdent().str();
@@ -271,8 +271,8 @@ namespace cling {
     if (resultValue)
       *resultValue = Value();
     const Token& Tok = getCurTok();
-    if (Tok.is(tok::ident) && (Tok.getIdent().equals("x")
-                               || Tok.getIdent().equals("X"))) {
+    if (Tok.is(tok::ident) &&
+        (Tok.getIdent() == "x" || Tok.getIdent() == "X")) {
       consumeToken();
       skipWhitespace();
 
@@ -335,7 +335,7 @@ namespace cling {
 
   bool MetaParser::isqCommand() {
     bool result = false;
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("q")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "q") {
       result = true;
       m_Actions.actOnqCommand();
     }
@@ -343,7 +343,7 @@ namespace cling {
   }
 
   bool MetaParser::isUCommand(MetaSema::ActionResult& actionResult) {
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("U")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "U") {
       consumeAnyStringToken(tok::eof);
       llvm::StringRef path;
       if (getCurTok().is(tok::raw_ident)) {
@@ -356,9 +356,8 @@ namespace cling {
   }
 
   bool MetaParser::isICommand() {
-    if (getCurTok().is(tok::ident) &&
-        (   getCurTok().getIdent().equals("I")
-         || getCurTok().getIdent().equals("include"))) {
+    if (getCurTok().is(tok::ident) && (getCurTok().getIdent() == "I" ||
+                                       getCurTok().getIdent() == "include")) {
       consumeAnyStringToken(tok::eof);
       llvm::StringRef path;
       if (getCurTok().is(tok::raw_ident))
@@ -407,8 +406,8 @@ namespace cling {
   }
 
   bool MetaParser::isAtCommand() {
-    if (getCurTok().is(tok::at) // && getCurTok().getIdent().equals("@")
-        ) {
+    if (getCurTok().is(tok::at) // && getCurTok().getIdent() == "@"
+    ) {
       consumeToken();
       skipWhitespace();
       m_Actions.actOnAtCommand();
@@ -418,8 +417,7 @@ namespace cling {
   }
 
   bool MetaParser::israwInputCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("rawInput")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "rawInput") {
       MetaSema::SwitchMode mode = MetaSema::kToggle;
       consumeToken();
       skipWhitespace();
@@ -432,8 +430,7 @@ namespace cling {
   }
 
   bool MetaParser::isdebugCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("debug")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "debug") {
       std::optional<int> mode;
       consumeToken();
       skipWhitespace();
@@ -446,8 +443,7 @@ namespace cling {
   }
 
   bool MetaParser::isprintDebugCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("printDebug")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "printDebug") {
       MetaSema::SwitchMode mode = MetaSema::kToggle;
       consumeToken();
       skipWhitespace();
@@ -460,9 +456,8 @@ namespace cling {
   }
 
   bool MetaParser::isstoreStateCommand() {
-     if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("storeState")) {
-       //MetaSema::SwitchMode mode = MetaSema::kToggle;
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "storeState") {
+      // MetaSema::SwitchMode mode = MetaSema::kToggle;
       consumeToken();
       skipWhitespace();
       if (!getCurTok().is(tok::stringlit))
@@ -477,7 +472,7 @@ namespace cling {
 
   bool MetaParser::iscompareStateCommand() {
     if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("compareState")) {
+        getCurTok().getIdent() == "compareState") {
       //MetaSema::SwitchMode mode = MetaSema::kToggle;
       consumeToken();
       skipWhitespace();
@@ -492,8 +487,7 @@ namespace cling {
   }
 
   bool MetaParser::isstatsCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("stats")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "stats") {
       consumeToken();
       skipWhitespace();
       if (!getCurTok().is(tok::ident))
@@ -511,8 +505,7 @@ namespace cling {
 
   // dumps/creates a trace of the requested representation.
   bool MetaParser::istraceCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("trace")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "trace") {
       consumeToken();
       skipWhitespace();
       if (!getCurTok().is(tok::ident))
@@ -520,9 +513,11 @@ namespace cling {
       llvm::StringRef ident = getCurTok().getIdent();
       consumeToken();
       skipWhitespace();
-      m_Actions.actOnstatsCommand(ident.equals("ast")
-        ? llvm::StringRef("asttree") : ident,
-        getCurTok().is(tok::ident) ? getCurTok().getIdent() : llvm::StringRef());
+      m_Actions.actOnstatsCommand(ident == "ast" ? llvm::StringRef("asttree")
+                                                 : ident,
+                                  getCurTok().is(tok::ident)
+                                      ? getCurTok().getIdent()
+                                      : llvm::StringRef());
       consumeToken();
       return true;
     }
@@ -530,8 +525,7 @@ namespace cling {
   }
 
   bool MetaParser::isundoCommand() {
-    if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("undo")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "undo") {
       consumeToken();
       skipWhitespace();
       const Token& next = getCurTok();
@@ -546,7 +540,7 @@ namespace cling {
 
   bool MetaParser::isdynamicExtensionsCommand() {
     if (getCurTok().is(tok::ident) &&
-        getCurTok().getIdent().equals("dynamicExtensions")) {
+        getCurTok().getIdent() == "dynamicExtensions") {
       MetaSema::SwitchMode mode = MetaSema::kToggle;
       consumeToken();
       skipWhitespace();
@@ -561,7 +555,7 @@ namespace cling {
   bool MetaParser::ishelpCommand() {
     const Token& Tok = getCurTok();
     if (Tok.is(tok::quest_mark) ||
-        (Tok.is(tok::ident) && Tok.getIdent().equals("help"))) {
+        (Tok.is(tok::ident) && Tok.getIdent() == "help")) {
       m_Actions.actOnhelpCommand();
       return true;
     }
@@ -569,7 +563,7 @@ namespace cling {
   }
 
   bool MetaParser::isfileExCommand() {
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("fileEx")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "fileEx") {
       m_Actions.actOnfileExCommand();
       return true;
     }
@@ -577,7 +571,7 @@ namespace cling {
   }
 
   bool MetaParser::isfilesCommand() {
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("files")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "files") {
       m_Actions.actOnfilesCommand();
       return true;
     }
@@ -587,8 +581,8 @@ namespace cling {
   bool MetaParser::isClassCommand() {
     const Token& Tok = getCurTok();
     if (Tok.is(tok::ident)) {
-      if (Tok.getIdent().equals("class") || Tok.getIdent().equals("Class")) {
-        const bool verbose = Tok.getIdent().equals("Class");
+      if (Tok.getIdent() == "class" || Tok.getIdent() == "Class") {
+        const bool verbose = Tok.getIdent() == "Class";
         consumeAnyStringToken(tok::eof);
         const Token& NextTok = getCurTok();
         llvm::StringRef className;
@@ -604,7 +598,7 @@ namespace cling {
   bool MetaParser::isNamespaceCommand() {
     const Token& Tok = getCurTok();
     if (Tok.is(tok::ident)) {
-      if (Tok.getIdent().equals("namespace")) {
+      if (Tok.getIdent() == "namespace") {
         consumeAnyStringToken(tok::eof);
         if (getCurTok().is(tok::raw_ident))
           return false;
@@ -616,7 +610,7 @@ namespace cling {
   }
 
   bool MetaParser::isgCommand() {
-    if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("g")) {
+    if (getCurTok().is(tok::ident) && getCurTok().getIdent() == "g") {
       consumeToken();
       skipWhitespace();
       llvm::StringRef varName;
@@ -631,7 +625,7 @@ namespace cling {
   bool MetaParser::isTypedefCommand() {
     const Token& Tok = getCurTok();
     if (Tok.is(tok::ident)) {
-      if (Tok.getIdent().equals("typedef")) {
+      if (Tok.getIdent() == "typedef") {
         consumeAnyStringToken(tok::eof);
         const Token& NextTok = getCurTok();
         llvm::StringRef typedefName;

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -690,7 +690,8 @@ namespace utils {
         {1,1,1,2,2,2,2};
       StringRef name = Template.getName();
       for(int k=0;stls[k];k++) {
-        if ( name.equals(stls[k]) ) return values[k];
+        if (name == stls[k])
+          return values[k];
       }
     }
     // Check in some struct if the Template decl is registered something like

--- a/interpreter/cling/lib/Utils/Paths.cpp
+++ b/interpreter/cling/lib/Utils/Paths.cpp
@@ -178,7 +178,7 @@ bool LookForFile(const std::vector<const char*>& Args, std::string& Path,
       return true;
     }
     // Don't write same same log entry twice when FilePath == Path
-    if (FileType && !FilePath.str().equals(Path))
+    if (FileType && FilePath.str() != Path)
       LogFileStatus("Ignoring", FileType, FilePath);
   }
   else if (llvm::sys::path::is_absolute(Path))
@@ -218,7 +218,7 @@ bool SplitPaths(llvm::StringRef PathStr,
 
 #if defined(_WIN32)
   // Support using a ':' delimiter on Windows.
-  const bool WindowsColon = Delim.equals(":");
+  const bool WindowsColon = Delim == ":";
 #endif
 
   bool AllExisted = true;

--- a/interpreter/cling/lib/Utils/SourceNormalization.cpp
+++ b/interpreter/cling/lib/Utils/SourceNormalization.cpp
@@ -91,7 +91,7 @@ class MinimalPPLexer: public Lexer {
     if (Ident.empty())
       return false;
 
-    if (Ident.equals("operator")) {
+    if (Ident == "operator") {
       // Tok is the operator, e.g. <=, ==, +...
       // however, for operator() and [], Tok only contains the
       // left side so we need to parse the closing right side
@@ -251,7 +251,7 @@ public:
         Ctor = true;
 
       // Constructor and Destructor identifiers must match
-      if (!First.equals(Ident)) {
+      if (First != Ident) {
         if (!SkipPointerRefs(Tok))
           return kNONE;
 
@@ -269,12 +269,12 @@ public:
     } else {
       bool SeenModifier = false;
       auto AnalyzeModifier = [&SeenModifier](llvm::StringRef Modifier) {
-        if (Modifier.equals("signed") || Modifier.equals("unsigned") ||
-            Modifier.equals("short") || Modifier.equals("long")) {
+        if (Modifier == "signed" || Modifier == "unsigned" ||
+            Modifier == "short" || Modifier == "long") {
           SeenModifier = true;
         }
       };
-      if (First.equals("struct") || First.equals("class")) {
+      if (First == "struct" || First == "class") {
         do {
           // Identifier(Tok).empty() is redundant 1st time, but simplifies code
           if (Identifier(Tok).empty() || !LexClean(Tok))
@@ -288,8 +288,8 @@ public:
         if (Tok.is(tok::colon))
           return !AdvanceTo(Tok, tok::l_brace) ? kClass : kNONE;
 
-      } else if (First.equals("static") || First.equals("constexpr") ||
-                 First.equals("inline") || First.equals("const")) {
+      } else if (First == "static" || First == "constexpr" ||
+                 First == "inline" || First == "const") {
         // First check if the current keyword is a modifier.
         llvm::StringRef Modifier = Identifier(Tok);
         AnalyzeModifier(Modifier);
@@ -377,7 +377,7 @@ public:
       }
 
       // class const method 'CLASS::method() const {'
-      if (!Ctor && Identifier(Tok).equals("const")) {
+      if (!Ctor && Identifier(Tok) == "const") {
         if (LexClean(Tok) && Tok.is(tok::l_brace))
           return kFunction;
       }
@@ -478,8 +478,8 @@ size_t cling::utils::getWrapPoint(std::string& source,
       do {
         if (Tok.getKind() == tok::raw_identifier) {
           StringRef keyword(Tok.getRawIdentifier());
-          if (keyword.equals("__global__") || keyword.equals("__device__") ||
-              keyword.equals("__host__"))
+          if (keyword == "__global__" || keyword == "__device__" ||
+              keyword == "__host__")
             // if attribute was found, skip the token and use the function
             // detection later
             Lex.Lex(Tok);
@@ -519,7 +519,7 @@ size_t cling::utils::getWrapPoint(std::string& source,
 
     if (Tok.getKind() == tok::raw_identifier && !Tok.needsCleaning()) {
       StringRef keyword(Tok.getRawIdentifier());
-      if (keyword.equals("using")) {
+      if (keyword == "using") {
         // FIXME: Using definitions and declarations should be decl extracted.
         // Until we have that, don't wrap them if they are the only input.
         if (Lex.AdvanceTo(Tok, tok::semi)) {
@@ -533,11 +533,11 @@ size_t cling::utils::getWrapPoint(std::string& source,
         // non-wrapped statement.
         return getFileOffset(Tok) + 1;
       }
-      if (keyword.equals("extern"))
+      if (keyword == "extern")
         return std::string::npos;
-      if (keyword.equals("namespace"))
+      if (keyword == "namespace")
         return std::string::npos;
-      if (keyword.equals("template"))
+      if (keyword == "template")
         return std::string::npos;
 
       auto HasBody{false};


### PR DESCRIPTION
This was removed in LLVM19
https://github.com/llvm/llvm-project/commit/deffae5da123b32098914d8346bf4358a6792bdc

This will reduce the changes needed when upgrading LLVM versions

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

