### PR TITLE
Use appropriate constructor in test

### DIFF
--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -45,13 +45,13 @@ TEST(RDataFrameNodes, RSlotStackPutBackTooMany)
 
 TEST(RDataFrameNodes, RLoopManagerGetLoopManagerUnchecked)
 {
-   ROOT::Detail::RDF::RLoopManager lm(nullptr, {});
+   ROOT::Detail::RDF::RLoopManager lm{};
    ASSERT_EQ(&lm, lm.GetLoopManagerUnchecked());
 }
 
 TEST(RDataFrameNodes, RLoopManagerJitWrongCode)
 {
-   ROOT::Detail::RDF::RLoopManager lm(nullptr, {});
+   ROOT::Detail::RDF::RLoopManager lm{};
    lm.ToJitExec("souble d = 3.14");
    EXPECT_THROW(lm.Run(), std::runtime_error) << "Bogus C++ code was jitted and nothing was detected!";
 }


### PR DESCRIPTION

Small followup to https://github.com/root-project/root/pull/17739

Use the RLoopManager constructor without a data source in the simple tests that just check for the validity of the constructed RLoopManager.
