### PR TITLE
[Minuit2] Cache transformed parameter values in MnHesse

### DIFF
--- a/math/minuit2/inc/Minuit2/MnHesse.h
+++ b/math/minuit2/inc/Minuit2/MnHesse.h
@@ -70,13 +70,6 @@ public:
    double TolerG2() const { return fStrategy.HessianG2Tolerance(); }
 
 private:
-
-   /// internal function to compute the Hessian using numerical derivative computation
-   MinimumState ComputeNumerical(const MnFcn &, const MinimumState &, const MnUserTransformation &, unsigned int maxcalls) const;
-
-   /// internal function to compute the Hessian using an analytical computation or externally provided in the FCNBase class
-   MinimumState ComputeAnalytical(const FCNBase &, const MinimumState &, const MnUserTransformation &) const;
-
    MnStrategy fStrategy;
 };
 

--- a/math/minuit2/inc/Minuit2/MnUserFcn.h
+++ b/math/minuit2/inc/Minuit2/MnUserFcn.h
@@ -12,6 +12,8 @@
 
 #include "Minuit2/MnFcn.h"
 
+#include <vector>
+
 namespace ROOT {
 
 namespace Minuit2 {
@@ -33,6 +35,12 @@ public:
    ~MnUserFcn() override {}
 
    double operator()(const MnAlgebraicVector &) const override;
+
+   // Access the parameter transformations.
+   // For internal use in the Minuit2 implementation.
+   const MnUserTransformation &transform() const { return fTransform; }
+
+   double callWithTransformedParams(std::vector<double> const &vpar) const;
 
 private:
    const MnUserTransformation &fTransform;

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -26,7 +26,6 @@
 #include "Minuit2/MinosError.h"
 #include "Minuit2/MnHesse.h"
 #include "Minuit2/MinuitParameter.h"
-#include "Minuit2/MnUserFcn.h"
 #include "Minuit2/MnPrint.h"
 #include "Minuit2/VariableMetricMinimizer.h"
 #include "Minuit2/SimplexMinimizer.h"

--- a/math/minuit2/src/MnHesse.cxx
+++ b/math/minuit2/src/MnHesse.cxx
@@ -27,6 +27,19 @@ namespace ROOT {
 
 namespace Minuit2 {
 
+namespace {
+
+/// Internal function to compute the Hessian using numerical derivative
+/// computation.
+MinimumState ComputeNumerical(const MnFcn &, const MinimumState &, const MnUserTransformation &, unsigned int maxcalls,
+                              MnStrategy const &strat);
+
+/// Internal function to compute the Hessian using an analytical computation or
+/// externally provided in the FCNBase class.
+MinimumState ComputeAnalytical(const FCNBase &, const MinimumState &, const MnUserTransformation &);
+
+} // namespace
+
 MnUserParameterState
 MnHesse::operator()(const FCNBase &fcn, const MnUserParameterState &state, unsigned int maxcalls) const
 {
@@ -49,8 +62,9 @@ MnHesse::operator()(const FCNBase &fcn, const MnUserParameterState &state, unsig
    // case of numerical gradient
    Numerical2PGradientCalculator gc(mfcn, state.Trafo(), fStrategy);
    FunctionGradient gra = gc(par);
-   MinimumState tmp = ComputeNumerical(mfcn, MinimumState(par, MinimumError(MnAlgebraicSymMatrix(n), 1.), gra, state.Edm(), state.NFcn()),
-              state.Trafo(), maxcalls);
+   MinimumState tmp = ComputeNumerical(
+      mfcn, MinimumState(par, MinimumError(MnAlgebraicSymMatrix(n), 1.), gra, state.Edm(), state.NFcn()), state.Trafo(),
+      maxcalls, fStrategy);
    return MnUserParameterState(tmp, fcn.Up(), state.Trafo());
 }
 
@@ -75,9 +89,12 @@ MinimumState MnHesse::operator()(const MnFcn &mfcn, const MinimumState &st, cons
       }
    }
    // case of numerical computation or only analytical first derivatives
-   return ComputeNumerical(mfcn, st, trafo, maxcalls);
+   return ComputeNumerical(mfcn, st, trafo, maxcalls, fStrategy);
 }
-MinimumState MnHesse::ComputeAnalytical(const FCNBase & fcn, const MinimumState &st, const MnUserTransformation &trafo) const
+
+namespace {
+
+MinimumState ComputeAnalytical(const FCNBase &fcn, const MinimumState &st, const MnUserTransformation &trafo)
 {
    unsigned int n = st.Parameters().Vec().size();
    MnAlgebraicSymMatrix vhmat(n);
@@ -147,9 +164,8 @@ MinimumState MnHesse::ComputeAnalytical(const FCNBase & fcn, const MinimumState 
    return MinimumState(st.Parameters(), err, gr, edm, st.NFcn());
 }
 
-
-MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st, const MnUserTransformation &trafo,
-                                 unsigned int maxcalls) const
+MinimumState ComputeNumerical(const MnFcn &mfcn, const MinimumState &st, const MnUserTransformation &trafo,
+                              unsigned int maxcalls, MnStrategy const &strat)
 {
    // internal interface from MinimumState and MnUserTransformation
    // Function who does the real Hessian calculations
@@ -177,7 +193,7 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    if (st.Gradient().IsAnalytical()) {
       print.Info("Using analytical gradient but a numerical Hessian calculator - it could be not optimal");
-      Numerical2PGradientCalculator igc(mfcn, trafo, fStrategy);
+      Numerical2PGradientCalculator igc(mfcn, trafo, strat);
       // should we check here if numerical gradient is compatible with analytical one ?
       FunctionGradient tmp = igc(st.Parameters());
       gst = tmp.Gstep();
@@ -201,7 +217,7 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
       print.Debug("Derivative parameter", i, "d =", d, "dmin =", dmin);
 
-      for (unsigned int icyc = 0; icyc < Ncycles(); icyc++) {
+      for (unsigned int icyc = 0; icyc < strat.HessianNCycles(); icyc++) {
          double sag = 0.;
          double fs1 = 0.;
          double fs2 = 0.;
@@ -261,9 +277,9 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
                      "diffg2 =", std::fabs(g2(i) - g2bfor) / g2(i));
 
          // see if converged
-         if (std::fabs((d - dlast) / d) < Tolerstp())
+         if (std::fabs((d - dlast) / d) < strat.HessianStepTolerance())
             break;
-         if (std::fabs((g2(i) - g2bfor) / g2(i)) < TolerG2())
+         if (std::fabs((g2(i) - g2bfor) / g2(i)) < strat.HessianG2Tolerance())
             break;
          d = std::min(d, 10. * dlast);
          d = std::max(d, 0.1 * dlast);
@@ -286,9 +302,9 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    print.Debug("Second derivatives", g2);
 
-   if (fStrategy.Strategy() > 0) {
+   if (strat.Strategy() > 0) {
       // refine first derivative
-      HessianGradientCalculator hgc(mfcn, trafo, fStrategy);
+      HessianGradientCalculator hgc(mfcn, trafo, strat);
       FunctionGradient gr = hgc(st.Parameters(), FunctionGradient(grd, g2, gst));
       // update gradient and step values
       grd = gr.Grad();
@@ -297,7 +313,7 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    // off-diagonal Elements
    // initial starting values
-   bool doCentralFD = fStrategy.HessianCentralFDMixedDerivatives();
+   bool doCentralFD = strat.HessianCentralFDMixedDerivatives();
    if (n > 0) {
       MPIProcess mpiprocOffDiagonal(n * (n - 1) / 2, 0);
       unsigned int startParIndexOffDiagonal = mpiprocOffDiagonal.StartElementIndex();
@@ -351,7 +367,7 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    MinimumError tmpErr = MnPosDef()(MinimumError(vhmat, 1.), prec); // pos-def version of hessian
 
-   if(fStrategy.HessianForcePosDef()) {
+   if (strat.HessianForcePosDef()) {
       vhmat = tmpErr.InvHessian();
    }
 
@@ -377,7 +393,7 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    // if matrix is made pos def returns anyway edm
    if (tmpErr.IsMadePosDef()) {
-      MinimumError err(vhmat, fStrategy.HessianForcePosDef() ? MinimumError::MnMadePosDef : MinimumError::MnNotPosDef);
+      MinimumError err(vhmat, strat.HessianForcePosDef() ? MinimumError::MnMadePosDef : MinimumError::MnNotPosDef);
       double edm = estim.Estimate(gr, err);
       return MinimumState(st.Parameters(), err, gr, edm, mfcn.NumOfCalls());
    }
@@ -391,6 +407,8 @@ MinimumState MnHesse::ComputeNumerical(const MnFcn &mfcn, const MinimumState &st
 
    return MinimumState(st.Parameters(), err, gr, edm, mfcn.NumOfCalls());
 }
+
+} // namespace
 
 /*
  MinimumError MnHesse::Hessian(const MnFcn& mfcn, const MinimumState& st, const MnUserTransformation& trafo) const {

--- a/math/minuit2/src/MnUserFcn.cxx
+++ b/math/minuit2/src/MnUserFcn.cxx
@@ -17,9 +17,6 @@ namespace Minuit2 {
 
 double MnUserFcn::operator()(const MnAlgebraicVector &v) const
 {
-   // call Fcn function transforming from a MnAlgebraicVector of internal values to a std::vector of external ones
-   fNumCall++;
-
    // calling fTransform() like here was not thread safe because it was using a cached vector
    // return Fcn()( fTransform(v) );
    // make a new thread-safe implementation creating a vector each time
@@ -38,6 +35,17 @@ double MnUserFcn::operator()(const MnAlgebraicVector &v) const
          vpar[ext] = v(i);
       }
    }
+
+   return callWithTransformedParams(vpar);
+}
+
+// Calling the underlying function with the transformed parameters.
+// For internal use in the Minuit2 implementation.
+double MnUserFcn::callWithTransformedParams(std::vector<double> const &vpar) const
+{
+   // call Fcn function transforming from a MnAlgebraicVector of internal values to a std::vector of external ones
+   fNumCall++;
+
    return Fcn()(vpar);
 }
 

--- a/math/minuit2/src/ModularFunctionMinimizer.cxx
+++ b/math/minuit2/src/ModularFunctionMinimizer.cxx
@@ -22,7 +22,6 @@
 #include "Minuit2/MnUserFcn.h"
 #include "Minuit2/FCNBase.h"
 #include "Minuit2/MnStrategy.h"
-#include "Minuit2/MnHesse.h"
 #include "Minuit2/MnLineSearch.h"
 #include "Minuit2/MnParabolaPoint.h"
 #include "Minuit2/MnPrint.h"


### PR DESCRIPTION
It was figured out with `perf` and `flamegraph.pl` that the main
performance bottleneck when using Minuits Hesse on RooFit likelihoods is
the transformation to internal Minuit parameters in MnHesse, which is a
relatively expensive trigonometric operation. It is done for all
parameters at every function operation, even if only one parameter is
changed. We need to do order n-squared function calls for the Hessian.
The total runtime of calling the RooFit function itself scales only
linearly with the number of parameters, thanks to the caching in RooFit.
However, the parameter transformation in MnHesse implements no caching
and therefore has quadratic cost.

This PR implements caching for the transformed parameters to make
this bottleneck go away completely.

With the changes in this PR, the plan-of-work item of "Speedup the
computation of the Hessian for big Higgs combinations at least by factor
of 2" is completed. Our ATLAS benchmark is now doing the Hesse step in
100 s instead of 120 s. But as the addressed bottleneck grows with the
number of fit parameters squared, this optimization will have a much
stronger impact on some reported user workflows, where computing the
Hessian takes hours right now. In any case, considering also the
performance improvements in other PRs in this development cycle, one
gets a 2 x speedup in our benchmark too (see #17816).

This change in Minuit indirectly affects all RooFit users. I saw that
this parameter transformation is also the main bottleneck in evaluating
Hessians with likelihoods from CMS combine.

## ATLAS Higgs combination benchmark

### With ROOT master

Total runtime of `minimize()` and `hesse()`: 160 s.

![atlas_old](https://github.com/user-attachments/assets/2dd53e3a-a468-4256-be5a-e7b3ef42ed11)

### With this PR and #17816

Total runtime of `minimize()` and `hesse()`: 105 s (34 % faster).

![atlas_new](https://github.com/user-attachments/assets/2cf301a8-8c30-4216-b9d8-6e3f899579a6)

The new bottlenecks are again in RooFit:

  * dirty flag propagation with `RooAbsArg::setValueDirty()` (about 10 s runtime, we can get rid of it easily because the new CPU evaluation backend doesn't use the dirty flag information anyway)
  * Other overhead in `RooFit::Evaluator::run()` that is not related to actual computation, again 10 more seconds. I don't know what to do about it.

In particular, the `setValueDirty()` is responsible for most of the runtime in the line search. If we get rid of it, the line search will bottleneck fits with AD much less, where the gradient step is very fast and the line search is the bottleneck of the overall minimization.