### PR TITLE
[ntuple] Simplify `RNTupleJoinTable` probe interface

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
@@ -140,59 +140,13 @@ public:
    bool IsBuilt() const { return fIsBuilt; }
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get the first entry number corresponding to the given join field value(s).
-   ///
-   /// \param[in] valuePtrs A vector of pointers to the join field values to look up.
-   ///
-   /// \return The first entry number that corresponds to `valuePtrs`. When no such entry exists, `kInvalidNTupleIndex`
-   /// is returned.
-   ///
-   /// Note that in case multiple entries corresponding to the provided join field value exist, the first occurrence is
-   /// returned. Use RNTupleJoinTable::GetAllEntryNumbers to get all entries.
-   ROOT::NTupleSize_t GetFirstEntryNumber(const std::vector<void *> &valuePtrs) const;
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get the entry number corresponding to the given join field value(s).
-   ///
-   /// \sa GetFirstEntryNumber(std::vector<void *> valuePtrs)
-   template <typename... Ts>
-   ROOT::NTupleSize_t GetFirstEntryNumber(Ts... values) const
-   {
-      if (sizeof...(Ts) != fJoinFieldNames.size())
-         throw RException(R__FAIL("number of values must match number of join fields"));
-
-      std::vector<void *> valuePtrs;
-      valuePtrs.reserve(sizeof...(Ts));
-      ([&] { valuePtrs.push_back(&values); }(), ...);
-
-      return GetFirstEntryNumber(valuePtrs);
-   }
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Get all entry numbers for the given join field value(s).
    ///
    /// \param[in] valuePtrs A vector of pointers to the join field values to look up.
    ///
-   /// \return The entry numbers that corresponds to `valuePtrs`. When no such entry exists, an empty vector is
-   /// returned.
-   const std::vector<ROOT::NTupleSize_t> *GetAllEntryNumbers(const std::vector<void *> &valuePtrs) const;
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get all entry numbers for the given join field value(s).
-   ///
-   /// \sa GetAllEntryNumbers(std::vector<void *> valuePtrs)
-   template <typename... Ts>
-   const std::vector<ROOT::NTupleSize_t> *GetAllEntryNumbers(Ts... values) const
-   {
-      if (sizeof...(Ts) != fJoinFieldNames.size())
-         throw RException(R__FAIL("number of values must match number of join fields"));
-
-      std::vector<void *> valuePtrs;
-      valuePtrs.reserve(sizeof...(Ts));
-      ([&] { valuePtrs.push_back(&values); }(), ...);
-
-      return GetAllEntryNumbers(valuePtrs);
-   }
+   /// \return The entry indexes that correspond to `valuePtrs`. An empty vector is returned when there are no matching
+   /// indexes.
+   std::vector<ROOT::NTupleSize_t> GetEntryIndexes(const std::vector<void *> &valuePtrs) const;
 };
 } // namespace Internal
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleJoinTable.hxx
@@ -67,14 +67,14 @@ private:
    };
 
    /// The join table itself. Maps field values (or combinations thereof in case the join table is defined for multiple
-   /// fields) to their respective entry numbers.
+   /// fields) to their respective entry indexes.
    std::unordered_map<RCombinedJoinFieldValue, std::vector<ROOT::NTupleSize_t>, RCombinedJoinFieldValueHash> fJoinTable;
 
-   /// Names of the join fields used for the mapping to their respective entry numbers.
+   /// Names of the join fields used for the mapping to their respective entry indexes.
    std::vector<std::string> fJoinFieldNames;
 
    /// The size (in bytes) for each join field, corresponding to `fJoinFieldNames`. This information is stored to be
-   /// able to properly cast incoming void pointers to the join field values in `GetAllEntryNumbers`.
+   /// able to properly cast incoming void pointers to the join field values in `GetEntryIndexes`.
    std::vector<std::size_t> fJoinFieldValueSizes;
 
    /// Only built join tables can be queried.
@@ -114,8 +114,7 @@ public:
    ///
    /// \param[in] pageSource The page source of the RNTuple for which to build the join table.
    ///
-   /// Only a built join table can be queried (with RNTupleJoinTable::GetFirstEntryNumber or
-   /// RNTupleJoinTable::GetAllEntryNumbers).
+   /// Only a built join table can be queried (with RNTupleJoinTable::GetEntryIndexes).
    void Build(RPageSource &pageSource);
 
    /////////////////////////////////////////////////////////////////////////////
@@ -140,7 +139,7 @@ public:
    bool IsBuilt() const { return fIsBuilt; }
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get all entry numbers for the given join field value(s).
+   /// \brief Get all entry indexes for the given join field value(s).
    ///
    /// \param[in] valuePtrs A vector of pointers to the join field values to look up.
    ///

--- a/tree/ntuple/v7/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/v7/src/RNTupleJoinTable.cxx
@@ -104,17 +104,8 @@ void ROOT::Experimental::Internal::RNTupleJoinTable::Build(RPageSource &pageSour
    fIsBuilt = true;
 }
 
-ROOT::NTupleSize_t
-ROOT::Experimental::Internal::RNTupleJoinTable::GetFirstEntryNumber(const std::vector<void *> &valuePtrs) const
-{
-   const auto entryIndices = GetAllEntryNumbers(valuePtrs);
-   if (!entryIndices)
-      return ROOT::kInvalidNTupleIndex;
-   return entryIndices->front();
-}
-
-const std::vector<ROOT::NTupleSize_t> *
-ROOT::Experimental::Internal::RNTupleJoinTable::GetAllEntryNumbers(const std::vector<void *> &valuePtrs) const
+std::vector<ROOT::NTupleSize_t>
+ROOT::Experimental::Internal::RNTupleJoinTable::GetEntryIndexes(const std::vector<void *> &valuePtrs) const
 {
    EnsureBuilt();
 
@@ -128,10 +119,10 @@ ROOT::Experimental::Internal::RNTupleJoinTable::GetAllEntryNumbers(const std::ve
       joinFieldValues.push_back(CastValuePtr(valuePtrs[i], fJoinFieldValueSizes[i]));
    }
 
-   auto entryNumber = fJoinTable.find(RCombinedJoinFieldValue(joinFieldValues));
+   auto entryIdxs = fJoinTable.find(RCombinedJoinFieldValue(joinFieldValues));
 
-   if (entryNumber == fJoinTable.end())
-      return nullptr;
+   if (entryIdxs == fJoinTable.end())
+      return {};
 
-   return &(entryNumber->second);
+   return entryIdxs->second;
 }

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -537,7 +537,12 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
       if (!joinTable->IsBuilt())
          joinTable->Build(*fAuxiliaryPageSources[i]);
 
-      auxEntryIdxs.push_back(joinTable->GetFirstEntryNumber(valPtrs));
+      auto entryIdxs = joinTable->GetEntryIndexes(valPtrs);
+
+      if (entryIdxs.empty())
+         auxEntryIdxs.push_back(kInvalidNTupleIndex);
+      else
+         auxEntryIdxs.push_back(entryIdxs[0]);
    }
 
    // For each auxiliary field, load its value according to the entry number we just found of the ntuple it belongs to.


### PR DESCRIPTION
With this change, `RNTupleJoinTable` returns all matching entries in all cases, and the responsibility of deciding which entry to use is more explicitly put on the downstream application. This is fine, because these decisions need to be made downstream anyways. The templated interface is removed as well, as its practical use is currently not clear enough.

The `RNTupleJoinTable` itself is in the process of a redesign, where it will store the mappings of join values to entry indexes in partitions. With this change, it won't be possible to directly return the pointer to the list of entry indexes stored in the join table anymore. The changes in this commit already anticipate this redesign by changing the return type of `GetEntryIndexes`.
