### PR TITLE
[tree] Fix interaction between GetEntries and GetListOfFriends

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -985,7 +985,14 @@ Long64_t TChain::GetEntries() const
       return fProofChain->GetEntries();
    }
    if (fEntries == TTree::kMaxEntries) {
-      const_cast<TChain*>(this)->LoadTree(TTree::kMaxEntries-1);
+      const auto readEntry = fReadEntry;
+      auto *thisChain = const_cast<TChain *>(this);
+      thisChain->LoadTree(TTree::kMaxEntries - 1);
+      thisChain->InvalidateCurrentTree();
+      if (readEntry >= 0)
+         thisChain->LoadTree(readEntry);
+      else
+         thisChain->fReadEntry = readEntry;
    }
    return fEntries;
 }

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -985,6 +985,10 @@ Long64_t TChain::GetEntries() const
       return fProofChain->GetEntries();
    }
    if (fEntries == TTree::kMaxEntries) {
+      // If the following is true, we are within a recursion about friend,
+      // and `LoadTree` will be no-op.
+      if (kLoadTree & fFriendLockStatus)
+         return fEntries;
       const auto readEntry = fReadEntry;
       auto *thisChain = const_cast<TChain *>(this);
       thisChain->LoadTree(TTree::kMaxEntries - 1);

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -345,7 +345,7 @@ Long64_t TTreeIndex::GetEntryNumberFriend(const TTree *parent)
    if (!parent) return -3;
    // We reached the end of the parent tree
    Long64_t pentry = parent->GetReadEntry();
-   if (pentry >= parent->GetEntries())
+   if (pentry >= parent->GetEntriesFast())
       return -2;
    GetMajorFormulaParent(parent);
    GetMinorFormulaParent(parent);

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -23,3 +23,5 @@ endif()
 ROOT_ADD_GTEST(ttreeindex_clone ttreeindex_clone.cxx LIBRARIES TreePlayer)
 
 ROOT_ADD_GTEST(ttreereader_friends ttreereader_friends.cxx LIBRARIES TreePlayer)
+
+ROOT_ADD_GTEST(ttreeindex_getlistoffriends ttreeindex_getlistoffriends.cxx LIBRARIES TreePlayer)

--- a/tree/treeplayer/test/ttreeindex_getlistoffriends.cxx
+++ b/tree/treeplayer/test/ttreeindex_getlistoffriends.cxx
@@ -1,0 +1,114 @@
+#include "TBranch.h"
+#include "TChain.h"
+#include "TCollection.h" // TRangeDynCast
+#include "TFile.h"
+#include "TFriendElement.h"
+#include "TObjArray.h"
+#include "TTree.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+void write_data(std::string_view treename, std::string_view filename)
+{
+   TFile f{filename.data(), "update"};
+   TTree t{treename.data(), treename.data()};
+   int runNumber{};
+   int eventNumber{};
+   float val{};
+   t.Branch("runNumber", &runNumber, "runNumber/I");
+   t.Branch("eventNumber", &eventNumber, "eventNumber/I");
+   t.Branch("val", &val, "val/F");
+   if (treename == "main") {
+      for (auto rn = 0; rn < 3; rn++) {
+         runNumber = rn;
+         for (auto en = 0; en < 5; en++) {
+            eventNumber = en;
+            val = en * rn;
+            t.Fill();
+         }
+      }
+   } else {
+      for (auto rn = 0; rn < 3; rn++) {
+         runNumber = rn;
+         for (auto en = 4; en >= 0; en--) {
+            eventNumber = en;
+            val = en * rn;
+            t.Fill();
+         }
+      }
+   }
+
+   f.Write();
+}
+
+struct TTreeIndexGH_17820 : public ::testing::Test {
+   constexpr static auto fFileName{"ttreeindex_getlistoffriends_gh_17820.root"};
+   constexpr static auto fMainName{"main"};
+   constexpr static auto fFriendName{"friend"};
+
+   static void SetUpTestCase()
+   {
+      write_data(fMainName, fFileName);
+      write_data(fFriendName, fFileName);
+   }
+
+   static void TearDownTestCase() { std::remove(fFileName); }
+};
+
+void expect_branch_names(const TObjArray *branches, const std::vector<std::string> &branchNames)
+{
+   auto nBranchNames = branchNames.size();
+   decltype(nBranchNames) nBranches{};
+   for (const auto *br : TRangeDynCast<TBranch>(branches)) {
+      EXPECT_STREQ(br->GetName(), branchNames[nBranches].c_str());
+      nBranches++;
+   }
+   EXPECT_EQ(nBranches, nBranchNames);
+}
+
+// Regression test for https://github.com/root-project/root/issues/17820
+TEST_F(TTreeIndexGH_17820, RunTest)
+{
+   TChain mainChain{fMainName};
+   mainChain.AddFile(fFileName);
+
+   TChain friendChain{fFriendName};
+   friendChain.AddFile(fFileName);
+   friendChain.BuildIndex("runNumber", "eventNumber");
+
+   mainChain.AddFriend(&friendChain);
+
+   // Calling GetEntries used to mess with the fTree data member of the main
+   // chain, not connecting it to the friend chain and thus losing the list
+   // of friends. This in turn corrupted the list of branches.
+   mainChain.GetEntries();
+
+   const auto *listOfBranches = mainChain.GetListOfBranches();
+   ASSERT_TRUE(listOfBranches);
+
+   const std::vector<std::string> expectedNames{"runNumber", "eventNumber", "val"};
+
+   expect_branch_names(listOfBranches, expectedNames);
+
+   const auto *curTree = mainChain.GetTree();
+   ASSERT_TRUE(curTree);
+
+   const auto *listOfFriends = mainChain.GetTree()->GetListOfFriends();
+   ASSERT_TRUE(listOfFriends);
+   EXPECT_EQ(listOfFriends->GetEntries(), 1);
+
+   auto *friendTree = dynamic_cast<TTree *>(dynamic_cast<TFriendElement *>(listOfFriends->At(0))->GetTree());
+   ASSERT_TRUE(friendTree);
+
+   EXPECT_STREQ(friendTree->GetName(), fFriendName);
+   const auto *friendFile = friendTree->GetCurrentFile();
+   ASSERT_TRUE(friendFile);
+   EXPECT_STREQ(friendFile->GetName(), fFileName);
+
+   const auto *friendBranches = friendTree->GetListOfBranches();
+   expect_branch_names(friendBranches, expectedNames);
+}


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/17820

Full analysis of the issue follows:

1. TChain::GetEntries calls TChain::LoadTree(TTree::kMaxEntries - 1)

2. Internally, this will set fReadEntry == -2, due to how LoadTree works and the fact it's trying to read beyond the last entry in the chain

3. This has an effect here https://github.com/root-project/root/blob/f33985dca2d6bc505e83498f7b4561ddd969be17/tree/tree/src/TChain.cxx#L1675-L1679 where `t` is the current friend being traversed in the list of friends of the *chain*. We call `t->LoadTree(TTree::kMaxEntries - 1)`.

4. Inside the call to LoadTree on the friend, we reach this line https://github.com/root-project/root/blob/f33985dca2d6bc505e83498f7b4561ddd969be17/tree/tree/src/TChain.cxx#L1484 where the fTree data member of the friend is invalidated.

5. Back to the LoadTree of the main chain, these lines https://github.com/root-project/root/blob/f33985dca2d6bc505e83498f7b4561ddd969be17/tree/tree/src/TChain.cxx#L1681-L1684 would normally connect the fTree data member of the main chain to the current friend, so the list of friends is properly populated. But due to 4., `friend->GetTree()` will return nullptr so the connection won't happen.

