### PR TITLE
[histpainter] adjust macros in docu [skip-ci]

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -1696,8 +1696,9 @@ Begin_Macro(source)
    htext5->SetMarkerSize(1.8);
    htext5->SetMarkerColor(kRed);
    htext4->SetBarOffset(0.2);
-   htext4->Draw("COL TEXT SAME");
    htext5->SetBarOffset(-0.2);
+   htext3->Draw("COL");
+   htext4->Draw("TEXT SAME");
    htext5->Draw("TEXT SAME");
 }
 End_Macro


### PR DESCRIPTION
When demonstrating drawing of shifted text,
draw first histogram with "COL" option,
then other with "TEXT SAME" option.
