### PR TITLE
[ntuple] Remove blanks between angle brackets earlier

### DIFF
--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -106,6 +106,25 @@ std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::stri
       canonicalType.erase(0, 2);
    }
 
+   // TClassEdit::CleanType inserts blanks between closing angle brackets, as they were required before C++11. We want
+   // to remove them for RNTuple.
+   auto angle = canonicalType.find('<');
+   if (angle != std::string::npos) {
+      auto dst = canonicalType.begin() + angle;
+      auto end = canonicalType.end();
+      for (auto src = dst; src != end; ++src) {
+         if (*src == ' ') {
+            auto next = src + 1;
+            if (next != end && *next == '>') {
+               // Skip this space before a closing angle bracket.
+               continue;
+            }
+         }
+         *(dst++) = *src;
+      }
+      canonicalType.erase(dst, end);
+   }
+
    if (canonicalType.substr(0, 6) == "array<") {
       canonicalType = "std::" + canonicalType;
    } else if (canonicalType.substr(0, 7) == "atomic<") {


### PR DESCRIPTION
... in `GetCanonicalTypePrefix`: This is required so substring operations work correctly in `RFieldBase::Create`, for example to get the item type of containers. It is hard to observe from the outside since template parameters are further processed in `GetRenormalizedTypeName` and `GetNormalizedUnresolvedTypeName` respectively. As a test, check field emulation of a templated type inside a vector.