### PR TITLE
[hist] Fix invalid int comparison and printf usage in TFormula

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -1101,7 +1101,7 @@ void TFormula::HandlePolN(TString &formula)
       // build replacement string (modified)
       TString replacement;
       if (isNewFormat && !paramNames.empty()) {
-         for (size_t i = 0; i <= degree && i < paramNames.size(); i++) {
+         for (Int_t i = 0; i <= degree && i < static_cast<Int_t>(paramNames.size()); i++) {
             if (i == 0) {
                replacement = TString::Format("[%s]", paramNames[i].Data());
             } else if (i == 1) {


### PR DESCRIPTION
#17623 introduced a warning (that is, a compile error in `dev=ON`) due to improper int comparisons.
This PR fixes it. I chose to cast to `Int_t` rather than `size_t` to automatically handle the case where `degree < 0` (which I assume is "impossible" but you never know, given that `degree` is derived from string parsing above...)