### PR TITLE
[ntuple] Make all compression settings unsigned

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -342,7 +342,7 @@ public:
    struct RSealPageConfig {
       const RPage *fPage = nullptr;                 ///< Input page to be sealed
       const RColumnElementBase *fElement = nullptr; ///< Corresponds to the page's elements, for size calculation etc.
-      std::uint32_t fCompressionSetting = 0;        ///< Compression algorithm and level to apply
+      std::uint32_t fCompressionSettings = 0;       ///< Compression algorithm and level to apply
       /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
       /// to store the additional 8 bytes.
       bool fWriteChecksum = true;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -268,7 +268,7 @@ public:
       struct RColumnInfo {
          RClusterDescriptor::RPageRange fPageRange;
          ROOT::NTupleSize_t fNElements = ROOT::kInvalidNTupleIndex;
-         int fCompressionSettings;
+         std::uint32_t fCompressionSettings;
          bool fIsSuppressed = false;
       };
 
@@ -342,7 +342,7 @@ public:
    struct RSealPageConfig {
       const RPage *fPage = nullptr;                 ///< Input page to be sealed
       const RColumnElementBase *fElement = nullptr; ///< Corresponds to the page's elements, for size calculation etc.
-      int fCompressionSetting = 0;                  ///< Compression algorithm and level to apply
+      std::uint32_t fCompressionSetting = 0;        ///< Compression algorithm and level to apply
       /// Adds a 8 byte little-endian xxhash3 checksum to the page payload. The buffer has to be large enough to
       /// to store the additional 8 bytes.
       bool fWriteChecksum = true;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -255,7 +255,7 @@ struct RChangeCompressionFunc {
       sealConf.fElement = &fDstColElement;
       sealConf.fPage = &page;
       sealConf.fBuffer = fBuffer;
-      sealConf.fCompressionSetting = *fMergeOptions.fCompressionSettings;
+      sealConf.fCompressionSettings = *fMergeOptions.fCompressionSettings;
       sealConf.fWriteChecksum = fSealedPage.GetHasChecksum();
       auto refSealedPage = RPageSink::SealPage(sealConf);
       fSealedPage = refSealedPage;

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -174,7 +174,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
       RSealPageConfig config;
       config.fPage = &page;
       config.fElement = &element;
-      config.fCompressionSetting = GetWriteOptions().GetCompression();
+      config.fCompressionSettings = GetWriteOptions().GetCompression();
       config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
       config.fAllowAlias = false;
       config.fBuffer = zipItem.fBuf.get();
@@ -201,7 +201,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::CommitPage(ColumnHandle_t colum
       RSealPageConfig config;
       config.fPage = &zipItem.fPage;
       config.fElement = &element;
-      config.fCompressionSetting = GetWriteOptions().GetCompression();
+      config.fCompressionSettings = GetWriteOptions().GetCompression();
       config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
       // Make sure the page buffer is not aliased so that we can free the uncompressed page.
       config.fAllowAlias = false;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -688,9 +688,9 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RSealPageConfig &config)
    }
    auto nBytesZipped = nBytesPacked;
 
-   if ((config.fCompressionSetting != 0) || !config.fElement->IsMappable() || !config.fAllowAlias ||
+   if ((config.fCompressionSettings != 0) || !config.fElement->IsMappable() || !config.fAllowAlias ||
        config.fWriteChecksum) {
-      nBytesZipped = RNTupleCompressor::Zip(pageBuf, nBytesPacked, config.fCompressionSetting, config.fBuffer);
+      nBytesZipped = RNTupleCompressor::Zip(pageBuf, nBytesPacked, config.fCompressionSettings, config.fBuffer);
       if (!isAdoptedBuffer)
          delete[] pageBuf;
       pageBuf = reinterpret_cast<unsigned char *>(config.fBuffer);
@@ -715,7 +715,7 @@ ROOT::Experimental::Internal::RPageSink::SealPage(const RPage &page, const RColu
    RSealPageConfig config;
    config.fPage = &page;
    config.fElement = &element;
-   config.fCompressionSetting = GetWriteOptions().GetCompression();
+   config.fCompressionSettings = GetWriteOptions().GetCompression();
    config.fWriteChecksum = GetWriteOptions().GetEnablePageChecksums();
    config.fAllowAlias = true;
    config.fBuffer = fSealPageBuffer.data();


### PR DESCRIPTION
Also rename the one spelling of `fCompressionSetting` to `fCompressionSettings` for consistency.