### PR TITLE
[CMake] Fix range splitting logic in ROOT_CREATE_HEADER_COPY_TARGETS

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1287,7 +1287,10 @@ macro(ROOT_CREATE_HEADER_COPY_TARGETS)
 
     list(LENGTH inputs LIST_LENGTH)
     # Windows doesn't support long command lines, so split them in packs:
-    foreach(range_start RANGE 0 ${LIST_LENGTH} 100)
+    # foreach(.. RANGE start stop) is inclusive for both start and stop, so we
+    # need to decrement the LIST_LENGTH to get the desired logic.
+    math(EXPR LIST_LENGTH_MINUS_ONE "${LIST_LENGTH}-1")
+    foreach(range_start RANGE 0 ${LIST_LENGTH_MINUS_ONE} 100)
       list(SUBLIST outputs ${range_start} 100 sub_outputs)
       list(SUBLIST inputs ${range_start} 100 sub_inputs)
       list(LENGTH sub_outputs SUB_LENGTH)


### PR DESCRIPTION
In CMake, `foreach(.. RANGE start stop)` is inclusive for both start and stop, so we need to decrement the LIST_LENGTH to get the desired logic.

I noticed this logic error when I changed something in ROOT that resulted one package to have *exactly* 100 header files, triggering the following error:

```txt
CMake Error at cmake/modules/RootMacros.cmake:1293 (list):
  list begin index: 100 is out of range 0 - 99
Call Stack (most recent call first):
  CMakeLists.txt:391 (ROOT_CREATE_HEADER_COPY_TARGETS)
```

Follow-up on 4d0f60386ce.