### PR TITLE
[df] Specify more precisely action type in test

### DIFF
--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -492,7 +492,7 @@ TEST_F(RNTupleDSTest, AlternativeColumnTypes)
       // Invalid outer field type
       auto dfInvalid = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
       dfInvalid.Define("firstJet", [](const std::pair<float, float> &jets) { return jets.first; }, {"jets"})
-         .Take<std::size_t, ROOT::RVec<std::size_t>>("firstJet")
+         .Take<float, ROOT::RVec<float>>("firstJet")
          .GetValue();
       FAIL() << "specifying templated actions with incompatible column types should throw";
    } catch (const std::runtime_error &err) {


### PR DESCRIPTION
The return type from the previous Define call is float, so use the same type for the Take action.

This is a completely non-functional change for the test, but in a local branch it was detected by some other modifications I am doing that anticipate the time of checking for type mismatch in the requested type of computation graph nodes.
