### PR TITLE
[RF] RooFit documentation improvements

### DIFF
--- a/roofit/roofit/test/WrapperRooPdf.h
+++ b/roofit/roofit/test/WrapperRooPdf.h
@@ -56,9 +56,7 @@ public:
       fParams->Print("v");
 #endif
       //       // iterate on fX
-      //       TIterator* itr = fX->createIterator() ;
-      //       RooAbsArg* arg = 0;
-      //       while( ( arg = dynamic_cast<RooAbsArg*>(itr->Next() ) ) ) {
+      //       for (auto *arg : *fX) {
       //          assert(arg != 0);
       //          arg->setDirtyInhibit(true); // for having faster setter later  in DoEval
       //       }
@@ -106,9 +104,7 @@ public:
    //    double operator() (double *x, double * p = 0)  {
    //       if (p != 0) SetParameters(p);
    //       // iterate on observables
-   //       TIterator* itr = fX->createIterator() ;
-   //       RooRealVar* var = 0;
-   //       while( ( var = dynamic_cast<RooRealVar*>(itr->Next() ) ) ) {
+   //       for (auto *var : dynamic_range_cast<RooRealVar *>(*fX)) {
    //          assert(var != 0);
    //          var->setVal(*x++);
    //       }

--- a/roofit/roofitcore/inc/RooLinkedList.h
+++ b/roofit/roofitcore/inc/RooLinkedList.h
@@ -29,10 +29,11 @@ class RooLinkedListIterImpl ;
 class RooFIter;
 class TIterator ;
 class RooAbsArg ;
-template<class T>
-class RooSTLRefCountList;
 
 /// \cond ROOFIT_INTERNAL
+
+template<class T>
+class RooSTLRefCountList;
 
 namespace RooLinkedListImplDetails {
     class Chunk;
@@ -114,7 +115,9 @@ protected:
   RooLinkedListElem* createElement(TObject* obj, RooLinkedListElem* elem=nullptr) ;
   void deleteElement(RooLinkedListElem*) ;
 
+  /// \cond ROOFIT_INTERNAL
   template<class T> friend class RooSTLRefCountList;
+  /// \endcond
   friend class RooLinkedListIterImpl ;
   friend class RooFIterForLinkedList ;
 

--- a/roofit/roofitcore/inc/RooWrapperPdf.h
+++ b/roofit/roofitcore/inc/RooWrapperPdf.h
@@ -56,7 +56,7 @@ public:
   bool forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
      // Just like with other wrapper classes like RooExtendPdf, we can safely
      // use the analytical integration capabilities of the wrapped object,
-     // becuase we don't do any no-linear transformation.
+     // because we don't do any no-linear transformation.
      return true;
   }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -175,3 +177,5 @@ std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbs
    // no constraints
    return nullptr;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/ConstraintHelpers.h
+++ b/roofit/roofitcore/src/ConstraintHelpers.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -22,3 +24,5 @@ std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbs
                                                  bool takeGlobalObservablesFromData);
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -387,3 +389,5 @@ RooArgList RooAbsMinimizerFcn::initFloatParams() const
 
    return out;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -127,3 +129,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsNumGenerator.cxx
+++ b/roofit/roofitcore/src/RooAbsNumGenerator.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -149,3 +151,5 @@ void RooAbsNumGenerator::attachParameters(const RooArgSet& vars)
   newParams.remove(*_cache->get(),true,true) ;
   _funcClone->recursiveRedirectServers(newParams) ;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsNumGenerator.h
+++ b/roofit/roofitcore/src/RooAbsNumGenerator.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -74,3 +76,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -769,3 +771,5 @@ void RooAbsOptTestStatistic::runRecalculateCache(std::size_t firstEvent, std::si
 {
    _dataClone->store()->recalculateCache(_projDeps, firstEvent, lastEvent, stepSize, _skipZeroWeights);
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -89,3 +91,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -611,3 +613,5 @@ void RooAbsTestStatistic::enableOffsetting(bool flag)
 
 double RooAbsTestStatistic::getCarry() const
 { return _evalCarry; }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -157,3 +159,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAcceptReject.cxx
+++ b/roofit/roofitcore/src/RooAcceptReject.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -319,3 +321,5 @@ std::string const& RooAcceptReject::generatorName() const {
    static const std::string name = "RooAcceptReject";
    return name;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAcceptReject.h
+++ b/roofit/roofitcore/src/RooAcceptReject.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -66,3 +68,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -177,3 +179,4 @@ double RooAdaptiveIntegratorND::integral(const double* /*yvec*/)
   return ret ;
 }
 
+/// \endcond

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.h
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -70,3 +72,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAddHelpers.cxx
+++ b/roofit/roofitcore/src/RooAddHelpers.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -316,3 +318,5 @@ void RooAddHelpers::updateCoefficients(RooAbsPdf const &addPdf, std::vector<doub
       coefCache[i] /= coefSum;
    }
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -61,3 +63,5 @@ public:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -21,8 +21,9 @@
 ///  - Every object it contains must have a unique name returned by GetName().
 ///
 ///  - Contained objects are not ordered, although the set can be traversed
-///    using an iterator returned by createIterator(). The iterator does not
-///    necessarily follow the object insertion order.
+///    just like standard library containers such as `std::vector`
+///    (in fact, the RooArgSet uses a `std::vector<RooAbsArg *>` under the hood).
+///    The iterator does not necessarily follow the object insertion order.
 ///
 ///  - Objects can be retrieved by name only, and not by index.
 ///

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -193,3 +195,5 @@ void RooBinIntegrator::recursive_integration(const UInt_t d, const double delta,
       }
    }
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooBinIntegrator.h
+++ b/roofit/roofitcore/src/RooBinIntegrator.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -58,3 +60,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -151,3 +153,5 @@ double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEve
   _evalCarry = carry;
   return result ;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooChi2Var.h
+++ b/roofit/roofitcore/src/RooChi2Var.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -59,3 +61,5 @@ protected:
 
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
+++ b/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -166,3 +168,5 @@ double RooConvIntegrandBinding::getMaxLimit(UInt_t index) const
   assert(isValid());
   return _vars[index]->getMax();
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooConvIntegrandBinding.h
+++ b/roofit/roofitcore/src/RooConvIntegrandBinding.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -51,3 +53,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFoamGenerator.cxx
+++ b/roofit/roofitcore/src/RooFoamGenerator.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -159,3 +161,5 @@ std::string const& RooFoamGenerator::generatorName() const {
    static const std::string name = "RooFoamGenerator";
    return name;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFoamGenerator.h
+++ b/roofit/roofitcore/src/RooFoamGenerator.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -60,3 +62,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -534,3 +536,5 @@ void RooFormula::installFormulaOrThrow(const std::string& formula) {
 
   _tFormula = std::move(theFormula);
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -83,3 +85,5 @@ private:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -273,3 +275,5 @@ void RooGenProdProj::operModeHook()
   _intList.at(0)->setOperMode(_operMode) ;
   if (_haveD) _intList.at(1)->setOperMode(Auto) ; // Denominator always stays in Auto mode (normalization integral)
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooGenProdProj.h
+++ b/roofit/roofitcore/src/RooGenProdProj.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -41,3 +43,5 @@ private:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -19,7 +19,7 @@
 \class RooHistPdf
 \ingroup Roofitcore
 
-A propability density function sampled from a
+A probability density function sampled from a
 multidimensional histogram. The histogram distribution is explicitly
 normalized by RooHistPdf and can have an arbitrary number of real or
 discrete dimensions.

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -293,3 +295,5 @@ double RooImproperIntegrator1D::integral(const double* yvec)
   if(_integrator3) result+= _integrator3->integral(yvec);
   return result;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.h
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -67,3 +69,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -341,3 +343,5 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
   if(absError) *absError = cum_sig;
   return cum_int;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooMCIntegrator.h
+++ b/roofit/roofitcore/src/RooMCIntegrator.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -67,3 +69,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -145,3 +147,5 @@ void RooMinimizerFcn::setOffsetting(bool flag)
 {
    _funct->enableOffsetting(flag);
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -51,3 +53,5 @@ private:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -356,3 +358,5 @@ void RooNLLVar::enableBinOffsetting(bool flag)
    }
    setValueDirty();
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooNLLVar.h
+++ b/roofit/roofitcore/src/RooNLLVar.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -74,3 +76,4 @@ private:
 
 #endif
 
+/// \endcond

--- a/roofit/roofitcore/src/RooNumGenFactory.cxx
+++ b/roofit/roofitcore/src/RooNumGenFactory.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -195,3 +197,5 @@ RooAbsNumGenerator* RooNumGenFactory::createSampler(RooAbsReal& func, const RooA
   RooAbsNumGenerator* engine =  proto->clone(func,genVars,condVars,config,verbose,maxFuncVal) ;
   return engine ;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooNumGenFactory.h
+++ b/roofit/roofitcore/src/RooNumGenFactory.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -52,4 +54,4 @@ protected:
 
 #endif
 
-
+/// \endcond

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -418,7 +420,7 @@ void RooRealMPFE::serverLoop()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Client-side function that instructs server process to start
-/// asynchronuous (re)calculation of function value. This function
+/// asynchronous (re)calculation of function value. This function
 /// returns immediately. The calculated value can be retrieved
 /// using getVal()
 
@@ -797,3 +799,4 @@ void RooMPSentinel::remove(RooRealMPFE& mpfe)
   _mpfeSet.remove(mpfe,true) ;
 }
 
+/// \endcond

--- a/roofit/roofitcore/src/RooRealMPFE.h
+++ b/roofit/roofitcore/src/RooRealMPFE.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -88,3 +90,5 @@ public:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooRombergIntegrator.cxx
+++ b/roofit/roofitcore/src/RooRombergIntegrator.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -550,3 +552,5 @@ double RooRombergIntegrator::integral(int iDim, int nSeg, std::span<double> wksp
 
    return output;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooRombergIntegrator.h
+++ b/roofit/roofitcore/src/RooRombergIntegrator.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -86,3 +88,5 @@ protected:
 };
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1017,7 +1017,7 @@ RooDataHist* RooSimultaneous::fillDataHist(RooDataHist *hist,
 ////////////////////////////////////////////////////////////////////////////////
 /// Special generator interface for generation of 'global observables' -- for RooStats tools.
 ///
-/// \note Why one can't just use RooAbsPdf::generate()? That's becaues when
+/// \note Why one can't just use RooAbsPdf::generate()? That's because when
 /// using the regular generate() method, a specific component pdf is selected
 /// for each generated entry according to the index category value. However,
 /// global observable values are independent of the current index category,

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -381,3 +383,5 @@ RooArgSet RooXYChi2Var::requiredExtraObservables() const
   if (_yvar) return RooArgSet(*_yvar) ;
   return RooArgSet() ;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooXYChi2Var.h
+++ b/roofit/roofitcore/src/RooXYChi2Var.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  *
@@ -81,3 +83,5 @@ protected:
 
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/TreeReadBuffer.h
+++ b/roofit/roofitcore/src/TreeReadBuffer.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -42,3 +44,5 @@ std::unique_ptr<TreeReadBuffer> createTreeReadBuffer(const TString &branchName, 
 }
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/ValueChecking.h
+++ b/roofit/roofitcore/src/ValueChecking.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * ValueChecking.h
  *
@@ -90,3 +92,5 @@ class FormatPdfTree {
 
 
 #endif /* ROOFIT_ROOFITCORE_INC_VALUECHECKING_H_ */
+
+/// \endcond

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -486,7 +486,7 @@ TEST(RooDataSet, RooStringVarStorage)
    ASSERT_STREQ(dataClone.get(1)->getStringValue("str"), "str2");
 }
 
-// root-project/root#15744: Test that reducing a RooCompositeDataStore with a cut tha depends on its index category
+// root-project/root#15744: Test that reducing a RooCompositeDataStore with a cut that depends on its index category
 // works properly
 TEST(RooDataSet, ReduceCompositeDataStoreByIndexCat)
 {

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -60,15 +60,15 @@ namespace RooStats {
     /// Applies a predefined style if fApplyStyle is true (default).
     void ApplyDefaultStyle(void);
 
-    void SetLineColor(Color_t color, const SamplingDistribution *samplDist = nullptr);
-    void SetLineWidth(Width_t lwidth, const SamplingDistribution *samplDist = nullptr);
-    void SetLineStyle(Style_t style, const SamplingDistribution *samplDist = nullptr);
+    void SetLineColor(Color_t color, const SamplingDistribution *sampleDist = nullptr);
+    void SetLineWidth(Width_t lwidth, const SamplingDistribution *sampleDist = nullptr);
+    void SetLineStyle(Style_t style, const SamplingDistribution *sampleDist = nullptr);
 
-    void SetMarkerColor(Color_t color, const SamplingDistribution *samplDist = nullptr);
-    void SetMarkerStyle(Style_t style, const SamplingDistribution *samplDist = nullptr);
-    void SetMarkerSize(Size_t size, const SamplingDistribution *samplDist = nullptr);
+    void SetMarkerColor(Color_t color, const SamplingDistribution *sampleDist = nullptr);
+    void SetMarkerStyle(Style_t style, const SamplingDistribution *sampleDist = nullptr);
+    void SetMarkerSize(Size_t size, const SamplingDistribution *sampleDist = nullptr);
 
-    void RebinDistribution(Int_t rebinFactor, const SamplingDistribution *samplDist = nullptr);
+    void RebinDistribution(Int_t rebinFactor, const SamplingDistribution *sampleDist = nullptr);
 
     void SetAxisTitle(char *varName) { fVarName = TString(varName); }
 
@@ -80,8 +80,8 @@ namespace RooStats {
     /// Intended use: Access to member functions of TH1F like GetMean(),
     /// GetRMS() etc.
     /// The return objects is managed by  SamplingDistPlot
-    TH1F* GetTH1F(const SamplingDistribution *samplDist = nullptr);
-    TH1 * GetHistogram(const SamplingDistribution *samplDist = nullptr) { return GetTH1F(samplDist); }
+    TH1F* GetTH1F(const SamplingDistribution *sampleDist = nullptr);
+    TH1 * GetHistogram(const SamplingDistribution *sampleDist = nullptr) { return GetTH1F(sampleDist); }
 
     /// return plotter class used to draw the sampling distribution histograms
     /// object is managed by SamplingDistPlot

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -388,8 +388,8 @@ void SamplingDistPlot::GetAbsoluteInterval(double &theMin, double &theMax, doubl
 /// Sets line color for given sampling distribution and
 /// fill color for the associated shaded TH1F.
 
-void SamplingDistPlot::SetLineColor(Color_t color, const SamplingDistribution *samplDist) {
-   if (samplDist == nullptr) {
+void SamplingDistPlot::SetLineColor(Color_t color, const SamplingDistribution *sampleDist) {
+   if (sampleDist == nullptr) {
       fHist->SetLineColor(color);
 
       TString shadedName(fHist->GetName());
@@ -404,11 +404,11 @@ void SamplingDistPlot::SetLineColor(Color_t color, const SamplingDistribution *s
       }
    } else {
 
-      TString shadedName(samplDist->GetName());
+      TString shadedName(sampleDist->GetName());
       shadedName += "_shaded";
 
       for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-         if (!strcmp(obj->GetName(), samplDist->GetName())) {
+         if (!strcmp(obj->GetName(), sampleDist->GetName())) {
             obj->SetLineColor(color);
             //break;
          }
@@ -425,14 +425,14 @@ void SamplingDistPlot::SetLineColor(Color_t color, const SamplingDistribution *s
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::SetLineWidth(Width_t lwidth, const SamplingDistribution *samplDist)
+void SamplingDistPlot::SetLineWidth(Width_t lwidth, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->SetLineWidth(lwidth);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->SetLineWidth(lwidth);
    break;
       }
@@ -444,14 +444,14 @@ void SamplingDistPlot::SetLineWidth(Width_t lwidth, const SamplingDistribution *
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::SetLineStyle(Style_t style, const SamplingDistribution *samplDist)
+void SamplingDistPlot::SetLineStyle(Style_t style, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->SetLineStyle(style);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->SetLineStyle(style);
    break;
       }
@@ -463,14 +463,14 @@ void SamplingDistPlot::SetLineStyle(Style_t style, const SamplingDistribution *s
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::SetMarkerStyle(Style_t style, const SamplingDistribution *samplDist)
+void SamplingDistPlot::SetMarkerStyle(Style_t style, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->SetMarkerStyle(style);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->SetMarkerStyle(style);
    break;
       }
@@ -482,14 +482,14 @@ void SamplingDistPlot::SetMarkerStyle(Style_t style, const SamplingDistribution 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::SetMarkerColor(Color_t color, const SamplingDistribution *samplDist)
+void SamplingDistPlot::SetMarkerColor(Color_t color, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->SetMarkerColor(color);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->SetMarkerColor(color);
    break;
       }
@@ -501,14 +501,14 @@ void SamplingDistPlot::SetMarkerColor(Color_t color, const SamplingDistribution 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::SetMarkerSize(Size_t size, const SamplingDistribution *samplDist)
+void SamplingDistPlot::SetMarkerSize(Size_t size, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->SetMarkerSize(size);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->SetMarkerSize(size);
    break;
       }
@@ -520,13 +520,13 @@ void SamplingDistPlot::SetMarkerSize(Size_t size, const SamplingDistribution *sa
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TH1F* SamplingDistPlot::GetTH1F(const SamplingDistribution *samplDist)
+TH1F* SamplingDistPlot::GetTH1F(const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     return fHist;
   }else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
         return obj;
       }
     }
@@ -537,14 +537,14 @@ TH1F* SamplingDistPlot::GetTH1F(const SamplingDistribution *samplDist)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SamplingDistPlot::RebinDistribution(Int_t rebinFactor, const SamplingDistribution *samplDist)
+void SamplingDistPlot::RebinDistribution(Int_t rebinFactor, const SamplingDistribution *sampleDist)
 {
-  if(samplDist == nullptr){
+  if(sampleDist == nullptr){
     fHist->Rebin(rebinFactor);
   }
   else{
     for(auto * obj : static_range_cast<TH1F*>(fItems)) {
-      if(!strcmp(obj->GetName(),samplDist->GetName())){
+      if(!strcmp(obj->GetName(),sampleDist->GetName())){
    obj->Rebin(rebinFactor);
    break;
       }


### PR DESCRIPTION
 * Don't mention `RooAbsArg::createIterator()` in the docs.

 * Exclude RooFit implementation details from doxygen build (can be optionally put back in by defining doxygen variable `ROOFIT_INTERNAL`). This was already done for a subset of the internal classes, but not for all yet.

 * Fix typos

Thanks for this forum post for bringing up these issues:
https://root-forum.cern.ch/t/root-docs-depreciated-classes-and-out-of-date-info/63029