### PR TITLE
Introduce `TObject::SavePrimitiveConstructor()` method

### DIFF
--- a/core/base/inc/TNamed.h
+++ b/core/base/inc/TNamed.h
@@ -32,6 +32,8 @@ protected:
    TString   fName;            //object identifier
    TString   fTitle;           //object title
 
+   void SavePrimitiveNameTitle(std::ostream &out, const char *variable_name);
+
 public:
    TNamed(): fName(), fTitle() { } // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TNamed(const char *name, const char *title) : fName(name), fTitle(title) { }

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -53,7 +53,7 @@ protected:
    void MakeZombie() { fBits |= kZombie; }
    virtual void DoError(int level, const char *location, const char *fmt, va_list va) const;
 
-   void SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs = "", Bool_t empty_line = kTRUE);
+   static void SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs = "", Bool_t empty_line = kTRUE);
 
 public:
    //----- Global bits (can be set for any object and should not be reused).

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -53,6 +53,8 @@ protected:
    void MakeZombie() { fBits |= kZombie; }
    virtual void DoError(int level, const char *location, const char *fmt, va_list va) const;
 
+   void SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs = "", Bool_t empty_line = kTRUE);
+
 public:
    //----- Global bits (can be set for any object and should not be reused).
    //----- Bits 0 - 13 are reserved as global bits. Bits 14 - 23 can be used

--- a/core/base/src/TNamed.cxx
+++ b/core/base/src/TNamed.cxx
@@ -131,6 +131,16 @@ void TNamed::Print(Option_t *) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Save object name and title into the output stream "out".
+
+void TNamed::SavePrimitiveNameTitle(std::ostream &out, const char *variable_name)
+{
+   TString name = GetName(), title = GetTitle();
+   out << "   " << variable_name << "->SetName(\"" << name.ReplaceSpecialCppChars() << "\");" << std::endl;
+   out << "   " << variable_name << "->SetTitle(\"" << title.ReplaceSpecialCppChars() << "\");" << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set the name of the TNamed.
 ///
 /// WARNING: if the object is a member of a THashTable or THashList container

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -764,6 +764,21 @@ void TObject::SaveAs(const char *filename, Option_t *option) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Save object constructor in the output stream "out".
+/// Can be used as first statement when implementing SavePrimitive() method for the object
+
+void TObject::SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs, Bool_t empty_line)
+{
+   if (empty_line)
+      out << "   " << std::endl;
+
+   out << "   ";
+   if (!gROOT->ClassSaved(cl))
+      out << cl->GetName() << " *";
+   out << variable_name << " = new " << cl->GetName() << "(" << constructor_agrs << ");" << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Save a primitive as a C++ statement(s) on output stream "out".
 
 void TObject::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2146,26 +2146,17 @@ void TGraph::SaveAs(const char *filename, Option_t *option) const
 
 void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << "   " << std::endl;
    static Int_t frameNumber = 0;
    frameNumber++;
 
-   TString fXName, fYName;
-
+   TString args;
    if (fNpoints >= 1) {
-      fXName = SaveArray(out, "fx", frameNumber, fX);
-      fYName = SaveArray(out, "fy", frameNumber, fY);
+      auto xname = SaveArray(out, "fx", frameNumber, fX);
+      auto yname = SaveArray(out, "fy", frameNumber, fY);
+      args.Form("%d, %s, %s", fNpoints, xname.Data(), yname.Data());
    }
 
-   if (gROOT->ClassSaved(TGraph::Class()))
-      out << "   ";
-   else
-      out << "   TGraph *";
-
-   if (fNpoints >= 1)
-      out << "graph = new TGraph(" << fNpoints << "," << fXName << "," << fYName << ");" << std::endl;
-   else
-      out << "graph = new TGraph();" << std::endl;
+   SavePrimitiveConstructor(out, Class(), "graph", args);
 
    SaveHistogramAndFunctions(out, "graph", frameNumber, option);
 }
@@ -2183,7 +2174,7 @@ TString TGraph::SaveArray(std::ostream &out, const char *suffix, Int_t frameNumb
 
    out << "   Double_t " << arrname << "[" << fNpoints << "] = { ";
    const auto old_precision{out.precision()};
-   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1}; 
+   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
    out << std::setprecision(max_precision);
    for (Int_t i = 0; i < fNpoints-1; i++) {
       out << arr[i] << ",";

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2151,8 +2151,8 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    TString args;
    if (fNpoints >= 1) {
-      auto xname = SaveArray(out, "fx", frameNumber, fX);
-      auto yname = SaveArray(out, "fy", frameNumber, fY);
+      TString xname = SaveArray(out, "fx", frameNumber, fX);
+      TString yname = SaveArray(out, "fy", frameNumber, fY);
       args.Form("%d, %s, %s", fNpoints, xname.Data(), yname.Data());
    }
 

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1034,16 +1034,8 @@ void THStack::RecursiveRemove(TObject *obj)
 
 void THStack::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(THStack::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   THStack *";
-   }
-   out<<GetName()<<" = new THStack();"<<std::endl;
-   out<<"   "<<GetName()<<"->SetName("<<quote<<GetName()<<quote<<");"<<std::endl;
-   out<<"   "<<GetName()<<"->SetTitle("<<quote<<GetTitle()<<quote<<");"<<std::endl;
+   SavePrimitiveConstructor(out, Class(), GetName());
+   SavePrimitiveNameTitle(out, GetName());
 
    if (fMinimum != -1111) {
       out<<"   "<<GetName()<<"->SetMinimum("<<fMinimum<<");"<<std::endl;
@@ -1071,12 +1063,12 @@ void THStack::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          TString hname = h->GetName();
          h->SetName(TString::Format("%s_stack_%d", hname.Data(), ++hcount).Data());
          h->SavePrimitive(out,"nodraw");
-         out<<"   "<<GetName()<<"->Add("<<h->GetName()<<","<<quote<<lnk->GetOption()<<quote<<");"<<std::endl;
-         lnk = lnk->Next();
+         out<<"   "<<GetName()<<"->Add("<<h->GetName()<<", \""<<lnk->GetOption()<<"\");"<<std::endl;
          h->SetName(hname.Data()); // restore histogram name
+         lnk = lnk->Next();
       }
    }
-   out<<"   "<<GetName()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
+   out << "   " << GetName() << "->Draw(\n" << option << "\");" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1595,15 +1595,8 @@ void TMultiGraph::RecursiveRemove(TObject *obj)
 
 void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TMultiGraph::Class()))
-      out<<"   ";
-   else
-      out<<"   TMultiGraph *";
-   out<<"multigraph = new TMultiGraph();"<<std::endl;
-   out<<"   multigraph->SetName("<<quote<<GetName()<<quote<<");"<<std::endl;
-   out<<"   multigraph->SetTitle("<<quote<<GetTitle()<<quote<<");"<<std::endl;
+   SavePrimitiveConstructor(out, Class(), "multigraph");
+   SavePrimitiveNameTitle(out, "multigraph");
 
    TIter iter(fGraphs);
 
@@ -1614,7 +1607,7 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (l) {
       out<<"   "<<l+7<<"->AddBin(multigraph);"<<std::endl;
    } else {
-      out<<"   multigraph->Draw(" <<quote<<option<<quote<<");"<<std::endl;
+      out<<"   multigraph->Draw(\"" << option << "\");"<<std::endl;
    }
    TAxis *xaxis = GetXaxis();
    TAxis *yaxis = GetYaxis();

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -301,25 +301,14 @@ void TPolyMarker::Print(Option_t *) const
 
 void TPolyMarker::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   out<<"   Double_t *dum = 0;"<<std::endl;
-   if (gROOT->ClassSaved(TPolyMarker::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   TPolyMarker *";
-   }
-   out<<"pmarker = new TPolyMarker("<<fN<<",dum,dum,"<<quote<<fOption<<quote<<");"<<std::endl;
+   SavePrimitiveConstructor(out, Class(), "pmarker", TString::Format("%d,\"%s\"", fN, fOption.Data()));
 
    SaveMarkerAttributes(out,"pmarker",1,1,1);
 
-   for (Int_t i=0;i<Size();i++) {
+   for (Int_t i=0;i<Size();i++)
       out<<"   pmarker->SetPoint("<<i<<","<<fX[i]<<","<<fY[i]<<");"<<std::endl;
-   }
-   if (!strstr(option, "nodraw")) {
-      out<<"   pmarker->Draw("
-         <<quote<<option<<quote<<");"<<std::endl;
-   }
+   if (!strstr(option, "nodraw"))
+      out<<"   pmarker->Draw(\"" << option << "\");" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Store invocation of object constructor in the created macro.
Replaces several lines in typical `SavePrimitive()` implementation.

PR also includes `TNamed::SavePrimitiveNameTitle` method as small extension.

And several examples for classes like TGraph, THStack, TPolyMarker how introduced methods can be used.

If approach is fine, one can simplify most of existing `SavePrimitive()` implementations.
At the same time one can revise code there.