### PR TITLE
[ntuple] Simplify and clean up compression

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -38,93 +38,12 @@ namespace Internal {
 */
 // clang-format on
 class RNTupleCompressor {
-private:
-   using Buffer_t = std::array<unsigned char, kMAXZIPBUF>;
-   std::unique_ptr<Buffer_t> fZipBuffer;
-
 public:
-   /// Data might be overwritten, if a zipped block in the middle of a large input data stream
-   /// turns out to be uncompressible
-   using Writer_t = std::function<void(const void *buffer, size_t nbytes, size_t offset)>;
-   static Writer_t MakeMemCopyWriter(unsigned char *dest)
-   {
-      return [=](const void *b, size_t n, size_t o) { memcpy(dest + o, b, n); };
-   }
-   static constexpr size_t kMaxSingleBlock = kMAXZIPBUF;
-
-   RNTupleCompressor() : fZipBuffer(std::make_unique<Buffer_t>()) {}
+   RNTupleCompressor() = delete;
    RNTupleCompressor(const RNTupleCompressor &other) = delete;
    RNTupleCompressor &operator=(const RNTupleCompressor &other) = delete;
-   RNTupleCompressor(RNTupleCompressor &&other) = default;
-   RNTupleCompressor &operator=(RNTupleCompressor &&other) = default;
-
-   /// Returns the size of the compressed data. Data is compressed in 16MB (kMAXZIPBUF) blocks and written
-   /// piecewise using the provided writer
-   size_t Zip(const void *from, size_t nbytes, int compression, Writer_t fnWriter)
-   {
-      R__ASSERT(from != nullptr);
-
-      auto cxLevel = compression % 100;
-      if (cxLevel == 0) {
-         fnWriter(from, nbytes, 0);
-         return nbytes;
-      }
-
-      auto cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(compression / 100);
-      unsigned int nZipBlocks = 1 + (nbytes - 1) / kMAXZIPBUF;
-      char *source = const_cast<char *>(static_cast<const char *>(from));
-      int szTarget = kMAXZIPBUF;
-      char *target = reinterpret_cast<char *>(fZipBuffer->data());
-      int szOutBlock = 0;
-      int szRemaining = nbytes;
-      size_t szZipData = 0;
-      for (unsigned int i = 0; i < nZipBlocks; ++i) {
-         int szSource = std::min(static_cast<int>(kMAXZIPBUF), szRemaining);
-         R__zipMultipleAlgorithm(cxLevel, &szSource, source, &szTarget, target, &szOutBlock, cxAlgorithm);
-         R__ASSERT(szOutBlock >= 0);
-         if ((szOutBlock == 0) || (szOutBlock >= szSource)) {
-            // Uncompressible block, we have to store the entire input data stream uncompressed
-            fnWriter(from, nbytes, 0);
-            return nbytes;
-         }
-
-         fnWriter(target, szOutBlock, szZipData);
-         szZipData += szOutBlock;
-         source += szSource;
-         szRemaining -= szSource;
-      }
-      R__ASSERT(szRemaining == 0);
-      R__ASSERT(szZipData < nbytes);
-      return szZipData;
-   }
-
-   /// Returns the size of the compressed data block. The data is written into the zip buffer.
-   /// This works only for small input buffer up to 16MB (kMAXZIPBUF)
-   size_t Zip(const void *from, size_t nbytes, int compression)
-   {
-      R__ASSERT(from != nullptr);
-      R__ASSERT(nbytes <= kMAXZIPBUF);
-
-      auto cxLevel = compression % 100;
-      if (cxLevel == 0) {
-         memcpy(fZipBuffer->data(), from, nbytes);
-         return nbytes;
-      }
-
-      auto cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(compression / 100);
-      int szSource = nbytes;
-      char *source = const_cast<char *>(static_cast<const char *>(from));
-      int szTarget = nbytes;
-      char *target = reinterpret_cast<char *>(fZipBuffer->data());
-      int szOut = 0;
-      R__zipMultipleAlgorithm(cxLevel, &szSource, source, &szTarget, target, &szOut, cxAlgorithm);
-      R__ASSERT(szOut >= 0);
-      if ((szOut > 0) && (static_cast<unsigned int>(szOut) < nbytes))
-         return szOut;
-
-      memcpy(fZipBuffer->data(), from, nbytes);
-      return nbytes;
-   }
+   RNTupleCompressor(RNTupleCompressor &&other) = delete;
+   RNTupleCompressor &operator=(RNTupleCompressor &&other) = delete;
 
    /// Returns the size of the compressed data, written into the provided output buffer.
    static std::size_t Zip(const void *from, std::size_t nbytes, int compression, void *to)
@@ -164,8 +83,6 @@ public:
       R__ASSERT(szZipData < nbytes);
       return szZipData;
    }
-
-   void *GetZipBuffer() { return fZipBuffer->data(); }
 };
 
 // clang-format off
@@ -176,16 +93,12 @@ public:
 */
 // clang-format on
 class RNTupleDecompressor {
-private:
-   using Buffer_t = std::array<unsigned char, kMAXZIPBUF>;
-   std::unique_ptr<Buffer_t> fUnzipBuffer;
-
 public:
-   RNTupleDecompressor() : fUnzipBuffer(std::make_unique<Buffer_t>()) {}
+   RNTupleDecompressor() = delete;
    RNTupleDecompressor(const RNTupleDecompressor &other) = delete;
    RNTupleDecompressor &operator=(const RNTupleDecompressor &other) = delete;
-   RNTupleDecompressor(RNTupleDecompressor &&other) = default;
-   RNTupleDecompressor &operator=(RNTupleDecompressor &&other) = default;
+   RNTupleDecompressor(RNTupleDecompressor &&other) = delete;
+   RNTupleDecompressor &operator=(RNTupleDecompressor &&other) = delete;
 
    /**
     * The nbytes parameter provides the size ls of the from buffer. The dataLen gives the size of the uncompressed data.
@@ -221,16 +134,6 @@ public:
          szRemaining -= unzipBytes;
       } while (szRemaining > 0);
       R__ASSERT(szRemaining == 0);
-   }
-
-   /**
-    * In-place decompression via unzip buffer
-    */
-   void Unzip(void *fromto, size_t nbytes, size_t dataLen)
-   {
-      R__ASSERT(dataLen <= kMAXZIPBUF);
-      Unzip(fromto, nbytes, dataLen, fUnzipBuffer->data());
-      memcpy(fromto, fUnzipBuffer->data(), dataLen);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -278,19 +278,12 @@ public:
 protected:
    std::unique_ptr<ROOT::RNTupleWriteOptions> fOptions;
 
-   /// Helper to zip pages and header/footer; includes a 16MB (kMAXZIPBUF) zip buffer.
-   /// There could be concrete page sinks that don't need a compressor.  Therefore, and in order to stay consistent
-   /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
-   std::unique_ptr<RNTupleCompressor> fCompressor;
-
    /// Flag if sink was initialized
    bool fIsInitialized = false;
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable and not checksummed, the returned sealed page
-   /// will point directly to the input page buffer.  Otherwise, the sealed page references an internal buffer
-   /// of fCompressor.  Thus, the buffer pointed to by the RSealedPage should never be freed.
-   /// Usage of this method requires construction of fCompressor.
+   /// will point directly to the input page buffer.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -283,7 +283,8 @@ protected:
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable and not checksummed, the returned sealed page
-   /// will point directly to the input page buffer.
+   /// will point directly to the input page buffer. Otherwise, the sealed page references fSealPageBuffer.  Thus,
+   /// the buffer pointed to by the RSealedPage should never be freed.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element);
 
 private:

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -771,8 +771,11 @@ ROOT::RResult<ROOT::RNTuple> ROOT::Experimental::Internal::RMiniFileReader::GetN
    auto objNbytes = key.GetSize() - key.fKeyLen;
    ReadBuffer(ntuple, objNbytes, offset);
    if (objNbytes != key.fObjLen) {
-      RNTupleDecompressor decompressor;
-      decompressor.Unzip(bufAnchor.get(), objNbytes, key.fObjLen);
+      // Decompress into a temporary buffer
+      auto unzipBuf = MakeUninitArray<unsigned char>(key.fObjLen);
+      RNTupleDecompressor::Unzip(bufAnchor.get(), objNbytes, key.fObjLen, unzipBuf.get());
+      // Then copy back to bufAnchor
+      memcpy(bufAnchor.get(), unzipBuf.get(), key.fObjLen);
    }
 
    // We require that future class versions only append members and store the checksum in the last 8 bytes

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -283,7 +283,6 @@ ROOT::Experimental::Internal::RPageSinkDaos::RPageSinkDaos(std::string_view ntup
       R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "The DAOS backend is experimental and still under development. "
                                                   << "Do not store real data with this version of RNTuple!";
    });
-   fCompressor = std::make_unique<RNTupleCompressor>();
    EnableDefaultMetrics("RPageSinkDaos");
 }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -311,8 +311,8 @@ void ROOT::Experimental::Internal::RPageSinkDaos::InitImpl(unsigned char *serial
    fNTupleIndex = locator.GetIndex();
 
    auto zipBuffer = MakeUninitArray<unsigned char>(length);
-   auto szZipHeader = fCompressor->Zip(serializedHeader, length, GetWriteOptions().GetCompression(),
-                                       RNTupleCompressor::MakeMemCopyWriter(zipBuffer.get()));
+   auto szZipHeader =
+      RNTupleCompressor::Zip(serializedHeader, length, GetWriteOptions().GetCompression(), zipBuffer.get());
    WriteNTupleHeader(zipBuffer.get(), szZipHeader, length);
 }
 
@@ -432,8 +432,8 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitClusterGroupImpl(unsigned cha
                                                                     std::uint32_t length)
 {
    auto bufPageListZip = MakeUninitArray<unsigned char>(length);
-   auto szPageListZip = fCompressor->Zip(serializedPageList, length, GetWriteOptions().GetCompression(),
-                                         RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
+   auto szPageListZip =
+      RNTupleCompressor::Zip(serializedPageList, length, GetWriteOptions().GetCompression(), bufPageListZip.get());
 
    auto offsetData = fClusterGroupId.fetch_add(1);
    fDaosContainer->WriteSingleAkey(
@@ -452,8 +452,8 @@ void ROOT::Experimental::Internal::RPageSinkDaos::CommitDatasetImpl(unsigned cha
                                                                     std::uint32_t length)
 {
    auto bufFooterZip = MakeUninitArray<unsigned char>(length);
-   auto szFooterZip = fCompressor->Zip(serializedFooter, length, GetWriteOptions().GetCompression(),
-                                       RNTupleCompressor::MakeMemCopyWriter(bufFooterZip.get()));
+   auto szFooterZip =
+      RNTupleCompressor::Zip(serializedFooter, length, GetWriteOptions().GetCompression(), bufFooterZip.get());
    WriteNTupleFooter(bufFooterZip.get(), szFooterZip, length);
    WriteNTupleAnchor();
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -47,7 +47,6 @@ ROOT::Experimental::Internal::RPageSinkFile::RPageSinkFile(std::string_view ntup
                                                            const ROOT::RNTupleWriteOptions &options)
    : RPagePersistentSink(ntupleName, options)
 {
-   fCompressor = std::make_unique<RNTupleCompressor>();
    EnableDefaultMetrics("RPageSinkFile");
    fFeatures.fCanMergePages = true;
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -71,8 +71,8 @@ ROOT::Experimental::Internal::RPageSinkFile::~RPageSinkFile() {}
 void ROOT::Experimental::Internal::RPageSinkFile::InitImpl(unsigned char *serializedHeader, std::uint32_t length)
 {
    auto zipBuffer = MakeUninitArray<unsigned char>(length);
-   auto szZipHeader = fCompressor->Zip(serializedHeader, length, GetWriteOptions().GetCompression(),
-                                       RNTupleCompressor::MakeMemCopyWriter(zipBuffer.get()));
+   auto szZipHeader =
+      RNTupleCompressor::Zip(serializedHeader, length, GetWriteOptions().GetCompression(), zipBuffer.get());
    fWriter->WriteNTupleHeader(zipBuffer.get(), szZipHeader, length);
 }
 
@@ -228,8 +228,8 @@ ROOT::Experimental::Internal::RPageSinkFile::CommitClusterGroupImpl(unsigned cha
                                                                     std::uint32_t length)
 {
    auto bufPageListZip = MakeUninitArray<unsigned char>(length);
-   auto szPageListZip = fCompressor->Zip(serializedPageList, length, GetWriteOptions().GetCompression(),
-                                         RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
+   auto szPageListZip =
+      RNTupleCompressor::Zip(serializedPageList, length, GetWriteOptions().GetCompression(), bufPageListZip.get());
 
    RNTupleLocator result;
    result.SetNBytesOnStorage(szPageListZip);
@@ -242,8 +242,8 @@ void ROOT::Experimental::Internal::RPageSinkFile::CommitDatasetImpl(unsigned cha
 {
    fWriter->UpdateStreamerInfos(fDescriptorBuilder.BuildStreamerInfos());
    auto bufFooterZip = MakeUninitArray<unsigned char>(length);
-   auto szFooterZip = fCompressor->Zip(serializedFooter, length, GetWriteOptions().GetCompression(),
-                                       RNTupleCompressor::MakeMemCopyWriter(bufFooterZip.get()));
+   auto szFooterZip =
+      RNTupleCompressor::Zip(serializedFooter, length, GetWriteOptions().GetCompression(), bufFooterZip.get());
    fWriter->WriteNTupleFooter(bufFooterZip.get(), szFooterZip, length);
    fWriter->Commit(GetWriteOptions().GetCompression());
 }

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -63,7 +63,6 @@ public:
    RPageSinkMock(const RColumnElementBase &elt) : RPageSink("test", ROOT::RNTupleWriteOptions()), fElement(elt)
    {
       fOptions->SetEnablePageChecksums(false);
-      fCompressor = std::make_unique<ROOT::Experimental::Internal::RNTupleCompressor>();
    }
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage &page) final
    {

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -2,87 +2,42 @@
 
 TEST(RNTupleZip, Basics)
 {
-   RNTupleCompressor compressor;
-   RNTupleDecompressor decompressor;
-
    std::string data = "xxxxxxxxxxxxxxxxxxxxxxxx";
-   auto szZipped = compressor.Zip(data.data(), data.length(), 101);
+   auto zipBuffer = std::unique_ptr<char[]>(new char[data.length()]);
+   auto szZipped = RNTupleCompressor::Zip(data.data(), data.length(), 101, zipBuffer.get());
    EXPECT_LT(szZipped, data.length());
    auto unzipBuffer = std::unique_ptr<char[]>(new char[data.length()]);
-   RNTupleDecompressor::Unzip(compressor.GetZipBuffer(), szZipped, data.length(), unzipBuffer.get());
+   RNTupleDecompressor::Unzip(zipBuffer.get(), szZipped, data.length(), unzipBuffer.get());
    EXPECT_EQ(data, std::string_view(unzipBuffer.get(), data.length()));
-
-   // inplace decompression
-   auto zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char [data.length()]);
-   memcpy(zipBuffer.get(), compressor.GetZipBuffer(), szZipped);
-   decompressor.Unzip(zipBuffer.get(), szZipped, data.length());
-   EXPECT_EQ(data, std::string_view(reinterpret_cast<char *>(zipBuffer.get()), data.length()));
 }
-
 
 TEST(RNTupleZip, Empty)
 {
-   RNTupleCompressor compressor;
-
    char x;
-   EXPECT_EQ(0U, compressor.Zip(&x, 0, 0));
-   EXPECT_EQ(0U, compressor.Zip(&x, 0, 101));
+   char z;
+   EXPECT_EQ(0U, RNTupleCompressor::Zip(&x, 0, 0, &z));
+   EXPECT_EQ(0U, RNTupleCompressor::Zip(&x, 0, 101, &z));
 
    // Don't crash
-   RNTupleDecompressor().Unzip(&x, 0, 0, &x);
+   RNTupleDecompressor::Unzip(&x, 0, 0, &x);
 }
-
 
 TEST(RNTupleZip, Uncompressed)
 {
-   RNTupleCompressor compressor;
    char X = 'x';
-   EXPECT_EQ(1U, compressor.Zip(&X, 1, 0));
-   RNTupleDecompressor().Unzip(compressor.GetZipBuffer(), 1, 1, &X);
+   char Z;
+   EXPECT_EQ(1U, RNTupleCompressor::Zip(&X, 1, 0, &Z));
+   RNTupleDecompressor::Unzip(&Z, 1, 1, &X);
    EXPECT_EQ('x', X);
 }
-
 
 TEST(RNTupleZip, Small)
 {
-   RNTupleCompressor compressor;
    char X = 'x';
-   EXPECT_EQ(1U, compressor.Zip(&X, 1, 101));
-   RNTupleDecompressor().Unzip(compressor.GetZipBuffer(), 1, 1, &X);
+   char Z;
+   EXPECT_EQ(1U, RNTupleCompressor::Zip(&X, 1, 101, &Z));
+   RNTupleDecompressor::Unzip(&Z, 1, 1, &X);
    EXPECT_EQ('x', X);
-}
-
-
-TEST(RNTupleZip, Large)
-{
-   constexpr unsigned int N = kMAXZIPBUF + 32;
-   auto zipBuffer = MakeUninitArray<unsigned char>(N);
-   auto unzipBuffer = MakeUninitArray<char>(N);
-   std::string data(N, 'x');
-
-   RNTupleCompressor compressor;
-   RNTupleDecompressor decompressor;
-
-   /// Trailing byte cannot be compressed, entire buffer returns uncompressed
-   int nWrites = 0;
-   auto szZip = compressor.Zip(data.data(), kMAXZIPBUF + 1, 101,
-      [&zipBuffer, &nWrites](const void *buffer, size_t nbytes, size_t offset) {
-         memcpy(zipBuffer.get() + offset, buffer, nbytes);
-         nWrites++;
-      });
-   EXPECT_EQ(2, nWrites);
-   EXPECT_EQ(static_cast<unsigned int>(kMAXZIPBUF) + 1, szZip);
-
-   nWrites = 0;
-   szZip = compressor.Zip(data.data(), data.length(), 101,
-      [&zipBuffer, &nWrites](const void *buffer, size_t nbytes, size_t offset) {
-         memcpy(zipBuffer.get() + offset, buffer, nbytes);
-         nWrites++;
-      });
-   EXPECT_LT(szZip, N);
-   EXPECT_EQ(2, nWrites);
-   RNTupleDecompressor::Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
-   EXPECT_EQ(data, std::string_view(unzipBuffer.get(), N));
 }
 
 TEST(RNTupleZip, LargeWithOutputBuffer)
@@ -92,14 +47,11 @@ TEST(RNTupleZip, LargeWithOutputBuffer)
    auto unzipBuffer = MakeUninitArray<char>(N);
    std::string data(N, 'x');
 
-   RNTupleCompressor compressor;
-   RNTupleDecompressor decompressor;
-
    /// Trailing byte cannot be compressed, entire buffer returns uncompressed
-   auto szZip = compressor.Zip(data.data(), kMAXZIPBUF + 1, 101, zipBuffer.get());
+   auto szZip = RNTupleCompressor::Zip(data.data(), kMAXZIPBUF + 1, 101, zipBuffer.get());
    EXPECT_EQ(static_cast<unsigned int>(kMAXZIPBUF) + 1, szZip);
 
-   szZip = compressor.Zip(data.data(), data.length(), 101, zipBuffer.get());
+   szZip = RNTupleCompressor::Zip(data.data(), data.length(), 101, zipBuffer.get());
    EXPECT_LT(szZip, N);
    RNTupleDecompressor::Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
    EXPECT_EQ(data, std::string_view(unzipBuffer.get(), N));


### PR DESCRIPTION
... eventually removing all member methods of RNTuple(De)Compressor; see the individual commits for more details. As a visible result, this saves 16 MiB of internal compression buffer per page sink.