### PR TITLE
Introduce TObject::SavePrimitiveArray

### DIFF
--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -55,6 +55,8 @@ protected:
 
    static void SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs = "", Bool_t empty_line = kTRUE);
 
+   static TString SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr);
+
 public:
    //----- Global bits (can be set for any object and should not be reused).
    //----- Bits 0 - 13 are reserved as global bits. Bits 14 - 23 can be used

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -797,7 +797,7 @@ TString TObject::SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t
       for (Int_t i = 0; i < len-1; i++) {
          out << arr[i] << ",";
          if (i && (i % 16 == 0))
-            out << std::endl << "   ";
+            out << "\n   ";
          else
             out << " ";
       }

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -46,6 +46,7 @@ class hierarchies (watch out for overlaps).
 #include <sstream>
 #include <fstream>
 #include <iostream>
+#include <iomanip>
 
 #include "Varargs.h"
 #include "snprintf.h"
@@ -777,6 +778,36 @@ void TObject::SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char
       out << cl->GetName() << " *";
    out << variable_name << " = new " << cl->GetName() << "(" << constructor_agrs << ");" << std::endl;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Save array in the output stream "out".
+/// Create unique variable name based on prefix value
+
+TString TObject::SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr)
+{
+   static int arrid = 0;
+
+   TString arrname = TString::Format("%s_darr%d", prefix, arrid++);
+
+   out << "   Double_t " << arrname << "[" << len << "] = { ";
+   if (len > 0) {
+      const auto old_precision{out.precision()};
+      constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
+      out << std::setprecision(max_precision);
+      for (Int_t i = 0; i < len-1; i++) {
+         out << arr[i] << ",";
+         if (i && (i % 16 == 0))
+            out << std::endl << "   ";
+         else
+            out << " ";
+      }
+      out << arr[len - 1];
+      out << std::setprecision(old_precision);
+   }
+   out << " };" << std::endl;
+   return arrname;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save a primitive as a C++ statement(s) on output stream "out".

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -785,7 +785,7 @@ void TObject::SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char
 
 TString TObject::SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr)
 {
-   static int arrid = 0;
+   thread_local int arrid = 0;
 
    TString arrname = TString::Format("%s_darr%d", prefix, arrid++);
 

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -66,7 +66,7 @@ protected:
    Double_t         **ShrinkAndCopy(Int_t size, Int_t iend);
    virtual Bool_t     DoMerge(const TGraph * g);
 
-   void               SaveHistogramAndFunctions(std::ostream &out, const char *varname, Int_t &frameNumber, Option_t *option);
+   void               SaveHistogramAndFunctions(std::ostream &out, const char *varname, Option_t *option);
 
 public:
    // TGraph status bits

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -66,7 +66,6 @@ protected:
    Double_t         **ShrinkAndCopy(Int_t size, Int_t iend);
    virtual Bool_t     DoMerge(const TGraph * g);
 
-   TString            SaveArray(std::ostream &out, const char *suffix, Int_t frameNumber, Double_t *arr);
    void               SaveHistogramAndFunctions(std::ostream &out, const char *varname, Int_t &frameNumber, Option_t *option);
 
 public:

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2163,7 +2163,7 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGraph::SaveHistogramAndFunctions(std::ostream &out, const char *varname, Option_t *option)
 {
-   static Int_t frameNumber = 0;
+   thread_local Int_t frameNumber = 0;
 
    SavePrimitiveNameTitle(out, varname);
 

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2150,41 +2150,14 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    TString args;
    if (fNpoints >= 1) {
-      TString xname = SaveArray(out, "fx", frameNumber, fX);
-      TString yname = SaveArray(out, "fy", frameNumber, fY);
+      TString xname = SavePrimitiveArray(out, "graph_x", fNpoints, fX);
+      TString yname = SavePrimitiveArray(out, "graph_y", fNpoints, fY);
       args.Form("%d, %s, %s", fNpoints, xname.Data(), yname.Data());
    }
 
    SavePrimitiveConstructor(out, Class(), "graph", args);
 
    SaveHistogramAndFunctions(out, "graph", frameNumber, option);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Save array as C++ code
-/// Returns name of created array
-
-TString TGraph::SaveArray(std::ostream &out, const char *suffix, Int_t frameNumber, Double_t *arr)
-{
-   TString name = gInterpreter->MapCppName(GetName());
-   if (name.IsNull())
-      name = "Graph";
-   TString arrname = TString::Format("%s_%s%d", name.Data(), suffix, frameNumber);
-
-   out << "   Double_t " << arrname << "[" << fNpoints << "] = { ";
-   const auto old_precision{out.precision()};
-   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
-   out << std::setprecision(max_precision);
-   for (Int_t i = 0; i < fNpoints-1; i++) {
-      out << arr[i] << ",";
-      if (i && (i % 16 == 0))
-         out << std::endl << "   ";
-      else
-         out << " ";
-   }
-   out << arr[fNpoints-1] << " };" << std::endl;
-   out << std::setprecision(old_precision);
-   return arrname;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1240,9 +1240,6 @@ void TGraphAsymmErrors::Print(Option_t *) const
 
 void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   static Int_t frameNumber = 3000;
-   frameNumber++;
-
    auto xname  = SavePrimitiveArray(out, "grae_fx", fNpoints, fX);
    auto yname  = SavePrimitiveArray(out, "grae_fy", fNpoints, fY);
    auto exlname = SavePrimitiveArray(out, "grae_fexl", fNpoints, fEXlow);
@@ -1255,7 +1252,7 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
       TString::Format("%d, %s, %s, %s, %s, %s, %s", fNpoints,
          xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data()));
 
-   SaveHistogramAndFunctions(out, "grae", frameNumber, option);
+   SaveHistogramAndFunctions(out, "grae", option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1240,26 +1240,20 @@ void TGraphAsymmErrors::Print(Option_t *) const
 
 void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << "   " << std::endl;
    static Int_t frameNumber = 3000;
    frameNumber++;
 
-   auto fXName   = SaveArray(out, "fx", frameNumber, fX);
-   auto fYName   = SaveArray(out, "fy", frameNumber, fY);
-   auto fElXName = SaveArray(out, "felx", frameNumber, fEXlow);
-   auto fElYName = SaveArray(out, "fely", frameNumber, fEYlow);
-   auto fEhXName = SaveArray(out, "fehx", frameNumber, fEXhigh);
-   auto fEhYName = SaveArray(out, "fehy", frameNumber, fEYhigh);
+   auto xname  = SavePrimitiveArray(out, "grae_fx", fNpoints, fX);
+   auto yname  = SavePrimitiveArray(out, "grae_fy", fNpoints, fY);
+   auto exlname = SavePrimitiveArray(out, "grae_fexl", fNpoints, fEXlow);
+   auto exhname = SavePrimitiveArray(out, "grae_fexh", fNpoints, fEXhigh);
+   auto eylname = SavePrimitiveArray(out, "grae_feyl", fNpoints, fEYlow);
+   auto eyhname = SavePrimitiveArray(out, "grae_feyh", fNpoints, fEYhigh);
 
-   if (gROOT->ClassSaved(TGraphAsymmErrors::Class()))
-      out<<"   ";
-   else
-      out << "   TGraphAsymmErrors *";
-   out << "grae = new TGraphAsymmErrors("<< fNpoints << ","
-                                    << fXName   << ","  << fYName  << ","
-                                    << fElXName  << ","  << fEhXName << ","
-                                    << fElYName  << ","  << fEhYName << ");"
-                                    << std::endl;
+   SavePrimitiveConstructor(
+      out, Class(), "grae",
+      TString::Format("%d, %s, %s, %s, %s, %s, %s", fNpoints,
+         xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data()));
 
    SaveHistogramAndFunctions(out, "grae", frameNumber, option);
 }

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -550,32 +550,25 @@ void TGraphBentErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << "   " << std::endl;
    static Int_t frameNumber = 2000;
    frameNumber++;
 
-   auto fXName   = SaveArray(out, "fx", frameNumber, fX);
-   auto fYName   = SaveArray(out, "fy", frameNumber, fY);
-   auto fElXName = SaveArray(out, "felx", frameNumber, fEXlow);
-   auto fElYName = SaveArray(out, "fely", frameNumber, fEYlow);
-   auto fEhXName = SaveArray(out, "fehx", frameNumber, fEXhigh);
-   auto fEhYName = SaveArray(out, "fehy", frameNumber, fEYhigh);
-   auto fEldXName = SaveArray(out, "feldx", frameNumber, fEXlowd);
-   auto fEldYName = SaveArray(out, "feldy", frameNumber, fEYlowd);
-   auto fEhdXName = SaveArray(out, "fehdx", frameNumber, fEXhighd);
-   auto fEhdYName = SaveArray(out, "fehdy", frameNumber, fEYhighd);
+   auto xname  = SavePrimitiveArray(out, "grbe_fx", fNpoints, fX);
+   auto yname  = SavePrimitiveArray(out, "grbe_fy", fNpoints, fY);
+   auto exlname = SavePrimitiveArray(out, "grbe_fexl", fNpoints, fEXlow);
+   auto exhname = SavePrimitiveArray(out, "grbe_fexh", fNpoints, fEXhigh);
+   auto eylname = SavePrimitiveArray(out, "grbe_feyl", fNpoints, fEYlow);
+   auto eyhname = SavePrimitiveArray(out, "grbe_feyh", fNpoints, fEYhigh);
+   auto exldname = SavePrimitiveArray(out, "grbe_fexld", fNpoints, fEXlowd);
+   auto exhdname = SavePrimitiveArray(out, "grbe_fexhd", fNpoints, fEXhighd);
+   auto eyldname = SavePrimitiveArray(out, "grbe_feyld", fNpoints, fEYlowd);
+   auto eyhdname = SavePrimitiveArray(out, "grbe_feyhd", fNpoints, fEYhighd);
 
-   if (gROOT->ClassSaved(TGraphBentErrors::Class()))
-      out << "   ";
-   else
-      out << "   TGraphBentErrors *";
-   out << "grbe = new TGraphBentErrors("<< fNpoints << ","
-                                    << fXName     << ","  << fYName  << ","
-                                    << fElXName   << ","  << fEhXName << ","
-                                    << fElYName   << ","  << fEhYName << ","
-                                    << fEldXName  << ","  << fEhdXName << ","
-                                    << fEldYName  << ","  << fEhdYName << ");"
-                                    << std::endl;
+   SavePrimitiveConstructor(
+      out, Class(), "grbe",
+      TString::Format("%d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s", fNpoints,
+         xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data(),
+         exldname.Data(), exhdname.Data(), eyldname.Data(), eyhdname.Data()));
 
    SaveHistogramAndFunctions(out, "grbe", frameNumber, option);
 }
@@ -659,7 +652,7 @@ void TGraphBentErrors::SwapPoints(Int_t pos1, Int_t pos2)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Update the fX, fY, fEXlow, fEXhigh, fEXlowd, fEXhighd, fEYlow, fEYhigh, fEYlowd,  
+/// Update the fX, fY, fEXlow, fEXhigh, fEXlowd, fEXhighd, fEYlow, fEYhigh, fEYlowd,
 /// and fEYhighd arrays with the sorted values.
 
 void TGraphBentErrors::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -550,9 +550,6 @@ void TGraphBentErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   static Int_t frameNumber = 2000;
-   frameNumber++;
-
    auto xname  = SavePrimitiveArray(out, "grbe_fx", fNpoints, fX);
    auto yname  = SavePrimitiveArray(out, "grbe_fy", fNpoints, fY);
    auto exlname = SavePrimitiveArray(out, "grbe_fexl", fNpoints, fEXlow);
@@ -570,7 +567,7 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
          xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data(),
          exldname.Data(), exhdname.Data(), eyldname.Data(), eyhdname.Data()));
 
-   SaveHistogramAndFunctions(out, "grbe", frameNumber, option);
+   SaveHistogramAndFunctions(out, "grbe", option);
 }
 
 

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -721,9 +721,6 @@ void TGraphErrors::Print(Option_t *) const
 
 void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   static Int_t frameNumber = 1000;
-   frameNumber++;
-
    auto xname  = SavePrimitiveArray(out, "gre_fx", fNpoints, fX);
    auto yname  = SavePrimitiveArray(out, "gre_fy", fNpoints, fY);
    auto exname = SavePrimitiveArray(out, "gre_fex", fNpoints, fEX);
@@ -733,7 +730,7 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out, Class(), "gre",
       TString::Format("%d, %s, %s, %s, %s", fNpoints, xname.Data(), yname.Data(), exname.Data(), eyname.Data()));
 
-   SaveHistogramAndFunctions(out, "gre", frameNumber, option);
+   SaveHistogramAndFunctions(out, "gre", option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -721,23 +721,17 @@ void TGraphErrors::Print(Option_t *) const
 
 void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << "   " << std::endl;
    static Int_t frameNumber = 1000;
    frameNumber++;
 
-   auto fXName  = SaveArray(out, "fx", frameNumber, fX);
-   auto fYName  = SaveArray(out, "fy", frameNumber, fY);
-   auto fEXName = SaveArray(out, "fex", frameNumber, fEX);
-   auto fEYName = SaveArray(out, "fey", frameNumber, fEY);
+   auto xname  = SavePrimitiveArray(out, "gre_fx", fNpoints, fX);
+   auto yname  = SavePrimitiveArray(out, "gre_fy", fNpoints, fY);
+   auto exname = SavePrimitiveArray(out, "gre_fex", fNpoints, fEX);
+   auto eyname = SavePrimitiveArray(out, "gre_fey", fNpoints, fEY);
 
-   if (gROOT->ClassSaved(TGraphErrors::Class()))
-      out << "   ";
-   else
-      out << "   TGraphErrors *";
-   out << "gre = new TGraphErrors(" << fNpoints << ","
-                                    << fXName   << ","  << fYName  << ","
-                                    << fEXName  << ","  << fEYName << ");"
-                                    << std::endl;
+   SavePrimitiveConstructor(
+      out, Class(), "gre",
+      TString::Format("%d, %s, %s, %s, %s", fNpoints, xname.Data(), yname.Data(), exname.Data(), eyname.Data()));
 
    SaveHistogramAndFunctions(out, "gre", frameNumber, option);
 }

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -1728,16 +1728,7 @@ void TGraphMultiErrors::Print(Option_t *) const
 
 void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   out << "   " << std::endl;
-   static Int_t frameNumber = 5000;
-   frameNumber++;
-
-   if (gROOT->ClassSaved(TGraphMultiErrors::Class()))
-      out << "   ";
-   else
-      out << "   TGraphMultiErrors* ";
-
-   out << "tgme = new TGraphMultiErrors(" << fNpoints << ", " << fNYErrors << ");" << std::endl;
+   SavePrimitiveConstructor(out, Class(), "tgme", TString::Format("%d, %d", fNpoints, fNYErrors));
 
    for (Int_t j = 0; j < fNYErrors; j++) {
       fAttFill[j].SaveFillAttributes(out, TString::Format("tgme->GetAttFill(%d)", j).Data(), 0, 1001);
@@ -1753,7 +1744,7 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
              << std::endl;
    }
 
-   SaveHistogramAndFunctions(out, "tgme", frameNumber, option);
+   SaveHistogramAndFunctions(out, "tgme", option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -301,12 +301,20 @@ void TPolyMarker::Print(Option_t *) const
 
 void TPolyMarker::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   SavePrimitiveConstructor(out, Class(), "pmarker", TString::Format("%d,\"%s\"", fN, fOption.Data()));
+   TString args;
+
+   if (Size() > 0) {
+      TString arrxname = SavePrimitiveArray(out, "pmarker", Size(), fX);
+      TString arryname = SavePrimitiveArray(out, "pmarker", Size(), fY);
+      args.Form("%d, %s, %s, \"", Size(), arrxname.Data(), arryname.Data());
+   } else
+      args = "0, \"";
+   args.Append(TString(fOption).ReplaceSpecialCppChars() + "\"");
+
+   SavePrimitiveConstructor(out, Class(), "pmarker", args);
 
    SaveMarkerAttributes(out,"pmarker",1,1,1);
 
-   for (Int_t i=0;i<Size();i++)
-      out<<"   pmarker->SetPoint("<<i<<","<<fX[i]<<","<<fY[i]<<");"<<std::endl;
    if (!strstr(option, "nodraw"))
       out<<"   pmarker->Draw(\"" << option << "\");" << std::endl;
 }


### PR DESCRIPTION
1. Let store array of doubles as plain C array in output macro
2. Returns unique variable name which used then in other operation
3. Use in `TPolyMarker` to speedup creation of such objects, for 50K markers speedup from 37s to 0.5s
4. Use method in `TGraph` classes, removing `TGraph::SaveArray` 
5. Improve `SavePrimitive` methods of `TGraph` - based classes 