### PR TITLE
[ntuple] Add alignment calculation in RClassField::Attach method

### DIFF
--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -185,6 +185,15 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, TClass 
 
 void ROOT::Experimental::RClassField::Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo info)
 {
+   auto *cls = TClass::GetClass(GetTypeName().c_str());
+   if(cls) {
+      TIter memberIter(cls->GetListOfDataMembers());
+      TDataMember *dataMember;
+      while ((dataMember = (TDataMember*)memberIter())) {
+         std::size_t maxAlign = dataMember->GetUnitSize();
+         fMaxAlignment = std::max(fMaxAlignment, maxAlign);
+      }
+   }
    fMaxAlignment = std::max(fMaxAlignment, child->GetAlignment());
    fSubFieldsInfo.push_back(info);
    RFieldBase::Attach(std::move(child));


### PR DESCRIPTION
# This Pull request:
Add alignment calculation in RClassField::Attach method

## Changes or fixes:
1. Get the TypeName of the class
2. Loop over all the data members, and find maximum alignment requirement
3. Update the maximum alignment considering both the class members and child fields
4. This takes into account the transient members along with the persistent members.

Now this 
```
#include <ROOT/RField.hxx>

class ClassWithTransient {
  char a;
  int t; //!
  char b;
};

void ntuple_class_align() {
  ROOT::Experimental::RField<ClassWithTransient> f("f");
  std::cout << "value size: " << f.GetValueSize() << ", alignment: " << f.GetAlignment() << "\n";
}
```
Return this
```value size: 12, alignment: 4```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #16765 

