### PR TITLE
[Python] Use `magic` submodule from `IPython.Core`

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/kernel/magics/cppmagic.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/magics/cppmagic.py
@@ -13,22 +13,21 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from metakernel import Magic, option
+from IPython.core.magic import Magics, cell_magic, magics_class
 
 import sys
 
 #NOTE:actually JupyROOT is not capturing the error on %%cpp -d if the function is wrong
-class CppMagics(Magic):
-    def __init__(self, kernel):
-        super(CppMagics, self).__init__(kernel)
-    @option(
-        '-a', '--aclic', action='store', default="default", help='Compile code with ACLiC.'
-    )
-    @option(
-        '-d', '--declare', action='store', default=None, help='Declare functions and/or classes.'
-    )
+@magics_class
+class CppMagics(Magics):
+    @cell_magic
     def cell_cpp(self, args):
-        '''Executes the content of the cell as C++ code.'''
+        """Executes the content of the cell as C++ code.
+
+        Options (mutually exclusive):
+            -a : Compile code with ACLiC.
+            -d : Declare functions and/or classes.:
+        """
         if self.code.strip():
              execFunc = None
              if args == '-a':

--- a/bindings/jupyroot/python/JupyROOT/kernel/magics/jsrootmagic.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/magics/jsrootmagic.py
@@ -14,15 +14,14 @@
 
 from JupyROOT.helpers.utils import enableJSVis, disableJSVis, enableJSVisDebug, TBufferJSONErrorMessage, TBufferJSONAvailable
 
-from metakernel import Magic, option
+from IPython.core.magic import Magics, line_magic, magics_class
 
-class JSRootMagics(Magic):
-    def __init__(self, kernel):
-        super(JSRootMagics, self).__init__(kernel)
-    @option('arg', default="on", help='Enable or disable JavaScript visualisation. Possible values: on (default), off')
 
+@magics_class
+class JSRootMagics(Magics):
+    @line_magic
     def line_jsroot(self, args):
-        '''Change the visualisation of plots from images to interactive JavaScript objects.'''
+        """Enable or disable JavaScript visualisation. Possible values: on (default), off."""
         if args == 'on' or args == '':
            self.printErrorIfNeeded()
            enableJSVis()

--- a/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
@@ -18,11 +18,6 @@ from __future__ import print_function
 
 import sys
 
-try:
-    from metakernel import MetaKernel
-except ImportError:
-    raise Exception("Error: package metakernel not found.(install it running 'pip install metakernel')")
-
 import ROOT
 
 from JupyROOT.helpers.utils import setStyle, invokeAclic, GetDrawers


### PR DESCRIPTION
Relying on the `IPython.core.magic` module instead of `metakernel.magic`
avoids the metakernel dependency, making sure that failures to import
`metakernel` are not resulting in an error.

https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.magic.html

Also, remove the `@options` decorators with additions to the docstrings
only, because the `metakernel.magic` API was not used correctly there
anyway. If options are registered via the decorators, they need to be
retrieved with `Magic.get_args()` in the implementation of the magic,
which didn't happen. Instead, the input strings were just parsed
manually anyway.

Sister PR in roottest:
  * https://github.com/root-project/roottest/pull/1266