### PR TITLE
[io] TFileMergerTest: add missing TBranch include

### DIFF
--- a/io/io/test/TFileMergerTests.cxx
+++ b/io/io/test/TFileMergerTests.cxx
@@ -2,6 +2,7 @@
 
 #include "TFileMerger.h"
 #include "TFileMergeInfo.h"
+#include "TBranch.h"
 
 #include "TMemFile.h"
 #include "TTree.h"


### PR DESCRIPTION
A missing include in #17652 causes a compiler warning (aka an error in dev=ON)