### PR TITLE
Restrict `ipython<9.0.0` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ numba>=0.48
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel
+ipython<9.0.0 # ipython 9.0.0 is incompatible the the latest metakernel, as of 03/03/25
 notebook>=4.4.1
 metakernel>=0.20.0
 


### PR DESCRIPTION
The newest `ipython` broke the newest  metakernel package.

See also the upstream report:
https://github.com/Calysto/metakernel/issues/288

Restricting the ipython version, at least until the problem is fixed upstream in the ipython/metakernel duo, will solve the problem for all ROOT branches, because the `requirements.txt` is used for all CI images.

I was a bit hesitant if this is really the solution because the problem seems to be platform-dependent. However, that seems to be because ipython 9.0.0 has not reached all of pips channels yet. Compare for example these build logs:

Ubuntu 24.04, picks up `ipython==8.33.0`
https://productionresultssa15.blob.core.windows.net/actions-results/7a5c1f23-ff80-468b-80dd-33e4511651f6/workflow-job-run-5f5bc846-a2a7-5fbf-b892-8ca7512cbcea/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-03T09%3A12%3A05Z&sig=3lsuZ7wxDHR804tfJJdV0hj8o2pktHyD1cNe92gvKSI%3D&ske=2025-03-03T20%3A43%3A42Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-03T08%3A43%3A42Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-03T09%3A02%3A00Z&sv=2025-01-05

Fedora 41 picks up `ipython==9.0.0`:
https://productionresultssa15.blob.core.windows.net/actions-results/7a5c1f23-ff80-468b-80dd-33e4511651f6/workflow-job-run-c55417ba-26e1-5c15-ea21-28e4787be48e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-03T09%3A11%3A25Z&sig=5Q8wyCvctlAA18IQ23rJj3TAe2Sv%2FHNRrWK%2B8JZ84cI%3D&ske=2025-03-03T20%3A36%3A35Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-03T08%3A36%3A35Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-03T09%3A01%3A20Z&sv=2025-01-05
