### PR TITLE
[ntuple] Fix type normalization in template classes

### DIFF
--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -82,7 +82,7 @@ std::string GetNormalizedTemplateArg(const std::string &arg, F fnTypeNormalizer)
 
 std::pair<std::string, std::string> SplitTypePrefixFromTemplateArgs(const std::string &typeName)
 {
-   auto idxOpen = typeName.find_first_of("<");
+   auto idxOpen = typeName.find('<');
    if (idxOpen == std::string::npos)
       return {typeName, ""};
 
@@ -348,7 +348,7 @@ ROOT::Experimental::Internal::ParseArrayType(const std::string &typeName)
    std::string prefix{typeName};
    while (prefix.back() == ']') {
       auto posRBrace = prefix.size() - 1;
-      auto posLBrace = prefix.find_last_of('[', posRBrace);
+      auto posLBrace = prefix.rfind('[', posRBrace);
       if (posLBrace == std::string_view::npos) {
          throw RException(R__FAIL(std::string("invalid array type: ") + typeName));
       }

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -93,6 +93,13 @@ public:
    T fMember;
 };
 
+template <int I>
+class EdmHash {
+public:
+   typedef std::string value_type;
+   value_type fHash;
+};
+
 template <typename FirstT, typename SecondT = double>
 class DataVector {
 public:

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -93,11 +93,20 @@ public:
    T fMember;
 };
 
+template <typename T>
+struct EdmHashTrait {
+   using value_type = T;
+};
+
 template <int I>
 class EdmHash {
 public:
    typedef std::string value_type;
    value_type fHash;
+
+   template <typename T>
+   using value_typeT = typename EdmHashTrait<T>::value_type;
+   value_typeT<value_type> fHash2;
 };
 
 template <typename FirstT, typename SecondT = double>

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -96,6 +96,17 @@ public:
 template <typename FirstT, typename SecondT = double>
 class DataVector {
 public:
+   class Inner {
+      FirstT fFirst;
+      SecondT fSecond;
+   };
+
+   template <typename FirstU, typename SecondU = double>
+   class Nested {
+      FirstU fFirst;
+      SecondU fSecond;
+   };
+
    FirstT fFirst;
    SecondT fSecond;
 };

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class LowPrecisionFloats+;
 
 #pragma link C++ class EdmWrapper<CustomStruct> +;
+#pragma link C++ class EdmHash < 1> + ;
 
 #pragma link C++ class DataVector < int, double> + ;
 #pragma link C++ class DataVector < int, float> + ;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -27,6 +27,14 @@
 #pragma link C++ class DataVector < int, double> + ;
 #pragma link C++ class DataVector < int, float> + ;
 #pragma link C++ class DataVector < bool, std::vector < unsigned int>> + ;
+#pragma link C++ class DataVector < int, double> ::Inner + ;
+#pragma link C++ class DataVector < int, double> ::Inner + ;
+#pragma link C++ class DataVector < int, float> ::Inner + ;
+#pragma link C++ class DataVector < int, float> ::Inner + ;
+#pragma link C++ class DataVector < int, double> ::Nested < int, double> + ;
+#pragma link C++ class DataVector < int, double> ::Nested < int, float> + ;
+#pragma link C++ class DataVector < int, float> ::Nested < int, double> + ;
+#pragma link C++ class DataVector < int, float> ::Nested < int, float> + ;
 #pragma link C++ class InnerCV < const int, const volatile int, volatile const int, volatile int> + ;
 #pragma link C++ class IntegerTemplates < 0, 0> + ;
 #pragma link C++ class IntegerTemplates < -1, 1> + ;

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -208,10 +208,16 @@ TEST(RNTuple, TypeNameTemplatesNestedAlias)
    EXPECT_EQ("", hash->GetTypeAlias());
 
    const auto hashSubFields = hash->GetSubFields();
-   ASSERT_EQ(1, hashSubFields.size());
+   ASSERT_EQ(2, hashSubFields.size());
    EXPECT_EQ("fHash", hashSubFields[0]->GetFieldName());
    EXPECT_EQ("std::string", hashSubFields[0]->GetTypeName());
    EXPECT_EQ("EdmHash<1>::value_type", hashSubFields[0]->GetTypeAlias());
+
+   EXPECT_EQ("fHash2", hashSubFields[1]->GetFieldName());
+   EXPECT_EQ("std::string", hashSubFields[1]->GetTypeName());
+   // FIXME: This should really be EdmHash<1>::value_typeT<EdmHash<1>::value_type>, but this is the value we get from
+   // TDataMember::GetFullTypeName right now...
+   EXPECT_EQ("value_typeT<EdmHash<1>::value_type>", hashSubFields[1]->GetTypeAlias());
 }
 
 TEST(RNTuple, ContextDependentTypeNames)

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -201,6 +201,19 @@ TEST(RNTuple, TClassDefaultTemplateParameterNested)
    EXPECT_THROW(reader->GetView<DataVector<int>::Nested<int>>("f2"), ROOT::RException);
 }
 
+TEST(RNTuple, TypeNameTemplatesNestedAlias)
+{
+   auto hash = RFieldBase::Create("f", "EdmHash<1>").Unwrap();
+   EXPECT_EQ("EdmHash<1>", hash->GetTypeName());
+   EXPECT_EQ("", hash->GetTypeAlias());
+
+   const auto hashSubFields = hash->GetSubFields();
+   ASSERT_EQ(1, hashSubFields.size());
+   EXPECT_EQ("fHash", hashSubFields[0]->GetFieldName());
+   EXPECT_EQ("std::string", hashSubFields[0]->GetTypeName());
+   EXPECT_EQ("EdmHash<1>::value_type", hashSubFields[0]->GetTypeAlias());
+}
+
 TEST(RNTuple, ContextDependentTypeNames)
 {
    // Adapted from https://gitlab.cern.ch/amete/rntuple-bug-report-20250219, reproducer of


### PR DESCRIPTION
Templated classes can have nested types that can themselves be templated. Until now, `SplitTypePrefixFromTemplateArgs` assumed that there is only one set of template arguments at the end. The function is replaced by `FindTemplateAngleBrackets` which is then used by `GetRenormalizedTypeName` and `GetNormalizedUnresolvedTypeName` to extract the template arguments and construct a normalized type name.

Fixes #17848