### PR TITLE
[cling] Ensure correct template argument printing for large integers

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4164,7 +4164,6 @@ void ROOT::TMetaUtils::GetNormalizedName(std::string &norm_name, const clang::Qu
    policy.SuppressTagKeyword = true; // Never get the class or struct keyword
    policy.SuppressScope = true;      // Force the scope to be coming from a clang::ElaboratedType.
    policy.AnonymousTagLocations = false; // Do not extract file name + line number for anonymous types.
-   policy.AlwaysIncludeTypeForTemplateArgument = true; // Always include type for template arguments
    // The scope suppression is required for getting rid of the anonymous part of the name of a class defined in an anonymous namespace.
    // This gives us more control vs not using the clang::ElaboratedType and relying on the Policy.SuppressUnwrittenScope which would
    // strip both the anonymous and the inline namespace names (and we probably do not want the later to be suppressed).

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4164,6 +4164,7 @@ void ROOT::TMetaUtils::GetNormalizedName(std::string &norm_name, const clang::Qu
    policy.SuppressTagKeyword = true; // Never get the class or struct keyword
    policy.SuppressScope = true;      // Force the scope to be coming from a clang::ElaboratedType.
    policy.AnonymousTagLocations = false; // Do not extract file name + line number for anonymous types.
+   policy.AlwaysIncludeTypeForTemplateArgument = true; // Always include type for template arguments
    // The scope suppression is required for getting rid of the anonymous part of the name of a class defined in an anonymous namespace.
    // This gives us more control vs not using the clang::ElaboratedType and relying on the Policy.SuppressUnwrittenScope which would
    // strip both the anonymous and the inline namespace names (and we probably do not want the later to be suppressed).

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -1760,6 +1760,7 @@ namespace utils {
     PrintingPolicy Policy(Ctx.getPrintingPolicy());
     Policy.SuppressScope = false;
     Policy.AnonymousTagLocations = false;
+    Policy.AlwaysIncludeTypeForTemplateArgument = true;
     return FQQT.getAsString(Policy);
   }
 

--- a/interpreter/llvm-project/clang/lib/AST/TemplateBase.cpp
+++ b/interpreter/llvm-project/clang/lib/AST/TemplateBase.cpp
@@ -133,14 +133,8 @@ static void printIntegral(const TemplateArgument &TemplArg, raw_ostream &Out,
     } else
       Out << "(" << T->getCanonicalTypeInternal().getAsString(Policy) << ")"
           << Val;
-  } else {
+  } else
     Out << Val;
-    // Handle cases where the value is too large to fit into the underlying type
-    // i.e. where the unsignedness matters.
-    if (T->isBuiltinType())
-      if (Val.isUnsigned() && Val.getBitWidth() == 64 && Val.countLeadingOnes())
-        Out << "ull";
-  }
 }
 
 static unsigned getArrayDepth(QualType type) {


### PR DESCRIPTION
# This Pull request:
We do not need a patch to set `ULL` suffix manually on top of Clang.

`Policy.AlwaysIncludeTypeForTemplateArgument = true` does the job.

This will get rid of the patch: https://github.com/root-project/llvm-project/commit/5ae13042588e6ab98eefd33c8b43bfe7f52cb6ee

I started the process of upstreaming (https://github.com/llvm/llvm-project/pull/129235).
But on further digging, I realized we can simply use `AlwaysIncludeTypeForTemplateArgument = true`

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

