### PR TITLE
[Minuit2] Also cache transformed parameter values in gradient evaluation

### DIFF
--- a/math/minuit2/inc/Minuit2/MnMatrix.h
+++ b/math/minuit2/inc/Minuit2/MnMatrix.h
@@ -12,6 +12,8 @@
 
 #include <Minuit2/MnMatrixfwd.h> // For typedefs
 
+#include <ROOT/RSpan.hxx>
+
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -820,11 +822,12 @@ public:
          StackAllocatorHolder::Get().Deallocate(fData);
    }
 
-   LAVector(const LAVector &v)
+   LAVector(const LAVector &v) : LAVector{std::span<const double>{v.Data(), v.size()}} {}
+
+   explicit LAVector(std::span<const double> v)
       : fSize(v.size()), fData((double *)StackAllocatorHolder::Get().Allocate(sizeof(double) * v.size()))
    {
-      //     std::cout<<"LAVector(const LAVector& v)"<<std::endl;
-      std::memcpy(fData, v.Data(), fSize * sizeof(double));
+      std::memcpy(fData, v.data(), fSize * sizeof(double));
    }
 
    LAVector &operator=(const LAVector &v)

--- a/math/minuit2/inc/Minuit2/Numerical2PGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/Numerical2PGradientCalculator.h
@@ -39,11 +39,7 @@ public:
    {
    }
 
-   ~Numerical2PGradientCalculator() override {}
-
    FunctionGradient operator()(const MinimumParameters &) const override;
-
-   virtual FunctionGradient operator()(std::span<const double> params) const;
 
    FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 

--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -59,7 +59,6 @@ set(MINUIT2_HEADERS
     MnLineSearch.h
     MnMachinePrecision.h
     MnMatrix.h
-    MnMatrix.h
     MnMatrixfwd.h
     MnMigrad.h
     MnMinimize.h
@@ -128,6 +127,7 @@ set(MINUIT2_SOURCES
     MnGlobalCorrelationCoeff.cxx
     MnHesse.cxx
     MnLineSearch.cxx
+    MnMatrix.cxx
     MnMachinePrecision.cxx
     MnMinos.cxx
     MnParabolaFactory.cxx

--- a/math/minuit2/src/MnFcnCaller.h
+++ b/math/minuit2/src/MnFcnCaller.h
@@ -1,0 +1,56 @@
+#ifndef ROOT_Minuit2_MnFcnCaller
+#define ROOT_Minuit2_MnFcnCaller
+
+#include "Minuit2/MnUserFcn.h"
+
+namespace ROOT {
+
+namespace Minuit2 {
+
+// Helper class to call the MnFcn, cashing the transformed parameters in case
+// it is a MnUserFcn that does the parameter transformation when calling.
+class MnFcnCaller {
+public:
+   MnFcnCaller(const MnFcn &mfcn) : fMfcn{mfcn}, fIsUserFcn{static_cast<bool>(dynamic_cast<MnUserFcn const *>(&mfcn))}
+   {
+      if (!fIsUserFcn)
+         return;
+
+      MnUserTransformation const &transform = static_cast<MnUserFcn const &>(fMfcn).transform();
+
+      // get first initial values of parameter (in case some one is fixed)
+      fVpar.assign(transform.InitialParValues().begin(), transform.InitialParValues().end());
+   }
+
+   double operator()(const MnAlgebraicVector &v)
+   {
+      if (!fIsUserFcn)
+         return fMfcn(v);
+
+      MnUserTransformation const &transform = static_cast<MnUserFcn const &>(fMfcn).transform();
+
+      bool firstCall = fLastInput.size() != v.size();
+
+      fLastInput.resize(v.size());
+
+      for (unsigned int i = 0; i < v.size(); i++) {
+         if (firstCall || fLastInput[i] != v(i)) {
+            fVpar[transform.ExtOfInt(i)] = transform.Int2ext(i, v(i));
+            fLastInput[i] = v(i);
+         }
+      }
+
+      return static_cast<MnUserFcn const &>(fMfcn).callWithTransformedParams(fVpar);
+   }
+
+private:
+   MnFcn const &fMfcn;
+   bool fIsUserFcn = false;
+   std::vector<double> fLastInput;
+   std::vector<double> fVpar;
+};
+
+} // namespace Minuit2
+} // namespace ROOT
+
+#endif

--- a/math/minuit2/src/MnHesse.cxx
+++ b/math/minuit2/src/MnHesse.cxx
@@ -23,6 +23,8 @@
 #include "Minuit2/MnPrint.h"
 #include "Minuit2/MPIProcess.h"
 
+#include "./MnFcnCaller.h"
+
 namespace ROOT {
 
 namespace Minuit2 {
@@ -163,53 +165,6 @@ MinimumState ComputeAnalytical(const FCNBase &fcn, const MinimumState &st, const
 
    return MinimumState(st.Parameters(), err, gr, edm, st.NFcn());
 }
-
-namespace {
-
-// Helper class to call the MnFcn, cashing the transformed parameters in case
-// it is a MnUserFcn that does the parameter transformation when calling.
-class MnFcnCaller {
-public:
-   MnFcnCaller(const MnFcn &mfcn) : fMfcn{mfcn}, fIsUserFcn{static_cast<bool>(dynamic_cast<MnUserFcn const *>(&mfcn))}
-   {
-      if (!fIsUserFcn)
-         return;
-
-      MnUserTransformation const &transform = static_cast<MnUserFcn const &>(fMfcn).transform();
-
-      // get first initial values of parameter (in case some one is fixed)
-      fVpar.assign(transform.InitialParValues().begin(), transform.InitialParValues().end());
-   }
-
-   double operator()(const MnAlgebraicVector &v)
-   {
-      if (!fIsUserFcn)
-         return fMfcn(v);
-
-      MnUserTransformation const &transform = static_cast<MnUserFcn const &>(fMfcn).transform();
-
-      bool firstCall = fLastInput.size() != v.size();
-
-      fLastInput.resize(v.size());
-
-      for (unsigned int i = 0; i < v.size(); i++) {
-         if (firstCall || fLastInput[i] != v(i)) {
-            fVpar[transform.ExtOfInt(i)] = transform.Int2ext(i, v(i));
-            fLastInput[i] = v(i);
-         }
-      }
-
-      return static_cast<MnUserFcn const &>(fMfcn).callWithTransformedParams(fVpar);
-   }
-
-private:
-   MnFcn const &fMfcn;
-   bool fIsUserFcn = false;
-   std::vector<double> fLastInput;
-   std::vector<double> fVpar;
-};
-
-} // namespace
 
 MinimumState ComputeNumerical(const MnFcn &mfcn, const MinimumState &st, const MnUserTransformation &trafo,
                               unsigned int maxcalls, MnStrategy const &strat)

--- a/math/minuit2/src/Numerical2PGradientCalculator.cxx
+++ b/math/minuit2/src/Numerical2PGradientCalculator.cxx
@@ -41,25 +41,6 @@ FunctionGradient Numerical2PGradientCalculator::operator()(const MinimumParamete
    return (*this)(par, gra);
 }
 
-// comment it, because it was added
-FunctionGradient Numerical2PGradientCalculator::operator()(std::span<const double> params) const
-{
-   // calculate gradient from an std;:vector of paramteters
-
-   int npar = params.size();
-
-   MnAlgebraicVector par(npar);
-   for (int i = 0; i < npar; ++i) {
-      par(i) = params[i];
-   }
-
-   double fval = Fcn()(par);
-
-   MinimumParameters minpars = MinimumParameters(par, fval);
-
-   return (*this)(minpars);
-}
-
 FunctionGradient Numerical2PGradientCalculator::
 operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
 {
@@ -81,7 +62,7 @@ operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
 
    //print.Trace("Assumed precision eps", eps, "eps2", eps2);
 
-   double dfmin = 8. * eps2 * (std::fabs(fcnmin) + Fcn().Up());
+   double dfmin = 8. * eps2 * (std::fabs(fcnmin) + fFcn.Up());
    double vrysml = 8. * eps * eps;
    //   double vrysml = std::max(1.e-4, eps2);
    //    std::cout<<"dfmin= "<<dfmin<<std::endl;
@@ -156,13 +137,13 @@ operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
          stepb4 = step;
          //       MnAlgebraicVector pstep(n);
          //       pstep(i) = step;
-         //       double fs1 = Fcn()(pstate + pstep);
-         //       double fs2 = Fcn()(pstate - pstep);
+         //       double fs1 = fFcn(pstate + pstep);
+         //       double fs2 = fFcn(pstate - pstep);
 
          x(i) = xtf + step;
-         double fs1 = Fcn()(x);
+         double fs1 = fFcn(x);
          x(i) = xtf - step;
-         double fs2 = Fcn()(x);
+         double fs2 = fFcn(x);
          x(i) = xtf;
 
          double grdb4 = grd(i);

--- a/math/minuit2/src/Numerical2PGradientCalculator.cxx
+++ b/math/minuit2/src/Numerical2PGradientCalculator.cxx
@@ -27,6 +27,8 @@
 
 #include "Minuit2/MPIProcess.h"
 
+#include "./MnFcnCaller.h"
+
 namespace ROOT {
 
 namespace Minuit2 {
@@ -51,6 +53,8 @@ operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
    //    std::cout<<"initial grd: "<<Gradient.Grad()<<std::endl;
    //    std::cout<<"position: "<<par.Vec()<<std::endl;
    MnPrint print("Numerical2PGradientCalculator");
+
+   MnFcnCaller mfcnCaller{fFcn};
 
    assert(par.IsValid());
 
@@ -137,13 +141,13 @@ operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
          stepb4 = step;
          //       MnAlgebraicVector pstep(n);
          //       pstep(i) = step;
-         //       double fs1 = fFcn(pstate + pstep);
-         //       double fs2 = fFcn(pstate - pstep);
+         //       double fs1 = mfcnCaller(pstate + pstep);
+         //       double fs2 = mfcnCaller(pstate - pstep);
 
          x(i) = xtf + step;
-         double fs1 = fFcn(x);
+         double fs1 = mfcnCaller(x);
          x(i) = xtf - step;
-         double fs2 = fFcn(x);
+         double fs2 = mfcnCaller(x);
          x(i) = xtf;
 
          double grdb4 = grd(i);

--- a/math/minuit2/src/ParametricFunction.cxx
+++ b/math/minuit2/src/ParametricFunction.cxx
@@ -14,6 +14,7 @@
 #include "Minuit2/Numerical2PGradientCalculator.h"
 #include "Minuit2/FunctionGradient.h"
 #include "Minuit2/MnVectorTransform.h"
+#include "Minuit2/MinimumParameters.h"
 
 namespace ROOT {
 
@@ -35,7 +36,8 @@ std::vector<double> ParametricFunction::GetGradient(std::vector<double> const &x
    MnUserParameterState st(x, err);
 
    Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
-   FunctionGradient g = gc(x);
+   MnAlgebraicVector xVec{x};
+   FunctionGradient g = gc(MinimumParameters{xVec, mfcn(xVec)});
    const MnAlgebraicVector &grad = g.Vec();
    assert(grad.size() == x.size());
    MnVectorTransform vt;


### PR DESCRIPTION
Just like it was already done in MnHesse, the
Numerical2PGradientCalculator now caches the transformed parameter
values.

This speeds up the minimization in the ATLAS Higgs combination benchmark
by 10 % from 30.7 seconds down to 27.6 s.

In more optimized RooFit-based likelihoods, the relative speedup is even
more significant. Minimizing the CMS Higgs discovery likelihood is 50 %
faster, for example.