### PR TITLE
[RF] Remove irrelevant allocation in RooRealVar IO constructor

### DIFF
--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -148,9 +148,9 @@ public:
 
   double chopAt(double what, Int_t where) const ;
 
-  double _error;      ///< Symmetric error associated with current value
-  double _asymErrLo ; ///< Low side of asymmetric error associated with current value
-  double _asymErrHi ; ///< High side of asymmetric error associated with current value
+  double _error = 0.0;     ///< Symmetric error associated with current value
+  double _asymErrLo = 0.0; ///< Low side of asymmetric error associated with current value
+  double _asymErrHi = 0.0; ///< High side of asymmetric error associated with current value
   std::unique_ptr<RooAbsBinning> _binning;
   std::unordered_map<std::string,std::unique_ptr<RooAbsBinning>> _altNonSharedBinning ; ///<! Non-shareable alternative binnings
 

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -91,7 +91,7 @@ RooRealVarSharedProperties& RooRealVar::_nullProp()
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-RooRealVar::RooRealVar()  :  _error(0), _asymErrLo(0), _asymErrHi(0), _binning(new RooUniformBinning())
+RooRealVar::RooRealVar()
 {
   _fast = true ;
   TRACE_CREATE;


### PR DESCRIPTION
The IO constructor should not allocate memory for the smart pointer members like `_binning`, because it will be reset anyway by the IO.

Not doing this avoids some overhead when reading a large RooWorkspace.