### PR TITLE
[ntuple] Merger: handle RNTuples with empty schemas

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -113,6 +113,8 @@ public:
    explicit RNTupleMerger(std::unique_ptr<RPagePersistentSink> destination);
 
    /// Merge a given set of sources into the destination.
+   /// Note that sources with an empty schema (i.e. created from a Model that had no fields added to it) are in
+   /// general valid (depending on the merging mode) but add no entries to the destination.
    RResult<void> Merge(std::span<RPageSource *> sources, const RNTupleMergeOptions &mergeOpts = RNTupleMergeOptions());
 
 }; // end of class RNTupleMerger

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -415,8 +415,12 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterId(ROOT::
       const auto &clusterIds = GetClusterGroupDescriptor(fSortedClusterGroupIds[cgMidpoint]).GetClusterIds();
       R__ASSERT(!clusterIds.empty());
 
-      const auto firstElementInGroup =
-         GetClusterDescriptor(clusterIds.front()).GetColumnRange(physicalColumnId).GetFirstElementIndex();
+      const auto &clusterDesc = GetClusterDescriptor(clusterIds.front());
+      // this may happen if the RNTuple has an empty schema
+      if (!clusterDesc.ContainsColumn(physicalColumnId))
+         return ROOT::kInvalidDescriptorId;
+
+      const auto firstElementInGroup = clusterDesc.GetColumnRange(physicalColumnId).GetFirstElementIndex();
       if (firstElementInGroup > index) {
          // Look into the lower half of cluster groups
          R__ASSERT(cgMidpoint > 0);

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -815,14 +815,14 @@ void RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<const RCo
       // We need to figure out which columns are actually present in this cluster so we only merge their pages (the
       // missing columns are handled by synthesizing zero pages - see below).
       size_t nCommonColumnsInCluster = commonColumns.size();
-      do {
+      while (nCommonColumnsInCluster > 0) {
          // Since `commonColumns` is sorted by column input id, we can simply traverse it from the back and stop as
          // soon as we find a common column that appears in this cluster: we know that in that case all previous
          // columns must appear as well.
          if (clusterDesc.ContainsColumn(commonColumns[nCommonColumnsInCluster - 1].fInputId))
             break;
          --nCommonColumnsInCluster;
-      } while (nCommonColumnsInCluster > 0);
+      }
 
       // Convert columns to a ColumnSet for the ClusterPool query
       RCluster::ColumnSet_t commonColumnSet;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -1096,6 +1096,9 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       MergeSourceClusters(*source, columnInfos.fCommonColumns, columnInfos.fExtraDstColumns, mergeData);
    } // end loop over sources
 
+   if (fDestination->GetNEntries() == 0)
+      Warning("RNTuple::Merge", "Output RNTuple '%s' has no entries.", fDestination->GetNTupleName().c_str());
+
    // Commit the output
    fDestination->CommitClusterGroup();
    fDestination->CommitDataset();

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -133,7 +133,6 @@ TEST(RNTupleMerger, MergeSymmetric)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       RNTupleMergeOptions opts;
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
@@ -239,7 +238,6 @@ TEST(RNTupleMerger, MergeAsymmetric1)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       // We expect this to fail in Filter and Strict mode since the fields between the sources do NOT match
       RNTupleMergeOptions opts;
       {
@@ -311,7 +309,6 @@ TEST(RNTupleMerger, MergeAsymmetric2)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       // We expect this to fail in Filter and Strict mode since the fields between the sources do NOT match
       RNTupleMergeOptions opts;
       {
@@ -383,7 +380,6 @@ TEST(RNTupleMerger, MergeAsymmetric3)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       // We expect this to succeed except in all modes except Strict.
       RNTupleMergeOptions opts;
       {
@@ -471,7 +467,6 @@ TEST(RNTupleMerger, MergeVector)
          opts.SetCompression(0);
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), opts);
 
-         // Now merge the inputs
          RNTupleMergeOptions mopts;
          mopts.fMergingMode = mmode;
          RNTupleMerger merger{std::move(destination)};
@@ -569,7 +564,6 @@ TEST(RNTupleMerger, MergeInconsistentTypes)
       auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
       RNTupleMerger merger{std::move(destination)};
 
-      // Now merge the inputs
       // We expect this to fail since the fields between the sources do NOT match
       for (const auto mmode : {ENTupleMergingMode::kFilter, ENTupleMergingMode::kStrict, ENTupleMergingMode::kUnion}) {
          RNTupleMergeOptions opts;
@@ -613,10 +607,9 @@ TEST(RNTupleMerger, MergeThroughTFileMerger)
       }
    }
 
-   // Now merge the inputs
+   // Now merge the inputs through TFileMerger
    FileRaii fileGuard3("test_ntuple_merge_out.root");
    {
-      // Now merge the inputs through TFileMerger
       TFileMerger merger;
       merger.AddFile(fileGuard1.GetPath().c_str());
       merger.AddFile(fileGuard2.GetPath().c_str());
@@ -1054,7 +1047,6 @@ TEST(RNTupleMerger, MergeLateModelExtension)
       wopts.SetCompression(0);
       auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), wopts);
 
-      // Now merge the inputs
       auto opts = RNTupleMergeOptions{};
       opts.fCompressionSettings = 0;
       opts.fMergingMode = ENTupleMergingMode::kUnion;
@@ -1134,7 +1126,6 @@ TEST(RNTupleMerger, MergeCompression)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       RNTupleMergeOptions opts;
       {
          auto wopts = RNTupleWriteOptions();
@@ -1194,7 +1185,7 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
       }
    }
 
-   // Now merge the inputs
+   // Now merge the inputs. Do both with and without compression change
    FileRaii fileGuard3("test_ntuple_merge_diff_rep_out1.root");
    FileRaii fileGuard4("test_ntuple_merge_diff_rep_out2.root");
    {
@@ -1209,7 +1200,6 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
 
       auto sourcePtrs2 = sourcePtrs;
 
-      // Now merge the inputs. Do both with and without compression change
       {
          auto wopts = RNTupleWriteOptions();
          wopts.SetCompression(0);
@@ -1317,7 +1307,7 @@ TEST(RNTupleMerger, Double32)
       }
    }
 
-   // Now merge the inputs
+   // Now merge the inputs. Do both with and without compression change
    FileRaii fileGuard3("test_ntuple_merge_d32_out1.root");
    FileRaii fileGuard4("test_ntuple_merge_d32_out2.root");
    {
@@ -1332,7 +1322,6 @@ TEST(RNTupleMerger, Double32)
 
       auto sourcePtrs2 = sourcePtrs;
 
-      // Now merge the inputs. Do both with and without compression change
       {
          auto wopts = RNTupleWriteOptions();
          wopts.SetCompression(0);
@@ -1862,7 +1851,6 @@ TEST(RNTupleMerger, MergeAsymmetric1TFileMerger)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       // We expect this to fail in Filter and Strict mode since the fields between the sources do NOT match
       {
          auto nt1 = std::unique_ptr<TFile>(TFile::Open(fileGuard1.GetPath().c_str()));
@@ -2812,7 +2800,6 @@ TEST(RNTupleMerger, MergeEmptySchema)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       RNTupleMergeOptions opts;
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
@@ -2884,7 +2871,6 @@ TEST(RNTupleMerger, MergeFirstEmptySchema)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       RNTupleMergeOptions opts;
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
@@ -2971,7 +2957,6 @@ TEST(RNTupleMerger, MergeSecondEmptySchema)
          sourcePtrs.push_back(s.get());
       }
 
-      // Now merge the inputs
       RNTupleMergeOptions opts;
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -2800,6 +2800,9 @@ TEST(RNTupleMerger, MergeEmptySchema)
          sourcePtrs.push_back(s.get());
       }
 
+      ROOT::TestSupport::CheckDiagsRAII diags;
+      diags.requiredDiag(kWarning, "RNTuple::Merge", "Output RNTuple 'ntuple' has no entries.");
+
       RNTupleMergeOptions opts;
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());


### PR DESCRIPTION
# This Pull request:
fixes an edge case in the Merger where the input source(s) have an empty schema. Adds unit tests for the various cases.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

