### PR TITLE
[ntuple] Move RNTuple*Range out of Experimental

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -176,7 +176,7 @@ public:
       }
       const auto elemSize = fElement->GetSize();
       void *from = static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) +
-                   (localIndex.GetIndexInCluster() - fReadPageRef.Get().GetClusterRangeFirst()) * elemSize;
+                   (localIndex.GetIndexInCluster() - fReadPageRef.Get().GetLocalRangeFirst()) * elemSize;
       std::memcpy(to, from, elemSize);
    }
 
@@ -211,7 +211,7 @@ public:
          if (!fReadPageRef.Get().Contains(localIndex)) {
             MapPage(localIndex);
          }
-         ROOT::NTupleSize_t idxInPage = localIndex.GetIndexInCluster() - fReadPageRef.Get().GetClusterRangeFirst();
+         ROOT::NTupleSize_t idxInPage = localIndex.GetIndexInCluster() - fReadPageRef.Get().GetLocalRangeFirst();
 
          const void *from = static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) + idxInPage * elemSize;
          const ROOT::NTupleSize_t nBatch = std::min(count, fReadPageRef.Get().GetNElements() - idxInPage);
@@ -257,9 +257,9 @@ public:
          MapPage(localIndex);
       }
       // +1 to go from 0-based indexing to 1-based number of items
-      nItems = fReadPageRef.Get().GetClusterRangeLast() - localIndex.GetIndexInCluster() + 1;
+      nItems = fReadPageRef.Get().GetLocalRangeLast() - localIndex.GetIndexInCluster() + 1;
       return reinterpret_cast<CppT *>(static_cast<unsigned char *>(fReadPageRef.Get().GetBuffer()) +
-                                      (localIndex.GetIndexInCluster() - fReadPageRef.Get().GetClusterRangeFirst()) *
+                                      (localIndex.GetIndexInCluster() - fReadPageRef.Get().GetLocalRangeFirst()) *
                                          sizeof(CppT));
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -825,7 +825,7 @@ public:
    }
 
    /// Overload to read all elements in the given cluster range.
-   void *ReadBulk(RNTupleClusterRange range) { return ReadBulk(*range.begin(), nullptr, range.size()); }
+   void *ReadBulk(RNTupleLocalRange range) { return ReadBulk(*range.begin(), nullptr, range.size()); }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -825,7 +825,7 @@ public:
    }
 
    /// Overload to read all elements in the given cluster range.
-   void *ReadBulk(RNTupleLocalRange range) { return ReadBulk(*range.begin(), nullptr, range.size()); }
+   void *ReadBulk(ROOT::RNTupleLocalRange range) { return ReadBulk(*range.begin(), nullptr, range.size()); }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
@@ -19,11 +19,10 @@
 #include <ROOT/RNTupleUtil.hxx>
 
 namespace ROOT {
-namespace Experimental {
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleGlobalRange
+\class ROOT::RNTupleGlobalRange
 \ingroup NTuple
 \brief Used to loop over indexes (entries or collections) between start and end
 */
@@ -76,7 +75,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleLocalRange
+\class ROOT::RNTupleLocalRange
 \ingroup NTuple
 \brief Used to loop over entries of collections in a single cluster
 */
@@ -130,7 +129,14 @@ public:
    ROOT::NTupleSize_t size() const { return fEnd - fStart; }
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RNTupleGlobalRange [[deprecated("ROOT::Experimental::RNTupleGlobalRange moved to ROOT::RNTupleGlobalRange")]] =
+   ROOT::RNTupleGlobalRange;
+using RNTupleClusterRange [[deprecated("ROOT::Experimental::RNTupleClusterRange moved to ROOT::RNTupleLocalRange")]] =
+   ROOT::RNTupleLocalRange;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
@@ -76,12 +76,12 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleClusterRange
+\class ROOT::Experimental::RNTupleLocalRange
 \ingroup NTuple
 \brief Used to loop over entries of collections in a single cluster
 */
 // clang-format on
-class RNTupleClusterRange {
+class RNTupleLocalRange {
 private:
    const ROOT::DescriptorId_t fClusterId;
    const ROOT::NTupleSize_t fStart;
@@ -121,7 +121,7 @@ public:
       bool operator!=(const iterator &rh) const { return fLocalIndex != rh.fLocalIndex; }
    };
 
-   RNTupleClusterRange(ROOT::DescriptorId_t clusterId, ROOT::NTupleSize_t start, ROOT::NTupleSize_t end)
+   RNTupleLocalRange(ROOT::DescriptorId_t clusterId, ROOT::NTupleSize_t start, ROOT::NTupleSize_t end)
       : fClusterId(clusterId), fStart(start), fEnd(end)
    {
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -257,7 +257,7 @@ public:
    ///    ntuple->Show(i);
    /// }
    /// ~~~
-   RNTupleGlobalRange GetEntryRange() { return RNTupleGlobalRange(0, GetNEntries()); }
+   ROOT::RNTupleGlobalRange GetEntryRange() { return ROOT::RNTupleGlobalRange(0, GetNEntries()); }
 
    /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -38,7 +38,7 @@ namespace Internal {
 /// by the number of elements of the first principal column found in the subfields searched by BFS.
 /// If the field hierarchy is empty on columns, the returned field range is invalid (start and end set to
 /// kInvalidNTupleIndex). An attempt to use such a field range in RNTupleViewBase::GetFieldRange will throw.
-RNTupleGlobalRange GetFieldRange(const RFieldBase &field, const RPageSource &pageSource);
+ROOT::RNTupleGlobalRange GetFieldRange(const RFieldBase &field, const RPageSource &pageSource);
 
 } // namespace Internal
 
@@ -61,7 +61,7 @@ template <typename T>
 class RNTupleViewBase {
 protected:
    std::unique_ptr<RFieldBase> fField;
-   RNTupleGlobalRange fFieldRange;
+   ROOT::RNTupleGlobalRange fFieldRange;
    RFieldBase::RValue fValue;
 
    static std::unique_ptr<RFieldBase> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
@@ -81,17 +81,17 @@ protected:
       return field;
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range)
+   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : fField(std::move(field)), fFieldRange(range), fValue(fField->CreateValue())
    {
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
+   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
       : fField(std::move(field)), fFieldRange(range), fValue(fField->BindValue(objPtr))
    {
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, T *rawPtr)
+   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
       : fField(std::move(field)), fFieldRange(range), fValue(fField->BindValue(Internal::MakeAliasedSharedPtr(rawPtr)))
    {
    }
@@ -107,7 +107,7 @@ public:
    RFieldBase::RBulk CreateBulk() { return fField->CreateBulk(); }
 
    const RFieldBase::RValue &GetValue() const { return fValue; }
-   RNTupleGlobalRange GetFieldRange() const
+   ROOT::RNTupleGlobalRange GetFieldRange() const
    {
       if (!fFieldRange.IsValid()) {
          throw RException(R__FAIL("field iteration over empty fields is unsupported: " + fField->GetFieldName()));
@@ -133,17 +133,17 @@ class RNTupleView : public RNTupleViewBase<T> {
    friend class RNTupleCollectionView;
 
 protected:
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : RNTupleViewBase<T>(std::move(field), range)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
       : RNTupleViewBase<T>(std::move(field), range, objPtr)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, T *rawPtr)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
       : RNTupleViewBase<T>(std::move(field), range, rawPtr)
    {
    }
@@ -181,17 +181,17 @@ class RNTupleView<void> final : public RNTupleViewBase<void> {
    friend class RNTupleCollectionView;
 
 protected:
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : RNTupleViewBase<void>(std::move(field), range)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, std::shared_ptr<void> objPtr)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<void> objPtr)
       : RNTupleViewBase<void>(std::move(field), range, objPtr)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, RNTupleGlobalRange range, void *rawPtr)
+   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, void *rawPtr)
       : RNTupleViewBase<void>(std::move(field), range, rawPtr)
    {
    }
@@ -221,7 +221,7 @@ class RNTupleDirectAccessView {
 
 protected:
    RField<T> fField;
-   RNTupleGlobalRange fFieldRange;
+   ROOT::RNTupleGlobalRange fFieldRange;
 
    static RField<T> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
    {
@@ -237,7 +237,10 @@ protected:
       return field;
    }
 
-   RNTupleDirectAccessView(RField<T> field, RNTupleGlobalRange range) : fField(std::move(field)), fFieldRange(range) {}
+   RNTupleDirectAccessView(RField<T> field, ROOT::RNTupleGlobalRange range)
+      : fField(std::move(field)), fFieldRange(range)
+   {
+   }
 
 public:
    RNTupleDirectAccessView(const RNTupleDirectAccessView &other) = delete;
@@ -247,7 +250,7 @@ public:
    ~RNTupleDirectAccessView() = default;
 
    const RFieldBase &GetField() const { return fField; }
-   RNTupleGlobalRange GetFieldRange() const { return fFieldRange; }
+   ROOT::RNTupleGlobalRange GetFieldRange() const { return fFieldRange; }
 
    const T &operator()(ROOT::NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
    const T &operator()(RNTupleLocalIndex localIndex) { return *fField.Map(localIndex); }
@@ -308,22 +311,22 @@ public:
    RNTupleCollectionView &operator=(RNTupleCollectionView &&other) = default;
    ~RNTupleCollectionView() = default;
 
-   RNTupleLocalRange GetCollectionRange(ROOT::NTupleSize_t globalIndex)
+   ROOT::RNTupleLocalRange GetCollectionRange(ROOT::NTupleSize_t globalIndex)
    {
       ROOT::NTupleSize_t size;
       RNTupleLocalIndex collectionStart;
       fField.GetCollectionInfo(globalIndex, &collectionStart, &size);
-      return RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
-                               collectionStart.GetIndexInCluster() + size);
+      return ROOT::RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
+                                     collectionStart.GetIndexInCluster() + size);
    }
 
-   RNTupleLocalRange GetCollectionRange(RNTupleLocalIndex localIndex)
+   ROOT::RNTupleLocalRange GetCollectionRange(RNTupleLocalIndex localIndex)
    {
       ROOT::NTupleSize_t size;
       RNTupleLocalIndex collectionStart;
       fField.GetCollectionInfo(localIndex, &collectionStart, &size);
-      return RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
-                               collectionStart.GetIndexInCluster() + size);
+      return ROOT::RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
+                                     collectionStart.GetIndexInCluster() + size);
    }
 
    /// Raises an exception if there is no field with the given name.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -308,22 +308,22 @@ public:
    RNTupleCollectionView &operator=(RNTupleCollectionView &&other) = default;
    ~RNTupleCollectionView() = default;
 
-   RNTupleClusterRange GetCollectionRange(ROOT::NTupleSize_t globalIndex)
+   RNTupleLocalRange GetCollectionRange(ROOT::NTupleSize_t globalIndex)
    {
       ROOT::NTupleSize_t size;
       RNTupleLocalIndex collectionStart;
       fField.GetCollectionInfo(globalIndex, &collectionStart, &size);
-      return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
-                                 collectionStart.GetIndexInCluster() + size);
+      return RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
+                               collectionStart.GetIndexInCluster() + size);
    }
 
-   RNTupleClusterRange GetCollectionRange(RNTupleLocalIndex localIndex)
+   RNTupleLocalRange GetCollectionRange(RNTupleLocalIndex localIndex)
    {
       ROOT::NTupleSize_t size;
       RNTupleLocalIndex collectionStart;
       fField.GetCollectionInfo(localIndex, &collectionStart, &size);
-      return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
-                                 collectionStart.GetIndexInCluster() + size);
+      return RNTupleLocalRange(collectionStart.GetClusterId(), collectionStart.GetIndexInCluster(),
+                               collectionStart.GetIndexInCluster() + size);
    }
 
    /// Raises an exception if there is no field with the given name.

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -125,11 +125,8 @@ public:
    std::uint32_t GetMaxElements() const { return fMaxElements; }
    ROOT::NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
    ROOT::NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + ROOT::NTupleSize_t(fNElements) - 1; }
-   ROOT::NTupleSize_t GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
-   ROOT::NTupleSize_t GetClusterRangeLast() const
-   {
-      return GetClusterRangeFirst() + ROOT::NTupleSize_t(fNElements) - 1;
-   }
+   ROOT::NTupleSize_t GetLocalRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
+   ROOT::NTupleSize_t GetLocalRangeLast() const { return GetLocalRangeFirst() + ROOT::NTupleSize_t(fNElements) - 1; }
    const RClusterInfo& GetClusterInfo() const { return fClusterInfo; }
 
    bool Contains(ROOT::NTupleSize_t globalIndex) const

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -107,7 +107,7 @@ private:
       // Constructor used to store a page in fLookupByKey
       explicit RPagePosition(const RPage &page)
          : fGlobalFirstElement(page.GetGlobalRangeFirst()),
-           fClusterFirstElement({page.GetClusterInfo().GetId(), page.GetClusterRangeFirst()})
+           fClusterFirstElement({page.GetClusterInfo().GetId(), page.GetLocalRangeFirst()})
       {
       }
 

--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -19,7 +19,7 @@
 #include <ROOT/RNTupleView.hxx>
 #include <ROOT/RPageStorage.hxx>
 
-ROOT::Experimental::RNTupleGlobalRange
+ROOT::RNTupleGlobalRange
 ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPageSource &pageSource)
 {
    const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
@@ -39,9 +39,9 @@ ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPage
    }
 
    if (columnId == ROOT::kInvalidDescriptorId) {
-      return RNTupleGlobalRange(ROOT::kInvalidNTupleIndex, ROOT::kInvalidNTupleIndex);
+      return ROOT::RNTupleGlobalRange(ROOT::kInvalidNTupleIndex, ROOT::kInvalidNTupleIndex);
    }
 
    auto arraySize = std::max(std::uint64_t(1), desc.GetFieldDescriptor(field.GetOnDiskId()).GetNRepetitions());
-   return RNTupleGlobalRange(0, desc.GetNElements(columnId) / arraySize);
+   return ROOT::RNTupleGlobalRange(0, desc.GetNElements(columnId) / arraySize);
 }

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -43,8 +43,8 @@ TEST(Pages, Pool)
          EXPECT_FALSE(pageRef.Get().IsNull());
          EXPECT_EQ(50U, pageRef.Get().GetGlobalRangeFirst());
          EXPECT_EQ(59U, pageRef.Get().GetGlobalRangeLast());
-         EXPECT_EQ(10U, pageRef.Get().GetClusterRangeFirst());
-         EXPECT_EQ(19U, pageRef.Get().GetClusterRangeLast());
+         EXPECT_EQ(10U, pageRef.Get().GetLocalRangeFirst());
+         EXPECT_EQ(19U, pageRef.Get().GetLocalRangeLast());
 
          auto pageRef2 =
             pool.GetPage(RPagePool::RKey{1, std::type_index(typeid(void))}, ROOT::RNTupleLocalIndex(0, 15));


### PR DESCRIPTION
# This Pull request:
- renames `RNTupleClusterRange` to `RNTupleLocalRange` as we previously decided.
- moves `RNTupleGlobalRange` and `RNTupleLocalRange` out of Experimental

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


