### PR TITLE
[ntuple] Make RColumnRange's and RPageInfo's fields private

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -233,8 +233,14 @@ class RClusterDescriptor final {
    friend class Internal::RClusterDescriptorBuilder;
 
 public:
-   /// The window of element indexes of a particular column in a particular cluster
-   struct RColumnRange {
+   // clang-format off
+   /**
+   \class ROOT::Experimental::RClusterDescriptor::RColumnRange
+   \ingroup NTuple
+   \brief The window of element indexes of a particular column in a particular cluster
+   */
+   // clang-format on
+   class RColumnRange {
       ROOT::DescriptorId_t fPhysicalColumnId = ROOT::kInvalidDescriptorId;
       /// The global index of the first column element in the cluster
       ROOT::NTupleSize_t fFirstElementIndex = ROOT::kInvalidNTupleIndex;
@@ -251,6 +257,37 @@ public:
 
       // TODO(jblomer): we perhaps want to store summary information, such as average, min/max, etc.
       // Should this be done on the field level?
+
+   public:
+      RColumnRange() = default;
+
+      RColumnRange(ROOT::DescriptorId_t physicalColumnId, ROOT::NTupleSize_t firstElementIndex,
+                   ROOT::NTupleSize_t nElements, std::optional<std::uint32_t> compressionSettings,
+                   bool suppressed = false)
+         : fPhysicalColumnId(physicalColumnId),
+           fFirstElementIndex(firstElementIndex),
+           fNElements(nElements),
+           fCompressionSettings(compressionSettings),
+           fIsSuppressed(suppressed)
+      {
+      }
+
+      ROOT::DescriptorId_t GetPhysicalColumnId() const { return fPhysicalColumnId; }
+      void SetPhysicalColumnId(ROOT::DescriptorId_t id) { fPhysicalColumnId = id; }
+
+      ROOT::NTupleSize_t GetFirstElementIndex() const { return fFirstElementIndex; }
+      void SetFirstElementIndex(ROOT::NTupleSize_t idx) { fFirstElementIndex = idx; }
+      void IncrementFirstElementIndex(ROOT::NTupleSize_t by) { fFirstElementIndex += by; }
+
+      ROOT::NTupleSize_t GetNElements() const { return fNElements; }
+      void SetNElements(ROOT::NTupleSize_t n) { fNElements = n; }
+      void IncrementNElements(ROOT::NTupleSize_t by) { fNElements += by; }
+
+      std::optional<std::uint32_t> GetCompressionSettings() const { return fCompressionSettings; }
+      void SetCompressionSettings(std::optional<std::uint32_t> comp) { fCompressionSettings = comp; }
+
+      bool IsSuppressed() const { return fIsSuppressed; }
+      void SetIsSuppressed(bool suppressed) { fIsSuppressed = suppressed; }
 
       bool operator==(const RColumnRange &other) const
       {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -361,19 +361,20 @@ public:
       struct RPageInfoExtended : RPageInfo {
       private:
          /// Index (in cluster) of the first element in page.
-         ROOT::NTupleSize_t fFirstInPage = 0;
+         ROOT::NTupleSize_t fFirstElementIndex = 0;
          /// Page number in the corresponding RPageRange.
          ROOT::NTupleSize_t fPageNumber = 0;
 
       public:
          RPageInfoExtended() = default;
-         RPageInfoExtended(const RPageInfo &pageInfo, ROOT::NTupleSize_t firstInPage, ROOT::NTupleSize_t pageNumber)
-            : RPageInfo(pageInfo), fFirstInPage(firstInPage), fPageNumber(pageNumber)
+         RPageInfoExtended(const RPageInfo &pageInfo, ROOT::NTupleSize_t firstElementIndex,
+                           ROOT::NTupleSize_t pageNumber)
+            : RPageInfo(pageInfo), fFirstElementIndex(firstElementIndex), fPageNumber(pageNumber)
          {
          }
 
-         ROOT::NTupleSize_t GetFirstInPage() const { return fFirstInPage; }
-         void SetFirstInPage(ROOT::NTupleSize_t firstInPage) { fFirstInPage = firstInPage; }
+         ROOT::NTupleSize_t GetFirstElementIndex() const { return fFirstElementIndex; }
+         void SetFirstElementIndex(ROOT::NTupleSize_t firstInPage) { fFirstElementIndex = firstInPage; }
 
          ROOT::NTupleSize_t GetPageNumber() const { return fPageNumber; }
          void SetPageNumber(ROOT::NTupleSize_t pageNumber) { fPageNumber = pageNumber; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -327,6 +327,7 @@ public:
       /// We do not need to store the element size / uncompressed page size because we know to which column
       /// the page belongs
       struct RPageInfo {
+      private:
          /// The sum of the elements of all the pages must match the corresponding fNElements field in fColumnRanges
          std::uint32_t fNElements = std::uint32_t(-1);
          /// The meaning of fLocator depends on the storage backend.
@@ -334,11 +335,29 @@ public:
          /// If true, the 8 bytes following the serialized page are an xxhash of the on-disk page data
          bool fHasChecksum = false;
 
+      public:
+         RPageInfo() = default;
+         RPageInfo(std::uint32_t nElements, const RNTupleLocator &locator, bool hasChecksum)
+            : fNElements(nElements), fLocator(locator), fHasChecksum(hasChecksum)
+         {
+         }
+
          bool operator==(const RPageInfo &other) const
          {
             return fNElements == other.fNElements && fLocator == other.fLocator;
          }
+
+         std::uint32_t GetNElements() const { return fNElements; }
+         void SetNElements(std::uint32_t n) { fNElements = n; }
+
+         const RNTupleLocator &GetLocator() const { return fLocator; }
+         RNTupleLocator &GetLocator() { return fLocator; }
+         void SetLocator(const RNTupleLocator &locator) { fLocator = locator; }
+
+         bool HasChecksum() const { return fHasChecksum; }
+         void SetHasChecksum(bool hasChecksum) { fHasChecksum = hasChecksum; }
       };
+
       struct RPageInfoExtended : RPageInfo {
          /// Index (in cluster) of the first element in page.
          ROOT::NTupleSize_t fFirstInPage = 0;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -327,7 +327,7 @@ public:
       /// We do not need to store the element size / uncompressed page size because we know to which column
       /// the page belongs
       struct RPageInfo {
-      private:
+      protected:
          /// The sum of the elements of all the pages must match the corresponding fNElements field in fColumnRanges
          std::uint32_t fNElements = std::uint32_t(-1);
          /// The meaning of fLocator depends on the storage backend.
@@ -359,16 +359,24 @@ public:
       };
 
       struct RPageInfoExtended : RPageInfo {
+      private:
          /// Index (in cluster) of the first element in page.
          ROOT::NTupleSize_t fFirstInPage = 0;
          /// Page number in the corresponding RPageRange.
-         ROOT::NTupleSize_t fPageNo = 0;
+         ROOT::NTupleSize_t fPageNumber = 0;
 
+      public:
          RPageInfoExtended() = default;
-         RPageInfoExtended(const RPageInfo &pi, ROOT::NTupleSize_t i, ROOT::NTupleSize_t n)
-            : RPageInfo(pi), fFirstInPage(i), fPageNo(n)
+         RPageInfoExtended(const RPageInfo &pageInfo, ROOT::NTupleSize_t firstInPage, ROOT::NTupleSize_t pageNumber)
+            : RPageInfo(pageInfo), fFirstInPage(firstInPage), fPageNumber(pageNumber)
          {
          }
+
+         ROOT::NTupleSize_t GetFirstInPage() const { return fFirstInPage; }
+         void SetFirstInPage(ROOT::NTupleSize_t firstInPage) { fFirstInPage = firstInPage; }
+
+         ROOT::NTupleSize_t GetPageNumber() const { return fPageNumber; }
+         void SetPageNumber(ROOT::NTupleSize_t pageNumber) { fPageNumber = pageNumber; }
       };
 
       RPageRange() = default;

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -117,12 +117,12 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
 
       for (const auto &cluster : fClusterDescriptors) {
          auto columnRange = cluster.second.GetColumnRange(column.second.GetPhysicalId());
-         if (columnRange.fIsSuppressed)
+         if (columnRange.IsSuppressed())
             continue;
 
-         info.fNElements += columnRange.fNElements;
-         if (compression == -1 && columnRange.fCompressionSettings) {
-            compression = *columnRange.fCompressionSettings;
+         info.fNElements += columnRange.GetNElements();
+         if (compression == -1 && columnRange.GetCompressionSettings()) {
+            compression = *columnRange.GetCompressionSettings();
          }
          const auto &pageRange = cluster.second.GetPageRange(column.second.GetPhysicalId());
          auto idx = cluster2Idx[cluster.first];

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -127,12 +127,12 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
          const auto &pageRange = cluster.second.GetPageRange(column.second.GetPhysicalId());
          auto idx = cluster2Idx[cluster.first];
          for (const auto &page : pageRange.fPageInfos) {
-            nBytesOnStorage += page.fLocator.GetNBytesOnStorage();
-            nBytesInMemory += page.fNElements * elementSize;
-            clusters[idx].fNBytesOnStorage += page.fLocator.GetNBytesOnStorage();
-            clusters[idx].fNBytesInMemory += page.fNElements * elementSize;
+            nBytesOnStorage += page.GetLocator().GetNBytesOnStorage();
+            nBytesInMemory += page.GetNElements() * elementSize;
+            clusters[idx].fNBytesOnStorage += page.GetLocator().GetNBytesOnStorage();
+            clusters[idx].fNBytesInMemory += page.GetNElements() * elementSize;
             ++clusters[idx].fNPages;
-            info.fNBytesOnStorage += page.fLocator.GetNBytesOnStorage();
+            info.fNBytesOnStorage += page.GetLocator().GetNBytesOnStorage();
             ++info.fNPages;
             ++nPages;
          }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -747,16 +747,16 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, const RCluster
       for (const auto &pageInfo : pages.fPageInfos) {
          assert(pageIdx < sealedPages.size());
          assert(sealedPageData.fBuffers.size() == 0 || pageIdx < sealedPageData.fBuffers.size());
-         assert(pageInfo.fLocator.GetType() != RNTupleLocator::kTypePageZero);
+         assert(pageInfo.GetLocator().GetType() != RNTupleLocator::kTypePageZero);
 
          ROnDiskPage::Key key{columnId, pageIdx};
          auto onDiskPage = cluster->GetOnDiskPage(key);
 
-         const auto checksumSize = pageInfo.fHasChecksum * RPageStorage::kNBytesPageChecksum;
+         const auto checksumSize = pageInfo.HasChecksum() * RPageStorage::kNBytesPageChecksum;
          RPageStorage::RSealedPage &sealedPage = sealedPages[pageIdx];
-         sealedPage.SetNElements(pageInfo.fNElements);
-         sealedPage.SetHasChecksum(pageInfo.fHasChecksum);
-         sealedPage.SetBufferSize(pageInfo.fLocator.GetNBytesOnStorage() + checksumSize);
+         sealedPage.SetNElements(pageInfo.GetNElements());
+         sealedPage.SetHasChecksum(pageInfo.HasChecksum());
+         sealedPage.SetBufferSize(pageInfo.GetLocator().GetNBytesOnStorage() + checksumSize);
          sealedPage.SetBuffer(onDiskPage->GetAddress());
          // TODO(gparolini): more graceful error handling (skip the page?)
          sealedPage.VerifyChecksumIfEnabled().ThrowOnError();

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -189,7 +189,7 @@ try {
                   inFile->GetName());
             return -1;
          }
-         compression = (*firstColRange).fCompressionSettings.value();
+         compression = (*firstColRange).GetCompressionSettings().value();
          Info("RNTuple::Merge", "Using the first RNTuple's compression: %u", *compression);
       }
       sources.push_back(std::move(source));
@@ -710,7 +710,7 @@ void RNTupleMerger::MergeCommonColumns(RClusterPool &clusterPool, const RCluster
       sealedPages.resize(pages.fPageInfos.size());
 
       // Each column range potentially has a distinct compression settings
-      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).fCompressionSettings.value();
+      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).GetCompressionSettings().value();
       // If either the compression or the encoding of the source doesn't match that of the destination, we need
       // to reseal the page. Otherwise, if both match, we can fast merge.
       const bool needsResealing =

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1570,7 +1570,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
       // Get an ordered set of physical column ids
       std::set<ROOT::DescriptorId_t> onDiskColumnIds;
       for (const auto &columnRange : clusterDesc.GetColumnRangeIterable())
-         onDiskColumnIds.insert(context.GetOnDiskColumnId(columnRange.fPhysicalColumnId));
+         onDiskColumnIds.insert(context.GetOnDiskColumnId(columnRange.GetPhysicalColumnId()));
 
       auto outerFrame = pos;
       pos += SerializeListFramePreamble(onDiskColumnIds.size(), *where);
@@ -1579,7 +1579,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
          const auto &columnRange = clusterDesc.GetColumnRange(memId);
 
          auto innerFrame = pos;
-         if (columnRange.fIsSuppressed) {
+         if (columnRange.IsSuppressed()) {
             // Empty page range
             pos += SerializeListFramePreamble(0, *where);
             pos += SerializeInt64(kSuppressedColumnMarker, *where);
@@ -1592,8 +1592,8 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
                pos += SerializeUInt32(nElements, *where);
                pos += SerializeLocator(pi.fLocator, *where);
             }
-            pos += SerializeInt64(columnRange.fFirstElementIndex, *where);
-            pos += SerializeUInt32(columnRange.fCompressionSettings.value(), *where);
+            pos += SerializeInt64(columnRange.GetFirstElementIndex(), *where);
+            pos += SerializeUInt32(columnRange.GetCompressionSettings().value(), *where);
          }
 
          pos += SerializeFramePostscript(buffer ? innerFrame : nullptr, pos - innerFrame);

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1588,9 +1588,10 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
             pos += SerializeListFramePreamble(pageRange.fPageInfos.size(), *where);
 
             for (const auto &pi : pageRange.fPageInfos) {
-               std::int32_t nElements = pi.fHasChecksum ? -static_cast<std::int32_t>(pi.fNElements) : pi.fNElements;
+               std::int32_t nElements =
+                  pi.HasChecksum() ? -static_cast<std::int32_t>(pi.GetNElements()) : pi.GetNElements();
                pos += SerializeUInt32(nElements, *where);
-               pos += SerializeLocator(pi.fLocator, *where);
+               pos += SerializeLocator(pi.GetLocator(), *where);
             }
             pos += SerializeInt64(columnRange.GetFirstElementIndex(), *where);
             pos += SerializeUInt32(columnRange.GetCompressionSettings().value(), *where);
@@ -1885,7 +1886,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageListRaw(const vo
             result = DeserializeLocator(bytes, fnInnerFrameSizeLeft(), locator);
             if (!result)
                return R__FORWARD_ERROR(result);
-            pageRange.fPageInfos.push_back({static_cast<std::uint32_t>(nElements), locator, hasChecksum});
+            pageRange.fPageInfos.emplace_back(static_cast<std::uint32_t>(nElements), locator, hasChecksum);
             bytes += result.Unwrap();
          }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -608,7 +608,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
+      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
@@ -643,7 +643,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 
-      ROnDiskPage::Key key(columnId, pageInfo.fPageNo);
+      ROnDiskPage::Key key(columnId, pageInfo.GetPageNumber());
       auto onDiskPage = fCurrentCluster->GetOnDiskPage(key);
       R__ASSERT(onDiskPage && (sealedPage.GetBufferSize() == onDiskPage->GetSize()));
       sealedPage.SetBuffer(onDiskPage->GetAddress());
@@ -656,7 +656,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
+   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -608,7 +608,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
+      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
@@ -656,7 +656,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t colum
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
+   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -429,7 +429,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
+      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
@@ -474,7 +474,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
+   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -429,7 +429,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
+      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
                          RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
@@ -461,7 +461,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 
-      ROnDiskPage::Key key(columnId, pageInfo.fPageNo);
+      ROnDiskPage::Key key(columnId, pageInfo.GetPageNumber());
       auto onDiskPage = fCurrentCluster->GetOnDiskPage(key);
       R__ASSERT(onDiskPage && (sealedPage.GetBufferSize() == onDiskPage->GetSize()));
       sealedPage.SetBuffer(onDiskPage->GetAddress());
@@ -474,7 +474,7 @@ ROOT::Experimental::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t colum
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
+   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstInPage(),
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});

--- a/tree/ntuple/v7/test/ntuple_checksum.cxx
+++ b/tree/ntuple/v7/test/ntuple_checksum.cxx
@@ -104,8 +104,8 @@ TEST(RNTupleChecksum, OmitPageChecksum)
    const auto clusterId = descGuard->FindClusterId(pxColId, 0);
    const auto &clusterDesc = descGuard->GetClusterDescriptor(clusterId);
    const auto pageInfo = clusterDesc.GetPageRange(pxColId).fPageInfos[0];
-   EXPECT_EQ(4u, pageInfo.fLocator.GetNBytesOnStorage());
-   EXPECT_FALSE(pageInfo.fHasChecksum);
+   EXPECT_EQ(4u, pageInfo.GetLocator().GetNBytesOnStorage());
+   EXPECT_FALSE(pageInfo.HasChecksum());
 
    RPageStorage::RSealedPage sealedPage;
    pageSource->LoadSealedPage(pxColId, RNTupleLocalIndex{clusterId, 0}, sealedPage);

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -388,7 +388,7 @@ TEST(RNTuple, LargePages)
       const auto &desc = reader->GetDescriptor();
       const auto rndColId = desc.FindPhysicalColumnId(desc.FindFieldId("rnd"), 0, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(desc.FindClusterId(rndColId, 0));
-      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).fLocator.GetNBytesOnStorage(), kMAXZIPBUF);
+      EXPECT_GT(clusterDesc.GetPageRange(rndColId).Find(0).GetLocator().GetNBytesOnStorage(), kMAXZIPBUF);
 
       auto viewRnd = reader->GetView<std::uint32_t>("rnd");
       std::mt19937 gen;

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -247,7 +247,7 @@ TEST(RNTuple, DISABLED_Limits_LargePage)
    EXPECT_EQ(reader->GetNEntries(), NumElements);
    EXPECT_EQ(descriptor.GetNClusters(), 1);
    EXPECT_EQ(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos.size(), 1);
-   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].fLocator.GetNBytesOnStorage(),
+   EXPECT_GT(descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos[0].GetLocator().GetNBytesOnStorage(),
              static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()));
 
    auto id = model.GetDefaultEntry().GetPtr<std::uint64_t>("id");

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -815,7 +815,7 @@ static bool VerifyPageCompression(const std::string_view fileName, std::uint32_t
    bool ok = true;
    {
       auto reader = RNTupleReader::Open("ntuple", fileName);
-      auto compSettings = *reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).fCompressionSettings;
+      auto compSettings = *reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).GetCompressionSettings();
       if (compSettings != expectedComp) {
          std::cerr << "Advertised compression is wrong: " << compSettings << " instead of " << expectedComp << "\n";
          ok = false;

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -87,7 +87,7 @@ TEST(RPageStorage, ReadSealedPages)
       ASSERT_GE(sealedPage.GetBufferSize(), 12U);
       ASSERT_GE(sealedPage.GetDataSize(), 4U);
       EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.GetBuffer()));
-      firstElementInPage += pi.fNElements;
+      firstElementInPage += pi.GetNElements();
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -46,31 +46,31 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
    EXPECT_EQ(1u, colDesc16.GetRepresentationIndex());
 
    const auto &clusterDesc0 = desc.GetClusterDescriptor(0);
-   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetCompressionSettings());
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
-   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetCompressionSettings());
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
-   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetCompressionSettings());
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -333,8 +333,8 @@ TEST(RNTupleFillContext, FlushColumns)
    auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0, 0);
    auto &pageInfos = descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos;
    ASSERT_EQ(pageInfos.size(), 2);
-   EXPECT_EQ(pageInfos[0].fNElements, 1);
-   EXPECT_EQ(pageInfos[1].fNElements, 1);
+   EXPECT_EQ(pageInfos[0].GetNElements(), 1);
+   EXPECT_EQ(pageInfos[1].GetNElements(), 1);
 }
 
 TEST(RNTupleParallelWriter, ExplicitCommit)

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -210,31 +210,31 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
    EXPECT_EQ(1u, colDesc16.GetRepresentationIndex());
 
    const auto &clusterDesc0 = desc.GetClusterDescriptor(0);
-   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(0u, clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc0.GetColumnRange(colDesc16.GetPhysicalId()).GetCompressionSettings());
 
    const auto &clusterDesc1 = desc.GetClusterDescriptor(1);
-   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(1u, clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc1.GetColumnRange(colDesc32.GetPhysicalId()).GetCompressionSettings());
 
    const auto &clusterDesc2 = desc.GetClusterDescriptor(2);
-   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fNElements);
-   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fIsSuppressed);
-   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fNElements);
-   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fFirstElementIndex);
-   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).fCompressionSettings);
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc32.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_TRUE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).IsSuppressed());
+   EXPECT_EQ(1u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetNElements());
+   EXPECT_EQ(2u, clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetFirstElementIndex());
+   EXPECT_FALSE(clusterDesc2.GetColumnRange(colDesc16.GetPhysicalId()).GetCompressionSettings());
 
    auto ptrPx = reader->GetModel().GetDefaultEntry().GetPtr<float>("px");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -672,13 +672,13 @@ TEST(RNTuple, SerializeFooter)
    ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
    pageRange.fPhysicalColumnId = 17;
    // Two pages adding up to 100 elements, one with checksum one without
-   pageInfo.fNElements = 40;
-   pageInfo.fLocator.SetPosition(7000U);
-   pageInfo.fHasChecksum = true;
+   pageInfo.SetNElements(40);
+   pageInfo.GetLocator().SetPosition(7000U);
+   pageInfo.SetHasChecksum(true);
    pageRange.fPageInfos.emplace_back(pageInfo);
-   pageInfo.fNElements = 60;
-   pageInfo.fLocator.SetPosition(8000U);
-   pageInfo.fHasChecksum = false;
+   pageInfo.SetNElements(60);
+   pageInfo.GetLocator().SetPosition(8000U);
+   pageInfo.SetHasChecksum(false);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(17, 0, 100, pageRange);
    builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
@@ -750,12 +750,12 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(0u, columnRange.GetFirstElementIndex());
    pageRange = clusterDesc.GetPageRange(0).Clone();
    EXPECT_EQ(2u, pageRange.fPageInfos.size());
-   EXPECT_EQ(40u, pageRange.fPageInfos[0].fNElements);
-   EXPECT_EQ(7000u, pageRange.fPageInfos[0].fLocator.GetPosition<std::uint64_t>());
-   EXPECT_TRUE(pageRange.fPageInfos[0].fHasChecksum);
-   EXPECT_EQ(60u, pageRange.fPageInfos[1].fNElements);
-   EXPECT_EQ(8000u, pageRange.fPageInfos[1].fLocator.GetPosition<std::uint64_t>());
-   EXPECT_FALSE(pageRange.fPageInfos[1].fHasChecksum);
+   EXPECT_EQ(40u, pageRange.fPageInfos[0].GetNElements());
+   EXPECT_EQ(7000u, pageRange.fPageInfos[0].GetLocator().GetPosition<std::uint64_t>());
+   EXPECT_TRUE(pageRange.fPageInfos[0].HasChecksum());
+   EXPECT_EQ(60u, pageRange.fPageInfos[1].GetNElements());
+   EXPECT_EQ(8000u, pageRange.fPageInfos[1].GetLocator().GetPosition<std::uint64_t>());
+   EXPECT_FALSE(pageRange.fPageInfos[1].HasChecksum());
 }
 
 TEST(RNTuple, SerializeFooterXHeader)
@@ -993,7 +993,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    clusterBuilder.MarkSuppressedColumnRange(0);
    clusterBuilder.MarkSuppressedColumnRange(1);
    pageRange.fPhysicalColumnId = 2;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(2, 0, 505, pageRange);
    pageRange.fPhysicalColumnId = 3;
@@ -1006,11 +1006,11 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
    clusterBuilder.MarkSuppressedColumnRange(2);
    clusterBuilder.MarkSuppressedColumnRange(3);
    pageRange.fPhysicalColumnId = 0;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(0, 1, 505, pageRange);
    pageRange.fPhysicalColumnId = 1;
-   pageRange.fPageInfos[0].fNElements = 3;
+   pageRange.fPageInfos[0].SetNElements(3);
    clusterBuilder.CommitColumnRange(1, 0, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
    builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
@@ -1188,7 +1188,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationProjection)
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    clusterBuilder.MarkSuppressedColumnRange(0);
    pageRange.fPhysicalColumnId = 1;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(1, 0, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
@@ -1313,7 +1313,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);
    pageRange.fPhysicalColumnId = 0;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(0, 1, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
@@ -1421,7 +1421,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
    ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    pageRange.fPhysicalColumnId = 0;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(0, 0, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
@@ -1557,7 +1557,7 @@ TEST(RNTuple, DeserializeDescriptorModes)
       RClusterDescriptorBuilder clusterBuilder;
       clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
       pageRange.fPhysicalColumnId = 0;
-      pageInfo.fNElements = 1;
+      pageInfo.SetNElements(1);
       pageRange.fPageInfos.emplace_back(pageInfo);
       clusterBuilder.MarkSuppressedColumnRange(1);
       clusterBuilder.CommitColumnRange(0, 0, 505, pageRange);
@@ -1590,10 +1590,10 @@ TEST(RNTuple, DeserializeDescriptorModes)
       clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
       clusterBuilder.MarkSuppressedColumnRange(0);
       pageRange.fPhysicalColumnId = 1;
-      pageRange.fPageInfos[0].fNElements = 2;
+      pageRange.fPageInfos[0].SetNElements(2);
       clusterBuilder.CommitColumnRange(1, 0, 505, pageRange);
       pageRange.fPhysicalColumnId = 2;
-      pageRange.fPageInfos[0].fNElements = 2;
+      pageRange.fPageInfos[0].SetNElements(2);
       clusterBuilder.CommitColumnRange(2, 1, 505, pageRange);
       clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
       builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
@@ -1831,7 +1831,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred_HeaderExtBeforeSerializ
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);
    pageRange.fPhysicalColumnId = 0;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(0, 1, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();
@@ -1957,7 +1957,7 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferredInMainHeader)
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);
    pageRange.fPhysicalColumnId = 0;
-   pageInfo.fNElements = 1;
+   pageInfo.SetNElements(1);
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(0, 1, 505, pageRange);
    clusterBuilder.CommitSuppressedColumnRanges(builder.GetDescriptor()).ThrowOnError();

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -744,10 +744,10 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_EQ(100, clusterDesc.GetNEntries());
    auto columnIds = clusterDesc.GetColumnRangeIterable();
    EXPECT_EQ(1u, columnIds.size());
-   EXPECT_EQ(0, columnIds.begin()->fPhysicalColumnId);
+   EXPECT_EQ(0, columnIds.begin()->GetPhysicalColumnId());
    columnRange = clusterDesc.GetColumnRange(0);
-   EXPECT_EQ(100u, columnRange.fNElements);
-   EXPECT_EQ(0u, columnRange.fFirstElementIndex);
+   EXPECT_EQ(100u, columnRange.GetNElements());
+   EXPECT_EQ(0u, columnRange.GetFirstElementIndex());
    pageRange = clusterDesc.GetPageRange(0).Clone();
    EXPECT_EQ(2u, pageRange.fPageInfos.size());
    EXPECT_EQ(40u, pageRange.fPageInfos[0].fNElements);
@@ -1735,8 +1735,8 @@ TEST(RNTuple, DeserializeDescriptorModes)
             const auto columnRange0_1 = clusterDesc0.GetColumnRange(columnIds[1]);
             RClusterDescriptor::RColumnRange expect0_0{0, 0, 1, 505, false};
             RClusterDescriptor::RColumnRange expect0_1{};
-            expect0_1.fPhysicalColumnId = 1;
-            expect0_1.fIsSuppressed = true;
+            expect0_1.SetPhysicalColumnId(1);
+            expect0_1.SetIsSuppressed(true);
             EXPECT_EQ(expect0_0, columnRange0_0);
             EXPECT_EQ(expect0_1, columnRange0_1);
 
@@ -1745,8 +1745,8 @@ TEST(RNTuple, DeserializeDescriptorModes)
             const auto columnRange1_0 = clusterDesc1.GetColumnRange(columnIds[0]);
             const auto columnRange1_1 = clusterDesc1.GetColumnRange(columnIds[1]);
             RClusterDescriptor::RColumnRange expect1_0{};
-            expect1_0.fPhysicalColumnId = 0;
-            expect1_0.fIsSuppressed = true;
+            expect1_0.SetPhysicalColumnId(0);
+            expect1_0.SetIsSuppressed(true);
             RClusterDescriptor::RColumnRange expect1_1{1, 0, 2, 505, false};
             EXPECT_EQ(expect1_0, columnRange1_0);
             EXPECT_EQ(expect1_1, columnRange1_1);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -217,10 +217,10 @@ TEST(RNTuple, PageFilling)
    const auto &prX = clusterDesc.GetPageRange(colIdX);
    const auto &prY = clusterDesc.GetPageRange(colIdY);
    ASSERT_EQ(1u, prX.fPageInfos.size());
-   EXPECT_EQ(6u, prX.fPageInfos[0].fNElements);
+   EXPECT_EQ(6u, prX.fPageInfos[0].GetNElements());
    ASSERT_EQ(2u, prY.fPageInfos.size());
-   EXPECT_EQ(3u, prY.fPageInfos[0].fNElements);
-   EXPECT_EQ(3u, prY.fPageInfos[1].fNElements);
+   EXPECT_EQ(3u, prY.fPageInfos[0].GetNElements());
+   EXPECT_EQ(3u, prY.fPageInfos[1].GetNElements());
 }
 
 TEST(RNTuple, PageFillingString)
@@ -269,20 +269,20 @@ TEST(RNTuple, PageFillingString)
    const auto &cd1 = desc.GetClusterDescriptor(desc.FindClusterId(1, 0));
    const auto &pr1 = cd1.GetPageRange(1);
    ASSERT_EQ(2u, pr1.fPageInfos.size());
-   EXPECT_EQ(16u, pr1.fPageInfos[0].fNElements);
-   EXPECT_EQ(1u, pr1.fPageInfos[1].fNElements);
+   EXPECT_EQ(16u, pr1.fPageInfos[0].GetNElements());
+   EXPECT_EQ(1u, pr1.fPageInfos[1].GetNElements());
    const auto &cd2 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd1.GetId()));
    const auto &pr2 = cd2.GetPageRange(1);
    ASSERT_EQ(1u, pr2.fPageInfos.size());
-   EXPECT_EQ(16u, pr2.fPageInfos[0].fNElements);
+   EXPECT_EQ(16u, pr2.fPageInfos[0].GetNElements());
    const auto &cd3 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd2.GetId()));
    const auto &pr3 = cd3.GetPageRange(1);
    ASSERT_EQ(0u, pr3.fPageInfos.size());
    const auto &cd4 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd3.GetId()));
    const auto &pr4 = cd4.GetPageRange(1);
    ASSERT_EQ(2u, pr4.fPageInfos.size());
-   EXPECT_EQ(16u, pr4.fPageInfos[0].fNElements);
-   EXPECT_EQ(10u, pr4.fPageInfos[1].fNElements);
+   EXPECT_EQ(16u, pr4.fPageInfos[0].GetNElements());
+   EXPECT_EQ(10u, pr4.fPageInfos[1].GetNElements());
 }
 
 TEST(RNTuple, FlushColumns)
@@ -312,8 +312,8 @@ TEST(RNTuple, FlushColumns)
    auto columnId = descriptor.FindPhysicalColumnId(fieldId, 0, 0);
    auto &pageInfos = descriptor.GetClusterDescriptor(0).GetPageRange(columnId).fPageInfos;
    ASSERT_EQ(pageInfos.size(), 2);
-   EXPECT_EQ(pageInfos[0].fNElements, 1);
-   EXPECT_EQ(pageInfos[1].fNElements, 1);
+   EXPECT_EQ(pageInfos[0].GetNElements(), 1);
+   EXPECT_EQ(pageInfos[1].GetNElements(), 1);
 }
 
 TEST(RNTuple, WritePageBudgetLimit)
@@ -462,25 +462,25 @@ TEST(RNTuple, WritePageBudget)
    const auto &prDD = clusterDesc.GetPageRange(colIdDD);
 
    EXPECT_EQ(1u, prA.fPageInfos.size());
-   EXPECT_EQ(4u, prA.fPageInfos[0].fNElements);
+   EXPECT_EQ(4u, prA.fPageInfos[0].GetNElements());
    EXPECT_EQ(1u, prB.fPageInfos.size());
-   EXPECT_EQ(4u, prB.fPageInfos[0].fNElements);
+   EXPECT_EQ(4u, prB.fPageInfos[0].GetNElements());
    EXPECT_EQ(1u, prC.fPageInfos.size());
-   EXPECT_EQ(4u, prC.fPageInfos[0].fNElements);
+   EXPECT_EQ(4u, prC.fPageInfos[0].GetNElements());
    EXPECT_EQ(1u, prD.fPageInfos.size());
-   EXPECT_EQ(4u, prD.fPageInfos[0].fNElements);
+   EXPECT_EQ(4u, prD.fPageInfos[0].GetNElements());
    EXPECT_EQ(1u, prAD.fPageInfos.size());
-   EXPECT_EQ(4u, prAD.fPageInfos[0].fNElements);
+   EXPECT_EQ(4u, prAD.fPageInfos[0].GetNElements());
    EXPECT_EQ(2u, prBD.fPageInfos.size());
-   EXPECT_EQ(32u, prBD.fPageInfos[0].fNElements);
-   EXPECT_EQ(8u, prBD.fPageInfos[1].fNElements);
+   EXPECT_EQ(32u, prBD.fPageInfos[0].GetNElements());
+   EXPECT_EQ(8u, prBD.fPageInfos[1].GetNElements());
    EXPECT_EQ(2u, prCD.fPageInfos.size());
-   EXPECT_EQ(20u, prCD.fPageInfos[0].fNElements);
-   EXPECT_EQ(4u, prCD.fPageInfos[1].fNElements);
+   EXPECT_EQ(20u, prCD.fPageInfos[0].GetNElements());
+   EXPECT_EQ(4u, prCD.fPageInfos[1].GetNElements());
    EXPECT_EQ(3u, prDD.fPageInfos.size());
-   EXPECT_EQ(16u, prDD.fPageInfos[0].fNElements);
-   EXPECT_EQ(16u, prDD.fPageInfos[1].fNElements);
-   EXPECT_EQ(7u, prDD.fPageInfos[2].fNElements);
+   EXPECT_EQ(16u, prDD.fPageInfos[0].GetNElements());
+   EXPECT_EQ(16u, prDD.fPageInfos[1].GetNElements());
+   EXPECT_EQ(7u, prDD.fPageInfos[2].GetNElements());
 }
 
 #ifdef R__HAS_DAVIX
@@ -590,7 +590,7 @@ TEST(RPageSinkBuf, Basics)
    for (std::size_t i = 0; i < num_columns; i++) {
       const auto &columnPages = cluster0.GetPageRange(i);
       for (const auto &page : columnPages.fPageInfos) {
-         pagePositions.push_back(std::make_pair(i, page.fLocator.GetPosition<std::uint64_t>()));
+         pagePositions.push_back(std::make_pair(i, page.GetLocator().GetPosition<std::uint64_t>()));
       }
    }
 
@@ -921,13 +921,15 @@ TEST(RPageStorageFile, MultiKeyBlob_Pages)
                    .GetClusterDescriptor(0)
                    .GetPageRange(0)
                    .fPageInfos[0]
-                   .fLocator.GetNBytesOnStorage(),
+                   .GetLocator()
+                   .GetNBytesOnStorage(),
                 kMaxKeySize);
       EXPECT_GT(ntupleUcmp->GetDescriptor()
                    .GetClusterDescriptor(0)
                    .GetPageRange(0)
                    .fPageInfos[0]
-                   .fLocator.GetNBytesOnStorage(),
+                   .GetLocator()
+                   .GetNBytesOnStorage(),
                 kMaxKeySize);
 
       TRandom3 rnd(42);
@@ -1094,8 +1096,8 @@ TEST(RPageSink, SamePageMerging)
       const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
       const auto clusterId = desc.FindClusterId(pxColId, 0);
       const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
-      EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).fLocator.GetPosition<std::uint64_t>() ==
-                           clusterDesc.GetPageRange(pyColId).Find(0).fLocator.GetPosition<std::uint64_t>());
+      EXPECT_EQ(enable, clusterDesc.GetPageRange(pxColId).Find(0).GetLocator().GetPosition<std::uint64_t>() ==
+                           clusterDesc.GetPageRange(pyColId).Find(0).GetLocator().GetPosition<std::uint64_t>());
 
       auto viewPx = reader->GetView<float>("px");
       auto viewPy = reader->GetView<float>("py");

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -239,8 +239,8 @@ TEST_F(RPageStorageDaos, DisabledSamePageMerging)
    const auto pyColId = desc.FindPhysicalColumnId(desc.FindFieldId("py"), 0, 0);
    const auto clusterId = desc.FindClusterId(pxColId, 0);
    const auto &clusterDesc = desc.GetClusterDescriptor(clusterId);
-   EXPECT_FALSE(clusterDesc.GetPageRange(pxColId).Find(0).fLocator.GetPosition<RNTupleLocatorObject64>() ==
-                clusterDesc.GetPageRange(pyColId).Find(0).fLocator.GetPosition<RNTupleLocatorObject64>());
+   EXPECT_FALSE(clusterDesc.GetPageRange(pxColId).Find(0).GetLocator().GetPosition<RNTupleLocatorObject64>() ==
+                clusterDesc.GetPageRange(pyColId).Find(0).GetLocator().GetPosition<RNTupleLocatorObject64>());
 
    auto viewPx = reader->GetView<float>("px");
    auto viewPy = reader->GetView<float>("py");

--- a/tree/ntuple/v7/test/rfield_string.cxx
+++ b/tree/ntuple/v7/test/rfield_string.cxx
@@ -24,6 +24,7 @@ TEST(RNTuple, ReadString)
    if (ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(1).fPageInfos.size() < 2) {
       FAIL(); // This means all entries are inside the same page and numEntries should be increased.
    }
-   int nElementsPerPage = ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(1).fPageInfos.at(1).fNElements;
+   int nElementsPerPage =
+      ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(1).fPageInfos.at(1).GetNElements();
    EXPECT_EQ(contentString, viewSt(nElementsPerPage/7));
 }

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -157,13 +157,13 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
 
             // dump the page
             const void *pageBuf = onDiskPage->GetAddress();
-            const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.fHasChecksum;
+            const bool incChecksum = (options.fFlags & RPagesOptions::kIncludeChecksums) != 0 && pageInfo.HasChecksum();
             const std::size_t maybeChecksumSize = incChecksum * 8;
-            const std::uint64_t pageBufSize = pageInfo.fLocator.GetNBytesOnStorage() + maybeChecksumSize;
+            const std::uint64_t pageBufSize = pageInfo.GetLocator().GetNBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
             assert(colRange.GetCompressionSettings());
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
-               << "_elems_" << pageInfo.fNElements << "_comp_" << *colRange.GetCompressionSettings() << ".page";
+               << "_elems_" << pageInfo.GetNElements() << "_comp_" << *colRange.GetCompressionSettings() << ".page";
             const auto outFileName = ss.str();
             std::ofstream outFile{outFileName, std::ios_base::binary};
             if (!outFile)

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -149,7 +149,7 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             << "exporting column \"" << colInfo.fQualifiedName << "\" (" << pages.fPageInfos.size() << " pages)";
 
          // We should never try to export a suppressed column range
-         assert(!colRange.fIsSuppressed || pages.fPageInfos.empty());
+         assert(!colRange.IsSuppressed() || pages.fPageInfos.empty());
 
          for (const auto &pageInfo : pages.fPageInfos) {
             ROnDiskPage::Key key{columnId, pageIdx};
@@ -161,9 +161,9 @@ RNTupleExporter::RPagesResult RNTupleExporter::ExportPages(RPageSource &source, 
             const std::size_t maybeChecksumSize = incChecksum * 8;
             const std::uint64_t pageBufSize = pageInfo.fLocator.GetNBytesOnStorage() + maybeChecksumSize;
             std::ostringstream ss{options.fOutputPath, std::ios_base::ate};
-            assert(colRange.fCompressionSettings);
+            assert(colRange.GetCompressionSettings());
             ss << "/cluster_" << clusterDesc.GetId() << "_" << colInfo.fQualifiedName << "_page_" << pageIdx
-               << "_elems_" << pageInfo.fNElements << "_comp_" << *colRange.fCompressionSettings << ".page";
+               << "_elems_" << pageInfo.fNElements << "_comp_" << *colRange.GetCompressionSettings() << ".page";
             const auto outFileName = ss.str();
             std::ofstream outFile{outFileName, std::ios_base::binary};
             if (!outFile)

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -88,8 +88,8 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          const auto &pageRange = clusterDescriptor.GetPageRange(colId);
 
          for (const auto &page : pageRange.fPageInfos) {
-            compressedPageSizes.emplace_back(page.fLocator.GetNBytesOnStorage());
-            fUncompressedSize += page.fNElements * elemSize;
+            compressedPageSizes.emplace_back(page.GetLocator().GetNBytesOnStorage());
+            fUncompressedSize += page.GetNElements() * elemSize;
          }
       }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -67,21 +67,21 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          }
 
          auto columnRange = clusterDescriptor.GetColumnRange(colId);
-         if (columnRange.fIsSuppressed)
+         if (columnRange.IsSuppressed())
             continue;
 
-         nElems += columnRange.fNElements;
+         nElems += columnRange.GetNElements();
 
-         if (!fCompressionSettings && columnRange.fCompressionSettings) {
-            fCompressionSettings = *columnRange.fCompressionSettings;
-         } else if (fCompressionSettings && columnRange.fCompressionSettings &&
-                    (*fCompressionSettings != *columnRange.fCompressionSettings)) {
+         if (!fCompressionSettings && columnRange.GetCompressionSettings()) {
+            fCompressionSettings = *columnRange.GetCompressionSettings();
+         } else if (fCompressionSettings && columnRange.GetCompressionSettings() &&
+                    (*fCompressionSettings != *columnRange.GetCompressionSettings())) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
             // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.
             throw RException(R__FAIL("compression setting mismatch between column ranges (" +
                                      std::to_string(*fCompressionSettings) + " vs " +
-                                     std::to_string(*columnRange.fCompressionSettings) +
+                                     std::to_string(*columnRange.GetCompressionSettings()) +
                                      ") for column with physical ID " + std::to_string(colId)));
          }
 


### PR DESCRIPTION
Preparing for the move out of Experimental; we decided that we will use getters/setters instead of public fields in most cases.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


