### PR TITLE
[ntuple] Add `RNTupleProcessor::PrepareJoinModel`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -313,6 +313,10 @@ public:
    std::uint64_t GetModelId() const { return fModelId; }
    std::uint64_t GetSchemaId() const { return fSchemaId; }
 
+   /// Returns the names of the fields currently present in the model, including projected fields. Registered subfields
+   /// are not included, use GetRegisteredSubfields() for this.
+   const std::unordered_set<std::string> &GetFieldNames() const { return fFieldNames; }
+
    std::unique_ptr<REntry> CreateEntry() const;
    /// In a bare entry, all values point to nullptr. The resulting entry shall use BindValue() in order
    /// set memory addresses to be serialized / deserialized

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -390,6 +390,22 @@ public:
    static std::unique_ptr<RNTupleProcessor>
    CreateJoin(const std::vector<RNTupleOpenSpec> &ntuples, const std::vector<std::string> &joinFields,
               std::string_view processorName, std::vector<std::unique_ptr<RNTupleModel>> models = {});
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Prepare a model containing fields from the primary and auxiliary RNTuples for joining.
+   ///
+   /// \param[in] primaryModel The model of the primary RNTuple.
+   /// \param[in] auxModels Models of the auxiliary RNTuples.
+   /// \param[in] auxNTupleNames Names of the auxiliary RNTuples, corresponding to the models in `auxModels`.
+   ///
+   /// \return A new RNTupleModel containing the fields of all provided models.
+   ///
+   /// To prevent field name clashes when one or more models have fields with duplicate names, fields from each
+   /// auxiliary model are stored as a anonymous record, and subsequently registered as subfields in the join model.
+   /// This way, they can be accessed from the processor's entry as `auxNTupleName.fieldName`.
+   static std::unique_ptr<RNTupleModel> PrepareJoinModel(const RNTupleModel &primaryModel,
+                                                         const std::vector<RNTupleModel *> &auxModels,
+                                                         const std::vector<std::string> &auxNTupleNames);
 };
 
 // clang-format off

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -22,6 +22,34 @@ TEST(RNTupleProcessor, EmptyNTuple)
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
 }
 
+TEST(RNTupleProcessor, PrepareJoinModel)
+{
+   auto primaryModel = RNTupleModel::Create();
+   primaryModel->MakeField<int>("i");
+   primaryModel->MakeField<float>("x");
+
+   auto auxModel1 = RNTupleModel::Create();
+   auxModel1->MakeField<int>("i");
+   auxModel1->MakeField<float>("y");
+
+   auto auxModel2 = RNTupleModel::Create();
+   auxModel2->MakeField<int>("i");
+   auxModel2->MakeField<float>("z");
+
+   auto joinModel =
+      RNTupleProcessor::PrepareJoinModel(*primaryModel, {auxModel1.get(), auxModel2.get()}, {"aux1", "aux2"});
+
+   EXPECT_NO_THROW(joinModel->GetConstField("i"));
+   EXPECT_NO_THROW(joinModel->GetConstField("x"));
+   EXPECT_NO_THROW(joinModel->GetConstField("aux1.i"));
+   EXPECT_NO_THROW(joinModel->GetConstField("aux1.y"));
+   EXPECT_THROW(joinModel->GetConstField("y"), ROOT::RException);
+   EXPECT_NO_THROW(joinModel->GetConstField("aux2.i"));
+   EXPECT_NO_THROW(joinModel->GetConstField("aux2.z"));
+   EXPECT_THROW(joinModel->GetConstField("z"), ROOT::RException);
+   // TODO add test for projected fields
+}
+
 class RNTupleProcessorTest : public testing::Test {
 protected:
    const std::array<std::string, 2> fFileNames{"test_ntuple_processor1.root", "test_ntuple_processor2.root"};


### PR DESCRIPTION
The aim is to change the vector of model that currently needs to be passed to `RNTupleProcessor::CreateJoin` to a single model that already represents what the joined entries should look like. From the user's point of view, creating such models from scratch is tricky because we have to do some restructuring to prevent field name clashes. This static helper method provides a way to (correctly) create join models as expected by the processor.

To avoid having to freeze models and access all fields through an `REntry`, `RNTupleModel::GetFieldNames` is added as a companion to the `Get[Const|Mutable]Field` methods.

