### PR TITLE
[io] properly stream TClonesArray with empty slots

### DIFF
--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -2497,7 +2497,8 @@ namespace TStreamerInfoActions
       static INLINE_TEMPLATE_ARGS Int_t LoopOverCollection(TBuffer &buf, void *start, const void *end, const TConfiguration *config)
       {
          for(void *iter = start; iter != end; iter = (char*)iter + sizeof(void*) ) {
-            action(buf, *(void**)iter, config);
+            if (*(void**)iter)
+               action(buf, *(void**)iter, config);
          }
          return 0;
       }

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -2499,6 +2499,8 @@ namespace TStreamerInfoActions
          for(void *iter = start; iter != end; iter = (char*)iter + sizeof(void*) ) {
             if (*(void**)iter)
                action(buf, *(void**)iter, config);
+            else 
+               buf << static_cast<const Char_t *>(nullptr);
          }
          return 0;
       }
@@ -2518,8 +2520,10 @@ namespace TStreamerInfoActions
          const Int_t offset = config->fOffset;
 
          for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
-            T *x = (T*)( ((char*) (*(void**)iter) ) + offset );
-            buf >> *x;
+            if (*(void**)iter) {
+               T *x = (T*)( ((char*) (*(void**)iter) ) + offset );
+               buf >> *x;
+            }
          }
          return 0;
       }
@@ -2533,8 +2537,10 @@ namespace TStreamerInfoActions
             const Int_t offset = config->fOffset;
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
                buf >> temp;
-               To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
-               *x = (To)temp;
+               if (*(void**)iter) {
+                  To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
+                  *x = (To)temp;
+               }
             }
             return 0;
          }
@@ -2550,12 +2556,15 @@ namespace TStreamerInfoActions
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
                buf >> temp;
 
-               if ((temp & kIsReferenced) != 0) {
-                  HandleReferencedTObject(buf,*(void**)iter,config);
-               }
+               if (*(void**)iter)
+               {
+                  if ((temp & kIsReferenced) != 0) {
+                     HandleReferencedTObject(buf,*(void**)iter,config);
+                  }
 
-               To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
-               *x = (To)temp;
+                  To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
+                  *x = (To)temp;
+               }
             }
             return 0;
          }
@@ -2571,8 +2580,10 @@ namespace TStreamerInfoActions
             const Int_t offset = config->fOffset;
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
                buf.ReadWithFactor(&temp, conf->fFactor, conf->fXmin);
-               To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
-               *x = (To)temp;
+               if (*(void**)iter) {
+                  To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
+                  *x = (To)temp;
+               }
             }
             return 0;
          }
@@ -2588,8 +2599,10 @@ namespace TStreamerInfoActions
             const Int_t offset = config->fOffset;
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
                buf.ReadWithNbits(&temp, conf->fNbits);
-               To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
-               *x = (To)temp;
+               if (*(void**)iter) {
+                  To *x = (To*)( ((char*) (*(void**)iter) ) + offset );
+                  *x = (To)temp;
+               }
             }
             return 0;
          }
@@ -2601,8 +2614,12 @@ namespace TStreamerInfoActions
          const Int_t offset = config->fOffset;
 
          for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
-            T *x = (T*)( ((char*) (*(void**)iter) ) + offset );
-            buf << *x;
+            if (*(void**)iter) {
+               T *x = (T*)( ((char*) (*(void**)iter) ) + offset );
+               buf << *x;
+            }
+            else
+               buf << static_cast<const Char_t *>(nullptr);
          }
          return 0;
       }
@@ -2614,9 +2631,13 @@ namespace TStreamerInfoActions
             const Int_t offset = config->fOffset;
 
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
-               From *from = (From*)( ((char*) (*(void**)iter) ) + offset );
-               To to = (To)(*from);
-               buf << to;
+               if (*(void**)iter) {
+                  From *from = (From*)( ((char*) (*(void**)iter) ) + offset );
+                  To to = (To)(*from);
+                  buf << to;
+               } else {
+                  buf << static_cast<const Char_t *>(nullptr);
+               }
             }
             return 0;
          }
@@ -2631,8 +2652,13 @@ namespace TStreamerInfoActions
 
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
                From *from = (From*)( ((char*) (*(void**)iter) ) + offset );
-               To to = (To)(*from);
-               WriteCompressed(buf, &to, elem);
+               if (*(void**)iter) {
+                  To to = (To)(*from);
+                  WriteCompressed(buf, &to, elem);
+               } else {
+                  To to; // uninitialized value
+                  WriteCompressed(buf, &to, elem);
+               }
             }
             return 0;
          }
@@ -2645,9 +2671,14 @@ namespace TStreamerInfoActions
             const TStreamerElement *elem = config->fCompInfo->fElem;
 
             for(; iter != end; iter = (char*)iter + sizeof(void*) ) {
-               From *from = (From*)( ((char*) (*(void**)iter) ) + offset );
-               To to = (To)(*from);
-               WriteCompressed(buf, &to, elem);
+               if(*(void**)iter) {
+                  From *from = (From*)( ((char*) (*(void**)iter) ) + offset );
+                  To to = (To)(*from);
+                  WriteCompressed(buf, &to, elem);
+               } else {
+                  To to; // uninitialized value
+                  WriteCompressed(buf, &to, elem);
+               }
             }
             return 0;
          }
@@ -2694,14 +2725,20 @@ namespace TStreamerInfoActions
       {
          Int_t n = ( ((void**)end) - ((void**)iter) );
          char **arr = (char**)iter;
-         return ((TStreamerInfo*)config->fInfo)->ReadBuffer(buf, arr, &(config->fCompInfo), /*first*/ 0, /*last*/ 1, /*narr*/ n, config->fOffset, 1|2 );
+         if (arr)
+            return ((TStreamerInfo*)config->fInfo)->ReadBuffer(buf, arr, &(config->fCompInfo), /*first*/ 0, /*last*/ 1, /*narr*/ n, config->fOffset, 1|2 );
+         else
+            return 0;
       }
 
       static INLINE_TEMPLATE_ARGS Int_t GenericWrite(TBuffer &buf, void *iter, const void *end, const TConfiguration *config)
       {
          Int_t n = ( ((void**)end) - ((void**)iter) );
          char **arr = (char**)iter;
-         return ((TStreamerInfo*)config->fInfo)->WriteBufferAux(buf, arr, &(config->fCompInfo), /*first*/ 0, /*last*/ 1, n, config->fOffset, 1|2 );
+         if (arr)
+            return ((TStreamerInfo*)config->fInfo)->WriteBufferAux(buf, arr, &(config->fCompInfo), /*first*/ 0, /*last*/ 1, n, config->fOffset, 1|2 );
+         else
+            return 0;
       }
 
    };

--- a/io/io/test/TBufferFileTests.cxx
+++ b/io/io/test/TBufferFileTests.cxx
@@ -5,8 +5,12 @@
 #include "TClass.h"
 #include "TInterpreter.h"
 #include "TKey.h"
+#include "TClonesArray.h"
+#include "TObjString.h"
 #include <vector>
 #include <iostream>
+#include <iostream>
+
 
 // Tests ROOT-8367
 TEST(TBufferFile, ROOT_8367)
@@ -48,4 +52,20 @@ TEST(TBufferFile, ForeignZeroVersionClass)
    EXPECT_NE(f.Get<MyS0>("s0"), nullptr); // Before the fix, even if return was already not nullptr, this line was raising an Error thus test would fail with unexpected diagnostic
    EXPECT_NE(f.Get<MyS1>("s1"), nullptr);
    EXPECT_EQ(f.GetKey("s0")->GetObjlen(), 10);
+}
+
+// https://its.cern.ch/jira/browse/ROOT-6788
+TEST(TBufferFile, ROOT_6788)
+{  
+   TClonesArray clArray(TObjString::Class(), 100);
+   for (Int_t i=0; i<28; i++) {
+       new (clArray[i]) TObjString();
+   }
+   TBufferFile buf(TBuffer::kWrite, 10000);
+   for (Int_t i=0; i<27; i++) {
+       delete clArray.RemoveAt(i);
+   }
+   buf.SetBufferOffset(0);
+   buf.MapObject(&clArray);
+   clArray.Streamer(buf);
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-6788 by @olifre

This fixes the crash, but not sure if it is correct.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
