### PR TITLE
[tree] fix memleak detected by asan

### DIFF
--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -513,6 +513,7 @@ void RecursiveGlob(TList &out, const std::string &glob)
 std::vector<std::string> ExpandGlob(const std::string &glob)
 {
    TList l;
+   l.SetOwner();
    RecursiveGlob(l, glob);
 
    // Sort the files in alphanumeric order


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

as suggested by pcanal in https://github.com/root-project/root/issues/17843#issuecomment-2698615806

Leak is as follows:

```
==1641195==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 120 byte(s) in 3 object(s) allocated from:
    #0 0x7f59e336f1e7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f59e2c9c34b in TStorage::ObjectAlloc(unsigned long) /opt/root_src/core/base/src/TStorage.cxx:293
    #2 0x557a56766ec9 in TObject::operator new(unsigned long) /home/user/builds/build-root_src-Desktop-Debug/include/TObject.h:183
    #3 0x7f59e20064e2 in ROOT::Internal::TreeUtils::RecursiveGlob(TList&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /opt/root_src/tree/tree/src/InternalTreeUtils.cxx:491
    #4 0x7f59e2006846 in ROOT::Internal::TreeUtils::ExpandGlob(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /opt/root_src/tree/tree/src/InternalTreeUtils.cxx:516
    #5 0x7f59e2069d34 in TChain::Add(char const*, long long) /opt/root_src/tree/tree/src/TChain.cxx:401
    #6 0x557a5676342f in TTreeReaderFriend22() /tmp/reproducer.cpp:37
    #7 0x557a56766ad4 in main /tmp/reproducer.cpp:74
    #8 0x7f59e133dd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```
 using the reproducer linked above.