### PR TITLE
[CMake] Compare to the right CMake version for `-j 1` workaround

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT _clad_build_type STREQUAL "" AND NOT _clad_build_type STREQUAL ".")
   set(EXTRA_BUILD_ARGS --config ${_clad_build_type})
 endif()
 
-if(NOT MSVC AND CMAKE_VERSION VERSION_LESS 3.11.1)
+if(NOT MSVC AND CMAKE_VERSION VERSION_LESS 3.31.1)
   # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/26398
   # The problem got eventually fixed upstream in CMake.
   list(APPEND EXTRA_BUILD_ARGS "-j 1")


### PR DESCRIPTION
Follows up on e3fbf24ea1ed8c8, fixing a typo in a number that was committed there and not detected in the PR because of no full rebuild.