### PR TITLE
Remove unused code about autoloading from LinkDef files

### DIFF
--- a/math/mathmore/inc/Math/LinkDef_Func.h
+++ b/math/mathmore/inc/Math/LinkDef_Func.h
@@ -56,11 +56,4 @@
 #pragma link C++ function ROOT::MathMore::gamma_quantile(double,double,double);
 
 
-// for auto-loading of mathmore
-// one can do it by doing using namespace ROOT::Math::MathMore
-#ifdef USE_FOR_AUTLOADING
-#pragma link C++ class ROOT::MathMore;
-#endif
-
-
 #endif

--- a/roofit/histfactory/inc/LinkDef.h
+++ b/roofit/histfactory/inc/LinkDef.h
@@ -7,13 +7,6 @@
 #pragma link C++ namespace RooStats;
 #pragma link C++ namespace RooStats::HistFactory;
 
-// for auto-loading namespaces
-#ifdef USE_FOR_AUTLOADING
-#pragma link C++ class RooStats::HistFactory;
-#pragma link C++ class RooStats;
-#endif
-
-
 #pragma link C++ class PiecewiseInterpolation- ;
 #pragma link C++ class ParamHistFunc+ ;
 #pragma link C++ class RooStats::HistFactory::LinInterpVar+ ;

--- a/roofit/roofit/inc/LinkDef1.h
+++ b/roofit/roofit/inc/LinkDef1.h
@@ -131,10 +131,6 @@
 #pragma link C++ class RooCFunction4Binding<double,double,double,double,bool>+ ;
 #pragma link C++ class RooCFunction4PdfBinding<double,double,double,double,bool>+ ;
 
-//#ifdef USE_FOR_AUTLOADING
-//#pragma link C++ class RooFit ;
-//#else
 #pragma link C++ namespace RooFit ;
-//#endif
-//
+
 #endif

--- a/roofit/roostats/inc/LinkDef.h
+++ b/roofit/roostats/inc/LinkDef.h
@@ -17,12 +17,6 @@
 #pragma link C++ namespace RooStats;
 #pragma link C++ namespace RooStats::NumberCountingUtils;
 
-// for auto-loading namespaces
-#ifdef USE_FOR_AUTLOADING
-#pragma link C++ class RooStats::NumberCountingUtils;
-#pragma link C++ class RooStats;
-#endif
-
 #pragma link C++ class RooStats::SPlot+;
 #pragma link C++ class RooStats::NumberCountingPdfFactory+;
 


### PR DESCRIPTION
The `CLING_USE_AUTLOADING` is not defined anywhere, and hence the code is presumably not needed.