### PR TITLE
Enable untyped reading of TTree data

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -14,7 +14,8 @@
 
 #include "RColumnReaderBase.hxx"
 #include <ROOT/RVec.hxx>
-#include <Rtypes.h>  // Long64_t, R__CLING_PTRCHECK
+#include "ROOT/RDF/Utils.hxx"
+#include <Rtypes.h> // Long64_t, R__CLING_PTRCHECK
 #include <TTreeReader.h>
 #include <TTreeReaderValue.h>
 #include <TTreeReaderArray.h>
@@ -22,6 +23,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <cstddef>
 
 namespace ROOT {
 namespace Internal {
@@ -30,13 +32,15 @@ namespace RDF {
 /// RTreeColumnReader specialization for TTree values read via TTreeReaderValues
 template <typename T>
 class R__CLING_PTRCHECK(off) RTreeColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
-   std::unique_ptr<TTreeReaderValue<T>> fTreeValue;
+   std::unique_ptr<TTreeReaderUntypedValue> fTreeValue;
 
    void *GetImpl(Long64_t) final { return fTreeValue->Get(); }
+
 public:
    /// Construct the RTreeColumnReader. Actual initialization is performed lazily by the Init method.
    RTreeColumnReader(TTreeReader &r, const std::string &colName)
-      : fTreeValue(std::make_unique<TTreeReaderValue<T>>(r, colName.c_str()))
+      : fTreeValue(std::make_unique<TTreeReaderUntypedValue>(r, colName.c_str(),
+                                                             ROOT::Internal::RDF::TypeID2TypeName(typeid(T))))
    {
    }
 };
@@ -50,6 +54,7 @@ public:
    /// Construct the RTreeColumnReader. Actual initialization is performed lazily by the Init method.
    RTreeOpaqueColumnReader(TTreeReader &r, const std::string &colName)
       : fTreeValue(std::make_unique<ROOT::Internal::TTreeReaderOpaqueValue>(r, colName.c_str()))
+
    {
    }
 };
@@ -59,15 +64,20 @@ public:
 /// TTreeReaderArrays are used whenever the RDF column type is RVec<T>.
 template <typename T>
 class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Detail::RDF::RColumnReaderBase {
-   std::unique_ptr<TTreeReaderArray<T>> fTreeArray;
+   std::unique_ptr<TTreeReaderUntypedArray> fTreeArray;
+
+   using Byte_t = std::byte;
 
    /// We return a reference to this RVec to clients, to guarantee a stable address and contiguous memory layout.
-   RVec<T> fRVec;
+   RVec<Byte_t> fRVec;
 
    Long64_t fLastEntry = -1;
 
    /// Whether we already printed a warning about performing a copy of the TTreeReaderArray contents
    bool fCopyWarningPrinted = false;
+
+   /// The size of the collection value type.
+   std::size_t fValueSize{};
 
    void *GetImpl(Long64_t entry) final
    {
@@ -86,15 +96,14 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Det
             // trigger loading of the contents of the TTreeReaderArray
             // the address of the first element in the reader array is not necessarily equal to
             // the address returned by the GetAddress method
-            auto readerArrayAddr = &readerArray.At(0);
-            RVec<T> rvec(readerArrayAddr, readerArraySize);
+            RVec<Byte_t> rvec(readerArray.At(0), readerArraySize);
             swap(fRVec, rvec);
          } else {
-            RVec<T> emptyVec{};
+            RVec<Byte_t> emptyVec{};
             swap(fRVec, emptyVec);
          }
       } else {
-         // The storage is not contiguous or we don't know yet: we cannot but copy into the rvec
+         // The storage is not contiguous: we cannot but copy into the RVec
 #ifndef NDEBUG
          if (!fCopyWarningPrinted) {
             Warning("RTreeColumnReader::Get",
@@ -107,10 +116,27 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Det
          (void)fCopyWarningPrinted;
 #endif
          if (readerArraySize > 0) {
-            RVec<T> rvec(readerArray.begin(), readerArray.end());
-            swap(fRVec, rvec);
+            // Caching the value type size since GetValueSize might be expensive.
+            if (fValueSize == 0)
+               fValueSize = readerArray.GetValueSize();
+            assert(fValueSize > 0 && "Could not retrieve size of collection value type.");
+            // Array is not contiguous, make a full copy of it.
+            fRVec = RVec<Byte_t>{};
+            fRVec.reserve(readerArraySize * fValueSize);
+            for (std::size_t i{0}; i < readerArraySize; i++) {
+               auto val = readerArray.At(i);
+               std::copy(val, val + fValueSize, std::back_inserter(fRVec));
+            }
+            // RVec's `size()` method returns the value of the `fSize` data member, unlike std::vector's `size()`
+            // which returns the distance between begin and end divided by the size of the collection value type.
+            // This difference is important in this case: we reserved enough space in the RVec to fill
+            // `readerArraySize * fValueSize` bytes, but the reader will need to read just `readerArraySize` elements
+            // adjusted to the correct `fValueSize` bytes per element. Thus, we set the size of the RVec here to
+            // represent the correct size of the user-requested RVec<T>. This leaves the RVec<Byte_t> in an invalid
+            // state until it is cast to the correct type (by the `TryGet<T>` call).
+            fRVec.set_size(readerArraySize);
          } else {
-            RVec<T> emptyVec{};
+            RVec<Byte_t> emptyVec{};
             swap(fRVec, emptyVec);
          }
       }
@@ -120,7 +146,8 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Det
 
 public:
    RTreeColumnReader(TTreeReader &r, const std::string &colName)
-      : fTreeArray(std::make_unique<TTreeReaderArray<T>>(r, colName.c_str()))
+      : fTreeArray(
+           std::make_unique<TTreeReaderUntypedArray>(r, colName, ROOT::Internal::RDF::TypeID2TypeName(typeid(T))))
    {
    }
 };
@@ -131,10 +158,12 @@ public:
 template <>
 class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<bool>> final : public ROOT::Detail::RDF::RColumnReaderBase {
 
-   std::unique_ptr<TTreeReaderArray<bool>> fTreeArray;
+   using Byte_t = std::byte;
+
+   std::unique_ptr<TTreeReaderUntypedArray> fTreeArray;
 
    /// We return a reference to this RVec to clients, to guarantee a stable address and contiguous memory layout
-   RVec<bool> fRVec;
+   RVec<Byte_t> fRVec;
 
    // We always copy the contents of TTreeReaderArray<bool> into an RVec<bool> (never take a view into the memory
    // buffer) because the underlying memory buffer might be the one of a std::vector<bool>, which is not a contiguous
@@ -146,11 +175,23 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<bool>> final : public ROOT::
       auto &readerArray = *fTreeArray;
       const auto readerArraySize = readerArray.GetSize();
       if (readerArraySize > 0) {
-         // always perform a copy
-         RVec<bool> rvec(readerArray.begin(), readerArray.end());
-         swap(fRVec, rvec);
+         // Always perform a copy
+         fRVec = RVec<Byte_t>();
+         fRVec.reserve(readerArraySize * sizeof(bool));
+         for (std::size_t i{0}; i < readerArraySize; i++) {
+            auto val = readerArray.At(i);
+            std::copy(val, val + sizeof(bool), std::back_inserter(fRVec));
+         }
+         // RVec's `size()` method returns the value of the `fSize` data member, unlike std::vector's `size()`
+         // which returns the distance between begin and end divided by the size of the collection value type.
+         // This difference is important in this case: we reserved enough space in the RVec to fill
+         // `readerArraySize * fValueSize` bytes, but the reader will need to read just `readerArraySize` elements
+         // adjusted to the correct `fValueSize` bytes per element. Thus, we set the size of the RVec here to
+         // represent the correct size of the user-requested RVec<T>. This leaves the RVec<Byte_t> in an invalid
+         // state until it is cast to the correct type (by the `TryGet<T>` call).
+         fRVec.set_size(readerArraySize);
       } else {
-         RVec<bool> emptyVec{};
+         RVec<Byte_t> emptyVec{};
          swap(fRVec, emptyVec);
       }
       return &fRVec;
@@ -158,7 +199,8 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<bool>> final : public ROOT::
 
 public:
    RTreeColumnReader(TTreeReader &r, const std::string &colName)
-      : fTreeArray(std::make_unique<TTreeReaderArray<bool>>(r, colName.c_str()))
+      : fTreeArray(std::make_unique<TTreeReaderUntypedArray>(r, colName.c_str(),
+                                                             ROOT::Internal::RDF::TypeID2TypeName(typeid(bool))))
    {
    }
 };
@@ -168,32 +210,16 @@ public:
 /// This specialization is used when the requested type for reading is std::array
 template <typename T, std::size_t N>
 class R__CLING_PTRCHECK(off) RTreeColumnReader<std::array<T, N>> final : public ROOT::Detail::RDF::RColumnReaderBase {
-   std::unique_ptr<TTreeReaderArray<T>> fTreeArray;
-
-   /// We return a reference to this RVec to clients, to guarantee a stable address and contiguous memory layout
-   RVec<T> fArray;
+   std::unique_ptr<TTreeReaderUntypedArray> fTreeArray;
 
    Long64_t fLastEntry = -1;
 
-   void *GetImpl(Long64_t entry) final
-   {
-      if (entry == fLastEntry)
-         return fArray.data();
-
-      // This is a non-owning view on the contents of the TTreeReaderArray
-      RVec<T> view{&fTreeArray->At(0), fTreeArray->GetSize()};
-      swap(fArray, view);
-
-      fLastEntry = entry;
-      // The data member of this class is an RVec, to avoid an extra copy
-      // but we need to return the array buffer as the reader expects
-      // a std::array
-      return fArray.data();
-   }
+   void *GetImpl(Long64_t) final { return fTreeArray->At(0); }
 
 public:
    RTreeColumnReader(TTreeReader &r, const std::string &colName)
-      : fTreeArray(std::make_unique<TTreeReaderArray<T>>(r, colName.c_str()))
+      : fTreeArray(std::make_unique<TTreeReaderUntypedArray>(r, colName.c_str(),
+                                                             ROOT::Internal::RDF::TypeID2TypeName(typeid(T))))
    {
    }
 };

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -108,6 +108,8 @@ namespace Detail {
       void    *fWhere;    // memory location of the data
       TVirtualCollectionProxy *fCollection; // Handle to the collection containing the data chunk.
 
+      std::size_t fValueSize{}; // Size of the data type of the proxied branch.
+
    public:
       virtual void Print();
 
@@ -551,6 +553,8 @@ public:
       Int_t GetOffset() { return fOffset; }
 
       bool GetSuppressErrorsForMissingBranch() const { return fSuppressMissingBranchError; }
+
+      std::size_t GetValueSize() const { return fValueSize; }
    };
 } // namespace Detail
 

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -89,6 +89,7 @@ namespace Internal {
       virtual size_t GetSize(Detail::TBranchProxy*) = 0;
       virtual void* At(Detail::TBranchProxy*, size_t /*idx*/) = 0;
       virtual bool IsContiguous(Detail::TBranchProxy *) = 0;
+      virtual std::size_t GetValueSize(Detail::TBranchProxy *) = 0;
    };
 
 }

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -171,6 +171,30 @@ protected:
    const char *GetDerivedTypeName() const { return ""; }
 };
 
+class R__CLING_PTRCHECK(off) TTreeReaderUntypedValue final : public TTreeReaderValueBase {
+   std::string fElementTypeName;
+
+public:
+   TTreeReaderUntypedValue(TTreeReader &tr, std::string_view branchName, std::string_view typeName)
+      : TTreeReaderValueBase(&tr, branchName.data(), TDictionary::GetDictionary(typeName.data())),
+        fElementTypeName(typeName)
+   {
+   }
+
+   void *Get()
+   {
+      if (!fProxy) {
+         ErrorAboutMissingProxyIfNeeded();
+         return nullptr;
+      }
+      void *address = GetAddress(); // Needed to figure out if it's a pointer
+      return fProxy->IsaPointer() ? *(void **)address : (void *)address;
+   }
+
+protected:
+   const char *GetDerivedTypeName() const final { return fElementTypeName.c_str(); }
+};
+
 } // namespace Internal
 } // namespace ROOT
 

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -294,6 +294,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
          fClass = fElement->GetClassPointer();
          fMemberOffset = fElement->GetOffset();
          fArrayLength = fElement->GetArrayLength();
+         fValueSize = fElement->GetSize();
       } else {
          Error("Setup","Data member %s seems no longer be in class %s",fDataMember.Data(),pcl->GetName());
          return false;
@@ -357,6 +358,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
          if (leaf2) {
             fWhere = leaf2->GetValuePointer();
             fArrayLength = leaf2->GetLen();
+            fValueSize = leaf2->GetLenType();
             if (leaf2->GetLeafCount()) {
                fLeafCount = leaf2->GetLeafCount();
                fHasLeafCount = true;
@@ -392,6 +394,7 @@ bool ROOT::Detail::TBranchProxy::Setup()
             fElement = (TStreamerElement*)info->GetElements()->At(id);
             fIsaPointer = fElement->IsaPointer();
             fClass = fElement->GetClassPointer();
+            fValueSize = fElement->GetSize();
 
             if ((fIsMember || (be->GetType()!=3 && be->GetType() !=4))
                   && (be->GetType()!=31 && be->GetType()!=41)) {
@@ -533,16 +536,16 @@ bool ROOT::Detail::TBranchProxy::Setup()
 
             fElement = (TStreamerElement*)
                fClass->GetStreamerInfo()->GetElements()->FindObject(fDataMember);
-            if (fElement)
+            if (fElement) {
                fMemberOffset = fElement->GetOffset();
-            else {
+               fValueSize = fElement->GetSize();
+            } else {
                // Need to compose the proper sub name
 
                TString member;
 
                member += fDataMember;
                fMemberOffset = fClass->GetDataMemberOffset(member);
-
             }
             if (fMemberOffset < 0) {
                Error("Setup", "%s",

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <optional>
+#include <iostream>
 
 // pin vtable
 ROOT::Internal::TVirtualCollectionReader::~TVirtualCollectionReader() {}
@@ -72,6 +73,12 @@ public:
    }
 
    bool IsContiguous(ROOT::Detail::TBranchProxy *) override { return false; }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *proxy) override
+   {
+      auto *ca = GetCA(proxy);
+      return ca ? ca->GetClass()->Size() : 0;
+   }
 };
 
 bool IsCPContiguous(const TVirtualCollectionProxy &cp)
@@ -84,6 +91,14 @@ bool IsCPContiguous(const TVirtualCollectionProxy &cp)
    case ROOT::kROOTRVec: return true;
    default: return false;
    }
+}
+
+UInt_t GetCPValueSize(const TVirtualCollectionProxy &cp)
+{
+   // This works only if the collection proxy value type is a fundamental type
+   auto &&eDataType = cp.GetType();
+   auto *tDataType = TDataType::GetDataType(eDataType);
+   return tDataType ? tDataType->Size() : 0;
 }
 
 // Reader interface for STL
@@ -130,6 +145,12 @@ public:
    {
       auto cp = GetCP(proxy);
       return IsCPContiguous(*cp);
+   }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *proxy) override
+   {
+      auto cp = GetCP(proxy);
+      return GetCPValueSize(*cp);
    }
 };
 
@@ -190,6 +211,12 @@ public:
       auto cp = GetCP(proxy);
       return IsCPContiguous(*cp);
    }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *proxy) override
+   {
+      auto cp = GetCP(proxy);
+      return GetCPValueSize(*cp);
+   }
 };
 
 // Reader interface for leaf list
@@ -243,6 +270,15 @@ public:
    void SetBasicTypeSize(Int_t size) { fBasicTypeSize = size; }
 
    bool IsContiguous(ROOT::Detail::TBranchProxy *) override { return true; }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *proxy) override
+   {
+      auto cp = GetCP(proxy);
+      if (cp)
+         return GetCPValueSize(*cp);
+      else
+         return proxy->GetValueSize();
+   }
 };
 
 template <class BASE>
@@ -387,6 +423,18 @@ public:
    }
 
    bool IsContiguous(ROOT::Detail::TBranchProxy *) override { return false; }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *proxy) override
+   {
+      if (!proxy->Read()) {
+         fReadStatus = TTreeReaderValueBase::kReadError;
+         if (!proxy->GetSuppressErrorsForMissingBranch())
+            Error("TBasicTypeArrayReader::GetValueSize()", "Read error in TBranchProxy.");
+         return 0;
+      }
+      fReadStatus = TTreeReaderValueBase::kReadSuccess;
+      return proxy->GetValueSize();
+   }
 };
 
 class TBasicTypeClonesReader final : public TClonesReader {
@@ -433,6 +481,12 @@ public:
    }
 
    bool IsContiguous(ROOT::Detail::TBranchProxy *) override { return true; }
+
+   std::size_t GetValueSize(ROOT::Detail::TBranchProxy *) override
+   {
+      auto *leaf = fValueReader->GetLeaf();
+      return leaf ? leaf->GetLenType() : 0;
+   }
 
 protected:
    void ProxyRead() { fValueReader->ProxyRead(); }


### PR DESCRIPTION
TTreeReaderValue and TTreeReaderArray now expose APIs to get the current value of the branch they are proxying without knowing its type. For the case of arrays, the size of the type of the value is also exposed, so that readers can correctly interpret the collection type when giving it back to the user. The new APIs are used in RTreeColumnReader classes, thus RDataFrame does not need anymore to know the type of the value being requested by the user when reading from TTree.

Part 1 of N for https://github.com/root-project/root/pull/17895