### PR TITLE
[Docs] TTree example is missing the critical lines

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -270,6 +270,7 @@ For this reasons, ROOT offers the concept of friends for TTree and TChain.
 \anchor fullexample
 ## A Complete Example
 
+Start by creating a file and histogram:
 ~~~ {.cpp}
 // A simple example creating a tree
 // Compile it with: `g++ myTreeExample.cpp -o myTreeExample `root-config --cflags --libs`
@@ -288,7 +289,11 @@ int main()
 
    // Define a histogram and some simple structures
    TH1D hpx("hpx", "This is the px distribution", 100, -4, 4);
-
+   
+   ~~~
+   
+   Next, define the data structures:
+   ~~~ {.cpp}
    typedef struct {
       Float_t x, y, z;
    } Point;
@@ -300,13 +305,18 @@ int main()
    } Event;
    Point point;
    Event event;
+   
+   ~~~
+   
+   Finally, create  a tree, and branches, and fill it with data:
+   ~~~ {.cpp}
 
    // Create a ROOT Tree
    TTree tree("T", "An example of ROOT tree with a few branches");
    tree.Branch("point", &point, "x:y:z");
    tree.Branch("event", &event, "ntrack/I:nseg:nvertex:flag/i:temperature/F");
    tree.Branch("hpx", &hpx);
-
+   
    float px, py;
 
    TRandom3 myGenerator;


### PR DESCRIPTION
# This Pull request:
1. Modified the example to be in multiple code blocks
2. Added some comments

## Changes or fixes:
Doxygen version - 1.10.0 (ec....)
Screenshot of the changes
![Screenshot from 2025-03-06 17-35-13](https://github.com/user-attachments/assets/eb5312a7-9cb6-4595-ad93-f4df9ccc39a3)

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #17864 

