### PR TITLE
[NFC] Do not rely on string representation in test

### DIFF
--- a/bindings/pyroot/pythonizations/test/string_view.py
+++ b/bindings/pyroot/pythonizations/test/string_view.py
@@ -26,8 +26,7 @@ class StringView(unittest.TestCase):
             f.WriteObject(t, treename)
 
         df = ROOT.RDataFrame(treename, filename)
-        self.assertEqual(
-            str(df), "A data frame built on top of the tree dataset.")
+        self.assertEqual(df.GetNRuns(), 0)
         os.remove(filename)
 
     def test_17497(self):


### PR DESCRIPTION
The string representation of the dataframe might change and it is not the purpose of this test anyway.

Part 2 of N for https://github.com/root-project/root/pull/17895