### PR TITLE
Simplify nslots in RDataSource

### DIFF
--- a/tree/dataframe/inc/ROOT/RArrowDS.hxx
+++ b/tree/dataframe/inc/ROOT/RArrowDS.hxx
@@ -32,7 +32,6 @@ private:
    std::shared_ptr<arrow::Table> fTable;
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges;
    std::vector<std::string> fColumnNames;
-   size_t fNSlots = 0U;
 
    std::vector<std::pair<size_t, size_t>> fGetterIndex; // (columnId, visitorId)
    std::vector<std::unique_ptr<ROOT::Internal::RDF::TValueGetter>> fValueGetters; // Visitors to be used to track and get entries. One per column.

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -73,7 +73,6 @@ private:
    std::int64_t fDataLineNumber = 0;
    std::int64_t fLineNumber = 0;     // used to skip the last lines
    std::int64_t fMaxLineNumber = -1; // set to non-negative if fOptions.fSkipLastNLines is set
-   unsigned int fNSlots = 0U;
    std::unique_ptr<ROOT::Internal::RRawFile> fCsvFile;
    ULong64_t fEntryRangesRequested = 0ULL;
    ULong64_t fProcessedLines = 0ULL; // marks the progress of the consumption of the csv lines

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -51,7 +51,6 @@ class RLazyDS final : public ROOT::RDF::RDataSource {
    const PointerHolderPtrs_t fPointerHoldersModels;
    std::vector<PointerHolderPtrs_t> fPointerHolders;
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges{};
-   unsigned int fNSlots{0};
 
    Record_t GetColumnReadersImpl(std::string_view colName, const std::type_info &id) final
    {

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -114,6 +114,8 @@ protected:
 
    virtual std::string AsString() { return "generic data source"; };
 
+   unsigned int fNSlots{};
+
 public:
    RDataSource() = default;
    // Rule of five

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -101,7 +101,6 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// to new page sources when the files in the chain change.
    std::vector<std::vector<Internal::RNTupleColumnReader *>> fActiveColumnReaders;
 
-   unsigned int fNSlots = 0;
    ULong64_t fSeenEntries = 0;                ///< The number of entries so far returned by GetEntryRanges()
    std::vector<REntryRangeDS> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
    std::vector<REntryRangeDS> fNextRanges;    ///< Basis for the ranges populated by the PrepareNextRanges() call

--- a/tree/dataframe/inc/ROOT/RRootDS.hxx
+++ b/tree/dataframe/inc/ROOT/RRootDS.hxx
@@ -27,7 +27,6 @@ namespace RDF {
 /// It shows how to implement the RDataSource API for a complex kind of source such as TTrees.
 class RRootDS final : public ROOT::RDF::RDataSource {
 private:
-   unsigned int fNSlots = 0U;
    std::string fTreeName;
    std::string fFileNameGlob;
    mutable TChain fModelChain; // Mutable needed for getting the column type name

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -78,7 +78,6 @@ private:
    void SqliteError(int errcode);
 
    std::unique_ptr<Internal::RSqliteDSDataSet> fDataSet;
-   unsigned int fNSlots;
    ULong64_t fNRow;
    std::vector<std::string> fColumnNames;
    std::vector<ETypes> fColumnTypes;

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -25,7 +25,6 @@ namespace RDF {
 /// it returns entries from GetEntryRanges forever or until a Range stops the event loop (for test purposes).
 class RTrivialDS final : public ROOT::RDF::RDataSource {
 private:
-   unsigned int fNSlots = 0U;
    ULong64_t fSize = 0ULL;
    bool fSkipEvenEntries = false;
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges;

--- a/tree/dataframe/inc/ROOT/RVecDS.hxx
+++ b/tree/dataframe/inc/ROOT/RVecDS.hxx
@@ -55,7 +55,6 @@ class RVecDS final : public ROOT::RDF::RDataSource {
    const PointerHolderPtrs_t fPointerHoldersModels;
    std::vector<PointerHolderPtrs_t> fPointerHolders;
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges{};
-   unsigned int fNSlots{0};
    std::function<void()> fDeleteRVecs;
 
    Record_t GetColumnReadersImpl(std::string_view colName, const std::type_info &id)

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -350,7 +350,7 @@ constexpr char const *RSqliteDS::fgTypeNames[];
 ///
 /// The constructor opens the sqlite file, prepares the query engine and determines the column names and types.
 RSqliteDS::RSqliteDS(const std::string &fileName, const std::string &query)
-   : fDataSet(std::make_unique<Internal::RSqliteDSDataSet>()), fNSlots(0), fNRow(0)
+   : fDataSet(std::make_unique<Internal::RSqliteDSDataSet>()), fNRow(0)
 {
    static bool hasSqliteVfs = RegisterSqliteVfs();
    if (!hasSqliteVfs)

--- a/tree/dataframe/test/RStreamingDS.hxx
+++ b/tree/dataframe/test/RStreamingDS.hxx
@@ -8,7 +8,6 @@
 
 /// A RDataSource that provides multiple entry ranges
 class RStreamingDS final : public ROOT::RDF::RDataSource {
-   unsigned int fNSlots = 0u;
    unsigned int fCounter = 0u;
    const int fAns = 42;
    const int *fAnsPtr = &fAns;


### PR DESCRIPTION
The fNSlots data member is used by all data sources, thus it can be upstreamed to the base class.

Part 3 of N for https://github.com/root-project/root/pull/17895