### PR TITLE
[ntuple] Move Internal RNTupleUtils out of Experimental

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -297,6 +297,12 @@ public:
    std::uint32_t GetTag() const { return fTag; }
 };
 
+} // namespace Internal
+
+} // namespace Experimental
+
+namespace Internal {
+
 template <typename T>
 auto MakeAliasedSharedPtr(T *rawPtr)
 {
@@ -327,6 +333,8 @@ static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializable
 RResult<void> EnsureValidNameForRNTuple(std::string_view name, std::string_view where);
 
 } // namespace Internal
+
+namespace Experimental {
 
 // TODO(jblomer): remove before branching ROOT v6.36
 using EColumnType [[deprecated("ROOT::Experimental::EColumnType moved to ROOT::ENTupleColumnType")]] =

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -92,7 +92,9 @@ protected:
    }
 
    RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
-      : fField(std::move(field)), fFieldRange(range), fValue(fField->BindValue(Internal::MakeAliasedSharedPtr(rawPtr)))
+      : fField(std::move(field)),
+        fFieldRange(range),
+        fValue(fField->BindValue(ROOT::Internal::MakeAliasedSharedPtr(rawPtr)))
    {
    }
 

--- a/tree/ntuple/v7/src/RColumnElement.hxx
+++ b/tree/ntuple/v7/src/RColumnElement.hxx
@@ -318,9 +318,9 @@ inline void CastZigzagSplitUnpack(void *destination, const void *source, std::si
 namespace {
 
 using ROOT::ENTupleColumnType;
-using ROOT::Experimental::Internal::kTestFutureType;
-using ROOT::Experimental::Internal::MakeUninitArray;
 using ROOT::Experimental::Internal::RColumnElementBase;
+using ROOT::Internal::kTestFutureType;
+using ROOT::Internal::MakeUninitArray;
 
 template <typename CppT, ENTupleColumnType>
 class RColumnElement;

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -117,7 +117,7 @@ void ROOT::Experimental::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 {
    // Set fObjPtr to an aliased shared_ptr of the input raw pointer. Note that
    // fObjPtr will be non-empty but have use count zero.
-   fObjPtr = ROOT::Experimental::Internal::MakeAliasedSharedPtr(rawPtr);
+   fObjPtr = ROOT::Internal::MakeAliasedSharedPtr(rawPtr);
 }
 
 //------------------------------------------------------------------------------
@@ -246,7 +246,7 @@ ROOT::Experimental::RFieldBase::RFieldBase(std::string_view name, std::string_vi
      fPrincipalColumn(nullptr),
      fTraits(isSimple ? kTraitMappable : 0)
 {
-   ROOT::Experimental::Internal::EnsureValidNameForRNTuple(name, "Field");
+   ROOT::Internal::EnsureValidNameForRNTuple(name, "Field");
 }
 
 std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -375,7 +375,7 @@ void ROOT::Experimental::RClassField::PrepareStagingArea(const std::vector<const
 
    if (stagingAreaSize) {
       R__ASSERT(static_cast<Int_t>(stagingAreaSize) <= fStagingClass->Size()); // we may have removed rules
-      fStagingArea = Internal::MakeUninitArray<unsigned char>(stagingAreaSize);
+      fStagingArea = ROOT::Internal::MakeUninitArray<unsigned char>(stagingAreaSize);
    }
 }
 

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -56,6 +56,7 @@
 #endif
 #endif /* R__LITTLE_ENDIAN */
 
+using ROOT::Internal::MakeUninitArray;
 using ROOT::Internal::RNTupleCompressor;
 using ROOT::Internal::RNTupleDecompressor;
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -940,7 +940,7 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureFieldExists(ROOT::
 ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureValidDescriptor() const
 {
    // Reuse field name validity check
-   auto validName = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fDescriptor.GetName(), "Field");
+   auto validName = ROOT::Internal::EnsureValidNameForRNTuple(fDescriptor.GetName(), "Field");
    if (!validName) {
       return R__FORWARD_ERROR(validName);
    }
@@ -1062,7 +1062,7 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
    }
    // FieldZero is usually named "" and would be a false positive here
    if (fField.GetParentId() != ROOT::kInvalidDescriptorId) {
-      auto validName = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fField.GetFieldName(), "Field");
+      auto validName = ROOT::Internal::EnsureValidNameForRNTuple(fField.GetFieldName(), "Field");
       if (!validName) {
          return R__FORWARD_ERROR(validName);
       }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -40,6 +40,7 @@
 #include <vector>
 
 using ROOT::ENTupleColumnType;
+using ROOT::Internal::MakeUninitArray;
 using namespace ROOT::Experimental;
 using namespace ROOT::Experimental::Internal;
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -226,7 +226,7 @@ ROOT::RResult<void> ROOT::Experimental::RNTupleModel::RUpdater::AddProjectedFiel
 
 void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
-   RResult<void> nameValid = ROOT::Experimental::Internal::EnsureValidNameForRNTuple(fieldName, "Field");
+   RResult<void> nameValid = ROOT::Internal::EnsureValidNameForRNTuple(fieldName, "Field");
    if (!nameValid) {
       nameValid.Throw();
    }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -711,7 +711,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
    case ENTupleColumnType::kReal32Trunc: return SerializeUInt16(0x1C, buffer);
    case ENTupleColumnType::kReal32Quant: return SerializeUInt16(0x1D, buffer);
    default:
-      if (type == kTestFutureType)
+      if (type == ROOT::Internal::kTestFutureType)
          return SerializeUInt16(0x99, buffer);
       throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
@@ -773,7 +773,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeFieldStructure(ROOT::E
    case ENTupleStructure::kVariant: return SerializeUInt16(0x03, buffer);
    case ENTupleStructure::kStreamer: return SerializeUInt16(0x04, buffer);
    default:
-      if (structure == ROOT::Experimental::Internal::kTestFutureFieldStructure)
+      if (structure == ROOT::Internal::kTestFutureFieldStructure)
          return SerializeUInt16(0x99, buffer);
       throw RException(R__FAIL("ROOT bug: unexpected field structure type"));
    }
@@ -1048,7 +1048,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeLocator(const RNTupleL
       locatorType = 0x02;
       break;
    default:
-      if (locator.GetType() == kTestLocatorType) {
+      if (locator.GetType() == ROOT::Internal::kTestLocatorType) {
          // For the testing locator, use the same payload as Object64. We're not gonna really read it back anyway.
          size += SerializeLocatorPayloadObject64(locator, payloadp);
          locatorType = 0x7e;

--- a/tree/ntuple/v7/src/RNTupleUtil.cxx
+++ b/tree/ntuple/v7/src/RNTupleUtil.cxx
@@ -31,8 +31,7 @@ ROOT::RLogChannel &ROOT::Internal::NTupleLog()
    return sLog;
 }
 
-ROOT::RResult<void>
-ROOT::Experimental::Internal::EnsureValidNameForRNTuple(std::string_view name, std::string_view where)
+ROOT::RResult<void> ROOT::Internal::EnsureValidNameForRNTuple(std::string_view name, std::string_view where)
 {
    using codeAndRepr = std::pair<const char *, const char *>;
    constexpr static std::array<codeAndRepr, 4> forbiddenChars{codeAndRepr{"\u002E", "."}, codeAndRepr{"\u002F", "/"},

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <memory>
 
+using ROOT::Internal::MakeUninitArray;
+
 void ROOT::Experimental::Internal::RPageSinkBuf::RColumnBuf::DropBufferedPages()
 {
    fBufferedPages.clear();

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -42,6 +42,8 @@
 #include <unordered_map>
 #include <utility>
 
+using ROOT::Internal::MakeUninitArray;
+
 ROOT::Experimental::Internal::RPageStorage::RPageStorage(std::string_view name)
    : fMetrics(""), fPageAllocator(std::make_unique<RPageAllocatorHeap>()), fNTupleName(name)
 {
@@ -665,7 +667,7 @@ bool ROOT::Experimental::Internal::RWritePageMemoryManager::TryUpdate(RColumn &c
 ROOT::Experimental::Internal::RPageSink::RPageSink(std::string_view name, const ROOT::RNTupleWriteOptions &options)
    : RPageStorage(name), fOptions(options.Clone()), fWritePageMemoryManager(options.GetPageBufferBudget())
 {
-   ROOT::Experimental::Internal::EnsureValidNameForRNTuple(name, "RNTuple").ThrowOnError();
+   ROOT::Internal::EnsureValidNameForRNTuple(name, "RNTuple").ThrowOnError();
 }
 
 ROOT::Experimental::Internal::RPageSink::~RPageSink() {}

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -44,7 +44,7 @@ namespace {
 using AttributeKey_t = ROOT::Experimental::Internal::RDaosContainer::AttributeKey_t;
 using DistributionKey_t = ROOT::Experimental::Internal::RDaosContainer::DistributionKey_t;
 using ntuple_index_t = ROOT::Experimental::Internal::ntuple_index_t;
-using ROOT::Experimental::Internal::MakeUninitArray;
+using ROOT::Internal::MakeUninitArray;
 using ROOT::Internal::RNTupleCompressor;
 using ROOT::Internal::RNTupleDecompressor;
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -43,6 +43,7 @@
 #include <functional>
 #include <mutex>
 
+using ROOT::Internal::MakeUninitArray;
 using ROOT::Internal::RNTupleCompressor;
 using ROOT::Internal::RNTupleDecompressor;
 

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -163,7 +163,7 @@ protected:
    }
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
-      static const RColumnRepresentations representations{{{Internal::kTestFutureType}}, {}};
+      static const RColumnRepresentations representations{{{ROOT::Internal::kTestFutureType}}, {}};
       return representations;
    }
 
@@ -285,10 +285,7 @@ class RFutureField : public RFieldBase {
    std::size_t AppendImpl(const void *) final { return 0; }
 
 public:
-   RFutureField(std::string_view name)
-      : RFieldBase(name, "Future", ROOT::Experimental::Internal::kTestFutureFieldStructure, false)
-   {
-   }
+   RFutureField(std::string_view name) : RFieldBase(name, "Future", ROOT::Internal::kTestFutureFieldStructure, false) {}
 
    std::size_t GetValueSize() const final { return 0; }
    std::size_t GetAlignment() const final { return 0; }
@@ -372,7 +369,7 @@ class RPageSinkTestLocator : public RPageSinkFile {
       auto payload = ROOT::RNTupleLocatorObject64{0x420};
       RNTupleLocator result;
       result.SetPosition(payload);
-      result.SetType(ROOT::Experimental::Internal::kTestLocatorType);
+      result.SetType(ROOT::Internal::kTestLocatorType);
       result.SetNBytesOnStorage(sealedPage.GetDataSize());
       return result;
    }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -113,7 +113,7 @@ using EContainerFormat = RNTupleFileWriter::EContainerFormat;
 template <typename T>
 using RNTupleView = ROOT::Experimental::RNTupleView<T>;
 
-using ROOT::Experimental::Internal::MakeUninitArray;
+using ROOT::Internal::MakeUninitArray;
 
 /**
  * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object


### PR DESCRIPTION
Moving the following out of Experimental:

- `MakeAliasedSharedPtr`
- `MakeUninitArray`
- `EnsureValidNameForRNTuple`
- Some internal test values (e.g. `kTestFutureType`)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


