### PR TITLE
[ntuple] Initialize variable in ntuple_zip test

### DIFF
--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -13,7 +13,7 @@ TEST(RNTupleZip, Basics)
 
 TEST(RNTupleZip, Empty)
 {
-   char x;
+   char x = 0;
    char z;
    EXPECT_EQ(0U, RNTupleCompressor::Zip(&x, 0, 0, &z));
    EXPECT_EQ(0U, RNTupleCompressor::Zip(&x, 0, 101, &z));


### PR DESCRIPTION
GCC complains (with -O0):
```
warning: ‘x’ may be used uninitialized [-Wmaybe-uninitialized]
```