### PR TITLE
[ntuple] Rename Subfields related methods to be more consistent

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -142,8 +142,8 @@ private:
    };
 
    TClass *fClass;
-   /// Additional information kept for each entry in `fSubFields`
-   std::vector<RSubFieldInfo> fSubFieldsInfo;
+   /// Additional information kept for each entry in `fSubfields`
+   std::vector<RSubFieldInfo> fSubfieldsInfo;
    std::size_t fMaxAlignment = 1;
 
    /// The staging area stores inputs to I/O rules according to the offsets given by the streamer info of
@@ -264,11 +264,11 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void ConstructValue(void *where) const final { CallConstructValueOn(*fSubFields[0], where); }
+   void ConstructValue(void *where) const final { CallConstructValueOn(*fSubfields[0], where); }
 
-   std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
-   void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
-   void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final { CallReadOn(*fSubFields[0], localIndex, to); }
+   std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubfields[0], from); }
+   void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubfields[0], globalIndex, to); }
+   void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final { CallReadOn(*fSubfields[0], localIndex, to); }
 
 public:
    REnumField(std::string_view fieldName, std::string_view enumName);
@@ -277,8 +277,8 @@ public:
    ~REnumField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final { return fSubFields[0]->GetValueSize(); }
-   size_t GetAlignment() const final { return fSubFields[0]->GetAlignment(); }
+   size_t GetValueSize() const final { return fSubfields[0]->GetValueSize(); }
+   size_t GetAlignment() const final { return fSubfields[0]->GetAlignment(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -47,12 +47,12 @@ class RAtomicField : public RFieldBase {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void ConstructValue(void *where) const final { CallConstructValueOn(*fSubFields[0], where); }
-   std::unique_ptr<RDeleter> GetDeleter() const final { return GetDeleterOf(*fSubFields[0]); }
+   void ConstructValue(void *where) const final { CallConstructValueOn(*fSubfields[0], where); }
+   std::unique_ptr<RDeleter> GetDeleter() const final { return GetDeleterOf(*fSubfields[0]); }
 
-   std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
-   void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
-   void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final { CallReadOn(*fSubFields[0], localIndex, to); }
+   std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubfields[0], from); }
+   void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubfields[0], globalIndex, to); }
+   void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final { CallReadOn(*fSubfields[0], localIndex, to); }
 
 public:
    RAtomicField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
@@ -62,8 +62,8 @@ public:
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
 
-   size_t GetValueSize() const final { return fSubFields[0]->GetValueSize(); }
-   size_t GetAlignment() const final { return fSubFields[0]->GetAlignment(); }
+   size_t GetValueSize() const final { return fSubfields[0]->GetValueSize(); }
+   size_t GetAlignment() const final { return fSubfields[0]->GetAlignment(); }
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -78,7 +78,7 @@ public:
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetLength() const { return fArrayLength; }
    size_t GetValueSize() const final { return fItemSize * fArrayLength; }
-   size_t GetAlignment() const final { return fSubFields[0]->GetAlignment(); }
+   size_t GetAlignment() const final { return fSubfields[0]->GetAlignment(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -566,8 +566,8 @@ public:
    ROOT::ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    const RFieldBase *GetParent() const { return fParent; }
-   std::vector<RFieldBase *> GetSubFields();
-   std::vector<const RFieldBase *> GetSubFields() const;
+   std::vector<RFieldBase *> GetMutableSubfields();
+   std::vector<const RFieldBase *> GetConstSubfields() const;
    bool IsSimple() const { return fIsSimple; }
    bool IsArtificial() const { return fIsArtificial; }
    /// Get the field's description

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -248,7 +248,7 @@ private:
    {
       fIsSimple = false;
       fIsArtificial = true;
-      for (auto &field : fSubFields) {
+      for (auto &field : fSubfields) {
          field->SetArtificial();
       }
    }
@@ -258,7 +258,7 @@ protected:
    struct RBulkSpec;
 
    /// Collections and classes own sub fields
-   std::vector<std::unique_ptr<RFieldBase>> fSubFields;
+   std::vector<std::unique_ptr<RFieldBase>> fSubfields;
    /// Sub fields point to their mother field
    RFieldBase *fParent;
    /// All fields that have columns have a distinct main column. E.g., for simple fields (float, int, ...), the
@@ -640,13 +640,13 @@ public:
    void Advance()
    {
       auto itr = fStack.rbegin();
-      if (!itr->fFieldPtr->fSubFields.empty()) {
-         fStack.emplace_back(Position(itr->fFieldPtr->fSubFields[0].get(), 0));
+      if (!itr->fFieldPtr->fSubfields.empty()) {
+         fStack.emplace_back(Position(itr->fFieldPtr->fSubfields[0].get(), 0));
          return;
       }
 
       unsigned int nextIdxInParent = ++(itr->fIdxInParent);
-      while (nextIdxInParent >= itr->fFieldPtr->fParent->fSubFields.size()) {
+      while (nextIdxInParent >= itr->fFieldPtr->fParent->fSubfields.size()) {
          if (fStack.size() == 1) {
             itr->fFieldPtr = itr->fFieldPtr->fParent;
             itr->fIdxInParent = -1;
@@ -656,7 +656,7 @@ public:
          itr = fStack.rbegin();
          nextIdxInParent = ++(itr->fIdxInParent);
       }
-      itr->fFieldPtr = itr->fFieldPtr->fParent->fSubFields[nextIdxInParent].get();
+      itr->fFieldPtr = itr->fFieldPtr->fParent->fSubfields[nextIdxInParent].get();
    }
 
    iterator operator++(int) /* postfix */

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -335,7 +335,7 @@ public:
    void SetDescription(std::string_view description);
 
    /// Get the (qualified) names of subfields that have been registered to be included in entries from this model.
-   const std::unordered_set<std::string> &GetRegisteredSubfields() const { return fRegisteredSubfields; }
+   const std::unordered_set<std::string> &GetRegisteredSubfieldNames() const { return fRegisteredSubfields; }
 
    /// Estimate the memory usage for this model during writing
    ///

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -65,7 +65,7 @@ public:
    void InitImpl(RNTupleModel &model) final
    {
       auto &fieldZero = GetFieldZeroOfModel(model);
-      ConnectFields(fieldZero.GetSubFields(), 0);
+      ConnectFields(fieldZero.GetMutableSubfields(), 0);
    }
    void UpdateSchema(const RNTupleModelChangeset &changeset, ROOT::NTupleSize_t firstEntry) final
    {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -35,7 +35,7 @@ std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const
 {
    auto result = std::make_unique<RFieldZero>();
-   for (auto &f : fSubFields)
+   for (auto &f : fSubfields)
       result->Attach(f->Clone(f->GetFieldName()));
    return result;
 }
@@ -584,30 +584,30 @@ ROOT::Experimental::RRecordField::CloneImpl(std::string_view newName) const
 std::size_t ROOT::Experimental::RRecordField::AppendImpl(const void *from)
 {
    std::size_t nbytes = 0;
-   for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      nbytes += CallAppendOn(*fSubFields[i], static_cast<const unsigned char *>(from) + fOffsets[i]);
+   for (unsigned i = 0; i < fSubfields.size(); ++i) {
+      nbytes += CallAppendOn(*fSubfields[i], static_cast<const unsigned char *>(from) + fOffsets[i]);
    }
    return nbytes;
 }
 
 void ROOT::Experimental::RRecordField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
-   for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      CallReadOn(*fSubFields[i], globalIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
+   for (unsigned i = 0; i < fSubfields.size(); ++i) {
+      CallReadOn(*fSubfields[i], globalIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
 void ROOT::Experimental::RRecordField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
 {
-   for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      CallReadOn(*fSubFields[i], localIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
+   for (unsigned i = 0; i < fSubfields.size(); ++i) {
+      CallReadOn(*fSubfields[i], localIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
 void ROOT::Experimental::RRecordField::ConstructValue(void *where) const
 {
-   for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      CallConstructValueOn(*fSubFields[i], static_cast<unsigned char *>(where) + fOffsets[i]);
+   for (unsigned i = 0; i < fSubfields.size(); ++i) {
+      CallConstructValueOn(*fSubfields[i], static_cast<unsigned char *>(where) + fOffsets[i]);
    }
 }
 
@@ -623,7 +623,7 @@ std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RR
 {
    std::vector<std::unique_ptr<RDeleter>> itemDeleters;
    itemDeleters.reserve(fOffsets.size());
-   for (const auto &f : fSubFields) {
+   for (const auto &f : fSubfields) {
       itemDeleters.emplace_back(GetDeleterOf(*f));
    }
    return std::make_unique<RRecordDeleter>(std::move(itemDeleters), fOffsets);
@@ -634,9 +634,9 @@ ROOT::Experimental::RRecordField::SplitValue(const RValue &value) const
 {
    auto basePtr = value.GetPtr<unsigned char>().get();
    std::vector<RValue> result;
-   result.reserve(fSubFields.size());
-   for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      result.emplace_back(fSubFields[i]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), basePtr + fOffsets[i])));
+   result.reserve(fSubfields.size());
+   for (unsigned i = 0; i < fSubfields.size(); ++i) {
+      result.emplace_back(fSubfields[i]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), basePtr + fOffsets[i])));
    }
    return result;
 }
@@ -755,7 +755,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
 
 std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
 {
-   auto nbytesItem = CallAppendOn(*fSubFields[0], from);
+   auto nbytesItem = CallAppendOn(*fSubfields[0], from);
    fNWritten++;
    fPrincipalColumn->Append(&fNWritten);
    return sizeof(Internal::RColumnIndex) + nbytesItem;
@@ -778,14 +778,14 @@ void ROOT::Experimental::RNullableField::AcceptVisitor(Detail::RFieldVisitor &vi
 
 ROOT::Experimental::RUniquePtrField::RUniquePtrField(std::string_view fieldName, std::string_view typeName,
                                                      std::unique_ptr<RFieldBase> itemField)
-   : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubFields[0]))
+   : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubfields[0]))
 {
 }
 
 std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RUniquePtrField::CloneImpl(std::string_view newName) const
 {
-   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
+   auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<RUniquePtrField>(newName, GetTypeName(), std::move(newItemField));
 }
 
@@ -821,11 +821,11 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(ROOT::NTupleSize_t glob
       return;
 
    if (!isValidValue) {
-      valuePtr = CallCreateObjectRawPtrOn(*fSubFields[0]);
+      valuePtr = CallCreateObjectRawPtrOn(*fSubfields[0]);
       ptr->reset(reinterpret_cast<char *>(valuePtr));
    }
 
-   CallReadOn(*fSubFields[0], itemIndex, valuePtr);
+   CallReadOn(*fSubfields[0], itemIndex, valuePtr);
 }
 
 void ROOT::Experimental::RUniquePtrField::RUniquePtrDeleter::operator()(void *objPtr, bool dtorOnly)
@@ -840,7 +840,7 @@ void ROOT::Experimental::RUniquePtrField::RUniquePtrDeleter::operator()(void *ob
 
 std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RUniquePtrField::GetDeleter() const
 {
-   return std::make_unique<RUniquePtrDeleter>(GetDeleterOf(*fSubFields[0]));
+   return std::make_unique<RUniquePtrDeleter>(GetDeleterOf(*fSubfields[0]));
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>
@@ -849,7 +849,7 @@ ROOT::Experimental::RUniquePtrField::SplitValue(const RValue &value) const
    std::vector<RValue> result;
    const auto &ptr = value.GetRef<std::unique_ptr<char>>();
    if (ptr) {
-      result.emplace_back(fSubFields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), ptr.get())));
+      result.emplace_back(fSubfields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), ptr.get())));
    }
    return result;
 }
@@ -858,15 +858,15 @@ ROOT::Experimental::RUniquePtrField::SplitValue(const RValue &value) const
 
 ROOT::Experimental::ROptionalField::ROptionalField(std::string_view fieldName, std::string_view typeName,
                                                    std::unique_ptr<RFieldBase> itemField)
-   : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubFields[0]))
+   : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubfields[0]))
 {
-   if (fSubFields[0]->GetTraits() & kTraitTriviallyDestructible)
+   if (fSubfields[0]->GetTraits() & kTraitTriviallyDestructible)
       fTraits |= kTraitTriviallyDestructible;
 }
 
 bool *ROOT::Experimental::ROptionalField::GetEngagementPtr(void *optionalPtr) const
 {
-   return reinterpret_cast<bool *>(reinterpret_cast<unsigned char *>(optionalPtr) + fSubFields[0]->GetValueSize());
+   return reinterpret_cast<bool *>(reinterpret_cast<unsigned char *>(optionalPtr) + fSubfields[0]->GetValueSize());
 }
 
 const bool *ROOT::Experimental::ROptionalField::GetEngagementPtr(const void *optionalPtr) const
@@ -877,7 +877,7 @@ const bool *ROOT::Experimental::ROptionalField::GetEngagementPtr(const void *opt
 std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::ROptionalField::CloneImpl(std::string_view newName) const
 {
-   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
+   auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<ROptionalField>(newName, GetTypeName(), std::move(newItemField));
 }
 
@@ -895,13 +895,13 @@ void ROOT::Experimental::ROptionalField::ReadGlobalImpl(ROOT::NTupleSize_t globa
    auto engagementPtr = GetEngagementPtr(to);
    auto itemIndex = GetItemIndex(globalIndex);
    if (itemIndex.GetIndexInCluster() == ROOT::kInvalidNTupleIndex) {
-      if (*engagementPtr && !(fSubFields[0]->GetTraits() & kTraitTriviallyDestructible))
+      if (*engagementPtr && !(fSubfields[0]->GetTraits() & kTraitTriviallyDestructible))
          fItemDeleter->operator()(to, true /* dtorOnly */);
       *engagementPtr = false;
    } else {
-      if (!(*engagementPtr) && !(fSubFields[0]->GetTraits() & kTraitTriviallyConstructible))
-         CallConstructValueOn(*fSubFields[0], to);
-      CallReadOn(*fSubFields[0], itemIndex, to);
+      if (!(*engagementPtr) && !(fSubfields[0]->GetTraits() & kTraitTriviallyConstructible))
+         CallConstructValueOn(*fSubfields[0], to);
+      CallReadOn(*fSubfields[0], itemIndex, to);
       *engagementPtr = true;
    }
 }
@@ -924,8 +924,8 @@ void ROOT::Experimental::ROptionalField::ROptionalDeleter::operator()(void *objP
 std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::ROptionalField::GetDeleter() const
 {
    return std::make_unique<ROptionalDeleter>(
-      (fSubFields[0]->GetTraits() & kTraitTriviallyDestructible) ? nullptr : GetDeleterOf(*fSubFields[0]),
-      fSubFields[0]->GetValueSize());
+      (fSubfields[0]->GetTraits() & kTraitTriviallyDestructible) ? nullptr : GetDeleterOf(*fSubfields[0]),
+      fSubfields[0]->GetValueSize());
 }
 
 std::vector<ROOT::Experimental::RFieldBase::RValue>
@@ -934,7 +934,7 @@ ROOT::Experimental::ROptionalField::SplitValue(const RValue &value) const
    std::vector<RValue> result;
    const auto valuePtr = value.GetPtr<void>().get();
    if (*GetEngagementPtr(valuePtr)) {
-      result.emplace_back(fSubFields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), valuePtr)));
+      result.emplace_back(fSubfields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), valuePtr)));
    }
    return result;
 }
@@ -943,7 +943,7 @@ size_t ROOT::Experimental::ROptionalField::GetValueSize() const
 {
    const auto alignment = GetAlignment();
    // real size is the sum of the value size and the engagement boolean
-   const auto actualSize = fSubFields[0]->GetValueSize() + sizeof(bool);
+   const auto actualSize = fSubfields[0]->GetValueSize() + sizeof(bool);
    auto padding = 0;
    if (alignment > 1) {
       auto remainder = actualSize % alignment;
@@ -955,7 +955,7 @@ size_t ROOT::Experimental::ROptionalField::GetValueSize() const
 
 size_t ROOT::Experimental::ROptionalField::GetAlignment() const
 {
-   return fSubFields[0]->GetAlignment();
+   return fSubfields[0]->GetAlignment();
 }
 
 //------------------------------------------------------------------------------
@@ -974,7 +974,7 @@ ROOT::Experimental::RAtomicField::RAtomicField(std::string_view fieldName, std::
 std::unique_ptr<ROOT::Experimental::RFieldBase>
 ROOT::Experimental::RAtomicField::CloneImpl(std::string_view newName) const
 {
-   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetFieldName());
+   auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<RAtomicField>(newName, GetTypeName(), std::move(newItemField));
 }
 
@@ -982,7 +982,7 @@ std::vector<ROOT::Experimental::RFieldBase::RValue>
 ROOT::Experimental::RAtomicField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   result.emplace_back(fSubFields[0]->BindValue(value.GetPtr<void>()));
+   result.emplace_back(fSubfields[0]->BindValue(value.GetPtr<void>()));
    return result;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -505,7 +505,7 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view name, const RRec
      fSize(source.fSize),
      fOffsets(source.fOffsets)
 {
-   for (const auto &f : source.GetSubFields())
+   for (const auto &f : source.GetConstSubfields())
       Attach(f->Clone(f->GetFieldName()));
    fTraits = source.fTraits;
 }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -469,8 +469,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
          // We use the type names of subfields of the newly created item fields to create the map's type name to
          // ensure the inner type names are properly normalized.
-         auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
-         auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+         auto keyTypeName = itemField->GetConstSubfields()[0]->GetTypeName();
+         auto valueTypeName = itemField->GetConstSubfields()[1]->GetTypeName();
 
          result = std::make_unique<RMapField>(fieldName, "std::map<" + keyTypeName + "," + valueTypeName + ">",
                                               std::move(itemField));
@@ -485,8 +485,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
          // We use the type names of subfields of the newly created item fields to create the map's type name to
          // ensure the inner type names are properly normalized.
-         auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
-         auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+         auto keyTypeName = itemField->GetConstSubfields()[0]->GetTypeName();
+         auto valueTypeName = itemField->GetConstSubfields()[1]->GetTypeName();
 
          result = std::make_unique<RMapField>(
             fieldName, "std::unordered_map<" + keyTypeName + "," + valueTypeName + ">", std::move(itemField));
@@ -501,8 +501,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
          // We use the type names of subfields of the newly created item fields to create the map's type name to
          // ensure the inner type names are properly normalized.
-         auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
-         auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+         auto keyTypeName = itemField->GetConstSubfields()[0]->GetTypeName();
+         auto valueTypeName = itemField->GetConstSubfields()[1]->GetTypeName();
 
          result = std::make_unique<RMapField>(fieldName, "std::multimap<" + keyTypeName + "," + valueTypeName + ">",
                                               std::move(itemField));
@@ -518,8 +518,8 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
 
          // We use the type names of subfields of the newly created item fields to create the map's type name to
          // ensure the inner type names are properly normalized.
-         auto keyTypeName = itemField->GetSubFields()[0]->GetTypeName();
-         auto valueTypeName = itemField->GetSubFields()[1]->GetTypeName();
+         auto keyTypeName = itemField->GetConstSubfields()[0]->GetTypeName();
+         auto valueTypeName = itemField->GetConstSubfields()[1]->GetTypeName();
 
          result = std::make_unique<RMapField>(
             fieldName, "std::unordered_multimap<" + keyTypeName + "," + valueTypeName + ">", std::move(itemField));
@@ -712,7 +712,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RFieldBase::EntryToColumnElementIndex(ROO
    return result;
 }
 
-std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetSubFields()
+std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetMutableSubfields()
 {
    std::vector<RFieldBase *> result;
    result.reserve(fSubFields.size());
@@ -722,7 +722,7 @@ std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::Ge
    return result;
 }
 
-std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetSubFields() const
+std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetConstSubfields() const
 {
    std::vector<const RFieldBase *> result;
    result.reserve(fSubFields.size());

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -695,7 +695,7 @@ void ROOT::Experimental::RFieldBase::Attach(std::unique_ptr<ROOT::Experimental::
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to attach subfield to already connected field"));
    child->fParent = this;
-   fSubFields.emplace_back(std::move(child));
+   fSubfields.emplace_back(std::move(child));
 }
 
 ROOT::NTupleSize_t ROOT::Experimental::RFieldBase::EntryToColumnElementIndex(ROOT::NTupleSize_t globalIndex) const
@@ -715,8 +715,8 @@ ROOT::NTupleSize_t ROOT::Experimental::RFieldBase::EntryToColumnElementIndex(ROO
 std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetMutableSubfields()
 {
    std::vector<RFieldBase *> result;
-   result.reserve(fSubFields.size());
-   for (const auto &f : fSubFields) {
+   result.reserve(fSubfields.size());
+   for (const auto &f : fSubfields) {
       result.emplace_back(f.get());
    }
    return result;
@@ -725,8 +725,8 @@ std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::Ge
 std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetConstSubfields() const
 {
    std::vector<const RFieldBase *> result;
-   result.reserve(fSubFields.size());
-   for (const auto &f : fSubFields) {
+   result.reserve(fSubfields.size());
+   for (const auto &f : fSubfields) {
       result.emplace_back(f.get());
    }
    return result;
@@ -808,7 +808,7 @@ std::size_t ROOT::Experimental::RFieldBase::ReadBulk(const RBulkSpec &bulkSpec)
 
 ROOT::Experimental::RFieldBase::RSchemaIterator ROOT::Experimental::RFieldBase::begin()
 {
-   return fSubFields.empty() ? RSchemaIterator(this, -1) : RSchemaIterator(fSubFields[0].get(), 0);
+   return fSubfields.empty() ? RSchemaIterator(this, -1) : RSchemaIterator(fSubfields[0].get(), 0);
 }
 
 ROOT::Experimental::RFieldBase::RSchemaIterator ROOT::Experimental::RFieldBase::end()
@@ -818,7 +818,7 @@ ROOT::Experimental::RFieldBase::RSchemaIterator ROOT::Experimental::RFieldBase::
 
 ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::begin() const
 {
-   return fSubFields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubFields[0].get(), 0);
+   return fSubfields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubfields[0].get(), 0);
 }
 
 ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::end() const
@@ -828,7 +828,7 @@ ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldB
 
 ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::cbegin() const
 {
-   return fSubFields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubFields[0].get(), 0);
+   return fSubfields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubfields[0].get(), 0);
 }
 
 ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::cend() const
@@ -987,7 +987,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
 
    BeforeConnectPageSource(pageSource);
 
-   for (auto &f : fSubFields) {
+   for (auto &f : fSubfields) {
       if (f->GetOnDiskId() == ROOT::kInvalidDescriptorId) {
          f->SetOnDiskId(pageSource.GetSharedDescriptorGuard()->FindFieldId(f->GetFieldName(), GetOnDiskId()));
       }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -79,7 +79,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, const R
      fSubFieldsInfo(source.fSubFieldsInfo),
      fMaxAlignment(source.fMaxAlignment)
 {
-   for (const auto &f : source.GetSubFields()) {
+   for (const auto &f : source.GetConstSubfields()) {
       RFieldBase::Attach(f->Clone(f->GetFieldName()));
    }
    fTraits = source.GetTraits();
@@ -953,8 +953,8 @@ ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName, const RF
    : ROOT::Experimental::RFieldBase(fieldName, "TObject", ROOT::ENTupleStructure::kRecord, false /* isSimple */)
 {
    fTraits |= kTraitTypeChecksum;
-   Attach(source.GetSubFields()[0]->Clone("fUniqueID"));
-   Attach(source.GetSubFields()[1]->Clone("fBits"));
+   Attach(source.GetConstSubfields()[0]->Clone("fUniqueID"));
+   Attach(source.GetConstSubfields()[1]->Clone("fBits"));
 }
 
 ROOT::Experimental::RField<TObject>::RField(std::string_view fieldName)
@@ -1150,7 +1150,7 @@ ROOT::Experimental::RVariantField::RVariantField(std::string_view name, const RV
      fVariantOffset(source.fVariantOffset),
      fNWritten(source.fNWritten.size(), 0)
 {
-   for (const auto &f : source.GetSubFields())
+   for (const auto &f : source.GetConstSubfields())
       Attach(f->Clone(f->GetFieldName()));
    fTraits = source.fTraits;
 }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -30,8 +30,8 @@
 
 void ROOT::Experimental::RPrepareVisitor::VisitField(const RFieldBase &field)
 {
-   auto subFields = field.GetConstSubfields();
-   for (auto f : subFields) {
+   auto subfields = field.GetConstSubfields();
+   for (auto f : subfields) {
       RPrepareVisitor visitor;
       f->AcceptVisitor(visitor);
       fNumFields += visitor.fNumFields;
@@ -77,9 +77,9 @@ void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const RFieldBase &field
    fOutput << RNTupleFormatter::FitString(value, fAvailableSpaceValueString);
    fOutput << fFrameSymbol << std::endl;
 
-   auto subFields = field.GetConstSubfields();
+   auto subfields = field.GetConstSubfields();
    auto fieldNo = 1;
-   for (auto iField = subFields.begin(); iField != subFields.end(); ) {
+   for (auto iField = subfields.begin(); iField != subfields.end();) {
       RPrintSchemaVisitor visitor(*this);
       visitor.fFieldNo = fieldNo++;
       visitor.fFieldNoPrefix += std::to_string(fFieldNo) + ".";

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -30,7 +30,7 @@
 
 void ROOT::Experimental::RPrepareVisitor::VisitField(const RFieldBase &field)
 {
-   auto subFields = field.GetSubFields();
+   auto subFields = field.GetConstSubfields();
    for (auto f : subFields) {
       RPrepareVisitor visitor;
       f->AcceptVisitor(visitor);
@@ -77,7 +77,7 @@ void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const RFieldBase &field
    fOutput << RNTupleFormatter::FitString(value, fAvailableSpaceValueString);
    fOutput << fFrameSymbol << std::endl;
 
-   auto subFields = field.GetSubFields();
+   auto subFields = field.GetConstSubfields();
    auto fieldNo = 1;
    for (auto iField = subFields.begin(); iField != subFields.end(); ) {
       RPrintSchemaVisitor visitor(*this);
@@ -96,7 +96,7 @@ void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const RFieldBase &field
 void ROOT::Experimental::RPrintSchemaVisitor::VisitFieldZero(const RFieldZero &fieldZero)
 {
    auto fieldNo = 1;
-   for (auto f : fieldZero.GetSubFields()) {
+   for (auto f : fieldZero.GetConstSubfields()) {
       RPrintSchemaVisitor visitor(*this);
       visitor.fFieldNo = fieldNo++;
       f->AcceptVisitor(visitor);

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -300,7 +300,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    cloneModel->fRegisteredSubfields = fRegisteredSubfields;
    if (fDefaultEntry) {
       cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(cloneModel->fModelId, cloneModel->fSchemaId));
-      for (const auto &f : cloneModel->fFieldZero->GetSubFields()) {
+      for (const auto &f : cloneModel->fFieldZero->GetMutableSubfields()) {
          cloneModel->fDefaultEntry->AddValue(f->CreateValue());
       }
       for (const auto &f : cloneModel->fRegisteredSubfields) {
@@ -317,7 +317,7 @@ ROOT::Experimental::RFieldBase *ROOT::Experimental::RNTupleModel::FindField(std:
 
    auto *field = static_cast<ROOT::Experimental::RFieldBase *>(fFieldZero.get());
    for (auto subfieldName : ROOT::Split(fieldName, ".")) {
-      const auto subfields = field->GetSubFields();
+      const auto subfields = field->GetMutableSubfields();
       auto it = std::find_if(subfields.begin(), subfields.end(),
                              [&](const auto *f) { return f->GetFieldName() == subfieldName; });
       if (it != subfields.end()) {
@@ -468,7 +468,7 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
    }
 
    auto entry = std::unique_ptr<REntry>(new REntry(fModelId, fSchemaId));
-   for (const auto &f : fFieldZero->GetSubFields()) {
+   for (const auto &f : fFieldZero->GetMutableSubfields()) {
       entry->AddValue(f->CreateValue());
    }
    for (const auto &f : fRegisteredSubfields) {
@@ -486,7 +486,7 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
    }
 
    auto entry = std::unique_ptr<REntry>(new REntry(fModelId, fSchemaId));
-   for (const auto &f : fFieldZero->GetSubFields()) {
+   for (const auto &f : fFieldZero->GetMutableSubfields()) {
       entry->AddValue(f->BindValue(nullptr));
    }
    for (const auto &f : fRegisteredSubfields) {
@@ -497,7 +497,7 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
 
 ROOT::Experimental::REntry::RFieldToken ROOT::Experimental::RNTupleModel::GetToken(std::string_view fieldName) const
 {
-   const auto &topLevelFields = fFieldZero->GetSubFields();
+   const auto &topLevelFields = fFieldZero->GetConstSubfields();
    auto it = std::find_if(topLevelFields.begin(), topLevelFields.end(),
                           [&fieldName](const RFieldBase *f) { return f->GetFieldName() == fieldName; });
 

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -121,7 +121,7 @@ ROOT::Experimental::RNTupleParallelWriter::RNTupleParallelWriter(std::unique_ptr
                                                                  std::unique_ptr<Internal::RPageSink> sink)
    : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleParallelWriter")
 {
-   if (fModel->GetRegisteredSubfields().size() > 0) {
+   if (fModel->GetRegisteredSubfieldNames().size() > 0) {
       throw RException(R__FAIL("cannot create an RNTupleParallelWriter from a model with registered subfields"));
    }
    fModel->Freeze();

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -426,7 +426,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::AddAuxiliary(const RNTupleOpenSpe
       throw RException(R__FAIL("could not create auxiliary RNTuple parent field"));
    }
 
-   const auto &subFields = auxParentField->GetSubFields();
+   const auto &subFields = auxParentField->GetConstSubfields();
    fModel->AddField(std::move(auxParentField));
    for (const auto &field : subFields) {
       fModel->RegisterSubfield(field->GetQualifiedFieldName());

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -426,9 +426,9 @@ void ROOT::Experimental::RNTupleJoinProcessor::AddAuxiliary(const RNTupleOpenSpe
       throw RException(R__FAIL("could not create auxiliary RNTuple parent field"));
    }
 
-   const auto &subFields = auxParentField->GetConstSubfields();
+   const auto &subfields = auxParentField->GetConstSubfields();
    fModel->AddField(std::move(auxParentField));
-   for (const auto &field : subFields) {
+   for (const auto &field : subfields) {
       fModel->RegisterSubfield(field->GetQualifiedFieldName());
    }
 

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -32,7 +32,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
    fieldZero.SetOnDiskId(fieldZeroId);
    // Iterate only over fieldZero's direct subfields; their descendants are recursively handled in
    // RFieldBase::ConnectPageSource
-   for (auto &field : fieldZero.GetSubFields()) {
+   for (auto &field : fieldZero.GetMutableSubfields()) {
       // If the model has been created from the descriptor, the on-disk IDs are already set.
       // User-provided models instead need to find their corresponding IDs in the descriptor.
       if (field->GetOnDiskId() == ROOT::kInvalidDescriptorId) {

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -59,7 +59,7 @@ ROOT::Experimental::RNTupleWriter::Create(std::unique_ptr<RNTupleModel> model,
                                           std::unique_ptr<Internal::RPageSink> sink,
                                           const ROOT::RNTupleWriteOptions &options)
 {
-   if (model->GetRegisteredSubfields().size() > 0) {
+   if (model->GetRegisteredSubfieldNames().size() > 0) {
       throw RException(R__FAIL("cannot create an RNTupleWriter from a model with registered subfields"));
    }
    for (const auto &field : model->GetConstFieldZero()) {

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -86,7 +86,7 @@ const ROOT::Experimental::RNTupleDescriptor &ROOT::Experimental::Internal::RPage
 
 void ROOT::Experimental::Internal::RPageSinkBuf::InitImpl(RNTupleModel &model)
 {
-   ConnectFields(Internal::GetFieldZeroOfModel(model).GetSubFields(), 0U);
+   ConnectFields(Internal::GetFieldZeroOfModel(model).GetMutableSubfields(), 0U);
 
    fInnerModel = model.Clone();
    fInnerSink->Init(*fInnerModel);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -908,11 +908,11 @@ void ROOT::Experimental::Internal::RPagePersistentSink::InitImpl(RNTupleModel &m
    projectedFields.GetFieldZero().SetOnDiskId(0);
 
    RNTupleModelChangeset initialChangeset{model};
-   initialChangeset.fAddedFields.reserve(fieldZero.GetSubFields().size());
-   for (auto f : fieldZero.GetSubFields())
+   initialChangeset.fAddedFields.reserve(fieldZero.GetMutableSubfields().size());
+   for (auto f : fieldZero.GetMutableSubfields())
       initialChangeset.fAddedFields.emplace_back(f);
-   initialChangeset.fAddedProjectedFields.reserve(projectedFields.GetFieldZero().GetSubFields().size());
-   for (auto f : projectedFields.GetFieldZero().GetSubFields())
+   initialChangeset.fAddedProjectedFields.reserve(projectedFields.GetFieldZero().GetMutableSubfields().size());
+   for (auto f : projectedFields.GetFieldZero().GetMutableSubfields())
       initialChangeset.fAddedProjectedFields.emplace_back(f);
    UpdateSchema(initialChangeset, 0U);
 

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -552,13 +552,13 @@ TEST(RNTupleDescriptor, BuildStreamerInfos)
       descBuilder.AddFieldLink(0, 1);
       int i = 2;
       // In this test, we only support field hierarchies up to 2 levels
-      for (const auto &child : field.GetSubFields()) {
+      for (const auto &child : field.GetConstSubfields()) {
          fieldBuilder = RFieldDescriptorBuilder::FromField(*child);
          descBuilder.AddField(fieldBuilder.FieldId(i).MakeDescriptor().Unwrap());
          descBuilder.AddFieldLink(1, i);
          const auto childId = i;
          i++;
-         for (const auto &grandChild : child->GetSubFields()) {
+         for (const auto &grandChild : child->GetConstSubfields()) {
             fieldBuilder = RFieldDescriptorBuilder::FromField(*grandChild);
             descBuilder.AddField(fieldBuilder.FieldId(i).MakeDescriptor().Unwrap());
             descBuilder.AddFieldLink(childId, i);

--- a/tree/ntuple/v7/test/ntuple_emulated.cxx
+++ b/tree/ntuple/v7/test/ntuple_emulated.cxx
@@ -74,9 +74,9 @@ struct Outer_Simple {
       const auto &outer = model->GetConstField("f");
       ASSERT_EQ(outer.GetTypeName(), "Outer_Simple");
       ASSERT_EQ(outer.GetStructure(), ROOT::ENTupleStructure::kRecord);
-      ASSERT_EQ(outer.GetSubFields().size(), 2);
+      ASSERT_EQ(outer.GetConstSubfields().size(), 2);
 
-      const auto subfields = outer.GetSubFields();
+      const auto subfields = outer.GetConstSubfields();
       ASSERT_EQ(subfields[0]->GetFieldName(), "fInt1");
 
       const auto *inner = subfields[1];
@@ -84,8 +84,8 @@ struct Outer_Simple {
       ASSERT_EQ(inner->GetFieldName(), "fInner");
       ASSERT_EQ(inner->GetStructure(), ROOT::ENTupleStructure::kRecord);
       ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
-      ASSERT_EQ(inner->GetSubFields().size(), 2);
-      ASSERT_EQ(inner->GetSubFields()[0]->GetFieldName(), "fInt1");
+      ASSERT_EQ(inner->GetConstSubfields().size(), 2);
+      ASSERT_EQ(inner->GetConstSubfields()[0]->GetFieldName(), "fInt1");
    }
 
    // Now test loading entries with a reader.
@@ -176,30 +176,30 @@ struct Outer_Vecs {
       const auto &outers = model->GetConstField("outers");
       ASSERT_EQ(outers.GetTypeName(), "std::vector<Outer_Vecs>");
       ASSERT_EQ(outers.GetStructure(), ROOT::ENTupleStructure::kCollection);
-      ASSERT_EQ(outers.GetSubFields().size(), 1);
+      ASSERT_EQ(outers.GetConstSubfields().size(), 1);
 
-      const auto subfields = outers.GetSubFields();
+      const auto subfields = outers.GetConstSubfields();
       const auto *outer = subfields[0];
       ASSERT_EQ(outer->GetTypeName(), "Outer_Vecs");
       ASSERT_EQ(outer->GetStructure(), ROOT::ENTupleStructure::kRecord);
       ASSERT_NE(outer->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
 
-      const auto outersubfields = outer->GetSubFields();
+      const auto outersubfields = outer->GetConstSubfields();
       ASSERT_EQ(outersubfields.size(), 3);
 
       const auto *inners = outersubfields[0];
       ASSERT_EQ(inners->GetTypeName(), "std::vector<Inner_Vecs>");
       ASSERT_EQ(inners->GetFieldName(), "fInners");
       ASSERT_EQ(inners->GetStructure(), ROOT::ENTupleStructure::kCollection);
-      ASSERT_EQ(inners->GetSubFields().size(), 1);
-      ASSERT_EQ(inners->GetSubFields()[0]->GetFieldName(), "_0");
+      ASSERT_EQ(inners->GetConstSubfields().size(), 1);
+      ASSERT_EQ(inners->GetConstSubfields()[0]->GetFieldName(), "_0");
 
-      const auto innersubfields = inners->GetSubFields();
+      const auto innersubfields = inners->GetConstSubfields();
       const auto *inner = innersubfields[0];
       ASSERT_EQ(inner->GetTypeName(), "Inner_Vecs");
       ASSERT_EQ(inner->GetStructure(), ROOT::ENTupleStructure::kRecord);
-      ASSERT_EQ(inner->GetSubFields().size(), 1);
-      ASSERT_EQ(inner->GetSubFields()[0]->GetFieldName(), "fFlt");
+      ASSERT_EQ(inner->GetConstSubfields().size(), 1);
+      ASSERT_EQ(inner->GetConstSubfields()[0]->GetFieldName(), "fFlt");
    }
 
    // Now test loading entries with a reader
@@ -262,15 +262,15 @@ struct TemplatedWrapper {
       const auto &vecField = model->GetConstField("vec");
       ASSERT_EQ(vecField.GetTypeName(), "std::vector<TemplatedWrapper<float>>");
       ASSERT_EQ(vecField.GetStructure(), ROOT::ENTupleStructure::kCollection);
-      ASSERT_EQ(vecField.GetSubFields().size(), 1);
+      ASSERT_EQ(vecField.GetConstSubfields().size(), 1);
 
-      const auto *wrapperField = vecField.GetSubFields()[0];
+      const auto *wrapperField = vecField.GetConstSubfields()[0];
       ASSERT_EQ(wrapperField->GetTypeName(), "TemplatedWrapper<float>");
       ASSERT_EQ(wrapperField->GetStructure(), ROOT::ENTupleStructure::kRecord);
       ASSERT_NE(wrapperField->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
-      ASSERT_EQ(wrapperField->GetSubFields().size(), 1);
+      ASSERT_EQ(wrapperField->GetConstSubfields().size(), 1);
 
-      const auto *innerField = wrapperField->GetSubFields()[0];
+      const auto *innerField = wrapperField->GetConstSubfields()[0];
       ASSERT_EQ(innerField->GetTypeName(), "float");
       ASSERT_EQ(innerField->GetFieldName(), "fValue");
       ASSERT_EQ(innerField->GetStructure(), ROOT::ENTupleStructure::kLeaf);
@@ -341,15 +341,15 @@ struct Outer_EmptyStruct {
       const auto &outer = model->GetConstField("f");
       ASSERT_EQ(outer.GetTypeName(), "Outer_EmptyStruct");
       ASSERT_EQ(outer.GetStructure(), ROOT::ENTupleStructure::kRecord);
-      ASSERT_EQ(outer.GetSubFields().size(), 1);
+      ASSERT_EQ(outer.GetConstSubfields().size(), 1);
 
-      const auto subfields = outer.GetSubFields();
+      const auto subfields = outer.GetConstSubfields();
       const auto *inner = subfields[0];
       ASSERT_EQ(inner->GetTypeName(), "Inner_EmptyStruct");
       ASSERT_EQ(inner->GetFieldName(), "fInner");
       ASSERT_EQ(inner->GetStructure(), ROOT::ENTupleStructure::kRecord);
       ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
-      ASSERT_EQ(inner->GetSubFields().size(), 0);
+      ASSERT_EQ(inner->GetConstSubfields().size(), 0);
    }
 
    // Now test loading entries with a reader
@@ -419,16 +419,16 @@ struct Inner_EmptyVec {
       const auto &outer = model->GetConstField("f");
       ASSERT_EQ(outer.GetTypeName(), "std::vector<Inner_EmptyVec>");
       ASSERT_EQ(outer.GetStructure(), ROOT::ENTupleStructure::kCollection);
-      ASSERT_EQ(outer.GetSubFields().size(), 1);
+      ASSERT_EQ(outer.GetConstSubfields().size(), 1);
       ASSERT_EQ(outer.GetTraits() & RFieldBase::kTraitEmulatedField, 0);
 
-      const auto subfields = outer.GetSubFields();
+      const auto subfields = outer.GetConstSubfields();
       const auto *inner = subfields[0];
       ASSERT_EQ(inner->GetTypeName(), "Inner_EmptyVec");
       ASSERT_EQ(inner->GetFieldName(), "_0");
       ASSERT_EQ(inner->GetStructure(), ROOT::ENTupleStructure::kRecord);
       ASSERT_NE(inner->GetTraits() & RFieldBase::kTraitEmulatedField, 0);
-      ASSERT_EQ(inner->GetSubFields().size(), 0);
+      ASSERT_EQ(inner->GetConstSubfields().size(), 0);
    }
 
    // Now test loading entries with a reader

--- a/tree/ntuple/v7/test/ntuple_limits.cxx
+++ b/tree/ntuple/v7/test/ntuple_limits.cxx
@@ -40,7 +40,7 @@ TEST(RNTuple, Limits_ManyFields)
    const auto &model = reader->GetModel();
 
    EXPECT_EQ(descriptor.GetNFields(), 1 + NumFields);
-   EXPECT_EQ(model.GetConstFieldZero().GetSubFields().size(), NumFields);
+   EXPECT_EQ(model.GetConstFieldZero().GetConstSubfields().size(), NumFields);
    EXPECT_EQ(reader->GetNEntries(), 1);
 
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_model.cxx
+++ b/tree/ntuple/v7/test/ntuple_model.cxx
@@ -340,7 +340,7 @@ TEST(RNTupleModel, Expire)
    auto token = model->GetToken("struct");
    EXPECT_FLOAT_EQ(1.0, model->GetDefaultEntry().GetPtr<CustomStruct>(token)->a);
 
-   EXPECT_TRUE(model->GetRegisteredSubfields().empty());
+   EXPECT_TRUE(model->GetRegisteredSubfieldNames().empty());
    EXPECT_TRUE(model->GetDescription().empty());
 
    EXPECT_THROW(model->MakeField<float>("E"), ROOT::RException);

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -21,8 +21,8 @@ struct RFieldBaseTest : public ROOT::Experimental::RFieldBase {
 
       if (fPrincipalColumn)
          return fnColumnElementIndexToEntry(fPrincipalColumn->GetFirstElementIndex());
-      if (!fSubFields.empty())
-         return static_cast<const RFieldBaseTest &>(*fSubFields[0]).GetFirstEntry();
+      if (!fSubfields.empty())
+         return static_cast<const RFieldBaseTest &>(*fSubfields[0]).GetFirstEntry();
       R__ASSERT(false);
       return 0;
    }

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -288,7 +288,7 @@ TEST(RNTuple, MultiColumnRepresentationNullable)
       auto fldVector = RFieldBase::Create("vector", "std::vector<std::optional<float>>").Unwrap();
       fldScalar->SetColumnRepresentatives(
          {{ROOT::ENTupleColumnType::kIndex32}, {ROOT::ENTupleColumnType::kSplitIndex64}});
-      fldVector->GetSubFields()[0]->SetColumnRepresentatives(
+      fldVector->GetMutableSubfields()[0]->SetColumnRepresentatives(
          {{ROOT::ENTupleColumnType::kSplitIndex64}, {ROOT::ENTupleColumnType::kIndex32}});
       model->AddField(std::move(fldScalar));
       model->AddField(std::move(fldVector));

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -207,17 +207,17 @@ TEST(RNTuple, TypeNameTemplatesNestedAlias)
    EXPECT_EQ("EdmHash<1>", hash->GetTypeName());
    EXPECT_EQ("", hash->GetTypeAlias());
 
-   const auto hashSubFields = hash->GetConstSubfields();
-   ASSERT_EQ(2, hashSubFields.size());
-   EXPECT_EQ("fHash", hashSubFields[0]->GetFieldName());
-   EXPECT_EQ("std::string", hashSubFields[0]->GetTypeName());
-   EXPECT_EQ("EdmHash<1>::value_type", hashSubFields[0]->GetTypeAlias());
+   const auto hashSubfields = hash->GetConstSubfields();
+   ASSERT_EQ(2, hashSubfields.size());
+   EXPECT_EQ("fHash", hashSubfields[0]->GetFieldName());
+   EXPECT_EQ("std::string", hashSubfields[0]->GetTypeName());
+   EXPECT_EQ("EdmHash<1>::value_type", hashSubfields[0]->GetTypeAlias());
 
-   EXPECT_EQ("fHash2", hashSubFields[1]->GetFieldName());
-   EXPECT_EQ("std::string", hashSubFields[1]->GetTypeName());
+   EXPECT_EQ("fHash2", hashSubfields[1]->GetFieldName());
+   EXPECT_EQ("std::string", hashSubfields[1]->GetTypeName());
    // FIXME: This should really be EdmHash<1>::value_typeT<EdmHash<1>::value_type>, but this is the value we get from
    // TDataMember::GetFullTypeName right now...
-   EXPECT_EQ("value_typeT<EdmHash<1>::value_type>", hashSubFields[1]->GetTypeAlias());
+   EXPECT_EQ("value_typeT<EdmHash<1>::value_type>", hashSubfields[1]->GetTypeAlias());
 }
 
 TEST(RNTuple, ContextDependentTypeNames)

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -207,7 +207,7 @@ TEST(RNTuple, TypeNameTemplatesNestedAlias)
    EXPECT_EQ("EdmHash<1>", hash->GetTypeName());
    EXPECT_EQ("", hash->GetTypeAlias());
 
-   const auto hashSubFields = hash->GetSubFields();
+   const auto hashSubFields = hash->GetConstSubfields();
    ASSERT_EQ(2, hashSubFields.size());
    EXPECT_EQ("fHash", hashSubFields[0]->GetFieldName());
    EXPECT_EQ("std::string", hashSubFields[0]->GetTypeName());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1692,8 +1692,8 @@ TEST(RNTuple, HalfPrecisionFloat)
    EXPECT_EQ("float", f1Fld->GetTypeName());
 
    auto fVecFld = RFieldBase::Create("fVec", "std::vector<float>").Unwrap();
-   dynamic_cast<RField<float> *>(fVecFld->GetSubFields()[0])->SetHalfPrecision();
-   EXPECT_EQ(ROOT::ENTupleColumnType::kReal16, fVecFld->GetSubFields()[0]->GetColumnRepresentatives()[0][0]);
+   dynamic_cast<RField<float> *>(fVecFld->GetMutableSubfields()[0])->SetHalfPrecision();
+   EXPECT_EQ(ROOT::ENTupleColumnType::kReal16, fVecFld->GetConstSubfields()[0]->GetColumnRepresentatives()[0][0]);
 
    auto model = RNTupleModel::Create();
    model->AddField(std::move(f1Fld));
@@ -1830,9 +1830,9 @@ TEST(RNTuple, Double32Extended)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    auto obj = reader->GetModel().GetDefaultEntry().GetPtr<LowPrecisionFloats>("obj");
-   EXPECT_EQ("Double32_t", reader->GetModel().GetConstField("obj").GetSubFields()[1]->GetTypeAlias());
+   EXPECT_EQ("Double32_t", reader->GetModel().GetConstField("obj").GetConstSubfields()[1]->GetTypeAlias());
    EXPECT_EQ("Double32_t",
-             reader->GetModel().GetConstField("obj").GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
+             reader->GetModel().GetConstField("obj").GetConstSubfields()[2]->GetConstSubfields()[0]->GetTypeAlias());
    EXPECT_DOUBLE_EQ(0.0, obj->a);
    EXPECT_DOUBLE_EQ(1.0, obj->b);
    EXPECT_DOUBLE_EQ(2.0, obj->c[0]);

--- a/tree/ntuple/v7/test/rfield_streamer.cxx
+++ b/tree/ntuple/v7/test/rfield_streamer.cxx
@@ -107,7 +107,7 @@ TEST(RField, IgnoreUnsplitComment)
    auto fieldClass = RFieldBase::Create("f", "IgnoreUnsplitComment").Unwrap();
 
    // Only one member, so we know that it is first sub field
-   const auto fieldMember = fieldClass->GetSubFields()[0];
+   const auto fieldMember = fieldClass->GetConstSubfields()[0];
    EXPECT_EQ(std::string("v"), fieldMember->GetFieldName());
    EXPECT_EQ(nullptr, dynamic_cast<const ROOT::Experimental::RStreamerField *>(fieldMember));
 }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -435,18 +435,18 @@ public:
    ///
    /// \param[in] typeNamePattern The type or class name to count. May contain regular expression patterns for grouping
    /// multiple kinds of types or classes.
-   /// \param[in] searchInSubFields If set to `false`, only top-level fields will be considered.
+   /// \param[in] searchInSubfields If set to `false`, only top-level fields will be considered.
    ///
    /// \return The number of fields that matches the provided type.
-   size_t GetFieldCountByType(const std::regex &typeNamePattern, bool searchInSubFields = true) const;
+   size_t GetFieldCountByType(const std::regex &typeNamePattern, bool searchInSubfields = true) const;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the number of fields of a given type or class present in the RNTuple.
    ///
-   /// \see GetFieldCountByType(const std::regex &typeNamePattern, bool searchInSubFields) const
-   size_t GetFieldCountByType(std::string_view typeNamePattern, bool searchInSubFields = true) const
+   /// \see GetFieldCountByType(const std::regex &typeNamePattern, bool searchInSubfields) const
+   size_t GetFieldCountByType(std::string_view typeNamePattern, bool searchInSubfields = true) const
    {
-      return GetFieldCountByType(std::regex{std::string(typeNamePattern)}, searchInSubFields);
+      return GetFieldCountByType(std::regex{std::string(typeNamePattern)}, searchInSubfields);
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -455,20 +455,20 @@ public:
    /// \param[in] fieldNamePattern The name of the field name to get. Because field names are unique by design,
    /// providing a single field name will return a vector containing just the ID of that field. However, regular
    /// expression patterns are supported in order to get the IDs of all fields whose name follow a certain structure.
-   /// \param[in] searchInSubFields If set to `false`, only top-level fields will be considered.
+   /// \param[in] searchInSubfields If set to `false`, only top-level fields will be considered.
    ///
    /// \return A vector containing the IDs of fields that match the provided name.
    const std::vector<ROOT::DescriptorId_t>
-   GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubFields = true) const;
+   GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubfields = true) const;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the IDs of (sub-)fields whose name matches the given string.
    ///
-   /// \see GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubFields) const
+   /// \see GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubfields) const
    const std::vector<ROOT::DescriptorId_t>
-   GetFieldsByName(std::string_view fieldNamePattern, bool searchInSubFields = true)
+   GetFieldsByName(std::string_view fieldNamePattern, bool searchInSubfields = true)
    {
-      return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, searchInSubFields);
+      return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, searchInSubfields);
    }
 };
 } // namespace Experimental

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -143,7 +143,7 @@ void ROOT::Experimental::RNTupleImporter::ReportSchema()
    for (const auto &f : fImportFields) {
       std::cout << "Importing '" << f.fField->GetFieldName() << "' [" << f.fField->GetTypeName() << "]\n";
    }
-   for (const auto &f : Internal::GetProjectedFieldsOfModel(*fModel).GetFieldZero().GetSubFields()) {
+   for (const auto &f : Internal::GetProjectedFieldsOfModel(*fModel).GetFieldZero().GetConstSubfields()) {
       std::cout << "Importing (projected) '" << f->GetFieldName() << "' [" << f->GetTypeName() << "]\n";
    }
 }
@@ -323,7 +323,7 @@ ROOT::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSchema()
       fModel->AddField(std::move(collectionField));
 
       // Add projected fields for all leaf count arrays
-      for (const auto leaf : c.fRecordField->GetSubFields()) {
+      for (const auto leaf : c.fRecordField->GetConstSubfields()) {
          const auto name = leaf->GetFieldName();
          auto projectedField = RFieldBase::Create(name, "ROOT::VecOps::RVec<" + leaf->GetTypeName() + ">").Unwrap();
          fModel->AddProjectedField(std::move(projectedField), [&name, &c](const std::string &fieldName) {
@@ -403,10 +403,10 @@ void ROOT::Experimental::RNTupleImporter::Import()
          const auto sizeOfRecord = c.fRecordField->GetValueSize();
          c.fFieldBuffer.resize(sizeOfRecord * (*c.fCountVal));
 
-         const auto nLeafs = c.fRecordField->GetSubFields().size();
+         const auto nLeafs = c.fRecordField->GetConstSubfields().size();
          for (std::size_t l = 0; l < nLeafs; ++l) {
             const auto offset = c.fRecordField->GetOffsets()[l];
-            const auto sizeOfLeaf = c.fRecordField->GetSubFields()[l]->GetValueSize();
+            const auto sizeOfLeaf = c.fRecordField->GetConstSubfields()[l]->GetValueSize();
             const auto idxImportBranch = c.fLeafBranchIndexes[l];
             for (Int_t j = 0; j < *c.fCountVal; ++j) {
                memcpy(c.fFieldBuffer.data() + j * sizeOfRecord + offset,

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -482,12 +482,12 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(std::string_view fie
 }
 
 size_t ROOT::Experimental::RNTupleInspector::GetFieldCountByType(const std::regex &typeNamePattern,
-                                                                 bool includeSubFields) const
+                                                                 bool includeSubfields) const
 {
    size_t typeCount = 0;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
-      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
+      if (!includeSubfields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
          continue;
       }
 
@@ -500,13 +500,13 @@ size_t ROOT::Experimental::RNTupleInspector::GetFieldCountByType(const std::rege
 }
 
 const std::vector<ROOT::DescriptorId_t>
-ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubFields) const
+ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubfields) const
 {
    std::vector<ROOT::DescriptorId_t> fieldIds;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
 
-      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
+      if (!searchInSubfields && fldInfo.GetDescriptor().GetParentId() != fDescriptor.GetFieldZeroId()) {
          continue;
       }
 


### PR DESCRIPTION
Following the same pattern as in `RNTupleModel`, the const version of `GetSubFields` become `GetConstSubfields` and the non-const becomes `GetMutableSubfields`.

Note that the `F` is not capitalized anymore because we decided to keep "subfields" as a single word throughout the whole API.

In addition, the `GetRegisteredSubfields` method becomes `GetRegisteredSubfieldNames` for clarity.