### PR TITLE
Improve `SavePrimitive()` methods in hist classes

### DIFF
--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -130,6 +130,7 @@ public:
       TEfficiency&  operator+=(const TEfficiency& rhs);
       TEfficiency&  operator=(const TEfficiency& rhs);
       void          Paint(Option_t* opt) override;
+      void          RecursiveRemove(TObject *obj) override;
       void          SavePrimitive(std::ostream& out,Option_t* opt="") override;
       void          SetBetaAlpha(Double_t alpha);
       void          SetBetaBeta(Double_t beta);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -338,6 +338,8 @@ protected:
    virtual void GetRange(Double_t *xmin, Double_t *xmax) const;
    virtual TH1 *DoCreateHistogram(Double_t xmin, Double_t xmax, Bool_t recreate = kFALSE);
 
+   TString ProvideSaveName(Option_t *option);
+
 public:
 
    // TF1 status bits

--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -150,6 +150,7 @@ public:
    void                  Paint(Option_t *option="") override;
    void          Print(Option_t *chopt="") const override;
    TH1                  *Project(Option_t *option="x") const; // *MENU*
+   void                  RecursiveRemove(TObject *obj) override;
    Int_t                 RemovePoint(Int_t ipoint); // *MENU*
    void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void          Scale(Double_t c1=1., Option_t *option="z"); // *MENU*

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -146,6 +146,7 @@ protected:
    Int_t            AxisChoice(Option_t *axis) const;
    virtual Int_t    BufferFill(Double_t x, Double_t w);
    virtual Bool_t   FindNewAxisLimits(const TAxis* axis, const Double_t point, Double_t& newMin, Double_t &newMax);
+   TString          ProvideSaveName(Option_t *option, Bool_t testfdir = kFALSE);
    virtual void     SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option = "");
    static Bool_t    RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis);
    static Bool_t    SameLimitsAndNBins(const TAxis& axis1, const TAxis& axis2);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -444,6 +444,7 @@ public:
            void     UseCurrentStyle() override;
    static  TH1     *TransformHisto(TVirtualFFT *fft, TH1* h_output,  Option_t *option);
 
+   static void      SavePrimitiveFunctions(std::ostream &out, const char *varname, TList *lst);
 
    // TODO: Remove obsolete methods in v6-04
    virtual Double_t GetCellContent(Int_t binx, Int_t biny) const

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3236,47 +3236,44 @@ TString TF1::ProvideSaveName(Option_t *option)
 
 void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   Int_t i;
-   char quote = '"';
-
    // Save the function as C code independent from ROOT.
-   if (strstr(option, "cc")) {
-      out << "double " << GetName() << "(double xv) {" << std::endl;
+   if (option && strstr(option, "cc")) {
+      out << "double " << GetName() << "(double xv) {\n";
       Double_t dx = (fXmax - fXmin) / (fNpx - 1);
-      out << "   double x[" << fNpx << "] = {" << std::endl;
+      out << "   double x[" << fNpx << "] = {\n";
       out << "   ";
       Int_t n = 0;
-      for (i = 0; i < fNpx; i++) {
-         out << fXmin + dx *i ;
-         if (i < fNpx - 1) out << ", ";
+      for (Int_t i = 0; i < fNpx; i++) {
+         out << fXmin + dx * i;
+         if (i < fNpx - 1)
+            out << ", ";
          if (n++ == 10) {
-            out << std::endl;
-            out << "   ";
+            out << "\n   ";
             n = 0;
          }
       }
-      out << std::endl;
-      out << "   };" << std::endl;
-      out << "   double y[" << fNpx << "] = {" << std::endl;
+      out << "\n";
+      out << "   };\n";
+      out << "   double y[" << fNpx << "] = {\n";
       out << "   ";
       n = 0;
-      for (i = 0; i < fNpx; i++) {
+      for (Int_t i = 0; i < fNpx; i++) {
          out << Eval(fXmin + dx * i);
-         if (i < fNpx - 1) out << ", ";
+         if (i < fNpx - 1)
+            out << ", ";
          if (n++ == 10) {
-            out << std::endl;
-            out << "   ";
+            out << "\n   ";
             n = 0;
          }
       }
-      out << std::endl;
-      out << "   };" << std::endl;
-      out << "   if (xv<x[0]) return y[0];" << std::endl;
-      out << "   if (xv>x[" << fNpx - 1 << "]) return y[" << fNpx - 1 << "];" << std::endl;
-      out << "   int i, j=0;" << std::endl;
-      out << "   for (i=1; i<" << fNpx << "; i++) { if (xv < x[i]) break; j++; }" << std::endl;
-      out << "   return y[j] + (y[j + 1] - y[j]) / (x[j + 1] - x[j]) * (xv - x[j]);" << std::endl;
-      out << "}" << std::endl;
+      out << "\n";
+      out << "   };\n";
+      out << "   if (xv<x[0]) return y[0];\n";
+      out << "   if (xv>x[" << fNpx - 1 << "]) return y[" << fNpx - 1 << "];\n";
+      out << "   int i, j=0;\n";
+      out << "   for (i=1; i<" << fNpx << "; i++) { if (xv < x[i]) break; j++; }\n";
+      out << "   return y[j] + (y[j + 1] - y[j]) / (x[j + 1] - x[j]) * (xv - x[j]);\n";
+      out << "}\n";
       return;
    }
 
@@ -3286,61 +3283,60 @@ void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    out << "   " << std::endl;
    if (!fType) {
-      out << "   TF1 *" << f1Name.Data() << " = new TF1(" << quote << GetName() << quote << "," << quote << GetTitle() << quote << "," << fXmin << "," << fXmax <<  addToGlobList << ");" << std::endl;
-      if (fNpx != 100) {
-         out << "   " << f1Name.Data() << "->SetNpx(" << fNpx << ");" << std::endl;
-      }
+      out << "   TF1 *" << f1Name << " = new TF1(\"" << GetName() << "\", \""
+          << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << fXmin << "," << fXmax << addToGlobList << ");\n";
+      if (fNpx != 100)
+         out << "   " << f1Name << "->SetNpx(" << fNpx << ");\n";
    } else {
-      out << "   TF1 *" << f1Name.Data() << " = new TF1(" << quote << "*" << GetName() << quote << "," << fXmin << "," << fXmax << "," << GetNpar() << ");" << std::endl;
-      out << "    //The original function : " << GetTitle() << " had originally been created by:" << std::endl;
-      out << "    //TF1 *" << GetName() << " = new TF1(" << quote << GetName() << quote << "," << GetTitle() << "," << fXmin << "," << fXmax << "," << GetNpar();
-      out << ", 1" << addToGlobList << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetRange(" << fXmin << "," << fXmax << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetName(" << quote << GetName() << quote << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetTitle(" << quote << GetTitle() << quote << ");" << std::endl;
-      if (fNpx != 100) {
-         out << "   " << f1Name.Data() << "->SetNpx(" << fNpx << ");" << std::endl;
-      }
+      out << "   TF1 *" << f1Name << " = new TF1(\"" << "*" << GetName() << "\", " << fXmin << "," << fXmax
+          << "," << GetNpar() << ");\n";
+      out << "    // The original function : " << GetTitle() << " had originally been created by:\n";
+      out << "    // TF1 *" << GetName() << " = new TF1(\"" << GetName() << "\", " << GetTitle() << ","
+          << fXmin << "," << fXmax << "," << GetNpar() << ", 1" << addToGlobList << ");\n";
+      out << "   " << f1Name << "->SetRange(" << fXmin << "," << fXmax << ");\n";
+      SavePrimitiveNameTitle(out, f1Name);
+      if (fNpx != 100)
+         out << "   " << f1Name << "->SetNpx(" << fNpx << ");\n";
       Double_t dx = (fXmax - fXmin) / fNpx;
       Double_t xv[1];
       Double_t *parameters = GetParameters();
       InitArgs(xv, parameters);
-      for (i = 0; i <= fNpx; i++) {
-         xv[0]    = fXmin + dx * i;
+      for (Int_t i = 0; i <= fNpx; i++) {
+         xv[0] = fXmin + dx * i;
          Double_t save = EvalPar(xv, parameters);
-         out << "   " << f1Name.Data() << "->SetSavedPoint(" << i << "," << save << ");" << std::endl;
+         out << "   " << f1Name << "->SetSavedPoint(" << i << "," << save << ");\n";
       }
-      out << "   " << f1Name.Data() << "->SetSavedPoint(" << fNpx + 1 << "," << fXmin << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetSavedPoint(" << fNpx + 2 << "," << fXmax << ");" << std::endl;
+      out << "   " << f1Name << "->SetSavedPoint(" << fNpx + 1 << "," << fXmin << ");\n";
+      out << "   " << f1Name << "->SetSavedPoint(" << fNpx + 2 << "," << fXmax << ");\n";
    }
 
-   if (TestBit(kNotDraw)) {
-      out << "   " << f1Name.Data() << "->SetBit(TF1::kNotDraw);" << std::endl;
-   }
+   if (TestBit(kNotDraw))
+      out << "   " << f1Name.Data() << "->SetBit(TF1::kNotDraw);\n";
 
-   SaveFillAttributes(out, f1Name.Data(), 0, 1001);
-   SaveMarkerAttributes(out, f1Name.Data(), 1, 1, 1);
-   SaveLineAttributes(out, f1Name.Data(), 1, 1, 4);
+   SaveFillAttributes(out, f1Name, 0, 1001);
+   SaveMarkerAttributes(out, f1Name, 1, 1, 1);
+   SaveLineAttributes(out, f1Name, 1, 1, 4);
 
    if (GetChisquare() != 0) {
-      out << "   " << f1Name.Data() << "->SetChisquare(" << GetChisquare() << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetNDF(" << GetNDF() << ");" << std::endl;
+      out << "   " << f1Name << "->SetChisquare(" << GetChisquare() << ");\n";
+      out << "   " << f1Name << "->SetNDF(" << GetNDF() << ");\n";
    }
 
-   if (GetXaxis()) GetXaxis()->SaveAttributes(out, f1Name.Data(), "->GetXaxis()");
-   if (GetYaxis()) GetYaxis()->SaveAttributes(out, f1Name.Data(), "->GetYaxis()");
+   if (GetXaxis())
+      GetXaxis()->SaveAttributes(out, f1Name, "->GetXaxis()");
+   if (GetYaxis())
+      GetYaxis()->SaveAttributes(out, f1Name, "->GetYaxis()");
 
    Double_t parmin, parmax;
-   for (i = 0; i < GetNpar(); i++) {
-      out << "   " << f1Name.Data() << "->SetParameter(" << i << "," << GetParameter(i) << ");" << std::endl;
-      out << "   " << f1Name.Data() << "->SetParError(" << i << "," << GetParError(i) << ");" << std::endl;
+   for (Int_t i = 0; i < GetNpar(); i++) {
+      out << "   " << f1Name << "->SetParameter(" << i << "," << GetParameter(i) << ");\n";
+      out << "   " << f1Name << "->SetParError(" << i << "," << GetParError(i) << ");\n";
       GetParLimits(i, parmin, parmax);
-      out << "   " << f1Name.Data() << "->SetParLimits(" << i << "," << parmin << "," << parmax << ");" << std::endl;
+      out << "   " << f1Name << "->SetParLimits(" << i << "," << parmin << "," << parmax << ");\n";
    }
-   if (!strstr(option, "nodraw"))
-      out << "   " << f1Name.Data() << "->Draw(" << quote << option << quote << ");" << std::endl;
+   if (!option || !strstr(option, "nodraw"))
+      out << "   " << f1Name << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Static function setting the current function.

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3214,8 +3214,7 @@ void TF1::Save(Double_t xmin, Double_t xmax, Double_t, Double_t, Double_t, Doubl
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Start saving function as primitive
-/// Declare variable in stream according to provided draw options
+/// Provide variable name for function for saving as primitive
 /// When TH1 or TGraph stores list of functions, it applies special coding of created variable names
 
 TString TF1::ProvideSaveName(Option_t *option)
@@ -3228,7 +3227,7 @@ TString TF1::ProvideSaveName(Option_t *option)
       sscanf(l + 1, "%d", &number);
 
    funcName += number;
-   return funcName;
+   return gInterpreter->MapCppName(funcName);
 }
 
 

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -841,44 +841,46 @@ void TF2::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
 
 void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    TString f2Name = ProvideSaveName(option);
-   out<<"   "<<std::endl;
-   out<<"   TF2 *";
-   if (!fMethodCall) {
-      out<<f2Name.Data()<<" = new TF2("<<quote<<f2Name.Data()<<quote<<","<<quote<<GetTitle()<<quote<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<");"<<std::endl;
-   } else {
-      out<<f2Name.Data()<<" = new TF2("<<quote<<f2Name.Data()<<quote<<","<<GetTitle()<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<","<<GetNpar()<<");"<<std::endl;
-   }
+   out << "   \n";
+   out << "   TF2 *";
+   if (!fMethodCall)
+      out << f2Name << " = new TF2(\"" << GetName() << "\", \"" << TString(GetTitle()).ReplaceSpecialCppChars()
+          << "\", " << fXmin << "," << fXmax << "," << fYmin << "," << fYmax << ");\n";
+   else
+      out << f2Name << " = new TF2(\"" << GetName() << "\", " << GetTitle() << ", " << fXmin << "," << fXmax << ","
+          << fYmin << "," << fYmax << "," << GetNpar() << ");\n";
 
-   SaveFillAttributes(out, f2Name.Data(), 0, 1001);
-   SaveMarkerAttributes(out, f2Name.Data(), 1, 1, 1);
-   SaveLineAttributes(out, f2Name.Data(), 1, 1, 4);
+   SaveFillAttributes(out, f2Name, 0, 1001);
+   SaveMarkerAttributes(out, f2Name, 1, 1, 1);
+   SaveLineAttributes(out, f2Name, 1, 1, 4);
 
    if (GetNpx() != 30)
-      out<<"   "<<f2Name.Data()<<"->SetNpx("<<GetNpx()<<");"<<std::endl;
+      out << "   " << f2Name << "->SetNpx(" << GetNpx() << ");\n";
    if (GetNpy() != 30)
-      out<<"   "<<f2Name.Data()<<"->SetNpy("<<GetNpy()<<");"<<std::endl;
+      out << "   " << f2Name << "->SetNpy(" << GetNpy() << ");\n";
 
    if (GetChisquare() != 0)
-      out<<"   "<<f2Name.Data()<<"->SetChisquare("<<GetChisquare()<<");"<<std::endl;
+      out << "   " << f2Name << "->SetChisquare(" << GetChisquare() << ");\n";
 
    Double_t parmin, parmax;
-   for (Int_t i=0;i<GetNpar();i++) {
-      out<<"   "<<f2Name.Data()<<"->SetParameter("<<i<<","<<GetParameter(i)<<");"<<std::endl;
-      out<<"   "<<f2Name.Data()<<"->SetParError("<<i<<","<<GetParError(i)<<");"<<std::endl;
-      GetParLimits(i,parmin,parmax);
-      out<<"   "<<f2Name.Data()<<"->SetParLimits("<<i<<","<<parmin<<","<<parmax<<");"<<std::endl;
+   for (Int_t i = 0; i < GetNpar(); i++) {
+      out << "   " << f2Name << "->SetParameter(" << i << "," << GetParameter(i) << ");\n";
+      out << "   " << f2Name << "->SetParError(" << i << "," << GetParError(i) << ");\n";
+      GetParLimits(i, parmin, parmax);
+      out << "   " << f2Name << "->SetParLimits(" << i << "," << parmin << "," << parmax << ");\n";
    }
-   if (!strstr(option, "nodraw"))
-      out<<"   "<<f2Name.Data()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
 
-   if (GetXaxis()) GetXaxis()->SaveAttributes(out, f2Name.Data(), "->GetXaxis()");
-   if (GetYaxis()) GetYaxis()->SaveAttributes(out, f2Name.Data(), "->GetYaxis()");
-   if (GetZaxis()) GetZaxis()->SaveAttributes(out, f2Name.Data(), "->GetZaxis()");
+   if (GetXaxis())
+      GetXaxis()->SaveAttributes(out, f2Name, "->GetXaxis()");
+   if (GetYaxis())
+      GetYaxis()->SaveAttributes(out, f2Name, "->GetYaxis()");
+   if (GetZaxis())
+      GetZaxis()->SaveAttributes(out, f2Name, "->GetZaxis()");
+
+   if (!option || !strstr(option, "nodraw"))
+      out << "   " << f2Name << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the number and values of contour levels

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -842,13 +842,9 @@ void TF2::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
 void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
-   TString f2Name(GetName());
+   TString f2Name = ProvideSaveName(option);
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TF2::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   TF2 *";
-   }
+   out<<"   TF2 *";
    if (!fMethodCall) {
       out<<f2Name.Data()<<" = new TF2("<<quote<<f2Name.Data()<<quote<<","<<quote<<GetTitle()<<quote<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<");"<<std::endl;
    } else {
@@ -874,7 +870,8 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       GetParLimits(i,parmin,parmax);
       out<<"   "<<f2Name.Data()<<"->SetParLimits("<<i<<","<<parmin<<","<<parmax<<");"<<std::endl;
    }
-   out<<"   "<<f2Name.Data()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
+   if (!strstr(option, "nodraw"))
+      out<<"   "<<f2Name.Data()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
 
    if (GetXaxis()) GetXaxis()->SaveAttributes(out, f2Name.Data(), "->GetXaxis()");
    if (GetYaxis()) GetYaxis()->SaveAttributes(out, f2Name.Data(), "->GetYaxis()");

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -607,45 +607,48 @@ void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
 
 void TF3::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    TString f3Name = ProvideSaveName(option);
-   out<<"   "<<std::endl;
-   out<<"   TF3 *";
+   out << "   \n";
+   out << "   TF3 *";
 
-   if (!fMethodCall) {
-      out<<f3Name.Data()<<" = new TF3("<<quote<<f3Name.Data()<<quote<<","<<quote<<GetTitle()<<quote<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<","<<fZmin<<","<<fZmax<<");"<<std::endl;
-   } else {
-      out<<f3Name.Data()<<" = new TF3("<<quote<<f3Name.Data()<<quote<<","<<GetTitle()<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<","<<fZmin<<","<<fZmax<<","<<GetNpar()<<");"<<std::endl;
-   }
+   if (!fMethodCall)
+      out << f3Name << " = new TF3(\"" << GetName() << "\", \"" << TString(GetTitle()).ReplaceSpecialCppChars() << "\","
+          << fXmin << "," << fXmax << "," << fYmin << "," << fYmax << "," << fZmin << "," << fZmax << ");\n";
+   else
+      out << f3Name << " = new TF3(\"" << GetName() << "\", " << GetTitle() << "," << fXmin << "," << fXmax << ","
+          << fYmin << "," << fYmax << "," << fZmin << "," << fZmax << "," << GetNpar() << ");\n";
 
-   SaveFillAttributes(out, f3Name.Data(), 0, 1001);
-   SaveMarkerAttributes(out, f3Name.Data(), 1, 1, 1);
-   SaveLineAttributes(out, f3Name.Data(), 1, 1, 4);
+   SaveFillAttributes(out, f3Name, 0, 1001);
+   SaveMarkerAttributes(out, f3Name, 1, 1, 1);
+   SaveLineAttributes(out, f3Name, 1, 1, 4);
 
    if (GetNpx() != 30)
-      out<<"   "<<f3Name.Data()<<"->SetNpx("<<GetNpx()<<");"<<std::endl;
+      out << "   " << f3Name << "->SetNpx(" << GetNpx() << ");\n";
    if (GetNpy() != 30)
-      out<<"   "<<f3Name.Data()<<"->SetNpy("<<GetNpy()<<");"<<std::endl;
+      out << "   " << f3Name << "->SetNpy(" << GetNpy() << ");\n";
    if (GetNpz() != 30)
-      out<<"   "<<f3Name.Data()<<"->SetNpz("<<GetNpz()<<");"<<std::endl;
+      out << "   " << f3Name << "->SetNpz(" << GetNpz() << ");\n";
 
    if (GetChisquare() != 0)
-      out<<"   "<<f3Name.Data()<<"->SetChisquare("<<GetChisquare()<<");"<<std::endl;
+      out << "   " << f3Name << "->SetChisquare(" << GetChisquare() << ");\n";
 
    Double_t parmin, parmax;
-   for (Int_t i=0;i<GetNpar();i++) {
-      out<<"   "<<f3Name.Data()<<"->SetParameter("<<i<<","<<GetParameter(i)<<");"<<std::endl;
-      out<<"   "<<f3Name.Data()<<"->SetParError("<<i<<","<<GetParError(i)<<");"<<std::endl;
-      GetParLimits(i,parmin,parmax);
-      out<<"   "<<f3Name.Data()<<"->SetParLimits("<<i<<","<<parmin<<","<<parmax<<");"<<std::endl;
+   for (Int_t i = 0; i < GetNpar(); i++) {
+      out << "   " << f3Name << "->SetParameter(" << i << "," << GetParameter(i) << ");\n";
+      out << "   " << f3Name << "->SetParError(" << i << "," << GetParError(i) << ");\n";
+      GetParLimits(i, parmin, parmax);
+      out << "   " << f3Name << "->SetParLimits(" << i << "," << parmin << "," << parmax << ");\n";
    }
 
-   if (GetXaxis()) GetXaxis()->SaveAttributes(out, f3Name.Data(), "->GetXaxis()");
-   if (GetYaxis()) GetYaxis()->SaveAttributes(out, f3Name.Data(), "->GetYaxis()");
-   if (GetZaxis()) GetZaxis()->SaveAttributes(out, f3Name.Data(), "->GetZaxis()");
+   if (GetXaxis())
+      GetXaxis()->SaveAttributes(out, f3Name, "->GetXaxis()");
+   if (GetYaxis())
+      GetYaxis()->SaveAttributes(out, f3Name, "->GetYaxis()");
+   if (GetZaxis())
+      GetZaxis()->SaveAttributes(out, f3Name, "->GetZaxis()");
 
-   if (!strstr(option, "nodraw"))
-      out<<"   "<<f3Name.Data()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
+   if (!option || !strstr(option, "nodraw"))
+      out << "   " << f3Name << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -608,13 +608,10 @@ void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
 void TF3::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
-   TString f3Name(GetName());
+   TString f3Name = ProvideSaveName(option);
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TF3::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   TF3 *";
-   }
+   out<<"   TF3 *";
+
    if (!fMethodCall) {
       out<<f3Name.Data()<<" = new TF3("<<quote<<f3Name.Data()<<quote<<","<<quote<<GetTitle()<<quote<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<","<<fZmin<<","<<fZmax<<");"<<std::endl;
    } else {
@@ -647,8 +644,8 @@ void TF3::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (GetYaxis()) GetYaxis()->SaveAttributes(out, f3Name.Data(), "->GetYaxis()");
    if (GetZaxis()) GetZaxis()->SaveAttributes(out, f3Name.Data(), "->GetZaxis()");
 
-   out<<"   "<<f3Name.Data()<<"->Draw("
-      <<quote<<option<<quote<<");"<<std::endl;
+   if (!strstr(option, "nodraw"))
+      out<<"   "<<f3Name.Data()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2194,7 +2194,8 @@ void TGraph::SaveHistogramAndFunctions(std::ostream &out, const char *varname, O
       out << "   " << l + 7 << "->AddBin(" << varname << ");\n";
       return;
    }
-   out << "   " << varname << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
+   if (!option || !strstr(option, "nodraw"))
+      out << "   " << varname << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2173,30 +2173,29 @@ void TGraph::SaveHistogramAndFunctions(std::ostream &out, const char *varname, O
 
    if (fHistogram) {
       TString hname = fHistogram->GetName();
-      fHistogram->SetName(TString::Format("Graph_%s%d", hname.Data(), ++frameNumber).Data());
+      fHistogram->SetName(TString::Format("Graph_histogram%d", ++frameNumber).Data());
       fHistogram->SavePrimitive(out, "nodraw");
-      out << "   " <<varname << "->SetHistogram(" << gInterpreter->MapCppName(fHistogram->GetName()) << ");"
-          << std::endl;
-      out << "   " << std::endl;
+      out << "   " <<varname << "->SetHistogram(" << fHistogram->GetName() << ");\n";
+      out << "   \n";
       fHistogram->SetName(hname.Data());
    }
 
    TH1::SavePrimitiveFunctions(out, varname, fFunctions);
 
-   const char *soption = option ? option : "";
-   const char *l = strstr(soption, "multigraph");
+   if (!option)
+      option = "";
+   const char *l = strstr(option, "multigraph");
    if (l) {
-      out << "   multigraph->Add("<<varname<<",\"" << l + 10 << "\");" << std::endl;
+      out << "   multigraph->Add(" << varname << ",\"" << l + 10 << "\");\n";
       return;
    }
-   l = strstr(soption, "th2poly");
+   l = strstr(option, "th2poly");
    if (l) {
-      out << "   " << l + 7 << "->AddBin("<<varname<<");" << std::endl;
+      out << "   " << l + 7 << "->AddBin(" << varname << ");\n";
       return;
    }
-   out << "   "<<varname<<"->Draw(\"" << soption << "\");" << std::endl;
+   out << "   " << varname << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiply the values of a TGraph by a constant c1.

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2181,21 +2181,7 @@ void TGraph::SaveHistogramAndFunctions(std::ostream &out, const char *varname, O
       fHistogram->SetName(hname.Data());
    }
 
-   // save list of functions
-   TIter next(fFunctions);
-   while (auto obj = next()) {
-      obj->SavePrimitive(out, TString::Format("nodraw #%d\n", ++frameNumber).Data());
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   "<<varname<<"->GetListOfFunctions()->Add(ptstats);" << std::endl;
-         out << "   ptstats->SetParent("<<varname<<"->GetListOfFunctions());" << std::endl;
-      } else {
-         auto objname = TString::Format("%s%d", obj->GetName(), frameNumber);
-         if (obj->InheritsFrom("TF1")) {
-            out << "   " << objname << "->SetParent("<<varname<<");\n";
-         }
-         out << "   "<<varname<<"->GetListOfFunctions()->Add(" << objname << ");" << std::endl;
-      }
-   }
+   TH1::SavePrimitiveFunctions(out, varname, fFunctions);
 
    const char *soption = option ? option : "";
    const char *l = strstr(soption, "multigraph");

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1501,19 +1501,7 @@ void TGraph2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "   graph2d->SetPoint(" << i << "," << fX[i] << "," << fY[i] << "," << fZ[i] << ");" << std::endl;
    }
 
-   // save list of functions
-   TIter next(fFunctions);
-   TObject *obj;
-   while ((obj = next())) {
-      obj->SavePrimitive(out, "nodraw");
-      out << "   graph2d->GetListOfFunctions()->Add(" << obj->GetName() << ");" << std::endl;
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   ptstats->SetParent(graph2d->GetListOfFunctions());" << std::endl;
-      } else if (obj->InheritsFrom("TF1")) {
-         out << "   " << obj->GetName()  << "->SetParent(graph);\n";
-      }
-
-   }
+   TH1::SavePrimitiveFunctions(out, "graph2d", fFunctions);
 
    out << "   graph2d->Draw(" << quote << option << quote << ");" << std::endl;
 }

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1421,6 +1421,19 @@ TH1 *TGraph2D::Project(Option_t *option) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Recursively remove object from the list of functions
+
+void TGraph2D::RecursiveRemove(TObject *obj)
+{
+   if (fFunctions) {
+      if (!fFunctions->TestBit(kInvalidObject))
+         fFunctions->RecursiveRemove(obj);
+   }
+   if (fHistogram == obj)
+      fHistogram = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Deletes point number ipoint
 
 Int_t TGraph2D::RemovePoint(Int_t ipoint)

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1474,36 +1474,32 @@ Int_t TGraph2D::RemovePoint(Int_t ipoint)
 
 void TGraph2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out << "   " << std::endl;
-   if (gROOT->ClassSaved(TGraph2D::Class())) {
-      out << "   ";
-   } else {
-      out << "   TGraph2D *";
-   }
+   TString arrx = SavePrimitiveArray(out, "graph2d_x", fNpoints, fX, kTRUE);
+   TString arry = SavePrimitiveArray(out, "graph2d_y", fNpoints, fY);
+   TString arrz = SavePrimitiveArray(out, "graph2d_z", fNpoints, fZ);
 
-   out << "graph2d = new TGraph2D(" << fNpoints << ");" << std::endl;
-   out << "   graph2d->SetName(" << quote << GetName() << quote << ");" << std::endl;
-   out << "   graph2d->SetTitle(" << quote << GetTitle()             << ";"
-                                           << GetXaxis()->GetTitle() << ";"
-                                           << GetYaxis()->GetTitle() << ";"
-                                           << GetZaxis()->GetTitle() << quote << ");" << std::endl;
+   SavePrimitiveConstructor(out, Class(), "graph2d",
+                            TString::Format("%d, %s, %s, %s", fNpoints, arrx.Data(), arry.Data(), arrz.Data()), kFALSE);
 
-   if (fDirectory == nullptr) {
-      out << "   graph2d->SetDirectory(0);" << std::endl;
-   }
+   out << "   graph2d->SetName(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");" << std::endl;
+
+   TString title = fTitle;
+   if (fHistogram)
+      title = TString(fHistogram->GetTitle()) + ";" + fHistogram->GetXaxis()->GetTitle() + ";" +
+              fHistogram->GetYaxis()->GetTitle() + ";" + fHistogram->GetZaxis()->GetTitle();
+
+   out << "   graph2d->SetTitle(\"" << title.ReplaceSpecialCppChars() << "\");\n";
+
+   if (!fDirectory)
+      out << "   graph2d->SetDirectory(nullptr);\n";
 
    SaveFillAttributes(out, "graph2d", 0, 1001);
    SaveLineAttributes(out, "graph2d", 1, 1, 1);
    SaveMarkerAttributes(out, "graph2d", 1, 1, 1);
 
-   for (Int_t i = 0; i < fNpoints; i++) {
-      out << "   graph2d->SetPoint(" << i << "," << fX[i] << "," << fY[i] << "," << fZ[i] << ");" << std::endl;
-   }
-
    TH1::SavePrimitiveFunctions(out, "graph2d", fFunctions);
 
-   out << "   graph2d->Draw(" << quote << option << quote << ");" << std::endl;
+   out << "   graph2d->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1481,7 +1481,7 @@ void TGraph2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    SavePrimitiveConstructor(out, Class(), "graph2d",
                             TString::Format("%d, %s, %s, %s", fNpoints, arrx.Data(), arry.Data(), arrz.Data()), kFALSE);
 
-   out << "   graph2d->SetName(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");" << std::endl;
+   out << "   graph2d->SetName(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");\n";
 
    TString title = fTitle;
    if (fHistogram)
@@ -1499,7 +1499,8 @@ void TGraph2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    TH1::SavePrimitiveFunctions(out, "graph2d", fFunctions);
 
-   out << "   graph2d->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
+   if (!option || !strstr(option, "nodraw"))
+      out << "   graph2d->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -1736,12 +1736,11 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
    }
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      out << "   tgme->SetPoint(" << i << ", " << fX[i] << ", " << fY[i] << ");" << std::endl;
-      out << "   tgme->SetPointEX(" << i << ", " << fExL[i] << ", " << fExH[i] << ");" << std::endl;
+      out << "   tgme->SetPoint(" << i << ", " << fX[i] << ", " << fY[i] << ");\n";
+      out << "   tgme->SetPointEX(" << i << ", " << fExL[i] << ", " << fExH[i] << ");\n";
 
       for (Int_t j = 0; j < fNYErrors; j++)
-         out << "   tgme->SetPointEY(" << i << ", " << j << ", " << fEyL[j][i] << ", " << fEyH[j][i] << ");"
-             << std::endl;
+         out << "   tgme->SetPointEY(" << i << ", " << j << ", " << fEyL[j][i] << ", " << fEyH[j][i] << ");\n";
    }
 
    SaveHistogramAndFunctions(out, "tgme", option);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7459,6 +7459,7 @@ void TH1::SavePrimitiveFunctions(std::ostream &out, const char *varname, TList *
       Bool_t withopt = kTRUE;
       if (obj->InheritsFrom(TF1::Class())) {
          objvarname += funcNumber;
+         objvarname = gInterpreter->MapCppName(objvarname);
          out << "   " << objvarname << "->SetParent(" << varname << ");\n";
       } else if (obj->InheritsFrom("TPaveStats")) {
          objvarname = "ptstats";

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7368,65 +7368,52 @@ void TH1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   if (TMath::Abs(GetBarOffset()) > 1e-5) {
-      out<<"   "<<hname<<"->SetBarOffset("<<GetBarOffset()<<");"<<std::endl;
-   }
-   if (TMath::Abs(GetBarWidth()-1) > 1e-5) {
-      out<<"   "<<hname<<"->SetBarWidth("<<GetBarWidth()<<");"<<std::endl;
-   }
-   if (fMinimum != -1111) {
-      out<<"   "<<hname<<"->SetMinimum("<<fMinimum<<");"<<std::endl;
-   }
-   if (fMaximum != -1111) {
-      out<<"   "<<hname<<"->SetMaximum("<<fMaximum<<");"<<std::endl;
-   }
-   if (fNormFactor != 0) {
-      out<<"   "<<hname<<"->SetNormFactor("<<fNormFactor<<");"<<std::endl;
-   }
-   if (fEntries != 0) {
-      out<<"   "<<hname<<"->SetEntries("<<fEntries<<");"<<std::endl;
-   }
-   if (!fDirectory) {
-      out<<"   "<<hname<<"->SetDirectory(nullptr);"<<std::endl;
-   }
-   if (TestBit(kNoStats)) {
-      out<<"   "<<hname<<"->SetStats(0);"<<std::endl;
-   }
-   if (fOption.Length() != 0) {
-      out<<"   "<<hname<<"->SetOption("<<quote<<fOption.Data()<<quote<<");"<<std::endl;
-   }
+   if (TMath::Abs(GetBarOffset()) > 1e-5)
+      out << "   " << hname << "->SetBarOffset(" << GetBarOffset() << ");\n";
+   if (TMath::Abs(GetBarWidth() - 1) > 1e-5)
+      out << "   " << hname << "->SetBarWidth(" << GetBarWidth() << ");\n";
+   if (fMinimum != -1111)
+      out << "   " << hname << "->SetMinimum(" << fMinimum << ");\n";
+   if (fMaximum != -1111)
+      out << "   " << hname << "->SetMaximum(" << fMaximum << ");\n";
+   if (fNormFactor != 0)
+      out << "   " << hname << "->SetNormFactor(" << fNormFactor << ");\n";
+   if (fEntries != 0)
+      out << "   " << hname << "->SetEntries(" << fEntries << ");\n";
+   if (!fDirectory)
+      out << "   " << hname << "->SetDirectory(nullptr);\n";
+   if (TestBit(kNoStats))
+      out << "   " << hname << "->SetStats(0);\n";
+   if (fOption.Length() != 0)
+      out << "   " << hname << "->SetOption(\n" << TString(fOption).ReplaceSpecialCppChars() << "\");\n";
 
    // save contour levels
    Int_t ncontours = GetContour();
    if (ncontours > 0) {
-      out<<"   "<<hname<<"->SetContour("<<ncontours<<");"<<std::endl;
+      out << "   " << hname << "->SetContour(" << ncontours << ");\n";
       Double_t zlevel;
-      for (Int_t bin=0;bin<ncontours;bin++) {
+      for (Int_t bin = 0; bin < ncontours; bin++) {
          if (gPad->GetLogz()) {
-            zlevel = TMath::Power(10,GetContourLevel(bin));
+            zlevel = TMath::Power(10, GetContourLevel(bin));
          } else {
             zlevel = GetContourLevel(bin);
          }
-         out<<"   "<<hname<<"->SetContourLevel("<<bin<<","<<zlevel<<");"<<std::endl;
+         out << "   " << hname << "->SetContourLevel(" << bin << "," << zlevel << ");\n";
       }
    }
 
    SavePrimitiveFunctions(out, hname, fFunctions);
 
    // save attributes
-   SaveFillAttributes(out,hname,0,1001);
-   SaveLineAttributes(out,hname,1,1,1);
-   SaveMarkerAttributes(out,hname,1,1,1);
-   fXaxis.SaveAttributes(out,hname,"->GetXaxis()");
-   fYaxis.SaveAttributes(out,hname,"->GetYaxis()");
-   fZaxis.SaveAttributes(out,hname,"->GetZaxis()");
-   TString opt = option;
-   opt.ToLower();
-   if (!opt.Contains("nodraw")) {
-      out<<"   "<<hname<<"->Draw("
-         <<quote<<option<<quote<<");"<<std::endl;
-   }
+   SaveFillAttributes(out, hname, 0, 1001);
+   SaveLineAttributes(out, hname, 1, 1, 1);
+   SaveMarkerAttributes(out, hname, 1, 1, 1);
+   fXaxis.SaveAttributes(out, hname, "->GetXaxis()");
+   fYaxis.SaveAttributes(out, hname, "->GetYaxis()");
+   fZaxis.SaveAttributes(out, hname, "->GetZaxis()");
+
+   if (!option || !strstr(option, "nodraw"))
+      out << "   " << hname << "->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH1K.cxx
+++ b/hist/hist/src/TH1K.cxx
@@ -146,58 +146,29 @@ void   TH1K::Reset(Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Save primitive as a C++ statement(s) on output stream out
 /// Note the following restrictions in the code generated:
-///  - variable bin size not implemented
-///  - Objects in list of functions not saved (fits)
-///  - Contours not saved
+///  - variable bin size not implemented, not supported by TH1K
 
 void TH1K::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   out<<"   "<<"TH1 *";
+   TString hname = ProvideSaveName(option);
 
-   out<<GetName()<<" = new "<<ClassName()<<"("<<quote<<GetName()<<quote<<","<<quote<<GetTitle()<<quote
-                 <<","<<GetXaxis()->GetNbins()
-                 <<","<<GetXaxis()->GetXmin()
-                 <<","<<GetXaxis()->GetXmax()
-                 <<","<<fKOrd;
-   out <<");"<<std::endl;
-
-   if (fDirectory == nullptr) {
-      out<<"   "<<GetName()<<"->SetDirectory(0);"<<std::endl;
-   }
-   if (TestBit(kNoStats)) {
-      out<<"   "<<GetName()<<"->SetStats(0);"<<std::endl;
-   }
-   if (fOption.Length() != 0) {
-      out<<"   "<<GetName()<<"->SetOption("<<quote<<fOption.Data()<<quote<<");"<<std::endl;
-   }
+   out << "   \n";
+   out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << GetName() << "\", \""
+       << TString(GetTitle()).ReplaceSpecialCppChars() << "\"," << GetXaxis()->GetNbins() << ","
+       << GetXaxis()->GetXmin() << "," << GetXaxis()->GetXmax() << "," << fKOrd << ");\n";
 
    if (fNIn) {
-      out<<"   Float_t Arr[]={"<<std::endl;
-      for (int i=0; i<fNIn; i++) {
-         out<< fArray[i];
-         if (i != fNIn-1) {out<< ",";} else { out<< "};";}
-         if (i%10 == 9)   {out<< std::endl;}
-      }
-      out<< std::endl;
-      out<<"   for(int i=0;i<" << fNIn << ";i++)"<<GetName()<<"->Fill(Arr[i]);";
-      out<< std::endl;
-   }
-   SaveFillAttributes(out,GetName(),0,1001);
-   SaveLineAttributes(out,GetName(),1,1,1);
-   SaveMarkerAttributes(out,GetName(),1,1,1);
-   fXaxis.SaveAttributes(out,GetName(),"->GetXaxis()");
-   fYaxis.SaveAttributes(out,GetName(),"->GetYaxis()");
-   fZaxis.SaveAttributes(out,GetName(),"->GetZaxis()");
-   TString opt = option;
-   opt.ToLower();
-   if (!opt.Contains("nodraw")) {
-      out<<"   "<<GetName()<<"->Draw("
-      <<quote<<option<<quote<<");"<<std::endl;
-   }
-}
+      std::vector<Double_t> content(fNIn);
+      for (int i = 0; i < fNIn; i++)
+         content[i] = fArray[i];
 
+      TString arrname = SavePrimitiveArray(out, hname, fNIn, content.data());
+      out << "   for(Int_t i = 0; i < " << fNIn << "; i++)\n";
+      out << "      " << hname << "->Fill(" << arrname << "[i]);\n";
+   }
+
+   TH1::SavePrimitiveHelp(out, hname, option);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compare.

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -1319,46 +1319,42 @@ Long64_t TH2Poly::Merge(TCollection *coll)
 
 void TH2Poly::SavePrimitive(std::ostream &out, Option_t *option)
 {
-
-   //histogram pointer has by default the histogram name.
-   //however, in case histogram has no directory, it is safer to add a
-   //incremental suffix
+   // histogram pointer has by default the histogram name.
+   // however, in case histogram has no directory, it is safer to add a
+   // incremental suffix
    TString hname = ProvideSaveName(option, kTRUE);
 
-   out <<"   \n";
+   out << "   \n";
 
-   //Construct the class initialization
+   // Construct the class initialization
    out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << fCellX << ", " << fXaxis.GetXmin() << ", "
        << fXaxis.GetXmax() << ", " << fCellY << ", " << fYaxis.GetXmin() << ", " << fYaxis.GetXmax() << ");\n";
 
    // Save Bins
-   TIter       next(fBins);
-
-   while(auto obj = next()){
-      auto th2pBin = (TH2PolyBin*) obj;
-      th2pBin->GetPolygon()->SavePrimitive(out, TString::Format("th2poly%s",hname.Data()));
+   TIter next(fBins);
+   while (auto obj = next()) {
+      auto th2pBin = (TH2PolyBin *)obj;
+      th2pBin->GetPolygon()->SavePrimitive(out, TString::Format("th2poly%s", hname.Data()));
    }
 
    // save bin contents
-   out<<"   \n";
-   Int_t bin;
-   for (bin=1;bin<=GetNumberOfBins();bin++) {
+   out << "   \n";
+   for (Int_t bin = 1; bin <= GetNumberOfBins(); bin++) {
       Double_t bc = GetBinContent(bin);
-      if (bc) {
-         out<<"   "<<hname<<"->SetBinContent("<<bin<<","<<bc<<");\n";
-      }
+      if (bc)
+         out << "   " << hname << "->SetBinContent(" << bin << "," << bc << ");\n";
    }
 
    // save bin errors
    if (fSumw2.fN) {
-      for (bin=1;bin<=GetNumberOfBins();bin++) {
+      for (Int_t bin = 1; bin <= GetNumberOfBins(); bin++) {
          Double_t be = GetBinError(bin);
-         if (be) {
-            out<<"   "<<hname<<"->SetBinError("<<bin<<","<<be<<");\n";
-         }
+         if (be)
+            out << "   " << hname << "->SetBinError(" << bin << "," << be << ");\n";
       }
    }
+
    TH1::SavePrimitiveHelp(out, hname, option);
 }
 

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -1319,46 +1319,34 @@ Long64_t TH2Poly::Merge(TCollection *coll)
 
 void TH2Poly::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   out <<"   "<<std::endl;
-   out <<"   "<< ClassName() <<" *";
 
    //histogram pointer has by default the histogram name.
    //however, in case histogram has no directory, it is safer to add a
    //incremental suffix
-   static Int_t hcounter = 0;
-   TString histName = GetName();
-   if (!fDirectory && !histName.Contains("Graph")) {
-      hcounter++;
-      histName += "__";
-      histName += hcounter;
-   }
+   TString hname = ProvideSaveName(option, kTRUE);
 
-   TString hname = gInterpreter->MapCppName(histName.Data());
+   out <<"   \n";
 
    //Construct the class initialization
-   out << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
-       << GetTitle() << "\", " << fCellX << ", " << fXaxis.GetXmin()
-       << ", " << fXaxis.GetXmax()
-       << ", " << fCellY << ", " << fYaxis.GetXmin() << ", "
-       << fYaxis.GetXmax() << ");" << std::endl;
+   out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
+       << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << fCellX << ", " << fXaxis.GetXmin() << ", "
+       << fXaxis.GetXmax() << ", " << fCellY << ", " << fYaxis.GetXmin() << ", " << fYaxis.GetXmax() << ");\n";
 
    // Save Bins
    TIter       next(fBins);
-   TObject    *obj;
-   TH2PolyBin *th2pBin;
 
-   while((obj = next())){
-      th2pBin = (TH2PolyBin*) obj;
+   while(auto obj = next()){
+      auto th2pBin = (TH2PolyBin*) obj;
       th2pBin->GetPolygon()->SavePrimitive(out, TString::Format("th2poly%s",hname.Data()));
    }
 
    // save bin contents
-   out<<"   "<<std::endl;
+   out<<"   \n";
    Int_t bin;
    for (bin=1;bin<=GetNumberOfBins();bin++) {
       Double_t bc = GetBinContent(bin);
       if (bc) {
-         out<<"   "<<hname<<"->SetBinContent("<<bin<<","<<bc<<");"<<std::endl;
+         out<<"   "<<hname<<"->SetBinContent("<<bin<<","<<bc<<");\n";
       }
    }
 
@@ -1367,7 +1355,7 @@ void TH2Poly::SavePrimitive(std::ostream &out, Option_t *option)
       for (bin=1;bin<=GetNumberOfBins();bin++) {
          Double_t be = GetBinError(bin);
          if (be) {
-            out<<"   "<<hname<<"->SetBinError("<<bin<<","<<be<<");"<<std::endl;
+            out<<"   "<<hname<<"->SetBinError("<<bin<<","<<be<<");\n";
          }
       }
    }

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1603,24 +1603,26 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    while (auto g = iter())
       g->SavePrimitive(out, TString::Format("multigraph%s", iter.GetOption()).Data());
 
-   const char *l = strstr(option,"th2poly");
+   const char *l = strstr(option, "th2poly");
    if (l) {
-      out<<"   "<<l+7<<"->AddBin(multigraph);"<<std::endl;
+      out << "   " << l + 7 << "->AddBin(multigraph);\n";
    } else {
-      out<<"   multigraph->Draw(\"" << option << "\");"<<std::endl;
+      out << "   multigraph->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
    }
    TAxis *xaxis = GetXaxis();
    TAxis *yaxis = GetYaxis();
 
    if (xaxis) {
-     out<<"   multigraph->GetXaxis()->SetLimits("<<xaxis->GetXmin()<<", "<<xaxis->GetXmax()<<");"<<std::endl;
-     xaxis->SaveAttributes(out, "multigraph","->GetXaxis()");
+      out << "   multigraph->GetXaxis()->SetLimits(" << xaxis->GetXmin() << ", " << xaxis->GetXmax() << ");\n";
+      xaxis->SaveAttributes(out, "multigraph", "->GetXaxis()");
    }
-   if (yaxis) yaxis->SaveAttributes(out, "multigraph","->GetYaxis()");
-   if (fMinimum != -1111) out<<"   multigraph->SetMinimum("<<fMinimum<<");"<<std::endl;
-   if (fMaximum != -1111) out<<"   multigraph->SetMaximum("<<fMaximum<<");"<<std::endl;
+   if (yaxis)
+      yaxis->SaveAttributes(out, "multigraph", "->GetYaxis()");
+   if (fMinimum != -1111)
+      out << "   multigraph->SetMinimum(" << fMinimum << ");\n";
+   if (fMaximum != -1111)
+      out << "   multigraph->SetMaximum(" << fMaximum << ");\n";
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set multigraph maximum.

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -302,7 +302,6 @@ void TPolyMarker::Print(Option_t *) const
 void TPolyMarker::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    TString args;
-
    if (Size() > 0) {
       TString arrxname = SavePrimitiveArray(out, "pmarker", Size(), fX, kTRUE);
       TString arryname = SavePrimitiveArray(out, "pmarker", Size(), fY);
@@ -313,10 +312,10 @@ void TPolyMarker::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    SavePrimitiveConstructor(out, Class(), "pmarker", args, Size() == 0);
 
-   SaveMarkerAttributes(out,"pmarker",1,1,1);
+   SaveMarkerAttributes(out, "pmarker", 1, 1, 1);
 
-   if (!strstr(option, "nodraw"))
-      out<<"   pmarker->Draw(\"" << option << "\");" << std::endl;
+   if (!option || !strstr(option, "nodraw"))
+      out << "   pmarker->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -1630,43 +1630,33 @@ void TProfile::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "}; " << std::endl;
    }
 
-   char quote = '"';
-   out<<"   "<<std::endl;
-   out<<"   "<<ClassName()<<" *";
-
    //histogram pointer has by default the histogram name.
    //however, in case histogram has no directory, it is safer to add a incremental suffix
-   static Int_t hcounter = 0;
-   TString histName = gInterpreter->MapCppName(GetName());
-   if (!fDirectory) {
-      hcounter++;
-      histName += "__";
-      histName += hcounter;
-   }
-   const char *hname = histName.Data();
+   TString hname = ProvideSaveName(option, kTRUE);
 
-   out << hname << " = new " << ClassName() << "(" << quote << hname << quote << "," << quote << GetTitle() << quote
-       << "," << GetXaxis()->GetNbins();
+   out<<"   \n";
+
+   out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
+       << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins();
    if (nonEqiX)
       out << ", xAxis";
    else
-      out << "," << GetXaxis()->GetXmin()
-          << "," << GetXaxis()->GetXmax()
-          <<","<<quote<<GetErrorOption()<<quote<<");"<<std::endl;
+      out << ", " << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax() << ", \""
+          << TString(GetErrorOption()).ReplaceSpecialCppChars() << "\");\n";
 
    // save bin entries
    Int_t bin;
    for (bin=0;bin<fNcells;bin++) {
       Double_t bi = GetBinEntries(bin);
       if (bi) {
-         out<<"   "<<hname<<"->SetBinEntries("<<bin<<","<<bi<<");"<<std::endl;
+         out<<"   "<<hname<<"->SetBinEntries("<<bin<<","<<bi<<");\n";
       }
    }
    //save bin contents
    for (bin=0;bin<fNcells;bin++) {
       Double_t bc = fArray[bin];
       if (bc) {
-         out<<"   "<<hname<<"->SetBinContent("<<bin<<","<<bc<<");"<<std::endl;
+         out<<"   "<<hname<<"->SetBinContent("<<bin<<","<<bc<<");\n";
       }
    }
    // save bin errors
@@ -1674,7 +1664,7 @@ void TProfile::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       for (bin=0;bin<fNcells;bin++) {
          Double_t be = TMath::Sqrt(fSumw2.fArray[bin]);
          if (be) {
-            out<<"   "<<hname<<"->SetBinError("<<bin<<","<<be<<");"<<std::endl;
+            out<<"   "<<hname<<"->SetBinError("<<bin<<","<<be<<");\n";
          }
       }
    }

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -1848,56 +1848,98 @@ TProfile2D * TProfile2D::RebinY(Int_t ngroup,const char * newname ) {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save primitive as a C++ statement(s) on output stream out.
-///
-/// Note the following restrictions in the code generated:
-///  - variable bin size not implemented
-///  - SetErrorOption not implemented
 
 void TProfile2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out <<"   "<<std::endl;
-   out <<"   "<<ClassName()<<" *";
+   TString hname = ProvideSaveName(option, kTRUE);
 
-   out << GetName() << " = new " << ClassName() << "(" << quote
-   << GetName() << quote << "," << quote<< GetTitle() << quote
-   << "," << GetXaxis()->GetNbins();
-   out << "," << GetXaxis()->GetXmin()
-   << "," << GetXaxis()->GetXmax();
-   out << "," << GetYaxis()->GetNbins();
-   out << "," << GetYaxis()->GetXmin()
-   << "," << GetYaxis()->GetXmax();
-   out << "," << fZmin
-       << "," << fZmax;
-   out << ");" << std::endl;
+   TString sxaxis, syaxis;
 
+   out << "   \n";
 
-   // save bin entries
-   Int_t bin;
-   for (bin=0;bin<fNcells;bin++) {
-      Double_t bi = GetBinEntries(bin);
-      if (bi) {
-         out<<"   "<<GetName()<<"->SetBinEntries("<<bin<<","<<bi<<");"<<std::endl;
+   // Check if the profile has equidistant X bins or not.  If not, we
+   // create an array holding the bins.
+   if (GetXaxis()->GetXbins()->fN && GetXaxis()->GetXbins()->fArray)
+      sxaxis = SavePrimitiveArray(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
+
+   // Check if the profile has equidistant y bins or not.  If not, we
+   // create an array holding the bins.
+   if (GetYaxis()->GetXbins()->fN && GetYaxis()->GetXbins()->fArray)
+      syaxis = SavePrimitiveArray(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
+
+   out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
+       << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins() << ", ";
+   if (!sxaxis.IsNull())
+      out << sxaxis;
+   else
+      out << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax();
+
+   out << ", " << GetYaxis()->GetNbins() << ", ";
+   if (!syaxis.IsNull())
+      out << syaxis;
+   else
+      out << GetYaxis()->GetXmin() << ", " << GetYaxis()->GetXmax();
+
+   if (sxaxis.IsNull() && syaxis.IsNull())
+      out << ", " << fZmin << ", " << fZmax;
+
+   out << ", \"" << TString(GetErrorOption()).ReplaceSpecialCppChars() << "\");\n";
+
+   Bool_t save_errors = fSumw2.fN > 0;
+   Int_t numentries = 0, numcontent = 0, numerrors = 0;
+
+   std::vector<Double_t> entries(fNcells), content(fNcells), errors(save_errors ? fNcells : 0);
+   for (Int_t bin = 0; bin < fNcells; bin++) {
+      entries[bin] = GetBinEntries(bin);
+      if (entries[bin])
+         numentries++;
+      content[bin] = fArray[bin];
+      if (content[bin])
+         numcontent++;
+      if (save_errors) {
+         errors[bin] = TMath::Sqrt(fSumw2.fArray[bin]);
+         if (errors[bin])
+            numerrors++;
       }
    }
-   //save bin contents
-   for (bin=0;bin<fNcells;bin++) {
-      Double_t bc = fArray[bin];
-      if (bc) {
-         out<<"   "<<GetName()<<"->SetBinContent("<<bin<<","<<bc<<");"<<std::endl;
+
+   if ((numentries < 100) && (numcontent < 100) && (numerrors < 100)) {
+      // in case of few non-empty bins store them as before
+      for (Int_t bin = 0; bin < fNcells; bin++) {
+         if (entries[bin])
+            out << "   " << hname << "->SetBinEntries(" << bin << "," << entries[bin] << ");\n";
       }
-   }
-   // save bin errors
-   if (fSumw2.fN) {
-      for (bin=0;bin<fNcells;bin++) {
-         Double_t be = TMath::Sqrt(fSumw2.fArray[bin]);
-         if (be) {
-            out<<"   "<<GetName()<<"->SetBinError("<<bin<<","<<be<<");"<<std::endl;
+      for (Int_t bin = 0; bin < fNcells; bin++) {
+         if (content[bin])
+            out << "   " << hname << "->SetBinContent(" << bin << "," << content[bin] << ");\n";
+      }
+      if (save_errors)
+         for (Int_t bin = 0; bin < fNcells; bin++) {
+            if (errors[bin])
+               out << "   " << hname << "->SetBinError(" << bin << "," << errors[bin] << ");\n";
          }
+   } else {
+      if (numentries > 0) {
+         TString arr = SavePrimitiveArray(out, hname, fNcells, entries.data());
+         out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
+         out << "      if (" << arr << "[bin])\n";
+         out << "         " << hname << "->SetBinEntries(bin, " << arr << "[bin]);\n";
+      }
+      if (numcontent > 0) {
+         TString arr = SavePrimitiveArray(out, hname, fNcells, content.data());
+         out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
+         out << "      if (" << arr << "[bin])\n";
+         out << "         " << hname << "->SetBinContent(bin, " << arr << "[bin]);\n";
+      }
+      if (numerrors > 0) {
+         TString arr = SavePrimitiveArray(out, hname, fNcells, errors.data());
+         out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
+         out << "      if (" << arr << "[bin])\n";
+         out << "         " << hname << "->SetBinError(bin, " << arr << "[bin]);\n";
       }
    }
 
-   TH1::SavePrimitiveHelp(out, GetName(), option);
+   TH1::SavePrimitiveHelp(out, hname, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/test/test_TH1_SaveAs.cxx
+++ b/hist/hist/test/test_TH1_SaveAs.cxx
@@ -129,7 +129,7 @@ struct TestSaveAs {
       constexpr Int_t NC = 29; // lines in C file (excl. empty and commented out lines)
       Int_t idx = 0;
       TString ref[NC] = {"{",
-                         "   TH1D *h__1 = new TH1D(\"h__1\",\"h_title\",5,0,5);",
+                         "   TH1D *h__1 = new TH1D(\"h__1\", \"h_title\", 5, 0, 5);",
                          "   h__1->SetBinContent(0,5.2);",
                          "   h__1->SetBinContent(2,10.8);",
                          "   h__1->SetBinContent(3,12.3);",


### PR DESCRIPTION
1. Use common method to store list of functions for `TH1`, `TGraph`, `TGraph2D`, `TEfficiency`
2. Provide `RecursiveRemove` for TGraph2D and `TEfficiency` to properly work with list of functions
3. Use SavePrimitiveArray to store irregular axes bins, support in all classes saving with irregular bins
4. Use SavePrimitiveArray for large histogram and profile objects when more than 100 non-empty bins are detected
5. Fix storage of `TProfile3D` and `TH1K` 
6. Use `gInterpreter->MapCppName` when variable name should be derived from object name
7. Avoid usage of `quote` and `std::endl`