### PR TITLE
[Python] Reduce time before asyncronous run in JupyROOT unit test

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
@@ -101,7 +101,7 @@ class Runner(object):
     >>> r.AsyncRun("ss");time.sleep(1)
     ss
     >>> def g(msg):
-    ...    time.sleep(.5)
+    ...    time.sleep(.25)
     ...    print(msg)
     >>> r= Runner(g, p)
     >>> r.AsyncRun("Asynchronous");print("Synchronous");time.sleep(1)


### PR DESCRIPTION
Only waiting 0.25 seconds before printing "Asyncronous" should increase the probability to have this string printed by the time the main thread waits one second, which is what the unit test expects.

Hopefully avoids test failures like these:
https://github.com/root-project/root/actions/runs/13712379279/job/38351177011#step:13:22736

