### PR TITLE
[Minuit2] Add timing printouts to Minuit2 info logging

### DIFF
--- a/math/minuit2/inc/Minuit2/MinimumSeedGenerator.h
+++ b/math/minuit2/inc/Minuit2/MinimumSeedGenerator.h
@@ -19,7 +19,6 @@ class MnFcn;
 class GradientCalculator;
 class MnUserParameterState;
 class MnStrategy;
-class AnalyticalGradientCalculator;
 
 /** base class for seed generators (starting values); the seed generator
     prepares initial starting values from the input (MnUserParameterState)
@@ -27,15 +26,9 @@ class AnalyticalGradientCalculator;
  */
 
 class MinimumSeedGenerator {
-
 public:
-   virtual ~MinimumSeedGenerator() {}
-
    virtual MinimumSeed
    operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &, const MnStrategy &) const = 0;
-
-   virtual MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
-                                  const MnStrategy &) const = 0;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MnPrint.h
+++ b/math/minuit2/inc/Minuit2/MnPrint.h
@@ -12,11 +12,13 @@
 
 #include "Minuit2/MnConfig.h"
 
-#include <sstream>
-#include <utility>
 #include <cassert>
-#include <string>
+#include <chrono>
 #include <ios>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace ROOT {
 namespace Minuit2 {
@@ -140,6 +142,19 @@ public:
    {
       Log(eTrace, args...);
    }
+
+   class TimingScope {
+
+   public:
+      TimingScope(MnPrint &mnPrint, std::string const &message);
+
+      ~TimingScope();
+
+   private:
+      std::chrono::steady_clock::time_point fBegin;
+      MnPrint &fMnPrint;
+      const std::string fMessage;
+   };
 
 private:
    // low level logging

--- a/math/minuit2/inc/Minuit2/MnSeedGenerator.h
+++ b/math/minuit2/inc/Minuit2/MnSeedGenerator.h
@@ -11,6 +11,7 @@
 #define ROOT_Minuit2_MnSeedGenerator
 
 #include "Minuit2/MinimumSeedGenerator.h"
+#include "Minuit2/AnalyticalGradientCalculator.h"
 
 namespace ROOT {
 
@@ -25,8 +26,9 @@ public:
    MinimumSeed operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &,
                           const MnStrategy &) const override;
 
-   MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
-                          const MnStrategy &) const override;
+private:
+   MinimumSeed CallWithAnalyticalGradientCalculator(const MnFcn &, const AnalyticalGradientCalculator &,
+                                                    const MnUserParameterState &, const MnStrategy &) const;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/SimplexSeedGenerator.h
+++ b/math/minuit2/inc/Minuit2/SimplexSeedGenerator.h
@@ -28,9 +28,6 @@ class SimplexSeedGenerator : public MinimumSeedGenerator {
 public:
    MinimumSeed operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &,
                           const MnStrategy &) const override;
-
-   MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
-                          const MnStrategy &) const override;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/src/MnPrint.cxx
+++ b/math/minuit2/src/MnPrint.cxx
@@ -419,5 +419,64 @@ std::ostream &operator<<(std::ostream &os, const std::pair<double, double> &poin
    return os;
 }
 
+MnPrint::TimingScope::TimingScope(MnPrint &mnPrint, std::string const &message)
+   : fBegin{std::chrono::steady_clock::now()}, fMnPrint{mnPrint}, fMessage{message}
+{
+}
+
+namespace {
+
+template<class T>
+std::string printTime(T duration) {
+   std::stringstream ss;
+   // Here, nanoseconds are represented as "long int", so the maximum value
+   // corresponds to about 300 years. Nobody will wait that long for a
+   // computation to complete, so for timing measurements it's fine to cast to
+   // nanoseconds to keep things simple.
+   double ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+   bool forceSeconds = false;
+   // The largest unit that we consider for pretty-printing is days.
+   if (ns >= 24 * 360e9) {
+      auto days = std::floor(ns / (24 * 360e9));
+      ss << days << " d ";
+      ns -= days * 24 * 360e9; // subtract the days to print only the rest
+      // to avoid printouts like "1 d 4 h 23 min 324 ns", we force to print
+      // seconds if we print either days, hours, or minutes
+      forceSeconds = true;
+   }
+   if (ns >= 360e9) {
+      auto hours = std::floor(ns / 360e9);
+      ss << hours << " h ";
+      ns -= hours * 360e9;
+      forceSeconds = true;
+   }
+   if (ns >= 60e9) {
+      auto minutes = std::floor(ns / 60e9);
+      ss << minutes << " min ";
+      ns -= minutes * 60e9;
+      forceSeconds = true;
+   }
+   if (ns >= 1e9 || forceSeconds) {
+      ss << (1e-9 * ns) << " s";
+   } else if (ns >= 1e6) {
+      ss << (1e-6 * ns) << " ms";
+   } else if (ns >= 1e3) {
+      ss << (1e-3 * ns) << " μs";
+   } else {
+      ss << ns << " ns";
+   }
+   return ss.str();
+}
+
+} // namespace
+
+MnPrint::TimingScope::~TimingScope()
+{
+   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+   std::stringstream ss;
+   ss << fMessage << " " << printTime(end - fBegin);
+   fMnPrint.Info(ss.str());
+}
+
 } // namespace Minuit2
 } // namespace ROOT

--- a/math/minuit2/src/MnSeedGenerator.cxx
+++ b/math/minuit2/src/MnSeedGenerator.cxx
@@ -41,6 +41,9 @@ namespace Minuit2 {
 MinimumSeed MnSeedGenerator::
 operator()(const MnFcn &fcn, const GradientCalculator &gc, const MnUserParameterState &st, const MnStrategy &stra) const
 {
+   if(auto *agc = dynamic_cast<AnalyticalGradientCalculator const*>(&gc)) {
+      return CallWithAnalyticalGradientCalculator(fcn, *agc, st, stra);
+   }
 
    MnPrint print("MnSeedGenerator");
 
@@ -118,8 +121,9 @@ operator()(const MnFcn &fcn, const GradientCalculator &gc, const MnUserParameter
    return MinimumSeed(state, st.Trafo());
 }
 
-MinimumSeed MnSeedGenerator::operator()(const MnFcn &fcn, const AnalyticalGradientCalculator &gc,
-                                        const MnUserParameterState &st, const MnStrategy &stra) const
+MinimumSeed
+MnSeedGenerator::CallWithAnalyticalGradientCalculator(const MnFcn &fcn, const AnalyticalGradientCalculator &gc,
+                                                      const MnUserParameterState &st, const MnStrategy &stra) const
 {
    MnPrint print("MnSeedGenerator");
 

--- a/math/minuit2/src/MnSeedGenerator.cxx
+++ b/math/minuit2/src/MnSeedGenerator.cxx
@@ -56,10 +56,17 @@ operator()(const MnFcn &fcn, const GradientCalculator &gc, const MnUserParameter
    MnAlgebraicVector x(n);
    for (unsigned int i = 0; i < n; i++)
       x(i) = st.IntParameters()[i];
-   double fcnmin = fcn(x);
 
-   MinimumParameters pa(x, fcnmin);
+   // We want to time everything with function evaluations. The MnSeedGenerator
+   // with numeric gradient only does one function and one gradient evaluation
+   // by default, and we're timing it here. If the G2 is negative, we also have
+   // to run a NegativeG2LineSearch later, but this is timed separately inside
+   // the line search.
+   auto timingScope = std::make_unique<MnPrint::TimingScope>(print, "Evaluated function and gradient in");
+   MinimumParameters pa(x, fcn(x));
    FunctionGradient dgrad = gc(pa);
+   timingScope.reset();
+
    MnAlgebraicSymMatrix mat(n);
    double dcovar = 1.;
    if (st.HasCovariance()) {

--- a/math/minuit2/src/ModularFunctionMinimizer.cxx
+++ b/math/minuit2/src/ModularFunctionMinimizer.cxx
@@ -33,35 +33,23 @@ namespace Minuit2 {
 FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNBase &fcn, const MnUserParameterState &st,
                                                    const MnStrategy &strategy, unsigned int maxfcn, double toler) const
 {
+   // need MnUserFcn for difference int-ext parameters
+   MnUserFcn mfcn(fcn, st.Trafo());
+   std::unique_ptr<GradientCalculator> gc;
+
    if (!fcn.HasGradient()) {
       // minimize from a FCNBase and a MnUserparameterState - interface used by all the previous ones
       // based on FCNBase. Create in this case a NumericalGradient calculator
       // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
-
-      // need MnUserFcn for difference int-ext parameters
-      MnUserFcn mfcn(fcn, st.Trafo());
-      Numerical2PGradientCalculator gc(mfcn, st.Trafo(), strategy);
-
-      unsigned int npar = st.VariableParameters();
-      if (maxfcn == 0)
-         maxfcn = 200 + 100 * npar + 5 * npar * npar;
-      MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
-
-      return Minimize(mfcn, gc, mnseeds, strategy, maxfcn, toler);
-   }
-   // minimize from a function with gradient and a MnUserParameterState -
-   // interface based on function with gradient (external/analytical gradients)
-   // Create in this case an AnalyticalGradient calculator
-   // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
-
-   MnUserFcn mfcn(fcn, st.Trafo());
-   std::unique_ptr<AnalyticalGradientCalculator> gc;
-   if (fcn.gradParameterSpace() == GradientParameterSpace::Internal) {
-        //        std::cout << "-- ModularFunctionMinimizer::Minimize: Internal parameter space" << std::endl;
-        gc = std::unique_ptr<AnalyticalGradientCalculator>(new ExternalInternalGradientCalculator(fcn, st.Trafo()));
+      gc = std::make_unique<Numerical2PGradientCalculator>(mfcn, st.Trafo(), strategy);
+   } else if (fcn.gradParameterSpace() == GradientParameterSpace::Internal) {
+      // minimize from a function with gradient and a MnUserParameterState -
+      // interface based on function with gradient (external/analytical gradients)
+      // Create in this case an AnalyticalGradient calculator
+      // Create the minuit FCN wrapper (MnUserFcn) containing the transformation (int<->ext)
+      gc = std::make_unique<ExternalInternalGradientCalculator>(fcn, st.Trafo());
    } else {
-        //        std::cout << "-- ModularFunctionMinimizer::Minimize: External parameter space" << std::endl;
-        gc = std::make_unique<AnalyticalGradientCalculator>(fcn, st.Trafo());
+      gc = std::make_unique<AnalyticalGradientCalculator>(fcn, st.Trafo());
    }
 
    unsigned int npar = st.VariableParameters();

--- a/math/minuit2/src/NegativeG2LineSearch.cxx
+++ b/math/minuit2/src/NegativeG2LineSearch.cxx
@@ -34,6 +34,9 @@ MinimumState NegativeG2LineSearch::operator()(const MnFcn &fcn, const MinimumSta
    //
    MnPrint print("NegativeG2LineSearch");
 
+   // Print the runtime on returning from the function
+   MnPrint::TimingScope timingScope(print, "Done after");
+
    bool negG2 = HasNegativeG2(st.Gradient(), prec);
    if (!negG2)
       return st;

--- a/math/minuit2/src/SimplexSeedGenerator.cxx
+++ b/math/minuit2/src/SimplexSeedGenerator.cxx
@@ -46,13 +46,6 @@ operator()(const MnFcn &fcn, const GradientCalculator &, const MnUserParameterSt
    return MinimumSeed(state, st.Trafo());
 }
 
-MinimumSeed SimplexSeedGenerator::operator()(const MnFcn &fcn, const AnalyticalGradientCalculator &gc,
-                                             const MnUserParameterState &st, const MnStrategy &stra) const
-{
-   // base class interface
-   return (*this)(fcn, (const GradientCalculator &)(gc), st, stra);
-}
-
 } // namespace Minuit2
 
 } // namespace ROOT

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -88,13 +88,13 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    }
 
    std::vector<MinimumState> result;
-   if (StorageLevel() > 0)
-      result.reserve(10);
-   else
-      result.reserve(2);
+   result.reserve(StorageLevel() > 0 ? 10 : 2);
 
    // do actual iterations
    print.Info("Start iterating until Edm is <", edmval, "with call limit =", maxfcn);
+
+   // print time after returning
+   MnPrint::TimingScope timingScope(print, "Stop iterating after");
 
    AddResult(result, seed.State());
 


### PR DESCRIPTION
Add timing output to Minuit2.

This is a commit that was already used for months to produce benchmark results. Having this integrated will make this much easier in the future.

Also, do some general code improvements in Minuit2.

To see how the output looks like, here is the output of the basic RooFit tutorial with it:
```txt
Processing rf101_basics.C...
[#1] INFO:Fitting -- RooAbsPdf::fitTo(gauss_over_gauss_Int[x]) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- using CPU computation library compiled with -mavx2
[#1] INFO:Fitting -- RooAddition::defaultErrorLevel(nll_gauss_over_gauss_Int[x]_gaussData) Summation contains a RooNLLVar, using its error level
[#1] INFO:Minimization -- RooAbsMinimizerFcn::setOptimizeConst: activating const optimization
Minuit2Minimizer: Minimize with max-calls 1000 convergence for edm < 1 strategy 1
Info in <Minuit2>: MnSeedGenerator Computing seed using NumericalGradient calculator
Info in <Minuit2>: MnSeedGenerator Evaluated function and gradient in 1.69814 ms
Info in <Minuit2>: MnSeedGenerator Initial state: FCN =       25019.17874 Edm =      0.6681313755 NCalls =     11
Info in <Minuit2>: MnSeedGenerator Initial state
  Minimum value : 25019.17874
  Edm           : 0.6681313755
  Internal parameters:	[     0.1001674212    -0.4269993197]	
  Internal gradient  :	[     -199.0219374       198.822706]	
  Internal covariance matrix:
[[  1.8457099e-05              0]
 [              0  4.9112618e-05]]]
Info in <Minuit2>: VariableMetricBuilder Start iterating until Edm is < 0.001 with call limit = 1000
Info in <Minuit2>: VariableMetricBuilder    0 - FCN =       25019.17874 Edm =      0.6681313755 NCalls =     11
Info in <Minuit2>: VariableMetricBuilder    1 - FCN =       25018.53024 Edm =   0.0008770078528 NCalls =     16
Info in <Minuit2>: VariableMetricBuilder    2 - FCN =       25018.52941 Edm =   2.479668541e-07 NCalls =     21
Info in <Minuit2>: MnHesse Done after 1.73435 ms
Info in <Minuit2>: VariableMetricBuilder After Hessian
Info in <Minuit2>: VariableMetricBuilder    3 - FCN =       25018.52941 Edm =   2.897241488e-07 NCalls =     33
Info in <Minuit2>: VariableMetricBuilder Stop iterating after 3.23749 ms
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 25018.5294078543411
Edm   = 2.89724148791174924e-07
Nfcn  = 33
mean	  = 1.01746	 +/-  0.0300149	(limited)
sigma	  = 2.9787	 +/-  0.0219221	(limited)
Info in <Minuit2>: Minuit2Minimizer::Hesse Using max-calls 1000
Info in <Minuit2>: MnHesse Done after 1.46044 ms
Info in <Minuit2>: Minuit2Minimizer::Hesse Hesse is valid - matrix is accurate
[#1] INFO:Minimization -- RooAbsMinimizerFcn::setOptimizeConst: deactivating const optimization
RooRealVar::mean = 1.01746 +/- 0.0300144  L(-10 - 10)
RooRealVar::sigma = 2.9787 +/- 0.0219217  L(0.1 - 10)
```

Note that RooFit already has some timing option for it's minimizer wrapper (RooMinimizer), but the timing is not granular enough: it can't separately measure the time for seeding, negative-g2-line-learch, and minimizer iterations because this all happens behind a single Minuit2 API call.