### PR TITLE
[RF] Add timing printouts to RooFit likelihood creation

### DIFF
--- a/roofit/roofitcore/res/RooFitImplHelpers.h
+++ b/roofit/roofitcore/res/RooFitImplHelpers.h
@@ -15,6 +15,8 @@
 #include <RooAbsArg.h>
 #include <RooAbsReal.h>
 
+#include <chrono>
+#include <functional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -104,6 +106,21 @@ std::string makeValidVarName(std::string const &in);
 void replaceAll(std::string &inOut, std::string_view what, std::string_view with);
 
 std::string makeSliceCutString(RooArgSet const &sliceDataSet);
+
+// Similar to ROOT::Minuit2::MnPrint::TimingScope from the Minuit2
+// implementation details.
+class TimingScope {
+
+public:
+   TimingScope(std::function<void(std::string const&)> printer, std::string const &message);
+
+   ~TimingScope();
+
+private:
+   std::chrono::steady_clock::time_point fBegin;
+   std::function<void(std::string const&)> fPrinter;
+   const std::string fMessage;
+};
 
 } // namespace Detail
 } // namespace RooFit

--- a/roofit/roofitcore/src/RooFitImplHelpers.cxx
+++ b/roofit/roofitcore/src/RooFitImplHelpers.cxx
@@ -335,6 +335,65 @@ std::string makeSliceCutString(RooArgSet const &sliceDataSet)
    return cutString.str();
 }
 
+TimingScope::TimingScope(std::function<void(std::string const&)> printer, std::string const &message)
+   : fBegin{std::chrono::steady_clock::now()}, fPrinter{printer}, fMessage{message}
+{
+}
+
+namespace {
+
+template<class T>
+std::string printTime(T duration) {
+   std::stringstream ss;
+   // Here, nanoseconds are represented as "long int", so the maximum value
+   // corresponds to about 300 years. Nobody will wait that long for a
+   // computation to complete, so for timing measurements it's fine to cast to
+   // nanoseconds to keep things simple.
+   double ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+   bool forceSeconds = false;
+   // The largest unit that we consider for pretty-printing is days.
+   if (ns >= 24 * 360e9) {
+      auto days = std::floor(ns / (24 * 360e9));
+      ss << days << " d ";
+      ns -= days * 24 * 360e9; // subtract the days to print only the rest
+      // to avoid printouts like "1 d 4 h 23 min 324 ns", we force to print
+      // seconds if we print either days, hours, or minutes
+      forceSeconds = true;
+   }
+   if (ns >= 360e9) {
+      auto hours = std::floor(ns / 360e9);
+      ss << hours << " h ";
+      ns -= hours * 360e9;
+      forceSeconds = true;
+   }
+   if (ns >= 60e9) {
+      auto minutes = std::floor(ns / 60e9);
+      ss << minutes << " min ";
+      ns -= minutes * 60e9;
+      forceSeconds = true;
+   }
+   if (ns >= 1e9 || forceSeconds) {
+      ss << (1e-9 * ns) << " s";
+   } else if (ns >= 1e6) {
+      ss << (1e-6 * ns) << " ms";
+   } else if (ns >= 1e3) {
+      ss << (1e-3 * ns) << " μs";
+   } else {
+      ss << ns << " ns";
+   }
+   return ss.str();
+}
+
+} // namespace
+
+TimingScope::~TimingScope()
+{
+   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+   std::stringstream ss;
+   ss << fMessage << " " << printTime(end - fBegin);
+   fPrinter(ss.str());
+}
+
 } // namespace Detail
 } // namespace RooFit
 


### PR DESCRIPTION
This patch was already applied locally to create benchmark results for conferences, but of course it would be better to have this merged inside ROOT to get benchmark results quicker and in a more reproducible way.

## Reproducing ATLAS benchmark from ICHEP 2024

With the changes in this PR, it is finally possible to reproduce the results presented on [slide 11 in the ICHEP 2024 talk](https://indico.cern.ch/event/1291157/contributions/5889615/attachments/2900877/5087038/roofit_ichep_2024.pdf) easily.

In particular, this is very useful to validate new releases of Clad.

Below are the required scripts to do that. You can use them as follows:

  1. Create a new clean directory
  2. Create the files `analyze.py`, `fit_macro.C`, and `run.sh` with the content below
  3. Run `./run.sh`

With current ROOT master, the plot looks like this:

![plot](https://github.com/user-attachments/assets/5d4c594c-37e5-497d-8359-32684c6e6136)

Compared to the ICHEP version, more granular information has been added, splitting up the total script runtime into the relevant pieces and "other".

Also, all evaluation backends enjoyed a speed boost thanks to the improvements to Minuit 2 in the ROOT 6.36 development cycle. This means that in the current state of ROOT `master`, the jitting time unique to the `codegen` backend is not amortized by a single minimization.

Script contents:

`analyze.py`
```python
#!/usr/bin/env python

import numpy as np
import matplotlib.pyplot as plt


steps = {
    "NLL creation": "Creation of NLL object took ",
    "Funciton JIT": "Function JIT time: ",
    "Gradient generation": "Gradient generation time: ",
    "Gradient to machine code": "Gradient IR to machine code time: ",
    "Seeding step": "MnSeedGenerator Evaluated function and gradient in ",
    "NegativeG2LineSearch": "NegativeG2LineSearch Done after ",
    "Minimization": "VariableMetricBuilder Stop iterating after ",
    "Hesse": "MnHesse Done after ",
    "Total": "user	",
}


def parse_output(filename):
    """Parse output generated like
    { time ./roofitAtlasHiggsBenchmark; } &> filename
    """

    with open(filename, "r") as f:
        lines = f.read().split("\n")

    relevant_lines = {}

    def time_string_to_seconds(s):
        s = s.replace("ms", "*1e-3")
        s = s.replace("s", "")
        s = s.replace("min", "*60+")
        s = s.replace("m", "*60+")
        return float(eval(s))

    for line in lines:
        for key, val in steps.items():
            if val in line:
                time_str = line.split(val)[-1]
                relevant_lines[key] = time_string_to_seconds(time_str)

    # Replace Total with other:
    measured = 0.0
    for key, val in relevant_lines.items():
        if key != "Total":
            measured = measured + val

    # Fill irrelevant steps with zeros:
    for key in steps:
        if key not in relevant_lines:
            relevant_lines[key] = 0.0

    relevant_lines["Other"] = relevant_lines["Total"] - measured
    del relevant_lines["Total"]

    # We don't care of measuring Hesse (for now)
    del relevant_lines["Hesse"]

    return relevant_lines


backends = ["legacy", "cpu", "codegen"]


parsed = {backend: parse_output(f"output_{backend}.txt") for backend in backends}


data = {}
for key in parsed[backends[0]]:
    data[key] = np.array([parsed[backend][key] for backend in backends])


jit_color = np.array([0.06, 0.21, 0.70])


colors = {
    "NLL creation": [0.30, 0.70, 0.50],
    "Funciton JIT": (1.0 - 0.3 * (1.0 - jit_color)),
    "Gradient generation": (1.0 - 0.6 * (1.0 - jit_color)),
    "Gradient to machine code": (1.0 - (1.0 - jit_color)),
    "Seeding step": [0.70, 0.05, 0.70],
    "NegativeG2LineSearch": [0.4, 1.0, 0.3],
    "Minimization": [1.0, 0.2, 0.2],
    "Hesse": [1.0, 0.9, 0.3],
    "Other": [0.8, 0.8, 0.8],
}


width = 0.5

bottom = np.zeros(3)

fig, ax = plt.subplots(figsize=(7, 4))

for boolean, weight_count in data.items():
    p = ax.bar(backends, weight_count, width, label=boolean, bottom=bottom, facecolor=colors[boolean])
    bottom += weight_count

ax.set_title("")
ax.set_xlabel("Evaluation backend")
ax.set_ylabel("Time [s]")
ax.legend(loc="upper right", ncols=2)

ax.set_axisbelow(True)
ax.grid(color="k", linestyle=":", linewidth=1, alpha=0.5)

# plt.show()
plt.savefig("plot.png")
```

`fit_macro.sh`
```C++
#include <RooCategory.h>
#include <RooWorkspace.h>
#include <RooRealVar.h>
#include <RooRandom.h>
#include <RooSimultaneous.h>
#include <RooUniform.h>
#include <RooMinimizer.h>
#include <RooStats/ModelConfig.h>

#include <TFile.h>
#include <TRandom.h>
#include <TError.h>

void fit_macro(const char *evalBackend = "cpu")
{
   using namespace RooFit;

   std::cout << "EvalBackend: " << evalBackend << std::endl;

   gErrorIgnoreLevel = kInfo;
   RooMsgService::instance().getStream(1).removeTopic(RooFit::Minimization);
   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
   RooMsgService::instance().getStream(1).removeTopic(RooFit::Eval);

   std::string workspaceFile = "WS-VHbb-STXS_mu_toy_new.root";
   std::string workspaceName = "combined";

   std::unique_ptr<TFile> tfile{TFile::Open(workspaceFile.c_str())};
   RooWorkspace *ws = tfile->Get<RooWorkspace>(workspaceName.c_str());
   auto mc = static_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));

   RooAbsPdf *pdf = mc->GetPdf();

   RooArgSet const *globObs = mc->GetGlobalObservables();
   RooAbsData *data = ws->data("toyData");

   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(
         *data, GlobalObservables(*globObs), Offset(true), Optimize(2), EvalBackend(evalBackend))};

   double val = nll->getVal();

   std::cout << "Initial value: " << val << std::endl;

   RooMinimizer minim{*nll};
   minim.setStrategy(0);

   minim.minimize("Minuit2", "MIGRAD");
   //minim.hesse();
}
```

`run.sh`
```bash
#!/usr/bin/env bash

BASE_URL=https://root.cern/files/rootbench

wget -nc $BASE_URL/atlas-higgs-workspaces-2021/WS-VHbb-STXS_mu_toy_new.root

echo "Running fit with legacy backend"
{ time root -b -q -e ".x fit_macro.C(\"legacy\")"; } &> output_legacy.txt
echo "Running fit with cpu backend"
{ time root -b -q -e ".x fit_macro.C(\"cpu\")"; } &> output_cpu.txt
echo "Running fit with codegen backend"
{ time root -b -q -e ".x fit_macro.C(\"codegen\")"; } &> output_codegen.txt

echo "Making the plot"
python3 analyze.py
```