### PR TITLE
[skip-ci] activate back the tutorials

### DIFF
--- a/documentation/doxygen/makeinput.sh
+++ b/documentation/doxygen/makeinput.sh
@@ -71,12 +71,12 @@ echo "        ../../tmva/                      \\" >> Doxyfile_INPUT
 echo "        ../../roofit/                    \\" >> Doxyfile_INPUT
 echo "        ../../tree/                      \\" >> Doxyfile_INPUT
 echo "        ../../sql/                       \\" >> Doxyfile_INPUT
+echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
 echo "        ../../bindings/tpython/          \\" >> Doxyfile_INPUT
 echo "        ../../bindings/pyroot/           \\" >> Doxyfile_INPUT
 echo "        ../../bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py          \\" >> Doxyfile_INPUT
 echo "        ../../bindings/r/                \\" >> Doxyfile_INPUT
 
-#echo "        ../../tutorials/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/clib/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/lzma/                 \\" >> Doxyfile_INPUT
 # echo "        ../../core/newdelete/            \\" >> Doxyfile_INPUT


### PR DESCRIPTION
If the tutorials build is deactivated the script CleanNamesspaces.sh is not generated and we get an error.

