### PR TITLE
[skip-ci] Disable the execution of TMVA_RNN_Classification.C

### DIFF
--- a/tutorials/machine_learning/TMVA_RNN_Classification.C
+++ b/tutorials/machine_learning/TMVA_RNN_Classification.C
@@ -6,8 +6,6 @@
 /// This is an example of using a RNN in TMVA. We do classification using a toy time dependent data set
 /// that is generated when running this example macro
 ///
-/// \macro_image
-/// \macro_output
 /// \macro_code
 ///
 /// \author Lorenzo Moneta


### PR DESCRIPTION
When generating the doc for this tutorial it seems that from time tot time it enters an infinite loop of messages like:
```
Error in <TString::AssertElement>: out of bounds: i = 75, Length = 74
```
I was not able able to reproduce it locally. Lettsee if disabling its execution during the doc build will avoid that loop.

