### PR TITLE
[ntuple] Extend `RNTupleOpenSpec` to allow creating processors from a `TDirectory`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -39,9 +39,11 @@ struct RNTupleProcessorEntryLoader;
 /// Used to specify the underlying RNTuples in RNTupleProcessor
 struct RNTupleOpenSpec {
    std::string fNTupleName;
-   std::string fStorage;
+   std::variant<std::string, TDirectory *> fStorage;
 
-   RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(s) {}
+   RNTupleOpenSpec(std::string_view n, const std::variant<std::string, TDirectory *> &s) : fNTupleName(n), fStorage(s)
+   {
+   }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/test/ntuple_processor.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor.cxx
@@ -13,8 +13,7 @@ TEST(RNTupleProcessor, EmptyNTuple)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
 
-   RNTupleOpenSpec ntuple{"ntuple", fileGuard.GetPath()};
-   auto proc = RNTupleProcessor::Create(ntuple);
+   auto proc = RNTupleProcessor::Create({"ntuple", fileGuard.GetPath()});
 
    int nEntries = 0;
    for ([[maybe_unused]] const auto &entry : *proc) {
@@ -135,8 +134,7 @@ protected:
 
 TEST_F(RNTupleProcessorTest, Base)
 {
-   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
-   auto proc = RNTupleProcessor::Create(ntuple);
+   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
 
    int nEntries = 0;
 
@@ -155,12 +153,11 @@ TEST_F(RNTupleProcessorTest, Base)
 
 TEST_F(RNTupleProcessorTest, BaseWithModel)
 {
-   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
 
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
 
-   auto proc = RNTupleProcessor::Create(ntuple, std::move(model));
+   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, std::move(model));
 
    int nEntries = 0;
 
@@ -183,17 +180,15 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
 
 TEST_F(RNTupleProcessorTest, BaseWithBareModel)
 {
-   RNTupleOpenSpec ntuple{fNTupleNames[0], fFileNames[0]};
-
    auto model = RNTupleModel::CreateBare();
    model->MakeField<float>("x");
 
-   auto proc = RNTupleProcessor::Create(ntuple, std::move(model));
+   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, std::move(model));
 
    EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
 
    {
-      auto namedProc = RNTupleProcessor::Create(ntuple, "my_ntuple");
+      auto namedProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, "my_ntuple");
       EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
    }
 
@@ -218,11 +213,10 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
 
 TEST_F(RNTupleProcessorTest, ChainedChain)
 {
-   std::vector<RNTupleOpenSpec> ntuples{{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}};
-
    std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
-   innerProcs.push_back(RNTupleProcessor::CreateChain(ntuples));
-   innerProcs.push_back(RNTupleProcessor::Create(ntuples[0]));
+   innerProcs.push_back(
+      RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}}));
+   innerProcs.push_back(RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}));
 
    auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
 

--- a/tree/ntuple/v7/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_chain.cxx
@@ -73,9 +73,8 @@ protected:
 
 TEST(RNTupleChainProcessor, EmptySpec)
 {
-   std::vector<RNTupleOpenSpec> ntuples;
    try {
-      auto proc = RNTupleProcessor::CreateChain(ntuples);
+      auto proc = RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec>{});
       FAIL() << "creating a processor without at least one RNTuple should throw";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("at least one RNTuple must be provided"));
@@ -84,10 +83,8 @@ TEST(RNTupleChainProcessor, EmptySpec)
 
 TEST_F(RNTupleChainProcessorTest, SingleNTuple)
 {
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}};
-
    int nEntries = 0;
-   auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}});
    for (const auto &entry : *proc) {
       EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
       EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
@@ -101,15 +98,14 @@ TEST_F(RNTupleChainProcessorTest, SingleNTuple)
 
 TEST_F(RNTupleChainProcessorTest, Basic)
 {
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}};
-
    std::uint64_t nEntries = 0;
-   auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}});
 
    EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
 
    {
-      auto namedProc = RNTupleProcessor::CreateChain(ntuples, "my_ntuple");
+      auto namedProc =
+         RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, "my_ntuple");
       EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
    }
 
@@ -133,9 +129,8 @@ TEST_F(RNTupleChainProcessorTest, WithModel)
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
 
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}};
-
-   auto proc = RNTupleProcessor::CreateChain(ntuples, std::move(model));
+   auto proc =
+      RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, std::move(model));
    for (const auto &entry : *proc) {
       auto x = entry.GetPtr<float>("x");
       EXPECT_EQ(static_cast<float>(proc->GetNEntriesProcessed() - 1), *x);
@@ -154,9 +149,8 @@ TEST_F(RNTupleChainProcessorTest, WithBareModel)
    auto model = RNTupleModel::CreateBare();
    auto fldY = model->MakeField<std::vector<float>>("y");
 
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}};
-
-   auto proc = RNTupleProcessor::CreateChain(ntuples, std::move(model));
+   auto proc =
+      RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, std::move(model));
    for (const auto &entry : *proc) {
       auto y = entry.GetPtr<std::vector<float>>("y");
       std::vector<float> yExp = {static_cast<float>(proc->GetNEntriesProcessed() - 1),
@@ -174,9 +168,7 @@ TEST_F(RNTupleChainProcessorTest, WithBareModel)
 
 TEST_F(RNTupleChainProcessorTest, MissingFields)
 {
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[2]}};
-
-   auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[2]}});
    auto entry = proc->begin();
 
    while (proc->GetNEntriesProcessed() < 5) {
@@ -208,12 +200,10 @@ TEST_F(RNTupleChainProcessorTest, EmptyNTuples)
    std::uint64_t nEntries = 0;
 
    // Empty ntuples are skipped (as long as their model complies)
-   ntuples = {{fNTupleName, fileGuard.GetPath()},
-              {fNTupleName, fFileNames[0]},
-              {fNTupleName, fileGuard.GetPath()},
-              {fNTupleName, fFileNames[1]}};
-
-   auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fileGuard.GetPath()},
+                                              {fNTupleName, fFileNames[0]},
+                                              {fNTupleName, fileGuard.GetPath()},
+                                              {fNTupleName, fFileNames[1]}});
 
    for (const auto &entry : *proc) {
       auto x = entry.GetPtr<float>("x");
@@ -237,9 +227,7 @@ TEST_F(RNTupleChainProcessorTest, LoadRandomEntry)
 {
    using ROOT::Experimental::Internal::RNTupleProcessorEntryLoader;
 
-   std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}};
-
-   auto proc = RNTupleProcessor::CreateChain(ntuples);
+   auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}});
    auto x = proc->GetEntry().GetPtr<float>("x");
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 3);

--- a/tutorials/io/ntuple/ntpl012_processor_chain.C
+++ b/tutorials/io/ntuple/ntpl012_processor_chain.C
@@ -29,7 +29,7 @@ using ROOT::Experimental::RNTupleWriter;
 // Number of events to generate for each ntuple.
 constexpr int kNEvents = 10000;
 
-void Write(const RNTupleOpenSpec &ntuple)
+void Write(std::string_view ntupleName, std::string_view fileName)
 {
    auto model = RNTupleModel::Create();
 
@@ -38,7 +38,7 @@ void Write(const RNTupleOpenSpec &ntuple)
    auto fldVpz = model->MakeField<std::vector<float>>("vpz");
    auto fldN = model->MakeField<std::uint64_t>("vn");
 
-   auto writer = RNTupleWriter::Recreate(std::move(model), ntuple.fNTupleName, ntuple.fStorage);
+   auto writer = RNTupleWriter::Recreate(std::move(model), ntupleName, fileName);
 
    for (int i = 0; i < kNEvents; ++i) {
       fldVpx->clear();
@@ -81,8 +81,8 @@ void Read(const std::vector<RNTupleOpenSpec> &ntuples)
       // a new ntuple in the chain is opened for processing.
       if (static_cast<int>(processor->GetCurrentProcessorNumber()) > prevProcessorNumber) {
          prevProcessorNumber = processor->GetCurrentProcessorNumber();
-         std::cout << "Processing " << ntuples.at(prevProcessorNumber).fNTupleName << " ("
-                   << processor->GetNEntriesProcessed() << " total entries processed so far)" << std::endl;
+         std::cout << "Processing `ntuple" << prevProcessorNumber + 1 << "` (" << processor->GetNEntriesProcessed()
+                   << " total entries processed so far)" << std::endl;
       }
 
       // We can use the pointer to the field obtained while creating our model to read the field's data for the current
@@ -99,14 +99,14 @@ void Read(const std::vector<RNTupleOpenSpec> &ntuples)
 
 void ntpl012_processor_chain()
 {
+   Write("ntuple1", "ntuple1.root");
+   Write("ntuple2", "ntuple2.root");
+   Write("ntuple3", "ntuple3.root");
+
    // The ntuples to generate and subsequently process. The model of the first ntuple will be used to construct the
    // entry used by the processor.
    std::vector<RNTupleOpenSpec> ntuples = {
       {"ntuple1", "ntuple1.root"}, {"ntuple2", "ntuple2.root"}, {"ntuple3", "ntuple3.root"}};
-
-   for (const auto &ntuple : ntuples) {
-      Write(ntuple);
-   }
 
    Read(ntuples);
 }


### PR DESCRIPTION
This PR changes `RNTupleOpenSpec` to accept a `TDirectory` (or one of its descendants) instead of a plain file name, and create a `RNTupleProcessor` from there. This provides more flexibility for creating `RNTupleProcessor` objects. Among others, it enables processing RNTuples stored in subdirectories and `TMemFile`s.

One caveat is that the use of `std::variant` is not very ergonomic in Python. After discussing different solutions with @vepadulano, we concluded that the specification would/should not be used for anything beyond creating `RNTupleProcessor`s, and that public access to its data members is not strictly required. It has therefore been changed to a write-only class, and the `RNTupleProcessor` creation factory arguments have been updated accordingly.