### PR TITLE
[ntuple] Split primary and auxiliary models in  `RNTupleJoinProcessor::CreateJoin`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -337,6 +337,9 @@ public:
    const std::string &GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
 
+   /// Get the names of the fields currently present in the model, including projected fields. Registered subfields
+   /// are not included, use GetRegisteredSubfieldnames() for this.
+   const std::unordered_set<std::string> &GetFieldNames() const { return fFieldNames; }
    /// Get the (qualified) names of subfields that have been registered to be included in entries from this model.
    const std::unordered_set<std::string> &GetRegisteredSubfieldNames() const { return fRegisteredSubfields; }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -562,6 +562,22 @@ private:
    void SetModel(std::unique_ptr<RNTupleModel> primaryModel, std::vector<std::unique_ptr<RNTupleModel>> auxModels);
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect all fields, once the primary and all auxiliary RNTuples have been added.
+   void ConnectFields();
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Populate fJoinFieldTokens with tokens for join fields belonging to the main RNTuple in the join model.
+   ///
+   /// \param[in] joinFields The names of the fields used in the join.
+   void SetJoinFieldTokens(const std::vector<std::string> &joinFields)
+   {
+      fJoinFieldTokens.reserve(joinFields.size());
+      for (const auto &fieldName : joinFields) {
+         fJoinFieldTokens.emplace_back(fEntry->GetToken(fieldName));
+      }
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleJoinProcessor.
    ///
    /// \param[in] mainNTuple The source specification (name and storage location) of the primary RNTuple.
@@ -581,22 +597,6 @@ private:
                         const std::vector<std::string> &joinFields, std::string_view processorName,
                         std::unique_ptr<RNTupleModel> primaryModel = nullptr,
                         std::vector<std::unique_ptr<RNTupleModel>> auxModels = {});
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Connect all fields, once the primary and all auxiliary RNTuples have been added.
-   void ConnectFields();
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Populate fJoinFieldTokens with tokens for join fields belonging to the main RNTuple in the join model.
-   ///
-   /// \param[in] joinFields The names of the fields used in the join.
-   void SetJoinFieldTokens(const std::vector<std::string> &joinFields)
-   {
-      fJoinFieldTokens.reserve(joinFields.size());
-      for (const auto &fieldName : joinFields) {
-         fJoinFieldTokens.emplace_back(fEntry->GetToken(fieldName));
-      }
-   }
 
 public:
    RNTupleJoinProcessor(const RNTupleJoinProcessor &) = delete;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -583,15 +583,6 @@ private:
                         std::vector<std::unique_ptr<RNTupleModel>> auxModels = {});
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Add an auxiliary RNTuple to the processor.
-   ///
-   /// \param[in] auxNTuple The source specification (name and storage location) of the auxiliary RNTuple.
-   /// \param[in] joinFields The names of the fields used in the join.
-   /// \param[in] ntupleIdx The index of the ntuple according to fNTuples.
-   void
-   AddAuxiliary(const RNTupleOpenSpec &auxNTuple, const std::vector<std::string> &joinFields, std::size_t ntupleIdx);
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Connect all fields, once the primary and all auxiliary RNTuples have been added.
    void ConnectFields();
 

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -398,6 +398,13 @@ ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(const RNTupleOpen
          return fieldName.substr(0, n.fNTupleName.size()) == n.fNTupleName;
       });
 
+      // If the current field name does not begin with the name of one of the auxiliary ntuples, we are dealing with a
+      // field from the primary ntuple, so it can be added as a field context. Otherwise, if it does begin with the
+      // name, but is not equal to just the name (e.g. it is a subfield of `auxNTupleName`, which means it is a proper
+      // field in the corresponding auxiliary ntuple) we also need to add it as a field context. If it is exactly equal
+      // to an auxiliary ntuple name, it is the untyped record field containing the auxiliary fields itself. This one we
+      // don't want to add as a field context, because there is nothing to read from.
+      // TODO(fdegeus) handle the case where a primary field has the name of an auxiliary ntuple.
       if (auxNTupleName == auxNTuples.end()) {
          fFieldContexts.try_emplace(fieldName, field.Clone(field.GetFieldName()), fEntry->GetToken(fieldName));
       } else if (fieldName != auxNTupleName->fNTupleName) {

--- a/tree/ntuple/v7/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/v7/test/ntuple_processor_join.cxx
@@ -243,24 +243,21 @@ TEST_F(RNTupleJoinProcessorTest, MissingEntries)
 
 TEST_F(RNTupleJoinProcessorTest, WithModel)
 {
-   auto model1 = RNTupleModel::Create();
-   auto i = model1->MakeField<int>("i");
-   auto x = model1->MakeField<float>("x");
+   auto primaryModel = RNTupleModel::Create();
+   auto i = primaryModel->MakeField<int>("i");
+   auto x = primaryModel->MakeField<float>("x");
 
-   auto model2 = RNTupleModel::Create();
-   auto y = model2->MakeField<std::vector<float>>("y");
+   std::vector<std::unique_ptr<RNTupleModel>> auxModels;
 
-   auto model3 = RNTupleModel::Create();
-   auto z = model3->MakeField<float>("z");
+   auxModels.push_back(RNTupleModel::Create());
+   auto y = auxModels.back()->MakeField<std::vector<float>>("y");
 
-   std::vector<std::unique_ptr<RNTupleModel>> models;
-   models.push_back(std::move(model1));
-   models.push_back(std::move(model2));
-   models.push_back(std::move(model3));
+   auxModels.push_back(RNTupleModel::Create());
+   auto z = auxModels.back()->MakeField<float>("z");
 
    auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]},
                                             {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-                                            std::move(models));
+                                            std::move(primaryModel), std::move(auxModels));
 
    int nEntries = 0;
    std::vector<float> yExpected;


### PR DESCRIPTION
To reflect the interface changes introduced in #17964, instead of a single list of models (one per primary/auxiliary ntuple), a distinction is made between the models of the primary and auxiliary ntuples.

Same as before, internally they are combined into one singular model used by the processor. This model has to have the schemas of auxiliary RNTuples as untyped record fields, where the name of the record field is the name of the RNTuple.

A new addition is the added support for _partial_ model specification in the list of auxiliary models. This means that users can pass a null pointer in the position of the corresponding ntuple, and then only for that ntuple, the processor will infer the model from the on-disk descriptor.

Helps move forward #17132.
