### PR TITLE
Add GetVoidArray for access to TArrayC data through a void*

### DIFF
--- a/core/cont/inc/TArrayC.h
+++ b/core/cont/inc/TArrayC.h
@@ -42,6 +42,8 @@ public:
    void          Copy(TArrayC &array) const {array.Set(fN,fArray);}
    const Char_t *GetArray() const { return fArray; }
    Char_t       *GetArray() { return fArray; }
+   const void *GetVoidArray() const { return static_cast<const void *>(fArray); }
+   void *GetVoidArray() { return static_cast<void *>(fArray); }
    Double_t      GetAt(Int_t i) const override { return At(i); }
    Stat_t        GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void          Reset(Char_t val=0)  {memset(fArray,val,fN*sizeof(Char_t));}


### PR DESCRIPTION
# This Pull request:

## Changes:

Introduce the `GetVoidArray` methods to the `TArrayC` class, enabling an alternative way to access to the underlying data through a void*. This is particularly needed for the UHI use case of the `TH1C` class, bypassing the cppyy interpretation of `char*` as `str`.

## Checklist:

- [x] tested changes locally

