### PR TITLE
Differentiate empty bins and bins with 0 content

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -5768,7 +5768,7 @@ void THistPainter::PaintColorLevelsFast(Option_t*)
 
 void THistPainter::PaintColorLevels(Option_t*)
 {
-   Double_t z, zc, xk, xstep, yk, ystep, xlow, xup, ylow, yup;
+   Double_t z, e, zc, xk, xstep, yk, ystep, xlow, xup, ylow, yup;
 
    Double_t zmin = fH->GetMinimum();
    Double_t zmax = fH->GetMaximum();
@@ -5841,6 +5841,7 @@ void THistPainter::PaintColorLevels(Option_t*)
          xstep = fXaxis->GetBinWidth(i);
          if (!IsInside(xk+0.5*xstep,yk+0.5*ystep)) continue;
          z     = fH->GetBinContent(bin);
+         e     = fH->GetBinError(bin);
          // if fH is a profile histogram do not draw empty bins
          if (prof2d) {
             const Double_t binEntries = prof2d->GetBinEntries(bin);
@@ -5849,7 +5850,7 @@ void THistPainter::PaintColorLevels(Option_t*)
          } else {
             // don't draw the empty bins for non-profile histograms
             // with positive content
-            if (z == 0) {
+            if (z == 0 && e == 0) {
                if (zmin >= 0 || Hoption.Logz) continue;
                if (Hoption.Color == 2) continue;
             }

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -283,11 +283,12 @@ using `TH1::GetOption`:
 | "ARR"        | Arrow mode. Shows gradient between adjacent cells.|
 | "BOX"        | A box is drawn for each cell with surface proportional to the content's absolute value. A negative content is marked with a X. |
 | "BOX1"       | A button is drawn for each cell with surface proportional to content's absolute value. A sunken button is drawn for negative values a raised one for positive.|
-| "COL"        | A box is drawn for each cell with a color scale varying with contents. All the none empty bins are painted. Empty bins are not painted unless some bins have a negative content because in that case the null bins might be not empty.  `TProfile2D` histograms are handled differently because, for this type of 2D histograms, it is possible to know if an empty bin has been filled or not. So even if all the bins' contents are positive some empty bins might be painted. And vice versa, if some bins have a negative content some empty bins might be not painted (default).|
+| "COL"        | A box is drawn for each cell with a color scale varying with contents. All the none empty bins (bins with content and error equal to 0) are painted. Empty bins are not painted unless some bins have a negative content because in that case the null bins might be not empty.  `TProfile2D` histograms are handled differently because, for this type of 2D histograms, it is possible to know if an empty bin has been filled or not. So even if all the bins' contents are positive some empty bins might be painted. And vice versa, if some bins have a negative content some empty bins might be not painted (default).|
+| "COL1"       | Same as "COL" but in case of histogram with negative content the empty bins are not drawn.
 | "COLZ"       | Same as "COL". In addition the color palette is also drawn.|
 | "COL2"       | Alternative rendering algorithm to "COL". Can significantly improve rendering performance for large, non-sparse 2-D histograms.|
 | "COLZ2"      | Same as "COL2". In addition the color palette is also drawn.|
-| "Z CJUST"   | In combination with colored options "COL","CONT0" etc: Justify labels in the color palette at color boundaries. For more details see `TPaletteAxis`|
+| "Z CJUST"    | In combination with colored options "COL","CONT0" etc: Justify labels in the color palette at color boundaries. For more details see `TPaletteAxis`|
 | "CANDLE"     | Draw a candle plot along X axis.|
 | "CANDLEX"    | Same as "CANDLE".|
 | "CANDLEY"    | Draw a candle plot along Y axis.|
@@ -1050,8 +1051,8 @@ is the color change between cells.
 
 The color palette in TStyle can be modified via `gStyle->SetPalette()`.
 
-All the non-empty bins are painted. Empty bins are not painted unless
-some bins have a negative content because in that case the null bins
+All the non-empty bins are painted. Empty bins (bins with content and error equal to 0) are 
+not painted unless some bins have a negative content because in that case the null bins
 might be not empty.
 
 `TProfile2D` histograms are handled differently because, for this type of 2D


### PR DESCRIPTION
As suggested [here](https://root-forum.cern.ch/t/not-plotting-zero-bins-in-th2-with-negative-entries/19633/15) this PR differentiate empty bins and bins with zero content when using the drawing option COL. The following little taste shows how it is working.

```
void col1(){
  auto h = new TH2D ("h2","h2",10,0.5,10.5,10,0.5,10.5);
  h->Fill(1.,1.,1.);
  h->Fill(2.,2.,2.);
  h->Fill(3.,3.,3.);
  h->Fill(4.,4.,4.);
  h->Fill(5.,5.,5.);
  h->Fill(6.,6.,6.);    
  h->Fill(6.,6.,-6.);
  printf("Error for bin #%d = %g\n",6,h->GetBinError(6,6));
  h->Fill(7.,7.,-7.);
  printf("Error for bin #%d = %g\n",8,h->GetBinError(8,8));
  h->Draw("COL1 Z");
}
```