### PR TITLE
[ntuple] cast uint64_t to size_t to avoid warnings on windows 32 bit

### DIFF
--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -345,9 +345,12 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadStructureImpl()
       fCounters->fNRead.Add(2);
    } else {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallRead, fCounters->fTimeCpuRead);
-      ROOT::Internal::RRawFile::RIOVec readRequests[2] = {
-         {fStructureBuffer.fPtrHeader, fAnchor->GetSeekHeader(), fAnchor->GetNBytesHeader(), 0},
-         {fStructureBuffer.fPtrFooter, fAnchor->GetSeekFooter(), fAnchor->GetNBytesFooter(), 0}};
+      R__ASSERT(fAnchor->GetNBytesHeader() < std::numeric_limits<std::size_t>::max());
+      R__ASSERT(fAnchor->GetNBytesFooter() < std::numeric_limits<std::size_t>::max());
+      ROOT::Internal::RRawFile::RIOVec readRequests[2] = {{fStructureBuffer.fPtrHeader, fAnchor->GetSeekHeader(),
+                                                           static_cast<std::size_t>(fAnchor->GetNBytesHeader()), 0},
+                                                          {fStructureBuffer.fPtrFooter, fAnchor->GetSeekFooter(),
+                                                           static_cast<std::size_t>(fAnchor->GetNBytesFooter()), 0}};
       fFile->ReadV(readRequests, 2);
       fCounters->fNReadV.Inc();
    }


### PR DESCRIPTION
Fixes a couple of warnings seen e.g. [here](https://productionresultssa0.blob.core.windows.net/actions-results/eabe3d86-8e05-4d80-bc61-11f6a51832be/workflow-job-run-e2de9dfa-13eb-5b6c-b554-6d55fd0c2ac9/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-11T10%3A35%3A14Z&sig=qjJ5c740GztuEQO9LtEKEjnrQRwR39KpG%2FpsxUeQluo%3D&ske=2025-03-11T19%3A40%3A05Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-11T07%3A40%3A05Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-11T10%3A25%3A09Z&sv=2025-01-05) (latest nightly)

NB: the assert + static cast should be fine because they happen in the branch where we checked that `fAnchor->GetNBytesHeader() + fAnchor->GetNBytesFooter() < readvLimits.fMaxTotalSize` (which should be less than `size_t::max()` on any platform)