### PR TITLE
[python] Add UHI PlottableHistogram protocol Support to 1D TH1 Derived Classes

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -130,6 +130,7 @@ set(py_sources
   ROOT/_pythonization/_ttree.py
   ROOT/_pythonization/_tvector3.py
   ROOT/_pythonization/_tvectort.py
+  ROOT/_pythonization/_uhi.py
   ${PYROOT_EXTRA_PYTHON_SOURCES}
 )
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -228,6 +228,12 @@ _th1_derived_classes_to_pythonize = [
 for klass in _th1_derived_classes_to_pythonize:
     pythonization(klass)(inject_constructor_releasing_ownership)
 
+    from ROOT._pythonization._uhi import add_plotting_features
+    
+    # Add UHI components
+    uhi_components = [add_plotting_features]
+    for uc in uhi_components:
+        pythonization(klass)(uc)
 
 @pythonization('TH1')
 def pythonize_th1(klass):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
@@ -1,0 +1,157 @@
+# Author: Silia Taider CERN  03/2025
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+from __future__ import annotations
+from abc import ABC, abstractmethod
+import enum
+from typing import Tuple, Iterator, Union, Callable, Any
+
+
+# Implementation of the plotting component of the UHI
+class Kind(str, enum.Enum):
+    COUNT = "COUNT"
+    MEAN = "MEAN"
+
+class PlottableAxisTraits:
+    def __init__(self, circular: bool = False, discrete: bool = False):
+        self._circular = circular
+        self._discrete = discrete
+
+    @property
+    def circular(self) -> bool:
+        return self._circular
+
+    @property
+    def discrete(self) -> bool:
+        return self._discrete
+
+
+class PlottableAxisBase(ABC):
+    def __init__(self, tAxis: Any) -> None:
+        self.tAx = tAxis
+
+    @property
+    @abstractmethod
+    def traits(self) -> PlottableAxisTraits:
+        pass
+
+    @abstractmethod
+    def __getitem__(self, index: int) -> Union[Tuple[float, float], str]:
+        pass
+
+    def __len__(self) -> int:
+        return self.tAx.GetNbins()
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, PlottableAxisBase):
+            return False
+        return len(self) == len(other) and all(a == b for a, b in zip(self, other))
+    
+    @abstractmethod
+    def __iter__(self) -> Iterator[Union[Tuple[float, float], str]]:
+        pass
+
+class PlottableAxisContinuous(PlottableAxisBase):
+    @property
+    def traits(self) -> PlottableAxisTraits:
+        return PlottableAxisTraits(circular=False, discrete=False)
+
+    def __getitem__(self, index: int) -> Tuple[float, float]:
+        return (self.tAx.GetBinLowEdge(index + 1), self.tAx.GetBinUpEdge(index + 1))
+
+    def __iter__(self) -> Iterator[Tuple[float, float]]:
+        for i in range(len(self)):
+            yield self[i]
+
+class PlottableAxisDiscrete(PlottableAxisBase):
+    @property
+    def traits(self) -> PlottableAxisTraits:
+        return PlottableAxisTraits(circular=False, discrete=True)
+
+    def __getitem__(self, index: int) -> str:
+        return self.tAx.GetBinLabel(index + 1)
+
+    def __iter__(self) -> Iterator[str]:
+        for i in range(len(self)):
+            yield self[i]
+
+class PlottableAxisFactory:
+    @staticmethod
+    def create(tAxis) -> Union[PlottableAxisContinuous, PlottableAxisDiscrete]:
+        if all(tAxis.GetBinLabel(i + 1) for i in range(tAxis.GetNbins())):
+            return PlottableAxisDiscrete(tAxis)
+        return PlottableAxisContinuous(tAxis)
+    
+def _hasWeights(hist: Any) -> bool:
+    return bool(hist.GetSumw2() and hist.GetSumw2N())
+
+def _shape(hist: Any) -> Tuple[int, ...]:
+    return tuple(getattr(hist, f"GetNbins{ax}")() + 2 for ax in "XYZ"[:hist.GetDimension()])
+
+def _axes(self) -> Tuple[Union[PlottableAxisContinuous, PlottableAxisDiscrete], ...]:
+    return tuple(
+            PlottableAxisFactory.create(getattr(self, f"Get{ax}axis")()) for ax in "XYZ"[:self.GetDimension()]
+        )
+
+def _kind(self) -> Kind:
+    return Kind.COUNT if not _hasWeights(self) else Kind.MEAN
+
+def _values_default(self) -> np.typing.NDArray[Any]:
+    import numpy as np
+
+    llv = self.GetArray()
+    ret = np.frombuffer(llv, dtype=llv.typecode, count=self.GetSize())
+    return ret.reshape(_shape(self), order="F")[tuple([slice(1, -1)] * len(_shape(self)))]
+
+# Special case for TH1K: we need the array length to correspond to the number of bins
+# according to the UHI plotting protocol
+def _values_by_copy(self) -> np.typing.NDArray[Any]:
+    import numpy as np
+    
+    return np.array([self.GetBinContent(i) for i in range(1, self.GetNbinsX() + 1)])
+
+def _variances(self) -> np.typing.NDArray[Any]:
+    import numpy as np
+
+    if not _hasWeights(self):
+        return self.values()
+    
+    sumw2_array = self.GetSumw2()
+    size = sumw2_array.GetSize()
+    arr = np.frombuffer(sumw2_array.GetArray(), dtype=np.float64, count=size)
+
+    reshaped = arr.reshape(_shape(self), order="F")
+    return reshaped[tuple([slice(1, -1)] * len(_shape(self)))]
+
+def _counts(self) -> np.typing.NDArray[Any]:
+    import numpy as np
+
+    if not _hasWeights(self):
+        return self.values()
+
+    sumw = self.values()
+    return np.divide(
+        self.values() ** 2,
+        self.variances(),
+        out=np.zeros_like(sumw, dtype=np.float64),
+        where=self.variances() != 0,
+    )
+
+values_func_dict: dict[str, Callable] = {
+    "TH1C": _values_by_copy,
+    "TH1K": _values_by_copy,
+    "TProfile": _values_by_copy,
+}
+
+def add_plotting_features(klass: Any) -> None:
+    klass.kind = property(_kind)
+    klass.variances = _variances
+    klass.counts = _counts
+    klass.axes = property(_axes)
+    klass.values = values_func_dict.get(klass.__name__, _values_default)

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -20,6 +20,20 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)
+# TODO: Introduce ROOT_ADD_PYTHON_TEST
+if(MSVC)
+set(ROOT_ENV ROOTSYS=${ROOTSYS}
+    PYTHONPATH=${ROOTSYS}/bin;$ENV{PYTHONPATH})
+else()
+set(ROOT_ENV ROOTSYS=${ROOTSYS}
+    PATH=${ROOTSYS}/bin:$ENV{PATH}
+    LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
+    PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+endif()
+ROOT_ADD_TEST(pyunittests-bindings-pyroot-pythonizations-pyroot-uhi-plotting
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uhi_plotting.py
+    ENVIRONMENT ${ROOT_ENV}
+    PYTHON_DEPS uhi numpy)
 
 # STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)

--- a/bindings/pyroot/pythonizations/test/uhi_plotting.py
+++ b/bindings/pyroot/pythonizations/test/uhi_plotting.py
@@ -1,0 +1,30 @@
+"""
+Tests to verify that th1 1D histograms conform to the UHI PlottableHistogram protocol.
+"""
+
+import ROOT
+from ROOT._pythonization._th1 import _th1_derived_classes_to_pythonize
+
+import pytest
+from uhi.typing.plottable import PlottableHistogram
+import numpy as np
+
+th1_classes = [getattr(ROOT, klass) for klass in _th1_derived_classes_to_pythonize]
+
+@pytest.mark.parametrize("hist_type", th1_classes)
+class TestTH1Plotting:
+    @pytest.fixture
+    def hist_setup(self, hist_type):
+        hist = hist_type("h", "h", 10, 0, 5)
+        for _ in range(100):
+            hist.Fill(ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5))
+        yield hist
+
+    def test_isinstance_plottablehistogram(self, hist_setup):
+        assert isinstance(hist_setup, PlottableHistogram)
+
+    def test_histogram_values(self, hist_setup):
+        assert np.allclose(hist_setup.values(), [hist_setup.GetBinContent(i) for i in range(1, hist_setup.GetNbinsX() + 1)])
+
+if __name__ == "__main__":
+    pytest.main(args=[__file__])


### PR DESCRIPTION
# This Pull request:

## Adds:

This PR introduces the [Unified Histogram Interface](https://uhi.readthedocs.io/en/latest/index.html) plottable histogram functionality to the `TH1`-derived classes in ROOT. The changes include the addition of the methods described by the UHI `PlottableHistogram` protocol, ensuring compatibility with third party plotting libraries that support the protocol.

**Note:**  Currently, support is limited to 1D histograms.

## Checklist:

- [x] tested changes locally


