### PR TITLE
[skip-ci] Temporarily exclude the ML tutorials

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -1081,6 +1081,7 @@ EXCLUDE_PATTERNS       = */G__* \
                          */gui/qt5webdisplay/* \
                          */gui/qt6webdisplay/* \
                          */tutorials/visualisation/webgui/qt5web/* \
+                         */tutorials/machine_learning/* \
                          */math/mathcore/src/CDT*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names


### PR DESCRIPTION
Temporarily exclude the ML tutorials to remove the huge dump of error messages

