### PR TITLE
[Minuit2] Add missing operator to add algebraic vector objects

### DIFF
--- a/math/minuit2/inc/Minuit2/MnMatrix.h
+++ b/math/minuit2/inc/Minuit2/MnMatrix.h
@@ -1109,6 +1109,12 @@ operator+(const ABObj<vec, LAVector> &a, const ABObj<vec, LAVector> &b)
    return {ABSum<ABObj<vec, LAVector>, ABObj<vec, LAVector>>(a, b)};
 }
 
+template <class V>
+ABObj<vec, ABSum<ABObj<vec, LAVector>, ABObj<vec, V>>> operator+(const ABObj<vec, LAVector> &a, const ABObj<vec, V> &b)
+{
+   return {ABSum<ABObj<vec, LAVector>, ABObj<vec, V>>(a, b)};
+}
+
 inline ABObj<vec, ABSum<ABObj<vec, LAVector>, ABObj<vec, LAVector>>>
 operator-(const ABObj<vec, LAVector> &a, const ABObj<vec, LAVector> &b)
 {


### PR DESCRIPTION
This is to accommodate the mathematical operations in recent Fumili developments:
   * https://github.com/root-project/root/pull/17558