### PR TITLE
[python] Remove fragile test

### DIFF
--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -13,37 +13,6 @@ def _leak(obj):
 
 class MemoryStlString(unittest.TestCase):
 
-    def test_15703(self):
-        """Regression test for https://github.com/root-project/root/issues/15703"""
-
-        ROOT.gInterpreter.Declare("""
-        #ifndef TEST_15703
-        #define TEST_15703
-        #include <string>
-        class foo {
-            public:
-            const std::string leak (std::size_t size) const {
-                std::string result;
-                result.reserve(size);
-                return result;
-            }
-        };
-
-        auto get_rss_KB() {
-            ProcInfo_t info;
-            gSystem->GetProcInfo(&info);
-            return info.fMemResident;
-        }
-        #endif // TEST_15703
-        """)
-        obj = ROOT.foo()
-        _leak(obj)
-        before = ROOT.get_rss_KB()
-        _leak(obj)
-        after = ROOT.get_rss_KB()
-        delta = after - before
-        self.assertLess(delta, 16)
-
     def test_tstyle_memory_management(self):
         """Regression test for https://github.com/root-project/root/issues/16918"""
 


### PR DESCRIPTION
This test is fragile because we cannot be sure that RSS is a stable metric to evaluate the absence of a memory leak. The test itself has already demonstrated to be limited, in fact it was already modified or relaxed twice before:

https://github.com/root-project/root/commit/038054b3e5fdec0a499f0e25f571f88016565557 https://github.com/root-project/root/commit/015f44025d607d793922ba1eaae4aa9297339b07

It now starts also causing intermittent failures on MacOS which are not representative of a new memory leak, so it is better to just remove it.
