### PR TITLE
Align RDataSource cleanup routine with other sources

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -737,10 +737,10 @@ void RLoopManager::RunDataSource()
 {
    assert(fDataSource != nullptr);
    DSRunRAII _{*fDataSource};
+   RCallCleanUpTask cleanup(*this);
    auto ranges = fDataSource->GetEntryRanges();
    while (!ranges.empty() && fNStopsReceived < fNChildren) {
       RDSRangeRAII __{*this, 0u, 0ull};
-      RCallCleanUpTask cleanup(*this);
       try {
          for (const auto &range : ranges) {
             const auto start = range.first;


### PR DESCRIPTION
The call to cleanup routines was introduced in commit https://github.com/root-project/root/commit/0a719b4f5633bf340686dab20328ff3c5ad9cbad

The commit description informs it was done to avoid having setup and teardown routines called multiple times for the same column. In single-thread processing, the concept of one task is the processing of the entire computation graph for that run. As such, CleanupTask is called in RunTreeReader and RunEmptySource at the end of the function. In the case of RunDataSource, this routine is called in-between every event range processing. This commit aligns the RunDataSource logic with the logic of the other two single-thread processing methods, i.e. CleanupTask is now called at the end of the run.

Part 6 of N for https://github.com/root-project/root/pull/17895