### PR TITLE
[ci] Add Ubuntu 25.04 and Fedora 42 configurations

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora42.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora42.txt
@@ -1,0 +1,12 @@
+BLA_VENDOR=OpenBLAS
+builtin_cppzmq=OFF
+builtin_nlohmannjson=ON
+builtin_unuran=OFF
+builtin_zeromq=OFF
+builtin_zlib=ON
+builtin_zstd=ON
+ccache=ON
+pythia8=OFF
+roofit_multiprocess=OFF
+unuran=OFF
+vdt=OFF

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu2504.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu2504.txt
@@ -1,0 +1,3 @@
+ccache=ON
+pythia8=OFF
+tmva-cpu=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -363,6 +363,8 @@ jobs:
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
           - image: fedora41
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
+          - image: fedora42
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9
@@ -372,6 +374,8 @@ jobs:
           - image: ubuntu2404
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2410
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
+          - image: ubuntu2504
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
           - image: debian125
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20", "dev=ON"]


### PR DESCRIPTION
Add Ubuntu 25.04 and Fedora 42 configurations

### Fedora 42

We have to set `vdt=OFF` and `builtin_vdt=OFF` for now. The [minimum required CMake version for vdt is 3.2](https://github.com/dpiparo/vdt/blob/master/CMakeLists.txt#L2), but Fedora 42 ships with CMake 4.0, which [removed compatibility with CMake < 3.5](https://github.com/eclipse-ecal/ecal/issues/2041). Same for the builtin `zeromq` and the `roofit_multiprocess` feature that depends on it. Also `unuran` had to be disabled. I think the configuration should be revisited once Fedora 42 is actually released.
We also require `BLA_VENDOR=OpenBLAS` to avoid using flexiblas, like we currently have on `alma9` (flexiblas collides with the blas loaded inside numpy).

### Ubuntu 25.04

So far, a copy of the 24.10 configuration.