### PR TITLE
Add option for generic Python tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -20,20 +20,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)
-# TODO: Introduce ROOT_ADD_PYTHON_TEST
-if(MSVC)
-set(ROOT_ENV ROOTSYS=${ROOTSYS}
-    PYTHONPATH=${ROOTSYS}/bin;$ENV{PYTHONPATH})
-else()
-set(ROOT_ENV ROOTSYS=${ROOTSYS}
-    PATH=${ROOTSYS}/bin:$ENV{PATH}
-    LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
-    PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
-endif()
-ROOT_ADD_TEST(pyunittests-bindings-pyroot-pythonizations-pyroot-uhi-plotting
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uhi_plotting.py
-    ENVIRONMENT ${ROOT_ENV}
-    PYTHON_DEPS uhi numpy)
+ROOT_ADD_PYUNITTEST(uhi_plotting uhi_plotting.py GENERIC PYTHON_DEPS uhi numpy)
 
 # STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)


### PR DESCRIPTION
Follow up to https://github.com/root-project/root/pull/17950

In the linked PR we found ourselves in need to create a Python ctest test that uses `pytest` as the test driver. The currently available `ROOT_ADD_PYUNITTEST` cmake function is limited because it only allows Python tests written with `unittest`, so we can introduce a new one more generic.