### PR TITLE
cut command splitting by null bytes fails on MacOS and BSD

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -169,7 +169,7 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
-      trueExe=$(cut -d $'\000' -f1 /proc/$$/cmdline) || return 1
+      trueExe=$(xargs -0 < /proc/$$/cmdline | awk NR==1'{ printf "%s",$1 }') || return 1
       # Qemu emulation has cmdline start with the emulator
       if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
          # but qemu sets comm to the emulated command

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -169,7 +169,7 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
-      trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
+      trueExe=$(cut -d ' ' -f1 /proc/$$/cmdline | tr -d '\0') || return 1
       # Qemu emulation has cmdline start with the emulator
       if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
          # but qemu sets comm to the emulated command

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -169,7 +169,7 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
-      trueExe=$(cut -d ' ' -f1 /proc/$$/cmdline | tr -d '\0') || return 1
+      trueExe=$(cut -d $'\000' -f1 /proc/$$/cmdline) || return 1
       # Qemu emulation has cmdline start with the emulator
       if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
          # but qemu sets comm to the emulated command

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -169,7 +169,7 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
-      trueExe=$(xargs -0 < /proc/$$/cmdline | awk NR==1'{ printf "%s",$1 }') || return 1
+      trueExe=$(xargs -0 -n 1 < /proc/$$/cmdline 2>/dev/null | head -n 1) || return 1
       # Qemu emulation has cmdline start with the emulator
       if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
          # but qemu sets comm to the emulated command


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/17969

This prevents errors in freebsd and macos, with the cut command being implemented differently vs Linux and complaining about a bad delimiter (empty) when using `-d ''`. While this might be a 'bug' in the freebsd and macos implementation of "cut", it makes sense to find an alternative here that is more cross-platform compliant.

All credit for the solution goes to eamjensen and mkelement0

Related: https://apple.stackexchange.com/questions/268352/how-to-use-cut-with-null-delimiter
https://stackoverflow.com/questions/23011370/how-to-recognize-whether-bash-or-dash-is-being-used-within-a-script/23011530?noredirect=1#comment140210695_23011530

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
