### PR TITLE
Improve exception safety of RDataSource range processing

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -97,6 +97,8 @@ public:
    }
 };
 
+struct RDSRangeRAII;
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT
@@ -126,6 +128,7 @@ class RLoopManager : public RNodeBase {
    };
 
    friend struct RCallCleanUpTask;
+   friend struct ROOT::Internal::RDF::RDSRangeRAII;
 
    std::vector<RDFInternal::RActionBase *> fBookedActions; ///< Non-owning pointers to actions to be run
    std::vector<RDFInternal::RActionBase *> fRunActions;    ///< Non-owning pointers to actions already run


### PR DESCRIPTION
Create an internal RAII struct to manage the calls to the initialization and finalization routines for the nodes of the computation graphs and the data source.

Part 7 of N for https://github.com/root-project/root/pull/17895