### PR TITLE
[v632][cmake] Build Clad with one core only when needed

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -85,8 +85,12 @@ ExternalProject_Add(
              -DLLVM_DIR=${LLVM_BINARY_DIR}
              -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
              ${_clad_extra_cmake_args}
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS}
-  INSTALL_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} --target install
+  # FIXME
+  # Building with 1 core is a temporary workaround for #16654 and has to be 
+  # there until the behaviour of the clad build on ubuntu 24.10 is understood.
+  # The performance penalty in the build is negligible.
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} -j 1
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} -j 1 --target install
   BUILD_BYPRODUCTS ${CLAD_BYPRODUCTS}
   ${_clad_cmake_logging_settings}
   # We need the target clangBasic to be built before building clad. However, we

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT _clad_build_type STREQUAL "" AND NOT _clad_build_type STREQUAL ".")
   set(EXTRA_BUILD_ARGS --config ${_clad_build_type})
 endif()
 
-if(NOT MSVC AND CMAKE_VERSION VERSION_LESS 3.11.1)
+if(NOT MSVC AND CMAKE_VERSION VERSION_LESS 3.31.1)
   # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/26398
   # The problem got eventually fixed upstream in CMake.
   list(APPEND EXTRA_BUILD_ARGS "-j 1")

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -23,6 +23,13 @@ endif(MSVC)
 if(NOT _clad_build_type STREQUAL "" AND NOT _clad_build_type STREQUAL ".")
   set(EXTRA_BUILD_ARGS --config ${_clad_build_type})
 endif()
+
+if(NOT MSVC AND CMAKE_VERSION VERSION_LESS 3.11.1)
+  # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/26398
+  # The problem got eventually fixed upstream in CMake.
+  list(APPEND EXTRA_BUILD_ARGS "-j 1")
+endif()
+
 set(_CLAD_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR}/clad-prefix/src/clad-build/${_clad_build_type}/lib${LLVM_LIBDIR_SUFFIX})
 
 # build byproducts only needed by Ninja
@@ -85,12 +92,8 @@ ExternalProject_Add(
              -DLLVM_DIR=${LLVM_BINARY_DIR}
              -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
              ${_clad_extra_cmake_args}
-  # FIXME
-  # Building with 1 core is a temporary workaround for #16654 and has to be 
-  # there until the behaviour of the clad build on ubuntu 24.10 is understood.
-  # The performance penalty in the build is negligible.
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} -j 1
-  INSTALL_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} -j 1 --target install
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS}
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS} --target install
   BUILD_BYPRODUCTS ${CLAD_BYPRODUCTS}
   ${_clad_cmake_logging_settings}
   # We need the target clangBasic to be built before building clad. However, we


### PR DESCRIPTION
Backports of:
  * https://github.com/root-project/root/pull/16682
  * https://github.com/root-project/root/pull/17880
  * https://github.com/root-project/root/pull/17888

Closes #17978.