### PR TITLE
[ci] Use Python 3.12+ tarfile data extraction filter

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -290,7 +290,12 @@ def download_artifacts(obj_prefix: str):
         print(f"\nExtracting archive {tar_path}")
 
         with tarfile.open(tar_path) as tar:
-            tar.extractall(WORKDIR)
+            # TODO: Simplify after ROOT is Python 3.12+ only
+            # c.f. https://docs.python.org/3.12/library/tarfile.html#extraction-filters
+            if hasattr(tarfile, "data_filter"):
+                tar.extractall(WORKDIR, filter="data")
+            else:
+                tar.extractall(WORKDIR)
 
         build_utils.log.add(f'\ncd {WORKDIR} && tar -xf {tar_path}\n')
 


### PR DESCRIPTION
Fixes the following deprecation warning:
```txt
  /__w/root/root/.github/workflows/root-ci-config/build_root.py:293: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
```

Analogous to:
  * https://github.com/scikit-hep/pyhf/pull/2455

See also:
  * https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter