### PR TITLE
Fix an error in the ctor from a file

### DIFF
--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -362,7 +362,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const char *filename, const char *format, O
             ntokensToBeSaved++ ;
          }
       }
-      if (ntokens >= 2 && (ntokensToBeSaved < 2 || ntokensToBeSaved > 4)) { //first condition not to repeat the previous error message
+      if (ntokens >= 2 && (ntokensToBeSaved < 2 || ntokensToBeSaved > 6)) { //first condition not to repeat the previous error message
          Error("TGraphAsymmErrors", "Incorrect input format! There are %d \"%%lg\" tag(s) in format whereas 2,3 or 4 are expected!", ntokensToBeSaved);
          delete [] isTokenToBeSaved;
          return ;

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -363,7 +363,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const char *filename, const char *format, O
          }
       }
       if (ntokens >= 2 && (ntokensToBeSaved < 2 || ntokensToBeSaved > 6)) { //first condition not to repeat the previous error message
-         Error("TGraphAsymmErrors", "Incorrect input format! There are %d \"%%lg\" tag(s) in format whereas 2,3 or 4 are expected!", ntokensToBeSaved);
+         Error("TGraphAsymmErrors", "Incorrect input format! There are %d \"%%lg\" tag(s) in format whereas 2, 3, 4, 5 or 6 are expected!", ntokensToBeSaved);
          delete [] isTokenToBeSaved;
          return ;
       }
@@ -401,7 +401,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const char *filename, const char *format, O
                token = R__STRTOK_R(nullptr, option, &rest); // next token
                token_idx++ ;
             }
-            if (!isLineToBeSkipped && value_idx > 1) { //i.e. 2,3 or 4
+            if (!isLineToBeSkipped && value_idx > 1) { //i.e. 2, 3, 4, 5 or 6
                x = value[0];
                y = value[1];
                exl = value[2];


### PR DESCRIPTION
The TGraphAsymmErrors constructor from a data file did not work properly when the value separator was not " " and with more than 4 parameters. This was reported in[ this forum post.](https://root-forum.cern.ch/t/tgraphasymmerrors-error-with-constructor-from-file/63118)

