### PR TITLE
[DF][ntuple] Enable RNTuple Snapshotting to `TDirectory`

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -283,8 +283,8 @@ BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperA
          auto loopManager = snapHelperArgs->fLoopManager;
 
          actionPtr.reset(new Action_t(
-            Helper_t(filename, treename, colNames, outputColNames, options, loopManager, std::move(isDefine)), colNames,
-            prevNode, colRegister));
+            Helper_t(filename, dirname, treename, colNames, outputColNames, options, loopManager, std::move(isDefine)),
+            colNames, prevNode, colRegister));
       } else {
          // multi-thread snapshot to RNTuple is not yet supported
          // TODO(fdegeus) Add MT snapshotting

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1351,11 +1351,6 @@ public:
                                      "way to convert TTrees to RNTuple is through the RNTupleImporter.");
          }
 
-         if (!dirname.empty()) {
-            throw std::runtime_error(
-               "RDataFrame: Snapshotting an RNTuple to a TFile sub-directory is currently not supported.");
-         }
-
          // The data source of the RNTuple resulting from the Snapshot action does not exist yet here, so we create one
          // without a data source for now, and set it once the actual data source can be created (i.e., after
          // writing the RNTuple).
@@ -3250,11 +3245,6 @@ private:
          if (fLoopManager->GetTree()) {
             throw std::runtime_error("Snapshotting from TTree to RNTuple is not yet supported. The current recommended "
                                      "way to convert TTrees to RNTuple is through the RNTupleImporter.");
-         }
-
-         if (!dirname.empty()) {
-            throw std::runtime_error(
-               "RDataFrame: Snapshotting an RNTuple to a TFile sub-directory is currently not supported.");
          }
 
          auto newRDF =


### PR DESCRIPTION
This PR lifts the restriction of not being able to Snapshot to RNTuple in a TDirectory (i.e., `dir/ntuple`). I naively/wrongly assumed that it wasn't possible to read back RNTuples in sub-directories, but it actually just works fine.

