### PR TITLE
[RF] Avoid setting out-of-range value in NaNPacker tests

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -693,7 +693,7 @@ TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
 
    RooArgSet normSet{x};
    ASSERT_FALSE(std::isnan(pdf.getVal(normSet)));
-   a1.setVal(-9.);
+   a1.setVal(-5.);
    ASSERT_TRUE(std::isnan(pdf.getVal(normSet)));
 
    RooMinimizer minim(*nll);
@@ -708,7 +708,7 @@ TEST_P(LikelihoodGradientJobErrorTest, FitSimpleLinear)
    // now with multiprocess
    std::unique_ptr<RooAbsReal> nll_mp(pdf.createNLL(*data, RooFit::ModularL(true)));
 
-   a1.setVal(-9.);
+   a1.setVal(-5.);
    a1.removeError();
    ASSERT_TRUE(std::isnan(pdf.getVal(normSet)));
 

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -155,7 +155,7 @@ TEST(RooNaNPacker, FitSimpleLinear)
 
    RooArgSet normSet{x};
    ASSERT_FALSE(std::isnan(pdf.getVal(normSet)));
-   a1.setVal(-9.);
+   a1.setVal(-5.);
    ASSERT_TRUE(std::isnan(pdf.getVal(normSet)));
 
    RooMinimizer minim(*nll);


### PR DESCRIPTION
This would clip to the nearest in-range value anyway, so we should pass the lower limit directly.