### PR TITLE
[CMake] Use `clangCppInterOp` directly as input for Cling target

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -120,7 +120,8 @@ ROOT_LINKER_LIBRARY(Cling
         $<TARGET_OBJECTS:ClingUtils>
         $<TARGET_OBJECTS:Dictgen>
         $<TARGET_OBJECTS:MetaCling>
-        LIBRARIES ${CLING_LIBRARIES} clangCppInterOp ${LINK_LIBS} ${CLING_PLUGIN_LINK_LIBS})
+        $<TARGET_OBJECTS:clangCppInterOp>
+        LIBRARIES ${CLING_LIBRARIES} ${LINK_LIBS} ${CLING_PLUGIN_LINK_LIBS})
 
 # When these two link at the same time, they can exhaust the RAM on many machines, since they both link against llvm.
 add_dependencies(Cling rootcling_stage1)


### PR DESCRIPTION
Use `clangCppInterOp` directly as input for Cling target, just like the other objects that are used (like `MetaCling`).

This fixes the following CMake generation error on my system:
```txt
CMake Error: install(EXPORT "ROOTExports" ...) includes target "Cling" which requires target "clangCppInterOp" that is not in any export set.
CMake Error in CMakeLists.txt:
  export called with target "Cling" which requires target "clangCppInterOp"
  that is not in any export set.
```