### PR TITLE
[ntuple] Move RField hierarchy out of Experimental

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -28,12 +28,6 @@ using namespace ROOT::Browsable;
 
 using namespace std::string_literals;
 
-// FIXME: this exposes RField and RIntegralField into the global namespace
-template<typename T>
-using RField = ROOT::Experimental::RField<T>;
-template<typename T>
-using RIntegralField = ROOT::Experimental::RIntegralField<T>;
-
 // ==============================================================================================
 
 /** \class RFieldProvider
@@ -83,7 +77,7 @@ class RFieldProvider : public RProvider {
       }
 
       template <typename T>
-      void FillHistogramImpl(const ROOT::Experimental::RFieldBase &field, ROOT::Experimental::RNTupleView<T> &view)
+      void FillHistogramImpl(const ROOT::RFieldBase &field, ROOT::Experimental::RNTupleView<T> &view)
       {
          std::string title = "Drawing of RField "s + field.GetFieldName();
 
@@ -107,21 +101,21 @@ class RFieldProvider : public RProvider {
          fHist->BufferEmpty();
       }
 
-      template<typename T>
-      void FillHistogram(const RIntegralField<T> &field)
+      template <typename T>
+      void FillHistogram(const ROOT::RIntegralField<T> &field)
       {
          auto view = fNtplReader->GetView<T>(field.GetOnDiskId());
          FillHistogramImpl(field, view);
       }
 
-      template<typename T>
-      void FillHistogram(const RField<T> &field)
+      template <typename T>
+      void FillHistogram(const ROOT::RField<T> &field)
       {
          auto view = fNtplReader->GetView<T>(field.GetOnDiskId());
          FillHistogramImpl(field, view);
       }
 
-      void FillStringHistogram(const RField<std::string> &field)
+      void FillStringHistogram(const ROOT::RField<std::string> &field)
       {
          std::map<std::string, int> values;
 
@@ -161,21 +155,21 @@ class RFieldProvider : public RProvider {
          return fHist.release();
       }
 
-      void VisitField(const ROOT::Experimental::RFieldBase & /* field */) final {}
-      void VisitBoolField(const RField<bool> &field) final { FillHistogram(field); }
-      void VisitFloatField(const RField<float> &field) final { FillHistogram(field); }
-      void VisitDoubleField(const RField<double> &field) final { FillHistogram(field); }
-      void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
-      void VisitInt8Field(const RIntegralField<std::int8_t> &field) final { FillHistogram(field); }
-      void VisitInt16Field(const RIntegralField<std::int16_t> &field) final { FillHistogram(field); }
-      void VisitInt32Field(const RIntegralField<std::int32_t> &field) final { FillHistogram(field); }
-      void VisitInt64Field(const RIntegralField<std::int64_t> &field) final { FillHistogram(field); }
-      void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
-      void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) final { FillHistogram(field); }
-      void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) final { FillHistogram(field); }
-      void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) final { FillHistogram(field); }
-      void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) final { FillHistogram(field); }
-      void VisitCardinalityField(const ROOT::Experimental::RCardinalityField &field) final
+      void VisitField(const ROOT::RFieldBase & /* field */) final {}
+      void VisitBoolField(const ROOT::RField<bool> &field) final { FillHistogram(field); }
+      void VisitFloatField(const ROOT::RField<float> &field) final { FillHistogram(field); }
+      void VisitDoubleField(const ROOT::RField<double> &field) final { FillHistogram(field); }
+      void VisitCharField(const ROOT::RField<char> &field) final { FillHistogram(field); }
+      void VisitInt8Field(const ROOT::RIntegralField<std::int8_t> &field) final { FillHistogram(field); }
+      void VisitInt16Field(const ROOT::RIntegralField<std::int16_t> &field) final { FillHistogram(field); }
+      void VisitInt32Field(const ROOT::RIntegralField<std::int32_t> &field) final { FillHistogram(field); }
+      void VisitInt64Field(const ROOT::RIntegralField<std::int64_t> &field) final { FillHistogram(field); }
+      void VisitStringField(const ROOT::RField<std::string> &field) final { FillStringHistogram(field); }
+      void VisitUInt16Field(const ROOT::RIntegralField<std::uint16_t> &field) final { FillHistogram(field); }
+      void VisitUInt32Field(const ROOT::RIntegralField<std::uint32_t> &field) final { FillHistogram(field); }
+      void VisitUInt64Field(const ROOT::RIntegralField<std::uint64_t> &field) final { FillHistogram(field); }
+      void VisitUInt8Field(const ROOT::RIntegralField<std::uint8_t> &field) final { FillHistogram(field); }
+      void VisitCardinalityField(const ROOT::RCardinalityField &field) final
       {
          if (const auto f32 = field.As32Bit()) {
             FillHistogram(*f32);

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -33,9 +33,9 @@
 
 namespace ROOT {
 class RNTuple;
+class RFieldBase;
 
 namespace Experimental {
-class RFieldBase;
 
 namespace Internal {
 class RNTupleColumnReader;
@@ -84,13 +84,12 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// in GetColumnReaders(), we move a clone of the field into a new column reader for RDataFrame.
    /// Only the clone connects to the backing page store and acquires I/O resources.
    /// The field IDs are set in the context of the first source and used as keys in fFieldId2QualifiedName.
-   std::vector<std::unique_ptr<ROOT::Experimental::RFieldBase>> fProtoFields;
+   std::vector<std::unique_ptr<ROOT::RFieldBase>> fProtoFields;
    /// Columns may be requested with types other than with which they were initially added as proto fields. For example,
    /// a column with a `ROOT::RVec<float>` proto field may instead be requested as a `std::vector<float>`. In case this
    /// happens, we create an alternative proto field and store it here, with the original index in `fProtoFields` as
    /// key. A single column can have more than one alternative proto fields.
-   std::unordered_map<std::size_t, std::vector<std::unique_ptr<ROOT::Experimental::RFieldBase>>>
-      fAlternativeProtoFields;
+   std::unordered_map<std::size_t, std::vector<std::unique_ptr<ROOT::RFieldBase>>> fAlternativeProtoFields;
    /// Connects the IDs of active proto fields and their subfields to their fully qualified name (a.b.c.d).
    /// This enables the column reader to rewire the field IDs when the file changes (chain),
    /// using the fully qualified name as a search key in the descriptor of the other page sources.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -448,7 +448,7 @@ RNTupleDS::GetColumnReaders(unsigned int slot, std::string_view name, const std:
 {
    // At this point we can assume that `name` will be found in fColumnNames
    const auto index = std::distance(fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), name));
-   const auto requestedType = Internal::GetRenormalizedTypeName(ROOT::Internal::RDF::TypeID2TypeName(tid));
+   const auto requestedType = ROOT::Internal::GetRenormalizedTypeName(ROOT::Internal::RDF::TypeID2TypeName(tid));
 
    RFieldBase *field;
    // If the field corresponding to the provided name is not a cardinality column and the requested type is different

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -377,17 +377,16 @@ TEST(RNTupleDS, CollectionFieldTypes)
          std::set<std::set<Electron>>{{Electron{1.f}, Electron{2.f}}, {Electron{3.f}}};
 
       // Untyped collection
-      auto fldJetPt = ROOT::Experimental::RVectorField::CreateUntyped(
-         "jet_pt", std::make_unique<ROOT::Experimental::RField<float>>("_0"));
+      auto fldJetPt = ROOT::RVectorField::CreateUntyped("jet_pt", std::make_unique<ROOT::RField<float>>("_0"));
       model->AddField(std::move(fldJetPt));
 
       // Untyped collection with an untyped record, with a projection
-      std::vector<std::unique_ptr<ROOT::Experimental::RFieldBase>> muon;
-      muon.emplace_back(std::make_unique<ROOT::Experimental::RField<float>>("muon_pt"));
-      auto fldMuonRecord = std::make_unique<ROOT::Experimental::RRecordField>("_0", std::move(muon));
-      auto fldMuons = ROOT::Experimental::RVectorField::CreateUntyped("muon", std::move(fldMuonRecord));
+      std::vector<std::unique_ptr<ROOT::RFieldBase>> muon;
+      muon.emplace_back(std::make_unique<ROOT::RField<float>>("muon_pt"));
+      auto fldMuonRecord = std::make_unique<ROOT::RRecordField>("_0", std::move(muon));
+      auto fldMuons = ROOT::RVectorField::CreateUntyped("muon", std::move(fldMuonRecord));
       model->AddField(std::move(fldMuons));
-      auto muonPtField = ROOT::Experimental::RFieldBase::Create("muon_pt", "ROOT::VecOps::RVec<float>").Unwrap();
+      auto muonPtField = ROOT::RFieldBase::Create("muon_pt", "ROOT::VecOps::RVec<float>").Unwrap();
       model->AddProjectedField(std::move(muonPtField), [](const std::string &fieldName) {
          if (fieldName == "muon_pt")
             return "muon";

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -78,7 +78,7 @@ private:
    /// The entry and its tokens are also linked to a specific schema, identified by a schema ID
    std::uint64_t fSchemaId = 0;
    /// Corresponds to the fields of the linked model
-   std::vector<RFieldBase::RValue> fValues;
+   std::vector<ROOT::RFieldBase::RValue> fValues;
    /// For fast lookup of token IDs given a (sub)field name present in the entry
    std::unordered_map<std::string, std::size_t> fFieldName2Token;
    /// To ensure that the entry is standalone, a copy of all field types
@@ -89,7 +89,7 @@ private:
    REntry() = default;
    explicit REntry(std::uint64_t modelId, std::uint64_t schemaId) : fModelId(modelId), fSchemaId(schemaId) {}
 
-   void AddValue(RFieldBase::RValue &&value)
+   void AddValue(ROOT::RFieldBase::RValue &&value)
    {
       fFieldName2Token[value.GetField().GetQualifiedFieldName()] = fValues.size();
       fFieldTypes.push_back(value.GetField().GetTypeName());
@@ -98,7 +98,7 @@ private:
 
    /// While building the entry, adds a new value to the list and return the value's shared pointer
    template <typename T>
-   std::shared_ptr<T> AddValue(RField<T> &field)
+   std::shared_ptr<T> AddValue(ROOT::RField<T> &field)
    {
       fFieldName2Token[field.GetQualifiedFieldName()] = fValues.size();
       fFieldTypes.push_back(field.GetTypeName());
@@ -107,14 +107,14 @@ private:
       return value.template GetPtr<T>();
    }
 
-   /// Update the RValue for a field in the entry. To be used when its underlying RFieldBase changes, which typically
-   /// happens when page source the field values are read from changes.
-   void UpdateValue(RFieldToken token, RFieldBase::RValue &&value) { std::swap(fValues.at(token.fIndex), value); }
-   void UpdateValue(RFieldToken token, RFieldBase::RValue &value) { std::swap(fValues.at(token.fIndex), value); }
+   /// Update the RValue for a field in the entry. To be used when its underlying ROOT::RFieldBase changes, which
+   /// typically happens when page source the field values are read from changes.
+   void UpdateValue(RFieldToken token, ROOT::RFieldBase::RValue &&value) { std::swap(fValues.at(token.fIndex), value); }
+   void UpdateValue(RFieldToken token, ROOT::RFieldBase::RValue &value) { std::swap(fValues.at(token.fIndex), value); }
 
    /// Return the RValue currently bound to the provided field.
-   RFieldBase::RValue &GetValue(RFieldToken token) { return fValues.at(token.fIndex); }
-   RFieldBase::RValue &GetValue(std::string_view fieldName) { return GetValue(GetToken(fieldName)); }
+   ROOT::RFieldBase::RValue &GetValue(RFieldToken token) { return fValues.at(token.fIndex); }
+   ROOT::RFieldBase::RValue &GetValue(std::string_view fieldName) { return GetValue(GetToken(fieldName)); }
 
    void Read(ROOT::NTupleSize_t index)
    {
@@ -157,9 +157,9 @@ private:
    void EnsureMatchingType(RFieldToken token [[maybe_unused]]) const
    {
       if constexpr (!std::is_void_v<T>) {
-         if (fFieldTypes[token.fIndex] != RField<T>::TypeName()) {
+         if (fFieldTypes[token.fIndex] != ROOT::RField<T>::TypeName()) {
             throw RException(R__FAIL("type mismatch for field " + FindFieldName(token) + ": " +
-                                     fFieldTypes[token.fIndex] + " vs. " + RField<T>::TypeName()));
+                                     fFieldTypes[token.fIndex] + " vs. " + ROOT::RField<T>::TypeName()));
          }
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -37,6 +37,8 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+} // namespace Experimental
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Template specializations for concrete C++ fundamental types
 ////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +78,7 @@ public:
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<char>;
@@ -98,7 +100,7 @@ public:
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 // For other integral types, we introduce an intermediate RIntegralField. It is specialized for fixed-width integer
@@ -125,7 +127,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::uint8_t>;
@@ -142,7 +144,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::int16_t>;
@@ -159,7 +161,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::uint16_t>;
@@ -176,7 +178,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::int32_t>;
@@ -193,7 +195,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::uint32_t>;
@@ -210,7 +212,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::int64_t>;
@@ -227,7 +229,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 extern template class RSimpleField<std::uint64_t>;
@@ -244,7 +246,7 @@ public:
    RIntegralField &operator=(RIntegralField &&other) = default;
    ~RIntegralField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 namespace Internal {
@@ -388,7 +390,7 @@ protected:
       fPrincipalColumn = fAvailableColumns[0].get();
    }
 
-   void GenerateColumns(const RNTupleDescriptor &desc) final
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final
    {
       std::uint16_t representationIndex = 0;
       do {
@@ -493,7 +495,7 @@ public:
 
    explicit RField(std::string_view name) : RRealField<float>(name, TypeName()) {}
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 template <>
@@ -512,12 +514,19 @@ public:
 
    explicit RField(std::string_view name) : RRealField<double>(name, TypeName()) {}
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 
    // Set the column representation to 32 bit floating point and the type alias to Double32_t
    void SetDouble32();
 };
+
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+template <typename T>
+using RIntegralField [[deprecated("ROOT::Experimental::RIntegralField moved to ROOT::RIntegralField")]] =
+   ROOT::RIntegralField<T>;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -42,6 +42,8 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+} // namespace Experimental
+
 /// The field for a class representing a collection of elements via `TVirtualCollectionProxy`.
 /// Objects of such type behave as collections that can be accessed through the corresponding member functions in
 /// `TVirtualCollectionProxy`. For STL collections, these proxies are provided. Custom classes need to implement the
@@ -163,7 +165,7 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -182,7 +184,7 @@ public:
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final { return fProxy->Sizeof(); }
    size_t GetAlignment() const final { return alignof(std::max_align_t); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
    void
    GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
    {
@@ -414,7 +416,15 @@ public:
    ~RField() final = default;
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RSetField [[deprecated("ROOT::Experimental::RSetField moved to ROOT::RSetField")]] = ROOT::RSetField;
+using RMapField [[deprecated("ROOT::Experimental::RMapField moved to ROOT::RMapField")]] = ROOT::RMapField;
+using RProxiedCollectionField
+   [[deprecated("ROOT::Experimental::RProxiedCollectionField moved to ROOT::RProxiedCollectionField")]] =
+      ROOT::RProxiedCollectionField;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -36,6 +36,8 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+} // namespace Experimental
+
 namespace Internal {
 std::unique_ptr<RFieldBase> CreateEmulatedField(std::string_view fieldName,
                                                 std::vector<std::unique_ptr<RFieldBase>> itemFields,
@@ -119,7 +121,7 @@ public:
       return std::max<size_t>(1ul, fSize);
    }
    size_t GetAlignment() const final { return fMaxAlignment; }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 
    const std::vector<std::size_t> &GetOffsets() const { return fOffsets; }
 };
@@ -250,7 +252,13 @@ public:
    ~RField() final = default;
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RRecordField [[deprecated("ROOT::Experimental::RRecordField moved to ROOT::RRecordField")]] = ROOT::RRecordField;
+using RPairField [[deprecated("ROOT::Experimental::RPairField moved to ROOT::RPairField")]] = ROOT::RPairField;
+using RTupleField [[deprecated("ROOT::Experimental::RTupleField moved to ROOT::RTupleField")]] = ROOT::RTupleField;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -39,6 +39,8 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+} // namespace Experimental
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Template specializations for C++ std::atomic
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,7 +67,7 @@ public:
    size_t GetValueSize() const final { return fSubfields[0]->GetValueSize(); }
    size_t GetAlignment() const final { return fSubfields[0]->GetAlignment(); }
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 template <typename ItemT>
@@ -100,7 +102,7 @@ protected:
    }
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
    void ConstructValue(void *where) const final { memset(where, 0, GetValueSize()); }
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
@@ -114,7 +116,7 @@ public:
 
    size_t GetValueSize() const final { return kWordSize * ((fN + kBitsPerWord - 1) / kBitsPerWord); }
    size_t GetAlignment() const final { return alignof(Word_t); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 
    /// Get the number of bits in the bitset, i.e. the N in std::bitset<N>
    std::size_t GetN() const { return fN; }
@@ -153,7 +155,7 @@ public:
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -171,7 +173,7 @@ class RNullableField : public RFieldBase {
 protected:
    const RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final;
 
    std::size_t AppendNull();
    std::size_t AppendValue(const void *from);
@@ -188,7 +190,7 @@ public:
    RNullableField &operator=(RNullableField &&other) = default;
    ~RNullableField() override = default;
 
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 class ROptionalField : public RNullableField {
@@ -299,7 +301,7 @@ private:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::string(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::string>>(); }
@@ -321,7 +323,7 @@ public:
 
    size_t GetValueSize() const final { return sizeof(std::string); }
    size_t GetAlignment() const final { return std::alignment_of<std::string>(); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -375,7 +377,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -429,7 +431,16 @@ public:
    ~RField() final = default;
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RAtomicField [[deprecated("ROOT::Experimental::RAtomicField moved to ROOT::RAtomicField")]] = ROOT::RAtomicField;
+using RVariantField [[deprecated("ROOT::Experimental::RVariantField moved to ROOT::RVariantField")]] =
+   ROOT::RVariantField;
+using RNullableField [[deprecated("ROOT::Experimental::RNullableField moved to ROOT::RNullableField")]] =
+   ROOT::RNullableField;
+using RBitsetField [[deprecated("ROOT::Experimental::RBitsetField moved to ROOT::RBitsetField")]] = ROOT::RBitsetField;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -35,6 +35,8 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+} // namespace Experimental
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Template specializations for C++ std::array and C-style arrays
 ////////////////////////////////////////////////////////////////////////////////
@@ -79,7 +81,7 @@ public:
    size_t GetLength() const { return fArrayLength; }
    size_t GetValueSize() const final { return fItemSize * fArrayLength; }
    size_t GetAlignment() const final { return fSubfields[0]->GetAlignment(); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
 template <typename ItemT, std::size_t N>
@@ -134,7 +136,7 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -156,7 +158,7 @@ public:
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
    void
    GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
    {
@@ -218,7 +220,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::vector<char>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -240,7 +242,7 @@ public:
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final { return sizeof(std::vector<char>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
    void
    GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
    {
@@ -277,7 +279,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::vector<bool>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::vector<bool>>>(); }
@@ -298,7 +300,7 @@ public:
 
    size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
    void
    GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
    {
@@ -359,10 +361,18 @@ public:
    std::size_t GetAlignment() const final;
 
    std::vector<RFieldBase::RValue> SplitValue(const RFieldBase::RValue &value) const final;
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const final;
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RArrayField [[deprecated("ROOT::Experimental::RArrayField moved to ROOT::RArrayField")]] = ROOT::RArrayField;
+using RVectorField [[deprecated("ROOT::Experimental::RVectorField moved to ROOT::RVectorField")]] = ROOT::RVectorField;
+using RRVecField [[deprecated("ROOT::Experimental::RRVecField moved to ROOT::RRVecField")]] = ROOT::RRVecField;
+using RArrayAsRVecField [[deprecated("ROOT::Experimental::RArrayAsRVecField moved to ROOT::RArrayAsRVecField")]] =
+   ROOT::RArrayAsRVecField;
 } // namespace Experimental
+
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
@@ -16,7 +16,6 @@
 class TClass;
 
 namespace ROOT {
-namespace Experimental {
 namespace Internal {
 
 /// Applies RNTuple specific type name normalization rules (see specs) that help the string parsing in
@@ -59,8 +58,6 @@ std::tuple<std::string, std::vector<std::size_t>> ParseArrayType(const std::stri
 std::vector<std::string> TokenizeTypeList(std::string_view templateType);
 
 } // namespace Internal
-
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -42,39 +42,39 @@ by the RPrintSchemaVisitor class. The RFieldBase class and classes which inherit
 // clang-format on
 class RFieldVisitor {
 public:
-   virtual void VisitField(const RFieldBase &field) = 0;
-   virtual void VisitFieldZero(const RFieldZero &field) { VisitField(field); }
-   virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
-   virtual void VisitArrayAsRVecField(const RArrayAsRVecField &field) { VisitField(field); }
-   virtual void VisitAtomicField(const RAtomicField &field) { VisitField(field); }
-   virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
-   virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
-   virtual void VisitClassField(const RClassField &field) { VisitField(field); }
-   virtual void VisitTObjectField(const RField<TObject> &field) { VisitField(field); }
-   virtual void VisitStreamerField(const RStreamerField &field) { VisitField(field); }
-   virtual void VisitProxiedCollectionField(const RProxiedCollectionField &field) { VisitField(field); }
-   virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
-   virtual void VisitCardinalityField(const RCardinalityField &field) { VisitField(field); }
-   virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
-   virtual void VisitEnumField(const REnumField &field) { VisitField(field); }
-   virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
-   virtual void VisitByteField(const RField<std::byte> &field) { VisitField(field); }
-   virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
+   virtual void VisitField(const ROOT::RFieldBase &field) = 0;
+   virtual void VisitFieldZero(const ROOT::RFieldZero &field) { VisitField(field); }
+   virtual void VisitArrayField(const ROOT::RArrayField &field) { VisitField(field); }
+   virtual void VisitArrayAsRVecField(const ROOT::RArrayAsRVecField &field) { VisitField(field); }
+   virtual void VisitAtomicField(const ROOT::RAtomicField &field) { VisitField(field); }
+   virtual void VisitBitsetField(const ROOT::RBitsetField &field) { VisitField(field); }
+   virtual void VisitBoolField(const ROOT::RField<bool> &field) { VisitField(field); }
+   virtual void VisitClassField(const ROOT::RClassField &field) { VisitField(field); }
+   virtual void VisitTObjectField(const ROOT::RField<TObject> &field) { VisitField(field); }
+   virtual void VisitStreamerField(const ROOT::RStreamerField &field) { VisitField(field); }
+   virtual void VisitProxiedCollectionField(const ROOT::RProxiedCollectionField &field) { VisitField(field); }
+   virtual void VisitRecordField(const ROOT::RRecordField &field) { VisitField(field); }
+   virtual void VisitCardinalityField(const ROOT::RCardinalityField &field) { VisitField(field); }
+   virtual void VisitDoubleField(const ROOT::RField<double> &field) { VisitField(field); }
+   virtual void VisitEnumField(const ROOT::REnumField &field) { VisitField(field); }
+   virtual void VisitFloatField(const ROOT::RField<float> &field) { VisitField(field); }
+   virtual void VisitByteField(const ROOT::RField<std::byte> &field) { VisitField(field); }
+   virtual void VisitCharField(const ROOT::RField<char> &field) { VisitField(field); }
    // We have to accept RIntegralField here because there can be multiple basic types that map to the same fixed-width
    // integer type; for example on 64-bit Unix systems, both long and long long map to std::int64_t.
-   virtual void VisitInt8Field(const RIntegralField<std::int8_t> &field) { VisitField(field); }
-   virtual void VisitInt16Field(const RIntegralField<std::int16_t> &field) { VisitField(field); }
-   virtual void VisitInt32Field(const RIntegralField<std::int32_t> &field) { VisitField(field); }
-   virtual void VisitInt64Field(const RIntegralField<std::int64_t> &field) { VisitField(field); }
-   virtual void VisitNullableField(const RNullableField &field) { VisitField(field); }
-   virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
-   virtual void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) { VisitField(field); }
-   virtual void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) { VisitField(field); }
-   virtual void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) { VisitField(field); }
-   virtual void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) { VisitField(field); }
-   virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
-   virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
-   virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
+   virtual void VisitInt8Field(const ROOT::RIntegralField<std::int8_t> &field) { VisitField(field); }
+   virtual void VisitInt16Field(const ROOT::RIntegralField<std::int16_t> &field) { VisitField(field); }
+   virtual void VisitInt32Field(const ROOT::RIntegralField<std::int32_t> &field) { VisitField(field); }
+   virtual void VisitInt64Field(const ROOT::RIntegralField<std::int64_t> &field) { VisitField(field); }
+   virtual void VisitNullableField(const ROOT::RNullableField &field) { VisitField(field); }
+   virtual void VisitStringField(const ROOT::RField<std::string> &field) { VisitField(field); }
+   virtual void VisitUInt8Field(const ROOT::RIntegralField<std::uint8_t> &field) { VisitField(field); }
+   virtual void VisitUInt16Field(const ROOT::RIntegralField<std::uint16_t> &field) { VisitField(field); }
+   virtual void VisitUInt32Field(const ROOT::RIntegralField<std::uint32_t> &field) { VisitField(field); }
+   virtual void VisitUInt64Field(const ROOT::RIntegralField<std::uint64_t> &field) { VisitField(field); }
+   virtual void VisitVectorField(const ROOT::RVectorField &field) { VisitField(field); }
+   virtual void VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field) { VisitField(field); }
+   virtual void VisitRVecField(const ROOT::RRVecField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -96,8 +96,8 @@ private:
 
 public:
    RPrepareVisitor() = default;
-   void VisitField(const RFieldBase &field) final;
-   void VisitFieldZero(const RFieldZero &field) final;
+   void VisitField(const ROOT::RFieldBase &field) final;
+   void VisitFieldZero(const ROOT::RFieldZero &field) final;
 
    unsigned int GetDeepestLevel() const { return fDeepestLevel; }
    unsigned int GetNumFields() const { return fNumFields; }
@@ -137,8 +137,8 @@ public:
       SetAvailableSpaceForStrings();
    }
    /// Prints summary of Field
-   void VisitField(const RFieldBase &field) final;
-   void VisitFieldZero(const RFieldZero &fieldZero) final;
+   void VisitField(const ROOT::RFieldBase &field) final;
+   void VisitFieldZero(const ROOT::RFieldZero &fieldZero) final;
    void SetFrameSymbol(char s) { fFrameSymbol = s; }
    void SetWidth(int w) { fWidth = w; }
    void SetDeepestLevel(int d);
@@ -183,56 +183,56 @@ public:
    };
 
 private:
-   RFieldBase::RValue fValue;
+   ROOT::RFieldBase::RValue fValue;
    /// The output is directed to fOutput which may differ from std::cout.
    std::ostream &fOutput;
    unsigned int fLevel;
    RPrintOptions fPrintOptions;
 
    void PrintIndent();
-   void PrintName(const RFieldBase &field);
-   void PrintCollection(const RFieldBase &field);
-   void PrintRecord(const RFieldBase &field);
+   void PrintName(const ROOT::RFieldBase &field);
+   void PrintCollection(const ROOT::RFieldBase &field);
+   void PrintRecord(const ROOT::RFieldBase &field);
 
 public:
-   RPrintValueVisitor(RFieldBase::RValue value, std::ostream &output, unsigned int level = 0,
+   RPrintValueVisitor(ROOT::RFieldBase::RValue value, std::ostream &output, unsigned int level = 0,
                       RPrintOptions options = RPrintOptions())
       : fValue(value), fOutput{output}, fLevel(level), fPrintOptions(options)
    {
    }
 
-   void VisitField(const RFieldBase &field) final;
+   void VisitField(const ROOT::RFieldBase &field) final;
 
-   void VisitBoolField(const RField<bool> &field) final;
-   void VisitDoubleField(const RField<double> &field) final;
-   void VisitFloatField(const RField<float> &field) final;
-   void VisitByteField(const RField<std::byte> &field) final;
-   void VisitCharField(const RField<char> &field) final;
-   void VisitInt8Field(const RIntegralField<std::int8_t> &field) final;
-   void VisitInt16Field(const RIntegralField<std::int16_t> &field) final;
-   void VisitInt32Field(const RIntegralField<std::int32_t> &field) final;
-   void VisitInt64Field(const RIntegralField<std::int64_t> &field) final;
-   void VisitStringField(const RField<std::string> &field) final;
-   void VisitUInt8Field(const RIntegralField<std::uint8_t> &field) final;
-   void VisitUInt16Field(const RIntegralField<std::uint16_t> &field) final;
-   void VisitUInt32Field(const RIntegralField<std::uint32_t> &field) final;
-   void VisitUInt64Field(const RIntegralField<std::uint64_t> &field) final;
+   void VisitBoolField(const ROOT::RField<bool> &field) final;
+   void VisitDoubleField(const ROOT::RField<double> &field) final;
+   void VisitFloatField(const ROOT::RField<float> &field) final;
+   void VisitByteField(const ROOT::RField<std::byte> &field) final;
+   void VisitCharField(const ROOT::RField<char> &field) final;
+   void VisitInt8Field(const ROOT::RIntegralField<std::int8_t> &field) final;
+   void VisitInt16Field(const ROOT::RIntegralField<std::int16_t> &field) final;
+   void VisitInt32Field(const ROOT::RIntegralField<std::int32_t> &field) final;
+   void VisitInt64Field(const ROOT::RIntegralField<std::int64_t> &field) final;
+   void VisitStringField(const ROOT::RField<std::string> &field) final;
+   void VisitUInt8Field(const ROOT::RIntegralField<std::uint8_t> &field) final;
+   void VisitUInt16Field(const ROOT::RIntegralField<std::uint16_t> &field) final;
+   void VisitUInt32Field(const ROOT::RIntegralField<std::uint32_t> &field) final;
+   void VisitUInt64Field(const ROOT::RIntegralField<std::uint64_t> &field) final;
 
-   void VisitCardinalityField(const RCardinalityField &field) final;
-   void VisitArrayField(const RArrayField &field) final;
-   void VisitArrayAsRVecField(const RArrayAsRVecField &field) final;
-   void VisitClassField(const RClassField &field) final;
-   void VisitTObjectField(const RField<TObject> &field) final;
-   void VisitStreamerField(const RStreamerField &field) final;
-   void VisitRecordField(const RRecordField &field) final;
-   void VisitProxiedCollectionField(const RProxiedCollectionField &field) final;
-   void VisitVectorField(const RVectorField &field) final;
-   void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
-   void VisitRVecField(const RRVecField &field) final;
-   void VisitBitsetField(const RBitsetField &field) final;
-   void VisitNullableField(const RNullableField &field) final;
-   void VisitEnumField(const REnumField &field) final;
-   void VisitAtomicField(const RAtomicField &field) final;
+   void VisitCardinalityField(const ROOT::RCardinalityField &field) final;
+   void VisitArrayField(const ROOT::RArrayField &field) final;
+   void VisitArrayAsRVecField(const ROOT::RArrayAsRVecField &field) final;
+   void VisitClassField(const ROOT::RClassField &field) final;
+   void VisitTObjectField(const ROOT::RField<TObject> &field) final;
+   void VisitStreamerField(const ROOT::RStreamerField &field) final;
+   void VisitRecordField(const ROOT::RRecordField &field) final;
+   void VisitProxiedCollectionField(const ROOT::RProxiedCollectionField &field) final;
+   void VisitVectorField(const ROOT::RVectorField &field) final;
+   void VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field) final;
+   void VisitRVecField(const ROOT::RRVecField &field) final;
+   void VisitBitsetField(const ROOT::RBitsetField &field) final;
+   void VisitNullableField(const ROOT::RNullableField &field) final;
+   void VisitEnumField(const ROOT::REnumField &field) final;
+   void VisitAtomicField(const ROOT::RAtomicField &field) final;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -43,13 +43,14 @@
 
 namespace ROOT {
 
+class RFieldBase;
+
 namespace Internal {
 class RColumnElementBase;
 }
 
 namespace Experimental {
 
-class RFieldBase;
 class RNTupleDescriptor;
 class RNTupleModel;
 
@@ -123,7 +124,7 @@ public:
 
    /// In general, we create a field simply from the C++ type name. For untyped fields, however, we potentially need
    /// access to sub fields, which is provided by the ntuple descriptor argument.
-   std::unique_ptr<RFieldBase>
+   std::unique_ptr<ROOT::RFieldBase>
    CreateField(const RNTupleDescriptor &ntplDesc, const ROOT::RCreateFieldOptions &options = {}) const;
 
    ROOT::DescriptorId_t GetId() const { return fFieldId; }
@@ -1276,7 +1277,7 @@ public:
    explicit RFieldDescriptorBuilder(const RFieldDescriptor &fieldDesc);
 
    /// Make a new RFieldDescriptorBuilder based off a live NTuple field.
-   static RFieldDescriptorBuilder FromField(const RFieldBase &field);
+   static RFieldDescriptorBuilder FromField(const ROOT::RFieldBase &field);
 
    RFieldDescriptorBuilder &FieldId(ROOT::DescriptorId_t fieldId)
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -42,7 +42,7 @@ class RNTupleWriter;
 namespace Internal {
 class RProjectedFields;
 
-RFieldZero &GetFieldZeroOfModel(RNTupleModel &model);
+ROOT::RFieldZero &GetFieldZeroOfModel(RNTupleModel &model);
 RProjectedFields &GetProjectedFieldsOfModel(RNTupleModel &model);
 
 // clang-format off
@@ -62,12 +62,12 @@ class RProjectedFields {
 public:
    /// The map keys are the projected target fields, the map values are the backing source fields
    /// Note that sub fields are treated individually and indepently of their parent field
-   using FieldMap_t = std::unordered_map<const RFieldBase *, const RFieldBase *>;
+   using FieldMap_t = std::unordered_map<const ROOT::RFieldBase *, const ROOT::RFieldBase *>;
 
 private:
-   explicit RProjectedFields(std::unique_ptr<RFieldZero> fieldZero) : fFieldZero(std::move(fieldZero)) {}
+   explicit RProjectedFields(std::unique_ptr<ROOT::RFieldZero> fieldZero) : fFieldZero(std::move(fieldZero)) {}
    /// The projected fields are attached to this zero field
-   std::unique_ptr<RFieldZero> fFieldZero;
+   std::unique_ptr<ROOT::RFieldZero> fFieldZero;
    /// Maps the source fields from fModel to the target projected fields attached to fFieldZero
    FieldMap_t fFieldMap;
    /// The model this set of projected fields belongs to
@@ -75,10 +75,13 @@ private:
 
    /// Asserts that the passed field is a valid target of the source field provided in the field map.
    /// Checks the field without looking into sub fields.
-   RResult<void> EnsureValidMapping(const RFieldBase *target, const FieldMap_t &fieldMap);
+   RResult<void> EnsureValidMapping(const ROOT::RFieldBase *target, const FieldMap_t &fieldMap);
 
 public:
-   explicit RProjectedFields(const RNTupleModel &model) : fFieldZero(std::make_unique<RFieldZero>()), fModel(&model) {}
+   explicit RProjectedFields(const RNTupleModel &model)
+      : fFieldZero(std::make_unique<ROOT::RFieldZero>()), fModel(&model)
+   {
+   }
    RProjectedFields(const RProjectedFields &) = delete;
    RProjectedFields(RProjectedFields &&) = default;
    RProjectedFields &operator=(const RProjectedFields &) = delete;
@@ -88,11 +91,11 @@ public:
    /// The new model needs to be a clone of fModel
    std::unique_ptr<RProjectedFields> Clone(const RNTupleModel &newModel) const;
 
-   RFieldZero &GetFieldZero() { return *fFieldZero; }
-   const RFieldBase *GetSourceField(const RFieldBase *target) const;
+   ROOT::RFieldZero &GetFieldZero() { return *fFieldZero; }
+   const ROOT::RFieldBase *GetSourceField(const ROOT::RFieldBase *target) const;
    /// Adds a new projected field. The field map needs to provide valid source fields of fModel for 'field'
    /// and each of its sub fields.
-   RResult<void> Add(std::unique_ptr<RFieldBase> field, const FieldMap_t &fieldMap);
+   RResult<void> Add(std::unique_ptr<ROOT::RFieldBase> field, const FieldMap_t &fieldMap);
    bool IsEmpty() const { return fFieldZero->begin() == fFieldZero->end(); }
 };
 
@@ -117,7 +120,7 @@ that were used for writing and are no longer connected to a page sink.
 */
 // clang-format on
 class RNTupleModel {
-   friend RFieldZero &Internal::GetFieldZeroOfModel(RNTupleModel &);
+   friend ROOT::RFieldZero &Internal::GetFieldZeroOfModel(RNTupleModel &);
    friend Internal::RProjectedFields &Internal::GetProjectedFieldsOfModel(RNTupleModel &);
 
 public:
@@ -149,7 +152,7 @@ private:
    };
 
    /// Hierarchy of fields consisting of simple types and collections (sub trees)
-   std::unique_ptr<RFieldZero> fFieldZero;
+   std::unique_ptr<ROOT::RFieldZero> fFieldZero;
    /// Contains field values corresponding to the created top-level fields, as well as registered subfields
    std::unique_ptr<REntry> fDefaultEntry;
    /// Keeps track of which field names are taken, including projected field names.
@@ -180,13 +183,13 @@ private:
    void EnsureNotBare() const;
 
    /// The field name can be a top-level field or a nested field. Returns nullptr if the field is not in the model.
-   RFieldBase *FindField(std::string_view fieldName) const;
+   ROOT::RFieldBase *FindField(std::string_view fieldName) const;
 
    /// Add a subfield to the provided entry. If `initializeValue` is false, a nullptr will be bound to the entry value
    /// (used in bare models).
    void AddSubfield(std::string_view fieldName, REntry &entry, bool initializeValue = true) const;
 
-   RNTupleModel(std::unique_ptr<RFieldZero> fieldZero);
+   RNTupleModel(std::unique_ptr<ROOT::RFieldZero> fieldZero);
 
 public:
    RNTupleModel(const RNTupleModel &) = delete;
@@ -195,10 +198,10 @@ public:
 
    std::unique_ptr<RNTupleModel> Clone() const;
    static std::unique_ptr<RNTupleModel> Create();
-   static std::unique_ptr<RNTupleModel> Create(std::unique_ptr<RFieldZero> fieldZero);
+   static std::unique_ptr<RNTupleModel> Create(std::unique_ptr<ROOT::RFieldZero> fieldZero);
    /// A bare model has no default entry
    static std::unique_ptr<RNTupleModel> CreateBare();
-   static std::unique_ptr<RNTupleModel> CreateBare(std::unique_ptr<RFieldZero> fieldZero);
+   static std::unique_ptr<RNTupleModel> CreateBare(std::unique_ptr<ROOT::RFieldZero> fieldZero);
 
    /// Creates a new field given a `name` or `{name, description}` pair and a
    /// corresponding, default-constructed value that is managed by a shared pointer.
@@ -242,7 +245,7 @@ public:
    {
       EnsureNotFrozen();
       EnsureValidFieldName(fieldNameDesc.fName);
-      auto field = std::make_unique<RField<T>>(fieldNameDesc.fName);
+      auto field = std::make_unique<ROOT::RField<T>>(fieldNameDesc.fName);
       field->SetDescription(fieldNameDesc.fDescription);
       std::shared_ptr<T> ptr;
       if (fDefaultEntry)
@@ -255,7 +258,7 @@ public:
    /// Adds a field whose type is not known at compile time.  Thus there is no shared pointer returned.
    ///
    /// Throws an exception if the field is null.
-   void AddField(std::unique_ptr<RFieldBase> field);
+   void AddField(std::unique_ptr<ROOT::RFieldBase> field);
 
    /// Register a subfield so it can be accessed directly from entries belonging to the model. Because registering a
    /// subfield does not fundamentally change the model, previously created entries will not be invalidated, nor
@@ -276,7 +279,7 @@ public:
    /// ~~~ {.cpp}
    /// auto model = RNTupleModel::Create();
    /// model->MakeField<float>("met");
-   /// auto metProjection = RFieldBase::Create("missingE", "float").Unwrap();
+   /// auto metProjection = ROOT::RFieldBase::Create("missingE", "float").Unwrap();
    /// model->AddProjectedField(std::move(metProjection), [](const std::string &) { return "met"; });
    /// ~~~
    ///
@@ -292,7 +295,7 @@ public:
    ///
    /// auto model = RNTupleModel::Create();
    /// model->MakeField<std::vector<P>>("points");
-   /// auto pxProjection = RFieldBase::Create("pxs", "std::vector<int>").Unwrap();
+   /// auto pxProjection = ROOT::RFieldBase::Create("pxs", "std::vector<int>").Unwrap();
    /// model->AddProjectedField(std::move(pxProjection), [](const std::string &fieldName) {
    ///   if (fieldName == "pxs")
    ///     return "points";
@@ -302,7 +305,7 @@ public:
    /// ~~~
    ///
    /// Creating projections for fields containing `std::variant` or fixed-size arrays is unsupported.
-   RResult<void> AddProjectedField(std::unique_ptr<RFieldBase> field, FieldMappingFunc_t mapping);
+   RResult<void> AddProjectedField(std::unique_ptr<ROOT::RFieldBase> field, FieldMappingFunc_t mapping);
 
    void Freeze();
    void Unfreeze();
@@ -320,16 +323,16 @@ public:
    /// Creates a token to be used in REntry methods to address a field present in the entry
    REntry::RFieldToken GetToken(std::string_view fieldName) const;
    /// Calls the given field's CreateBulk() method. Throws an exception if no field with the given name exists.
-   RFieldBase::RBulk CreateBulk(std::string_view fieldName) const;
+   ROOT::RFieldBase::RBulk CreateBulk(std::string_view fieldName) const;
 
    REntry &GetDefaultEntry();
    const REntry &GetDefaultEntry() const;
 
    /// Mutable access to the root field is used to make adjustments to the fields.
-   RFieldZero &GetMutableFieldZero();
-   const RFieldZero &GetConstFieldZero() const { return *fFieldZero; }
-   RFieldBase &GetMutableField(std::string_view fieldName);
-   const RFieldBase &GetConstField(std::string_view fieldName) const;
+   ROOT::RFieldZero &GetMutableFieldZero();
+   const ROOT::RFieldZero &GetConstFieldZero() const { return *fFieldZero; }
+   ROOT::RFieldBase &GetMutableField(std::string_view fieldName);
+   const ROOT::RFieldBase &GetConstField(std::string_view fieldName) const;
 
    const std::string &GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
@@ -361,15 +364,16 @@ You will not normally use this directly; see `RNTupleModel::RUpdater` instead.
 struct RNTupleModelChangeset {
    RNTupleModel &fModel;
    /// Points to the fields in fModel that were added as part of an updater transaction
-   std::vector<RFieldBase *> fAddedFields;
+   std::vector<ROOT::RFieldBase *> fAddedFields;
    /// Points to the projected fields in fModel that were added as part of an updater transaction
-   std::vector<RFieldBase *> fAddedProjectedFields;
+   std::vector<ROOT::RFieldBase *> fAddedProjectedFields;
 
    RNTupleModelChangeset(RNTupleModel &model) : fModel(model) {}
    bool IsEmpty() const { return fAddedFields.empty() && fAddedProjectedFields.empty(); }
 
-   void AddField(std::unique_ptr<RFieldBase> field);
-   ROOT::RResult<void> AddProjectedField(std::unique_ptr<RFieldBase> field, RNTupleModel::FieldMappingFunc_t mapping);
+   void AddField(std::unique_ptr<ROOT::RFieldBase> field);
+   ROOT::RResult<void>
+   AddProjectedField(std::unique_ptr<ROOT::RFieldBase> field, RNTupleModel::FieldMappingFunc_t mapping);
 };
 
 } // namespace Internal
@@ -408,9 +412,9 @@ public:
       return objPtr;
    }
 
-   void AddField(std::unique_ptr<RFieldBase> field);
+   void AddField(std::unique_ptr<ROOT::RFieldBase> field);
 
-   RResult<void> AddProjectedField(std::unique_ptr<RFieldBase> field, FieldMappingFunc_t mapping);
+   RResult<void> AddProjectedField(std::unique_ptr<ROOT::RFieldBase> field, FieldMappingFunc_t mapping);
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -102,20 +102,20 @@ protected:
       friend class RNTupleJoinProcessor;
 
    private:
-      std::unique_ptr<RFieldBase> fProtoField;
-      std::unique_ptr<RFieldBase> fConcreteField;
+      std::unique_ptr<ROOT::RFieldBase> fProtoField;
+      std::unique_ptr<ROOT::RFieldBase> fConcreteField;
       REntry::RFieldToken fToken;
       // Which RNTuple the field belongs to, in case the field belongs to an auxiliary RNTuple, according to the order
       // in which it was specified. For chained RNTuples, this value will always be 0.
       std::size_t fNTupleIdx;
 
    public:
-      RFieldContext(std::unique_ptr<RFieldBase> protoField, REntry::RFieldToken token, std::size_t ntupleIdx = 0)
+      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, REntry::RFieldToken token, std::size_t ntupleIdx = 0)
          : fProtoField(std::move(protoField)), fToken(token), fNTupleIdx(ntupleIdx)
       {
       }
 
-      const RFieldBase &GetProtoField() const { return *fProtoField; }
+      const ROOT::RFieldBase &GetProtoField() const { return *fProtoField; }
       /// Concrete pages need to be reset explicitly before the page source they belong to is destroyed.
       void ResetConcreteField() { fConcreteField.reset(); }
       void SetConcreteField() { fConcreteField = fProtoField->Clone(fProtoField->GetFieldName()); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -38,7 +38,7 @@ namespace Internal {
 /// by the number of elements of the first principal column found in the subfields searched by BFS.
 /// If the field hierarchy is empty on columns, the returned field range is invalid (start and end set to
 /// kInvalidNTupleIndex). An attempt to use such a field range in RNTupleViewBase::GetFieldRange will throw.
-ROOT::RNTupleGlobalRange GetFieldRange(const RFieldBase &field, const RPageSource &pageSource);
+ROOT::RNTupleGlobalRange GetFieldRange(const ROOT::RFieldBase &field, const RPageSource &pageSource);
 
 } // namespace Internal
 
@@ -60,38 +60,38 @@ View can only be created by a reader or by a collection view.
 template <typename T>
 class RNTupleViewBase {
 protected:
-   std::unique_ptr<RFieldBase> fField;
+   std::unique_ptr<ROOT::RFieldBase> fField;
    ROOT::RNTupleGlobalRange fFieldRange;
-   RFieldBase::RValue fValue;
+   ROOT::RFieldBase::RValue fValue;
 
-   static std::unique_ptr<RFieldBase> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
+   static std::unique_ptr<ROOT::RFieldBase> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
    {
-      std::unique_ptr<RFieldBase> field;
+      std::unique_ptr<ROOT::RFieldBase> field;
       {
          const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
          const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
          if constexpr (std::is_void_v<T>) {
             field = fieldDesc.CreateField(desc);
          } else {
-            field = std::make_unique<RField<T>>(fieldDesc.GetFieldName());
+            field = std::make_unique<ROOT::RField<T>>(fieldDesc.GetFieldName());
          }
       }
       field->SetOnDiskId(fieldId);
-      Internal::CallConnectPageSourceOnField(*field, pageSource);
+      ROOT::Internal::CallConnectPageSourceOnField(*field, pageSource);
       return field;
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
+   RNTupleViewBase(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : fField(std::move(field)), fFieldRange(range), fValue(fField->CreateValue())
    {
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
+   RNTupleViewBase(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
       : fField(std::move(field)), fFieldRange(range), fValue(fField->BindValue(objPtr))
    {
    }
 
-   RNTupleViewBase(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
+   RNTupleViewBase(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
       : fField(std::move(field)),
         fFieldRange(range),
         fValue(fField->BindValue(ROOT::Internal::MakeAliasedSharedPtr(rawPtr)))
@@ -105,10 +105,10 @@ public:
    RNTupleViewBase &operator=(RNTupleViewBase &&other) = default;
    ~RNTupleViewBase() = default;
 
-   const RFieldBase &GetField() const { return *fField; }
-   RFieldBase::RBulk CreateBulk() { return fField->CreateBulk(); }
+   const ROOT::RFieldBase &GetField() const { return *fField; }
+   ROOT::RFieldBase::RBulk CreateBulk() { return fField->CreateBulk(); }
 
-   const RFieldBase::RValue &GetValue() const { return fValue; }
+   const ROOT::RFieldBase::RValue &GetValue() const { return fValue; }
    ROOT::RNTupleGlobalRange GetFieldRange() const
    {
       if (!fFieldRange.IsValid()) {
@@ -135,17 +135,17 @@ class RNTupleView : public RNTupleViewBase<T> {
    friend class RNTupleCollectionView;
 
 protected:
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : RNTupleViewBase<T>(std::move(field), range)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<T> objPtr)
       : RNTupleViewBase<T>(std::move(field), range, objPtr)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, T *rawPtr)
       : RNTupleViewBase<T>(std::move(field), range, rawPtr)
    {
    }
@@ -183,17 +183,17 @@ class RNTupleView<void> final : public RNTupleViewBase<void> {
    friend class RNTupleCollectionView;
 
 protected:
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range)
       : RNTupleViewBase<void>(std::move(field), range)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<void> objPtr)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, std::shared_ptr<void> objPtr)
       : RNTupleViewBase<void>(std::move(field), range, objPtr)
    {
    }
 
-   RNTupleView(std::unique_ptr<RFieldBase> field, ROOT::RNTupleGlobalRange range, void *rawPtr)
+   RNTupleView(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range, void *rawPtr)
       : RNTupleViewBase<void>(std::move(field), range, rawPtr)
    {
    }
@@ -222,24 +222,24 @@ class RNTupleDirectAccessView {
    friend class RNTupleCollectionView;
 
 protected:
-   RField<T> fField;
+   ROOT::RField<T> fField;
    ROOT::RNTupleGlobalRange fFieldRange;
 
-   static RField<T> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
+   static ROOT::RField<T> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
    {
       const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
-      if (fieldDesc.GetTypeName() != RField<T>::TypeName()) {
+      if (fieldDesc.GetTypeName() != ROOT::RField<T>::TypeName()) {
          throw RException(R__FAIL("type mismatch for field " + fieldDesc.GetFieldName() + ": " +
-                                  fieldDesc.GetTypeName() + " vs. " + RField<T>::TypeName()));
+                                  fieldDesc.GetTypeName() + " vs. " + ROOT::RField<T>::TypeName()));
       }
-      RField<T> field(fieldDesc.GetFieldName());
+      ROOT::RField<T> field(fieldDesc.GetFieldName());
       field.SetOnDiskId(fieldId);
-      Internal::CallConnectPageSourceOnField(field, pageSource);
+      ROOT::Internal::CallConnectPageSourceOnField(field, pageSource);
       return field;
    }
 
-   RNTupleDirectAccessView(RField<T> field, ROOT::RNTupleGlobalRange range)
+   RNTupleDirectAccessView(ROOT::RField<T> field, ROOT::RNTupleGlobalRange range)
       : fField(std::move(field)), fFieldRange(range)
    {
    }
@@ -251,7 +251,7 @@ public:
    RNTupleDirectAccessView &operator=(RNTupleDirectAccessView &&other) = default;
    ~RNTupleDirectAccessView() = default;
 
-   const RFieldBase &GetField() const { return fField; }
+   const ROOT::RFieldBase &GetField() const { return fField; }
    ROOT::RNTupleGlobalRange GetFieldRange() const { return fFieldRange; }
 
    const T &operator()(ROOT::NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
@@ -270,14 +270,14 @@ class RNTupleCollectionView {
 
 private:
    Internal::RPageSource *fSource;
-   RField<RNTupleCardinality<std::uint64_t>> fField;
-   RFieldBase::RValue fValue;
+   ROOT::RField<RNTupleCardinality<std::uint64_t>> fField;
+   ROOT::RFieldBase::RValue fValue;
 
    RNTupleCollectionView(ROOT::DescriptorId_t fieldId, const std::string &fieldName, Internal::RPageSource *source)
       : fSource(source), fField(fieldName), fValue(fField.CreateValue())
    {
       fField.SetOnDiskId(fieldId);
-      Internal::CallConnectPageSourceOnField(fField, *source);
+      ROOT::Internal::CallConnectPageSourceOnField(fField, *source);
    }
 
    static RNTupleCollectionView Create(ROOT::DescriptorId_t fieldId, Internal::RPageSource *source)

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -55,9 +55,11 @@ public:
 
    ROOT::NTupleSize_t GetNEntries() const final { return 0; }
 
-   void ConnectFields(const std::vector<RFieldBase *> &fields, ROOT::NTupleSize_t firstEntry)
+   void ConnectFields(const std::vector<ROOT::RFieldBase *> &fields, ROOT::NTupleSize_t firstEntry)
    {
-      auto connectField = [&](RFieldBase &f) { CallConnectPageSinkOnField(f, *this, firstEntry); };
+      auto connectField = [&](ROOT::RFieldBase &f) {
+         ROOT::Internal::CallConnectPageSinkOnField(f, *this, firstEntry);
+      };
       for (auto *f : fields) {
          connectField(*f);
          for (auto &descendant : *f) {

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -118,7 +118,7 @@ private:
    ROOT::DescriptorId_t fNFields = 0;
    ROOT::DescriptorId_t fNColumns = 0;
 
-   void ConnectFields(const std::vector<RFieldBase *> &fields, ROOT::NTupleSize_t firstEntry);
+   void ConnectFields(const std::vector<ROOT::RFieldBase *> &fields, ROOT::NTupleSize_t firstEntry);
    void FlushClusterImpl(std::function<void(void)> FlushClusterFn);
 
 public:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -31,8 +31,7 @@
 #include <memory>
 #include <type_traits>
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::RFieldZero::CloneImpl(std::string_view /*newName*/) const
 {
    auto result = std::make_unique<RFieldZero>();
    for (auto &f : fSubfields)
@@ -40,15 +39,14 @@ ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const
    return result;
 }
 
-void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RFieldZero::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitFieldZero(*this);
 }
 
 //------------------------------------------------------------------------------
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RCardinalityField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitIndex64},
                                                   {ENTupleColumnType::kIndex64},
@@ -58,34 +56,31 @@ ROOT::Experimental::RCardinalityField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RCardinalityField::GenerateColumns(const RNTupleDescriptor &desc)
+void ROOT::RCardinalityField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
 
-void ROOT::Experimental::RCardinalityField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RCardinalityField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitCardinalityField(*this);
 }
 
-const ROOT::Experimental::RField<ROOT::RNTupleCardinality<std::uint32_t>> *
-ROOT::Experimental::RCardinalityField::As32Bit() const
+const ROOT::RField<ROOT::RNTupleCardinality<std::uint32_t>> *ROOT::RCardinalityField::As32Bit() const
 {
    return dynamic_cast<const RField<RNTupleCardinality<std::uint32_t>> *>(this);
 }
 
-const ROOT::Experimental::RField<ROOT::RNTupleCardinality<std::uint64_t>> *
-ROOT::Experimental::RCardinalityField::As64Bit() const
+const ROOT::RField<ROOT::RNTupleCardinality<std::uint64_t>> *ROOT::RCardinalityField::As64Bit() const
 {
    return dynamic_cast<const RField<RNTupleCardinality<std::uint64_t>> *>(this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<char>;
+template class ROOT::RSimpleField<char>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<char>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<char>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kChar}}, {{ENTupleColumnType::kInt8},
                                                                                 {ENTupleColumnType::kUInt8},
@@ -105,33 +100,31 @@ ROOT::Experimental::RField<char>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<char>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitCharField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<std::byte>;
+template class ROOT::RSimpleField<std::byte>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::byte>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<std::byte>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kByte}}, {});
    return representations;
 }
 
-void ROOT::Experimental::RField<std::byte>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<std::byte>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitByteField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<int8_t>;
+template class ROOT::RSimpleField<int8_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::int8_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kInt8}}, {{ENTupleColumnType::kChar},
                                                                                 {ENTupleColumnType::kUInt8},
@@ -151,17 +144,16 @@ ROOT::Experimental::RIntegralField<std::int8_t>::GetColumnRepresentations() cons
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::int8_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt8Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<uint8_t>;
+template class ROOT::RSimpleField<uint8_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::uint8_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kUInt8}}, {{ENTupleColumnType::kChar},
                                                                                  {ENTupleColumnType::kInt8},
@@ -181,17 +173,16 @@ ROOT::Experimental::RIntegralField<std::uint8_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::uint8_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt8Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<bool>;
+template class ROOT::RSimpleField<bool>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<bool>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kBit}}, {{ENTupleColumnType::kChar},
                                                                                {ENTupleColumnType::kInt8},
@@ -211,17 +202,16 @@ ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<bool>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitBoolField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<float>;
+template class ROOT::RSimpleField<float>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<float>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<float>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitReal32},
                                                   {ENTupleColumnType::kReal32},
@@ -232,17 +222,16 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<float>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitFloatField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<double>;
+template class ROOT::RSimpleField<double>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<double>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<double>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitReal64},
                                                   {ENTupleColumnType::kReal64},
@@ -255,22 +244,21 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<double>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitDoubleField(*this);
 }
 
-void ROOT::Experimental::RField<double>::SetDouble32()
+void ROOT::RField<double>::SetDouble32()
 {
    fTypeAlias = "Double32_t";
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<int16_t>;
+template class ROOT::RSimpleField<int16_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::int16_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitInt16}, {ENTupleColumnType::kInt16}},
                                                  {{ENTupleColumnType::kChar},
@@ -290,17 +278,16 @@ ROOT::Experimental::RIntegralField<std::int16_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::int16_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt16Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<uint16_t>;
+template class ROOT::RSimpleField<uint16_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::uint16_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitUInt16}, {ENTupleColumnType::kUInt16}},
                                                  {{ENTupleColumnType::kChar},
@@ -320,17 +307,16 @@ ROOT::Experimental::RIntegralField<std::uint16_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::uint16_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt16Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<int32_t>;
+template class ROOT::RSimpleField<int32_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::int32_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitInt32}, {ENTupleColumnType::kInt32}},
                                                  {{ENTupleColumnType::kChar},
@@ -350,17 +336,16 @@ ROOT::Experimental::RIntegralField<std::int32_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::int32_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt32Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<uint32_t>;
+template class ROOT::RSimpleField<uint32_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::uint32_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitUInt32}, {ENTupleColumnType::kUInt32}},
                                                  {{ENTupleColumnType::kChar},
@@ -380,17 +365,16 @@ ROOT::Experimental::RIntegralField<std::uint32_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::uint32_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt32Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<uint64_t>;
+template class ROOT::RSimpleField<uint64_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::uint64_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitUInt64}, {ENTupleColumnType::kUInt64}},
                                                  {{ENTupleColumnType::kChar},
@@ -410,17 +394,16 @@ ROOT::Experimental::RIntegralField<std::uint64_t>::GetColumnRepresentations() co
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::uint64_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitUInt64Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-template class ROOT::Experimental::RSimpleField<int64_t>;
+template class ROOT::RSimpleField<int64_t>;
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RIntegralField<std::int64_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitInt64}, {ENTupleColumnType::kInt64}},
                                                  {{ENTupleColumnType::kChar},
@@ -440,15 +423,14 @@ ROOT::Experimental::RIntegralField<std::int64_t>::GetColumnRepresentations() con
    return representations;
 }
 
-void ROOT::Experimental::RIntegralField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RIntegralField<std::int64_t>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt64Field(*this);
 }
 
 //------------------------------------------------------------------------------
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RField<std::string>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitIndex64, ENTupleColumnType::kChar},
                                                   {ENTupleColumnType::kIndex64, ENTupleColumnType::kChar},
@@ -458,17 +440,17 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RField<std::string>::GenerateColumns()
+void ROOT::RField<std::string>::GenerateColumns()
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, char>();
 }
 
-void ROOT::Experimental::RField<std::string>::GenerateColumns(const RNTupleDescriptor &desc)
+void ROOT::RField<std::string>::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, char>(desc);
 }
 
-std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const void *from)
+std::size_t ROOT::RField<std::string>::AppendImpl(const void *from)
 {
    auto typedValue = static_cast<const std::string *>(from);
    auto length = typedValue->length();
@@ -478,7 +460,7 @@ std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const void *from
    return length + fPrincipalColumn->GetElement()->GetPackedSize();
 }
 
-void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
+void ROOT::RField<std::string>::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
    auto typedValue = static_cast<std::string *>(to);
    RNTupleLocalIndex collectionStart;
@@ -492,15 +474,15 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(ROOT::NTupleSize_t 
    }
 }
 
-void ROOT::Experimental::RField<std::string>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RField<std::string>::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitStringField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RRecordField::RRecordField(std::string_view name, const RRecordField &source)
-   : ROOT::Experimental::RFieldBase(name, source.GetTypeName(), ROOT::ENTupleStructure::kRecord, false /* isSimple */),
+ROOT::RRecordField::RRecordField(std::string_view name, const RRecordField &source)
+   : ROOT::RFieldBase(name, source.GetTypeName(), ROOT::ENTupleStructure::kRecord, false /* isSimple */),
      fMaxAlignment(source.fMaxAlignment),
      fSize(source.fSize),
      fOffsets(source.fOffsets)
@@ -510,13 +492,12 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view name, const RRec
    fTraits = source.fTraits;
 }
 
-ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName, std::string_view typeName)
-   : ROOT::Experimental::RFieldBase(fieldName, typeName, ROOT::ENTupleStructure::kRecord, false /* isSimple */)
+ROOT::RRecordField::RRecordField(std::string_view fieldName, std::string_view typeName)
+   : ROOT::RFieldBase(fieldName, typeName, ROOT::ENTupleStructure::kRecord, false /* isSimple */)
 {
 }
 
-void ROOT::Experimental::RRecordField::RRecordField::AttachItemFields(
-   std::vector<std::unique_ptr<RFieldBase>> itemFields)
+void ROOT::RRecordField::AttachItemFields(std::vector<std::unique_ptr<RFieldBase>> itemFields)
 {
    fTraits |= kTraitTrivialType;
    for (auto &item : itemFields) {
@@ -530,18 +511,16 @@ void ROOT::Experimental::RRecordField::RRecordField::AttachItemFields(
    fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::Internal::CreateEmulatedField(std::string_view fieldName,
-                                                  std::vector<std::unique_ptr<RFieldBase>> itemFields,
-                                                  std::string_view emulatedFromType)
+std::unique_ptr<ROOT::RFieldBase>
+ROOT::Internal::CreateEmulatedField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                    std::string_view emulatedFromType)
 {
    return std::unique_ptr<RFieldBase>(new RRecordField(fieldName, std::move(itemFields), emulatedFromType));
 }
 
-ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
-                                               std::vector<std::unique_ptr<RFieldBase>> itemFields,
-                                               std::string_view emulatedFromType)
-   : ROOT::Experimental::RFieldBase(fieldName, emulatedFromType, ROOT::ENTupleStructure::kRecord, false /* isSimple */)
+ROOT::RRecordField::RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                 std::string_view emulatedFromType)
+   : ROOT::RFieldBase(fieldName, emulatedFromType, ROOT::ENTupleStructure::kRecord, false /* isSimple */)
 {
    fTraits |= kTraitTrivialType;
    fOffsets.reserve(itemFields.size());
@@ -559,13 +538,12 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
    fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
-ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
-                                               std::vector<std::unique_ptr<RFieldBase>> itemFields)
-   : ROOT::Experimental::RRecordField(fieldName, std::move(itemFields), "")
+ROOT::RRecordField::RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields)
+   : ROOT::RRecordField(fieldName, std::move(itemFields), "")
 {
 }
 
-std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const
+std::size_t ROOT::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const
 {
    if (itemAlignment > 1) {
       auto remainder = baseOffset % itemAlignment;
@@ -575,13 +553,12 @@ std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOff
    return 0;
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RRecordField::CloneImpl(std::string_view newName) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::RRecordField::CloneImpl(std::string_view newName) const
 {
    return std::unique_ptr<RRecordField>(new RRecordField(newName, *this));
 }
 
-std::size_t ROOT::Experimental::RRecordField::AppendImpl(const void *from)
+std::size_t ROOT::RRecordField::AppendImpl(const void *from)
 {
    std::size_t nbytes = 0;
    for (unsigned i = 0; i < fSubfields.size(); ++i) {
@@ -590,28 +567,28 @@ std::size_t ROOT::Experimental::RRecordField::AppendImpl(const void *from)
    return nbytes;
 }
 
-void ROOT::Experimental::RRecordField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
+void ROOT::RRecordField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
    for (unsigned i = 0; i < fSubfields.size(); ++i) {
       CallReadOn(*fSubfields[i], globalIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
-void ROOT::Experimental::RRecordField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
+void ROOT::RRecordField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
 {
    for (unsigned i = 0; i < fSubfields.size(); ++i) {
       CallReadOn(*fSubfields[i], localIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
-void ROOT::Experimental::RRecordField::ConstructValue(void *where) const
+void ROOT::RRecordField::ConstructValue(void *where) const
 {
    for (unsigned i = 0; i < fSubfields.size(); ++i) {
       CallConstructValueOn(*fSubfields[i], static_cast<unsigned char *>(where) + fOffsets[i]);
    }
 }
 
-void ROOT::Experimental::RRecordField::RRecordDeleter::operator()(void *objPtr, bool dtorOnly)
+void ROOT::RRecordField::RRecordDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    for (unsigned i = 0; i < fItemDeleters.size(); ++i) {
       fItemDeleters[i]->operator()(reinterpret_cast<unsigned char *>(objPtr) + fOffsets[i], true /* dtorOnly */);
@@ -619,7 +596,7 @@ void ROOT::Experimental::RRecordField::RRecordDeleter::operator()(void *objPtr, 
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RRecordField::GetDeleter() const
+std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RRecordField::GetDeleter() const
 {
    std::vector<std::unique_ptr<RDeleter>> itemDeleters;
    itemDeleters.reserve(fOffsets.size());
@@ -629,8 +606,7 @@ std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RR
    return std::make_unique<RRecordDeleter>(std::move(itemDeleters), fOffsets);
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::RRecordField::SplitValue(const RValue &value) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::RRecordField::SplitValue(const RValue &value) const
 {
    auto basePtr = value.GetPtr<unsigned char>().get();
    std::vector<RValue> result;
@@ -641,39 +617,38 @@ ROOT::Experimental::RRecordField::SplitValue(const RValue &value) const
    return result;
 }
 
-void ROOT::Experimental::RRecordField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RRecordField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitRecordField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RBitsetField::RBitsetField(std::string_view fieldName, std::size_t N)
-   : ROOT::Experimental::RFieldBase(fieldName, "std::bitset<" + std::to_string(N) + ">", ROOT::ENTupleStructure::kLeaf,
-                                    false /* isSimple */, N),
+ROOT::RBitsetField::RBitsetField(std::string_view fieldName, std::size_t N)
+   : ROOT::RFieldBase(fieldName, "std::bitset<" + std::to_string(N) + ">", ROOT::ENTupleStructure::kLeaf,
+                      false /* isSimple */, N),
      fN(N)
 {
    fTraits |= kTraitTriviallyDestructible;
 }
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RBitsetField::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RBitsetField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kBit}}, {});
    return representations;
 }
 
-void ROOT::Experimental::RBitsetField::GenerateColumns()
+void ROOT::RBitsetField::GenerateColumns()
 {
    GenerateColumnsImpl<bool>();
 }
 
-void ROOT::Experimental::RBitsetField::GenerateColumns(const RNTupleDescriptor &desc)
+void ROOT::RBitsetField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<bool>(desc);
 }
 
-std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const void *from)
+std::size_t ROOT::RBitsetField::AppendImpl(const void *from)
 {
    const auto *asULongArray = static_cast<const Word_t *>(from);
    bool elementValue;
@@ -687,7 +662,7 @@ std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const void *from)
    return fN;
 }
 
-void ROOT::Experimental::RBitsetField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
+void ROOT::RBitsetField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
    auto *asULongArray = static_cast<Word_t *>(to);
    bool elementValue;
@@ -699,7 +674,7 @@ void ROOT::Experimental::RBitsetField::ReadGlobalImpl(ROOT::NTupleSize_t globalI
    }
 }
 
-void ROOT::Experimental::RBitsetField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
+void ROOT::RBitsetField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
 {
    auto *asULongArray = static_cast<Word_t *>(to);
    bool elementValue;
@@ -712,22 +687,21 @@ void ROOT::Experimental::RBitsetField::ReadInClusterImpl(RNTupleLocalIndex local
    }
 }
 
-void ROOT::Experimental::RBitsetField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RBitsetField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitBitsetField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RNullableField::RNullableField(std::string_view fieldName, std::string_view typeName,
-                                                   std::unique_ptr<RFieldBase> itemField)
-   : ROOT::Experimental::RFieldBase(fieldName, typeName, ROOT::ENTupleStructure::kCollection, false /* isSimple */)
+ROOT::RNullableField::RNullableField(std::string_view fieldName, std::string_view typeName,
+                                     std::unique_ptr<RFieldBase> itemField)
+   : ROOT::RFieldBase(fieldName, typeName, ROOT::ENTupleStructure::kCollection, false /* isSimple */)
 {
    Attach(std::move(itemField));
 }
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RNullableField::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RNullableField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{ENTupleColumnType::kSplitIndex64},
                                                   {ENTupleColumnType::kIndex64},
@@ -737,23 +711,23 @@ ROOT::Experimental::RNullableField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RNullableField::GenerateColumns()
+void ROOT::RNullableField::GenerateColumns()
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::Experimental::RNullableField::GenerateColumns(const RNTupleDescriptor &desc)
+void ROOT::RNullableField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
 
-std::size_t ROOT::Experimental::RNullableField::AppendNull()
+std::size_t ROOT::RNullableField::AppendNull()
 {
    fPrincipalColumn->Append(&fNWritten);
    return sizeof(ROOT::Internal::RColumnIndex);
 }
 
-std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
+std::size_t ROOT::RNullableField::AppendValue(const void *from)
 {
    auto nbytesItem = CallAppendOn(*fSubfields[0], from);
    fNWritten++;
@@ -761,7 +735,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
    return sizeof(ROOT::Internal::RColumnIndex) + nbytesItem;
 }
 
-ROOT::RNTupleLocalIndex ROOT::Experimental::RNullableField::GetItemIndex(ROOT::NTupleSize_t globalIndex)
+ROOT::RNTupleLocalIndex ROOT::RNullableField::GetItemIndex(ROOT::NTupleSize_t globalIndex)
 {
    RNTupleLocalIndex collectionStart;
    ROOT::NTupleSize_t collectionSize;
@@ -769,27 +743,26 @@ ROOT::RNTupleLocalIndex ROOT::Experimental::RNullableField::GetItemIndex(ROOT::N
    return (collectionSize == 0) ? RNTupleLocalIndex() : collectionStart;
 }
 
-void ROOT::Experimental::RNullableField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RNullableField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitNullableField(*this);
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RUniquePtrField::RUniquePtrField(std::string_view fieldName, std::string_view typeName,
-                                                     std::unique_ptr<RFieldBase> itemField)
+ROOT::RUniquePtrField::RUniquePtrField(std::string_view fieldName, std::string_view typeName,
+                                       std::unique_ptr<RFieldBase> itemField)
    : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubfields[0]))
 {
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RUniquePtrField::CloneImpl(std::string_view newName) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::RUniquePtrField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<RUniquePtrField>(newName, GetTypeName(), std::move(newItemField));
 }
 
-std::size_t ROOT::Experimental::RUniquePtrField::AppendImpl(const void *from)
+std::size_t ROOT::RUniquePtrField::AppendImpl(const void *from)
 {
    auto typedValue = static_cast<const std::unique_ptr<char> *>(from);
    if (*typedValue) {
@@ -799,7 +772,7 @@ std::size_t ROOT::Experimental::RUniquePtrField::AppendImpl(const void *from)
    }
 }
 
-void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
+void ROOT::RUniquePtrField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
    auto ptr = static_cast<std::unique_ptr<char> *>(to);
    bool isValidValue = static_cast<bool>(*ptr);
@@ -828,7 +801,7 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(ROOT::NTupleSize_t glob
    CallReadOn(*fSubfields[0], itemIndex, valuePtr);
 }
 
-void ROOT::Experimental::RUniquePtrField::RUniquePtrDeleter::operator()(void *objPtr, bool dtorOnly)
+void ROOT::RUniquePtrField::RUniquePtrDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    auto typedPtr = static_cast<std::unique_ptr<char> *>(objPtr);
    if (*typedPtr) {
@@ -838,13 +811,12 @@ void ROOT::Experimental::RUniquePtrField::RUniquePtrDeleter::operator()(void *ob
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::RUniquePtrField::GetDeleter() const
+std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RUniquePtrField::GetDeleter() const
 {
    return std::make_unique<RUniquePtrDeleter>(GetDeleterOf(*fSubfields[0]));
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::RUniquePtrField::SplitValue(const RValue &value) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::RUniquePtrField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    const auto &ptr = value.GetRef<std::unique_ptr<char>>();
@@ -856,32 +828,31 @@ ROOT::Experimental::RUniquePtrField::SplitValue(const RValue &value) const
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::ROptionalField::ROptionalField(std::string_view fieldName, std::string_view typeName,
-                                                   std::unique_ptr<RFieldBase> itemField)
+ROOT::ROptionalField::ROptionalField(std::string_view fieldName, std::string_view typeName,
+                                     std::unique_ptr<RFieldBase> itemField)
    : RNullableField(fieldName, typeName, std::move(itemField)), fItemDeleter(GetDeleterOf(*fSubfields[0]))
 {
    if (fSubfields[0]->GetTraits() & kTraitTriviallyDestructible)
       fTraits |= kTraitTriviallyDestructible;
 }
 
-bool *ROOT::Experimental::ROptionalField::GetEngagementPtr(void *optionalPtr) const
+bool *ROOT::ROptionalField::GetEngagementPtr(void *optionalPtr) const
 {
    return reinterpret_cast<bool *>(reinterpret_cast<unsigned char *>(optionalPtr) + fSubfields[0]->GetValueSize());
 }
 
-const bool *ROOT::Experimental::ROptionalField::GetEngagementPtr(const void *optionalPtr) const
+const bool *ROOT::ROptionalField::GetEngagementPtr(const void *optionalPtr) const
 {
    return GetEngagementPtr(const_cast<void *>(optionalPtr));
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::ROptionalField::CloneImpl(std::string_view newName) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::ROptionalField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<ROptionalField>(newName, GetTypeName(), std::move(newItemField));
 }
 
-std::size_t ROOT::Experimental::ROptionalField::AppendImpl(const void *from)
+std::size_t ROOT::ROptionalField::AppendImpl(const void *from)
 {
    if (*GetEngagementPtr(from)) {
       return AppendValue(from);
@@ -890,7 +861,7 @@ std::size_t ROOT::Experimental::ROptionalField::AppendImpl(const void *from)
    }
 }
 
-void ROOT::Experimental::ROptionalField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
+void ROOT::ROptionalField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
    auto engagementPtr = GetEngagementPtr(to);
    auto itemIndex = GetItemIndex(globalIndex);
@@ -906,12 +877,12 @@ void ROOT::Experimental::ROptionalField::ReadGlobalImpl(ROOT::NTupleSize_t globa
    }
 }
 
-void ROOT::Experimental::ROptionalField::ConstructValue(void *where) const
+void ROOT::ROptionalField::ConstructValue(void *where) const
 {
    *GetEngagementPtr(where) = false;
 }
 
-void ROOT::Experimental::ROptionalField::ROptionalDeleter::operator()(void *objPtr, bool dtorOnly)
+void ROOT::ROptionalField::ROptionalDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    if (fItemDeleter) {
       auto engagementPtr = reinterpret_cast<bool *>(reinterpret_cast<unsigned char *>(objPtr) + fEngagementPtrOffset);
@@ -921,15 +892,14 @@ void ROOT::Experimental::ROptionalField::ROptionalDeleter::operator()(void *objP
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase::RDeleter> ROOT::Experimental::ROptionalField::GetDeleter() const
+std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::ROptionalField::GetDeleter() const
 {
    return std::make_unique<ROptionalDeleter>(
       (fSubfields[0]->GetTraits() & kTraitTriviallyDestructible) ? nullptr : GetDeleterOf(*fSubfields[0]),
       fSubfields[0]->GetValueSize());
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::ROptionalField::SplitValue(const RValue &value) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::ROptionalField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    const auto valuePtr = value.GetPtr<void>().get();
@@ -939,7 +909,7 @@ ROOT::Experimental::ROptionalField::SplitValue(const RValue &value) const
    return result;
 }
 
-size_t ROOT::Experimental::ROptionalField::GetValueSize() const
+size_t ROOT::ROptionalField::GetValueSize() const
 {
    const auto alignment = GetAlignment();
    // real size is the sum of the value size and the engagement boolean
@@ -953,15 +923,15 @@ size_t ROOT::Experimental::ROptionalField::GetValueSize() const
    return actualSize + padding;
 }
 
-size_t ROOT::Experimental::ROptionalField::GetAlignment() const
+size_t ROOT::ROptionalField::GetAlignment() const
 {
    return fSubfields[0]->GetAlignment();
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RAtomicField::RAtomicField(std::string_view fieldName, std::string_view typeName,
-                                               std::unique_ptr<RFieldBase> itemField)
+ROOT::RAtomicField::RAtomicField(std::string_view fieldName, std::string_view typeName,
+                                 std::unique_ptr<RFieldBase> itemField)
    : RFieldBase(fieldName, typeName, ROOT::ENTupleStructure::kLeaf, false /* isSimple */)
 {
    if (itemField->GetTraits() & kTraitTriviallyConstructible)
@@ -971,22 +941,20 @@ ROOT::Experimental::RAtomicField::RAtomicField(std::string_view fieldName, std::
    Attach(std::move(itemField));
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase>
-ROOT::Experimental::RAtomicField::CloneImpl(std::string_view newName) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::RAtomicField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
    return std::make_unique<RAtomicField>(newName, GetTypeName(), std::move(newItemField));
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::RAtomicField::SplitValue(const RValue &value) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::RAtomicField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    result.emplace_back(fSubfields[0]->BindValue(value.GetPtr<void>()));
    return result;
 }
 
-void ROOT::Experimental::RAtomicField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RAtomicField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitAtomicField(*this);
 }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -68,43 +68,43 @@ public:
 
 } // anonymous namespace
 
-void ROOT::Experimental::Internal::CallFlushColumnsOnField(RFieldBase &field)
+void ROOT::Internal::CallFlushColumnsOnField(RFieldBase &field)
 {
    field.FlushColumns();
 }
-void ROOT::Experimental::Internal::CallCommitClusterOnField(RFieldBase &field)
+void ROOT::Internal::CallCommitClusterOnField(RFieldBase &field)
 {
    field.CommitCluster();
 }
-void ROOT::Experimental::Internal::CallConnectPageSinkOnField(RFieldBase &field, Internal::RPageSink &sink,
-                                                              ROOT::NTupleSize_t firstEntry)
+void ROOT::Internal::CallConnectPageSinkOnField(RFieldBase &field, ROOT::Experimental::Internal::RPageSink &sink,
+                                                ROOT::NTupleSize_t firstEntry)
 {
    field.ConnectPageSink(sink, firstEntry);
 }
-void ROOT::Experimental::Internal::CallConnectPageSourceOnField(RFieldBase &field, Internal::RPageSource &source)
+void ROOT::Internal::CallConnectPageSourceOnField(RFieldBase &field, ROOT::Experimental::Internal::RPageSource &source)
 {
    field.ConnectPageSource(source);
 }
 
-ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-ROOT::Experimental::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
-                                                  const ROOT::RCreateFieldOptions &options,
-                                                  const RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId)
+ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
+ROOT::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
+                                    const ROOT::RCreateFieldOptions &options,
+                                    const ROOT::Experimental::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId)
 {
    return RFieldBase::Create(fieldName, typeName, options, desc, fieldId);
 }
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations()
+ROOT::RFieldBase::RColumnRepresentations::RColumnRepresentations()
 {
    // A single representations with an empty set of columns
    fSerializationTypes.emplace_back(ColumnRepresentation_t());
    fDeserializationTypes.emplace_back(ColumnRepresentation_t());
 }
 
-ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
-   const Selection_t &serializationTypes, const Selection_t &deserializationExtraTypes)
+ROOT::RFieldBase::RColumnRepresentations::RColumnRepresentations(const Selection_t &serializationTypes,
+                                                                 const Selection_t &deserializationExtraTypes)
    : fSerializationTypes(serializationTypes), fDeserializationTypes(serializationTypes)
 {
    fDeserializationTypes.insert(fDeserializationTypes.end(), deserializationExtraTypes.begin(),
@@ -113,7 +113,7 @@ ROOT::Experimental::RFieldBase::RColumnRepresentations::RColumnRepresentations(
 
 //------------------------------------------------------------------------------
 
-void ROOT::Experimental::RFieldBase::RValue::BindRawPtr(void *rawPtr)
+void ROOT::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 {
    // Set fObjPtr to an aliased shared_ptr of the input raw pointer. Note that
    // fObjPtr will be non-empty but have use count zero.
@@ -122,7 +122,7 @@ void ROOT::Experimental::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RFieldBase::RBulk::RBulk(RBulk &&other)
+ROOT::RFieldBase::RBulk::RBulk(RBulk &&other)
    : fField(other.fField),
      fValueSize(other.fValueSize),
      fCapacity(other.fCapacity),
@@ -136,7 +136,7 @@ ROOT::Experimental::RFieldBase::RBulk::RBulk(RBulk &&other)
    std::swap(fMaskAvail, other.fMaskAvail);
 }
 
-ROOT::Experimental::RFieldBase::RBulk &ROOT::Experimental::RFieldBase::RBulk::operator=(RBulk &&other)
+ROOT::RFieldBase::RBulk &ROOT::RFieldBase::RBulk::operator=(RBulk &&other)
 {
    std::swap(fField, other.fField);
    std::swap(fDeleter, other.fDeleter);
@@ -151,13 +151,13 @@ ROOT::Experimental::RFieldBase::RBulk &ROOT::Experimental::RFieldBase::RBulk::op
    return *this;
 }
 
-ROOT::Experimental::RFieldBase::RBulk::~RBulk()
+ROOT::RFieldBase::RBulk::~RBulk()
 {
    if (fValues)
       ReleaseValues();
 }
 
-void ROOT::Experimental::RFieldBase::RBulk::ReleaseValues()
+void ROOT::RFieldBase::RBulk::ReleaseValues()
 {
    if (fIsAdopted)
       return;
@@ -171,7 +171,7 @@ void ROOT::Experimental::RFieldBase::RBulk::ReleaseValues()
    operator delete(fValues);
 }
 
-void ROOT::Experimental::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, std::size_t size)
+void ROOT::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, std::size_t size)
 {
    if (fCapacity < size) {
       if (fIsAdopted) {
@@ -197,14 +197,14 @@ void ROOT::Experimental::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, 
    fSize = size;
 }
 
-void ROOT::Experimental::RFieldBase::RBulk::CountValidValues()
+void ROOT::RFieldBase::RBulk::CountValidValues()
 {
    fNValidValues = 0;
    for (std::size_t i = 0; i < fSize; ++i)
       fNValidValues += static_cast<std::size_t>(fMaskAvail[i]);
 }
 
-void ROOT::Experimental::RFieldBase::RBulk::AdoptBuffer(void *buf, std::size_t capacity)
+void ROOT::RFieldBase::RBulk::AdoptBuffer(void *buf, std::size_t capacity)
 {
    ReleaseValues();
    fValues = buf;
@@ -220,14 +220,14 @@ void ROOT::Experimental::RFieldBase::RBulk::AdoptBuffer(void *buf, std::size_t c
 
 //------------------------------------------------------------------------------
 
-void ROOT::Experimental::RFieldBase::RCreateObjectDeleter<void>::operator()(void *)
+void ROOT::RFieldBase::RCreateObjectDeleter<void>::operator()(void *)
 {
    R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "possibly leaking object from RField<T>::CreateObject<void>";
 }
 
 template <>
-std::unique_ptr<void, typename ROOT::Experimental::RFieldBase::RCreateObjectDeleter<void>::deleter>
-ROOT::Experimental::RFieldBase::CreateObject<void>() const
+std::unique_ptr<void, typename ROOT::RFieldBase::RCreateObjectDeleter<void>::deleter>
+ROOT::RFieldBase::CreateObject<void>() const
 {
    static RCreateObjectDeleter<void>::deleter gDeleter;
    return std::unique_ptr<void, RCreateObjectDeleter<void>::deleter>(CreateObjectRawPtr(), gDeleter);
@@ -235,8 +235,8 @@ ROOT::Experimental::RFieldBase::CreateObject<void>() const
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RFieldBase::RFieldBase(std::string_view name, std::string_view type,
-                                           ROOT::ENTupleStructure structure, bool isSimple, std::size_t nRepetitions)
+ROOT::RFieldBase::RFieldBase(std::string_view name, std::string_view type, ROOT::ENTupleStructure structure,
+                             bool isSimple, std::size_t nRepetitions)
    : fName(name),
      fType(type),
      fStructure(structure),
@@ -249,7 +249,7 @@ ROOT::Experimental::RFieldBase::RFieldBase(std::string_view name, std::string_vi
    ROOT::Internal::EnsureValidNameForRNTuple(name, "Field");
 }
 
-std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const
+std::string ROOT::RFieldBase::GetQualifiedFieldName() const
 {
    std::string result = GetFieldName();
    auto parent = GetParent();
@@ -260,15 +260,15 @@ std::string ROOT::Experimental::RFieldBase::GetQualifiedFieldName() const
    return result;
 }
 
-ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
+ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
+ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
 {
    return R__FORWARD_RESULT(
       RFieldBase::Create(fieldName, typeName, ROOT::RCreateFieldOptions{}, nullptr, ROOT::kInvalidDescriptorId));
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RCheckResult>
-ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::string &typeName)
+std::vector<ROOT::RFieldBase::RCheckResult>
+ROOT::RFieldBase::Check(const std::string &fieldName, const std::string &typeName)
 {
    RFieldZero fieldZero;
    ROOT::RCreateFieldOptions cfOpts{};
@@ -289,10 +289,10 @@ ROOT::Experimental::RFieldBase::Check(const std::string &fieldName, const std::s
    return result;
 }
 
-ROOT::RResult<std::unique_ptr<ROOT::Experimental::RFieldBase>>
-ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::string &typeName,
-                                       const ROOT::RCreateFieldOptions &options, const RNTupleDescriptor *desc,
-                                       ROOT::DescriptorId_t fieldId)
+ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
+ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeName,
+                         const ROOT::RCreateFieldOptions &options, const ROOT::Experimental::RNTupleDescriptor *desc,
+                         ROOT::DescriptorId_t fieldId)
 {
    using ROOT::Internal::ParseArrayType;
    using ROOT::Internal::ParseUIntTypeToken;
@@ -319,7 +319,7 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    if (resolvedType.empty())
       return R__FORWARD_RESULT(fnFail("no type name specified for field '" + fieldName + "'"));
 
-   std::unique_ptr<ROOT::Experimental::RFieldBase> result;
+   std::unique_ptr<ROOT::RFieldBase> result;
 
    const auto maybeGetChildId = [desc, fieldId](int childId) {
       if (desc) {
@@ -618,14 +618,13 @@ ROOT::Experimental::RFieldBase::Create(const std::string &fieldName, const std::
    return R__FORWARD_RESULT(fnFail("unknown type: " + typeName, RInvalidField::RCategory::kUnknownType));
 }
 
-const ROOT::Experimental::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RFieldBase::GetColumnRepresentations() const
+const ROOT::RFieldBase::RColumnRepresentations &ROOT::RFieldBase::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations;
    return representations;
 }
 
-std::unique_ptr<ROOT::Experimental::RFieldBase> ROOT::Experimental::RFieldBase::Clone(std::string_view newName) const
+std::unique_ptr<ROOT::RFieldBase> ROOT::RFieldBase::Clone(std::string_view newName) const
 {
    auto clone = CloneImpl(newName);
    clone->fTypeAlias = fTypeAlias;
@@ -636,23 +635,23 @@ std::unique_ptr<ROOT::Experimental::RFieldBase> ROOT::Experimental::RFieldBase::
    return clone;
 }
 
-std::size_t ROOT::Experimental::RFieldBase::AppendImpl(const void * /* from */)
+std::size_t ROOT::RFieldBase::AppendImpl(const void * /* from */)
 {
    R__ASSERT(false && "A non-simple RField must implement its own AppendImpl");
    return 0;
 }
 
-void ROOT::Experimental::RFieldBase::ReadGlobalImpl(ROOT::NTupleSize_t /*index*/, void * /* to */)
+void ROOT::RFieldBase::ReadGlobalImpl(ROOT::NTupleSize_t /*index*/, void * /* to */)
 {
    R__ASSERT(false);
 }
 
-void ROOT::Experimental::RFieldBase::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
+void ROOT::RFieldBase::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to)
 {
    ReadGlobalImpl(fPrincipalColumn->GetGlobalIndex(localIndex), to);
 }
 
-std::size_t ROOT::Experimental::RFieldBase::ReadBulkImpl(const RBulkSpec &bulkSpec)
+std::size_t ROOT::RFieldBase::ReadBulkImpl(const RBulkSpec &bulkSpec)
 {
    const auto valueSize = GetValueSize();
    std::size_t nRead = 0;
@@ -672,7 +671,7 @@ std::size_t ROOT::Experimental::RFieldBase::ReadBulkImpl(const RBulkSpec &bulkSp
    return nRead;
 }
 
-void *ROOT::Experimental::RFieldBase::CreateObjectRawPtr() const
+void *ROOT::RFieldBase::CreateObjectRawPtr() const
 {
    void *where = operator new(GetValueSize());
    R__ASSERT(where != nullptr);
@@ -680,19 +679,18 @@ void *ROOT::Experimental::RFieldBase::CreateObjectRawPtr() const
    return where;
 }
 
-ROOT::Experimental::RFieldBase::RValue ROOT::Experimental::RFieldBase::CreateValue()
+ROOT::RFieldBase::RValue ROOT::RFieldBase::CreateValue()
 {
    void *obj = CreateObjectRawPtr();
    return RValue(this, std::shared_ptr<void>(obj, RSharedPtrDeleter(GetDeleter())));
 }
 
-std::vector<ROOT::Experimental::RFieldBase::RValue>
-ROOT::Experimental::RFieldBase::SplitValue(const RValue & /*value*/) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::RFieldBase::SplitValue(const RValue & /*value*/) const
 {
    return std::vector<RValue>();
 }
 
-void ROOT::Experimental::RFieldBase::Attach(std::unique_ptr<ROOT::Experimental::RFieldBase> child)
+void ROOT::RFieldBase::Attach(std::unique_ptr<ROOT::RFieldBase> child)
 {
    // Note that during a model update, new fields will be attached to the zero field. The zero field, however,
    // does not change its inital state because only its sub fields get connected by RPageSink::UpdateSchema.
@@ -702,7 +700,7 @@ void ROOT::Experimental::RFieldBase::Attach(std::unique_ptr<ROOT::Experimental::
    fSubfields.emplace_back(std::move(child));
 }
 
-ROOT::NTupleSize_t ROOT::Experimental::RFieldBase::EntryToColumnElementIndex(ROOT::NTupleSize_t globalIndex) const
+ROOT::NTupleSize_t ROOT::RFieldBase::EntryToColumnElementIndex(ROOT::NTupleSize_t globalIndex) const
 {
    std::size_t result = globalIndex;
    for (auto f = this; f != nullptr; f = f->GetParent()) {
@@ -716,7 +714,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RFieldBase::EntryToColumnElementIndex(ROO
    return result;
 }
 
-std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetMutableSubfields()
+std::vector<ROOT::RFieldBase *> ROOT::RFieldBase::GetMutableSubfields()
 {
    std::vector<RFieldBase *> result;
    result.reserve(fSubfields.size());
@@ -726,7 +724,7 @@ std::vector<ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::Ge
    return result;
 }
 
-std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBase::GetConstSubfields() const
+std::vector<const ROOT::RFieldBase *> ROOT::RFieldBase::GetConstSubfields() const
 {
    std::vector<const RFieldBase *> result;
    result.reserve(fSubfields.size());
@@ -736,7 +734,7 @@ std::vector<const ROOT::Experimental::RFieldBase *> ROOT::Experimental::RFieldBa
    return result;
 }
 
-void ROOT::Experimental::RFieldBase::FlushColumns()
+void ROOT::RFieldBase::FlushColumns()
 {
    if (!fAvailableColumns.empty()) {
       const auto activeRepresentationIndex = fPrincipalColumn->GetRepresentationIndex();
@@ -748,7 +746,7 @@ void ROOT::Experimental::RFieldBase::FlushColumns()
    }
 }
 
-void ROOT::Experimental::RFieldBase::CommitCluster()
+void ROOT::RFieldBase::CommitCluster()
 {
    if (!fAvailableColumns.empty()) {
       const auto activeRepresentationIndex = fPrincipalColumn->GetRepresentationIndex();
@@ -763,14 +761,14 @@ void ROOT::Experimental::RFieldBase::CommitCluster()
    CommitClusterImpl();
 }
 
-void ROOT::Experimental::RFieldBase::SetDescription(std::string_view description)
+void ROOT::RFieldBase::SetDescription(std::string_view description)
 {
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("cannot set field description once field is connected"));
    fDescription = std::string(description);
 }
 
-void ROOT::Experimental::RFieldBase::SetOnDiskId(ROOT::DescriptorId_t id)
+void ROOT::RFieldBase::SetOnDiskId(ROOT::DescriptorId_t id)
 {
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("cannot set field ID once field is connected"));
@@ -779,7 +777,7 @@ void ROOT::Experimental::RFieldBase::SetOnDiskId(ROOT::DescriptorId_t id)
 
 /// Write the given value into columns. The value object has to be of the same type as the field.
 /// Returns the number of uncompressed bytes written.
-std::size_t ROOT::Experimental::RFieldBase::Append(const void *from)
+std::size_t ROOT::RFieldBase::Append(const void *from)
 {
    if (~fTraits & kTraitMappable)
       return AppendImpl(from);
@@ -788,17 +786,17 @@ std::size_t ROOT::Experimental::RFieldBase::Append(const void *from)
    return fPrincipalColumn->GetElement()->GetPackedSize();
 }
 
-ROOT::Experimental::RFieldBase::RBulk ROOT::Experimental::RFieldBase::CreateBulk()
+ROOT::RFieldBase::RBulk ROOT::RFieldBase::CreateBulk()
 {
    return RBulk(this);
 }
 
-ROOT::Experimental::RFieldBase::RValue ROOT::Experimental::RFieldBase::BindValue(std::shared_ptr<void> objPtr)
+ROOT::RFieldBase::RValue ROOT::RFieldBase::BindValue(std::shared_ptr<void> objPtr)
 {
    return RValue(this, objPtr);
 }
 
-std::size_t ROOT::Experimental::RFieldBase::ReadBulk(const RBulkSpec &bulkSpec)
+std::size_t ROOT::RFieldBase::ReadBulk(const RBulkSpec &bulkSpec)
 {
    if (fIsSimple) {
       /// For simple types, ignore the mask and memcopy the values into the destination
@@ -810,38 +808,37 @@ std::size_t ROOT::Experimental::RFieldBase::ReadBulk(const RBulkSpec &bulkSpec)
    return ReadBulkImpl(bulkSpec);
 }
 
-ROOT::Experimental::RFieldBase::RSchemaIterator ROOT::Experimental::RFieldBase::begin()
+ROOT::RFieldBase::RSchemaIterator ROOT::RFieldBase::begin()
 {
    return fSubfields.empty() ? RSchemaIterator(this, -1) : RSchemaIterator(fSubfields[0].get(), 0);
 }
 
-ROOT::Experimental::RFieldBase::RSchemaIterator ROOT::Experimental::RFieldBase::end()
+ROOT::RFieldBase::RSchemaIterator ROOT::RFieldBase::end()
 {
    return RSchemaIterator(this, -1);
 }
 
-ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::begin() const
+ROOT::RFieldBase::RConstSchemaIterator ROOT::RFieldBase::begin() const
 {
    return fSubfields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubfields[0].get(), 0);
 }
 
-ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::end() const
+ROOT::RFieldBase::RConstSchemaIterator ROOT::RFieldBase::end() const
 {
    return RConstSchemaIterator(this, -1);
 }
 
-ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::cbegin() const
+ROOT::RFieldBase::RConstSchemaIterator ROOT::RFieldBase::cbegin() const
 {
    return fSubfields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubfields[0].get(), 0);
 }
 
-ROOT::Experimental::RFieldBase::RConstSchemaIterator ROOT::Experimental::RFieldBase::cend() const
+ROOT::RFieldBase::RConstSchemaIterator ROOT::RFieldBase::cend() const
 {
    return RConstSchemaIterator(this, -1);
 }
 
-ROOT::Experimental::RFieldBase::RColumnRepresentations::Selection_t
-ROOT::Experimental::RFieldBase::GetColumnRepresentatives() const
+ROOT::RFieldBase::RColumnRepresentations::Selection_t ROOT::RFieldBase::GetColumnRepresentatives() const
 {
    if (fColumnRepresentatives.empty()) {
       return {GetColumnRepresentations().GetSerializationDefault()};
@@ -855,8 +852,7 @@ ROOT::Experimental::RFieldBase::GetColumnRepresentatives() const
    return result;
 }
 
-void ROOT::Experimental::RFieldBase::SetColumnRepresentatives(
-   const RColumnRepresentations::Selection_t &representatives)
+void ROOT::RFieldBase::SetColumnRepresentatives(const RColumnRepresentations::Selection_t &representatives)
 {
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("cannot set column representative once field is connected"));
@@ -875,9 +871,9 @@ void ROOT::Experimental::RFieldBase::SetColumnRepresentatives(
    }
 }
 
-const ROOT::Experimental::RFieldBase::ColumnRepresentation_t &
-ROOT::Experimental::RFieldBase::EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc,
-                                                            std::uint16_t representationIndex) const
+const ROOT::RFieldBase::ColumnRepresentation_t &
+ROOT::RFieldBase::EnsureCompatibleColumnTypes(const ROOT::Experimental::RNTupleDescriptor &desc,
+                                              std::uint16_t representationIndex) const
 {
    static const ColumnRepresentation_t kEmpty;
 
@@ -912,20 +908,20 @@ ROOT::Experimental::RFieldBase::EnsureCompatibleColumnTypes(const RNTupleDescrip
                             "(representation index: " + std::to_string(representationIndex) + ")"));
 }
 
-size_t ROOT::Experimental::RFieldBase::AddReadCallback(ReadCallback_t func)
+size_t ROOT::RFieldBase::AddReadCallback(ReadCallback_t func)
 {
    fReadCallbacks.push_back(func);
    fIsSimple = false;
    return fReadCallbacks.size() - 1;
 }
 
-void ROOT::Experimental::RFieldBase::RemoveReadCallback(size_t idx)
+void ROOT::RFieldBase::RemoveReadCallback(size_t idx)
 {
    fReadCallbacks.erase(fReadCallbacks.begin() + idx);
    fIsSimple = (fTraits & kTraitMappable) && !fIsArtificial && fReadCallbacks.empty();
 }
 
-void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const ROOT::RNTupleWriteOptions &options)
+void ROOT::RFieldBase::AutoAdjustColumnTypes(const ROOT::RNTupleWriteOptions &options)
 {
    if ((options.GetCompression() == 0) && HasDefaultColumnRepresentative()) {
       ColumnRepresentation_t rep = GetColumnRepresentations().GetSerializationDefault();
@@ -951,9 +947,9 @@ void ROOT::Experimental::RFieldBase::AutoAdjustColumnTypes(const ROOT::RNTupleWr
       SetColumnRepresentatives({{ROOT::ENTupleColumnType::kSplitReal32}});
 }
 
-void ROOT::Experimental::RFieldBase::ConnectPageSink(Internal::RPageSink &pageSink, ROOT::NTupleSize_t firstEntry)
+void ROOT::RFieldBase::ConnectPageSink(ROOT::Experimental::Internal::RPageSink &pageSink, ROOT::NTupleSize_t firstEntry)
 {
-   if (dynamic_cast<ROOT::Experimental::RFieldZero *>(this))
+   if (dynamic_cast<ROOT::RFieldZero *>(this))
       throw RException(R__FAIL("invalid attempt to connect zero field to page sink"));
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to connect an already connected field to a page sink"));
@@ -971,15 +967,15 @@ void ROOT::Experimental::RFieldBase::ConnectPageSink(Internal::RPageSink &pageSi
 
    if (HasExtraTypeInfo()) {
       pageSink.RegisterOnCommitDatasetCallback(
-         [this](Internal::RPageSink &sink) { sink.UpdateExtraTypeInfo(GetExtraTypeInfo()); });
+         [this](ROOT::Experimental::Internal::RPageSink &sink) { sink.UpdateExtraTypeInfo(GetExtraTypeInfo()); });
    }
 
    fState = EState::kConnectedToSink;
 }
 
-void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pageSource)
+void ROOT::RFieldBase::ConnectPageSource(ROOT::Experimental::Internal::RPageSource &pageSource)
 {
-   if (dynamic_cast<ROOT::Experimental::RFieldZero *>(this))
+   if (dynamic_cast<ROOT::RFieldZero *>(this))
       throw RException(R__FAIL("invalid attempt to connect zero field to page source"));
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to connect an already connected field to a page source"));
@@ -1001,7 +997,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
    // Do not generate columns nor set fColumnRepresentatives for artificial fields.
    if (!fIsArtificial) {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
-      const RNTupleDescriptor &desc = descriptorGuard.GetRef();
+      const ROOT::Experimental::RNTupleDescriptor &desc = descriptorGuard.GetRef();
       GenerateColumns(desc);
       if (fColumnRepresentatives.empty()) {
          // If we didn't get columns from the descriptor, ensure that we actually expect a field without columns
@@ -1028,7 +1024,7 @@ void ROOT::Experimental::RFieldBase::ConnectPageSource(Internal::RPageSource &pa
    fState = EState::kConnectedToSource;
 }
 
-void ROOT::Experimental::RFieldBase::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::RFieldBase::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitField(*this);
 }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -50,6 +50,8 @@
 #include <utility>
 #include <variant>
 
+using ROOT::Internal::GetRenormalizedTypeName;
+
 namespace {
 
 TClass *EnsureValidClass(std::string_view className)
@@ -91,7 +93,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
 }
 
 ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, TClass *classp)
-   : ROOT::Experimental::RFieldBase(fieldName, Internal::GetRenormalizedTypeName(classp->GetName()),
+   : ROOT::Experimental::RFieldBase(fieldName, GetRenormalizedTypeName(classp->GetName()),
                                     ROOT::ENTupleStructure::kRecord, false /* isSimple */),
      fClass(classp)
 {
@@ -113,10 +115,12 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, TClass 
    // Classes with, e.g., custom streamers are not supported through this field. Empty classes, however, are.
    // Can be overwritten with the "rntuple.streamerMode=true" class attribute
    if (!fClass->CanSplit() && fClass->Size() > 1 &&
-       Internal::GetRNTupleSerializationMode(fClass) != Internal::ERNTupleSerializationMode::kForceNativeMode) {
+       ROOT::Internal::GetRNTupleSerializationMode(fClass) !=
+          ROOT::Internal::ERNTupleSerializationMode::kForceNativeMode) {
       throw RException(R__FAIL(GetTypeName() + " cannot be stored natively in RNTuple"));
    }
-   if (Internal::GetRNTupleSerializationMode(fClass) == Internal::ERNTupleSerializationMode::kForceStreamerMode) {
+   if (ROOT::Internal::GetRNTupleSerializationMode(fClass) ==
+       ROOT::Internal::ERNTupleSerializationMode::kForceStreamerMode) {
       throw RException(R__FAIL(GetTypeName() + " has streamer mode enforced, not supported as native RNTuple class"));
    }
 
@@ -170,7 +174,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, TClass 
 
       auto subField = RFieldBase::Create(dataMember->GetName(), typeName).Unwrap();
 
-      const auto normTypeName = Internal::GetNormalizedUnresolvedTypeName(origTypeName);
+      const auto normTypeName = ROOT::Internal::GetNormalizedUnresolvedTypeName(origTypeName);
       if (normTypeName == subField->GetTypeName()) {
          subField->fTypeAlias = "";
       } else {
@@ -492,7 +496,7 @@ ROOT::Experimental::REnumField::REnumField(std::string_view fieldName, std::stri
 }
 
 ROOT::Experimental::REnumField::REnumField(std::string_view fieldName, TEnum *enump)
-   : ROOT::Experimental::RFieldBase(fieldName, Internal::GetRenormalizedTypeName(enump->GetQualifiedName()),
+   : ROOT::Experimental::RFieldBase(fieldName, GetRenormalizedTypeName(enump->GetQualifiedName()),
                                     ROOT::ENTupleStructure::kLeaf, false /* isSimple */)
 {
    // Avoid accidentally supporting std types through TEnum.
@@ -602,7 +606,7 @@ ROOT::Experimental::RProxiedCollectionField::RCollectionIterableOnce::GetIterato
 }
 
 ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string_view fieldName, TClass *classp)
-   : RFieldBase(fieldName, Internal::GetRenormalizedTypeName(classp->GetName()), ROOT::ENTupleStructure::kCollection,
+   : RFieldBase(fieldName, GetRenormalizedTypeName(classp->GetName()), ROOT::ENTupleStructure::kCollection,
                 false /* isSimple */),
      fNWritten(0)
 {
@@ -616,7 +620,7 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
       throw RException(R__FAIL("collection proxies whose value type is a pointer are not supported"));
    if (!fProxy->GetCollectionClass()->HasDictionary()) {
       throw RException(R__FAIL("dictionary not available for type " +
-                               Internal::GetRenormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
+                               GetRenormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
    }
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);
@@ -830,7 +834,7 @@ ROOT::Experimental::RStreamerField::RStreamerField(std::string_view fieldName, s
 }
 
 ROOT::Experimental::RStreamerField::RStreamerField(std::string_view fieldName, TClass *classp)
-   : ROOT::Experimental::RFieldBase(fieldName, Internal::GetRenormalizedTypeName(classp->GetName()),
+   : ROOT::Experimental::RFieldBase(fieldName, GetRenormalizedTypeName(classp->GetName()),
                                     ROOT::ENTupleStructure::kStreamer, false /* isSimple */),
      fClass(classp),
      fIndex(0)

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -16,11 +16,11 @@
 
 ROOT::Experimental::RArrayField::RArrayField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
                                              std::size_t arrayLength)
-   : ROOT::Experimental::RFieldBase(fieldName,
-                                    "std::array<" + itemField->GetTypeName() + "," +
-                                       Internal::GetNormalizedInteger(static_cast<unsigned long long>(arrayLength)) +
-                                       ">",
-                                    ROOT::ENTupleStructure::kLeaf, false /* isSimple */, arrayLength),
+   : ROOT::Experimental::RFieldBase(
+        fieldName,
+        "std::array<" + itemField->GetTypeName() + "," +
+           ROOT::Internal::GetNormalizedInteger(static_cast<unsigned long long>(arrayLength)) + ">",
+        ROOT::ENTupleStructure::kLeaf, false /* isSimple */, arrayLength),
      fItemSize(itemField->GetValueSize()),
      fArrayLength(arrayLength)
 {

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+using ROOT::Experimental::RField;
+
 namespace {
 
 const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
@@ -68,7 +70,7 @@ std::string GetNormalizedTemplateArg(const std::string &arg, F fnTypeNormalizer)
 
    if (std::isdigit(arg[0]) || arg[0] == '-') {
       // Integer template argument
-      return ROOT::Experimental::Internal::GetNormalizedInteger(arg);
+      return ROOT::Internal::GetNormalizedInteger(arg);
    }
 
    std::string qualifier;
@@ -122,7 +124,7 @@ std::vector<AnglePos> FindTemplateAngleBrackets(const std::string &typeName)
 
 } // namespace
 
-std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::string &typeName)
+std::string ROOT::Internal::GetCanonicalTypePrefix(const std::string &typeName)
 {
    std::string canonicalType{TClassEdit::CleanType(typeName.c_str(), /*mode=*/1)};
    if (canonicalType.substr(0, 7) == "struct ") {
@@ -222,7 +224,7 @@ std::string ROOT::Experimental::Internal::GetCanonicalTypePrefix(const std::stri
    return canonicalType;
 }
 
-std::string ROOT::Experimental::Internal::GetRenormalizedTypeName(const std::string &metaNormalizedName)
+std::string ROOT::Internal::GetRenormalizedTypeName(const std::string &metaNormalizedName)
 {
    const std::string canonicalTypePrefix{GetCanonicalTypePrefix(metaNormalizedName)};
    // RNTuple resolves Double32_t for the normalized type name but keeps Double32_t for the type alias
@@ -264,7 +266,7 @@ std::string ROOT::Experimental::Internal::GetRenormalizedTypeName(const std::str
    return normName;
 }
 
-std::string ROOT::Experimental::Internal::GetNormalizedUnresolvedTypeName(const std::string &origName)
+std::string ROOT::Internal::GetNormalizedUnresolvedTypeName(const std::string &origName)
 {
    const TClassEdit::EModType modType = static_cast<TClassEdit::EModType>(
       TClassEdit::kDropStlDefault | TClassEdit::kDropComparator | TClassEdit::kDropHash);
@@ -332,19 +334,19 @@ std::string ROOT::Experimental::Internal::GetNormalizedUnresolvedTypeName(const 
    return normName;
 }
 
-std::string ROOT::Experimental::Internal::GetNormalizedInteger(long long val)
+std::string ROOT::Internal::GetNormalizedInteger(long long val)
 {
    return std::to_string(val);
 }
 
-std::string ROOT::Experimental::Internal::GetNormalizedInteger(unsigned long long val)
+std::string ROOT::Internal::GetNormalizedInteger(unsigned long long val)
 {
    if (val > std::numeric_limits<std::int64_t>::max())
       return std::to_string(val) + "u";
    return std::to_string(val);
 }
 
-std::string ROOT::Experimental::Internal::GetNormalizedInteger(const std::string &intTemplateArg)
+std::string ROOT::Internal::GetNormalizedInteger(const std::string &intTemplateArg)
 {
    R__ASSERT(!intTemplateArg.empty());
    if (intTemplateArg[0] == '-')
@@ -352,7 +354,7 @@ std::string ROOT::Experimental::Internal::GetNormalizedInteger(const std::string
    return GetNormalizedInteger(ParseUIntTypeToken(intTemplateArg));
 }
 
-long long ROOT::Experimental::Internal::ParseIntTypeToken(const std::string &intToken)
+long long ROOT::Internal::ParseIntTypeToken(const std::string &intToken)
 {
    std::size_t nChars = 0;
    long long res = std::stoll(intToken, &nChars);
@@ -374,7 +376,7 @@ long long ROOT::Experimental::Internal::ParseIntTypeToken(const std::string &int
    throw RException(R__FAIL("invalid integer type token: " + intToken));
 }
 
-unsigned long long ROOT::Experimental::Internal::ParseUIntTypeToken(const std::string &uintToken)
+unsigned long long ROOT::Internal::ParseUIntTypeToken(const std::string &uintToken)
 {
    std::size_t nChars = 0;
    unsigned long long res = std::stoull(uintToken, &nChars);
@@ -394,8 +396,7 @@ unsigned long long ROOT::Experimental::Internal::ParseUIntTypeToken(const std::s
    throw RException(R__FAIL("invalid integer type token: " + uintToken));
 }
 
-ROOT::Experimental::Internal::ERNTupleSerializationMode
-ROOT::Experimental::Internal::GetRNTupleSerializationMode(TClass *cl)
+ROOT::Internal::ERNTupleSerializationMode ROOT::Internal::GetRNTupleSerializationMode(TClass *cl)
 {
    auto am = cl->GetAttributeMap();
    if (!am || !am->HasKey("rntuple.streamerMode"))
@@ -414,8 +415,7 @@ ROOT::Experimental::Internal::GetRNTupleSerializationMode(TClass *cl)
    }
 }
 
-std::tuple<std::string, std::vector<std::size_t>>
-ROOT::Experimental::Internal::ParseArrayType(const std::string &typeName)
+std::tuple<std::string, std::vector<std::size_t>> ROOT::Internal::ParseArrayType(const std::string &typeName)
 {
    std::vector<std::size_t> sizeVec;
 
@@ -439,7 +439,7 @@ ROOT::Experimental::Internal::ParseArrayType(const std::string &typeName)
    return std::make_tuple(prefix, sizeVec);
 }
 
-std::vector<std::string> ROOT::Experimental::Internal::TokenizeTypeList(std::string_view templateType)
+std::vector<std::string> ROOT::Internal::TokenizeTypeList(std::string_view templateType)
 {
    std::vector<std::string> result;
    if (templateType.empty())

--- a/tree/ntuple/v7/src/RFieldUtils.cxx
+++ b/tree/ntuple/v7/src/RFieldUtils.cxx
@@ -25,8 +25,6 @@
 #include <utility>
 #include <vector>
 
-using ROOT::Experimental::RField;
-
 namespace {
 
 const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -28,7 +28,7 @@
 
 //----------------------------- RPrepareVisitor --------------------------------
 
-void ROOT::Experimental::RPrepareVisitor::VisitField(const RFieldBase &field)
+void ROOT::Experimental::RPrepareVisitor::VisitField(const ROOT::RFieldBase &field)
 {
    auto subfields = field.GetConstSubfields();
    for (auto f : subfields) {
@@ -39,8 +39,7 @@ void ROOT::Experimental::RPrepareVisitor::VisitField(const RFieldBase &field)
    }
 }
 
-
-void ROOT::Experimental::RPrepareVisitor::VisitFieldZero(const RFieldZero &field)
+void ROOT::Experimental::RPrepareVisitor::VisitFieldZero(const ROOT::RFieldZero &field)
 {
    VisitField(field);
    fNumFields--;
@@ -62,7 +61,7 @@ void ROOT::Experimental::RPrintSchemaVisitor::SetNumFields(int n)
    SetAvailableSpaceForStrings();
 }
 
-void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const RFieldBase &field)
+void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const ROOT::RFieldBase &field)
 {
    fOutput << fFrameSymbol << ' ';
 
@@ -92,8 +91,7 @@ void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const RFieldBase &field
    }
 }
 
-
-void ROOT::Experimental::RPrintSchemaVisitor::VisitFieldZero(const RFieldZero &fieldZero)
+void ROOT::Experimental::RPrintSchemaVisitor::VisitFieldZero(const ROOT::RFieldZero &fieldZero)
 {
    auto fieldNo = 1;
    for (auto f : fieldZero.GetConstSubfields()) {
@@ -115,13 +113,13 @@ void ROOT::Experimental::RPrintValueVisitor::PrintIndent()
       fOutput << "  ";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::PrintName(const RFieldBase &field)
+void ROOT::Experimental::RPrintValueVisitor::PrintName(const ROOT::RFieldBase &field)
 {
    if (fPrintOptions.fPrintName)
       fOutput << "\"" << field.GetFieldName() << "\": ";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const RFieldBase &field)
+void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const ROOT::RFieldBase &field)
 {
    PrintIndent();
    PrintName(field);
@@ -142,7 +140,7 @@ void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const RFieldBase &f
    fOutput << "]";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::PrintRecord(const RFieldBase &field)
+void ROOT::Experimental::RPrintValueVisitor::PrintRecord(const ROOT::RFieldBase &field)
 {
    PrintIndent();
    PrintName(field);
@@ -171,15 +169,14 @@ void ROOT::Experimental::RPrintValueVisitor::PrintRecord(const RFieldBase &field
    fOutput << "}";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitField(const RFieldBase &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitField(const ROOT::RFieldBase &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << "\"<unsupported type: " << field.GetTypeName() << ">\"";
 }
 
-
-void ROOT::Experimental::RPrintValueVisitor::VisitBoolField(const RField<bool> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitBoolField(const ROOT::RField<bool> &field)
 {
    PrintIndent();
    PrintName(field);
@@ -189,23 +186,21 @@ void ROOT::Experimental::RPrintValueVisitor::VisitBoolField(const RField<bool> &
       fOutput << "false";
 }
 
-
-void ROOT::Experimental::RPrintValueVisitor::VisitDoubleField(const RField<double> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitDoubleField(const ROOT::RField<double> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<double>();
 }
 
-
-void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const RField<float> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const ROOT::RField<float> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<float>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const RField<std::byte> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const ROOT::RField<std::byte> &field)
 {
    PrintIndent();
    PrintName(field);
@@ -215,42 +210,42 @@ void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const RField<std::by
    std::cout.fill(prev);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const RField<char> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const ROOT::RField<char> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<char>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RIntegralField<std::int8_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const ROOT::RIntegralField<std::int8_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << static_cast<int>(fValue.GetRef<std::int8_t>());
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RIntegralField<std::int16_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const ROOT::RIntegralField<std::int16_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int16_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt32Field(const RIntegralField<std::int32_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt32Field(const ROOT::RIntegralField<std::int32_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int32_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RIntegralField<std::int64_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const ROOT::RIntegralField<std::int64_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::int64_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::string> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const ROOT::RField<std::string> &field)
 {
    PrintIndent();
    PrintName(field);
@@ -258,35 +253,35 @@ void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::
    fOutput << "\"" << fValue.GetRef<std::string>() << "\"";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RIntegralField<std::uint8_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const ROOT::RIntegralField<std::uint8_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << static_cast<int>(fValue.GetRef<std::uint8_t>());
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const RIntegralField<std::uint16_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const ROOT::RIntegralField<std::uint16_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::uint16_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const RIntegralField<std::uint32_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const ROOT::RIntegralField<std::uint32_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::uint32_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RIntegralField<std::uint64_t> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const ROOT::RIntegralField<std::uint64_t> &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << fValue.GetRef<std::uint64_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardinalityField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const ROOT::RCardinalityField &field)
 {
    PrintIndent();
    PrintName(field);
@@ -301,7 +296,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardin
    R__ASSERT(false && "unsupported cardinality size type");
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const ROOT::RBitsetField &field)
 {
    constexpr auto nBitsULong = sizeof(unsigned long) * 8;
    const auto *asULongArray = fValue.GetPtr<unsigned long>().get();
@@ -320,39 +315,39 @@ void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField
    fOutput << str << "\"";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitArrayField(const RArrayField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitArrayField(const ROOT::RArrayField &field)
 {
    PrintCollection(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitArrayAsRVecField(const RArrayAsRVecField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitArrayAsRVecField(const ROOT::RArrayAsRVecField &field)
 {
    PrintCollection(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitStreamerField(const RStreamerField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitStreamerField(const ROOT::RStreamerField &field)
 {
    PrintIndent();
    PrintName(field);
    fOutput << "<streamer mode>";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const ROOT::RClassField &field)
 {
    PrintRecord(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitTObjectField(const RField<TObject> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitTObjectField(const ROOT::RField<TObject> &field)
 {
    PrintRecord(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const ROOT::RRecordField &field)
 {
    PrintRecord(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const ROOT::RNullableField &field)
 {
    PrintIndent();
    PrintName(field);
@@ -368,7 +363,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableF
    }
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const ROOT::REnumField &field)
 {
    PrintIndent();
    PrintName(field);
@@ -380,7 +375,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &fi
    intValue.GetField().AcceptVisitor(visitor);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const ROOT::RAtomicField &field)
 {
    PrintIndent();
    PrintName(field);
@@ -392,22 +387,22 @@ void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField
    itemValue.GetField().AcceptVisitor(visitor);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitProxiedCollectionField(const RProxiedCollectionField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitProxiedCollectionField(const ROOT::RProxiedCollectionField &field)
 {
    PrintCollection(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitVectorField(const RVectorField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitVectorField(const ROOT::RVectorField &field)
 {
    PrintCollection(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitVectorBoolField(const RField<std::vector<bool>> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field)
 {
    PrintCollection(field);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitRVecField(const RRVecField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitRVecField(const ROOT::RRVecField &field)
 {
    PrintCollection(field);
 }

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -58,7 +58,7 @@ ROOT::Experimental::RNTupleFillContext::~RNTupleFillContext()
 void ROOT::Experimental::RNTupleFillContext::FlushColumns()
 {
    for (auto &field : Internal::GetFieldZeroOfModel(*fModel)) {
-      Internal::CallFlushColumnsOnField(field);
+      ROOT::Internal::CallFlushColumnsOnField(field);
    }
 }
 
@@ -68,7 +68,7 @@ void ROOT::Experimental::RNTupleFillContext::FlushCluster()
       return;
    }
    for (auto &field : Internal::GetFieldZeroOfModel(*fModel)) {
-      Internal::CallCommitClusterOnField(field);
+      ROOT::Internal::CallCommitClusterOnField(field);
    }
    auto nEntriesInCluster = fNEntries - fLastFlushed;
    if (fStagedClusterCommitting) {

--- a/tree/ntuple/v7/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/v7/src/RNTupleJoinTable.cxx
@@ -60,8 +60,8 @@ void ROOT::Experimental::Internal::RNTupleJoinTable::Build(RPageSource &pageSour
    auto desc = pageSource.GetSharedDescriptorGuard();
 
    fJoinFieldValueSizes.reserve(fJoinFieldNames.size());
-   std::vector<std::unique_ptr<RFieldBase>> fields;
-   std::vector<RFieldBase::RValue> fieldValues;
+   std::vector<std::unique_ptr<ROOT::RFieldBase>> fields;
+   std::vector<ROOT::RFieldBase::RValue> fieldValues;
    fieldValues.reserve(fJoinFieldNames.size());
 
    for (const auto &fieldName : fJoinFieldNames) {
@@ -79,7 +79,7 @@ void ROOT::Experimental::Internal::RNTupleJoinTable::Build(RPageSource &pageSour
 
       auto field = fieldDesc.CreateField(desc.GetRef());
 
-      CallConnectPageSourceOnField(*field, pageSource);
+      ROOT::Internal::CallConnectPageSourceOnField(*field, pageSource);
 
       fieldValues.emplace_back(field->CreateValue());
       fJoinFieldValueSizes.emplace_back(field->GetValueSize());

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -165,7 +165,7 @@ void ROOT::Experimental::RNTupleProcessor::ConnectField(RFieldContext &fieldCont
 
    fieldContext.SetConcreteField();
    fieldContext.fConcreteField->SetOnDiskId(fieldId);
-   Internal::CallConnectPageSourceOnField(*fieldContext.fConcreteField, pageSource);
+   ROOT::Internal::CallConnectPageSourceOnField(*fieldContext.fConcreteField, pageSource);
 
    auto valuePtr = entry.GetPtr<void>(fieldContext.fToken);
    auto value = fieldContext.fConcreteField->BindValue(valuePtr);
@@ -416,15 +416,15 @@ void ROOT::Experimental::RNTupleJoinProcessor::AddAuxiliary(const RNTupleOpenSpe
    // subfields to the join model. This way they can be accessed through the processor as `auxNTupleName.fieldName`,
    // which is necessary in case there are duplicate field names between the main ntuple and (any of the) auxiliary
    // ntuples.
-   std::vector<std::unique_ptr<RFieldBase>> auxFields;
+   std::vector<std::unique_ptr<ROOT::RFieldBase>> auxFields;
    auxFields.reserve(entry->fValues.size());
    for (const auto &val : *entry) {
       auto &field = val.GetField();
 
       auxFields.emplace_back(field.Clone(field.GetQualifiedFieldName()));
    }
-   std::unique_ptr<RFieldBase> auxParentField =
-      std::make_unique<RRecordField>(auxNTuple.fNTupleName, std::move(auxFields));
+   std::unique_ptr<ROOT::RFieldBase> auxParentField =
+      std::make_unique<ROOT::RRecordField>(auxNTuple.fNTupleName, std::move(auxFields));
 
    if (!auxParentField) {
       throw RException(R__FAIL("could not create auxiliary RNTuple parent field"));
@@ -558,7 +558,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
       if (auxEntryIdxs[fieldContext.fNTupleIdx - 1] == ROOT::kInvalidNTupleIndex) {
          // No matching entry exists, so we reset the field's value to a default value.
          // TODO(fdegeus): further consolidate how non-existing join matches should be handled. N.B.: in case
-         // ConstructValue is not used anymore in the future, remove friend in RFieldBase.
+         // ConstructValue is not used anymore in the future, remove friend in ROOT::RFieldBase.
          fieldContext.fProtoField->ConstructValue(value.GetPtr<void>().get());
       } else {
          value.Read(auxEntryIdxs[fieldContext.fNTupleIdx - 1]);

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -38,7 +38,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
       if (field->GetOnDiskId() == ROOT::kInvalidDescriptorId) {
          field->SetOnDiskId(fSource->GetSharedDescriptorGuard()->FindFieldId(field->GetFieldName(), fieldZeroId));
       }
-      Internal::CallConnectPageSourceOnField(*field, *fSource);
+      ROOT::Internal::CallConnectPageSourceOnField(*field, *fSource);
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -20,7 +20,7 @@
 #include <ROOT/RPageStorage.hxx>
 
 ROOT::RNTupleGlobalRange
-ROOT::Experimental::Internal::GetFieldRange(const RFieldBase &field, const RPageSource &pageSource)
+ROOT::Experimental::Internal::GetFieldRange(const ROOT::RFieldBase &field, const RPageSource &pageSource)
 {
    const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
 

--- a/tree/ntuple/v7/src/RNTupleWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleWriter.cxx
@@ -63,7 +63,7 @@ ROOT::Experimental::RNTupleWriter::Create(std::unique_ptr<RNTupleModel> model,
       throw RException(R__FAIL("cannot create an RNTupleWriter from a model with registered subfields"));
    }
    for (const auto &field : model->GetConstFieldZero()) {
-      if (field.GetTraits() & RFieldBase::kTraitEmulatedField)
+      if (field.GetTraits() & ROOT::RFieldBase::kTraitEmulatedField)
          throw RException(
             R__FAIL("creating a RNTupleWriter from a model containing emulated fields is currently unsupported."));
    }
@@ -91,7 +91,7 @@ ROOT::Experimental::RNTupleWriter::Recreate(std::initializer_list<std::pair<std:
    for (const auto &fieldDesc : fields) {
       std::string typeName(fieldDesc.first);
       std::string fieldName(fieldDesc.second);
-      auto field = RFieldBase::Create(fieldName, typeName);
+      auto field = ROOT::RFieldBase::Create(fieldName, typeName);
       model->AddField(field.Unwrap());
    }
    return Create(std::move(model), std::move(sink), options);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -63,14 +63,14 @@ ROOT::Experimental::Internal::RPageSinkBuf::AddColumn(ROOT::DescriptorId_t /*fie
    return ColumnHandle_t{fNColumns++, &column};
 }
 
-void ROOT::Experimental::Internal::RPageSinkBuf::ConnectFields(const std::vector<RFieldBase *> &fields,
+void ROOT::Experimental::Internal::RPageSinkBuf::ConnectFields(const std::vector<ROOT::RFieldBase *> &fields,
                                                                ROOT::NTupleSize_t firstEntry)
 {
-   auto connectField = [&](RFieldBase &f) {
+   auto connectField = [&](ROOT::RFieldBase &f) {
       // Field Zero would have id 0.
       ++fNFields;
       f.SetOnDiskId(fNFields);
-      CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
+      ROOT::Internal::CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
    };
    for (auto *f : fields) {
       connectField(*f);
@@ -101,13 +101,13 @@ void ROOT::Experimental::Internal::RPageSinkBuf::UpdateSchema(const RNTupleModel
 
    // The buffered page sink maintains a copy of the RNTupleModel for the inner sink; replicate the changes there
    // TODO(jalopezg): we should be able, in general, to simplify the buffered sink.
-   auto cloneAddField = [&](const RFieldBase *field) {
+   auto cloneAddField = [&](const ROOT::RFieldBase *field) {
       auto cloned = field->Clone(field->GetFieldName());
       auto p = &(*cloned);
       fInnerModel->AddField(std::move(cloned));
       return p;
    };
-   auto cloneAddProjectedField = [&](RFieldBase *field) {
+   auto cloneAddProjectedField = [&](ROOT::RFieldBase *field) {
       auto cloned = field->Clone(field->GetFieldName());
       auto p = &(*cloned);
       auto &projectedFields = Internal::GetProjectedFieldsOfModel(changeset.fModel);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -813,7 +813,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
    if (descriptor.GetNLogicalColumns() > descriptor.GetNPhysicalColumns()) {
       // If we already have alias columns, add an offset to the alias columns so that the new physical columns
       // of the changeset follow immediately the already existing physical columns
-      auto getNColumns = [](const RFieldBase &f) -> std::size_t {
+      auto getNColumns = [](const ROOT::RFieldBase &f) -> std::size_t {
          const auto &reps = f.GetColumnRepresentatives();
          if (reps.empty())
             return 0;
@@ -828,14 +828,14 @@ void ROOT::Experimental::Internal::RPagePersistentSink::UpdateSchema(const RNTup
       fDescriptorBuilder.ShiftAliasColumns(nNewPhysicalColumns);
    }
 
-   auto addField = [&](RFieldBase &f) {
+   auto addField = [&](ROOT::RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
       f.SetOnDiskId(fieldId);
-      CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
+      ROOT::Internal::CallConnectPageSinkOnField(f, *this, firstEntry); // issues in turn calls to `AddColumn()`
    };
-   auto addProjectedField = [&](RFieldBase &f) {
+   auto addProjectedField = [&](ROOT::RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();
       auto sourceFieldId = GetProjectedFieldsOfModel(changeset.fModel).GetSourceField(&f)->GetOnDiskId();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());

--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -114,7 +114,7 @@ public:
 };
 } // namespace
 
-namespace ROOT::Experimental {
+namespace ROOT {
 template <>
 struct IsCollectionProxy<StructUsingCollectionProxy<char>> : std::true_type {
 };
@@ -130,6 +130,6 @@ struct IsCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<f
 };
 
 // Intentionally omit `IsCollectionProxy<StructUsingCollectionProxy<int>>`
-} // namespace ROOT::Experimental
+} // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -633,22 +633,22 @@ TEST(RNTuple, BareEntry)
    EXPECT_EQ(2.0, *ntuple->GetModel().GetDefaultEntry().GetPtr<float>("pt"));
 }
 
-namespace ROOT::Experimental::Internal {
+namespace ROOT::Internal {
 struct RFieldCallbackInjector {
    template <typename FieldT>
-   static void Inject(FieldT &field, ROOT::Experimental::RFieldBase::ReadCallback_t func)
+   static void Inject(FieldT &field, ROOT::RFieldBase::ReadCallback_t func)
    {
       field.AddReadCallback(func);
    }
 };
-} // namespace ROOT::Experimental::Internal
+} // namespace ROOT::Internal
 namespace {
 unsigned gNCallReadCallback = 0;
 }
 
 TEST(RNTuple, ReadCallback)
 {
-   using RFieldCallbackInjector = ROOT::Experimental::Internal::RFieldCallbackInjector;
+   using RFieldCallbackInjector = ROOT::Internal::RFieldCallbackInjector;
 
    FileRaii fileGuard("test_ntuple_readcb.ntuple");
    {

--- a/tree/ntuple/v7/test/ntuple_compat.cxx
+++ b/tree/ntuple/v7/test/ntuple_compat.cxx
@@ -36,8 +36,7 @@ TEST(RNTupleCompat, FeatureFlag)
    RNTupleDescriptorBuilder descBuilder;
    descBuilder.SetNTuple("ntpl", "");
    descBuilder.SetFeature(RNTupleDescriptor::kFeatureFlagTest);
-   descBuilder.AddField(
-      RFieldDescriptorBuilder::FromField(ROOT::Experimental::RFieldZero()).FieldId(0).MakeDescriptor().Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder::FromField(ROOT::RFieldZero()).FieldId(0).MakeDescriptor().Unwrap());
    ASSERT_TRUE(static_cast<bool>(descBuilder.EnsureValidDescriptor()));
 
    RNTupleWriteOptions options;
@@ -154,8 +153,7 @@ TEST(RNTupleCompat, FwdCompat_FutureNTupleAnchor)
 }
 
 template <>
-class ROOT::Experimental::RField<ROOT::Internal::RTestFutureColumn> final
-   : public RSimpleField<ROOT::Internal::RTestFutureColumn> {
+class ROOT::RField<ROOT::Internal::RTestFutureColumn> final : public RSimpleField<ROOT::Internal::RTestFutureColumn> {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {
@@ -234,7 +232,7 @@ TEST(RNTupleCompat, FutureColumnType_Nested)
       auto model = RNTupleModel::Create();
       std::vector<std::unique_ptr<RFieldBase>> itemFields;
       itemFields.emplace_back(new RField<std::vector<ROOT::Internal::RTestFutureColumn>>("vec"));
-      auto field = std::make_unique<ROOT::Experimental::RRecordField>("future", std::move(itemFields));
+      auto field = std::make_unique<ROOT::RRecordField>("future", std::move(itemFields));
       model->AddField(std::move(field));
       auto floatP = model->MakeField<float>("float");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
@@ -335,7 +333,7 @@ TEST(RNTupleCompat, FutureFieldStructuralRole_Nested)
       std::vector<std::unique_ptr<RFieldBase>> itemFields;
       itemFields.emplace_back(new RField<int>("int"));
       itemFields.emplace_back(new RFutureField("future"));
-      auto field = std::make_unique<ROOT::Experimental::RRecordField>("record", std::move(itemFields));
+      auto field = std::make_unique<ROOT::RRecordField>("record", std::move(itemFields));
       model->AddField(std::move(field));
       model->MakeField<float>("float");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -586,7 +586,7 @@ TEST(RNTupleDescriptor, BuildStreamerInfos)
    EXPECT_TRUE(streamerInfoMap.empty());
 
    std::vector<std::unique_ptr<RFieldBase>> itemFields;
-   streamerInfoMap = fnBuildStreamerInfosOf(ROOT::Experimental::RRecordField("f", std::move(itemFields)));
+   streamerInfoMap = fnBuildStreamerInfosOf(ROOT::RRecordField("f", std::move(itemFields)));
    EXPECT_TRUE(streamerInfoMap.empty());
 
    streamerInfoMap = fnBuildStreamerInfosOf(*RFieldBase::Create("f", "CustomStruct").Unwrap());

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -1244,7 +1244,7 @@ TEST(RNTupleMerger, MultipleRepresentations)
       *ptrPx = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 1);
       *ptrPx = 2.0;
       writer->Fill();

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -2,7 +2,7 @@
 #include <TRandom3.h>
 
 namespace {
-struct RFieldBaseTest : public ROOT::Experimental::RFieldBase {
+struct RFieldBaseTest : public ROOT::RFieldBase {
    /// Returns the global index of the first entry that has a stored on-disk value.  For deferred fields, this allows
    /// for differentiating zero-initialized values read before the addition of the field from actual stored data.
    ROOT::NTupleSize_t GetFirstEntry() const

--- a/tree/ntuple/v7/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/v7/test/ntuple_multi_column.cxx
@@ -16,12 +16,12 @@ TEST(RNTuple, MultiColumnRepresentationSimple)
       *ptrPx = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 1);
       *ptrPx = 2.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 0);
       *ptrPx = 3.0;
       writer->Fill();
@@ -154,16 +154,16 @@ TEST(RNTuple, MultiColumnRepresentationString)
       *ptrStr = "abc";
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("str")), 1);
       ptrStr->clear();
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("str")), 0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("str")), 1);
       *ptrStr = "x";
       writer->Fill();
@@ -195,17 +195,17 @@ TEST(RNTuple, MultiColumnRepresentationVector)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 1);
       ptrVec->push_back(1.0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 0);
       ptrVec->clear();
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 1);
       ptrVec->push_back(2.0);
       ptrVec->push_back(3.0);
@@ -245,17 +245,17 @@ TEST(RNTuple, MultiColumnRepresentationMany)
       ptrVec->push_back(1.0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 1);
       (*ptrVec)[0] = 2.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 2);
       (*ptrVec)[0] = 3.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vec")), 3);
       (*ptrVec)[0] = 4.0;
       writer->Fill();
@@ -299,18 +299,18 @@ TEST(RNTuple, MultiColumnRepresentationNullable)
       ptrVector->push_back(13.0);
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("scalar")), 1);
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vector._0")), 1);
       ptrScalar->reset();
       ptrVector->clear();
       ptrVector->push_back(std::optional<float>());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("scalar")), 0);
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("vector._0")), 0);
       *ptrScalar = 3.0;
       ptrVector->clear();
@@ -359,7 +359,7 @@ TEST(RNTuple, MultiColumnRepresentationBulk)
       *ptrPx = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 1);
       *ptrPx = 2.0;
       writer->Fill();
@@ -399,7 +399,7 @@ TEST(RNTuple, MultiColumnRepresentationFriends)
       *ptrPt = 1.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("pt")), 1);
       *ptrPt = 2.0;
       writer->Fill();
@@ -409,7 +409,7 @@ TEST(RNTuple, MultiColumnRepresentationFriends)
       *ptrEta = 3.0;
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("eta")), 1);
       *ptrEta = 4.0;
       writer->Fill();

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -266,7 +266,7 @@ AddReal32QuantField(RNTupleModel &model, const std::string &fieldName, std::size
 namespace {
 
 // Test writing index32/64 columns
-class RFieldTestIndexColumn final : public ROOT::Experimental::RSimpleField<RColumnIndex> {
+class RFieldTestIndexColumn final : public ROOT::RSimpleField<RColumnIndex> {
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final
    {

--- a/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/v7/test/ntuple_parallel_writer.cxx
@@ -177,12 +177,12 @@ TEST(RNTupleParallelWriter, StagedMultiColumn)
       *px = 1.0;
       c->Fill(*e);
       c->FlushCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(c->GetModel().GetConstField("px")), 1);
       *px = 2.0;
       c->Fill(*e);
       c->FlushCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(c->GetModel().GetConstField("px")), 0);
       *px = 3.0;
       c->Fill(*e);

--- a/tree/ntuple/v7/test/ntuple_print.cxx
+++ b/tree/ntuple/v7/test/ntuple_print.cxx
@@ -119,8 +119,7 @@ TEST(RNtuplePrint, ArrayAsRVec)
 {
    std::stringstream os;
    RPrepareVisitor prepVisitor;
-   ROOT::Experimental::RArrayAsRVecField testField("arrayasrvecfield",
-                                                   std::make_unique<ROOT::Experimental::RField<float>>("myfloat"), 0);
+   ROOT::RArrayAsRVecField testField("arrayasrvecfield", std::make_unique<ROOT::RField<float>>("myfloat"), 0);
    testField.AcceptVisitor(prepVisitor);
    RPrintSchemaVisitor visitor(os, '$');
    visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -338,8 +338,8 @@ TEST(RNTupleShow, Objects)
 
 TEST(RNTupleShow, Collections)
 {
-   using ROOT::Experimental::RRecordField;
-   using ROOT::Experimental::RVectorField;
+   using ROOT::RRecordField;
+   using ROOT::RVectorField;
 
    std::string rootFileName{"test_ntuple_show_collection.root"};
    std::string ntupleName{"Collections"};

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -1112,7 +1112,7 @@ TEST(RPageSinkFile, StreamerInfo)
 
    auto model = RNTupleModel::Create();
    model->MakeField<CustomStruct>("f1");
-   model->AddField(std::make_unique<ROOT::Experimental::RStreamerField>("f2", "StructWithArrays"));
+   model->AddField(std::make_unique<ROOT::RStreamerField>("f2", "StructWithArrays"));
    auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
    writer->Fill(); // need one entry to trigger streamer info record for streamer field
    writer.reset();

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -67,8 +67,8 @@ using RColumnSwitch = ROOT::Internal::RColumnSwitch;
 using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
 template <class T>
-using RField = ROOT::Experimental::RField<T>;
-using RFieldBase = ROOT::Experimental::RFieldBase;
+using RField = ROOT::RField<T>;
+using RFieldBase = ROOT::RFieldBase;
 using RFieldDescriptor = ROOT::Experimental::RFieldDescriptor;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;
 using RNTupleAtomicCounter = ROOT::Experimental::Detail::RNTupleAtomicCounter;

--- a/tree/ntuple/v7/test/ntuple_type_name.cxx
+++ b/tree/ntuple/v7/test/ntuple_type_name.cxx
@@ -2,19 +2,18 @@
 
 TEST(RNTuple, TypeNameBasics)
 {
-   EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
-   EXPECT_STREQ("std::vector<std::string>", ROOT::Experimental::RField<std::vector<std::string>>::TypeName().c_str());
-   EXPECT_STREQ("CustomStruct", ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
-   EXPECT_STREQ("DerivedB", ROOT::Experimental::RField<DerivedB>::TypeName().c_str());
+   EXPECT_STREQ("float", ROOT::RField<float>::TypeName().c_str());
+   EXPECT_STREQ("std::vector<std::string>", ROOT::RField<std::vector<std::string>>::TypeName().c_str());
+   EXPECT_STREQ("CustomStruct", ROOT::RField<CustomStruct>::TypeName().c_str());
+   EXPECT_STREQ("DerivedB", ROOT::RField<DerivedB>::TypeName().c_str());
 
    auto field = RField<DerivedB>("derived");
    EXPECT_EQ(sizeof(DerivedB), field.GetValueSize());
 
    EXPECT_STREQ("std::pair<std::pair<float,CustomStruct>,std::int32_t>",
-                (ROOT::Experimental::RField<std::pair<std::pair<float, CustomStruct>, int>>::TypeName().c_str()));
-   EXPECT_STREQ(
-      "std::tuple<std::tuple<char,CustomStruct,char>,std::int32_t>",
-      (ROOT::Experimental::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
+                (ROOT::RField<std::pair<std::pair<float, CustomStruct>, int>>::TypeName().c_str()));
+   EXPECT_STREQ("std::tuple<std::tuple<char,CustomStruct,char>,std::int32_t>",
+                (ROOT::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
 }
 
 TEST(RNTuple, TypeNameNormalization)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -119,7 +119,7 @@ TEST(RNTuple, CreateField)
    std::vector<std::unique_ptr<RFieldBase>> itemFields;
    itemFields.push_back(std::make_unique<RField<std::uint32_t>>("u32"));
    itemFields.push_back(std::make_unique<RField<std::uint8_t>>("u8"));
-   ROOT::Experimental::RRecordField record("test", std::move(itemFields));
+   ROOT::RRecordField record("test", std::move(itemFields));
    EXPECT_EQ(alignof(std::uint32_t), record.GetAlignment());
    // Check that trailing padding is added after `u8` to comply with the alignment requirements of uint32_t
    EXPECT_EQ(sizeof(std::uint32_t) + alignof(std::uint32_t), record.GetValueSize());
@@ -586,8 +586,7 @@ TEST(RNTuple, StdMap)
    EXPECT_THROW(RFieldBase::Create("myInvalidMap", "std::map<char, std::string, int>").Unwrap(), ROOT::RException);
 
    auto invalidInnerField = RFieldBase::Create("someIntField", "int").Unwrap();
-   EXPECT_THROW(std::make_unique<ROOT::Experimental::RMapField>("myInvalidMap", "std::map<char, int>",
-                                                                std::move(invalidInnerField)),
+   EXPECT_THROW(std::make_unique<ROOT::RMapField>("myInvalidMap", "std::map<char, int>", std::move(invalidInnerField)),
                 ROOT::RException);
 
    FileRaii fileGuard("test_ntuple_rfield_stdmap.root");
@@ -1631,7 +1630,7 @@ TEST(RNTuple, Casting)
    fldI1->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
    auto fldI2 = RFieldBase::Create("i2", "std::int32_t").Unwrap();
    fldI2->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kSplitInt32}});
-   auto fldF = ROOT::Experimental::RFieldBase::Create("F", "float").Unwrap();
+   auto fldF = RFieldBase::Create("F", "float").Unwrap();
    fldF->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
    try {
       fldF->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kBit}});
@@ -1652,7 +1651,7 @@ TEST(RNTuple, Casting)
 
    try {
       auto model = RNTupleModel::Create();
-      auto f = ROOT::Experimental::RFieldBase::Create("i1", "std::int32_t").Unwrap();
+      auto f = RFieldBase::Create("i1", "std::int32_t").Unwrap();
       f->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
       model->AddField(std::move(f));
       auto reader = RNTupleReader::Open(std::move(model), "ntuple", fileGuard.GetPath());
@@ -2214,7 +2213,7 @@ TEST(RNTuple, Traits)
 
 TEST(RNTuple, RColumnRepresentations)
 {
-   using RColumnRepresentations = ROOT::Experimental::RFieldBase::RColumnRepresentations;
+   using RColumnRepresentations = RFieldBase::RColumnRepresentations;
    RColumnRepresentations colReps1;
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t(), colReps1.GetSerializationDefault());
    EXPECT_EQ(RColumnRepresentations::Selection_t{RFieldBase::ColumnRepresentation_t()},

--- a/tree/ntuple/v7/test/rfield_basics.cxx
+++ b/tree/ntuple/v7/test/rfield_basics.cxx
@@ -4,8 +4,6 @@ class NoDict {};
 
 TEST(RField, Check)
 {
-   using ROOT::Experimental::RFieldBase;
-
    auto report = RFieldBase::Check("f", "CustomStruct");
    EXPECT_TRUE(report.empty());
 

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -12,11 +12,11 @@ namespace {
 class RNoDictionary {};
 } // namespace
 
-namespace ROOT::Experimental {
+namespace ROOT {
 template <>
 struct IsCollectionProxy<CyclicCollectionProxy> : std::true_type {
 };
-} // namespace ROOT::Experimental
+} // namespace ROOT
 
 TEST(RNTuple, TClass) {
    auto modelFail = RNTupleModel::Create();
@@ -75,7 +75,7 @@ TEST(RNTuple, DiamondInheritance)
 TEST(RTNuple, TObject)
 {
    // Ensure that TObject cannot be accidentally handled through the generic RClassField field
-   EXPECT_THROW(ROOT::Experimental::RClassField("obj", "TObject"), ROOT::RException);
+   EXPECT_THROW(ROOT::RClassField("obj", "TObject"), ROOT::RException);
 
    FileRaii fileGuard("test_ntuple_tobject.root");
    {
@@ -220,7 +220,7 @@ TEST(RNTuple, TClassTypeChecksum)
    EXPECT_TRUE(f1->GetTraits() & RFieldBase::kTraitTypeChecksum);
    EXPECT_EQ(TClass::GetClass("CustomStruct")->GetCheckSum(), f1->GetTypeChecksum());
 
-   auto f2 = std::make_unique<ROOT::Experimental::RStreamerField>("f2", "TRotation");
+   auto f2 = std::make_unique<ROOT::RStreamerField>("f2", "TRotation");
    EXPECT_TRUE(f2->GetTraits() & RFieldBase::kTraitTypeChecksum);
    EXPECT_EQ(TClass::GetClass("TRotation")->GetCheckSum(), f2->GetTypeChecksum());
 

--- a/tree/ntuple/v7/test/rfield_streamer.cxx
+++ b/tree/ntuple/v7/test/rfield_streamer.cxx
@@ -12,7 +12,7 @@ TEST(RField, StreamerDirect)
    FileRaii fileGuard("test_ntuple_rfield_streamer_direct.root");
    {
       auto model = RNTupleModel::Create();
-      model->AddField(std::make_unique<ROOT::Experimental::RStreamerField>("pt", "std::vector<float>"));
+      model->AddField(std::make_unique<ROOT::RStreamerField>("pt", "std::vector<float>"));
       auto ptrPt = model->GetDefaultEntry().GetPtr<std::vector<float>>("pt");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       ptrPt->push_back(1.0);
@@ -92,14 +92,14 @@ TEST(RField, ForceNativeMode)
    ASSERT_TRUE(cl != nullptr);
    EXPECT_TRUE(cl->CanSplit());
    auto f = RFieldBase::Create("f", "CustomStreamerForceStreamed").Unwrap();
-   EXPECT_TRUE(dynamic_cast<ROOT::Experimental::RStreamerField *>(f.get()) != nullptr);
+   EXPECT_TRUE(dynamic_cast<ROOT::RStreamerField *>(f.get()) != nullptr);
 
    // "Force Streamed" attribute set by selection XML
    cl = TClass::GetClass("ForceStreamedXML");
    ASSERT_TRUE(cl != nullptr);
    EXPECT_TRUE(cl->CanSplit());
    f = RFieldBase::Create("f", "ForceStreamedXML").Unwrap();
-   EXPECT_TRUE(dynamic_cast<ROOT::Experimental::RStreamerField *>(f.get()) != nullptr);
+   EXPECT_TRUE(dynamic_cast<ROOT::RStreamerField *>(f.get()) != nullptr);
 }
 
 TEST(RField, IgnoreUnsplitComment)
@@ -109,12 +109,12 @@ TEST(RField, IgnoreUnsplitComment)
    // Only one member, so we know that it is first sub field
    const auto fieldMember = fieldClass->GetConstSubfields()[0];
    EXPECT_EQ(std::string("v"), fieldMember->GetFieldName());
-   EXPECT_EQ(nullptr, dynamic_cast<const ROOT::Experimental::RStreamerField *>(fieldMember));
+   EXPECT_EQ(nullptr, dynamic_cast<const ROOT::RStreamerField *>(fieldMember));
 }
 
 TEST(RField, UnsupportedStreamed)
 {
-   using ROOT::Experimental::RStreamerField;
+   using ROOT::RStreamerField;
    auto success = std::make_unique<RStreamerField>("name", "std::vector<int>");
    EXPECT_THROW(RStreamerField("name", "int"), ROOT::RException); // no TClass of fundamental types
 

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -124,16 +124,16 @@ TEST(RNTuple, InsideCollection)
    auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec_a", "float").Unwrap());
    fieldInner->SetOnDiskId(idA);
 
-   auto field = std::make_unique<ROOT::Experimental::RVectorField>("klassVec", std::move(fieldInner));
+   auto field = std::make_unique<ROOT::RVectorField>("klassVec", std::move(fieldInner));
    field->SetOnDiskId(idKlassVec);
-   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*field, *source);
+   ROOT::Internal::CallConnectPageSourceOnField(*field, *source);
 
    auto fieldCardinality64 = RFieldBase::Create("", "ROOT::RNTupleCardinality<std::uint64_t>").Unwrap();
    fieldCardinality64->SetOnDiskId(idKlassVec);
-   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fieldCardinality64, *source);
+   ROOT::Internal::CallConnectPageSourceOnField(*fieldCardinality64, *source);
    auto fieldCardinality32 = RFieldBase::Create("", "ROOT::RNTupleCardinality<std::uint32_t>").Unwrap();
    fieldCardinality32->SetOnDiskId(idKlassVec);
-   ROOT::Experimental::Internal::CallConnectPageSourceOnField(*fieldCardinality32, *source);
+   ROOT::Internal::CallConnectPageSourceOnField(*fieldCardinality32, *source);
 
    auto value = field->CreateValue();
    value.Read(0);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -103,7 +103,7 @@ Current limitations of the importer:
 class RNTupleImporter {
 public:
    /// Used to make adjustments to the fields of the output model.
-   using FieldModifier_t = std::function<void(RFieldBase &)>;
+   using FieldModifier_t = std::function<void(ROOT::RFieldBase &)>;
 
    /// Used to report every ~100 MB (compressed), and at the end about the status of the import.
    class RProgressCallback {
@@ -137,8 +137,8 @@ private:
       RImportField &operator=(RImportField &&other) = default;
 
       /// The field is kept during schema preparation and transferred to the fModel before the writing starts
-      RFieldBase *fField = nullptr;
-      std::unique_ptr<RFieldBase::RValue> fValue; ///< Set if a value is generated, only for transformed fields
+      ROOT::RFieldBase *fField = nullptr;
+      std::unique_ptr<ROOT::RFieldBase::RValue> fValue; ///< Set if a value is generated, only for transformed fields
       void *fFieldBuffer = nullptr; ///< Usually points to the corresponding RImportBranch::fBranchBuffer but not always
    };
 
@@ -186,9 +186,10 @@ private:
       /// The leafs of the array as we encounter them traversing the TTree schema.
       /// Eventually, the fields are moved as leaves to an untyped collection of untyped records that in turn
       /// is attached to the RNTuple model.
-      std::vector<std::unique_ptr<RFieldBase>> fLeafFields;
+      std::vector<std::unique_ptr<ROOT::RFieldBase>> fLeafFields;
       std::vector<size_t> fLeafBranchIndexes; ///< Points to the correspondings leaf branches in fImportBranches
-      RRecordField *fRecordField = nullptr; ///< Points to the item field of the untyped collection field in the model.
+      ROOT::RRecordField *fRecordField =
+         nullptr; ///< Points to the item field of the untyped collection field in the model.
       std::vector<unsigned char> fFieldBuffer; ///< The collection field memory representation. Bound to the entry.
    };
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -232,7 +232,7 @@ TEST(RNTupleImporter, ConvertDotsInBranchNames)
 TEST(RNTupleImporter, FieldModifier)
 {
    using ROOT::ENTupleColumnType;
-   using ROOT::Experimental::RFieldBase;
+   using ROOT::RFieldBase;
 
    FileRaii fileGuard("test_ntuple_importer_column_modifier.root");
    {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -10,10 +10,10 @@
 #include "ntupleutil_test.hxx"
 
 using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RFieldBase;
 using ROOT::RNTuple;
 using ROOT::RNTupleWriteOptions;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RFieldBase;
 using ROOT::Experimental::RNTupleInspector;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
@@ -800,7 +800,7 @@ TEST(RNTupleInspector, MultiColumnRepresentations)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
       writer->CommitCluster();
-      ROOT::Experimental::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
          const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 1);
       writer->Fill();
    }


### PR DESCRIPTION
# This Pull request:
Moves out of Experimental the `RFieldBase` hierarchy as well as the functions in `RFieldUtils.hxx` 


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


