### PR TITLE
[Core] Fix leak in list of colours.

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -731,6 +731,7 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    fTimer       = 0;
    fApplication = nullptr;
    fColors      = setNameLocked(new TObjArray(1000), "ListOfColors");
+   fColors->SetOwner();
    fTypes       = nullptr;
    fGlobals     = nullptr;
    fGlobalFunctions = nullptr;


### PR DESCRIPTION
The global list of colours was not owning its objects, so if it gets cloned, the clones would leak.

Fix #18002.
