### PR TITLE
[CMake] Fix building Clad with `builtin_llvm=OFF`

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -96,7 +96,7 @@ ExternalProject_Add(
              -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
              -DCMAKE_CXX_FLAGS=${CLAD_CXX_FLAGS}
              -DCMAKE_INSTALL_PREFIX=${clad_install_dir}/plugins
-             -DLLVM_DIR=${LLVM_BINARY_DIR}
+             -DLLVM_DIR=${LLVM_DIR}
              -DClang_DIR=${CLANG_CMAKE_DIR}
              ${_clad_extra_cmake_args}
   BUILD_COMMAND ${CMAKE_COMMAND} --build . ${EXTRA_BUILD_ARGS}


### PR DESCRIPTION
Right now, I get the following error when building ROOT with `builtin_llvm=OFF` and `clad=ON`:
```txt
CMake Error at CMakeLists.txt:94 (find_package):
  Could not find a package configuration file provided by "LLVM" with any of
  the following names:

    LLVMConfig.cmake
    llvm-config.cmake

  Add the installation prefix of "LLVM" to CMAKE_PREFIX_PATH or set
  "LLVM_DIR" to a directory containing one of the above files.  If "LLVM"
  provides a separate development package or SDK, be sure it has been
  installed.

CMake Error at /home/rembserj/code/root/root_build/interpreter/cling/tools/plugins/clad/clad-prefix/src/clad-stamp/clad-configure-RelWithDebInfo.cmake:47 (message):
  Stopping after outputting logs.
```

This commit suggests to set the `LLVM_DIR` to Clad to the actual `LLVM_DIR` that is found by `find_package(LLVM)`.

For `builtin_llvm=ON` this should also work, because `LLVM_DIR` is correctly set in the `interpreter/CMakeLists.txt` file.

For some more context, here are the values of these variables when I build with `builtin_llvm=OFF`:
  * `LLVM_BINARY_DIR`: /nix/store/q45c1db56miy74dx02ibnql0cvxn3b13-llvm-18.1.8-lib
  * `LLVM_DIR`: /nix/store/8w3mp5c3mmnb0g2fnns881am7663g24d-llvm-18.1.8-dev/lib/cmake/llvm

And here fore `builtin_llvm=ON`, where it doesn't matter:
  * `LLVM_BINARY_DIR`: /home/rembserj/code/root/root_build/interpreter/llvm-project/llvm
  * `LLVM_DIR`: /home/rembserj/code/root/root_build/interpreter/llvm-project/llvm

Looks like the problem for me is that on NixOS, the binary and development parts of the package are split into different prefixes.