### PR TITLE
[RF] Fix tutorial category of `rf206_treevistools`

### DIFF
--- a/tutorials/roofit/roofit/rf206_treevistools.C
+++ b/tutorials/roofit/roofit/rf206_treevistools.C
@@ -1,5 +1,5 @@
 /// \file
-/// \ingroup tutorial_roofit
+/// \ingroup tutorial_roofit_main
 /// \notebook -nodraw
 /// Addition and convolution: tools for visualization of RooAbsArg expression trees
 ///

--- a/tutorials/roofit/roofit/rf206_treevistools.py
+++ b/tutorials/roofit/roofit/rf206_treevistools.py
@@ -1,5 +1,5 @@
 ## \file
-## \ingroup tutorial_roofit
+## \ingroup tutorial_roofit_main
 ## \notebook -nodraw
 ## Addition and convolution: tools for visualization of ROOT.RooAbsArg expression trees
 ##


### PR DESCRIPTION
I think this was an oversight due to conflict resolution.

That will fixup the RooFit tutorial page:
https://root.cern/doc/master/group__tutorial__roofit.html