### PR TITLE
[df] Avoid creating readers for unavailable columns

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -342,13 +342,13 @@ public:
    RInterface<RDFDetail::RFilterWithMissingValues<Proxied>, DS_t> FilterAvailable(std::string_view column)
    {
       const auto columns = ColumnNames_t{column.data()};
-      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
       // For now disable this functionality in case of an empty data source and
       // the column name was not defined previously.
       if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
          GetValidatedColumnNames(1, columns);
       using F_t = RDFDetail::RFilterWithMissingValues<Proxied>;
       auto filterPtr = std::make_shared<F_t>(/*discardEntry*/ true, fProxiedPtr, fColRegister, columns);
+      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
       return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, fColRegister);
    }
 
@@ -393,13 +393,13 @@ public:
    RInterface<RDFDetail::RFilterWithMissingValues<Proxied>, DS_t> FilterMissing(std::string_view column)
    {
       const auto columns = ColumnNames_t{column.data()};
-      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
       // For now disable this functionality in case of an empty data source and
       // the column name was not defined previously.
       if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
          GetValidatedColumnNames(1, columns);
       using F_t = RDFDetail::RFilterWithMissingValues<Proxied>;
       auto filterPtr = std::make_shared<F_t>(/*discardEntry*/ false, fProxiedPtr, fColRegister, columns);
+      CheckAndFillDSColumns(columns, TTraits::TypeList<void>{});
       return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, fColRegister);
    }
 
@@ -683,8 +683,6 @@ public:
       if (ROOT::Internal::RDF::GetDataSourceLabel(*this) == "EmptyDS")
          RDFInternal::CheckForDefinition(where, column, fColRegister, fLoopManager->GetBranchNames(),
                                          GetDataSource() ? GetDataSource()->GetColumnNames() : ColumnNames_t{});
-      const auto validColumnNames = ColumnNames_t{column.data()};
-      CheckAndFillDSColumns(validColumnNames, TTraits::TypeList<T>{});
 
       // Declare return type to the interpreter, for future use by jitted actions
       auto retTypeName = RDFInternal::TypeID2TypeName(typeid(T));
@@ -695,8 +693,10 @@ public:
          retTypeName = "CLING_UNKNOWN_TYPE_" + demangledType;
       }
 
+      const auto validColumnNames = ColumnNames_t{column.data()};
       auto newColumn = std::make_shared<ROOT::Internal::RDF::RDefaultValueFor<T>>(
          column, retTypeName, defaultValue, validColumnNames, fColRegister, *fLoopManager);
+      CheckAndFillDSColumns(validColumnNames, TTraits::TypeList<T>{});
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddDefine(std::move(newColumn));


### PR DESCRIPTION
DefaultValueFor, FilterAvailable and FilterMissing register the column which might have missing values during the creation of a RDefaultValueFor or RFilterWithMissingValues object. Move the creation of the data source column readers after this is done, to avoid creating a reader for a column that might potentially be missing at that time.

Part 9 of N for https://github.com/root-project/root/pull/17895