### PR TITLE
[hist] Improve TH1::GetQuantiles

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1958,13 +1958,12 @@ Double_t TF1::GetProb() const
    return TMath::Prob(fChisquare, fNDF);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute Quantiles for density distribution of this function
 ///
 /// Quantile x_p of a probability distribution Function F is defined as
 /// \f[
-///     F(x_{p}) = \int_{xmin}^{x_{p}} f dx = p with 0 <= p <= 1.
+///     F(x_{p}) = \int_{xmin}^{x_{p}} f dx = p \text{with} 0 <= p <= 1.
 /// \f]
 /// For instance the median \f$ x_{\frac{1}{2}} \f$ of a distribution is defined as that value
 /// of the random variable for which the distribution function equals 0.5:
@@ -1989,7 +1988,6 @@ Double_t TF1::GetProb() const
 /// \author Eddy Offermann
 /// \warning Function leads to undefined behavior if xp or p are null or
 /// their size does not match with n
-
 
 Int_t TF1::GetQuantiles(Int_t n, Double_t *xp, const Double_t *p)
 {

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -4507,8 +4507,8 @@ TVirtualHistPainter *TH1::GetPainter(Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute Quantiles for this histogram
-/// Quantile x_p := Q(p) is defined as the value x_p such that the cumulative
+/// Compute Quantiles for this histogram.
+/// A quantile x_p := Q(p) is defined as the value x_p such that the cumulative
 /// probability distribution Function F of variable X yields:
 ///
 /// ~~~ {.cpp}
@@ -4527,16 +4527,20 @@ TVirtualHistPainter *TH1::GetPainter(Option_t *option)
 /// \author Eddy Offermann
 /// code from Eddy Offermann, Renaissance
 ///
-/// \param[in] n maximum size of array xp and size of array p (if given)
+/// \param[in] n maximum size of the arrays xp and p (if given)
 /// \param[out] xp array to be filled with nq quantiles evaluated at (p). Memory has to be preallocated by caller.
-/// If p is null (default value), then xp is actually set to the (first n) histogram bin edges
+///   - If `p == nullptr`, the quantiles are computed at the (first `n`) probabilities p given by the CDF of the histogram;
+///   `n` must thus be smaller or equal Nbins+1, otherwise the extra values of `xp` will not be filled and `nq` will be smaller than `n`.
+///     If all bins have non-zero entries, the quantiles happen to be the bin centres.
+///     Empty bins will, however, be skipped in the quantiles.
+///     If the CDF is e.g. [0., 0., 0.1, ...], the quantiles would be, [3., 3., 3., ...], with the third bin starting
+///     at 3.
 /// \param[in] p array of cumulative probabilities where quantiles should be evaluated.
-///   - if p is null, the CDF of the histogram will be used instead as array, and will
-///     have a size = number of bins + 1 in h. It will correspond to the
-///     quantiles calculated at the lowest edge of the histogram (quantile=0) and
-///     all the upper edges of the bins. (nbins might be > n).
-///   - if p is not null, it is assumed to contain at least n values.
-/// \return value nq (<=n) with the number of quantiles computed
+///   - if `p == nullptr`, the CDF of the histogram will be used to compute the quantiles, and will
+///     have a size of n.
+///   - Otherwise, it is assumed to contain at least n values.
+/// \return number of quantiles computed
+/// \note Unlike in TF1::GetQuantiles, `p` is here an optional argument
 ///
 /// Note that the Integral of the histogram is automatically recomputed
 /// if the number of entries is different of the number of entries when

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <fstream>
 #include <limits>
@@ -4603,16 +4604,17 @@ Int_t TH1::GetQuantiles(Int_t n, Double_t *xp, const Double_t *p)
    if (fIntegral[nbins+1] != fEntries) ComputeIntegral();
 
    Int_t i, ibin;
-   Double_t *prob = (Double_t*)p;
    Int_t nq = n;
+   std::unique_ptr<Double_t[]> localProb;
    if (p == nullptr) {
       nq = nbins+1;
-      prob = new Double_t[nq];
-      prob[0] = 0;
+      localProb.reset(new Double_t[nq]);
+      localProb[0] = 0;
       for (i=1;i<nq;i++) {
-         prob[i] = fIntegral[i]/fIntegral[nbins];
+         localProb[i] = fIntegral[i] / fIntegral[nbins];
       }
    }
+   Double_t const *const prob = p ? p : localProb.get();
 
    for (i = 0; i < nq; i++) {
       ibin = TMath::BinarySearch(nbins,fIntegral,prob[i]);
@@ -4646,7 +4648,6 @@ Int_t TH1::GetQuantiles(Int_t n, Double_t *xp, const Double_t *p)
       }
    }
 
-   if (!p) delete [] prob;
    return nq;
 }
 


### PR DESCRIPTION
- Improve documentation of TH1::GetQuantiles and TF1::GetQuantiles
- Remove manual allocation and a const_cast in `TH1::GetQuantiles`.

This PR is an attempt to fix #16793, which proposed to remove the default parameter of `TH1::GetQuantiles`. As discussed there, the removal is not a good idea.
The existing documentation also created confusion about what the function does when the last parameter is left at its default value, which is clarified here.

So TL;DR: Don't change the default parameter, but clarify what it does.

Fix #16793 