### PR TITLE
Improve SavePrimitive in TG classes

### DIFF
--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -1113,7 +1113,7 @@ TString& TString::ReplaceAll(const char *s1, Ssiz_t ls1, const char *s2,
 
 TString &TString::ReplaceSpecialCppChars()
 {
-   return ReplaceAll("\\","\\\\").ReplaceAll("\"","\\\"");
+   return ReplaceAll("\\","\\\\").ReplaceAll("\"","\\\"").ReplaceAll("\n","\\n").ReplaceAll("\t","\\t");
 }
 
 

--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -128,7 +128,7 @@ protected:
    // some protected methods use in gui builder
    virtual void StartGuiBuilding(Bool_t on = kTRUE);
 
-   TString SaveCtorArgs(std::ostream &out, UInt_t dflt_options = kChildFrame);
+   TString SaveCtorArgs(std::ostream &out, UInt_t dflt_options = kChildFrame, Bool_t check_white_pixel = kFALSE);
 
 private:
    TGFrame(const TGFrame&) = delete;

--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -128,6 +128,8 @@ protected:
    // some protected methods use in gui builder
    virtual void StartGuiBuilding(Bool_t on = kTRUE);
 
+   TString SaveCtorArgs(std::ostream &out, UInt_t dflt_options = kChildFrame);
+
 private:
    TGFrame(const TGFrame&) = delete;
    TGFrame& operator=(const TGFrame&) = delete;

--- a/gui/gui/inc/TGListTree.h
+++ b/gui/gui/inc/TGListTree.h
@@ -51,6 +51,8 @@ protected:
    UInt_t           fHeight;       // item height
    ///@}
 
+   virtual TString SaveTreeItem(std::ostream &, const char *, const char *) { return ""; }
+
 public:
    TGListTreeItem(TGClient *client = gClient);
    virtual ~TGListTreeItem() {}
@@ -117,8 +119,6 @@ public:
    virtual void    HandleDrag() {}
    virtual void    HandleDrop() {}
 
-   virtual void    SavePrimitive(std::ostream&, Option_t*, Int_t) {}
-
    ClassDef(TGListTreeItem,0)  // Abstract base-class for items that go into a TGListTree container.
 };
 
@@ -143,6 +143,10 @@ private:
 
    TGListTreeItemStd(const TGListTreeItemStd&) = delete;
    TGListTreeItemStd& operator=(const TGListTreeItemStd&) = delete;
+
+protected:
+
+   TString         SaveTreeItem(std::ostream &out, const char *treevarname, const char *parent_var_name) override;
 
 public:
    TGListTreeItemStd(TGClient *fClient = gClient, const char *name = nullptr,
@@ -185,8 +189,6 @@ public:
    Color_t         GetColor() const override { return fColor; }
    void            SetColor(Color_t color) override { fHasColor = true;fColor = color; }
    void            ClearColor() override { fHasColor = false; }
-
-   void            SavePrimitive(std::ostream &out, Option_t *option, Int_t n) override;
 
    ClassDefOverride(TGListTreeItemStd,0)  //Item that goes into a TGListTree container
 };
@@ -272,7 +274,7 @@ protected:
    void  DrawNode(Handle_t id, TGListTreeItem *item, Int_t x, Int_t y);
    virtual void UpdateChecked(TGListTreeItem *item, Bool_t redraw = kFALSE);
 
-   void  SaveChildren(std::ostream &out, TGListTreeItem *item, Int_t &n);
+   void  SaveChildren(std::ostream &out, const char *parent_var_name, TGListTreeItem *item);
    void  RemoveReference(TGListTreeItem *item);
    void  PDeleteItem(TGListTreeItem *item);
    void  PDeleteChildren(TGListTreeItem *item);

--- a/gui/gui/src/TG3DLine.cxx
+++ b/gui/gui/src/TG3DLine.cxx
@@ -61,23 +61,23 @@ void TGHorizontal3DLine::DrawBorder()
 
 void TGHorizontal3DLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << "   TGHorizontal3DLine *";
-   out << GetName() << " = new TGHorizontal3DLine(" << fParent->GetName()
+   out << "   TGHorizontal3DLine *" << GetName() << " = new TGHorizontal3DLine(" << fParent->GetName()
        << "," << GetWidth() << "," << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (!GetOptions()) {
-         out << ");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() << ");" << std::endl;
+         out << ", " << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << ", " << GetOptionString() << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -106,21 +106,20 @@ void TGVertical3DLine::DrawBorder()
 
 void TGVertical3DLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << "   TGVertical3DLine *";
-   out << GetName() << " = new TGVertical3DLine(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGVertical3DLine *" << GetName() << " = new TGVertical3DLine(" << fParent->GetName() << "," << GetWidth()
+       << "," << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
+      if (!GetOptions())
+         out << ");\n";
+      else
+         out << "," << GetOptionString() << ");\n";
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TG3DLine.cxx
+++ b/gui/gui/src/TG3DLine.cxx
@@ -61,21 +61,11 @@ void TGHorizontal3DLine::DrawBorder()
 
 void TGHorizontal3DLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out);
 
    out << "   TGHorizontal3DLine *" << GetName() << " = new TGHorizontal3DLine(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");\n";
-      } else {
-         out << ", " << GetOptionString() << ");\n";
-      }
-   } else {
-      out << ", " << GetOptionString() << ", ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TG3DLine.cxx
+++ b/gui/gui/src/TG3DLine.cxx
@@ -96,20 +96,11 @@ void TGVertical3DLine::DrawBorder()
 
 void TGVertical3DLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out);
 
    out << "   TGVertical3DLine *" << GetName() << " = new TGVertical3DLine(" << fParent->GetName() << "," << GetWidth()
-       << "," << GetHeight();
+       << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions())
-         out << ");\n";
-      else
-         out << "," << GetOptionString() << ");\n";
-   } else {
-      out << "," << GetOptionString() << ", ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -1966,7 +1966,7 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 void TGPictureButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    if (!fPic) {
-      Error("SavePrimitive()", "pixmap not found or the file format is not supported for picture button %d ", fWidgetId);
+      Error("SavePrimitive", "pixmap not found or the file format is not supported for picture button %d ", fWidgetId);
       return;
    }
 
@@ -1983,29 +1983,24 @@ void TGPictureButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
       }
    }
 
-   char quote = '"';
    TString picname = gSystem->UnixPathName(fPic->GetName());
    gSystem->ExpandPathName(picname);
 
-   out <<"   TGPictureButton *";
-
-   out << GetName() << " = new TGPictureButton(" << fParent->GetName()
-       << ",gClient->GetPicture(" << quote
-       << picname << quote << ")";
+   out << "   TGPictureButton *" << GetName() << " = new TGPictureButton(" << fParent->GetName()
+       << ", gClient->GetPicture(\"" << picname.ReplaceSpecialCppChars() << "\")";
 
    if (GetOptions() == (kRaisedFrame | kDoubleBorder)) {
       if (fNormGC == GetDefaultGC()()) {
          if (fWidgetId == -1) {
-            out << ");" << std::endl;
+            out << ");\n";
          } else {
-            out << "," << fWidgetId << ");" << std::endl;
+            out << "," << fWidgetId << ");\n";
          }
       } else {
-         out << "," << fWidgetId << "," << parGC.Data() << ");" << std::endl;
+         out << "," << fWidgetId << "," << parGC << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << parGC.Data() << "," << GetOptionString()
-          << ");" << std::endl;
+      out << "," << fWidgetId << "," << parGC << "," << GetOptionString() << ");\n";
    }
 
    TGButton::SavePrimitive(out,option);

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -1888,7 +1888,7 @@ void TGButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (fState == kButtonEngaged)
       out << "   " << GetName() << "->SetState(kButtonEngaged);\n";
 
-   if (fBackground != fgDefaultFrameBackground) {
+   if (fBackground != GetDefaultFrameBackground()) {
       SaveUserColor(out, option);
       out << "   " << GetName() << "->ChangeBackground(ucolor);\n";
    }
@@ -1915,7 +1915,7 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
    parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) || (GetOptions() != (kRaisedFrame | kDoubleBorder))) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -1928,8 +1928,6 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          parGC.Form("uGC->GetGC()");
       }
    }
-
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
 
    out << "   TGTextButton *" << GetName() << " = new TGTextButton(" << fParent->GetName()
        << ", \"" << outext.ReplaceSpecialCppChars() << "\"";
@@ -1952,13 +1950,12 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
    }
 
-   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");" << std::endl;
-   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << ",";
-   out << fMTop << "," << fMBottom << ");" << std::endl;
-   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");" << std::endl;
+   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");\n";
+   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << "," << fMTop << "," << fMBottom
+       << ");\n";
+   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");\n";
 
-   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight()
-       << ");" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
 
    TGButton::SavePrimitive(out,option);
 }

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -1878,36 +1878,26 @@ const TGGC &TGRadioButton::GetDefaultGC()
 
 void TGButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (fState == kButtonDown) {
-      out << "   " << GetName() << "->SetState(kButtonDown);"  << std::endl;
-   }
-   if (fState == kButtonDisabled) {
-      out << "   " << GetName() << "->SetState(kButtonDisabled);"  << std::endl;
-   }
-   if (fState == kButtonEngaged) {
-      out << "   " << GetName() << "->SetState(kButtonEngaged);"  << std::endl;
-   }
+   if (fState == kButtonDown)
+      out << "   " << GetName() << "->SetState(kButtonDown);\n";
+   if (fState == kButtonDisabled)
+      out << "   " << GetName() << "->SetState(kButtonDisabled);\n";
+   if (fState == kButtonEngaged)
+      out << "   " << GetName() << "->SetState(kButtonEngaged);\n";
+
    if (fBackground != fgDefaultFrameBackground) {
       SaveUserColor(out, option);
-      out << "   " << GetName() << "->ChangeBackground(ucolor);" << std::endl;
+      out << "   " << GetName() << "->ChangeBackground(ucolor);\n";
    }
 
-   if (fTip) {
-      TString tiptext = fTip->GetText()->GetString();
-      tiptext.ReplaceAll("\n", "\\n");
-      out << "   ";
-      out << GetName() << "->SetToolTipText(" << quote
-          << tiptext << quote << ");"  << std::endl;
-   }
-   if (fCommand.Length() > 0) {
-      out << "   " << GetName() << "->SetCommand(" << quote << fCommand
-          << quote << ");" << std::endl;
-   }
+   if (fTip)
+      out << "   " << GetName() << "->SetToolTipText(\""
+          << TString(fTip->GetText()->GetString()).ReplaceSpecialCppChars() << "\");\n";
+   if (fCommand.Length() > 0)
+      out << "   " << GetName() << "->SetCommand(\"" << TString(fCommand).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1915,12 +1905,9 @@ void TGButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    TString outext(fLabel->GetString());
    if (fLabel->GetHotPos() > 0)
       outext.Insert(fLabel->GetHotPos()-1, "&");
-   if (outext.First('\n') >= 0)
-      outext.ReplaceAll("\n", "\\n");
 
    // font + GC
    option = GetName()+5;         // unique digit id of the name
@@ -1944,26 +1931,25 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
 
-   out << "   TGTextButton *";
-   out << GetName() << " = new TGTextButton(" << fParent->GetName()
-       << "," << quote << outext.Data() << quote;
+   out << "   TGTextButton *" << GetName() << " = new TGTextButton(" << fParent->GetName()
+       << ", \"" << outext.ReplaceSpecialCppChars() << "\"";
 
    if (GetOptions() == (kRaisedFrame | kDoubleBorder)) {
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
             if (fWidgetId == -1) {
-               out << ");" << std::endl;
+               out << ");\n";
             } else {
-               out << "," << fWidgetId <<");" << std::endl;
+               out << "," << fWidgetId <<");\n";
             }
          } else {
-            out << "," << fWidgetId << "," << parGC << ");" << std::endl;
+            out << "," << fWidgetId << "," << parGC << ");\n";
          }
       } else {
-         out << "," << fWidgetId << "," << parGC << "," << parFont << ");" << std::endl;
+         out << "," << fWidgetId << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");" << std::endl;
+      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
    }
 
    out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");" << std::endl;
@@ -2033,23 +2019,18 @@ void TGPictureButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 
 void TGCheckButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    TString outext(fLabel->GetString());
    if (fLabel->GetHotPos() > 0)
       outext.Insert(fLabel->GetHotPos()-1, "&");
-   if (outext.First('\n') >= 0)
-      outext.ReplaceAll("\n", "\\n");
 
-   out <<"   TGCheckButton *";
-   out << GetName() << " = new TGCheckButton(" << fParent->GetName()
-       << "," << quote << outext.Data() << quote;
+   out <<"   TGCheckButton *" << GetName() << " = new TGCheckButton(" << fParent->GetName()
+       << ", \"" << outext.ReplaceSpecialCppChars() << "\"";
 
    // font + GC
    option = GetName()+5;         // unique digit id of the name
    TString parGC, parFont;
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
    if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
@@ -2069,31 +2050,31 @@ void TGCheckButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
             if (fWidgetId == -1) {
-               out << ");" << std::endl;
+               out << ");\n";
             } else {
-               out << "," << fWidgetId << ");" << std::endl;
+               out << "," << fWidgetId << ");\n";
             }
          } else {
-            out << "," << fWidgetId << "," << parGC << ");" << std::endl;
+            out << "," << fWidgetId << "," << parGC << ");\n";
          }
       } else {
-         out << "," << fWidgetId << "," << parGC << "," << parFont << ");" << std::endl;
+         out << "," << fWidgetId << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");" << std::endl;
+      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
    }
 
    TGButton::SavePrimitive(out,option);
    if (fState == kButtonDisabled) {
       if (IsDisabledAndSelected())
-         out << "   " << GetName() << "->SetDisabledAndSelected(kTRUE);" << std::endl;
+         out << "   " << GetName() << "->SetDisabledAndSelected(kTRUE);\n";
       else
-         out << "   " << GetName() << "->SetDisabledAndSelected(kFALSE);" << std::endl;
+         out << "   " << GetName() << "->SetDisabledAndSelected(kFALSE);\n";
    }
-   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");" << std::endl;
-   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << ",";
-   out << fMTop << "," << fMBottom << ");" << std::endl;
-   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");" << std::endl;
+   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");\n";
+   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << "," << fMTop << "," << fMBottom
+       << ");\n";
+   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2101,23 +2082,18 @@ void TGCheckButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGRadioButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    TString outext(fLabel->GetString());
    if (fLabel->GetHotPos() > 0)
-      outext.Insert(fLabel->GetHotPos()-1, "&");
-   if (outext.First('\n') >= 0)
-      outext.ReplaceAll("\n", "\\n");
+      outext.Insert(fLabel->GetHotPos() - 1, "&");
 
-   out << "   TGRadioButton *";
-   out << GetName() << " = new TGRadioButton(" << fParent->GetName()
-       << "," << quote << outext.Data() << quote;
+   out << "   TGRadioButton *" << GetName() << " = new TGRadioButton(" << fParent->GetName() << ", \""
+       << outext.ReplaceSpecialCppChars() << "\"";
 
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
    if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
@@ -2137,31 +2113,31 @@ void TGRadioButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
             if (fWidgetId == -1) {
-               out <<");" << std::endl;
+               out << ");\n";
             } else {
-               out << "," << fWidgetId << ");" << std::endl;
+               out << "," << fWidgetId << ");\n";
             }
          } else {
-            out << "," << fWidgetId << "," << parGC << ");" << std::endl;
+            out << "," << fWidgetId << "," << parGC << ");\n";
          }
       } else {
-         out << "," << fWidgetId << "," << parGC << "," << parFont << ");" << std::endl;
+         out << "," << fWidgetId << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");" << std::endl;
+      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
    }
 
-   TGButton::SavePrimitive(out,option);
+   TGButton::SavePrimitive(out, option);
    if (fState == kButtonDisabled) {
       if (IsDisabledAndSelected())
-         out << "   " << GetName() << "->SetDisabledAndSelected(kTRUE);" << std::endl;
+         out << "   " << GetName() << "->SetDisabledAndSelected(kTRUE);\n";
       else
-         out << "   " << GetName() << "->SetDisabledAndSelected(kFALSE);" << std::endl;
+         out << "   " << GetName() << "->SetDisabledAndSelected(kFALSE);\n";
    }
-   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");" << std::endl;
-   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << ",";
-   out << fMTop << "," << fMBottom << ");" << std::endl;
-   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");" << std::endl;
+   out << "   " << GetName() << "->SetTextJustify(" << fTMode << ");\n";
+   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << "," << fMTop << "," << fMBottom
+       << ");\n";
+   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -1915,7 +1915,7 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
    parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) || (GetOptions() != (kRaisedFrame | kDoubleBorder))) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);

--- a/gui/gui/src/TGButtonGroup.cxx
+++ b/gui/gui/src/TGButtonGroup.cxx
@@ -628,7 +628,8 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[dereference]
    parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
+       (fBackground != GetDefaultFrameBackground())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -642,7 +643,8 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
    out << "\n   // buttongroup frame\n";
 
@@ -664,7 +666,7 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          out << "," << GetOptionString() << ", " << parGC << "," << parFont <<");\n";
       }
    } else {
-      out << "," << GetOptionString() << "," << parGC << "," << parFont << ",ucolor);\n";
+      out << "," << GetOptionString() << "," << parGC << "," << parFont << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
@@ -677,7 +679,7 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out << ");\n";
 
    TIter next(GetList());
-   while (auto f = (TGFrameElement *)next()) {
+   while (auto f = static_cast<TGFrameElement *>(next())) {
       f->fFrame->SavePrimitive(out, option);
       if (f->fFrame->InheritsFrom("TGButton"))
          continue;
@@ -718,7 +720,8 @@ void TGHButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
+       (fBackground != GetDefaultFrameBackground())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -793,15 +796,14 @@ void TGHButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote ='"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
+       (fBackground != GetDefaultFrameBackground())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -815,56 +817,54 @@ void TGVButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // vertical buttongroup frame" << std::endl;
+   out << "\n   // vertical buttongroup frame\n";
 
-   out << "   TGVButtonGroup *";
-   out << GetName() << " = new TGVButtonGroup(" << fParent->GetName()
-       << "," << quote << fText->GetString() << quote;
+   out << "   TGVButtonGroup *" << GetName() << " = new TGVButtonGroup(" << fParent->GetName()
+       << ", \"" << TString(fText->GetString()).ReplaceSpecialCppChars() << "\"";
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
-            out <<");" << std::endl;
+            out << ");\n";
          } else {
-            out << "," << parGC.Data() <<");" << std::endl;
+            out << "," << parGC << ");\n";
          }
       } else {
-         out << "," << parGC.Data() << "," << parFont.Data() <<");" << std::endl;
+         out << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << parGC.Data() << "," << parFont.Data() << ",ucolor);" << std::endl;
+      out << "," << parGC << "," << parFont << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   TGFrameElement *f;
    TIter next(GetList());
-   while ((f = (TGFrameElement *)next())) {
-      f->fFrame->SavePrimitive(out,option);
-      if (f->fFrame->InheritsFrom("TGButton")) continue;
-      else {
-         out << "   " << GetName() << "->AddFrame(" << f->fFrame->GetName();
-         f->fLayout->SavePrimitive(out, option);
-         out << ");"<< std::endl;
-      }
+   while (auto f = static_cast<TGFrameElement *>(next())) {
+      f->fFrame->SavePrimitive(out, option);
+      if (f->fFrame->InheritsFrom("TGButton"))
+         continue;
+      out << "   " << GetName() << "->AddFrame(" << f->fFrame->GetName();
+      f->fLayout->SavePrimitive(out, option);
+      out << ");\n";
    }
 
    if (!IsEnabled())
-      out << "   " << GetName() <<"->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() <<"->SetState(kFALSE);\n";
 
    if (IsExclusive())
-      out << "   " << GetName() <<"->SetExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() <<"->SetExclusive(kTRUE);\n";
 
    if (IsRadioButtonExclusive())
-      out << "   " << GetName() <<"->SetRadioButtonExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() <<"->SetRadioButtonExclusive(kTRUE);\n";
 
    if (!IsBorderDrawn())
-      out << "   " << GetName() <<"->SetBorderDrawn(kFALSE);" << std::endl;
+      out << "   " << GetName() <<"->SetBorderDrawn(kFALSE);\n";
 
    out << "   " << GetName() << "->Resize(" << GetWidth()
-       << "," << GetHeight() << ");"<< std::endl;
+       << "," << GetHeight() << ");\n";
 
-   out << "   " << GetName() << "->Show();" << std::endl;
+   out << "   " << GetName() << "->Show();\n";
 }

--- a/gui/gui/src/TGButtonGroup.cxx
+++ b/gui/gui/src/TGButtonGroup.cxx
@@ -712,13 +712,11 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGHButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote ='"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
    if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
@@ -734,64 +732,60 @@ void TGHButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // horizontal buttongroup frame" << std::endl;
+   out << "\n   // horizontal buttongroup frame\n";
 
-   out << "   TGHButtonGroup *";
-   out << GetName() << " = new TGHButtonGroup(" << fParent->GetName()
-       << "," << quote << fText->GetString() << quote;
+   out << "   TGHButtonGroup *" << GetName() << " = new TGHButtonGroup(" << fParent->GetName() << ", \""
+       << TString(fText->GetString()).ReplaceSpecialCppChars() << "\"";
    if (fBackground == GetDefaultFrameBackground()) {
 
       if (fFontStruct == GetDefaultFontStruct()) {
 
          if (fNormGC == GetDefaultGC()()) {
-            out << ");" << std::endl;
+            out << ");\n";
          } else {
-            out << "," << parGC.Data() <<");" << std::endl;
+            out << "," << parGC << ");\n";
          }
       } else {
-         out << "," << parGC.Data() << "," << parFont.Data() <<");" << std::endl;
+         out << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << parGC.Data() << "," << parFont.Data() << ",ucolor);" << std::endl;
+      out << "," << parGC << "," << parFont << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   TGFrameElement *f;
    TIter next(GetList());
-   while ((f = (TGFrameElement *)next())) {
-      f->fFrame->SavePrimitive(out,option);
-      if (f->fFrame->InheritsFrom("TGButton")){
+   while (auto f = (TGFrameElement *)next()) {
+      f->fFrame->SavePrimitive(out, option);
+      if (f->fFrame->InheritsFrom("TGButton")) {
          out << "   " << GetName() << "->SetLayoutHints(";
          f->fLayout->SavePrimitive(out, "nocoma");
-         out << "," << f->fFrame->GetName();
-         out << ");"<< std::endl;
-      }
-      else {
+         out << "," << f->fFrame->GetName() << ");\n";
+      } else {
          out << "   " << GetName() << "->AddFrame(" << f->fFrame->GetName();
          f->fLayout->SavePrimitive(out, option);
-         out << ");"<< std::endl;
+         out << ");\n";
       }
    }
 
    if (!IsEnabled())
-      out << "   " << GetName() <<"->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->SetState(kFALSE);\n";
 
    if (IsExclusive())
-      out << "   " << GetName() <<"->SetExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() << "->SetExclusive(kTRUE);\n";
 
    if (IsRadioButtonExclusive())
-      out << "   " << GetName() <<"->SetRadioButtonExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() << "->SetRadioButtonExclusive(kTRUE);\n";
 
    if (!IsBorderDrawn())
-      out << "   " << GetName() <<"->SetBorderDrawn(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->SetBorderDrawn(kFALSE);\n";
 
-   out << "   " << GetName() <<"->Resize(" << GetWidth() << ","
-       << GetHeight() << ");" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
 
-   out << "   " << GetName() << "->Show();" << std::endl;
+   out << "   " << GetName() << "->Show();\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGButtonGroup.cxx
+++ b/gui/gui/src/TGButtonGroup.cxx
@@ -618,10 +618,8 @@ void TGButtonGroup::SetLayoutHints(TGLayoutHints *l, TGButton *button)
 
 void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote ='"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5;         // unique digit id of the name
    TString parGC, parFont;
    // coverity[returned_null]
    // coverity[dereference]
@@ -646,68 +644,67 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
 
-   out << std::endl << "   // buttongroup frame" << std::endl;
+   out << "\n   // buttongroup frame\n";
 
-   out << "   TGButtonGroup *";
-   out << GetName() << " = new TGButtonGroup(" << fParent->GetName()
-       << ","<< quote << fText->GetString() << quote;
+   out << "   TGButtonGroup *" << GetName() << " = new TGButtonGroup(" << fParent->GetName()
+       << ", \"" << TString(fText->GetString()).ReplaceSpecialCppChars() << "\"";
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
             if (!GetOptions()) {
-               out <<");" << std::endl;
+               out <<");\n";
             } else {
-               out << "," << GetOptionString() <<");" << std::endl;
+               out << "," << GetOptionString() <<");\n";
             }
          } else {
-            out << "," << GetOptionString() << "," << parGC.Data() <<");" << std::endl;
+            out << "," << GetOptionString() << ", " << parGC <<");\n";
          }
       } else {
-         out << "," << GetOptionString() << "," << parGC.Data() << "," << parFont.Data() <<");" << std::endl;
+         out << "," << GetOptionString() << ", " << parGC << "," << parFont <<");\n";
       }
    } else {
-      out << "," << GetOptionString() << "," << parGC.Data() << "," << parFont.Data() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << "," << parGC << "," << parFont << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager
    out << "   " << GetName() <<"->SetLayoutManager(";
    // coverity[returned_null]
    // coverity[dereference]
    GetLayoutManager()->SavePrimitive(out, option);
-   out << ");"<< std::endl;
+   out << ");\n";
 
-   TGFrameElement *f;
    TIter next(GetList());
-   while ((f = (TGFrameElement *)next())) {
-      f->fFrame->SavePrimitive(out,option);
-      if (f->fFrame->InheritsFrom("TGButton")) continue;
+   while (auto f = (TGFrameElement *)next()) {
+      f->fFrame->SavePrimitive(out, option);
+      if (f->fFrame->InheritsFrom("TGButton"))
+         continue;
       else {
          out << "   " << GetName() << "->AddFrame(" << f->fFrame->GetName();
          f->fLayout->SavePrimitive(out, option);
-         out << ");"<< std::endl;
+         out << ");\n";
       }
    }
 
    if (IsExclusive())
-      out << "   " << GetName() <<"->SetExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() <<"->SetExclusive(kTRUE);\n";
 
    if (IsRadioButtonExclusive())
-      out << "   " << GetName() <<"->SetRadioButtonExclusive(kTRUE);" << std::endl;
+      out << "   " << GetName() <<"->SetRadioButtonExclusive(kTRUE);\n";
 
    if (!IsBorderDrawn())
-      out << "   " << GetName() <<"->SetBorderDrawn(kFALSE);" << std::endl;
+      out << "   " << GetName() <<"->SetBorderDrawn(kFALSE);\n";
 
 
    out << "   " << GetName() << "->Resize(" << GetWidth()
-       << "," << GetHeight() << ");" << std::endl;
+       << "," << GetHeight() << ");\n";
 
    if (!IsEnabled())
-      out << "   " << GetName() <<"->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() <<"->SetState(kFALSE);\n";
 
-   out << "   " << GetName() << "->Show();" << std::endl;
+   out << "   " << GetName() << "->Show();\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGButtonGroup.cxx
+++ b/gui/gui/src/TGButtonGroup.cxx
@@ -628,8 +628,7 @@ void TGButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[dereference]
    parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
-       (fBackground != GetDefaultFrameBackground())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -720,8 +719,7 @@ void TGHButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
-       (fBackground != GetDefaultFrameBackground())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -802,8 +800,7 @@ void TGVButtonGroup::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
-       (fBackground != GetDefaultFrameBackground())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);

--- a/gui/gui/src/TGCanvas.cxx
+++ b/gui/gui/src/TGCanvas.cxx
@@ -2445,57 +2445,50 @@ void TGCanvas::ClearViewPort()
 
 void TGCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // canvas widget" << std::endl;
+   out << "\n   // canvas widget\n";
 
-   out << "   TGCanvas *";
-   out << GetName() << " = new TGCanvas("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGCanvas *" << GetName() << " = new TGCanvas(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out << ");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() << ");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    TGViewPort *vp = GetViewPort();
-   out << std::endl << "   // canvas viewport" << std::endl;
-   out << "   TGViewPort *" << vp->GetName() << " = " << GetName()
-       << "->GetViewPort();" << std::endl;
+   out << "\n   // canvas viewport\n";
+   out << "   TGViewPort *" << vp->GetName() << " = " << GetName() << "->GetViewPort();\n";
 
-   TGContainer *cont = (TGContainer*)GetContainer();
+   TGContainer *cont = (TGContainer *)GetContainer();
    cont->SavePrimitive(out, option);
 
-   out << "   " << vp->GetName() << "->AddFrame(" << cont->GetName()
-       << ");" << std::endl;
+   out << "   " << vp->GetName() << "->AddFrame(" << cont->GetName() << ");\n";
 
    out << "   " << cont->GetName() << "->SetLayoutManager(";
    cont->GetLayoutManager()->SavePrimitive(out, option);
-   out << ");"<< std::endl;
+   out << ");\n";
 
-   out << "   " << cont->GetName() << "->MapSubwindows();" << std::endl;
+   out << "   " << cont->GetName() << "->MapSubwindows();\n";
 
-   out << "   " << GetName() << "->SetContainer(" << cont->GetName()
-       << ");" << std::endl;
+   out << "   " << GetName() << "->SetContainer(" << cont->GetName() << ");\n";
 
-   out << "   " << GetName() << "->MapSubwindows();" << std::endl;
+   out << "   " << GetName() << "->MapSubwindows();\n";
 
    if (fHScrollbar && fHScrollbar->IsMapped())
-      out << "   " << GetName() << "->SetHsbPosition(" << GetHsbPosition()
-          << ");" << std::endl;
-
+      out << "   " << GetName() << "->SetHsbPosition(" << GetHsbPosition() << ");\n";
 
    if (fVScrollbar && fVScrollbar->IsMapped())
-      out << "   " << GetName() << "->SetVsbPosition(" << GetVsbPosition()
-          << ");" << std::endl;
-
+      out << "   " << GetName() << "->SetVsbPosition(" << GetVsbPosition() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2503,26 +2496,27 @@ void TGCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGContainer::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // canvas container" << std::endl;
+   out << "\n   // canvas container\n";
 
    if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class())) {
-      out << GetName() << " = new TGContainer(" << GetCanvas()->GetName();
+      out << "   TGContainer *" << GetName() << " = new TGContainer(" << GetCanvas()->GetName();
    } else {
-      out << GetName() << " = new TGContainer(" << fParent->GetName();
-      out << "," << GetWidth() << "," << GetHeight();
+      out << "   TGContainer *" << GetName() << " = new TGContainer(" << fParent->GetName() << "," << GetWidth() << ","
+          << GetHeight();
    }
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() <<");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TGCanvas.cxx
+++ b/gui/gui/src/TGCanvas.cxx
@@ -2445,23 +2445,13 @@ void TGCanvas::ClearViewPort()
 
 void TGCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder);
 
    out << "\n   // canvas widget\n";
 
    out << "   TGCanvas *" << GetName() << " = new TGCanvas(" << fParent->GetName() << "," << GetWidth() << ","
-       << GetHeight();
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
@@ -2496,27 +2486,18 @@ void TGCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGContainer::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder);
 
    out << "\n   // canvas container\n";
 
-   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class())) {
-      out << "   TGContainer *" << GetName() << " = new TGContainer(" << GetCanvas()->GetName();
-   } else {
-      out << "   TGContainer *" << GetName() << " = new TGContainer(" << fParent->GetName() << "," << GetWidth() << ","
-          << GetHeight();
-   }
+   out << "   TGContainer *" << GetName() << " = new TGContainer(";
+   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class()))
+      out << GetCanvas()->GetName();
+   else
+      out << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
+   out << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TGColorSelect.cxx
+++ b/gui/gui/src/TGColorSelect.cxx
@@ -676,30 +676,24 @@ void TGColorSelect::SetAlphaColor(ULong_t color, Bool_t emit)
 
 void TGColorSelect::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    static Int_t nn = 1;
-   TString cvar = TString::Format("ColPar%d",nn);
+   TString cvar = TString::Format("ColPar%d",nn++);
 
    ULong_t color = GetColor();
    const char *colorname = TColor::PixelAsHexString(color);
    gClient->GetColorByName(colorname, color);
 
-   out << std::endl << "   // color select widget" << std::endl;
-   out << "   ULong_t " << cvar.Data() << ";" << std::endl;
-   out << "   gClient->GetColorByName(" << quote << colorname << quote
-       << ", " << cvar.Data() << ");" << std::endl;
+   out << "\n   // color select widget\n";
+   out << "   ULong_t " << cvar << ";\n";
+   out << "   gClient->GetColorByName(\n" << colorname << "\", " << cvar << ");\n";
 
-   out <<"   TGColorSelect *";
-   out << GetName() << " = new TGColorSelect(" << fParent->GetName()
-       << ", " << cvar.Data() << ", " << WidgetId() << ");" << std::endl;
-   nn++;
+   out <<"   TGColorSelect *" << GetName() << " = new TGColorSelect(" << fParent->GetName()
+       << ", " << cvar << ", " << WidgetId() << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (!IsEnabled()) {
-      out << "   " << GetName() << "->Disable();" << std::endl;
-   }
-   out << std::endl;
+   if (!IsEnabled())
+      out << "   " << GetName() << "->Disable();\n";
 }
 

--- a/gui/gui/src/TGComboBox.cxx
+++ b/gui/gui/src/TGComboBox.cxx
@@ -705,46 +705,43 @@ void TGComboBox::RemoveAll()
 
 void TGComboBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // combo box" << std::endl;
-   out << "   TGComboBox *";
+   out << "\n   // combo box\n";
 
    if (!fTextEntry) {
-      out << GetName() << " = new TGComboBox(" << fParent->GetName() << "," << fWidgetId;
+      out << "   TGComboBox *" << GetName() << " = new TGComboBox(" << fParent->GetName() << "," << fWidgetId;
    } else {
-      out << GetName() << " = new TGComboBox(" << fParent->GetName() << ",";
-      out << '\"' <<  fTextEntry->GetText() << '\"' << "," <<fWidgetId;
+      out << "   TGComboBox *" << GetName() << " = new TGComboBox(" << fParent->GetName() << ", \""
+          << TString(fTextEntry->GetText()).ReplaceSpecialCppChars() << "\"," << fWidgetId;
    }
 
    if (fBackground == GetWhitePixel()) {
       if (GetOptions() == (kHorizontalFrame | kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() << ");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   TGTextLBEntry *b;
-   TGFrameElement *el;
    TGListBox *lb = GetListBox();
 
    TIter next(((TGLBContainer *)lb->GetContainer())->GetList());
 
-   while ((el = (TGFrameElement *) next())) {
-      b = (TGTextLBEntry *) el->fFrame;
+   while (auto el = (TGFrameElement *)next()) {
+      auto b = (TGTextLBEntry *)el->fFrame;
       out << "   " << GetName() << "->AddEntry(";
       b->SavePrimitive(out, option);
-      out <<  ");" << std::endl;
+      out << ");" << std::endl;
    }
 
-   out << "   " << GetName() << "->Resize(" << GetWidth()  << ","
-       << GetHeight() << ");" << std::endl;
-   out << "   " << GetName() << "->Select(" << GetSelected() << ");" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
+   out << "   " << GetName() << "->Select(" << GetSelected() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGComboBox.cxx
+++ b/gui/gui/src/TGComboBox.cxx
@@ -759,16 +759,13 @@ TGLineStyleComboBox::TGLineStyleComboBox(const TGWindow *p, Int_t id,
 
 void TGLineStyleComboBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << std::endl << "   // line style combo box" << std::endl;
-   out << "   TGLineStyleComboBox *";
-
-   out << GetName() << " = new TGLineStyleComboBox(" << fParent->GetName()
-       << "," << fWidgetId << ");" << std::endl;
+   out << "\n   // line style combo box\n";
+   out << "   TGLineStyleComboBox *" << GetName() << " = new TGLineStyleComboBox(" << fParent->GetName() << ","
+       << fWidgetId << ");\n";
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-   out << "   " << GetName() << "->Resize(" << GetWidth()  << ","
-       << GetHeight() << ");" << std::endl;
-   out << "   " << GetName() << "->Select(" << GetSelected() << ");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
+   out << "   " << GetName() << "->Select(" << GetSelected() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -801,16 +798,13 @@ TGLineWidthComboBox::TGLineWidthComboBox(const TGWindow *p, Int_t id,
 
 void TGLineWidthComboBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << std::endl << "   // line width combo box" << std::endl;
-   out << "   TGLineWidthComboBox *";
-
-   out << GetName() << " = new TGLineWidthComboBox(" << fParent->GetName()
-       << "," << fWidgetId << ");" << std::endl;
+   out << "\n   // line width combo box\n";
+   out << "   TGLineWidthComboBox *" << GetName() << " = new TGLineWidthComboBox(" << fParent->GetName() << ","
+       << fWidgetId << ");\n";
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-   out << "   " << GetName() << "->Resize(" << GetWidth()  << ","
-       << GetHeight() << ");" << std::endl;
-   out << "   " << GetName() << "->Select(" << GetSelected() << ");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
+   out << "   " << GetName() << "->Select(" << GetSelected() << ");\n";
 }
 
 static const char *gFonts[][2] = {    //   unix name,     name
@@ -828,7 +822,7 @@ static const char *gFonts[][2] = {    //   unix name,     name
    { "-*-courier-bold-o-*-*-12-*-*-*-*-*-*-*",     "11. courier bold italic"  },
    { "-*-symbol-medium-r-*-*-12-*-*-*-*-*-*-*",    "12. symbol"               },
    { "-*-times-medium-r-*-*-12-*-*-*-*-*-*-*",     "13. times"                },
-   { 0, 0}
+   { nullptr, nullptr }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGComboBox.cxx
+++ b/gui/gui/src/TGComboBox.cxx
@@ -705,27 +705,16 @@ void TGComboBox::RemoveAll()
 
 void TGComboBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out, kHorizontalFrame | kSunkenFrame | kDoubleBorder);
 
    out << "\n   // combo box\n";
 
-   if (!fTextEntry) {
-      out << "   TGComboBox *" << GetName() << " = new TGComboBox(" << fParent->GetName() << "," << fWidgetId;
-   } else {
-      out << "   TGComboBox *" << GetName() << " = new TGComboBox(" << fParent->GetName() << ", \""
-          << TString(fTextEntry->GetText()).ReplaceSpecialCppChars() << "\"," << fWidgetId;
-   }
+   out << "   TGComboBox *" << GetName() << " = new TGComboBox(" << fParent->GetName();
+   if (fTextEntry)
+      out << ", \""  << TString(fTextEntry->GetText()).ReplaceSpecialCppChars() << "\"";
+   out << ", " << fWidgetId << extra_args << ");\n";
 
-   if (fBackground == GetWhitePixel()) {
-      if (GetOptions() == (kHorizontalFrame | kSunkenFrame | kDoubleBorder)) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGDockableFrame.cxx
+++ b/gui/gui/src/TGDockableFrame.cxx
@@ -456,60 +456,55 @@ void TGDockableFrame::SetWindowName(const char *name)
 
 void TGDockableFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
-   out << std::endl << "   // dockable frame" << std::endl;
-   out << "   TGDockableFrame *";
-   out << GetName()<<" = new TGDockableFrame(" << fParent->GetName();
+   out << "\n   // dockable frame\n";
+   out << "   TGDockableFrame *" << GetName()<<" = new TGDockableFrame(" << fParent->GetName();
 
    if (GetOptions() == kHorizontalFrame) {
       if (fWidgetId == -1) {
-         out << ");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << fWidgetId << ");" << std::endl;
+         out << "," << fWidgetId << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << GetOptionString() << ");" << std::endl;
+      out << "," << fWidgetId << "," << GetOptionString() << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (GetContainer()->GetList()->First()) {
       out << "   TGCompositeFrame *" << GetContainer()->GetName() << " = "
-          << GetName() << "->GetContainer();" << std::endl;
+          << GetName() << "->GetContainer();\n";
 
-      TGFrameElement *el;
       TIter next(GetContainer()->GetList());
 
-      while ((el = (TGFrameElement *) next())) {
+      while (auto el = (TGFrameElement *) next()) {
          el->fFrame->SavePrimitive(out, option);
          out << "   " << GetName() << "->AddFrame(" << el->fFrame->GetName();
          el->fLayout->SavePrimitive(out, option);
-         out << ");"<< std::endl;
+         out << ");\n";
       }
    }
-   out << std::endl << "   // next lines belong to the dockable frame widget" << std::endl;
+   out << "\n   // next lines belong to the dockable frame widget\n";
    if (EnableUndock())
-      out << "   " << GetName() << "->EnableUndock(kTRUE);" << std::endl;
+      out << "   " << GetName() << "->EnableUndock(kTRUE);\n";
    else
-      out << "   " << GetName() << "->EnableUndock(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->EnableUndock(kFALSE);\n";
 
    if (EnableHide())
-      out << "   " << GetName() << "->EnableHide(kTRUE);" << std::endl;
+      out << "   " << GetName() << "->EnableHide(kTRUE);\n";
    else
-      out << "   " << GetName() << "->EnableHide(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->EnableHide(kFALSE);\n";
 
-   if (fDockName != "")
-      out << "   " << GetName() << "->SetWindowName(" << quote << fDockName
-          << quote << ");" << std::endl;
+   if (fDockName.Length() > 0)
+      out << "   " << GetName() << "->SetWindowName(\"" << TString(fDockName).ReplaceSpecialCppChars() << "\");\n";
 
    if (IsUndocked())
-      out << "   " << GetName() << "->UndockContainer();" << std::endl;
+      out << "   " << GetName() << "->UndockContainer();\n";
    else
-      out << "   " << GetName() << "->DockContainer();" << std::endl;
+      out << "   " << GetName() << "->DockContainer();\n";
 
    if (IsHidden())
-      out << "   " << GetName() << "->HideContainer();" << std::endl;
+      out << "   " << GetName() << "->HideContainer();\n";
 
-   out << std::endl;
+   out << "   \n";
 }

--- a/gui/gui/src/TGDoubleSlider.cxx
+++ b/gui/gui/src/TGDoubleSlider.cxx
@@ -624,35 +624,29 @@ void TGDoubleHSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 {
    SaveUserColor(out, option);
 
-   out <<"   TGDoubleHSlider *";
-   out << GetName() << " = new TGDoubleHSlider(" << fParent->GetName()
-       << "," << GetWidth() << ",";
-   out << GetSString() << "," << WidgetId() << ",";
-   out << GetOptionString() << ",ucolor";
+   out << "   TGDoubleHSlider *" << GetName() << " = new TGDoubleHSlider(" << fParent->GetName() << "," << GetWidth()
+       << ", " << GetSString() << ", " << WidgetId() << ", " << GetOptionString() << ", ucolor";
    if (fMarkEnds) {
       if (fReversedScale)
-         out << ",kTRUE,kTRUE);" << std::endl;
+         out << ", kTRUE, kTRUE);\n";
       else
-         out << ",kFALSE,kTRUE);" << std::endl;
+         out << ", kFALSE, kTRUE);\n";
    } else if (fReversedScale) {
-      out << ",kTRUE);" << std::endl;
+      out << ", kTRUE);\n";
    } else {
-      out << ");" << std::endl;
+      out << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fWidth)
-      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax
-          << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax << ");\n";
 
-   if (fSmin != fWidth/8*3 || fSmax != fWidth/8*5)
-      out << "   " << GetName() << "->SetPosition(" << GetMinPosition()
-          << "," << GetMaxPosition() << ");" << std::endl;
+   if (fSmin != fWidth / 8 * 3 || fSmax != fWidth / 8 * 5)
+      out << "   " << GetName() << "->SetPosition(" << GetMinPosition() << "," << GetMaxPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() << "->SetScale(" << fScale << ");" << std::endl;
-
+      out << "   " << GetName() << "->SetScale(" << fScale << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -662,35 +656,27 @@ void TGDoubleVSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 {
    SaveUserColor(out, option);
 
-   out<<"   TGDoubleVSlider *";
-   out << GetName() << " = new TGDoubleVSlider("<< fParent->GetName()
-       << "," << GetHeight() << ",";
-   out << GetSString() << "," << WidgetId() << ",";
-   out << GetOptionString() << ",ucolor";
+   out << "   TGDoubleVSlider *" << GetName() << " = new TGDoubleVSlider(" << fParent->GetName() << "," << GetHeight()
+       << "," << GetSString() << "," << WidgetId() << "," << GetOptionString() << ", ucolor";
    if (fMarkEnds) {
       if (fReversedScale)
-         out << ",kTRUE,kTRUE);" << std::endl;
+         out << ",kTRUE,kTRUE);\n";
       else
-         out << ",kFALSE,kTRUE);" << std::endl;
+         out << ",kFALSE,kTRUE);\n";
    } else if (fReversedScale) {
-      out << ",kTRUE);" << std::endl;
+      out << ",kTRUE);\n";
    } else {
-      out << ");" << std::endl;
+      out << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fHeight)
-      out << "   " << GetName() <<"->SetRange(" << fVmin << "," << fVmax
-          << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax << ");\n";
 
-
-   if (fSmin != fHeight/8*3 || fSmax != fHeight/8*5)
-      out << "   " << GetName() << "->SetPosition(" << GetMinPosition()
-          << "," << GetMaxPosition() << ");" << std::endl;
-
+   if (fSmin != fHeight / 8 * 3 || fSmax != fHeight / 8 * 5)
+      out << "   " << GetName() << "->SetPosition(" << GetMinPosition() << "," << GetMaxPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() << "->SetScale(" << fScale << ");" << std::endl;
-
+      out << "   " << GetName() << "->SetScale(" << fScale << ");\n";
 }

--- a/gui/gui/src/TGFSComboBox.cxx
+++ b/gui/gui/src/TGFSComboBox.cxx
@@ -401,26 +401,17 @@ void TGFSComboBox::Update(const char *path)
 
 void TGFSComboBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetWhitePixel()) SaveUserColor(out, option);
+   // store options and color if differ from defauls
+   TString extra_args = SaveCtorArgs(out, kHorizontalFrame | kSunkenFrame | kDoubleBorder, kTRUE);
 
-   out << std::endl << "   // file system combo box" << std::endl;
-   out << "   TGFSComboBox *";
-   out << GetName() << " = new TGFSComboBox(" << fParent->GetName()
-                                          << "," << fWidgetId;
-   if (fBackground == GetWhitePixel()) {
-      if (GetOptions() == (kHorizontalFrame | kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
+   out << "\n   // file system combo box\n";
+   out << "   TGFSComboBox *" << GetName() << " = new TGFSComboBox(" << fParent->GetName()
+                                          << "," << fWidgetId << extra_args << ");\n";
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    out << "   " << GetName() << "->Resize(" << GetWidth()  << ","
-       << GetHeight() << ");" << std::endl;
-   out << "   " << GetName() << "->Select(" << GetSelected() << ");" << std::endl;
+       << GetHeight() << ");\n";
+   out << "   " << GetName() << "->Select(" << GetSelected() << ");\n";
 
 }

--- a/gui/gui/src/TGFSContainer.cxx
+++ b/gui/gui/src/TGFSContainer.cxx
@@ -911,33 +911,23 @@ void TGFileContainer::StartRefreshTimer(ULong_t msec)
 
 void TGFileContainer::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if necessary
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame);
 
-   char quote = '"';
-   out << std::endl << "   // container frame" << std::endl;
-   out << "   TGFileContainer *";
+   out << "\n   // container frame\n";
+   out << "   TGFileContainer *" << GetName() << " = new TGFileContainer(";
 
-   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class())) {
-      out << GetName() << " = new TGFileContainer(" << GetCanvas()->GetName();
-   } else {
-      out << GetName() << " = new TGFileContainer(" << fParent->GetName();
-      out << "," << GetWidth() << "," << GetHeight();
-   }
+   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class()))
+      out << GetCanvas()->GetName();
+   else
+      out << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == kSunkenFrame) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
+   out << extra_args << ");\n";
+
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-   out << "   " << GetCanvas()->GetName() << "->SetContainer("
-                << GetName() << ");" << std::endl;
-   out << "   " << GetName() << "->DisplayDirectory();" << std::endl;
-   out << "   " << GetName() << "->AddFile("<< quote << ".." << quote << ");" << std::endl;
-   out << "   " << GetName() << "->StopRefreshTimer();" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
+   out << "   " << GetCanvas()->GetName() << "->SetContainer(" << GetName() << ");\n";
+   out << "   " << GetName() << "->DisplayDirectory();\n";
+   out << "   " << GetName() << "->AddFile(\"..\");\n";
+   out << "   " << GetName() << "->StopRefreshTimer();\n";
 }

--- a/gui/gui/src/TGFont.cxx
+++ b/gui/gui/src/TGFont.cxx
@@ -1883,16 +1883,12 @@ void TGFontPool::Print(Option_t *opt) const
 
 void TGFont::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   char quote = '"';
+   out << "   \n";
 
-   if (gROOT->ClassSaved(TGFont::Class())) {
-      out << std::endl;
-   } else {
-      //  declare a font object to reflect required user changes
-      out << std::endl;
-      out << "   TGFont *ufont;         // will reflect user font changes" << std::endl;
-   }
-   out << "   ufont = gClient->GetFont(" << quote << GetName() << quote << ");" << std::endl;
+   //  declare a font object to reflect required user changes
+   if (!gROOT->ClassSaved(TGFont::Class()))
+      out << "   TGFont *ufont;         // will reflect user font changes\n";
+   out << "   ufont = gClient->GetFont(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -3183,8 +3183,7 @@ void TGGroupFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[dereference]
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
-       (fBackground != GetDefaultFrameBackground())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2478,15 +2478,10 @@ Bool_t TGHeaderFrame::HandleMotion(Event_t* event)
 
 void TGFrame::SaveUserColor(std::ostream &out, Option_t *option)
 {
-   char quote = '"';
+   //  declare a color variable to reflect required user changes
+   if (!gROOT->ClassSaved(TGFrame::Class()))
+      out << "\n   ULong_t ucolor;        // will reflect user color changes\n";
 
-   if (gROOT->ClassSaved(TGFrame::Class())) {
-      out << std::endl;
-   } else {
-      //  declare a color variable to reflect required user changes
-      out << std::endl;
-      out << "   ULong_t ucolor;        // will reflect user color changes" << std::endl;
-   }
    ULong_t ucolor;
    if (option && !strcmp(option, "slider"))
       ucolor = GetDefaultFrameBackground();
@@ -2494,11 +2489,28 @@ void TGFrame::SaveUserColor(std::ostream &out, Option_t *option)
       ucolor = GetBackground();
    if ((ucolor != fgUserColor) || (ucolor == GetWhitePixel())) {
       const char *ucolorname = TColor::PixelAsHexString(ucolor);
-      out << "   gClient->GetColorByName(" << quote << ucolorname << quote
-          << ",ucolor);" << std::endl;
+      out << "   gClient->GetColorByName(\"" << ucolorname << "\", ucolor);\n";
       fgUserColor = ucolor;
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return options and custom color as constructor args
+/// Used in the SavePrimitive methods, includes comma "," if any argument is not default
+
+TString TGFrame::SaveCtorArgs(std::ostream &out, UInt_t dflt_options)
+{
+   if (GetBackground() == GetDefaultFrameBackground()) {
+      if (GetOptions() == dflt_options)
+         return "";
+      return TString(", ") + GetOptionString();
+   }
+
+   SaveUserColor(out, "");
+
+   return TString(", ") + GetOptionString() + ", ucolor";
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns a frame option string - used in SavePrimitive().

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2498,9 +2498,11 @@ void TGFrame::SaveUserColor(std::ostream &out, Option_t *option)
 /// Return options and custom color as constructor args
 /// Used in the SavePrimitive methods, includes comma "," if any argument is not default
 
-TString TGFrame::SaveCtorArgs(std::ostream &out, UInt_t dflt_options)
+TString TGFrame::SaveCtorArgs(std::ostream &out, UInt_t dflt_options, Bool_t check_white_pixel)
 {
-   if (GetBackground() == GetDefaultFrameBackground()) {
+   Pixel_t default_color = check_white_pixel ? GetWhitePixel() : GetDefaultFrameBackground();
+
+   if (GetBackground() == default_color) {
       if (GetOptions() == dflt_options)
          return "";
       return TString(", ") + GetOptionString();

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2762,7 +2762,7 @@ void TGCompositeFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
        << "," << GetHeight() << extra_args << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from the composite frame type
    // coverity[returned_null]
@@ -3518,43 +3518,35 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
 
 void TGTransientFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
-   out << std::endl << "   // transient frame" << std::endl;
-   out << "   TGTransientFrame *";
-   out << GetName()<<" = new TGTransientFrame(gClient->GetRoot(),0"
-       << "," << GetWidth() << "," << GetHeight() << "," << GetOptionString() <<");" << std::endl;
+   out << "\n   // transient frame\n";
+   out << "   TGTransientFrame *" << GetName() << " = new TGTransientFrame(gClient->GetRoot(),0"
+       << "," << GetWidth() << "," << GetHeight() << "," << GetOptionString() << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from transient frame type
    // coverity[returned_null]
    // coverity[dereference]
-   TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   TGLayoutManager *lm = GetLayoutManager();
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);
 
    if (fWindowName.Length()) {
-      out << "   " << GetName() << "->SetWindowName(" << quote << GetWindowName()
-          << quote << ");" << std::endl;
+      out << "   " << GetName() << "->SetWindowName(\n"
+          << TString(GetWindowName()).ReplaceSpecialCppChars() << "\");\n";
    }
    if (fIconName.Length()) {
-      out <<"   "<<GetName()<< "->SetIconName("<<quote<<GetIconName()<<quote<<");"<<std::endl;
+      out << "   " << GetName() << "->SetIconName(\"" << TString(GetIconName()).ReplaceSpecialCppChars() << "\");\n";
    }
    if (fIconPixmap.Length()) {
-      out << "   " << GetName() << "->SetIconPixmap(" << quote << GetIconPixmap()
-          << quote << ");" << std::endl;
+      out << "   " << GetName() << "->SetIconPixmap(\"" << TString(GetIconPixmap()).ReplaceSpecialCppChars()
+          << "\");\n";
    }
 }

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2785,7 +2785,7 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
 {
    // iteration over all active classes to exclude the base ones
    TString opt = option;
-   TBits *bc = new TBits();
+   TBits bc;
    TClass *c1, *c2, *c3;
    UInt_t k = 0;      // will mark k-bit of TBits if the class is a base class
 
@@ -2802,7 +2802,7 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
          else {
             c3 = c2->GetBaseClass(c1);
             if (c3 != 0) {
-               bc->SetBitNumber(k, kTRUE);
+               bc.SetBitNumber(k, kTRUE);
                break;
             }
          }
@@ -2819,9 +2819,9 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
    TIter nextdo(gROOT->GetListOfClasses());
    while ((c2 = (TClass *)nextdo())) {
       // for used GUI header files
-      if (bc->TestBitNumber(k) == 0 && c2->InheritsFrom(TGObject::Class()) == 1) {
+      if (bc.TestBitNumber(k) == 0 && c2->InheritsFrom(TGObject::Class()) == 1) {
          // for any used ROOT header files activate the line below, comment the line above
-         //if (bc->TestBitNumber(k) == 0) {
+         //if (bc.TestBitNumber(k) == 0) {
          const char *iname;
          iname = c2->GetDeclFileName();
          if (iname[0] && strstr(iname,".h")) {
@@ -2881,7 +2881,6 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
    }
 
    // writes include files in C++ macro
-   TObjString *inc;
    ilist = (TList *)gROOT->GetListOfSpecials()->FindObject("ListOfIncludes");
 
    if (!ilist) {
@@ -2896,22 +2895,16 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
    out << std::endl;
 
    TIter nexti(ilist);
-   while((inc = (TObjString *)nexti())) {
-         out << "#ifndef ROOT_" << inc->GetString() << std::endl;
-         out << "#include " << quote << inc->GetString() << ".h" << quote << std::endl;
-         out << "#endif" << std::endl;
-         if (strstr(inc->GetString(),"TRootEmbeddedCanvas")) {
-            out << "#ifndef ROOT_TCanvas" << std::endl;
-            out << "#include " << quote << "TCanvas.h" << quote << std::endl;
-            out << "#endif" << std::endl;
-         }
+   while (auto inc = (TObjString *)nexti()) {
+      out << "#include \"" << inc->GetString() << ".h\"\n";
+      if (strstr(inc->GetString(), "TRootEmbeddedCanvas"))
+         out << "#include \"TCanvas.h\"\n";
    }
-   out << std::endl << "#include " << quote << "Riostream.h" << quote << std::endl;
+   out << "\n#include \"Riostream.h\"\n\n";
    // deletes created ListOfIncludes
    gROOT->GetListOfSpecials()->Remove(ilist);
    ilist->Delete();
    delete ilist;
-   delete bc;
 
    // writes the macro entry point equal to the fname
    out << std::endl;
@@ -2965,11 +2958,9 @@ void TGMainFrame::SaveSource(const char *filename, Option_t *option)
    out << "   " <<GetName()<< "->MapSubwindows();" << std::endl;
 
    TIter nexth(gListOfHiddenFrames);
-   TGFrame *fhidden;
-   while ((fhidden = (TGFrame*)nexth())) {
-      out << "   " <<fhidden->GetName()<< "->UnmapWindow();" << std::endl;
+   while (auto fhidden = static_cast<TGFrame *>(nexth())) {
+      out << "   " << fhidden->GetName() << "->UnmapWindow();" << std::endl;
    }
-
    out << std::endl;
    gListOfHiddenFrames->Clear();
 
@@ -3250,7 +3241,7 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
    // iterate over all active classes to exclude the base ones
 
    TString opt = option;
-   TBits *bc = new TBits();
+   TBits bc;
    TClass *c1, *c2, *c3;
    UInt_t k = 0;      // will mark k-bit of TBits if the class is a base class
 
@@ -3266,7 +3257,7 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
          else {
             c3 = c2->GetBaseClass(c1);
             if (c3 != 0) {
-               bc->SetBitNumber(k, kTRUE);
+               bc.SetBitNumber(k, kTRUE);
                break;
             }
          }
@@ -3283,9 +3274,9 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
    TIter nextdo(gROOT->GetListOfClasses());
    while ((c2 = (TClass *)nextdo())) {
       // to have only used GUI header files
-      if (bc->TestBitNumber(k) == 0 && c2->InheritsFrom(TGObject::Class()) == 1) {
+      if (bc.TestBitNumber(k) == 0 && c2->InheritsFrom(TGObject::Class()) == 1) {
          // for any used ROOT header files activate the line below, comment the line above
-         //if (bc->TestBitNumber(k) == 0) {
+         //if (bc.TestBitNumber(k) == 0) {
          const char *iname;
          iname = c2->GetDeclFileName();
          if (iname[0] && strstr(iname,".h")) {
@@ -3337,7 +3328,6 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
    }
 
    // writes include files in C++ macro
-   TObjString *inc;
    ilist = (TList *)gROOT->GetListOfSpecials()->FindObject("ListOfIncludes");
 
    if (!ilist) {
@@ -3354,23 +3344,16 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
    out << std::endl << std::endl;
 
    TIter nexti(ilist);
-   while((inc = (TObjString *)nexti())) {
-      out <<"#ifndef ROOT_"<< inc->GetString() << std::endl;
-      out <<"#include "<< quote << inc->GetString() <<".h"<< quote << std::endl;
-      out <<"#endif" << std::endl;
-      if (strstr(inc->GetString(),"TRootEmbeddedCanvas")) {
-         out <<"#ifndef ROOT_TCanvas"<< std::endl;
-         out <<"#include "<< quote <<"TCanvas.h"<< quote << std::endl;
-         out <<"#endif" << std::endl;
-      }
+   while(auto inc = (TObjString *)nexti()) {
+      out << "#include \"" << inc->GetString() << ".h\"\n";
+      if (strstr(inc->GetString(), "TRootEmbeddedCanvas"))
+         out << "#include \"TCanvas.h\"\n";
    }
-   out << std::endl << "#include " << quote << "Riostream.h" << quote << std::endl;
-   out << std::endl << std::endl;
+   out << "\n#include \"Riostream.h\"\n\n";
    // deletes created ListOfIncludes
    gROOT->GetListOfSpecials()->Remove(ilist);
    ilist->Delete();
    delete ilist;
-   delete bc;
 
    // writes the macro entry point equal to the fname
    out << std::endl;
@@ -3433,10 +3416,8 @@ void TGTransientFrame::SaveSource(const char *filename, Option_t *option)
    out << "   " <<GetName()<< "->MapSubwindows();" << std::endl;
 
    TIter nexth(gListOfHiddenFrames);
-   TGFrame *fhidden;
-   while ((fhidden = (TGFrame*)nexth())) {
-      out << "   " <<fhidden->GetName()<< "->UnmapWindow();" << std::endl;
-   }
+   while (auto fhidden = static_cast<TGFrame *>(nexth()))
+      out << "   " << fhidden->GetName() << "->UnmapWindow();" << std::endl;
    out << std::endl;
    gListOfHiddenFrames->Clear();
 

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2505,65 +2505,33 @@ void TGFrame::SaveUserColor(std::ostream &out, Option_t *option)
 
 TString TGFrame::GetOptionString() const
 {
-   TString options;
+   TString str;
+   auto add = [this, &str](Int_t bit, const char *name) {
+      if (fOptions & bit) {
+         if (str.Length() > 0)
+            str.Append(" | ");
+         str.Append(name);
+      }
+   };
 
    if (!GetOptions()) {
-      options = "kChildFrame";
+      str = "kChildFrame";
    } else {
-      if (fOptions & kMainFrame) {
-         if (options.Length() == 0) options  = "kMainFrame";
-         else                       options += " | kMainFrame";
-      }
-      if (fOptions & kVerticalFrame) {
-         if (options.Length() == 0) options  = "kVerticalFrame";
-         else                       options += " | kVerticalFrame";
-      }
-      if (fOptions & kHorizontalFrame) {
-         if (options.Length() == 0) options  = "kHorizontalFrame";
-         else                       options += " | kHorizontalFrame";
-      }
-      if (fOptions & kSunkenFrame) {
-         if (options.Length() == 0) options  = "kSunkenFrame";
-         else                       options += " | kSunkenFrame";
-      }
-      if (fOptions & kRaisedFrame) {
-         if (options.Length() == 0) options  = "kRaisedFrame";
-         else                       options += " | kRaisedFrame";
-      }
-      if (fOptions & kDoubleBorder) {
-         if (options.Length() == 0) options  = "kDoubleBorder";
-         else                       options += " | kDoubleBorder";
-      }
-      if (fOptions & kFitWidth) {
-         if (options.Length() == 0) options  = "kFitWidth";
-         else                       options += " | kFitWidth";
-      }
-      if (fOptions & kFixedWidth) {
-         if (options.Length() == 0) options  = "kFixedWidth";
-         else                       options += " | kFixedWidth";
-      }
-      if (fOptions & kFitHeight) {
-         if (options.Length() == 0) options  = "kFitHeight";
-         else                       options += " | kFitHeight";
-      }
-      if (fOptions & kFixedHeight) {
-         if (options.Length() == 0) options  = "kFixedHeight";
-         else                       options += " | kFixedHeight";
-      }
-      if (fOptions & kOwnBackground) {
-         if (options.Length() == 0) options  = "kOwnBackground";
-         else                       options += " | kOwnBackground";
-      }
-      if (fOptions & kTransientFrame) {
-         if (options.Length() == 0) options  = "kTransientFrame";
-         else                       options += " | kTransientFrame";
-      }
-      if (fOptions & kTempFrame) {
-         if (options.Length() == 0) options  = "kTempFrame";
-         else                       options += " | kTempFrame";
-      }
+      add(kMainFrame, "kMainFrame");
+      add(kVerticalFrame, "kVerticalFrame");
+      add(kHorizontalFrame, "kHorizontalFrame");
+      add(kSunkenFrame, "kSunkenFrame");
+      add(kRaisedFrame, "kRaisedFrame");
+      add(kDoubleBorder, "kDoubleBorder");
+      add(kFitWidth, "kFitWidth");
+      add(kFixedWidth, "kFixedWidth");
+      add(kFitHeight, "kFitHeight");
+      add(kFixedHeight, "kFixedHeight");
+      add(kOwnBackground, "kOwnBackground");
+      add(kTransientFrame, "kTransientFrame");
+      add(kTempFrame, "kTempFrame");
    }
-   return options;
+   return str;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -3066,12 +3066,9 @@ void TGMainFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       return;
    }
 
-   char quote = '"';
-
-   out << std::endl << "   // main frame" << std::endl;
-   out << "   TGMainFrame *";
-   out << GetName() << " = new TGMainFrame(gClient->GetRoot(),10,10,"   // layout alg.
-       << GetOptionString() << ");" <<std::endl;
+   out << "\n   // main frame\n";
+   out << "   TGMainFrame *" << GetName() << " = new TGMainFrame(gClient->GetRoot(), 5, 5, "   // layout alg.
+       << GetOptionString() << ");\n";
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
 
@@ -3079,31 +3076,26 @@ void TGMainFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[returned_null]
    // coverity[dereference]
    TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);
 
-   if (fWindowName.Length()) {
-      out << "   " << GetName() << "->SetWindowName(" << quote << GetWindowName()
-          << quote << ");" << std::endl;
-   }
-   if (fIconName.Length()) {
-      out <<"   "<<GetName()<< "->SetIconName("<<quote<<GetIconName()<<quote<<");"<<std::endl;
-   }
-   if (fIconPixmap.Length()) {
-      out << "   " << GetName() << "->SetIconPixmap(" << quote << GetIconPixmap()
-          << quote << ");" << std::endl;
-   }
+   if (fWindowName.Length())
+      out << "   " << GetName() << "->SetWindowName(\"" << TString(GetWindowName()).ReplaceSpecialCppChars()
+          << "\");\n";
+   if (fIconName.Length())
+      out << "   " << GetName() << "->SetIconName(\"" << TString(GetIconName()).ReplaceSpecialCppChars() << "\");\n";
+   if (fIconPixmap.Length())
+      out << "   " << GetName() << "->SetIconPixmap(\"" << TString(GetIconPixmap()).ReplaceSpecialCppChars() << "\");\n";
+
+   out << "   " << GetName() << "->MapSubwindows();\n";
+   out << "   " << GetName() << "->Resize({" << GetDefaultWidth() << ", " << GetDefaultHeight() << "});\n";
+   out << "   " << GetName() << "->MapWindow();\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -2747,27 +2747,18 @@ void TGCompositeFrame::SavePrimitiveSubframes(std::ostream &out, Option_t *optio
 
 void TGCompositeFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
-
-   if (!strcmp(GetName(),"")) {
-      SetName(Form("fCompositeframe%d",fgCounter));
+   if (!strcmp(GetName(), "")) {
+      SetName(Form("fCompositeframe%d", fgCounter));
       fgCounter++;
    }
 
-   out << std::endl << "   // composite frame" << std::endl;
-   out << "   TGCompositeFrame *";
-   out << GetName() << " = new TGCompositeFrame(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
+   out << "\n   // composite frame\n";
+   out << "   TGCompositeFrame *" << GetName() << " = new TGCompositeFrame(" << fParent->GetName() << "," << GetWidth()
+       << "," << GetHeight() << extra_args << ");\n";
+
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
 
@@ -2775,16 +2766,11 @@ void TGCompositeFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    // coverity[returned_null]
    // coverity[dereference]
    TGLayoutManager *lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);
@@ -3114,39 +3100,25 @@ void TGMainFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGHorizontalFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << std::endl << "   // horizontal frame" << std::endl;
-   out << "   TGHorizontalFrame *";
-   out << GetName() << " = new TGHorizontalFrame(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "\n   // horizontal frame\n";
+   out << "   TGHorizontalFrame *" << GetName() << " = new TGHorizontalFrame(" << fParent->GetName() << ","
+       << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from the main frame type
    // coverity[returned_null]
    // coverity[dereference]
-   TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   TGLayoutManager *lm = GetLayoutManager();
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);
@@ -3157,39 +3129,25 @@ void TGHorizontalFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""
 
 void TGVerticalFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << std::endl << "   // vertical frame" << std::endl;
-   out << "   TGVerticalFrame *";
-   out << GetName() << " = new TGVerticalFrame(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "\n   // vertical frame\n";
+   out << "   TGVerticalFrame *" << GetName() << " = new TGVerticalFrame(" << fParent->GetName() << "," << GetWidth()
+       << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from the main frame type
    // coverity[returned_null]
    // coverity[dereference]
-   TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   TGLayoutManager *lm = GetLayoutManager();
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);
@@ -3200,23 +3158,14 @@ void TGVerticalFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 
 void TGFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGFrame *";
-   out << GetName() << " = new TGFrame("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGFrame *" << GetName() << " = new TGFrame("<< fParent->GetName()
+       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3224,19 +3173,18 @@ void TGFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGGroupFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
    // coverity[returned_null]
    // coverity[dereference]
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
    // coverity[returned_null]
    // coverity[dereference]
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC) ||
+       (fBackground != GetDefaultFrameBackground())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);
@@ -3250,53 +3198,48 @@ void TGGroupFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // " << quote << GetTitle() << quote << " group frame" << std::endl;
-   out << "   TGGroupFrame *";
-   out << GetName() <<" = new TGGroupFrame("<<fParent->GetName()
-       << "," << quote << GetTitle() << quote;
+   out << "\n   // \"" << GetTitle() << "\" group frame\n";
+   out << "   TGGroupFrame *" << GetName() << " = new TGGroupFrame(" << fParent->GetName() << ", \""
+       << TString(GetTitle()).ReplaceSpecialCppChars() << "\"";
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (fFontStruct == GetDefaultFontStruct()) {
          if (fNormGC == GetDefaultGC()()) {
             if (GetOptions() & kVerticalFrame) {
-               out <<");" << std::endl;
+               out << ");\n";
             } else {
-               out << "," << GetOptionString() <<");" << std::endl;
+               out << "," << GetOptionString() << ");\n";
             }
          } else {
-            out << "," << GetOptionString() << "," << parGC.Data() <<");" << std::endl;
+            out << "," << GetOptionString() << "," << parGC << ");\n";
          }
       } else {
-         out << "," << GetOptionString() << "," << parGC.Data() << "," << parFont.Data() << ");" << std::endl;
+         out << "," << GetOptionString() << "," << parGC << "," << parFont << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << "," << parGC.Data() << "," << parFont.Data() << ",ucolor);"  << std::endl;
+      out << "," << GetOptionString() << "," << parGC << "," << parFont << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (GetTitlePos() != -1)
-      out << "   " << GetName() <<"->SetTitlePos(";
-   if (GetTitlePos() == 0)
-      out << "TGGroupFrame::kCenter);" << std::endl;
-   if (GetTitlePos() == 1)
-      out << "TGGroupFrame::kRight);" << std::endl;
+      out << "   " << GetName() << "->SetTitlePos(TGGroupFrame::" << (GetTitlePos() == 0 ? "kCenter" : "kRight")
+          << ");\n";
 
    SavePrimitiveSubframes(out, option);
 
    // setting layout manager
-   out << "   " << GetName() <<"->SetLayoutManager(";
+   out << "   " << GetName() << "->SetLayoutManager(";
    // coverity[returned_null]
    // coverity[dereference]
    GetLayoutManager()->SavePrimitive(out, option);
-   out << ");"<< std::endl;
+   out << ");\n";
 
-   out << "   " << GetName() <<"->Resize(" << GetWidth() << ","
-       << GetHeight() << ");" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save the GUI transient frame widget in a C++ macro file.

--- a/gui/gui/src/TGGC.cxx
+++ b/gui/gui/src/TGGC.cxx
@@ -843,7 +843,7 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
             break;
          case kGCDashList:
             if (GetDashLen() > (Int_t)sizeof(GetDashes()))
-               Warning("TGGC::SavePrimitive", "dash list can have only up to %ld elements",
+               Warning("SavePrimitive", "dash list can have only up to %ld elements",
                        (Long_t)sizeof(GetDashes()));
             out << "   " << valname << ".fDashLen = "
                 << TMath::Min(GetDashLen(),(Int_t)sizeof(GetDashes())) << ";\n";

--- a/gui/gui/src/TGGC.cxx
+++ b/gui/gui/src/TGGC.cxx
@@ -626,27 +626,20 @@ TString TGGC::GetMaskString() const
 
 void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (gROOT->ClassSaved(TGGC::Class())) {
-      out << std::endl;
-   } else {
-      //  declare graphics context object to reflect required user changes
-      out << std::endl;
-      out << "   TGGC   *uGC;           // will reflect user GC changes" << std::endl;
-   }
+   out << "   \n";
+   //  declare graphics context object to reflect required user changes
+   if (!gROOT->ClassSaved(TGGC::Class()))
+      out << "   TGGC   *uGC;           // will reflect user GC changes\n";
 
    Mask_t fmask = GetMask();
 
+   TString valname = TString::Format("val%s", option);
    const char *colorname;
-   TString valname;
-   char quote ='"';
    ULong_t color;
 
-   valname = TString::Format("val%s", option);
-
-   out << "   // graphics context changes" << std::endl;
-   //out << "   TGGC *uGC" << option << ";" << std::endl;
-   out << "   GCValues_t " << valname.Data() << ";" << std::endl;
-   out << "   " << valname.Data() << ".fMask = " << GetMaskString() << ";" << std::endl;
+   out << "   // graphics context changes\n";
+   out << "   GCValues_t " << valname << ";\n";
+   out << "   " << valname << ".fMask = " << GetMaskString() << ";\n";
 
    for (Mask_t bit = 1; bit <= fmask; bit <<= 1) {
       switch (bit & fmask) {
@@ -654,7 +647,7 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          case 0:
             continue;
          case kGCFunction:
-            out << "   " << valname.Data() << ".fFunction = ";
+            out << "   " << valname << ".fFunction = ";
             switch (GetFunction()) {
                case kGXclear:
                   out << "kGXclear";
@@ -705,28 +698,26 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kGXset";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCPlaneMask:
-            out << "   " << valname.Data() << ".fPlaneMask = " << GetPlaneMask() << ";" << std::endl;
+            out << "   " << valname << ".fPlaneMask = " << GetPlaneMask() << ";\n";
             break;
          case kGCForeground:
             color = GetForeground();
             colorname = TColor::PixelAsHexString(color);
-            out << "   gClient->GetColorByName(" << quote << colorname << quote
-                << "," << valname.Data() << ".fForeground);" << std::endl;
+            out << "   gClient->GetColorByName(\"" << colorname << "\", " << valname << ".fForeground);\n";
             break;
          case kGCBackground:
             color = GetBackground();
             colorname = TColor::PixelAsHexString(color);
-            out << "   gClient->GetColorByName(" << quote << colorname << quote
-                << "," << valname.Data() << ".fBackground);" << std::endl;
+            out << "   gClient->GetColorByName(\"" << colorname << "\", " << valname << ".fBackground);\n";
             break;
          case kGCLineWidth:
-            out << "   " << valname.Data() << ".fLineWidth = " << GetLineWidth() << ";" << std::endl;
+            out << "   " << valname << ".fLineWidth = " << GetLineWidth() << ";\n";
             break;
          case kGCLineStyle:
-            out << "   " << valname.Data() << ".fLineStyle = ";
+            out << "   " << valname << ".fLineStyle = ";
             switch (GetLineStyle()) {
                case kLineSolid:
                   out << "kLineSolid";
@@ -738,10 +729,10 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kLineDoubleDash";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCCapStyle:
-            out << "   " << valname.Data() << ".fCapStyle = ";
+            out << "   " << valname << ".fCapStyle = ";
             switch (GetCapStyle()) {
                case kCapNotLast:
                   out << "kCapNotLast";
@@ -756,10 +747,10 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kCapProjecting";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCJoinStyle:
-            out << "   " << valname.Data() << ".fJoinStyle = ";
+            out << "   " << valname << ".fJoinStyle = ";
             switch (GetJoinStyle()) {
                case kJoinMiter:
                   out << "kJoinMiter";
@@ -771,10 +762,10 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kJoinBevel";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCFillStyle:
-            out << "   " << valname.Data() << ".fFillStyle = ";
+            out << "   " << valname << ".fFillStyle = ";
             switch (GetFillStyle()) {
                case kFillSolid:
                   out << "kFillSolid";
@@ -789,10 +780,10 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kFillOpaqueStippled";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCFillRule:
-            out << "   " << valname.Data() << ".fFillRule = ";
+            out << "   " << valname << ".fFillRule = ";
             switch (GetFillRule()) {
                case kEvenOddRule:
                   out << "kEvenOddRule";
@@ -801,25 +792,25 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kWindingRule";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCTile:
-            out << "   " << valname.Data() << ".fTile = " << GetTile() << ";" << std::endl;
+            out << "   " << valname << ".fTile = " << GetTile() << ";\n";
             break;
          case kGCStipple:
-            out << "   " << valname.Data() << ".fStipple = " << GetStipple() << ";" << std::endl;
+            out << "   " << valname << ".fStipple = " << GetStipple() << ";\n";
             break;
          case kGCTileStipXOrigin:
-            out << "   " << valname.Data() << ".fTsXOrigin = " << GetTileStipXOrigin() << ";" << std::endl;
+            out << "   " << valname << ".fTsXOrigin = " << GetTileStipXOrigin() << ";\n";
             break;
          case kGCTileStipYOrigin:
-            out << "   " << valname.Data() << ".fTsYOrigin = " << GetTileStipYOrigin() << ";" << std::endl;
+            out << "   " << valname << ".fTsYOrigin = " << GetTileStipYOrigin() << ";\n";
             break;
          case kGCFont:
-            out << "   " << valname.Data() << ".fFont = ufont->GetFontHandle();" << std::endl;
+            out << "   " << valname << ".fFont = ufont->GetFontHandle();\n";
             break;
          case kGCSubwindowMode:
-            out << "   " << valname.Data() << ".fSubwindowMode = ";
+            out << "   " << valname << ".fSubwindowMode = ";
             switch (GetSubwindowMode()) {
                case kClipByChildren:
                   out << "kClipByChildren";
@@ -828,39 +819,39 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kIncludeInferiors";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCGraphicsExposures:
-            out << "   " << valname.Data() << ".fGraphicsExposures = ";
+            out << "   " << valname << ".fGraphicsExposures = ";
             if (GetGraphicsExposures())
                out << "kTRUE";
             else
                out << "kFALSE";
-            out << ";" << std::endl;
+            out << ";\n";
             break;
          case kGCClipXOrigin:
-            out << "   " << valname.Data() << ".fClipXOrigin = " << GetClipXOrigin() << ";" << std::endl;
+            out << "   " << valname << ".fClipXOrigin = " << GetClipXOrigin() << ";\n";
             break;
          case kGCClipYOrigin:
-            out << "   " << valname.Data() << ".fClipYOrigin = " << GetClipYOrigin() << ";" << std::endl;
+            out << "   " << valname << ".fClipYOrigin = " << GetClipYOrigin() << ";\n";
             break;
          case kGCClipMask:
-            out << "   " << valname.Data() << ".fClipMask = " << GetClipMask() << ";" << std::endl;
+            out << "   " << valname << ".fClipMask = " << GetClipMask() << ";\n";
             break;
          case kGCDashOffset:
-            out << "   " << valname.Data() << ".fDashOffset = " << GetDashOffset() << ";" << std::endl;
+            out << "   " << valname << ".fDashOffset = " << GetDashOffset() << ";\n";
             break;
          case kGCDashList:
             if (GetDashLen() > (Int_t)sizeof(GetDashes()))
                Warning("TGGC::SavePrimitive", "dash list can have only up to %ld elements",
                        (Long_t)sizeof(GetDashes()));
-            out << "   " << valname.Data() << ".fDashLen = "
-                << TMath::Min(GetDashLen(),(Int_t)sizeof(GetDashes())) << ";" << std::endl;
-            out << "   memcpy(GetDashes()," << valname.Data() << ".fDashes,"
-                                            << valname.Data() << ".fDashLen);" << std::endl;
+            out << "   " << valname << ".fDashLen = "
+                << TMath::Min(GetDashLen(),(Int_t)sizeof(GetDashes())) << ";\n";
+            out << "   memcpy(GetDashes()," << valname << ".fDashes,"
+                                            << valname << ".fDashLen);\n";
             break;
          case kGCArcMode:
-            out << "   " << valname.Data() << ".fArcMode = ";
+            out << "   " << valname << ".fArcMode = ";
             switch (GetArcMode()) {
                case kArcChord:
                   out << "kArcChord";
@@ -869,11 +860,11 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                   out << "kArcPieSlice";
                   break;
             }
-            out << ";" << std::endl;
+            out << ";\n";
             break;
       }
    }
-   out << "   uGC = gClient->GetGC(&" << valname.Data() << ", kTRUE);" << std::endl;
+   out << "   uGC = gClient->GetGC(&" << valname << ", kTRUE);\n";
 }
 
 

--- a/gui/gui/src/TGIcon.cxx
+++ b/gui/gui/src/TGIcon.cxx
@@ -202,41 +202,28 @@ void TGIcon::SetImagePath(const char *path)
 
 void TGIcon::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
-
    if (!fPic) {
       Error("SavePrimitive()", "icon pixmap not found ");
       return;
    }
 
-   TString picname = gSystem->UnixPathName(fPic->GetName());
-   gSystem->ExpandPathName(picname);
-
-   out <<"   TGIcon *";
    if (!fImage) {
-      out << GetName() << " = new TGIcon(" << fParent->GetName()
-         << ",gClient->GetPicture(" << quote
-         << picname   // if no path
-         << quote << ")" << "," << GetWidth() << "," << GetHeight();
-      if (fBackground == GetDefaultFrameBackground()) {
-         if (!GetOptions()) {
-            out <<");" << std::endl;
-         } else {
-            out << "," << GetOptionString() <<");" << std::endl;
-         }
-      } else {
-         out << "," << GetOptionString() << ",ucolor);" << std::endl;
-      }
+      // save options and color if necessary
+      auto extra_args = SaveCtorArgs(out);
+
+      TString picname = gSystem->UnixPathName(fPic->GetName());
+      gSystem->ExpandPathName(picname);
+
+      out << "   TGIcon *" << GetName() << " = new TGIcon(" << fParent->GetName() << ", gClient->GetPicture(\""
+          << picname.ReplaceSpecialCppChars() << "\"), " << GetWidth() << "," << GetHeight() << extra_args << ");\n";
    } else {
       TString name = fPath;
       name += "/";
       name += fImage->GetName();
       name.Chop();
-      out << GetName() << " = new TGIcon(" << fParent->GetName()  << ","
-          << quote << name.Data() << quote << ");" << std::endl;
+      out << "   TGIcon *" << GetName() << " = new TGIcon(" << fParent->GetName() << ", \""
+          << name.ReplaceSpecialCppChars() << "\");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TGLabel.cxx
+++ b/gui/gui/src/TGLabel.cxx
@@ -478,30 +478,19 @@ void TGLabel::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   // save options and color if necessary
+   auto extra_args = SaveCtorArgs(out);
 
    TString label = GetText()->GetString();
 
    out << "   TGLabel *" << GetName() << " = new TGLabel("<< fParent->GetName()
        << ", \"" << label.ReplaceSpecialCppChars() << "\"";
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         if (fFont->GetFontStruct() == GetDefaultFontStruct()) {
-            if (fNormGC == GetDefaultGC()()) {
-               out <<");\n";
-            } else {
-               out << "," << parGC << ");\n";
-            }
-         } else {
-            out << "," << parGC << "," << parFont << ");\n";
-         }
-      } else {
-         out << "," << parGC << "," << parFont << "," << GetOptionString() <<");\n";
-      }
-   } else {
-      out << "," << parGC << "," << parFont << "," << GetOptionString() << ", ucolor);\n";
-   }
+   if ((extra_args.Length() > 0) || (fFont->GetFontStruct() != GetDefaultFontStruct()))
+      out << "," << parGC << "," << parFont << extra_args;
+   else if (fNormGC != GetDefaultGC()())
+      out << ", " << parGC;
+   out << ");\n";
+
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGLabel.cxx
+++ b/gui/gui/src/TGLabel.cxx
@@ -458,8 +458,6 @@ Bool_t TGLabel::HasOwnFont() const
 
 void TGLabel::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // font + GC
    option = GetName()+5;         // unique digit id of the name
    TString parGC, parFont;
@@ -480,43 +478,40 @@ void TGLabel::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
    TString label = GetText()->GetString();
-   label.ReplaceAll("\"","\\\"");
-   label.ReplaceAll("\n","\\n");
 
-   out << "   TGLabel *";
-   out << GetName() << " = new TGLabel("<< fParent->GetName()
-       << "," << quote << label << quote;
+   out << "   TGLabel *" << GetName() << " = new TGLabel("<< fParent->GetName()
+       << ", \"" << label.ReplaceSpecialCppChars() << "\"";
    if (fBackground == GetDefaultFrameBackground()) {
       if (!GetOptions()) {
          if (fFont->GetFontStruct() == GetDefaultFontStruct()) {
             if (fNormGC == GetDefaultGC()()) {
-               out <<");" << std::endl;
+               out <<");\n";
             } else {
-               out << "," << parGC.Data() << ");" << std::endl;
+               out << "," << parGC << ");\n";
             }
          } else {
-            out << "," << parGC.Data() << "," << parFont.Data() << ");" << std::endl;
+            out << "," << parGC << "," << parFont << ");\n";
          }
       } else {
-         out << "," << parGC.Data() << "," << parFont.Data() << "," << GetOptionString() <<");" << std::endl;
+         out << "," << parGC << "," << parFont << "," << GetOptionString() <<");\n";
       }
    } else {
-      out << "," << parGC.Data() << "," << parFont.Data() << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << parGC << "," << parFont << "," << GetOptionString() << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fDisabled)
-      out << "   " << GetName() << "->Disable();" << std::endl;
+      out << "   " << GetName() << "->Disable();\n";
 
-   out << "   " << GetName() << "->SetTextJustify(" <<  GetTextJustify() << ");" << std::endl;
-   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << ",";
-   out << fMTop << "," << fMBottom << ");" << std::endl;
-   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");" << std::endl;
-
+   out << "   " << GetName() << "->SetTextJustify(" << GetTextJustify() << ");\n";
+   out << "   " << GetName() << "->SetMargins(" << fMLeft << "," << fMRight << "," << fMTop << "," << fMBottom
+       << ");\n";
+   out << "   " << GetName() << "->SetWrapLength(" << fWrapLength << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGLayout.cxx
+++ b/gui/gui/src/TGLayout.cxx
@@ -974,11 +974,10 @@ TGDimension TGListDetailsLayout::GetDefaultSize() const
 
 void TGLayoutHints::SavePrimitive(std::ostream &out, Option_t * option/*= ""*/)
 {
+   UInt_t pad = GetPadLeft() + GetPadRight() + GetPadTop() + GetPadBottom();
 
-   TString hints;
-   UInt_t pad = GetPadLeft()+GetPadRight()+GetPadTop()+GetPadBottom();
-
-   if (!GetLayoutHints()) return;
+   if (!GetLayoutHints())
+      return;
 
    if ((option == 0) || strcmp(option, "nocoma"))
       out << ", ";
@@ -987,46 +986,29 @@ void TGLayoutHints::SavePrimitive(std::ostream &out, Option_t * option/*= ""*/)
       out << "new TGLayoutHints(kLHintsNormal)";
       return;
    }
-   if (fLayoutHints & kLHintsLeft) {
-      if (hints.Length() == 0) hints  = "kLHintsLeft";
-      else                     hints += " | kLHintsLeft";
-   }
-   if (fLayoutHints & kLHintsCenterX) {
-      if  (hints.Length() == 0) hints  = "kLHintsCenterX";
-      else                      hints += " | kLHintsCenterX";
-   }
-   if (fLayoutHints & kLHintsRight) {
-      if (hints.Length() == 0) hints  = "kLHintsRight";
-      else                     hints += " | kLHintsRight";
-   }
-   if (fLayoutHints & kLHintsTop) {
-      if (hints.Length() == 0) hints  = "kLHintsTop";
-      else                     hints += " | kLHintsTop";
-   }
-   if (fLayoutHints & kLHintsCenterY) {
-      if (hints.Length() == 0) hints  = "kLHintsCenterY";
-      else                     hints += " | kLHintsCenterY";
-   }
-   if (fLayoutHints & kLHintsBottom) {
-      if (hints.Length() == 0) hints  = "kLHintsBottom";
-      else                     hints += " | kLHintsBottom";
-   }
-   if (fLayoutHints & kLHintsExpandX) {
-      if (hints.Length() == 0) hints  = "kLHintsExpandX";
-      else                     hints += " | kLHintsExpandX";
-   }
-   if (fLayoutHints & kLHintsExpandY) {
-      if (hints.Length() == 0) hints  = "kLHintsExpandY";
-      else                     hints += " | kLHintsExpandY";
-   }
+
+   TString hints;
+   auto add = [this, &hints](UInt_t mask, const char *name) {
+      if (fLayoutHints & mask) {
+         if (hints.Length())
+            hints.Append(" | ");
+         hints.Append(name);
+      }
+   };
+   add(kLHintsLeft, "kLHintsLeft");
+   add(kLHintsCenterX, "kLHintsCenterX");
+   add(kLHintsRight, "kLHintsRight");
+   add(kLHintsTop, "kLHintsTop");
+   add(kLHintsCenterY, "kLHintsCenterY");
+   add(kLHintsBottom, "kLHintsBottom");
+   add(kLHintsExpandX, "kLHintsExpandX");
+   add(kLHintsExpandY, "kLHintsExpandY");
 
    out << "new TGLayoutHints(" << hints;
 
-   if (pad) {
-      out << "," << GetPadLeft() << "," << GetPadRight()
-          << "," << GetPadTop()  << "," << GetPadBottom();
-   }
-   out<< ")";
+   if (pad)
+      out << "," << GetPadLeft() << "," << GetPadRight() << "," << GetPadTop() << "," << GetPadBottom();
+   out << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1034,9 +1016,7 @@ void TGLayoutHints::SavePrimitive(std::ostream &out, Option_t * option/*= ""*/)
 
 void TGVerticalLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-
    out << "new TGVerticalLayout(" << fMain->GetName() << ")";
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1044,7 +1024,6 @@ void TGVerticalLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
 void TGHorizontalLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-
    out << "new TGHorizontalLayout(" << fMain->GetName() << ")";
 }
 
@@ -1054,8 +1033,7 @@ void TGHorizontalLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGRowLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGRowLayout(" << fMain->GetName() << ","
-                             << fSep << ")";
+   out << "new TGRowLayout(" << fMain->GetName() << "," << fSep << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1064,9 +1042,7 @@ void TGRowLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGColumnLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGColumnLayout(" << fMain->GetName() << ","
-                                << fSep << ")";
-
+   out << "new TGColumnLayout(" << fMain->GetName() << "," << fSep << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1075,12 +1051,8 @@ void TGColumnLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGMatrixLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGMatrixLayout(" << fMain->GetName() << ","
-                                << fRows << ","
-                                << fColumns << ","
-                                << fSep << ","
-                                << fHints <<")";
-
+   out << "new TGMatrixLayout(" << fMain->GetName() << "," << fRows << "," << fColumns << "," << fSep << "," << fHints
+       << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1089,9 +1061,7 @@ void TGMatrixLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGTileLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGTileLayout(" << fMain->GetName() << ","
-                              << fSep << ")";
-
+   out << "new TGTileLayout(" << fMain->GetName() << "," << fSep << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1100,9 +1070,7 @@ void TGTileLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGListLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGListLayout(" << fMain->GetName() << ","
-                              << fSep << ")";
-
+   out << "new TGListLayout(" << fMain->GetName() << "," << fSep << ")";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1111,7 +1079,5 @@ void TGListLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 void TGListDetailsLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
 
-   out << "new TGListDetailsLayout(" << fMain->GetName() << ","
-                                     << fSep << "," << fWidth << ")";
-
+   out << "new TGListDetailsLayout(" << fMain->GetName() << "," << fSep << "," << fWidth << ")";
 }

--- a/gui/gui/src/TGListBox.cxx
+++ b/gui/gui/src/TGListBox.cxx
@@ -1681,9 +1681,5 @@ void TGListBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGTextLBEntry::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   TString content = GetText()->GetString();
-   content.ReplaceAll('\\', "\\\\");
-   content.ReplaceAll("\"", "\\\"");
-   char quote = '"';
-   out << quote << content << quote << "," << EntryId();
+   out << "\"" << TString(GetText()->GetString()).ReplaceSpecialCppChars() <<  "\", " << EntryId();
 }

--- a/gui/gui/src/TGListBox.cxx
+++ b/gui/gui/src/TGListBox.cxx
@@ -1650,41 +1650,30 @@ TGLBEntry *TGListBox::FindEntry(const char *name) const
 
 void TGListBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetWhitePixel()) SaveUserColor(out, option);
+   // store options and color if differ from defauls
+   TString extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder, kTRUE);
 
-   out << std::endl << "   // list box" << std::endl;
+   out << "\n   // list box\n";
+   out << "   TGListBox *" << GetName() << " = new TGListBox(" << fParent->GetName();
+   if (!extra_args.IsNull())
+      out << "," << fWidgetId << "," << extra_args;
+   else if (fWidgetId != -1)
+      out << "," << fWidgetId;
+   out << ");\n";
 
-   out<<"   TGListBox *";
-   out << GetName() << " = new TGListBox(" << fParent->GetName();
-
-   if (fBackground == GetWhitePixel()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         if (fWidgetId == -1) {
-            out <<");" << std::endl;
-         } else {
-            out << "," << fWidgetId << ");" << std::endl;
-         }
-      } else {
-         out << "," << fWidgetId << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << fWidgetId << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (!fLbc->GetList()) return;
+   if (!fLbc->GetList())
+      return;
 
-   TGFrameElement *el;
    TIter next(fLbc->GetList());
-
-   while ((el = (TGFrameElement *) next())) {
+   while (auto el = static_cast<TGFrameElement *>(next())) {
       out << "   " << GetName() << "->AddEntry(";
       el->fFrame->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
-   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight()
-       << ");" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGListTree.cxx
+++ b/gui/gui/src/TGListTree.cxx
@@ -2597,49 +2597,37 @@ const TGPicture *TGListTree::GetUncheckedPic()
 
 void TGListTree::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetWhitePixel()) SaveUserColor(out, option);
+   // store options and color if differ from defaults
+   TString extra_args = SaveCtorArgs(out, kSunkenFrame, kTRUE);
 
-   out << std::endl << "   // list tree" << std::endl;
-   out << "   TGListTree *";
+   out << "\n   // list tree\n";
+   out << "   TGListTree *" << GetName() << " = new TGListTree(";
 
-   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class())) {
-      out << GetName() << " = new TGListTree(" << GetCanvas()->GetName();
-   } else {
-      out << GetName() << " = new TGListTree(" << fParent->GetName();
-      out << "," << GetWidth() << "," << GetHeight();
-   }
+   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class()))
+      out << GetCanvas()->GetName();
+   else
+      out << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
+   out << extra_args << ");\n";
 
-   if (fBackground == GetWhitePixel()) {
-      if (GetOptions() == kSunkenFrame) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-
-   out << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    static Int_t n = 0;
 
-   TGListTreeItem *current;
-   current = GetFirstItem();
+   TGListTreeItem *current = GetFirstItem();
 
-   out << std::endl;
+   out << "   \n";
 
    while (current) {
       out << "   TGListTreeItem *item" << n << " = " << GetName() << "->AddItem(";
       current->SavePrimitive(out, TString::Format("%d",n), n);
       if (current->IsOpen())
-         out << "   " << GetName() << "->OpenItem(item" << n << ");" << std::endl;
+         out << "   " << GetName() << "->OpenItem(item" << n << ");\n";
       else
-         out << "   " << GetName() << "->CloseItem(item" << n << ");" << std::endl;
+         out << "   " << GetName() << "->CloseItem(item" << n << ");\n";
 
       if (current == fSelected)
-         out << "   " << GetName() << "->SetSelected(item" << n << ");" << std::endl;
+         out << "   " << GetName() << "->SetSelected(item" << n << ");\n";
 
       n++;
       if (current->fFirstchild) {
@@ -2648,7 +2636,7 @@ void TGListTree::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       current = current->fNextsibling;
    }
 
-   out << std::endl;
+   out << "   \n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGListView.cxx
+++ b/gui/gui/src/TGListView.cxx
@@ -1723,58 +1723,36 @@ const TGGC &TGListView::GetDefaultGC()
 
 void TGListView::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if necessary
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder);
 
-   out << std::endl << "   // list view" << std::endl;
-   out <<"   TGListView *";
-   out << GetName() << " = new TGListView(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "\n   // list view\n";
+   out << "   TGListView *" << GetName() << " = new TGListView(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    GetContainer()->SavePrimitive(out, option);
 
-   out << std::endl;
-   out << "   " << GetName() << "->SetContainer(" << GetContainer()->GetName()
-                << ");" << std::endl;
+   out << "   \n";
+   out << "   " << GetName() << "->SetContainer(" << GetContainer()->GetName() << ");\n";
    out << "   " << GetName() << "->SetViewMode(";
    switch (fViewMode) {
-      case kLVLargeIcons:
-         out << "kLVLargeIcons";
-         break;
-      case kLVSmallIcons:
-         out << "kLVSmallIcons";
-         break;
-      case kLVList:
-         out << "kLVList";
-         break;
-      case kLVDetails:
-         out << "kLVDetails";
-         break;
+   case kLVLargeIcons: out << "kLVLargeIcons"; break;
+   case kLVSmallIcons: out << "kLVSmallIcons"; break;
+   case kLVList: out << "kLVList"; break;
+   case kLVDetails: out << "kLVDetails"; break;
    }
-   out << ");" << std::endl;
+   out << ");\n";
 
-   out << "   " << GetContainer()->GetName() << "->Resize();" << std::endl;
+   out << "   " << GetContainer()->GetName() << "->Resize();\n";
 
-   if (fHScrollbar && fHScrollbar->IsMapped()) {
-   out << "   " << GetName() << "->SetHsbPosition(" << GetHsbPosition()
-       << ");" << std::endl;
-   }
+   if (fHScrollbar && fHScrollbar->IsMapped())
+      out << "   " << GetName() << "->SetHsbPosition(" << GetHsbPosition() << ");\n";
 
-   if (fVScrollbar && fVScrollbar->IsMapped()) {
-   out << "   " << GetName() << "->SetVsbPosition(" << GetVsbPosition()
-       << ");" << std::endl;
-   }
+   if (fVScrollbar && fVScrollbar->IsMapped())
+      out << "   " << GetName() << "->SetVsbPosition(" << GetVsbPosition() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1782,26 +1760,17 @@ void TGListView::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGLVContainer::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if necessary
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder);
 
-   out << std::endl << "   // list view container" << std::endl;
-   out << "   TGLVContainer *";
+   out << "\n   // list view container\n";
+   out << "   TGLVContainer *" << GetName() << " = new TGLVContainer(";
+   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class()))
+      out <<  GetCanvas()->GetName();
+    else
+      out << fParent->GetName() << ", " << GetWidth() << "," << GetHeight();
+   out << extra_args << ");\n";
 
-   if ((fParent->GetParent())->InheritsFrom(TGCanvas::Class())) {
-      out << GetName() << " = new TGLVContainer(" << GetCanvas()->GetName();
-   } else {
-      out << GetName() << " = new TGLVContainer(" << fParent->GetName();
-      out << "," << GetWidth() << "," << GetHeight();
-   }
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 }

--- a/gui/gui/src/TGMdiFrame.cxx
+++ b/gui/gui/src/TGMdiFrame.cxx
@@ -190,40 +190,26 @@ TString TGMdiFrame::GetMdiHintsString() const
 
 void TGMdiFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
    TGMdiTitleBar *tb = fMain->GetWindowList()->GetDecorFrame()->GetTitleBar();
 
-   out << std::endl <<"   // MDI frame "<< quote << GetWindowName() << quote << std::endl;
-   out << "   TGMdiFrame *";
-   out << GetName() << " = new TGMdiFrame(" << fMain->GetName()
-       << "," << GetWidth() + GetBorderWidth()*2
-       << "," << GetHeight() + tb->GetHeight() + GetBorderWidth()*2;
+   out << "\n   // MDI frame \"" << GetWindowName() << "\"\n";
+   out << "   TGMdiFrame *" << GetName() << " = new TGMdiFrame(" << fMain->GetName() << ","
+       << GetWidth() + GetBorderWidth() * 2 << "," << GetHeight() + tb->GetHeight() + GetBorderWidth() * 2 << extra_args
+       << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    SavePrimitiveSubframes(out, option);
 
-   out << "   " << GetName() << "->SetWindowName(" << quote << GetWindowName()
-       << quote << ");" << std::endl;
-   out << "   " << GetName() << "->SetMdiHints(" << GetMdiHintsString()
-       << ");" << std::endl;
+   out << "   " << GetName() << "->SetWindowName(\"" << TString(GetWindowName()).ReplaceSpecialCppChars() << "\");\n";
+   out << "   " << GetName() << "->SetMdiHints(" << GetMdiHintsString() << ");\n";
    if ((GetX() != 5) && (GetY() != 23))
-      out << "   " << GetName() << "->Move(" << GetX() << "," << GetY()
-          << ");" << std::endl;
+      out << "   " << GetName() << "->Move(" << GetX() << "," << GetY() << ");\n";
 
-   out << "   " << GetName() << "->MapSubwindows();" << std::endl;
-   out << "   " << GetName() << "->Layout();" << std::endl;
+   out << "   " << GetName() << "->MapSubwindows();\n";
+   out << "   " << GetName() << "->Layout();\n";
 }

--- a/gui/gui/src/TGMdiMainFrame.cxx
+++ b/gui/gui/src/TGMdiMainFrame.cxx
@@ -1220,54 +1220,37 @@ Bool_t TGMdiContainer::HandleConfigureNotify(Event_t *event)
 
 void TGMdiMainFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << std::endl << "   // MDI main frame" << std::endl;
-   out << "   TGMdiMainFrame *";
-   out << GetName() << " = new TGMdiMainFrame(" << fParent->GetName()
-       << "," << GetMenu()->GetName() << "," << GetWidth() << "," << GetHeight();
+   out << "\n   // MDI main frame\n";
+   out << "   TGMdiMainFrame *" << GetName() << " = new TGMdiMainFrame(" << fParent->GetName() << ","
+       << GetMenu()->GetName() << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   TGMdiFrameList *travel=fChildren;
+   TGMdiFrameList *travel = fChildren;
    travel->SetCycleNext(travel);
    for (travel = fChildren; travel; travel = travel->GetNext()) {
       TGMdiFrame *mf = travel->GetDecorFrame()->GetMdiFrame();
-      if (mf) mf->SavePrimitive(out, option);
+      if (mf)
+         mf->SavePrimitive(out, option);
    }
    if (fArrangementMode) {
       out << "   " << GetName() << "->ArrangeFrames(";
       switch (fArrangementMode) {
 
-         case kMdiTileHorizontal:
-            out << "kMdiTileHorizontal);" << std::endl;
-         break;
+      case kMdiTileHorizontal: out << "kMdiTileHorizontal);\n"; break;
 
-         case kMdiTileVertical:
-            out << "kMdiTileVertical);" << std::endl;
-         break;
+      case kMdiTileVertical: out << "kMdiTileVertical);\n"; break;
 
-         case kMdiCascade:
-            out << "kMdiCascade);" << std::endl;
-         break;
+      case kMdiCascade: out << "kMdiCascade);\n"; break;
       }
    }
    if (fResizeMode != kMdiOpaque)
-      out << "   " << GetName() << "->SetResizeMode(kMdiNonOpaque);" << std::endl;
+      out << "   " << GetName() << "->SetResizeMode(kMdiNonOpaque);\n";
 
    if (fCurrent)
-      out << "   " << GetName() << "->SetCurrent(" << GetCurrent()->GetName()
-          << ");" << std::endl;
+      out << "   " << GetName() << "->SetCurrent(" << GetCurrent()->GetName() << ");\n";
 }
-
-

--- a/gui/gui/src/TGMdiMenu.cxx
+++ b/gui/gui/src/TGMdiMenu.cxx
@@ -174,26 +174,23 @@ void TGMdiMenuBar::HideFrames(TGMdiTitleIcon *icon, TGMdiButtons *buttons)
 
 void TGMdiMenuBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << std::endl;
-   out << "   // MDI menu bar" << std::endl;
+   out << "\n   // MDI menu bar\n";
 
-   out << "   TGMdiMenuBar *";
-   out << GetName() << " = new TGMdiMenuBar(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight() << ");" << std::endl;
+   out << "   TGMdiMenuBar *" << GetName() << " = new TGMdiMenuBar(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << ");\n";
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (!fList) return;
+   if (!fList)
+      return;
 
-   out << "   TGMenuBar *" << fBar->GetName() << " = " << GetName()
-       << "->GetMenuBar();" << std::endl;
+   out << "   TGMenuBar *" << fBar->GetName() << " = " << GetName() << "->GetMenuBar();\n";
 
-   TGFrameElement *el;
    TIter next(fBar->GetList());
 
-   while ((el = (TGFrameElement *)next())) {
+   while (auto el = static_cast<TGFrameElement *>(next())) {
       el->fFrame->SavePrimitive(out, option);
       el->fLayout->SavePrimitive(out, option);
-      out << ");" << std::endl;
+      out << ");\n";
    }
 }

--- a/gui/gui/src/TGNumberEntry.cxx
+++ b/gui/gui/src/TGNumberEntry.cxx
@@ -724,7 +724,7 @@ static char *TranslateToStr(char *text, Long_t l,
    case TGNumberFormat::kNESMinSec:
       return DIntToStr(text, l, kFALSE, ':');
    case TGNumberFormat::kNESMinSecCent:
-      return DIntToStr(text, l % (60 * 6000), ':', '.');       
+      return DIntToStr(text, l % (60 * 6000), ':', '.');
    case TGNumberFormat::kNESHourMin:
       return DIntToStr(text, l % (24 * 60), kFALSE, ':');
    case TGNumberFormat::kNESDayMYear:
@@ -2193,13 +2193,11 @@ void TGNumberEntry::Modified()
 
 void TGNumberEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // to calculate the digits parameter
    Int_t w = fNumericEntry->GetWidth();
    Int_t h = fNumericEntry->GetHeight();
-   Int_t charw  = fNumericEntry->GetCharWidth("0123456789");
-   Int_t digits = (30*w - 240 -20*h)/(3*charw) + 3;
+   Int_t charw = fNumericEntry->GetCharWidth("0123456789");
+   Int_t digits = (30 * w - 240 - 20 * h) / (3 * charw) + 3;
 
    // for time format
    Int_t hour, min, sec;
@@ -2209,107 +2207,89 @@ void TGNumberEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    Int_t yy, mm, dd;
    GetDate(yy, mm, dd);
 
-   out << "   TGNumberEntry *";
-   out << GetName() << " = new TGNumberEntry(" << fParent->GetName() << ", (Double_t) ";
-   switch (GetNumStyle()){
-      case kNESInteger:
-         out << GetIntNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealOne:
-         out << GetNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealTwo:
-         out << GetNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealThree:
-         out << GetNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealFour:
-         out << GetNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESReal:
-         out << GetNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESDegree:
-         out << GetIntNumber() << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMinSec:
-         out << min*60 + sec << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMinSecCent:
-         //GetTime returns the centisecs in the hour variable
-         out << min*6000 + sec*100 + hour << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHourMin:
-         out << hour*60 + min << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHourMinSec:
-         out << hour*3600 + min*60 + sec << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESDayMYear:
-         out << yy << mm << dd << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMDayYear:
-         out << yy << mm << dd << "," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHex:
-      {  char hex[256];
-         ULong_t l = GetHexNumber();
-         IntToHexStr(hex, l);
-         std::ios::fmtflags f = out.flags(); // store flags
-         out << "0x" << std::hex << "U," << digits << "," << WidgetId()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         out.flags( f ); // restore flags (reset std::hex)
-         break;
-      }
+   out << "   TGNumberEntry *" << GetName() << " = new TGNumberEntry(" << fParent->GetName() << ", (Double_t) ";
+   switch (GetNumStyle()) {
+   case kNESInteger:
+      out << GetIntNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESRealOne:
+      out << GetNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESRealTwo:
+      out << GetNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESRealThree:
+      out << GetNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESRealFour:
+      out << GetNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESReal:
+      out << GetNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESDegree:
+      out << GetIntNumber() << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESMinSec:
+      out << min * 60 + sec << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESMinSecCent:
+      // GetTime returns the centisecs in the hour variable
+      out << min * 6000 + sec * 100 + hour << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) "
+          << GetNumStyle();
+      break;
+   case kNESHourMin:
+      out << hour * 60 + min << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESHourMinSec:
+      out << hour * 3600 + min * 60 + sec << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) "
+          << GetNumStyle();
+      break;
+   case kNESDayMYear:
+      out << yy << mm << dd << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESMDayYear:
+      out << yy << mm << dd << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESHex: {
+      char hex[256];
+      ULong_t l = GetHexNumber();
+      IntToHexStr(hex, l);
+      std::ios::fmtflags f = out.flags(); // store flags
+      out << "0x" << std::hex << "U," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      out.flags(f); // restore flags (reset std::hex)
+      break;
    }
-   if (GetNumMax() ==1) {
+   }
+   if (GetNumMax() == 1) {
       if (GetNumMin() == 0) {
          if (GetNumLimits() == kNELNoLimits) {
             if (GetNumAttr() == kNEAAnyNumber) {
-               out << ");" << std::endl;
+               out << ");\n";
             } else {
-               out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ");" << std::endl;
+               out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ");\n";
             }
          } else {
-            out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-                << ",(TGNumberFormat::ELimit) " << GetNumLimits() << ");" << std::endl;
+            out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits()
+                << ");\n";
          }
       } else {
-         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-             << ",(TGNumberFormat::ELimit) " << GetNumLimits()
-             << "," << GetNumMin() << ");" << std::endl;
+         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits()
+             << "," << GetNumMin() << ");\n";
       }
    } else {
-         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-             << ",(TGNumberFormat::ELimit) " << GetNumLimits()
-             << "," << GetNumMin() << "," << GetNumMax() << ");" << std::endl;
+      out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits() << ","
+          << GetNumMin() << "," << GetNumMax() << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
    if (fButtonDown->GetState() == kButtonDisabled)
-      out << "   " << GetName() << "->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->SetState(kFALSE);\n";
 
    TGToolTip *tip = GetNumberEntry()->GetToolTip();
    if (tip) {
       TString tiptext = tip->GetText()->GetString();
-      tiptext.ReplaceAll("\n", "\\n");
-      out << "   ";
-      out << GetName() << "->GetNumberEntry()->SetToolTipText(" << quote
-          << tiptext << quote << ");"  << std::endl;
+      out << "   " << GetName() << "->GetNumberEntry()->SetToolTipText(\"" << tiptext.ReplaceSpecialCppChars() << "\");\n";
    }
 }
 
@@ -2318,8 +2298,6 @@ void TGNumberEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGNumberEntryField::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // for time format
    Int_t hour, min, sec;
    GetTime(hour, min, sec);
@@ -2329,109 +2307,65 @@ void TGNumberEntryField::SavePrimitive(std::ostream &out, Option_t *option /*= "
    GetDate(yy, mm, dd);
 
    out << "   TGNumberEntryField *";
-   out << GetName() << " = new TGNumberEntryField(" << fParent->GetName()
-       << ", " << WidgetId() << ", (Double_t) ";
-   switch (GetNumStyle()){
-      case kNESInteger:
-         out << GetIntNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealOne:
-         out << GetNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealTwo:
-         out << GetNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealThree:
-         out << GetNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESRealFour:
-         out << GetNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESReal:
-         out << GetNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESDegree:
-         out << GetIntNumber()
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMinSec:
-         out << min*60 + sec
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMinSecCent:
-         //GetTime returns centisec in the hour variable
-         out << min*6000 + sec*100 + hour
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHourMin:
-         out << hour*60 + min
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHourMinSec:
-         out << hour*3600 + min*60 + sec
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESDayMYear:
-         out << yy << mm << dd
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESMDayYear:
-         out << yy << mm << dd
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         break;
-      case kNESHex:
-      {  char hex[256];
-         ULong_t l = GetHexNumber();
-         IntToHexStr(hex, l);
-         std::ios::fmtflags f = out.flags(); // store flags
-         out << "0x" << std::hex << "U"
-             << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-         out.flags( f ); // restore flags (reset std::hex)
-         break;
-      }
+   out << GetName() << " = new TGNumberEntryField(" << fParent->GetName() << ", " << WidgetId() << ", (Double_t) ";
+   switch (GetNumStyle()) {
+   case kNESInteger: out << GetIntNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESRealOne: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESRealTwo: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESRealThree: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESRealFour: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESReal: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESDegree: out << GetIntNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESMinSec: out << min * 60 + sec << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESMinSecCent:
+      // GetTime returns centisec in the hour variable
+      out << min * 6000 + sec * 100 + hour << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      break;
+   case kNESHourMin: out << hour * 60 + min << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESHourMinSec: out << hour * 3600 + min * 60 + sec << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESDayMYear: out << yy << mm << dd << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESMDayYear: out << yy << mm << dd << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
+   case kNESHex: {
+      char hex[256];
+      ULong_t l = GetHexNumber();
+      IntToHexStr(hex, l);
+      std::ios::fmtflags f = out.flags(); // store flags
+      out << "0x" << std::hex << "U"
+          << ",(TGNumberFormat::EStyle) " << GetNumStyle();
+      out.flags(f); // restore flags (reset std::hex)
+      break;
    }
-   if (GetNumMax() ==1) {
+   }
+   if (GetNumMax() == 1) {
       if (GetNumMin() == 0) {
          if (GetNumLimits() == kNELNoLimits) {
             if (GetNumAttr() == kNEAAnyNumber) {
-               out << ");" << std::endl;
+               out << ");\n";
             } else {
-               out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ");" << std::endl;
+               out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ");\n";
             }
          } else {
-            out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-                << ",(TGNumberFormat::ELimit) " << GetNumLimits() << ");" << std::endl;
+            out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits()
+                << ");\n";
          }
       } else {
-         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-             << ",(TGNumberFormat::ELimit) " << GetNumLimits()
-             << "," << GetNumMin() << ");" << std::endl;
+         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits()
+             << "," << GetNumMin() << ");\n";
       }
    } else {
-         out << ",(TGNumberFormat::EAttribute) " << GetNumAttr()
-             << ",(TGNumberFormat::ELimit) " << GetNumLimits()
-             << "," << GetNumMin() << "," << GetNumMax() << ");" << std::endl;
+      out << ",(TGNumberFormat::EAttribute) " << GetNumAttr() << ",(TGNumberFormat::ELimit) " << GetNumLimits() << ","
+          << GetNumMin() << "," << GetNumMax() << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
    if (!IsEnabled())
-      out << "   " << GetName() << "->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->SetState(kFALSE);\n";
 
-   out << "   " << GetName() << "->Resize("<< GetWidth() << "," << GetName()
-       << "->GetDefaultHeight());" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetName() << "->GetDefaultHeight());\n";
 
    TGToolTip *tip = GetToolTip();
    if (tip) {
       TString tiptext = tip->GetText()->GetString();
-      tiptext.ReplaceAll("\n", "\\n");
-      out << "   ";
-      out << GetName() << "->SetToolTipText(" << quote
-          << tiptext << quote << ");"  << std::endl;
+      out << "   " << GetName() << "->SetToolTipText(\"" << tiptext.ReplaceSpecialCppChars() << "\");\n";
    }
 }

--- a/gui/gui/src/TGProgressBar.cxx
+++ b/gui/gui/src/TGProgressBar.cxx
@@ -395,41 +395,35 @@ void TGVProgressBar::DoRedraw()
 
 void TGProgressBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   const char *barcolor;
-   char quote = '"';
    switch (fBarType) {
-      case kFancy:
-         if (GetOptions() != (kSunkenFrame | kDoubleBorder | kOwnBackground))
-            out << "   " << GetName() << "->ChangeOptions(" << GetOptionString()
-                << ");" << std::endl;
-         if (GetBackground() != GetWhitePixel()) {
-            SaveUserColor(out, option);
-            out << "   " << GetName() << "->SetBackgroundColor(ucolor);" << std::endl;
-         }
-         break;
+   case kFancy:
+      if (GetOptions() != (kSunkenFrame | kDoubleBorder | kOwnBackground))
+         out << "   " << GetName() << "->ChangeOptions(" << GetOptionString() << ");\n";
+      if (GetBackground() != GetWhitePixel()) {
+         SaveUserColor(out, option);
+         out << "   " << GetName() << "->SetBackgroundColor(ucolor);\n";
+      }
+      break;
 
-      case kStandard:
-         if (GetOptions() != (kSunkenFrame | kOwnBackground))
-            out << "   " << GetName() << "->ChangeOptions(" << GetOptionString()
-                << ");" << std::endl;
-         if (GetBackground() != GetDefaultFrameBackground()) {
-            SaveUserColor(out, option);
-            out << "   " << GetName() << "->SetBackgroundColor(ucolor);" << std::endl;
-         }
-         break;
+   case kStandard:
+      if (GetOptions() != (kSunkenFrame | kOwnBackground))
+         out << "   " << GetName() << "->ChangeOptions(" << GetOptionString() << ");\n";
+      if (GetBackground() != GetDefaultFrameBackground()) {
+         SaveUserColor(out, option);
+         out << "   " << GetName() << "->SetBackgroundColor(ucolor);\n";
+      }
+      break;
    }
 
    if (fBarColorGC.GetForeground() != GetDefaultSelectedBackground()) {
-      barcolor = TColor::PixelAsHexString(fBarColorGC.GetForeground());
-      out << "   " << GetName() <<"->SetBarColor(" << quote << barcolor << quote
-          << ");"  << std::endl;
+      out << "   " << GetName() << "->SetBarColor(\"" << TColor::PixelAsHexString(fBarColorGC.GetForeground())
+          << "\");\n";
    }
 
    if (fMin != 0 && fMax != 100)
-      out << "   " << GetName() << "->SetRange(" << fMin << "," << fMax << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fMin << "," << fMax << ");\n";
 
-   out <<"   "<< GetName() <<"->SetPosition("<< fPos <<");"<< std::endl;
-
+   out << "   " << GetName() << "->SetPosition(" << fPos << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGProgressBar.cxx
+++ b/gui/gui/src/TGProgressBar.cxx
@@ -431,23 +431,19 @@ void TGProgressBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVProgressBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
+   out << "   TGVProgressBar *" << GetName() << " = new TGVProgressBar(" << fParent->GetName();
 
-   out << "   TGVProgressBar *";
-   out << GetName() << " = new TGVProgressBar(" << fParent->GetName();
-
-   if ((fBarType == kFancy) && (fBarWidth == kProgressBarTextWidth)) {
-      out << ",TGProgressBar::kFancy";
-   } else if ((fBarType == kStandard) && (fBarWidth == kProgressBarStandardWidth)){
-      out << ",TGProgressBar::kStandard";
-   }
-
-   out << "," << GetHeight() <<");" << std::endl;
+   if ((fBarType == kFancy) && (fBarWidth == kProgressBarTextWidth))
+      out << ", TGProgressBar::kFancy";
+   else if ((fBarType == kStandard) && (fBarWidth == kProgressBarStandardWidth))
+      out << ", TGProgressBar::kStandard";
+   out << ", " << GetHeight() << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (GetFillType() == kBlockFill)
-      out << "   " << GetName() <<"->SetFillType(TGProgressBar::kBlockFill);"<< std::endl;
+      out << "   " << GetName() << "->SetFillType(TGProgressBar::kBlockFill);\n";
 
    TGProgressBar::SavePrimitive(out, option);
 }
@@ -457,36 +453,32 @@ void TGVProgressBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGHProgressBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
-   out <<"   TGHProgressBar *";
-   out << GetName() <<" = new TGHProgressBar("<< fParent->GetName();
+   out << "   TGHProgressBar *" << GetName() << " = new TGHProgressBar(" << fParent->GetName();
 
    if ((fBarType == kFancy) && (fBarWidth == kProgressBarTextWidth)) {
       out << ",TGProgressBar::kFancy";
-   } else if ((fBarType == kStandard) && (fBarWidth == kProgressBarStandardWidth)){
+   } else if ((fBarType == kStandard) && (fBarWidth == kProgressBarStandardWidth)) {
       out << ",TGProgressBar::kStandard";
    }
+   out << "," << GetWidth() << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-
-   out << "," << GetWidth() << ");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (GetFillType() == kBlockFill)
-      out << "   " << GetName() <<"->SetFillType(TGProgressBar::kBlockFill);"<< std::endl;
+      out << "   " << GetName() << "->SetFillType(TGProgressBar::kBlockFill);\n";
 
    if (GetShowPos()) {
-      out << "   " << GetName() <<"->ShowPosition(kTRUE,";
+      out << "   " << GetName() << "->ShowPosition(kTRUE,";
       if (UsePercent()) {
          out << "kTRUE,";
       } else {
          out << "kFALSE,";
       }
-      out << quote << GetFormat() << quote << ");"<< std::endl;
+      out << "\"" << GetFormat() << "\");\n";
 
    } else if (UsePercent() && !GetFillType()) {
-      out << "   " << GetName() <<"->ShowPosition();" << std::endl;
+      out << "   " << GetName() << "->ShowPosition();\n";
    }
    TGProgressBar::SavePrimitive(out, option);
 }

--- a/gui/gui/src/TGScrollBar.cxx
+++ b/gui/gui/src/TGScrollBar.cxx
@@ -922,26 +922,17 @@ void TGVScrollBar::SetPosition(Int_t pos)
 
 void TGHScrollBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out <<"   TGHScrollBar *";
-   out << GetName() << " = new TGHScrollBar(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGHScrollBar *" << GetName() << " = new TGHScrollBar(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   out << "   " << GetName() <<"->SetRange(" << GetRange() << "," << GetPageSize() << ");" << std::endl;
-   out << "   " << GetName() <<"->SetPosition(" << GetPosition() << ");" << std::endl;
+   out << "   " << GetName() << "->SetRange(" << GetRange() << "," << GetPageSize() << ");\n";
+   out << "   " << GetName() << "->SetPosition(" << GetPosition() << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -949,25 +940,15 @@ void TGHScrollBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVScrollBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out<<"   TGVScrollBar *";
-   out << GetName() <<" = new TGVScrollBar("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGVScrollBar *" << GetName() << " = new TGVScrollBar(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   out << "   " << GetName() <<"->SetRange(" << GetRange() << "," << GetPageSize() << ");" << std::endl;
-   out << "   " << GetName() <<"->SetPosition(" << GetPosition() << ");" << std::endl;
+   out << "   " << GetName() << "->SetRange(" << GetRange() << "," << GetPageSize() << ");\n";
+   out << "   " << GetName() << "->SetPosition(" << GetPosition() << ");\n";
 }

--- a/gui/gui/src/TGShapedFrame.cxx
+++ b/gui/gui/src/TGShapedFrame.cxx
@@ -77,40 +77,25 @@ TGShapedFrame::~TGShapedFrame()
 
 void TGShapedFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and custom color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << std::endl << "   // shaped frame" << std::endl;
-   out << "   TGShapedFrame *";
-   out << GetName() << " = new TGShapedFrame(" << fImage->GetName()
-       << "," << fParent->GetName() << "," << GetWidth() << ","
-       << GetHeight();
+   out << "\n   // shaped frame\n";
+   out << "   TGShapedFrame *" << GetName() << " = new TGShapedFrame(" << fImage->GetName() << "," << fParent->GetName()
+       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from the main frame type
    // coverity[returned_null]
    // coverity[dereference]
-   TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   TGLayoutManager *lm = GetLayoutManager();
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);

--- a/gui/gui/src/TGShutter.cxx
+++ b/gui/gui/src/TGShutter.cxx
@@ -385,30 +385,16 @@ TGShutterItem::~TGShutterItem()
 void TGShutterItem::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    TGTextButton *b = (TGTextButton *)fButton;
-   const char *text = b->GetText()->GetString();
-   char hotpos = b->GetText()->GetHotPos();
-   Int_t lentext = b->GetText()->GetLength();
-   char *outext = new char[lentext + 2]; // should be +2 because of \0
-   Int_t i = 0;
+   TString outtext = b->GetText()->GetString();
+   Int_t hotpos = b->GetText()->GetHotPos();
+   if ((hotpos > 0) && (hotpos < outtext.Length()))
+      outtext.Insert(hotpos - 1, "&");
 
-   while (lentext) {
-      if (i == hotpos - 1) {
-         outext[i] = '&';
-         i++;
-      }
-      outext[i] = *text;
-      i++;
-      text++;
-      lentext--;
-   }
-   outext[i] = 0;
-
-   out << "\n   // \"" << outext << "\" shutter item \n";
+   out << "\n   // \"" << outtext << "\" shutter item \n";
    out << "   TGShutterItem *" << GetName() << " = new TGShutterItem(" << fParent->GetName() << ", new TGHotString(\""
-       << TString(outext).ReplaceSpecialCppChars() << "\"), " << fButton->WidgetId() << ", " << GetOptionString()
+       << outtext.ReplaceSpecialCppChars() << "\"), " << fButton->WidgetId() << ", " << GetOptionString()
        << ");\n";
 
-   delete[] outext;
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
@@ -449,10 +435,9 @@ void TGShutter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (!fList)
       return;
 
-   TGFrameElement *el;
    TIter next(fList);
 
-   while ((el = (TGFrameElement *)next())) {
+   while (auto el = static_cast<TGFrameElement *>(next())) {
       el->fFrame->SavePrimitive(out, option);
       out << "   " << GetName() << "->AddItem(" << el->fFrame->GetName();
       // el->fLayout->SavePrimitive(out, option);

--- a/gui/gui/src/TGShutter.cxx
+++ b/gui/gui/src/TGShutter.cxx
@@ -384,16 +384,15 @@ TGShutterItem::~TGShutterItem()
 
 void TGShutterItem::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    TGTextButton *b = (TGTextButton *)fButton;
    const char *text = b->GetText()->GetString();
    char hotpos = b->GetText()->GetHotPos();
    Int_t lentext = b->GetText()->GetLength();
-   char *outext = new char[lentext+2];       // should be +2 because of \0
-   Int_t i=0;
+   char *outext = new char[lentext + 2]; // should be +2 because of \0
+   Int_t i = 0;
 
    while (lentext) {
-      if (i == hotpos-1) {
+      if (i == hotpos - 1) {
          outext[i] = '&';
          i++;
       }
@@ -402,34 +401,31 @@ void TGShutterItem::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       text++;
       lentext--;
    }
-   outext[i]=0;
+   outext[i] = 0;
 
-   out << std::endl;
-   out << "   // " << quote << outext << quote << " shutter item " << std::endl;
-   out << "   TGShutterItem *";
-   out << GetName() << " = new TGShutterItem(" << fParent->GetName()
-       << ", new TGHotString(" << quote << outext << quote << "),"
-       << fButton->WidgetId() << "," << GetOptionString() << ");" << std::endl;
+   out << "\n   // \"" << outext << "\" shutter item \n";
+   out << "   TGShutterItem *" << GetName() << " = new TGShutterItem(" << fParent->GetName() << ", new TGHotString(\""
+       << TString(outext).ReplaceSpecialCppChars() << "\"), " << fButton->WidgetId() << ", " << GetOptionString()
+       << ");\n";
 
-   delete [] outext;
+   delete[] outext;
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    TList *list = ((TGCompositeFrame *)GetContainer())->GetList();
 
-   if (!list) return;
+   if (!list)
+      return;
 
-   out << "   TGCompositeFrame *" << GetContainer()->GetName()
-       << " = (TGCompositeFrame *)" << GetName() << "->GetContainer();" << std::endl;
+   out << "   TGCompositeFrame *" << GetContainer()->GetName() << " = (TGCompositeFrame *)" << GetName()
+       << "->GetContainer();\n";
 
-   TGFrameElement *el;
    TIter next(list);
-
-   while ((el = (TGFrameElement *) next())) {
+   while (auto el = static_cast<TGFrameElement *>(next())) {
       el->fFrame->SavePrimitive(out, option);
-      out << "   " << GetContainer()->GetName() <<"->AddFrame(" << el->fFrame->GetName();
+      out << "   " << GetContainer()->GetName() << "->AddFrame(" << el->fFrame->GetName();
       el->fLayout->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 }
 
@@ -438,34 +434,31 @@ void TGShutterItem::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGShutter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   out << std::endl;
-   out << "   // shutter" << std::endl;
+   out << "\n   // shutter\n";
 
-   out << "   TGShutter *";
-   out << GetName() << " = new TGShutter(" << fParent->GetName() << ","
-       << GetOptionString() << ");" << std::endl;
+   out << "   TGShutter *" << GetName() << " = new TGShutter(" << fParent->GetName() << "," << GetOptionString()
+       << ");\n";
 
    if ((fDefWidth > 0) || (fDefHeight > 0)) {
       out << "   " << GetName() << "->SetDefaultSize(";
-      out << fDefWidth << "," << fDefHeight << ");" << std::endl;
+      out << fDefWidth << "," << fDefHeight << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (!fList) return;
+   if (!fList)
+      return;
 
    TGFrameElement *el;
    TIter next(fList);
 
-   while ((el = (TGFrameElement *) next())) {
+   while ((el = (TGFrameElement *)next())) {
       el->fFrame->SavePrimitive(out, option);
-      out << "   " << GetName() <<"->AddItem(" << el->fFrame->GetName();
-      //el->fLayout->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << "   " << GetName() << "->AddItem(" << el->fFrame->GetName();
+      // el->fLayout->SavePrimitive(out, option);
+      out << ");\n";
    }
 
-   out << "   " << GetName() << "->SetSelectedItem("
-       << GetSelectedItem()->GetName() << ");" << std::endl;
-   out << "   " <<GetName()<< "->Resize("<<GetWidth()<<","<<GetHeight()<<");"<<std::endl;
+   out << "   " << GetName() << "->SetSelectedItem(" << GetSelectedItem()->GetName() << ");\n";
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetHeight() << ");\n";
 }
-

--- a/gui/gui/src/TGSlider.cxx
+++ b/gui/gui/src/TGSlider.cxx
@@ -581,6 +581,9 @@ TString TGSlider::GetTypeString() const
          else                     stype += " | kScaleBoth";
       }
    }
+
+   if (stype.Length() == 0)
+      stype = "0";
    return stype;
 }
 
@@ -589,36 +592,26 @@ TString TGSlider::GetTypeString() const
 
 void TGHSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out <<"   TGHSlider *";
-   out << GetName() << " = new TGHSlider(" << fParent->GetName()
-       << "," << GetWidth() << ",";
-   out << GetTypeString() << "," << WidgetId();
+   out <<"   TGHSlider *" << GetName() << " = new TGHSlider(" << fParent->GetName()
+       << "," << GetWidth() << "," << GetTypeString() << "," << WidgetId() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fWidth)
-      out << "   " << GetName() <<"->SetRange(" << fVmin << "," << fVmax << ");" << std::endl;
+      out << "   " << GetName() <<"->SetRange(" << fVmin << "," << fVmax << ");\n";
 
    if (fPos != (Int_t)fWidth/2)
-      out << "   " << GetName() <<"->SetPosition(" << GetPosition() << ");" << std::endl;
+      out << "   " << GetName() <<"->SetPosition(" << GetPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() <<"->SetScale(" << fScale << ");" << std::endl;
+      out << "   " << GetName() <<"->SetScale(" << fScale << ");\n";
 
    if (!IsEnabled())
-      out << "   " << GetName() <<"->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() <<"->SetState(kFALSE);\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -626,35 +619,24 @@ void TGHSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out<<"   TGVSlider *";
-   out << GetName() <<" = new TGVSlider("<< fParent->GetName()
-       << "," << GetHeight() << ",";
-   out << GetTypeString() << "," << WidgetId();
+   out << "   TGVSlider *" << GetName() << " = new TGVSlider(" << fParent->GetName() << "," << GetHeight() << ","
+       << GetTypeString() << "," << WidgetId() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fHeight)
-      out << "   " << GetName() <<"->SetRange(" << fVmin << "," << fVmax << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax << ");\n";
 
-   if (fPos != (Int_t)fHeight/2)
-      out << "   " << GetName() <<"->SetPosition(" << GetPosition() << ");" << std::endl;
+   if (fPos != (Int_t)fHeight / 2)
+      out << "   " << GetName() << "->SetPosition(" << GetPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() <<"->SetScale(" << fScale << ");" << std::endl;
+      out << "   " << GetName() << "->SetScale(" << fScale << ");\n";
 
    if (!IsEnabled())
-      out << "   " << GetName() <<"->SetState(kFALSE);" << std::endl;
+      out << "   " << GetName() << "->SetState(kFALSE);\n";
 }

--- a/gui/gui/src/TGSplitFrame.cxx
+++ b/gui/gui/src/TGSplitFrame.cxx
@@ -751,39 +751,25 @@ void TGSplitFrame::UnSplit(const char *which)
 
 void TGSplitFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << std::endl << "   // splittable frame" << std::endl;
-   out << "   TGSplitFrame *";
-   out << GetName() << " = new TGSplitFrame(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "\n   // splittable frame\n";
+   out << "   TGSplitFrame *" << GetName() << " = new TGSplitFrame(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    // setting layout manager if it differs from the main frame type
    // coverity[returned_null]
    // coverity[dereference]
-   TGLayoutManager * lm = GetLayoutManager();
-   if ((GetOptions() & kHorizontalFrame) &&
-       (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-      ;
-   } else if ((GetOptions() & kVerticalFrame) &&
-              (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-      ;
-   } else {
-      out << "   " << GetName() <<"->SetLayoutManager(";
+   TGLayoutManager *lm = GetLayoutManager();
+   if (!((GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+       !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+      out << "   " << GetName() << "->SetLayoutManager(";
       lm->SavePrimitive(out, option);
-      out << ");"<< std::endl;
+      out << ");\n";
    }
 
    SavePrimitiveSubframes(out, option);

--- a/gui/gui/src/TGSplitter.cxx
+++ b/gui/gui/src/TGSplitter.cxx
@@ -582,31 +582,22 @@ Bool_t TGVFileSplitter::HandleDoubleClick(Event_t *)
 
 void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGVSplitter *";
-   out << GetName() <<" = new TGVSplitter("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGVSplitter *" << GetName() <<" = new TGVSplitter("<< fParent->GetName()
+       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
    // TGVSplitter->SetFrame( theframe ) can only be saved here
    // if fFrame is the frame on the left (since the frame on the
    // right will only be saved afterwards)... The other case is
    // handled in TGCompositeFrame::SavePrimitiveSubframes()
    if (GetLeft()) {
       out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetLeft()) out << ",kTRUE);" << std::endl;
-      else           out << ",kFALSE);"<< std::endl;
+      if (GetLeft()) out << ",kTRUE);n";
+      else           out << ",kFALSE);n";
    }
 }
 
@@ -615,31 +606,22 @@ void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   // save options and color if not default
+   auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGHSplitter *";
-   out << GetName() <<" = new TGHSplitter("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGHSplitter *" << GetName() <<" = new TGHSplitter("<< fParent->GetName()
+       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out <<");" << std::endl;
-      } else {
-         out << "," << GetOptionString() <<");" << std::endl;
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
-   }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
    // TGHSplitter->SetFrame( theframe ) can only be saved here
    // if fFrame is the frame above (since the frame below will
    // only be saved afterwards)... The other case is handled in
    // TGCompositeFrame::SavePrimitiveSubframes()
    if (GetAbove()) {
       out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetAbove()) out << ",kTRUE);" << std::endl;
-      else            out << ",kFALSE);"<< std::endl;
+      if (GetAbove()) out << ",kTRUE);\n";
+      else            out << ",kFALSE);\n";
    }
 }
 
@@ -648,21 +630,11 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVFileSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out);
 
    out << "   TGVFileSplitter *" << GetName() << " = new TGVFileSplitter(" << fParent->GetName() << "," << GetWidth()
-       << "," << GetHeight();
+       << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGSplitter.cxx
+++ b/gui/gui/src/TGSplitter.cxx
@@ -648,26 +648,24 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
 void TGVFileSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << "   TGVFileSplitter *";
-   out << GetName() <<" = new TGVFileSplitter("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGVFileSplitter *" << GetName() << " = new TGVFileSplitter(" << fParent->GetName() << "," << GetWidth()
+       << "," << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (!GetOptions()) {
-         out <<");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() <<");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-   if (GetLeft()) out << ",kTRUE);" << std::endl;
-   else           out << ",kFALSE);"<< std::endl;
+   out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName() << ", " << (GetLeft() ? "kTRUE" : "kFALSE")
+       << ");\n";
 }
-

--- a/gui/gui/src/TGSplitter.cxx
+++ b/gui/gui/src/TGSplitter.cxx
@@ -585,8 +585,8 @@ void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // save options and color if not default
    auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGVSplitter *" << GetName() <<" = new TGVSplitter("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
+   out << "   TGVSplitter *" << GetName() << " = new TGVSplitter(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
@@ -596,8 +596,10 @@ void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // handled in TGCompositeFrame::SavePrimitiveSubframes()
    if (GetLeft()) {
       out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetLeft()) out << ",kTRUE);n";
-      else           out << ",kFALSE);n";
+      if (GetLeft())
+         out << ",kTRUE);n";
+      else
+         out << ",kFALSE);n";
    }
 }
 
@@ -609,8 +611,8 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // save options and color if not default
    auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGHSplitter *" << GetName() <<" = new TGHSplitter("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight() << extra_args << ");\n";
+   out << "   TGHSplitter *" << GetName() << " = new TGHSplitter(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << extra_args << ");\n";
 
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
@@ -620,8 +622,10 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // TGCompositeFrame::SavePrimitiveSubframes()
    if (GetAbove()) {
       out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetAbove()) out << ",kTRUE);\n";
-      else            out << ",kFALSE);\n";
+      if (GetAbove())
+         out << ",kTRUE);\n";
+      else
+         out << ",kFALSE);\n";
    }
 }
 

--- a/gui/gui/src/TGStatusBar.cxx
+++ b/gui/gui/src/TGStatusBar.cxx
@@ -376,23 +376,13 @@ TGDimension TGStatusBar::GetDefaultSize() const
 
 void TGStatusBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kHorizontalFrame);
 
    out << "\n   // status bar\n";
 
    out << "   TGStatusBar *" << GetName() << " = new TGStatusBar(" << fParent->GetName() << "," << GetWidth() << ","
-       << GetHeight();
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kHorizontalFrame)) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ", ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGStatusBar.cxx
+++ b/gui/gui/src/TGStatusBar.cxx
@@ -376,59 +376,48 @@ TGDimension TGStatusBar::GetDefaultSize() const
 
 void TGStatusBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl;
-   out << "   // status bar" << std::endl;
+   out << "\n   // status bar\n";
 
-   out << "   TGStatusBar *";
-   out << GetName() <<" = new TGStatusBar("<< fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGStatusBar *" << GetName() << " = new TGStatusBar(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (GetOptions() == (kSunkenFrame | kHorizontalFrame)) {
-         out <<");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() <<");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ", ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   int i; char quote = '"';
-
-   if (fNpart > 1)  {
-      out << "   Int_t parts" << GetName()+5 << "[] = {" << fParts[0];
-
-      for (i=1; i<fNpart; i++) {
-         out  << "," << fParts[i];
-      }
-      out << "};" << std::endl;
-
-      out << "   " << GetName() << "->SetParts(parts" << GetName()+5
-          << "," << fNpart << ");" <<std::endl;
+   if (fNpart > 1) {
+      out << "   " << GetName() << "->SetParts((Int_t []) {";
+      for (Int_t i = 0; i < fNpart; i++)
+         out << (i == 0 ? "" : ", ") << fParts[i];
+      out << "}, " << fNpart << ");\n";
    }
-   for (i=0; i<fNpart; i++) {
+   for (Int_t i = 0; i < fNpart; i++) {
       if (fStatusPart[i]->GetText()) {
-         out << "   " << GetName() << "->SetText(" << quote
-             << fStatusPart[i]->GetText()->GetString()
-             << quote << "," << i << ");" << std::endl;
+         out << "   " << GetName() << "->SetText(\""
+             << TString(fStatusPart[i]->GetText()->GetString()).ReplaceSpecialCppChars() << "\", " << i << ");\n";
       } else {
-         if (!fStatusPart[i]->GetList()->First()) continue;
-         out << "   TGCompositeFrame *" << fStatusPart[i]->GetName()
-             << " = " << GetName() << "->GetBarPart(" << i << ");" << std::endl;
+         if (!fStatusPart[i]->GetList()->First())
+            continue;
+         out << "   TGCompositeFrame *" << fStatusPart[i]->GetName() << " = " << GetName() << "->GetBarPart(" << i
+             << ");\n";
 
-         TGFrameElement *el;
          TIter next(fStatusPart[i]->GetList());
-
-         while ((el = (TGFrameElement *) next())) {
+         while (auto el = static_cast<TGFrameElement *>(next())) {
             el->fFrame->SavePrimitive(out, option);
-            out << "   " << fStatusPart[i]->GetName() << "->AddFrame("
-                << el->fFrame->GetName();
+            out << "   " << fStatusPart[i]->GetName() << "->AddFrame(" << el->fFrame->GetName();
             el->fLayout->SavePrimitive(out, option);
-            out << ");" << std::endl;
+            out << ");\n";
          }
       }
    }

--- a/gui/gui/src/TGTab.cxx
+++ b/gui/gui/src/TGTab.cxx
@@ -784,13 +784,11 @@ TGLayoutManager *TGTab::GetLayoutManager() const
 
 void TGTab::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
    if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC)) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
@@ -806,80 +804,66 @@ void TGTab::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl << "   // tab widget" << std::endl;
+   out << "\n   // tab widget\n";
 
-   out << "   TGTab *";
-   out << GetName() << " = new TGTab(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGTab *" << GetName() << " = new TGTab(" << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (GetOptions() == kChildFrame) {
          if (fFontStruct == GetDefaultFontStruct()) {
             if (fNormGC == GetDefaultGC()()) {
-               out <<");" << std::endl;
+               out << ");\n";
             } else {
-               out << "," << parGC.Data() <<");" << std::endl;
+               out << "," << parGC << ");\n";
             }
          } else {
-            out << "," << parGC.Data() << "," << parFont.Data() <<");" << std::endl;
+            out << "," << parGC << "," << parFont << ");\n";
          }
       } else {
-         out << "," << parGC.Data() << "," << parFont.Data() << "," << GetOptionString() <<");" << std::endl;
+         out << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << parGC.Data() << "," << parFont.Data() << "," << GetOptionString()  << ",ucolor);" << std::endl;
+      out << "," << parGC << "," << parFont << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   TGCompositeFrame *cf;
-   TGLayoutManager * lm;
-   for (Int_t i=0; i<GetNumberOfTabs(); i++) {
-      cf = GetTabContainer(i);
-      if (!cf || !GetTabTab(i)) continue;
-      out << std::endl << "   // container of " << quote
-          << GetTabTab(i)->GetString() << quote << std::endl;
-      out << "   TGCompositeFrame *" << cf->GetName() << ";" << std::endl;
-      out << "   " << cf->GetName() << " = " << GetName()
-                   << "->AddTab(" << quote << GetTabTab(i)->GetString()
-                   << quote << ");" << std::endl;
-      lm = cf->GetLayoutManager();
+   for (Int_t i = 0; i < GetNumberOfTabs(); i++) {
+      auto cf = GetTabContainer(i);
+      if (!cf || !GetTabTab(i))
+         continue;
+      out << "\n   // container of \"" << GetTabTab(i)->GetString() << "\"\n";
+      out << "   TGCompositeFrame *" << cf->GetName() << " = " << GetName() << "->AddTab(\""
+          << GetTabTab(i)->GetString() << "\");\n";
+      auto lm = cf->GetLayoutManager();
       if (lm) {
-         if ((cf->GetOptions() & kHorizontalFrame) &&
-            (lm->InheritsFrom(TGHorizontalLayout::Class()))) {
-            ;
-         } else if ((GetOptions() & kVerticalFrame) &&
-            (lm->InheritsFrom(TGVerticalLayout::Class()))) {
-            ;
-         } else {
-            out << "   " << cf->GetName() <<"->SetLayoutManager(";
+         if (!((cf->GetOptions() & kHorizontalFrame) && lm->InheritsFrom(TGHorizontalLayout::Class())) &&
+             !((GetOptions() & kVerticalFrame) && lm->InheritsFrom(TGVerticalLayout::Class()))) {
+            out << "   " << cf->GetName() << "->SetLayoutManager(";
             lm->SavePrimitive(out, option);
-            out << ");" << std::endl;
+            out << ");\n";
          }
          if (!IsEnabled(i)) {
-            out << "   " << GetName() << "->SetEnabled(" << i << ", kFALSE);" << std::endl;
+            out << "   " << GetName() << "->SetEnabled(" << i << ", kFALSE);\n";
          }
       }
       cf->SavePrimitiveSubframes(out, option);
 
       if (GetTabTab(i)->IsCloseShown()) {
-         out << "   TGTabElement *tab" << i << " = "
-             << GetName() << "->GetTabTab(" << i << ");" << std::endl;
-         out << "   tab" << i << "->ShowClose(kTRUE);" << std::endl;
+         out << "   TGTabElement *tab" << i << " = " << GetName() << "->GetTabTab(" << i << ");\n";
+         out << "   tab" << i << "->ShowClose(kTRUE);\n";
       }
       if (GetTabTab(i)->GetBackground() != GetTabTab(i)->GetDefaultFrameBackground()) {
          GetTabTab(i)->SaveUserColor(out, option);
-         out << "   TGTabElement *tab" << i << " = "
-             << GetName() << "->GetTabTab(" << i << ");" << std::endl;
-         out << "   tab" << i << "->ChangeBackground(ucolor);" << std::endl;
+         out << "   TGTabElement *tab" << i << " = " << GetName() << "->GetTabTab(" << i << ");\n";
+         out << "   tab" << i << "->ChangeBackground(ucolor);\n";
       }
-
    }
-   out << std::endl << "   " << GetName() << "->SetTab(" << GetCurrent() << ");" << std::endl;
-   out << std::endl << "   " << GetName() << "->Resize(" << GetName()
-       << "->GetDefaultSize());" << std::endl;
+   out << "\n   " << GetName() << "->SetTab(" << GetCurrent() << ");\n";
+   out <<  "   " << GetName() << "->Resize(" << GetName() << "->GetDefaultSize());\n";
 }
 
 // __________________________________________________________________________

--- a/gui/gui/src/TGTab.cxx
+++ b/gui/gui/src/TGTab.cxx
@@ -804,30 +804,18 @@ void TGTab::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out);
 
    out << "\n   // tab widget\n";
 
    out << "   TGTab *" << GetName() << " = new TGTab(" << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == kChildFrame) {
-         if (fFontStruct == GetDefaultFontStruct()) {
-            if (fNormGC == GetDefaultGC()()) {
-               out << ");\n";
-            } else {
-               out << "," << parGC << ");\n";
-            }
-         } else {
-            out << "," << parGC << "," << parFont << ");\n";
-         }
-      } else {
-         out << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << parGC << "," << parFont << "," << GetOptionString() << ",ucolor);\n";
-   }
+   if (!extra_args.IsNull() || (fFontStruct != GetDefaultFontStruct()))
+      out << "," << parGC << "," << parFont << "," << extra_args;
+   else if (fNormGC != GetDefaultGC()())
+      out << "," << parGC;
+   out << ");\n";
+
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGTableLayout.cxx
+++ b/gui/gui/src/TGTableLayout.cxx
@@ -667,69 +667,41 @@ void TGTableLayoutHints::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
    // Save table layout hints as a C++ statement(s) on output stream out.
 
-   TString hints;
    UInt_t pad = GetPadLeft()+GetPadRight()+GetPadTop()+GetPadBottom();
 
-   if (!GetLayoutHints()) return;
+   if (!GetLayoutHints())
+      return;
 
-   if ((fLayoutHints == kLHintsNormal) && (pad == 0)) return;
+   if ((fLayoutHints == kLHintsNormal) && (pad == 0))
+      return;
 
-   if (fLayoutHints & kLHintsLeft) {
-      if (hints.Length() == 0) hints  = "kLHintsLeft";
-      else                     hints += " | kLHintsLeft";
-   }
-   if (fLayoutHints & kLHintsCenterX) {
-      if  (hints.Length() == 0) hints  = "kLHintsCenterX";
-      else                     hints += " | kLHintsCenterX";
-   }
-   if (fLayoutHints & kLHintsRight) {
-      if (hints.Length() == 0) hints  = "kLHintsRight";
-      else                     hints += " | kLHintsRight";
-   }
-   if (fLayoutHints & kLHintsTop) {
-      if (hints.Length() == 0) hints  = "kLHintsTop";
-      else                     hints += " | kLHintsTop";
-   }
-   if (fLayoutHints & kLHintsCenterY) {
-      if (hints.Length() == 0) hints  = "kLHintsCenterY";
-      else                     hints += " | kLHintsCenterY";
-   }
-   if (fLayoutHints & kLHintsBottom) {
-      if (hints.Length() == 0) hints  = "kLHintsBottom";
-      else                     hints += " | kLHintsBottom";
-   }
-   if (fLayoutHints & kLHintsExpandX) {
-      if (hints.Length() == 0) hints  = "kLHintsExpandX";
-      else                     hints += " | kLHintsExpandX";
-   }
-   if (fLayoutHints & kLHintsExpandY) {
-      if (hints.Length() == 0) hints  = "kLHintsExpandY";
-      else                     hints += " | kLHintsExpandY";
-   }
-   if (fLayoutHints & kLHintsShrinkX) {
-      if (hints.Length() == 0) hints  = "kLHintsShrinkX";
-      else                     hints += " | kLHintsShrinkX";
-   }
-   if (fLayoutHints & kLHintsShrinkY) {
-      if (hints.Length() == 0) hints  = "kLHintsShrinkY";
-      else                     hints += " | kLHintsShrinkY";
-   }
-   if (fLayoutHints & kLHintsFillX) {
-      if (hints.Length() == 0) hints  = "kLHintsFillX";
-      else                     hints += " | kLHintsFillX";
-   }
-   if (fLayoutHints & kLHintsFillY) {
-      if (hints.Length() == 0) hints  = "kLHintsFillY";
-      else                     hints += " | kLHintsFillY";
-   }
-   out << ", new TGTableLayoutHints(" << GetAttachLeft() << "," << GetAttachRight()
-       << "," << GetAttachTop()  << "," << GetAttachBottom()
-       << "," << hints;
+   TString hints;
+   auto add = [this, &hints](UInt_t mask, const char *name) {
+      if (fLayoutHints & mask) {
+         if (hints.Length())
+            hints.Append(" | ");
+         hints.Append(name);
+      }
+   };
 
-   if (pad) {
-      out << "," << GetPadLeft() << "," << GetPadRight()
-          << "," << GetPadTop()  << "," << GetPadBottom();
-   }
+   add(kLHintsLeft, "kLHintsLeft");
+   add(kLHintsCenterX, "kLHintsCenterX");
+   add(kLHintsRight, "kLHintsRight");
+   add(kLHintsTop, "kLHintsTop");
+   add(kLHintsCenterY, "kLHintsCenterY");
+   add(kLHintsBottom, "kLHintsBottom");
+   add(kLHintsExpandX, "kLHintsExpandX");
+   add(kLHintsExpandY, "kLHintsExpandY");
+   add(kLHintsShrinkX, "kLHintsShrinkX");
+   add(kLHintsShrinkY, "kLHintsShrinkY");
+   add(kLHintsFillX, "kLHintsFillX");
+   add(kLHintsFillY, "kLHintsFillY");
+
+   out << ", new TGTableLayoutHints(" << GetAttachLeft() << "," << GetAttachRight() << "," << GetAttachTop() << ","
+       << GetAttachBottom() << "," << hints;
+
+   if (pad)
+      out << "," << GetPadLeft() << "," << GetPadRight() << "," << GetPadTop() << "," << GetPadBottom();
    out << ")";
 }
 
@@ -746,9 +718,8 @@ void TGTableLayout::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
          out << ", kTRUE";
       else
          out << ", kFALSE";
-   out << fSep;
+      out << fSep;
    }
-   out  << ")";
+   out << ")";
    // hints parameter is not used/saved currently
-
 }

--- a/gui/gui/src/TGTextEdit.cxx
+++ b/gui/gui/src/TGTextEdit.cxx
@@ -2206,25 +2206,19 @@ const TGGC &TGTextEdit::GetCursor1GC()
 
 void TGTextEdit::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out << "   TGTextEdit *";
-   out << GetName() << " = new TGTextEdit(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight()
-       << ");"<< std::endl;
+   out << "   TGTextEdit *" << GetName() << " = new TGTextEdit(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight() << ");\n";
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   if (IsReadOnly()) {
-      out << "   " << GetName() << "->SetReadOnly(kTRUE);" << std::endl;
-   }
+   if (IsReadOnly())
+      out << "   " << GetName() << "->SetReadOnly(kTRUE);\n";
 
-   if (!IsMenuEnabled()) {
-      out << "   " << GetName() << "->EnableMenu(kFALSE);" << std::endl;
-   }
+   if (!IsMenuEnabled())
+      out << "   " << GetName() << "->EnableMenu(kFALSE);\n";
 
-   if (fCanvas->GetBackground() != TGFrame::fgWhitePixel) {
-      out << "   " << GetName() << "->ChangeBackground(" << fCanvas->GetBackground() << ");" << std::endl;
-   }
+   if (fCanvas->GetBackground() != TGFrame::fgWhitePixel)
+      out << "   " << GetName() << "->ChangeBackground(" << fCanvas->GetBackground() << ");\n";
 
    TGText *txt = GetText();
    Bool_t fromfile = strlen(txt->GetFileName()) ? kTRUE : kFALSE;
@@ -2235,8 +2229,8 @@ void TGTextEdit::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       fn = gSystem->UnixPathName(filename);
       gSystem->ExpandPathName(fn);
    } else {
-      fn = TString::Format("Txt%s", GetName()+5);
+      fn = TString::Format("Txt%s", GetName() + 5);
       txt->Save(fn.Data());
    }
-   out << "   " << GetName() << "->LoadFile(" << quote << fn.Data() << quote << ");" << std::endl;
+   out << "   " << GetName() << "->LoadFile(\"" << fn.ReplaceSpecialCppChars() << "\");\n";
 }

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -1826,17 +1826,15 @@ const TGGC &TGTextEntry::GetDefaultSelectedBackgroundGC()
 
 void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-
    // font + GC
-   option = GetName()+5;         // unique digit id of the name
+   option = GetName() + 5; // unique digit id of the name
    TString parGC, parFont;
    // coverity[returned_null]
    // coverity[dereference]
-   parFont.Form("%s::GetDefaultFontStruct()",IsA()->GetName());
+   parFont.Form("%s::GetDefaultFontStruct()", IsA()->GetName());
    // coverity[returned_null]
    // coverity[dereference]
-   parGC.Form("%s::GetDefaultGC()()",IsA()->GetName());
+   parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
    if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC.GetGC())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
@@ -1852,68 +1850,57 @@ void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetWhitePixel()) SaveUserColor(out, option);
+   if (fBackground != GetWhitePixel())
+      SaveUserColor(out, option);
 
-   out << "   TGTextEntry *";
-   out << GetName() << " = new TGTextEntry(" << fParent->GetName()
-       << ", new TGTextBuffer(" << GetBuffer()->GetBufferLength() << ")";
+   out << "   TGTextEntry *" << GetName() << " = new TGTextEntry(" << fParent->GetName() << ", new TGTextBuffer("
+       << GetBuffer()->GetBufferLength() << ")";
 
    if (fBackground == GetWhitePixel()) {
       if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
          if (fFontStruct == GetDefaultFontStruct()) {
             if (fNormGC() == GetDefaultGC()()) {
                if (fWidgetId == -1) {
-                  out <<");" << std::endl;
+                  out << ");\n";
                } else {
-                  out << "," << fWidgetId << ");" << std::endl;
+                  out << "," << fWidgetId << ");\n";
                }
             } else {
-               out << "," << fWidgetId << "," << parGC.Data() << ");" << std::endl;
+               out << "," << fWidgetId << "," << parGC << ");\n";
             }
          } else {
-            out << "," << fWidgetId << "," << parGC.Data() << "," << parFont.Data()
-                <<");" << std::endl;
+            out << "," << fWidgetId << "," << parGC << "," << parFont << ");\n";
          }
       } else {
-         out << "," << fWidgetId << "," << parGC.Data() << "," << parFont.Data()
-             << "," << GetOptionString() << ");" << std::endl;
+         out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << fWidgetId << "," << parGC.Data() << "," << parFont.Data()
-          << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   out << "   " << GetName() << "->SetMaxLength(" << GetMaxLength() << ");" << std::endl;
+   out << "   " << GetName() << "->SetMaxLength(" << GetMaxLength() << ");\n";
 
    out << "   " << GetName() << "->SetAlignment(";
 
    if (fAlignment == kTextLeft)
-      out << "kTextLeft);"    << std::endl;
+      out << "kTextLeft);\n";
+   else if (fAlignment == kTextRight)
+      out << "kTextRight);\n";
+   else /* if (fAlignment == kTextCenterX) */
+      out << "kTextCenterX);\n";
 
-   if (fAlignment == kTextRight)
-      out << "kTextRight);"   << std::endl;
+   out << "   " << GetName() << "->SetText(\"" << TString(GetText()).ReplaceSpecialCppChars() << "\");\n";
 
-   if (fAlignment == kTextCenterX)
-      out << "kTextCenterX);" << std::endl;
-
-   out << "   " << GetName() << "->SetText(" << quote << GetText() << quote
-       << ");" << std::endl;
-
-   out << "   " << GetName() << "->Resize("<< GetWidth() << "," << GetName()
-       << "->GetDefaultHeight());" << std::endl;
+   out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetName() << "->GetDefaultHeight());\n";
 
    if ((fDefWidth > 0) || (fDefHeight > 0)) {
-      out << "   " << GetName() << "->SetDefaultSize(";
-      out << fDefWidth << "," << fDefHeight << ");" << std::endl;
+      out << "   " << GetName() << "->SetDefaultSize(" << fDefWidth << "," << fDefHeight << ");\n";
    }
 
    if (fTip) {
       TString tiptext = fTip->GetText()->GetString();
-      tiptext.ReplaceAll("\n", "\\n");
-      out << "   ";
-      out << GetName() << "->SetToolTipText(" << quote
-          << tiptext << quote << ");"  << std::endl;
+      out << "   " << GetName() << "->SetToolTipText(\"" << tiptext.ReplaceSpecialCppChars() << "\");\n";
    }
 }

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -1836,7 +1836,7 @@ void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[dereference]
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC.GetGC()) || (fBackground != GetWhitePixel())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC.GetGC())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -1850,33 +1850,19 @@ void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       }
    }
 
-   if (fBackground != GetWhitePixel())
-      SaveUserColor(out, option);
+   // store options and color if differ from defauls
+   TString extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder, kTRUE);
 
    out << "   TGTextEntry *" << GetName() << " = new TGTextEntry(" << fParent->GetName() << ", new TGTextBuffer("
        << GetBuffer()->GetBufferLength() << ")";
+   if (!extra_args.IsNull() || (fFontStruct != GetDefaultFontStruct()))
+      out << ", " << fWidgetId << ", " << parGC << ", " << parFont << extra_args;
+   else if (fNormGC() != GetDefaultGC()())
+      out << ", " << fWidgetId << ", " << parGC;
+   else if (fWidgetId != -1)
+      out << ", " << fWidgetId;
+   out << ");\n";
 
-   if (fBackground == GetWhitePixel()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         if (fFontStruct == GetDefaultFontStruct()) {
-            if (fNormGC() == GetDefaultGC()()) {
-               if (fWidgetId == -1) {
-                  out << ");\n";
-               } else {
-                  out << "," << fWidgetId << ");\n";
-               }
-            } else {
-               out << "," << fWidgetId << "," << parGC << ");\n";
-            }
-         } else {
-            out << "," << fWidgetId << "," << parGC << "," << parFont << ");\n";
-         }
-      } else {
-         out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << fWidgetId << "," << parGC << "," << parFont << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
@@ -1895,12 +1881,10 @@ void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    out << "   " << GetName() << "->Resize(" << GetWidth() << "," << GetName() << "->GetDefaultHeight());\n";
 
-   if ((fDefWidth > 0) || (fDefHeight > 0)) {
+   if ((fDefWidth > 0) || (fDefHeight > 0))
       out << "   " << GetName() << "->SetDefaultSize(" << fDefWidth << "," << fDefHeight << ");\n";
-   }
 
-   if (fTip) {
-      TString tiptext = fTip->GetText()->GetString();
-      out << "   " << GetName() << "->SetToolTipText(\"" << tiptext.ReplaceSpecialCppChars() << "\");\n";
-   }
+   if (fTip)
+      out << "   " << GetName() << "->SetToolTipText(\""
+          << TString(fTip->GetText()->GetString()).ReplaceSpecialCppChars() << "\");\n";
 }

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -1836,7 +1836,7 @@ void TGTextEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // coverity[dereference]
    parGC.Form("%s::GetDefaultGC()()", IsA()->GetName());
 
-   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC.GetGC())) {
+   if ((GetDefaultFontStruct() != fFontStruct) || (GetDefaultGC()() != fNormGC.GetGC()) || (fBackground != GetWhitePixel())) {
       TGFont *ufont = gClient->GetResourcePool()->GetFontPool()->FindFont(fFontStruct);
       if (ufont) {
          ufont->SavePrimitive(out, option);

--- a/gui/gui/src/TGTextView.cxx
+++ b/gui/gui/src/TGTextView.cxx
@@ -1560,17 +1560,15 @@ const TGGC &TGTextView::GetDefaultSelectedBackgroundGC()
 
 void TGTextView::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
-   out << "   TGTextView *";
-   out << GetName() << " = new TGTextView(" << fParent->GetName()
+   out << "   TGTextView *" << GetName() << " = new TGTextView(" << fParent->GetName()
        << "," << GetWidth() << "," << GetHeight()
-       << ");"<< std::endl;
+       << ");\n";
 
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fCanvas->GetBackground() != TGFrame::fgWhitePixel) {
-      out << "   " << GetName() << "->ChangeBackground(" << fCanvas->GetBackground() << ");" << std::endl;
+      out << "   " << GetName() << "->ChangeBackground(" << fCanvas->GetBackground() << ");\n";
    }
 
    TGText *txt = GetText();
@@ -1582,8 +1580,8 @@ void TGTextView::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       fn = gSystem->UnixPathName(filename);
       gSystem->ExpandPathName(fn);
    } else {
-      fn = TString::Format("Txt%s", GetName()+5);
+      fn.Form("Txt%s", GetName()+5);
       txt->Save(fn.Data());
    }
-   out << "   " << GetName() << "->LoadFile(" << quote << fn.Data() << quote << ");" << std::endl;
+   out << "   " << GetName() << "->LoadFile(\"" << fn.ReplaceSpecialCppChars() << "\");\n";
 }

--- a/gui/gui/src/TGToolBar.cxx
+++ b/gui/gui/src/TGToolBar.cxx
@@ -270,75 +270,67 @@ void TGToolBar::ButtonClicked()
 
 void TGToolBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   out << std::endl;
-   out << "   // tool bar" << std::endl;
+   out << "\n   // tool bar\n";
 
-   out << "   TGToolBar *";
-   out << GetName() << " = new TGToolBar(" << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << "   TGToolBar *" << GetName() << " = new TGToolBar(" << fParent->GetName() << "," << GetWidth() << ","
+       << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (!GetOptions()) {
-         out <<");" << std::endl;
+         out << ");" << std::endl;
       } else {
-         out << "," << GetOptionString() <<");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
-
-   char quote = '"';
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    int i = 0;
 
-   TGFrameElement *f;
    TIter next(GetList());
 
-   while ((f = (TGFrameElement *) next())) {
+   while (auto f = static_cast<TGFrameElement *>(next())) {
       if (f->fFrame->InheritsFrom(TGPictureButton::Class())) {
          if (!gROOT->ClassSaved(TGPictureButton::Class())) {
             //  declare a structure used for picture buttons
-            out << std::endl << "   ToolBarData_t t;" << std::endl;
+            out << "   ToolBarData_t toolbardata;\n";
          }
 
          TGPictureButton *pb = (TGPictureButton *)f->fFrame;
          TString picname = gSystem->UnixPathName(pb->GetPicture()->GetName());
          gSystem->ExpandPathName(picname);
 
-         out << "   t.fPixmap = " << quote << picname << quote << ";" << std::endl;
-         out << "   t.fTipText = " << quote
-             << pb->GetToolTip()->GetText()->GetString() << quote << ";" << std::endl;
+         out << "   toolbardata.fPixmap = \"" << picname.ReplaceSpecialCppChars() << "\";\n";
+         out << "   toolbardata.fTipText = \""
+             << TString(pb->GetToolTip()->GetText()->GetString()).ReplaceSpecialCppChars() << "\";\n";
+         if (pb->GetState() == kButtonDown)
+            out << "   toolbardata.fStayDown = kTRUE;\n";
+          else
+            out << "   toolbardata.fStayDown = kFALSE;\n";
+         out << "   toolbardata.fId = " << i + 1 << ";\n";
+         out << "   toolbardata.fButton = nullptr;\n";
+         out << "   " << GetName() << "->AddButton(" << GetParent()->GetName() << ", &toolbardata, "
+             << f->fLayout->GetPadLeft() << ");\n";
          if (pb->GetState() == kButtonDown) {
-            out << "   t.fStayDown = kTRUE;" << std::endl;
-         } else {
-            out << "   t.fStayDown = kFALSE;" << std::endl;
-         }
-         out << "   t.fId = " << i+1 << ";" << std::endl;
-         out << "   t.fButton = 0;" << std::endl;
-         out << "   " << GetName() << "->AddButton(" << GetParent()->GetName()
-             << ",&t," << f->fLayout->GetPadLeft() << ");" << std::endl;
-         if (pb->GetState() == kButtonDown) {
-            out << "   TGButton *" << pb->GetName() <<  " = t.fButton;" << std::endl;
-            out << "   " << pb->GetName() << "->SetState(kButtonDown);"  << std::endl;
+            out << "   toolbardata.fButton->SetState(kButtonDown);\n";
          }
          if (pb->GetState() == kButtonDisabled) {
-            out << "   TGButton *" << pb->GetName() <<  " = t.fButton;" << std::endl;
-            out << "   " << pb->GetName() << "->SetState(kButtonDisabled);" << std::endl;
+            out << "   toolbardata.fButton->SetState(kButtonDisabled);\n";
          }
          if (pb->GetState() == kButtonEngaged) {
-            out << "   TGButton *" << pb->GetName() <<  " = t.fButton;" << std::endl;
-            out << "   " << pb->GetName() << "->SetState(kButtonEngaged);"  << std::endl;
+            out << "   toolbardata.fButton->SetState(kButtonEngaged);\n";
          }
          i++;
       } else {
          f->fFrame->SavePrimitive(out, option);
-         out << "   " << GetName()<<"->AddFrame(" << f->fFrame->GetName();
+         out << "   " << GetName() << "->AddFrame(" << f->fFrame->GetName();
          f->fLayout->SavePrimitive(out, option);
-         out << ");"<< std::endl;
+         out << ");\n";
       }
    }
 }

--- a/gui/gui/src/TGToolBar.cxx
+++ b/gui/gui/src/TGToolBar.cxx
@@ -270,23 +270,13 @@ void TGToolBar::ButtonClicked()
 
 void TGToolBar::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out);
 
    out << "\n   // tool bar\n";
 
    out << "   TGToolBar *" << GetName() << " = new TGToolBar(" << fParent->GetName() << "," << GetWidth() << ","
-       << GetHeight();
+       << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (!GetOptions()) {
-         out << ");" << std::endl;
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/gui/gui/src/TGTripleSlider.cxx
+++ b/gui/gui/src/TGTripleSlider.cxx
@@ -710,9 +710,8 @@ void TGTripleVSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 {
    SaveUserColor(out, option);
 
-   out<<"   TGTripleVSlider *";
-   out << GetName() << " = new TGTripleVSlider("<< fParent->GetName()
-       << "," << GetHeight() << ",";
+   out << "   TGTripleVSlider *" << GetName() << " = new TGTripleVSlider(" << fParent->GetName() << "," << GetHeight()
+       << ",";
    out << GetSString() << "," << WidgetId() << ",";
    out << GetOptionString() << ",ucolor";
    if (fMarkEnds) {
@@ -727,29 +726,25 @@ void TGTripleVSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
    }
    if (!fConstrained) {
       if (fRelative)
-         out << ",kFALSE,kTRUE);" << std::endl;
+         out << ",kFALSE,kTRUE);\n";
       else
-         out << ",kFALSE,kFALSE);" << std::endl;
-   }
-   else if (fRelative) {
-      out << ",kTRUE);" << std::endl;
-   }
-   else {
-      out << ");" << std::endl;
+         out << ",kFALSE,kFALSE);\n";
+   } else if (fRelative) {
+      out << ",kTRUE);\n";
+   } else {
+      out << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fHeight)
-      out << "   " << GetName() <<"->SetRange(" << fVmin << "," << fVmax
-          << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax << ");\n";
 
-   if (fSmin != fHeight/8*3 || fSmax != fHeight/8*5)
-      out << "   " << GetName() << "->SetPosition(" << GetMinPosition()
-          << "," << GetMaxPosition() << ");" << std::endl;
+   if (fSmin != fHeight / 8 * 3 || fSmax != fHeight / 8 * 5)
+      out << "   " << GetName() << "->SetPosition(" << GetMinPosition() << "," << GetMaxPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() << "->SetScale(" << fScale << ");" << std::endl;
+      out << "   " << GetName() << "->SetScale(" << fScale << ");\n";
 
-   out << "   " << GetName() << "->SetPointerPosition(" << fSCz << ");" << std::endl;
+   out << "   " << GetName() << "->SetPointerPosition(" << fSCz << ");\n";
 }

--- a/gui/gui/src/TGTripleSlider.cxx
+++ b/gui/gui/src/TGTripleSlider.cxx
@@ -659,11 +659,8 @@ void TGTripleHSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
 {
    SaveUserColor(out, option);
 
-   out <<"   TGTripleHSlider *";
-   out << GetName() << " = new TGTripleHSlider(" << fParent->GetName()
-       << "," << GetWidth() << ",";
-   out << GetSString() << "," << WidgetId() << ",";
-   out << GetOptionString() << ",ucolor";
+   out << "   TGTripleHSlider *" << GetName() << " = new TGTripleHSlider(" << fParent->GetName() << "," << GetWidth()
+       << "," << GetSString() << "," << WidgetId() << "," << GetOptionString() << ", ucolor";
    if (fMarkEnds) {
       if (fReversedScale)
          out << ",kTRUE,kTRUE";
@@ -676,31 +673,27 @@ void TGTripleHSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
    }
    if (!fConstrained) {
       if (fRelative)
-         out << ",kFALSE,kTRUE);" << std::endl;
+         out << ",kFALSE,kTRUE);\n";
       else
-         out << ",kFALSE,kFALSE);" << std::endl;
-   }
-   else if (fRelative) {
-      out << ",kTRUE);" << std::endl;
-   }
-   else {
-      out << ");" << std::endl;
+         out << ",kFALSE,kFALSE);\n";
+   } else if (fRelative) {
+      out << ",kTRUE);\n";
+   } else {
+      out << ");\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
    if (fVmin != 0 || fVmax != (Int_t)fWidth)
-      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax
-          << ");" << std::endl;
+      out << "   " << GetName() << "->SetRange(" << fVmin << "," << fVmax << ");\n";
 
-   if (fSmin != fWidth/8*3 || fSmax != fWidth/8*5)
-      out << "   " << GetName() << "->SetPosition(" << GetMinPosition()
-          << "," << GetMaxPosition() << ");" << std::endl;
+   if (fSmin != fWidth / 8 * 3 || fSmax != fWidth / 8 * 5)
+      out << "   " << GetName() << "->SetPosition(" << GetMinPosition() << "," << GetMaxPosition() << ");\n";
 
    if (fScale != 10)
-      out << "   " << GetName() << "->SetScale(" << fScale << ");" << std::endl;
+      out << "   " << GetName() << "->SetScale(" << fScale << ");\n";
 
-   out << "   " << GetName() << "->SetPointerPosition(" << fSCz << ");" << std::endl;
+   out << "   " << GetName() << "->SetPointerPosition(" << fSCz << ");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -711,9 +704,7 @@ void TGTripleVSlider::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/
    SaveUserColor(out, option);
 
    out << "   TGTripleVSlider *" << GetName() << " = new TGTripleVSlider(" << fParent->GetName() << "," << GetHeight()
-       << ",";
-   out << GetSString() << "," << WidgetId() << ",";
-   out << GetOptionString() << ",ucolor";
+       << "," << GetSString() << "," << WidgetId() << "," << GetOptionString() << ", ucolor";
    if (fMarkEnds) {
       if (fReversedScale)
          out << ",kTRUE,kTRUE";

--- a/gui/gui/src/TGXYLayout.cxx
+++ b/gui/gui/src/TGXYLayout.cxx
@@ -138,32 +138,38 @@ TGXYLayoutHints::TGXYLayoutHints(Double_t x, Double_t y, Double_t w, Double_t h,
 
 void TGXYLayoutHints::SavePrimitive(std::ostream &out, Option_t * /*option = ""*/)
 {
-   TString flag = "";
+   TString flag;
    if (fFlag & kLRubberX) {
-      if (flag.Length() == 0)  flag  = "TGXYLayoutHints::kLRubberX";
-      else                     flag += " | TGXYLayoutHints::kLRubberX";
+      if (flag.Length() == 0)
+         flag = "TGXYLayoutHints::kLRubberX";
+      else
+         flag += " | TGXYLayoutHints::kLRubberX";
    }
    if (fFlag & kLRubberY) {
-      if  (flag.Length() == 0) flag  = "TGXYLayoutHints::kLRubberY";
-      else                      flag += " | TGXYLayoutHints::kLRubberY";
+      if (flag.Length() == 0)
+         flag = "TGXYLayoutHints::kLRubberY";
+      else
+         flag += " | TGXYLayoutHints::kLRubberY";
    }
    if (fFlag & kLRubberW) {
-      if (flag.Length() == 0) flag  = "TGXYLayoutHints::kLRubberW";
-      else                     flag += " | TGXYLayoutHints::kLRubberW";
+      if (flag.Length() == 0)
+         flag = "TGXYLayoutHints::kLRubberW";
+      else
+         flag += " | TGXYLayoutHints::kLRubberW";
    }
    if (fFlag & kLRubberH) {
-      if (flag.Length() == 0) flag  = "TGXYLayoutHints::kLRubberH";
-      else                     flag += " | TGXYLayoutHints::kLRubberH";
+      if (flag.Length() == 0)
+         flag = "TGXYLayoutHints::kLRubberH";
+      else
+         flag += " | TGXYLayoutHints::kLRubberH";
    }
 
-   out << ", new TGXYLayoutHints(" << GetX() << ", " << GetY() << ", "
-       << GetW() << ", " << GetH();
+   out << ", new TGXYLayoutHints(" << GetX() << ", " << GetY() << ", " << GetW() << ", " << GetH();
 
    if (!flag.Length())
       out << ")";
    else
       out << ", " << flag << ")";
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -306,5 +312,4 @@ TGDimension TGXYLayout::GetDefaultSize() const
 void TGXYLayout::SavePrimitive(std::ostream &out, Option_t * /*option = ""*/)
 {
    out << "new TGXYLayout(" << fMain->GetName() << ")";
-
 }

--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -2099,11 +2099,10 @@ void TRootCanvas::Activated(Int_t id)
 
 void TRootContainer::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   out << std::endl << "   // canvas container" << std::endl;
-   out << "   Int_t canvasID = gVirtualX->InitWindow((ULongptr_t)"
-       << GetParent()->GetParent()->GetName() << "->GetId());" << std::endl;
-   out << "   Window_t winC = gVirtualX->GetWindowID(canvasID);" << std::endl;
-   out << "   TGCompositeFrame *";
-   out << GetName() << " = new TGCompositeFrame(gClient,winC"
-       << "," << GetParent()->GetName() << ");" << std::endl;
+   out << "\n   // canvas container\n";
+   out << "   Int_t canvasID = gVirtualX->InitWindow((ULongptr_t)" << GetParent()->GetParent()->GetName()
+       << "->GetId());\n";
+   out << "   Window_t winC = gVirtualX->GetWindowID(canvasID);\n";
+   out << "   TGCompositeFrame *" << GetName() << " = new TGCompositeFrame(gClient, winC, " << GetParent()->GetName()
+       << ");\n";
 }

--- a/gui/gui/src/TRootEmbeddedCanvas.cxx
+++ b/gui/gui/src/TRootEmbeddedCanvas.cxx
@@ -535,43 +535,37 @@ Bool_t TRootEmbeddedCanvas::HandleDNDLeave()
 
 void TRootEmbeddedCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   if (!GetCanvas()) return;
+   if (!GetCanvas())
+      return;
 
-   if (fBackground != GetDefaultFrameBackground()) SaveUserColor(out, option);
+   if (fBackground != GetDefaultFrameBackground())
+      SaveUserColor(out, option);
 
-   char quote ='"';
-
-   out << std::endl << "   // embedded canvas" << std::endl;
-   out << "   TRootEmbeddedCanvas *";
-   out << GetName() << " = new TRootEmbeddedCanvas(0" << "," << fParent->GetName()
-       << "," << GetWidth() << "," << GetHeight();
+   out << std::endl << "\n   // embedded canvas\n";
+   out << "   TRootEmbeddedCanvas *" << GetName() << " = new TRootEmbeddedCanvas(0" << "," << fParent->GetName() << ","
+       << GetWidth() << "," << GetHeight();
 
    if (fBackground == GetDefaultFrameBackground()) {
       if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out <<");" << std::endl;
+         out << ");\n";
       } else {
-         out << "," << GetOptionString() <<");" << std::endl;
+         out << "," << GetOptionString() << ");\n";
       }
    } else {
-      out << "," << GetOptionString() << ",ucolor);" << std::endl;
+      out << "," << GetOptionString() << ",ucolor);\n";
    }
    if (option && strstr(option, "keep_names"))
-      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 
-   out << "   Int_t w" << GetName() << " = " << GetName()
-       << "->GetCanvasWindowId();" << std::endl;
+   out << "   Int_t w" << GetName() << " = " << GetName() << "->GetCanvasWindowId();\n";
 
    static int n = 123;
    TString cname = TString::Format("c%d", n);
 
-   out << "   TCanvas *";
-   out <<  cname << " = new TCanvas(";
-   out << quote << cname.Data() << quote << ", 10, 10, w"
-       << GetName() << ");" << std::endl;
-   out << "   " << GetName() << "->AdoptCanvas(" << cname
-       << ");" << std::endl;
+   out << "   TCanvas *" << cname << " = new TCanvas(\"" << cname << "\", 10, 10, w" << GetName() << ");\n";
+   out << "   " << GetName() << "->AdoptCanvas(" << cname << ");\n";
 
    n++;
-   //Next line is a connection to TCanvas::SavePrimitives()
-   //GetCanvas()->SavePrimitive(out,option);
+   // Next line is a connection to TCanvas::SavePrimitives()
+   // GetCanvas()->SavePrimitive(out,option);
 }

--- a/gui/gui/src/TRootEmbeddedCanvas.cxx
+++ b/gui/gui/src/TRootEmbeddedCanvas.cxx
@@ -538,22 +538,12 @@ void TRootEmbeddedCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= 
    if (!GetCanvas())
       return;
 
-   if (fBackground != GetDefaultFrameBackground())
-      SaveUserColor(out, option);
+   auto extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder);
 
-   out << std::endl << "\n   // embedded canvas\n";
+   out << "\n   // embedded canvas\n";
    out << "   TRootEmbeddedCanvas *" << GetName() << " = new TRootEmbeddedCanvas(0" << "," << fParent->GetName() << ","
-       << GetWidth() << "," << GetHeight();
+       << GetWidth() << "," << GetHeight() << extra_args << ");\n";
 
-   if (fBackground == GetDefaultFrameBackground()) {
-      if (GetOptions() == (kSunkenFrame | kDoubleBorder)) {
-         out << ");\n";
-      } else {
-         out << "," << GetOptionString() << ");\n";
-      }
-   } else {
-      out << "," << GetOptionString() << ",ucolor);\n";
-   }
    if (option && strstr(option, "keep_names"))
       out << "   " << GetName() << "->SetName(\"" << GetName() << "\");\n";
 

--- a/tutorials/visualisation/gui/drag_and_drop.C
+++ b/tutorials/visualisation/gui/drag_and_drop.C
@@ -183,13 +183,13 @@ DNDMainFrame::DNDMainFrame(const TGWindow *p, int w, int h) : TGMainFrame(p, w, 
    fListTree->SetToolTipItem(item, "2D Histogram");
    item->SetDNDSource(kTRUE);
 
-   TString rootsys(gSystem->UnixPathName(gSystem->Getenv("ROOTSYS")));
+   TString link = gROOT->GetTutorialsDir();
 #ifdef R__WIN32
    // remove the drive letter (e.g. "C:/") from $ROOTSYS, if any
-   if (rootsys[1] == ':' && rootsys[2] == '/')
-      rootsys.Remove(0, 3);
+   if (link[1] == ':' && link[2] == '/')
+      link.Remove(0, 3);
 #endif
-   TString link = TString::Format("/%s/tutorials/visualisation/image/rose512.jpg", rootsys.Data());
+   link.Append("/visualisation/image/rose512.jpg");
    if (!gSystem->AccessPathName(link.Data(), kReadPermission)) {
       TImage *img = TImage::Open(link.Data());
       if (img) {


### PR DESCRIPTION
1. Introduce `TGFrame::SaveCrtrArgs` method to prepare options and custom color for use in saved constructor. There are many places in code where such combination handled with many if statements
2. Use new method where it make sence
3. Replace std::endl by `\n` and quote by `\"`
4. ~~Fix several problems where with custom colors also font and `uGC->GetGC()` must be initialized. Otherwise when saved into the macro arguments will remain empty~~, not necessary
5. Add to TGMainFrame::SavePrimitive several commands to popup window
6. Always use TString::ReplaceSpecialCppChars when saving text or tooltips
7. Simplify implementation of `TGFrame::GetOptionString()`

Tested with several macros from tutorials like calendar.C or listBox.C or statusBar.C