### PR TITLE
[ntuple] Move Descriptor classes out of Experimental

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -56,7 +56,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    };
 
    /// A clone of the first pages source's descriptor.
-   RNTupleDescriptor fPrincipalDescriptor;
+   ROOT::RNTupleDescriptor fPrincipalDescriptor;
 
    /// The data source may be constructed with an ntuple name and a list of files
    std::string fNTupleName;
@@ -149,7 +149,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// column is added as a `ROOT::VecOps::RVec`. Otherwise, the collection field's on-disk type is used. Note, however,
    /// that inner record members of such collections will still be added as `ROOT::VecOps::RVec` (e.g., `std::set<Jet>
    /// will be added as a `std::set`, but `Jet.[pt|eta] will be added as `ROOT::VecOps::RVec<float>).
-   void AddField(const RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
+   void AddField(const ROOT::RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
                  std::vector<RFieldInfo> fieldInfos, bool convertToRVec = true);
 
    /// The main function of the fThreadStaging background thread

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -86,7 +86,7 @@ public:
    }
    // Field is only used for reading
    void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumns(const RNTupleDescriptor &desc) final
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final
    {
       GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
    }
@@ -239,7 +239,7 @@ public:
 
 RNTupleDS::~RNTupleDS() = default;
 
-void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
+void RNTupleDS::AddField(const ROOT::RNTupleDescriptor &desc, std::string_view colName, ROOT::DescriptorId_t fieldId,
                          std::vector<RNTupleDS::RFieldInfo> fieldInfos, bool convertToRVec)
 {
    // As an example for the mapping of RNTuple fields to RDF columns, let's consider an RNTuple

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -128,7 +128,7 @@ private:
       return std::make_unique<RArraySizeField>(fArrayLength);
    }
    void GenerateColumns() final { assert(false && "RArraySizeField fields must only be used for reading"); }
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final {}
+   void GenerateColumns(const ROOT::RNTupleDescriptor &) final {}
    void ReadGlobalImpl(ROOT::NTupleSize_t /*globalIndex*/, void *to) final
    {
       *static_cast<std::size_t *>(to) = fArrayLength;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -166,22 +166,21 @@ private:
 
    /// Returns the id of member 'name' in the class field given by 'fieldId', or kInvalidDescriptorId if no such
    /// member exist. Looks recursively in base classes.
-   ROOT::DescriptorId_t LookupMember(const ROOT::Experimental::RNTupleDescriptor &desc, std::string_view memberName,
-                                     ROOT::DescriptorId_t classFieldId);
+   ROOT::DescriptorId_t
+   LookupMember(const ROOT::RNTupleDescriptor &desc, std::string_view memberName, ROOT::DescriptorId_t classFieldId);
    /// Sets fStagingClass according to the given name and version
    void SetStagingClass(const std::string &className, unsigned int classVersion);
    /// If there are rules with inputs (source members), create the staging area according to the TClass instance
    /// that corresponds to the on-disk field.
-   void PrepareStagingArea(const std::vector<const TSchemaRule *> &rules,
-                           const ROOT::Experimental::RNTupleDescriptor &desc,
-                           const ROOT::Experimental::RFieldDescriptor &classFieldId);
+   void PrepareStagingArea(const std::vector<const TSchemaRule *> &rules, const ROOT::RNTupleDescriptor &desc,
+                           const ROOT::RFieldDescriptor &classFieldId);
    /// Register post-read callback corresponding to a ROOT I/O customization rules.
    void AddReadCallbacksFromIORule(const TSchemaRule *rule);
    /// Given the on-disk information from the page source, find all the I/O customization rules that apply
    /// to the class field at hand, to which the fieldDesc descriptor, if provided, must correspond.
    /// Fields may not have an on-disk representation (e.g., when inserted by schema evolution), in which case the passed
    /// field descriptor is nullptr.
-   std::vector<const TSchemaRule *> FindRules(const ROOT::Experimental::RFieldDescriptor *fieldDesc);
+   std::vector<const TSchemaRule *> FindRules(const ROOT::RFieldDescriptor *fieldDesc);
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -233,7 +232,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RStreamerFieldDeleter>(fClass); }
@@ -245,7 +244,7 @@ protected:
 
    bool HasExtraTypeInfo() const final { return true; }
    // Returns the list of seen streamer infos
-   ROOT::Experimental::RExtraTypeInfoDescriptor GetExtraTypeInfo() const final;
+   ROOT::RExtraTypeInfoDescriptor GetExtraTypeInfo() const final;
 
 public:
    RStreamerField(std::string_view fieldName, std::string_view className, std::string_view typeAlias = "");
@@ -338,7 +337,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    // Field is only used for reading
    void GenerateColumns() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &) final;
 
 public:
    RCardinalityField(RCardinalityField &&other) = default;
@@ -355,7 +354,7 @@ template <typename T>
 class RSimpleField : public RFieldBase {
 protected:
    void GenerateColumns() override { GenerateColumnsImpl<T>(); }
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) override { GenerateColumnsImpl<T>(desc); }
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) override { GenerateColumnsImpl<T>(desc); }
 
    void ConstructValue(void *where) const final { new (where) T{0}; }
 

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -390,7 +390,7 @@ protected:
       fPrincipalColumn = fAvailableColumns[0].get();
    }
 
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final
    {
       std::uint16_t representationIndex = 0;
       do {

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -162,7 +162,7 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -102,7 +102,7 @@ protected:
    }
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
    void ConstructValue(void *where) const final { memset(where, 0, GetValueSize()); }
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
@@ -173,7 +173,7 @@ class RNullableField : public RFieldBase {
 protected:
    const RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &) final;
 
    std::size_t AppendNull();
    std::size_t AppendValue(const void *from);
@@ -301,7 +301,7 @@ private:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::string(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::string>>(); }
@@ -377,7 +377,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -133,7 +133,7 @@ protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -217,7 +217,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::vector<char>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final;
@@ -276,7 +276,7 @@ protected:
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumns() final;
-   void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc) final;
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
    void ConstructValue(void *where) const final { new (where) std::vector<bool>(); }
    std::unique_ptr<RDeleter> GetDeleter() const final { return std::make_unique<RTypedDeleter<std::vector<bool>>>(); }

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -61,7 +61,7 @@ void CallConnectPageSinkOnField(RFieldBase &, ROOT::Experimental::Internal::RPag
 void CallConnectPageSourceOnField(RFieldBase &, ROOT::Experimental::Internal::RPageSource &);
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
 CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
-                    const ROOT::Experimental::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
+                    const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 } // namespace Internal
 
@@ -92,8 +92,8 @@ class RFieldBase {
    friend void Internal::CallConnectPageSourceOnField(RFieldBase &, ROOT::Experimental::Internal::RPageSource &);
    friend ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
    Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
-                                 const ROOT::RCreateFieldOptions &options,
-                                 const ROOT::Experimental::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
+                                 const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
+                                 ROOT::DescriptorId_t fieldId);
 
    using ReadCallback_t = std::function<void(void *)>;
 
@@ -344,7 +344,7 @@ protected:
 
    /// For reading, use the on-disk column list
    template <typename... ColumnCppTs>
-   void GenerateColumnsImpl(const ROOT::Experimental::RNTupleDescriptor &desc)
+   void GenerateColumnsImpl(const ROOT::RNTupleDescriptor &desc)
    {
       std::uint16_t representationIndex = 0;
       do {
@@ -372,15 +372,15 @@ protected:
    /// Implementations in derived classes should create the backing columns corresponsing to the field type for reading.
    /// The default implementation does not attach any columns to the field. The method should check, using the page
    /// source and fOnDiskId, if the column types match and throw if they don't.
-   virtual void GenerateColumns(const ROOT::Experimental::RNTupleDescriptor & /*desc*/) {}
+   virtual void GenerateColumns(const ROOT::RNTupleDescriptor & /*desc*/) {}
    /// Returns the on-disk column types found in the provided descriptor for fOnDiskId and the given
    /// representation index. If there are no columns for the given representation index, return an empty
    /// ColumnRepresentation_t list. Otherwise, the returned reference points into the static array returned by
    /// GetColumnRepresentations().
    /// Throws an exception if the types on disk don't match any of the deserialization types from
    /// GetColumnRepresentations().
-   const ColumnRepresentation_t &EnsureCompatibleColumnTypes(const ROOT::Experimental::RNTupleDescriptor &desc,
-                                                             std::uint16_t representationIndex) const;
+   const ColumnRepresentation_t &
+   EnsureCompatibleColumnTypes(const ROOT::RNTupleDescriptor &desc, std::uint16_t representationIndex) const;
    /// When connecting a field to a page sink, the field's default column representation is subject
    /// to adjustment according to the write options. E.g., if compression is turned off, encoded columns
    /// are changed to their unencoded counterparts.
@@ -476,10 +476,7 @@ protected:
    // The page sink's callback when the data set gets committed will call this method to get the field's extra
    // type information. This has to happen at the end of writing because the type information may change depending
    // on the data that's written, e.g. for polymorphic types in the streamer field.
-   virtual ROOT::Experimental::RExtraTypeInfoDescriptor GetExtraTypeInfo() const
-   {
-      return ROOT::Experimental::RExtraTypeInfoDescriptor();
-   }
+   virtual ROOT::RExtraTypeInfoDescriptor GetExtraTypeInfo() const { return ROOT::RExtraTypeInfoDescriptor(); }
 
    /// Add a new subfield to the list of nested fields
    void Attach(std::unique_ptr<RFieldBase> child);
@@ -495,7 +492,7 @@ protected:
    /// `desc` and `fieldId` must be passed if `options.fEmulateUnknownTypes` is true, otherwise they can be left blank.
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
-          const ROOT::Experimental::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
+          const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 public:
    template <bool IsConstT>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1591,6 +1591,25 @@ inline RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc)
 }
 
 } // namespace Internal
+
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using RNTupleDescriptor [[deprecated("ROOT::Experimental::RNTupleDescriptor moved to ROOT::RNTupleDescriptor")]] =
+   ROOT::RNTupleDescriptor;
+using RFieldDescriptor [[deprecated("ROOT::Experimental::RFieldDescriptor moved to ROOT::RFieldDescriptor")]] =
+   ROOT::RFieldDescriptor;
+using RColumnDescriptor [[deprecated("ROOT::Experimental::RColumnDescriptor moved to ROOT::RColumnDescriptor")]] =
+   ROOT::RColumnDescriptor;
+using RClusterDescriptor [[deprecated("ROOT::Experimental::RClusterDescriptor moved to ROOT::RClusterDescriptor")]] =
+   ROOT::RClusterDescriptor;
+using RClusterGroupDescriptor
+   [[deprecated("ROOT::Experimental::RClusterGroupDescriptor moved to ROOT::RClusterGroupDescriptor")]] =
+      ROOT::RClusterGroupDescriptor;
+using RExtraTypeInfoDescriptor
+   [[deprecated("ROOT::Experimental::RExtraTypeInfoDescriptor moved to ROOT::RExtraTypeInfoDescriptor")]] =
+      ROOT::RExtraTypeInfoDescriptor;
+} // namespace Experimental
+
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleDescriptor

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -51,8 +51,11 @@ class RColumnElementBase;
 
 namespace Experimental {
 
-class RNTupleDescriptor;
 class RNTupleModel;
+
+}
+
+class RNTupleDescriptor;
 
 namespace Internal {
 class RColumnDescriptorBuilder;
@@ -67,7 +70,7 @@ RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc);
 
 // clang-format off
 /**
-\class ROOT::Experimental::RFieldDescriptor
+\class ROOT::RFieldDescriptor
 \ingroup NTuple
 \brief Meta-data stored for every field of an ntuple
 */
@@ -151,7 +154,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RColumnDescriptor
+\class ROOT::RColumnDescriptor
 \ingroup NTuple
 \brief Meta-data stored for every column of an ntuple
 */
@@ -223,7 +226,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RClusterDescriptor
+\class ROOT::RClusterDescriptor
 \ingroup NTuple
 \brief Meta-data for a set of ntuple clusters
 
@@ -309,7 +312,7 @@ public:
 
    // clang-format off
    /**
-   \class ROOT::Experimental::RClusterDescriptor::RPageInfo
+   \class ROOT::RClusterDescriptor::RPageInfo
    \ingroup NTuple
    \brief Information about a single page in the context of a cluster's page range.
    */
@@ -371,7 +374,7 @@ public:
 
    // clang-format off
    /**
-   \class ROOT::Experimental::RClusterDescriptor::RPageRange
+   \class ROOT::RClusterDescriptor::RPageRange
    \ingroup NTuple
    \brief Records the partition of data into pages for a particular column in a particular cluster
    */
@@ -503,7 +506,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RClusterGroupDescriptor
+\class ROOT::RClusterGroupDescriptor
 \ingroup NTuple
 \brief Clusters are bundled in cluster groups.
 
@@ -565,7 +568,7 @@ enum class EExtraTypeInfoIds {
 
 // clang-format off
 /**
-\class ROOT::Experimental::RExtraTypeInfoDescriptor
+\class ROOT::RExtraTypeInfoDescriptor
 \ingroup NTuple
 \brief Field specific extra type information from the header / extenstion header
 
@@ -604,7 +607,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor
+\class ROOT::RNTupleDescriptor
 \ingroup NTuple
 \brief The on-storage meta-data of an ntuple
 
@@ -825,13 +828,14 @@ public:
    void IncGeneration() { fGeneration++; }
 
    /// Re-create the C++ model from the stored meta-data
-   std::unique_ptr<RNTupleModel> CreateModel(const RCreateModelOptions &options = RCreateModelOptions()) const;
+   std::unique_ptr<ROOT::Experimental::RNTupleModel>
+   CreateModel(const RCreateModelOptions &options = RCreateModelOptions()) const;
    void PrintInfo(std::ostream &output) const;
 };
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable
+\class ROOT::RNTupleDescriptor::RColumnDescriptorIterable
 \ingroup NTuple
 \brief Used to loop over a field's associated columns
 */
@@ -885,7 +889,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
+\class ROOT::RNTupleDescriptor::RFieldDescriptorIterable
 \ingroup NTuple
 \brief Used to loop over a field's child fields
 */
@@ -946,7 +950,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RClusterGroupDescriptorIterable
+\class ROOT::RNTupleDescriptor::RClusterGroupDescriptorIterable
 \ingroup NTuple
 \brief Used to loop over all the cluster groups of an ntuple (in unspecified order)
 
@@ -997,7 +1001,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RClusterDescriptorIterable
+\class ROOT::RNTupleDescriptor::RClusterDescriptorIterable
 \ingroup NTuple
 \brief Used to loop over all the clusters of an ntuple (in unspecified order)
 
@@ -1048,7 +1052,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RExtraTypeInfoDescriptorIterable
+\class ROOT::RNTupleDescriptor::RExtraTypeInfoDescriptorIterable
 \ingroup NTuple
 \brief Used to loop over all the extra type info record of an ntuple (in unspecified order)
 */
@@ -1096,7 +1100,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDescriptor::RHeaderExtension
+\class ROOT::RNTupleDescriptor::RHeaderExtension
 \ingroup NTuple
 \brief Summarizes information about fields and the corresponding columns that were added after the header has been serialized
 */
@@ -1171,7 +1175,7 @@ namespace Internal {
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RColumnDescriptorBuilder
+\class ROOT::Internal::RColumnDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RColumnDescriptor
 
@@ -1253,7 +1257,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RFieldDescriptorBuilder
+\class ROOT::Internal::RFieldDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RFieldDescriptor
 
@@ -1352,7 +1356,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RClusterDescriptorBuilder
+\class ROOT::Internal::RClusterDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RClusterDescriptor
 
@@ -1413,7 +1417,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder
+\class ROOT::Internal::RClusterGroupDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RClusterGroupDescriptor
 */
@@ -1468,7 +1472,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder
+\class ROOT::Internal::RExtraTypeInfoDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RExtraTypeInfoDescriptor
 */
@@ -1506,7 +1510,7 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::Internal::RNTupleDescriptorBuilder
+\class ROOT::Internal::RNTupleDescriptorBuilder
 \ingroup NTuple
 \brief A helper class for piece-wise construction of an RNTupleDescriptor
 
@@ -1578,7 +1582,7 @@ public:
    void ShiftAliasColumns(std::uint32_t offset);
 
    /// Get the streamer info records for custom classes. Currently requires the corresponding dictionaries to be loaded.
-   RNTupleSerializer::StreamerInfoMap_t BuildStreamerInfos() const;
+   ROOT::Experimental::Internal::RNTupleSerializer::StreamerInfoMap_t BuildStreamerInfos() const;
 };
 
 inline RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc)
@@ -1587,7 +1591,6 @@ inline RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc)
 }
 
 } // namespace Internal
-} // namespace Experimental
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleDescriptor

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -95,7 +95,7 @@ class RNTupleMerger final {
    std::optional<TTaskGroup> fTaskGroup;
    std::unique_ptr<RNTupleModel> fModel;
 
-   void MergeCommonColumns(RClusterPool &clusterPool, const RClusterDescriptor &clusterDesc,
+   void MergeCommonColumns(RClusterPool &clusterPool, const ROOT::RClusterDescriptor &clusterDesc,
                            std::span<const RColumnMergeInfo> commonColumns,
                            const RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
                            RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -86,10 +86,10 @@ private:
    /// descriptor.  Using the descriptor's generation number, we know if the cached descriptor is stale.
    /// Retrieving descriptor data from an RNTupleReader is supposed to be for testing and information purposes,
    /// not on a hot code path.
-   std::optional<RNTupleDescriptor> fCachedDescriptor;
+   std::optional<ROOT::RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
    /// If not nullopt, these will used when creating the model
-   std::optional<RNTupleDescriptor::RCreateModelOptions> fCreateModelOptions;
+   std::optional<ROOT::RNTupleDescriptor::RCreateModelOptions> fCreateModelOptions;
 
    RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Internal::RPageSource> source,
                  const ROOT::RNTupleReadOptions &options);
@@ -164,10 +164,10 @@ public:
                                               const ROOT::RNTupleReadOptions &options = ROOT::RNTupleReadOptions());
 
    /// The caller imposes the way the model is reconstructed
-   static std::unique_ptr<RNTupleReader> Open(const RNTupleDescriptor::RCreateModelOptions &createModelOpts,
+   static std::unique_ptr<RNTupleReader> Open(const ROOT::RNTupleDescriptor::RCreateModelOptions &createModelOpts,
                                               std::string_view ntupleName, std::string_view storage,
                                               const ROOT::RNTupleReadOptions &options = ROOT::RNTupleReadOptions());
-   static std::unique_ptr<RNTupleReader> Open(const RNTupleDescriptor::RCreateModelOptions &createModelOpts,
+   static std::unique_ptr<RNTupleReader> Open(const ROOT::RNTupleDescriptor::RCreateModelOptions &createModelOpts,
                                               const RNTuple &ntuple,
                                               const ROOT::RNTupleReadOptions &options = ROOT::RNTupleReadOptions());
    std::unique_ptr<RNTupleReader> Clone()
@@ -184,7 +184,7 @@ public:
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call
    /// to LoadEntry or to any of the views returned from the reader.
-   const RNTupleDescriptor &GetDescriptor();
+   const ROOT::RNTupleDescriptor &GetDescriptor();
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
    ///
@@ -228,7 +228,7 @@ public:
       // TODO(jblomer): can be templated depending on the factory method / constructor
       if (R__unlikely(!fModel)) {
          fModel = fSource->GetSharedDescriptorGuard()->CreateModel(
-            fCreateModelOptions.value_or(RNTupleDescriptor::RCreateModelOptions{}));
+            fCreateModelOptions.value_or(ROOT::RNTupleDescriptor::RCreateModelOptions{}));
          ConnectModel(*fModel);
       }
       LoadEntry(index, fModel->GetDefaultEntry());

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -33,17 +33,20 @@
 class TVirtualStreamerInfo;
 
 namespace ROOT {
-namespace Experimental {
 
-enum class EExtraTypeInfoIds;
-class RClusterDescriptor;
 class RNTupleDescriptor;
+class RClusterDescriptor;
+enum class EExtraTypeInfoIds;
 
 namespace Internal {
 
 class RClusterDescriptorBuilder;
 class RNTupleDescriptorBuilder;
 
+} // namespace Internal
+
+namespace Experimental {
+namespace Internal {
 // clang-format off
 /**
 \class ROOT::Experimental::Internal::RNTupleSerializer
@@ -59,7 +62,7 @@ Deserialization errors throw exceptions. Only when indicated or when passed as a
 */
 // clang-format on
 class RNTupleSerializer {
-   static RResult<std::vector<RClusterDescriptorBuilder>>
+   static RResult<std::vector<ROOT::Internal::RClusterDescriptorBuilder>>
    DeserializePageListRaw(const void *buffer, std::uint64_t bufSize, ROOT::DescriptorId_t clusterGroupId,
                           const RNTupleDescriptor &desc);
 
@@ -225,11 +228,10 @@ public:
    /// in order to avoid accidentally changing the on-disk numbers when adjusting the enum classes.
    static RResult<std::uint32_t> SerializeFieldStructure(ROOT::ENTupleStructure structure, void *buffer);
    static RResult<std::uint32_t> SerializeColumnType(ROOT::ENTupleColumnType type, void *buffer);
-   static RResult<std::uint32_t> SerializeExtraTypeInfoId(ROOT::Experimental::EExtraTypeInfoIds id, void *buffer);
+   static RResult<std::uint32_t> SerializeExtraTypeInfoId(ROOT::EExtraTypeInfoIds id, void *buffer);
    static RResult<std::uint32_t> DeserializeFieldStructure(const void *buffer, ROOT::ENTupleStructure &structure);
    static RResult<std::uint32_t> DeserializeColumnType(const void *buffer, ROOT::ENTupleColumnType &type);
-   static RResult<std::uint32_t>
-   DeserializeExtraTypeInfoId(const void *buffer, ROOT::Experimental::EExtraTypeInfoIds &id);
+   static RResult<std::uint32_t> DeserializeExtraTypeInfoId(const void *buffer, ROOT::EExtraTypeInfoIds &id);
 
    static std::uint32_t SerializeEnvelopePreamble(std::uint16_t envelopeType, void *buffer);
    static RResult<std::uint32_t> SerializeEnvelopePostscript(unsigned char *envelope, std::uint64_t size);
@@ -272,8 +274,8 @@ public:
    /// fields and columns tagged as part of the header extension (see `RNTupleDescriptorBuilder::BeginHeaderExtension`).
    static RResult<std::uint32_t> SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc,
                                                             const RContext &context, bool forHeaderExtension = false);
-   static RResult<std::uint32_t>
-   DeserializeSchemaDescription(const void *buffer, std::uint64_t bufSize, RNTupleDescriptorBuilder &descBuilder);
+   static RResult<std::uint32_t> DeserializeSchemaDescription(const void *buffer, std::uint64_t bufSize,
+                                                              ROOT::Internal::RNTupleDescriptorBuilder &descBuilder);
 
    static RResult<RContext> SerializeHeader(void *buffer, const RNTupleDescriptor &desc);
    static RResult<std::uint32_t> SerializePageList(void *buffer, const RNTupleDescriptor &desc,
@@ -282,9 +284,9 @@ public:
    static RResult<std::uint32_t> SerializeFooter(void *buffer, const RNTupleDescriptor &desc, const RContext &context);
 
    static RResult<void>
-   DeserializeHeader(const void *buffer, std::uint64_t bufSize, RNTupleDescriptorBuilder &descBuilder);
+   DeserializeHeader(const void *buffer, std::uint64_t bufSize, ROOT::Internal::RNTupleDescriptorBuilder &descBuilder);
    static RResult<void>
-   DeserializeFooter(const void *buffer, std::uint64_t bufSize, RNTupleDescriptorBuilder &descBuilder);
+   DeserializeFooter(const void *buffer, std::uint64_t bufSize, ROOT::Internal::RNTupleDescriptorBuilder &descBuilder);
 
    enum class EDescriptorDeserializeMode {
       /// Deserializes the descriptor as-is without performing any additional fixup. The produced descriptor is

--- a/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageNullSink.hxx
@@ -47,9 +47,9 @@ public:
       return {fNColumns++, &column};
    }
 
-   const RNTupleDescriptor &GetDescriptor() const final
+   const ROOT::RNTupleDescriptor &GetDescriptor() const final
    {
-      static RNTupleDescriptor descriptor;
+      static ROOT::RNTupleDescriptor descriptor;
       return descriptor;
    }
 
@@ -76,7 +76,7 @@ public:
    {
       ConnectFields(changeset.fAddedFields, firstEntry);
    }
-   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &) final {}
+   void UpdateExtraTypeInfo(const ROOT::RExtraTypeInfoDescriptor &) final {}
 
    void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitPage(ColumnHandle_t, const ROOT::Internal::RPage &page) final

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -131,13 +131,13 @@ public:
 
    ColumnHandle_t AddColumn(ROOT::DescriptorId_t fieldId, ROOT::Internal::RColumn &column) final;
 
-   const RNTupleDescriptor &GetDescriptor() const final;
+   const ROOT::RNTupleDescriptor &GetDescriptor() const final;
 
    ROOT::NTupleSize_t GetNEntries() const final { return fInnerSink->GetNEntries(); }
 
    void InitImpl(RNTupleModel &model) final;
    void UpdateSchema(const RNTupleModelChangeset &changeset, ROOT::NTupleSize_t firstEntry) final;
-   void UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo) final;
+   void UpdateExtraTypeInfo(const ROOT::RExtraTypeInfoDescriptor &extraTypeInfo) final;
 
    void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const ROOT::Internal::RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -269,7 +269,7 @@ public:
       ROOT::NTupleSize_t fNEntries = 0;
 
       struct RColumnInfo {
-         RClusterDescriptor::RPageRange fPageRange;
+         ROOT::RClusterDescriptor::RPageRange fPageRange;
          ROOT::NTupleSize_t fNElements = ROOT::kInvalidNTupleIndex;
          std::uint32_t fCompressionSettings;
          bool fIsSuppressed = false;
@@ -448,9 +448,9 @@ private:
    /// Used to calculate the number of entries in the current cluster
    ROOT::NTupleSize_t fPrevClusterNEntries = 0;
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.
-   std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;
+   std::vector<ROOT::RClusterDescriptor::RColumnRange> fOpenColumnRanges;
    /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
-   std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
+   std::vector<ROOT::RClusterDescriptor::RPageRange> fOpenPageRanges;
 
    /// Union of the streamer info records that are sent from streamer fields to the sink before committing the dataset.
    RNTupleSerializer::StreamerInfoMap_t fStreamerInfos;
@@ -462,7 +462,7 @@ protected:
    };
 
    RFeatures fFeatures;
-   Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
+   ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
    /// Default I/O performance counters that get registered in fMetrics
    struct RCounters {
@@ -688,7 +688,7 @@ protected:
    struct RClusterInfo {
       ROOT::DescriptorId_t fClusterId = 0;
       /// Location of the page on disk
-      RClusterDescriptor::RPageInfoExtended fPageInfo;
+      ROOT::RClusterDescriptor::RPageInfoExtended fPageInfo;
       /// The first element number of the page's column in the given cluster
       std::uint64_t fColumnOffset = 0;
    };
@@ -718,7 +718,8 @@ protected:
    /// commonly used as part of `LoadClusters()` in derived classes.
    void PrepareLoadCluster(
       const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap,
-      std::function<void(ROOT::DescriptorId_t, ROOT::NTupleSize_t, const RClusterDescriptor::RPageInfo &)> perPageFunc);
+      std::function<void(ROOT::DescriptorId_t, ROOT::NTupleSize_t, const ROOT::RClusterDescriptor::RPageInfo &)>
+         perPageFunc);
 
    /// Enables the default set of metrics provided by RPageSource. `prefix` will be used as the prefix for
    /// the counters registered in the internal RNTupleMetrics object.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -166,7 +166,7 @@ private:
 
 protected:
    void LoadStructureImpl() final {}
-   RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
+   ROOT::RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
    /// The cloned page source creates a new connection to the pool/container.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -159,7 +159,7 @@ private:
    /// The cluster pool asynchronously preloads the next few clusters
    std::unique_ptr<RClusterPool> fClusterPool;
 
-   RNTupleDescriptorBuilder fDescriptorBuilder;
+   ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
    ROOT::Internal::RPageRef
    LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, ROOT::NTupleSize_t idxInCluster) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -158,7 +158,7 @@ private:
 
 protected:
    void LoadStructureImpl() final;
-   RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
+   ROOT::RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
    /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -141,7 +141,7 @@ private:
    /// Takes the fFile to read ntuple blobs from it
    RMiniFileReader fReader;
    /// The descriptor is created from the header and footer either in AttachImpl or in CreateFromAnchor
-   RNTupleDescriptorBuilder fDescriptorBuilder;
+   ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
    /// The cluster pool asynchronously preloads the next few clusters
    std::unique_ptr<RClusterPool> fClusterPool;
    /// Populated by LoadStructureImpl(), reset at the end of Attach()

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -56,7 +56,7 @@ const ROOT::RFieldBase::RColumnRepresentations &ROOT::RCardinalityField::GetColu
    return representations;
 }
 
-void ROOT::RCardinalityField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RCardinalityField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
@@ -445,7 +445,7 @@ void ROOT::RField<std::string>::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, char>();
 }
 
-void ROOT::RField<std::string>::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RField<std::string>::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, char>(desc);
 }
@@ -643,7 +643,7 @@ void ROOT::RBitsetField::GenerateColumns()
    GenerateColumnsImpl<bool>();
 }
 
-void ROOT::RBitsetField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RBitsetField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<bool>(desc);
 }
@@ -716,7 +716,7 @@ void ROOT::RNullableField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::RNullableField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RNullableField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }

--- a/tree/ntuple/v7/src/RFieldBase.cxx
+++ b/tree/ntuple/v7/src/RFieldBase.cxx
@@ -88,8 +88,8 @@ void ROOT::Internal::CallConnectPageSourceOnField(RFieldBase &field, ROOT::Exper
 
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
 ROOT::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
-                                    const ROOT::RCreateFieldOptions &options,
-                                    const ROOT::Experimental::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId)
+                                    const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
+                                    ROOT::DescriptorId_t fieldId)
 {
    return RFieldBase::Create(fieldName, typeName, options, desc, fieldId);
 }
@@ -291,7 +291,7 @@ ROOT::RFieldBase::Check(const std::string &fieldName, const std::string &typeNam
 
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
 ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeName,
-                         const ROOT::RCreateFieldOptions &options, const ROOT::Experimental::RNTupleDescriptor *desc,
+                         const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
                          ROOT::DescriptorId_t fieldId)
 {
    using ROOT::Internal::ParseArrayType;
@@ -872,7 +872,7 @@ void ROOT::RFieldBase::SetColumnRepresentatives(const RColumnRepresentations::Se
 }
 
 const ROOT::RFieldBase::ColumnRepresentation_t &
-ROOT::RFieldBase::EnsureCompatibleColumnTypes(const ROOT::Experimental::RNTupleDescriptor &desc,
+ROOT::RFieldBase::EnsureCompatibleColumnTypes(const ROOT::RNTupleDescriptor &desc,
                                               std::uint16_t representationIndex) const
 {
    static const ColumnRepresentation_t kEmpty;
@@ -997,7 +997,7 @@ void ROOT::RFieldBase::ConnectPageSource(ROOT::Experimental::Internal::RPageSour
    // Do not generate columns nor set fColumnRepresentatives for artificial fields.
    if (!fIsArtificial) {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
-      const ROOT::Experimental::RNTupleDescriptor &desc = descriptorGuard.GetRef();
+      const ROOT::RNTupleDescriptor &desc = descriptorGuard.GetRef();
       GenerateColumns(desc);
       if (fColumnRepresentatives.empty()) {
          // If we didn't get columns from the descriptor, ensure that we actually expect a field without columns

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -193,8 +193,7 @@ void ROOT::RClassField::Attach(std::unique_ptr<RFieldBase> child, RSubFieldInfo 
    RFieldBase::Attach(std::move(child));
 }
 
-std::vector<const ROOT::TSchemaRule *>
-ROOT::RClassField::FindRules(const ROOT::Experimental::RFieldDescriptor *fieldDesc)
+std::vector<const ROOT::TSchemaRule *> ROOT::RClassField::FindRules(const ROOT::RFieldDescriptor *fieldDesc)
 {
    ROOT::Detail::TSchemaRuleSet::TMatches rules;
    const auto ruleset = fClass->GetSchemaRules();
@@ -312,8 +311,8 @@ void ROOT::RClassField::ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to
    }
 }
 
-ROOT::DescriptorId_t ROOT::RClassField::LookupMember(const ROOT::Experimental::RNTupleDescriptor &desc,
-                                                     std::string_view memberName, ROOT::DescriptorId_t classFieldId)
+ROOT::DescriptorId_t ROOT::RClassField::LookupMember(const ROOT::RNTupleDescriptor &desc, std::string_view memberName,
+                                                     ROOT::DescriptorId_t classFieldId)
 {
    auto idSourceMember = desc.FindFieldId(memberName, classFieldId);
    if (idSourceMember != ROOT::kInvalidDescriptorId)
@@ -343,8 +342,8 @@ void ROOT::RClassField::SetStagingClass(const std::string &className, unsigned i
 }
 
 void ROOT::RClassField::PrepareStagingArea(const std::vector<const TSchemaRule *> &rules,
-                                           const ROOT::Experimental::RNTupleDescriptor &desc,
-                                           const ROOT::Experimental::RFieldDescriptor &classFieldDesc)
+                                           const ROOT::RNTupleDescriptor &desc,
+                                           const ROOT::RFieldDescriptor &classFieldDesc)
 {
    std::size_t stagingAreaSize = 0;
    for (const auto rule : rules) {
@@ -406,7 +405,7 @@ void ROOT::RClassField::BeforeConnectPageSource(ROOT::Experimental::Internal::RP
          SetStagingClass(GetTypeName(), GetTypeVersion());
    } else {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
-      const ROOT::Experimental::RNTupleDescriptor &desc = descriptorGuard.GetRef();
+      const ROOT::RNTupleDescriptor &desc = descriptorGuard.GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(GetOnDiskId());
 
       // Check that we have the same type.
@@ -719,7 +718,7 @@ void ROOT::RProxiedCollectionField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::RProxiedCollectionField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RProxiedCollectionField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
@@ -873,7 +872,7 @@ void ROOT::RStreamerField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, std::byte>();
 }
 
-void ROOT::RStreamerField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RStreamerField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, std::byte>(desc);
 }
@@ -889,10 +888,10 @@ void ROOT::RStreamerField::RStreamerFieldDeleter::operator()(void *objPtr, bool 
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
-ROOT::Experimental::RExtraTypeInfoDescriptor ROOT::RStreamerField::GetExtraTypeInfo() const
+ROOT::RExtraTypeInfoDescriptor ROOT::RStreamerField::GetExtraTypeInfo() const
 {
-   ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder extraTypeInfoBuilder;
-   extraTypeInfoBuilder.ContentId(ROOT::Experimental::EExtraTypeInfoIds::kStreamerInfo)
+   ROOT::Internal::RExtraTypeInfoDescriptorBuilder extraTypeInfoBuilder;
+   extraTypeInfoBuilder.ContentId(ROOT::EExtraTypeInfoIds::kStreamerInfo)
       .TypeVersion(GetTypeVersion())
       .TypeName(GetTypeName())
       .Content(ROOT::Experimental::Internal::RNTupleSerializer::SerializeStreamerInfos(fStreamerInfos));
@@ -1229,7 +1228,7 @@ void ROOT::RVariantField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnSwitch>();
 }
 
-void ROOT::RVariantField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RVariantField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnSwitch>(desc);
 }

--- a/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/v7/src/RFieldSequenceContainer.cxx
@@ -405,7 +405,7 @@ void ROOT::RRVecField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::RRVecField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RRVecField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
@@ -578,7 +578,7 @@ void ROOT::RVectorField::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::RVectorField::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RVectorField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
@@ -677,7 +677,7 @@ void ROOT::RField<std::vector<bool>>::GenerateColumns()
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>();
 }
 
-void ROOT::RField<std::vector<bool>>::GenerateColumns(const ROOT::Experimental::RNTupleDescriptor &desc)
+void ROOT::RField<std::vector<bool>>::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
 {
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -34,7 +34,10 @@
 #include <set>
 #include <utility>
 
-bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &other) const
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::Internal::RNTupleSerializer;
+
+bool ROOT::RFieldDescriptor::operator==(const RFieldDescriptor &other) const
 {
    return fFieldId == other.fFieldId && fFieldVersion == other.fFieldVersion && fTypeVersion == other.fTypeVersion &&
           fFieldName == other.fFieldName && fFieldDescription == other.fFieldDescription &&
@@ -44,7 +47,7 @@ bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &ot
           fLogicalColumnIds == other.fLogicalColumnIds && other.fTypeChecksum == other.fTypeChecksum;
 }
 
-ROOT::Experimental::RFieldDescriptor ROOT::Experimental::RFieldDescriptor::Clone() const
+ROOT::RFieldDescriptor ROOT::RFieldDescriptor::Clone() const
 {
    RFieldDescriptor clone;
    clone.fFieldId = fFieldId;
@@ -66,8 +69,7 @@ ROOT::Experimental::RFieldDescriptor ROOT::Experimental::RFieldDescriptor::Clone
 }
 
 std::unique_ptr<ROOT::RFieldBase>
-ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplDesc,
-                                                  const ROOT::RCreateFieldOptions &options) const
+ROOT::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplDesc, const ROOT::RCreateFieldOptions &options) const
 {
    if (GetStructure() == ROOT::ENTupleStructure::kStreamer) {
       auto streamerField = std::make_unique<ROOT::RStreamerField>(GetFieldName(), GetTypeName());
@@ -148,7 +150,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
    }
 }
 
-bool ROOT::Experimental::RFieldDescriptor::IsCustomClass() const
+bool ROOT::RFieldDescriptor::IsCustomClass() const
 {
    if (fStructure != ROOT::ENTupleStructure::kRecord && fStructure != ROOT::ENTupleStructure::kStreamer)
       return false;
@@ -169,7 +171,7 @@ bool ROOT::Experimental::RFieldDescriptor::IsCustomClass() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &other) const
+bool ROOT::RColumnDescriptor::operator==(const RColumnDescriptor &other) const
 {
    return fLogicalColumnId == other.fLogicalColumnId && fPhysicalColumnId == other.fPhysicalColumnId &&
           fBitsOnStorage == other.fBitsOnStorage && fType == other.fType && fFieldId == other.fFieldId &&
@@ -177,7 +179,7 @@ bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &
           fValueRange == other.fValueRange;
 }
 
-ROOT::Experimental::RColumnDescriptor ROOT::Experimental::RColumnDescriptor::Clone() const
+ROOT::RColumnDescriptor ROOT::RColumnDescriptor::Clone() const
 {
    RColumnDescriptor clone;
    clone.fLogicalColumnId = fLogicalColumnId;
@@ -194,8 +196,8 @@ ROOT::Experimental::RColumnDescriptor ROOT::Experimental::RColumnDescriptor::Clo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::Experimental::RClusterDescriptor::RPageInfoExtended
-ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ROOT::NTupleSize_t idxInCluster) const
+ROOT::RClusterDescriptor::RPageInfoExtended
+ROOT::RClusterDescriptor::RPageRange::Find(ROOT::NTupleSize_t idxInCluster) const
 {
    const auto N = fCumulativeNElements.size();
    R__ASSERT(N > 0);
@@ -225,8 +227,10 @@ ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ROOT::NTupleSize_t idxI
    return RPageInfoExtended{pageInfo, firstInPage, midpoint};
 }
 
-std::size_t ROOT::Experimental::RClusterDescriptor::RPageRange::ExtendToFitColumnRange(
-   const RColumnRange &columnRange, const ROOT::Internal::RColumnElementBase &element, std::size_t pageSize)
+std::size_t
+ROOT::RClusterDescriptor::RPageRange::ExtendToFitColumnRange(const RColumnRange &columnRange,
+                                                             const ROOT::Internal::RColumnElementBase &element,
+                                                             std::size_t pageSize)
 {
    R__ASSERT(fPhysicalColumnId == columnRange.GetPhysicalColumnId());
    R__ASSERT(!columnRange.IsSuppressed());
@@ -261,13 +265,13 @@ std::size_t ROOT::Experimental::RClusterDescriptor::RPageRange::ExtendToFitColum
    return nElementsRequired - nElements;
 }
 
-bool ROOT::Experimental::RClusterDescriptor::operator==(const RClusterDescriptor &other) const
+bool ROOT::RClusterDescriptor::operator==(const RClusterDescriptor &other) const
 {
    return fClusterId == other.fClusterId && fFirstEntryIndex == other.fFirstEntryIndex &&
           fNEntries == other.fNEntries && fColumnRanges == other.fColumnRanges && fPageRanges == other.fPageRanges;
 }
 
-std::uint64_t ROOT::Experimental::RClusterDescriptor::GetNBytesOnStorage() const
+std::uint64_t ROOT::RClusterDescriptor::GetNBytesOnStorage() const
 {
    std::uint64_t nbytes = 0;
    for (const auto &pr : fPageRanges) {
@@ -278,7 +282,7 @@ std::uint64_t ROOT::Experimental::RClusterDescriptor::GetNBytesOnStorage() const
    return nbytes;
 }
 
-ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::Clone() const
+ROOT::RClusterDescriptor ROOT::RClusterDescriptor::Clone() const
 {
    RClusterDescriptor clone;
    clone.fClusterId = fClusterId;
@@ -292,12 +296,12 @@ ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::C
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ROOT::Experimental::RExtraTypeInfoDescriptor::operator==(const RExtraTypeInfoDescriptor &other) const
+bool ROOT::RExtraTypeInfoDescriptor::operator==(const RExtraTypeInfoDescriptor &other) const
 {
    return fContentId == other.fContentId && fTypeName == other.fTypeName && fTypeVersion == other.fTypeVersion;
 }
 
-ROOT::Experimental::RExtraTypeInfoDescriptor ROOT::Experimental::RExtraTypeInfoDescriptor::Clone() const
+ROOT::RExtraTypeInfoDescriptor ROOT::RExtraTypeInfoDescriptor::Clone() const
 {
    RExtraTypeInfoDescriptor clone;
    clone.fContentId = fContentId;
@@ -309,7 +313,7 @@ ROOT::Experimental::RExtraTypeInfoDescriptor ROOT::Experimental::RExtraTypeInfoD
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const
+bool ROOT::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const
 {
    // clang-format off
    return fName == other.fName &&
@@ -324,7 +328,7 @@ bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &
    // clang-format on
 }
 
-ROOT::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElements(ROOT::DescriptorId_t physicalColumnId) const
+ROOT::NTupleSize_t ROOT::RNTupleDescriptor::GetNElements(ROOT::DescriptorId_t physicalColumnId) const
 {
    ROOT::NTupleSize_t result = 0;
    for (const auto &cd : fClusterDescriptors) {
@@ -337,7 +341,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElements(ROOT::Des
 }
 
 ROOT::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, ROOT::DescriptorId_t parentId) const
+ROOT::RNTupleDescriptor::FindFieldId(std::string_view fieldName, ROOT::DescriptorId_t parentId) const
 {
    std::string leafName(fieldName);
    auto posDot = leafName.find_last_of('.');
@@ -356,7 +360,7 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, R
    return ROOT::kInvalidDescriptorId;
 }
 
-std::string ROOT::Experimental::RNTupleDescriptor::GetQualifiedFieldName(ROOT::DescriptorId_t fieldId) const
+std::string ROOT::RNTupleDescriptor::GetQualifiedFieldName(ROOT::DescriptorId_t fieldId) const
 {
    if (fieldId == ROOT::kInvalidDescriptorId)
       return "";
@@ -368,14 +372,14 @@ std::string ROOT::Experimental::RNTupleDescriptor::GetQualifiedFieldName(ROOT::D
    return prefix + "." + fieldDescriptor.GetFieldName();
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindFieldId(std::string_view fieldName) const
 {
    return FindFieldId(fieldName, GetFieldZeroId());
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindLogicalColumnId(ROOT::DescriptorId_t fieldId,
-                                                                                std::uint32_t columnIndex,
-                                                                                std::uint16_t representationIndex) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindLogicalColumnId(ROOT::DescriptorId_t fieldId,
+                                                                  std::uint32_t columnIndex,
+                                                                  std::uint16_t representationIndex) const
 {
    auto itr = fFieldDescriptors.find(fieldId);
    if (itr == fFieldDescriptors.cend())
@@ -388,9 +392,9 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindLogicalColumnId(
    return itr->second.GetLogicalColumnIds()[idx];
 }
 
-ROOT::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindPhysicalColumnId(ROOT::DescriptorId_t fieldId, std::uint32_t columnIndex,
-                                                            std::uint16_t representationIndex) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindPhysicalColumnId(ROOT::DescriptorId_t fieldId,
+                                                                   std::uint32_t columnIndex,
+                                                                   std::uint16_t representationIndex) const
 {
    auto logicalId = FindLogicalColumnId(fieldId, columnIndex, representationIndex);
    if (logicalId == ROOT::kInvalidDescriptorId)
@@ -398,8 +402,8 @@ ROOT::Experimental::RNTupleDescriptor::FindPhysicalColumnId(ROOT::DescriptorId_t
    return GetColumnDescriptor(logicalId).GetPhysicalId();
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterId(ROOT::DescriptorId_t physicalColumnId,
-                                                                          ROOT::NTupleSize_t index) const
+ROOT::DescriptorId_t
+ROOT::RNTupleDescriptor::FindClusterId(ROOT::DescriptorId_t physicalColumnId, ROOT::NTupleSize_t index) const
 {
    if (GetNClusterGroups() == 0)
       return ROOT::kInvalidDescriptorId;
@@ -461,7 +465,7 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterId(ROOT::
    return ROOT::kInvalidDescriptorId;
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterId(ROOT::NTupleSize_t entryIdx) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindClusterId(ROOT::NTupleSize_t entryIdx) const
 {
    if (GetNClusterGroups() == 0)
       return ROOT::kInvalidDescriptorId;
@@ -513,7 +517,7 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterId(ROOT::
    return ROOT::kInvalidDescriptorId;
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindNextClusterId(ROOT::DescriptorId_t clusterId) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindNextClusterId(ROOT::DescriptorId_t clusterId) const
 {
    // TODO(jblomer): we may want to shortcut the common case and check if clusterId + 1 contains
    // firstEntryInNextCluster. This shortcut would currently always trigger. We do not want, however, to depend
@@ -524,7 +528,7 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindNextClusterId(RO
    return FindClusterId(firstEntryInNextCluster);
 }
 
-ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(ROOT::DescriptorId_t clusterId) const
+ROOT::DescriptorId_t ROOT::RNTupleDescriptor::FindPrevClusterId(ROOT::DescriptorId_t clusterId) const
 {
    // TODO(jblomer): we may want to shortcut the common case and check if clusterId - 1 contains
    // firstEntryInNextCluster. This shortcut would currently always trigger. We do not want, however, to depend
@@ -537,7 +541,7 @@ ROOT::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(RO
 }
 
 std::vector<ROOT::DescriptorId_t>
-ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const RNTupleDescriptor &desc) const
+ROOT::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const RNTupleDescriptor &desc) const
 {
    auto fieldZeroId = desc.GetFieldZeroId();
 
@@ -549,14 +553,13 @@ ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const
    return fields;
 }
 
-ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
-   const RNTupleDescriptor &ntuple, const RFieldDescriptor &field)
+ROOT::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(const RNTupleDescriptor &ntuple,
+                                                                              const RFieldDescriptor &field)
    : fNTuple(ntuple), fColumns(field.GetLogicalColumnIds())
 {
 }
 
-ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(
-   const RNTupleDescriptor &ntuple)
+ROOT::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescriptorIterable(const RNTupleDescriptor &ntuple)
    : fNTuple(ntuple)
 {
    std::deque<ROOT::DescriptorId_t> fieldIdQueue{ntuple.GetFieldZeroId()};
@@ -575,7 +578,7 @@ ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable::RColumnDescrip
    }
 }
 
-std::vector<std::uint64_t> ROOT::Experimental::RNTupleDescriptor::GetFeatureFlags() const
+std::vector<std::uint64_t> ROOT::RNTupleDescriptor::GetFeatureFlags() const
 {
    std::vector<std::uint64_t> result;
    unsigned int base = 0;
@@ -595,9 +598,8 @@ std::vector<std::uint64_t> ROOT::Experimental::RNTupleDescriptor::GetFeatureFlag
    return result;
 }
 
-ROOT::RResult<void>
-ROOT::Experimental::RNTupleDescriptor::AddClusterGroupDetails(ROOT::DescriptorId_t clusterGroupId,
-                                                              std::vector<RClusterDescriptor> &clusterDescs)
+ROOT::RResult<void> ROOT::RNTupleDescriptor::AddClusterGroupDetails(ROOT::DescriptorId_t clusterGroupId,
+                                                                    std::vector<RClusterDescriptor> &clusterDescs)
 {
    auto iter = fClusterGroupDescriptors.find(clusterGroupId);
    if (iter == fClusterGroupDescriptors.end())
@@ -624,7 +626,7 @@ ROOT::Experimental::RNTupleDescriptor::AddClusterGroupDetails(ROOT::DescriptorId
    return RResult<void>::Success();
 }
 
-ROOT::RResult<void> ROOT::Experimental::RNTupleDescriptor::DropClusterGroupDetails(ROOT::DescriptorId_t clusterGroupId)
+ROOT::RResult<void> ROOT::RNTupleDescriptor::DropClusterGroupDetails(ROOT::DescriptorId_t clusterGroupId)
 {
    auto iter = fClusterGroupDescriptors.find(clusterGroupId);
    if (iter == fClusterGroupDescriptors.end())
@@ -639,7 +641,7 @@ ROOT::RResult<void> ROOT::Experimental::RNTupleDescriptor::DropClusterGroupDetai
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel>
-ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &options) const
+ROOT::RNTupleDescriptor::CreateModel(const RCreateModelOptions &options) const
 {
    auto fieldZero = std::make_unique<ROOT::RFieldZero>();
    fieldZero->SetOnDiskId(GetFieldZeroId());
@@ -665,7 +667,7 @@ ROOT::Experimental::RNTupleDescriptor::CreateModel(const RCreateModelOptions &op
    return model;
 }
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::CloneSchema() const
+ROOT::RNTupleDescriptor ROOT::RNTupleDescriptor::CloneSchema() const
 {
    RNTupleDescriptor clone;
    clone.fName = fName;
@@ -690,7 +692,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clo
    return clone;
 }
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clone() const
+ROOT::RNTupleDescriptor ROOT::RNTupleDescriptor::Clone() const
 {
    RNTupleDescriptor clone = CloneSchema();
 
@@ -710,13 +712,13 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptor::Clo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ROOT::Experimental::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
+bool ROOT::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
 {
    return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds &&
           fMinEntry == other.fMinEntry && fEntrySpan == other.fEntrySpan && fNClusters == other.fNClusters;
 }
 
-ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDescriptor::CloneSummary() const
+ROOT::RClusterGroupDescriptor ROOT::RClusterGroupDescriptor::CloneSummary() const
 {
    RClusterGroupDescriptor clone;
    clone.fClusterGroupId = fClusterGroupId;
@@ -728,7 +730,7 @@ ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDes
    return clone;
 }
 
-ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDescriptor::Clone() const
+ROOT::RClusterGroupDescriptor ROOT::RClusterGroupDescriptor::Clone() const
 {
    RClusterGroupDescriptor clone = CloneSummary();
    clone.fClusterIds = fClusterIds;
@@ -737,9 +739,11 @@ ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDes
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::RResult<void> ROOT::Experimental::Internal::RClusterDescriptorBuilder::CommitColumnRange(
-   ROOT::DescriptorId_t physicalId, std::uint64_t firstElementIndex, std::uint32_t compressionSettings,
-   const RClusterDescriptor::RPageRange &pageRange)
+ROOT::RResult<void>
+ROOT::Internal::RClusterDescriptorBuilder::CommitColumnRange(ROOT::DescriptorId_t physicalId,
+                                                             std::uint64_t firstElementIndex,
+                                                             std::uint32_t compressionSettings,
+                                                             const RClusterDescriptor::RPageRange &pageRange)
 {
    if (physicalId != pageRange.fPhysicalColumnId)
       return R__FAIL("column ID mismatch");
@@ -755,7 +759,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RClusterDescriptorBuilder::Com
 }
 
 ROOT::RResult<void>
-ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRange(ROOT::DescriptorId_t physicalId)
+ROOT::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRange(ROOT::DescriptorId_t physicalId)
 {
    if (fCluster.fColumnRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
@@ -768,7 +772,7 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::MarkSuppressedColumnRan
 }
 
 ROOT::RResult<void>
-ROOT::Experimental::Internal::RClusterDescriptorBuilder::CommitSuppressedColumnRanges(const RNTupleDescriptor &desc)
+ROOT::Internal::RClusterDescriptorBuilder::CommitSuppressedColumnRanges(const RNTupleDescriptor &desc)
 {
    for (auto &[_, columnRange] : fCluster.fColumnRanges) {
       if (!columnRange.IsSuppressed())
@@ -804,8 +808,8 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::CommitSuppressedColumnR
    return RResult<void>::Success();
 }
 
-ROOT::Experimental::Internal::RClusterDescriptorBuilder &
-ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges(const RNTupleDescriptor &desc)
+ROOT::Internal::RClusterDescriptorBuilder &
+ROOT::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges(const RNTupleDescriptor &desc)
 {
    /// Carries out a depth-first traversal of a field subtree rooted at `rootFieldId`.  For each field, `visitField` is
    /// called passing the field ID and the number of overall repetitions, taking into account the repetitions of each
@@ -867,8 +871,7 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges
    return *this;
 }
 
-ROOT::RResult<ROOT::Experimental::RClusterDescriptor>
-ROOT::Experimental::Internal::RClusterDescriptorBuilder::MoveDescriptor()
+ROOT::RResult<ROOT::RClusterDescriptor> ROOT::Internal::RClusterDescriptorBuilder::MoveDescriptor()
 {
    if (fCluster.fClusterId == ROOT::kInvalidDescriptorId)
       return R__FAIL("unset cluster ID");
@@ -893,9 +896,8 @@ ROOT::Experimental::Internal::RClusterDescriptorBuilder::MoveDescriptor()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder
-ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder::FromSummary(
-   const RClusterGroupDescriptor &clusterGroupDesc)
+ROOT::Internal::RClusterGroupDescriptorBuilder
+ROOT::Internal::RClusterGroupDescriptorBuilder::FromSummary(const RClusterGroupDescriptor &clusterGroupDesc)
 {
    RClusterGroupDescriptorBuilder builder;
    builder.ClusterGroupId(clusterGroupDesc.GetId())
@@ -907,8 +909,7 @@ ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder::FromSummary(
    return builder;
 }
 
-ROOT::RResult<ROOT::Experimental::RClusterGroupDescriptor>
-ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder::MoveDescriptor()
+ROOT::RResult<ROOT::RClusterGroupDescriptor> ROOT::Internal::RClusterGroupDescriptorBuilder::MoveDescriptor()
 {
    if (fClusterGroup.fClusterGroupId == ROOT::kInvalidDescriptorId)
       return R__FAIL("unset cluster group ID");
@@ -919,8 +920,7 @@ ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder::MoveDescriptor()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::RResult<ROOT::Experimental::RExtraTypeInfoDescriptor>
-ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder::MoveDescriptor()
+ROOT::RResult<ROOT::RExtraTypeInfoDescriptor> ROOT::Internal::RExtraTypeInfoDescriptorBuilder::MoveDescriptor()
 {
    if (fExtraTypeInfo.fContentId == EExtraTypeInfoIds::kInvalid)
       throw RException(R__FAIL("invalid extra type info content id"));
@@ -931,15 +931,14 @@ ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder::MoveDescriptor()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ROOT::RResult<void>
-ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureFieldExists(ROOT::DescriptorId_t fieldId) const
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::EnsureFieldExists(ROOT::DescriptorId_t fieldId) const
 {
    if (fDescriptor.fFieldDescriptors.count(fieldId) == 0)
       return R__FAIL("field with id '" + std::to_string(fieldId) + "' doesn't exist");
    return RResult<void>::Success();
 }
 
-ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::EnsureValidDescriptor() const
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::EnsureValidDescriptor() const
 {
    // Reuse field name validity check
    auto validName = ROOT::Internal::EnsureValidNameForRNTuple(fDescriptor.GetName(), "Field");
@@ -974,7 +973,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::Ensu
    return RResult<void>::Success();
 }
 
-ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RNTupleDescriptorBuilder::MoveDescriptor()
+ROOT::RNTupleDescriptor ROOT::Internal::RNTupleDescriptorBuilder::MoveDescriptor()
 {
    EnsureValidDescriptor().ThrowOnError();
    fDescriptor.fSortedClusterGroupIds.reserve(fDescriptor.fClusterGroupDescriptors.size());
@@ -990,22 +989,21 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Internal::RNTupleDescr
    return result;
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::SetNTuple(const std::string_view name,
-                                                                       const std::string_view description)
+void ROOT::Internal::RNTupleDescriptorBuilder::SetNTuple(const std::string_view name,
+                                                         const std::string_view description)
 {
    fDescriptor.fName = std::string(name);
    fDescriptor.fDescription = std::string(description);
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::SetFeature(unsigned int flag)
+void ROOT::Internal::RNTupleDescriptorBuilder::SetFeature(unsigned int flag)
 {
    if (flag % 64 == 0)
       throw RException(R__FAIL("invalid feature flag: " + std::to_string(flag)));
    fDescriptor.fFeatureFlags.insert(flag);
 }
 
-ROOT::RResult<ROOT::Experimental::RColumnDescriptor>
-ROOT::Experimental::Internal::RColumnDescriptorBuilder::MakeDescriptor() const
+ROOT::RResult<ROOT::RColumnDescriptor> ROOT::Internal::RColumnDescriptorBuilder::MakeDescriptor() const
 {
    if (fColumn.GetLogicalId() == ROOT::kInvalidDescriptorId)
       return R__FAIL("invalid logical column id");
@@ -1028,7 +1026,7 @@ ROOT::Experimental::Internal::RColumnDescriptorBuilder::MakeDescriptor() const
    return fColumn.Clone();
 }
 
-ROOT::Experimental::Internal::RFieldDescriptorBuilder::RFieldDescriptorBuilder(const RFieldDescriptor &fieldDesc)
+ROOT::Internal::RFieldDescriptorBuilder::RFieldDescriptorBuilder(const RFieldDescriptor &fieldDesc)
    : fField(fieldDesc.Clone())
 {
    fField.fParentId = ROOT::kInvalidDescriptorId;
@@ -1036,8 +1034,8 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::RFieldDescriptorBuilder(c
    fField.fLogicalColumnIds = {};
 }
 
-ROOT::Experimental::Internal::RFieldDescriptorBuilder
-ROOT::Experimental::Internal::RFieldDescriptorBuilder::FromField(const ROOT::RFieldBase &field)
+ROOT::Internal::RFieldDescriptorBuilder
+ROOT::Internal::RFieldDescriptorBuilder::FromField(const ROOT::RFieldBase &field)
 {
    RFieldDescriptorBuilder fieldDesc;
    fieldDesc.FieldVersion(field.GetFieldVersion())
@@ -1053,8 +1051,7 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::FromField(const ROOT::RFi
    return fieldDesc;
 }
 
-ROOT::RResult<ROOT::Experimental::RFieldDescriptor>
-ROOT::Experimental::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
+ROOT::RResult<ROOT::RFieldDescriptor> ROOT::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
 {
    if (fField.GetId() == ROOT::kInvalidDescriptorId) {
       return R__FAIL("invalid field id");
@@ -1075,7 +1072,7 @@ ROOT::Experimental::Internal::RFieldDescriptorBuilder::MakeDescriptor() const
    return fField.Clone();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddField(const RFieldDescriptor &fieldDesc)
+void ROOT::Internal::RNTupleDescriptorBuilder::AddField(const RFieldDescriptor &fieldDesc)
 {
    fDescriptor.fFieldDescriptors.emplace(fieldDesc.GetId(), fieldDesc.Clone());
    if (fDescriptor.fHeaderExtension)
@@ -1085,8 +1082,8 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddField(const RFie
    }
 }
 
-ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddFieldLink(ROOT::DescriptorId_t fieldId,
-                                                                                         ROOT::DescriptorId_t linkId)
+ROOT::RResult<void>
+ROOT::Internal::RNTupleDescriptorBuilder::AddFieldLink(ROOT::DescriptorId_t fieldId, ROOT::DescriptorId_t linkId)
 {
    auto fieldExists = RResult<void>::Success();
    if (!(fieldExists = EnsureFieldExists(fieldId)))
@@ -1110,9 +1107,8 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddF
    return RResult<void>::Success();
 }
 
-ROOT::RResult<void>
-ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddFieldProjection(ROOT::DescriptorId_t sourceId,
-                                                                           ROOT::DescriptorId_t targetId)
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::AddFieldProjection(ROOT::DescriptorId_t sourceId,
+                                                                                 ROOT::DescriptorId_t targetId)
 {
    auto fieldExists = RResult<void>::Success();
    if (!(fieldExists = EnsureFieldExists(sourceId)))
@@ -1139,7 +1135,7 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddFieldProjection(ROOT:
    return RResult<void>::Success();
 }
 
-ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddColumn(RColumnDescriptor &&columnDesc)
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::AddColumn(RColumnDescriptor &&columnDesc)
 {
    const auto fieldId = columnDesc.GetFieldId();
    const auto columnIndex = columnDesc.GetIndex();
@@ -1193,8 +1189,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddC
    return RResult<void>::Success();
 }
 
-ROOT::RResult<void>
-ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddClusterGroup(RClusterGroupDescriptor &&clusterGroup)
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::AddClusterGroup(RClusterGroupDescriptor &&clusterGroup)
 {
    const auto id = clusterGroup.GetId();
    if (fDescriptor.fClusterGroupDescriptors.count(id) > 0)
@@ -1205,7 +1200,7 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddClusterGroup(RCluster
    return RResult<void>::Success();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::Reset()
+void ROOT::Internal::RNTupleDescriptorBuilder::Reset()
 {
    fDescriptor.fName = "";
    fDescriptor.fDescription = "";
@@ -1216,18 +1211,18 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::Reset()
    fDescriptor.fHeaderExtension.reset();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::SetSchemaFromExisting(const RNTupleDescriptor &descriptor)
+void ROOT::Internal::RNTupleDescriptorBuilder::SetSchemaFromExisting(const RNTupleDescriptor &descriptor)
 {
    fDescriptor = descriptor.CloneSchema();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::BeginHeaderExtension()
+void ROOT::Internal::RNTupleDescriptorBuilder::BeginHeaderExtension()
 {
    if (!fDescriptor.fHeaderExtension)
       fDescriptor.fHeaderExtension = std::make_unique<RNTupleDescriptor::RHeaderExtension>();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::ShiftAliasColumns(std::uint32_t offset)
+void ROOT::Internal::RNTupleDescriptorBuilder::ShiftAliasColumns(std::uint32_t offset)
 {
    if (fDescriptor.GetNLogicalColumns() == 0)
       return;
@@ -1250,7 +1245,7 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::ShiftAliasColumns(s
    }
 }
 
-ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddCluster(RClusterDescriptor &&clusterDesc)
+ROOT::RResult<void> ROOT::Internal::RNTupleDescriptorBuilder::AddCluster(RClusterDescriptor &&clusterDesc)
 {
    auto clusterId = clusterDesc.GetId();
    if (fDescriptor.fClusterDescriptors.count(clusterId) > 0)
@@ -1260,7 +1255,7 @@ ROOT::RResult<void> ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddC
 }
 
 ROOT::RResult<void>
-ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
+ROOT::Internal::RNTupleDescriptorBuilder::AddExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
 {
    // Make sure we have no duplicates
    if (std::find(fDescriptor.fExtraTypeInfoDescriptors.begin(), fDescriptor.fExtraTypeInfoDescriptors.end(),
@@ -1271,8 +1266,7 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::AddExtraTypeInfo(RExtraT
    return RResult<void>::Success();
 }
 
-void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::ReplaceExtraTypeInfo(
-   RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
+void ROOT::Internal::RNTupleDescriptorBuilder::ReplaceExtraTypeInfo(RExtraTypeInfoDescriptor &&extraTypeInfoDesc)
 {
    auto it = std::find(fDescriptor.fExtraTypeInfoDescriptors.begin(), fDescriptor.fExtraTypeInfoDescriptors.end(),
                        extraTypeInfoDesc);
@@ -1282,8 +1276,7 @@ void ROOT::Experimental::Internal::RNTupleDescriptorBuilder::ReplaceExtraTypeInf
       fDescriptor.fExtraTypeInfoDescriptors.emplace_back(std::move(extraTypeInfoDesc));
 }
 
-ROOT::Experimental::Internal::RNTupleSerializer::StreamerInfoMap_t
-ROOT::Experimental::Internal::RNTupleDescriptorBuilder::BuildStreamerInfos() const
+RNTupleSerializer::StreamerInfoMap_t ROOT::Internal::RNTupleDescriptorBuilder::BuildStreamerInfos() const
 {
    RNTupleSerializer::StreamerInfoMap_t streamerInfoMap;
    const auto &desc = GetDescriptor();
@@ -1325,83 +1318,76 @@ ROOT::Experimental::Internal::RNTupleDescriptorBuilder::BuildStreamerInfos() con
    return streamerInfoMap;
 }
 
-ROOT::Experimental::RClusterDescriptor::RColumnRangeIterable
-ROOT::Experimental::RClusterDescriptor::GetColumnRangeIterable() const
+ROOT::RClusterDescriptor::RColumnRangeIterable ROOT::RClusterDescriptor::GetColumnRangeIterable() const
 {
    return RColumnRangeIterable(*this);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetFieldIterable(const RFieldDescriptor &fieldDesc) const
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable
+ROOT::RNTupleDescriptor::GetFieldIterable(const RFieldDescriptor &fieldDesc) const
 {
    return RFieldDescriptorIterable(*this, fieldDesc);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable ROOT::Experimental::RNTupleDescriptor::GetFieldIterable(
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable ROOT::RNTupleDescriptor::GetFieldIterable(
    const RFieldDescriptor &fieldDesc,
    const std::function<bool(ROOT::DescriptorId_t, ROOT::DescriptorId_t)> &comparator) const
 {
    return RFieldDescriptorIterable(*this, fieldDesc, comparator);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetFieldIterable(ROOT::DescriptorId_t fieldId) const
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable
+ROOT::RNTupleDescriptor::GetFieldIterable(ROOT::DescriptorId_t fieldId) const
 {
    return GetFieldIterable(GetFieldDescriptor(fieldId));
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable ROOT::Experimental::RNTupleDescriptor::GetFieldIterable(
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable ROOT::RNTupleDescriptor::GetFieldIterable(
    ROOT::DescriptorId_t fieldId,
    const std::function<bool(ROOT::DescriptorId_t, ROOT::DescriptorId_t)> &comparator) const
 {
    return GetFieldIterable(GetFieldDescriptor(fieldId), comparator);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetTopLevelFields() const
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable ROOT::RNTupleDescriptor::GetTopLevelFields() const
 {
    return GetFieldIterable(GetFieldZeroId());
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetTopLevelFields(
+ROOT::RNTupleDescriptor::RFieldDescriptorIterable ROOT::RNTupleDescriptor::GetTopLevelFields(
    const std::function<bool(ROOT::DescriptorId_t, ROOT::DescriptorId_t)> &comparator) const
 {
    return GetFieldIterable(GetFieldZeroId(), comparator);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetColumnIterable() const
+ROOT::RNTupleDescriptor::RColumnDescriptorIterable ROOT::RNTupleDescriptor::GetColumnIterable() const
 {
    return RColumnDescriptorIterable(*this);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetColumnIterable(const RFieldDescriptor &fieldDesc) const
+ROOT::RNTupleDescriptor::RColumnDescriptorIterable
+ROOT::RNTupleDescriptor::GetColumnIterable(const RFieldDescriptor &fieldDesc) const
 {
    return RColumnDescriptorIterable(*this, fieldDesc);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RColumnDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetColumnIterable(ROOT::DescriptorId_t fieldId) const
+ROOT::RNTupleDescriptor::RColumnDescriptorIterable
+ROOT::RNTupleDescriptor::GetColumnIterable(ROOT::DescriptorId_t fieldId) const
 {
    return RColumnDescriptorIterable(*this, GetFieldDescriptor(fieldId));
 }
 
-ROOT::Experimental::RNTupleDescriptor::RClusterGroupDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetClusterGroupIterable() const
+ROOT::RNTupleDescriptor::RClusterGroupDescriptorIterable ROOT::RNTupleDescriptor::GetClusterGroupIterable() const
 {
    return RClusterGroupDescriptorIterable(*this);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RClusterDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetClusterIterable() const
+ROOT::RNTupleDescriptor::RClusterDescriptorIterable ROOT::RNTupleDescriptor::GetClusterIterable() const
 {
    return RClusterDescriptorIterable(*this);
 }
 
-ROOT::Experimental::RNTupleDescriptor::RExtraTypeInfoDescriptorIterable
-ROOT::Experimental::RNTupleDescriptor::GetExtraTypeInfoIterable() const
+ROOT::RNTupleDescriptor::RExtraTypeInfoDescriptorIterable ROOT::RNTupleDescriptor::GetExtraTypeInfoIterable() const
 {
    return RExtraTypeInfoDescriptorIterable(*this);
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -62,7 +62,7 @@ struct ColumnInfo {
    }
 };
 
-std::string GetFieldName(ROOT::DescriptorId_t fieldId, const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
+std::string GetFieldName(ROOT::DescriptorId_t fieldId, const ROOT::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fieldId);
    if (fieldDesc.GetParentId() == ROOT::kInvalidDescriptorId)
@@ -70,7 +70,7 @@ std::string GetFieldName(ROOT::DescriptorId_t fieldId, const ROOT::Experimental:
    return GetFieldName(fieldDesc.GetParentId(), ntupleDesc) + "." + fieldDesc.GetFieldName();
 }
 
-std::string GetFieldDescription(ROOT::DescriptorId_t fFieldId, const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
+std::string GetFieldDescription(ROOT::DescriptorId_t fFieldId, const ROOT::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fFieldId);
    return fieldDesc.GetFieldDescription();
@@ -78,7 +78,7 @@ std::string GetFieldDescription(ROOT::DescriptorId_t fFieldId, const ROOT::Exper
 
 } // anonymous namespace
 
-void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) const
+void ROOT::RNTupleDescriptor::PrintInfo(std::ostream &output) const
 {
    std::vector<ColumnInfo> columns;
    std::vector<ClusterInfo> clusters;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -40,6 +40,8 @@
 #include <vector>
 
 using ROOT::ENTupleColumnType;
+using ROOT::RFieldDescriptor;
+using ROOT::RNTupleDescriptor;
 using ROOT::Internal::MakeUninitArray;
 using ROOT::Internal::RColumnElementBase;
 

--- a/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/v7/src/RNTupleParallelWriter.cxx
@@ -29,8 +29,8 @@ namespace {
 
 using ROOT::DescriptorId_t;
 using ROOT::NTupleSize_t;
-using ROOT::Experimental::RExtraTypeInfoDescriptor;
-using ROOT::Experimental::RNTupleDescriptor;
+using ROOT::RExtraTypeInfoDescriptor;
+using ROOT::RNTupleDescriptor;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::Internal::RNTupleModelChangeset;
 using ROOT::Experimental::Internal::RPageSink;

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -248,7 +248,7 @@ void ROOT::Experimental::RNTupleReader::Show(ROOT::NTupleSize_t index, std::ostr
    output << "}" << std::endl;
 }
 
-const ROOT::Experimental::RNTupleDescriptor &ROOT::Experimental::RNTupleReader::GetDescriptor()
+const ROOT::RNTupleDescriptor &ROOT::Experimental::RNTupleReader::GetDescriptor()
 {
    auto descriptorGuard = fSource->GetSharedDescriptorGuard();
    if (!fCachedDescriptor || fCachedDescriptor->GetGeneration() != descriptorGuard->GetGeneration())

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -113,7 +113,7 @@ ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, con
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(const RNTupleDescriptor::RCreateModelOptions &createModelOpts,
+ROOT::Experimental::RNTupleReader::Open(const ROOT::RNTupleDescriptor::RCreateModelOptions &createModelOpts,
                                         std::string_view ntupleName, std::string_view storage,
                                         const ROOT::RNTupleReadOptions &options)
 {
@@ -124,7 +124,7 @@ ROOT::Experimental::RNTupleReader::Open(const RNTupleDescriptor::RCreateModelOpt
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader>
-ROOT::Experimental::RNTupleReader::Open(const RNTupleDescriptor::RCreateModelOptions &createModelOpts,
+ROOT::Experimental::RNTupleReader::Open(const ROOT::RNTupleDescriptor::RCreateModelOptions &createModelOpts,
                                         const ROOT::RNTuple &ntuple, const ROOT::RNTupleReadOptions &options)
 {
    auto reader = std::unique_ptr<RNTupleReader>(
@@ -137,7 +137,7 @@ const ROOT::Experimental::RNTupleModel &ROOT::Experimental::RNTupleReader::GetMo
 {
    if (!fModel) {
       fModel = fSource->GetSharedDescriptorGuard()->CreateModel(
-         fCreateModelOptions.value_or(RNTupleDescriptor::RCreateModelOptions{}));
+         fCreateModelOptions.value_or(ROOT::RNTupleDescriptor::RCreateModelOptions{}));
       ConnectModel(*fModel);
    }
    return *fModel;
@@ -169,7 +169,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       {
          auto descriptorGuard = fSource->GetSharedDescriptorGuard();
          name = descriptorGuard->GetName();
-         RNTupleDescriptor::RCreateModelOptions opts;
+         ROOT::RNTupleDescriptor::RCreateModelOptions opts;
          opts.SetCreateBare(true);
          // When printing the schema we always try to reconstruct the whole thing even when we are missing the
          // dictionaries.

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1307,7 +1307,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeClusterGroup(const v
    return frameSize;
 }
 
-void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const RNTupleDescriptor &desc,
+void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const ROOT::RNTupleDescriptor &desc,
                                                                           bool forHeaderExtension)
 {
    auto fieldZeroId = desc.GetFieldZeroId();
@@ -1354,10 +1354,8 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
    }
 }
 
-ROOT::RResult<std::uint32_t>
-ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc,
-                                                                            const RContext &context,
-                                                                            bool forHeaderExtension)
+ROOT::RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(
+   void *buffer, const ROOT::RNTupleDescriptor &desc, const RContext &context, bool forHeaderExtension)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -1365,7 +1363,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(void
 
    std::size_t nFields = 0, nColumns = 0, nAliasColumns = 0, fieldListOffset = 0;
    // Columns in the extension header that are attached to a field of the regular header
-   std::vector<std::reference_wrapper<const RColumnDescriptor>> extraColumns;
+   std::vector<std::reference_wrapper<const ROOT::RColumnDescriptor>> extraColumns;
    if (forHeaderExtension) {
       // A call to `RNTupleDescriptorBuilder::BeginHeaderExtension()` is not strictly required after serializing the
       // header, which may happen, e.g., in unit tests.  Ensure an empty schema extension is serialized in this case
@@ -1660,7 +1658,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeHeader(void *buffer, c
 }
 
 ROOT::RResult<std::uint32_t>
-ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer, const RNTupleDescriptor &desc,
+ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer, const ROOT::RNTupleDescriptor &desc,
                                                                    std::span<ROOT::DescriptorId_t> physClusterIDs,
                                                                    const RContext &context)
 {
@@ -1968,7 +1966,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeFooter(const void *b
 ROOT::RResult<std::vector<ROOT::Internal::RClusterDescriptorBuilder>>
 ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageListRaw(const void *buffer, std::uint64_t bufSize,
                                                                         ROOT::DescriptorId_t clusterGroupId,
-                                                                        const RNTupleDescriptor &desc)
+                                                                        const ROOT::RNTupleDescriptor &desc)
 {
    auto base = reinterpret_cast<const unsigned char *>(buffer);
    auto bytes = base;
@@ -2055,7 +2053,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageListRaw(const vo
             return R__FORWARD_ERROR(res);
          }
 
-         RClusterDescriptor::RPageRange pageRange;
+         ROOT::RClusterDescriptor::RPageRange pageRange;
          pageRange.SetPhysicalColumnId(j);
          for (std::uint32_t k = 0; k < nPages; ++k) {
             if (fnInnerFrameSizeLeft() < static_cast<int>(sizeof(std::uint32_t)))
@@ -2104,7 +2102,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageListRaw(const vo
 ROOT::RResult<void>
 ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageList(const void *buffer, std::uint64_t bufSize,
                                                                      ROOT::DescriptorId_t clusterGroupId,
-                                                                     RNTupleDescriptor &desc,
+                                                                     ROOT::RNTupleDescriptor &desc,
                                                                      EDescriptorDeserializeMode mode)
 {
    auto clusterBuildersRes = RNTupleSerializer::DeserializePageListRaw(buffer, bufSize, clusterGroupId, desc);
@@ -2113,7 +2111,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageList(const void 
 
    auto clusterBuilders = clusterBuildersRes.Unwrap();
 
-   std::vector<RClusterDescriptor> clusters;
+   std::vector<ROOT::RClusterDescriptor> clusters;
    clusters.reserve(clusterBuilders.size());
 
    // Conditionally fixup the clusters depending on the attach purpose

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -37,10 +37,17 @@
 #include <set>
 #include <unordered_map>
 
+using ROOT::Internal::RClusterDescriptorBuilder;
+using ROOT::Internal::RClusterGroupDescriptorBuilder;
+using ROOT::Internal::RColumnDescriptorBuilder;
+using ROOT::Internal::RExtraTypeInfoDescriptorBuilder;
+using ROOT::Internal::RFieldDescriptorBuilder;
+using ROOT::Internal::RNTupleDescriptorBuilder;
+
 namespace {
 using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
 
-ROOT::RResult<std::uint32_t> SerializeField(const ROOT::Experimental::RFieldDescriptor &fieldDesc,
+ROOT::RResult<std::uint32_t> SerializeField(const ROOT::RFieldDescriptor &fieldDesc,
                                             ROOT::DescriptorId_t onDiskParentId,
                                             ROOT::DescriptorId_t onDiskProjectionSourceId, void *buffer)
 {
@@ -98,7 +105,7 @@ ROOT::RResult<std::uint32_t> SerializeField(const ROOT::Experimental::RFieldDesc
 /// required buffer size is returned
 // clang-format on
 ROOT::RResult<std::uint32_t>
-SerializeFieldList(const ROOT::Experimental::RNTupleDescriptor &desc, std::span<const ROOT::DescriptorId_t> fieldList,
+SerializeFieldList(const ROOT::RNTupleDescriptor &desc, std::span<const ROOT::DescriptorId_t> fieldList,
                    std::size_t firstOnDiskId, const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
                    void *buffer)
 {
@@ -125,8 +132,8 @@ SerializeFieldList(const ROOT::Experimental::RNTupleDescriptor &desc, std::span<
    return pos - base;
 }
 
-ROOT::RResult<std::uint32_t> DeserializeField(const void *buffer, std::uint64_t bufSize,
-                                              ROOT::Experimental::Internal::RFieldDescriptorBuilder &fieldDesc)
+ROOT::RResult<std::uint32_t>
+DeserializeField(const void *buffer, std::uint64_t bufSize, ROOT::Internal::RFieldDescriptorBuilder &fieldDesc)
 {
    using ENTupleStructure = ROOT::ENTupleStructure;
 
@@ -220,7 +227,7 @@ ROOT::RResult<std::uint32_t> DeserializeField(const void *buffer, std::uint64_t 
 }
 
 ROOT::RResult<std::uint32_t>
-SerializePhysicalColumn(const ROOT::Experimental::RColumnDescriptor &columnDesc,
+SerializePhysicalColumn(const ROOT::RColumnDescriptor &columnDesc,
                         const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
 {
    R__ASSERT(!columnDesc.IsAliasColumn());
@@ -270,8 +277,7 @@ SerializePhysicalColumn(const ROOT::Experimental::RColumnDescriptor &columnDesc,
 }
 
 ROOT::RResult<std::uint32_t>
-SerializeColumnsOfFields(const ROOT::Experimental::RNTupleDescriptor &desc,
-                         std::span<const ROOT::DescriptorId_t> fieldList,
+SerializeColumnsOfFields(const ROOT::RNTupleDescriptor &desc, std::span<const ROOT::DescriptorId_t> fieldList,
                          const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer,
                          bool forHeaderExtension)
 {
@@ -303,8 +309,8 @@ SerializeColumnsOfFields(const ROOT::Experimental::RNTupleDescriptor &desc,
    return pos - base;
 }
 
-ROOT::RResult<std::uint32_t> DeserializeColumn(const void *buffer, std::uint64_t bufSize,
-                                               ROOT::Experimental::Internal::RColumnDescriptorBuilder &columnDesc)
+ROOT::RResult<std::uint32_t>
+DeserializeColumn(const void *buffer, std::uint64_t bufSize, ROOT::Internal::RColumnDescriptorBuilder &columnDesc)
 {
    using ROOT::ENTupleColumnType;
 
@@ -363,8 +369,7 @@ ROOT::RResult<std::uint32_t> DeserializeColumn(const void *buffer, std::uint64_t
    return frameSize;
 }
 
-ROOT::RResult<std::uint32_t>
-SerializeExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &desc, void *buffer)
+ROOT::RResult<std::uint32_t> SerializeExtraTypeInfo(const ROOT::RExtraTypeInfoDescriptor &desc, void *buffer)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -387,8 +392,7 @@ SerializeExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &desc,
    return size;
 }
 
-ROOT::RResult<std::uint32_t>
-SerializeExtraTypeInfoList(const ROOT::Experimental::RNTupleDescriptor &ntplDesc, void *buffer)
+ROOT::RResult<std::uint32_t> SerializeExtraTypeInfoList(const ROOT::RNTupleDescriptor &ntplDesc, void *buffer)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -405,11 +409,10 @@ SerializeExtraTypeInfoList(const ROOT::Experimental::RNTupleDescriptor &ntplDesc
    return pos - base;
 }
 
-ROOT::RResult<std::uint32_t>
-DeserializeExtraTypeInfo(const void *buffer, std::uint64_t bufSize,
-                         ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder &desc)
+ROOT::RResult<std::uint32_t> DeserializeExtraTypeInfo(const void *buffer, std::uint64_t bufSize,
+                                                      ROOT::Internal::RExtraTypeInfoDescriptorBuilder &desc)
 {
-   using ROOT::Experimental::EExtraTypeInfoIds;
+   using ROOT::EExtraTypeInfoIds;
 
    auto base = reinterpret_cast<const unsigned char *>(buffer);
    auto bytes = base;
@@ -504,7 +507,7 @@ ROOT::RResult<void> DeserializeLocatorPayloadObject64(const unsigned char *buffe
    return ROOT::RResult<void>::Success();
 }
 
-std::uint32_t SerializeAliasColumn(const ROOT::Experimental::RColumnDescriptor &columnDesc,
+std::uint32_t SerializeAliasColumn(const ROOT::RColumnDescriptor &columnDesc,
                                    const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
                                    void *buffer)
 {
@@ -524,7 +527,7 @@ std::uint32_t SerializeAliasColumn(const ROOT::Experimental::RColumnDescriptor &
    return pos - base;
 }
 
-std::uint32_t SerializeAliasColumnsOfFields(const ROOT::Experimental::RNTupleDescriptor &desc,
+std::uint32_t SerializeAliasColumnsOfFields(const ROOT::RNTupleDescriptor &desc,
                                             std::span<const ROOT::DescriptorId_t> fieldList,
                                             const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
                                             void *buffer, bool forHeaderExtension)
@@ -847,27 +850,24 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeFieldStructure(const
 }
 
 ROOT::RResult<std::uint32_t>
-ROOT::Experimental::Internal::RNTupleSerializer::SerializeExtraTypeInfoId(ROOT::Experimental::EExtraTypeInfoIds id,
-                                                                          void *buffer)
+ROOT::Experimental::Internal::RNTupleSerializer::SerializeExtraTypeInfoId(ROOT::EExtraTypeInfoIds id, void *buffer)
 {
-   using ROOT::Experimental::EExtraTypeInfoIds;
    switch (id) {
-   case EExtraTypeInfoIds::kStreamerInfo: return SerializeUInt32(0x00, buffer);
+   case ROOT::EExtraTypeInfoIds::kStreamerInfo: return SerializeUInt32(0x00, buffer);
    default: return R__FAIL("unexpected extra type info id");
    }
 }
 
 ROOT::RResult<std::uint32_t>
 ROOT::Experimental::Internal::RNTupleSerializer::DeserializeExtraTypeInfoId(const void *buffer,
-                                                                            ROOT::Experimental::EExtraTypeInfoIds &id)
+                                                                            ROOT::EExtraTypeInfoIds &id)
 {
-   using ROOT::Experimental::EExtraTypeInfoIds;
    std::uint32_t onDiskValue;
    auto result = DeserializeUInt32(buffer, onDiskValue);
    switch (onDiskValue) {
-   case 0x00: id = EExtraTypeInfoIds::kStreamerInfo; break;
+   case 0x00: id = ROOT::EExtraTypeInfoIds::kStreamerInfo; break;
    default:
-      id = EExtraTypeInfoIds::kInvalid;
+      id = ROOT::EExtraTypeInfoIds::kInvalid;
       R__LOG_DEBUG(0, ROOT::Internal::NTupleLog()) << "Unknown extra type info id: " << onDiskValue;
    }
    return result;
@@ -1619,8 +1619,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeSchemaDescription(co
 }
 
 ROOT::RResult<ROOT::Experimental::Internal::RNTupleSerializer::RContext>
-ROOT::Experimental::Internal::RNTupleSerializer::SerializeHeader(void *buffer,
-                                                                 const ROOT::Experimental::RNTupleDescriptor &desc)
+ROOT::Experimental::Internal::RNTupleSerializer::SerializeHeader(void *buffer, const ROOT::RNTupleDescriptor &desc)
 {
    RContext context;
 
@@ -1760,8 +1759,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList(void *buffer,
 }
 
 ROOT::RResult<std::uint32_t>
-ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooter(void *buffer,
-                                                                 const ROOT::Experimental::RNTupleDescriptor &desc,
+ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooter(void *buffer, const ROOT::RNTupleDescriptor &desc,
                                                                  const RContext &context)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
@@ -1967,7 +1965,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeFooter(const void *b
    return RResult<void>::Success();
 }
 
-ROOT::RResult<std::vector<ROOT::Experimental::Internal::RClusterDescriptorBuilder>>
+ROOT::RResult<std::vector<ROOT::Internal::RClusterDescriptorBuilder>>
 ROOT::Experimental::Internal::RNTupleSerializer::DeserializePageListRaw(const void *buffer, std::uint64_t bufSize,
                                                                         ROOT::DescriptorId_t clusterGroupId,
                                                                         const RNTupleDescriptor &desc)

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -130,7 +130,8 @@ void ROOT::Experimental::Internal::RPageSinkBuf::UpdateSchema(const RNTupleModel
    fInnerSink->UpdateSchema(innerChangeset, firstEntry);
 }
 
-void ROOT::Experimental::Internal::RPageSinkBuf::UpdateExtraTypeInfo(const RExtraTypeInfoDescriptor &extraTypeInfo)
+void ROOT::Experimental::Internal::RPageSinkBuf::UpdateExtraTypeInfo(
+   const ROOT::RExtraTypeInfoDescriptor &extraTypeInfo)
 {
    RPageSink::RSinkGuard g(fInnerSink->GetSinkGuard());
    Detail::RNTuplePlainTimer timer(fCounters->fTimeWallCriticalSection, fCounters->fTimeCpuCriticalSection);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -81,7 +81,7 @@ void ROOT::Experimental::Internal::RPageSinkBuf::ConnectFields(const std::vector
    fBufferedColumns.resize(fNColumns);
 }
 
-const ROOT::Experimental::RNTupleDescriptor &ROOT::Experimental::Internal::RPageSinkBuf::GetDescriptor() const
+const ROOT::RNTupleDescriptor &ROOT::Experimental::Internal::RPageSinkBuf::GetDescriptor() const
 {
    return fInnerSink->GetDescriptor();
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -43,8 +43,13 @@
 #include <utility>
 
 using ROOT::Internal::MakeUninitArray;
+using ROOT::Internal::RClusterDescriptorBuilder;
+using ROOT::Internal::RClusterGroupDescriptorBuilder;
 using ROOT::Internal::RColumn;
+using ROOT::Internal::RColumnDescriptorBuilder;
 using ROOT::Internal::RColumnElementBase;
+using ROOT::Internal::RExtraTypeInfoDescriptorBuilder;
+using ROOT::Internal::RFieldDescriptorBuilder;
 
 ROOT::Experimental::Internal::RPageStorage::RPageStorage(std::string_view name)
    : fMetrics(""), fPageAllocator(std::make_unique<ROOT::Internal::RPageAllocatorHeap>()), fNTupleName(name)

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -156,7 +156,7 @@ struct RDaosContainerNTupleLocator {
    }
 
    int InitNTupleDescriptorBuilder(ROOT::Experimental::Internal::RDaosContainer &cont,
-                                   ROOT::Experimental::Internal::RNTupleDescriptorBuilder &builder)
+                                   ROOT::Internal::RNTupleDescriptorBuilder &builder)
    {
       std::unique_ptr<unsigned char[]> buffer, zipBuffer;
       auto &anchor = fAnchor.emplace();
@@ -197,11 +197,10 @@ struct RDaosContainerNTupleLocator {
       return 0;
    }
 
-   static std::pair<RDaosContainerNTupleLocator, ROOT::Experimental::Internal::RNTupleDescriptorBuilder>
+   static std::pair<RDaosContainerNTupleLocator, ROOT::Internal::RNTupleDescriptorBuilder>
    LocateNTuple(ROOT::Experimental::Internal::RDaosContainer &cont, const std::string &ntupleName)
    {
-      auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName),
-                                   ROOT::Experimental::Internal::RNTupleDescriptorBuilder());
+      auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), ROOT::Internal::RNTupleDescriptorBuilder());
 
       auto &loc = result.first;
       auto &builder = result.second;
@@ -503,10 +502,10 @@ ROOT::Experimental::Internal::RPageSourceDaos::RPageSourceDaos(std::string_view 
 
 ROOT::Experimental::Internal::RPageSourceDaos::~RPageSourceDaos() = default;
 
-ROOT::Experimental::RNTupleDescriptor
+ROOT::RNTupleDescriptor
 ROOT::Experimental::Internal::RPageSourceDaos::AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode)
 {
-   ROOT::Experimental::RNTupleDescriptor ntplDesc;
+   ROOT::RNTupleDescriptor ntplDesc;
    std::unique_ptr<unsigned char[]> buffer, zipBuffer;
 
    auto [locator, descBuilder] = RDaosContainerNTupleLocator::LocateNTuple(*fDaosContainer, fNTupleName);
@@ -550,7 +549,7 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(ROOT::Descrip
 {
    const auto clusterId = localIndex.GetClusterId();
 
-   RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -698,7 +698,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
       PrepareLoadCluster(
          clusterKey, *pageZeroMap,
          [&](ROOT::DescriptorId_t physicalColumnId, ROOT::NTupleSize_t pageNo,
-             const RClusterDescriptor::RPageInfo &pageInfo) {
+             const ROOT::RClusterDescriptor::RPageInfo &pageInfo) {
             const auto &pageLocator = pageInfo.GetLocator();
             uint32_t position, offset;
             std::tie(position, offset) = DecodeDaosPagePosition(pageLocator.GetPosition<RNTupleLocatorObject64>());

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -357,7 +357,7 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadStructureImpl()
    }
 }
 
-ROOT::Experimental::RNTupleDescriptor
+ROOT::RNTupleDescriptor
 ROOT::Experimental::Internal::RPageSourceFile::AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode)
 {
    auto unzipBuf = reinterpret_cast<unsigned char *>(fStructureBuffer.fPtrFooter) + fAnchor->GetNBytesFooter();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -397,7 +397,7 @@ void ROOT::Experimental::Internal::RPageSourceFile::LoadSealedPage(ROOT::Descrip
 {
    const auto clusterId = localIndex.GetClusterId();
 
-   RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
@@ -514,7 +514,7 @@ ROOT::Experimental::Internal::RPageSourceFile::PrepareSingleCluster(
    auto pageZeroMap = std::make_unique<ROnDiskPageMap>();
    PrepareLoadCluster(clusterKey, *pageZeroMap,
                       [&](ROOT::DescriptorId_t physicalColumnId, ROOT::NTupleSize_t pageNo,
-                          const RClusterDescriptor::RPageInfo &pageInfo) {
+                          const ROOT::RClusterDescriptor::RPageInfo &pageInfo) {
                          const auto &pageLocator = pageInfo.GetLocator();
                          if (pageLocator.GetType() == RNTupleLocator::kTypeUnknown)
                             throw RException(R__FAIL("tried to read a page with an unknown locator"));

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-using ROOT::Experimental::RNTupleDescriptor;
 using ROOT::Experimental::Internal::RCluster;
 using ROOT::Experimental::Internal::RClusterPool;
 using ROOT::Experimental::Internal::ROnDiskPage;
@@ -50,17 +49,17 @@ public:
 
    RPageSourceMock() : RPageSource("test", RNTupleReadOptions())
    {
-      ROOT::Experimental::Internal::RNTupleDescriptorBuilder descBuilder;
+      ROOT::Internal::RNTupleDescriptorBuilder descBuilder;
       descBuilder.SetNTuple("ntpl", "");
       for (unsigned i = 0; i <= 5; ++i) {
-         descBuilder.AddCluster(ROOT::Experimental::Internal::RClusterDescriptorBuilder()
+         descBuilder.AddCluster(ROOT::Internal::RClusterDescriptorBuilder()
                                    .ClusterId(i)
                                    .FirstEntryIndex(i)
                                    .NEntries(1)
                                    .MoveDescriptor()
                                    .Unwrap());
       }
-      ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder cgBuilder;
+      ROOT::Internal::RClusterGroupDescriptorBuilder cgBuilder;
       cgBuilder.ClusterGroupId(0).MinEntry(0).EntrySpan(6).NClusters(6);
       cgBuilder.AddSortedClusters({0, 1, 2, 3, 4, 5});
       descBuilder.AddClusterGroup(cgBuilder.MoveDescriptor().Unwrap());

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -674,7 +674,7 @@ TEST(RNTupleDescriptor, CloneSchema)
    EXPECT_NE(desc.GetOnDiskHeaderSize(), 0);
    EXPECT_NE(desc.GetOnDiskFooterSize(), 0);
 
-   const auto descOnlySchema = ROOT::Experimental::Internal::CloneDescriptorSchema(desc);
+   const auto descOnlySchema = ROOT::Internal::CloneDescriptorSchema(desc);
    EXPECT_EQ(descOnlySchema.GetNFields(), 8);
    EXPECT_EQ(descOnlySchema.GetNLogicalColumns(), 7);
    EXPECT_EQ(descOnlySchema.GetNPhysicalColumns(), 4);

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -22,7 +22,7 @@
 
 using ROOT::ENTupleColumnType;
 using ROOT::NTupleSize_t;
-using ROOT::Experimental::RNTupleDescriptor;
+using ROOT::RNTupleDescriptor;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::Internal::RCluster;
 using ROOT::Experimental::Internal::RPageSink;
@@ -51,7 +51,7 @@ protected:
 
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, NTupleSize_t) final {}
-   void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
+   void UpdateExtraTypeInfo(const ROOT::RExtraTypeInfoDescriptor &) final {}
    void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitSealedPage(ROOT::DescriptorId_t, const RPageStorage::RSealedPage &) final {}
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup>) final {}

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -671,11 +671,11 @@ TEST(RNTuple, SerializeFooter)
                         .MakeDescriptor()
                         .Unwrap());
 
-   ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RColumnRange columnRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    RClusterDescriptorBuilder clusterBuilder;
    clusterBuilder.ClusterId(84).FirstEntryIndex(0).NEntries(100);
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
    pageRange.SetPhysicalColumnId(17);
    // Two pages adding up to 100 elements, one with checksum one without
    pageInfo.SetNElements(40);
@@ -993,8 +993,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentation)
                         .Unwrap());
 
    RClusterDescriptorBuilder clusterBuilder;
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    // First cluster
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    clusterBuilder.MarkSuppressedColumnRange(0);
@@ -1189,8 +1189,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationProjection)
                         .Unwrap());
 
    RClusterDescriptorBuilder clusterBuilder;
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    // First cluster
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    clusterBuilder.MarkSuppressedColumnRange(0);
@@ -1314,8 +1314,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred)
                         .Unwrap());
    context.MapSchema(builder.GetDescriptor(), /*forHeaderExtension=*/true);
 
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    // Second cluster
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);
@@ -1424,8 +1424,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationIncremental)
 
    // First cluster
    RClusterDescriptorBuilder clusterBuilder;
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    pageRange.SetPhysicalColumnId(0);
    pageInfo.SetNElements(1);
@@ -1557,8 +1557,8 @@ TEST(RNTuple, DeserializeDescriptorModes)
       context = RNTupleSerializer::SerializeHeader(bufHeader.get(), builder.GetDescriptor()).Unwrap();
       sizeHeader = context.GetHeaderSize();
 
-      ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-      ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+      ROOT::RClusterDescriptor::RPageRange pageRange;
+      ROOT::RClusterDescriptor::RPageInfo pageInfo;
 
       // First cluster
       RClusterDescriptorBuilder clusterBuilder;
@@ -1832,8 +1832,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferred_HeaderExtBeforeSerializ
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
 
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    // Second cluster
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);
@@ -1958,8 +1958,8 @@ TEST(RNTuple, SerializeMultiColumnRepresentationDeferredInMainHeader)
    clusterBuilder.ClusterId(13).FirstEntryIndex(0).NEntries(1);
    builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
 
-   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   ROOT::Experimental::RClusterDescriptor::RPageInfo pageInfo;
+   ROOT::RClusterDescriptor::RPageRange pageRange;
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
    // Second cluster
    clusterBuilder.ClusterId(17).FirstEntryIndex(1).NEntries(2);
    clusterBuilder.MarkSuppressedColumnRange(1);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -42,7 +42,7 @@ protected:
 
    void InitImpl(RNTupleModel &) final {}
    void UpdateSchema(const ROOT::Experimental::Internal::RNTupleModelChangeset &, ROOT::NTupleSize_t) final {}
-   void UpdateExtraTypeInfo(const ROOT::Experimental::RExtraTypeInfoDescriptor &) final {}
+   void UpdateExtraTypeInfo(const ROOT::RExtraTypeInfoDescriptor &) final {}
    void CommitSuppressedColumn(ColumnHandle_t) final {}
    void CommitPage(ColumnHandle_t /*columnHandle*/, const RPage & /*page*/) final { fCounters.fNCommitPage++; }
    void CommitSealedPage(ROOT::DescriptorId_t, const RPageStorage::RSealedPage &) final

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -53,32 +53,32 @@
 #include <variant>
 #include <vector>
 
+using ROOT::EExtraTypeInfoIds;
 using ROOT::RNTupleLocalIndex;
 using ROOT::RNTupleLocator;
 using ROOT::RNTupleLocatorObject64;
-using ROOT::Experimental::EExtraTypeInfoIds;
 using ROOT::Internal::RColumnIndex;
-using RClusterDescriptor = ROOT::Experimental::RClusterDescriptor;
-using RClusterDescriptorBuilder = ROOT::Experimental::Internal::RClusterDescriptorBuilder;
-using RClusterGroupDescriptorBuilder = ROOT::Experimental::Internal::RClusterGroupDescriptorBuilder;
-using RColumnDescriptorBuilder = ROOT::Experimental::Internal::RColumnDescriptorBuilder;
+using RClusterDescriptor = ROOT::RClusterDescriptor;
+using RClusterDescriptorBuilder = ROOT::Internal::RClusterDescriptorBuilder;
+using RClusterGroupDescriptorBuilder = ROOT::Internal::RClusterGroupDescriptorBuilder;
+using RColumnDescriptorBuilder = ROOT::Internal::RColumnDescriptorBuilder;
 using RColumnElementBase = ROOT::Internal::RColumnElementBase;
 using RColumnSwitch = ROOT::Internal::RColumnSwitch;
-using ROOT::Experimental::Internal::RExtraTypeInfoDescriptorBuilder;
-using RFieldDescriptorBuilder = ROOT::Experimental::Internal::RFieldDescriptorBuilder;
+using ROOT::Internal::RExtraTypeInfoDescriptorBuilder;
+using RFieldDescriptorBuilder = ROOT::Internal::RFieldDescriptorBuilder;
 template <class T>
 using RField = ROOT::RField<T>;
 using RFieldBase = ROOT::RFieldBase;
-using RFieldDescriptor = ROOT::Experimental::RFieldDescriptor;
+using RFieldDescriptor = ROOT::RFieldDescriptor;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;
 using RNTupleAtomicCounter = ROOT::Experimental::Detail::RNTupleAtomicCounter;
 using RNTupleAtomicTimer = ROOT::Experimental::Detail::RNTupleAtomicTimer;
 using RNTupleCalcPerf = ROOT::Experimental::Detail::RNTupleCalcPerf;
 using RNTupleCompressor = ROOT::Internal::RNTupleCompressor;
 using RNTupleDecompressor = ROOT::Internal::RNTupleDecompressor;
-using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
+using RNTupleDescriptor = ROOT::RNTupleDescriptor;
 using RNTupleFillStatus = ROOT::Experimental::RNTupleFillStatus;
-using RNTupleDescriptorBuilder = ROOT::Experimental::Internal::RNTupleDescriptorBuilder;
+using RNTupleDescriptorBuilder = ROOT::Internal::RNTupleDescriptorBuilder;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
 using RNTupleJoinTable = ROOT::Experimental::Internal::RNTupleJoinTable;
 using RNTupleParallelWriter = ROOT::Experimental::RNTupleParallelWriter;

--- a/tree/ntuple/v7/test/rfield_streamer.cxx
+++ b/tree/ntuple/v7/test/rfield_streamer.cxx
@@ -211,7 +211,7 @@ TEST(RField, StreamerMerge)
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
    const auto &typeInfo = *desc.GetExtraTypeInfoIterable().begin();
-   EXPECT_EQ(ROOT::Experimental::EExtraTypeInfoIds::kStreamerInfo, typeInfo.GetContentId());
+   EXPECT_EQ(ROOT::EExtraTypeInfoIds::kStreamerInfo, typeInfo.GetContentId());
    auto streamerInfoMap = RNTupleSerializer::DeserializeStreamerInfos(typeInfo.GetContent()).Unwrap();
    EXPECT_EQ(4u, streamerInfoMap.size());
    std::array<bool, 4> seenStreamerInfos{false, false, false, false};
@@ -286,7 +286,7 @@ TEST(RField, StreamerMergeIncremental)
    const auto &desc = reader->GetDescriptor();
    EXPECT_EQ(1u, desc.GetNExtraTypeInfos());
    const auto &typeInfo = *desc.GetExtraTypeInfoIterable().begin();
-   EXPECT_EQ(ROOT::Experimental::EExtraTypeInfoIds::kStreamerInfo, typeInfo.GetContentId());
+   EXPECT_EQ(ROOT::EExtraTypeInfoIds::kStreamerInfo, typeInfo.GetContentId());
    auto streamerInfoMap = RNTupleSerializer::DeserializeStreamerInfos(typeInfo.GetContent()).Unwrap();
    EXPECT_EQ(4u, streamerInfoMap.size());
    std::array<bool, 4> seenStreamerInfos{false, false, false, false};

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -83,21 +83,21 @@ public:
    /// RColumnInspector that belongs to this field.
    class RColumnInspector {
    private:
-      const RColumnDescriptor &fColumnDescriptor;
+      const ROOT::RColumnDescriptor &fColumnDescriptor;
       const std::vector<std::uint64_t> fCompressedPageSizes = {};
       std::uint32_t fElementSize = 0;
       std::uint64_t fNElements = 0;
 
    public:
-      RColumnInspector(const RColumnDescriptor &colDesc, const std::vector<std::uint64_t> &compressedPageSizes,
+      RColumnInspector(const ROOT::RColumnDescriptor &colDesc, const std::vector<std::uint64_t> &compressedPageSizes,
                        std::uint32_t elemSize, std::uint64_t nElems)
          : fColumnDescriptor(colDesc),
            fCompressedPageSizes(compressedPageSizes),
            fElementSize(elemSize),
-           fNElements(nElems){};
+           fNElements(nElems) {};
       ~RColumnInspector() = default;
 
-      const RColumnDescriptor &GetDescriptor() const { return fColumnDescriptor; }
+      const ROOT::RColumnDescriptor &GetDescriptor() const { return fColumnDescriptor; }
       const std::vector<std::uint64_t> &GetCompressedPageSizes() const { return fCompressedPageSizes; }
       std::uint64_t GetNPages() const { return fCompressedPageSizes.size(); }
       std::uint64_t GetCompressedSize() const
@@ -118,23 +118,23 @@ public:
    /// the RFieldDescriptor that belongs to this field.
    class RFieldTreeInspector {
    private:
-      const RFieldDescriptor &fRootFieldDescriptor;
+      const ROOT::RFieldDescriptor &fRootFieldDescriptor;
       std::uint64_t fCompressedSize = 0;
       std::uint64_t fUncompressedSize = 0;
 
    public:
-      RFieldTreeInspector(const RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
-         : fRootFieldDescriptor(fieldDesc), fCompressedSize(onDiskSize), fUncompressedSize(inMemSize){};
+      RFieldTreeInspector(const ROOT::RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
+         : fRootFieldDescriptor(fieldDesc), fCompressedSize(onDiskSize), fUncompressedSize(inMemSize) {};
       ~RFieldTreeInspector() = default;
 
-      const RFieldDescriptor &GetDescriptor() const { return fRootFieldDescriptor; }
+      const ROOT::RFieldDescriptor &GetDescriptor() const { return fRootFieldDescriptor; }
       std::uint64_t GetCompressedSize() const { return fCompressedSize; }
       std::uint64_t GetUncompressedSize() const { return fUncompressedSize; }
    };
 
 private:
    std::unique_ptr<Internal::RPageSource> fPageSource;
-   RNTupleDescriptor fDescriptor;
+   ROOT::RNTupleDescriptor fDescriptor;
    std::optional<std::uint32_t> fCompressionSettings; ///< The compression settings are unknown for an empty ntuple
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
@@ -202,8 +202,8 @@ public:
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the descriptor for the RNTuple being inspected.
    ///
-   /// \return A static copy of the RNTupleDescriptor belonging to the inspected RNTuple.
-   const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
+   /// \return A static copy of the ROOT::RNTupleDescriptor belonging to the inspected RNTuple.
+   const ROOT::RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the compression settings of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleExporter.cxx
@@ -32,11 +32,12 @@ ROOT::RLogChannel &RNTupleExporterLog()
 }
 
 struct RColumnExportInfo {
-   const RColumnDescriptor *fColDesc;
-   const RFieldDescriptor *fFieldDesc;
+   const ROOT::RColumnDescriptor *fColDesc;
+   const ROOT::RFieldDescriptor *fFieldDesc;
    std::string fQualifiedName;
 
-   RColumnExportInfo(const RNTupleDescriptor &desc, const RColumnDescriptor &colDesc, const RFieldDescriptor &fieldDesc)
+   RColumnExportInfo(const ROOT::RNTupleDescriptor &desc, const ROOT::RColumnDescriptor &colDesc,
+                     const ROOT::RFieldDescriptor &fieldDesc)
       : fColDesc(&colDesc),
         fFieldDesc(&fieldDesc),
         // NOTE: we don't need to keep the column representation index into account because exactly 1 representation
@@ -64,8 +65,9 @@ bool ItemIsFilteredOut(const RNTupleExporter::RFilter<T> &filter, const T &item)
    return isFiltered;
 }
 
-RAddColumnsResult AddColumnsFromField(std::vector<RColumnExportInfo> &vec, const RNTupleDescriptor &desc,
-                                      const RFieldDescriptor &fieldDesc, const RNTupleExporter::RPagesOptions &options)
+RAddColumnsResult AddColumnsFromField(std::vector<RColumnExportInfo> &vec, const ROOT::RNTupleDescriptor &desc,
+                                      const ROOT::RFieldDescriptor &fieldDesc,
+                                      const RNTupleExporter::RPagesOptions &options)
 {
    R__LOG_DEBUG(1, RNTupleExporterLog()) << "processing field \"" << desc.GetQualifiedFieldName(fieldDesc.GetId())
                                          << "\"";
@@ -89,7 +91,7 @@ RAddColumnsResult AddColumnsFromField(std::vector<RColumnExportInfo> &vec, const
    return res;
 }
 
-int CountPages(const RNTupleDescriptor &desc, std::span<const RColumnExportInfo> columns)
+int CountPages(const ROOT::RNTupleDescriptor &desc, std::span<const RColumnExportInfo> columns)
 {
    int nPages = 0;
    auto clusterId = desc.FindClusterId(0, 0);


### PR DESCRIPTION
# This Pull request:
Moves the following classes out of Experimental:
- `RNTupleDescriptor`
- `R(Field|Column|Cluster|ClusterGroup|ExtraTypeInfo)Descriptor`
- Their Builders

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

