### PR TITLE
[CMake] Raise minimum CMake version for Cling to 3.10

### DIFF
--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -1,12 +1,4 @@
-if(WIN32)
-  # We need cmake to support exporting of symbols not only from libraries but
-  # from executables too. This way cling can find symbols from its own
-  # executable during runtime.
-  cmake_minimum_required(VERSION 3.6.2)
-else(WIN32)
-  # support of earlier cmake versions will be removed soon
-  cmake_minimum_required(VERSION 3.5)
-endif(WIN32)
+cmake_minimum_required(VERSION 3.10)
 
 # If we are not building as a part of LLVM, build Cling as an
 # standalone project, using LLVM as an external library:

--- a/interpreter/cling/tools/demo/CMakeLists.txt
+++ b/interpreter/cling/tools/demo/CMakeLists.txt
@@ -6,7 +6,7 @@
 # LICENSE.TXT for details.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # Keep symbols for JIT resolution
 set(LLVM_NO_DEAD_STRIP 1)


### PR DESCRIPTION
The recent cmake version 3.31.5 gives the following warning:

```txt
CMake Deprecation Warning at interpreter/cling/CMakeLists.txt:8 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```

Raise the minimum version to CMake 3.10, which was released in 2017: https://www.kitware.com/cmake-3-10-0-available-for-download/


Whoever is reviewing this, please also take a look at this related `roottest` PR with the same branch name so they are tested together:
https://github.com/root-project/roottest/pull/1284