### PR TITLE
[tmva][sofie] Fix fusing of operators for generic cases

### DIFF
--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -36,9 +36,8 @@ private:
    std::unique_ptr<OperatorsMapImpl> fOperatorsMapImpl;
    // Type of the tensors
    std::unordered_map<std::string, ETensorType> fTensorTypeMap;
-
-   // all model inputs
-   std::map<std::string, int> allInputs;
+   // flag list of fused operators
+   std::vector<bool> fFusedOperators;
 
 
 public:
@@ -67,7 +66,7 @@ public:
 
    // Parse the index'th node from the ONNX graph
    std::unique_ptr<ROperator> ParseOperator(const size_t /*index*/, const onnx::GraphProto & /*graphproto*/,
-                                            const std::vector<size_t> & /*nodes*/);
+                                            const std::vector<size_t> & /*nodes*/, const std::vector<int> & /* children */);
 
    // check a graph for missing operators
    void CheckGraph(const onnx::GraphProto & g, int & level, std::map<std::string, int> & missingOperators);

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -276,7 +276,7 @@ ETensorType RModelParser_ONNX::GetTensorType(const std::string &name)
 
 // Parse an operator
 std::unique_ptr<ROperator>
-RModelParser_ONNX::ParseOperator(const size_t i, const onnx::GraphProto &graphproto, const std::vector<size_t> &nodes)
+RModelParser_ONNX::ParseOperator(const size_t i, const onnx::GraphProto &graphproto, const std::vector<size_t> &nodes, const std::vector<int> & children)
 {
    if (i >= nodes.size())
       throw std::runtime_error("TMVA::SOFIE - Error in parsing ordered operators " + std::to_string(i) + " is >=  " + std::to_string(nodes.size()));
@@ -286,12 +286,16 @@ RModelParser_ONNX::ParseOperator(const size_t i, const onnx::GraphProto &graphpr
    if (fVerbose)
       std::cout << "Parsing operator " << op_type << std::endl;
 
+   // skip already fused operators
+   if (fFusedOperators[idx]) return nullptr;
+
    // try to fuse with following operator in case it is not last one
-   if (i < nodes.size() - 1) {
-      int idx2 = nodes[i+1];
+   if (children.size() == 1) {
+      int idx2 = children.front();
       if (op_type == "MatMul") {
         // Fuse MatMul and Add
          if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Add") {
+            fFusedOperators[idx2] = true;
             return ParseFuseMatMulAdd(*this, graphproto.node(idx), graphproto.node(idx2));
          }
          else {
@@ -301,41 +305,28 @@ RModelParser_ONNX::ParseOperator(const size_t i, const onnx::GraphProto &graphpr
       // Fuse Conv or ConvTranspose without bias and Add
          if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Add") {
             if (nodeproto.op_type() == "Conv") {
+               fFusedOperators[idx2] = true;
                return ParseFuseConvAdd(*this, graphproto.node(idx), graphproto.node(idx2));
             } else {
+               fFusedOperators[idx2] = true;
                return ParseFuseConvTransposeAdd(*this, graphproto.node(idx), graphproto.node(idx2));
             }
          }
       } else if (nodeproto.op_type() == "Gemm") {
-            // Fuse Gemm with activation operators
-            if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Relu") {
-                  return ParseFuseGemmRelu(*this, graphproto.node(idx), graphproto.node(idx2));
-            }
-
-            // else if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Softmax") {
-            //       return ParseFuseGemmSoftmax(*this, graphproto.node(idx), graphproto.node(idx2));
-            // }
+         // Fuse Gemm with activation operators
+         if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Relu") {
+            fFusedOperators[idx2] = true;
+            return ParseFuseGemmRelu(*this, graphproto.node(idx), graphproto.node(idx2));
+         }
       } else if (nodeproto.op_type() == "BatchNormalization") {
          if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Relu") {
+            fFusedOperators[idx2] = true;
             return ParseFuseBatchnormRelu(*this, graphproto.node(idx), graphproto.node(idx2));
          }
       }
    }
 
-   // skip then the following Add if it was fused before
-   if (idx > 0 && op_type == "Add") {
-      int idx0 = nodes[i - 1];
-      if (graphproto.node(idx0).op_type() == "MatMul")
-         return nullptr;
-      else if (graphproto.node(idx0).op_type() == "ConvTranspose")
-         return nullptr;
-   } else if(idx > 0 && op_type == "Relu"){
-      int idx0 = nodes[i - 1];
-      if (graphproto.node(idx0).op_type() == "Gemm")
-         return nullptr;
-      else if (graphproto.node(idx0).op_type() == "BatchNormalization")
-         return nullptr;
-   }
+
 
    auto it = fOperatorsMapImpl->fOperatorsMap.find(op_type);
    if (it == fOperatorsMapImpl->fOperatorsMap.end()) {
@@ -493,10 +484,6 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
       std::string input_name = valueinfoproto.name();
 
       ETensorType type = static_cast<ETensorType>(valueinfoproto.type().tensor_type().elem_type());
-      // why we have this??? we can support all input types
-      //if (type != ETensorType::FLOAT && type != ETensorType::INT32 && type != ETensorType::INT64) {
-      //   throw std::runtime_error("TMVA::SOFIE Data type in input tensor " + input_name + " not supported!\n");
-      //}
 
       std::vector<Dim> fShape;
       bool existParam = false;
@@ -620,12 +607,13 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
 
    // make order of nodes:
    if (verbose)
-      std::cout << "\nRe-Order graph operator list\n";
+      std::cout << "\n***********************\nRe-Order graph operator list\n*************************\n";
    std::vector<size_t> nodesOrder;
    nodesOrder.reserve(graph.node_size());
    std::vector<bool> foundNodes(graph.node_size());
+
    // loop at graph inputs
-   //std::map<std::string, int> allInputs;
+   std::map<std::string, int> allInputs;
    for (int i = 0; i < graph.input_size(); i++) {
       allInputs[graph.input(i).name()] = -1;
    }
@@ -649,7 +637,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
                if (fVerbose) {
                   std::cout << "\t\t input " << name << " "
                      << bool(allInputs.find(name) != allInputs.end()) << "  " <<
-                     bool(allInitializedTensors.find(name) != allInitializedTensors.end()) <<
+                     bool(allInitializedTensors.find(name) != allInitializedTensors.end()) << "  " <<
                      existInputs << std::endl;
                }
             }
@@ -664,6 +652,8 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
             }
             continue;
          }
+
+         // adding node to the currectly ordered list
          if (verbose)
             std::cout << "===> New node " << graph.node(i).op_type() << "  " << graph.node(i).name() << " order " << i << std::endl;
 
@@ -683,19 +673,43 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
       }
    } while ((int)nodesOrder.size() < graph.node_size());
 
-   // scan operators for orders
+
+   // find list of children for each operator (used for fusing oiperators)
+   std::vector<std::vector<int>> nodesChildren(graph.node_size());
+
+   for (int k = 0; k < graph.node_size(); k++) {
+      int i = nodesOrder[k];
+      // compute the number of output for the operators
+      if (graph.node(i).output_size() > 0) nodesChildren[i].reserve(graph.node(i).output_size());
+      for (const auto& output_name : graph.node(i).output()) {
+         // loop on all nodes
+         for (int l = k; l < graph.node_size(); l++) {
+            int j = nodesOrder[l];
+            for (const auto& input_name : graph.node(j).input()) {
+               if (input_name == output_name)
+                  nodesChildren[i].push_back(j);
+            }
+         }
+      }
+   }
+
+   // print lit of order operators with list of inputs and list of children nodes
    if (verbose) {
       std::cout << "\nGraph operator list (re-ordered)\n";
       for (int k = 0; k < graph.node_size(); k++) {
          int i = nodesOrder[k];
-         std::cout << "\tOperator " << i << " : " << graph.node(i).op_type() << " , " << graph.node(i).input_size()
-                   << " inputs : {";
-         for (int j = 0; j < graph.node(i).input_size(); j++) {
+         std::cout << "\tOperator " << i << " : " << graph.node(i).op_type() << " , " << graph.node(i).name() << " input tensors : {";
+            for (int j = 0; j < graph.node(i).input_size(); j++) {
             std::cout << graph.node(i).input(j);
             if (j < graph.node(i).input_size() - 1)
                std::cout << ", ";
          }
-         std::cout << " }" << std::endl;
+         std::cout << " } ";
+         std::cout << " children : {";
+         for ( const auto & ichild : nodesChildren[i]) {
+            std::cout << " [ " << ichild << " " << graph.node(ichild).op_type() << " , " << graph.node(ichild).name() << "]";
+         }
+         std::cout << "}" << std::endl;
       }
    }
 
@@ -707,6 +721,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
    // we have to record order of node execution separately to
    // account for fused operators
    size_t node_order_exec = 0;
+   fFusedOperators = std::vector<bool>(graph.node_size(), false);
    for (int i = 0; i < graph.node_size(); i++) {
       std::string op_type = graph.node(nodesOrder[i]).op_type();
 
@@ -714,7 +729,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
          std::cout << "\t" << i << "  " << nodesOrder[i] << " parsing operator " << op_type << std::endl;
       }
 
-      std::unique_ptr<ROperator> op = ParseOperator(i, graph, nodesOrder);
+      std::unique_ptr<ROperator> op = ParseOperator(i, graph, nodesOrder, nodesChildren[i]);
       if (!op) {
          if (verbose) {
             std::cout << "\t\tskipping operator since it is fused with previous one" << std::endl;


### PR DESCRIPTION
Fix the fusing for operators looking at all the children of a specific node in the ONNX graph and do not assume that the nodes are contiguous in the topological ONNX order

