### PR TITLE
[ci] Add ruff python linter and formatter to the code analysis workflow

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,4 +1,4 @@
-name: clang-tools code analysis
+name: code analysis
 
 on: pull_request
   # push:
@@ -30,3 +30,44 @@ jobs:
       run: sudo apt-get install -y clang-format
     - name: run clang-format script
       run: .ci/format_script.sh
+
+  ruff:
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip-ci]'))
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Get the list of changed files
+      id: diff
+      run: |
+        git fetch --depth=1 origin $GITHUB_BASE_REF 
+        git diff --name-only origin/$GITHUB_BASE_REF > changed_files.txt
+
+    - name: Install ruff
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: "--version"
+
+    - name: Lint code
+      run: |
+        files=$(cat changed_files.txt | grep '\.py$' || echo "")
+        if [ -n "$files" ]; then
+          echo "$files" | xargs ruff check --diff || true
+          echo "$files" | xargs ruff check
+        else
+          echo "No python files to lint"
+        fi
+
+    - name: Format code
+      if: always()
+      run: |
+        files=$(cat changed_files.txt | grep '\.py$' || echo "")
+        if [ -n "$files" ]; then
+          echo "$files" | xargs ruff format --diff
+        else
+          echo "No python files to format"
+        fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ The primary branch for development is `master`.
 > Please follow the [coding conventions](https://root.cern.ch/coding-conventions), as this is a simple item for
 > reviewers to otherwise get stuck on.
 > To make your (and our own) life easier, we provide a
-> [`clang-format` configuration file](https://github.com/root-project/root/blob/master/.clang-format).
+> [`clang-format` configuration file](https://github.com/root-project/root/blob/master/.clang-format) as well
+> as a [`ruff` configuration file](https://github.com/root-project/root/blob/master/ruff.toml)
 
 By providing code, you agree to transfer your copyright on the code to the "ROOT project".
 Of course you will be duly credited: for sizable contributions your name will appear in the
@@ -117,10 +118,15 @@ ROOT has automated CI tests :cop: that are used for pull requests:
     [project member](https://github.com/orgs/root-project/people) is allowed to initiate this build.
     The results are posted to the pull request.
     Compared to ROOT's nightly builds, PRs are tested with less tests, on less platforms.
-- *Formatting check*: `clang-format` automatically checks that a PR
+- *Linting check*: `ruff` automatically checks that a PR adheres to the project's
+    [style guide](https://github.com/root-project/root/blob/master/.ruff.toml).
+    If any linting violations are found, it provides you with a detailed report that you should address in your PR.
+- *Formatting check*: 
+    - `clang-format`: automatically checks that a PR
     [follows](https://github.com/root-project/root/blob/master/.clang-format) ROOT's
     [coding conventions](https://root.cern/contribute/coding_conventions/).
     If coding violations are found, it provides you with a `patch` output that you likely want to apply to your PR.
+    - `ruff`: ensures Python code in the PR adheres to the project's [style guidelines](https://github.com/root-project/root/blob/master/ruff.toml).
 - *Simple Static Analysis*: PRs are analyzed using [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/).
 
 Typically, PRs must pass all these tests; we will ask you to fix any issues that may arise.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,13 @@
+line-length = 120
+
+[lint]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E4",
+    "E7",
+    "E9",
+    # isort
+    "I001"
+]


### PR DESCRIPTION
# This Pull request:

## Adds:
This PR introduces Ruff to the CI workflow for checking and formatting Python code. 
Uses the default ruff configuration and sets `line-length = 120` to be consistent with our [C++ code style](https://github.com/root-project/root/blob/master/.clang-format#L63)

This PR closes #17142

