### PR TITLE
[ntuple] Implement `Detail::RRawPtrWriteEntry`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -18,7 +18,7 @@ def _REntry_GetPtr(self, key):
 
 def _REntry_CallGetPtr(self, key):
     # key can be either a RFieldToken already or a string. In the latter case, get a token to use it twice.
-    if not hasattr(type(key), "__cpp_name__") or type(key).__cpp_name__ != "ROOT::REntry::RFieldToken":
+    if not hasattr(type(key), "__cpp_name__") or type(key).__cpp_name__ != "ROOT::RFieldToken":
         key = self.GetToken(key)
     fieldType = self.GetTypeName(key)
     return self._GetPtr[fieldType](key)

--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -22,6 +22,7 @@ HEADERS
   ROOT/REntry.hxx
   ROOT/RField.hxx
   ROOT/RFieldBase.hxx
+  ROOT/RFieldToken.hxx
   ROOT/RFieldUtils.hxx
   ROOT/RFieldVisitor.hxx
   ROOT/RMiniFile.hxx

--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -54,6 +54,7 @@ HEADERS
   ROOT/RPageSinkBuf.hxx
   ROOT/RPageStorage.hxx
   ROOT/RPageStorageFile.hxx
+  ROOT/RRawPtrWriteEntry.hxx
 SOURCES
   v7/src/RCluster.cxx
   v7/src/RClusterPool.cxx

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -43,6 +43,10 @@ namespace Experimental {
 
 class RNTupleJoinProcessor;
 
+namespace Detail {
+class RRawPtrWriteEntry;
+} // namespace Detail
+
 namespace Internal {
 class RPageSink;
 class RPageSource;
@@ -83,6 +87,7 @@ This is and can only be partially enforced through C++.
 class RFieldBase {
    friend class ROOT::RClassField;                             // to mark members as artificial
    friend class ROOT::Experimental::RNTupleJoinProcessor;      // needs ConstructValue
+   friend class ROOT::Experimental::Detail::RRawPtrWriteEntry; // to call Append()
    friend struct ROOT::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Internal::RFieldRepresentationModifier; // used for unit tests
    friend void Internal::CallFlushColumnsOnField(RFieldBase &);

--- a/tree/ntuple/v7/inc/ROOT/RFieldToken.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldToken.hxx
@@ -24,6 +24,12 @@ namespace ROOT {
 class REntry;
 class RNTupleModel;
 
+namespace Experimental {
+namespace Detail {
+class RRawPtrWriteEntry;
+} // namespace Detail
+} // namespace Experimental
+
 // clang-format off
 /**
 \class ROOT::RFieldToken
@@ -36,8 +42,9 @@ It can be used for fast indexing in REntry's methods, e.g. REntry::BindValue(). 
 class RFieldToken {
    friend class REntry;
    friend class RNTupleModel;
+   friend class Experimental::Detail::RRawPtrWriteEntry;
 
-   std::size_t fIndex = 0;                      ///< The index in `fValues` that belongs to the field
+   std::size_t fIndex = 0;                      ///< The index of the field (top-level or registered subfield)
    std::uint64_t fSchemaId = std::uint64_t(-1); ///< Safety check to prevent tokens from other models being used
    RFieldToken(std::size_t index, std::uint64_t schemaId) : fIndex(index), fSchemaId(schemaId) {}
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldToken.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldToken.hxx
@@ -1,0 +1,50 @@
+/// \file ROOT/RFieldToken.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
+/// \date 2025-03-19
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RFieldToken
+#define ROOT7_RFieldToken
+
+#include <cstddef> // for std::size_t
+#include <cstdint> // for std::uint64_t
+
+namespace ROOT {
+
+class REntry;
+class RNTupleModel;
+
+// clang-format off
+/**
+\class ROOT::RFieldToken
+\ingroup NTuple
+\brief A field token identifies a (sub)field in an entry
+
+It can be used for fast indexing in REntry's methods, e.g. REntry::BindValue(). The field token can also be created by the model.
+*/
+// clang-format on
+class RFieldToken {
+   friend class REntry;
+   friend class RNTupleModel;
+
+   std::size_t fIndex = 0;                      ///< The index in `fValues` that belongs to the field
+   std::uint64_t fSchemaId = std::uint64_t(-1); ///< Safety check to prevent tokens from other models being used
+   RFieldToken(std::size_t index, std::uint64_t schemaId) : fIndex(index), fSchemaId(schemaId) {}
+
+public:
+   RFieldToken() = default; // The default constructed token cannot be used by any entry
+};
+
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
@@ -116,23 +116,25 @@ public:
    /// Fill an entry into this context, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
    /// and check RNTupleFillStatus::ShouldFlushCluster.
    ///
-   /// This method will perform a light check whether the entry comes from the context's own model.
+   /// This method will check the entry's model ID to ensure it comes from the context's own model or throw an exception
+   /// otherwise.
    void FillNoFlush(ROOT::REntry &entry, ROOT::RNTupleFillStatus &status) { FillNoFlushImpl(entry, status); }
-   /// Fill an entry into this context.  This method will perform a light check whether the entry comes from the
-   /// context's own model.
+   /// Fill an entry into this context.  This method will check the entry's model ID to ensure it comes from the
+   /// context's own model or throw an exception otherwise.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(ROOT::REntry &entry) { return FillImpl(entry); }
 
    /// Fill an RRawPtrWriteEntry into this context, but don't commit the cluster. The calling code must pass an
    /// RNTupleFillStatus and check RNTupleFillStatus::ShouldFlushCluster.
    ///
-   /// This method will perform a light check whether the entry comes from the context's own model.
+   /// This method will check the entry's model ID to ensure it comes from the context's own model or throw an exception
+   /// otherwise.
    void FillNoFlush(Detail::RRawPtrWriteEntry &entry, ROOT::RNTupleFillStatus &status)
    {
       FillNoFlushImpl(entry, status);
    }
-   /// Fill an RRawPtrWriteEntry into this context.  This method will perform a light check whether the entry comes from
-   /// the context's own model.
+   /// Fill an RRawPtrWriteEntry into this context.  This method will check the entry's model ID to ensure it comes
+   /// from the context's own model or throw an exception otherwise.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(Detail::RRawPtrWriteEntry &entry) { return FillImpl(entry); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RPageStorage.hxx>
+#include <ROOT/RRawPtrWriteEntry.hxx>
 #include <ROOT/RNTupleFillStatus.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -121,6 +122,20 @@ public:
    /// context's own model.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(ROOT::REntry &entry) { return FillImpl(entry); }
+
+   /// Fill an RRawPtrWriteEntry into this context, but don't commit the cluster. The calling code must pass an
+   /// RNTupleFillStatus and check RNTupleFillStatus::ShouldFlushCluster.
+   ///
+   /// This method will perform a light check whether the entry comes from the context's own model.
+   void FillNoFlush(Detail::RRawPtrWriteEntry &entry, ROOT::RNTupleFillStatus &status)
+   {
+      FillNoFlushImpl(entry, status);
+   }
+   /// Fill an RRawPtrWriteEntry into this context.  This method will perform a light check whether the entry comes from
+   /// the context's own model.
+   /// \return The number of uncompressed bytes written.
+   std::size_t Fill(Detail::RRawPtrWriteEntry &entry) { return FillImpl(entry); }
+
    /// Flush column data, preparing for CommitCluster or to reduce memory usage. This will trigger compression of pages,
    /// but not actually write to storage.
    void FlushColumns();
@@ -131,6 +146,10 @@ public:
 
    const ROOT::RNTupleModel &GetModel() const { return *fModel; }
    std::unique_ptr<ROOT::REntry> CreateEntry() const { return fModel->CreateEntry(); }
+   std::unique_ptr<Detail::RRawPtrWriteEntry> CreateRawPtrWriteEntry() const
+   {
+      return fModel->CreateRawPtrWriteEntry();
+   }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fLastFlushed; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
@@ -125,7 +125,7 @@ public:
    void CommitStagedClusters();
 
    const ROOT::RNTupleModel &GetModel() const { return *fModel; }
-   std::unique_ptr<ROOT::REntry> CreateEntry() { return fModel->CreateEntry(); }
+   std::unique_ptr<ROOT::REntry> CreateEntry() const { return fModel->CreateEntry(); }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fLastFlushed; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -19,6 +19,7 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RFieldToken.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <string_view>
 
@@ -305,7 +306,7 @@ public:
    /// set memory addresses to be serialized / deserialized
    std::unique_ptr<ROOT::REntry> CreateBareEntry() const;
    /// Creates a token to be used in REntry methods to address a field present in the entry
-   ROOT::REntry::RFieldToken GetToken(std::string_view fieldName) const;
+   ROOT::RFieldToken GetToken(std::string_view fieldName) const;
    /// Calls the given field's CreateBulk() method. Throws an exception if no field with the given name exists.
    ROOT::RFieldBase::RBulk CreateBulk(std::string_view fieldName) const;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -37,6 +37,12 @@ class RNTupleWriteOptions;
 class RNTupleModel;
 class RNTupleWriter;
 
+namespace Experimental {
+namespace Detail {
+class RRawPtrWriteEntry;
+} // namespace Detail
+} // namespace Experimental
+
 namespace Internal {
 class RProjectedFields;
 
@@ -305,6 +311,8 @@ public:
    /// In a bare entry, all values point to nullptr. The resulting entry shall use BindValue() in order
    /// set memory addresses to be serialized / deserialized
    std::unique_ptr<ROOT::REntry> CreateBareEntry() const;
+   std::unique_ptr<Experimental::Detail::RRawPtrWriteEntry> CreateRawPtrWriteEntry() const;
+
    /// Creates a token to be used in REntry methods to address a field present in the entry
    ROOT::RFieldToken GetToken(std::string_view fieldName) const;
    /// Calls the given field's CreateBulk() method. Throws an exception if no field with the given name exists.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -18,6 +18,7 @@
 
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
+#include <ROOT/RFieldToken.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleJoinTable.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -124,14 +125,13 @@ protected:
    private:
       std::unique_ptr<ROOT::RFieldBase> fProtoField;
       std::unique_ptr<ROOT::RFieldBase> fConcreteField;
-      ROOT::REntry::RFieldToken fToken;
+      ROOT::RFieldToken fToken;
       // Which RNTuple the field belongs to, in case the field belongs to an auxiliary RNTuple, according to the order
       // in which it was specified. For chained RNTuples, this value will always be 0.
       std::size_t fNTupleIdx;
 
    public:
-      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, ROOT::REntry::RFieldToken token,
-                    std::size_t ntupleIdx = 0)
+      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, ROOT::RFieldToken token, std::size_t ntupleIdx = 0)
          : fProtoField(std::move(protoField)), fToken(token), fNTupleIdx(ntupleIdx)
       {
       }
@@ -532,7 +532,7 @@ class RNTupleJoinProcessor : public RNTupleProcessor {
 private:
    std::vector<std::unique_ptr<Internal::RPageSource>> fAuxiliaryPageSources;
    /// Tokens representing the join fields present in the main RNTuple
-   std::vector<ROOT::REntry::RFieldToken> fJoinFieldTokens;
+   std::vector<ROOT::RFieldToken> fJoinFieldTokens;
    std::vector<std::unique_ptr<Internal::RNTupleJoinTable>> fJoinTables;
    bool fJoinTablesAreBuilt = false;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -104,16 +104,16 @@ public:
    /// The simplest user interface if the default entry that comes with the ntuple model is used.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill() { return fFillContext.Fill(fFillContext.fModel->GetDefaultEntry()); }
-   /// Multiple entries can have been instantiated from the ntuple model.  This method will perform
-   /// a light check whether the entry comes from the ntuple's own model.
+   /// Multiple entries can have been instantiated from the ntuple model.  This method will check the entry's model ID
+   /// to ensure it comes from the writer's own model or throw an exception otherwise.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(ROOT::REntry &entry) { return fFillContext.Fill(entry); }
    /// Fill an entry into this ntuple, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
    /// and check RNTupleFillStatus::ShouldFlushCluster.
    void FillNoFlush(ROOT::REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoFlush(entry, status); }
 
-   /// Fill an RRawPtrWriteEntry into this ntuple.  This method will perform
-   /// a light check whether the entry comes from the ntuple's own model
+   /// Fill an RRawPtrWriteEntry into this ntuple.  This method will check the entry's model ID to ensure it comes from
+   /// the writer's own model or throw an exception otherwise.
    /// \return The number of uncompressed bytes written.
    std::size_t Fill(Experimental::Detail::RRawPtrWriteEntry &entry) { return fFillContext.Fill(entry); }
    /// Fill an RRawPtrWriteEntry into this ntuple, but don't commit the cluster. The calling code must pass an

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -127,7 +127,7 @@ public:
    /// and model updating fail.
    void CommitDataset();
 
-   std::unique_ptr<ROOT::REntry> CreateEntry() { return fFillContext.CreateEntry(); }
+   std::unique_ptr<ROOT::REntry> CreateEntry() const { return fFillContext.CreateEntry(); }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fFillContext.GetLastFlushed(); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -25,6 +25,7 @@
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPageStorage.hxx>
+#include <ROOT/RRawPtrWriteEntry.hxx>
 
 #include <cstddef>
 #include <cstdint>
@@ -110,6 +111,18 @@ public:
    /// Fill an entry into this ntuple, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
    /// and check RNTupleFillStatus::ShouldFlushCluster.
    void FillNoFlush(ROOT::REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoFlush(entry, status); }
+
+   /// Fill an RRawPtrWriteEntry into this ntuple.  This method will perform
+   /// a light check whether the entry comes from the ntuple's own model
+   /// \return The number of uncompressed bytes written.
+   std::size_t Fill(Experimental::Detail::RRawPtrWriteEntry &entry) { return fFillContext.Fill(entry); }
+   /// Fill an RRawPtrWriteEntry into this ntuple, but don't commit the cluster. The calling code must pass an
+   /// RNTupleFillStatus and check RNTupleFillStatus::ShouldFlushCluster.
+   void FillNoFlush(Experimental::Detail::RRawPtrWriteEntry &entry, RNTupleFillStatus &status)
+   {
+      fFillContext.FillNoFlush(entry, status);
+   }
+
    /// Flush column data, preparing for CommitCluster or to reduce memory usage. This will trigger compression of pages,
    /// but not actually write to storage (unless buffered writing is turned off).
    void FlushColumns() { fFillContext.FlushColumns(); }
@@ -128,6 +141,10 @@ public:
    void CommitDataset();
 
    std::unique_ptr<ROOT::REntry> CreateEntry() const { return fFillContext.CreateEntry(); }
+   std::unique_ptr<Experimental::Detail::RRawPtrWriteEntry> CreateRawPtrWriteEntry() const
+   {
+      return fFillContext.CreateRawPtrWriteEntry();
+   }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fFillContext.GetLastFlushed(); }

--- a/tree/ntuple/v7/inc/ROOT/RRawPtrWriteEntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RRawPtrWriteEntry.hxx
@@ -1,0 +1,127 @@
+/// \file ROOT/RRawPtrWriteEntry.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
+/// \date 2025-03-19
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RRawPtrWriteEntry
+#define ROOT7_RRawPtrWriteEntry
+
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RFieldToken.hxx>
+#include <ROOT/RError.hxx>
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace ROOT {
+
+class RNTupleModel;
+
+namespace Experimental {
+
+class RNTupleFillContext;
+
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RRawPtrWriteEntry
+\ingroup NTuple
+\brief A container of const raw pointers, corresponding to a row in the data set
+
+This class can be used to write constant data products in frameworks.  All other users are encouraged to use the API
+provided by REntry, with safe interfaces, type checks, and shared object ownership.
+*/
+// clang-format on
+class RRawPtrWriteEntry {
+   friend class ROOT::RNTupleModel;
+   friend class ROOT::Experimental::RNTupleFillContext;
+
+private:
+   /// The entry must be linked to a specific model, identified by a model ID
+   std::uint64_t fModelId = 0;
+   /// The entry and its tokens are also linked to a specific schema, identified by a schema ID
+   std::uint64_t fSchemaId = 0;
+   /// Corresponds to the fields of the linked model
+   std::vector<ROOT::RFieldBase *> fFields;
+   /// The raw pointers corresponding to the fields
+   std::vector<const void *> fRawPtrs;
+   /// For fast lookup of token IDs given a (sub)field name present in the entry
+   std::unordered_map<std::string, std::size_t> fFieldName2Token;
+
+   explicit RRawPtrWriteEntry(std::uint64_t modelId, std::uint64_t schemaId) : fModelId(modelId), fSchemaId(schemaId) {}
+
+   void AddField(ROOT::RFieldBase &field)
+   {
+      fFieldName2Token[field.GetQualifiedFieldName()] = fFields.size();
+      fFields.emplace_back(&field);
+      fRawPtrs.emplace_back(nullptr);
+   }
+
+   std::size_t Append()
+   {
+      std::size_t bytesWritten = 0;
+      for (std::size_t i = 0; i < fFields.size(); i++) {
+         bytesWritten += fFields[i]->Append(fRawPtrs[i]);
+      }
+      return bytesWritten;
+   }
+
+   void EnsureMatchingModel(RFieldToken token) const
+   {
+      if (fSchemaId != token.fSchemaId) {
+         throw RException(R__FAIL("invalid token for this entry, "
+                                  "make sure to use a token from a model with the same schema as this entry."));
+      }
+   }
+
+public:
+   RRawPtrWriteEntry(const RRawPtrWriteEntry &other) = delete;
+   RRawPtrWriteEntry &operator=(const RRawPtrWriteEntry &other) = delete;
+   RRawPtrWriteEntry(RRawPtrWriteEntry &&other) = default;
+   RRawPtrWriteEntry &operator=(RRawPtrWriteEntry &&other) = default;
+   ~RRawPtrWriteEntry() = default;
+
+   /// The ordinal of the (sub)field fieldName; can be used in other methods to address the corresponding value
+   RFieldToken GetToken(std::string_view fieldName) const
+   {
+      auto it = fFieldName2Token.find(std::string(fieldName));
+      if (it == fFieldName2Token.end()) {
+         throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
+      }
+      return RFieldToken(it->second, fSchemaId);
+   }
+
+   template <typename T>
+   void BindRawPtr(RFieldToken token, const T *rawPtr)
+   {
+      EnsureMatchingModel(token);
+      fRawPtrs[token.fIndex] = rawPtr;
+   }
+
+   template <typename T>
+   void BindRawPtr(std::string_view fieldName, const T *rawPtr)
+   {
+      BindRawPtr(GetToken(fieldName), rawPtr);
+   }
+
+   std::uint64_t GetModelId() const { return fModelId; }
+   std::uint64_t GetSchemaId() const { return fSchemaId; }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -15,6 +15,7 @@
 
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RFieldToken.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/StringUtils.hxx>
@@ -505,7 +506,7 @@ std::unique_ptr<ROOT::REntry> ROOT::RNTupleModel::CreateBareEntry() const
    return entry;
 }
 
-ROOT::REntry::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
+ROOT::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
 {
    const auto &topLevelFields = fFieldZero->GetConstSubfields();
    auto it = std::find_if(topLevelFields.begin(), topLevelFields.end(),
@@ -514,7 +515,7 @@ ROOT::REntry::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldNam
    if (it == topLevelFields.end()) {
       throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }
-   return ROOT::REntry::RFieldToken(std::distance(topLevelFields.begin(), it), fSchemaId);
+   return ROOT::RFieldToken(std::distance(topLevelFields.begin(), it), fSchemaId);
 }
 
 ROOT::RFieldBase::RBulk ROOT::RNTupleModel::CreateBulk(std::string_view fieldName) const

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -506,6 +506,23 @@ std::unique_ptr<ROOT::REntry> ROOT::RNTupleModel::CreateBareEntry() const
    return entry;
 }
 
+std::unique_ptr<ROOT::Experimental::Detail::RRawPtrWriteEntry> ROOT::RNTupleModel::CreateRawPtrWriteEntry() const
+{
+   switch (fModelState) {
+   case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
+   case EState::kExpired: throw RException(R__FAIL("invalid attempt to create entry of expired model"));
+   case EState::kFrozen: break;
+   }
+
+   auto entry = std::unique_ptr<Experimental::Detail::RRawPtrWriteEntry>(
+      new Experimental::Detail::RRawPtrWriteEntry(fModelId, fSchemaId));
+   for (const auto &f : fFieldZero->GetMutableSubfields()) {
+      entry->AddField(*f);
+   }
+   // fRegisteredSubfields are not relevant for writing
+   return entry;
+}
+
 ROOT::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
 {
    const auto &topLevelFields = fFieldZero->GetConstSubfields();

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -777,7 +777,7 @@ TEST(REntry, Basics)
    EXPECT_THROW(e->BindValue("pt", ptrDouble), ROOT::RException);
 
    // Default constructed tokens cannot be used
-   ROOT::REntry::RFieldToken token;
+   ROOT::RFieldToken token;
    EXPECT_THROW(e->GetPtr<void>(token), ROOT::RException);
 
    float pt;

--- a/tutorials/io/ntuple/ntpl014_framework.C
+++ b/tutorials/io/ntuple/ntpl014_framework.C
@@ -28,6 +28,7 @@
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/REntry.hxx>
+#include <ROOT/RFieldToken.hxx>
 #include <ROOT/RNTupleFillContext.hxx>
 #include <ROOT/RNTupleFillStatus.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -53,7 +54,7 @@ using ROOT::Experimental::RNTupleFillContext;
 using ROOT::Experimental::RNTupleFillStatus;
 using ROOT::Experimental::RNTupleParallelWriter;
 
-using ModelTokensPair = std::pair<std::unique_ptr<ROOT::RNTupleModel>, std::vector<ROOT::REntry::RFieldToken>>;
+using ModelTokensPair = std::pair<std::unique_ptr<ROOT::RNTupleModel>, std::vector<ROOT::RFieldToken>>;
 
 // A DataProduct associates an arbitrary address to an index in the model.
 struct DataProduct {
@@ -92,7 +93,7 @@ public:
 class ParallelOutputter final : public Outputter {
    FileService &fFileService;
    std::unique_ptr<RNTupleParallelWriter> fParallelWriter;
-   std::vector<ROOT::REntry::RFieldToken> fTokens;
+   std::vector<ROOT::RFieldToken> fTokens;
 
    struct SlotData {
       std::shared_ptr<RNTupleFillContext> fillContext;
@@ -159,7 +160,7 @@ class SerializingOutputter final : public Outputter {
    FileService &fFileService;
    std::unique_ptr<ROOT::RNTupleWriter> fWriter;
    std::mutex fWriterMutex;
-   std::vector<ROOT::REntry::RFieldToken> fTokens;
+   std::vector<ROOT::RFieldToken> fTokens;
 
    struct SlotData {
       std::unique_ptr<ROOT::REntry> entry;
@@ -247,7 +248,7 @@ ModelTokensPair CreateEventModel()
    // We recommend creating a bare model if the default entry is not used.
    auto model = ROOT::RNTupleModel::CreateBare();
    // For more efficient access, also create field tokens.
-   std::vector<ROOT::REntry::RFieldToken> tokens;
+   std::vector<ROOT::RFieldToken> tokens;
 
    model->MakeField<decltype(Event::eventId)>("eventId");
    tokens.push_back(model->GetToken("eventId"));
@@ -271,7 +272,7 @@ ModelTokensPair CreateEventModel()
 std::vector<DataProduct> CreateEventDataProducts(Event &event)
 {
    std::vector<DataProduct> products;
-   // The indices have to match the order of std::vector<REntry::RFieldToken> above.
+   // The indices have to match the order of std::vector<ROOT::RFieldToken> above.
    products.emplace_back(0, &event.eventId);
    products.emplace_back(1, &event.runId);
    products.emplace_back(2, &event.electrons);
@@ -292,7 +293,7 @@ ModelTokensPair CreateRunModel()
    // We recommend creating a bare model if the default entry is not used.
    auto model = ROOT::RNTupleModel::CreateBare();
    // For more efficient access, also create field tokens.
-   std::vector<ROOT::REntry::RFieldToken> tokens;
+   std::vector<ROOT::RFieldToken> tokens;
 
    model->MakeField<decltype(Run::runId)>("runId");
    tokens.push_back(model->GetToken("runId"));
@@ -307,7 +308,7 @@ ModelTokensPair CreateRunModel()
 std::vector<DataProduct> CreateRunDataProducts(Run &run)
 {
    std::vector<DataProduct> products;
-   // The indices have to match the order of std::vector<REntry::RFieldToken> above.
+   // The indices have to match the order of std::vector<ROOT::RFieldToken> above.
    products.emplace_back(0, &run.runId);
    products.emplace_back(1, &run.nEvents);
    return products;


### PR DESCRIPTION
It is a container of `const` raw pointers that can be used to write constant data products in frameworks.

Closes #17900