### PR TITLE
Improve stressGUI, fix TG SavePrimitive methods

### DIFF
--- a/gui/gui/src/TGColorSelect.cxx
+++ b/gui/gui/src/TGColorSelect.cxx
@@ -685,7 +685,7 @@ void TGColorSelect::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
    out << "\n   // color select widget\n";
    out << "   ULong_t " << cvar << ";\n";
-   out << "   gClient->GetColorByName(\n" << colorname << "\", " << cvar << ");\n";
+   out << "   gClient->GetColorByName(\"" << colorname << "\", " << cvar << ");\n";
 
    out <<"   TGColorSelect *" << GetName() << " = new TGColorSelect(" << fParent->GetName()
        << ", " << cvar << ", " << WidgetId() << ");\n";

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -3519,15 +3519,12 @@ void TGTransientFrame::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
 
    SavePrimitiveSubframes(out, option);
 
-   if (fWindowName.Length()) {
-      out << "   " << GetName() << "->SetWindowName(\n"
-          << TString(GetWindowName()).ReplaceSpecialCppChars() << "\");\n";
-   }
-   if (fIconName.Length()) {
+   if (fWindowName.Length())
+      out << "   " << GetName() << "->SetWindowName(\"" << TString(GetWindowName()).ReplaceSpecialCppChars()
+          << "\");\n";
+   if (fIconName.Length())
       out << "   " << GetName() << "->SetIconName(\"" << TString(GetIconName()).ReplaceSpecialCppChars() << "\");\n";
-   }
-   if (fIconPixmap.Length()) {
+   if (fIconPixmap.Length())
       out << "   " << GetName() << "->SetIconPixmap(\"" << TString(GetIconPixmap()).ReplaceSpecialCppChars()
           << "\");\n";
-   }
 }

--- a/gui/gui/src/TGListBox.cxx
+++ b/gui/gui/src/TGListBox.cxx
@@ -1650,15 +1650,13 @@ TGLBEntry *TGListBox::FindEntry(const char *name) const
 
 void TGListBox::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   // store options and color if differ from defauls
+   // store options and color if differ from defaults
    TString extra_args = SaveCtorArgs(out, kSunkenFrame | kDoubleBorder, kTRUE);
 
    out << "\n   // list box\n";
    out << "   TGListBox *" << GetName() << " = new TGListBox(" << fParent->GetName();
-   if (!extra_args.IsNull())
-      out << "," << fWidgetId << "," << extra_args;
-   else if (fWidgetId != -1)
-      out << "," << fWidgetId;
+   if (!extra_args.IsNull() || (fWidgetId != -1))
+      out << ", " << fWidgetId << extra_args;
    out << ");\n";
 
    if (option && strstr(option, "keep_names"))

--- a/gui/gui/src/TGNumberEntry.cxx
+++ b/gui/gui/src/TGNumberEntry.cxx
@@ -2252,12 +2252,9 @@ void TGNumberEntry::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << yy << mm << dd << "," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
       break;
    case kNESHex: {
-      char hex[256];
-      ULong_t l = GetHexNumber();
-      IntToHexStr(hex, l);
-      std::ios::fmtflags f = out.flags(); // store flags
-      out << "0x" << std::hex << "U," << digits << "," << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-      out.flags(f); // restore flags (reset std::hex)
+      char hexstr[256];
+      IntToHexStr(hexstr, GetHexNumber());
+      out << "0x" << hexstr << "U, " << digits << ", " << WidgetId() << ",(TGNumberFormat::EStyle) " << GetNumStyle();
       break;
    }
    }
@@ -2306,8 +2303,7 @@ void TGNumberEntryField::SavePrimitive(std::ostream &out, Option_t *option /*= "
    Int_t yy, mm, dd;
    GetDate(yy, mm, dd);
 
-   out << "   TGNumberEntryField *";
-   out << GetName() << " = new TGNumberEntryField(" << fParent->GetName() << ", " << WidgetId() << ", (Double_t) ";
+   out << "   TGNumberEntryField *" << GetName() << " = new TGNumberEntryField(" << fParent->GetName() << ", " << WidgetId() << ", (Double_t) ";
    switch (GetNumStyle()) {
    case kNESInteger: out << GetIntNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
    case kNESRealOne: out << GetNumber() << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
@@ -2326,13 +2322,9 @@ void TGNumberEntryField::SavePrimitive(std::ostream &out, Option_t *option /*= "
    case kNESDayMYear: out << yy << mm << dd << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
    case kNESMDayYear: out << yy << mm << dd << ",(TGNumberFormat::EStyle) " << GetNumStyle(); break;
    case kNESHex: {
-      char hex[256];
-      ULong_t l = GetHexNumber();
-      IntToHexStr(hex, l);
-      std::ios::fmtflags f = out.flags(); // store flags
-      out << "0x" << std::hex << "U"
-          << ",(TGNumberFormat::EStyle) " << GetNumStyle();
-      out.flags(f); // restore flags (reset std::hex)
+      char hexstr[256];
+      IntToHexStr(hexstr, GetHexNumber());
+      out << "0x" << hexstr << "U, (TGNumberFormat::EStyle) " << GetNumStyle();
       break;
    }
    }

--- a/gui/gui/src/TGSplitter.cxx
+++ b/gui/gui/src/TGSplitter.cxx
@@ -585,7 +585,7 @@ void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // save options and color if not default
    auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGVSplitter *" << GetName() << " = new TGVSplitter(" << fParent->GetName() << "," << GetWidth() << ","
+   out << "   TGVSplitter *" << GetName() << " = new TGVSplitter(" << fParent->GetName() << ", " << GetWidth() << ", "
        << GetHeight() << extra_args << ");\n";
 
    if (option && strstr(option, "keep_names"))
@@ -594,13 +594,8 @@ void TGVSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // if fFrame is the frame on the left (since the frame on the
    // right will only be saved afterwards)... The other case is
    // handled in TGCompositeFrame::SavePrimitiveSubframes()
-   if (GetLeft()) {
-      out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetLeft())
-         out << ",kTRUE);n";
-      else
-         out << ",kFALSE);n";
-   }
+   if (GetLeft())
+      out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName() << ", kTRUE);\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -611,7 +606,7 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // save options and color if not default
    auto extra_args = SaveCtorArgs(out);
 
-   out << "   TGHSplitter *" << GetName() << " = new TGHSplitter(" << fParent->GetName() << "," << GetWidth() << ","
+   out << "   TGHSplitter *" << GetName() << " = new TGHSplitter(" << fParent->GetName() << ", " << GetWidth() << ", "
        << GetHeight() << extra_args << ");\n";
 
    if (option && strstr(option, "keep_names"))
@@ -620,13 +615,8 @@ void TGHSplitter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // if fFrame is the frame above (since the frame below will
    // only be saved afterwards)... The other case is handled in
    // TGCompositeFrame::SavePrimitiveSubframes()
-   if (GetAbove()) {
-      out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName();
-      if (GetAbove())
-         out << ",kTRUE);\n";
-      else
-         out << ",kFALSE);\n";
-   }
+   if (GetAbove())
+      out << "   " << GetName() << "->SetFrame(" << GetFrame()->GetName() << ", kTRUE);\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGTab.cxx
+++ b/gui/gui/src/TGTab.cxx
@@ -811,7 +811,7 @@ void TGTab::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out << "   TGTab *" << GetName() << " = new TGTab(" << fParent->GetName() << "," << GetWidth() << "," << GetHeight();
 
    if (!extra_args.IsNull() || (fFontStruct != GetDefaultFontStruct()))
-      out << "," << parGC << "," << parFont << "," << extra_args;
+      out << "," << parGC << "," << parFont << extra_args;
    else if (fNormGC != GetDefaultGC()())
       out << "," << parGC;
    out << ");\n";


### PR DESCRIPTION
In stressGUI disable web mode and with `-keep` flag also preserve created macro files

Running all these macro, found and fix several old and new errors.
Now all these macros are usable