### PR TITLE
[v634][RF] Move some private implementation details to `RooFit::Detail`

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -120,6 +120,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFit/Detail/CodeSquashContext.h
     RooFit/Detail/MathFuncs.h
     RooFit/Detail/NormalizationHelpers.h
+    RooFit/Detail/RooNLLVarNew.h
+    RooFit/Detail/RooNormalizedPdf.h
     RooFit/EvalContext.h
     RooFit/Evaluator.h
     RooFit/Floats.h

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -233,6 +233,7 @@
 #pragma link C++ class RooRealSumFunc + ;
 #pragma link C++ class RooResolutionModel+ ;
 #pragma link C++ class RooTruthModel+ ;
+#pragma link C++ class RooFit::Detail::RooFixedProdPdf+ ;
 #pragma link C++ class RooProdPdf+ ;
 #pragma read sourceClass="RooProdPdf" targetClass="RooProdPdf" version="[-5]" \
   source="RooLinkedList _pdfNSetList" target="_pdfNSetList"                  \
@@ -334,5 +335,7 @@
 #pragma link off class RooErrorHandler+ ;
 #pragma link C++ class RooBinSamplingPdf+;
 #pragma link C++ class RooBinWidthFunction+;
+#pragma link C++ class RooFit::Detail::RooNLLVarNew+;
+#pragma link C++ class RooFit::Detail::RooNormalizedPdf+ ;
 
 #endif

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -70,8 +70,7 @@ template <class T>
 std::unique_ptr<T> compileForNormSet(T const &arg, RooArgSet const &normSet)
 {
    RooFit::Detail::CompileContext ctx{normSet};
-   std::unique_ptr<RooAbsArg> head = arg.compileForNormSet(normSet, ctx);
-   return std::unique_ptr<T>{static_cast<T *>(head.release())};
+   return std::unique_ptr<T>{static_cast<T *>(arg.compileForNormSet(normSet, ctx).release())};
 }
 
 } // namespace Detail

--- a/roofit/roofitcore/inc/RooFit/Detail/RooNLLVarNew.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/RooNLLVarNew.h
@@ -23,6 +23,9 @@
 
 #include <Math/Util.h>
 
+namespace RooFit {
+namespace Detail {
+
 class RooNLLVarNew : public RooAbsReal {
 
 public:
@@ -54,6 +57,12 @@ public:
 
    void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
+   RooAbsPdf const &pdf() const { return *_pdf; }
+   RooAbsReal const &weightVar() const { return *_weightVar; }
+   bool binnedL() const { return _binnedL; }
+   int simCount() const { return _simCount; }
+   RooAbsReal const *expectedEvents() const { return _expectedEvents ? &**_expectedEvents : nullptr; }
+
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
@@ -77,7 +86,11 @@ private:
    std::vector<double> _binw;
    mutable ROOT::Math::KahanSum<double> _offset{0.}; ///<! Offset as KahanSum to avoid loss of precision
 
-}; // end class RooNLLVar
+   ClassDefOverride(RooFit::Detail::RooNLLVarNew, 0);
+};
+
+} // namespace Detail
+} // namespace RooFit
 
 #endif
 

--- a/roofit/roofitcore/inc/RooFit/Detail/RooNormalizedPdf.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/RooNormalizedPdf.h
@@ -16,19 +16,23 @@
 #include <RooAbsPdf.h>
 #include <RooRealProxy.h>
 
+namespace RooFit {
+namespace Detail {
+
 class RooNormalizedPdf : public RooAbsPdf {
 public:
    RooNormalizedPdf(RooAbsPdf &pdf, RooArgSet const &normSet)
       : _pdf("numerator", "numerator", this, pdf),
         _normIntegral(
            "denominator", "denominator", this,
-           std::unique_ptr<RooAbsReal>{pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), pdf.normRange())},
-           true, false),
+           std::unique_ptr<RooAbsReal>{pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), pdf.normRange())}, true,
+           false),
         _normSet{normSet}
    {
       auto name = std::string(pdf.GetName()) + "_over_" + _normIntegral->GetName();
       SetName(name.c_str());
       SetTitle(name.c_str());
+      _normRange = pdf.normRange(); // so that e.g. RooAddPdf can query over what we are normalized
    }
 
    RooNormalizedPdf(const RooNormalizedPdf &other, const char *name)
@@ -51,7 +55,8 @@ public:
       return _pdf->getAnalyticalIntegralWN(allVars, analVars, &_normSet, rangeName);
    }
    /// Forward calculation of analytical integrals to input p.d.f
-   double analyticalIntegralWN(Int_t code, const RooArgSet * /*normSet*/, const char *rangeName = nullptr) const override
+   double
+   analyticalIntegralWN(Int_t code, const RooArgSet * /*normSet*/, const char *rangeName = nullptr) const override
    {
       return _pdf->analyticalIntegralWN(code, &_normSet, rangeName);
    }
@@ -67,6 +72,9 @@ public:
    void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
    bool canComputeBatchWithCuda() const override { return true; }
+
+   RooAbsPdf const &pdf() const { return *_pdf; }
+   RooAbsReal const &normIntegral() const { return *_normIntegral; }
 
 protected:
    void doEval(RooFit::EvalContext &) const override;
@@ -85,6 +93,11 @@ private:
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooRealProxy _normIntegral;
    RooArgSet _normSet;
+
+   ClassDefOverride(RooFit::Detail::RooNormalizedPdf, 0);
 };
+
+} // namespace Detail
+} // namespace RooFit
 
 #endif

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -19,7 +19,7 @@
 #include <RooSimultaneous.h>
 
 #include "RooFitImplHelpers.h"
-#include "RooNLLVarNew.h"
+#include "RooFit/Detail/RooNLLVarNew.h"
 
 #include <ROOT/StringUtils.hxx>
 
@@ -93,8 +93,8 @@ getSingleDataSpans(RooAbsData const &data, std::string_view rangeName, std::stri
          assignSpan(weight, {buffer.data(), nNonZeroWeight});
          assignSpan(weightSumW2, {bufferSumW2.data(), nNonZeroWeight});
       }
-      insert(RooNLLVarNew::weightVarName, weight);
-      insert(RooNLLVarNew::weightVarNameSumW2, weightSumW2);
+      insert(RooFit::Detail::RooNLLVarNew::weightVarName, weight);
+      insert(RooFit::Detail::RooNLLVarNew::weightVarNameSumW2, weightSumW2);
    }
 
    // Get the real-valued batches and cast the also to double branches to put in

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -42,7 +42,7 @@
 #include "ConstraintHelpers.h"
 #include "RooEvaluatorWrapper.h"
 #include "RooFitImplHelpers.h"
-#include "RooNLLVarNew.h"
+#include "RooFit/Detail/RooNLLVarNew.h"
 
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
 #include "RooChi2Var.h"
@@ -347,15 +347,15 @@ std::unique_ptr<RooAbsArg> createSimultaneousNLL(RooSimultaneous const &simPdf, 
          // are extended. Therefore, we have to make sure that we don't request
          // extended NLL objects for channels that can't be extended.
          const bool isPdfExtended = isSimPdfExtended && pdf->extendMode() != RooAbsPdf::CanNotBeExtended;
-         auto nll =
-            std::make_unique<RooNLLVarNew>(name.c_str(), name.c_str(), *pdf, *observables, isPdfExtended, offset);
+         auto nll = std::make_unique<RooFit::Detail::RooNLLVarNew>(name.c_str(), name.c_str(), *pdf, *observables,
+                                                                   isPdfExtended, offset);
          // Rename the special variables
          nll->setPrefix(std::string("_") + catName + "_");
          nllTerms.addOwned(std::move(nll));
       }
    }
 
-   for (auto *nll : static_range_cast<RooNLLVarNew *>(nllTerms)) {
+   for (auto *nll : static_range_cast<RooFit::Detail::RooNLLVarNew *>(nllTerms)) {
       nll->setSimCount(nllTerms.size());
    }
 
@@ -400,8 +400,8 @@ std::unique_ptr<RooAbsReal> createNLLNew(RooAbsPdf &pdf, RooAbsData &data, std::
       simPdf->wrapPdfsInBinSamplingPdfs(data, integrateOverBinsPrecision);
       nllTerms.addOwned(createSimultaneousNLL(*simPdf, isExtended, rangeName, offset));
    } else {
-      nllTerms.addOwned(
-         std::make_unique<RooNLLVarNew>("RooNLLVarNew", "RooNLLVarNew", finalPdf, observables, isExtended, offset));
+      nllTerms.addOwned(std::make_unique<RooFit::Detail::RooNLLVarNew>("RooNLLVarNew", "RooNLLVarNew", finalPdf,
+                                                                       observables, isExtended, offset));
    }
    if (constraints) {
       nllTerms.addOwned(std::move(constraints));

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -62,7 +62,7 @@
 
 #include "RooAbsAnaConvPdf.h"
 
-#include "RooNormalizedPdf.h"
+#include "RooFit/Detail/RooNormalizedPdf.h"
 #include "RooMsgService.h"
 #include "Riostream.h"
 #include "RooResolutionModel.h"
@@ -677,7 +677,7 @@ RooAbsAnaConvPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Co
       std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf *>(_convSet[0].Clone()));
       ctx.compileServers(*pdfClone, normSet);
 
-      auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, normSet);
+      auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
       // The direct servers are this pdf and the normalization integral, which
       // don't need to be compiled further.
@@ -717,7 +717,7 @@ RooAbsAnaConvPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Co
    ctx.compileServers(*pdfClone, normSet);
 
    // Finally, this RooAbsAnaConvPdf needs to be normalized
-   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, normSet);
+   auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -33,7 +33,7 @@ for changes to trigger a refilling of the cache histogram.
 #include "RooDataHist.h"
 #include "RooHistPdf.h"
 #include "RooExpensiveObjectCache.h"
-#include "RooNormalizedPdf.h"
+#include "RooFit/Detail/RooNormalizedPdf.h"
 
 ClassImp(RooAbsCachedPdf);
 
@@ -415,7 +415,7 @@ RooAbsCachedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
    std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf *>(this->Clone()));
    ctx.compileServers(*pdfClone, {});
 
-   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, normSet);
+   auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -138,7 +138,7 @@ called for each data event.
 #include "RooAbsPdf.h"
 
 #include "FitHelpers.h"
-#include "RooNormalizedPdf.h"
+#include "RooFit/Detail/RooNormalizedPdf.h"
 #include "RooMsgService.h"
 #include "RooArgSet.h"
 #include "RooArgProxy.h"
@@ -2793,7 +2793,7 @@ RooAbsPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
    std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf *>(this->Clone()));
    ctx.compileServers(*pdfClone, normSet);
 
-   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, normSet);
+   auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -33,7 +33,7 @@ in the two sets.
 #include "RooErrorHandler.h"
 #include "RooArgSet.h"
 #include "RooNameReg.h"
-#include "RooNLLVarNew.h"
+#include "RooFit/Detail/RooNLLVarNew.h"
 #include "RooMsgService.h"
 #include "RooBatchCompute.h"
 #include "RooFuncWrapper.h"
@@ -169,7 +169,7 @@ void RooAddition::translate(RooFit::Detail::CodeSquashContext &ctx) const
    std::size_t i = 0;
    for (auto *component : static_range_cast<RooAbsReal *>(_set)) {
 
-      if (!dynamic_cast<RooNLLVarNew *>(component) || _set.size() == 1) {
+      if (!dynamic_cast<RooFit::Detail::RooNLLVarNew *>(component) || _set.size() == 1) {
          result += ctx.getResult(*component);
          ++i;
          if (i < _set.size()) result += '+';
@@ -202,7 +202,7 @@ double RooAddition::defaultErrorLevel() const
 
   std::unique_ptr<RooArgSet> comps{getComponents()};
   for(RooAbsArg * arg : *comps) {
-    if (dynamic_cast<RooNLLVarNew*>(arg)) {
+    if (dynamic_cast<RooFit::Detail::RooNLLVarNew*>(arg)) {
       nllArg = static_cast<RooAbsReal*>(arg) ;
     }
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -23,7 +23,7 @@ This class calls functions from `RooBatchCompute` library to provide faster
 computation times.
 **/
 
-#include "RooNLLVarNew.h"
+#include "RooFit/Detail/RooNLLVarNew.h"
 
 #include <RooHistPdf.h>
 #include <RooBatchCompute.h>
@@ -45,6 +45,11 @@ computation times.
 #include <numeric>
 #include <stdexcept>
 #include <vector>
+
+ClassImp(RooFit::Detail::RooNLLVarNew);
+
+namespace RooFit {
+namespace Detail {
 
 // Declare constexpr static members to make them available if odr-used in C++14.
 constexpr const char *RooNLLVarNew::weightVarName;
@@ -372,5 +377,7 @@ void RooNLLVarNew::translate(RooFit::Detail::CodeSquashContext &ctx) const
       ctx.addToCodeBody(resName + " += " + expected + " - " + weightSumName + " * std::log(" + expected + ");\n");
    }
 }
+} // namespace Detail
+} // namespace RooFit
 
 /// \endcond

--- a/roofit/roofitcore/src/RooNormalizedPdf.cxx
+++ b/roofit/roofitcore/src/RooNormalizedPdf.cxx
@@ -10,10 +10,13 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include "RooNormalizedPdf.h"
+#include "RooFit/Detail/RooNormalizedPdf.h"
+
 #include "RooBatchCompute.h"
 
 #include <array>
+
+ClassImp(RooFit::Detail::RooNormalizedPdf);
 
 /**
  * \class RooNormalizedPdf
@@ -21,6 +24,9 @@
  * A RooNormalizedPdf wraps a pdf divided by its integral for a given
  * normalization set into a new self-normalized pdf.
  */
+
+namespace RooFit {
+namespace Detail {
 
 void RooNormalizedPdf::doEval(RooFit::EvalContext &ctx) const
 {
@@ -53,3 +59,6 @@ void RooNormalizedPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
    // For now just return function/normalization integral.
    ctx.addResult(this, ctx.getResult(_pdf) + "/" + ctx.getResult(_normIntegral));
 }
+
+} // namespace Detail
+} // namespace RooFit

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -73,6 +73,7 @@ have to appear in any specific place in the list.
 
 using std::endl, std::string, std::vector, std::list, std::ostream, std::map, std::ostringstream;
 
+ClassImp(RooFit::Detail::RooFixedProdPdf);
 ClassImp(RooProdPdf);
 
 
@@ -2311,98 +2312,6 @@ std::unique_ptr<RooArgSet> RooProdPdf::fillNormSetForServer(RooArgSet const &nor
    }
 }
 
-/// A RooProdPdf with a fixed normalization set can be replaced by this class.
-/// Its purpose is to provide the right client-server interface for the
-/// evaluation of RooProdPdf cache elements that were created for a given
-/// normalization set.
-class RooFixedProdPdf : public RooAbsPdf {
-public:
-   RooFixedProdPdf(std::unique_ptr<RooProdPdf> &&prodPdf, RooArgSet const &normSet)
-      : RooAbsPdf(prodPdf->GetName(), prodPdf->GetTitle()), _normSet{normSet},
-        _servers("!servers", "List of servers", this), _prodPdf{std::move(prodPdf)}
-   {
-      initialize();
-   }
-   RooFixedProdPdf(const RooFixedProdPdf &other, const char *name = nullptr)
-      : RooAbsPdf(other, name), _normSet{other._normSet},
-        _servers("!servers", "List of servers", this), _prodPdf{static_cast<RooProdPdf *>(other._prodPdf->Clone())}
-   {
-      initialize();
-   }
-   TObject *clone(const char *newname) const override { return new RooFixedProdPdf(*this, newname); }
-
-   bool selfNormalized() const override { return true; }
-
-   inline bool canComputeBatchWithCuda() const override { return true; }
-
-   void doEval(RooFit::EvalContext &ctx) const override
-   {
-      _prodPdf->doEvalImpl(this, *_cache, ctx);
-   }
-
-   void translate(RooFit::Detail::CodeSquashContext &ctx) const override
-   {
-      if (_cache->_isRearranged) {
-         ctx.addResult(this, ctx.buildCall("RooFit::Detail::MathFuncs::ratio", *_cache->_rearrangedNum, *_cache->_rearrangedDen));
-      } else {
-         ctx.addResult(this, ctx.buildCall("RooFit::Detail::MathFuncs::product", _cache->_partList, _cache->_partList.size()));
-      }
-   }
-
-   ExtendMode extendMode() const override { return _prodPdf->extendMode(); }
-   double expectedEvents(const RooArgSet * /*nset*/) const override { return _prodPdf->expectedEvents(&_normSet); }
-   std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet * /*nset*/) const override
-   {
-      return _prodPdf->createExpectedEventsFunc(&_normSet);
-   }
-
-   // Analytical Integration handling
-   bool forceAnalyticalInt(const RooAbsArg &dep) const override { return _prodPdf->forceAnalyticalInt(dep); }
-   Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &analVars, const RooArgSet *normSet,
-                                 const char *rangeName = nullptr) const override
-   {
-      return _prodPdf->getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName);
-   }
-   Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &numVars, const char *rangeName = nullptr) const override
-   {
-      return _prodPdf->getAnalyticalIntegral(allVars, numVars, rangeName);
-   }
-   double analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName) const override
-   {
-      return _prodPdf->analyticalIntegralWN(code, normSet, rangeName);
-   }
-   double analyticalIntegral(Int_t code, const char *rangeName = nullptr) const override
-   {
-      return _prodPdf->analyticalIntegral(code, rangeName);
-   }
-
-private:
-   void initialize()
-   {
-      _cache = _prodPdf->createCacheElem(&_normSet, nullptr);
-      auto &cache = *_cache;
-
-      // The actual servers for a given normalization set depend on whether the
-      // cache is rearranged or not. See RooProdPdf::calculateBatch to see
-      // which args in the cache are used directly.
-      if (cache._isRearranged) {
-         _servers.add(*cache._rearrangedNum);
-         _servers.add(*cache._rearrangedDen);
-      } else {
-         for (std::size_t i = 0; i < cache._partList.size(); ++i) {
-            _servers.add(cache._partList[i]);
-         }
-      }
-   }
-
-   double evaluate() const override { return _prodPdf->calculate(*_cache); }
-
-   RooArgSet _normSet;
-   std::unique_ptr<RooProdPdf::CacheElem> _cache;
-   RooSetProxy _servers;
-   std::unique_ptr<RooProdPdf> _prodPdf;
-};
-
 std::unique_ptr<RooAbsArg>
 RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
@@ -2426,8 +2335,61 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
       ctx.compileServer(*server, *prodPdfClone, depList);
    }
 
-   auto fixedProdPdf = std::make_unique<RooFixedProdPdf>(std::move(prodPdfClone), normSet);
+   auto fixedProdPdf = std::make_unique<RooFit::Detail::RooFixedProdPdf>(std::move(prodPdfClone), normSet);
    ctx.markAsCompiled(*fixedProdPdf);
 
    return fixedProdPdf;
 }
+
+namespace RooFit {
+namespace Detail {
+
+RooFixedProdPdf::RooFixedProdPdf(std::unique_ptr<RooProdPdf> &&prodPdf, RooArgSet const &normSet)
+   : RooAbsPdf(prodPdf->GetName(), prodPdf->GetTitle()),
+     _normSet{normSet},
+     _servers("!servers", "List of servers", this),
+     _prodPdf{std::move(prodPdf)}
+{
+   initialize();
+}
+
+RooFixedProdPdf::RooFixedProdPdf(const RooFixedProdPdf &other, const char *name)
+   : RooAbsPdf(other, name),
+     _normSet{other._normSet},
+     _servers("!servers", "List of servers", this),
+     _prodPdf{static_cast<RooProdPdf *>(other._prodPdf->Clone())}
+{
+   initialize();
+}
+
+void RooFixedProdPdf::initialize()
+{
+   _cache = _prodPdf->createCacheElem(&_normSet, nullptr);
+   auto &cache = *_cache;
+
+   // The actual servers for a given normalization set depend on whether the
+   // cache is rearranged or not. See RooProdPdf::calculateBatch to see
+   // which args in the cache are used directly.
+   if (cache._isRearranged) {
+      _servers.add(*cache._rearrangedNum);
+      _servers.add(*cache._rearrangedDen);
+   } else {
+      for (std::size_t i = 0; i < cache._partList.size(); ++i) {
+         _servers.add(cache._partList[i]);
+      }
+   }
+}
+
+void RooFixedProdPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   if (_cache->_isRearranged) {
+      ctx.addResult(
+         this, ctx.buildCall("RooFit::Detail::MathFuncs::ratio", *_cache->_rearrangedNum, *_cache->_rearrangedDen));
+   } else {
+      ctx.addResult(this,
+                    ctx.buildCall("RooFit::Detail::MathFuncs::product", _cache->_partList, _cache->_partList.size()));
+   }
+}
+
+} // namespace Detail
+} // namespace RooFit

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -46,7 +46,7 @@ to the fractions of the various functions. **This requires setting the last argu
 
 #include "RooRealSumPdf.h"
 
-#include "RooNormalizedPdf.h"
+#include "RooFit/Detail/RooNormalizedPdf.h"
 #include "RooRealIntegral.h"
 #include "RooRealProxy.h"
 #include "RooRealVar.h"
@@ -777,7 +777,7 @@ RooRealSumPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Compi
    RooArgSet depList;
    pdfClone->getObservables(&normSet, depList);
 
-   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, depList);
+   auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, depList);
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.


### PR DESCRIPTION
Move some private inaccessible implementation details to the public `RooFit::Detail` namespace.

This non-functional change enables to compile the ongoing CMS Combine developments also against the upcoming ROOT 6.34.06, which makes it easier to test and validate these developments.

Basically backporting parts of #16772.