### PR TITLE
Fix/improve SavePrimitive in g3d classes

### DIFF
--- a/graf3d/g3d/src/THelix.cxx
+++ b/graf3d/g3d/src/THelix.cxx
@@ -175,28 +175,6 @@ THelix::THelix(Double_t const* xyz, Double_t const* v, Double_t w,
 }
 
 
-#if 0
-////////////////////////////////////////////////////////////////////////////////
-/// Helix copy constructor.
-
-THelix::THelix(const THelix &h) : TPolyLine3D()
-{
-   fX0   = h.fX0;
-   fY0   = h.fY0;
-   fZ0   = h.fZ0;
-   fVt   = h.fVt;
-   fPhi0 = h.fPhi0;
-   fVz   = h.fVz;
-   fW    = h.fW;
-   for (Int_t i=0; i<3; i++) fAxis[i] = h.fAxis[i];
-   fRotMat = new TRotMatrix(*(h.fRotMat));
-   fRange[0] = h.fRange[0];
-   fRange[1] = h.fRange[1];
-
-   fOption = h.fOption;
-}
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 /// assignment operator
 
@@ -298,24 +276,22 @@ void THelix::Print(Option_t *option) const
 
 void THelix::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(THelix::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   THelix *";
-   }
-   out<<"helix = new THelix("<<fX0<<","<<fY0<<","<<fZ0<<","
-      <<fVt*TMath::Cos(fPhi0)<<","<<fVt*TMath::Sin(fPhi0)<<","<<fVz<<","
-      <<fW<<","<<fRange[0]<<","<<fRange[1]<<","<<(Int_t)kHelixT<<","
-      <<fAxis[0]<<","<<fAxis[1]<<","<<fAxis[2]<<","
-      <<quote<<fOption<<quote<<");"<<std::endl;
+   SavePrimitiveConstructor(out, Class(), "helix",
+                            TString::Format("%g, %g, %g, %g, %g, %g, %g", fX0, fY0, fZ0, fVt * TMath::Cos(fPhi0),
+                                            fVt * TMath::Sin(fPhi0), fVz, fW));
 
-   SaveLineAttributes(out,"helix",1,1,1);
+   if ((fRange[0] != 0.) || (fRange[1] != 1.))
+      out << "   helix->SetRange(" << fRange[0] << ", " << fRange[1] << ", kHelixT);\n";
 
-   out<<"   helix->Draw();"<<std::endl;
+   if ((fAxis[0] != 0.) || (fAxis[1] != 0.) || (fAxis[2] != 1.))
+      out << "   helix->SetAxis(" << fAxis[0] << ", " << fAxis[1] << ", " << fAxis[2] << ");\n";
+   if (fOption.Length())
+      out << "   helix->SetOption(\"" << TString(fOption).ReplaceSpecialCppChars() << "\");\n";
+
+   SaveLineAttributes(out, "helix", 1, 1, 1);
+
+   out << "   helix->Draw();\n";
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set a new axis for the helix.  This will make a new rotation matrix.

--- a/graf3d/g3d/src/TMarker3DBox.cxx
+++ b/graf3d/g3d/src/TMarker3DBox.cxx
@@ -350,25 +350,13 @@ void TMarker3DBox::PaintH3(TH1 *h, Option_t *option)
 
 void TMarker3DBox::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TMarker3DBox::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   TMarker3DBox *";
-   }
-   out<<"marker3DBox = new TMarker3DBox("<<fX<<","
-                                         <<fY<<","
-                                         <<fZ<<","
-                                         <<fDx<<","
-                                         <<fDy<<","
-                                         <<fDz<<","
-                                         <<fTheta<<","
-                                         <<fPhi<<");"<<std::endl;
+   SavePrimitiveConstructor(out, Class(), "marker3DBox",
+                            TString::Format("%g, %g, %g, %g, %g, %g, %g, %g", fX, fY, fZ, fDx, fDy, fDz, fTheta, fPhi));
 
-   SaveLineAttributes(out,"marker3DBox",1,1,1);
-   SaveFillAttributes(out,"marker3DBox",1,0);
+   SaveLineAttributes(out, "marker3DBox", 1, 1, 1);
+   SaveFillAttributes(out, "marker3DBox", 1, 0);
 
-   out<<"   marker3DBox->Draw();"<<std::endl;
+   out << "   marker3DBox->Draw();\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TPolyLine3D.cxx
+++ b/graf3d/g3d/src/TPolyLine3D.cxx
@@ -557,23 +557,23 @@ void TPolyLine3D::Print(Option_t *option) const
 
 void TPolyLine3D::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   char quote = '"';
-   out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TPolyLine3D::Class())) {
-      out<<"   ";
-   } else {
-      out<<"   TPolyLine3D *";
+   TString arrarg;
+   if (Size() > 0) {
+      std::vector<Double_t> arr(Size() * 3);
+      for (Int_t i = 0; i < Size() * 3; i++)
+         arr[i] = fP[i];
+      arrarg = SavePrimitiveArray(out, "pline3D", Size() * 3, arr.data(), kTRUE);
+      arrarg.Append(", ");
    }
-   Int_t size=Size();
-   out<<"pline3D = new TPolyLine3D("<<fN<<","<<quote<<fOption<<quote<<");"<<std::endl;
 
-   SaveLineAttributes(out,"pline3D",1,1,1);
+   SavePrimitiveConstructor(
+      out, Class(), "pline3D",
+      TString::Format("%d, %s\"%s\"", Size(), arrarg.Data(), TString(fOption).ReplaceSpecialCppChars().Data()),
+      arrarg.IsNull());
 
-   if (size > 0) {
-      for (Int_t i=0;i<size;i++)
-         out<<"   pline3D->SetPoint("<<i<<","<<fP[3*i]<<","<<fP[3*i+1]<<","<<fP[3*i+2]<<");"<<std::endl;
-   }
-   out<<"   pline3D->Draw();"<<std::endl;
+   SaveLineAttributes(out, "pline3D", 1, 1, 1);
+
+   out << "   pline3D->Draw();\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Improve `TPolyLine3D` and `TMarker3DBox`. 

Replace `THelix::SavePrimitive`. 
Implementation is broken and not usable.
For real implementation many changes are required.
