### PR TITLE
[CMake] Don't force builtin libpng/gif/tiff/jpeg on macOS

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -499,7 +499,7 @@ if(asimage)
     if(GIF_FOUND)
        set(_gifinclude  --with-gif --with-gif-includes=${GIF_INCLUDE_DIR} --without-builtin-gif)
     else()
-       set(_gifinclude)
+       set(_gifinclude  --with-builtin-ungif)
     endif()
     if(PNG_FOUND)
       set(_pnginclude  --with-png-includes=${PNG_INCLUDE_DIR})
@@ -511,11 +511,10 @@ if(asimage)
     else()
       set(_tiffinclude --with-tiff=no)
     endif()
-    if(cocoa)
-      set(_jpeginclude --without-x --with-builtin-jpeg)
-      set(_gifinclude  --with-builtin-ungif)
-      set(_pnginclude  --with-builtin-png)
-      set(_tiffinclude --with-tiff=no)
+    if(x11)
+      set(_xinclude --with-x)
+    else()
+      set(_xinclude --without-x)
     endif()
     if(builtin_freetype)
       set(_ttf_include --with-ttf-includes=-I${FREETYPE_INCLUDE_DIR})
@@ -537,6 +536,7 @@ if(asimage)
                         --without-svg --disable-glx ${_after_mmx}
                         ${_gifinclude} --with-jpeg ${_jpeginclude}
                         --with-png ${_pnginclude} ${_tiffinclude}
+                        ${_xinclude}
                         CC=${CMAKE_C_COMPILER} CFLAGS=${_after_cflags}
       LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1 LOG_OUTPUT_ON_FAILURE 1
       BUILD_IN_SOURCE 1

--- a/graf2d/asimage/CMakeLists.txt
+++ b/graf2d/asimage/CMakeLists.txt
@@ -9,10 +9,6 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-if(cocoa)  # Not needed to locate PNG, JPG, TIFF libraries
-  set(ASEXTRA_LIBRARIES)
-endif()
-
 ROOT_STANDARD_LIBRARY_PACKAGE(ASImage
   NO_INSTALL_HEADERS
   HEADERS


### PR DESCRIPTION
There is probably no reason to do this anymore. These libraries should be installed on the system, and if not, the automatic detection a few lines above the removed lines will take care of it.

Both the ROOT conda package and the nix package have patches to circumvent this already, and it would be better to do this upstream too.