### PR TITLE
[skip-ci] execute only debugging commands

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -140,7 +140,8 @@ jobs:
       working-directory: ${{ env.DOC_LOCATION }}
       shell: bash
       run: |
-        source ROOT-CI/build/bin/thisroot.sh
+#        source ROOT-CI/build/bin/thisroot.sh
+        ls ROOT-CI/build/bin/
         export DOXYGEN_OUTPUT_DIRECTORY=/github/home/${DOC_DIR}
         cd ROOT-CI/src/documentation/doxygen
         pwd
@@ -149,7 +150,7 @@ jobs:
         which doxygen
         echo $ROOTSYS
         nproc --all
-        make -j `nproc --all`
+#        make -j `nproc --all`
 
     - name: Create documentation archives
       working-directory: ${{ env.DOC_LOCATION }}


### PR DESCRIPTION
execute only debugging commands. In principle this should not produce errors.

