### PR TITLE
[skip-ci] add set -x

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -140,6 +140,7 @@ jobs:
       working-directory: ${{ env.DOC_LOCATION }}
       shell: bash
       run: |
+        set -x
         ls ROOT-CI/build/bin/
         source ROOT-CI/build/bin/thisroot.sh
         export DOXYGEN_OUTPUT_DIRECTORY=/github/home/${DOC_DIR}


### PR DESCRIPTION
add `set -x` to see which command does not work. Might be `source`

