### PR TITLE
[tmva] Fix using  TString in Python

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -300,29 +300,6 @@ public:
       return out.str();
    }
 
-   // Generate code for Session data members (e.g. internal vectors)
-   virtual std::string GenerateSessionMembersCode(std::string opName) override {
-
-      size_t outputChannelSize = fShapeY[2];  // size/channel = D * H * W
-      size_t kernelSize = fAttrKernelShape[0];
-      for (size_t i = 1; i < fDim; i++) {
-         outputChannelSize *= fShapeY[2 + i];
-         kernelSize *= fAttrKernelShape[i];
-      }
-
-      opName = "op_" + opName;
-      std::stringstream out;
-      // matrix with convolution kernels
-      // out << "std::vector<" << fType << "> fVec_" << opName << "_f = std::vector<" << fType << ">("
-      //     << fShapeW[0] * fShapeW[1] * kernelSize << ");\n";
-      // // output matrix of im2col
-      // out << "std::vector<" << fType << "> fVec_" << opName << "_xcol = std::vector<" << fType << ">("
-      //     << fShapeW[1] * kernelSize * outputChannelSize << ");\n";
-      // out << "\n";
-
-      return out.str();
-   }
-
    std::string Generate(std::string OpName) override {
       OpName = "op_" + OpName;
 

--- a/tutorials/machine_learning/TMVA_SOFIE_Inference.py
+++ b/tutorials/machine_learning/TMVA_SOFIE_Inference.py
@@ -49,7 +49,7 @@ print("Generating inference code for the Keras model from ",modelFile,"in the he
 #Generating inference
 
 inputFileName = "Higgs_data.root"
-inputFile = ROOT.gROOT.GetTutorialDir() + "/machine_learning/data/" + inputFileName
+inputFile = str(ROOT.gROOT.GetTutorialDir()) + "/machine_learning/data/" + inputFileName
 
 
 

--- a/tutorials/machine_learning/TMVA_SOFIE_Models.py
+++ b/tutorials/machine_learning/TMVA_SOFIE_Models.py
@@ -41,7 +41,7 @@ def CreateModel(nlayers = 4, nunits = 64):
 
 def PrepareData() :
    #get the input data
-   inputFile = ROOT.gROOT.GetTutorialDir() + "machine_learning/data/Higgs_data.root"
+   inputFile = str(ROOT.gROOT.GetTutorialDir()) + "machine_learning/data/Higgs_data.root"
 
    df1 = ROOT.RDataFrame("sig_tree", inputFile)
    sigData = df1.AsNumpy(columns=['m_jj', 'm_jjj', 'm_lv', 'm_jlv', 'm_bb', 'm_wbb', 'm_wwbb'])

--- a/tutorials/machine_learning/TMVA_SOFIE_RDataFrame.py
+++ b/tutorials/machine_learning/TMVA_SOFIE_RDataFrame.py
@@ -37,7 +37,7 @@ ROOT.gInterpreter.Declare('#include "Higgs_trained_model_generated.hxx"')
 ROOT.gInterpreter.Declare('auto sofie_functor = TMVA::Experimental::SofieFunctor<7,TMVA_SOFIE_'+modelName+'::Session>(0,"Higgs_trained_model_generated.dat");')
 
 # run inference over input data
-inputFile = ROOT.gROOT.GetTutorialDir() + "machine_learning/data/Higgs_data.root"
+inputFile = str(ROOT.gROOT.GetTutorialDir()) + "machine_learning/data/Higgs_data.root"
 df1 = ROOT.RDataFrame("sig_tree", inputFile)
 h1 = df1.Define("DNN_Value", "sofie_functor(rdfslot_,m_jj, m_jjj, m_lv, m_jlv, m_bb, m_wbb, m_wwbb)").Histo1D(("h_sig", "", 100, 0, 1),"DNN_Value")
 

--- a/tutorials/machine_learning/pytorch/ClassificationPyTorch.py
+++ b/tutorials/machine_learning/pytorch/ClassificationPyTorch.py
@@ -32,7 +32,7 @@ factory = TMVA.Factory('TMVAClassification',
 
 
 # Load data
-data = TFile.Open(gROOT.GetTutorialDir() + '/machine_learning/data/tmva_class_example.root')
+data = TFile.Open(str(gROOT.GetTutorialDir()) + '/machine_learning/data/tmva_class_example.root')
 signal = data.Get('TreeS')
 background = data.Get('TreeB')
 


### PR DESCRIPTION
# This Pull request:

-  Avoid using the automatic conversions from TString to Python string which causes a lot of errors like  
 `Error in <TString::AssertElement>: out of bounds`.  Use now `str(TString)`

- Fix warning in ROperator_Conv