### PR TITLE
[skip-ci][ci] Remove Fedora40 builds

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora40.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora40.txt
@@ -1,5 +1,0 @@
-builtin_zstd=ON
-builtin_zlib=ON
-builtin_nlohmannjson=On
-builtin_vdt=On
-ccache=On

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -359,12 +359,10 @@ jobs:
         # Common configs: {Release,Debug,RelWithDebInfo)
         # Build options: https://root.cern/install/build_from_source/#all-build-options
         include:
-          - image: fedora40
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
           - image: fedora41
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: fedora42
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9


### PR DESCRIPTION
since its EOL is coinciding with the foreseen release date of ROOT 6.36.00

