### PR TITLE
fix thisroot.sh on freebsd

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -169,7 +169,7 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
-      trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
+      trueExe=$(cut -d '' -f1 /proc/$$/cmdline 2>/dev/null) || trueExe=$(xargs -0 -n 1 < /proc/$$/cmdline | head -n 1) || return 1
       # Qemu emulation has cmdline start with the emulator
       if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
          # but qemu sets comm to the emulated command


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

cut command splitting by null bytes fails on MacOS and BSD

Fixes https://github.com/root-project/root/issues/17969

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)