### PR TITLE
[webcanv] fix several TCanvas::Update() problems

### DIFF
--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -334,6 +334,9 @@ RBrowser::RBrowser(bool use_rcanvas)
          if (catched && (catched->fWindow == &win))
             catched->fWindow = nullptr;
       }
+
+      if (fWebWindow)
+         CheckWidgtesModified(0);
    });
 
    Show();

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -310,6 +310,9 @@ RBrowser::RBrowser(bool use_rcanvas)
       if (!fWebWindow || !fCatchWindowShow || kind.empty())
          return false;
 
+      // before create new widget check if other disappear
+      CheckWidgtesModified(0);
+
       auto widget = RBrowserWidgetProvider::DetectCatchedWindow(kind, win);
       if (widget) {
          widget->fBrowser = this;

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -89,6 +89,7 @@ protected:
 
    Bool_t fReadOnly{kFALSE};       ///<! in read-only mode canvas cannot be changed from client side
    Long64_t fCanvVersion{1};       ///<! actual canvas version, changed with every new Modified() call
+   Long64_t fLastDrawVersion{0};   ///<! last draw version
    UInt_t fClientBits{0};          ///<! latest status bits from client like editor visible or not
    std::vector<TPad *> fAllPads;   ///<! list of all pads recognized during streaming
    std::map<TObject *,bool> fUsedObjs; ///<! map of used objects during streaming

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1894,6 +1894,9 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
                CheckCanvasModified();
       }
 
+      if (indx == 1)
+         fLastDrawVersion = fWebConn[indx].fDrawVersion;
+
    } else if (arg == "RELOAD") {
 
       // trigger reload of canvas data
@@ -2422,6 +2425,9 @@ Bool_t TWebCanvas::WaitWhenCanvasPainted(Long64_t ver)
 
    while (cnt++ < cnt_limit) {
 
+      // handle send operations, check connection timeouts
+      fWindow->Sync();
+
       if (!fWindow->HasConnection(0, false)) {
          if (gDebug > 2)
             Info("WaitWhenCanvasPainted", "no connections - abort");
@@ -2431,6 +2437,12 @@ Bool_t TWebCanvas::WaitWhenCanvasPainted(Long64_t ver)
       if ((fWebConn.size() > 1) && (fWebConn[1].fDrawVersion >= ver)) {
          if (gDebug > 2)
             Info("WaitWhenCanvasPainted", "ver %ld got painted", (long)ver);
+         return kTRUE;
+      }
+
+      if (!fWindow->HasConnection(0) && (fLastDrawVersion > 0)) {
+         if (gDebug > 2)
+            Info("WaitWhenCanvasPainted", "ver %ld got painted before client disconnected", (long)fLastDrawVersion);
          return kTRUE;
       }
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1403,6 +1403,9 @@ void TWebCanvas::Show()
    if (gROOT->IsWebDisplayBatch())
       return;
 
+   if (fWindow && !fWindow->HasConnection(0))
+      fLastDrawVersion = 0;
+
    ROOT::RWebDisplayArgs args;
    args.SetWidgetKind("TCanvas");
    args.SetSize(Canvas()->GetWindowWidth(), Canvas()->GetWindowHeight());

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -2388,6 +2388,8 @@ Bool_t TWebCanvas::PerformUpdate(Bool_t async)
 
    if (!fProcessingData && !IsAsyncMode() && !async)
       WaitWhenCanvasPainted(fCanvVersion);
+   else if (fWindow)
+      fWindow->Sync();
 
    return kTRUE;
 }

--- a/js/modules/base/ObjectPainter.mjs
+++ b/js/modules/base/ObjectPainter.mjs
@@ -387,7 +387,8 @@ class ObjectPainter extends BasePainter {
          pad_name = this.pad_name;
 
       let c = this.getCanvSvg();
-      if (!pad_name || c.empty()) return c;
+      if (!pad_name || c.empty())
+         return c;
 
       const cp = c.property('pad_painter');
       if (cp?.pads_cache && cp.pads_cache[pad_name])
@@ -395,7 +396,8 @@ class ObjectPainter extends BasePainter {
 
       c = c.select('.primitives_layer .__root_pad_' + pad_name);
       if (cp) {
-         if (!cp.pads_cache) cp.pads_cache = {};
+         if (!cp.pads_cache)
+            cp.pads_cache = {};
          cp.pads_cache[pad_name] = c.node();
       }
       return c;
@@ -1002,11 +1004,8 @@ class ObjectPainter extends BasePainter {
    /** @summary Analyze if all text draw operations are completed
      * @private */
    #checkAllTextDrawing(draw_g, resolveFunc, try_optimize) {
-      let all_args = draw_g.property('all_args'), missing = 0;
-      if (!all_args) {
-         console.log('Text drawing is finished - why calling #checkAllTextDrawing?????');
-         all_args = [];
-      }
+      const all_args = draw_g.property('all_args') || [];
+      let missing = 0;
 
       all_args.forEach(arg => { if (!arg.ready) missing++; });
 

--- a/js/modules/base/RObjectPainter.mjs
+++ b/js/modules/base/RObjectPainter.mjs
@@ -106,7 +106,7 @@ class RObjectPainter extends ObjectPainter {
 
          if ((val[pos] === '-') || (val[pos] === '+')) {
             if (operand) {
-               console.log('Fail to parse RPadLength ' + value);
+               console.log(`Fail to parse RPadLength ${value}`);
                return dflt;
             }
             operand = (val[pos] === '-') ? -1 : 1;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '21/03/2025',
+version_date = '24/03/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/draw/TASImagePainter.mjs
+++ b/js/modules/draw/TASImagePainter.mjs
@@ -25,9 +25,9 @@ class TASImagePainter extends ObjectPainter {
       if (d.check('CONST')) {
          this.options.constRatio = true;
          if (obj) obj.fConstRatio = true;
-         console.log('use const');
       }
-      if (d.check('Z')) this.options.Zscale = true;
+      if (d.check('Z'))
+         this.options.Zscale = true;
    }
 
    /** @summary Create RGBA buffers */

--- a/js/modules/geom/geobase.mjs
+++ b/js/modules/geom/geobase.mjs
@@ -442,7 +442,8 @@ class PolygonsCreator {
       this.reduce = reduce;
 
       if (this.multi) {
-         if (reduce !== 2) console.error('polygon not supported for not-reduced faces');
+         if (reduce !== 2)
+            console.error('polygon not supported for not-reduced faces');
 
          let polygon;
 
@@ -464,15 +465,12 @@ class PolygonsCreator {
          const first = this.mnormal ? polygon.vertices[0] : polygon.vertices.at(-1),
                next = this.mnormal ? this.v3 : this.v2;
 
-         if (next.diff(first) < 1e-12) {
-            // console.log(`polygon closed!!! nvertices = ${polygon.vertices.length}`);
+         if (next.diff(first) < 1e-12)
             this.multi = 0;
-         } else
-         if (this.mnormal)
+         else if (this.mnormal)
             polygon.vertices.push(this.v3);
           else
             polygon.vertices.unshift(this.v2);
-
 
          return;
       }
@@ -1247,7 +1245,6 @@ function createPolygonBuffer(shape, faces_limit) {
          }
       } else {
          // let three.js calculate our faces
-         // console.log(`triangulate polygon ${shape.fShapeId}`);
          cut_faces = THREE.ShapeUtils.triangulateShape(pnts, []);
       }
       numfaces += cut_faces.length*2;
@@ -3518,7 +3515,6 @@ class ClonedNodes {
          return result;
       }
 
-      // console.log(`Volume boundary ${currNode.vol}  cnt=${cnt}  faces=${facecnt}`);
       result.max = maxNode.vol;
       result.min = currNode.vol;
       result.sortidcut = currNode.sortid; // latest node is not included
@@ -3610,8 +3606,6 @@ class ClonedNodes {
                 camVol = 0;
 
              camFact = maxVol / ((camVol > 0) ? (camVol > 0) : minVol);
-
-             // console.log(`Limit for camera ${camVol}  faces in camera view ${arg.totalcam}`);
          }
       }
 

--- a/js/modules/gpad/RCanvasPainter.mjs
+++ b/js/modules/gpad/RCanvasPainter.mjs
@@ -402,8 +402,6 @@ class RCanvasPainter extends RPadPainter {
          this._submreq[req.reqid] = req; // fast access to submitted requests
       }
 
-      // console.log('Sending request ', msg.slice(0,60));
-
       this.sendWebsocket('REQ:' + msg);
       return req;
    }

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -1250,7 +1250,6 @@ class TPavePainter extends ObjectPainter {
          else
             opt = opt.slice(0, parc) + opt.slice(parc + 3);
          this.setPaveDrawOption(opt);
-         console.log('Exec', `exec:${set_opt}("${opt}")`);
          this.interactiveRedraw(true, `exec:${set_opt}("${opt}")`);
       }, 'Usage of ARC draw option');
       menu.addSizeMenu('radius', 0, 0.2, 0.02, pave.fCornerRadius, val => {

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -99,7 +99,7 @@
                </menu>
             </MenuButton>
             <ToolbarSpacer />
-            <Button icon="sap-icon://message-warning" visible="{/ErrorVisible}" type="Critical" press="onShowConsoleErrors" tooltip="{/ErrorTooltip}"/>
+            <Button icon="sap-icon://message-warning" visible="{/ErrorVisible}" type="Reject" press="onShowConsoleErrors" tooltip="{/ErrorTooltip}"/>
             <MenuButton text="Help" type="Transparent">
                <menu>
                   <Menu itemSelected="onHelpMenuAction">


### PR DESCRIPTION
1. On JSROOT side fix problem with sub-pads update. New logic was failing when only subpad data were modified
2. Fix problem when canvas first drawn and then browser window was closed. In such case pending connection remains and blocked `gPad->Update()` for very long time
3. Correctly handle `canv->Show()` now. After it called `gPad->Update()` will really wait for next drawing
4. Use `win.Sync()` in TWebCanvas to handle (re-)connection timeouts properly
5. If JSROOT fails, show error indicator more clearly

PR solves several problem with demos.C macro which can run several canvases. If any of canvas closed there, `TWebCanvas::Update` was blocking for very long time making it unusable.