### PR TITLE
[hist] number of TH1 events is floating point in general

### DIFF
--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -138,7 +138,7 @@ public:
       void          SetConfidenceLevel(Double_t level);
       void          SetDirectory(TDirectory* dir);
       void          SetName(const char* name) override;
-      Bool_t        SetPassedEvents(Int_t bin,Int_t events);
+      Bool_t        SetPassedEvents(Int_t bin, Double_t events);
       Bool_t        SetPassedHistogram(const TH1& rPassed,Option_t* opt);
       void          SetPosteriorMode(Bool_t on = true) { SetBit(kPosteriorMode,on); SetShortestInterval(on); }
       void          SetPosteriorAverage(Bool_t on = true) { SetBit(kPosteriorMode,!on); }

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -3519,14 +3519,14 @@ void TEfficiency::SetName(const char* name)
 ///
 /// Note: - requires: 0 <= events <= fTotalHistogram->GetBinContent(bin)
 
-Bool_t TEfficiency::SetPassedEvents(Int_t bin,Int_t events)
+Bool_t TEfficiency::SetPassedEvents(Int_t bin, Double_t events)
 {
    if(events <= fTotalHistogram->GetBinContent(bin)) {
       fPassedHistogram->SetBinContent(bin,events);
       return true;
    }
    else {
-      Error("SetPassedEvents(Int_t,Int_t)","total number of events (%.1lf) in bin %i is less than given number of passed events %i",fTotalHistogram->GetBinContent(bin),bin,events);
+      Error("SetPassedEvents(Int_t,Double_t)","total number of events (%.1lf) in bin %i is less than given number of passed events %.1lf",fTotalHistogram->GetBinContent(bin),bin,events);
       return false;
    }
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-10907
As follow-up of / together with https://github.com/root-project/root/pull/14821
See: https://root-forum.cern.ch/t/tefficiency-with-floats/40146/5?u=ferhue

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)