### PR TITLE
[skip-ci] Reactivate ML tutorials

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -1080,7 +1080,6 @@ EXCLUDE_PATTERNS       = */G__* \
                          */gui/cefdisplay/* \
                          */gui/qt5webdisplay/* \
                          */gui/qt6webdisplay/* \
-                         */tutorials/machine_learning/* \
                          */tutorials/visualisation/webgui/qt5web/* \
                          */math/mathcore/src/CDT*
 


### PR DESCRIPTION
This [PR](https://github.com/root-project/root/pull/18098) fixes the issue with TString causing many error messages.
Therefore the ML tutorials can be reactivated.

