### PR TITLE
[tutorials] Add Python equivalents to graphs tutorials

### DIFF
--- a/tutorials/visualisation/graphs/gr001_simple.py
+++ b/tutorials/visualisation/graphs/gr001_simple.py
@@ -1,0 +1,75 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview This tutorial demonstrates how to create simple graphs in ROOT. The example is divided into two sections:
+## - The first section plots data generated from arrays.
+## - The second section plots data read from a text file.
+##
+## \macro_image
+## \macro_code
+##
+## \author Rene Brun, Jamie Gooding
+
+import re
+
+import numpy as np
+import ROOT
+
+c1 = ROOT.TCanvas("c1", "Two simple graphs", 200, 10, 700, 500)
+c1.Divide(
+    2, 1
+)  # Dividing the canvas in subpads for distinguishing the two examples, [See documentation](https://root.cern/doc/master/classTCanvas.html)
+
+# First Example (Available data)
+c1.cd(1)
+
+n = 20
+x = np.linspace(0, n - 1, n)
+y = 10 * np.sin(x + 0.2)
+
+gr1 = ROOT.TGraph(n, x, y)  # Create a TGraph object, storing the number of data n and the x, y variables
+
+# Set the color, width and style for the markers and line
+
+gr1.SetLineColor(2)
+gr1.SetLineWidth(4)
+gr1.SetMarkerColor(4)
+gr1.SetMarkerStyle(21)
+gr1.SetTitle("Graph from available data")  # Choose title for the graph
+gr1.GetXaxis().SetTitle("X title")  # Choose title for the axis
+gr1.GetYaxis().SetTitle("Y title")
+
+# Uncomment the following line to set a custom range for the x-axis (respectively for the y-axis):
+# gr1.GetXaxis().SetRangeUser(0, 1.8)
+
+gr1.Draw(
+    "ACP"
+)  # "A" draw axes, "C" = draw a smooth line through the markers (optional) and "P" = draw markers for data points
+# Optional customization can be done on a ROOT interactive session
+
+
+# SECOND EXAMPLE (Data stored in a text file)
+c1.cd(2)
+
+w = np.array([])
+z = np.array([])
+
+# Open the data file
+with open(f"{ROOT.gROOT.GetTutorialDir()}/visualisation/graphs/data_basic.txt") as file:  # Open the data file
+    for line in file:
+        w_str, z_str = re.split(r"\s+", line)[:2]
+        w = np.append(w, float(w_str))
+        z = np.append(z, float(z_str))
+
+m = len(w)
+
+gr2 = ROOT.TGraph(m, w, z)  # Create a TGraph object for the file data
+gr2.SetLineColor(4)
+gr2.SetLineWidth(2)
+gr2.SetMarkerColor(2)
+gr2.SetMarkerStyle(20)
+gr2.SetTitle("Graph from data file")
+gr2.GetXaxis().SetTitle("W title")
+gr2.GetYaxis().SetTitle("Z title")
+
+gr2.Draw("ACP")

--- a/tutorials/visualisation/graphs/gr002_errors.py
+++ b/tutorials/visualisation/graphs/gr002_errors.py
@@ -1,0 +1,39 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook -js
+## \preview Create and draw a graph with error bars. If more graphs are needed, see the
+## [gr03_err2gr.C](https://root.cern/doc/master/gerrors2_8C.html) tutorial
+##
+## See the [TGraphErrors documentation](https://root.cern/doc/master/classTGraphErrors.html)
+##
+## \macro_image
+## \macro_code
+## \author Rene Brun, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+c1 = ROOT.TCanvas("c1", "A Simple Graph with error bars", 200, 10, 700, 500)
+
+c1.SetGrid()
+c1.GetFrame().SetBorderSize(12)
+
+#  We will use the constructor requiring: the number of points, arrays containing the x-and y-axis values, and arrays with the x- andy-axis errors
+
+n = 10
+x = np.array([-0.22, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95])
+y = np.array([1, 2.9, 5.6, 7.4, 9, 9.6, 8.7, 6.3, 4.5, 1])
+ex = np.array([0.05, 0.1, 0.07, 0.07, 0.04, 0.05, 0.06, 0.07, 0.08, 0.05])
+ey = np.array([0.8, 0.7, 0.6, 0.5, 0.4, 0.4, 0.5, 0.6, 0.7, 0.8])
+
+# If all x-axis errors should zero, just provide a single 0 in place of ex
+gr = ROOT.TGraphErrors(n, x, y, ex, ey)
+
+gr.SetTitle("TGraphErrors Example")
+gr.SetMarkerColor(4)
+gr.SetMarkerStyle(21)
+
+# To draw in a new/empty canvas or pad, include the option "A" so that the axes are drawn (leave it out if the graph is to be drawn on top of an existing plot
+gr.Draw("ALP")
+
+c1.Update()

--- a/tutorials/visualisation/graphs/gr003_errors2.py
+++ b/tutorials/visualisation/graphs/gr003_errors2.py
@@ -1,0 +1,54 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook -js
+## \preview Create and draw two graphs with error bars, superposed on the same canvas
+##
+## We first draw an empty frame with the axes, then draw the graphs on top of it
+## Note that the graphs should have the same or very close ranges (in both axis),
+## otherwise they may not be visible in the frame.
+##
+## Alternatively, an automatic axis scaling can be achieved via a
+## [TMultiGraph](https://root.cern/doc/master/classTMultiGraph.html)
+##
+## See the [TGraphErrors documentation](https://root.cern/doc/master/classTGraphErrors.html)
+##
+## \macro_image
+## \macro_code
+## \author Rene Brun, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+c1 = ROOT.TCanvas("c1", "2 graphs with errors", 200, 10, 700, 500)
+c1.SetGrid()
+
+# draw a frame to define the range
+hr = c1.DrawFrame(-0.4, 0, 1.2, 12)
+hr.SetXTitle("X title")
+hr.SetYTitle("Y title")
+c1.GetFrame().SetBorderSize(12)
+
+# create first graph
+# We will use the constructor requiring: the number of points, arrays containing the x-and y-axis values, and arrays with the x- andy-axis errors
+n1 = 10
+xval1 = np.array([-0.22, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95])
+yval1 = np.array([1, 2.9, 5.6, 7.4, 9, 9.6, 8.7, 6.3, 4.5, 1])
+ex1 = np.array([0.05, 0.1, 0.07, 0.07, 0.04, 0.05, 0.06, 0.07, 0.08, 0.05])
+ey1 = np.array([0.8, 0.7, 0.6, 0.5, 0.4, 0.4, 0.5, 0.6, 0.7, 0.8])
+# If all x-axis errors should zero, just provide a single 0 in place of ex1
+gr1 = ROOT.TGraphErrors(n1, xval1, yval1, ex1, ey1)
+gr1.SetMarkerColor(ROOT.kBlue)
+gr1.SetMarkerStyle(21)
+# Since we already have a frame in the canvas, we draw the graph without the option "A" (which draws axes for this graph)
+gr1.Draw("LP")
+
+# create second graph
+n2 = 10
+xval2 = np.array([-0.28, 0.005, 0.19, 0.29, 0.45, 0.56, 0.65, 0.80, 0.90, 1.01])
+yval2 = np.array([0.82, 3.86, 7, 9, 10, 10.55, 9.64, 7.26, 5.42, 2])
+ex2 = np.array([0.04, 0.12, 0.08, 0.06, 0.05, 0.04, 0.07, 0.06, 0.08, 0.04])
+ey2 = np.array([0.6, 0.8, 0.7, 0.4, 0.3, 0.3, 0.4, 0.5, 0.6, 0.7])
+gr2 = ROOT.TGraphErrors(n2, xval2, yval2, ex2, ey2)
+gr2.SetMarkerColor(ROOT.kRed)
+gr2.SetMarkerStyle(20)
+gr2.Draw("LP")

--- a/tutorials/visualisation/graphs/gr004_errors_asym.py
+++ b/tutorials/visualisation/graphs/gr004_errors_asym.py
@@ -1,0 +1,33 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview This tutorial demonstrates the use of TGraphAsymmErrors to plot a graph with asymmetrical errors on both the x and y axes.
+## The errors for the x values are divided into low (left side of the marker) and high (right side of the marker) errors.
+## Similarly, for the y values, there are low (lower side of the marker) and high (upper side of the marker) errors.
+##
+## \macro_image
+## \macro_code
+##
+## \author Miro Helbich, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+c2 = ROOT.TCanvas("c2", "", 700, 500)
+
+c2.SetGrid()
+npoints = 3
+xaxis = np.array([1.0, 2.0, 3.0])
+yaxis = np.array([10.0, 20.0, 30.0])
+
+exl = np.array([0.5, 0.2, 0.1])  # Lower x errors
+exh = np.array([0.5, 0.3, 0.4])  # Higher x errors
+eyl = np.array([3.0, 5.0, 4.0])  # Lower y errors
+eyh = np.array([3.0, 5.0, 4.0])  # Higher y errors
+
+gr = ROOT.TGraphAsymmErrors(
+    npoints, xaxis, yaxis, exl, exh, eyl, eyh
+)  # Create the TGraphAsymmErrors object with data and asymmetrical errors
+
+gr.SetTitle("A simple graph with asymmetrical errors")
+gr.Draw("A*")  # "A" = draw axes and "*" = draw markers at the points with error bars

--- a/tutorials/visualisation/graphs/gr005_apply.py
+++ b/tutorials/visualisation/graphs/gr005_apply.py
@@ -1,0 +1,35 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview A macro to demonstrate the functionality of TGraph::Apply() method.
+## TGraph::Apply applies a function `f` to all the data TGraph points, `f` may be a 1-D function TF1 or 2-d function TF2.
+## The Y values of the graph are replaced by the ROOT.values computed using the function.
+##
+##
+## The Apply() method can be used as well for TGraphErrors and TGraphAsymmErrors.
+##
+## \macro_image
+## \macro_code
+##
+## \author Miro Helbich, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+npoints = 3
+xaxis = np.array([1.0, 2.0, 3.0])
+yaxis = np.array([10.0, 20.0, 30.0])
+
+gr1 = ROOT.TGraph(npoints, xaxis, yaxis)
+ff = ROOT.TF2("ff", "-1./y")  # Defining the function `f`
+
+c1 = ROOT.TCanvas("c1", "c1", 0, 0, 700, 500)
+c1.Divide(2, 1)
+
+c1.cd(1)
+gr1.DrawClone("A*")  # Using DrawClone to create a copy of the graph in the canvas.
+c1.cd(2)
+gr1.Apply(ff)  # Applies the function `f` to all the data TGraph points
+gr1.Draw("A*")
+# Without DrawClone, the modifications to gr1 via Apply(ff) are reflected in the original graph
+# displayed in c1 (the two drawn graphs are not independent).

--- a/tutorials/visualisation/graphs/gr006_scatter.py
+++ b/tutorials/visualisation/graphs/gr006_scatter.py
@@ -1,0 +1,40 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview Draw a scatter plot for 4 variables, mapped to: x, y, marker colour and marker size.
+##
+## TScatter is available since ROOT v.6.30. See the [TScatter documentation](https://root.cern/doc/master/classTScatter.html)
+##
+## \macro_image
+## \macro_code
+## \author Olivier Couet, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+canvas = ROOT.TCanvas()
+canvas.SetRightMargin(0.14)
+ROOT.gStyle.SetPalette(ROOT.kBird, 0, 0.6)  # define a transparent palette
+
+n = 175
+
+x = np.array([])
+y = np.array([])
+c = np.array([])
+s = np.array([])
+
+# Define four random data sets
+r = ROOT.TRandom()
+for i in range(n):
+    x = np.append(x, 100 * r.Rndm(i))
+    y = np.append(y, 200 * r.Rndm(i))
+    c = np.append(c, 300 * r.Rndm(i))
+    s = np.append(s, 400 * r.Rndm(i))
+
+scatter = ROOT.TScatter(n, x, y, c, s)
+scatter.SetMarkerStyle(20)
+scatter.SetTitle("Scatter plot titleX titleY titleZ title")
+scatter.GetXaxis().SetRangeUser(20.0, 90.0)
+scatter.GetYaxis().SetRangeUser(55.0, 90.0)
+scatter.GetZaxis().SetRangeUser(10.0, 200.0)
+scatter.Draw("A")

--- a/tutorials/visualisation/graphs/gr007_multigraph.py
+++ b/tutorials/visualisation/graphs/gr007_multigraph.py
@@ -1,0 +1,76 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview TMultiGraph is used to combine multiple graphs into one plot.
+## Allowing to overlay different graphs can be useful for comparing different datasets
+## or for plotting multiple related graphs on the same canvas.
+##
+## \macro_image
+## \macro_code
+##
+## \author Rene Brun, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+ROOT.gStyle.SetOptFit()
+c1 = ROOT.TCanvas("c1", "multigraph", 700, 500)
+c1.SetGrid()
+
+# Initialize a TMultiGraph to hold multiple graphs
+# This ensures the entire dataset from all added graphs is visible without manual range adjustments.
+mg = ROOT.TMultiGraph()
+
+# Create first graph
+n1 = 10
+px1 = np.array([-0.1, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95])
+py1 = np.array([-1, 2.9, 5.6, 7.4, 9, 9.6, 8.7, 6.3, 4.5, 1])
+ex1 = np.array([0.05, 0.1, 0.07, 0.07, 0.04, 0.05, 0.06, 0.07, 0.08, 0.05])
+ey1 = np.array([0.8, 0.7, 0.6, 0.5, 0.4, 0.4, 0.5, 0.6, 0.7, 0.8])
+gr1 = ROOT.TGraphErrors(n1, px1, py1, ex1, ey1)
+gr1.SetMarkerColor(ROOT.kBlue)
+gr1.SetMarkerStyle(21)
+
+gr1.Fit("gaus", "q")
+func1 = gr1.GetListOfFunctions().FindObject("gaus")
+func1.SetLineColor(ROOT.kBlue)
+
+# Add the first graph to the multigraph
+mg.Add(gr1)
+
+# Create second graph
+n2 = 10
+x2 = np.array([-0.28, 0.005, 0.19, 0.29, 0.45, 0.56, 0.65, 0.80, 0.90, 1.01])
+y2 = np.array([2.1, 3.86, 7, 9, 10, 10.55, 9.64, 7.26, 5.42, 2])
+ex2 = np.array([0.04, 0.12, 0.08, 0.06, 0.05, 0.04, 0.07, 0.06, 0.08, 0.04])
+ey2 = np.array([0.6, 0.8, 0.7, 0.4, 0.3, 0.3, 0.4, 0.5, 0.6, 0.7])
+gr2 = ROOT.TGraphErrors(n2, x2, y2, ex2, ey2)
+gr2.SetMarkerColor(ROOT.kRed)
+gr2.SetMarkerStyle(20)
+
+gr2.Fit("pol5", "q")
+func2 = gr2.GetListOfFunctions().FindObject("pol5")
+func2.SetLineColor(ROOT.kRed)
+func2.SetLineStyle(2)
+
+# Add the second graph to the multigraph
+mg.Add(gr2)
+
+mg.Draw("ap")
+
+# Force drawing of canvas to generate the fit TPaveStats
+c1.Update()
+
+stats1 = gr1.GetListOfFunctions().FindObject("stats")
+stats2 = gr2.GetListOfFunctions().FindObject("stats")
+
+if stats1 and stats2:
+    stats1.SetTextColor(ROOT.kBlue)
+    stats2.SetTextColor(ROOT.kRed)
+    stats1.SetX1NDC(0.12)
+    stats1.SetX2NDC(0.32)
+    stats1.SetY1NDC(0.82)
+    stats2.SetX1NDC(0.72)
+    stats2.SetX2NDC(0.92)
+    stats2.SetY1NDC(0.75)
+    c1.Modified()

--- a/tutorials/visualisation/graphs/gr009_bent_err.py
+++ b/tutorials/visualisation/graphs/gr009_bent_err.py
@@ -18,29 +18,50 @@ import ROOT
 
 c1 = ROOT.TCanvas()
 n = 10
-x = ROOT.std.vector('double')()
-for i in [-0.22, 0.05, 0.25, 0.35, 0.5, 0.61,0.7,0.85,0.89,0.95]: x.push_back(i)
-y = ROOT.std.vector('double')()
-for i in [1,2.9,5.6,7.4,9,9.6,8.7,6.3,4.5,1]: y.push_back(i)
-exl = ROOT.std.vector('double')()
-for i in [.05,.1,.07,.07,.04,.05,.06,.07,.08,.05]: exl.push_back(i)
-eyl = ROOT.std.vector('double')()
-for i in [.8,.7,.6,.5,.4,.4,.5,.6,.7,.8]: eyl.push_back(i)
-exh = ROOT.std.vector('double')()
-for i in [.02,.08,.05,.05,.03,.03,.04,.05,.06,.03]: exh.push_back(i)
-eyh = ROOT.std.vector('double')()
-for i in [.6,.5,.4,.3,.2,.2,.3,.4,.5,.6]: eyh.push_back(i)
-exld = ROOT.std.vector('double')()
-for i in [.0,.0,.0,.0,.0,.0,.0,.0,.0,.0]: exld.push_back(i)
-eyld = ROOT.std.vector('double')()
-for i in [.0,.0,.05,.0,.0,.0,.0,.0,.0,.0]: eyld.push_back(i)
-exhd = ROOT.std.vector('double')()
-for i in [.0,.0,.0,.0,.0,.0,.0,.0,.0,.0]: exhd.push_back(i)
-eyhd = ROOT.std.vector('double')()
-for i in [.0,.0,.0,.0,.0,.0,.0,.0,.05,.0]: eyhd.push_back(i)
+x = ROOT.std.vector("double")()  # The equivalent is also achieveable with numpy arrays
+for i in [-0.22, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95]:
+    x.push_back(i)
+y = ROOT.std.vector("double")()
+for i in [1, 2.9, 5.6, 7.4, 9, 9.6, 8.7, 6.3, 4.5, 1]:
+    y.push_back(i)
+exl = ROOT.std.vector("double")()
+for i in [0.05, 0.1, 0.07, 0.07, 0.04, 0.05, 0.06, 0.07, 0.08, 0.05]:
+    exl.push_back(i)
+eyl = ROOT.std.vector("double")()
+for i in [0.8, 0.7, 0.6, 0.5, 0.4, 0.4, 0.5, 0.6, 0.7, 0.8]:
+    eyl.push_back(i)
+exh = ROOT.std.vector("double")()
+for i in [0.02, 0.08, 0.05, 0.05, 0.03, 0.03, 0.04, 0.05, 0.06, 0.03]:
+    exh.push_back(i)
+eyh = ROOT.std.vector("double")()
+for i in [0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.3, 0.4, 0.5, 0.6]:
+    eyh.push_back(i)
+exld = ROOT.std.vector("double")()
+for i in [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]:
+    exld.push_back(i)
+eyld = ROOT.std.vector("double")()
+for i in [0.0, 0.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]:
+    eyld.push_back(i)
+exhd = ROOT.std.vector("double")()
+for i in [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]:
+    exhd.push_back(i)
+eyhd = ROOT.std.vector("double")()
+for i in [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05, 0.0]:
+    eyhd.push_back(i)
 
 gr = ROOT.TGraphBentErrors(
-   n,x.data(),y.data(),exl.data(),exh.data(),eyl.data(),eyh.data(),exld.data(),exhd.data(),eyld.data(),eyhd.data())
+    n,
+    x.data(),
+    y.data(),
+    exl.data(),
+    exh.data(),
+    eyl.data(),
+    eyh.data(),
+    exld.data(),
+    exhd.data(),
+    eyld.data(),
+    eyhd.data(),
+)
 
 gr.SetTitle("TGraphBentErrors Example")
 gr.SetMarkerColor(4)

--- a/tutorials/visualisation/graphs/gr010_approx_smooth.py
+++ b/tutorials/visualisation/graphs/gr010_approx_smooth.py
@@ -1,0 +1,89 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook -js
+## \preview Create a TGraphSmooth and show the usage of the interpolation function Approx.
+##
+## See the [TGraphSmooth documentation](https://root.cern/doc/master/classTGraphSmooth.html)
+##
+## \macro_image
+## \macro_code
+## \author Christian Stratowa, Jamie Gooding
+
+from ctypes import c_double
+
+import numpy as np
+import ROOT
+
+# vC1 = ROOT.TCanvas()
+# # grxy = ROOT.TGraph()
+# grin = ROOT.TGraph()
+# grout = ROOT.TGraph()
+
+
+def DrawSmooth(pad, title, xt, yt):
+    vC1.cd(pad)
+    vFrame = ROOT.gPad.DrawFrame(0, 0, 15, 150)
+    vFrame.SetTitle(title)
+    vFrame.SetTitleSize(0.2)
+    vFrame.SetXTitle(xt)
+    vFrame.SetYTitle(yt)
+    grxy.SetMarkerColor(ROOT.kBlue)
+    grxy.SetMarkerStyle(21)
+    grxy.SetMarkerSize(0.5)
+    grxy.Draw("P")
+    grin.SetMarkerColor(ROOT.kRed)
+    grin.SetMarkerStyle(5)
+    grin.SetMarkerSize(0.7)
+    grin.Draw("P")
+    grout.DrawClone("LP")
+
+
+# Test data (square)
+n = 11
+x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 6.0, 6.0, 8.0, 9.0, 10.0])
+y = np.array([1.0, 4.0, 9.0, 16.0, 25.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0])
+
+grxy = ROOT.TGraph(n, x, y)
+
+# X values, for which y values should be interpolated
+nout = 14
+xout = np.array([1.2, 1.7, 2.5, 3.2, 4.4, 5.2, 5.7, 6.5, 7.6, 8.3, 9.7, 10.4, 11.3, 13])
+
+# Create Canvas
+vC1 = ROOT.TCanvas("vC1", "square", 200, 10, 700, 700)
+vC1.Divide(2, 2)
+
+# Initialize graph with data
+grin = ROOT.TGraph(n, x, y)
+# Interpolate at equidistant points (use mean for tied x-values)
+gs = ROOT.TGraphSmooth("normal")
+grout = gs.Approx(grin, "linear")
+DrawSmooth(1, "Approx: ties = mean", "X-axis", "Y-axis")
+
+# Re-initialize graph with data
+# (since graph points were set to unique vales)
+grin = ROOT.TGraph(n, x, y)
+# Interpolate at given points xout
+grout = gs.Approx(grin, "linear", 14, xout, 0, 130)
+DrawSmooth(2, "Approx: ties = mean", "", "")
+
+# Print output variables for given values xout
+vNout = grout.GetN()
+vXout = c_double()
+vYout = c_double()
+for k in range(vNout):
+    grout.GetPoint(k, vXout, vYout)
+    print(f"k= {k}  vXout[k]= {vXout.value}  vYout[k]= {vYout.value}")
+
+# Re-initialize graph with data
+grin = ROOT.TGraph(n, x, y)
+# Interpolate at equidistant points (use min for tied x-values)
+#   _grout = gs.Approx(grin,"linear", 50, 0, 0, 0, 1, 0, "min")_
+grout = gs.Approx(grin, "constant", 50, 0, 0, 0, 1, 0.5, "min")
+DrawSmooth(3, "Approx: ties = min", "", "")
+
+# Re-initialize graph with data
+grin = ROOT.TGraph(n, x, y)
+# Interpolate at equidistant points (use max for tied x-values)
+grout = gs.Approx(grin, "linear", 14, xout, 0, 0, 2, 0, "max")
+DrawSmooth(4, "Approx: ties = max", "", "")

--- a/tutorials/visualisation/graphs/gr011_graph2d_errorsfit.py
+++ b/tutorials/visualisation/graphs/gr011_graph2d_errorsfit.py
@@ -1,0 +1,57 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview Create, draw and fit a TGraph2DErrors. See the [TGraph2DErrors documentation](https://root.cern/doc/master/classTGraph2DErrors.html)
+##
+## \macro_image
+## \macro_code
+## \author Olivier Couet, Jamie Gooding
+
+from ctypes import c_double
+
+import ROOT
+
+c1 = ROOT.TCanvas("c1")
+
+e = 0.3
+nd = 500
+
+# To generate some random data to put into the graph
+r = ROOT.TRandom()
+f2 = ROOT.TF2("f2", "1000*(([0]*sin(x)/x)*([1]*sin(y)/y))+200", -6, 6, -6, 6)
+f2.SetParameters(1, 1)
+
+dte = ROOT.TGraph2DErrors(nd)
+
+# Fill the 2D graph. It was created only specifying the number of points, so all
+# elements are empty. We now "fill" the values and errors with SetPoint and SetPointError.
+# Note that the first point has index zero
+x = c_double()
+y = c_double()
+zmax = 0
+for i in range(nd):
+    f2.GetRandom2(x, y)
+    rnd = r.Uniform(-e, e)  # Generate a random number in [-e,e]
+    z = f2.Eval(x, y) * (1 + rnd)
+    if z > zmax:
+        zmax = z
+    dte.SetPoint(i, x, y, z)
+    ex = 0.05 * r.Rndm()
+    ey = 0.05 * r.Rndm()
+    ez = abs(z * rnd)
+    dte.SetPointError(i, ex, ey, ez)
+
+# If the fit is not needed, just draw dte here and skip the lines below
+# dte.Draw("A p0")
+
+# To do the fit we use a function, in this example the same f2 from above
+f2.SetParameters(0.5, 1.5)
+dte.Fit(f2)
+fit2 = dte.FindObject("f2")
+fit2.SetTitle("Minuit fit result on the Graph2DErrors points")
+fit2.SetMaximum(zmax)
+ROOT.gStyle.SetHistTopMargin(0)
+fit2.SetLineColor(1)
+fit2.SetLineWidth(1)
+fit2.Draw("surf1")
+dte.Draw("same p0")

--- a/tutorials/visualisation/graphs/gr012_polar.py
+++ b/tutorials/visualisation/graphs/gr012_polar.py
@@ -1,0 +1,98 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview Create and draw a polar graph. See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
+##
+## Since TGraphPolar is a TGraphErrors, it is painted with
+## [TGraphPainter](https://root.cern/doc/master/classTGraphPainter.html) options.
+##
+## With GetPolargram we retrieve the polar axis to format it; see the
+## [TGraphPolargram documentation](https://root.cern/doc/master/classTGraphPolargram.html)
+##
+## \macro_image
+## \macro_code
+## \author Olivier Couet, Jamie Gooding
+
+# Illustrates how to use TGraphPolar
+
+import math
+
+import numpy as np
+import ROOT
+
+CPol = ROOT.TCanvas("CPol", "TGraphPolar Examples", 1200, 600)
+CPol.Divide(2, 1)
+
+# Left-side pad. Two graphs without errors
+CPol.cd(1)
+xmin = 0
+xmax = math.pi * 2
+
+x = np.array([])
+y = np.array([])
+xval1 = np.array([])
+yval1 = np.array([])
+
+# Graph 1 to be drawn with line and fill
+fplot = ROOT.TF1("fplot", "cos(2*x)*cos(20*x)", xmin, xmax)
+for ipt in range(1000):
+    x = np.append(x, ipt * (xmax - xmin) / 1000 + xmin)
+    y = np.append(y, fplot.Eval(x[ipt]))
+
+grP = ROOT.TGraphPolar(1000, x, y)
+grP.SetLineColor(2)
+grP.SetLineWidth(2)
+grP.SetFillStyle(3012)
+grP.SetFillColor(2)
+grP.Draw("AFL")
+
+# Graph 2 to be drawn superposed over graph 1, with curve and polymarker
+for ipt in range(20):
+    xval1 = np.append(xval1, x[math.floor(1000 / 20 * ipt)])
+    yval1 = np.append(yval1, y[math.floor(1000 / 20 * ipt)])
+
+grP1 = ROOT.TGraphPolar(20, xval1, yval1)
+grP1.SetMarkerStyle(29)
+grP1.SetMarkerSize(2)
+grP1.SetMarkerColor(4)
+grP1.SetLineColor(4)
+grP1.Draw("CP")
+
+# To format the polar axis, we retrieve the TGraphPolargram.
+# First update the canvas, otherwise GetPolargram returns 0
+CPol.Update()
+if grP1.GetPolargram():
+    grP1.GetPolargram().SetTextColor(8)
+    grP1.GetPolargram().SetRangePolar(-math.pi, math.pi)
+    grP1.GetPolargram().SetNdivPolar(703)
+    grP1.GetPolargram().SetToRadian()  # tell ROOT that the x and xval1 are in radians
+
+
+# Right-side pad. One graph with errors
+CPol.cd(2)
+x2 = np.array([])
+y2 = np.array([])
+ex = np.array([])
+ey = np.array([])
+for ipt in range(30):
+    x2 = np.append(x2, x[math.floor(1000 / 30 * ipt)])
+    y2 = np.append(y2, 1.2 + 0.4 * math.sin(math.pi * 2 * ipt / 30))
+    ex = np.append(ex, 0.2 + 0.1 * math.cos(2 * math.pi / 30 * ipt))
+    ey = np.append(ey, 0.2)
+
+# Grah to be drawn with polymarker and errors
+grPE = ROOT.TGraphPolar(30, x2, y2, ex, ey)
+grPE.SetMarkerStyle(22)
+grPE.SetMarkerSize(1.5)
+grPE.SetMarkerColor(5)
+grPE.SetLineColor(6)
+grPE.SetLineWidth(2)
+grPE.Draw("EP")
+
+# To format the polar axis, we retrieve the TGraphPolargram.
+# First update the canvas, otherwise GetPolargram returns 0
+CPol.Update()
+if grPE.GetPolargram():
+    grPE.GetPolargram().SetTextSize(0.03)
+    grPE.GetPolargram().SetTwoPi()
+    grPE.GetPolargram().SetToRadian()  # tell ROOT that the x2 values are in radians

--- a/tutorials/visualisation/graphs/gr013_polar2.py
+++ b/tutorials/visualisation/graphs/gr013_polar2.py
@@ -1,0 +1,48 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview Create and draw a polar graph with errors and polar axis in radians (PI fractions).
+## See the [TGraphPolar documentation](https:#root.cern/doc/master/classTGraphPolar.html)
+##
+## Since TGraphPolar is a TGraphErrors, it is painted with
+## [TGraphPainter](https:#root.cern/doc/master/classTGraphPainter.html) options.
+##
+## With GetPolargram we retrieve the polar axis to format it see the
+## [TGraphPolargram documentation](https:#root.cern/doc/master/classTGraphPolargram.html)
+##
+## \macro_image
+## \macro_code
+## \author Olivier Couet, Jamie Gooding
+
+import numpy as np
+import ROOT
+
+CPol = ROOT.TCanvas("CPol", "TGraphPolar Example", 500, 500)
+
+theta = np.array([])
+radius = np.array([])
+etheta = np.array([])
+eradius = np.array([])
+
+for i in range(8):
+    theta = np.append(theta, (i + 1) * (np.pi / 4.0))
+    radius = np.append(radius, (i + 1) * 0.05)
+    etheta = np.append(etheta, np.pi / 8.0)
+    eradius = np.append(eradius, 0.05)
+
+grP1 = ROOT.TGraphPolar(8, theta, radius, etheta, eradius)
+grP1.SetTitle("")
+
+grP1.SetMarkerStyle(20)
+grP1.SetMarkerSize(2.0)
+grP1.SetMarkerColor(4)
+grP1.SetLineColor(2)
+grP1.SetLineWidth(3)
+# Draw with polymarker and errors
+grP1.Draw("PE")
+
+# To format the polar axis, we retrieve the TGraphPolargram.
+# First update the canvas, otherwise GetPolargram returns 0
+CPol.Update()
+if grP1.GetPolargram():
+    grP1.GetPolargram().SetToRadian()  # tell ROOT that the theta values are in radians

--- a/tutorials/visualisation/graphs/gr014_polar3.py
+++ b/tutorials/visualisation/graphs/gr014_polar3.py
@@ -1,0 +1,34 @@
+## \file
+## \ingroup tutorial_graphs
+## \notebook
+## \preview Create a polar graph using a TF1 and draw it with PI axis.
+## See the [TGraphPolar documentation](https://root.cern/doc/master/classTGraphPolar.html)
+##
+## Since TGraphPolar is a TGraphErrors, it is painted with
+## [TGraphPainter](https://root.cern/doc/master/classTGraphPainter.html) options.
+##
+## \macro_image
+## \macro_code
+## \author Olivier Couet, Jamie Gooding
+
+import math
+
+import numpy as np
+import ROOT
+
+CPol = ROOT.TCanvas("CPol", "TGraphPolar Examples", 500, 500)
+
+rmin = 0
+rmax = math.pi * 2
+r = np.array([])
+theta = np.array([])
+
+fp1 = ROOT.TF1("fplot", "cos(x)", rmin, rmax)
+for ipt in range(1000):
+    r = np.append(r, ipt * (rmax - rmin) / 1000 + rmin)
+    theta = np.append(theta, fp1.Eval(r[ipt]))
+
+grP1 = ROOT.TGraphPolar(1000, r, theta)
+grP1.SetTitle("")
+grP1.SetLineColor(2)
+grP1.Draw("AOL")

--- a/tutorials/visualisation/graphs/index.md
+++ b/tutorials/visualisation/graphs/index.md
@@ -37,25 +37,25 @@ The graph tutorials below are divided in groups of increasing complexity, starti
 These examples showcase the creation of different types of graphs and basic ways to plot them.
 
 | **Tutorial** || **Description** |
-|------|--------|-----------------|
-| gr001_simple.C |  | Create a simple graph from available data or from a file, and draw it. |
-| gr002_errors.C |  | Create and draw a graph with error bars.|
-| gr003_errors2.C |  | Create and draw two graphs with error bars, superposed on the same canvas (not using TMultiGraph). |
-| gr004_errors_asym.C |  | Create and draw a graph with asymmetric x & y errors. |
-| gr005_apply.C |  | Demonstrate the functionality of the TGraph::Apply() method. |
-| gr006_scatter.C |  | Scatter plot for 4 variables, mapped to: x, y, marker color and marker size. |
-| gr007_multigraph.C |  | Create and draw a TMultiGraph (several graphs superposed). |
-| gr008_multierrors.C |  | Graph with multiple y errors in each bin. |
-| gr009_bent_err.C | gr009_bent_err.py | Graph with bent (non-vertical/non-horizontal) error bars. |
-| gr010_approx_smooth.C |  | Create a TGraphSmooth and show the usage of the interpolation function Approx. |
-| gr011_graph2d_errorsfit.C |  | Create, draw and fit a TGraph2DErrors. |
-| gr012_polar.C |  | Create and draw a polar graph. |
-| gr013_polar2.C |  | Polar graph with errors and polar axis in radians (PI fractions). |
-| gr014_polar3.C |  | Create a polar graph using a TF1 and draw it with PI axis. |
-| gr015_smooth.C |  | Show scatter plot smoothers: ksmooth, lowess, supsmu |
-| gr016_struct.C |  | Draw a simple graph structure. |
-| gr017_time.C |  | Example of TGraphTime. |
-| gr018_time2.C |  | TGraphTime to visualize a set of particles with their time stamp in a MonteCarlo program. |
+|---------------------------|-------------------------------|-----------------|
+| gr001_simple.C            | gr001_simple.py               | Create a simple graph from available data or from a file, and draw it. |
+| gr002_errors.C            | gr002_errors.py               | Create and draw a graph with error bars.|
+| gr003_errors2.C           | gr003_errors2.py              | Create and draw two graphs with error bars, superposed on the same canvas (not using TMultiGraph). |
+| gr004_errors_asym.C       | gr004_errors_asym.py          | Create and draw a graph with asymmetric x & y errors. |
+| gr005_apply.C             | gr005_apply.py                | Demonstrate the functionality of the TGraph::Apply() method. |
+| gr006_scatter.C           | gr006_scatter.py              | Scatter plot for 4 variables, mapped to: x, y, marker color and marker size. |
+| gr007_multigraph.C        | gr007_multigraph.py           | Create and draw a TMultiGraph (several graphs superposed). |
+| gr008_multierrors.C       |                               | Graph with multiple y errors in each bin. |
+| gr009_bent_err.C          | gr009_bent_err.py             | Graph with bent (non-vertical/non-horizontal) error bars. |
+| gr010_approx_smooth.C     | gr010_approx_smooth.py        | Create a TGraphSmooth and show the usage of the interpolation function Approx. |
+| gr011_graph2d_errorsfit.C | gr011_graph2d_errorsfit.py    | Create, draw and fit a TGraph2DErrors. |
+| gr012_polar.C             | gr012_polar.py                | Create and draw a polar graph. |
+| gr013_polar2.C            | gr013_polar2.py               | Polar graph with errors and polar axis in radians (PI fractions). |
+| gr014_polar3.C            | gr014_polar3.py               | Create a polar graph using a TF1 and draw it with PI axis. |
+| gr015_smooth.C            |                               | Show scatter plot smoothers: ksmooth, lowess, supsmu |
+| gr016_struct.C            |                               | Draw a simple graph structure. |
+| gr017_time.C              |                               | Example of TGraphTime. |
+| gr018_time2.C             |                               | TGraphTime to visualize a set of particles with their time stamp in a MonteCarlo program. |
 
 
 \anchor modifying


### PR DESCRIPTION
# This Pull request:
Adds PyROOT equivalents to many of the Graphs tutorials.


## Changes or fixes:
Adds PyROOT equivalents to:
- gr001_simple
- gr002_errors
- gr003_errors2
- gr004_errors_asym
- gr005_apply
- gr006_scatter
- gr007_multigraph
- gr010_approx_smooth
- gr011_graph2d_errorsfit
- gr012_polar
- gr013_polar2
- gr014_polar3

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

