### PR TITLE
[tutorials] Rename `ntuple` to `reader` and `writer`

### DIFF
--- a/tutorials/io/ntuple/ntpl001_staff.C
+++ b/tutorials/io/ntuple/ntpl001_staff.C
@@ -63,14 +63,14 @@ void Ingest() {
 
    // We hand-over the data model to a newly created ntuple of name "Staff", stored in kNTupleFileName
    // In return, we get a unique pointer to an ntuple that we can fill
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "Staff", kNTupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "Staff", kNTupleFileName);
 
    std::string record;
    while (std::getline(fin, record)) {
       std::istringstream iss(record);
       iss >> *fldCategory >> *fldFlag >> *fldAge >> *fldService >> *fldChildren >> *fldGrade >> *fldStep >> *fldHrweek
           >> *fldCost >> *fldDivision >> *fldNation;
-      ntuple->Fill();
+      writer->Fill();
    }
 
    // The ntuple unique pointer goes out of scope here.  On destruction, the ntuple flushes unwritten data to disk
@@ -85,22 +85,22 @@ void Analyze() {
    std::shared_ptr<int> fldAge = model->MakeField<int>("Age");
 
    // Create an ntuple and attach the read model to it
-   auto ntuple = RNTupleReader::Open(std::move(model), "Staff", kNTupleFileName);
+   auto reader = RNTupleReader::Open(std::move(model), "Staff", kNTupleFileName);
 
    // Quick overview of the ntuple and list of fields.
-   ntuple->PrintInfo();
+   reader->PrintInfo();
 
    std::cout << "The first entry in JSON format:" << std::endl;
-   ntuple->Show(0);
+   reader->Show(0);
    // In a future version of RNTuple, there will be support for ntuple->Scan()
 
    auto c = new TCanvas("c", "", 200, 10, 700, 500);
    TH1I h("h", "Age Distribution CERN, 1988", 100, 0, 100);
    h.SetFillColor(48);
 
-   for (auto entryId : *ntuple) {
+   for (auto entryId : *reader) {
       // Populate fldAge
-      ntuple->LoadEntry(entryId);
+      reader->LoadEntry(entryId);
       h.Fill(*fldAge);
    }
 

--- a/tutorials/io/ntuple/ntpl002_vector.C
+++ b/tutorials/io/ntuple/ntpl002_vector.C
@@ -56,7 +56,7 @@ void Write()
 
    // We hand-over the data model to a newly created ntuple of name "F", stored in kNTupleFileName
    // In return, we get a unique pointer to an ntuple that we can fill
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "F", kNTupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "F", kNTupleFileName);
 
    TH1F hpx("hpx", "This is the px distribution", 100, -4, 4);
    hpx.SetFillColor(48);
@@ -96,7 +96,7 @@ void Write()
             break;
       }
 
-      ntuple->Fill();
+      writer->Fill();
    }
 
    hpx.DrawCopy();
@@ -117,13 +117,13 @@ void Read()
 
    // Create an ntuple without imposing a specific data model.  We could generate the data model from the ntuple
    // but here we prefer the view because we only want to access a single field
-   auto ntuple = RNTupleReader::Open(std::move(model), "F", kNTupleFileName);
+   auto reader = RNTupleReader::Open(std::move(model), "F", kNTupleFileName);
 
    // Quick overview of the ntuple's key meta-data
-   ntuple->PrintInfo();
+   reader->PrintInfo();
 
    std::cout << "Entry number 42 in JSON format:" << std::endl;
-   ntuple->Show(41);
+   reader->Show(41);
    // In a future version of RNTuple, there will be support for ntuple->Scan()
 
    TCanvas *c2 = new TCanvas("c2", "Dynamic Filling Example", 200, 10, 700, 500);
@@ -131,8 +131,8 @@ void Read()
    h.SetFillColor(48);
 
    // Iterate through all the events using i as event number and as an index for accessing the view
-   for (auto entryId : *ntuple) {
-      ntuple->LoadEntry(entryId);
+   for (auto entryId : *reader) {
+      reader->LoadEntry(entryId);
 
       for (auto px : *fldVpx) {
          h.Fill(px);

--- a/tutorials/io/ntuple/ntpl005_introspection.C
+++ b/tutorials/io/ntuple/ntpl005_introspection.C
@@ -63,11 +63,11 @@ void Generate()
    ROOT::RNTupleWriteOptions options;
    options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
 
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "Vector3", kNTupleFileName, options);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "Vector3", kNTupleFileName, options);
    TRandom r;
    for (unsigned int i = 0; i < 500000; ++i) {
       fldVector3->SetXYZ(r.Gaus(0,1), r.Landau(0,1), r.Gaus(100,10));
-      ntuple->Fill();
+      writer->Fill();
    }
 }
 
@@ -75,20 +75,20 @@ void Generate()
 void ntpl005_introspection() {
    Generate();
 
-   auto ntuple = RNTupleReader::Open("Vector3", kNTupleFileName);
+   auto reader = RNTupleReader::Open("Vector3", kNTupleFileName);
 
    // Display the schema of the ntuple
-   ntuple->PrintInfo();
+   reader->PrintInfo();
 
    // Display information about the storage layout of the data
-   ntuple->PrintInfo(ENTupleInfo::kStorageDetails);
+   reader->PrintInfo(ENTupleInfo::kStorageDetails);
 
    // Display the first entry
-   ntuple->Show(0);
+   reader->Show(0);
 
    // Collect I/O runtime counters when processing the data set.
    // Maintaining the counters comes with a small performance overhead, so it has to be explicitly enabled
-   ntuple->EnableMetrics();
+   reader->EnableMetrics();
 
    // Plot the y components of vector3
    TCanvas *c1 = new TCanvas("c1","RNTuple Demo", 10, 10, 600, 800);
@@ -98,8 +98,8 @@ void ntpl005_introspection() {
    {
       /// We enclose viewX in a scope in order to indicate to the RNTuple when we are not
       /// anymore interested in v3.fX
-      auto viewX = ntuple->GetView<double>("v3.fX");
-      for (auto i : ntuple->GetEntryRange()) {
+      auto viewX = reader->GetView<double>("v3.fX");
+      for (auto i : reader->GetEntryRange()) {
          h1.Fill(viewX(i));
       }
    }
@@ -107,22 +107,22 @@ void ntpl005_introspection() {
 
    c1->cd(2);
    TH1F h2("y", "y component of Vector3", 100, -5, 20);
-   auto viewY = ntuple->GetView<double>("v3.fY");
-   for (auto i : ntuple->GetEntryRange()) {
+   auto viewY = reader->GetView<double>("v3.fY");
+   for (auto i : reader->GetEntryRange()) {
       h2.Fill(viewY(i));
    }
    h2.DrawCopy();
 
    // Display the I/O operation statistics performed by the RNTuple reader
-   ntuple->PrintInfo(ENTupleInfo::kMetrics);
+   reader->PrintInfo(ENTupleInfo::kMetrics);
 
    // We read 2 out of the 3 Vector3 members and thus should have requested approximately 2/3 of the file
    FileStat_t fileStat;
    auto retval = gSystem->GetPathInfo(kNTupleFileName, fileStat);
    assert(retval == 0);
    float fileSize = static_cast<float>(fileStat.fSize);
-   float nbytesRead = ntuple->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadPayload")->GetValueAsInt() +
-                      ntuple->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadOverhead")->GetValueAsInt();
+   float nbytesRead = reader->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadPayload")->GetValueAsInt() +
+                      reader->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadOverhead")->GetValueAsInt();
 
    std::cout << "File size:      " << fileSize / 1024. / 1024. << " MiB" << std::endl;
    std::cout << "Read from file: " << nbytesRead / 1024. / 1024. << " MiB" << std::endl;

--- a/tutorials/io/ntuple/ntpl007_mtFill.C
+++ b/tutorials/io/ntuple/ntpl007_mtFill.C
@@ -49,7 +49,7 @@ constexpr int kNEventsPerThread = 25000;
 
 // Thread function to generate and write events
 void FillData(std::unique_ptr<REntry> entry, RNTupleWriter *writer) {
-   // Protect the ntuple->Fill() call
+   // Protect the writer->Fill() call
    static std::mutex gLock;
 
    static std::atomic<std::uint32_t> gThreadId;

--- a/tutorials/io/ntuple/ntpl011_global_temperatures.C
+++ b/tutorials/io/ntuple/ntpl011_global_temperatures.C
@@ -88,7 +88,7 @@ void Ingest()
 
    // Hand-over the data model to a newly created ntuple of name "globalTempData", stored in kNTupleFileName.
    // In return, get a unique pointer to a fillable ntuple (first compress the file).
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName);
 
    // Download data in 4MB blocks
    RRawFile::ROptions options;
@@ -117,7 +117,7 @@ void Ingest()
       *fieldCountry = country;
       *fieldCity = city;
 
-      ntuple->Fill();
+      writer->Fill();
 
       if (++nRecords % 1000000 == 0)
          std::cout << "  ... converted " << nRecords << " records" << std::endl;

--- a/tutorials/io/ntuple/ntpl015_processor_join.C
+++ b/tutorials/io/ntuple/ntpl015_processor_join.C
@@ -41,17 +41,17 @@ void WriteMain(std::string_view ntupleName, std::string_view ntupleFileName)
    auto fldI = model->MakeField<std::uint32_t>("i");
    auto fldVpx = model->MakeField<float>("vpx");
 
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
 
    // The main ntuple only contains a subset of the entries present in the auxiliary ntuple.
    for (int i = 0; i < kNEvents; i += 5) {
       *fldI = i;
       *fldVpx = gRandom->Gaus();
 
-      ntuple->Fill();
+      writer->Fill();
    }
 
-   std::cout << "Wrote " << ntuple->GetNEntries() << " to the main RNTuple" << std::endl;
+   std::cout << "Wrote " << writer->GetNEntries() << " to the main RNTuple" << std::endl;
 }
 
 void WriteAux(std::string_view ntupleName, std::string_view ntupleFileName)
@@ -61,16 +61,16 @@ void WriteAux(std::string_view ntupleName, std::string_view ntupleFileName)
    auto fldI = model->MakeField<std::uint32_t>("i");
    auto fldVpy = model->MakeField<float>("vpy");
 
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
 
    for (int i = 0; i < kNEvents; ++i) {
       *fldI = i;
       *fldVpy = gRandom->Gaus();
 
-      ntuple->Fill();
+      writer->Fill();
    }
 
-   std::cout << "Wrote " << ntuple->GetNEntries() << " to the auxiliary RNTuple" << std::endl;
+   std::cout << "Wrote " << writer->GetNEntries() << " to the auxiliary RNTuple" << std::endl;
 }
 
 void Read()


### PR DESCRIPTION
...distinguishing more explicitly between the use of `RNTupleReader` and `RNTupleWriter`.
