### PR TITLE
[skip-ci] Add reference in Bayesian methods section

### DIFF
--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -217,9 +217,10 @@ passed events.
 In Bayesian statistics a likelihood-function (how probable is it to get the
 observed data assuming a true efficiency) and a prior probability (what is the
 probability that a certain true efficiency is actually realised) are used to
-determine a posterior probability by using Bayes theorem. At the moment, only
-beta distributions (have 2 free parameters) are supported as prior
-probabilities.
+determine a posterior probability by using Bayes theorem. At the moment,
+only beta distributions (with 2 free parameters) are supported as prior
+probabilities, as explained in D. Casadei, Estimating the selection efficiency,
+2012 JINST 7 P08021, https://doi.org/10.1088/1748-0221/7/08/P08021 (https://arxiv.org/abs/0908.0130).
 
 \f{eqnarray*}{
  P(\epsilon | k ; N) &=& \frac{1}{norm} \times P(k | \epsilon ; N) \times Prior(\epsilon) \\

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -1272,7 +1272,10 @@ Double_t TEfficiency::MidPInterval(Double_t total,Double_t passed,Double_t level
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
-Calculates the boundaries for a Bayesian confidence interval (shortest or central interval depending on the option)
+Calculates the boundaries for a Bayesian confidence interval (shortest or central
+interval depending on the option)  as explained in D. Casadei, Estimating the selection efficiency,
+2012 JINST 7 P08021, https://doi.org/10.1088/1748-0221/7/08/P08021 (https://arxiv.org/abs/0908.0130).
+
 
 \param[in] total number of total events
 \param[in] passed 0 <= number of passed events <= total


### PR DESCRIPTION
Add a reference to:

 D. Casadei, Estimating the selection efficiency, 2012 JINST 7 P08021, https://doi.org/10.1088/1748-0221/7/08/P08021 (https://arxiv.org/abs/0908.0130).

As requested by D. Casadei in an email to root-dev@cern.ch

