### PR TITLE
[python] Add UHI Indexing Support (Access, Setting, and Slicing) to TH1 Derived Classes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -452,3 +452,17 @@ class ROOTFacade(types.ModuleType):
         tpd = cppyy.gbl.TPyDispatcher
         type(self).TPyDispatcher = tpd
         return tpd
+
+    # Create the uhi namespace
+    @property
+    def uhi(self):
+        uhi_module = types.ModuleType("uhi")
+        uhi_module.__file__ = "<module ROOT>"
+        uhi_module.__package__ = self
+        try:
+            from ._pythonization._uhi import _add_module_level_uhi_helpers
+
+            _add_module_level_uhi_helpers(uhi_module)
+        except ImportError:
+            raise Exception("Failed to pythonize the namespace uhi")
+        return uhi_module

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -240,17 +240,17 @@ _th1_derived_classes_to_pythonize = [
 for klass in _th1_derived_classes_to_pythonize:
     pythonization(klass)(inject_constructor_releasing_ownership)
 
-    from ROOT._pythonization._uhi import add_plotting_features
-    
-    # Add UHI components
-    uhi_components = [add_plotting_features]
-    for uc in uhi_components:
-        pythonization(klass)(uc)
+    from ROOT._pythonization._uhi import _add_plotting_features
+
+    # Add UHI plotting features
+    pythonization(klass)(_add_plotting_features)
+
 
 @pythonization('TH1')
 def pythonize_th1(klass):
     # Parameters:
     # klass: class to be pythonized
+    from ROOT._pythonization._uhi import _add_indexing_features
 
     # Support hist *= scalar
     klass.__imul__ = _imul
@@ -261,5 +261,8 @@ def pythonize_th1(klass):
 
     klass._Original_SetDirectory = klass.SetDirectory
     klass.SetDirectory = _SetDirectory_SetOwnership
+
+    # Add UHI indexing features
+    _add_indexing_features(klass)
 
     inject_clone_releasing_ownership(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
@@ -1,22 +1,412 @@
 # Author: Silia Taider CERN  03/2025
 
 ################################################################################
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 from __future__ import annotations
-from abc import ABC, abstractmethod
+
 import enum
-from typing import Tuple, Iterator, Union, Callable, Any
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Tuple, Union
+import types
+
+"""
+Implementation of the module level helper functions for the UHI
+"""
 
 
-# Implementation of the plotting component of the UHI
+def _underflow(hist: Any, axis: int) -> int:
+    return 0
+
+
+def _overflow(hist: Any, axis: int) -> int:
+    return _get_axis(hist, axis).GetNbins() + 1
+
+
+class _loc:
+    """
+    Represents a location-based index for histograms, returning the bin corresponding
+    to a specified value on a given axis. Supports addition and subtraction to shift
+    the computed bin by an integer offset.
+
+    Example:
+        v = h[loc(b) + 1]  # Returns the bin above the one containing the value `b`
+    """
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+        self.offset = 0
+
+    def __add__(self, other: int) -> _loc:
+        if isinstance(other, int):
+            self.offset += other
+            return self
+        raise TypeError(f"Unsupported type for addition: {type(other).__name__}. Expected an integer.")
+
+    def __sub__(self, other: int) -> _loc:
+        if isinstance(other, int):
+            self.offset -= other
+            return self
+        raise TypeError(f"Unsupported type for substraction: {type(other).__name__}. Expected an integer.")
+
+    def __call__(self, hist: Any, axis: int) -> int:
+        return _get_axis(hist, axis).FindBin(self.value) + self.offset
+
+
+class _rebin:
+    """
+    Represents a rebinning operation for histograms, where bins are grouped together
+    by the factor ngroup.
+
+    Example:
+        h_rebinned = h[::ROOT.uhi.rebin(2)]  # Rebin the histogram with a grouping factor of 2
+    """
+
+    def __init__(self, ngroup):
+        self.ngroup = ngroup
+
+    def __call__(self, hist):
+        rebin_methods = {1: "Rebin", 2: "Rebin2D", 3: "Rebin3D"}
+        rebin_method = rebin_methods.get(hist.GetDimension())
+        rebin_method = getattr(hist, rebin_method)
+        return rebin_method(*self.ngroup, newname=hist.GetName())
+
+
+def _sum(hist, axis):
+    """
+    Represents a summation operation for histograms, which either computes the integral
+    (1D histograms) or projects the histogram along specified axes (2D and 3D histograms).
+
+    Example:
+        ans = h[::ROOT.uhi.sum]  # Compute the integral for a 1D histogram
+        h_projected = h[:, ::ROOT.uhi.sum]  # Project the Y axis for a 2D histogram
+        h_projected = h[:, :, ::ROOT.uhi.sum]  # Project the Z axis for a 3D histogram
+    """
+    dim = hist.GetDimension()
+
+    def _invalid_axis(axis, dim):
+        raise ValueError(f"Invalid axis {axis} for {dim}D histogram")
+
+    if isinstance(axis, int):
+        axis = (axis,)
+    if dim == 1:
+        return hist.Integral()
+    if dim == 2:
+        return hist.ProjectionX() if axis == (0,) else hist.ProjectionY() if axis == (1,) else _invalid_axis(axis, dim)
+    if dim == 3:
+        # It is not possible from the interface to specify the options "yx", "zy", "zx"
+        project_map = {
+            (0,): "yz",
+            (1,): "xz",
+            (2,): "xy",
+            (0, 1): "z",
+            (0, 2): "y",
+            (1, 2): "x",
+        }
+        return hist.Project3D(project_map[axis]) if axis in project_map else _invalid_axis(axis, dim)
+    raise NotImplementedError(f"Summing not implemented for {dim}D histograms")
+
+
+def _add_module_level_uhi_helpers(module: types.ModuleType) -> None:
+    module.underflow = _underflow
+    module.overflow = _overflow
+    module.loc = _loc
+    module.rebin = _rebin
+    module.sum = _sum
+
+
+"""
+Implementation of the indexing component of the UHI
+"""
+
+
+@contextmanager
+def _temporarily_disable_add_directory():
+    """
+    Temporarily disable adding the new created histograms to the list of objects in memory
+    """
+    import ROOT
+
+    old_status = ROOT.TH1.AddDirectoryStatus()
+    ROOT.TH1.AddDirectory(False)
+    try:
+        yield
+    finally:
+        ROOT.TH1.AddDirectory(old_status)
+
+
+def _get_axis(self, axis):
+    return getattr(self, f"Get{['X', 'Y', 'Z'][axis]}axis")()
+
+
+def _get_axis_len(self, axis):
+    return _get_axis(self, axis).GetNbins()
+
+
+def _process_index_for_axis(self, index, axis):
+    """Process an index for a histogram axis handling callables and index shifting."""
+    if callable(index):
+        # If the index is a `loc`, `underflow`, `overflow`, or `len`
+        return _get_axis_len(self, axis) if index is len else index(self, axis)
+
+    if isinstance(index, int):
+        # Shift the indices by 1 to align with the UHI convention,
+        # where 0 corresponds to the first bin, unlike ROOT where 0 represents underflow and 1 is the first bin.
+        index = index + 1
+        nbins = _get_axis_len(self, axis)
+        if abs(index) > nbins:
+            raise IndexError(f"Histogram index {index} out of range for axis {axis}")
+        return index
+
+    raise index
+
+
+def _compute_uhi_index(self, index, axis):
+    """Convert tag functors to valid bin indices."""
+    if isinstance(index, _rebin) or index is _sum:
+        index = slice(None, None, index)
+
+    if callable(index) or isinstance(index, int):
+        return _process_index_for_axis(self, index, axis)
+
+    if isinstance(index, slice):
+        start, stop = _resolve_slice_indices(self, index, axis)
+        return slice(start, stop, index.step)
+
+    raise TypeError(f"Unsupported index type: {type(index).__name__}")
+
+
+def _compute_common_index(self, index):
+    """Normalize and expand the index to match the histogram dimension."""
+    dim = self.GetDimension()
+    if isinstance(index, dict):
+        expanded_index = [slice(None)] * dim
+        for axis, value in index.items():
+            expanded_index[axis] = value
+        index = tuple(expanded_index)
+
+    if not isinstance(index, tuple):
+        index = (index,)
+
+    if index.count(...) > 1:
+        raise IndexError("Only one ellipsis is allowed in the index.")
+
+    if any(idx is ... for idx in index):
+        expanded_index = []
+        for idx in index:
+            if idx is ...:
+                break
+            expanded_index.append(idx)
+        # fill remaining dimensions with `slice(None)`
+        expanded_index.extend([slice(None)] * (dim - len(expanded_index)))
+        index = tuple(expanded_index)
+
+    if len(index) != dim:
+        raise IndexError(f"Expected {dim} indices, got {len(index)}")
+
+    return [_compute_uhi_index(self, idx, axis) for axis, idx in enumerate(index)]
+
+
+def _setbin(self, index, value):
+    """Set the bin content for a specific bin index"""
+    self.SetBinContent(index, value)
+
+
+def _resolve_slice_indices(self, index, axis):
+    """Resolve slice start and stop indices for a given axis"""
+    start, stop = index.start, index.stop
+    start = _process_index_for_axis(self, start, axis) if start is not None else _underflow(self, axis)
+    stop = _process_index_for_axis(self, stop, axis) if stop is not None else _overflow(self, axis) + 1
+    if start < _underflow(self, axis) or stop > (_overflow(self, axis) + 1) or start > stop:
+        raise IndexError(f"Slice indices {start, stop} out of range for axis {axis}")
+    return start, stop
+
+
+def _apply_actions(hist, actions):
+    """Apply rebinning or summing actions to the histogram, returns a new histogram"""
+    if not actions or all(a is None for a in actions):
+        return hist
+
+    if any(a is _sum for a in actions):
+        sum_axes = tuple(i for i, a in enumerate(actions) if a is _sum)
+        hist = _sum(hist, sum_axes)
+
+    if any(isinstance(a, _rebin) for a in actions):
+        rebins = [a.ngroup if isinstance(a, _rebin) else 1 for a in actions if a is not _sum]
+        hist = _rebin(rebins)(hist)
+
+    if any(a is not None and not (isinstance(a, _rebin) or a is _sum) for a in actions):
+        raise ValueError(f"Unsupported action detected in actions {actions}")
+
+    return hist
+
+
+def _get_processed_slices(self, index):
+    """Process slices and extract actions for each axis"""
+    if len(index) != self.GetDimension():
+        raise IndexError(f"Expected {self.GetDimension()} indices, got {len(index)}")
+    processed_slices, out_of_range_indices, actions = [], [], [None] * self.GetDimension()
+    for i, idx in enumerate(index):
+        axis_bins = range(_get_axis(self, i).GetNbins() + 2)
+        if isinstance(idx, slice):
+            slice_range = range(idx.start, idx.stop)
+            processed_slices.append(slice_range)
+            uflow = [b for b in axis_bins if b < idx.start]
+            oflow = [b for b in axis_bins if b >= idx.stop]
+            out_of_range_indices.append((uflow, oflow))
+            actions[i] = idx.step
+        else:
+            processed_slices.append([idx])
+
+    return processed_slices, out_of_range_indices, actions
+
+
+def _get_slice_indices(slices):
+    """
+    This function uses numpy's meshgrid to create a grid of indices from the input slices,
+    and reshapes the grid into a list of all possible index combinations.
+
+    Example:
+        slices = [range(2), range(3)]
+        # This represents two dimensions:
+        #   - The first dimension has indices [0, 1]
+        #   - The second dimension has indices [0, 1, 2]
+
+        result = _get_slice_indices(slices)
+        # result:
+        # [[0, 0],
+        #  [0, 1],
+        #  [0, 2],
+        #  [1, 0],
+        #  [1, 1],
+        #  [1, 2]]
+    """
+    import numpy as np
+
+    return np.array(np.meshgrid(*slices)).T.reshape(-1, len(slices))
+
+
+def _set_flow_bins(self, target_hist, out_of_range_indices):
+    """
+    Accumulate content from bins outside the slice range into flow bins.
+    """
+    dim = self.GetDimension()
+    uflow_bin = tuple(_underflow(self, axis) for axis in range(dim))
+    oflow_bin = tuple(_overflow(self, axis) for axis in range(dim))
+    flow_sum = 0
+
+    for axis, (underflow_indices, overflow_indices) in enumerate(out_of_range_indices):
+        all_axes = [range(_overflow(self, j)) for j in range(dim)]
+
+        def sum_bin_content(indices_list, target_bin):
+            current_val = target_hist.GetBinContent(*target_bin)
+            temp_axes = list(all_axes)
+            temp_axes[axis] = indices_list
+            for idx in _get_slice_indices(temp_axes):
+                current_val += self.GetBinContent(*tuple(map(int, idx)))
+            target_hist.SetBinContent(*target_bin, current_val)
+            return current_val
+
+        flow_sum += sum_bin_content(underflow_indices, uflow_bin)
+        flow_sum += sum_bin_content(overflow_indices, oflow_bin)
+
+    return flow_sum
+
+
+def _slice_get(self, index):
+    """
+    This method creates a new histogram containing only the data from the
+    specified slice.
+
+    Steps:
+    - Process the slices and extract the actions for each axis.
+    - Clone the original histogram and reset its contents.
+    - Set the bin content for each index in the slice.
+    - Update the number of entries in the cloned histogram (also updates the statistics).
+    - Apply any rebinning or summing actions to the resulting histogram.
+    """
+    processed_slices, out_of_range_indices, actions = _get_processed_slices(self, index)
+    slice_indices = _get_slice_indices(processed_slices)
+    with _temporarily_disable_add_directory():
+        target_hist = self.Clone()
+        target_hist.Reset()
+
+    for indices in slice_indices:
+        indices = tuple(map(int, indices))
+        target_hist.SetBinContent(*indices, self.GetBinContent(self.GetBin(*indices)))
+
+    flow_sum = _set_flow_bins(self, target_hist, out_of_range_indices)
+
+    target_hist.SetEntries(target_hist.GetEffectiveEntries() + flow_sum)
+
+    return _apply_actions(target_hist, actions)
+
+
+def _slice_set(self, index, value):
+    """
+    This method modifies the histogram by updating the bin contents for the
+    specified slice. It supports assigning a scalar value to all bins or
+    assigning an array of values, provided the array's shape matches the slice.
+    """
+    import numpy as np
+
+    processed_slices, _, actions = _get_processed_slices(self, index)
+    slice_indices = _get_slice_indices(processed_slices)
+    if isinstance(value, np.ndarray):
+        if value.size != len(slice_indices):
+            raise ValueError(f"Expected {len(slice_indices)} bin values, got {value.size}")
+
+        expected_shape = tuple(len(slice_range) for slice_range in processed_slices)
+        if value.shape != expected_shape:
+            raise ValueError(f"Shape mismatch: expected {expected_shape}, got {value.shape}")
+
+        for indices, val in zip(slice_indices, value.ravel()):
+            _setbin(self, self.GetBin(*map(int, indices)), val)
+    elif np.isscalar(value):
+        for indices in slice_indices:
+            _setbin(self, self.GetBin(*map(int, indices)), value)
+    else:
+        raise TypeError(f"Unsupported value type: {type(value).__name__}")
+
+    _apply_actions(self, actions)
+
+
+def _getitem(self, index):
+    index = _compute_common_index(self, index)
+    if all(isinstance(i, int) for i in index):
+        return self.GetBinContent(*index)
+
+    if any(isinstance(i, slice) for i in index):
+        return _slice_get(self, index)
+
+
+def _setitem(self, index, value):
+    index = _compute_common_index(self, index)
+    if all(isinstance(i, int) for i in index):
+        _setbin(self, self.GetBin(*index), value)
+    elif any(isinstance(i, slice) for i in index):
+        _slice_set(self, index, value)
+
+
+def _add_indexing_features(klass: Any) -> None:
+    klass.__getitem__ = _getitem
+    klass.__setitem__ = _setitem
+
+
+"""
+Implementation of the plotting component of the UHI
+"""
+
+
 class Kind(str, enum.Enum):
     COUNT = "COUNT"
     MEAN = "MEAN"
+
 
 class PlottableAxisTraits:
     def __init__(self, circular: bool = False, discrete: bool = False):
@@ -38,12 +428,10 @@ class PlottableAxisBase(ABC):
 
     @property
     @abstractmethod
-    def traits(self) -> PlottableAxisTraits:
-        pass
+    def traits(self) -> PlottableAxisTraits: ...
 
     @abstractmethod
-    def __getitem__(self, index: int) -> Union[Tuple[float, float], str]:
-        pass
+    def __getitem__(self, index: int) -> Union[Tuple[float, float], str]: ...
 
     def __len__(self) -> int:
         return self.tAx.GetNbins()
@@ -52,10 +440,11 @@ class PlottableAxisBase(ABC):
         if not isinstance(other, PlottableAxisBase):
             return False
         return len(self) == len(other) and all(a == b for a, b in zip(self, other))
-    
+
     @abstractmethod
     def __iter__(self) -> Iterator[Union[Tuple[float, float], str]]:
         pass
+
 
 class PlottableAxisContinuous(PlottableAxisBase):
     @property
@@ -69,6 +458,7 @@ class PlottableAxisContinuous(PlottableAxisBase):
         for i in range(len(self)):
             yield self[i]
 
+
 class PlottableAxisDiscrete(PlottableAxisBase):
     @property
     def traits(self) -> PlottableAxisTraits:
@@ -81,47 +471,53 @@ class PlottableAxisDiscrete(PlottableAxisBase):
         for i in range(len(self)):
             yield self[i]
 
+
 class PlottableAxisFactory:
     @staticmethod
     def create(tAxis) -> Union[PlottableAxisContinuous, PlottableAxisDiscrete]:
         if all(tAxis.GetBinLabel(i + 1) for i in range(tAxis.GetNbins())):
             return PlottableAxisDiscrete(tAxis)
         return PlottableAxisContinuous(tAxis)
-    
+
+
 def _hasWeights(hist: Any) -> bool:
     return bool(hist.GetSumw2() and hist.GetSumw2N())
 
-def _shape(hist: Any) -> Tuple[int, ...]:
-    return tuple(getattr(hist, f"GetNbins{ax}")() + 2 for ax in "XYZ"[:hist.GetDimension()])
+
+def _shape(hist: Any, include_flow_bins: bool = True) -> Tuple[int, ...]:
+    return tuple(_get_axis(hist, i).GetNbins() + (2 if include_flow_bins else 0) for i in range(hist.GetDimension()))
+
 
 def _axes(self) -> Tuple[Union[PlottableAxisContinuous, PlottableAxisDiscrete], ...]:
-    return tuple(
-            PlottableAxisFactory.create(getattr(self, f"Get{ax}axis")()) for ax in "XYZ"[:self.GetDimension()]
-        )
+    return tuple(PlottableAxisFactory.create(_get_axis(self, i)) for i in range(self.GetDimension()))
+
 
 def _kind(self) -> Kind:
     return Kind.COUNT if not _hasWeights(self) else Kind.MEAN
 
-def _values_default(self) -> np.typing.NDArray[Any]:
+
+def _values_default(self) -> np.typing.NDArray[Any]:  # noqa: F821
     import numpy as np
 
     llv = self.GetArray()
     ret = np.frombuffer(llv, dtype=llv.typecode, count=self.GetSize())
     return ret.reshape(_shape(self), order="F")[tuple([slice(1, -1)] * len(_shape(self)))]
 
+
 # Special case for TH1K: we need the array length to correspond to the number of bins
 # according to the UHI plotting protocol
-def _values_by_copy(self) -> np.typing.NDArray[Any]:
+def _values_by_copy(self) -> np.typing.NDArray[Any]:  # noqa: F821
     import numpy as np
-    
+
     return np.array([self.GetBinContent(i) for i in range(1, self.GetNbinsX() + 1)])
 
-def _variances(self) -> np.typing.NDArray[Any]:
+
+def _variances(self) -> np.typing.NDArray[Any]:  # noqa: F821
     import numpy as np
 
     if not _hasWeights(self):
         return self.values()
-    
+
     sumw2_array = self.GetSumw2()
     size = sumw2_array.GetSize()
     arr = np.frombuffer(sumw2_array.GetArray(), dtype=np.float64, count=size)
@@ -129,7 +525,8 @@ def _variances(self) -> np.typing.NDArray[Any]:
     reshaped = arr.reshape(_shape(self), order="F")
     return reshaped[tuple([slice(1, -1)] * len(_shape(self)))]
 
-def _counts(self) -> np.typing.NDArray[Any]:
+
+def _counts(self) -> np.typing.NDArray[Any]:  # noqa: F821
     import numpy as np
 
     if not _hasWeights(self):
@@ -143,13 +540,15 @@ def _counts(self) -> np.typing.NDArray[Any]:
         where=self.variances() != 0,
     )
 
+
 values_func_dict: dict[str, Callable] = {
     "TH1C": _values_by_copy,
     "TH1K": _values_by_copy,
     "TProfile": _values_by_copy,
 }
 
-def add_plotting_features(klass: Any) -> None:
+
+def _add_plotting_features(klass: Any) -> None:
     klass.kind = property(_kind)
     klass.variances = _variances
     klass.counts = _counts

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)
 ROOT_ADD_PYUNITTEST(uhi_plotting uhi_plotting.py GENERIC PYTHON_DEPS uhi numpy)
+ROOT_ADD_PYUNITTEST(uhi_indexing uhi_indexing.py GENERIC PYTHON_DEPS uhi numpy)
 
 # STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)

--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -1,0 +1,320 @@
+"""
+Tests to verify that TH1 and derived histograms conform to the UHI Indexing interfaces (setting, accessing and slicing).
+"""
+
+import pytest
+import ROOT
+from ROOT._pythonization._th1 import _th1_derived_classes_to_pythonize
+from ROOT._pythonization._th2 import _th2_derived_classes_to_pythonize
+from ROOT._pythonization._th3 import _th3_derived_classes_to_pythonize
+from ROOT._pythonization._uhi import (
+    _get_axis,
+    _get_processed_slices,
+    _get_slice_indices,
+    _shape,
+    _temporarily_disable_add_directory,
+)
+from ROOT.uhi import loc, overflow, rebin, sum, underflow
+
+th1_classes = {
+    ("test_hist", "Test Histogram", 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th1_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), 1.0),
+    },
+    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th2_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0),
+    },
+    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4, 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th3_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(
+            ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0
+        ),
+    },
+}
+
+
+@pytest.fixture(
+    params=[
+        (constructor_args, hist_class, hist_config["fill"])
+        for constructor_args, hist_config in th1_classes.items()
+        for hist_class in hist_config["classes"]
+    ],
+    scope="function",
+    ids=lambda param: param[1].__name__,
+)
+def hist_setup(request):
+    constructor_args, hist_class, fill = request.param
+    with _temporarily_disable_add_directory():
+        hist = hist_class(*constructor_args)
+        for _ in range(10000):
+            fill(hist)
+        yield hist
+
+
+def _special_setting(hist):
+    # For these classes, SetBinContent works differently than for other classes,
+    # as in it does not set the bin content to the specified value, but does some other calculations
+    # for that, these classes will be tested differently
+    return isinstance(hist, (ROOT.TProfile, ROOT.TProfile2D, ROOT.TProfile2Poly, ROOT.TProfile3D, ROOT.TH1K))
+
+
+def _get_index_for_dimension(hist, index):
+    return (index,) * hist.GetDimension()
+
+
+def _iterate_bins(hist):
+    dim = hist.GetDimension()
+    for i in range(1, hist.GetNbinsX() + 1):
+        for j in range(1, hist.GetNbinsY() + 1) if dim > 1 else [None]:
+            for k in range(1, hist.GetNbinsZ() + 1) if dim > 2 else [None]:
+                yield tuple(filter(None, (i, j, k)))
+
+
+class TestTH1Indexing:
+    def test_access_with_bin_number(self, hist_setup):
+        for index in [0, 8]:
+            assert hist_setup[_get_index_for_dimension(hist_setup, index)] == hist_setup.GetBinContent(
+                *_get_index_for_dimension(hist_setup, index + 1)
+            )
+
+    def test_access_with_data_coordinates(self, hist_setup):
+        for value in [1, 4]:
+            value_indices = _get_index_for_dimension(hist_setup, value)
+            loc_indices = tuple(loc(idx) for idx in value_indices)
+            assert hist_setup[loc_indices] == hist_setup.GetBinContent(hist_setup.FindBin(*value_indices))
+
+    def test_access_flow_bins(self, hist_setup):
+        for flow_type, index in [(underflow, 0), (overflow, 11)]:
+            flow_indices = (flow_type,) * hist_setup.GetDimension()
+            assert hist_setup[flow_indices] == hist_setup.GetBinContent(*_get_index_for_dimension(hist_setup, index))
+
+    def test_access_with_len(self, hist_setup):
+        len_indices = (len,) * hist_setup.GetDimension()
+        bin_counts = (_get_axis(hist_setup, i).GetNbins() for i in range(hist_setup.GetDimension()))
+        assert hist_setup[len_indices] == hist_setup.GetBinContent(*bin_counts)
+
+    def test_access_with_ellipsis(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Access cannot be tested here")
+
+        hist_copy = hist_setup[...]
+        for bin_indices in _iterate_bins(hist_setup):
+            assert hist_copy.GetBinContent(*bin_indices) == hist_setup.GetBinContent(*bin_indices)
+
+    def test_setting_with_bin_number(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        for index in [0, 8]:
+            hist_setup[_get_index_for_dimension(hist_setup, index)] = 60
+            assert hist_setup.GetBinContent(*_get_index_for_dimension(hist_setup, index + 1)) == 60
+
+    def test_setting_with_data_coordinates(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        value_indices = _get_index_for_dimension(hist_setup, 2)
+        loc_indices = tuple(loc(idx) for idx in value_indices)
+        hist_setup[loc_indices] = 70
+        assert hist_setup.GetBinContent(hist_setup.FindBin(*value_indices)) == 70
+
+    def test_setting_flow_bins(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        for flow_type, index in [(underflow, 0), (overflow, 11)]:
+            flow_indices = (flow_type,) * hist_setup.GetDimension()
+            hist_setup[flow_indices] = 85
+            assert hist_setup.GetBinContent(*_get_index_for_dimension(hist_setup, index)) == 85
+
+    def test_setting_with_array(self, hist_setup):
+        import numpy as np
+
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        expected = np.full(_shape(hist_setup), 3, dtype=np.int64)
+        hist_setup[...] = expected
+        for bin_indices in _iterate_bins(hist_setup):
+            assert hist_setup.GetBinContent(*bin_indices) == 3
+
+    def test_setting_with_scalar(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        hist_setup[...] = 3
+        for bin_indices in _iterate_bins(hist_setup):
+            assert hist_setup.GetBinContent(*bin_indices) == 3
+
+    def _test_slices_match(self, hist_setup, slice_ranges, processed_slices):
+        dim = hist_setup.GetDimension()
+        slices, _, _ = _get_processed_slices(hist_setup, processed_slices[dim])
+        expected_indices = _get_slice_indices(slices)
+        sliced_hist = hist_setup[tuple(slice_ranges[dim])]
+
+        for bin_indices in expected_indices:
+            bin_indices = tuple(map(int, bin_indices))
+            assert sliced_hist.GetBinContent(*bin_indices) == hist_setup.GetBinContent(*bin_indices)
+
+        for bin_indices in _iterate_bins(hist_setup):
+            if list(bin_indices) not in expected_indices.tolist():
+                assert sliced_hist.GetBinContent(*bin_indices) == 0
+
+    def test_slicing_with_endpoints(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        slice_ranges = {
+            1: [slice(4, 7)],
+            2: [slice(4, 7), slice(3, 6)],
+            3: [slice(4, 7), slice(3, 6), slice(2, 5)],
+        }
+        processed_slices = {
+            1: [slice(5, 8)],
+            2: [slice(5, 8), slice(4, 7)],
+            3: [slice(5, 8), slice(4, 7), slice(3, 6)],
+        }
+        self._test_slices_match(hist_setup, slice_ranges, processed_slices)
+
+    def test_slicing_without_endpoints(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        processed_slices = {
+            1: [slice(0, 8)],
+            2: [slice(0, 8), slice(4, 11)],
+            3: [slice(0, 8), slice(4, 11), slice(3, 6)],
+        }
+        slice_ranges = {
+            1: [slice(None, 7)],
+            2: [slice(None, 7), slice(3, None)],
+            3: [slice(None, 7), slice(3, None), slice(2, 5)],
+        }
+        self._test_slices_match(hist_setup, slice_ranges, processed_slices)
+
+    def test_slicing_with_data_coordinates(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        processed_slices = {
+            1: [slice(hist_setup.FindBin(2), 11)],
+            2: [slice(hist_setup.FindBin(2), 11), slice(hist_setup.FindBin(3), 11)],
+            3: [
+                slice(hist_setup.FindBin(2), 11),
+                slice(hist_setup.FindBin(3), 11),
+                slice(hist_setup.FindBin(1.5), 11),
+            ],
+        }
+        slice_ranges = {
+            1: [slice(loc(2), None)],
+            2: [slice(loc(2), None), slice(loc(3), None)],
+            3: [slice(loc(2), None), slice(loc(3), None), slice(loc(1.5), None)],
+        }
+        self._test_slices_match(hist_setup, slice_ranges, processed_slices)
+
+    def test_slicing_over_everything_with_action_rebin(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        rebin_indices = tuple(slice(None, None, rebin(2)) for _ in range(hist_setup.GetDimension()))
+        sliced_hist = hist_setup[rebin_indices]
+        assert sliced_hist.GetNbinsX() == hist_setup.GetNbinsX() // 2
+        assert sliced_hist.GetDimension() < 2 or sliced_hist.GetNbinsY() == hist_setup.GetNbinsY() // 2
+        assert sliced_hist.GetDimension() < 3 or sliced_hist.GetNbinsZ() == hist_setup.GetNbinsZ() // 2
+
+    def test_slicing_over_everything_with_action_sum(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        dim = hist_setup.GetDimension()
+
+        if dim == 1:
+            integral = hist_setup[::sum]
+            assert integral == hist_setup.Integral()
+
+        if dim == 2:
+            sum_x = hist_setup[:, ::sum]
+            assert isinstance(sum_x, ROOT.TH1)
+            assert sum_x.GetNbinsX() == hist_setup.GetNbinsX()
+
+            sum_y = hist_setup[::sum, :]
+            assert isinstance(sum_y, ROOT.TH1)
+            assert sum_y.GetNbinsX() == hist_setup.GetNbinsY()
+
+        if dim == 3:
+            sum_z = hist_setup[:, :, ::sum]
+            assert isinstance(sum_z, ROOT.TH2)
+
+            sum_yz = hist_setup[:, ::sum, ::sum]
+            assert isinstance(sum_yz, ROOT.TH1)
+
+            sum_xz = hist_setup[::sum, :, ::sum]
+            assert isinstance(sum_xz, ROOT.TH1)
+
+            sum_xy = hist_setup[::sum, ::sum, :]
+            assert isinstance(sum_xy, ROOT.TH1)
+
+    def test_slicing_with_action_rebin_and_sum(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Slicing cannot be tested here")
+
+        dim = hist_setup.GetDimension()
+
+        if dim == 1:
+            sliced_hist_rebin = hist_setup[5 : 9 : rebin(2)]
+            assert isinstance(sliced_hist_rebin, ROOT.TH1)
+            assert sliced_hist_rebin.GetNbinsX() == hist_setup.GetNbinsX() // 2
+
+            sliced_hist_sum = hist_setup[5:9:sum]
+            assert isinstance(sliced_hist_sum, float)
+            assert sliced_hist_sum == hist_setup.Integral(6, 9)
+
+        if dim == 2:
+            sliced_hist = hist_setup[:: rebin(2), 5:9:sum]
+            assert isinstance(sliced_hist, ROOT.TH1)
+            assert sliced_hist.GetNbinsX() == hist_setup.GetNbinsX() // 2
+
+        if dim == 3:
+            sliced_hist = hist_setup[:: rebin(2), ::sum, 5 : 9 : rebin(3)]
+            assert isinstance(sliced_hist, ROOT.TH2)
+            assert sliced_hist.GetNbinsX() == hist_setup.GetNbinsX() // 2
+            assert sliced_hist.GetNbinsY() == hist_setup.GetNbinsZ() // 3
+
+    def test_slicing_with_dict_syntax(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        slices = {dim: slice(4, 7) for dim in range(hist_setup.GetDimension())}
+        sliced_hist = hist_setup[tuple(slices.values())]
+        dict_sliced_hist = hist_setup[slices]
+        for bin_indices in _iterate_bins(hist_setup):
+            assert sliced_hist.GetBinContent(*bin_indices) == dict_sliced_hist.GetBinContent(*bin_indices)
+
+    def test_integral_full_slice(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        # Check if slicing over everything preserves the integral
+        sliced_hist = hist_setup[...]
+
+        assert hist_setup.Integral() == pytest.approx(sliced_hist.Integral(), rel=10e-6)
+
+    def test_statistics_slice(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        # Check if slicing over a range updates the statistics
+        dim = hist_setup.GetDimension()
+        [_get_axis(hist_setup, i).SetRange(3, 5) for i in range(dim)]
+        slice_indices = tuple(slice(2, 7) for _ in range(dim))
+        sliced_hist = hist_setup[slice_indices]
+
+        assert hist_setup.Integral() == pytest.approx(sliced_hist.Integral(), rel=1e-6)
+        assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), abs=1e-3)
+        assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), abs=1e-3)
+        assert hist_setup.GetEffectiveEntries() == sliced_hist.GetEffectiveEntries()
+
+
+if __name__ == "__main__":
+    pytest.main(args=[__file__])


### PR DESCRIPTION
# This Pull request:

## Adds:

This PR introduces the [Unified Histogram Interface](https://uhi.readthedocs.io/en/latest/index.html) indexing functionality to the `TH1`-derived classes in ROOT. The changes include the addition of pythonizations to allow accessing, setting and slicing the histograms as per the UHI specifications.

### What you can do:
#### Access
- [x] ```v = h[b]          # Returns bin contents, indexed by bin number```
- [x] ```v = h[loc(b)]     # Returns the bin containing the value```
- [x] ```v = h[loc(b) + 1] # Returns the bin above the one containing the value```
- [x] ```v = h[underflow]  # Underflow and overflow can be accessed with special tags```

#### Setting
- [x] ```h[b] = v         # Returns bin contents, indexed by bin number```
- [x] ```h[loc(b)] = v    # Returns the bin containing the value```
- [x] ```h[underflow] = v # Underflow and overflow can be accessed with special tags```
- [x] ```h[...] = array(...) # Setting with an array or histogram sets the contents if the sizes match```

#### Slicing
- [x] ```h1 = h[:]             # Slice over everything```
- [x] ```h2 = h[a:b]           # Slice of histogram (includes flow bins)```
- [x] ```h2 = h[:b]            # Leaving out endpoints is okay```
- [x] ```h2 = h[loc(v):]       # Slices can be in data coordinates, too```
- [x] ```h2 = h[::rebin(2)]    # Modification operations (rebin)```
- [x] ```h2 = h[a:b:rebin(2)]  # Modifications can combine with slices```
- [x] ```h2 = h[a:b, ...]      # Ellipsis work just like normal numpy```
- [x] ```h[{0: slice(None, None, bh.rebin(2))}]```
- [x] ```v2 = h[:, ::sum]         # Projection operations```
- [x] ```v2 = h[a:b, ::sum]       # Adding endpoints to projection operations```

Special "tag" functors added are `underflow`, `overflow`, `loc`, `rebin`, and `sum`.

See POC in #17111 

### What is to be implemented:
- [ ] Support for `THn` histograms

## Checklist:

- [x] tested changes locally