### PR TITLE
[io] Bypass TTree::ChangeFile when using TFileMerger

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -277,7 +277,7 @@ public:
       // Set this bit to block an unwanted automatic call to TTree::ChangeFile
       // e.g. during TFileMerger operations (bypassing any set MaxTreeSize)
       // This is a transient bit and has no relevance for I/O.
-      kCannotChange  = BIT(18)
+      kCancelTTreeChangeRequest = BIT(18)
    };
    enum ERelativeTo { kBeg = 0, kCur = 1, kEnd = 2 };
    enum { kStartBigFile  = 2000000000 };

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -273,7 +273,11 @@ public:
       kWriteError    = BIT(14),
       kBinaryFile    = BIT(15),
       kRedirected    = BIT(16),
-      kReproducible  = BIT(17)
+      kReproducible  = BIT(17),
+      // Set this bit to block an unwanted automatic call to TTree::ChangeFile
+      // e.g. during TFileMerger operations (bypassing any set MaxTreeSize)
+      // This is a transient bit and has no relevance for I/O.
+      kCannotChange  = BIT(18)
    };
    enum ERelativeTo { kBeg = 0, kCur = 1, kEnd = 2 };
    enum { kStartBigFile  = 2000000000 };

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -978,6 +978,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
    }
 
    fOutputFile->SetBit(kMustCleanup);
+   fOutputFile->SetBit(TFile::kCannotChange);
 
    TDirectory::TContext ctxt;
 
@@ -1039,6 +1040,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
       Clear();
    } else {
       fOutputFile->ResetBit(kMustCleanup);
+      fOutputFile->ResetBit(TFile::kCannotChange);
       SafeDelete(fOutputFile);
    }
    return result;

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -978,7 +978,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
    }
 
    fOutputFile->SetBit(kMustCleanup);
-   fOutputFile->SetBit(TFile::kCannotChange);
+   fOutputFile->SetBit(TFile::kCancelTTreeChangeRequest);
 
    TDirectory::TContext ctxt;
 
@@ -1040,7 +1040,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
       Clear();
    } else {
       fOutputFile->ResetBit(kMustCleanup);
-      fOutputFile->ResetBit(TFile::kCannotChange);
+      fOutputFile->ResetBit(TFile::kCancelTTreeChangeRequest);
       SafeDelete(fOutputFile);
    }
    return result;

--- a/io/io/test/TFileMergerTests.cxx
+++ b/io/io/test/TFileMergerTests.cxx
@@ -5,8 +5,11 @@
 #include "TBranch.h"
 
 #include "TMemFile.h"
+#include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"
+
+#include <memory>
 
 static void CreateATuple(TMemFile &file, const char *name, double value)
 {
@@ -161,37 +164,30 @@ TEST(TFileMerger, MergeBranches)
    file3->Write();
 }
 
-
-#include <memory>
-#include <TFile.h>
-#include <TFileMerger.h>
-#include <TTree.h>
-
 // https://github.com/root-project/root/issues/6640
 TEST(TFileMerger, ChangeFile)
 {
    {
       TFile f{"file6640mergerinput.root", "RECREATE"};
-   
+
       TTree t{"T", "SetMaxTreeSize(1000)", 99, &f};
       int x;
       auto nentries = 20000;
-   
+
       t.Branch("x", &x, "x/I");
-   
+
       // Call function to forcedly trigger TTree::ChangeFile.
       // This will produce in total 3 files:
       // * file6640mergerinput.root
       // * file6640mergerinput_1.root
       // * file6640mergerinput_2.root
       TTree::SetMaxTreeSize(1000);
-   
-      for (auto i = 0; i < nentries; i++)
-      {
-        x = i;
-        t.Fill();
+
+      for (auto i = 0; i < nentries; i++) {
+         x = i;
+         t.Fill();
       }
-   
+
       // Write last file to disk
       auto cf = t.GetCurrentFile();
       cf->Write();

--- a/io/io/test/TFileMergerTests.cxx
+++ b/io/io/test/TFileMergerTests.cxx
@@ -8,6 +8,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"
+#include "TSystem.h"
 
 #include <memory>
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2791,7 +2791,7 @@ TFile* TTree::ChangeFile(TFile* file)
          break;
       }
       ++nus;
-      Warning("ChangeFile", "file %s already exists, trying with %d underscores", fname, nus+1);
+      Warning("ChangeFile", "file %s already exists, trying with %d underscores", fname, nus + 1);
    }
    Int_t compress = file->GetCompressionSettings();
    TFile* newfile = TFile::Open(fname, "recreate", "chain files", compress);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2742,8 +2742,8 @@ bool TTree::EnableCache()
 
 TFile* TTree::ChangeFile(TFile* file)
 {
-   // Changing file clashes with the design of TMemFile and derivates, see #6523.
-   // as well as with TFileMerger operations, see #6640
+   // Changing file clashes with the design of TMemFile and derivates, see #6523,
+   // as well as with TFileMerger operations, see #6640.
    if ((dynamic_cast<TMemFile *>(file)) || file->TestBit(TFile::kCannotChange))
       return file;
    file->cd();

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2744,7 +2744,7 @@ TFile* TTree::ChangeFile(TFile* file)
 {
    // Changing file clashes with the design of TMemFile and derivates, see #6523,
    // as well as with TFileMerger operations, see #6640.
-   if ((dynamic_cast<TMemFile *>(file)) || file->TestBit(TFile::kCannotChange))
+   if ((dynamic_cast<TMemFile *>(file)) || file->TestBit(TFile::kCancelTTreeChangeRequest))
       return file;
    file->cd();
    Write();


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/6640

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)