### PR TITLE
[RDF] Provide access to the shared_ptr in RResultPtr.

### DIFF
--- a/tutorials/analysis/dataframe/df039_RResultPtr_basics.C
+++ b/tutorials/analysis/dataframe/df039_RResultPtr_basics.C
@@ -1,0 +1,58 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+/// Usage of RResultPtr.
+///
+/// This tutorial illustrates what is the difference between lazy and immediate results and how to use either of them in RDataFrame.
+/// "Lazy" or deferred results are only produced once they are accessed. This allows for declaring multiple desired results, and producing
+/// them in a single run of the event loop.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date 2025
+/// \author Stephan Hageboeck (CERN)
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RDFHelpers.hxx>
+
+#include <iostream>
+
+// A function that adds a "lazy" histogram to a computation graph.
+// The event loop will not run if only the RResultPtr is declared.
+ROOT::RDF::RResultPtr<TH1D> histoLater(ROOT::RDF::RNode & rdf) {
+   return rdf.Histo1D({"Histo2", "Histogram running later", 10, 0, 20}, {"x"});
+}
+
+// A function that immediately produces a result.
+std::shared_ptr<TH1D> histoNow(ROOT::RDF::RNode & rdf) {
+   auto histo = rdf.Histo1D({"Histo2", "Histogram running later", 10, 0, 20}, {"x"});
+   return histo.GetSharedPtr();
+}
+
+
+void df039_RResultPtr_basics()
+{
+   // Create a simple dataframe that fills event numbers into a histogram.
+   ROOT::RDataFrame bare_rdf(10);
+   auto rdf = bare_rdf.Define("x", [&](unsigned long long entry) -> unsigned int {
+         if (entry == 0) std::cout << "Event loop is running\n";
+         return entry;
+      }, {"rdfentry_"});
+
+   // Book a histogram action. This will be stored as RResultPtr.
+   // The action won't run yet.
+   ROOT::RDF::RResultPtr<TH1D> histo1 = rdf.Histo1D({"Histo1", "Histogram", 10, 0, 10}, {"x"});
+   std::cout << "Declared histo1\n";
+
+   // When RDF results are declared in functions, one has to choose if one wants run it to immediately or lazily.
+   // To run the event loop in a lazy fashion, return RResultPtr. This is equivalent to histo1 above, but happens
+   // inside a function.
+   auto rNode = ROOT::RDF::AsRNode(rdf);
+   ROOT::RDF::RResultPtr<TH1D> histo2 = histoLater(rNode);
+   std::cout << "Declared histo2\n";
+
+   // If the function should produce the result immediately, a shared_ptr to the underlying result should be returned.
+   std::shared_ptr<TH1D> histo3 = histoNow(rNode);
+   std::cout << "Declared histo3\n";
+}

--- a/tutorials/analysis/dataframe/df040_RResultPtr_lifetimeManagement.C
+++ b/tutorials/analysis/dataframe/df040_RResultPtr_lifetimeManagement.C
@@ -1,0 +1,66 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+/// Usage of RResultPtr: Lifetime management.
+///
+/// This tutorial illustrates how to manage the lifetime of RDataFrame results.
+/// When RDataFrame results are declared in functions (or scopes in general), 
+/// they are destroyed at the end of the scope.
+/// To prevent this, one needs to copy the RResultPtr or obtain a copy of its
+/// underlying shared_ptr.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date 2025
+/// \author Stephan Hageboeck (CERN)
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RDFHelpers.hxx>
+#include <TCanvas.h>
+#include <THStack.h>
+#include <random>
+#include <vector>
+
+// Canvas that should survive the running of this macro:
+TCanvas *c1, *c2;
+
+void df040_RResultPtr_lifetimeManagement()
+{
+   // Create a simple dataframe that fills random numbers into histograms.
+   ROOT::RDataFrame bare_rdf(10);
+   std::mt19937 generator{1};
+   std::normal_distribution gaus{5., 1.};
+   auto rdf = bare_rdf.Define("x", [&]() -> double {
+         return gaus(generator);
+      }, {});
+
+   ROOT::RDF::TH1DModel histoModel{"Histo", "Histo;x", 10, 0, 10};
+
+   // Keeping the results alive is vital when they are passed to other entities or when they are drawn.
+   // Compare the following situations:
+
+   // 1. The wrong way (the result ht is destroyed at the end of the loop body):
+   THStack histStack1("histStack1", "Stacking result histograms (wrong way)");
+   for(int i=0; i<2; i++) {
+        auto ht = rdf.Histo1D(histoModel, {"x"});
+        ht->SetFillColor(kBlue+i);
+        histStack1.Add(ht.GetPtr()); // Wrong, this histogram will not survive
+   }
+   c1 = new TCanvas("c1", "THStack without obtaining a shared_ptr (wrong)");
+   histStack1.DrawClone();
+   c1->Draw();
+
+   // 2. The right way: Results survive because we copy the shared_ptr:
+   THStack histStack2("histStack2", "THStack with shared_ptr (correct way)");
+   std::vector<std::shared_ptr<TH1D>> results;
+   for(int i=0; i<2; i++) {
+        auto ht = rdf.Histo1D(histoModel, {"x"});
+        ht->SetFillColor(kBlue+2*i);
+        histStack2.Add(ht.GetPtr());
+        results.push_back(ht.GetSharedPtr()); // Makes the histogram survive
+   }
+   c2 = new TCanvas("c2", "Drawing with obtaining a shared_ptr (right)");
+   histStack2.DrawClone();
+   c2->Draw();
+}

--- a/tutorials/analysis/dataframe/index.md
+++ b/tutorials/analysis/dataframe/index.md
@@ -41,7 +41,7 @@ To get started these examples show how to create a simple RDataFrame, how to pro
 | df000_simple.C | df000_simple.py | Simple RDataFrame example in C++. |
 | df001_introduction.C | df001_introduction.py | Basic RDataFrame usage. |
 | df002_dataModel.C | df002_dataModel.py | Show how to work with non-flat data models, e.g. vectors of tracks.|
-
+| df039_RResultPtr_basics.C | | Learn the difference between lazy and immediate actions. |
 
 \anchor processingdata
 ## Processing your data
@@ -63,6 +63,7 @@ A collection of building block examples for your analysis.
 | df025_RNode.C | | Manipulate RDF objects in functions, loops and conditional branches.|
 | df036_missingBranches.C | df036_missingBranches.py | Deal with missing values due to a missing branch when switching to a new file in a chain. |
 | df037_TTreeEventMatching.C | df037_TTreeEventMatching.py | Deal with missing values due to not finding a matching event in an auxiliary dataset. |
+| df040_RResultPtr_lifetimeManagement.C | | Lifetime management of RResultPtr and the underlying objects. |
 
 
 \anchor readwrite


### PR DESCRIPTION
Users reported problems with losing the underlying object when the RResultPtr goes out of scope. By adding GetSharedPtr(), this can be avoided.

Fix #14766.