### PR TITLE
[ci] Format only changed lines with ruff

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -67,7 +67,28 @@ jobs:
       run: |
         files=$(cat changed_files.txt | grep '\.py$' || echo "")
         if [ -n "$files" ]; then
-          echo "$files" | xargs ruff format --diff
+          diff_command=""
+          apply_command=""
+          for file in $files; do
+            while IFS=- read -r start length; do
+              [ -z "$start" ] && continue
+              length=${length:-1}
+              end=$((start + length))
+              diff_command+="ruff format --diff --range $start-$end $file && "
+              apply_command+="ruff format --range $start-$end $file && "
+            done < <(git diff --unified=0 origin/$GITHUB_BASE_REF "$file" | grep '^@@' | sed -E 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2-\4/')
+          done
+
+          if [ -n "$diff_command" ]; then
+            diff_command=${diff_command% && }
+            if ! eval "$diff_command"; then
+              apply_command=${apply_command% && }
+              echo -e "::error::Formatting failed. To apply the changes locally, run the following command:\n$apply_command"
+              exit 123
+            fi
+          else
+            echo "No ranges detected to format."
+          fi
         else
           echo "No python files to format"
         fi


### PR DESCRIPTION
# This Pull request:

## Adds:
This PR updates the ruff formatting workflow to detect and act on the changed lines instead of the whole file.
On failure, the command to run is highlighted so that it can directly be copied and applied locally
![image](https://github.com/user-attachments/assets/3d294b23-ed74-4697-b74f-649bf1602d5b)

**Note**: linting still applies to the full file.

Could be improved once astral-sh/ruff#12800 is implemented
This PR closes #18167

