### PR TITLE
[RF] Avoid a double-loop over computation graph in RooRealIntegral ctor

### DIFF
--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -390,17 +390,23 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   // Initial fill of list of LValue branches
   RooArgSet exclLVBranches("exclLVBranches") ;
   RooArgSet branchList;
-  RooArgSet branchListVD;
   function.branchNodeServerList(&branchList) ;
+
+  RooArgList branchListVDAll;
+  function.treeNodeServerList(&branchListVDAll,nullptr,true,false,/*valueOnly=*/true);
+  // The branchListVD is similar to branchList but considers only value
+  // dependence, and we want to exclude the function itself
+  RooArgSet branchListVD;
+  branchListVD.reserve(branchListVDAll.size());
+  for (RooAbsArg *branch : branchListVDAll) {
+    if (branch != &function) branchListVD.add(*branch);
+  }
 
   for (auto branch: branchList) {
     RooAbsRealLValue    *realArgLV = dynamic_cast<RooAbsRealLValue*>(branch) ;
     RooAbsCategoryLValue *catArgLV = dynamic_cast<RooAbsCategoryLValue*>(branch) ;
     if ((realArgLV && (realArgLV->isJacobianOK(intDepList)!=0)) || catArgLV) {
       exclLVBranches.add(*branch) ;
-    }
-    if (branch != &function && function.dependsOnValue(*branch)) {
-      branchListVD.add(*branch) ;
     }
   }
   exclLVBranches.remove(depList,true,true) ;


### PR DESCRIPTION
The problem is that `dependsOnValue` has to traverse the full computation graph itself, to check whether any of the nodes depends on "branch". And since the code calls "dependsOnValue" in a loop over all branches, we have an expensive double loop that is the bottleneck for the creation of toy data for large HistFactory workspaces.

The solution is to use `treeNodeServerList`, which can figure out the value servers in a single pass over the computation graph.