### PR TITLE
[ntuple] Move REntry out of Experimental

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rntuple.py
@@ -18,7 +18,7 @@ def _REntry_GetPtr(self, key):
 
 def _REntry_CallGetPtr(self, key):
     # key can be either a RFieldToken already or a string. In the latter case, get a token to use it twice.
-    if not hasattr(type(key), "__cpp_name__") or type(key).__cpp_name__ != "ROOT::Experimental::REntry::RFieldToken":
+    if not hasattr(type(key), "__cpp_name__") or type(key).__cpp_name__ != "ROOT::REntry::RFieldToken":
         key = self.GetToken(key)
     fieldType = self.GetTypeName(key)
     return self._GetPtr[fieldType](key)
@@ -41,7 +41,7 @@ def _REntry_setitem(self, key, value):
         ptr_proxy.__assign__(value)
 
 
-@pythonization("REntry", ns="ROOT::Experimental")
+@pythonization("REntry", ns="ROOT")
 def pythonize_REntry(klass):
     klass._GetPtr = klass.GetPtr
     klass.GetPtr = _REntry_GetPtr

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1892,7 +1892,7 @@ void EnsureValidSnapshotRNTupleOutput(const RSnapshotOptions &opts, const std::s
 
 /// Helper function to update the value of an RNTuple's field in the provided entry.
 template <typename T>
-void SetFieldsHelper(T &value, std::string_view fieldName, ROOT::Experimental::REntry *entry)
+void SetFieldsHelper(T &value, std::string_view fieldName, ROOT::REntry *entry)
 {
    entry->BindRawPtr(fieldName, &value);
 }
@@ -1912,7 +1912,7 @@ class R__CLING_PTRCHECK(off) SnapshotRNTupleHelper : public RActionImpl<Snapshot
    ColumnNames_t fOutputFieldNames;
    std::unique_ptr<ROOT::Experimental::RNTupleWriter> fWriter{nullptr};
 
-   ROOT::Experimental::REntry *fOutputEntry;
+   ROOT::REntry *fOutputEntry;
 
    std::vector<bool> fIsDefine;
 

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -31,16 +31,19 @@
 #include <unordered_map>
 
 namespace ROOT {
-namespace Experimental {
 
+namespace Experimental {
+class RNTupleReader;
+class RNTupleFillContext;
 class RNTupleProcessor;
 class RNTupleSingleProcessor;
 class RNTupleChainProcessor;
 class RNTupleJoinProcessor;
+} // namespace Experimental
 
 // clang-format off
 /**
-\class ROOT::Experimental::REntry
+\class ROOT::REntry
 \ingroup NTuple
 \brief The REntry is a collection of values in an ntuple corresponding to a complete row in the data set.
 
@@ -49,20 +52,20 @@ with values are managed through shared pointers.
 */
 // clang-format on
 class REntry {
-   friend class ROOT::RNTupleModel;
-   friend class RNTupleReader;
-   friend class RNTupleFillContext;
-   friend class RNTupleProcessor;
-   friend class RNTupleSingleProcessor;
-   friend class RNTupleChainProcessor;
-   friend class RNTupleJoinProcessor;
+   friend class RNTupleModel;
+   friend class Experimental::RNTupleReader;
+   friend class Experimental::RNTupleFillContext;
+   friend class Experimental::RNTupleProcessor;
+   friend class Experimental::RNTupleSingleProcessor;
+   friend class Experimental::RNTupleChainProcessor;
+   friend class Experimental::RNTupleJoinProcessor;
 
 public:
    /// The field token identifies a (sub)field in this entry. It can be used for fast indexing in REntry's methods, e.g.
    /// BindValue(). The field token can also be created by the model.
    class RFieldToken {
       friend class REntry;
-      friend class ROOT::RNTupleModel;
+      friend class RNTupleModel;
 
       std::size_t fIndex = 0;                      ///< The index in `fValues` that belongs to the field
       std::uint64_t fSchemaId = std::uint64_t(-1); ///< Safety check to prevent tokens from other models being used
@@ -247,6 +250,9 @@ public:
    ConstIterator_t end() const { return fValues.cend(); }
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+using REntry [[deprecated("ROOT::Experimental::REntry moved to ROOT::REntry")]] = ROOT::REntry;
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -44,6 +44,7 @@ class TVirtualStreamerInfo;
 namespace ROOT {
 
 class TSchemaRule;
+class REntry;
 
 namespace Detail {
 class RFieldVisitor;
@@ -51,7 +52,6 @@ class RFieldVisitor;
 
 namespace Experimental {
 
-class REntry;
 class RNTupleCollectionView;
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillContext.hxx
@@ -90,7 +90,7 @@ public:
    /// and check RNTupleFillStatus::ShouldFlushCluster.
    ///
    /// This method will perform a light check whether the entry comes from the context's own model.
-   void FillNoFlush(REntry &entry, RNTupleFillStatus &status)
+   void FillNoFlush(ROOT::REntry &entry, RNTupleFillStatus &status)
    {
       if (R__unlikely(entry.GetModelId() != fModel->GetModelId()))
          throw RException(R__FAIL("mismatch between entry and model"));
@@ -108,7 +108,7 @@ public:
    /// Fill an entry into this context.  This method will perform a light check whether the entry comes from the
    /// context's own model.
    /// \return The number of uncompressed bytes written.
-   std::size_t Fill(REntry &entry)
+   std::size_t Fill(ROOT::REntry &entry)
    {
       RNTupleFillStatus status;
       FillNoFlush(entry, status);
@@ -125,7 +125,7 @@ public:
    void CommitStagedClusters();
 
    const ROOT::RNTupleModel &GetModel() const { return *fModel; }
-   std::unique_ptr<REntry> CreateEntry() { return fModel->CreateEntry(); }
+   std::unique_ptr<ROOT::REntry> CreateEntry() { return fModel->CreateEntry(); }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fLastFlushed; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -145,7 +145,7 @@ private:
    /// Hierarchy of fields consisting of simple types and collections (sub trees)
    std::unique_ptr<ROOT::RFieldZero> fFieldZero;
    /// Contains field values corresponding to the created top-level fields, as well as registered subfields
-   std::unique_ptr<ROOT::Experimental::REntry> fDefaultEntry;
+   std::unique_ptr<ROOT::REntry> fDefaultEntry;
    /// Keeps track of which field names are taken, including projected field names.
    std::unordered_set<std::string> fFieldNames;
    /// Free text set by the user
@@ -178,7 +178,7 @@ private:
 
    /// Add a subfield to the provided entry. If `initializeValue` is false, a nullptr will be bound to the entry value
    /// (used in bare models).
-   void AddSubfield(std::string_view fieldName, ROOT::Experimental::REntry &entry, bool initializeValue = true) const;
+   void AddSubfield(std::string_view fieldName, ROOT::REntry &entry, bool initializeValue = true) const;
 
    RNTupleModel(std::unique_ptr<ROOT::RFieldZero> fieldZero);
 
@@ -305,17 +305,17 @@ public:
    std::uint64_t GetModelId() const { return fModelId; }
    std::uint64_t GetSchemaId() const { return fSchemaId; }
 
-   std::unique_ptr<ROOT::Experimental::REntry> CreateEntry() const;
+   std::unique_ptr<ROOT::REntry> CreateEntry() const;
    /// In a bare entry, all values point to nullptr. The resulting entry shall use BindValue() in order
    /// set memory addresses to be serialized / deserialized
-   std::unique_ptr<ROOT::Experimental::REntry> CreateBareEntry() const;
+   std::unique_ptr<ROOT::REntry> CreateBareEntry() const;
    /// Creates a token to be used in REntry methods to address a field present in the entry
-   ROOT::Experimental::REntry::RFieldToken GetToken(std::string_view fieldName) const;
+   ROOT::REntry::RFieldToken GetToken(std::string_view fieldName) const;
    /// Calls the given field's CreateBulk() method. Throws an exception if no field with the given name exists.
    ROOT::RFieldBase::RBulk CreateBulk(std::string_view fieldName) const;
 
-   ROOT::Experimental::REntry &GetDefaultEntry();
-   const ROOT::Experimental::REntry &GetDefaultEntry() const;
+   ROOT::REntry &GetDefaultEntry();
+   const ROOT::REntry &GetDefaultEntry() const;
 
    /// Mutable access to the root field is used to make adjustments to the fields.
    ROOT::RFieldZero &GetMutableFieldZero();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -124,13 +124,14 @@ protected:
    private:
       std::unique_ptr<ROOT::RFieldBase> fProtoField;
       std::unique_ptr<ROOT::RFieldBase> fConcreteField;
-      REntry::RFieldToken fToken;
+      ROOT::REntry::RFieldToken fToken;
       // Which RNTuple the field belongs to, in case the field belongs to an auxiliary RNTuple, according to the order
       // in which it was specified. For chained RNTuples, this value will always be 0.
       std::size_t fNTupleIdx;
 
    public:
-      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, REntry::RFieldToken token, std::size_t ntupleIdx = 0)
+      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, ROOT::REntry::RFieldToken token,
+                    std::size_t ntupleIdx = 0)
          : fProtoField(std::move(protoField)), fToken(token), fNTupleIdx(ntupleIdx)
       {
       }
@@ -144,7 +145,7 @@ protected:
 
    std::string fProcessorName;
    std::vector<RNTupleOpenSpec> fNTuples;
-   std::unique_ptr<REntry> fEntry;
+   std::unique_ptr<ROOT::REntry> fEntry;
    std::unique_ptr<Internal::RPageSource> fPageSource;
    /// Maps the (qualified) field name to its corresponding field context.
    std::unordered_map<std::string, RFieldContext> fFieldContexts;
@@ -161,7 +162,7 @@ protected:
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create and connect a concrete field to the current page source, based on its proto field.
-   void ConnectField(RFieldContext &fieldContext, Internal::RPageSource &pageSource, REntry &entry);
+   void ConnectField(RFieldContext &fieldContext, Internal::RPageSource &pageSource, ROOT::REntry &entry);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided entry number.
@@ -175,7 +176,7 @@ protected:
    /// \brief Point the entry's field values of the processor to the pointers from the provided entry.
    ///
    /// \param[in] entry The entry whose field values to use.
-   virtual void SetEntryPointers(const REntry &entry) = 0;
+   virtual void SetEntryPointers(const ROOT::REntry &entry) = 0;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor
@@ -233,7 +234,7 @@ public:
    /// \brief Get a reference to the entry used by the processor.
    ///
    /// \return A reference to the entry used by the processor.
-   const REntry &GetEntry() const { return *fEntry; }
+   const ROOT::REntry &GetEntry() const { return *fEntry; }
 
    // clang-format off
    /**
@@ -250,10 +251,10 @@ public:
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
-      using value_type = REntry;
+      using value_type = ROOT::REntry;
       using difference_type = std::ptrdiff_t;
-      using pointer = REntry *;
-      using reference = const REntry &;
+      using pointer = ROOT::REntry *;
+      using reference = const ROOT::REntry &;
 
       RIterator(RNTupleProcessor &processor, ROOT::NTupleSize_t entryNumber)
          : fProcessor(processor), fCurrentEntryNumber(entryNumber)
@@ -451,7 +452,7 @@ private:
 
    /////////////////////////////////////////////////////////////////////////////
    /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const REntry &entry) final;
+   void SetEntryPointers(const ROOT::REntry &entry) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
@@ -495,7 +496,7 @@ private:
 
    /////////////////////////////////////////////////////////////////////////////
    /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const REntry &) final;
+   void SetEntryPointers(const ROOT::REntry &) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
@@ -531,7 +532,7 @@ class RNTupleJoinProcessor : public RNTupleProcessor {
 private:
    std::vector<std::unique_ptr<Internal::RPageSource>> fAuxiliaryPageSources;
    /// Tokens representing the join fields present in the main RNTuple
-   std::vector<REntry::RFieldToken> fJoinFieldTokens;
+   std::vector<ROOT::REntry::RFieldToken> fJoinFieldTokens;
    std::vector<std::unique_ptr<Internal::RNTupleJoinTable>> fJoinTables;
    bool fJoinTablesAreBuilt = false;
 
@@ -545,7 +546,7 @@ private:
 
    /////////////////////////////////////////////////////////////////////////////
    /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const REntry &) final;
+   void SetEntryPointers(const ROOT::REntry &) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -181,7 +181,7 @@ public:
 
    ROOT::NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
    const ROOT::RNTupleModel &GetModel();
-   std::unique_ptr<REntry> CreateEntry();
+   std::unique_ptr<ROOT::REntry> CreateEntry();
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call
    /// to LoadEntry() or to any of the views returned from the reader.
@@ -235,7 +235,7 @@ public:
       LoadEntry(index, fModel->GetDefaultEntry());
    }
    /// Fills a user provided entry after checking that the entry has been instantiated from the RNTuple model
-   void LoadEntry(ROOT::NTupleSize_t index, REntry &entry)
+   void LoadEntry(ROOT::NTupleSize_t index, ROOT::REntry &entry)
    {
       if (R__unlikely(entry.GetModelId() != fModel->GetModelId()))
          throw RException(R__FAIL("mismatch between entry and model"));

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -106,10 +106,10 @@ public:
    /// Multiple entries can have been instantiated from the ntuple model.  This method will perform
    /// a light check whether the entry comes from the ntuple's own model.
    /// \return The number of uncompressed bytes written.
-   std::size_t Fill(REntry &entry) { return fFillContext.Fill(entry); }
+   std::size_t Fill(ROOT::REntry &entry) { return fFillContext.Fill(entry); }
    /// Fill an entry into this ntuple, but don't commit the cluster. The calling code must pass an RNTupleFillStatus
    /// and check RNTupleFillStatus::ShouldFlushCluster.
-   void FillNoFlush(REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoFlush(entry, status); }
+   void FillNoFlush(ROOT::REntry &entry, RNTupleFillStatus &status) { fFillContext.FillNoFlush(entry, status); }
    /// Flush column data, preparing for CommitCluster or to reduce memory usage. This will trigger compression of pages,
    /// but not actually write to storage (unless buffered writing is turned off).
    void FlushColumns() { fFillContext.FlushColumns(); }
@@ -127,7 +127,7 @@ public:
    /// and model updating fail.
    void CommitDataset();
 
-   std::unique_ptr<REntry> CreateEntry() { return fFillContext.CreateEntry(); }
+   std::unique_ptr<ROOT::REntry> CreateEntry() { return fFillContext.CreateEntry(); }
 
    /// Return the entry number that was last flushed in a cluster.
    ROOT::NTupleSize_t GetLastFlushed() const { return fFillContext.GetLastFlushed(); }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -24,8 +24,6 @@
 #include <memory>
 #include <utility>
 
-using ROOT::Experimental::REntry;
-
 namespace {
 std::uint64_t GetNewModelId()
 {
@@ -274,7 +272,7 @@ std::unique_ptr<ROOT::RNTupleModel> ROOT::RNTupleModel::Create()
 std::unique_ptr<ROOT::RNTupleModel> ROOT::RNTupleModel::Create(std::unique_ptr<ROOT::RFieldZero> fieldZero)
 {
    auto model = CreateBare(std::move(fieldZero));
-   model->fDefaultEntry = std::unique_ptr<REntry>(new REntry(model->fModelId, model->fSchemaId));
+   model->fDefaultEntry = std::unique_ptr<ROOT::REntry>(new ROOT::REntry(model->fModelId, model->fSchemaId));
    return model;
 }
 
@@ -296,7 +294,8 @@ std::unique_ptr<ROOT::RNTupleModel> ROOT::RNTupleModel::Clone() const
    cloneModel->fProjectedFields = fProjectedFields->Clone(*cloneModel);
    cloneModel->fRegisteredSubfields = fRegisteredSubfields;
    if (fDefaultEntry) {
-      cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(cloneModel->fModelId, cloneModel->fSchemaId));
+      cloneModel->fDefaultEntry =
+         std::unique_ptr<ROOT::REntry>(new ROOT::REntry(cloneModel->fModelId, cloneModel->fSchemaId));
       for (const auto &f : cloneModel->fFieldZero->GetMutableSubfields()) {
          cloneModel->fDefaultEntry->AddValue(f->CreateValue());
       }
@@ -341,7 +340,8 @@ void ROOT::RNTupleModel::AddField(std::unique_ptr<ROOT::RFieldBase> field)
    fFieldZero->Attach(std::move(field));
 }
 
-void ROOT::RNTupleModel::AddSubfield(std::string_view qualifiedFieldName, REntry &entry, bool initializeValue) const
+void ROOT::RNTupleModel::AddSubfield(std::string_view qualifiedFieldName, ROOT::REntry &entry,
+                                     bool initializeValue) const
 {
    auto field = FindField(qualifiedFieldName);
    if (initializeValue)
@@ -441,13 +441,13 @@ const ROOT::RFieldBase &ROOT::RNTupleModel::GetConstField(std::string_view field
    return *f;
 }
 
-REntry &ROOT::RNTupleModel::GetDefaultEntry()
+ROOT::REntry &ROOT::RNTupleModel::GetDefaultEntry()
 {
    EnsureNotBare();
    return *fDefaultEntry;
 }
 
-const REntry &ROOT::RNTupleModel::GetDefaultEntry() const
+const ROOT::REntry &ROOT::RNTupleModel::GetDefaultEntry() const
 {
    if (!IsFrozen())
       throw RException(R__FAIL("invalid attempt to get default entry of unfrozen model"));
@@ -455,7 +455,7 @@ const REntry &ROOT::RNTupleModel::GetDefaultEntry() const
    return *fDefaultEntry;
 }
 
-std::unique_ptr<REntry> ROOT::RNTupleModel::CreateEntry() const
+std::unique_ptr<ROOT::REntry> ROOT::RNTupleModel::CreateEntry() const
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
@@ -463,7 +463,7 @@ std::unique_ptr<REntry> ROOT::RNTupleModel::CreateEntry() const
    case EState::kFrozen: break;
    }
 
-   auto entry = std::unique_ptr<REntry>(new REntry(fModelId, fSchemaId));
+   auto entry = std::unique_ptr<ROOT::REntry>(new ROOT::REntry(fModelId, fSchemaId));
    for (const auto &f : fFieldZero->GetMutableSubfields()) {
       entry->AddValue(f->CreateValue());
    }
@@ -473,7 +473,7 @@ std::unique_ptr<REntry> ROOT::RNTupleModel::CreateEntry() const
    return entry;
 }
 
-std::unique_ptr<REntry> ROOT::RNTupleModel::CreateBareEntry() const
+std::unique_ptr<ROOT::REntry> ROOT::RNTupleModel::CreateBareEntry() const
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
@@ -481,7 +481,7 @@ std::unique_ptr<REntry> ROOT::RNTupleModel::CreateBareEntry() const
    case EState::kFrozen: break;
    }
 
-   auto entry = std::unique_ptr<REntry>(new REntry(fModelId, fSchemaId));
+   auto entry = std::unique_ptr<ROOT::REntry>(new ROOT::REntry(fModelId, fSchemaId));
    for (const auto &f : fFieldZero->GetMutableSubfields()) {
       entry->AddValue(f->BindValue(nullptr));
    }
@@ -491,7 +491,7 @@ std::unique_ptr<REntry> ROOT::RNTupleModel::CreateBareEntry() const
    return entry;
 }
 
-REntry::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
+ROOT::REntry::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
 {
    const auto &topLevelFields = fFieldZero->GetConstSubfields();
    auto it = std::find_if(topLevelFields.begin(), topLevelFields.end(),
@@ -500,7 +500,7 @@ REntry::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) con
    if (it == topLevelFields.end()) {
       throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }
-   return REntry::RFieldToken(std::distance(topLevelFields.begin(), it), fSchemaId);
+   return ROOT::REntry::RFieldToken(std::distance(topLevelFields.begin(), it), fSchemaId);
 }
 
 ROOT::RFieldBase::RBulk ROOT::RNTupleModel::CreateBulk(std::string_view fieldName) const

--- a/tree/ntuple/v7/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/v7/src/RNTupleProcessor.cxx
@@ -157,7 +157,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleProcessor> ROOT::Experimental::RNTupl
 }
 
 void ROOT::Experimental::RNTupleProcessor::ConnectField(RFieldContext &fieldContext, Internal::RPageSource &pageSource,
-                                                        REntry &entry)
+                                                        ROOT::REntry &entry)
 {
    pageSource.Attach();
    auto desc = pageSource.GetSharedDescriptorGuard();
@@ -224,7 +224,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleSingleProcessor::LoadEntry(ROOT::N
    return entryNumber;
 }
 
-void ROOT::Experimental::RNTupleSingleProcessor::SetEntryPointers(const REntry &entry)
+void ROOT::Experimental::RNTupleSingleProcessor::SetEntryPointers(const ROOT::REntry &entry)
 {
    for (const auto &value : *fEntry) {
       auto &field = value.GetField();
@@ -297,7 +297,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::GetNEntries()
    return fNEntries;
 }
 
-void ROOT::Experimental::RNTupleChainProcessor::SetEntryPointers(const REntry &entry)
+void ROOT::Experimental::RNTupleChainProcessor::SetEntryPointers(const ROOT::REntry &entry)
 {
    for (const auto &value : *fEntry) {
       auto &field = value.GetField();
@@ -464,7 +464,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::ConnectFields()
    }
 }
 
-void ROOT::Experimental::RNTupleJoinProcessor::SetEntryPointers(const REntry &entry)
+void ROOT::Experimental::RNTupleJoinProcessor::SetEntryPointers(const ROOT::REntry &entry)
 {
    for (const auto &[_, fieldContext] : fFieldContexts) {
       auto fieldName = fieldContext.GetProtoField().GetQualifiedFieldName();

--- a/tree/ntuple/v7/src/RNTupleReader.cxx
+++ b/tree/ntuple/v7/src/RNTupleReader.cxx
@@ -143,7 +143,7 @@ const ROOT::RNTupleModel &ROOT::Experimental::RNTupleReader::GetModel()
    return *fModel;
 }
 
-std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleReader::CreateEntry()
+std::unique_ptr<ROOT::REntry> ROOT::Experimental::RNTupleReader::CreateEntry()
 {
    return GetModel().CreateEntry();
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -777,7 +777,7 @@ TEST(REntry, Basics)
    EXPECT_THROW(e->BindValue("pt", ptrDouble), ROOT::RException);
 
    // Default constructed tokens cannot be used
-   ROOT::Experimental::REntry::RFieldToken token;
+   ROOT::REntry::RFieldToken token;
    EXPECT_THROW(e->GetPtr<void>(token), ROOT::RException);
 
    float pt;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -223,7 +223,7 @@ private:
    FieldModifier_t fFieldModifier;
 
    std::unique_ptr<ROOT::RNTupleModel> fModel;
-   std::unique_ptr<REntry> fEntry;
+   std::unique_ptr<ROOT::REntry> fEntry;
    std::vector<RImportBranch> fImportBranches;
    std::vector<RImportField> fImportFields;
    /// Maps the count leaf to the information about the corresponding untyped collection


### PR DESCRIPTION
# This Pull request:
Moves `REntry` out of Experimental.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


