### PR TITLE
[webgui] reduce `source_dir` usage in widgets [skip-ci]

### DIFF
--- a/ui5/browser/browser.html
+++ b/ui5/browser/browser.html
@@ -12,10 +12,9 @@
       </div>
    </body>
 
-
    <script type='module'>
 
-      import { parse, browser, decodeUrl, toJSON, source_dir } from 'jsroot';
+      import { parse, browser, decodeUrl, toJSON } from 'jsroot';
 
       import { connectWebWindow } from 'jsroot/webwindow';
 
@@ -29,7 +28,7 @@
                XMLView.create({
                   id: "TopBrowserId",
                   viewName: "rootui5.browser.view.Browser",
-                  viewData: { conn_handle: handle, jsroot: { parse, browser, decodeUrl, toJSON, source_dir, connectWebWindow } }
+                  viewData: { conn_handle: handle, jsroot: { parse, browser, decodeUrl, toJSON, connectWebWindow } }
                }).then(oView => oView.placeAt("BrowserDiv"));
          });
       });

--- a/ui5/eve7/eve.mjs
+++ b/ui5/eve7/eve.mjs
@@ -1,21 +1,19 @@
 // initialization of EVE
 
-function initEVE(source_dir) {
+function initEVE() {
    if (globalThis.EVE)
       return Promise.resolve(globalThis.EVE);
 
-   let mpath = source_dir + 'modules/';
-
-   return Promise.all([import(mpath+'three.mjs'),
-                       import(mpath+'three_addons.mjs'),
-                       import(mpath+'core.mjs'),
-                       import(mpath+'draw.mjs'),
-                       import(mpath+'base/TAttLineHandler.mjs'),
-                       import(mpath+'gui/menu.mjs'),
-                       import(mpath+'base/colors.mjs'),
-                       import(mpath+'base/base3d.mjs'),
-                       import(mpath+'geom/geobase.mjs'),
-                       import(mpath+'geom/TGeoPainter.mjs')])
+   return Promise.all([import('jsrootsys/modules/three.mjs'),
+                       import('jsrootsys/modules/three_addons.mjs'),
+                       import('jsrootsys/modules/core.mjs'),
+                       import('jsrootsys/modules/draw.mjs'),
+                       import('jsrootsys/modules/base/TAttLineHandler.mjs'),
+                       import('jsrootsys/modules/gui/menu.mjs'),
+                       import('jsrootsys/modules/base/colors.mjs'),
+                       import('jsrootsys/modules/base/base3d.mjs'),
+                       import('jsrootsys/modules/geom/geobase.mjs'),
+                       import('jsrootsys/modules/geom/TGeoPainter.mjs')])
     .then(arr => {
        globalThis.THREE = Object.assign({}, arr.shift(), arr.shift());
 

--- a/ui5/eve7/index.html
+++ b/ui5/eve7/index.html
@@ -25,11 +25,10 @@
 
    <script type='module'>
 
-      import { source_dir } from 'jsroot/core';
       import { connectWebWindow } from 'jsroot/webwindow';
       import { initEVE } from 'rootui5sys/eve7/eve.mjs';
 
-      initEVE(source_dir).then(() => connectWebWindow({
+      initEVE().then(() => connectWebWindow({
          // socket_kind: "file",  // used for offline
          ui5: true,
          //  openui5src: "https://openui5.hana.ondemand.com/1.128.0/",

--- a/ui5/geom/controller/GeomViewer.controller.js
+++ b/ui5/geom/controller/GeomViewer.controller.js
@@ -60,10 +60,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          this.websocket.connect(viewData.conn_href);
 
-         if (this.jsroot?.browser?.qt5)
-            ResizeHandler.register(this.getView(), () => {
-               this.getView().rerender();
-            });
+         if (this.jsroot?.browser?.qt5 || this.jsroot?.browser?.qt6)
+            ResizeHandler.register(this.getView(), () => this.getView().rerender());
 
          Promise.all([import(this.jsroot.source_dir + 'modules/geom/geobase.mjs'), import(this.jsroot.source_dir + 'modules/geom/TGeoPainter.mjs')]).then(arr => {
             this.geo = Object.assign({}, arr[0], arr[1]);

--- a/ui5/geom/controller/GeomViewer.controller.js
+++ b/ui5/geom/controller/GeomViewer.controller.js
@@ -63,7 +63,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          if (this.jsroot?.browser?.qt5 || this.jsroot?.browser?.qt6)
             ResizeHandler.register(this.getView(), () => this.getView().rerender());
 
-         Promise.all([import(this.jsroot.source_dir + 'modules/geom/geobase.mjs'), import(this.jsroot.source_dir + 'modules/geom/TGeoPainter.mjs')]).then(arr => {
+         Promise.all([import('jsrootsys/modules/geom/geobase.mjs'), import('jsrootsys/modules/geom/TGeoPainter.mjs')]).then(arr => {
             this.geo = Object.assign({}, arr[0], arr[1]);
             this.checkSendRequest();
          });

--- a/ui5/geom/index.html
+++ b/ui5/geom/index.html
@@ -46,7 +46,7 @@
    <script type='module'>
 
      import { connectWebWindow } from 'jsroot/webwindow';
-     import { parse, decodeUrl, toJSON, source_dir, browser } from 'jsroot/core';
+     import { parse, decodeUrl, toJSON, browser } from 'jsroot/core';
 
      connectWebWindow({
         ui5: true,
@@ -59,7 +59,7 @@
          sap.ui.require(['sap/ui/core/mvc/XMLView'], XMLView => {
              XMLView.create({
                 viewName: is_hierarchy ? 'rootui5.geom.view.GeomHierarchy' : 'rootui5.geom.view.GeomViewer',
-                viewData: { conn_handle: handle, jsroot: { parse, decodeUrl, toJSON, source_dir, browser } }
+                viewData: { conn_handle: handle, jsroot: { parse, decodeUrl, toJSON, browser } }
              }).then(oView => oView.placeAt("GeomDiv"));
           });
      });

--- a/ui5/panel/Controller.js
+++ b/ui5/panel/Controller.js
@@ -23,7 +23,7 @@ sap.ui.define([
                this.websocket.send("PANEL_READY");
          }
 
-         // assign several core methods which are used like: parse, toJSON, source_dir
+         // assign several core methods which are used like: parse, toJSON
          this.jsroot = data?.jsroot;
 
          // TODO: use more specific API between Canvas and Panel

--- a/ui5/tree/index.html
+++ b/ui5/tree/index.html
@@ -31,7 +31,7 @@
    <script type='module'>
 
      import { connectWebWindow } from 'jsroot/webwindow';
-     import { parse, decodeUrl, toJSON, source_dir } from 'jsroot/core';
+     import { parse, decodeUrl, toJSON } from 'jsroot/core';
 
      connectWebWindow({
         ui5: true,
@@ -40,7 +40,7 @@
          sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
              XMLView.create({
                 viewName: "rootui5.tree.view.TreeViewer",
-                viewData: { conn_handle: handle, jsroot: { parse, decodeUrl, toJSON, source_dir } }
+                viewData: { conn_handle: handle, jsroot: { parse, decodeUrl, toJSON } }
              }).then(oView => oView.placeAt("ViewerDiv"));
           });
      });


### PR DESCRIPTION
This is location of JSROOT scripts, 
but normally one should use `import {something } from 'jsroot'` statement
Now `<!--jsroot_importmap-->` used in all widgets

Fix geometry resize in qt6