### PR TITLE
Make basket size option a serializable type

### DIFF
--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -32,8 +32,7 @@ struct RSnapshotOptions {
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
    RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy,
-                    bool overwriteIfExists = false, bool vector2RVec = true,
-                    const std::optional<int> &basketSize = std::nullopt,
+                    bool overwriteIfExists = false, bool vector2RVec = true, int basketSize = -1,
                     ESnapshotOutputFormat outputFormat = ESnapshotOutputFormat::kDefault)
       : fMode(mode),
         fCompressionAlgorithm(comprAlgo),
@@ -56,7 +55,7 @@ struct RSnapshotOptions {
    bool fLazy = false;                              ///< Do not start the event loop when Snapshot is called
    bool fOverwriteIfExists = false;  ///< If fMode is "UPDATE", overwrite object in output file if it already exists
    bool fVector2RVec = true;         ///< If set to true will convert std::vector columns to RVec when saving to disk
-   std::optional<int> fBasketSize{}; ///< Set a custom basket size option. For more details, see
+   int fBasketSize = -1;             ///< Set a custom basket size option. For more details, see
                                      ///< https://root.cern/manual/trees/#baskets-clusters-and-the-tree-header
    ESnapshotOutputFormat fOutputFormat = ESnapshotOutputFormat::kDefault; ///< Which data format to write to
 };


### PR DESCRIPTION
The type given to the fBasketSize member of the RSnapshotOptions, std::optional<int>, is not serializable by ROOT. This can lead to warnings and potentially faulty behaviour in distributed RDataFrame (and similar scenarios that require objects to be serializable). For example, this can be seen in the test output:

TStreamerInfo::Build:0: RuntimeWarning: ROOT::RDF::RSnapshotOptions: optional<int> has no streamer or dictionary, data member "fBasketSize" will not be saved
TStreamerInfo::Build:0: RuntimeWarning: _Optional_base<int,true,true>: base class _Optional_base_impl<int,_Optional_base<int,true,true> > has no streamer or dictionary it will not be saved
TStreamerInfo::Build:0: RuntimeWarning: _Optional_base<int,true,true>: _Optional_payload<int,true,true,true> has no streamer or dictionary, data member "_M_payload" will not be saved