### PR TITLE
[CPyCppyy] Use macros from the C Python API for better compatibility

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
@@ -226,7 +226,7 @@ bool CPyCppyy::Instance_IsLively(PyObject* pyobject)
 
 // the instance fails the lively test if it owns the C++ object while having a
 // reference count of 1 (meaning: it could delete the C++ instance any moment)
-    if (pyobject->ob_refcnt <= 1 && (((CPPInstance*)pyobject)->fFlags & CPPInstance::kIsOwner))
+    if (Py_REFCNT(pyobject) <= 1 && (((CPPInstance*)pyobject)->fFlags & CPPInstance::kIsOwner))
         return false;
 
     return true;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.h
@@ -25,7 +25,7 @@ inline uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf)
     // improved overloads for implicit conversions
         PyObject* pyobj = CPyCppyy_PyArgs_GET_ITEM(args, i);
         hash += (uint64_t)Py_TYPE(pyobj);
-        hash += (uint64_t)(pyobj->ob_refcnt == 1 ? 1 : 0);
+        hash += (uint64_t)(Py_REFCNT(pyobj) == 1 ? 1 : 0);
         hash += (hash << 10); hash ^= (hash >> 6);
     }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -214,23 +214,13 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
-PyObject _CPyCppyy_NullPtrStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyNullPtr_t_Type};
+struct {
+   PyObject_HEAD
+} _CPyCppyy_NullPtrStruct{PyObject_HEAD_INIT(&PyNullPtr_t_Type)};
 
-PyObject _CPyCppyy_DefaultStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyDefault_t_Type};
+struct {
+   PyObject_HEAD
+} _CPyCppyy_DefaultStruct{PyObject_HEAD_INIT(&PyDefault_t_Type)};
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)
@@ -779,7 +769,7 @@ static PyObject* BindObject(PyObject*, PyObject* args, PyObject* kwds)
 
 // not a pre-existing object; get the address and bind
     void* addr = nullptr;
-    if (arg0 != &_CPyCppyy_NullPtrStruct) {
+    if (arg0 != gNullPtrObject) {
         addr = CPyCppyy_PyCapsule_GetPointer(arg0, nullptr);
         if (PyErr_Occurred()) {
             PyErr_Clear();

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -2094,7 +2094,7 @@ bool CPyCppyy::STLStringMoveConverter::SetArg(
         if (pyobj->fFlags & CPPInstance::kIsRValue) {
             pyobj->fFlags &= ~CPPInstance::kIsRValue;
             moveit_reason = 2;
-        } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+        } else if (Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF) {
             moveit_reason = 1;
         } else
             moveit_reason = 0;
@@ -2331,7 +2331,7 @@ bool CPyCppyy::InstanceMoveConverter::SetArg(
     if (pyobj->fFlags & CPPInstance::kIsRValue) {
         pyobj->fFlags &= ~CPPInstance::kIsRValue;
         moveit_reason = 2;
-    } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+    } else if (Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF) {
         moveit_reason = 1;
     }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -549,7 +549,7 @@ static PyObject* vector_iter(PyObject* v) {
 
 // tell the iterator code to set a life line if this container is a temporary
     vi->vi_flags = vectoriterobject::kDefault;
-    if (v->ob_refcnt <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
+    if (Py_REFCNT(v) <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
         vi->vi_flags = vectoriterobject::kNeedLifeLine;
 
     PyObject* pyvalue_type = PyObject_GetAttr((PyObject*)Py_TYPE(v), PyStrings::gValueType);


### PR DESCRIPTION
Use macros from the C Python API for better compatibility between Python versions and also to compile with Python builds with free threading (aka. without the GIL).