### PR TITLE
[ntuple] Move RNTupleView out of Experimental

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -77,7 +77,7 @@ class RFieldProvider : public RProvider {
       }
 
       template <typename T>
-      void FillHistogramImpl(const ROOT::RFieldBase &field, ROOT::Experimental::RNTupleView<T> &view)
+      void FillHistogramImpl(const ROOT::RFieldBase &field, ROOT::RNTupleView<T> &view)
       {
          std::string title = "Drawing of RField "s + field.GetFieldName();
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -45,17 +45,11 @@ class TVirtualStreamerInfo;
 namespace ROOT {
 
 class TSchemaRule;
-class REntry;
+class RNTupleCollectionView;
 
 namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
-
-namespace Experimental {
-
-class RNTupleCollectionView;
-
-} // namespace Experimental
 
 /// The container field for an ntuple model, which itself has no physical representation.
 /// Therefore, the zero field must not be connected to a page source or sink.
@@ -317,7 +311,7 @@ public:
 /// It is used in the templated RField<RNTupleCardinality<SizeT>> form, which represents the collection sizes either
 /// as 32bit unsigned int (std::uint32_t) or as 64bit unsigned int (std::uint64_t).
 class RCardinalityField : public RFieldBase {
-   friend class ROOT::Experimental::RNTupleCollectionView; // to access GetCollectionInfo()
+   friend class ROOT::RNTupleCollectionView; // to access GetCollectionInfo()
 
 private:
    void GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -282,65 +282,65 @@ public:
    /// }
    /// ~~~
    template <typename T>
-   RNTupleView<T> GetView(std::string_view fieldName)
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName)
    {
       return GetView<T>(RetrieveFieldId(fieldName));
    }
 
    template <typename T>
-   RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
    template <typename T>
-   RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
    }
 
    template <typename T>
-   RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId)
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId)
    {
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
-      auto range = Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range);
+      auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return ROOT::RNTupleView<T>(std::move(field), range);
    }
 
    template <typename T>
-   RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
    {
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
-      auto range = Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, objPtr);
+      auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
    }
 
    template <typename T>
-   RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr)
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr)
    {
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource);
-      auto range = Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, rawPtr);
+      auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
    template <typename T>
-   RNTupleDirectAccessView<T> GetDirectAccessView(std::string_view fieldName)
+   ROOT::RNTupleDirectAccessView<T> GetDirectAccessView(std::string_view fieldName)
    {
       return GetDirectAccessView<T>(RetrieveFieldId(fieldName));
    }
 
    template <typename T>
-   RNTupleDirectAccessView<T> GetDirectAccessView(ROOT::DescriptorId_t fieldId)
+   ROOT::RNTupleDirectAccessView<T> GetDirectAccessView(ROOT::DescriptorId_t fieldId)
    {
-      auto field = RNTupleDirectAccessView<T>::CreateField(fieldId, *fSource);
-      auto range = Internal::GetFieldRange(field, *fSource);
-      return RNTupleDirectAccessView<T>(std::move(field), range);
+      auto field = ROOT::RNTupleDirectAccessView<T>::CreateField(fieldId, *fSource);
+      auto range = ROOT::Internal::GetFieldRange(field, *fSource);
+      return ROOT::RNTupleDirectAccessView<T>(std::move(field), range);
    }
 
    /// Raises an exception if:
    /// * there is no field with the given name or,
    /// * the field is not a collection
-   RNTupleCollectionView GetCollectionView(std::string_view fieldName)
+   ROOT::RNTupleCollectionView GetCollectionView(std::string_view fieldName)
    {
       auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName);
       if (fieldId == ROOT::kInvalidDescriptorId) {
@@ -350,9 +350,9 @@ public:
       return GetCollectionView(fieldId);
    }
 
-   RNTupleCollectionView GetCollectionView(ROOT::DescriptorId_t fieldId)
+   ROOT::RNTupleCollectionView GetCollectionView(ROOT::DescriptorId_t fieldId)
    {
-      return RNTupleCollectionView::Create(fieldId, fSource.get());
+      return ROOT::RNTupleCollectionView::Create(fieldId, fSource.get());
    }
 
    RIterator begin() { return RIterator(0); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -29,7 +29,10 @@
 #include <unordered_map>
 
 namespace ROOT {
+
 namespace Experimental {
+class RNTupleReader;
+} // namespace Experimental
 
 namespace Internal {
 
@@ -38,13 +41,14 @@ namespace Internal {
 /// by the number of elements of the first principal column found in the subfields searched by BFS.
 /// If the field hierarchy is empty on columns, the returned field range is invalid (start and end set to
 /// kInvalidNTupleIndex). An attempt to use such a field range in RNTupleViewBase::GetFieldRange will throw.
-ROOT::RNTupleGlobalRange GetFieldRange(const ROOT::RFieldBase &field, const RPageSource &pageSource);
+ROOT::RNTupleGlobalRange
+GetFieldRange(const ROOT::RFieldBase &field, const ROOT::Experimental::Internal::RPageSource &pageSource);
 
 } // namespace Internal
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleViewBase
+\class ROOT::RNTupleViewBase
 \ingroup NTuple
 \brief An RNTupleView provides read-only access to a single field of an RNTuple
 
@@ -86,7 +90,8 @@ protected:
    ROOT::RNTupleGlobalRange fFieldRange;
    ROOT::RFieldBase::RValue fValue;
 
-   static std::unique_ptr<ROOT::RFieldBase> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
+   static std::unique_ptr<ROOT::RFieldBase>
+   CreateField(ROOT::DescriptorId_t fieldId, ROOT::Experimental::Internal::RPageSource &pageSource)
    {
       std::unique_ptr<ROOT::RFieldBase> field;
       {
@@ -151,14 +156,14 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleView
+\class ROOT::RNTupleView
 \ingroup NTuple
 \brief An RNTupleView for a known type. See RNTupleViewBase.
 */
 // clang-format on
 template <typename T>
 class RNTupleView : public RNTupleViewBase<T> {
-   friend class RNTupleReader;
+   friend class ROOT::Experimental::RNTupleReader;
    friend class RNTupleCollectionView;
 
 protected:
@@ -202,14 +207,14 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleView
+\class ROOT::RNTupleView
 \ingroup NTuple
 \brief An RNTupleView that can be used when the type is unknown at compile time. See RNTupleViewBase.
 */
 // clang-format on
 template <>
 class RNTupleView<void> final : public RNTupleViewBase<void> {
-   friend class RNTupleReader;
+   friend class ROOT::Experimental::RNTupleReader;
    friend class RNTupleCollectionView;
 
 protected:
@@ -243,21 +248,22 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleDirectAccessView
+\class ROOT::RNTupleDirectAccessView
 \ingroup NTuple
 \brief A view variant that provides direct access to the I/O buffers. Only works for mappable fields.
 */
 // clang-format on
 template <typename T>
 class RNTupleDirectAccessView {
-   friend class RNTupleReader;
+   friend class ROOT::Experimental::RNTupleReader;
    friend class RNTupleCollectionView;
 
 protected:
    ROOT::RField<T> fField;
    ROOT::RNTupleGlobalRange fFieldRange;
 
-   static ROOT::RField<T> CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource)
+   static ROOT::RField<T>
+   CreateField(ROOT::DescriptorId_t fieldId, ROOT::Experimental::Internal::RPageSource &pageSource)
    {
       const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
@@ -295,27 +301,28 @@ public:
 
 // clang-format off
 /**
-\class ROOT::Experimental::RNTupleCollectionView
+\class ROOT::RNTupleCollectionView
 \ingroup NTuple
 \brief A view for a collection, that can itself generate new ntuple views for its nested fields.
 */
 // clang-format on
 class RNTupleCollectionView {
-   friend class RNTupleReader;
+   friend class ROOT::Experimental::RNTupleReader;
 
 private:
-   Internal::RPageSource *fSource;
+   ROOT::Experimental::Internal::RPageSource *fSource;
    ROOT::RField<RNTupleCardinality<std::uint64_t>> fField;
    ROOT::RFieldBase::RValue fValue;
 
-   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, const std::string &fieldName, Internal::RPageSource *source)
+   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, const std::string &fieldName,
+                         ROOT::Experimental::Internal::RPageSource *source)
       : fSource(source), fField(fieldName), fValue(fField.CreateValue())
    {
       fField.SetOnDiskId(fieldId);
       ROOT::Internal::CallConnectPageSourceOnField(fField, *source);
    }
 
-   static RNTupleCollectionView Create(ROOT::DescriptorId_t fieldId, Internal::RPageSource *source)
+   static RNTupleCollectionView Create(ROOT::DescriptorId_t fieldId, ROOT::Experimental::Internal::RPageSource *source)
    {
       std::string fieldName;
       {
@@ -405,6 +412,20 @@ public:
    }
 };
 
+namespace Experimental {
+// TODO(gparolini): remove before branching ROOT v6.36
+template <typename T>
+using RNTupleViewBase [[deprecated("ROOT::Experimental::RNTupleViewBase moved to ROOT::RNTupleViewBase")]] =
+   ROOT::RNTupleViewBase<T>;
+template <typename T>
+using RNTupleView [[deprecated("ROOT::Experimental::RNTupleView moved to ROOT::RNTupleView")]] = ROOT::RNTupleView<T>;
+template <typename T>
+using RNTupleDirectAccessView
+   [[deprecated("ROOT::Experimental::RNTupleDirectAccessView moved to ROOT::RNTupleDirectAccessView")]] =
+      ROOT::RNTupleDirectAccessView<T>;
+using RNTupleCollectionView
+   [[deprecated("ROOT::Experimental::RNTupleCollectionView moved to ROOT::RNTupleCollectionView")]] =
+      ROOT::RNTupleCollectionView;
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/src/RNTupleView.cxx
+++ b/tree/ntuple/v7/src/RNTupleView.cxx
@@ -19,8 +19,8 @@
 #include <ROOT/RNTupleView.hxx>
 #include <ROOT/RPageStorage.hxx>
 
-ROOT::RNTupleGlobalRange
-ROOT::Experimental::Internal::GetFieldRange(const ROOT::RFieldBase &field, const RPageSource &pageSource)
+ROOT::RNTupleGlobalRange ROOT::Internal::GetFieldRange(const ROOT::RFieldBase &field,
+                                                       const ROOT::Experimental::Internal::RPageSource &pageSource)
 {
    const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
 

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -111,7 +111,7 @@ using RPrintSchemaVisitor = ROOT::Internal::RPrintSchemaVisitor;
 using RRawFile = ROOT::Internal::RRawFile;
 using EContainerFormat = RNTupleFileWriter::EContainerFormat;
 template <typename T>
-using RNTupleView = ROOT::Experimental::RNTupleView<T>;
+using RNTupleView = ROOT::RNTupleView<T>;
 
 using ROOT::Internal::MakeUninitArray;
 

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -425,9 +425,9 @@ TEST(RNTuple, ViewFrameworkUse)
    auto reader = RNTupleReader::Open(*ntpl);
    reader->EnableMetrics();
 
-   std::optional<ROOT::Experimental::RNTupleView<void>> viewPx;
-   std::optional<ROOT::Experimental::RNTupleView<void>> viewPy;
-   std::optional<ROOT::Experimental::RNTupleView<void>> viewPz;
+   std::optional<ROOT::RNTupleView<void>> viewPx;
+   std::optional<ROOT::RNTupleView<void>> viewPy;
+   std::optional<ROOT::RNTupleView<void>> viewPz;
 
    float px = 0, py = 0, pz = 0;
    for (auto i : reader->GetEntryRange()) {


### PR DESCRIPTION
# This Pull request:
Moves out of Experimental the `RNTupleView` class directory 


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


