### PR TITLE
[HistFactory] Disable global histogram registration for HistFactory.

### DIFF
--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -464,8 +464,8 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
-
-  TH1 * ptr = static_cast<TH1 *>(hist->Clone());
+  TDirectory::TContext ctx{nullptr}; // Suppress any kind of registration
+  TH1 *ptr = static_cast<TH1 *>(hist->Clone());
 
   if(!ptr){
     std::cerr << "Not all necessary info are set to access the input file. Check your config" << std::endl;
@@ -475,6 +475,7 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
+  ptr->SetBit(kMustCleanup, false); // Don't try to clean up this histogram
   ptr->SetDirectory(nullptr);
 
 

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -83,6 +83,7 @@ RooFit::OwningPtr<RooWorkspace>
 RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measurement &measurement,
                                                    HistoToWorkspaceFactoryFast::Configuration const &cfg)
 {
+  TDirectory::TContext dirContext{nullptr};
   std::unique_ptr<TFile> outFile;
 
   auto& msgSvc = RooMsgService::instance();
@@ -133,7 +134,8 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
     // This holds the TGraphs that are created during the fit
     std::string outputFileName = measurement.GetOutputFilePrefix() + "_" + measurement.GetName() + ".root";
     cxcoutIHF << "Creating the output file: " << outputFileName << std::endl;
-    outFile = std::make_unique<TFile>(outputFileName.c_str(), "recreate");
+    outFile = std::make_unique<TFile>(outputFileName.c_str(), "RECREATE_WITHOUT_GLOBALREGISTRATION");
+    gDirectory = nullptr; // Prevent global registration of histograms. They are owned by HF.
 
     cxcoutIHF << "Creating the HistoToWorkspaceFactoryFast factory" << std::endl;
     HistoToWorkspaceFactoryFast factory{measurement, cfg};


### PR DESCRIPTION
The HistFactory histograms are owned by the HistFactory models, and they are explicitly written to files. Therefore, they should not participate in directory registration.

Fix #18172