### PR TITLE
Implement TGraph2D::RemoveDuplicates

### DIFF
--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -150,6 +150,7 @@ public:
    TH1                  *Project(Option_t *option="x") const; // *MENU*
    void                  RecursiveRemove(TObject *obj) override;
    Int_t                 RemovePoint(Int_t ipoint); // *MENU*
+   Int_t                 RemoveDuplicates();
    void                  SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void          Scale(Double_t c1=1., Option_t *option="z"); // *MENU*
    virtual void          Set(Int_t n);

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -108,6 +108,11 @@ Specific drawing options can be used to paint a TGraph2D:
 | "LINE"   | Draw a 3D polyline. |
 | "CONT5"  | Draw a contour plot using Delaunay triangles.|
 
+The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
+meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
+algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates
+(see RemoveDuplicates()).
+
 A TGraph2D can be also drawn with any options valid to draw a 2D histogram
 (like `COL`, `SURF`, `LEGO`, `CONT` etc..).
 
@@ -1414,6 +1419,34 @@ TH1 *TGraph2D::Project(Option_t *option) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Deletes duplicated points.
+///
+/// The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
+/// meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
+/// algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates.
+/// This function provides a way to handle such duplicates.
+///
+/// Example:
+/// ~~~ {.cpp}
+/// g->RemoveDuplicates();
+/// g->Draw("TRI1");
+/// ~~~
+
+Int_t TGraph2D::RemoveDuplicates()
+{
+   for (int i=0; i<fNpoints; i++) {
+      double x = fX[i];
+      double y = fY[i];
+      for (int j=i+1; j<fNpoints; j++) {
+         if (x==fX[j] && y==fY[j]) {RemovePoint(j); j--;}
+      }
+   }
+
+   return fNpoints;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Recursively remove object from the list of functions
 
 void TGraph2D::RecursiveRemove(TObject *obj)
@@ -1426,6 +1459,7 @@ void TGraph2D::RecursiveRemove(TObject *obj)
       fHistogram = nullptr;
 }
 
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Deletes point number ipoint
 
@@ -1433,26 +1467,12 @@ Int_t TGraph2D::RemovePoint(Int_t ipoint)
 {
    if (ipoint < 0) return -1;
    if (ipoint >= fNpoints) return -1;
-
-   fNpoints--;
-   Double_t *newX = new Double_t[fNpoints];
-   Double_t *newY = new Double_t[fNpoints];
-   Double_t *newZ = new Double_t[fNpoints];
-   Int_t j = -1;
-   for (Int_t i = 0; i < fNpoints + 1; i++) {
-      if (i == ipoint) continue;
-      j++;
-      newX[j] = fX[i];
-      newY[j] = fY[i];
-      newZ[j] = fZ[i];
+   for (Int_t i = ipoint; i < fNpoints - 1; i++) {
+      fX[i] = fX[i+1];
+      fY[i] = fY[i+1];
+      fZ[i] = fZ[i+1];
    }
-   delete [] fX;
-   delete [] fY;
-   delete [] fZ;
-   fX = newX;
-   fY = newY;
-   fZ = newZ;
-   fSize = fNpoints;
+   fNpoints--;
    if (fHistogram) {
       delete fHistogram;
       fHistogram = nullptr;

--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -13,6 +13,7 @@
 
 #include "Math/Delaunay2D.h"
 #include "Rtypes.h"
+#include "TError.h"
 
 //#include <thread>
 
@@ -179,6 +180,8 @@ void Delaunay2D::DoFindTriangles() {
    std::vector<CDT::V2d<double>> points(fNpoints);
    for (i = 0; i < fNpoints; ++i) points[i] = CDT::V2d<double>::make(fXN[i], fYN[i]);
    CDT::RemoveDuplicates(points);
+   if (fNpoints-points.size() > 0)
+      Warning("DoFindTriangles","This TGraph2D has duplicated vertices. To remove them call RemoveDuplicates before drawing");
 
    CDT::Triangulation<double> cdt;
    cdt.insertVertices(points);


### PR DESCRIPTION
#The Delaunay triangulation algorithm assumes that each (x, y) coordinate corresponds to a unique z value,
meaning duplicate (x, y) points are not allowed. Consequently, when using drawing options that rely on this
algorithm (e.g., TRI, SURF, etc.), a warning may appear instructing you to remove duplicates.
This function provides a way to handle such duplicates.

