### PR TITLE
[ntuple] Add `GetView<void>` with type name string or `std::type_info` argument

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -296,6 +296,12 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
+   }
+
    /// Provides access to an individual (sub)field, reading its values into `rawPtr`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
@@ -303,6 +309,12 @@ public:
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID.
@@ -327,6 +339,15 @@ public:
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
+   {
+      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, objPtr);
+   }
+
    /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `rawPtr`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
@@ -336,6 +357,15 @@ public:
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
+   {
+      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
    /// Provides direct access to the I/O buffers of a **mappable** (sub)field.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -308,19 +308,17 @@ public:
    /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `typeName`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
+   ROOT::RNTupleView<void> GetView(std::string_view fieldName, void *rawPtr, std::string_view typeName)
    {
-      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
+      return GetView(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
    /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `ti`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
+   ROOT::RNTupleView<void> GetView(std::string_view fieldName, void *rawPtr, const std::type_info &ti)
    {
-      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+      return GetView(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID.
@@ -360,23 +358,20 @@ public:
    /// provided by `typeName`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
+   ROOT::RNTupleView<void> GetView(ROOT::DescriptorId_t fieldId, void *rawPtr, std::string_view typeName)
    {
-      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto field = RNTupleView<void>::CreateField(fieldId, *fSource, typeName);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, rawPtr);
+      return RNTupleView<void>(std::move(field), range, rawPtr);
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
    /// provided by `ti`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
+   ROOT::RNTupleView<void> GetView(ROOT::DescriptorId_t fieldId, void *rawPtr, const std::type_info &ti)
    {
-      return GetView<T>(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+      return GetView(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    /// Provides direct access to the I/O buffers of a **mappable** (sub)field.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -302,6 +302,12 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
    }
 
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+   }
+
    /// Provides access to an individual (sub)field, reading its values into `rawPtr`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
@@ -315,6 +321,12 @@ public:
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID.
@@ -348,6 +360,12 @@ public:
       return RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
+   {
+      return GetView<T>(fieldId, objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+   }
+
    /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `rawPtr`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
@@ -366,6 +384,12 @@ public:
       auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return RNTupleView<T>(std::move(field), range, rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
+   {
+      return GetView<T>(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    /// Provides direct access to the I/O buffers of a **mappable** (sub)field.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -296,24 +296,6 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
-   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `typeName`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
-   {
-      return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
-   }
-
-   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `ti`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
-   {
-      return GetView<T>(RetrieveFieldId(fieldName), objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
-   }
-
    /// Provides access to an individual (sub)field, reading its values into `rawPtr`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
@@ -361,29 +343,6 @@ public:
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
-   }
-
-   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
-   /// provided by `typeName`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
-   {
-      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
-      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, objPtr);
-   }
-
-   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
-   /// provided by `ti`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
-   {
-      return GetView<T>(fieldId, objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `rawPtr`.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -296,12 +296,18 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
    {
@@ -317,12 +323,18 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
    {
@@ -351,6 +363,10 @@ public:
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
    {
@@ -360,6 +376,10 @@ public:
       return RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
    {
@@ -377,6 +397,10 @@ public:
       return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `rawPtr` as the type
+   /// provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
    {
@@ -386,6 +410,10 @@ public:
       return RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -88,15 +88,19 @@ protected:
    ROOT::RNTupleGlobalRange fFieldRange;
    ROOT::RFieldBase::RValue fValue;
 
-   static std::unique_ptr<ROOT::RFieldBase>
-   CreateField(ROOT::DescriptorId_t fieldId, ROOT::Experimental::Internal::RPageSource &pageSource)
+   static std::unique_ptr<ROOT::RFieldBase> CreateField(ROOT::DescriptorId_t fieldId,
+                                                        Experimental::Internal::RPageSource &pageSource,
+                                                        std::string_view typeName = "")
    {
       std::unique_ptr<ROOT::RFieldBase> field;
       {
          const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
          const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
          if constexpr (std::is_void_v<T>) {
-            field = fieldDesc.CreateField(desc);
+            if (typeName.empty())
+               field = fieldDesc.CreateField(desc);
+            else
+               field = ROOT::RFieldBase::Create(fieldDesc.GetFieldName(), std::string(typeName)).Unwrap();
          } else {
             field = std::make_unique<ROOT::RField<T>>(fieldDesc.GetFieldName());
          }

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -573,22 +573,6 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
    }
 
-   // Shared pointer interface from type name string
-   {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, "std::int32_t");
-      viewFoo(0);
-      EXPECT_EQ(42, *int32SharedPtr);
-      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
-   }
-
-   // Shared pointer interface from std::type_info
-   {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, typeid(std::int32_t));
-      viewFoo(0);
-      EXPECT_EQ(42, *int32SharedPtr);
-      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
-   }
-
    // Reading as a type when the on-disk value doesn't fit in this type is not possible
    try {
       auto viewBar = reader->GetView<void>("bar", int32SharedPtr.get(), "std::int32_t");

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -557,7 +557,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    // Read "foo" as std::int32_t (instead of its on-disk type std::uint64_t)
    auto int32SharedPtr = std::make_shared<std::int32_t>();
 
-   // Raw pointer interface
+   // Raw pointer interface from type name string
    {
       auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), "std::int32_t");
       viewFoo(0);
@@ -565,9 +565,25 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
    }
 
-   // Shared pointer interface
+   // Raw pointer interface from std::type_info
+   {
+      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), typeid(std::int32_t));
+      viewFoo(0);
+      EXPECT_EQ(42, *int32SharedPtr);
+      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
+   }
+
+   // Shared pointer interface from type name string
    {
       auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, "std::int32_t");
+      viewFoo(0);
+      EXPECT_EQ(42, *int32SharedPtr);
+      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
+   }
+
+   // Shared pointer interface from std::type_info
+   {
+      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, typeid(std::int32_t));
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -584,13 +600,25 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    // Read "baz" as std::vector<double> (instead of its on-disk type std::vector<float>)
    std::vector<double> doubleVec;
    void *doubleVecPtr = &doubleVec;
-
    std::vector<double> expDoubleVec{1., 2., 3.};
-   auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
-   viewBaz(0);
-   EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
-   EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
-   EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+
+   // From type name string
+   {
+      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
+      viewBaz(0);
+      EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
+      EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
+      EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+   }
+
+   // From std::type_info
+   {
+      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, typeid(std::vector<double>));
+      viewBaz(0);
+      EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
+      EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
+      EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+   }
 
    try {
       std::vector<int> intVec;

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -559,7 +559,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Raw pointer interface from type name string
    {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), "std::int32_t");
+      auto viewFoo = reader->GetView("foo", int32SharedPtr.get(), "std::int32_t");
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -567,7 +567,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Raw pointer interface from std::type_info
    {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), typeid(std::int32_t));
+      auto viewFoo = reader->GetView("foo", int32SharedPtr.get(), typeid(std::int32_t));
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -575,7 +575,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Reading as a type when the on-disk value doesn't fit in this type is not possible
    try {
-      auto viewBar = reader->GetView<void>("bar", int32SharedPtr.get(), "std::int32_t");
+      auto viewBar = reader->GetView("bar", int32SharedPtr.get(), "std::int32_t");
       viewBar(0);
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("value out of range: 18446744073709551615 for type i"));
@@ -588,7 +588,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // From type name string
    {
-      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
+      auto viewBaz = reader->GetView("baz", doubleVecPtr, "std::vector<double>");
       viewBaz(0);
       EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
       EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
@@ -597,7 +597,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // From std::type_info
    {
-      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, typeid(std::vector<double>));
+      auto viewBaz = reader->GetView("baz", doubleVecPtr, typeid(std::vector<double>));
       viewBaz(0);
       EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
       EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
@@ -607,7 +607,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    try {
       std::vector<int> intVec;
       void *bazAsIntsPtr = &intVec;
-      reader->GetView<void>("baz", bazAsIntsPtr, "std::vector<int>");
+      reader->GetView("baz", bazAsIntsPtr, "std::vector<int>");
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("On-disk column types {`SplitReal32`} for field `baz._0` cannot be "
                                                  "matched to its in-memory type `std::int32_t`"));


### PR DESCRIPTION
Enables passing a type name string to `GetView<void>` to signal that the pointer has a different underlying type than the on-disk field's type. The field used by `RNTupleView` will be constructed with this type, in turn benefitting from RNTuples built-in type- and bounds-checking.

To illustrate further, assuming `myInt` is a `std::uint64_t` on-disk:
```cpp
std::int32_t myInt;
void* myIntPtr = &myInt;
auto myIntView = reader->GetView<void>("myInt", myIntPtr);
myIntView(0);
doSomething(myInt);
```
`GetView<void>` will currently always reconstruct the field used for loading the values from the on-disk descriptor. However, in the example above this can lead to undefined behavior when the actual values on disk don't fit in `std::int32_t`. The change proposed in this PR enables passing the type name string to `GetView<void>`, which is then used for the construction of the field instead, leveraging RNTuple's internal type- and bounds-checking:
```cpp
std::int32_t myInt;
void* myIntPtr = &myInt;
auto myIntView = reader->GetView<void>("myInt", myIntPtr, "std::int32_t");
myIntView(0);
doSomething(myInt);
```

This feature was requested by and discussed with ATLAS.