### PR TITLE
Replace `SavePrimitiveArray` by `SavePrimitiveVector`

### DIFF
--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -57,6 +57,8 @@ protected:
 
    static TString SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line = kFALSE);
 
+   static TString SavePrimitiveVector(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line = kFALSE);
+
 public:
    //----- Global bits (can be set for any object and should not be reused).
    //----- Bits 0 - 13 are reserved as global bits. Bits 14 - 23 can be used

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -55,8 +55,6 @@ protected:
 
    static void SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char *variable_name, const char *constructor_agrs = "", Bool_t empty_line = kTRUE);
 
-   static TString SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line = kFALSE);
-
    static TString SavePrimitiveVector(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line = kFALSE);
 
 public:

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -779,37 +779,6 @@ void TObject::SavePrimitiveConstructor(std::ostream &out, TClass *cl, const char
    out << variable_name << " = new " << cl->GetName() << "(" << constructor_agrs << ");\n";
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Save array in the output stream "out".
-/// Create unique variable name based on prefix value
-
-TString TObject::SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line)
-{
-   thread_local int arrid = 0;
-
-   TString arrname = TString::Format("%s_darr%d", prefix, arrid++);
-
-   if (empty_line)
-      out << "   \n";
-
-   out << "   Double_t " << arrname << "[" << len << "] = { ";
-   if (len > 0) {
-      const auto old_precision{out.precision()};
-      constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
-      out << std::setprecision(max_precision);
-      for (Int_t i = 0; i < len-1; i++) {
-         out << arr[i] << ",";
-         if (i && (i % 16 == 0))
-            out << "\n   ";
-         else
-            out << " ";
-      }
-      out << arr[len - 1];
-      out << std::setprecision(old_precision);
-   }
-   out << " };" << std::endl;
-   return arrname;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save array in the output stream "out" as vector.

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -811,6 +811,41 @@ TString TObject::SavePrimitiveArray(std::ostream &out, const char *prefix, Int_t
    return arrname;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Save array in the output stream "out" as vector.
+/// Create unique variable name based on prefix value
+/// Returns name of vector which can be used in constructor or in other places of C++ code
+
+TString TObject::SavePrimitiveVector(std::ostream &out, const char *prefix, Int_t len, Double_t *arr, Bool_t empty_line)
+{
+   thread_local int vectid = 0;
+
+   TString vectame = TString::Format("%s_vect%d", prefix, vectid++);
+
+   if (empty_line)
+      out << "   \n";
+
+   out << "   std::vector<Double_t> " << vectame;
+   if (len > 0) {
+      const auto old_precision{out.precision()};
+      constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
+      out << std::setprecision(max_precision);
+      Bool_t use_new_lines = len > 15;
+
+      out << "{";
+      for (Int_t i = 0; i < len; i++) {
+         out << (((i % 10 == 0) && use_new_lines) ? "\n      " : " ") << arr[i];
+         if (i < len - 1)
+            out << ",";
+      }
+      out << (use_new_lines ? "\n   }" : " }");
+
+      out << std::setprecision(old_precision);
+   }
+   out << ";\n";
+   return vectame;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save a primitive as a C++ statement(s) on output stream "out".

--- a/graf2d/graf/src/TCutG.cxx
+++ b/graf2d/graf/src/TCutG.cxx
@@ -368,22 +368,23 @@ Double_t TCutG::IntegralHist(TH2 *h, Option_t *option) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Save primitive as a C++ statement(s) on output stream out.
 
-void TCutG::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
+void TCutG::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   TString arrx = SavePrimitiveArray(out, "cutg", fNpoints, fX, kTRUE);
-   TString arry = SavePrimitiveArray(out, "cutg", fNpoints, fY);
-   SavePrimitiveConstructor(out, Class(), "cutg",
-                            TString::Format("\"%s\", %d, %s, %s", GetName(), fNpoints, arrx.Data(), arry.Data()),
-                            kFALSE);
-   out << "   cutg->SetVarX(\"" << GetVarX() << "\");" << std::endl;
-   out << "   cutg->SetVarY(\"" << GetVarY() << "\");" << std::endl;
-   out << "   cutg->SetTitle(\"" << TString(GetTitle()).ReplaceSpecialCppChars() << "\");" << std::endl;
+   TString arrx = SavePrimitiveVector(out, "cutg", fNpoints, fX, kTRUE);
+   TString arry = SavePrimitiveVector(out, "cutg", fNpoints, fY);
+   SavePrimitiveConstructor(
+      out, Class(), "cutg",
+      TString::Format("\"%s\", %d, %s.data(), %s.data()", GetName(), fNpoints, arrx.Data(), arry.Data()), kFALSE);
+   out << "   cutg->SetVarX(\"" << GetVarX() << "\");\n";
+   out << "   cutg->SetVarY(\"" << GetVarY() << "\");\n";
+   out << "   cutg->SetTitle(\"" << TString(GetTitle()).ReplaceSpecialCppChars() << "\");\n";
 
    SaveFillAttributes(out, "cutg", 0, 1001);
    SaveLineAttributes(out, "cutg", 1, 1, 1);
    SaveMarkerAttributes(out, "cutg", 1, 1, 1);
 
-   out << "   cutg->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");" << std::endl;
+   if (!option || !strstr(option, "nodraw"))
+      out << "   cutg->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -577,13 +577,13 @@ void TPolyLine::Print(Option_t *) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Save primitive as a C++ statement(s) on output stream out
 
-void TPolyLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
+void TPolyLine::SavePrimitive(std::ostream &out, Option_t *option)
 {
    TString args;
    if (Size() > 0) {
-      TString arrx = SavePrimitiveArray(out, "polyline", Size(), fX, kTRUE);
-      TString arry = SavePrimitiveArray(out, "polyline", Size(), fY);
-      args.Form("%d, %s, %s, ", Size(), arrx.Data(), arry.Data());
+      TString arrx = SavePrimitiveVector(out, "polyline", Size(), fX, kTRUE);
+      TString arry = SavePrimitiveVector(out, "polyline", Size(), fY);
+      args.Form("%d, %s.data(), %s.data(), ", Size(), arrx.Data(), arry.Data());
    } else {
       args.Form("%d, ", fN);
    }
@@ -593,7 +593,8 @@ void TPolyLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    SaveFillAttributes(out, "polyline", 0, 1001);
    SaveLineAttributes(out, "polyline", 1, 1, 1);
 
-   out << "   polyline->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");" << std::endl;
+   if (!option || !strstr(option, "nodraw"))
+      out << "   polyline->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TPolyLine3D.cxx
+++ b/graf3d/g3d/src/TPolyLine3D.cxx
@@ -555,15 +555,15 @@ void TPolyLine3D::Print(Option_t *option) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Save primitive as a C++ statement(s) on output stream.
 
-void TPolyLine3D::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
+void TPolyLine3D::SavePrimitive(std::ostream &out, Option_t *option)
 {
    TString arrarg;
    if (Size() > 0) {
       std::vector<Double_t> arr(Size() * 3);
       for (Int_t i = 0; i < Size() * 3; i++)
          arr[i] = fP[i];
-      arrarg = SavePrimitiveArray(out, "pline3D", Size() * 3, arr.data(), kTRUE);
-      arrarg.Append(", ");
+      arrarg = SavePrimitiveVector(out, "pline3D", Size() * 3, arr.data(), kTRUE);
+      arrarg.Append(".data(), ");
    }
 
    SavePrimitiveConstructor(
@@ -573,7 +573,8 @@ void TPolyLine3D::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
    SaveLineAttributes(out, "pline3D", 1, 1, 1);
 
-   out << "   pline3D->Draw();\n";
+   if (!option || !strstr(option, "nodraw"))
+      out << "   pline3D->Draw(\"" << TString(option).ReplaceSpecialCppChars() << "\");\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TPolyMarker3D.cxx
+++ b/graf3d/g3d/src/TPolyMarker3D.cxx
@@ -490,10 +490,10 @@ void TPolyMarker3D::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    for (Int_t i = 0; i < Size() * 3; i++)
       arr[i] = fP[i];
 
-   TString arrname = SavePrimitiveArray(out, "pmarker3D", Size() * 3, arr.data(), kTRUE);
+   TString vectname = SavePrimitiveVector(out, "pmarker3D", Size() * 3, arr.data(), kTRUE);
 
    SavePrimitiveConstructor(out, Class(), "pmarker3D",
-                            TString::Format("%d, %s, %d, \"%s\"", Size(), arrname.Data(), GetMarkerStyle(),
+                            TString::Format("%d, %s.data(), %d, \"%s\"", Size(), vectname.Data(), GetMarkerStyle(),
                                             TString(fOption).ReplaceSpecialCppChars().Data()),
                             kFALSE);
 

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -3190,31 +3190,31 @@ void TEfficiency::SavePrimitive(std::ostream& out,Option_t* option)
    // Check if the histogram has equidistant X bins or not.  If not, we
    // create an array holding the bins.
    if (fTotalHistogram->GetXaxis()->GetXbins()->fN && fTotalHistogram->GetXaxis()->GetXbins()->fArray)
-      sxaxis = SavePrimitiveArray(out, name + "_x", fTotalHistogram->GetXaxis()->GetXbins()->fN, fTotalHistogram->GetXaxis()->GetXbins()->fArray);
+      sxaxis = SavePrimitiveVector(out, name + "_x", fTotalHistogram->GetXaxis()->GetXbins()->fN, fTotalHistogram->GetXaxis()->GetXbins()->fArray);
    // If the histogram is 2 or 3 dimensional, check if the histogram
    // has equidistant Y bins or not.  If not, we create an array
    // holding the bins.
    if (GetDimension() > 1 && fTotalHistogram->GetYaxis()->GetXbins()->fN && fTotalHistogram->GetYaxis()->GetXbins()->fArray)
-      syaxis = SavePrimitiveArray(out, name + "_y", fTotalHistogram->GetYaxis()->GetXbins()->fN, fTotalHistogram->GetYaxis()->GetXbins()->fArray);
+      syaxis = SavePrimitiveVector(out, name + "_y", fTotalHistogram->GetYaxis()->GetXbins()->fN, fTotalHistogram->GetYaxis()->GetXbins()->fArray);
    // IF the histogram is 3 dimensional, check if the histogram
    // has equidistant Z bins or not.  If not, we create an array
    // holding the bins.
    if (GetDimension() > 2 && fTotalHistogram->GetZaxis()->GetXbins()->fN && fTotalHistogram->GetZaxis()->GetXbins()->fArray)
-      szaxis = SavePrimitiveArray(out, name + "_z", fTotalHistogram->GetZaxis()->GetXbins()->fN, fTotalHistogram->GetZaxis()->GetXbins()->fArray);
+      szaxis = SavePrimitiveVector(out, name + "_z", fTotalHistogram->GetZaxis()->GetXbins()->fN, fTotalHistogram->GetZaxis()->GetXbins()->fArray);
 
    out << "   " << ClassName() << " *" << name << " = new " << ClassName() << "(\"" << GetName() << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\"";
    // X dimentsion args
    out << ", " << fTotalHistogram->GetXaxis()->GetNbins() << ", ";
    if (!sxaxis.IsNull())
-      out << sxaxis;
+      out << sxaxis << ".data()";
    else
       out << fTotalHistogram->GetXaxis()->GetXmin() << "," << fTotalHistogram->GetXaxis()->GetXmax();
 
    if (GetDimension() > 1) {
       out << ", " << fTotalHistogram->GetYaxis()->GetNbins() << ", ";
       if (!syaxis.IsNull())
-         out << syaxis;
+         out << syaxis << ".data()";
       else
          out << fTotalHistogram->GetYaxis()->GetXmin() << ", " << fTotalHistogram->GetYaxis()->GetXmax();
    }
@@ -3222,7 +3222,7 @@ void TEfficiency::SavePrimitive(std::ostream& out,Option_t* option)
    if (GetDimension() > 2) {
       out << ", " << fTotalHistogram->GetZaxis()->GetNbins() << ", ";
       if (!szaxis.IsNull())
-         out << szaxis;
+         out << szaxis << ".data()";
       else
          out << fTotalHistogram->GetZaxis()->GetXmin() << ", " << fTotalHistogram->GetZaxis()->GetXmax();
    }

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3324,9 +3324,9 @@ void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          Save(fXmin, fXmax, 0, 0, 0, 0);
       }
       if (!fSave.empty()) {
-         TString arrs = SavePrimitiveArray(out, f1Name, fSave.size(), fSave.data());
+         TString vect = SavePrimitiveVector(out, f1Name, fSave.size(), fSave.data());
          out << "   for (int n = 0; n < " << fSave.size() << "; n++)\n";
-         out << "      " << f1Name << "->SetSavedPoint(n, "  << arrs << "[n]);\n";
+         out << "      " << f1Name << "->SetSavedPoint(n, "  << vect << "[n]);\n";
       }
 
       if (saved)

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -898,21 +898,21 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    }
 
    if (!fSave.empty()) {
-      TString arrs = SavePrimitiveArray(out, f2Name, fSave.size(), fSave.data());
+      TString vect = SavePrimitiveVector(out, f2Name, fSave.size(), fSave.data());
       out << "   for (int n = 0; n < " << fSave.size() << "; n++)\n";
-      out << "      " << f2Name << "->SetSavedPoint(n, " << arrs << "[n]);\n";
+      out << "      " << f2Name << "->SetSavedPoint(n, " << vect << "[n]);\n";
    }
 
    if (saved)
       fSave.clear();
 
    if (fContour.fN > 0) {
-      TString arrname;
+      TString vectname;
       if (fContour.fArray[0] != -9999)
-         arrname = SavePrimitiveArray(out, f2Name, fContour.fN, fContour.GetArray());
+         vectname = SavePrimitiveVector(out, f2Name, fContour.fN, fContour.GetArray());
       out << "   " << f2Name << "->SetContour(" << fContour.fN;
-      if (!arrname.IsNull())
-         out << ", " << arrname;
+      if (!vectname.IsNull())
+         out << ", " << vectname << ".data()";
       out << ");\n";
    }
 

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2147,9 +2147,9 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    TString args;
    if (fNpoints >= 1) {
-      TString xname = SavePrimitiveArray(out, "graph_x", fNpoints, fX, kTRUE);
-      TString yname = SavePrimitiveArray(out, "graph_y", fNpoints, fY);
-      args.Form("%d, %s, %s", fNpoints, xname.Data(), yname.Data());
+      TString xname = SavePrimitiveVector(out, "graph_x", fNpoints, fX, kTRUE);
+      TString yname = SavePrimitiveVector(out, "graph_y", fNpoints, fY);
+      args.Form("%d, %s.data(), %s.data()", fNpoints, xname.Data(), yname.Data());
    }
 
    SavePrimitiveConstructor(out, Class(), "graph", args, fNpoints < 1);

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1467,12 +1467,12 @@ Int_t TGraph2D::RemovePoint(Int_t ipoint)
 
 void TGraph2D::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   TString arrx = SavePrimitiveArray(out, "graph2d_x", fNpoints, fX, kTRUE);
-   TString arry = SavePrimitiveArray(out, "graph2d_y", fNpoints, fY);
-   TString arrz = SavePrimitiveArray(out, "graph2d_z", fNpoints, fZ);
+   TString arrx = SavePrimitiveVector(out, "graph2d_x", fNpoints, fX, kTRUE);
+   TString arry = SavePrimitiveVector(out, "graph2d_y", fNpoints, fY);
+   TString arrz = SavePrimitiveVector(out, "graph2d_z", fNpoints, fZ);
 
    SavePrimitiveConstructor(out, Class(), "graph2d",
-                            TString::Format("%d, %s, %s, %s", fNpoints, arrx.Data(), arry.Data(), arrz.Data()), kFALSE);
+                            TString::Format("%d, %s.data(), %s.data(), %s.data()", fNpoints, arrx.Data(), arry.Data(), arrz.Data()), kFALSE);
 
    if (strcmp(GetName(), "Graph2D"))
       out << "   graph2d->SetName(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");\n";

--- a/hist/hist/src/TGraph2DAsymmErrors.cxx
+++ b/hist/hist/src/TGraph2DAsymmErrors.cxx
@@ -579,21 +579,23 @@ void TGraph2DAsymmErrors::SetPoint(Int_t i, Double_t x, Double_t y, Double_t z)
 
 void TGraph2DAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   TString arrx = SavePrimitiveArray(out, "gr2daerr_x", fNpoints, fX, kTRUE);
-   TString arry = SavePrimitiveArray(out, "gr2daerr_y", fNpoints, fY);
-   TString arrz = SavePrimitiveArray(out, "gr2daerr_z", fNpoints, fZ);
-   TString arrexl = SavePrimitiveArray(out, "gr2daerr_exl", fNpoints, fEXlow);
-   TString arrexh = SavePrimitiveArray(out, "gr2daerr_exh", fNpoints, fEXhigh);
-   TString arreyl = SavePrimitiveArray(out, "gr2daerr_eyl", fNpoints, fEYlow);
-   TString arreyh = SavePrimitiveArray(out, "gr2daerr_eyh", fNpoints, fEYhigh);
-   TString arrezl = SavePrimitiveArray(out, "gr2daerr_ezl", fNpoints, fEZlow);
-   TString arrezh = SavePrimitiveArray(out, "gr2daerr_ezh", fNpoints, fEZhigh);
+   TString arrx = SavePrimitiveVector(out, "gr2daerr_x", fNpoints, fX, kTRUE);
+   TString arry = SavePrimitiveVector(out, "gr2daerr_y", fNpoints, fY);
+   TString arrz = SavePrimitiveVector(out, "gr2daerr_z", fNpoints, fZ);
+   TString arrexl = SavePrimitiveVector(out, "gr2daerr_exl", fNpoints, fEXlow);
+   TString arrexh = SavePrimitiveVector(out, "gr2daerr_exh", fNpoints, fEXhigh);
+   TString arreyl = SavePrimitiveVector(out, "gr2daerr_eyl", fNpoints, fEYlow);
+   TString arreyh = SavePrimitiveVector(out, "gr2daerr_eyh", fNpoints, fEYhigh);
+   TString arrezl = SavePrimitiveVector(out, "gr2daerr_ezl", fNpoints, fEZlow);
+   TString arrezh = SavePrimitiveVector(out, "gr2daerr_ezh", fNpoints, fEZhigh);
 
-   SavePrimitiveConstructor(out, Class(), "gr2daerr",
-                            TString::Format("%d, %s, %s, %s, %s, %s, %s, %s, %s, %s", fNpoints, arrx.Data(),
-                                            arry.Data(), arrz.Data(), arrexl.Data(), arrexh.Data(), arreyl.Data(),
-                                            arreyh.Data(), arrezl.Data(), arrezh.Data()),
-                            kFALSE);
+   SavePrimitiveConstructor(
+      out, Class(), "gr2daerr",
+      TString::Format(
+         "%d, %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data()",
+         fNpoints, arrx.Data(), arry.Data(), arrz.Data(), arrexl.Data(), arrexh.Data(), arreyl.Data(), arreyh.Data(),
+         arrezl.Data(), arrezh.Data()),
+      kFALSE);
 
    if (strcmp(GetName(), "Graph2D"))
       out << "   gr2daerr->SetName(\"" << TString(GetName()).ReplaceSpecialCppChars() << "\");\n";

--- a/hist/hist/src/TGraph2DErrors.cxx
+++ b/hist/hist/src/TGraph2DErrors.cxx
@@ -453,16 +453,17 @@ void TGraph2DErrors::SetPointError(Int_t i, Double_t ex, Double_t ey, Double_t e
 
 void TGraph2DErrors::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   TString arrx = SavePrimitiveArray(out, "gr2derr_x", fNpoints, fX, kTRUE);
-   TString arry = SavePrimitiveArray(out, "gr2derr_y", fNpoints, fY);
-   TString arrz = SavePrimitiveArray(out, "gr2derr_z", fNpoints, fZ);
-   TString arrex = SavePrimitiveArray(out, "gr2derr_ex", fNpoints, fEX);
-   TString arrey = SavePrimitiveArray(out, "gr2derr_ey", fNpoints, fEY);
-   TString arrez = SavePrimitiveArray(out, "gr2derr_ez", fNpoints, fEZ);
+   TString arrx = SavePrimitiveVector(out, "gr2derr_x", fNpoints, fX, kTRUE);
+   TString arry = SavePrimitiveVector(out, "gr2derr_y", fNpoints, fY);
+   TString arrz = SavePrimitiveVector(out, "gr2derr_z", fNpoints, fZ);
+   TString arrex = SavePrimitiveVector(out, "gr2derr_ex", fNpoints, fEX);
+   TString arrey = SavePrimitiveVector(out, "gr2derr_ey", fNpoints, fEY);
+   TString arrez = SavePrimitiveVector(out, "gr2derr_ez", fNpoints, fEZ);
 
    SavePrimitiveConstructor(out, Class(), "gr2derr",
-                            TString::Format("%d, %s, %s, %s, %s, %s, %s", fNpoints, arrx.Data(), arry.Data(),
-                                            arrz.Data(), arrex.Data(), arrey.Data(), arrez.Data()),
+                            TString::Format("%d, %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data()",
+                                            fNpoints, arrx.Data(), arry.Data(), arrz.Data(), arrex.Data(), arrey.Data(),
+                                            arrez.Data()),
                             kFALSE);
 
    if (strcmp(GetName(), "Graph2D"))

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1242,17 +1242,18 @@ void TGraphAsymmErrors::Print(Option_t *) const
 
 void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   auto xname  = SavePrimitiveArray(out, "grae_fx", fNpoints, fX, kTRUE);
-   auto yname  = SavePrimitiveArray(out, "grae_fy", fNpoints, fY);
-   auto exlname = SavePrimitiveArray(out, "grae_fexl", fNpoints, fEXlow);
-   auto exhname = SavePrimitiveArray(out, "grae_fexh", fNpoints, fEXhigh);
-   auto eylname = SavePrimitiveArray(out, "grae_feyl", fNpoints, fEYlow);
-   auto eyhname = SavePrimitiveArray(out, "grae_feyh", fNpoints, fEYhigh);
+   auto xname  = SavePrimitiveVector(out, "grae_fx", fNpoints, fX, kTRUE);
+   auto yname  = SavePrimitiveVector(out, "grae_fy", fNpoints, fY);
+   auto exlname = SavePrimitiveVector(out, "grae_fexl", fNpoints, fEXlow);
+   auto exhname = SavePrimitiveVector(out, "grae_fexh", fNpoints, fEXhigh);
+   auto eylname = SavePrimitiveVector(out, "grae_feyl", fNpoints, fEYlow);
+   auto eyhname = SavePrimitiveVector(out, "grae_feyh", fNpoints, fEYhigh);
 
-   SavePrimitiveConstructor(
-      out, Class(), "grae",
-      TString::Format("%d, %s, %s, %s, %s, %s, %s", fNpoints,
-         xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data()), kFALSE);
+   SavePrimitiveConstructor(out, Class(), "grae",
+                            TString::Format("%d, %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data()",
+                                            fNpoints, xname.Data(), yname.Data(), exlname.Data(), exhname.Data(),
+                                            eylname.Data(), eyhname.Data()),
+                            kFALSE);
 
    SaveHistogramAndFunctions(out, "grae", option);
 }

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -550,22 +550,24 @@ void TGraphBentErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   auto xname  = SavePrimitiveArray(out, "grbe_fx", fNpoints, fX, kTRUE);
-   auto yname  = SavePrimitiveArray(out, "grbe_fy", fNpoints, fY);
-   auto exlname = SavePrimitiveArray(out, "grbe_fexl", fNpoints, fEXlow);
-   auto exhname = SavePrimitiveArray(out, "grbe_fexh", fNpoints, fEXhigh);
-   auto eylname = SavePrimitiveArray(out, "grbe_feyl", fNpoints, fEYlow);
-   auto eyhname = SavePrimitiveArray(out, "grbe_feyh", fNpoints, fEYhigh);
-   auto exldname = SavePrimitiveArray(out, "grbe_fexld", fNpoints, fEXlowd);
-   auto exhdname = SavePrimitiveArray(out, "grbe_fexhd", fNpoints, fEXhighd);
-   auto eyldname = SavePrimitiveArray(out, "grbe_feyld", fNpoints, fEYlowd);
-   auto eyhdname = SavePrimitiveArray(out, "grbe_feyhd", fNpoints, fEYhighd);
+   auto xname  = SavePrimitiveVector(out, "grbe_fx", fNpoints, fX, kTRUE);
+   auto yname  = SavePrimitiveVector(out, "grbe_fy", fNpoints, fY);
+   auto exlname = SavePrimitiveVector(out, "grbe_fexl", fNpoints, fEXlow);
+   auto exhname = SavePrimitiveVector(out, "grbe_fexh", fNpoints, fEXhigh);
+   auto eylname = SavePrimitiveVector(out, "grbe_feyl", fNpoints, fEYlow);
+   auto eyhname = SavePrimitiveVector(out, "grbe_feyh", fNpoints, fEYhigh);
+   auto exldname = SavePrimitiveVector(out, "grbe_fexld", fNpoints, fEXlowd);
+   auto exhdname = SavePrimitiveVector(out, "grbe_fexhd", fNpoints, fEXhighd);
+   auto eyldname = SavePrimitiveVector(out, "grbe_feyld", fNpoints, fEYlowd);
+   auto eyhdname = SavePrimitiveVector(out, "grbe_feyhd", fNpoints, fEYhighd);
 
-   SavePrimitiveConstructor(
-      out, Class(), "grbe",
-      TString::Format("%d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s", fNpoints,
-         xname.Data(), yname.Data(), exlname.Data(), exhname.Data(), eylname.Data(), eyhname.Data(),
-         exldname.Data(), exhdname.Data(), eyldname.Data(), eyhdname.Data()), kFALSE);
+   SavePrimitiveConstructor(out, Class(), "grbe",
+                            TString::Format("%d, %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), %s.data(), "
+                                            "%s.data(), %s.data(), %s.data(), %s.data()",
+                                            fNpoints, xname.Data(), yname.Data(), exlname.Data(), exhname.Data(),
+                                            eylname.Data(), eyhname.Data(), exldname.Data(), exhdname.Data(),
+                                            eyldname.Data(), eyhdname.Data()),
+                            kFALSE);
 
    SaveHistogramAndFunctions(out, "grbe", option);
 }

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -721,14 +721,14 @@ void TGraphErrors::Print(Option_t *) const
 
 void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   auto xname  = SavePrimitiveArray(out, "gre_fx", fNpoints, fX, kTRUE);
-   auto yname  = SavePrimitiveArray(out, "gre_fy", fNpoints, fY);
-   auto exname = SavePrimitiveArray(out, "gre_fex", fNpoints, fEX);
-   auto eyname = SavePrimitiveArray(out, "gre_fey", fNpoints, fEY);
+   auto xname  = SavePrimitiveVector(out, "gre_fx", fNpoints, fX, kTRUE);
+   auto yname  = SavePrimitiveVector(out, "gre_fy", fNpoints, fY);
+   auto exname = SavePrimitiveVector(out, "gre_fex", fNpoints, fEX);
+   auto eyname = SavePrimitiveVector(out, "gre_fey", fNpoints, fEY);
 
    SavePrimitiveConstructor(
       out, Class(), "gre",
-      TString::Format("%d, %s, %s, %s, %s", fNpoints, xname.Data(), yname.Data(), exname.Data(), eyname.Data()), kFALSE);
+      TString::Format("%d, %s.data(), %s.data(), %s.data(), %s.data()", fNpoints, xname.Data(), yname.Data(), exname.Data(), eyname.Data()), kFALSE);
 
    SaveHistogramAndFunctions(out, "gre", option);
 }

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7283,17 +7283,17 @@ void TH1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // Check if the histogram has equidistant X bins or not.  If not, we
    // create an array holding the bins.
    if (GetXaxis()->GetXbins()->fN && GetXaxis()->GetXbins()->fArray)
-      sxaxis = SavePrimitiveArray(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
+      sxaxis = SavePrimitiveVector(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
    // If the histogram is 2 or 3 dimensional, check if the histogram
    // has equidistant Y bins or not.  If not, we create an array
    // holding the bins.
    if (fDimension > 1 && GetYaxis()->GetXbins()->fN && GetYaxis()->GetXbins()->fArray)
-      syaxis = SavePrimitiveArray(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
+      syaxis = SavePrimitiveVector(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
    // IF the histogram is 3 dimensional, check if the histogram
    // has equidistant Z bins or not.  If not, we create an array
    // holding the bins.
    if (fDimension > 2 && GetZaxis()->GetXbins()->fN && GetZaxis()->GetXbins()->fArray)
-      szaxis = SavePrimitiveArray(out, hname + "_z", GetZaxis()->GetXbins()->fN, GetZaxis()->GetXbins()->fArray);
+      szaxis = SavePrimitiveVector(out, hname + "_z", GetZaxis()->GetXbins()->fN, GetZaxis()->GetXbins()->fArray);
 
    const auto old_precision{out.precision()};
    constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
@@ -7302,20 +7302,20 @@ void TH1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins();
    if (!sxaxis.IsNull())
-      out << ", " << sxaxis;
+      out << ", " << sxaxis << ".data()";
    else
       out << ", " << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax();
    if (fDimension > 1) {
       out << ", " << GetYaxis()->GetNbins();
       if (!syaxis.IsNull())
-         out << ", " << syaxis;
+         out << ", " << syaxis << ".data()";
       else
          out << ", " << GetYaxis()->GetXmin() << ", " << GetYaxis()->GetXmax();
    }
    if (fDimension > 2) {
       out << ", " << GetZaxis()->GetNbins();
       if (!szaxis.IsNull())
-         out << ", " << szaxis;
+         out << ", " << szaxis << ".data()";
       else
          out << ", " << GetZaxis()->GetXmin() << ", " << GetZaxis()->GetXmax();
    }
@@ -7349,16 +7349,16 @@ void TH1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          }
    } else {
       if (numbins > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, content.data());
+         TString vectname = SavePrimitiveVector(out, hname, fNcells, content.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinContent(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vectname << "[bin])\n";
+         out << "         " << hname << "->SetBinContent(bin, " << vectname << "[bin]);\n";
       }
       if (numerrors > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, errors.data());
+         TString vectname = SavePrimitiveVector(out, hname, fNcells, errors.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinError(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vectname << "[bin])\n";
+         out << "         " << hname << "->SetBinError(bin, " << vectname << "[bin]);\n";
       }
    }
 
@@ -7395,16 +7395,16 @@ void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *opti
    // save contour levels
    Int_t ncontours = GetContour();
    if (ncontours > 0) {
-      TString arrname;
+      TString vectname;
       if (TestBit(kUserContour)) {
          std::vector<Double_t> levels(ncontours);
          for (Int_t bin = 0; bin < ncontours; bin++)
             levels[bin] = GetContourLevel(bin);
-         arrname = SavePrimitiveArray(out, hname, ncontours, levels.data());
+         vectname = SavePrimitiveVector(out, hname, ncontours, levels.data());
       }
       out << "   " << hname << "->SetContour(" << ncontours;
-      if (!arrname.IsNull())
-         out << ", " << arrname;
+      if (!vectname.IsNull())
+         out << ", " << vectname << ".data()";
       out << ");\n";
    }
 

--- a/hist/hist/src/TH1K.cxx
+++ b/hist/hist/src/TH1K.cxx
@@ -162,9 +162,9 @@ void TH1K::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       for (int i = 0; i < fNIn; i++)
          content[i] = fArray[i];
 
-      TString arrname = SavePrimitiveArray(out, hname, fNIn, content.data());
+      TString vectname = SavePrimitiveVector(out, hname, fNIn, content.data());
       out << "   for(Int_t i = 0; i < " << fNIn << "; i++)\n";
-      out << "      " << hname << "->Fill(" << arrname << "[i]);\n";
+      out << "      " << hname << "->Fill(" << vectname << "[i]);\n";
    }
 
    TH1::SavePrimitiveHelp(out, hname, option);

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -303,9 +303,9 @@ void TPolyMarker::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    TString args;
    if (Size() > 0) {
-      TString arrxname = SavePrimitiveArray(out, "pmarker", Size(), fX, kTRUE);
-      TString arryname = SavePrimitiveArray(out, "pmarker", Size(), fY);
-      args.Form("%d, %s, %s, \"", Size(), arrxname.Data(), arryname.Data());
+      TString arrxname = SavePrimitiveVector(out, "pmarker", Size(), fX, kTRUE);
+      TString arryname = SavePrimitiveVector(out, "pmarker", Size(), fY);
+      args.Form("%d, %s.data(), %s.data(), \"", Size(), arrxname.Data(), arryname.Data());
    } else
       args = "0, \"";
    args.Append(TString(fOption).ReplaceSpecialCppChars() + "\"");

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -1622,12 +1622,12 @@ void TProfile::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // Check if the profile has equidistant X bins or not.  If not, we
    // create an array holding the bins.
    if (GetXaxis()->GetXbins()->fN && GetXaxis()->GetXbins()->fArray)
-      sxaxis = SavePrimitiveArray(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
+      sxaxis = SavePrimitiveVector(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
 
    out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins() << ", ";
    if (!sxaxis.IsNull())
-      out << sxaxis;
+      out << sxaxis << ".data()";
    else
       out << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax();
    out << ", \"" << TString(GetErrorOption()).ReplaceSpecialCppChars() << "\");\n";
@@ -1667,22 +1667,22 @@ void TProfile::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          }
    } else {
       if (numentries > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, entries.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, entries.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinEntries(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinEntries(bin, " << vect << "[bin]);\n";
       }
       if (numcontent > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, content.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, content.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinContent(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinContent(bin, " << vect << "[bin]);\n";
       }
       if (numerrors > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, errors.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, errors.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinError(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinError(bin, " << vect << "[bin]);\n";
       }
    }
 

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -1860,23 +1860,23 @@ void TProfile2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // Check if the profile has equidistant X bins or not.  If not, we
    // create an array holding the bins.
    if (GetXaxis()->GetXbins()->fN && GetXaxis()->GetXbins()->fArray)
-      sxaxis = SavePrimitiveArray(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
+      sxaxis = SavePrimitiveVector(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
 
    // Check if the profile has equidistant y bins or not.  If not, we
    // create an array holding the bins.
    if (GetYaxis()->GetXbins()->fN && GetYaxis()->GetXbins()->fArray)
-      syaxis = SavePrimitiveArray(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
+      syaxis = SavePrimitiveVector(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
 
    out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins() << ", ";
    if (!sxaxis.IsNull())
-      out << sxaxis;
+      out << sxaxis << ".data()";
    else
       out << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax();
 
    out << ", " << GetYaxis()->GetNbins() << ", ";
    if (!syaxis.IsNull())
-      out << syaxis;
+      out << syaxis << ".data()";
    else
       out << GetYaxis()->GetXmin() << ", " << GetYaxis()->GetXmax();
 
@@ -1920,22 +1920,22 @@ void TProfile2D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          }
    } else {
       if (numentries > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, entries.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, entries.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinEntries(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinEntries(bin, " << vect << "[bin]);\n";
       }
       if (numcontent > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, content.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, content.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinContent(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinContent(bin, " << vect << "[bin]);\n";
       }
       if (numerrors > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, errors.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, errors.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinError(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinError(bin, " << vect << "[bin]);\n";
       }
    }
 

--- a/hist/hist/src/TProfile3D.cxx
+++ b/hist/hist/src/TProfile3D.cxx
@@ -1227,27 +1227,27 @@ void TProfile3D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    // Check if custom X/Y/Z axes are configured.
    if (GetXaxis()->GetXbins()->fN && GetXaxis()->GetXbins()->fArray && GetYaxis()->GetXbins()->fN &&
        GetYaxis()->GetXbins()->fArray && GetZaxis()->GetXbins()->fN && GetZaxis()->GetXbins()->fArray) {
-      sxaxis = SavePrimitiveArray(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
-      syaxis = SavePrimitiveArray(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
-      szaxis = SavePrimitiveArray(out, hname + "_z", GetZaxis()->GetXbins()->fN, GetZaxis()->GetXbins()->fArray);
+      sxaxis = SavePrimitiveVector(out, hname + "_x", GetXaxis()->GetXbins()->fN, GetXaxis()->GetXbins()->fArray);
+      syaxis = SavePrimitiveVector(out, hname + "_y", GetYaxis()->GetXbins()->fN, GetYaxis()->GetXbins()->fArray);
+      szaxis = SavePrimitiveVector(out, hname + "_z", GetZaxis()->GetXbins()->fN, GetZaxis()->GetXbins()->fArray);
    }
 
    out << "   " << ClassName() << " *" << hname << " = new " << ClassName() << "(\"" << hname << "\", \""
        << TString(GetTitle()).ReplaceSpecialCppChars() << "\", " << GetXaxis()->GetNbins() << ", ";
    if (!sxaxis.IsNull())
-      out << sxaxis;
+      out << sxaxis << ".data()";
    else
       out << GetXaxis()->GetXmin() << ", " << GetXaxis()->GetXmax();
 
    out << ", " << GetYaxis()->GetNbins() << ", ";
    if (!syaxis.IsNull())
-      out << syaxis;
+      out << syaxis << ".data()";
    else
       out << GetYaxis()->GetXmin() << ", " << GetYaxis()->GetXmax();
 
    out << ", " << GetZaxis()->GetNbins() << ", ";
    if (!szaxis.IsNull())
-      out << szaxis;
+      out << szaxis << ".data()";
    else
       out << GetZaxis()->GetXmin() << ", " << GetZaxis()->GetXmax();
 
@@ -1288,22 +1288,22 @@ void TProfile3D::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          }
    } else {
       if (numentries > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, entries.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, entries.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinEntries(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinEntries(bin, " << vect << "[bin]);\n";
       }
       if (numcontent > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, content.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, content.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinContent(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinContent(bin, " << vect << "[bin]);\n";
       }
       if (numerrors > 0) {
-         TString arr = SavePrimitiveArray(out, hname, fNcells, errors.data());
+         TString vect = SavePrimitiveVector(out, hname, fNcells, errors.data());
          out << "   for (Int_t bin = 0; bin < " << fNcells << "; bin++)\n";
-         out << "      if (" << arr << "[bin])\n";
-         out << "         " << hname << "->SetBinError(bin, " << arr << "[bin]);\n";
+         out << "      if (" << vect << "[bin])\n";
+         out << "         " << hname << "->SetBinError(bin, " << vect << "[bin]);\n";
       }
    }
 

--- a/hist/hist/src/TScatter.cxx
+++ b/hist/hist/src/TScatter.cxx
@@ -258,15 +258,15 @@ void TScatter::SetMargin(Double_t margin)
 
 void TScatter::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   TString arr_x = SavePrimitiveArray(out, "scat_x", fNpoints, fGraph->GetX(), kTRUE);
-   TString arr_y = SavePrimitiveArray(out, "scat_y", fNpoints, fGraph->GetY());
-   TString arr_col = SavePrimitiveArray(out, "scat_col", fNpoints, fColor);
-   TString arr_size = SavePrimitiveArray(out, "scat_size", fNpoints, fSize);
+   TString arr_x = SavePrimitiveVector(out, "scat_x", fNpoints, fGraph->GetX(), kTRUE);
+   TString arr_y = SavePrimitiveVector(out, "scat_y", fNpoints, fGraph->GetY());
+   TString arr_col = SavePrimitiveVector(out, "scat_col", fNpoints, fColor);
+   TString arr_size = SavePrimitiveVector(out, "scat_size", fNpoints, fSize);
 
-   SavePrimitiveConstructor(
-      out, Class(), "scat",
-      TString::Format("%d, %s, %s, %s, %s", fNpoints, arr_x.Data(), arr_y.Data(), arr_col.Data(), arr_size.Data()),
-      kFALSE);
+   SavePrimitiveConstructor(out, Class(), "scat",
+                            TString::Format("%d, %s.data(), %s.data(), %s.data(), %s.data()", fNpoints, arr_x.Data(),
+                                            arr_y.Data(), arr_col.Data(), arr_size.Data()),
+                            kFALSE);
 
    SavePrimitiveNameTitle(out, "scat");
    SaveFillAttributes(out, "scat", 0, 1001);


### PR DESCRIPTION
Plain array is allocated in stack and therefore depending on platform maximal array size is limited.
Therefore instead of storing array store vector like:
```
   std::vector<Double_t> hp0__1_vect0{
      1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0
   };
```
Adjust all places where array was used and remove `SavePrimitiveArray` - it was introduced several weeks ago and was never released.

