### PR TITLE
[RFHS3] Remove mention of RapidYML backend, which is not supported.

### DIFF
--- a/roofit/doc/developers/roofit_hs3.md
+++ b/roofit/doc/developers/roofit_hs3.md
@@ -5,7 +5,7 @@
 \brief Guide on how to add JSON IO for you RooFit classes.
 
 ## RooFitHS3 Library
-_Contains facilities to serialize and deserialize RooWorkspaces to and from JSON and YML._
+_Contains facilities to serialize and deserialize RooWorkspaces to and from JSON._
 #### Note: This library is still at an experimental stage.
 
 ### Purpose
@@ -14,21 +14,20 @@ When using `RooFit`, statistical models can be conveniently handled and
 stored as a `RooWorkspace`. However, for the sake of interoperability
 with other statistical frameworks, and also ease of manipulation, it
 may be useful to store statistical models in text form. This library
-sets out to achieve exactly that, exporting to and importing from JSON
-and YML.
+sets out to achieve exactly that, exporting to and importing from JSON.
 
 ### Backend
 
 The default backend for this is the `nlohmann` JSON implementation,
 which ships with ROOT as a builtin dependency and will import from and
-export to JSON. Alternatively, the RapidYAML (`RYML`) implementation
-can be used to also import from and export to YML. This implementation
-can be selected at compile time with the `cmake` flag
-`roofit_hs3_ryml`.
+export to JSON.
+In the past, RapidYAML (`RYML`) was supported, but the effort to keep
+this implementation up to date was too high. YML users could use YML to
+JSON converters to migrate.
 
 ### Usage
 
-The main class providing import from and export to JSON and YML is the
+The main class providing import from and export to JSON is the
 RooJSONFactoryWSTool.
 
 ### Open-world philosophy
@@ -41,7 +40,7 @@ number of different pre-implemented functions and pdfs. What is more,
 you can easily create your own `RooFit` function by inheriting from
 `RooAbsReal` or your own `RooFit` pdf by inheriting from
 `RooAbsPdf`. This means that feature-complete serialization and
-deserialization to and from JSON and YML will probably never be fully
+deserialization to and from JSON will probably never be fully
 achieved. However, this may not impede your usage of this library, as
 it was written in such a way as to allow users (that is, people like
 you) to easily add missing importers and exporters for existing

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -49,7 +49,7 @@ with other statistical frameworks, and also ease of manipulation, it
 may be useful to store statistical models in text form.
 
 The RooJSONFactoryWSTool is a helper class to achieve exactly this,
-exporting to and importing from JSON and YML.
+exporting to and importing from JSON.
 
 In order to import a workspace from a JSON file, you can do
 
@@ -86,11 +86,6 @@ tool.exportJSON("myjson.json");
 ~~~
 
 For more details, consult the tutorial <a href="rf515__hfJSON_8py.html">rf515_hfJSON</a>.
-
-In order to import and export YML files, `ROOT` needs to be compiled
-with the external dependency <a
-href="https://github.com/biojppm/rapidyaml">RapidYAML</a>, which needs
-to be installed on your system when building `ROOT`.
 
 The RooJSONFactoryWSTool only knows about a limited set of classes for
 import and export. If import or export of a class you're interested in

--- a/roofit/jsoninterface/CMakeLists.txt
+++ b/roofit/jsoninterface/CMakeLists.txt
@@ -9,43 +9,17 @@
 # @author Jonas Rembser, CERN
 ############################################################################
 
-# If RapidYAML can be found on the system, we will also compile the RapidYAML backend besides the
-# nlohmann-json backend. Like this we can also convert to yaml.
-
-# The RapidYAML backend is always disabled because it doesn't work anymore for
-# RooFitHS3. The nlohmann_json interface is always used and works well, hence
-# rapidyaml was not tested anymore. The relevant code is still left in the
-# CMakeLists.txt in case someone wants to revive the RapilYAML backend.
-
-# message(STATUS "Looking for RapidYAML (used by RooFit)")
-# find_package(ryml)
-
-if(${RYML_FOUND})
-  message(STATUS "RapidYAML found, compiling also RooFit JSON Interface with RapidYAML parser")
-  set(ParserSources src/JSONParser.cxx src/RYMLParser.cxx)
-  add_compile_definitions(ROOFIT_WITH_RYML)
-else()
-  set(ParserSources src/JSONParser.cxx)
-  message(STATUS "RapidYAML not found, only compiling RooFit with nlohmann-json parser")
-endif()
-
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitJSONInterface
   HEADERS
     RooFit/Detail/JSONInterface.h
   SOURCES
     src/JSONInterface.cxx
-    ${ParserSources}
+    src/JSONParser.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   LIBRARIES
     Core
 )
-
-if(${RYML_FOUND})
-  target_include_directories(RooFitJSONInterface PRIVATE ${RYML_INCLUDE_DIRS})
-  target_link_libraries(RooFitJSONInterface PRIVATE -lc4core -lryml)
-  target_link_directories(RooFitJSONInterface PRIVATE ${RYML_LIB_DIR})
-endif()
 
 if(builtin_nlohmannjson)
   target_include_directories(RooFitJSONInterface PRIVATE ${CMAKE_SOURCE_DIR}/builtins)

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -75,8 +75,7 @@ std::unique_ptr<JSONTree> JSONTree::createImpl(Args &&...args)
 #ifdef ROOFIT_WITH_RYML
       return std::make_unique<TRYMLTree>(std::forward<Args>(args)...);
 #else
-      throw std::runtime_error(
-         "Requesting JSON tree with rapidyaml backend, but rapidyaml could not be found by ROOT when it was compiled.");
+      throw std::runtime_error("Requesting JSON tree with rapidyaml backend, which is currently unsupported.");
 #endif
    }
    return std::make_unique<TJSONTree>(std::forward<Args>(args)...);


### PR DESCRIPTION
Due to lack of time, only one RooFit backend can be supported. On CMake configure, it, however, looked like RapidYML should be found. Here, the corresponding YML messages and mentions throughout the documentation are removed.
If the backend should be revived, this commit can be reverted.

Fix #18128.

