### PR TITLE
No constraints to torch version in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ onnx
 # TMVA: PyMVA interfaces
 scikit-learn
 tensorflow<2.16 ; python_version < "3.12"
-torch<2.5 ; python_version < "3.13" # no torch version that fullfills version constraint available for Python 3.13
+torch
 xgboost
 
 # PyROOT: ROOT.Numba.Declare decorator


### PR DESCRIPTION
Now that https://github.com/pytorch/pytorch/issues/138333 is fixed, commit 24fd0d89b4e5c750e can be reverted.