### PR TITLE
[Python] Fix RDF Pythonization tests with `builtin_llvm=OFF`

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
@@ -1,6 +1,12 @@
 import unittest
-import ROOT
+
+import numba  # noqa: F401
 import numpy as np
+import ROOT
+
+# numba is not used directly, but tests can crash when ROOT is built with
+# builtin_llvm=OFF and numba is not imported at the beginning
+
 
 class PyDefine(unittest.TestCase):
     """

--- a/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 from rdf_filter_pyz_helper import CreateData, TYPE_TO_SYMBOL, filter_dict
 
+
 class PyFilter(unittest.TestCase):
     """
     Testing Pythonized Filters of RDF
@@ -12,16 +13,17 @@ class PyFilter(unittest.TestCase):
 
     def test_with_dtypes(self):
         """
-        Tests the pythonized filter with all the tree datatypes and 
+        Tests the pythonized filter with all the tree datatypes and
         """
         CreateData()
         rdf = ROOT.RDataFrame("TestData", "./RDF_Filter_Pyz_TestData.root")
-        test_cols =[str(c) for c in rdf.GetColumnNames()]
+        test_cols = [str(c) for c in rdf.GetColumnNames()]
         for col_name in test_cols:
-            func = filter_dict[TYPE_TO_SYMBOL[col_name]] # filter function
+            func = filter_dict[TYPE_TO_SYMBOL[col_name]]  # filter function
             x = rdf.Mean(col_name).GetValue()
-            if col_name == 'Bool_t': x = True
-            filtered = rdf.Filter(func, extra_args = {'x':x})
+            if col_name == "Bool_t":
+                x = True
+            filtered = rdf.Filter(func, extra_args={"x": x})
             res_root = filtered.AsNumpy()[col_name]
             if not isinstance(x, bool):
                 filtered2 = rdf.Filter(f"{col_name} > {x}")
@@ -31,19 +33,21 @@ class PyFilter(unittest.TestCase):
                 else:
                     filtered2 = rdf.Filter(f"{col_name} == false")
             res_root2 = filtered2.AsNumpy()[col_name]
-            self.assertTrue(np.array_equal(res_root,res_root2))
+            self.assertTrue(np.array_equal(res_root, res_root2))
 
         os.remove("./RDF_Filter_Pyz_TestData.root")
 
-    # CPP Overload 1: Filter(callable, col_list = [], name = "") => 3 Possibilities 
+    # CPP Overload 1: Filter(callable, col_list = [], name = "") => 3 Possibilities
     def test_filter_overload1_a(self):
         """
         Test to verify the first overload (1.a) of filter
         Filter(callable, col_list, name)
         """
         rdf = ROOT.RDataFrame(5).Define("x", "(double) rdfentry_")
+
         def x_greater_than_2(x):
-            return x>2
+            return x > 2
+
         fil1 = rdf.Filter(x_greater_than_2, ["x"], "x is more than 2")
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
 
@@ -53,20 +57,22 @@ class PyFilter(unittest.TestCase):
         Filter(callable, col_list)
         """
         rdf = ROOT.RDataFrame(5).Define("x", "(double) rdfentry_")
-        fil1 = rdf.Filter(lambda x: x>2, ["x"])
+        fil1 = rdf.Filter(lambda x: x > 2, ["x"])
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
-    
+
     def test_filter_overload1_c(self):
         """
         Test to verify the first overload (1.c) of filter
         Filter(callable)
         """
         rdf = ROOT.RDataFrame(5).Define("x", "(double) rdfentry_")
+
         def x_greater_than_2(x):
-            return x>2
+            return x > 2
+
         fil1 = rdf.Filter(x_greater_than_2)
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
-    
+
     # CPP Overload 3: Filter(callable, name)
     def test_filter_overload3(self):
         """
@@ -74,16 +80,20 @@ class PyFilter(unittest.TestCase):
         Filter(callable, name)
         """
         rdf = ROOT.RDataFrame(5).Define("x", "(double) rdfentry_")
+
         def x_greater_than_2(x):
-            return x>2
+            return x > 2
+
         fil1 = rdf.Filter(x_greater_than_2, "x is greater than 2")
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
-    
+
     def test_capture_from_scope(self):
         rdf = ROOT.RDataFrame(5).Define("x", "(double) rdfentry_")
         y = 2
+
         def x_greater_than_y(x):
             return x > y
+
         fil1 = rdf.Filter(x_greater_than_y, "x is greater than 2")
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
 
@@ -93,12 +103,14 @@ class PyFilter(unittest.TestCase):
         Filter operation.
         """
 
-        ROOT.gInterpreter.Declare("""
+        ROOT.gInterpreter.Declare(
+            """
         struct MyFunctor
         {
             bool operator()(ULong64_t l) { return l == 0; };
         };
-        """)
+        """
+        )
         f = ROOT.MyFunctor()
 
         rdf = ROOT.RDataFrame(5)
@@ -112,15 +124,17 @@ class PyFilter(unittest.TestCase):
         Filter operation.
         """
 
-        ROOT.gInterpreter.Declare("""
+        ROOT.gInterpreter.Declare(
+            """
         std::function<bool(ULong64_t)> myfun = [](ULong64_t l) { return l == 0; };
-        """)
+        """
+        )
 
         rdf = ROOT.RDataFrame(5)
         c = rdf.Filter(ROOT.myfun, ["rdfentry_"]).Count().GetValue()
 
         self.assertEqual(c, 1)
 
-    
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
@@ -1,9 +1,13 @@
-import unittest
-import ROOT
-import numpy as np
-
 import os
-from rdf_filter_pyz_helper import CreateData, TYPE_TO_SYMBOL, filter_dict
+import unittest
+
+import numba  # noqa: F401
+import numpy as np
+import ROOT
+from rdf_filter_pyz_helper import TYPE_TO_SYMBOL, CreateData, filter_dict
+
+# numba is not used directly, but tests can crash when ROOT is built with
+# builtin_llvm=OFF and numba is not imported at the beginning
 
 
 class PyFilter(unittest.TestCase):


### PR DESCRIPTION
On my machine, the RDF pythonization tests don't run when I build ROOT with `builtin_llvm=OFF`. There is a crash unless I do `import numba` in the beginning.

I guess it's not a priority to understand the underlying problem because not many people build ROOT like this and the workaround is easy, but at least the tests should be green.

We do the same "magically ordered imports" also in other Python tests where ROOT doesn't work together with xgboost because of `std::regexp` symbol clashes, unless you do the import in a certain order:

https://github.com/root-project/root/pull/15183
