### PR TITLE
[hist] allow specifying the floating point precision in GetExpFormula

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -247,7 +247,7 @@ public:
 #ifdef R__HAS_VECCORE
    ROOT::Double_v EvalParVec(const ROOT::Double_v *x, const Double_t *params = nullptr) const;
 #endif
-   TString        GetExpFormula(Option_t *option="") const;
+   TString        GetExpFormula(Option_t *option = "", const char *fl_format = "%g") const;
    TString        GetGradientFormula() const;
    TString        GetHessianFormula() const;
    TString        GetUniqueFuncName() const {

--- a/hist/hist/inc/v5/TFormula.h
+++ b/hist/hist/inc/v5/TFormula.h
@@ -237,7 +237,7 @@ public:
    virtual Int_t       GetNdim() const {return fNdim;}
    virtual Int_t       GetNpar() const {return fNpar;}
    virtual Int_t       GetNumber() const {return fNumber;}
-   virtual TString     GetExpFormula(Option_t *option="") const;
+   virtual TString     GetExpFormula(Option_t *option = "", const char *fl_format = "%g") const;
    Double_t            GetParameter(Int_t ipar) const;
    Double_t            GetParameter(const char *name) const;
    virtual Double_t   *GetParameters() const {return fParams;}

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -3599,8 +3599,12 @@ void TFormula::ReInitializeEvalMethod() {
 ///  - If option = "P" replace the parameter names with their values
 ///  - If option = "CLING" return the actual expression used to build the function  passed to cling
 ///  - If option = "CLINGP" replace in the CLING expression the parameter with their values
+///  @param fl_format specifies the printf floating point precision when option
+///  contains "p". Default is `%g` (6 decimals). If you need more precision,
+///  change e.g. to `%.9f`, or `%a` for a lossless representation. 
+///  @see https://cplusplus.com/reference/cstdio/printf/
 
-TString TFormula::GetExpFormula(Option_t *option) const
+TString TFormula::GetExpFormula(Option_t *option, const char *fl_format) const
 {
    TString opt(option);
    if (opt.IsNull() || TestBit(TFormula::kLambda) ) return fFormula;
@@ -3636,7 +3640,7 @@ TString TFormula::GetExpFormula(Option_t *option) const
             TString parNumbName = clingFormula(i+2,j-i-2);
             int parNumber = parNumbName.Atoi();
             assert(parNumber < fNpar);
-            TString replacement = TString::Format("%f",GetParameter(parNumber));
+            TString replacement = TString::Format(fl_format,GetParameter(parNumber));
             clingFormula.Replace(i,j-i+1, replacement );
             i += replacement.Length();
          }
@@ -3658,7 +3662,7 @@ TString TFormula::GetExpFormula(Option_t *option) const
                return expFormula;
             }
             TString parName = expFormula(i+1,j-i-1);
-            TString replacement = TString::Format("%g",GetParameter(parName));
+            TString replacement = TString::Format(fl_format, GetParameter(parName));
             expFormula.Replace(i,j-i+1, replacement );
             i += replacement.Length();
          }

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -3601,7 +3601,7 @@ void TFormula::ReInitializeEvalMethod() {
 ///  - If option = "CLINGP" replace in the CLING expression the parameter with their values
 ///  @param fl_format specifies the printf floating point precision when option
 ///  contains "p". Default is `%g` (6 decimals). If you need more precision,
-///  change e.g. to `%.9f`, or `%a` for a lossless representation. 
+///  change e.g. to `%.9f`, or `%a` for a lossless representation.
 ///  @see https://cplusplus.com/reference/cstdio/printf/
 
 TString TFormula::GetExpFormula(Option_t *option, const char *fl_format) const
@@ -3640,7 +3640,7 @@ TString TFormula::GetExpFormula(Option_t *option, const char *fl_format) const
             TString parNumbName = clingFormula(i+2,j-i-2);
             int parNumber = parNumbName.Atoi();
             assert(parNumber < fNpar);
-            TString replacement = TString::Format(fl_format,GetParameter(parNumber));
+            TString replacement = TString::Format(fl_format, GetParameter(parNumber));
             clingFormula.Replace(i,j-i+1, replacement );
             i += replacement.Length();
          }

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -3018,8 +3018,12 @@ Double_t TFormula::EvalParOld(const Double_t *x, const Double_t *uparams)
 ///  if expression in formula is: "[0]*(x>-[1])+[2]*exp(-[3]*x)"
 ///  and parameters are 3.25,-4.01,4.44,-0.04, GetExpFormula("p") will return:
 ///   "(3.25*(x>+4.01))+(4.44*exp(+0.04*x))"
+///  @param fl_format specifies the printf floating point precision when option
+///  contains "p". Default is `%g` (6 decimals). If you need more precision,
+///  change e.g. to `%.9f`, or `%a` for a lossless representation. 
+///  @see https://cplusplus.com/reference/cstdio/printf/
 
-TString TFormula::GetExpFormula(Option_t *option) const
+TString TFormula::GetExpFormula(Option_t *option, const char *fl_format) const
 {
    if (fNoper>0) {
       TString* tab=new TString[fNoper];
@@ -3193,7 +3197,7 @@ TString TFormula::GetExpFormula(Option_t *option) const
          char pbv[100];
          for (j=0;j<fNpar;j++) {
             snprintf(pb,sizeof(pb),"[%d]",j);
-            snprintf(pbv,100,"%g",fParams[j]);
+            snprintf(pbv, 100, fl_format, fParams[j]);
             ret.ReplaceAll(pb,pbv);
          }
          ret.ReplaceAll("--","+");

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -3020,7 +3020,7 @@ Double_t TFormula::EvalParOld(const Double_t *x, const Double_t *uparams)
 ///   "(3.25*(x>+4.01))+(4.44*exp(+0.04*x))"
 ///  @param fl_format specifies the printf floating point precision when option
 ///  contains "p". Default is `%g` (6 decimals). If you need more precision,
-///  change e.g. to `%.9f`, or `%a` for a lossless representation. 
+///  change e.g. to `%.9f`, or `%a` for a lossless representation.
 ///  @see https://cplusplus.com/reference/cstdio/printf/
 
 TString TFormula::GetExpFormula(Option_t *option, const char *fl_format) const

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -308,7 +308,7 @@ bool test16()  {
    // test GetExpFormula
    TFormula f("f","[2] + [0]*x + [1]*x*x");
    f.SetParameters(1,2,3);
-   return (f.GetExpFormula("CLING P") == TString("3.000000+1.000000*x[0]+2.000000*x[0]*x[0] ") );
+   return (f.GetExpFormula("CLING P", "%f") == TString("3.000000+1.000000*x[0]+2.000000*x[0]*x[0] ") );
 }
 
 bool test17() {

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -308,7 +308,7 @@ bool test16()  {
    // test GetExpFormula
    TFormula f("f","[2] + [0]*x + [1]*x*x");
    f.SetParameters(1,2,3);
-   return (f.GetExpFormula("CLING P", "%f") == TString("3.000000+1.000000*x[0]+2.000000*x[0]*x[0] ") );
+   return (f.GetExpFormula("CLING P", "%f") == TString("3.000000+1.000000*x[0]+2.000000*x[0]*x[0] "));
 }
 
 bool test17() {

--- a/tree/tree/test/TTreeRegressions.cxx
+++ b/tree/tree/test/TTreeRegressions.cxx
@@ -222,4 +222,3 @@ TEST(TTreeRegressions, PrintTopOnlySplit)
                     "branch: ev                           0\n";
    EXPECT_EQ(output, ref);
 }
-

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -646,12 +646,12 @@ Int_t TTreeFormula::RegisterDimensions(Int_t code, TLeaf *leaf) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// This method check for treat the case where expression contains $Atl and load up
-/// both fAliases and fExpr.
+/// This method check for treat the case where expression contains `Alt$(`
+/// and load up both fAliases and fExpr. It also checks for `MinIf$(` and `MaxIf$(`
 /// We return:
 /// -  -1 in case of failure
-/// -  0 in case we did not find $Alt
-/// -  the action number in case of success.
+/// -  0 in case we did not find any of `Alt$(`, `MinIf$(`, or `MaxIf$(`
+/// -  the action number in case of success. (kAlternate, kMinIf or kMaxIf)
 
 Int_t TTreeFormula::DefineAlternate(const char *expression)
 {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/10769

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)
