### PR TITLE
[ntuple] Use `std::string_view` instead of `const std::string &` in parameter types

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -96,7 +96,7 @@ public:
       daos_oclass_id_t fCid;
 
       ObjClassId(daos_oclass_id_t cid) : fCid(cid) {}
-      ObjClassId(const std::string &name) : fCid(daos_oclass_name2id(name.data())) {}
+      ObjClassId(std::string_view name) : fCid(daos_oclass_name2id(name.data())) {}
 
       bool IsUnknown() const { return fCid == OC_UNKNOWN; }
       std::string ToString() const;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -164,7 +164,7 @@ private:
    ROOT::DescriptorId_t
    LookupMember(const ROOT::RNTupleDescriptor &desc, std::string_view memberName, ROOT::DescriptorId_t classFieldId);
    /// Sets fStagingClass according to the given name and version
-   void SetStagingClass(const std::string &className, unsigned int classVersion);
+   void SetStagingClass(const std::string_view className, unsigned int classVersion);
    /// If there are rules with inputs (source members), create the staging area according to the TClass instance
    /// that corresponds to the on-disk field.
    void PrepareStagingArea(const std::vector<const TSchemaRule *> &rules, const ROOT::RNTupleDescriptor &desc,

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -60,7 +60,7 @@ void CallConnectPageSinkOnField(RFieldBase &, ROOT::Experimental::Internal::RPag
                                 ROOT::NTupleSize_t firstEntry = 0);
 void CallConnectPageSourceOnField(RFieldBase &, ROOT::Experimental::Internal::RPageSource &);
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
+CallFieldBaseCreate(std::string_view fieldName, std::string_view typeName, const ROOT::RCreateFieldOptions &options,
                     const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 } // namespace Internal
@@ -91,7 +91,7 @@ class RFieldBase {
    Internal::CallConnectPageSinkOnField(RFieldBase &, ROOT::Experimental::Internal::RPageSink &, ROOT::NTupleSize_t);
    friend void Internal::CallConnectPageSourceOnField(RFieldBase &, ROOT::Experimental::Internal::RPageSource &);
    friend ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-   Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
+   Internal::CallFieldBaseCreate(std::string_view fieldName, std::string_view typeName,
                                  const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
                                  ROOT::DescriptorId_t fieldId);
 
@@ -499,7 +499,7 @@ protected:
    /// normalized type name and type alias.
    /// `desc` and `fieldId` must be passed if `options.fEmulateUnknownTypes` is true, otherwise they can be left blank.
    static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
+   Create(std::string_view fieldName, std::string_view typeName, const ROOT::RCreateFieldOptions &options,
           const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 public:
@@ -538,12 +538,11 @@ public:
    /// Factory method to create a field from a certain type given as string.
    /// Note that the provided type name must be a valid C++ type name. Template arguments of templated types
    /// must be type names or integers (e.g., no expressions).
-   static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName);
+   static RResult<std::unique_ptr<RFieldBase>> Create(std::string_view fieldName, std::string_view typeName);
 
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing subfield (subtype).
-   static std::vector<RCheckResult> Check(const std::string &fieldName, const std::string &typeName);
+   static std::vector<RCheckResult> Check(std::string_view fieldName, std::string_view typeName);
 
    /// Generates an object of the field type and allocates new initialized memory according to the type.
    /// Implemented at the end of this header because the implementation is using RField<T>::TypeName()

--- a/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldUtils.hxx
@@ -22,24 +22,24 @@ namespace Internal {
 /// Applies RNTuple specific type name normalization rules (see specs) that help the string parsing in
 /// RFieldBase::Create(). The normalization of templated types does not include full normalization of the
 /// template arguments (hence "Prefix").
-std::string GetCanonicalTypePrefix(const std::string &typeName);
+std::string GetCanonicalTypePrefix(std::string_view typeName);
 
 /// Given a type name normalized by ROOT meta, renormalize it for RNTuple. E.g., insert std::prefix.
-std::string GetRenormalizedTypeName(const std::string &metaNormalizedName);
+std::string GetRenormalizedTypeName(std::string_view metaNormalizedName);
 
 /// Given a type info ask ROOT meta to demangle it, then renormalize the resulting type name for RNTuple. Useful to
 /// ensure that e.g. fundamental types are normalized to the type used by RNTuple (e.g. int -> std::int32_t).
 std::string GetRenormalizedDemangledTypeName(const std::type_info &ti);
 
 /// Applies all RNTuple type normalization rules except typedef resolution.
-std::string GetNormalizedUnresolvedTypeName(const std::string &origName);
+std::string GetNormalizedUnresolvedTypeName(std::string_view origName);
 
 /// Appends 'll' or 'ull' to the where necessary and strips the suffix if not needed.
-std::string GetNormalizedInteger(const std::string &intTemplateArg);
+std::string GetNormalizedInteger(std::string_view intTemplateArg);
 std::string GetNormalizedInteger(long long val);
 std::string GetNormalizedInteger(unsigned long long val);
-long long ParseIntTypeToken(const std::string &intToken);
-unsigned long long ParseUIntTypeToken(const std::string &uintToken);
+long long ParseIntTypeToken(std::string_view intToken);
+unsigned long long ParseUIntTypeToken(std::string_view uintToken);
 
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode {
@@ -55,7 +55,7 @@ ERNTupleSerializationMode GetRNTupleSerializationMode(TClass *cl);
 /// `{"unsigned char", {1, 2, 3}}`. Extra whitespace in `typeName` should be removed before calling this function.
 ///
 /// If `typeName` is not an array type, it returns a tuple `{T, {}}`. On error, it returns a default-constructed tuple.
-std::tuple<std::string, std::vector<std::size_t>> ParseArrayType(const std::string &typeName);
+std::tuple<std::string, std::vector<std::size_t>> ParseArrayType(std::string_view typeName);
 
 /// Used in RFieldBase::Create() in order to get the comma-separated list of template types
 /// E.g., gets {"int", "std::variant<double,int>"} from "int,std::variant<double,int>".

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -263,7 +263,7 @@ The functions in this class format strings which are displayed by RNTupleReader:
 class RNTupleFormatter {
 public:
    // Can abbreviate long strings, e.g. ("ExampleString" , space= 8) => "Examp..."
-   static std::string FitString(const std::string &str, int availableSpace);
+   static std::string FitString(std::string_view str, int availableSpace);
 };
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -167,8 +167,8 @@ private:
       /// Writes a TKey including the data record, given by buffer, into fFile; returns the file offset to the payload.
       /// The payload is already compressed
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
-                             std::uint64_t directoryOffset = 100, const std::string &className = "",
-                             const std::string &objectName = "", const std::string &title = "");
+                             std::uint64_t directoryOffset = 100, std::string_view className = "",
+                             std::string_view objectName = "", std::string_view title = "");
       /// Reserves an RBlob opaque key as data record and returns the offset of the record. If keyBuffer is specified,
       /// it must be written *before* the returned offset. (Note that the array type is purely documentation, the
       /// argument is actually just a pointer.)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1318,22 +1318,22 @@ public:
       fField.fProjectionSourceId = id;
       return *this;
    }
-   RFieldDescriptorBuilder &FieldName(const std::string &fieldName)
+   RFieldDescriptorBuilder &FieldName(std::string_view fieldName)
    {
       fField.fFieldName = fieldName;
       return *this;
    }
-   RFieldDescriptorBuilder &FieldDescription(const std::string &fieldDescription)
+   RFieldDescriptorBuilder &FieldDescription(std::string_view fieldDescription)
    {
       fField.fFieldDescription = fieldDescription;
       return *this;
    }
-   RFieldDescriptorBuilder &TypeName(const std::string &typeName)
+   RFieldDescriptorBuilder &TypeName(std::string_view typeName)
    {
       fField.fTypeName = typeName;
       return *this;
    }
-   RFieldDescriptorBuilder &TypeAlias(const std::string &typeAlias)
+   RFieldDescriptorBuilder &TypeAlias(std::string_view typeAlias)
    {
       fField.fTypeAlias = typeAlias;
       return *this;
@@ -1499,12 +1499,12 @@ public:
       fExtraTypeInfo.fTypeVersion = typeVersion;
       return *this;
    }
-   RExtraTypeInfoDescriptorBuilder &TypeName(const std::string &typeName)
+   RExtraTypeInfoDescriptorBuilder &TypeName(std::string_view typeName)
    {
       fExtraTypeInfo.fTypeName = typeName;
       return *this;
    }
-   RExtraTypeInfoDescriptorBuilder &Content(const std::string &content)
+   RExtraTypeInfoDescriptorBuilder &Content(std::string_view content)
    {
       fExtraTypeInfo.fContent = content;
       return *this;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
@@ -59,8 +59,10 @@ private:
    bool fIsEnabled = false;
 
 public:
-   RNTuplePerfCounter(const std::string &name, const std::string &unit, const std::string &desc)
-      : fName(name), fUnit(unit), fDescription(desc) {}
+   RNTuplePerfCounter(std::string_view name, std::string_view unit, std::string_view desc)
+      : fName(name), fUnit(unit), fDescription(desc)
+   {
+   }
    virtual ~RNTuplePerfCounter();
    void Enable() { fIsEnabled = true; }
    bool IsEnabled() const { return fIsEnabled; }
@@ -86,7 +88,7 @@ private:
    std::int64_t fCounter = 0;
 
 public:
-   RNTuplePlainCounter(const std::string &name, const std::string &unit, const std::string &desc)
+   RNTuplePlainCounter(std::string_view name, std::string_view unit, std::string_view desc)
       : RNTuplePerfCounter(name, unit, desc)
    {
    }
@@ -113,8 +115,10 @@ private:
    std::atomic<std::int64_t> fCounter{0};
 
 public:
-   RNTupleAtomicCounter(const std::string &name, const std::string &unit, const std::string &desc)
-      : RNTuplePerfCounter(name, unit, desc) { }
+   RNTupleAtomicCounter(std::string_view name, std::string_view unit, std::string_view desc)
+      : RNTuplePerfCounter(name, unit, desc)
+   {
+   }
 
    R__ALWAYS_INLINE
    void Inc() {
@@ -175,8 +179,8 @@ private:
    const MetricFunc_t fFunc;
 
 public:
-   RNTupleCalcPerf(const std::string &name, const std::string &unit, const std::string &desc,
-                   RNTupleMetrics &metrics, MetricFunc_t &&func)
+   RNTupleCalcPerf(std::string_view name, std::string_view unit, std::string_view desc, RNTupleMetrics &metrics,
+                   MetricFunc_t &&func)
       : RNTuplePerfCounter(name, unit, desc), fMetrics(metrics), fFunc(std::move(func))
    {
    }
@@ -211,7 +215,7 @@ When printing, the value is converted from ticks to nanoseconds.
 template <typename BaseCounterT>
 class RNTupleTickCounter : public BaseCounterT {
 public:
-   RNTupleTickCounter(const std::string &name, const std::string &unit, const std::string &desc)
+   RNTupleTickCounter(std::string_view name, std::string_view unit, std::string_view desc)
       : BaseCounterT(name, unit, desc)
    {
       R__ASSERT(unit == "ns");
@@ -294,10 +298,10 @@ private:
    std::string fName;
    bool fIsEnabled = false;
 
-   bool Contains(const std::string &name) const;
+   bool Contains(std::string_view name) const;
 
 public:
-   explicit RNTupleMetrics(const std::string &name) : fName(name) {}
+   explicit RNTupleMetrics(std::string_view name) : fName(name) {}
    RNTupleMetrics(const RNTupleMetrics &other) = delete;
    RNTupleMetrics & operator=(const RNTupleMetrics &other) = delete;
    RNTupleMetrics(RNTupleMetrics &&other) = default;
@@ -306,7 +310,7 @@ public:
 
    // TODO(jblomer): return a reference
    template <typename CounterPtrT, class... Args>
-   CounterPtrT MakeCounter(const std::string &name, Args&&... args)
+   CounterPtrT MakeCounter(std::string_view name, Args &&...args)
    {
       R__ASSERT(!Contains(name));
       auto counter = std::make_unique<std::remove_pointer_t<CounterPtrT>>(name, std::forward<Args>(args)...);
@@ -323,7 +327,7 @@ public:
 
    void ObserveMetrics(RNTupleMetrics &observee);
 
-   void Print(std::ostream &output, const std::string &prefix = "") const;
+   void Print(std::ostream &output, std::string_view prefix = "") const;
    void Enable();
    bool IsEnabled() const { return fIsEnabled; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleProcessor.hxx
@@ -59,7 +59,7 @@ private:
 
 public:
    RNTupleOpenSpec(std::string_view n, TDirectory *s) : fNTupleName(n), fStorage(s) {}
-   RNTupleOpenSpec(std::string_view n, const std::string &s) : fNTupleName(n), fStorage(s) {}
+   RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(s.data()) {}
 
    std::unique_ptr<Internal::RPageSource> CreatePageSource() const;
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -221,7 +221,7 @@ public:
    static std::uint32_t SerializeUInt64(std::uint64_t val, void *buffer);
    static std::uint32_t DeserializeUInt64(const void *buffer, std::uint64_t &val);
 
-   static std::uint32_t SerializeString(const std::string &val, void *buffer);
+   static std::uint32_t SerializeString(std::string_view val, void *buffer);
    static RResult<std::uint32_t> DeserializeString(const void *buffer, std::uint64_t bufSize, std::string &val);
 
    /// While we could just interpret the enums as ints, we make the translation explicit
@@ -306,7 +306,7 @@ public:
 
    // Helper functions to (de-)serialize the streamer info type extra information
    static std::string SerializeStreamerInfos(const StreamerInfoMap_t &infos);
-   static RResult<StreamerInfoMap_t> DeserializeStreamerInfos(const std::string &extraTypeInfoContent);
+   static RResult<StreamerInfoMap_t> DeserializeStreamerInfos(std::string_view extraTypeInfoContent);
 }; // class RNTupleSerializer
 
 } // namespace Internal

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -314,7 +314,7 @@ private:
    ROOT::RField<RNTupleCardinality<std::uint64_t>> fField;
    ROOT::RFieldBase::RValue fValue;
 
-   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, const std::string &fieldName,
+   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, std::string_view fieldName,
                          ROOT::Experimental::Internal::RPageSource *source)
       : fSource(source), fField(fieldName), fValue(fField.CreateValue())
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -329,8 +329,8 @@ private:
          const auto &desc = source->GetSharedDescriptorGuard().GetRef();
          const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
          if (fieldDesc.GetStructure() != ROOT::ENTupleStructure::kCollection) {
-            throw RException(
-               R__FAIL("invalid attemt to create collection view on non-collection field " + fieldDesc.GetFieldName()));
+            throw RException(R__FAIL("invalid attempt to create collection view on non-collection field " +
+                                     fieldDesc.GetFieldName()));
          }
          fieldName = fieldDesc.GetFieldName();
       }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptionsDaos.hxx
@@ -50,7 +50,7 @@ public:
    /// Set the object class used to generate OIDs that relate to user data. Any
    /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
    /// the OC_ prefix.
-   void SetObjectClass(const std::string &val) { fObjectClass = val; }
+   void SetObjectClass(std::string_view val) { fObjectClass = val; }
 
    uint32_t GetMaxCageSize() const { return fMaxCageSize; }
    /// Set the upper bound for page concatenation into cages, in bytes. It is assumed

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -504,7 +504,7 @@ protected:
    ///
    /// A subclass using the default set of metrics is always responsible for updating the counters
    /// appropriately, e.g. `fCounters->fNPageCommited.Inc()`
-   void EnableDefaultMetrics(const std::string &prefix);
+   void EnableDefaultMetrics(std::string_view prefix);
 
 public:
    RPagePersistentSink(std::string_view ntupleName, const ROOT::RNTupleWriteOptions &options);
@@ -728,7 +728,7 @@ protected:
    /// appropriately, e.g. `fCounters->fNRead.Inc()`
    /// Alternatively, a subclass might provide its own RNTupleMetrics object by overriding the
    /// `GetMetrics()` member function.
-   void EnableDefaultMetrics(const std::string &prefix);
+   void EnableDefaultMetrics(std::string_view prefix);
 
    /// Note that the underlying lock is not recursive. See `GetSharedDescriptorGuard()` for further information.
    RExclDescriptorGuard GetExclDescriptorGuard() { return RExclDescriptorGuard(fDescriptor, fDescriptorLock); }

--- a/tree/ntuple/v7/src/RFieldMeta.cxx
+++ b/tree/ntuple/v7/src/RFieldMeta.cxx
@@ -330,11 +330,11 @@ ROOT::DescriptorId_t ROOT::RClassField::LookupMember(const ROOT::RNTupleDescript
    return ROOT::kInvalidDescriptorId;
 }
 
-void ROOT::RClassField::SetStagingClass(const std::string &className, unsigned int classVersion)
+void ROOT::RClassField::SetStagingClass(const std::string_view className, unsigned int classVersion)
 {
-   TClass::GetClass(className.c_str())->GetStreamerInfo(classVersion);
+   TClass::GetClass(className.data())->GetStreamerInfo(classVersion);
    if (classVersion != GetTypeVersion()) {
-      fStagingClass = TClass::GetClass((className + std::string("@@") + std::to_string(classVersion)).c_str());
+      fStagingClass = TClass::GetClass((std::string(className) + "@@" + std::to_string(classVersion)).c_str());
    } else {
       fStagingClass = fClass;
    }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -408,11 +408,11 @@ void ROOT::Internal::RPrintValueVisitor::VisitRVecField(const ROOT::RRVecField &
 
 //---------------------------- RNTupleFormatter --------------------------------
 
-std::string ROOT::Internal::RNTupleFormatter::FitString(const std::string &str, int availableSpace)
+std::string ROOT::Internal::RNTupleFormatter::FitString(std::string_view str, int availableSpace)
 {
    int strSize{static_cast<int>(str.size())};
    if (strSize <= availableSpace)
-      return str + std::string(availableSpace - strSize, ' ');
+      return std::string(str) + std::string(availableSpace - strSize, ' ');
    else if (availableSpace < 3)
       return std::string(availableSpace, '.');
    return std::string(str, 0, availableSpace - 3) + "...";

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -166,7 +166,7 @@ struct RTFString {
    unsigned char fLName{0};
    char fData[255];
    RTFString() = default;
-   RTFString(const std::string &str)
+   RTFString(std::string_view str)
    {
       // The length of strings with 255 characters and longer are encoded with a 32-bit integer following the first
       // byte. This is currently not handled.
@@ -1037,7 +1037,7 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Write(const v
 
 std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::WriteKey(
    const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset, std::uint64_t directoryOffset,
-   const std::string &className, const std::string &objectName, const std::string &title)
+   std::string_view className, std::string_view objectName, std::string_view title)
 {
    if (offset > 0)
       fKeyOffset = offset;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -654,7 +654,7 @@ std::unique_ptr<ROOT::RNTupleModel> ROOT::RNTupleDescriptor::CreateModel(const R
          continue;
 
       if (options.GetReconstructProjections() && topDesc.IsProjectedField()) {
-         model->AddProjectedField(std::move(field), [this](const std::string &targetName) -> std::string {
+         model->AddProjectedField(std::move(field), [this](std::string_view targetName) -> std::string {
             return GetQualifiedFieldName(GetFieldDescriptor(FindFieldId(targetName)).GetProjectionSourceId());
          });
       } else {

--- a/tree/ntuple/v7/src/RNTupleMetrics.cxx
+++ b/tree/ntuple/v7/src/RNTupleMetrics.cxx
@@ -28,7 +28,7 @@ std::string ROOT::Experimental::Detail::RNTuplePerfCounter::ToString() const
    return fName + kFieldSeperator + fUnit + kFieldSeperator + fDescription + kFieldSeperator + GetValueAsString();
 }
 
-bool ROOT::Experimental::Detail::RNTupleMetrics::Contains(const std::string &name) const
+bool ROOT::Experimental::Detail::RNTupleMetrics::Contains(std::string_view name) const
 {
   return GetLocalCounter(name) != nullptr;
 }
@@ -63,7 +63,7 @@ ROOT::Experimental::Detail::RNTupleMetrics::GetCounter(std::string_view name) co
    return nullptr;
 }
 
-void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, const std::string &prefix) const
+void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, std::string_view prefix) const
 {
    if (!fIsEnabled) {
       output << fName << " metrics disabled!" << std::endl;
@@ -74,7 +74,7 @@ void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, con
       output << prefix << fName << kNamespaceSeperator << c->ToString() << std::endl;
    }
    for (const auto c : fObservedMetrics) {
-      c->Print(output, prefix + fName + ".");
+      c->Print(output, prefix.data() + fName + ".");
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -698,7 +698,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::DeserializeUInt64
    return DeserializeInt64(buffer, *reinterpret_cast<std::int64_t *>(&val));
 }
 
-std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeString(const std::string &val, void *buffer)
+std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeString(std::string_view val, void *buffer)
 {
    if (buffer) {
       auto pos = reinterpret_cast<unsigned char *>(buffer);
@@ -2156,7 +2156,7 @@ std::string ROOT::Experimental::Internal::RNTupleSerializer::SerializeStreamerIn
 }
 
 ROOT::RResult<ROOT::Experimental::Internal::RNTupleSerializer::StreamerInfoMap_t>
-ROOT::Experimental::Internal::RNTupleSerializer::DeserializeStreamerInfos(const std::string &extraTypeInfoContent)
+ROOT::Experimental::Internal::RNTupleSerializer::DeserializeStreamerInfos(std::string_view extraTypeInfoContent)
 {
    StreamerInfoMap_t infoMap;
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -447,7 +447,7 @@ ROOT::Experimental::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle,
    return LoadPageImpl(columnHandle, clusterInfo, idxInCluster);
 }
 
-void ROOT::Experimental::Internal::RPageSource::EnableDefaultMetrics(const std::string &prefix)
+void ROOT::Experimental::Internal::RPageSource::EnableDefaultMetrics(std::string_view prefix)
 {
    fMetrics = Detail::RNTupleMetrics(prefix);
    fCounters = std::make_unique<RCounters>(RCounters{
@@ -1264,7 +1264,7 @@ void ROOT::Experimental::Internal::RPagePersistentSink::CommitDatasetImpl()
    CommitDatasetImpl(bufFooter.get(), szFooter);
 }
 
-void ROOT::Experimental::Internal::RPagePersistentSink::EnableDefaultMetrics(const std::string &prefix)
+void ROOT::Experimental::Internal::RPagePersistentSink::EnableDefaultMetrics(std::string_view prefix)
 {
    fMetrics = Detail::RNTupleMetrics(prefix);
    fCounters = std::make_unique<RCounters>(RCounters{

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -140,14 +140,14 @@ struct RDaosContainerNTupleLocator {
    static const ntuple_index_t kReservedIndex = 0;
 
    RDaosContainerNTupleLocator() = default;
-   explicit RDaosContainerNTupleLocator(const std::string &ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)){};
+   explicit RDaosContainerNTupleLocator(std::string_view ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)) {};
 
    bool IsValid() { return fAnchor.has_value() && fAnchor->fNBytesHeader; }
    [[nodiscard]] ntuple_index_t GetIndex() const { return fIndex; };
-   static ntuple_index_t Hash(const std::string &ntupleName)
+   static ntuple_index_t Hash(std::string_view ntupleName)
    {
       // Convert string to numeric representation via `std::hash`.
-      uint64_t h = std::hash<std::string>{}(ntupleName);
+      uint64_t h = std::hash<std::string_view>{}(ntupleName);
       // Fold the hash into 32-bit using `boost::hash_combine()` algorithm and magic number.
       auto seed = static_cast<uint32_t>(h >> 32);
       seed ^= static_cast<uint32_t>(h & 0xffffffff) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
@@ -198,7 +198,7 @@ struct RDaosContainerNTupleLocator {
    }
 
    static std::pair<RDaosContainerNTupleLocator, ROOT::Internal::RNTupleDescriptorBuilder>
-   LocateNTuple(ROOT::Experimental::Internal::RDaosContainer &cont, const std::string &ntupleName)
+   LocateNTuple(ROOT::Experimental::Internal::RDaosContainer &cont, std::string_view ntupleName)
    {
       auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), ROOT::Internal::RNTupleDescriptorBuilder());
 
@@ -209,7 +209,7 @@ struct RDaosContainerNTupleLocator {
          if (ntupleName.empty() || ntupleName != builder.GetDescriptor().GetName()) {
             // Hash already taken by a differently-named ntuple.
             throw ROOT::RException(
-               R__FAIL("LocateNTuple: ntuple name '" + ntupleName + "' unavailable in this container."));
+               R__FAIL("LocateNTuple: ntuple name '" + std::string(ntupleName) + "' unavailable in this container."));
          }
       }
       return result;


### PR DESCRIPTION
This PR unifies the type signature for string-based parameters in the RNTuple interface, using `std::string_view` instead of `const std::string &`.

The only place where the type signature hasn't been changed is in `RNTupleModel::FieldMappingFunc_t`, because that would introduce a breaking interface change so we should discuss whether we want to change it here still.

