### PR TITLE
[RF] fix segfault in fillLegacyCorrMatrix

### DIFF
--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -658,6 +658,8 @@ void RooFitResult::fillLegacyCorrMatrix() const
     }
   }
 
+  if (!_GC) return ;
+
   for (unsigned int i = 0; i < static_cast<unsigned int>(_corrMatrix.GetSize()) ; ++i) {
 
     // Find the next global correlation slot to fill, skipping fixed parameters


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

segfault shown in https://root-forum.cern.ch/t/extracting-global-correlation-causes-a-seg-fault-with-sumw2error/55138

This does not fully solve https://github.com/root-project/root/issues/12935, it's just adding safety.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

