### PR TITLE
[CPyCppyy] Drop `__array__` from std::vector pythonizations

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -527,6 +527,13 @@ PyObject* VectorData(PyObject* self, PyObject*)
 }
 
 
+// This function implements __array__, added to std::vector python proxies and causes
+// a bug (see explanation at Utility::AddToClass(pyclass, "__array__"...) in CPyCppyy::Pythonize)
+// The recursive nature of this function, passes each subarray (pydata) to the next call and only
+// the final buffer is cast to a lowlevel view and resized (in VectorData), resulting in only the
+// first 1D array to be returned. See https://github.com/root-project/root/issues/17729
+// It is temporarily removed to prevent errors due to -Wunused-function, since it is no longer added.
+#if 0
 //---------------------------------------------------------------------------
 PyObject* VectorArray(PyObject* self, PyObject* args, PyObject* kwargs)
 {
@@ -537,7 +544,7 @@ PyObject* VectorArray(PyObject* self, PyObject* args, PyObject* kwargs)
     Py_DECREF(pydata);
     return newarr;
 }
-
+#endif
 
 //-----------------------------------------------------------------------------
 static PyObject* vector_iter(PyObject* v) {
@@ -1810,8 +1817,15 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
             Utility::AddToClass(pyclass, "__real_data", "data");
             Utility::AddToClass(pyclass, "data", (PyCFunction)VectorData);
 
+        // The addition of the __array__ utility to std::vector Python proxies causes a
+        // bug where the resulting array is a single dimension, causing loss of data when
+        // converting to numpy arrays, for >1dim vectors. Since this C++ pythonization
+        // was added with the upgrade in 6.32, and is only defined and used recursively,
+        // the safe option is to disable this function and no longer add it.
+#if 0
         // numpy array conversion
             Utility::AddToClass(pyclass, "__array__", (PyCFunction)VectorArray, METH_VARARGS | METH_KEYWORDS /* unused */);
+#endif
 
         // checked getitem
             if (HasAttrDirect(pyclass, PyStrings::gLen)) {

--- a/bindings/pyroot/cppyy/patches/CPyCppyy-Disable_std-vector-numpy-array-pythonization.patch
+++ b/bindings/pyroot/cppyy/patches/CPyCppyy-Disable_std-vector-numpy-array-pythonization.patch
@@ -1,0 +1,65 @@
+From 82295e09c77ae61e2fd8356be792d61addf2c801 Mon Sep 17 00:00:00 2001
+From: Aaron Jomy <aaronjomyjoseph@gmail.com>
+Date: Mon, 31 Mar 2025 14:27:32 +0200
+Subject: [PATCH] [CPyCppyy] Drop `__array__` from std::vector pythonizations
+
+The addition of the __array__ utility to std::vector Python proxies causes a
+bug where the resulting array is a single dimension, causing loss of data when
+converting to numpy arrays, for >1dim vectors. The recursive nature of this
+function, passes each subarray (pydata) to the next call and only the final
+buffer is cast to a lowlevel view and resized (in VectorData), resulting in
+only the first 1D array to be returned. See https://github.com/root-project/root/issues/17729
+
+Since this C++ pythonization was added with the upgrade in 6.32, and is only
+defined and used recursively, the safe option is to disable this function and
+no longer add it. It is temporarily removed to prevent errors due to -Wunused-function
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+index 9b87905bab..0510c1c6ac 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+@@ -527,6 +527,13 @@ PyObject* VectorData(PyObject* self, PyObject*)
+ }
+ 
+ 
++// This function implements __array__, added to std::vector python proxies and causes
++// a bug (see explanation at Utility::AddToClass(pyclass, "__array__"...) in CPyCppyy::Pythonize)
++// The recursive nature of this function, passes each subarray (pydata) to the next call and only
++// the final buffer is cast to a lowlevel view and resized (in VectorData), resulting in only the
++// first 1D array to be returned. See https://github.com/root-project/root/issues/17729
++// It is temporarily removed to prevent errors due to -Wunused-function, since it is no longer added.
++#if 0
+ //---------------------------------------------------------------------------
+ PyObject* VectorArray(PyObject* self, PyObject* args, PyObject* kwargs)
+ {
+@@ -537,7 +544,7 @@ PyObject* VectorArray(PyObject* self, PyObject* args, PyObject* kwargs)
+     Py_DECREF(pydata);
+     return newarr;
+ }
+-
++#endif
+ 
+ //-----------------------------------------------------------------------------
+ static PyObject* vector_iter(PyObject* v) {
+@@ -1810,8 +1817,15 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
+             Utility::AddToClass(pyclass, "__real_data", "data");
+             Utility::AddToClass(pyclass, "data", (PyCFunction)VectorData);
+ 
++        // The addition of the __array__ utility to std::vector Python proxies causes a
++        // bug where the resulting array is a single dimension, causing loss of data when
++        // converting to numpy arrays, for >1dim vectors. Since this C++ pythonization
++        // was added with the upgrade in 6.32, and is only defined and used recursively,
++        // the safe option is to disable this function and no longer add it.
++#if 0
+         // numpy array conversion
+             Utility::AddToClass(pyclass, "__array__", (PyCFunction)VectorArray, METH_VARARGS | METH_KEYWORDS /* unused */);
++#endif
+ 
+         // checked getitem
+             if (HasAttrDirect(pyclass, PyStrings::gLen)) {
+-- 
+2.43.0
+

--- a/bindings/pyroot/cppyy/sync-upstream
+++ b/bindings/pyroot/cppyy/sync-upstream
@@ -43,6 +43,7 @@ git apply patches/CPyCppyy-Prevent-construction-of-agg-init-for-tuple.patch
 git apply patches/CPyCppyy-Support-conversion-from-str-to-char.patch # https://github.com/wlav/CPyCppyy/pull/21
 git apply patches/CPyCppyy-Perform-function-style-casts.patch # https://github.com/wlav/CPyCppyy/pull/34
 git apply patches/CPyCppyy-Use-PyMapping_GetOptionalItemString-where-necessary.patch # https://github.com/wlav/CPyCppyy/pull/44
+git apply patches/CPyCppyy-Disable_std-vector-numpy-array-pythonization.patch
 git apply patches/cppyy-No-CppyyLegacy-namespace.patch
 git apply patches/cppyy-Remove-Windows-workaround.patch
 git apply patches/cppyy-Don-t-enable-cling-autoloading.patch


### PR DESCRIPTION
The addition of the `__array__` utility to std::vector Python proxies causes a bug where the resulting array is a single dimension, causing loss of data when converting to numpy arrays, for >1dim vectors. The recursive nature of this
function `VectorArray`, passes each subarray (pydata) to the next call and only the final buffer is cast to a lowlevel view and resized (in VectorData), resulting in only the first 1D array to be returned.

Since this C++ pythonization was added with the upgrade in 6.32, and is only defined and used recursively, the safe option is to disable this function and no longer add it. It is temporarily removed to prevent errors due to `-Wunused-function`

Fixes: https://github.com/root-project/root/issues/17729