### PR TITLE
[RF] Fix implementation of HS3 importers

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -337,8 +337,9 @@ std::string generate(const RooFit::JSONIO::ImportExpression &ex, const JSONNode 
          RooJSONFactoryWSTool::error(errMsg.str());
       } else if (p[k].is_seq()) {
          bool firstInner = true;
+         expression << "{";
          for (RooAbsArg *arg : tool->requestArgList<RooAbsReal>(p, k)) {
-            expression << (firstInner ? "{" : ",") << arg->GetName();
+            expression << (firstInner ? "" : ",") << arg->GetName();
             firstInner = false;
          }
          expression << "}";


### PR DESCRIPTION
Fix by @guitargeek.
The RooWSFactoryTool expression handler was not correctly matching branckets, leading to failures when importing valid JSON filed with RooProdPdf objects.

Can be tested with the following reproducer:
```python3 dump_json_to_workspace.py datacard_part1_nosys.json```

where ```dump_json_to_workspace.py``` is
```
import ROOT
import sys
import os

# Check if the user provided an input file
if len(sys.argv) != 2:
    print("Usage: python script.py <input_json_file>")
    sys.exit(1)

# Get the input file from command line
input_file = sys.argv[1]

# Ensure the file exists
if not os.path.isfile(input_file):
    print(f"Error: File '{input_file}' not found.")
    sys.exit(1)

# Extract the base name without extension
base_name = os.path.splitext(os.path.basename(input_file))[0]
output_file = f"{base_name}_imported.root"

ws = ROOT.RooWorkspace("w")
tool = ROOT.RooJSONFactoryWSTool(ws)
tool.importJSON(input_file)
ws.writeToFile(output_file)
```
and ```datacard_part1_nosys.json``` is
```
{"distributions":[{"factors":[],"name":"nuisancePdf","type":"product_dist"}],"metadata":{"hs3_version":"0.2","packages":[{"name":"ROOT","version":"6.30.07"}]}}
```