### PR TITLE
[Python] Correctly manage NumPy dependencey in pythonization tests

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -37,7 +37,7 @@ ROOT.RooMCStudy(model, ROOT.RooArgSet(x), FitOptions=dict(Save=True, PrintEvalEr
 */
 """
 
-from ._utils import _kwargs_to_roocmdargs, _dict_to_flat_map, cpp_signature
+from ._utils import _dict_to_flat_map, _kwargs_to_roocmdargs, cpp_signature
 
 
 @cpp_signature(

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -229,7 +229,6 @@ def _bindFunctionOrPdf(name, func, is_rooabspdf, *variables):
     """
 
     import ROOT
-    import numpy as np
 
     # use the C++ version if dealing with C++ function
     if "cppyy" in repr(type(func)):
@@ -245,10 +244,13 @@ def _bindFunctionOrPdf(name, func, is_rooabspdf, *variables):
             super(RooPyBindDerived, self).__init__(name, title, ROOT.RooArgList(*variables))
 
         def evaluate(self):
+            import numpy as np
+
             inputs = [np.array([v.getVal()]) for v in self.varlist()]
             return func(*inputs)[0]
 
         def doEvalPy(self, ctx):
+            import numpy as np
 
             def span_to_numpy(sp):
                 return np.frombuffer(sp.data(), dtype=np.float64, count=sp.size())

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -199,6 +199,13 @@ def _FillWithNumpyArray(self, *args):
     Raises:
     - ValueError: If weights length doesn't match data length
     """
+    import collections.abc
+
+    # If the first argument has no len() method, we don't even need to consider
+    # the array code path.
+    if not isinstance(args[0], collections.abc.Sized):
+       return self._Fill(*args)
+
     import numpy as np
 
     if args and isinstance(args[0], np.ndarray):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th1.py
@@ -166,8 +166,13 @@ Further examples can be found in the tutorials:
 \endpythondoc
 """
 
+from ROOT._pythonization._memory_utils import (
+    _SetDirectory_SetOwnership,
+    inject_clone_releasing_ownership,
+    inject_constructor_releasing_ownership,
+)
+
 from . import pythonization
-from ROOT._pythonization._memory_utils import inject_constructor_releasing_ownership, inject_clone_releasing_ownership, _SetDirectory_SetOwnership
 
 # Multiplication by constant
 
@@ -204,7 +209,7 @@ def _FillWithNumpyArray(self, *args):
     # If the first argument has no len() method, we don't even need to consider
     # the array code path.
     if not isinstance(args[0], collections.abc.Sized):
-       return self._Fill(*args)
+        return self._Fill(*args)
 
     import numpy as np
 

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -117,7 +117,7 @@ endif()
 if (dataframe)
     ROOT_ADD_PYUNITTEST(pyroot_rdfdescription rdfdescription.py)
 
-    ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_misc rdataframe_misc.py)
+    ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_misc rdataframe_misc.py PYTHON_DEPS numpy)
 endif()
 
 # SOFIE-GNN pythonizations
@@ -139,7 +139,7 @@ if (tmva AND dataframe)
 endif()
 
 # Passing Python callables to ROOT.TF
-ROOT_ADD_PYUNITTEST(pyroot_pyz_tf_pycallables tf_pycallables.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tf_pycallables tf_pycallables.py PYTHON_DEPS numpy)
 
 if(roofit)
 

--- a/bindings/pyroot/pythonizations/test/rdataframe_misc.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_misc.py
@@ -1,10 +1,10 @@
-import cppyy
+import array
+import os
 import platform
 import unittest
-import numpy
-import os
 
 import ROOT
+
 
 class DatasetContext:
     """A helper class to create the dataset for the tutorial below."""
@@ -22,8 +22,8 @@ class DatasetContext:
             with ROOT.TFile(filename, "RECREATE") as f:
                 t = ROOT.TTree(self.treename, self.treename)
 
-                x = numpy.array([0], dtype=int)
-                y = numpy.array([0], dtype=int)
+                x = array.array("i", [0])
+                y = array.array("i", [0])
                 t.Branch("x", x, "x/I")
                 t.Branch("y", y, "y/I")
 
@@ -69,7 +69,7 @@ class RDataFrameMisc(unittest.TestCase):
 
             # When passing explicitly the vector of strings, type dispatching will not be necessary
             # and the real C++ exception will immediately surface
-            with self.assertRaisesRegex(cppyy.gbl.std.invalid_argument, "RDataFrame: empty list of input files."):
+            with self.assertRaisesRegex(ROOT.std.invalid_argument, "RDataFrame: empty list of input files."):
                 ROOT.RDataFrame("events", ROOT.std.vector[ROOT.std.string]())
 
             with self.assertRaisesRegex(TypeError, "RDataFrame: empty list of input files."):
@@ -110,6 +110,8 @@ class RDataFrameMisc(unittest.TestCase):
             return
 
         with DatasetContext() as dataset:
+            import numpy
+
             rdf = self._get_rdf(dataset)
 
             npy_dict = rdf.AsNumpy()

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -1,7 +1,8 @@
-import unittest
-import ROOT
+import array
 import random
-import numpy as np
+import unittest
+
+import ROOT
 
 
 class STL_vector(unittest.TestCase):
@@ -55,9 +56,7 @@ class STL_vector(unittest.TestCase):
         tree = ROOT.TTree("tree", "Tree with std::vector")
 
         # list of random arrays with lengths between 0 and 5 (0 is always included)
-        entries_to_fill = [
-            np.array([random.uniform(10, 20) for _ in range(n % 5)]) for n in range(100)
-        ]
+        entries_to_fill = [array.array("f", [random.uniform(10, 20) for _ in range(n % 5)]) for n in range(100)]
 
         # Create variables to store std::vector elements
         entry_root = ROOT.std.vector(float)()
@@ -76,12 +75,14 @@ class STL_vector(unittest.TestCase):
 
         for i in range(tree.GetEntries()):
             tree.GetEntry(i)
-            entry_numpy = entries_to_fill[i]
-            entry_python_list = list(entry_root)
+            entry_array = entries_to_fill[i]
 
-            self.assertEqual(len(entry_numpy), len(entry_root))
-            self.assertEqual(bool(entry_python_list), bool(entry_root))  # numpy arrays cannot be converted to bool
-            np.testing.assert_allclose(entry_numpy, np.array(entry_root), rtol=1e-5)
+            self.assertEqual(len(entry_array), len(entry_root))
+
+            self.assertEqual(bool(list(entry_root)), bool(entry_root))  # numpy arrays cannot be converted to bool
+
+            for entry_array_i, entry_root_i in zip(entry_array, entry_root):
+                self.assertEqual(entry_array_i, entry_root_i)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/ttree_branch_attr.py
+++ b/bindings/pyroot/pythonizations/test/ttree_branch_attr.py
@@ -2,8 +2,6 @@ import unittest
 
 import ROOT
 
-import numpy as np
-
 
 class TTreeBranchAttr(unittest.TestCase):
     """

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -890,10 +890,16 @@ if(ROOT_pyroot_FOUND)
   file(GLOB requires_numpy   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
       analysis/dataframe/df026_AsNumpyArrays.py
       analysis/dataframe/df032_RDFFromNumpy.py
-      math/fit/combinedFit.py
-      math/fit/multifit.py
       math/fit/NumericalMinimization.py
-      roofit/roofit/rf409_NumPyPandasToRooFit.py)
+      math/fit/combinedFit.py
+      math/fit/fitConvolution.py
+      math/fit/multifit.py
+      math/pdf/pdf012_tStudent.py
+      roofit/roofit/rf102_dataimport.py
+      roofit/roofit/rf401_importttreethx.py
+      roofit/roofit/rf409_NumPyPandasToRooFit.py
+      roofit/roofit/rf617_simulation_based_inference_multidimensional.py
+  )
   file(GLOB requires_numba   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} analysis/dataframe/df038_NumbaDeclare.py)
   file(GLOB requires_pandas  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
       analysis/dataframe/df026_AsNumpyArrays.py

--- a/tutorials/analysis/dataframe/df036_missingBranches.py
+++ b/tutorials/analysis/dataframe/df036_missingBranches.py
@@ -12,9 +12,10 @@
 #
 # \date September 2024
 # \author Vincenzo Eduardo Padulano (CERN)
+import array
 import os
+
 import ROOT
-import numpy
 
 
 class DatasetContext:
@@ -31,8 +32,8 @@ class DatasetContext:
     def __init__(self):
         with ROOT.TFile(self.filenames[0], "RECREATE") as f:
             t = ROOT.TTree(self.treenames[0], self.treenames[0])
-            x = numpy.array([0], dtype=int)
-            y = numpy.array([0], dtype=int)
+            x = array.array('i', [0]) # any array can also be a numpy array
+            y = array.array('i', [0])
             t.Branch("x", x, "x/I")
             t.Branch("y", y, "y/I")
 
@@ -45,7 +46,7 @@ class DatasetContext:
 
         with ROOT.TFile(self.filenames[1], "RECREATE") as f:
             t = ROOT.TTree(self.treenames[1], self.treenames[1])
-            y = numpy.array([0], dtype=int)
+            y = array.array('i', [0]) # any array can also be a numpy array
             t.Branch("y", y, "y/I")
 
             for i in range(1, self.nentries + 1):
@@ -56,7 +57,7 @@ class DatasetContext:
 
         with ROOT.TFile(self.filenames[2], "RECREATE") as f:
             t = ROOT.TTree(self.treenames[2], self.treenames[2])
-            x = numpy.array([0], dtype=int)
+            x = array.array('i', [0]) # any array can also be a numpy array
             t.Branch("x", x, "x/I")
 
             for i in range(1, self.nentries + 1):

--- a/tutorials/analysis/dataframe/df036_missingBranches.py
+++ b/tutorials/analysis/dataframe/df036_missingBranches.py
@@ -24,16 +24,16 @@ class DatasetContext:
     filenames = [
         "df036_missingBranches_py_file_1.root",
         "df036_missingBranches_py_file_2.root",
-        "df036_missingBranches_py_file_3.root"
+        "df036_missingBranches_py_file_3.root",
     ]
     treenames = ["tree_1", "tree_2", "tree_3"]
     nentries = 5
 
     def __init__(self):
-        with ROOT.TFile(self.filenames[0], "RECREATE") as f:
+        with ROOT.TFile(self.filenames[0], "RECREATE"):
             t = ROOT.TTree(self.treenames[0], self.treenames[0])
-            x = array.array('i', [0]) # any array can also be a numpy array
-            y = array.array('i', [0])
+            x = array.array("i", [0])  # any array can also be a numpy array
+            y = array.array("i", [0])
             t.Branch("x", x, "x/I")
             t.Branch("y", y, "y/I")
 
@@ -44,9 +44,9 @@ class DatasetContext:
 
             t.Write()
 
-        with ROOT.TFile(self.filenames[1], "RECREATE") as f:
+        with ROOT.TFile(self.filenames[1], "RECREATE"):
             t = ROOT.TTree(self.treenames[1], self.treenames[1])
-            y = array.array('i', [0]) # any array can also be a numpy array
+            y = array.array("i", [0])  # any array can also be a numpy array
             t.Branch("y", y, "y/I")
 
             for i in range(1, self.nentries + 1):
@@ -55,9 +55,9 @@ class DatasetContext:
 
             t.Write()
 
-        with ROOT.TFile(self.filenames[2], "RECREATE") as f:
+        with ROOT.TFile(self.filenames[2], "RECREATE"):
             t = ROOT.TTree(self.treenames[2], self.treenames[2])
-            x = array.array('i', [0]) # any array can also be a numpy array
+            x = array.array("i", [0])  # any array can also be a numpy array
             t.Branch("x", x, "x/I")
 
             for i in range(1, self.nentries + 1):
@@ -101,11 +101,7 @@ def df036_missingBranches(dataset: DatasetContext):
 
     # Example 2: provide a default value for branch y, but skip events where
     # branch x is missing
-    display_2 = (
-        df.DefaultValueFor("y", default_value)
-        .FilterAvailable("x")
-        .Display(columnList=("x", "y"), nRows=15)
-    )
+    display_2 = df.DefaultValueFor("y", default_value).FilterAvailable("x").Display(columnList=("x", "y"), nRows=15)
 
     # Example 3: only keep events where branch y is missing and display values for branch x
     display_3 = df.FilterMissing("y").Display(columnList=("x",), nRows=15)

--- a/tutorials/analysis/dataframe/df037_TTreeEventMatching.py
+++ b/tutorials/analysis/dataframe/df037_TTreeEventMatching.py
@@ -13,9 +13,10 @@
 #
 # \date September 2024
 # \author Vincenzo Eduardo Padulano (CERN)
+import array
 import os
+
 import ROOT
-import numpy
 
 
 class DatasetContext:
@@ -31,8 +32,8 @@ class DatasetContext:
     def __init__(self):
         with ROOT.TFile(self.main_file, "RECREATE") as f:
             main_tree = ROOT.TTree(self.main_tree_name, self.main_tree_name)
-            idx = numpy.array([0], dtype=int)
-            x = numpy.array([0], dtype=int)
+            idx = array.array('i', [0]) # any array can also be a numpy array
+            x = array.array('i', [0])
             main_tree.Branch("idx", idx, "idx/I")
             main_tree.Branch("x", x, "x/I")
 
@@ -51,8 +52,8 @@ class DatasetContext:
         # The first auxiliary file has matching indices 1 and 2, but not 3
         with ROOT.TFile(self.aux_file_1, "RECREATE") as f:
             aux_tree_1 = ROOT.TTree(self.aux_tree_name_1, self.aux_tree_name_1)
-            idx = numpy.array([0], dtype=int)
-            y = numpy.array([0], dtype=int)
+            idx = array.array('i', [0]) # any array can also be a numpy array
+            y = array.array('i', [0])
             aux_tree_1.Branch("idx", idx, "idx/I")
             aux_tree_1.Branch("y", y, "y/I")
 
@@ -68,8 +69,8 @@ class DatasetContext:
         # The second auxiliary file has matching indices 1 and 3, but not 2
         with ROOT.TFile(self.aux_file_2, "RECREATE") as f:
             aux_tree_2 = ROOT.TTree(self.aux_tree_name_2, self.aux_tree_name_2)
-            idx = numpy.array([0], dtype=int)
-            z = numpy.array([0], dtype=int)
+            idx = array.array('i', [0]) # any array can also be a numpy array
+            z = array.array('i', [0])
             aux_tree_2.Branch("idx", idx, "idx/I")
             aux_tree_2.Branch("z", z, "z/I")
 

--- a/tutorials/analysis/dataframe/df037_TTreeEventMatching.py
+++ b/tutorials/analysis/dataframe/df037_TTreeEventMatching.py
@@ -30,10 +30,10 @@ class DatasetContext:
     aux_tree_name_2 = "auxdata_2"
 
     def __init__(self):
-        with ROOT.TFile(self.main_file, "RECREATE") as f:
+        with ROOT.TFile(self.main_file, "RECREATE"):
             main_tree = ROOT.TTree(self.main_tree_name, self.main_tree_name)
-            idx = array.array('i', [0]) # any array can also be a numpy array
-            x = array.array('i', [0])
+            idx = array.array("i", [0])  # any array can also be a numpy array
+            x = array.array("i", [0])
             main_tree.Branch("idx", idx, "idx/I")
             main_tree.Branch("x", x, "x/I")
 
@@ -50,10 +50,10 @@ class DatasetContext:
             main_tree.Write()
 
         # The first auxiliary file has matching indices 1 and 2, but not 3
-        with ROOT.TFile(self.aux_file_1, "RECREATE") as f:
+        with ROOT.TFile(self.aux_file_1, "RECREATE"):
             aux_tree_1 = ROOT.TTree(self.aux_tree_name_1, self.aux_tree_name_1)
-            idx = array.array('i', [0]) # any array can also be a numpy array
-            y = array.array('i', [0])
+            idx = array.array("i", [0])  # any array can also be a numpy array
+            y = array.array("i", [0])
             aux_tree_1.Branch("idx", idx, "idx/I")
             aux_tree_1.Branch("y", y, "y/I")
 
@@ -67,10 +67,10 @@ class DatasetContext:
             aux_tree_1.Write()
 
         # The second auxiliary file has matching indices 1 and 3, but not 2
-        with ROOT.TFile(self.aux_file_2, "RECREATE") as f:
+        with ROOT.TFile(self.aux_file_2, "RECREATE"):
             aux_tree_2 = ROOT.TTree(self.aux_tree_name_2, self.aux_tree_name_2)
-            idx = array.array('i', [0]) # any array can also be a numpy array
-            z = array.array('i', [0])
+            idx = array.array("i", [0])  # any array can also be a numpy array
+            z = array.array("i", [0])
             aux_tree_2.Branch("idx", idx, "idx/I")
             aux_tree_2.Branch("z", z, "z/I")
 
@@ -132,8 +132,7 @@ def df037_TTreeEventMatching(dataset: DatasetContext):
         .DefaultValueFor(aux_tree_1_coly, default_value)
         .DefaultValueFor(aux_tree_2_colidx, default_value)
         .DefaultValueFor(aux_tree_2_colz, default_value)
-        .Display(
-            ("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
+        .Display(("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
     )
 
     # Example 2: skip the entire entry when there was no match for a column
@@ -143,12 +142,11 @@ def df037_TTreeEventMatching(dataset: DatasetContext):
         df.DefaultValueFor(aux_tree_2_colidx, default_value)
         .DefaultValueFor(aux_tree_2_colz, default_value)
         .FilterAvailable(aux_tree_1_coly)
-        .Display(
-                ("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
+        .Display(("idx", aux_tree_1_colidx, aux_tree_2_colidx, "x", aux_tree_1_coly, aux_tree_2_colz))
     )
 
-   # Example 3: Keep entries from the main tree for which there is no
-   # corresponding match in entries of the first auxiliary tree
+    # Example 3: Keep entries from the main tree for which there is no
+    # corresponding match in entries of the first auxiliary tree
     display_3 = df.FilterMissing(aux_tree_1_colidx).Display(("idx", "x"))
 
     print("Example 1: provide default values for all columns")

--- a/tutorials/roofit/roostats/StandardHypoTestDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestDemo.py
@@ -28,9 +28,9 @@
 #
 # \author Lorenzo Moneta (C++ version), and P. P. (Python translation)
 
+import array
 from warnings import warn
 from gc import collect
-import numpy as np
 
 import ROOT
 
@@ -396,8 +396,8 @@ def StandardHypoTestDemo(
         htExp = ROOT.RooStats.HypoTestResult("Expected Result")
         htExp.Append(htr)
         # find quantiles in alt (S+B) distribution
-        p = np.array([i for i in range(5)], dtype=float)
-        q = np.array([0.5 for i in range(5)], dtype=float)
+        p = array.array('d', [i for i in range(5)])
+        q = array.array('d', [0.5 for i in range(5)])
         for i in range(5):
             sig = -2 + i
             p[i] = ROOT.Math.normal_cdf(sig, 1)

--- a/tutorials/roofit/roostats/StandardHypoTestDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestDemo.py
@@ -29,8 +29,8 @@
 # \author Lorenzo Moneta (C++ version), and P. P. (Python translation)
 
 import array
-from warnings import warn
 from gc import collect
+from warnings import warn
 
 import ROOT
 
@@ -151,7 +151,7 @@ def StandardHypoTestDemo(
     # get the workspace out of the file
     w = file.Get(workspaceName)
     if not w:
-        print(f"workspace not found")
+        print("workspace not found")
         return
 
     w.Print()
@@ -165,7 +165,7 @@ def StandardHypoTestDemo(
     # make sure ingredients are found
     if not data or not sbModel:
         w.Print()
-        print(f"data or ModelConfig was not found")
+        print("data or ModelConfig was not found")
         return
 
     # make b model
@@ -176,14 +176,14 @@ def StandardHypoTestDemo(
     if noSystematics:
         nuisPar = sbModel.GetNuisanceParameters()
         if nuisPar and nuisPar.getSize() > 0:
-            print(f"StandardHypoTestInvDemo")
+            print("StandardHypoTestInvDemo")
             print("  -  Switch off all systematics by setting them constant to their initial values")
-            RooStats.SetAllConstant(nuisPar)
+            ROOT.RooStats.SetAllConstant(nuisPar)
 
         if bModel:
             bnuisPar = bModel.GetNuisanceParameters()
             if bnuisPar:
-                RooStats.SetAllConstant(bnuisPar)
+                ROOT.RooStats.SetAllConstant(bnuisPar)
 
     if not bModel:
         ROOT.Info("StandardHypoTestInvDemo", "The background model {} does not exist".format(modelBName))
@@ -298,7 +298,7 @@ def StandardHypoTestDemo(
                     nuisPdf.GetName(),
                 )
             else:
-                Error(
+                ROOT.Error(
                     "StandardHypoTestDemo",
                     "Cannot run Hybrid calculator because no prior on the nuisance parameter is "
                     "specified or can be derived",
@@ -396,8 +396,8 @@ def StandardHypoTestDemo(
         htExp = ROOT.RooStats.HypoTestResult("Expected Result")
         htExp.Append(htr)
         # find quantiles in alt (S+B) distribution
-        p = array.array('d', [i for i in range(5)])
-        q = array.array('d', [0.5 for i in range(5)])
+        p = array.array("d", [i for i in range(5)])
+        q = array.array("d", [0.5 for i in range(5)])
         for i in range(5):
             sig = -2 + i
             p[i] = ROOT.Math.normal_cdf(sig, 1)

--- a/tutorials/roofit/roostats/rs_numberCountingCombination.py
+++ b/tutorials/roofit/roostats/rs_numberCountingCombination.py
@@ -31,7 +31,6 @@ import array
 
 import ROOT
 
-
 # use this order for safety on library loading
 
 # declare three variations on the same tutorial
@@ -69,9 +68,9 @@ def rs_numberCountingCombination_expected():
     #          alternatively you can use cppyy:
     #          cppyy.cppdef("double s[2]";")
     #          s_c = cppyy.gbl.s
-    s = array.array('d', [20.0, 10.0])  # expected signal
-    b = array.array('d', [100.0, 100.0])  # expected background
-    db = array.array('d', [0.0100, 0.0100])  # fractional background uncertainty
+    s = array.array("d", [20.0, 10.0])  # expected signal
+    b = array.array("d", [100.0, 100.0])  # expected background
+    db = array.array("d", [0.0100, 0.0100])  # fractional background uncertainty
 
     # Step 2, use a RooStats factory to build a PDF for a
     # number counting combination and add it to the workspace.
@@ -120,10 +119,10 @@ def rs_numberCountingCombination_expected():
     # Step 6, Use the Calculator to get a HypoTestResult
     htr = plc.GetHypoTest()
     assert htr != 0
-    print(f"-------------------------------------------------")
-    print(f"The p-value for the null is ", htr.NullPValue())
-    print(f"Corresponding to a significance of ", htr.Significance())
-    print(f"-------------------------------------------------\n\n")
+    print("-------------------------------------------------")
+    print("The p-value for the null is ", htr.NullPValue())
+    print("Corresponding to a significance of ", htr.Significance())
+    print("-------------------------------------------------\n\n")
 
     # expected case should return:
     # -------------------------------------------------
@@ -165,25 +164,25 @@ def rs_numberCountingCombination_expected():
     # Since the significance of the Hypothesis test was > 2-sigma it should not be:
     # eg. we exclude masterSignal=0 at 95% confidence.
     paramsOfInterest.setRealValue("masterSignal", 0.0)
-    print(f"-------------------------------------------------")
-    print(f"Consider this parameter point:")
+    print("-------------------------------------------------")
+    print("Consider this parameter point:")
     paramsOfInterest.first().Print()
     if lrint.IsInInterval(paramsOfInterest):
-        print(f"It IS in the interval.")
+        print("It IS in the interval.")
     else:
-        print(f"It is NOT in the interval.")
-        print(f"-------------------------------------------------\n\n")
+        print("It is NOT in the interval.")
+        print("-------------------------------------------------\n\n")
 
     # Step 10c, We also ask about the parameter point masterSignal=2, which is inside the interval.
     paramsOfInterest.setRealValue("masterSignal", 2.0)
-    print(f"-------------------------------------------------")
-    print(f"Consider this parameter point:")
+    print("-------------------------------------------------")
+    print("Consider this parameter point:")
     paramsOfInterest.first().Print()
     if lrint.IsInInterval(paramsOfInterest):
-        print(f"It IS in the interval.")
+        print("It IS in the interval.")
     else:
-        print(f"It is NOT in the interval.")
-        print(f"-------------------------------------------------\n\n")
+        print("It is NOT in the interval.")
+        print("-------------------------------------------------\n\n")
 
     del lrint
     del htr
@@ -228,6 +227,7 @@ def rs_numberCountingCombination_expected():
 
 
 def rs_numberCountingCombination_observed():
+    import ctypes
 
     ##############
     # The same example with observed data in a main
@@ -250,8 +250,8 @@ def rs_numberCountingCombination_observed():
     # to the signal contribution in the individual channels.
     # The model neglects correlations in background uncertainty,
     # but they could be added without much change to the example.
-    f = NumberCountingPdfFactory()
-    wspace = RooWorkspace()
+    f = ROOT.RooStats.NumberCountingPdfFactory()
+    wspace = ROOT.RooWorkspace()
     f.AddModel(s_c, 2, wspace, "TopLevelPdf", "masterSignal")
 
     # Step 3, use a RooStats factory to add datasets to the workspace.
@@ -273,15 +273,15 @@ def rs_numberCountingCombination_observed():
     # Step 4, Define the null hypothesis for the calculator
     # Here you need to know the name of the variables corresponding to hypothesis.
     mu = wspace.var("masterSignal")
-    poi = RooArgSet(mu)
-    nullParams = RooArgSet("nullParams")
+    poi = ROOT.RooArgSet(mu)
+    nullParams = ROOT.RooArgSet("nullParams")
     nullParams.addClone(mu)
     # here we explicitly set the value of the parameters for the null
     nullParams.setRealValue("masterSignal", 0)
 
     # Step 5, Create a calculator for doing the hypothesis test.
     # because this is a
-    plc = ProfileLikelihoodCalculator(
+    plc = ROOT.RooStats.ProfileLikelihoodCalculator(
         wspace.data("ObservedNumberCountingData"), wspace.pdf("TopLevelPdf"), poi, 0.05, nullParams
     )
 
@@ -290,10 +290,10 @@ def rs_numberCountingCombination_observed():
 
     # Step 7, Use the Calculator to get a HypoTestResult
     htr = plc.GetHypoTest()
-    print(f"-------------------------------------------------")
-    print(f"The p-value for the null is ", htr.NullPValue())
-    print(f"Corresponding to a significance of ", htr.Significance())
-    print(f"-------------------------------------------------\n\n")
+    print("-------------------------------------------------")
+    print("The p-value for the null is ", htr.NullPValue())
+    print("Corresponding to a significance of ", htr.Significance())
+    print("-------------------------------------------------\n\n")
 
     """
    # observed case should return:
@@ -325,6 +325,7 @@ def rs_numberCountingCombination_observed():
 
 
 def rs_numberCountingCombination_observedWithTau():
+    import ctypes
 
     ##############
     # The same example with observed data in a main
@@ -347,8 +348,8 @@ def rs_numberCountingCombination_observedWithTau():
     # to the signal contribution in the individual channels.
     # The model neglects correlations in background uncertainty,
     # but they could be added without much change to the example.
-    f = NumberCountingPdfFactory()
-    wspace = RooWorkspace()
+    f = ROOT.RooStats.NumberCountingPdfFactory()
+    wspace = ROOT.RooWorkspace()
     f.AddModel(s_c, 2, wspace, "TopLevelPdf", "masterSignal")
 
     # Step 3, use a RooStats factory to add datasets to the workspace.
@@ -370,24 +371,24 @@ def rs_numberCountingCombination_observedWithTau():
     # Step 4, Define the null hypothesis for the calculator
     # Here you need to know the name of the variables corresponding to hypothesis.
     mu = wspace.var("masterSignal")
-    poi = RooArgSet(mu)
-    nullParams = RooArgSet("nullParams")
+    poi = ROOT.RooArgSet(mu)
+    nullParams = ROOT.RooArgSet("nullParams")
     nullParams.addClone(mu)
     # here we explicitly set the value of the parameters for the null
     nullParams.setRealValue("masterSignal", 0)
 
     # Step 5, Create a calculator for doing the hypothesis test.
     # because this is a
-    plc = ProfileLikelihoodCalculator(
+    plc = ROOT.RooStats.ProfileLikelihoodCalculator(
         wspace.data("ObservedNumberCountingDataWithSideband"), wspace.pdf("TopLevelPdf"), poi, 0.05, nullParams
     )
 
     # Step 7, Use the Calculator to get a HypoTestResult
     htr = plc.GetHypoTest()
-    print(f"-------------------------------------------------")
-    print(f"The p-value for the null is ", htr.NullPValue())
-    print(f"Corresponding to a significance of ", htr.Significance())
-    print(f"-------------------------------------------------\n\n")
+    print("-------------------------------------------------")
+    print("The p-value for the null is ", htr.NullPValue())
+    print("Corresponding to a significance of ", htr.Significance())
+    print("-------------------------------------------------\n\n")
 
     """
    # observed case should return:

--- a/tutorials/roofit/roostats/rs_numberCountingCombination.py
+++ b/tutorials/roofit/roostats/rs_numberCountingCombination.py
@@ -27,7 +27,8 @@
 #
 # \author Kyle Cranmer (C++ version), and P. P. (Python translation)
 
-import numpy as np
+import array
+
 import ROOT
 
 
@@ -68,9 +69,9 @@ def rs_numberCountingCombination_expected():
     #          alternatively you can use cppyy:
     #          cppyy.cppdef("double s[2]";")
     #          s_c = cppyy.gbl.s
-    s = np.array([20.0, 10.0])  # expected signal
-    b = np.array([100.0, 100.0])  # expected background
-    db = np.array([0.0100, 0.0100])  # fractional background uncertainty
+    s = array.array('d', [20.0, 10.0])  # expected signal
+    b = array.array('d', [100.0, 100.0])  # expected background
+    db = array.array('d', [0.0100, 0.0100])  # fractional background uncertainty
 
     # Step 2, use a RooStats factory to build a PDF for a
     # number counting combination and add it to the workspace.


### PR DESCRIPTION
The dependency on Python libraries like NumPy needs to be declared in the CMakeLists.txt, such that the test gets disabled when the library is not available.

In some cases, the dependency on NumPy could be avoided by using the builtin "array" library.