### PR TITLE
[ntuple] Make `RNTupleJoinProcessor` composable

### DIFF
--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -39,8 +39,6 @@ class RFieldVisitor;
 
 namespace Experimental {
 
-class RNTupleJoinProcessor;
-
 namespace Detail {
 class RRawPtrWriteEntry;
 } // namespace Detail
@@ -82,7 +80,6 @@ This is and can only be partially enforced through C++.
 // clang-format on
 class RFieldBase {
    friend class ROOT::RClassField;                             // to mark members as artificial
-   friend class ROOT::Experimental::RNTupleJoinProcessor;      // needs ConstructValue
    friend class ROOT::Experimental::Detail::RRawPtrWriteEntry; // to call Append()
    friend struct ROOT::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Internal::RFieldRepresentationModifier; // used for unit tests

--- a/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
@@ -198,6 +198,15 @@ public:
                          ROOT::NTupleSize_t entryOffset = 0);
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get an entry index (if it exists) for the given join field (values), from any partition
+   ///
+   /// \param[in] valuePtrs A vector of pointers to the join field values to look up.
+   ///
+   /// \return An entry number that corresponds to `valuePtrs`. When there are no corresponding entries,
+   /// `kInvalidNTupleIndex` is returned.
+   ROOT::NTupleSize_t GetEntryIndex(const std::vector<void *> &valuePtrs) const;
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Get all entry indexes for the given join field value(s) within a partition.
    ///
    /// \param[in] valuePtrs A vector of pointers to the join field values to look up.

--- a/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
@@ -198,9 +198,12 @@ public:
                          ROOT::NTupleSize_t entryOffset = 0);
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get an entry index (if it exists) for the given join field (values), from any partition
+   /// \brief Get an entry index (if it exists) for the given join field value(s), from any partition.
    ///
    /// \param[in] valuePtrs A vector of pointers to the join field values to look up.
+   ///
+   /// \note If one or more corresponding entries exist for the given value(s), the first entry index found in the join
+   /// table is returned. To get *all* the entry indexes, use GetEntryIndexes.
    ///
    /// \return An entry number that corresponds to `valuePtrs`. When there are no corresponding entries,
    /// `kInvalidNTupleIndex` is returned.

--- a/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
@@ -149,7 +149,10 @@ private:
       ///
       /// \param[in] pageSource The page source of the RNTuple with the entries to map.
       /// \param[in] joinFieldNames Names of the join fields to use in the mapping.
-      REntryMapping(ROOT::Internal::RPageSource &pageSource, const std::vector<std::string> &joinFieldNames);
+      /// \param[in] entryOffset Offset to add to each entry index in the mapping. This can can be used when the
+      /// RNTuple represented by the provided page source is part of a chain of RNTuples.
+      REntryMapping(ROOT::Internal::RPageSource &pageSource, const std::vector<std::string> &joinFieldNames,
+                    ROOT::NTupleSize_t entryOffset = 0);
    };
    /// Names of the join fields used for the mapping to their respective entry indexes.
    std::vector<std::string> fJoinFieldNames;
@@ -187,9 +190,12 @@ public:
    /// \param[in] pageSource The page source of the RNTuple with the entries to map.
    /// \param[in] partitionKey Which partition to add the mapping to. If not provided, it will be added to the default
    /// partition.
+   /// \param[in] entryOffset Offset to add to each entry index in the mapping. This can can be used when the
+   /// RNTuple represented by the provided page source is part of a chain of RNTuples.
    ///
    /// \return A reference to the updated join table.
-   RNTupleJoinTable &Add(ROOT::Internal::RPageSource &pageSource, PartitionKey_t partitionKey = kDefaultPartitionKey);
+   RNTupleJoinTable &Add(ROOT::Internal::RPageSource &pageSource, PartitionKey_t partitionKey = kDefaultPartitionKey,
+                         ROOT::NTupleSize_t entryOffset = 0);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get all entry indexes for the given join field value(s) within a partition.

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -106,7 +106,6 @@ class RNTupleProcessor {
 protected:
    std::string fProcessorName;
    std::unique_ptr<ROOT::REntry> fEntry;
-   std::unique_ptr<ROOT::Internal::RPageSource> fPageSource;
    std::unique_ptr<ROOT::RNTupleModel> fModel;
 
    /// Total number of entries. Only to be used internally by the processor, not meant to be exposed in the public
@@ -451,6 +450,7 @@ class RNTupleSingleProcessor : public RNTupleProcessor {
 
 private:
    RNTupleOpenSpec fNTupleSpec;
+   std::unique_ptr<ROOT::Internal::RPageSource> fPageSource;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Connect the page source of the underlying RNTuple.
@@ -490,6 +490,13 @@ private:
    /// \param[in] model The model that specifies which fields should be read by the processor.
    RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::string_view processorName,
                           std::unique_ptr<ROOT::RNTupleModel> model);
+
+public:
+   RNTupleSingleProcessor(const RNTupleSingleProcessor &) = delete;
+   RNTupleSingleProcessor(RNTupleSingleProcessor &&) = delete;
+   RNTupleSingleProcessor &operator=(const RNTupleSingleProcessor &) = delete;
+   RNTupleSingleProcessor &operator=(RNTupleSingleProcessor &&) = delete;
+   ~RNTupleSingleProcessor() override { fModel.release(); };
 };
 
 // clang-format off

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -549,6 +549,13 @@ private:
    /// RNTuples are processed in the order in which they are specified.
    RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName,
                          std::unique_ptr<ROOT::RNTupleModel> model);
+
+public:
+   RNTupleChainProcessor(const RNTupleChainProcessor &) = delete;
+   RNTupleChainProcessor(RNTupleChainProcessor &&) = delete;
+   RNTupleChainProcessor &operator=(const RNTupleChainProcessor &) = delete;
+   RNTupleChainProcessor &operator=(RNTupleChainProcessor &&) = delete;
+   ~RNTupleChainProcessor() override = default;
 };
 
 // clang-format off

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -104,51 +104,9 @@ class RNTupleProcessor {
    friend class RNTupleJoinProcessor;
 
 protected:
-   // clang-format off
-   /**
-   \class ROOT::Experimental::RNTupleProcessor::RFieldContext
-   \ingroup NTuple
-   \brief Manager for a field as part of the RNTupleProcessor.
-
-   An RFieldContext contains two fields: a proto-field which is not connected to any page source but serves as the
-   blueprint for this particular field, and a concrete field that is connected to the page source currently connected
-   to the RNTupleProcessor for reading. When a new page source is connected, the current concrete field gets reset. A
-   new concrete field that is connected to this new page source is subsequently created from the proto-field.
-   */
-   // clang-format on
-   class RFieldContext {
-      friend class RNTupleProcessor;
-      friend class RNTupleSingleProcessor;
-      friend class RNTupleChainProcessor;
-      friend class RNTupleJoinProcessor;
-
-   private:
-      std::unique_ptr<ROOT::RFieldBase> fProtoField;
-      std::unique_ptr<ROOT::RFieldBase> fConcreteField;
-      ROOT::RFieldToken fToken;
-      // Which RNTuple the field belongs to, in case the field belongs to an auxiliary RNTuple, according to the order
-      // in which it was specified. For chained RNTuples, this value will always be 0.
-      std::size_t fNTupleIdx;
-
-   public:
-      RFieldContext(std::unique_ptr<ROOT::RFieldBase> protoField, ROOT::RFieldToken token, std::size_t ntupleIdx = 0)
-         : fProtoField(std::move(protoField)), fToken(token), fNTupleIdx(ntupleIdx)
-      {
-      }
-
-      const ROOT::RFieldBase &GetProtoField() const { return *fProtoField; }
-      /// Concrete pages need to be reset explicitly before the page source they belong to is destroyed.
-      void ResetConcreteField() { fConcreteField.reset(); }
-      void SetConcreteField() { fConcreteField = fProtoField->Clone(fProtoField->GetFieldName()); }
-      bool IsAuxiliary() const { return fNTupleIdx > 0; }
-   };
-
    std::string fProcessorName;
    std::unique_ptr<ROOT::REntry> fEntry;
    std::unique_ptr<ROOT::Internal::RPageSource> fPageSource;
-   /// Maps the (qualified) field name to its corresponding field context.
-   std::unordered_map<std::string, RFieldContext> fFieldContexts;
-
    std::unique_ptr<ROOT::RNTupleModel> fModel;
 
    /// Total number of entries. Only to be used internally by the processor, not meant to be exposed in the public

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -160,10 +160,6 @@ protected:
    std::size_t fCurrentProcessorNumber = 0;    //< Number of the currently open inner processor
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create and connect a concrete field to the current page source, based on its proto field.
-   void ConnectField(RFieldContext &fieldContext, ROOT::Internal::RPageSource &pageSource, ROOT::REntry &entry);
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided entry number.
    ///
    /// \param[in] entryNumber Entry number to load

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -183,6 +183,14 @@ protected:
    virtual ROOT::NTupleSize_t GetNEntries() = 0;
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add the entry mappings for this processor to the provided join table.
+   ///
+   /// \param[in] joinTable the join table to map the entries to.
+   /// \param[in] entryOffset In case the entry mapping is added from a chain, the offset of the entry indexes to use
+   /// with respect to the processor's position in the chain.
+   virtual void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) = 0;
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Create a new base RNTupleProcessor.
    ///
    /// \param[in] processorName Name of the processor. By default, this is the name of the underlying RNTuple for
@@ -463,6 +471,12 @@ private:
    }
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add the entry mappings for this processor to the provided join table.
+   ///
+   /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
+   void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleProcessor for processing a single RNTuple.
    ///
    /// \param[in] ntuple The source specification (name and storage location) for the RNTuple to process.
@@ -503,6 +517,12 @@ private:
    ///
    /// \note This requires opening all underlying RNTuples being processed in the chain, and could become costly!
    ROOT::NTupleSize_t GetNEntries() final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add the entry mappings for this processor to the provided join table.
+   ///
+   /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
+   void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleChainProcessor.
@@ -551,6 +571,12 @@ private:
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
    ROOT::NTupleSize_t GetNEntries() final { return fNEntries; }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add the entry mappings for this processor to the provided join table.
+   ///
+   /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
+   void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Set fModel by combining the primary and auxiliary models.

--- a/tree/ntuple/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/src/RNTupleJoinTable.cxx
@@ -33,7 +33,8 @@ ROOT::Experimental::Internal::RNTupleJoinTable::JoinValue_t CastValuePtr(void *v
 } // anonymous namespace
 
 ROOT::Experimental::Internal::RNTupleJoinTable::REntryMapping::REntryMapping(
-   ROOT::Internal::RPageSource &pageSource, const std::vector<std::string> &joinFieldNames)
+   ROOT::Internal::RPageSource &pageSource, const std::vector<std::string> &joinFieldNames,
+   ROOT::NTupleSize_t entryOffset)
    : fJoinFieldNames(joinFieldNames)
 {
    static const std::unordered_set<std::string> allowedTypes = {"std::int8_t",   "std::int16_t", "std::int32_t",
@@ -82,7 +83,7 @@ ROOT::Experimental::Internal::RNTupleJoinTable::REntryMapping::REntryMapping(
          castJoinValues.push_back(CastValuePtr(valuePtr.get(), fieldValue.GetField().GetValueSize()));
       }
 
-      fMapping[RCombinedJoinFieldValue(castJoinValues)].push_back(i);
+      fMapping[RCombinedJoinFieldValue(castJoinValues)].push_back(i + entryOffset);
    }
 }
 
@@ -116,9 +117,9 @@ ROOT::Experimental::Internal::RNTupleJoinTable::Create(const std::vector<std::st
 
 ROOT::Experimental::Internal::RNTupleJoinTable &
 ROOT::Experimental::Internal::RNTupleJoinTable::Add(ROOT::Internal::RPageSource &pageSource,
-                                                    PartitionKey_t partitionKey)
+                                                    PartitionKey_t partitionKey, ROOT::NTupleSize_t entryOffset)
 {
-   auto joinMapping = std::unique_ptr<REntryMapping>(new REntryMapping(pageSource, fJoinFieldNames));
+   auto joinMapping = std::unique_ptr<REntryMapping>(new REntryMapping(pageSource, fJoinFieldNames, entryOffset));
    fPartitions[partitionKey].emplace_back(std::move(joinMapping));
 
    return *this;

--- a/tree/ntuple/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/src/RNTupleJoinTable.cxx
@@ -125,6 +125,22 @@ ROOT::Experimental::Internal::RNTupleJoinTable::Add(ROOT::Internal::RPageSource 
    return *this;
 }
 
+ROOT::NTupleSize_t
+ROOT::Experimental::Internal::RNTupleJoinTable::GetEntryIndex(const std::vector<void *> &valuePtrs) const
+{
+
+   for (const auto &partition : fPartitions) {
+      for (const auto &joinMapping : partition.second) {
+         auto entriesForMapping = joinMapping->GetEntryIndexes(valuePtrs);
+         if (entriesForMapping) {
+            return (*entriesForMapping)[0];
+         }
+      }
+   }
+
+   return kInvalidNTupleIndex;
+}
+
 std::vector<ROOT::NTupleSize_t>
 ROOT::Experimental::Internal::RNTupleJoinTable::GetEntryIndexes(const std::vector<void *> &valuePtrs,
                                                                 PartitionKey_t partitionKey) const

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -250,6 +250,13 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
    }
 }
 
+void ROOT::Experimental::RNTupleSingleProcessor::AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable,
+                                                                       ROOT::NTupleSize_t entryOffset)
+{
+   Connect();
+   joinTable.Add(*fPageSource, Internal::RNTupleJoinTable::kDefaultPartitionKey, entryOffset);
+}
+
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
@@ -336,6 +343,16 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::LoadEntry(ROOT::NT
    fNEntriesProcessed++;
    fCurrentEntryNumber = entryNumber;
    return entryNumber;
+}
+
+void ROOT::Experimental::RNTupleChainProcessor::AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable,
+                                                                      ROOT::NTupleSize_t entryOffset)
+{
+   for (unsigned i = 0; i < fInnerProcessors.size(); ++i) {
+      const auto &innerProc = fInnerProcessors[i];
+      innerProc->AddEntriesToJoinTable(joinTable, entryOffset);
+      entryOffset += innerProc->GetNEntries();
+   }
 }
 
 //------------------------------------------------------------------------------
@@ -543,4 +560,10 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
    }
 
    return entryNumber;
+}
+
+void ROOT::Experimental::RNTupleJoinProcessor::AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable,
+                                                                     ROOT::NTupleSize_t entryOffset)
+{
+   joinTable.Add(*fPageSource, Internal::RNTupleJoinTable::kDefaultPartitionKey, entryOffset);
 }

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -134,7 +134,7 @@ ROOT::Experimental::RNTupleProcessor::CreateJoin(RNTupleOpenSpec primaryNTuple, 
       throw RException(R__FAIL("a maximum of four join fields is allowed"));
    }
 
-   if (std::set(joinFields.begin(), joinFields.end()).size() < joinFields.size()) {
+   if (std::unordered_set(joinFields.begin(), joinFields.end()).size() < joinFields.size()) {
       throw RException(R__FAIL("join fields must be unique"));
    }
 
@@ -194,7 +194,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleProcessor> ROOT::Experimental::RNTupl
       throw RException(R__FAIL("a maximum of four join fields is allowed"));
    }
 
-   if (std::set(joinFields.begin(), joinFields.end()).size() < joinFields.size()) {
+   if (std::unordered_set(joinFields.begin(), joinFields.end()).size() < joinFields.size()) {
       throw RException(R__FAIL("join fields must be unique"));
    }
 

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -181,7 +181,7 @@ TEST_F(RNTupleChainProcessorTest, MissingFields)
       entry++;
       FAIL() << "having missing fields in subsequent ntuples should throw";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field \"y\" not found in current RNTuple"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("field \"y\" not found in the current RNTuple"));
    }
 }
 


### PR DESCRIPTION
This PR adds the possibility to compose `RNTupleJoinProcessor`s from existing processor objects. Similar functionality is already in place for the `RNTupleChainProcessor` (see #17393), so with these additions the `RNTupleProcessor` is (almost*) fully composable.

*One caveat: the case where an auxiliary processor in the join is a join itself is not yet properly handled. This will be handled in a follow-up PR.
