### PR TITLE
Fix warning caused by RPadLength arithmetic operators

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -181,7 +181,7 @@ public:
    bool Empty() const { return fArr.empty(); }
 
    /// Add two `RPadLength`s.
-   friend RPadLength operator+(RPadLength lhs, const RPadLength &rhs)
+   friend RPadLength operator+(const RPadLength &lhs, const RPadLength &rhs)
    {
       RPadLength res;
       if (lhs.HasUser() || rhs.HasUser())
@@ -194,7 +194,7 @@ public:
    }
 
    /// Subtract two `RPadLength`s.
-   friend RPadLength operator-(RPadLength lhs, const RPadLength &rhs)
+   friend RPadLength operator-(const RPadLength &lhs, const RPadLength &rhs)
    {
       RPadLength res;
       if (lhs.HasUser() || rhs.HasUser())


### PR DESCRIPTION
Use `const` references as one should for `operator+` and `operator-`.

This fixes the following warning I get when building ROOT with tests:

```txt
In file included from /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/x86_64-unknown-linux-gnu/bits/c++allocator.h:33,
                 from /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/allocator.h:46,
                 from /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/memory:65,
                 from /nix/store/qf61vad876jgyd4vnn147cz2jyvy23vl-gtest-1.16.0-dev/include/gtest/gtest.h:55,
                 from /home/rembserj/code/root/root_src/graf2d/gpadv7/test/coords.cxx:12:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = double]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = double]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/alloc_traits.h:544:23,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:389:19,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:385:7,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:368:15,
    inlined from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:738:7,
    inlined from ‘ROOT::Experimental::RPadLength::~RPadLength()’ at /home/rembserj/code/root/root_src/graf2d/gpadv7/inc/ROOT/RPadLength.hxx:31:7,
    inlined from ‘virtual void PadCoord_AddSubtract_Test::TestBody()’ at /home/rembserj/code/root/root_src/graf2d/gpadv7/test/coords.cxx:36:26:
/nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/new_allocator.h:172:33: warning: ‘void operator delete(void*, std::size_t)’ called on pointer ‘<unknown>’ with nonzero offset [1, 9223372036854775800] [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = double]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_Tp1> >::allocate(allocator_type&, size_type) [with _Tp = double]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/alloc_traits.h:509:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:380:33,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:398:44,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:334:26,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = double; _Alloc = std::allocator<double>]’ at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:603:61,
    inlined from ‘ROOT::Experimental::RPadLength::RPadLength(const ROOT::Experimental::RPadLength&)’ at /home/rembserj/code/root/root_src/graf2d/gpadv7/inc/ROOT/RPadLength.hxx:31:7,
    inlined from ‘virtual void PadCoord_AddSubtract_Test::TestBody()’ at /home/rembserj/code/root/root_src/graf2d/gpadv7/test/coords.cxx:36:26:
/nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/new_allocator.h:151:55: note: returned from ‘void* operator new(std::size_t)’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```