### PR TITLE
SearchInstalledSoftware.cmake: correctly report name of option to disable

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -54,7 +54,7 @@ endmacro()
 # stop the configuration with a FATAL_ERROR in case of fail-on-missing=ON.
 #----------------------------------------------------------------------------
 macro(ROOT_CHECK_CONNECTION_AND_DISABLE_OPTION option_name)
-  ROOT_CHECK_CONNECTION("$(option_name)=OFF")
+  ROOT_CHECK_CONNECTION("${option_name}=OFF")
   if(NO_CONNECTION)
     message(STATUS "No internet connection, disabling '${option_name}' option")
     set(${option_name} OFF CACHE BOOL "Disabled because there is no internet connection" FORCE)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

```
CMake Error at cmake/modules/SearchInstalledSoftware.cmake:43 (message):
  No internet connection.  Please check your connection, set
  '-D$(option_name)=OFF' or disable 'fail-on-missing' to automatically
  disable options requiring internet access
Call Stack (most recent call first):
  cmake/modules/SearchInstalledSoftware.cmake:57 (ROOT_CHECK_CONNECTION)
  cmake/modules/SearchInstalledSoftware.cmake:66 (ROOT_CHECK_CONNECTION_AND_DISABLE_OPTION)
  CMakeLists.txt:280 (include)
```

will now become 

```
CMake Error at cmake/modules/SearchInstalledSoftware.cmake:43 (message):
  No internet connection.  Please check your connection, set
  '-Dclad=OFF' or disable 'fail-on-missing' to automatically
  disable options requiring internet access
Call Stack (most recent call first):
  cmake/modules/SearchInstalledSoftware.cmake:57 (ROOT_CHECK_CONNECTION)
  cmake/modules/SearchInstalledSoftware.cmake:66 (ROOT_CHECK_CONNECTION_AND_DISABLE_OPTION)
  CMakeLists.txt:280 (include)
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
