### PR TITLE
[h2root] explore/circumvent if occassional memory corruption issue stems from substring replacement

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -3,5 +3,4 @@ builtin_nlohmannjson=ON
 builtin_tbb=ON
 builtin_vdt=ON
 ccache=ON
-fortran=OFF
 tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu2404-cuda.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu2404-cuda.txt
@@ -7,7 +7,6 @@ tmva-cpu=ON
 tmva-gpu=ON
 tmva-cudnn=ON
 tmva-pymva=OFF
-fortran=OFF
 gdml=OFF
 spectrum=OFF
 sqlite=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -387,7 +387,7 @@ jobs:
           - image: alma9
             is_special: true
             property: march_native
-            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "fortran=OFF", "builtin_zlib=ON", "builtin_zstd=ON"]
+            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "builtin_zlib=ON", "builtin_zstd=ON"]
           - image: alma9
             is_special: true
             property: arm64

--- a/main/src/h2root.cxx
+++ b/main/src/h2root.cxx
@@ -329,6 +329,8 @@ int main(int argc, char **argv)
 
    if (!hfile) {
       printf("Error: can't open output file: %s \n",file_out);
+      if (argc <= 2)
+         delete[] file_out;
       return 1;
    }
 
@@ -339,7 +341,9 @@ int main(int argc, char **argv)
    hfile->ls();
    hfile->Close();
    delete hfile;
-   return(0);
+   if (argc <= 2)
+         delete[] file_out;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/main/src/h2root.cxx
+++ b/main/src/h2root.cxx
@@ -312,7 +312,11 @@ int main(int argc, char **argv)
 
    int lun = 10;
 #ifndef WIN32
-   hropen(lun,PASSCHAR("example"),PASSCHAR(file_in),PASSCHAR("px"),record_size,ier,7,strlen(file_in),2);
+   // "px" is a string being changed to "pxc" in the fortran side; since it's a temporary on C's side,
+   // we need a buffer of at least 3 chars on Cs side, too. Predefine it as a extra variable "px " since that way
+   // the space will be replaced by 'c' on the preallocated memory, instead of appending a new char (new memory) to "px".
+   auto opt = PASSCHAR("px ");
+   hropen(lun,PASSCHAR("example"),PASSCHAR(file_in),opt,record_size,ier,7,strlen(file_in),2);
 #else
    hropen(lun,PASSCHAR("example"),PASSCHAR(file_in),PASSCHAR("px"),record_size,ier);
 #endif

--- a/misc/minicern/CMakeLists.txt
+++ b/misc/minicern/CMakeLists.txt
@@ -16,3 +16,5 @@ target_link_libraries(minicern ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
 # Disable warnings, since what has worked for 40 years...
 # (see https://sft.its.cern.ch/jira/browse/ROOT-9179 for the warnings)
 set_target_properties(minicern PROPERTIES COMPILE_FLAGS "-O0 -w")
+# set_target_properties(minicern PROPERTIES COMPILE_FLAGS "-fsanitize=undefined -fsanitize=address")
+# target_link_options(minicern BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

By adding a space, we create an extra char that, on Fortran's side will be substituted by c, rather than appending to the (temporary passed as argument C-)string.

Related discussion: https://github.com/root-project/root/pull/15915/files

Fixes https://github.com/root-project/root/issues/14155