### PR TITLE
Fix build issue on macOS 15.4 / XCode 16.3

### DIFF
--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <vector>
+#include <functional>
 #include "Rtypes.h"
 
 namespace ROOT {


### PR DESCRIPTION
`less` is defined in functional according to the C++ standard.