### PR TITLE
[tmva][sofie]  Optimize LayerNormalization operator

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
@@ -47,8 +47,7 @@ public:
    }
 
 
-   std::string Generate(std::string OpName) override {
-      OpName = "op_" + OpName;
+   std::string Generate(std::string opName) override {
       if (fShape.empty()){
          throw std::runtime_error("TMVA SOFIE Operator Sigmoid called to Generate without being initialized first");
       }
@@ -57,9 +56,10 @@ public:
       for(auto& i: fShape){
          length *= i;
       }
-      out << "\t" << "for (int id = 0; id < " << length << " ; id++){\n";
-      out << "\t\t" << "tensor_" << fNY << "[id] = 1 / (1 + std::exp( - tensor_"  << fNX << "[id]));\n";
-      out << "\t}\n";
+      out << "\n//------ Sigmoid -- " << opName << "\n";
+      out << SP << "for (int id = 0; id < " << length << " ; id++){\n";
+      out << SP << SP  << "tensor_" << fNY << "[id] = 1 / (1 + std::exp( - tensor_"  << fNX << "[id]));\n";
+      out << SP << "}\n";
       return out.str();
    }
 


### PR DESCRIPTION
For square operations, do not use std::pow with base 2 since it is slower than simple multiplication This speeds up evaluation on ATLAS GNN tracking model by 40%

Also avoids allocating a small shape vector in LayerNorm and improve the indentation of the sigmoid operator

