### PR TITLE
RBrowser improve [skip-ci]

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -57,6 +57,7 @@ protected:
 
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(unsigned connid, std::vector<std::string> &args);
+   std::string ProcessDrop(unsigned connid, std::vector<std::string> &args);
    std::string NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget);
    void ProcessRunMacro(const std::string &file_path);
    void ProcessSaveFile(const std::string &fname, const std::string &content);

--- a/js/changes.md
+++ b/js/changes.md
@@ -23,6 +23,7 @@
 1. Support `TF12` - projection of `TF2`
 1. Upgrade three.js r168 -> r174
 1. Remove support of qt5 webengine, only qt6web is supported
+1. Set 'user-select: none' style in drawings to exclude text selection, using `settings.UserSelect` value
 1. Internals - use private members and methods
 1. Internals - use `WeakRef` class for cross-referencing of painters
 1. Internals - use negative indexes in arrays and Strings

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '1/04/2025',
+version_date = '4/04/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -266,6 +266,8 @@ settings = {
    DragAndDrop: !nodejs,
    /** @summary Interactive dragging of TGraph points */
    DragGraphs: true,
+   /** @summary Value of user-select style in interactive drawings */
+   UserSelect: 'none',
    /** @summary Show progress box, can be false, true or 'modal' */
    ProgressBox: !nodejs,
    /** @summary Show additional tool buttons on the canvas, false - disabled, true - enabled, 'popup' - only toggle button */
@@ -883,7 +885,7 @@ function createHttpRequest(url, kind, user_accept_callback, user_reject_callback
          if ((this.readyState === 2) && this.expected_size) {
             const len = parseInt(this.getResponseHeader('Content-Length'));
             if (Number.isInteger(len) && (len > this.expected_size) && !settings.HandleWrongHttpResponse) {
-               this.did_abort = true;
+               this.did_abort = 'large';
                this.abort();
                return this.error_callback(Error(`Server response size ${len} larger than expected ${this.expected_size}. Abort I/O operation`), 599);
             }

--- a/js/modules/gpad/RPadPainter.mjs
+++ b/js/modules/gpad/RPadPainter.mjs
@@ -429,6 +429,9 @@ class RPadPainter extends RObjectPainter {
          if (!this.isBatchMode() && !this.online_canvas)
             svg.append('svg:title').text('ROOT canvas');
 
+         if (!this.isBatchMode())
+            svg.style('user-select', settings.UserSelect || null);
+
          frect = svg.append('svg:path').attr('class', 'canvas_fillrect');
          if (!this.isBatchMode()) {
             frect.style('pointer-events', 'visibleFill')

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -664,6 +664,9 @@ class TPadPainter extends ObjectPainter {
          else if (!this.online_canvas)
             svg.append('svg:title').text('ROOT canvas');
 
+         if (!is_batch)
+            svg.style('user-select', settings.UserSelect || null);
+
          if (!is_batch || (this.pad.fFillStyle > 0))
             frect = svg.append('svg:path').attr('class', 'canvas_fillrect');
 

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -35,7 +35,7 @@ function injectHStyle(node) {
 .jsroot .${cssValueNum} { color: blue; }
 .jsroot .h_line { height: 18px; display: block; }
 .jsroot .${cssButton} { cursor: pointer; color: blue; text-decoration: underline; }
-.jsroot .${cssItem} { cursor: pointer; }
+.jsroot .${cssItem} { cursor: pointer; user-select: none; }
 .jsroot .${cssItem}:hover { text-decoration: underline; }
 .jsroot .h_childs { overflow: hidden; display: block; }
 .jsroot_fastcmd_btn { height: 32px; width: 32px; display: inline-block; margin: 2px; padding: 2px; background-position: left 2px top 2px;

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -835,6 +835,7 @@ class JSRootMenu {
       this.addchk(settings.ZoomTouch, 'Touch', flag => { settings.ZoomTouch = flag; });
       this.endsub();
       this.addchk(settings.HandleKeys, 'Keypress handling', flag => { settings.HandleKeys = flag; });
+      this.addchk(!settings.UserSelect, 'User select', flag => { settings.UserSelect = flag ? '' : 'none'; }, 'Set "user-select: none" for drawings to avoid text selection ');
       this.addchk(settings.MoveResize, 'Move and resize', flag => { settings.MoveResize = flag; });
       this.addchk(settings.DragAndDrop, 'Drag and drop', flag => { settings.DragAndDrop = flag; });
       this.addchk(settings.DragGraphs, 'Drag graph points', flag => { settings.DragGraphs = flag; });

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -222,7 +222,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }));
 
          this.columnNames   = ['Size',  'Time',  'Type',  'UID',  'GID',  'ClassName'];
-         this.columnFields  = ['fisze', 'mtime', 'ftype', 'fuid', 'fgid', 'className'];
+         this.columnFields  = ['fsize', 'mtime', 'ftype', 'fuid', 'fgid', 'className'];
          this.columnVisible = [ true,    false,   false,   false,  false,  false];
          for (let i = 0; i < this.columnNames.length; ++i) {
             t.addColumn(new tableColumn({
@@ -246,15 +246,10 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          t.addEventDelegate({
             onAfterRendering() {
                this.assignRowHandlers();
-               if (this._columnResized < 1) return;
-               this._columnResized = 0;
-               let fullsz = 4;
-
-               t.getColumns().forEach(col => {
-                  if (col.getVisible()) fullsz += 4 + col.$().width();
-               });
-               // this.getView().byId('masterPage').getParent().removeStyleClass('masterExpanded');
-               this.getView().byId('SplitAppBrowser').getAggregation('_navMaster').setWidth(fullsz + 'px');
+               if (this._columnResized > 0) {
+                  this._columnResized = 0;
+                  this.adjustToColumnsWidths(false);
+               }
             }
          }, this);
 
@@ -274,18 +269,38 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             this.oMenu.addItem(new MenuActionItem({
                icon: this.columnVisible[i] ? "sap-icon://accept" : "sap-icon://hide",
                label: this.columnNames[i],
-               press: [() => this.pressColumnMenu(i), this]
+               press: () => this.pressColumnMenu(i)
             }));
+         this.oMenu.addItem(new MenuActionItem({
+            icon: 'sap-icon://resize-horizontal',
+            label: 'Resize columns',
+            press: () => this.adjustToColumnsWidths(true)
+         }));
       },
 
       pressColumnMenu(indx) {
          this.columnVisible[indx] = !this.columnVisible[indx];
 
-         let t = this.getView().byId('treeTable');
+         const t = this.getView().byId('treeTable');
          t.getColumns()[indx+1].setVisible(this.columnVisible[indx]);
 
          this.oMenu.close();
          this.buildColumnsMenu();
+      },
+
+      adjustToColumnsWidths(auto_resize) {
+         if (auto_resize)
+            this.oMenu.close();
+         let fullsz = 4;
+         const t = this.getView().byId('treeTable');
+         t.getColumns().forEach(col => {
+            if (col.getVisible()) {
+               if (auto_resize)
+                  col.autoResize();
+               fullsz += 4 + col.$().width();
+            }
+         });
+         this.getView().byId('SplitAppBrowser').getAggregation('_navMaster').setWidth(fullsz + 'px');
       },
 
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -1027,7 +1027,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       assignRowHandlers() {
          let rows = this.byId("treeTable").getRows();
          for (let k = 0; k < rows.length; ++k) {
-            rows[k].$().dblclick(this.onRowDblClick.bind(this, rows[k]));
+            rows[k].$().dblclick(this.onRowDblClick.bind(this, rows[k]))
+                       .css('user-select', 'none');
          }
       },
 

--- a/ui5/browser/model/BrowserModel.js
+++ b/ui5/browser/model/BrowserModel.js
@@ -28,6 +28,7 @@ sap.ui.define([
          this.itemsFilter = '';
          this.showHidden = false;
          this.appendToCanvas = false;
+         this.handleDoubleClick = true;
          this.onlyLastCycle = 0; // 0 - not changed, -1 off , +1 on
 
          this.threshold = 100; // default threshold to prefetch items
@@ -53,8 +54,14 @@ sap.ui.define([
       /** @summary Set show hidden flag */
       setAppendToCanvas(flag) { this.appendToCanvas = flag; },
 
-      /** @summary Is show hidden flag set */
+      /** @summary Is append to canvas when double click set */
       isAppendToCanvas() { return this.appendToCanvas; },
+
+      /** @summary Set double click handler */
+      setHandleDoubleClick(flag) { this.handleDoubleClick = flag; },
+
+      /** @summary Is double-click handler activated */
+      isHandleDoubleClick() { return this.handleDoubleClick; },
 
       getOnlyLastCycle() { return this.onlyLastCycle; },
 

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -4,6 +4,7 @@
           xmlns:mvc="sap.ui.core.mvc"
           xmlns:t="sap.ui.table"
           xmlns:core="sap.ui.core"
+          xmlns:dnd="sap.ui.core.dnd"
           xmlns:l="sap.ui.layout"
           xmlns:tnt="sap.tnt">
   <Page showSubHeader="false" showHeader="false" showFooter="false">
@@ -54,6 +55,9 @@
                     <t:layoutData>
                       <FlexItemData growFactor="1"/>
                     </t:layoutData>
+                    <t:dragDropConfig>
+                      <dnd:DragDropInfo  sourceAggregation="rows" dragStart="onDragStart"/>
+                    </t:dragDropConfig>
                   </t:TreeTable>
                 </ScrollContainer>
               </content>

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -51,6 +51,7 @@
                           selectionMode="Single"
                           visibleRowCountMode="Auto"
                           showColumnVisibilityMenu="true"
+                          cellClick="onCellClick"
                           rows="{/nodes}" >
                     <t:layoutData>
                       <FlexItemData growFactor="1"/>

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -50,8 +50,9 @@
                           selectionBehavior="RowOnly"
                           selectionMode="Single"
                           visibleRowCountMode="Auto"
-                          showColumnVisibilityMenu="true"
+                          showColumnVisibilityMenu="false"
                           cellClick="onCellClick"
+                          cellContextmenu="onCellContextMenu"
                           rows="{/nodes}" >
                     <t:layoutData>
                       <FlexItemData growFactor="1"/>

--- a/ui5/browser/view/settingsmenu.fragment.xml
+++ b/ui5/browser/view/settingsmenu.fragment.xml
@@ -53,6 +53,7 @@
             <CheckBox text="Reverse order" selected="{/ReverseOrder}" />
             <CheckBox text="Show hidden files" selected="{/ShowHiddenFiles}" />
             <CheckBox text="Double click to run macro" selected="{/DBLCLKRun}" />
+            <CheckBox text="Draw by mouse double-click" selected="{/HandleDoubleClick}" tooltip="Plain click mode support also keyboard navigation"/>
           </VBox>
         </content>
       </ViewSettingsCustomTab>

--- a/ui5/geom/controller/GeomHierarchy.controller.js
+++ b/ui5/geom/controller/GeomHierarchy.controller.js
@@ -197,7 +197,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       assignRowHandlers() {
          let rows = this.byId("treeTable").getRows();
          for (let k = 0; k < rows.length; ++k)
-            rows[k].$().hover(this.onRowHover.bind(this, rows[k], true), this.onRowHover.bind(this, rows[k], false));
+            rows[k].$().hover(this.onRowHover.bind(this, rows[k], true), this.onRowHover.bind(this, rows[k], false))
+                       .css('user-select', 'none');
       },
 
       /** @brief Handler for mouse-hover event


### PR DESCRIPTION
1. Use `user-select: none` for text in list view to avoid text selection
2. Implement `drag-and-drop` functionality for items in Tree view
3. Let optionally use single-click handler for display, as openui5 default behavior does
4. Suppress custom context menu in Tree view
5. Provide other columns context menu for enabling/disabling and resize of columns
6. Update JSROOT with `user-select: none` for drawings