### PR TITLE
Reintroduce rcanvas_mt.cxx tutorial [skip-ci]

### DIFF
--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -509,6 +509,9 @@ public:
    RDefaultProvider()
    {
       // TODO: let read from rootrc or any other files
+      RegisterClass("ROOT::Experimental::RCanvas", "sap-icon://business-objects-experience", "", "",
+                    "libROOTObjectDraw7Provider");
+
       RegisterClass("ROOT::RNTuple", "sap-icon://table-chart", "libROOTNTupleBrowseProvider",
                     "libROOTNTupleDraw6Provider", "libROOTNTupleDraw7Provider");
    }

--- a/js/modules/gpad/RAxisPainter.mjs
+++ b/js/modules/gpad/RAxisPainter.mjs
@@ -949,7 +949,7 @@ class RAxisPainter extends RObjectPainter {
 
    /** @summary Change zooming in standalone mode */
    zoomStandalone(min, max) {
-      this.changeAxisAttr(1, 'zoomMin', min, 'zoomMax', max);
+      return this.changeAxisAttr(1, 'zoomMin', min, 'zoomMax', max);
    }
 
    /** @summary Redraw axis, used in standalone mode for RAxisDrawable */
@@ -961,15 +961,17 @@ class RAxisPainter extends RObjectPainter {
             labels_len = drawable.fLabels.length,
             min = (labels_len > 0) ? 0 : this.v7EvalAttr('min', 0),
             max = (labels_len > 0) ? labels_len : this.v7EvalAttr('max', 100);
-      let len = pp.getPadLength(drawable.fVertical, drawable.fLength);
+      let len = pp.getPadLength(drawable.fVertical, drawable.fLength),
+          smin = this.v7EvalAttr('zoomMin'),
+          smax = this.v7EvalAttr('zoomMax');
 
       // in vertical direction axis drawn in negative direction
-      if (drawable.fVertical) len -= pp.getPadHeight();
+      if (drawable.fVertical)
+         len -= pp.getPadHeight();
 
-      let smin = this.v7EvalAttr('zoomMin'),
-          smax = this.v7EvalAttr('zoomMax');
       if (smin === smax) {
-         smin = min; smax = max;
+         smin = min;
+         smax = max;
       }
 
       this.configureAxis('axis', min, max, smin, smax, drawable.fVertical, undefined, len, { reverse, labels: labels_len > 0 });

--- a/js/modules/gpad/RPadPainter.mjs
+++ b/js/modules/gpad/RPadPainter.mjs
@@ -1072,7 +1072,7 @@ class RPadPainter extends RObjectPainter {
 
       // empty object, no need to do something, take next
       if (snap.fDummy)
-         return this.drawNextSnap(lst, pindx, indx);
+         return this.drawNextSnap(lst, pindx + 1, indx);
 
       if (snap._typename === `${nsREX}TObjectDisplayItem`) {
          // identifier used in TObjectDrawable
@@ -1259,16 +1259,15 @@ class RPadPainter extends RObjectPainter {
          if (i >= snap.fPrimitives.length)
             break;
 
+
          const prim = snap.fPrimitives[i];
-         // ignore primitives without snapid or which are not produce drawings
-         if (prim.fDummy || !prim.fObjectID || ((prim._typename === `${nsREX}TObjectDisplayItem`) && ((prim.fKind === webSnapIds.kStyle) || (prim.fKind === webSnapIds.kColors) || (prim.fKind === webSnapIds.kPalette) || (prim.fKind === webSnapIds.kFont)))) {
-            i++;
-            continue;
-         }
 
          if (prim.fObjectID === sub.snapid) {
             i++;
             k++;
+         } else if (prim.fDummy || !prim.fObjectID || ((prim._typename === `${nsREX}TObjectDisplayItem`) && ((prim.fKind === webSnapIds.kStyle) || (prim.fKind === webSnapIds.kColors) || (prim.fKind === webSnapIds.kPalette) || (prim.fKind === webSnapIds.kFont)))) {
+            // ignore primitives without snapid or which are not produce drawings
+            i++;
          } else {
             missmatch = true;
             break;

--- a/tutorials/experimental/rcanvas/rcanvas_mt.cxx
+++ b/tutorials/experimental/rcanvas/rcanvas_mt.cxx
@@ -1,0 +1,128 @@
+/// \file
+/// \ingroup tutorial_rcanvas
+///
+/// This macro demonstrate usage of ROOT7 graphics from many threads
+/// Three different canvases in three different threads are started and regularly updated.
+/// Extra thread created in background and used to run http protocol, in/out websocket communications and process http
+/// requests
+/// Main application thread (CLING interactive session) remains fully functional
+///
+/// \macro_code
+///
+/// \date 2018-08-16
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+/// \author Sergey Linev
+
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RWebWindowsManager.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/TObjectDrawable.hxx"
+
+#include "TRandom3.h"
+#include "TEnv.h"
+#include "TROOT.h"
+#include "TH1.h"
+#include "TColor.h"
+
+#include <thread>
+#include <iostream>
+
+using namespace ROOT::Experimental;
+
+void draw_canvas(const std::string &title, Int_t col1)
+{
+   // Create histograms
+   auto hist1 = new TH1D("hist1", "hist1", 100, -10, 10);
+   auto hist2 = new TH1D("hist2", "hist2", 100, -10, 10);
+
+   hist1->SetLineColor(col1);
+   hist2->SetLineColor(kBlue);
+
+   TRandom3 random;
+   Float_t px, py;
+
+   for (int n = 0; n < 10000; ++n) {
+      random.Rannor(px, py);
+      hist1->Fill(px - 2);
+      hist2->Fill(py + 2);
+   }
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create(title);
+
+   canvas->Draw<TObjectDrawable>(hist1, "");
+   canvas->Draw<TObjectDrawable>(hist2, "same");
+
+   int maxloop = 100;
+
+   canvas->Show();
+
+   std::cout << title << " started" <<std::endl;
+
+   for (int loop = 0; loop < maxloop; ++loop) {
+
+      for (int n = 0; n < 10000; ++n) {
+         random.Rannor(px, py);
+         hist1->Fill(px - 2);
+         hist2->Fill(py + 2);
+      }
+
+      canvas->Modified();
+
+      canvas->Update();
+      canvas->Run(0.2); // let run canvas code for next 0.5 seconds
+
+      // if (loop == 0)
+      //    canvas->SaveAs(title + "_first.png");
+      // if (loop == maxloop - 1)
+      //    canvas->SaveAs(title + "_last.png");
+   }
+
+   std::cout << title << " completed" <<std::endl;
+
+   // remove from global list, will be destroyed with thread exit
+   canvas->Remove();
+}
+
+void rcanvas_mt(bool block_main_thread = false)
+{
+   TH1::AddDirectory(false);
+
+   if (block_main_thread) {
+      // let use special http thread to process requests, do not need main thread
+      // required while gSystem->ProcessEvents() will be blocked
+      gEnv->SetValue("WebGui.HttpThrd", "yes");
+
+      // let create special threads for data sending, optional
+      gEnv->SetValue("WebGui.SenderThrds", "yes");
+   }
+
+   ROOT::EnableThreadSafety();
+
+   // create instance in main thread, used to assign thread id as well
+   ROOT::RWebWindowsManager::Instance();
+
+   std::thread thrd1(draw_canvas, "First canvas", kRed);
+   std::thread thrd2(draw_canvas, "Second canvas", kBlue);
+   std::thread thrd3(draw_canvas, "Third canvas", kGreen);
+
+   if (block_main_thread) {
+      // wait until threads execution finished
+      thrd1.join();
+      thrd2.join();
+      thrd3.join();
+   } else {
+      // detach threads and return to CLING
+      thrd1.detach();
+      thrd2.detach();
+      thrd3.detach();
+   }
+}


### PR DESCRIPTION
Previous version was deleted because usage of RH1D.
Now use TH1D instead.

Fix problem with RCanvas update in jsroot

Add again entry for RBrowser to load library for RCanvas