### PR TITLE
Fix memory leak identified with valgrind in HistFactory histogram rea…

### DIFF
--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -456,7 +456,7 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
-  std::unique_ptr<TH1>hist(key->ReadObject<TH1>());
+  std::unique_ptr<TH1> hist(key->ReadObject<TH1>());
   if( !hist ) {
     cxcoutEHF << "Histogram '" << HistoName
         << "' wasn't found in file '" << InputFile

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -456,7 +456,7 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
-  auto hist = key->ReadObject<TH1>();
+  std::unique_ptr<TH1>hist(key->ReadObject<TH1>());
   if( !hist ) {
     cxcoutEHF << "Histogram '" << HistoName
         << "' wasn't found in file '" << InputFile


### PR DESCRIPTION
Fixing a minor leak in the HistFactory code identified with valgrind:

```
==231226== 2,528 (2,000 direct, 528 indirect) bytes in 2 blocks are definitely lost in loss record 14,688 of 15,884
==231226==    at 0x4848F95: operator new(unsigned long) (vg_replace_malloc.c:487)
==231226==    by 0x4F0806C: TStorage::ObjectAlloc(unsigned long) (TStorage.cxx:293)
==231226==    by 0x550EEF9: operator new (TObject.h:187)
==231226==    by 0x550EEF9: ROOT::new_TH1D(void*) (G__Hist.cxx:11950)
==231226==    by 0x4FA3918: TClass::NewObject(TClass::ENewType, bool) const (TClass.cxx:5125)
==231226==    by 0x4FA7013: TClass::New(TClass::ENewType, bool) const (TClass.cxx:5102)
==231226==    by 0x69BFB63: TKey::ReadObjectAny(TClass const*) (TKey.cxx:1087)
==231226==    by 0x751D59B: ReadObject<TH1> (TKey.h:104)
==231226==    by 0x751D59B: RooStats::HistFactory::Channel::GetHistogram(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unique_ptr<TFile, std::default_delete<TFile> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<TFile, std::default_delete<TFile> > > > >&) (Channel.cxx:459)
==231226==    by 0x751E37B: RooStats::HistFactory::Channel::CollectHistograms() (Channel.cxx:230)
==231226==    by 0x7561720: RooStats::HistFactory::Measurement::CollectHistograms() (Measurement.cxx:652)
==231226==    by 0x4BC9C30: TRExFit::ToRooStats(bool, bool) const (TRExFit.cc:3514)
==231226==    by 0x114EEB: FitExample(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (trex-fitter.cc:448)
==231226==    by 0x10FE1E: main (trex-fitter.cc:696)
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

