### PR TITLE
Fix a warning when compiling quartz on macos 15.4 with clt 16.3

### DIFF
--- a/graf2d/quartz/src/QuartzLine.mm
+++ b/graf2d/quartz/src/QuartzLine.mm
@@ -61,10 +61,11 @@ void SetLineType(CGContextRef ctx, Int_t n, Int_t *dash)
    assert(ctx != 0 && "SetLineType, ctx parameter is null");
 
    if (n) {
-      CGFloat lengths[n];
+      CGFloat* lengths = new CGFloat[n];
       for (int i = 0; i < n; i++)
          lengths[i] = dash[i];
       CGContextSetLineDash(ctx, 0, lengths, n);
+      delete[] lengths;
    } else {
       CGContextSetLineDash(ctx, 0, NULL, 0);
    }


### PR DESCRIPTION
Fix a warning when compiling quartz on macos 15.4 with clt 16.3

