### PR TITLE
Fixes for Mac beta

### DIFF
--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -345,7 +345,7 @@ private:
    // List of branches for which we want to suppress the printed error about
    // missing branch when switching to a new tree
    std::set<std::string> fSuppressErrorsForMissingBranches{};
-   std::vector<std::string> fMissingProxies{};
+   std::set<std::string> fMissingProxies{};
 
    friend class ROOT::Internal::TTreeReaderValueBase;
    friend class ROOT::Internal::TTreeReaderArrayBase;

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -376,6 +376,8 @@ bool TTreeReader::Notify()
 
 bool TTreeReader::SetProxies()
 {
+   fMissingProxies.clear();
+   fProxiesSet = false; // In the loop below, we cannot recreate proxies if this is true
 
    for (size_t i = 0; i < fValues.size(); ++i) {
       ROOT::Internal::TTreeReaderValueBase *reader = fValues[i];

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -401,13 +401,9 @@ bool TTreeReader::SetProxies()
       if (!reader->GetProxy()) {
          if (suppressErrorsForThisBranch ||
              (reader->GetSetupStatus() == ROOT::Internal::TTreeReaderValueBase::ESetupStatus::kSetupMissingBranch))
-            fMissingProxies.push_back(reader->fBranchName.Data());
+            fMissingProxies.insert(reader->fBranchName.Data());
          else
             return false;
-      } else {
-         // Erase the branch name from the missing proxies if it was present
-         fMissingProxies.erase(std::remove(fMissingProxies.begin(), fMissingProxies.end(), reader->fBranchName.Data()),
-                               fMissingProxies.end());
       }
    }
    // If at least one proxy was there and no error occurred, we assume the proxies to be set.

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -833,8 +833,10 @@ void ROOT::Internal::TTreeReaderValueBase::ErrorAboutMissingProxyIfNeeded()
    // Print the error only if the branch name does not appear in the list of
    // missing proxies that the user explicitly requested not to error about
    if (!fTreeReader || fTreeReader->fMissingProxies.count(fBranchName.Data()) == 0)
-      Error("TTreeReaderValue::Get()", "Value reader not properly initialized, did you call "
-                                       "TTreeReader::Set(Next)Entry() or TTreeReader::Next()?");
+      Error("TTreeReaderValue::Get()",
+            "Value reader for branch %s not properly initialized, did you call "
+            "TTreeReader::Set(Next)Entry() or TTreeReader::Next()?",
+            fBranchName.Data());
 }
 
 namespace cling {

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -832,8 +832,7 @@ void ROOT::Internal::TTreeReaderValueBase::ErrorAboutMissingProxyIfNeeded()
 {
    // Print the error only if the branch name does not appear in the list of
    // missing proxies that the user explicitly requested not to error about
-   if (!fTreeReader || std::find(fTreeReader->fMissingProxies.cbegin(), fTreeReader->fMissingProxies.cend(),
-                                 fBranchName.Data()) == fTreeReader->fMissingProxies.cend())
+   if (!fTreeReader || fTreeReader->fMissingProxies.count(fBranchName.Data()) == 0)
       Error("TTreeReaderValue::Get()", "Value reader not properly initialized, did you call "
                                        "TTreeReader::Set(Next)Entry() or TTreeReader::Next()?");
 }

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -8,7 +8,6 @@
 
 #include "data.h"
 
-#include "RErrorIgnoreRAII.hxx"
 #include "ROOT/TestSupport.hxx"
 
 #include <memory>
@@ -185,7 +184,10 @@ TEST(TTreeReaderLeafs, ArrayWithReaderValue)
    TTreeReader tr(tree.get());
    TTreeReaderValue<double> valueOfArr(tr, "arr");
    {
-      RErrorIgnoreRAII errorIgnRAII;
+      ROOT::TestSupport::CheckDiagsRAII check;
+      check.requiredDiag(kError, "TTreeReaderValueBase", "Must use TTreeReaderArray to read branch", false);
+      check.requiredDiag(kError, "TTreeReaderValueBase", /*The branch xxx*/ "contains data of type", false);
+      check.requiredDiag(kError, "TTreeReaderValue", /*Value reader for xxx*/ "not properly initialized", false);
       tr.Next();
       *valueOfArr;
    }

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -189,7 +189,7 @@ TEST(TTreeReaderLeafs, ArrayWithReaderValue)
       check.requiredDiag(kError, "TTreeReaderValueBase", /*The branch xxx*/ "contains data of type", false);
       check.requiredDiag(kError, "TTreeReaderValue", /*Value reader for xxx*/ "not properly initialized", false);
       tr.Next();
-      *valueOfArr;
+      EXPECT_EQ(valueOfArr.Get(), nullptr);
    }
    EXPECT_FALSE(valueOfArr.IsValid());
 }

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -963,7 +963,7 @@ if(ROOT_pyroot_FOUND)
       endif()
     endforeach()
 
-    if(NOT ${${tname}-depends} STREQUAL ${tutorial_name})
+    if(NOT "${${tname}-depends}" STREQUAL ${tutorial_name})
       set(tutorial_dependency ${${tname}-depends})
     else()
       set(tutorial_dependency "")


### PR DESCRIPTION
- Since the missing value feature has been added to RDF and TTreeReader, a crash was observed when running RDF with the missing value feature. When changing to another tree, branches didn't didn't get recreated, leaving them in an inconsistent state.
- Another crash only observed on Mac15 beta seems to have been a line in a test that's dereferencing a nullptr. It doesn't do anything with that value, but it still generated a SIGTRAP.
- Python tutorials were running in unspecified order, because a string comparison with an empty string in CMake was taking the wrong branch and removing all dependencies.

Note:
- [x] The first commit is from #18259, and will be rebased away. It's here to avoid a known failure. (Done)