### PR TITLE
[json] Check dictionary for std::map object in streaming

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1364,6 +1364,12 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
          map_convert = 2; // mapped into normal object
       else
          map_convert = 1;
+
+      if (!cl->HasDictionary()) {
+         Error("JsonWriteObject", "Cannot stream class %s without dictionary", cl->GetName());
+         AppendOutput(map_convert == 1 ? "[]" : "null");
+         goto post_process;
+      }
    }
 
    if (!obj) {

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1875,6 +1875,11 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
    if ((special_kind == TClassEdit::kMap) || (special_kind == TClassEdit::kMultiMap) ||
        (special_kind == TClassEdit::kUnorderedMap) || (special_kind == TClassEdit::kUnorderedMultiMap)) {
       map_convert = json->is_object() ? 2 : 1; // check if map was written as array or as object
+
+      if (objClass && !objClass->HasDictionary()) {
+         Error("JsonReadObject", "Cannot stream class %s without dictionary", objClass->GetName());
+         return obj;
+      }
    }
 
    // from now all operations performed with sub-element,

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -47,6 +47,12 @@ All STL containers by default converted into JSON Array. Vector of integers:
 ~~~
 Will produce JSON code "[1, 4, 7]".
 
+IMPORTANT: Before using any of `map` classes in I/O, one should create dictionary
+for it with the command like:
+```
+gInterpreter->GenerateDictionary("std::map<int,std::string>", "map;string")
+```
+
 There are special handling for map classes like `map` and `multimap`.
 They will create Array of pair objects with "first" and "second" as data members. Code:
 ~~~{.cpp}
@@ -63,9 +69,10 @@ Will generate json string:
 ]
 ~~~
 In special cases map container can be converted into JSON object. For that key parameter
-must be `std::string` and compact parameter should be 5.
-Like in example:
+must be `std::string` and compact parameter should be 5. Like in example:
 ~~~{.cpp}
+gInterpreter->GenerateDictionary("std::map<std::string,int>", "map;string")
+
 std::map<std::string,int> data;
 data["name1"] = 11;
 data["name2"] = 22;


### PR DESCRIPTION
When stream directly `std::map` object in macro like:
```
   std::map<int,string> m;
   m[1] = "number 1";
   m[2] = "number 2";
   auto json = TBufferJSON::ToJSON(&m);
```
Real dictionary class for `std::map` is required.
It checked automatically when map is member of user class,
but was not checked when map object itself streamed
