### PR TITLE
[cppyy] Disable warnings for invalid function casts

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -73,9 +73,13 @@ if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT MSVC)
     -Wno-unused-but-set-parameter)
 endif()
 
-# Disables warnings coming from PyCFunction casts
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 8)
-  target_compile_options(${libname} PRIVATE -Wno-cast-function-type)
+# Avoid warnings due to invalid function casts from C++ functions in CPyCppyy
+# to CPython API function typedefs (e.g. PyCFunction). This is a common pattern
+# in CPython extension implementations, explicitly encouraged by the official
+# CPython docs for C/C++ extensions. see
+# https://docs.python.org/3/extending/extending.html#keyword-parameters-for-extension-functions
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(${libname} PRIVATE -Wno-cast-function-type -Wno-bad-function-cast)
 endif()
 
 # Disables warnings in Python 3.8 caused by the temporary extra filed for tp_print compatibility


### PR DESCRIPTION
Some C++ functions defined in CPyCppyy are passed to CPython API, e.g. to build Python methods that use some C++ functionality. This is done by creating a instance of a PyMethodDef struct
(https://docs.python.org/3/c-api/structures.html#c.PyMethodDef). One data member of this struct is of type PyCFunction
(https://docs.python.org/3/c-api/structures.html#c.PyCFunction), a typedef of a function with signature
```
PyObject *PyCFunction(PyObject *self,
                      PyObject *args);
```
In many cases, the C++ functions that are used as the data member of the PyMethodDef are not directly implemented as PyCFunction, thus need to be cast. This cast is often invalid, since many of such functions do not really respect the function signature prescribed by the API. This pattern is actually encouraged for CPython extension implementations by the official CPython docs
(https://docs.python.org/3/extending/extending.html#keyword-parameters-for-extension-functions). As such, the compiler warnings that are generated becausee of the invalid function casts, for example
```
root/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx:1949:50: warning: cast from 'PyObject *(*)(PyObject *)' (aka '_object *(*)(_object *)') to 'PyCFunction' (aka '_object *(*)(_object *, _object *)') converts to incompatible function type [-Wcast-function-type-mismatch]
 1949 |         Utility::AddToClass(pyclass, "__repr__", (PyCFunction)ComplexRepr, METH_NOARGS);
```
cannot be avoided and have to be suppressed. This is also done upstream, see https://github.com/wlav/CPyCppyy/commit/33d4a6ebe8ddd2ea62f6c422ca76ea98dfeda6b3
