### PR TITLE
[df] Move RNTupleDS out of experimental

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -2039,7 +2039,7 @@ public:
       fWriter.reset();
       // We can now set the data source of the loop manager for the RDataFrame that is returned by the Snapshot call.
       fOutputLoopManager->SetDataSource(
-         std::make_unique<ROOT::Experimental::RNTupleDS>(fDirName + "/" + fNTupleName, fFileName));
+         std::make_unique<ROOT::RDF::RNTupleDS>(fDirName + "/" + fNTupleName, fFileName));
    }
 
    std::string GetActionName() { return "Snapshot"; }

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -32,18 +32,20 @@
 #include <unordered_map>
 
 namespace ROOT {
-class RNTuple;
 class RFieldBase;
-
-namespace Experimental {
-
-namespace Internal {
+class RDataFrame;
+class RNTuple;
+} // namespace ROOT
+namespace ROOT::Internal::RDF {
 class RNTupleColumnReader;
+}
+namespace ROOT::Experimental::Internal {
 class RPageSource;
 }
 
+namespace ROOT::RDF {
 class RNTupleDS final : public ROOT::RDF::RDataSource {
-   friend class Internal::RNTupleColumnReader;
+   friend class ROOT::Internal::RDF::RNTupleColumnReader;
 
    /// The PrepareNextRanges() method populates the fNextRanges list with REntryRangeDS records.
    /// The GetEntryRanges() swaps fNextRanges and fCurrentRanges and uses the list of
@@ -98,7 +100,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    std::vector<std::string> fColumnTypes;
    /// List of column readers returned by GetColumnReaders() organized by slot. Used to reconnect readers
    /// to new page sources when the files in the chain change.
-   std::vector<std::vector<Internal::RNTupleColumnReader *>> fActiveColumnReaders;
+   std::vector<std::vector<ROOT::Internal::RDF::RNTupleColumnReader *>> fActiveColumnReaders;
 
    ULong64_t fSeenEntries = 0;                ///< The number of entries so far returned by GetEntryRanges()
    std::vector<REntryRangeDS> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
@@ -198,17 +200,11 @@ public:
 protected:
    Record_t GetColumnReadersImpl(std::string_view name, const std::type_info &) final;
 };
+} // namespace ROOT::RDF
 
-} // namespace Experimental
-
-class RDataFrame;
-
-namespace RDF {
-namespace Experimental {
+namespace ROOT::RDF {
 RDataFrame FromRNTuple(std::string_view ntupleName, std::string_view fileName);
 RDataFrame FromRNTuple(std::string_view ntupleName, const std::vector<std::string> &fileNames);
-} // namespace Experimental
-} // namespace RDF
-} // namespace ROOT
+} // namespace ROOT::RDF
 
 #endif

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1383,7 +1383,7 @@ std::shared_ptr<ROOT::Detail::RDF::RLoopManager>
 ROOT::Detail::RDF::CreateLMFromRNTuple(std::string_view datasetName, std::string_view fileNameGlob,
                                        const ROOT::RDF::ColumnNames_t &defaultColumns)
 {
-   auto dataSource = std::make_unique<ROOT::Experimental::RNTupleDS>(datasetName, fileNameGlob);
+   auto dataSource = std::make_unique<ROOT::RDF::RNTupleDS>(datasetName, fileNameGlob);
    auto lm = std::make_shared<ROOT::Detail::RDF::RLoopManager>(std::move(dataSource), defaultColumns);
    return lm;
 }
@@ -1392,7 +1392,7 @@ std::shared_ptr<ROOT::Detail::RDF::RLoopManager>
 ROOT::Detail::RDF::CreateLMFromRNTuple(std::string_view datasetName, const std::vector<std::string> &fileNameGlobs,
                                        const ROOT::RDF::ColumnNames_t &defaultColumns)
 {
-   auto dataSource = std::make_unique<ROOT::Experimental::RNTupleDS>(datasetName, fileNameGlobs);
+   auto dataSource = std::make_unique<ROOT::RDF::RNTupleDS>(datasetName, fileNameGlobs);
    auto lm = std::make_shared<ROOT::Detail::RDF::RLoopManager>(std::move(dataSource), defaultColumns);
    return lm;
 }

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -17,8 +17,8 @@
 
 using ROOT::RNTupleModel;
 using ROOT::RNTupleWriter;
-using ROOT::Experimental::RNTupleDS;
 using ROOT::Experimental::Internal::RPageSource;
+using ROOT::RDF::RNTupleDS;
 
 namespace {
 
@@ -118,7 +118,7 @@ TEST_F(RNTupleDSTest, NFiles)
 
 TEST_F(RNTupleDSTest, CardinalityColumn)
 {
-   auto df = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+   auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
 
    // Check that the special column #<collection> works without jitting...
    auto identity = [](std::size_t sz) { return sz; };
@@ -142,7 +142,7 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
 
 static void ReadTest(const std::string &name, const std::string &fname)
 {
-   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+   auto df = ROOT::RDF::FromRNTuple(name, fname);
 
    auto count = df.Count();
    auto sumpt = df.Sum<float>("pt");
@@ -312,7 +312,7 @@ TEST_F(RNTupleDSTest, ChainTailScheduling)
 
 TEST_F(RNTupleDSTest, ModifyColumnValues)
 {
-   auto df = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+   auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
    auto dfCorrected =
       df.Define("jetsCorrected",
                 [](ROOT::RVec<float> &jets) {
@@ -431,7 +431,7 @@ TEST(RNTupleDS, CollectionFieldTypes)
 
 TEST_F(RNTupleDSTest, AlternativeColumnTypes)
 {
-   auto df = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+   auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
 
    // Alternative inner type
    auto usingDouble = df.Define("nJets", [](const ROOT::RVec<double> &jets) { return jets.size(); }, {"jets"})
@@ -496,7 +496,7 @@ TEST_F(RNTupleDSTest, AlternativeColumnTypes)
 
    try {
       // Invalid outer field type
-      auto dfInvalid = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+      auto dfInvalid = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
       dfInvalid.Define("firstJet", [](const std::pair<float, float> &jets) { return jets.first; }, {"jets"})
          .Take<float, ROOT::RVec<float>>("firstJet")
          .GetValue();
@@ -508,7 +508,7 @@ TEST_F(RNTupleDSTest, AlternativeColumnTypes)
 
    try {
       // Invalid inner field types
-      auto dfInvalid = ROOT::RDF::Experimental::FromRNTuple(fNtplName, fFileName);
+      auto dfInvalid = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
       dfInvalid.Define("nJets", [](const std::vector<std::uint64_t> &jets) { return jets.size(); }, {"jets"})
          .Take<std::size_t, ROOT::RVec<std::size_t>>("nJets")
          .GetValue();
@@ -585,7 +585,7 @@ void ReadArraysTest(const std::string &name, const std::string &fname)
 {
    // These tests use the columns that contain std::array data on disk as RVecs
    // reading them into RVecs and checking their values.
-   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+   auto df = ROOT::RDF::FromRNTuple(name, fname);
 
    auto count = df.Count();
 
@@ -696,7 +696,7 @@ void UseArraysAsRVec(const std::string &name, const std::string &fname)
 {
    // These tests use the columns that contain std::array data on disk as RVecs
    // passing them as arguments to functions that expect RVecs.
-   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+   auto df = ROOT::RDF::FromRNTuple(name, fname);
 
    auto df1 = df.Define("col1_short", [](const ROOT::RVecI &arr) { return ROOT::VecOps::Take(arr, 2); }, {"col1_arr"});
    auto take1 = df1.Take<ROOT::RVecI>("col1_short");
@@ -734,7 +734,7 @@ void UseArraySizeColumn(const std::string &name, const std::string &fname)
 {
    // These tests use the columns that contain std::array data on disk as RVecs
    // checking the size of the collection with the R_rdf_sizeof_* columns
-   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+   auto df = ROOT::RDF::FromRNTuple(name, fname);
 
    auto sizeOfCol1 = df.Take<std::size_t>("R_rdf_sizeof_col1_arr");
    // Use # here to exercise that too

--- a/tutorials/io/ntuple/ntpl004_dimuon.C
+++ b/tutorials/io/ntuple/ntpl004_dimuon.C
@@ -34,7 +34,7 @@
 #include <utility>
 
 // Import classes from experimental namespace for the time being
-using RNTupleDS = ROOT::Experimental::RNTupleDS;
+using RNTupleDS = ROOT::RDF::RNTupleDS;
 
 constexpr char const *kNTupleFileName = "http://root.cern/files/tutorials/ntpl004_dimuon_v1.root";
 


### PR DESCRIPTION
And into the ROOT::RDF namespace, aligning it with all other RDataSource implementations.
