### PR TITLE
[RF] Fix likelihood fits with constant probabliliy

### DIFF
--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -275,14 +275,12 @@ ReduceNLLOutput RooBatchComputeClass::reduceNLL(Config const &, std::span<const 
 
    ROOT::Math::KahanSum<double> nllSum;
 
-   for (std::size_t i = 0; i < probas.size(); ++i) {
+   for (std::size_t i = 0; i < weights.size(); ++i) {
 
-      const double eventWeight = weights.size() > 1 ? weights[i] : weights[0];
-
-      if (0. == eventWeight)
+      if (0. == weights[i])
          continue;
 
-      std::pair<double, double> logOut = getLog(probas[i], out);
+      std::pair<double, double> logOut = getLog(probas.size() == 1 ? probas[0] : probas[i], out);
       double term = logOut.first;
       badness += logOut.second;
 
@@ -290,7 +288,7 @@ ReduceNLLOutput RooBatchComputeClass::reduceNLL(Config const &, std::span<const 
          term -= std::log(offsetProbas[i]);
       }
 
-      term *= -eventWeight;
+      term *= -weights[i];
 
       nllSum.Add(term);
    }

--- a/roofit/roofitcore/inc/RooFit/Detail/RooNLLVarNew.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/RooNLLVarNew.h
@@ -73,8 +73,6 @@ private:
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _expectedEvents;
    std::unique_ptr<RooTemplateProxy<RooAbsPdf>> _offsetPdf;
-   mutable double _sumWeight = 0.0;  //!
-   mutable double _sumWeight2 = 0.0; //!
    bool _weightSquared = false;
    bool _binnedL = false;
    bool _doOffset = false;

--- a/roofit/roofitcore/test/stressRooFit.cxx
+++ b/roofit/roofitcore/test/stressRooFit.cxx
@@ -171,18 +171,18 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
    gBenchmark->Start("StressRooFit");
 
    int i(1);
-   for (list<RooUnitTest *>::iterator iter = testList.begin(); iter != testList.end(); ++iter) {
+   for (RooUnitTest *unitTest : testList) {
       if (oneTest < 0 || oneTest == i) {
          if (doDump) {
-            (*iter)->setDebug(true);
+            unitTest->setDebug(true);
          }
-         int status = (*iter)->isTestAvailable() ? (*iter)->runTest() : -1;
-         StatusPrint(i, (*iter)->GetName(), status);
+         int status = unitTest->isTestAvailable() ? unitTest->runTest() : -1;
+         StatusPrint(i, unitTest->GetName(), status);
          // increment retVal for every failed test
          if (!status)
             ++retVal;
       }
-      delete (*iter);
+      delete unitTest;
       i++;
    }
 


### PR DESCRIPTION
Fix likelihood fits with constant probabliliy, which is an edge case but it should still work with the new vectorizing CPU and CUDA backends.

If the probability is a scalar, the assumption that the number of events can be retrieved by `probas.size()` is wrong. The proposed solution is to always fill the weight buffer, even in case of unity weights, because then the number of events can be retrieved like `weights.size()`.

A new unit test to cover this case was implemented, and I verified locally that it also works with the CUDA backend.

Thanks to @Moelf for noticing this!