### PR TITLE
[CMake] Improve handling of RPATH options

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -416,29 +416,21 @@ include(RootInstallDirs)
 
 #---RPATH options-------------------------------------------------------------------------------
 
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
 # add to RPATH any directories outside the project that are in the linker search path
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(rpath)
   file(RELATIVE_PATH BINDIR_TO_LIBDIR "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
 
-  set(CMAKE_SKIP_RPATH FALSE)
-  set(CMAKE_SKIP_INSTALL_RPATH FALSE)
-
   if(APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
     set(CMAKE_INSTALL_NAME_DIR "@rpath")
-    set(CMAKE_INSTALL_RPATH "@loader_path;@loader_path/${BINDIR_TO_LIBDIR}")
+    list(APPEND CMAKE_INSTALL_RPATH @loader_path @loader_path/${BINDIR_TO_LIBDIR})
   else()
-    set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/${BINDIR_TO_LIBDIR}")
+    list(APPEND CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${BINDIR_TO_LIBDIR})
   endif()
 
   unset(BINDIR_TO_LIBDIR)
-else()
-  set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 endif()
 
 #---deal with the DCMAKE_IGNORE_PATH------------------------------------------------------------


### PR DESCRIPTION
Some improvements to the handling of RPATH options, which are necessary on my system because I need to add a custom RPATH to make my CUDA package from nix packages findable.

  1. Don't set CMake variables to `FALSE` if the default is `FALSE` already. This makes it impossible to change these variables from the CMake user configuration, unnecessarily taking flexibility out of the build system.

  2. If `rpath=ON`, ROOT adds the relative path from the binary directory to the lib directory to the RPATH. But it doesn't append it, overriding any `CMAKE_INSTALL_RPATH` that the user might set in the CMake configuration. This commit suggests to append instead.

  3. If `rpath=OFF`, ROOT sets `CMAKE_SKIP_INSTALL_RPATH` to `TRUE` without any apparent reason, again, preventing the user from defining the RPATH via `CMAKE_INSTALL_RPATH`. This commit suggests to remove that line.