### PR TITLE
[BP][6.32][tree] Don't dereference a nullptr in TTreeReaderValue test.

### DIFF
--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -188,7 +188,7 @@ TEST(TTreeReaderLeafs, ArrayWithReaderValue)
    {
       RErrorIgnoreRAII errorIgnRAII;
       tr.Next();
-      *valueOfArr;
+      EXPECT_EQ(valueOfArr.Get(), nullptr);
    }
    EXPECT_FALSE(valueOfArr.IsValid());
 }


### PR DESCRIPTION
BP of what's needed of https://github.com/root-project/root/pull/18265/

