### PR TITLE
[RF] Consistent collection proxy names between constructors

### DIFF
--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -41,7 +41,7 @@ http://www.idav.ucdavis.edu/education/CAGDNotes/Bernstein-Polynomials.pdf
 
 
 RooBernstein::RooBernstein(const char *name, const char *title, RooAbsRealLValue &x, const RooArgList &coefList)
-   : RooAbsPdf(name, title), _x("x", "Dependent", this, x), _coefList("coefficients", "List of coefficients", this)
+   : RooAbsPdf(name, title), _x("x", "Dependent", this, x), _coefList("coefList", "List of coefficients", this)
 {
    _coefList.addTyped<RooAbsReal>(coefList);
 }
@@ -49,7 +49,7 @@ RooBernstein::RooBernstein(const char *name, const char *title, RooAbsRealLValue
 RooBernstein::RooBernstein(const RooBernstein &other, const char *name)
    : RooAbsPdf(other, name),
      _x("x", this, other._x),
-     _coefList("coefList", this, other._coefList),
+     _coefList(this, other._coefList),
      _refRangeName{other._refRangeName},
      _buffer{other._buffer}
 {

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -45,7 +45,7 @@ RooChebychev::RooChebychev(const char* name, const char* title,
                            RooAbsReal& x, const RooArgList& coefList):
   RooAbsPdf(name, title),
   _x("x", "Dependent", this, x),
-  _coefList("coefficients","List of coefficients",this)
+  _coefList("coefList","List of coefficients",this)
 {
   _coefList.addTyped<RooAbsReal>(coefList);
 }
@@ -55,7 +55,7 @@ RooChebychev::RooChebychev(const char* name, const char* title,
 RooChebychev::RooChebychev(const RooChebychev& other, const char* name) :
   RooAbsPdf(other, name),
   _x("x", this, other._x),
-  _coefList("coefList",this,other._coefList),
+  _coefList(this,other._coefList),
   _refRangeName(other._refRangeName)
 {
 }

--- a/roofit/roofit/src/RooTFnBinding.cxx
+++ b/roofit/roofit/src/RooTFnBinding.cxx
@@ -18,10 +18,7 @@
 #include "Riostream.h"
 
 #include "RooTFnBinding.h"
-#include "RooAbsCategory.h"
 #include "TF3.h"
-
-using std::ostream;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -29,6 +26,7 @@ using std::ostream;
 RooTFnBinding::RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list) :
   RooAbsReal(name,title),
   _olist("obs","obs",this),
+  _plist("params","params",this),
   _func(func)
 {
   _olist.add(list) ;
@@ -37,12 +35,8 @@ RooTFnBinding::RooTFnBinding(const char *name, const char *title, TF1* func, con
 ////////////////////////////////////////////////////////////////////////////////
 
 RooTFnBinding::RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& obsList, const RooArgList& paramList) :
-  RooAbsReal(name,title),
-  _olist("obs","obs",this),
-  _plist("params","params",this),
-  _func(func)
+  RooTFnBinding{name, title, func, obsList}
 {
-  _olist.add(obsList) ;
   _plist.add(paramList) ;
 }
 
@@ -50,8 +44,8 @@ RooTFnBinding::RooTFnBinding(const char *name, const char *title, TF1* func, con
 
 RooTFnBinding::RooTFnBinding(const RooTFnBinding& other, const char* name) :
   RooAbsReal(other,name),
-  _olist("obs",this,other._olist),
-  _plist("params",this,other._plist),
+  _olist(this,other._olist),
+  _plist(this,other._plist),
   _func(other._func)
 {
 }
@@ -71,7 +65,7 @@ double RooTFnBinding::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooTFnBinding::printArgs(ostream& os) const
+void RooTFnBinding::printArgs(std::ostream& os) const
 {
   // Print object arguments and name/address of function pointer
   os << "[ TFn={" << _func->GetName() << "=" << _func->GetTitle() << "} " ;

--- a/roofit/roofitcore/inc/RooCollectionProxy.h
+++ b/roofit/roofitcore/inc/RooCollectionProxy.h
@@ -30,9 +30,12 @@ the serverRedirect changes.
 #ifndef roofit_roofitcore_RooFit_RooCollectionProxy_h
 #define roofit_roofitcore_RooFit_RooCollectionProxy_h
 
-#include <RooAbsProxy.h>
 #include <RooAbsArg.h>
+#include <RooAbsProxy.h>
 #include <RooArgSet.h>
+#include <RooMsgService.h>
+
+#include <ROOT/RConfig.hxx> // for R__SUGGEST_ALTERNATIVE
 
 #include <exception>
 
@@ -53,9 +56,27 @@ public:
    }
 
    /// Copy constructor.
+   /// \note Copying a collection proxy and giving it a name different from the
+   /// original proxy doesn't make sense in the context of how this class is
+   /// used. The copy constructor that doesn't take a name as the first
+   /// parameter should be preferred.
    template <class Other_t>
    RooCollectionProxy(const char *inName, RooAbsArg *owner, const Other_t &other)
+      R__SUGGEST_ALTERNATIVE("Copying a collection proxy and giving it a name different from the original proxy "
+                             "doesn't make sense in the context of how this class is used. The copy constructor that "
+                             "doesn't take a name as the first parameter should be preferred.")
       : RooCollection_t(other, inName),
+        _owner(owner),
+        _defValueServer(other.defValueServer()),
+        _defShapeServer(other.defShapeServer())
+   {
+      _owner->registerProxy(*this);
+   }
+
+   /// Copy constructor.
+   template <class Other_t>
+   RooCollectionProxy(RooAbsArg *owner, const Other_t &other)
+      : RooCollection_t(other, other.GetName()),
         _owner(owner),
         _defValueServer(other.defValueServer()),
         _defShapeServer(other.defShapeServer())

--- a/roofit/roofitcore/src/RooPolyFunc.cxx
+++ b/roofit/roofitcore/src/RooPolyFunc.cxx
@@ -135,7 +135,7 @@ RooPolyFunc::RooPolyFunc() {}
 /// Parameterised constructor
 
 RooPolyFunc::RooPolyFunc(const char *name, const char *title, const RooAbsCollection &vars)
-   : RooAbsReal(name, title), _vars("x", "list of dependent variables", this)
+   : RooAbsReal(name, title), _vars("vars", "list of dependent variables", this)
 {
    _vars.addTyped<RooAbsReal>(vars);
 }
@@ -143,8 +143,7 @@ RooPolyFunc::RooPolyFunc(const char *name, const char *title, const RooAbsCollec
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-RooPolyFunc::RooPolyFunc(const RooPolyFunc &other, const char *name)
-   : RooAbsReal(other, name), _vars("vars", this, other._vars)
+RooPolyFunc::RooPolyFunc(const RooPolyFunc &other, const char *name) : RooAbsReal(other, name), _vars(this, other._vars)
 {
    for (auto const &term : other._terms) {
       _terms.emplace_back(std::make_unique<RooListProxy>(term->GetName(), this, *term));

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -57,9 +57,9 @@ RooProfileLL::RooProfileLL(const char *name, const char *title,
 
 RooProfileLL::RooProfileLL(const RooProfileLL &other, const char *name)
    : RooAbsReal(other, name),
-     _nll("nll", this, other._nll),
-     _obs("obs", this, other._obs),
-     _par("par", this, other._par),
+     _nll("input", this, other._nll),
+     _obs(this, other._obs),
+     _par(this, other._par),
      _startFromMin(other._startFromMin),
      _paramFixed(other._paramFixed)
 {

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -79,7 +79,7 @@ RooProjectedPdf::RooProjectedPdf() : _cacheMgr(this,10)
  RooProjectedPdf::RooProjectedPdf(const RooProjectedPdf& other, const char* name) :
    RooAbsPdf(other,name),
    intpdf("!IntegratedPdf",this,other.intpdf),
-   intobs("!IntegrationObservable",this,other.intobs),
+   intobs("!IntegrationObservables",this,other.intobs),
    deps("!Dependents",this,other.deps),
    _cacheMgr(other._cacheMgr,this)
 {


### PR DESCRIPTION
We want consistent collection proxy names, because it doesn't make sense
to set different names in the different constructors of the same class.
This only breaks code that assumes a certain proxy name, like the RooFit
HS3 JSON I/O.

Also implement a new collection proxy constructor that just copies the
name. This constructor is now the recommended one.