### PR TITLE
[RF] Set default name argument value in `RooAbsArg::clone()` overrides

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -45,7 +45,7 @@ namespace HistFactory{
     void printAllInterpCodes();
     const std::vector<int>&  interpolationCodes() const { return _interpCode; }
 
-    TObject* clone(const char* newname) const override { return new FlexibleInterpVar(*this, newname); }
+    TObject* clone(const char* newname=nullptr) const override { return new FlexibleInterpVar(*this, newname); }
     ~FlexibleInterpVar() override ;
 
     void printMultiline(std::ostream& os, Int_t contents, bool verbose = false, TString indent = "") const override;

--- a/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
@@ -32,7 +32,7 @@ namespace HistFactory{
     LinInterpVar(const char *name, const char *title);
     LinInterpVar(const LinInterpVar&, const char*);
 
-    TObject* clone(const char* newname) const override { return new LinInterpVar(*this, newname); }
+    TObject* clone(const char* newname=nullptr) const override { return new LinInterpVar(*this, newname); }
 
 
   protected:

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -29,7 +29,7 @@ public:
   ParamHistFunc(const char *name, const char *title, const RooArgList& vars, const RooArgList& paramSet, const TH1* hist );
 
   ParamHistFunc(const ParamHistFunc& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new ParamHistFunc(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new ParamHistFunc(*this, newname); }
 
   const RooArgList& paramList() const { return _paramSet ; }
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -36,7 +36,7 @@ public:
   ~PiecewiseInterpolation() override ;
 
   PiecewiseInterpolation(const PiecewiseInterpolation& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new PiecewiseInterpolation(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new PiecewiseInterpolation(*this, newname); }
 
   /// Return pointer to the nominal hist function.
   const RooAbsReal* nominalHist() const {

--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -27,7 +27,7 @@ public:
 
   RooBarlowBeestonLL(const char *name, const char *title, RooAbsReal& nll /*, const RooArgSet& observables*/);
   RooBarlowBeestonLL(const RooBarlowBeestonLL& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooBarlowBeestonLL(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBarlowBeestonLL(*this,newname); }
 
   // A simple class to store the
   // necessary objects for a

--- a/roofit/roofit/inc/Roo2DKeysPdf.h
+++ b/roofit/roofit/inc/Roo2DKeysPdf.h
@@ -28,7 +28,7 @@ public:
   Roo2DKeysPdf(const char *name, const char *title,
              RooAbsReal& xx, RooAbsReal &yy, RooDataSet& data, TString options = "a", double widthScaleFactor = 1.0);
   Roo2DKeysPdf(const Roo2DKeysPdf& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new Roo2DKeysPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new Roo2DKeysPdf(*this,newname); }
 
   ~Roo2DKeysPdf() override;
 

--- a/roofit/roofit/inc/RooArgusBG.h
+++ b/roofit/roofit/inc/RooArgusBG.h
@@ -33,7 +33,7 @@ public:
   RooArgusBG(const char *name, const char *title,
         RooAbsReal::Ref _m, RooAbsReal::Ref _m0, RooAbsReal::Ref _c, RooAbsReal::Ref _p=0.5);
   RooArgusBG(const RooArgusBG& other,const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooArgusBG(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooArgusBG(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooBCPEffDecay.h
+++ b/roofit/roofit/inc/RooBCPEffDecay.h
@@ -36,7 +36,7 @@ public:
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
   RooBCPEffDecay(const RooBCPEffDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooBCPEffDecay(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBCPEffDecay(*this,newname) ; }
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooBCPGenDecay.h
+++ b/roofit/roofit/inc/RooBCPGenDecay.h
@@ -37,7 +37,7 @@ public:
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
   RooBCPGenDecay(const RooBCPGenDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooBCPGenDecay(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBCPGenDecay(*this,newname) ; }
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -38,7 +38,7 @@ public:
          const RooResolutionModel& model,
          DecayType type);
   RooBDecay(const RooBDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override
+  TObject* clone(const char* newname=nullptr) const override
   {
     return new RooBDecay(*this,newname);
   }

--- a/roofit/roofit/inc/RooBMixDecay.h
+++ b/roofit/roofit/inc/RooBMixDecay.h
@@ -34,7 +34,7 @@ public:
           DecayType type=DoubleSided) ;
 
   RooBMixDecay(const RooBMixDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooBMixDecay(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBMixDecay(*this,newname) ; }
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooBreitWigner.h
+++ b/roofit/roofit/inc/RooBreitWigner.h
@@ -28,7 +28,7 @@ public:
   RooBreitWigner(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _width);
   RooBreitWigner(const RooBreitWigner& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooBreitWigner(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBreitWigner(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooBukinPdf.h
+++ b/roofit/roofit/inc/RooBukinPdf.h
@@ -37,7 +37,7 @@ public:
 
   RooBukinPdf(const RooBukinPdf& other,const char* name=nullptr) ;
 
-  TObject* clone(const char* newname) const override { return new RooBukinPdf(*this,newname);   }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBukinPdf(*this,newname);   }
 
 protected:
   RooRealProxy x;

--- a/roofit/roofit/inc/RooCBShape.h
+++ b/roofit/roofit/inc/RooCBShape.h
@@ -29,7 +29,7 @@ public:
         RooAbsReal& _alpha, RooAbsReal& _n);
 
   RooCBShape(const RooCBShape& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooCBShape(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCBShape(*this,newname); }
 
   Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=nullptr ) const override;
   double analyticalIntegral(Int_t, const char *rangeName = nullptr) const override;

--- a/roofit/roofit/inc/RooCFunction1Binding.h
+++ b/roofit/roofit/inc/RooCFunction1Binding.h
@@ -222,7 +222,7 @@ public:
   } ;
   RooCFunction1Binding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
   RooCFunction1Binding(const RooCFunction1Binding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction1Binding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction1Binding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
@@ -285,7 +285,7 @@ public:
   } ;
   RooCFunction1PdfBinding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
   RooCFunction1PdfBinding(const RooCFunction1PdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction1PdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction1PdfBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer

--- a/roofit/roofit/inc/RooCFunction2Binding.h
+++ b/roofit/roofit/inc/RooCFunction2Binding.h
@@ -232,7 +232,7 @@ public:
   } ;
   RooCFunction2Binding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
   RooCFunction2Binding(const RooCFunction2Binding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction2Binding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction2Binding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
@@ -299,7 +299,7 @@ public:
   } ;
   RooCFunction2PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
   RooCFunction2PdfBinding(const RooCFunction2PdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction2PdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction2PdfBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer

--- a/roofit/roofit/inc/RooCFunction3Binding.h
+++ b/roofit/roofit/inc/RooCFunction3Binding.h
@@ -242,7 +242,7 @@ public:
   } ;
   RooCFunction3Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
   RooCFunction3Binding(const RooCFunction3Binding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction3Binding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction3Binding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
@@ -312,7 +312,7 @@ public:
   } ;
   RooCFunction3PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
   RooCFunction3PdfBinding(const RooCFunction3PdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction3PdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction3PdfBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer

--- a/roofit/roofit/inc/RooCFunction4Binding.h
+++ b/roofit/roofit/inc/RooCFunction4Binding.h
@@ -229,7 +229,7 @@ public:
   } ;
   RooCFunction4Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
   RooCFunction4Binding(const RooCFunction4Binding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction4Binding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction4Binding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
@@ -301,7 +301,7 @@ public:
   } ;
   RooCFunction4PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
   RooCFunction4PdfBinding(const RooCFunction4PdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCFunction4PdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCFunction4PdfBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer

--- a/roofit/roofit/inc/RooChebychev.h
+++ b/roofit/roofit/inc/RooChebychev.h
@@ -30,7 +30,7 @@ public:
                RooAbsReal& _x, const RooArgList& _coefList) ;
 
   RooChebychev(const RooChebychev& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooChebychev(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooChebychev(*this, newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooChiSquarePdf.h
+++ b/roofit/roofit/inc/RooChiSquarePdf.h
@@ -27,7 +27,7 @@ public:
                RooAbsReal& x,  RooAbsReal& ndof) ;
 
   RooChiSquarePdf(const RooChiSquarePdf& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooChiSquarePdf(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooChiSquarePdf(*this, newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooDecay.h
+++ b/roofit/roofit/inc/RooDecay.h
@@ -29,7 +29,7 @@ public:
   RooDecay(const char *name, const char *title, RooRealVar& t,
       RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;
   RooDecay(const RooDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooDecay(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooDecay(*this,newname) ; }
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooFunctor1DBinding.h
+++ b/roofit/roofit/inc/RooFunctor1DBinding.h
@@ -37,7 +37,7 @@ public:
   } ;
   RooFunctor1DBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& var);
   RooFunctor1DBinding(const RooFunctor1DBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooFunctor1DBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFunctor1DBinding(*this,newname); }
   void printArgs(std::ostream& os) const override ;
 
 protected:
@@ -62,7 +62,7 @@ public:
   } ;
   RooFunctor1DPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& vars);
   RooFunctor1DPdfBinding(const RooFunctor1DPdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooFunctor1DPdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFunctor1DPdfBinding(*this,newname); }
   void printArgs(std::ostream& os) const override ;
 
 protected:

--- a/roofit/roofit/inc/RooFunctorBinding.h
+++ b/roofit/roofit/inc/RooFunctorBinding.h
@@ -33,7 +33,7 @@ public:
   RooFunctorBinding() = default;
   RooFunctorBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
   RooFunctorBinding(const RooFunctorBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooFunctorBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFunctorBinding(*this,newname); }
   inline ~RooFunctorBinding() override { delete[] x ; }
   void printArgs(std::ostream& os) const override ;
 
@@ -58,7 +58,7 @@ public:
   RooFunctorPdfBinding() = default;
   RooFunctorPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
   RooFunctorPdfBinding(const RooFunctorPdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooFunctorPdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFunctorPdfBinding(*this,newname); }
   inline ~RooFunctorPdfBinding() override { delete[] x ; }
   void printArgs(std::ostream& os) const override ;
 

--- a/roofit/roofit/inc/RooGExpModel.h
+++ b/roofit/roofit/inc/RooGExpModel.h
@@ -52,7 +52,7 @@ public:
 
 
   RooGExpModel(const RooGExpModel& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooGExpModel(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooGExpModel(*this,newname) ; }
 
   Int_t basisCode(const char* name) const override ;
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooGamma.h
+++ b/roofit/roofit/inc/RooGamma.h
@@ -23,7 +23,7 @@ public:
   RooGamma(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _gamma, RooAbsReal& _beta, RooAbsReal& _mu);
   RooGamma(const RooGamma& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooGamma(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooGamma(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -33,7 +33,7 @@ public:
   RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& meanSF, RooAbsReal& sigmaSF) ;
   RooGaussModel(const RooGaussModel& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooGaussModel(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooGaussModel(*this,newname) ; }
 
   Int_t basisCode(const char* name) const override ;
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -31,7 +31,7 @@ public:
   RooGaussian(const char *name, const char *title,
          RooAbsReal::Ref _x, RooAbsReal::Ref _mean, RooAbsReal::Ref _sigma);
   RooGaussian(const RooGaussian& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname=nullptr) const override {
     return new RooGaussian(*this,newname);
   }
 

--- a/roofit/roofit/inc/RooHistConstraint.h
+++ b/roofit/roofit/inc/RooHistConstraint.h
@@ -19,7 +19,7 @@ public:
   RooHistConstraint() {} ;
   RooHistConstraint(const char *name, const char *title, const RooArgSet& phfSet, int threshold=1000000);
   RooHistConstraint(const RooHistConstraint& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooHistConstraint(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooHistConstraint(*this,newname); }
 
   double getLogVal(const RooArgSet* set=nullptr) const override ;
 

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -32,7 +32,7 @@ public:
            RooAbsReal& _x,
          RooAbsReal& _alpha, bool cacheAlpha=false);
   RooIntegralMorph(const RooIntegralMorph& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooIntegralMorph(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooIntegralMorph(*this,newname); }
 
   bool selfNormalized() const override {
     // P.d.f is self normalized

--- a/roofit/roofit/inc/RooJeffreysPrior.h
+++ b/roofit/roofit/inc/RooJeffreysPrior.h
@@ -21,7 +21,7 @@ public:
   RooJeffreysPrior(const char *name, const char *title, RooAbsPdf& nominal, const RooArgList& paramSet, const RooArgList& obsSet) ;
 
   RooJeffreysPrior(const RooJeffreysPrior& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooJeffreysPrior(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooJeffreysPrior(*this, newname); }
 
   const RooArgList& lowList() const { return _obsSet ; }
   const RooArgList& paramList() const { return _paramSet ; }

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -32,7 +32,7 @@ public:
 
   RooJohnson(const RooJohnson& other, const char* newName = nullptr);
 
-  TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname=nullptr) const override {
     return new RooJohnson(*this,newname);
   }
 

--- a/roofit/roofit/inc/RooKeysPdf.h
+++ b/roofit/roofit/inc/RooKeysPdf.h
@@ -35,7 +35,7 @@ public:
              RooAbsReal& x, RooRealVar& xdata, RooDataSet& data, Mirror mirror= NoMirror,
         double rho=1);
   RooKeysPdf(const RooKeysPdf& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override {return new RooKeysPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override {return new RooKeysPdf(*this,newname); }
   ~RooKeysPdf() override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,

--- a/roofit/roofit/inc/RooLandau.h
+++ b/roofit/roofit/inc/RooLandau.h
@@ -29,7 +29,7 @@ public:
       : RooLandau{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, RooAbsReal::Ref{_sigma}} {}
   RooLandau(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, RooAbsReal::Ref _sigma);
   RooLandau(const RooLandau& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooLandau(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooLandau(*this,newname); }
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooMomentMorph.h
+++ b/roofit/roofit/inc/RooMomentMorph.h
@@ -37,7 +37,7 @@ public:
   RooMomentMorph(const char *name, const char *title, RooAbsReal& _m, const RooArgList& varList,
           const RooArgList& pdfList, const TVectorD& mrefpoints, Setting setting = NonLinearPosFractions );
   RooMomentMorph(const RooMomentMorph& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooMomentMorph(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMomentMorph(*this,newname); }
   ~RooMomentMorph() override;
 
   void     setMode(const Setting& setting) { _setting = setting; }

--- a/roofit/roofit/inc/RooMultiBinomial.h
+++ b/roofit/roofit/inc/RooMultiBinomial.h
@@ -29,7 +29,7 @@ class RooMultiBinomial : public RooAbsReal {
 
   RooMultiBinomial(const char *name, const char *title, const RooArgList& effFuncList, const RooArgList& catList, bool ignoreNonVisible);
   RooMultiBinomial(const RooMultiBinomial& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooMultiBinomial(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMultiBinomial(*this,newname); }
 
  protected:
 

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -81,7 +81,7 @@ public:
   RooNDKeysPdf(const RooNDKeysPdf& other, const char* name=nullptr);
   ~RooNDKeysPdf() override;
 
-  TObject* clone(const char* newname) const override { return new RooNDKeysPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNDKeysPdf(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooNonCPEigenDecay.h
+++ b/roofit/roofit/inc/RooNonCPEigenDecay.h
@@ -77,7 +77,7 @@ public:
             DecayType       type = DoubleSided );
 
   RooNonCPEigenDecay(const RooNonCPEigenDecay& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname=nullptr) const override {
     return new RooNonCPEigenDecay(*this,newname);
   }
 

--- a/roofit/roofit/inc/RooNovosibirsk.h
+++ b/roofit/roofit/inc/RooNovosibirsk.h
@@ -35,7 +35,7 @@ public:
 
   RooNovosibirsk(const RooNovosibirsk& other,const char* name=nullptr) ;
 
-  TObject* clone(const char* newname) const override { return new RooNovosibirsk(*this,newname);   }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNovosibirsk(*this,newname);   }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooParamHistFunc.h
+++ b/roofit/roofit/inc/RooParamHistFunc.h
@@ -27,7 +27,7 @@ public:
   RooParamHistFunc(const char *name, const char *title, RooDataHist &dh, const RooAbsArg &x,
                    const RooParamHistFunc *paramSource = nullptr, bool paramRelative = true);
   RooParamHistFunc(const RooParamHistFunc& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooParamHistFunc(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooParamHistFunc(*this,newname); }
 
   std::list<double>* binBoundaries(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;

--- a/roofit/roofit/inc/RooParametricStepFunction.h
+++ b/roofit/roofit/inc/RooParametricStepFunction.h
@@ -32,7 +32,7 @@ public:
       RooAbsReal& x, const RooArgList& coefList, TArrayD const& limits, Int_t nBins=1) ;
 
   RooParametricStepFunction(const RooParametricStepFunction& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooParametricStepFunction(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooParametricStepFunction(*this, newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -24,7 +24,7 @@ public:
       : RooPoisson{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, noRounding} {}
   RooPoisson(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, bool noRounding=false);
   RooPoisson(const RooPoisson& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooPoisson(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooPoisson(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;

--- a/roofit/roofit/inc/RooStepFunction.h
+++ b/roofit/roofit/inc/RooStepFunction.h
@@ -31,7 +31,7 @@ class RooStepFunction : public RooAbsReal {
         RooAbsReal& x, const RooArgList& coefList, const RooArgList& limits, bool interpolate=false) ;
 
   RooStepFunction(const RooStepFunction& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooStepFunction(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooStepFunction(*this, newname); }
 
   const RooArgList& coefficients() { return _coefList; }
   const RooArgList& boundaries() { return _boundaryList; }

--- a/roofit/roofit/inc/RooTFnBinding.h
+++ b/roofit/roofit/inc/RooTFnBinding.h
@@ -23,7 +23,7 @@ public:
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list, const RooArgList& plist);
   RooTFnBinding(const RooTFnBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooTFnBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooTFnBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override ;
 

--- a/roofit/roofit/inc/RooTFnPdfBinding.h
+++ b/roofit/roofit/inc/RooTFnPdfBinding.h
@@ -22,7 +22,7 @@ public:
   RooTFnPdfBinding() = default;
   RooTFnPdfBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
   RooTFnPdfBinding(const RooTFnPdfBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooTFnPdfBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooTFnPdfBinding(*this,newname); }
 
   void printArgs(std::ostream& os) const override ;
 

--- a/roofit/roofit/inc/RooUnblindCPAsymVar.h
+++ b/roofit/roofit/inc/RooUnblindCPAsymVar.h
@@ -33,7 +33,7 @@ public:
   RooUnblindCPAsymVar(const char *name, const char *title,
             const char *blindString, RooAbsReal& cpasym, RooAbsCategory& blindState);
   RooUnblindCPAsymVar(const RooUnblindCPAsymVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooUnblindCPAsymVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooUnblindCPAsymVar(*this,newname); }
   ~RooUnblindCPAsymVar() override;
 
 protected:

--- a/roofit/roofit/inc/RooUnblindOffset.h
+++ b/roofit/roofit/inc/RooUnblindOffset.h
@@ -30,7 +30,7 @@ public:
          const char *blindString, double scale, RooAbsReal& blindValue,
          RooAbsCategory& blindState);
   RooUnblindOffset(const RooUnblindOffset& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooUnblindOffset(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooUnblindOffset(*this,newname); }
 
 protected:
 

--- a/roofit/roofit/inc/RooUnblindPrecision.h
+++ b/roofit/roofit/inc/RooUnblindPrecision.h
@@ -33,7 +33,7 @@ public:
             const char *blindString, double centralValue, double scale,
             RooAbsReal& blindValue, RooAbsCategory& blindState, bool sin2betaMode=false);
   RooUnblindPrecision(const RooUnblindPrecision& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooUnblindPrecision(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooUnblindPrecision(*this,newname); }
 
 protected:
 

--- a/roofit/roofit/inc/RooUnblindUniform.h
+++ b/roofit/roofit/inc/RooUnblindUniform.h
@@ -27,7 +27,7 @@ public:
   RooUnblindUniform(const char *name, const char *title,
             const char *blindString, double scale, RooAbsReal& blindValue);
   RooUnblindUniform(const RooUnblindUniform& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooUnblindUniform(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooUnblindUniform(*this,newname); }
 
 protected:
 

--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -26,7 +26,7 @@ public:
   RooUniform() {} ;
   RooUniform(const char *name, const char *title, const RooArgSet& _x);
   RooUniform(const RooUniform& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooUniform(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooUniform(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -27,7 +27,7 @@ public:
               RooAbsReal& _width, RooAbsReal& _sigma,
               bool doFast = false);
   RooVoigtian(const RooVoigtian& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooVoigtian(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooVoigtian(*this,newname); }
 
   /// Enable the fast evaluation of the complex error function using look-up
   /// tables (default is the "slow" CERNlib algorithm).

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -71,7 +71,7 @@ public:
   // Constructors, assignment etc.
   RooAbsCollection();
   RooAbsCollection(const char *name);
-  virtual TObject* clone(const char* newname) const = 0 ;
+  virtual TObject* clone(const char* newname=nullptr) const = 0 ;
   virtual TObject* create(const char* newname) const = 0 ;
   TObject* Clone(const char* newname=nullptr) const override {
     return clone(newname?newname:GetName()) ;

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -30,7 +30,7 @@ public:
   RooAddModel() ;
   RooAddModel(const char *name, const char *title, const RooArgList& pdfList, const RooArgList& coefList, bool ownPdfList=false) ;
   RooAddModel(const RooAddModel& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooAddModel(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooAddModel(*this,newname) ; }
   RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const override ;
 
   double evaluate() const override ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -41,7 +41,7 @@ public:
   RooAddPdf(const char *name, const char *title, const RooArgList& pdfList, const RooArgList& coefList, bool recursiveFraction=false) ;
 
   RooAddPdf(const RooAddPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooAddPdf(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooAddPdf(*this,newname) ; }
   ~RooAddPdf() override { TRACE_DESTROY; }
 
   bool checkObservables(const RooArgSet* nset) const override;

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -32,7 +32,7 @@ public:
   RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2);
 
   RooAddition(const RooAddition& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooAddition(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooAddition(*this, newname); }
 
   double defaultErrorLevel() const override ;
 

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -101,7 +101,7 @@ public:
   RooArgList(const RooArgList& other, const char *name="");
   /// Move constructor.
   RooArgList(RooArgList && other) : RooAbsCollection(std::move(other)) {}
-  TObject* clone(const char* newname) const override { return new RooArgList(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooArgList(*this,newname); }
   TObject* create(const char* newname) const override { return new RooArgList(newname); }
   RooArgList& operator=(const RooArgList& other) { RooAbsCollection::operator=(other) ; return *this ; }
 

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -108,7 +108,7 @@ public:
   explicit RooArgSet(const char *name);
 
   ~RooArgSet() override;
-  TObject* clone(const char* newname) const override { return new RooArgSet(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooArgSet(*this,newname); }
   TObject* create(const char* newname) const override { return new RooArgSet(newname); }
   RooArgSet& operator=(const RooArgSet& other) { RooAbsCollection::operator=(other) ; return *this ;}
 

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -34,7 +34,7 @@ public:
 
   RooBinSamplingPdf(const RooBinSamplingPdf& other, const char* name = nullptr);
 
-  TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname=nullptr) const override {
     return new RooBinSamplingPdf(*this, newname);
   }
 

--- a/roofit/roofitcore/inc/RooBinningCategory.h
+++ b/roofit/roofitcore/inc/RooBinningCategory.h
@@ -26,7 +26,7 @@ public:
   RooBinningCategory() = default;
   RooBinningCategory(const char *name, const char *title, RooAbsRealLValue& inputVar, const char* binningName=nullptr, const char* catTypeName=nullptr);
   RooBinningCategory(const RooBinningCategory& other, const char *name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooBinningCategory(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooBinningCategory(*this, newname); }
 
   /// Printing interface (human readable)
   void printMultiline(std::ostream& os, Int_t content, bool verbose=false, TString indent="") const override ;

--- a/roofit/roofitcore/inc/RooCachedPdf.h
+++ b/roofit/roofitcore/inc/RooCachedPdf.h
@@ -23,7 +23,7 @@ public:
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf, const RooArgSet& cacheObs);
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf);
   RooCachedPdf(const RooCachedPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCachedPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCachedPdf(*this,newname); }
 
   void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const override ;
 

--- a/roofit/roofitcore/inc/RooCachedReal.h
+++ b/roofit/roofitcore/inc/RooCachedReal.h
@@ -25,7 +25,7 @@ public:
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func, const RooArgSet& cacheObs);
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func);
   RooCachedReal(const RooCachedReal& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooCachedReal(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCachedReal(*this,newname); }
 
   /// If flag is true the RooHistFunc that represent the cache histogram
   /// will use special boundary conditions for use with cumulative distribution

--- a/roofit/roofitcore/inc/RooCategory.h
+++ b/roofit/roofitcore/inc/RooCategory.h
@@ -34,7 +34,7 @@ public:
   RooCategory(const RooCategory& other, const char* name=nullptr) ;
   RooCategory& operator=(const RooCategory&) = delete;
   ~RooCategory() override;
-  TObject* clone(const char* newname) const override { return new RooCategory(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooCategory(*this,newname); }
 
   /// Return current index.
   value_type getCurrentIndex() const final {

--- a/roofit/roofitcore/inc/RooChangeTracker.h
+++ b/roofit/roofitcore/inc/RooChangeTracker.h
@@ -27,7 +27,7 @@ public:
   RooChangeTracker(const char *name, const char *title, const RooArgSet& trackSet, bool checkValues=false) ;
 
   RooChangeTracker(const RooChangeTracker& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooChangeTracker(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooChangeTracker(*this, newname); }
 
   bool hasChanged(bool clearState) ;
 

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -26,7 +26,7 @@ public:
   RooConstVar() { }
   RooConstVar(const char *name, const char *title, double value);
   RooConstVar(const RooConstVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooConstVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooConstVar(*this,newname); }
 
   /// Return (constant) value.
   double getValV(const RooArgSet*) const override {

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -31,7 +31,7 @@ public:
   RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet, bool takeGlobalObservablesFromData=false) ;
 
   RooConstraintSum(const RooConstraintSum& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooConstraintSum(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooConstraintSum(*this, newname); }
 
   const RooArgList& list() { return _set1 ; }
 

--- a/roofit/roofitcore/inc/RooConvCoefVar.h
+++ b/roofit/roofitcore/inc/RooConvCoefVar.h
@@ -33,7 +33,7 @@ public:
   }
   RooConvCoefVar(const char *name, const char *title, const RooAbsAnaConvPdf& input, Int_t coefIdx, const RooArgSet* varList=nullptr) ;
   RooConvCoefVar(const RooConvCoefVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooConvCoefVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooConvCoefVar(*this,newname); }
 
   double getValV(const RooArgSet* nset=nullptr) const override ;
 

--- a/roofit/roofitcore/inc/RooDerivative.h
+++ b/roofit/roofitcore/inc/RooDerivative.h
@@ -36,7 +36,7 @@ public:
   ~RooDerivative() override ;
 
   RooDerivative(const RooDerivative& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooDerivative(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooDerivative(*this, newname); }
 
   Int_t order() const { return _order ; }
   double eps() const { return _eps ; }

--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -23,7 +23,7 @@ public:
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
   RooEffProd(const RooEffProd& other, const char* name=nullptr);
 
-  TObject* clone(const char* newname) const override { return new RooEffProd(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooEffProd(*this,newname); }
 
   RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype,
                                        const RooArgSet* auxProto, bool verbose) const override;

--- a/roofit/roofitcore/inc/RooEfficiency.h
+++ b/roofit/roofitcore/inc/RooEfficiency.h
@@ -29,7 +29,7 @@ public:
   }
   RooEfficiency(const char *name, const char *title, const RooAbsReal& effFunc, const RooAbsCategory& cat, const char* sigCatName);
   RooEfficiency(const RooEfficiency& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooEfficiency(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooEfficiency(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooErrorVar.h
+++ b/roofit/roofitcore/inc/RooErrorVar.h
@@ -33,7 +33,7 @@ public:
   }
   RooErrorVar(const char *name, const char *title, const RooRealVar& input) ;
   RooErrorVar(const RooErrorVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooErrorVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooErrorVar(*this,newname); }
   ~RooErrorVar() override ;
 
   double getValV(const RooArgSet* set=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -29,7 +29,7 @@ public:
   RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
           RooAbsReal::Ref norm, const char* rangeName=nullptr) ;
   RooExtendPdf(const RooExtendPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooExtendPdf(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooExtendPdf(*this,newname) ; }
 
   double evaluate() const override { return _pdf ; }
 

--- a/roofit/roofitcore/inc/RooExtendedBinding.h
+++ b/roofit/roofitcore/inc/RooExtendedBinding.h
@@ -22,7 +22,7 @@ public:
   RooExtendedBinding() {} ;
   RooExtendedBinding(const char *name, const char *title, RooAbsPdf& _pdf);
   RooExtendedBinding(const RooExtendedBinding& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooExtendedBinding(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooExtendedBinding(*this,newname); }
 
 protected:
 

--- a/roofit/roofitcore/inc/RooExtendedTerm.h
+++ b/roofit/roofitcore/inc/RooExtendedTerm.h
@@ -25,7 +25,7 @@ public:
   RooExtendedTerm() = default;
   RooExtendedTerm(const char *name, const char *title, const RooAbsReal& n) ;
   RooExtendedTerm(const RooExtendedTerm& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooExtendedTerm(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooExtendedTerm(*this,newname) ; }
 
   double evaluate() const override { return 1. ; }
 

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -31,7 +31,7 @@ public:
   RooFFTConvPdf(const char *name, const char *title, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
   RooFFTConvPdf(const char *name, const char *title, RooAbsReal& pdfConvVar, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
   RooFFTConvPdf(const RooFFTConvPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooFFTConvPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFFTConvPdf(*this,newname); }
   ~RooFFTConvPdf() override ;
 
   void setShift(double val1, double val2) { _shift1 = val1 ; _shift2 = val2 ; }

--- a/roofit/roofitcore/inc/RooFirstMoment.h
+++ b/roofit/roofitcore/inc/RooFirstMoment.h
@@ -31,7 +31,7 @@ public:
   RooFirstMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, bool intNSet=false) ;
 
   RooFirstMoment(const RooFirstMoment& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooFirstMoment(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFirstMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -35,7 +35,7 @@ public:
   RooFormulaVar(const char *name, const char *title, const char* formula, const RooArgList& dependents, bool checkVariables = true);
   RooFormulaVar(const char *name, const char *title, const RooArgList& dependents, bool checkVariables = true);
   RooFormulaVar(const RooFormulaVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooFormulaVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFormulaVar(*this,newname); }
 
   bool ok() const;
   const char* expression() const { return _formExpr.Data(); }

--- a/roofit/roofitcore/inc/RooFracRemainder.h
+++ b/roofit/roofitcore/inc/RooFracRemainder.h
@@ -30,7 +30,7 @@ public:
   RooFracRemainder(const char *name, const char *title, const RooArgSet& sumSet) ;
 
   RooFracRemainder(const RooFracRemainder& other, const char* name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooFracRemainder(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooFracRemainder(*this, newname); }
 
 protected:
 

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -30,7 +30,7 @@ public:
   RooGenericPdf(const char *name, const char *title, const char* formula, const RooArgList& dependents);
   RooGenericPdf(const char *name, const char *title, const RooArgList& dependents);
   RooGenericPdf(const RooGenericPdf& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooGenericPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooGenericPdf(*this,newname); }
 
   // I/O streaming interface (machine readable)
   bool readFromStream(std::istream& is, bool compact, bool verbose=false) override ;

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -38,7 +38,7 @@ public:
   RooHistFunc(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
              std::unique_ptr<RooDataHist> dhist, int intOrder=0);
   RooHistFunc(const RooHistFunc& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooHistFunc(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooHistFunc(*this,newname); }
   ~RooHistFunc() override ;
 
   /// Return RooDataHist that is represented.

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -37,7 +37,7 @@ public:
   RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
              std::unique_ptr<RooDataHist> dhist, int intOrder=0);
   RooHistPdf(const RooHistPdf& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooHistPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooHistPdf(*this,newname); }
 
   RooDataHist& dataHist()  {
     // Return RooDataHist that is represented

--- a/roofit/roofitcore/inc/RooLinearVar.h
+++ b/roofit/roofitcore/inc/RooLinearVar.h
@@ -32,7 +32,7 @@ public:
   RooLinearVar() {} ;
   RooLinearVar(const char *name, const char *title, RooAbsRealLValue& variable, const RooAbsReal& slope, const RooAbsReal& offset, const char *unit= "") ;
   RooLinearVar(const RooLinearVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooLinearVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooLinearVar(*this,newname); }
   ~RooLinearVar() override ;
 
   // Parameter value and error accessors

--- a/roofit/roofitcore/inc/RooMappedCategory.h
+++ b/roofit/roofitcore/inc/RooMappedCategory.h
@@ -32,7 +32,7 @@ public:
   RooMappedCategory();
   RooMappedCategory(const char *name, const char *title, RooAbsCategory& inputCat, const char* defCatName="NotMapped", Int_t defCatIdx=NoCatIdx);
   RooMappedCategory(const RooMappedCategory& other, const char *name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooMappedCategory(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMappedCategory(*this,newname); }
   ~RooMappedCategory() override;
 
   // Mapping function

--- a/roofit/roofitcore/inc/RooMoment.h
+++ b/roofit/roofitcore/inc/RooMoment.h
@@ -32,7 +32,7 @@ public:
        bool intNSet=false) ;
 
   RooMoment(const RooMoment& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooMoment(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }

--- a/roofit/roofitcore/inc/RooMultiCategory.h
+++ b/roofit/roofitcore/inc/RooMultiCategory.h
@@ -31,7 +31,7 @@ public:
   inline RooMultiCategory() { setShapeDirty(); }
   RooMultiCategory(const char *name, const char *title, const RooArgSet& inputCatList);
   RooMultiCategory(const RooMultiCategory& other, const char *name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooMultiCategory(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMultiCategory(*this,newname); }
 
   // Printing interface (human readable)
   void printMultiline(std::ostream& os, Int_t content, bool verbose=false, TString indent="") const override;

--- a/roofit/roofitcore/inc/RooMultiVarGaussian.h
+++ b/roofit/roofitcore/inc/RooMultiVarGaussian.h
@@ -39,7 +39,7 @@ public:
   void setAnaIntZ(double z) { _z = z ; }
 
   RooMultiVarGaussian(const RooMultiVarGaussian& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooMultiVarGaussian(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooMultiVarGaussian(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooNumCdf.h
+++ b/roofit/roofitcore/inc/RooNumCdf.h
@@ -18,7 +18,7 @@ class RooNumCdf : public RooNumRunningInt {
 public:
   RooNumCdf(const char *name, const char *title, RooAbsPdf& _pdf, RooRealVar& _x, const char* binningName="cache");
   RooNumCdf(const RooNumCdf& other, const char* name=nullptr) : RooNumRunningInt{other, name} {}
-  TObject* clone(const char* newname) const override { return new RooNumCdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNumCdf(*this,newname); }
 
 protected:
 

--- a/roofit/roofitcore/inc/RooNumConvPdf.h
+++ b/roofit/roofitcore/inc/RooNumConvPdf.h
@@ -33,7 +33,7 @@ public:
 
   RooNumConvPdf(const RooNumConvPdf& other, const char* name=nullptr) ;
 
-  TObject* clone(const char* newname) const override { return new RooNumConvPdf(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNumConvPdf(*this,newname) ; }
   ~RooNumConvPdf() override ;
 
   double evaluate() const override ;

--- a/roofit/roofitcore/inc/RooNumConvolution.h
+++ b/roofit/roofitcore/inc/RooNumConvolution.h
@@ -36,7 +36,7 @@ public:
 
   RooNumConvolution(const RooNumConvolution& other, const char* name=nullptr) ;
 
-  TObject* clone(const char* newname) const override { return new RooNumConvolution(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNumConvolution(*this,newname) ; }
   ~RooNumConvolution() override ;
 
   double evaluate() const override ;

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -23,7 +23,7 @@ class RooNumRunningInt : public RooAbsCachedReal {
 public:
   RooNumRunningInt(const char *name, const char *title, RooAbsReal& _func, RooRealVar& _x, const char* binningName="cache");
   RooNumRunningInt(const RooNumRunningInt& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooNumRunningInt(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNumRunningInt(*this,newname); }
   ~RooNumRunningInt() override ;
 
 protected:

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -55,7 +55,7 @@ public:
              const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   RooProdPdf(const RooProdPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooProdPdf(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooProdPdf(*this,newname) ; }
   ~RooProdPdf() override ;
 
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -37,7 +37,7 @@ public:
 
   void addTerm(RooAbsArg* term);
 
-  TObject* clone(const char* newname) const override { return new RooProduct(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooProduct(*this, newname); }
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
                                                    const RooArgSet* normSet,

--- a/roofit/roofitcore/inc/RooProfileLL.h
+++ b/roofit/roofitcore/inc/RooProfileLL.h
@@ -24,7 +24,7 @@ public:
 
   RooProfileLL(const char *name, const char *title, RooAbsReal& nll, const RooArgSet& observables);
   RooProfileLL(const RooProfileLL& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooProfileLL(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooProfileLL(*this,newname); }
 
   void setAlwaysStartFromMin(bool flag) { _startFromMin = flag ; }
   bool alwaysStartFromMin() const { return _startFromMin ; }

--- a/roofit/roofitcore/inc/RooProjectedPdf.h
+++ b/roofit/roofitcore/inc/RooProjectedPdf.h
@@ -24,7 +24,7 @@ public:
   RooProjectedPdf() ;
   RooProjectedPdf(const char *name, const char *title,  RooAbsReal& _intpdf, const RooArgSet& intObs);
   RooProjectedPdf(const RooProjectedPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooProjectedPdf(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooProjectedPdf(*this,newname); }
 
   // Analytical integration support
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooPullVar.h
+++ b/roofit/roofitcore/inc/RooPullVar.h
@@ -28,7 +28,7 @@ public:
   RooPullVar(const char *name, const char *title, RooRealVar& measurement, RooAbsReal& truth) ;
 
   RooPullVar(const RooPullVar& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooPullVar(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooPullVar(*this, newname); }
 
 
 protected:

--- a/roofit/roofitcore/inc/RooRangeBoolean.h
+++ b/roofit/roofitcore/inc/RooRangeBoolean.h
@@ -29,7 +29,7 @@ public:
   RooRangeBoolean() = default;
   RooRangeBoolean(const char* name, const char* title, RooAbsRealLValue& x, const char* rangeName) ;
   RooRangeBoolean(const RooRangeBoolean& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooRangeBoolean(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRangeBoolean(*this, newname); }
 
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;
 

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -34,7 +34,7 @@ public:
   RooRealIntegral(const char *name, const char *title, const RooAbsReal& function, const RooArgSet& depList,
         const RooArgSet* funcNormSet=nullptr, const RooNumIntConfig* config=nullptr, const char* rangeName=nullptr) ;
   RooRealIntegral(const RooRealIntegral& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooRealIntegral(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRealIntegral(*this,newname); }
   ~RooRealIntegral() override;
 
   double getValV(const RooArgSet* set=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -30,7 +30,7 @@ public:
   RooRealSumPdf(const char *name, const char *title,
          RooAbsReal& func1, RooAbsReal& func2, RooAbsReal& coef1) ;
   RooRealSumPdf(const RooRealSumPdf& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooRealSumPdf(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRealSumPdf(*this,newname) ; }
 
   double evaluate() const override ;
   bool checkObservables(const RooArgSet* nset) const override ;

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -45,7 +45,7 @@ public:
   RooRealVar(const char *name, const char *title, double value,
       double minValue, double maxValue, const char *unit= "") ;
   RooRealVar(const RooRealVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooRealVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRealVar(*this,newname); }
   ~RooRealVar() override;
 
   // Parameter value and error accessors

--- a/roofit/roofitcore/inc/RooRecursiveFraction.h
+++ b/roofit/roofitcore/inc/RooRecursiveFraction.h
@@ -26,7 +26,7 @@ public:
   RooRecursiveFraction(const char *name, const char *title, const RooArgList& fracSet) ;
 
   RooRecursiveFraction(const RooRecursiveFraction& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooRecursiveFraction(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRecursiveFraction(*this, newname); }
 
   RooArgList const &variables() const { return _list; }
 

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -30,7 +30,7 @@ public:
   inline RooResolutionModel() = default;
   RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooResolutionModel(const RooResolutionModel& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override = 0;
+  TObject* clone(const char* newname=nullptr) const override = 0;
   ~RooResolutionModel() override;
 
   virtual RooAbsGenContext* modelGenContext(const RooAbsAnaConvPdf&, const RooArgSet&,

--- a/roofit/roofitcore/inc/RooSecondMoment.h
+++ b/roofit/roofitcore/inc/RooSecondMoment.h
@@ -32,7 +32,7 @@ public:
   RooSecondMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, bool central=false, bool takeRoot=false, bool intNSet=false) ;
 
   RooSecondMoment(const RooSecondMoment& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooSecondMoment(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooSecondMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -61,7 +61,7 @@ public:
   RooSimultaneous(const char *name, const char *title, RooFit::Detail::FlatMap<std::string,RooAbsPdf*> const &pdfMap, RooAbsCategoryLValue& inIndexCat);
   RooSimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const RooSimultaneous& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooSimultaneous(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooSimultaneous(*this,newname) ; }
   ~RooSimultaneous() override ;
 
   double evaluate() const override ;

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -26,7 +26,7 @@ public:
   RooStringVar() { }
   RooStringVar(const char *name, const char *title, const char* value, Int_t size=1024) ;
   RooStringVar(const RooStringVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooStringVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooStringVar(*this,newname); }
 
   // Parameter value and error accessors
   virtual operator TString() {return TString(_string.c_str()); }

--- a/roofit/roofitcore/inc/RooSuperCategory.h
+++ b/roofit/roofitcore/inc/RooSuperCategory.h
@@ -30,7 +30,7 @@ public:
   RooSuperCategory();
   RooSuperCategory(const char *name, const char *title, const RooArgSet& inputCatList);
   RooSuperCategory(const RooSuperCategory& other, const char *name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooSuperCategory(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooSuperCategory(*this,newname); }
 
   bool setIndex(value_type index, bool printError = true) override ;
   using RooAbsCategoryLValue::setIndex;

--- a/roofit/roofitcore/inc/RooThresholdCategory.h
+++ b/roofit/roofitcore/inc/RooThresholdCategory.h
@@ -29,7 +29,7 @@ public:
   RooThresholdCategory(const char *name, const char *title, RooAbsReal& inputVar,
       const char* defCatName="Default", Int_t defCatIdx=0);
   RooThresholdCategory(const RooThresholdCategory& other, const char *name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooThresholdCategory(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooThresholdCategory(*this, newname); }
 
   // Mapping function
   bool addThreshold(double upperLimit, const char* catName, Int_t catIdx=-99999) ;

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -24,7 +24,7 @@ public:
   RooTruthModel() = default;
   RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooTruthModel(const RooTruthModel& other, const char* name=nullptr) : RooResolutionModel{other, name} {}
-  TObject* clone(const char* newname) const override { return new RooTruthModel(*this,newname) ; }
+  TObject* clone(const char* newname=nullptr) const override { return new RooTruthModel(*this,newname) ; }
 
   Int_t basisCode(const char* name) const override ;
 

--- a/roofit/roofitcore/inc/RooWrapperPdf.h
+++ b/roofit/roofitcore/inc/RooWrapperPdf.h
@@ -46,7 +46,7 @@ public:
     _func("inputFunction", this, other._func),
     _selfNormalized{other._selfNormalized} { }
 
-  TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname=nullptr) const override {
     return new RooWrapperPdf(*this, newname);
   }
 

--- a/roofit/roofitcore/src/RooChi2Var.h
+++ b/roofit/roofitcore/src/RooChi2Var.h
@@ -28,7 +28,7 @@ public:
              RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
 
   RooChi2Var(const RooChi2Var& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooChi2Var(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooChi2Var(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,
                                       const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) override {

--- a/roofit/roofitcore/src/RooNLLVar.h
+++ b/roofit/roofitcore/src/RooNLLVar.h
@@ -32,7 +32,7 @@ public:
             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
 
   RooNLLVar(const RooNLLVar& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooNLLVar(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooNLLVar(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
                                       const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) override;

--- a/roofit/roofitcore/src/RooRealMPFE.h
+++ b/roofit/roofitcore/src/RooRealMPFE.h
@@ -33,7 +33,7 @@ public:
   // Constructors, assignment etc
   RooRealMPFE(const char *name, const char *title, RooAbsReal& arg, bool calcInline=false) ;
   RooRealMPFE(const RooRealMPFE& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooRealMPFE(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooRealMPFE(*this,newname); }
   ~RooRealMPFE() override;
 
   void calculate() const ;

--- a/roofit/roofitcore/src/RooXYChi2Var.h
+++ b/roofit/roofitcore/src/RooXYChi2Var.h
@@ -34,7 +34,7 @@ public:
   /// \endcond ROOFIT_INTERNAL
 
   RooXYChi2Var(const RooXYChi2Var& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooXYChi2Var(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooXYChi2Var(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
                                       const RooArgSet&, RooAbsTestStatistic::Configuration const&) override {

--- a/roofit/roofitmore/inc/RooHypatia2.h
+++ b/roofit/roofitmore/inc/RooHypatia2.h
@@ -29,7 +29,7 @@ public:
          RooAbsReal& x, RooAbsReal& lambda, RooAbsReal& zeta, RooAbsReal& beta,
          RooAbsReal& sigma, RooAbsReal& mu, RooAbsReal& a, RooAbsReal& n, RooAbsReal& a2, RooAbsReal& n2);
   RooHypatia2(const RooHypatia2& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooHypatia2(*this,newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooHypatia2(*this,newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;

--- a/roofit/roofitmore/inc/RooLegendre.h
+++ b/roofit/roofitmore/inc/RooLegendre.h
@@ -27,7 +27,7 @@ public:
   RooLegendre(const char *name, const char *title, RooAbsReal& ctheta, int l1, int m1, int l2, int m2);
 
   RooLegendre(const RooLegendre& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooLegendre(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooLegendre(*this, newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitmore/inc/RooNonCentralChiSquare.h
+++ b/roofit/roofitmore/inc/RooNonCentralChiSquare.h
@@ -25,7 +25,7 @@ public:
                           RooAbsReal& _k,
                           RooAbsReal& _lambda);
    RooNonCentralChiSquare(const RooNonCentralChiSquare& other, const char* name=nullptr) ;
-   TObject* clone(const char* newname) const override { return new RooNonCentralChiSquare(*this,newname); }
+   TObject* clone(const char* newname=nullptr) const override { return new RooNonCentralChiSquare(*this,newname); }
 
    void SetErrorTolerance(double t) {fErrorTol = t;}
    void SetMaxIters(Int_t mi) {fMaxIters = mi;}

--- a/roofit/roofitmore/inc/RooSpHarmonic.h
+++ b/roofit/roofitmore/inc/RooSpHarmonic.h
@@ -24,7 +24,7 @@ public:
   RooSpHarmonic(const char *name, const char *title, RooAbsReal& ctheta, RooAbsReal& phi, int l1, int m1, int l2, int m2);
 
   RooSpHarmonic(const RooSpHarmonic& other, const char *name = nullptr);
-  TObject* clone(const char* newname) const override { return new RooSpHarmonic(*this, newname); }
+  TObject* clone(const char* newname=nullptr) const override { return new RooSpHarmonic(*this, newname); }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roostats/inc/RooStats/Heaviside.h
+++ b/roofit/roostats/inc/RooStats/Heaviside.h
@@ -25,7 +25,7 @@ namespace RooStats {
             RooAbsReal& _x,
             RooAbsReal& _c);
       Heaviside(const Heaviside& other, const char* name=nullptr) ;
-      TObject* clone(const char* newname) const override { return new Heaviside(*this,newname); }
+      TObject* clone(const char* newname=nullptr) const override { return new Heaviside(*this,newname); }
 
    protected:
 


### PR DESCRIPTION
The `RooAbsArg::clone()` method has a default `nullptr` value for the `newname` argument.

Not setting the default value in the derived classes brings us in the awkwared situation where the default empty newname works only when calling the function via a `RooAbsArg` base class pointer or reference, and one has to do `clone(nullptr)` explicitly when creating a clone with the same name. Or even having to pass the original name explicitly in the case of PyROOT, because passing `ROOT.nullptr` for a string is not supported.