### PR TITLE
[cppyy] Do not use non-C++ GCC warning

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 # CPython docs for C/C++ extensions. see
 # https://docs.python.org/3/extending/extending.html#keyword-parameters-for-extension-functions
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(${libname} PRIVATE -Wno-cast-function-type -Wno-bad-function-cast)
+  target_compile_options(${libname} PRIVATE -Wno-cast-function-type)
 endif()
 
 # Disables warnings in Python 3.8 caused by the temporary extra filed for tp_print compatibility


### PR DESCRIPTION
Although `bad-function-cast` is present for both Clang and GCC, on the latter it is only used for C and Objective-C code. Using `no-cast-function-type` seems to already disable the PyCFunction-cast-related warnings seen with AppleClang.
