### PR TITLE
[BP 634][math] Bypass clang warning only when it can actually occur

### DIFF
--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -227,8 +227,11 @@ namespace FitUtil {
      }
 
 #ifdef R__HAS_VECCORE
+
+#if __clang_major__ > 16
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
 
      inline double ExecFunc(const IModelFunctionTempl<ROOT::Double_v> *f, const double *x, const double *p) const
      {
@@ -250,7 +253,11 @@ namespace FitUtil {
         auto res = (*f)(xx, p);
         return vecCore::Get<ROOT::Double_v>(res, 0);
      }
+
+#if __clang_major__ > 16
 #pragma clang diagnostic pop
+#endif
+
 #endif
 
      // objects of this class are not meant to be copied / assigned


### PR DESCRIPTION
i.e. for versions < 17

