### PR TITLE
[TMVA][SOFIE] Make it possible to build SOFIE without TFile support

### DIFF
--- a/tmva/sofie/CMakeLists.txt
+++ b/tmva/sofie/CMakeLists.txt
@@ -11,6 +11,12 @@
 
 #sofie is built only if protobuf is found
 
+set(sofie_root_support ON CACHE BOOL "" FORCE)
+
+if(sofie_root_support)
+    list(APPEND EXTRA_SOFIE_DEPENDENCIES RIO)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofie
   HEADERS
    TMVA/OperatorList.hxx
@@ -79,13 +85,19 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofie
     src/RFunction_Sum.cxx
     src/SOFIE_common.cxx
   DEPENDENCIES
+    Core
     TMVA
+    ${EXTRA_SOFIE_DEPENDENCIES}
 )
 
 target_include_directories(ROOTTMVASofie PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(ROOTTMVASofie PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE)
+
+if(sofie_root_support)
+  target_compile_definitions(ROOTTMVASofie PRIVATE SOFIE_SUPPORT_ROOT_BINARY)
+endif()
 
 # tests requires protobuf
 if (tmva-sofie)

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -4,7 +4,9 @@
 #include <memory>
 #include <string>
 
+#ifdef SOFIE_SUPPORT_ROOT_BINARY
 #include "TFile.h"
+#endif
 
 #include "TMVA/RModel.hxx"
 #include "TMVA/SOFIE_common.hxx"
@@ -1040,6 +1042,7 @@ void RModel::ReadInitializedTensorsFromFile(long pos) {
 
     // generate the code to read initialized tensors from a ROOT data file
     if(fWeightFile == WeightFileType::RootBinary) {
+#ifdef SOFIE_SUPPORT_ROOT_BINARY
         fGC += "  {\n";
         fGC += "   std::unique_ptr<TFile> rootFile(TFile::Open(filename.c_str(), \"READ\"));\n";
         fGC += "   if (!rootFile->IsOpen()) {\n";
@@ -1071,6 +1074,9 @@ void RModel::ReadInitializedTensorsFromFile(long pos) {
             fGC += "  }\n";
         }
         fGC += "  }\n";
+#else
+        throw std::runtime_error("SOFIE was not built with ROOT file support.");
+#endif // SOFIE_SUPPORT_ROOT_BINARY
     }
 }
 
@@ -1096,6 +1102,7 @@ long RModel::WriteInitializedTensorsToFile(std::string filename) {
 
     // Write the initialized tensors to the file
     if (fWeightFile == WeightFileType::RootBinary) {
+#ifdef SOFIE_SUPPORT_ROOT_BINARY
         if(fIsGNNComponent || fIsGNN) {
             throw std::runtime_error("SOFIE-GNN yet not supports writing to a ROOT file.");
         }
@@ -1139,6 +1146,9 @@ long RModel::WriteInitializedTensorsToFile(std::string filename) {
         // this needs to be changed, similar to the text file
         return -1;
 
+#else
+        throw std::runtime_error("SOFIE was not built with ROOT file support.");
+#endif // SOFIE_SUPPORT_ROOT_BINARY
     } else if (fWeightFile == WeightFileType::Text) {
         std::ofstream f;
         if(fIsGNNComponent) {

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -63,6 +63,7 @@ add_custom_command(TARGET SofieCompileModels_ONNX POST_BUILD
 if (BLAS_FOUND)  # we need BLAS for compiling the models
 ROOT_ADD_GTEST(TestCustomModelsFromONNX TestCustomModelsFromONNX.cxx
   LIBRARIES
+    MathCore
     ROOTTMVASofie
     BLAS::BLAS
   INCLUDE_DIRS
@@ -83,7 +84,7 @@ target_include_directories(emitFromROOT PRIVATE
    ${CMAKE_SOURCE_DIR}/tmva/inc
    ${CMAKE_CURRENT_BINARY_DIR}
 )
-target_link_libraries(emitFromROOT protobuf::libprotobuf ROOTTMVASofie ROOTTMVASofieParser)
+target_link_libraries(emitFromROOT protobuf::libprotobuf RIO ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 ## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromROOT PRIVATE -Wno-unused-parameter -Wno-array-bounds)


### PR DESCRIPTION
Make it possible to build SOFIE without TFile support with a hidden flag. We already use many of such hidden flags in RooFit. This will make it easy to build SOFIE without the ROOT dependency if one wants to.