### PR TITLE
[core] Allow to skip arguments by TApplication.

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -72,6 +72,7 @@ private:
 
    static Bool_t      fgGraphNeeded;    // True if graphics libs need to be initialized
    static Bool_t      fgGraphInit;      // True if graphics libs initialized
+   static Bool_t      fgSkipArguments;  // True if GetOptions() should skip processing positional arguments
 
    TApplication(const TApplication&) = delete;
    TApplication& operator=(const TApplication&) = delete;
@@ -163,6 +164,7 @@ public:
    static TList   *GetApplications();
    static void     CreateApplication();
    static void     NeedGraphicsLibs();
+   static void     SkipParsingArguments();
 
    ClassDefOverride(TApplication,0)  //GUI application singleton
 };

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -53,6 +53,7 @@ TApplication (see TRint).
 TApplication *gApplication = nullptr;
 Bool_t TApplication::fgGraphNeeded = kFALSE;
 Bool_t TApplication::fgGraphInit = kFALSE;
+Bool_t TApplication::fgSkipArguments = kFALSE;
 TList *TApplication::fgApplications = nullptr;  // List of available applications
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -235,6 +236,15 @@ TApplication::~TApplication()
 void TApplication::NeedGraphicsLibs()
 {
    fgGraphNeeded = kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Static method. This method should be called if TApplication should skip
+/// processing positional arguments leaving this to user.
+
+void TApplication::SkipParsingArguments()
+{
+      fgSkipArguments = kTRUE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -472,6 +482,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                argv[i] = null;
          }
       } else if (argv[i][0] != '-' && argv[i][0] != '+') {
+         if (fgSkipArguments) continue;
          Long64_t size;
          Long_t id, flags, modtime;
          char *arg = strchr(argv[i], '(');


### PR DESCRIPTION
# This Pull request:

Current `TApplication` constructor will process all known input options and also positional arguments if they are valid files. With this commit the static function `TApplication::SkipParsingArguments()` tells `TApplication` to ignore arguments (but not options) and let to handle them by users, e.g. it can be file name which is not root file but must be converted from binary format to something else.

Currently I don't think there is possibility to do that beside doing some nasty manual operations on arguments.

```c++
int main(int argc, char* argv[])
{
    std::vector<std::string> v_argv;
    v_argv.reserve(argc + 5);
    for (int i = 0; i < argc; ++i) { v_argv.push_back(argv[i]); }
    spdlog::info("argc = {}  argv = {}", argc, v_argv);

    // TApplication app("app", &argc, argv, nullptr, -1);
    // TApplication::SkipParsingArguments();
    TApplication app("app", &argc, argv);

    v_argv.clear();
    for (int i = 0; i < argc; ++i) { v_argv.push_back(argv[i]); }
    spdlog::info("argc = {}  argv = {}", argc, v_argv);

    v_argv.clear();
    for (int i = 0; i < app.Argc(); ++i) { v_argv.push_back(app.Argv()[i]); }
    spdlog::info("Argc = {}  Argv = {}", app.Argc(), v_argv);
}
```
gives me:
```
argc = 5  argv = ["./bin/smxwebgui", "--aaa", "-x", "-b", "/home/rafal/cbm/data/data_1sec.bin"]
argc = 2  argv = ["./bin/smxwebgui", "--aaa"]
Argc = 5  Argv = ["./bin/smxwebgui", "--aaa", "-x", "-b", "/home/rafal/cbm/data/data_1sec.bin"]
```
With `TApplication::SkipParsingArguments();`, the output would look like:
```
argc = 5  argv = ["./bin/smxwebgui", "--aaa", "-x", "-b", "/home/rafal/cbm/data/data_1sec.bin"]
argc = 3  argv = ["./bin/smxwebgui", "--aaa", "/home/rafal/cbm/data/data_1sec.bin"] 
Argc = 5  Argv = ["./bin/smxwebgui", "--aaa", "-x", "-b", "/home/rafal/cbm/data/data_1sec.bin"] 
```

## Changes or fixes:

* Adds static function `TApplication::SkipArguments();`

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

