### PR TITLE
[skip-ci] Minor documentation improvement for --web=server

### DIFF
--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -153,6 +153,7 @@ bool RWebDisplayArgs::SetPosAsStr(const std::string &str)
 ///       local - either cef or qt6
 ///         off - disable web display
 ///          on - first try "local", then "native", then "default" (default option)
+///      server - run as web server without display (URL printed to command line; also available via e.g. RWebWindow::GetUrl)
 ///    `<prog>` - any program name which will be started to open widget URL, like "/usr/bin/opera"
 
 RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -756,13 +756,14 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 /// As display args one can use string like "firefox" or "chrome" - these are two main supported web browsers.
 /// See RWebDisplayArgs::SetBrowserKind() for all available options. Default value for the browser can be configured
 /// when starting root with --web argument like: "root --web=chrome". When root started in web server mode "root --web=server",
-/// no any web browser will be started - just URL will be printout, which can be entered in any running web browser
+/// no web browser will be started - just the URL will be printed, which can be opened in any running web browser.
+/// Also configurable via ROOT_WEBDISPLAY environment variable taking the same options.
 ///
 /// If allowed, same window can be displayed several times (like for RCanvas or TCanvas)
 ///
 /// Following parameters can be configured in rootrc file:
 ///
-///      WebGui.Display: kind of display like chrome or firefox or browser, can be overwritten by --web=value command line argument
+///      WebGui.Display: kind of display, identical to --web option and ROOT_WEBDISPLAY environment variable documented above
 ///      WebGui.OnetimeKey: if configured requires unique key every time window is connected (default yes)
 ///      WebGui.SingleConnMode: if configured the only connection and the only user of any widget is possible (default yes)
 ///      WebGui.Chrome: full path to Google Chrome executable


### PR DESCRIPTION
# This Pull request:

Minorly improves documentation for `--web=server` since I didn't find it immediately and also the environment variable `ROOT_WEBDISPLAY` was not documented at all.

Note that I believe that the `embed`/`embedded` option should also be documented in `RWebDisplayArgs` but I don't understand it enough to do so.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)


