### PR TITLE
[proof] Deprecate PROOF and PROOFLITE with warnings

### DIFF
--- a/proof/proof/inc/TProof.h
+++ b/proof/proof/inc/TProof.h
@@ -1071,7 +1071,7 @@ public:
    static Int_t         GetParameter(TCollection *c, const char *par, Double_t &value);
 
    ClassDefOverride(TProof,0)  //PROOF control class
-};
+} R__DEPRECATED(6,38, "Legacy interactive distributed processing engine. Use RDataFrame instead.");
 
 // Global object with default PROOF session
 R__EXTERN TProof *gProof;

--- a/proof/proof/inc/TProofLite.h
+++ b/proof/proof/inc/TProofLite.h
@@ -168,6 +168,6 @@ public:
    static Int_t GetNumberOfWorkers(const char *url = 0);
 
    ClassDefOverride(TProofLite,0)  //PROOF-Lite control class
-};
+} R__DEPRECATED(6,38, "Legacy interactive distributed processing engine. Use RDataFrame instead.");
 
 #endif


### PR DESCRIPTION
since the tools will be removed in 6.38.00. RDataFrame and DistRDF can be used instead.
