### PR TITLE
[ntuple] Merger: properly compress generated zero pages

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -30,6 +30,10 @@ namespace ROOT {
 
 class RNTuple;
 
+namespace Internal {
+class RPageAllocator;
+}
+
 namespace Experimental::Internal {
 
 enum class ENTupleMergingMode {
@@ -98,7 +102,8 @@ class RNTupleMerger final {
    void MergeCommonColumns(RClusterPool &clusterPool, const ROOT::RClusterDescriptor &clusterDesc,
                            std::span<const RColumnMergeInfo> commonColumns,
                            const RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
-                           RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData);
+                           RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData,
+                           ROOT::Internal::RPageAllocator &pageAlloc);
 
    void MergeSourceClusters(RPageSource &source, std::span<const RColumnMergeInfo> commonColumns,
                             std::span<const RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData);

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -3062,6 +3062,4 @@ TEST(RNTupleMerger, MergeStaggeredIncremental)
          EXPECT_FLOAT_EQ(*pnBar, expBar);
       }
    }
-
-   fileGuardMerged.PreserveFile();
 }


### PR DESCRIPTION
# This Pull request:
ensures that the synthesized zero pages in the RNTupleMerger are properly compressed.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #18298

