### PR TITLE
[webgui] testing /snap/bin/chromium

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -307,6 +307,7 @@ find_program(PERL_EXECUTABLE perl)
 set(perl ${PERL_EXECUTABLE})
 
 find_program(CHROME_EXECUTABLE NAMES chrome.exe chromium chromium-browser chrome chrome-browser google-chrome-stable Google\ Chrome
+             HINTS /snap/bin
              PATH_SUFFIXES "Google/Chrome/Application")
 if(CHROME_EXECUTABLE)
   if(WIN32)

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -109,6 +109,9 @@ public:
    /// resize web window - if possible
    virtual bool Resize(int, int) { return false; }
 
+   /// remove file which was used to startup widget - if possible
+   virtual void RemoveStartupFiles() {}
+
    static bool NeedHttpServer(const RWebDisplayArgs &args);
 
    static std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args);

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include "TString.h"
 
 namespace ROOT {
 
@@ -35,6 +36,7 @@ protected:
       virtual std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) = 0;
       virtual bool IsActive() const { return true; }
       virtual ~Creator() = default;
+      virtual bool IsSnapChromium() const { return false; }
    };
 
    class BrowserCreator : public Creator {
@@ -50,6 +52,7 @@ protected:
       BrowserCreator(bool custom = true, const std::string &exec = "");
       std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) override;
       ~BrowserCreator() override = default;
+      static FILE *TemporaryFile(TString &name, int use_home_dir = 0, const char *suffix = nullptr);
    };
 
    class SafariCreator : public BrowserCreator {
@@ -67,6 +70,7 @@ protected:
       ChromeCreator(bool is_edge = false);
       ~ChromeCreator() override = default;
       bool IsActive() const override { return !fProg.empty(); }
+      bool IsSnapChromium() const override { return fProg == "/snap/bin/chromium"; }
       void ProcessGeometry(std::string &, const RWebDisplayArgs &) override;
       std::string MakeProfile(std::string &exec, bool) override;
    };

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -122,13 +122,15 @@ class RWebBrowserHandle : public RWebDisplayHandle {
    browser_process_id fPid;
 
 public:
-   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &tmpfile, const std::string &dump) :
-      RWebDisplayHandle(url), fTmpDir(tmpdir), fTmpFile(tmpfile)
+   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &tmpfile,
+                     const std::string &dump)
+      : RWebDisplayHandle(url), fTmpDir(tmpdir), fTmpFile(tmpfile)
    {
       SetContent(dump);
    }
 
-   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &tmpfile, browser_process_id pid)
+   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &tmpfile,
+                     browser_process_id pid)
       : RWebDisplayHandle(url), fTmpDir(tmpdir), fTmpFile(tmpfile), fHasPid(true), fPid(pid)
    {
    }
@@ -137,19 +139,30 @@ public:
    {
 #ifdef _MSC_VER
       if (fHasPid)
-         gSystem->Exec(("taskkill /F /PID "s + std::to_string(fPid) + " >NUL 2>NUL").c_str());
-      std::string rmdir = "rmdir /S /Q ", rmfile = "del /F ";
+         gSystem->Exec(("taskkill /F /PID " s + std::to_string(fPid) + " >NUL 2>NUL").c_str());
+      std::string rmdir = "rmdir /S /Q ";
 #else
       if (fHasPid)
          kill(fPid, SIGKILL);
-      std::string rmdir = "rm -rf ", rmfile = "rm -f ";
+      std::string rmdir = "rm -rf ";
 #endif
       if (!fTmpDir.empty())
          gSystem->Exec((rmdir + fTmpDir).c_str());
-      if (!fTmpFile.empty())
-         gSystem->Exec((rmfile + fTmpFile).c_str());
+      RemoveStartupFiles();
    }
 
+   void RemoveStartupFiles() override
+   {
+#ifdef _MSC_VER
+      std::string rmfile = "del /F ";
+#else
+      std::string rmfile = "rm -f ";
+#endif
+      if (!fTmpFile.empty()) {
+         gSystem->Exec((rmfile + fTmpFile).c_str());
+         fTmpFile.clear();
+      }
+   }
 };
 
 } // namespace ROOT

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -587,6 +587,7 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator(bool _edge) : BrowserCreator(tru
    TestProg("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
 #endif
 #ifdef R__LINUX
+   TestProg("/snap/bin/chromium"); // test snap before to detect it properly
    TestProg("/usr/bin/chromium");
    TestProg("/usr/bin/chromium-browser");
    TestProg("/usr/bin/chrome-browser");

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -820,7 +820,7 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
 
       for (auto &conn : fPendingConn)
          if (_CanTrustIn(conn, key, ntry, is_remote, true /* test_first_time */))
-             return true;
+            return true;
 
       return false;
    }
@@ -860,6 +860,9 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
          // preserve key for longpoll or when with session key used for HMAC hash of messages
          // conn->fKey.clear();
          conn->ResetStamps();
+         // remove files which are required for startup
+         if (conn->fDisplayHandle)
+            conn->fDisplayHandle->RemoveStartupFiles();
          if (conn->fWasFirst)
             fConn.emplace(fConn.begin(), conn);
          else


### PR DESCRIPTION
Partially resolves https://root-forum.cern.ch/t/63182/ 
Let use snap installation of chromium on the platform where pre-compiled ROOT version is used

Also add special handling of temporary directory. 
snap version of chromium has limitation that files from `/tmp`
cannot be accessed. Therefore if TMPDIR is not set, try to use directly home directory.

Adjust batch code to use new functionality with temp directory

Delete temporary HTML file as soon as connection is established
