### PR TITLE
[ntuple] Remove `GetView<void>` with external address

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -279,9 +279,21 @@ public:
    }
 
    template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
+   }
+
+   template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
    template <typename T>
@@ -301,11 +313,29 @@ public:
    }
 
    template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
+   {
+      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, objPtr);
+   }
+
+   template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr)
    {
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
+   {
+      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
+      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
+      return RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -278,12 +278,18 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
    {
@@ -296,12 +302,18 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
+   /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
    {
@@ -324,6 +336,10 @@ public:
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
    {
@@ -333,6 +349,10 @@ public:
       return RNTupleView<T>(std::move(field), range, objPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
    {
@@ -347,6 +367,10 @@ public:
       return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `rawPtr` as the type
+   /// provided by `typeName`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
    {
@@ -356,6 +380,10 @@ public:
       return RNTupleView<T>(std::move(field), range, rawPtr);
    }
 
+   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
+   /// provided by `ti`.
+   ///
+   /// \sa GetView(std::string_view, std::shared_ptr<T>)
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -285,6 +285,12 @@ public:
    }
 
    template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+   }
+
+   template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr);
@@ -294,6 +300,12 @@ public:
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
    {
       return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
+   {
+      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    template <typename T>
@@ -322,6 +334,12 @@ public:
    }
 
    template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
+   {
+      return GetView<T>(fieldId, objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+   }
+
+   template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr)
    {
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
@@ -336,6 +354,12 @@ public:
       auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return RNTupleView<T>(std::move(field), range, rawPtr);
+   }
+
+   template <typename T>
+   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
+   {
+      return GetView<T>(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -278,24 +278,6 @@ public:
       return GetView<T>(RetrieveFieldId(fieldName), objPtr);
    }
 
-   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `typeName`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, std::string_view typeName)
-   {
-      return GetView<T>(RetrieveFieldId(fieldName), objPtr, typeName);
-   }
-
-   /// Provides access to an individual (sub)field, reading its values into `objPtr` as the type provided by `ti`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr, const std::type_info &ti)
-   {
-      return GetView<T>(RetrieveFieldId(fieldName), objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
-   }
-
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr)
    {
@@ -334,29 +316,6 @@ public:
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
-   }
-
-   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
-   /// provided by `typeName`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, std::string_view typeName)
-   {
-      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
-      auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, objPtr);
-   }
-
-   /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
-   /// provided by `ti`.
-   ///
-   /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr, const std::type_info &ti)
-   {
-      return GetView<T>(fieldId, objPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -287,19 +287,17 @@ public:
    /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `typeName`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, std::string_view typeName)
+   ROOT::RNTupleView<void> GetView(std::string_view fieldName, void *rawPtr, std::string_view typeName)
    {
-      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, typeName);
+      return GetView(RetrieveFieldId(fieldName), rawPtr, typeName);
    }
 
    /// Provides access to an individual (sub)field, reading its values into `rawPtr` as the type provided by `ti`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(std::string_view fieldName, T *rawPtr, const std::type_info &ti)
+   ROOT::RNTupleView<void> GetView(std::string_view fieldName, void *rawPtr, const std::type_info &ti)
    {
-      return GetView<T>(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+      return GetView(RetrieveFieldId(fieldName), rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    template <typename T>
@@ -330,23 +328,20 @@ public:
    /// provided by `typeName`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, std::string_view typeName)
+   ROOT::RNTupleView<void> GetView(ROOT::DescriptorId_t fieldId, void *rawPtr, std::string_view typeName)
    {
-      static_assert(std::is_void_v<T>, "calling GetView with a type name string is only allowed for [T = void]");
-      auto field = RNTupleView<T>::CreateField(fieldId, *fSource, typeName);
+      auto field = RNTupleView<void>::CreateField(fieldId, *fSource, typeName);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
-      return RNTupleView<T>(std::move(field), range, rawPtr);
+      return RNTupleView<void>(std::move(field), range, rawPtr);
    }
 
    /// Provides access to an individual (sub)field from its on-disk ID, reading its values into `objPtr` as the type
    /// provided by `ti`.
    ///
    /// \sa GetView(std::string_view, std::shared_ptr<T>)
-   template <typename T>
-   ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr, const std::type_info &ti)
+   ROOT::RNTupleView<void> GetView(ROOT::DescriptorId_t fieldId, void *rawPtr, const std::type_info &ti)
    {
-      return GetView<T>(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
+      return GetView(fieldId, rawPtr, ROOT::Internal::GetRenormalizedDemangledTypeName(ti));
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -311,6 +311,7 @@ public:
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, std::shared_ptr<T> objPtr)
    {
+      static_assert(!std::is_void_v<T>, "invalid attempt to call GetView<void> without a type name");
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, objPtr);
@@ -319,6 +320,7 @@ public:
    template <typename T>
    ROOT::RNTupleView<T> GetView(ROOT::DescriptorId_t fieldId, T *rawPtr)
    {
+      static_assert(!std::is_void_v<T>, "invalid attempt to call GetView<void> without a type name");
       auto field = ROOT::RNTupleView<T>::CreateField(fieldId, *fSource);
       auto range = ROOT::Internal::GetFieldRange(*field, *fSource);
       return ROOT::RNTupleView<T>(std::move(field), range, rawPtr);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -88,15 +88,19 @@ protected:
    ROOT::RNTupleGlobalRange fFieldRange;
    ROOT::RFieldBase::RValue fValue;
 
-   static std::unique_ptr<ROOT::RFieldBase>
-   CreateField(ROOT::DescriptorId_t fieldId, ROOT::Experimental::Internal::RPageSource &pageSource)
+   static std::unique_ptr<ROOT::RFieldBase> CreateField(ROOT::DescriptorId_t fieldId,
+                                                        Experimental::Internal::RPageSource &pageSource,
+                                                        std::string_view typeName = "")
    {
       std::unique_ptr<ROOT::RFieldBase> field;
       {
          const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
          const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
          if constexpr (std::is_void_v<T>) {
-            field = fieldDesc.CreateField(desc);
+            if (typeName.empty())
+               field = fieldDesc.CreateField(desc);
+            else
+               field = ROOT::RFieldBase::Create(fieldDesc.GetFieldName(), std::string(typeName)).Unwrap();
          } else {
             field = std::make_unique<ROOT::RField<T>>(fieldDesc.GetFieldName());
          }

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -573,22 +573,6 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
    }
 
-   // Shared pointer interface from type name string
-   {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, "std::int32_t");
-      viewFoo(0);
-      EXPECT_EQ(42, *int32SharedPtr);
-      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
-   }
-
-   // Shared pointer interface from std::type_info
-   {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, typeid(std::int32_t));
-      viewFoo(0);
-      EXPECT_EQ(42, *int32SharedPtr);
-      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
-   }
-
    // Reading as a type when the on-disk value doesn't fit in this type is not possible
    try {
       auto viewBar = reader->GetView<void>("bar", int32SharedPtr.get(), "std::int32_t");

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -557,7 +557,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    // Read "foo" as std::int32_t (instead of its on-disk type std::uint64_t)
    auto int32SharedPtr = std::make_shared<std::int32_t>();
 
-   // Raw pointer interface
+   // Raw pointer interface from type name string
    {
       auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), "std::int32_t");
       viewFoo(0);
@@ -565,9 +565,25 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
    }
 
-   // Shared pointer interface
+   // Raw pointer interface from std::type_info
+   {
+      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), typeid(std::int32_t));
+      viewFoo(0);
+      EXPECT_EQ(42, *int32SharedPtr);
+      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
+   }
+
+   // Shared pointer interface from type name string
    {
       auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, "std::int32_t");
+      viewFoo(0);
+      EXPECT_EQ(42, *int32SharedPtr);
+      EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
+   }
+
+   // Shared pointer interface from std::type_info
+   {
+      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr, typeid(std::int32_t));
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -584,13 +600,25 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    // Read "baz" as std::vector<double> (instead of its on-disk type std::vector<float>)
    std::vector<double> doubleVec;
    void *doubleVecPtr = &doubleVec;
-
    std::vector<double> expDoubleVec{1., 2., 3.};
-   auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
-   viewBaz(0);
-   EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
-   EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
-   EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+
+   // From type name string
+   {
+      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
+      viewBaz(0);
+      EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
+      EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
+      EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+   }
+
+   // From std::type_info
+   {
+      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, typeid(std::vector<double>));
+      viewBaz(0);
+      EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
+      EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
+      EXPECT_STREQ("std::vector<double>", viewBaz.GetField().GetTypeName().c_str());
+   }
 
    try {
       std::vector<int> intVec;

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -559,7 +559,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Raw pointer interface from type name string
    {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), "std::int32_t");
+      auto viewFoo = reader->GetView("foo", int32SharedPtr.get(), "std::int32_t");
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -567,7 +567,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Raw pointer interface from std::type_info
    {
-      auto viewFoo = reader->GetView<void>("foo", int32SharedPtr.get(), typeid(std::int32_t));
+      auto viewFoo = reader->GetView("foo", int32SharedPtr.get(), typeid(std::int32_t));
       viewFoo(0);
       EXPECT_EQ(42, *int32SharedPtr);
       EXPECT_STREQ("std::int32_t", viewFoo.GetField().GetTypeName().c_str());
@@ -575,7 +575,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // Reading as a type when the on-disk value doesn't fit in this type is not possible
    try {
-      auto viewBar = reader->GetView<void>("bar", int32SharedPtr.get(), "std::int32_t");
+      auto viewBar = reader->GetView("bar", int32SharedPtr.get(), "std::int32_t");
       viewBar(0);
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("value out of range: 18446744073709551615 for type i"));
@@ -588,7 +588,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // From type name string
    {
-      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, "std::vector<double>");
+      auto viewBaz = reader->GetView("baz", doubleVecPtr, "std::vector<double>");
       viewBaz(0);
       EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
       EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
@@ -597,7 +597,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
 
    // From std::type_info
    {
-      auto viewBaz = reader->GetView<void>("baz", doubleVecPtr, typeid(std::vector<double>));
+      auto viewBaz = reader->GetView("baz", doubleVecPtr, typeid(std::vector<double>));
       viewBaz(0);
       EXPECT_EQ(expDoubleVec, viewBaz.GetValue().GetRef<std::vector<double>>());
       EXPECT_STREQ("baz", viewBaz.GetField().GetFieldName().c_str());
@@ -607,7 +607,7 @@ TEST(RNTuple, VoidWithExternalAddressAndTypeName)
    try {
       std::vector<int> intVec;
       void *bazAsIntsPtr = &intVec;
-      reader->GetView<void>("baz", bazAsIntsPtr, "std::vector<int>");
+      reader->GetView("baz", bazAsIntsPtr, "std::vector<int>");
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("On-disk column types {`SplitReal32`} for field `baz._0` cannot be "
                                                  "matched to its in-memory type `std::int32_t`"));

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -274,12 +274,6 @@ TEST(RNTuple, ViewWithExternalAddress)
    auto view_1 = reader->GetView("pt", data_1);
    view_1(0);
    EXPECT_FLOAT_EQ(42.0, *data_1);
-
-   // Void shared_ptr
-   std::shared_ptr<void> data_2{new float()};
-   auto view_2 = reader->GetView("pt", data_2);
-   view_2(0);
-   EXPECT_FLOAT_EQ(42.0, *static_cast<float *>(data_2.get()));
 }
 
 TEST(RNTuple, BindEmplaceTyped)
@@ -341,7 +335,7 @@ TEST(RNTuple, BindEmplaceVoid)
 
    // bind to shared_ptr
    std::shared_ptr<void> value1{new float()};
-   auto view = reader->GetView<void>("pt", nullptr);
+   auto view = reader->GetView<void>("pt");
    view.Bind(value1);
    view(0);
    EXPECT_FLOAT_EQ(11.f, *reinterpret_cast<float *>(value1.get()));
@@ -433,7 +427,7 @@ TEST(RNTuple, ViewFrameworkUse)
    for (auto i : reader->GetEntryRange()) {
       if (i > 1) {
          if (!viewPx) {
-            viewPx = reader->GetView<void>("px", &px);
+            viewPx = reader->GetView("px", &px, "float");
          }
          (*viewPx)(i);
          EXPECT_FLOAT_EQ(i, px);
@@ -441,7 +435,7 @@ TEST(RNTuple, ViewFrameworkUse)
 
       if (i > 3) {
          if (!viewPy) {
-            viewPy = reader->GetView<void>("py", &py);
+            viewPy = reader->GetView("py", &py, "float");
          }
          (*viewPy)(i);
          EXPECT_FLOAT_EQ(0.2 + i, py);
@@ -449,7 +443,7 @@ TEST(RNTuple, ViewFrameworkUse)
 
       if (i > 7) {
          if (!viewPz) {
-            viewPz = reader->GetView<void>("pz", &pz);
+            viewPz = reader->GetView("pz", &pz, "float");
          }
          (*viewPz)(i);
          EXPECT_FLOAT_EQ(0.4 + i, pz);


### PR DESCRIPTION
This interface is potentially dangerous since the underlying field is constructed based on the on-disk type name, without being able to verify that the passed pointer is compatible.

---

I left `GetView<void>("f")` without external address because in principle we can do type checking there (https://github.com/root-project/root/issues/18316).