### PR TITLE
[cmake][macOS] Auto-detect `CMAKE_OSX_SYSROOT` when not set

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -13,6 +13,20 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
     set(libcxx ON CACHE BOOL "Build using libc++" FORCE)
   endif()
 
+  if(NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL "")
+    execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
+      OUTPUT_VARIABLE SDK_PATH
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT EXISTS "${SDK_PATH}")
+      message(FATAL_ERROR "Could not detect macOS SDK path")
+    endif()
+
+    set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "SDK path" FORCE)
+  endif()
+  message(STATUS "Using SDK path: ${CMAKE_OSX_SYSROOT}")
+
   #TODO: check haveconfig and rpath -> set rpath true
   #TODO: check Thread, define link command
   #TODO: more stuff check configure script


### PR DESCRIPTION
This will fix a build error when building with the latest CMake (4.0) version

# This Pull request:

Related: https://github.com/root-project/root/issues/18312

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

