### PR TITLE
tree: Fix address for nested split obj with io rule.

### DIFF
--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -176,7 +176,7 @@ protected:
 
    TString  GetRealFileName() const;
 
-   virtual void SetAddressImpl(void *addr, bool /* implied */) { SetAddress(addr); }
+   virtual void SetAddressImpl(void *addr, bool /* implied */, Int_t /* offset */) { SetAddress(addr); }
 
 private:
    Int_t    GetBasketAndFirst(TBasket*& basket, Long64_t& first, TBuffer* user_buffer);

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -145,7 +145,7 @@ protected:
    void SetReadLeavesPtr();
    void SetReadActionSequence();
    void SetupAddressesImpl();
-   void SetAddressImpl(void *addr, bool implied) override;
+   void SetAddressImpl(void *addr, bool implied, Int_t offset) override;
 
    void FillLeavesImpl(TBuffer& b);
    void FillLeavesMakeClass(TBuffer& b);


### PR DESCRIPTION
In the case a nested split object has a rule applying to it, we need to read its component (the sub-branches) into the 'fOnfileObject' rather than the user in-memory object

The example usage (and skeleton for test) can be seen at https://github.com/jblomer/auto_ptr_demo