### PR TITLE
[TMVA][SOFIE] Fix RModel move constructor and assignment

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -33,16 +33,14 @@ private:
    std::vector<std::shared_ptr<RModel>> fSubGraphs;    ///<!  sub-graph models (transient)
    RModel * fParentGraph = nullptr;
 
-   const std::string SP = "   ";
-
    // memory pool information for intermediate tensors
    MemoryPoolInfo fIntermediateMemoryInfo;    ///<!  intermediate memory info (transient)
    std::unordered_map<std::string_view, size_t> fIntermediateTensorFrequencyLookup;    ///<!  lookup table for intermediate tensor frequency (transient)
 
 public:
    // Rule of five: explicitly define move semantics, disallow copy
-   RModel(RModel &&other);
-   RModel &operator=(RModel &&other);
+   RModel(RModel &&other) = default;
+   RModel &operator=(RModel &&other) = default;
    RModel(const RModel &other) = delete;
    RModel &operator=(const RModel &other) = delete;
    ~RModel() = default;

--- a/tmva/sofie/inc/TMVA/RModel_Base.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_Base.hxx
@@ -43,7 +43,6 @@ protected:
 
    std::unordered_set<std::string> fNeededBlasRoutines;
 
-   const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath", "memory", "span"};
    std::unordered_set<std::string> fNeededStdLib = {"vector"};
    std::unordered_set<std::string> fCustomOpHeaders;
 
@@ -74,7 +73,8 @@ public:
    }
    void AddNeededStdLib(std::string libname)
    {
-      if (fAllowedStdLib.find(libname) != fAllowedStdLib.end()) {
+      static const std::unordered_set<std::string> allowedStdLib = {"vector", "algorithm", "cmath", "memory", "span"};
+      if (allowedStdLib.find(libname) != allowedStdLib.end()) {
          fNeededStdLib.insert(libname);
       }
    }

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -13,44 +13,15 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
+namespace {
+const std::string SP = "   ";
+}
+
 std::underlying_type_t<Options> operator|(Options opA, Options opB) {
     return static_cast<std::underlying_type_t<Options>>(opA) | static_cast<std::underlying_type_t<Options>>(opB);
 }
 std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, Options opB) {
     return opA | static_cast<std::underlying_type_t<Options>>(opB);
-}
-
-RModel::RModel(RModel&& other) {
-    fInputTensorInfos = std::move(other.fInputTensorInfos);
-    fReadyInputTensorInfos = std::move(other.fReadyInputTensorInfos);
-    fOutputTensorNames = other.fOutputTensorNames;
-    fInputTensorNames = other.fInputTensorNames;
-    fOperators = std::move(other.fOperators);
-    fInitializedTensors = std::move(other.fInitializedTensors);
-    fIntermediateTensorInfos = std::move(other.fIntermediateTensorInfos);
-    fName = other.fName;
-    fFileName = other.fFileName;
-    fParseTime = other.fParseTime;
-    fGC = other.fGC;
-    fNeededBlasRoutines = other.fNeededBlasRoutines;
-    fNeededStdLib = other.fNeededStdLib;
-}
-
-RModel& RModel::operator=(RModel&& other) {
-    fInputTensorInfos = std::move(other.fInputTensorInfos);
-    fReadyInputTensorInfos = std::move(other.fReadyInputTensorInfos);
-    fOutputTensorNames = other.fOutputTensorNames;
-    fInputTensorNames = other.fInputTensorNames;
-    fOperators = std::move(other.fOperators);
-    fInitializedTensors = std::move(other.fInitializedTensors);
-    fIntermediateTensorInfos = std::move(other.fIntermediateTensorInfos);
-    fName = other.fName;
-    fFileName = other.fFileName;
-    fParseTime = other.fParseTime;
-    fGC = other.fGC;
-    fNeededBlasRoutines = other.fNeededBlasRoutines;
-    fNeededStdLib = other.fNeededStdLib;
-    return *this;
 }
 
 const std::vector<size_t>& RModel::GetTensorShape(std::string name) const {


### PR DESCRIPTION
The move constructor and assignment were defined manually, leading to the classic oversight that it was not updated when data members and base classes were added.

It is safer to let it get defined by the compiler, since also all data members are trivially movable and there is no manual memory management.

The only other channge that was required to make the default move work was to avoid a `const std::vector` data member of the RModel_Base class.