### PR TITLE
[webgui] let use `ROOT::RWebDisplayHandle::DisplayUrl` with qt6 and cef

### DIFF
--- a/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
+++ b/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
@@ -38,6 +38,7 @@ protected:
    unsigned fValid{kValid};  ///< used to verify if instance valid or not
 
    CefRefPtr<CefBrowser> fBrowser; ///< associated browser
+   bool fCloseBrowser = true;
 
 public:
    RCefWebDisplayHandle(const std::string &url) : ROOT::RWebDisplayHandle(url) {}

--- a/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
+++ b/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
@@ -84,6 +84,8 @@ std::unique_ptr<ROOT::RWebDisplayHandle> RCefWebDisplayHandle::CefCreator::Displ
 {
 
    auto handle = std::make_unique<RCefWebDisplayHandle>(args.GetFullUrl());
+   if (!args.IsStandalone())
+      handle->fCloseBrowser = false;
 
    if (fCefApp) {
       fCefApp->SetNextHandle(handle.get());
@@ -233,7 +235,7 @@ RCefWebDisplayHandle::~RCefWebDisplayHandle()
 
 void RCefWebDisplayHandle::CloseBrowser()
 {
-   if (fBrowser) {
+   if (fBrowser && fCloseBrowser) {
       auto host = fBrowser->GetHost();
       if (host) host->CloseBrowser(true);
       fBrowser = nullptr;

--- a/gui/qt6webdisplay/rootqt6.cpp
+++ b/gui/qt6webdisplay/rootqt6.cpp
@@ -68,7 +68,8 @@ namespace ROOT {
 class RQt6WebDisplayHandle : public RWebDisplayHandle {
 protected:
 
-   RootWebView *fView{nullptr};  ///< pointer on widget, need to release when handle is destroyed
+   RootWebView *fView = nullptr;  ///< pointer on widget, need to release when handle is destroyed
+   bool fDeleteView = true;       ///< is view must be deleted
 
    class Qt6Creator : public Creator {
       QApplication *qapp{nullptr};  ///< created QApplication
@@ -139,7 +140,13 @@ protected:
          RootWebView *view = new RootWebView(qparent, args.GetWidth(), args.GetHeight(), args.GetX(), args.GetY());
 
          if (!args.IsHeadless()) {
-            if (!qparent) handle->fView = view;
+            if (!qparent) {
+               handle->fView = view;
+               if (!args.IsStandalone()) {
+                  handle->fDeleteView = false;
+                  view->setAttribute(Qt::WA_DeleteOnClose);
+               }
+            }
             view->load(QUrl(fullurl));
             view->show();
          } else {
@@ -217,7 +224,7 @@ public:
    ~RQt6WebDisplayHandle() override
    {
       // now view can be safely destroyed
-      if (fView) {
+      if (fView && fDeleteView) {
          delete fView;
          fView = nullptr;
       }


### PR DESCRIPTION
Method `ROOT::RWebDisplayHandle::DisplayUrl()` let display arbitrary web page in pre-configured web browser.

Now  Qt6 or CEF engine will work.

Update WebDisplay.md docu - add threads, TWebCanvas, widgets embeding
