### PR TITLE
[BP6.28][math][fitter] Fix crash when doing a weighted likelihood fit

### DIFF
--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -870,14 +870,16 @@ bool Fitter::DoMinimization(std::unique_ptr<ObjFunc_t>  objFunc, const ROOT::Mat
 template<class ObjFunc_t>
 bool Fitter::DoWeightMinimization(std::unique_ptr<ObjFunc_t> objFunc, const ROOT::Math::IMultiGenFunction * chi2func) {
    // perform the minimization initializing the minimizer starting from a given obj function
-   // and apply afterwards the correction for weights. This applyies only for logL fitting
+   // and apply afterwards the correction for weights. This applies only for logL fitting
    this->fFitType = objFunc->Type();
    fExtObjFunction = nullptr;
-   fObjFunction = std::move(objFunc);
+   // need to use a temporary shared pointer to the objective function since we cannot use the unique pointer when it has been moved
+   std::shared_ptr<ObjFunc_t> sObjFunc{ std::move(objFunc)};
+   fObjFunction = sObjFunc;
    if (!DoInitMinimizer()) return false;
    if (!DoMinimization(chi2func)) return false;
-   objFunc->UseSumOfWeightSquare();
-   return ApplyWeightCorrection(*objFunc);
+   sObjFunc->UseSumOfWeightSquare();
+   return ApplyWeightCorrection(*sObjFunc);
 }
 
 

--- a/test/stressHistoFit.cxx
+++ b/test/stressHistoFit.cxx
@@ -770,6 +770,7 @@ int test1DObjects(vector< vector<algoType> >& listH,
       for (int i = 1; i <= h1->GetNbinsX() + 1; ++i)
          h1->SetBinContent(i, rndm.Poisson(func->Eval(h1->GetBinCenter(i))));
 
+      h1->Sumw2(); // make as a weighted histo to test weighted fits
       gTestIndex++;
       if (gSelectedTest == 0 || gSelectedTest == gTestIndex) {
          // fill equal bin 1D  histogram
@@ -795,10 +796,12 @@ int test1DObjects(vector< vector<algoType> >& listH,
          if (h2) delete h2;
          TString hname = "H1D_VarBins";
          h2 = new TH1D(hname, "Histogram1D Variable Bins", nbinsX, v);
-         for (int i = 1; i <= h2->GetNbinsX(); ++i)
-            h2->SetBinContent(i,rndm.Poisson(func->Integral(h2->GetXaxis()->GetBinLowEdge(i),
-                                                            h2->GetXaxis()->GetBinUpEdge(i)) ));
-
+         for (int i = 1; i <= h2->GetNbinsX(); ++i) {
+            double expValue = func->Integral(h2->GetXaxis()->GetBinLowEdge(i),
+                                             h2->GetXaxis()->GetBinUpEdge(i));
+            h2->SetBinContent(i,rndm.Poisson(expValue));
+         }
+         h2->Sumw2(); // make as a weighted histo to test weighted fits
          if (c0 && !__DRAW__) delete c0;
          c0 = new TCanvas(TString::Format("c%d_H1D", gTestIndex), "Histogram1D Variable");
          ObjectWrapper<TH1D *> owh2(h2);
@@ -1209,6 +1212,7 @@ void init_structures()
    noGraphAlgos.push_back( algoType( "Minuit2",     "Migrad",      "EX", CompareResult()) );
    noGraphAlgos.push_back( algoType( "Minuit",      "Migrad",      "L", CompareResult(defCmpOpt,3,0.1)) );  // normal binned likelihood fit
    noGraphAlgos.push_back( algoType( "Minuit2",     "Migrad",      "L", CompareResult(defCmpOpt,3,0.1)) );
+   noGraphAlgos.push_back( algoType( "Minuit2",     "Migrad",      "WL", CompareResult(defCmpOpt,3,0.1)) );
    noGraphAlgos.push_back( algoType( "Minuit2",     "Migrad",      "G", CompareResult()) ); // gradient chi2 fit
    //noGraphAlgos.push_back( algoType( "Minuit",      "Migrad",      "G", CompareResult()) );   // skip TMinuit with G
    noGraphAlgos.push_back( algoType( "Minuit2",     "Minimize",    "G", CompareResult()) );


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Related: https://root-forum.cern.ch/t/segmentation-fault-in-th1-fit-using-wl-option-in-root-6-30-x-was-the-poisson-likelihood-behavior-recently-made-stricter/63335/3

Only tip-of-the-branch failing is 6.28

BP of https://github.com/root-project/root/pull/14488

A bug was introduced in #10439 affecting the weighted likelihood fits

Add missing test for Weighted likelihood fits in stressHistoFit

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

