### PR TITLE
[core] rootcling: avoid UB if ROOTSYS not defined

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4073,13 +4073,17 @@ int RootClingMain(int argc,
 
    llvm::cl::ParseCommandLineOptions(argc, argv, "rootcling");
 
-   std::string llvmResourceDir = std::string(gDriverConfig->fTROOT__GetEtcDir()) + "/cling";
+   const char *etcDir = gDriverConfig->fTROOT__GetEtcDir();
+   std::string llvmResourceDir = etcDir ? std::string(etcDir) + "/cling" : "";
+   
    if (gBareClingSubcommand) {
       std::vector<const char *> clingArgsC;
       clingArgsC.push_back(executableFileName);
       // Help cling finds its runtime (RuntimeUniverse.h and such).
-      clingArgsC.push_back("-I");
-      clingArgsC.push_back(gDriverConfig->fTROOT__GetEtcDir());
+      if (etcDir) {
+         clingArgsC.push_back("-I");
+         clingArgsC.push_back(etcDir);
+      }
 
       //clingArgsC.push_back("-resource-dir");
       //clingArgsC.push_back(llvmResourceDir.c_str());
@@ -4218,8 +4222,10 @@ int RootClingMain(int argc,
       clingArgs.push_back(FullWDiag);
    }
 
-   std::string includeDir = llvm::sys::path::convert_to_slash(gDriverConfig->fTROOT__GetIncludeDir());
-   clingArgs.push_back(std::string("-I") + includeDir);
+   const char *includeDir = gDriverConfig->fTROOT__GetIncludeDir();
+   if (includeDir) {
+       clingArgs.push_back(std::string("-I") + includeDir);
+   }
 
    std::vector<std::string> pcmArgs;
    for (size_t parg = 0, n = clingArgs.size(); parg < n; ++parg) {
@@ -4243,7 +4249,9 @@ int RootClingMain(int argc,
    }
 
    // cling-only arguments
-   clingArgs.push_back(std::string("-I") + llvm::sys::path::convert_to_slash(gDriverConfig->fTROOT__GetEtcDir()));
+   if (etcDir)
+      clingArgs.push_back(std::string("-I") + llvm::sys::path::convert_to_slash(etcDir));
+   
    // We do not want __ROOTCLING__ in the pch!
    if (!gOptGeneratePCH) {
       clingArgs.push_back("-D__ROOTCLING__");
@@ -4300,9 +4308,9 @@ int RootClingMain(int argc,
       for (const std::string &modulemap : gOptModuleMapFiles)
          clingArgsInterpreter.push_back("-fmodule-map-file=" + modulemap);
 
-      clingArgsInterpreter.push_back("-fmodule-map-file=" +
-                                     std::string(gDriverConfig->fTROOT__GetIncludeDir()) +
-                                     "/ROOT.modulemap");
+      if (includeDir) {
+         clingArgsInterpreter.push_back("-fmodule-map-file=" + std::string(includeDir) + "/ROOT.modulemap");
+      }
       std::string ModuleMapCWD = ROOT::FoundationUtils::GetCurrentDir() + "/module.modulemap";
       if (llvm::sys::fs::exists(ModuleMapCWD))
          clingArgsInterpreter.push_back("-fmodule-map-file=" + ModuleMapCWD);

--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -24,12 +24,18 @@ static void (*dlsymaddr)() = &usedToIdentifyRootClingByDlSym;
 ROOT::Internal::RootCling::TROOTSYSSetter gROOTSYSSetter;
 
 static const char *GetIncludeDir() {
-   static std::string incdir = std::string(getenv("ROOTSYS")) + "/include";
+   auto renv = getenv("ROOTSYS");
+   if (!renv)
+      return "";
+   static std::string incdir = std::string(renv) + "/include";
    return incdir.c_str();
 }
 
 static const char *GetEtcDir() {
-   static std::string etcdir = std::string(getenv("ROOTSYS")) + "/etc";
+   auto renv = getenv("ROOTSYS");
+   if (!renv)
+      return "";
+   static std::string etcdir = std::string(renv) + "/etc";
    return etcdir.c_str();
 }
 

--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -26,7 +26,7 @@ ROOT::Internal::RootCling::TROOTSYSSetter gROOTSYSSetter;
 static const char *GetIncludeDir() {
    auto renv = getenv("ROOTSYS");
    if (!renv)
-      return "";
+      return nullptr;
    static std::string incdir = std::string(renv) + "/include";
    return incdir.c_str();
 }
@@ -34,7 +34,7 @@ static const char *GetIncludeDir() {
 static const char *GetEtcDir() {
    auto renv = getenv("ROOTSYS");
    if (!renv)
-      return "";
+      return nullptr;
    static std::string etcdir = std::string(renv) + "/etc";
    return etcdir.c_str();
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

std::string(nullptr) is ill-defined. Found out by clang-tidy

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)