### PR TITLE
[TMVA][SOFIE] Implement wrapper for `BLAS::sgemm_` call

### DIFF
--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -705,6 +705,21 @@ inline GNN_Data Copy(const GNN_Data & data) {
    return out;
 }
 
+inline void Gemm_Call(float *output, bool transa, bool transb, int m, int n, int k, float alpha, const float *A,
+                      const float *B, float beta, const float *C)
+{
+   char ct = 't';
+   char cn = 'n';
+   const int *lda = transa ? &k : &m;
+   const int *ldb = transb ? &n : &k;
+   const int *ldc = &m;
+   if (C != nullptr) {
+      std::copy(C, C + m * n, output);
+   }
+   TMVA::Experimental::SOFIE::BLAS::sgemm_(transa ? &ct : &cn, transb ? &ct : &cn, &m, &n, &k, &alpha, A, lda, B, ldb,
+                                           &beta, output, ldc);
+}
+
 }//SOFIE
 }//Experimental
 }//TMVA


### PR DESCRIPTION
Clad can't do reverse mode AD if you use functions that take parameters that are at the same time an input and an output, like the matrix C in `sgemm_`.

This can be avoided by creating a wrapper where the input and output arrays are separate, and then there is an internal copy.

Having a wrapper like this improves the SOFIE code anyway, because the copying code is now written out by SOFIE before the `sgemm_` call. So by having a wrapper, one also reduces the verbosity of the generated code.