### PR TITLE
[webgui] Fix build on Windows

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -142,7 +142,7 @@ public:
    {
 #ifdef _MSC_VER
       if (fHasPid)
-         gSystem->Exec(("taskkill /F /PID " s + std::to_string(fPid) + " >NUL 2>NUL").c_str());
+         gSystem->Exec(("taskkill /F /PID " + std::to_string(fPid) + " >NUL 2>NUL").c_str());
       std::string rmdir = "rmdir /S /Q ";
 #else
       if (fHasPid)


### PR DESCRIPTION
Probably caused by `clang-format` in commit 2361862592, but the suffix is not needed because `std::to_string` is already a `std::string`.