### PR TITLE
Speedup retrieval of branch names

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -133,10 +133,29 @@ void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, c
 void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, TBranch *b,
                           std::string prefix, std::string &friendName, bool allowDuplicates)
 {
+   // We want to avoid situations of overlap between the prefix and the
+   // sub-branch name that might happen when the branch is composite, e.g.
+   // prefix=reco_Wdecay2_from_tbar_4vect_NOSYS.fCoordinates.
+   // subBranchName=fCoordinates.fPt
+   // which would lead to a repetition of fCoordinates in the output branch name
+   // Boundary to search for the token before the last dot
+   auto prefixEndingDot = std::string::npos;
+   if (!prefix.empty() && prefix.back() == '.')
+      prefixEndingDot = prefix.size() - 2;
+   std::string lastPrefixToken{};
+   if (auto prefixLastRealDot = prefix.find_last_of('.', prefixEndingDot); prefixLastRealDot != std::string::npos)
+      lastPrefixToken = prefix.substr(prefixLastRealDot + 1, prefixEndingDot - prefixLastRealDot);
+
    for (auto sb : *b->GetListOfBranches()) {
       TBranch *subBranch = static_cast<TBranch *>(sb);
       auto subBranchName = std::string(subBranch->GetName());
       auto fullName = prefix + subBranchName;
+
+      if (auto subNameFirstDot = subBranchName.find_first_of('.'); subNameFirstDot != std::string::npos) {
+         // Concatenate the prefix to the sub-branch name without overlaps
+         if (!lastPrefixToken.empty() && lastPrefixToken == subBranchName.substr(0, subNameFirstDot))
+            fullName = prefix + subBranchName.substr(subNameFirstDot + 1);
+      }
 
       std::string newPrefix;
       if (!prefix.empty())

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -101,6 +101,13 @@ configure_file(pyspec.json . COPYONLY)
 configure_file(spec_ordering_samples_withFriends.json . COPYONLY)
 ROOT_ADD_GTEST(datasource_csv datasource_csv.cxx LIBRARIES ROOTDataFrame)
 
+ROOT_ADD_GTEST(datasource_tree datasource_tree.cxx LIBRARIES RIO Tree ROOTDataFrame)
+ROOT_GENERATE_DICTIONARY(ClassWithNestedSameNameDict
+                         ${CMAKE_CURRENT_SOURCE_DIR}/ClassWithNestedSameName.hxx
+                         MODULE datasource_tree
+                         LINKDEF ClassWithNestedSameNameLinkDef.hxx
+                         OPTIONS -inlineInputHeader)
+
 #### TESTS REQUIRING EXTRA ROOT FEATURES ####
 if (imt)
    ROOT_ADD_GTEST(dataframe_concurrency dataframe_concurrency.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/ClassWithNestedSameName.hxx
+++ b/tree/dataframe/test/ClassWithNestedSameName.hxx
@@ -1,0 +1,16 @@
+#ifndef CLASSWITHNESTEDSAMENAME
+#define CLASSWITHNESTEDSAMENAME
+
+struct Particle {
+   float fPt{42.f};
+};
+
+struct DataMember {
+   Particle fInner{};
+};
+
+struct TopLevel {
+   DataMember fInner{};
+};
+
+#endif // CLASSWITHNESTEDSAMENAME

--- a/tree/dataframe/test/ClassWithNestedSameNameLinkDef.hxx
+++ b/tree/dataframe/test/ClassWithNestedSameNameLinkDef.hxx
@@ -1,0 +1,7 @@
+#ifdef __CLING__
+
+#pragma link C++ class Particle + ;
+#pragma link C++ class DataMember + ;
+#pragma link C++ class TopLevel + ;
+
+#endif

--- a/tree/dataframe/test/datasource_tree.cxx
+++ b/tree/dataframe/test/datasource_tree.cxx
@@ -1,0 +1,58 @@
+/* TTree-specific tests for RDataFrame */
+#include <cstdio>
+
+#include <TTree.h>
+#include <TFile.h>
+#include <TChain.h>
+
+#include <ROOT/RDataFrame.hxx>
+
+#include <gtest/gtest.h>
+
+#include "ClassWithNestedSameName.hxx"
+
+struct InputTreeRAII {
+   const char *fTreeName{"nestedsamename"};
+   const char *fFileName{"nestedsamename.root"};
+
+   InputTreeRAII()
+   {
+      std::unique_ptr<TFile> ofile{TFile::Open(fFileName, "recreate")};
+
+      std::unique_ptr<TTree> myTree = std::make_unique<TTree>(fTreeName, fTreeName);
+
+      TopLevel obj{};
+
+      myTree->Branch("toplevel", &obj);
+      myTree->Fill();
+      ofile->Write();
+   }
+
+   ~InputTreeRAII() { std::remove(fFileName); }
+};
+
+void expect_vec_eq(const std::vector<std::string> &v1, const std::vector<std::string> &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size()) << "Vectors 'v1' and 'v2' are of unequal length";
+   for (std::size_t i = 0ull; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]) << "Vectors 'v1' and 'v2' differ at index " << i;
+   }
+}
+
+TEST(RTTreeDS, BranchWithNestedSameName)
+{
+   // Test that a toplevel branch with data member "fInner" with in turn another data member with the same name is
+   // properly retrieved in the list of branch names
+   InputTreeRAII dataset{};
+
+   ROOT::RDataFrame df{dataset.fTreeName, dataset.fFileName};
+   auto branchNames = df.GetColumnNames();
+
+   std::vector<std::string> expectedBranchNames{"toplevel", "toplevel.fInner", "toplevel.fInner.fInner.fPt", "fInner",
+                                                "fInner.fInner.fPt"};
+
+   std::sort(expectedBranchNames.begin(), expectedBranchNames.end());
+   std::sort(branchNames.begin(), branchNames.end());
+
+   expect_vec_eq(branchNames, expectedBranchNames);
+}

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -71,10 +71,15 @@ class TVirtualIndex;
 class TBranchRef;
 class TBasket;
 class TStreamerInfo;
+class TTree;
 class TTreeCache;
 class TTreeCloner;
 class TFileMergeInfo;
 class TVirtualPerfStats;
+
+namespace ROOT::Internal::TreeUtils {
+void TBranch__SetTree(TTree *tree, TObjArray &branches);
+}
 
 class TTree : public TNamed, public TAttLine, public TAttFill, public TAttMarker {
 
@@ -160,11 +165,17 @@ private:
    mutable std::atomic<Long64_t> fIMTTotBytes;    ///<! Total bytes for the IMT flush baskets
    mutable std::atomic<Long64_t> fIMTZipBytes;    ///<! Zip bytes for the IMT flush baskets.
 
+   std::unordered_map<std::string, TBranch *>
+      fNamesToBranches; ///<! maps names to their branches, useful when retrieving branches by name
+
    void             InitializeBranchLists(bool checkLeafCount);
    void             SortBranchesByTime();
    Int_t            FlushBasketsImpl() const;
    void             MarkEventCluster();
    Long64_t         GetMedianClusterSize();
+
+   void RegisterBranchFullName(std::pair<std::string, TBranch *> &&kv) { fNamesToBranches.insert(kv); }
+   friend void ROOT::Internal::TreeUtils::TBranch__SetTree(TTree *tree, TObjArray &branches);
 
 protected:
    virtual void     KeepCircular();


### PR DESCRIPTION
When the input `TTree` has a large dataset schema `O(10k)` and when the branch types are non trivial (i.e. many of the branches store some kind of nested data structure with possibly multiple levels of sub-branches representing the data members), retrieving the full list of available branches in the tree may become a costly operation. Anecdotally, a `TTree` used by an ATLAS analysis with >30k total leaves results in a retrieval time of around 2 minutes on my machine. With the changes in this PR, this time goes down **to around 6 seconds**. Main two contributors:
* a new transient map data member in `TTree`. When the `TTree` is being read, it already needs to traverse all its branch hierarchy. Take this opportunity to fill a map that connects the string with the full name of the leaf to the `TBranch` pointer. Then use this map when retrieving the branch.
* A fix in the logic in `RDF` that retrieves the full list of branches, such that in cases where the parent branch name is overlapping with the name of one of its sub branches, the concatenated string is first deduplicated before being passed to `TTree::GetBranch.` This ensures that a proper match in the aforementioned map can be found.
