### PR TITLE
Prevent type sufix to appear in ROOT normalized name

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -635,6 +635,8 @@ bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::s
          // TMetaUtils::GetNormalizedName, we just do the 'strip leading std' and fix
          // white space.
          clang::PrintingPolicy policy(fInterpreter->getCI()->getASTContext().getPrintingPolicy());
+         // For now we do not want the integral type suffixes in the normalized name.
+         policy.NeverIncludeTypeForTemplateArgument = true;
          policy.SuppressTagKeyword = true; // Never get the class or struct keyword
          policy.SuppressScope = true;      // Force the scope to be coming from a clang::ElaboratedType.
          // The scope suppression is required for getting rid of the anonymous part of the name of a class defined in an anonymous namespace.
@@ -1411,6 +1413,8 @@ void ROOT::TMetaUtils::GetQualifiedName(std::string &qual_name, const clang::Nam
 {
    llvm::raw_string_ostream stream(qual_name);
    clang::PrintingPolicy policy( cl.getASTContext().getPrintingPolicy() );
+   // For now we do not want the integral type suffixes in the normalized name.
+   policy.NeverIncludeTypeForTemplateArgument = true;
    policy.SuppressTagKeyword = true; // Never get the class or struct keyword
    policy.SuppressUnwrittenScope = true; // Don't write the inline or anonymous namespace names.
 
@@ -4161,6 +4165,8 @@ void ROOT::TMetaUtils::GetNormalizedName(std::string &norm_name, const clang::Qu
 
    clang::ASTContext &ctxt = interpreter.getCI()->getASTContext();
    clang::PrintingPolicy policy(ctxt.getPrintingPolicy());
+   // For now we do not want the integral type suffixes in the normalized name.
+   policy.NeverIncludeTypeForTemplateArgument = true;
    policy.SuppressTagKeyword = true; // Never get the class or struct keyword
    policy.SuppressScope = true;      // Force the scope to be coming from a clang::ElaboratedType.
    policy.AnonymousTagLocations = false; // Do not extract file name + line number for anonymous types.

--- a/interpreter/llvm-project/clang/include/clang/AST/PrettyPrinter.h
+++ b/interpreter/llvm-project/clang/include/clang/AST/PrettyPrinter.h
@@ -76,6 +76,7 @@ struct PrintingPolicy {
         SuppressImplicitBase(false), FullyQualifiedName(false),
         PrintCanonicalTypes(false), PrintInjectedClassNameWithArguments(true),
         UsePreferredNames(true), AlwaysIncludeTypeForTemplateArgument(false),
+        NeverIncludeTypeForTemplateArgument(false),
         CleanUglifiedParameters(false), EntireContentsOfLargeArray(true),
         UseEnumerators(true) {}
 
@@ -325,6 +326,13 @@ struct PrintingPolicy {
   /// parameters.
   LLVM_PREFERRED_TYPE(bool)
   unsigned AlwaysIncludeTypeForTemplateArgument : 1;
+
+  /// Whether to never use type suffixes (eg: 1U) on integral non-type template
+  /// parameters.  This is useful to cancel the behavior of
+  /// TemplateParameterList::shouldIncludeTypeForArgument sometimes request the
+  /// type suffix even if AlwaysIncludeTypeForTemplateArgument is not true.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned NeverIncludeTypeForTemplateArgument : 1;
 
   /// Whether to strip underscores when printing reserved parameter names.
   /// e.g. std::vector<class _Tp> becomes std::vector<class Tp>.

--- a/interpreter/llvm-project/clang/lib/AST/DeclTemplate.cpp
+++ b/interpreter/llvm-project/clang/lib/AST/DeclTemplate.cpp
@@ -240,6 +240,8 @@ bool TemplateParameterList::hasAssociatedConstraints() const {
 bool TemplateParameterList::shouldIncludeTypeForArgument(
     const PrintingPolicy &Policy, const TemplateParameterList *TPL,
     unsigned Idx) {
+  if (Policy.NeverIncludeTypeForTemplateArgument)
+    return false;
   if (!TPL || Idx >= TPL->size() || Policy.AlwaysIncludeTypeForTemplateArgument)
     return true;
   const NamedDecl *TemplParam = TPL->getParam(Idx);


### PR DESCRIPTION
This fixes #18363 and thus https://github.com/cms-sw/cmssw/issues/47697.

The companion PR is https://github.com/root-project/roottest/pull/1302

This PR actually 2 related parts
a - an update to LLVM type printer and its use within ROOT
b - an improvement in the detection of unwanted auto-parsing

**a. LLVM update**

 The update to LLVM allows to completely prevent the addition of type suffixes when printing names rather than the current default (there for some types - and in addition, at least how we use it in ROOT, even for those types not consistently there).

In practice, in the failing case, we were getting this normalized name:
```
class reco::PFRecHitSoALayout<128UL,false>::ViewTemplateFreeParams<128,false,true,true>
```
instead of 
```
class reco::PFRecHitSoALayout<128,false>::ViewTemplateFreeParams<128,false,true,true>
```
Note that in the failing case only **one** of the two integers is suffixed by "UL".  I did not tracked down the cause of this discrepancy.
In addition, we also produce alternate spelling of names to ease lookup (by preventing auto-parsing in some trivial case of alternative spelling).

As a side note, another source of confusion is the following.
In the successful run of the example with get:
```
70:      instance.AdoptAlternate(::ROOT::AddClassAlternate("reco::PFRecHitSoALayout<128,false>","reco::PFRecHitSoA"));
72:      instance.AdoptAlternate(::ROOT::AddClassAlternate("reco::PFRecHitSoALayout<128,false>","reco::PFRecHitSoALayout<128ul, false>"));
119:      instance.AdoptAlternate(::ROOT::AddClassAlternate("reco::PFRecHitSoALayout<128,false>::ViewTemplateFreeParams<128,false,true,true>","reco::PFRecHitSoA::View"));
121:      instance.AdoptAlternate(::ROOT::AddClassAlternate("reco::PFRecHitSoALayout<128,false>::ViewTemplateFreeParams<128,false,true,true>","reco::PFRecHitSoALayout<128ul, false>::ViewTemplateFreeParams<128ul, false, true, true>"));
```
where the alternate have the suffix ... but in lower case.  The alternates here are produced by `abi::__cxa_demangle`. (the exact same spelling appears for the alternate in the failing case).

