### PR TITLE
[hist] remove default 1deg offset in th2poly textn

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -4287,7 +4287,7 @@ Int_t THistPainter::MakeChopt(Option_t *choptin)
       }
       memcpy(l,"    ", 4);
       l = strstr(chopt,"N");
-      if (l && fH->InheritsFrom(TH2Poly::Class())) Hoption.Text += 3000;
+      if (l && fH->InheritsFrom(TH2Poly::Class())) Hoption.Text = 3000 + (Hoption.Text != 1 ? Hoption.Text : 0);
       Hoption.Color = 0;
    }
    l = strstr(chopt,"COLZ");


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/18374

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

