### PR TITLE
[TPython] Use functions and not macros for reference counting

### DIFF
--- a/bindings/tpython/CMakeLists.txt
+++ b/bindings/tpython/CMakeLists.txt
@@ -30,13 +30,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTPython
     Python3::Python
 )
 
-# Disables warnings originating from deprecated register keyword in Python
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(ROOTTPython PRIVATE -Wno-register)
-endif()
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(ROOTTPython PRIVATE -Wno-register)
-    target_compile_options(ROOTTPython PRIVATE -Wno-deprecated-register)
-endif()
-
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/bindings/tpython/src/TPyArg.cxx
+++ b/bindings/tpython/src/TPyArg.cxx
@@ -45,7 +45,7 @@ void TPyArg::CallConstructor(PyObject *&pyself, PyObject *pyclass, const std::ve
    for (int i = 0; i < nArgs; ++i)
       PyTuple_SET_ITEM(pyargs, i, (PyObject *)args[i]);
    pyself = PyObject_Call(pyclass, pyargs, NULL);
-   Py_DECREF(pyargs);
+   Py_DecRef(pyargs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -55,7 +55,7 @@ void CallConstructor(PyObject *&pyself, PyObject *pyclass)
 
    PyObject *pyargs = PyTuple_New(0);
    pyself = PyObject_Call(pyclass, pyargs, NULL);
-   Py_DECREF(pyargs);
+   Py_DecRef(pyargs);
 }
 
 //- generic dispatcher -------------------------------------------------------
@@ -68,7 +68,7 @@ PyObject *TPyArg::CallMethod(PyObject *pymeth, const std::vector<TPyArg> &args)
    for (int i = 0; i < nArgs; ++i)
       PyTuple_SET_ITEM(pyargs, i, (PyObject *)args[i]);
    PyObject *result = PyObject_Call(pymeth, pyargs, NULL);
-   Py_DECREF(pyargs);
+   Py_DecRef(pyargs);
    return result;
 }
 
@@ -77,7 +77,7 @@ void TPyArg::CallDestructor(PyObject *&pyself, PyObject *, const std::vector<TPy
 {
    PyGILRAII gilRaii;
 
-   Py_XDECREF(pyself); // calls actual dtor if ref-count down to 0
+   Py_DecRef(pyself); // calls actual dtor if ref-count down to 0
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,7 +85,7 @@ void TPyArg::CallDestructor(PyObject *&pyself)
 {
    PyGILRAII gilRaii;
 
-   Py_XDECREF(pyself);
+   Py_DecRef(pyself);
 }
 
 //- constructors/destructor --------------------------------------------------
@@ -94,7 +94,7 @@ TPyArg::TPyArg(PyObject *pyobject)
    PyGILRAII gilRaii;
 
    // Construct a TPyArg from a python object.
-   Py_XINCREF(pyobject);
+   Py_IncRef(pyobject);
    fPyObject = pyobject;
 }
 
@@ -145,7 +145,7 @@ TPyArg::TPyArg(const TPyArg &s)
 {
    PyGILRAII gilRaii;
 
-   Py_XINCREF(s.fPyObject);
+   Py_IncRef(s.fPyObject);
    fPyObject = s.fPyObject;
 }
 
@@ -157,7 +157,7 @@ TPyArg &TPyArg::operator=(const TPyArg &s)
    PyGILRAII gilRaii;
 
    if (&s != this) {
-      Py_XINCREF(s.fPyObject);
+      Py_IncRef(s.fPyObject);
       fPyObject = s.fPyObject;
    }
    return *this;
@@ -170,7 +170,7 @@ TPyArg::~TPyArg()
 {
    PyGILRAII gilRaii;
 
-   Py_XDECREF(fPyObject);
+   Py_DecRef(fPyObject);
    fPyObject = NULL;
 }
 
@@ -180,6 +180,6 @@ TPyArg::operator PyObject *() const
    PyGILRAII gilRaii;
 
    // Extract the python object.
-   Py_XINCREF(fPyObject);
+   Py_IncRef(fPyObject);
    return fPyObject;
 }

--- a/bindings/tpython/src/TPyClassGenerator.cxx
+++ b/bindings/tpython/src/TPyClassGenerator.cxx
@@ -56,8 +56,8 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
    PyObject *pyname = PyUnicode_FromString(name);
    PyObject *keys = PyDict_Keys(modules);
    Bool_t isModule = PySequence_Contains(keys, pyname);
-   Py_DECREF(keys);
-   Py_DECREF(pyname);
+   Py_DecRef(keys);
+   Py_DecRef(pyname);
 
    if (isModule) {
       // the normal TClass::GetClass mechanism doesn't allow direct returns, so
@@ -77,10 +77,10 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
 
       for (int i = 0; i < PyList_GET_SIZE(keys); ++i) {
          PyObject *key = PyList_GET_ITEM(keys, i);
-         Py_INCREF(key);
+         Py_IncRef(key);
 
          PyObject *attr = PyDict_GetItem(dct, key);
-         Py_INCREF(attr);
+         Py_IncRef(attr);
 
          // TODO: refactor the code below with the class method code
          if (PyCallable_Check(attr) && !(PyType_Check(attr) || PyObject_HasAttr(attr, bases))) {
@@ -97,8 +97,8 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             int nVars = var_names ? PyTuple_GET_SIZE(var_names) : 0 /* TODO: probably large number, all default? */;
             if (nVars < 0)
                nVars = 0;
-            Py_XDECREF(var_names);
-            Py_XDECREF(func_code);
+            Py_DecRef(var_names);
+            Py_DecRef(func_code);
 
             nsCode << " TPyReturn " << func_name << "(";
             for (int ivar = 0; ivar < nVars; ++ivar) {
@@ -117,12 +117,12 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             nsCode << "  return TPyReturn(TPyArg::CallMethod((PyObject*)" << std::showbase << (uintptr_t)attr << ", v)); }\n";
          }
 
-         Py_DECREF(attr);
-         Py_DECREF(key);
+         Py_DecRef(attr);
+         Py_DecRef(key);
       }
 
-      Py_DECREF(keys);
-      Py_DECREF(bases);
+      Py_DecRef(keys);
+      Py_DecRef(bases);
 
       nsCode << " }";
 
@@ -161,10 +161,10 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
       return 0; // module apparently disappeared
    }
 
-   Py_INCREF(mod);
+   Py_IncRef(mod);
    PyObject *pyclass = PyDict_GetItemString(PyModule_GetDict(mod), const_cast<char *>(clName.c_str()));
-   Py_XINCREF(pyclass);
-   Py_DECREF(mod);
+   Py_IncRef(pyclass);
+   Py_DecRef(mod);
 
    if (!pyclass) {
       PyErr_Clear(); // the class is no longer available?!
@@ -175,7 +175,7 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
    PyObject *attrs = PyObject_Dir(pyclass);
    if (!attrs) {
       PyErr_Clear();
-      Py_DECREF(pyclass);
+      Py_DecRef(pyclass);
       return 0;
    }
 
@@ -189,7 +189,7 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
    Bool_t hasConstructor = kFALSE, hasDestructor = kFALSE;
    for (int i = 0; i < PyList_GET_SIZE(attrs); ++i) {
       PyObject *label = PyList_GET_ITEM(attrs, i);
-      Py_INCREF(label);
+      Py_IncRef(label);
       PyObject *attr = PyObject_GetAttr(pyclass, label);
 
       // collect only member functions (i.e. callable elements in __dict__)
@@ -221,10 +221,10 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             var_names ? PyTuple_GET_SIZE(var_names) - 1 /* self */ : 0 /* TODO: probably large number, all default? */;
          if (nVars < 0)
             nVars = 0;
-         Py_XDECREF(var_names);
-         Py_XDECREF(func_code);
+         Py_DecRef(var_names);
+         Py_DecRef(func_code);
 #if PY_VERSION_HEX < 0x03000000
-         Py_XDECREF(im_func);
+         Py_DecRef(im_func);
 #endif
 
          // method declaration as appropriate
@@ -258,7 +258,7 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
       }
 
       // no decref of attr for now (b/c of hard-wired ptr); need cleanup somehow
-      Py_DECREF(label);
+      Py_DecRef(label);
    }
 
    // special case if no constructor or destructor
@@ -278,9 +278,9 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
    if (useNS)
       proxyCode << " }";
 
-   Py_DECREF(attrs);
+   Py_DecRef(attrs);
    // done with pyclass, decref here, assuming module is kept
-   Py_DECREF(pyclass);
+   Py_DecRef(pyclass);
 
    // body compilation
    if (!gInterpreter->LoadText(proxyCode.str().c_str()))

--- a/bindings/tpython/src/TPyReturn.cxx
+++ b/bindings/tpython/src/TPyReturn.cxx
@@ -57,7 +57,7 @@ TPyReturn::TPyReturn()
    PyGILRAII gilRaii;
 
    // Construct a TPyReturn object from Py_None.
-   Py_INCREF(Py_None);
+   Py_IncRef(Py_None);
    fPyObject = Py_None;
 }
 
@@ -70,7 +70,7 @@ TPyReturn::TPyReturn(PyObject *pyobject)
    PyGILRAII gilRaii;
 
    if (!pyobject) {
-      Py_INCREF(Py_None);
+      Py_IncRef(Py_None);
       fPyObject = Py_None;
    } else
       fPyObject = pyobject; // steals reference
@@ -83,7 +83,7 @@ TPyReturn::TPyReturn(const TPyReturn &other)
 {
    PyGILRAII gilRaii;
 
-   Py_INCREF(other.fPyObject);
+   Py_IncRef(other.fPyObject);
    fPyObject = other.fPyObject;
 }
 
@@ -95,8 +95,8 @@ TPyReturn &TPyReturn::operator=(const TPyReturn &other)
    PyGILRAII gilRaii;
 
    if (this != &other) {
-      Py_INCREF(other.fPyObject);
-      Py_DECREF(fPyObject);
+      Py_IncRef(other.fPyObject);
+      Py_DecRef(fPyObject);
       fPyObject = other.fPyObject;
    }
 
@@ -110,7 +110,7 @@ TPyReturn::~TPyReturn()
 {
    PyGILRAII gilRaii;
 
-   Py_DECREF(fPyObject);
+   Py_DecRef(fPyObject);
 }
 
 //- public members -----------------------------------------------------------
@@ -224,6 +224,6 @@ TPyReturn::operator PyObject *() const
    if (fPyObject == Py_None)
       return 0;
 
-   Py_INCREF(fPyObject);
+   Py_IncRef(fPyObject);
    return fPyObject;
 }

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -109,7 +109,7 @@ public:
    CachedPyString &operator=(CachedPyString const &) = delete;
    CachedPyString &operator=(CachedPyString &&) = delete;
 
-   ~CachedPyString() { Py_DECREF(fObj); }
+   ~CachedPyString() { Py_DecRef(fObj); }
 
    PyObject *obj() { return fObj; }
 
@@ -215,7 +215,7 @@ Bool_t TPython::Initialize()
 
          // retrieve the main dictionary
          gMainDict = PyModule_GetDict(PyImport_AddModule(const_cast<char *>("__main__")));
-         // The gMainDict is borrowed, i.e. we are not calling Py_INCREF(gMainDict).
+         // The gMainDict is borrowed, i.e. we are not calling Py_IncRef(gMainDict).
          // Like this, we avoid unexpectedly affecting how long __main__ is kept
          // alive. The gMainDict is only used in Exec(), ExecScript(), and Eval(),
          // which should not be called after __main__ is garbage collected anyway.
@@ -261,7 +261,7 @@ Bool_t TPython::Import(const char *mod_name)
    PyObject *values = PyDict_Values(dct);
    for (int i = 0; i < PyList_GET_SIZE(values); ++i) {
       PyObject *value = PyList_GET_ITEM(values, i);
-      Py_INCREF(value);
+      Py_IncRef(value);
 
       // collect classes
       if (PyType_Check(value) || PyObject_HasAttr(value, basesStr.obj())) {
@@ -282,15 +282,15 @@ Bool_t TPython::Import(const char *mod_name)
          // force class creation (this will eventually call TPyClassGenerator)
          TClass::GetClass(fullname.c_str(), kTRUE);
 
-         Py_XDECREF(pyClName);
+         Py_DecRef(pyClName);
       }
 
-      Py_DECREF(value);
+      Py_DecRef(value);
    }
 
-   Py_DECREF(values);
-   Py_DECREF(mod);
-   Py_DECREF(modNameObj);
+   Py_DecRef(values);
+   Py_DecRef(mod);
+   Py_DecRef(modNameObj);
 
    if (PyErr_Occurred())
       return kFALSE;
@@ -334,7 +334,7 @@ void TPython::LoadMacro(const char *name)
    // create Cling classes for all new python classes
    for (int i = 0; i < PyList_GET_SIZE(current); ++i) {
       PyObject *value = PyList_GET_ITEM(current, i);
-      Py_INCREF(value);
+      Py_IncRef(value);
 
       if (!PySequence_Contains(old, value)) {
          // collect classes
@@ -359,16 +359,16 @@ void TPython::LoadMacro(const char *name)
                TClass::GetClass(fullname.c_str(), kTRUE);
             }
 
-            Py_XDECREF(pyClName);
-            Py_XDECREF(pyModName);
+            Py_DecRef(pyClName);
+            Py_DecRef(pyModName);
          }
       }
 
-      Py_DECREF(value);
+      Py_DecRef(value);
    }
 
-   Py_DECREF(current);
-   Py_DECREF(old);
+   Py_DecRef(current);
+   Py_DecRef(old);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -445,7 +445,7 @@ Bool_t TPython::Exec(const char *cmd, std::any *result, std::string const &resul
 
    // test for error
    if (pyObjectResult) {
-      Py_DECREF(pyObjectResult);
+      Py_DecRef(pyObjectResult);
       return kTRUE;
    }
 
@@ -471,7 +471,7 @@ Bool_t TPython::Bind(TObject *object, const char *label)
 
       if (bound) {
          Bool_t bOk = PyDict_SetItemString(gMainDict, const_cast<char *>(label), bound) == 0;
-         Py_DECREF(bound);
+         Py_DecRef(bound);
 
          return bOk;
       }


### PR DESCRIPTION
This is recommended by the C Python documentation for runtime dynamic embedding of Python.

This prevents linker errors when building TPython against GIL-less Python.