### PR TITLE
[tmva][sofie] Remove explicit function definitions that can be implicit

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -38,13 +38,6 @@ private:
    std::unordered_map<std::string_view, size_t> fIntermediateTensorFrequencyLookup;    ///<!  lookup table for intermediate tensor frequency (transient)
 
 public:
-   // Rule of five: explicitly define move semantics, disallow copy
-   RModel(RModel &&other) = default;
-   RModel &operator=(RModel &&other) = default;
-   RModel(const RModel &other) = delete;
-   RModel &operator=(const RModel &other) = delete;
-   ~RModel() = default;
-
    /**
        Default constructor. Needed to allow serialization of ROOT objects. See
        https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle

--- a/tmva/sofie/inc/TMVA/RModel_Base.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_Base.hxx
@@ -101,11 +101,6 @@ enum class FunctionRelation { INVALID = 0, NODES_EDGES = 1, NODES_GLOBALS = 2, E
 
 class RModel_GNNBase : public RModel_Base {
 public:
-   /**
-       Default constructor. Needed to allow serialization of ROOT objects. See
-       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-   */
-   RModel_GNNBase() = default;
    virtual void Generate() = 0;
    virtual ~RModel_GNNBase() = default;
 };

--- a/tmva/sofie/inc/TMVA/RModel_GNN.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GNN.hxx
@@ -39,17 +39,6 @@ struct GNN_Init {
 
    std::string filename;
 
-   ~GNN_Init()
-   {
-      edges_update_block.reset();
-      nodes_update_block.reset();
-      globals_update_block.reset();
-
-      edge_node_agg_block.reset();
-      edge_global_agg_block.reset();
-      node_global_agg_block.reset();
-   }
-
    template <typename T>
    void createUpdateFunction(T &updateFunction)
    {
@@ -116,19 +105,7 @@ private:
    std::size_t num_global_features;
 
 public:
-   /**
-       Default constructor. Needed to allow serialization of ROOT objects. See
-       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-   */
-   RModel_GNN() = default;
    RModel_GNN(GNN_Init &graph_input_struct);
-
-   // Rule of five: explicitly define move semantics, disallow copy
-   RModel_GNN(RModel_GNN &&other);
-   RModel_GNN &operator=(RModel_GNN &&other);
-   RModel_GNN(const RModel_GNN &other) = delete;
-   RModel_GNN &operator=(const RModel_GNN &other) = delete;
-   ~RModel_GNN() final = default;
 
    void Generate() final;
 };

--- a/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
+++ b/tmva/sofie/inc/TMVA/RModel_GraphIndependent.hxx
@@ -55,13 +55,6 @@ struct GraphIndependent_Init {
       }
       }
    }
-
-   ~GraphIndependent_Init()
-   {
-      edges_update_block.reset();
-      nodes_update_block.reset();
-      globals_update_block.reset();
-   }
 };
 
 class RModel_GraphIndependent final : public RModel_GNNBase {
@@ -80,19 +73,7 @@ private:
    std::size_t num_global_features;
 
 public:
-   /**
-       Default constructor. Needed to allow serialization of ROOT objects. See
-       https://root.cern/manual/io_custom_classes/#restrictions-on-types-root-io-can-handle
-   */
-   RModel_GraphIndependent() = default;
    RModel_GraphIndependent(GraphIndependent_Init &graph_input_struct);
-
-   // Rule of five: explicitly define move semantics, disallow copy
-   RModel_GraphIndependent(RModel_GraphIndependent &&other);
-   RModel_GraphIndependent &operator=(RModel_GraphIndependent &&other);
-   RModel_GraphIndependent(const RModel_GraphIndependent &other) = delete;
-   RModel_GraphIndependent &operator=(const RModel_GraphIndependent &other) = delete;
-   ~RModel_GraphIndependent() final = default;
 
    void Generate() final;
 };

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -25,8 +25,6 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-//typedef RTensor tensor_t;
-
 enum class ETensorType{
    UNDEFINED = 0, FLOAT = 1, UINT8 = 2, INT8 = 3, UINT16 = 4, INT16 = 5, INT32 = 6, INT64 = 7, STRING = 8, BOOL = 9, //order sensitive
     FLOAT16 = 10, DOUBLE = 11, UINT32 = 12, UINT64 = 13, COMPLEX64 = 14, COMPLEX28 = 15, BFLOAT16 = 16

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1298,13 +1298,13 @@ void RModel::OutputGenerated(std::string filename, bool append) {
 void RModel::Streamer(TBuffer &R__b) {
     if (R__b.IsReading()) {
         RModel::Class()->ReadBuffer(R__b, this);
-        for(auto i=RModel::fInitializedTensors.begin(); i!=RModel::fInitializedTensors.end(); ++i) {
-            i->second.CastPersistentToShared();
+        for (auto & i : fInitializedTensors) {
+            i.second.CastPersistentToShared();
         }
     }
     else {
-        for(auto i=RModel::fInitializedTensors.begin(); i!=RModel::fInitializedTensors.end(); ++i) {
-            i->second.CastSharedToPersistent();
+        for (auto & i : fInitializedTensors) {
+            i.second.CastSharedToPersistent();
         }
         RModel::Class()->WriteBuffer(R__b, this);
     }

--- a/tmva/sofie/src/RModel_GNN.cxx
+++ b/tmva/sofie/src/RModel_GNN.cxx
@@ -10,42 +10,6 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
-RModel_GNN::RModel_GNN(RModel_GNN&& other) {
-    edges_update_block = std::move(other.edges_update_block);
-    nodes_update_block = std::move(other.nodes_update_block);
-    globals_update_block = std::move(other.globals_update_block);
-
-    edge_node_agg_block = std::move(other.edge_node_agg_block);
-    edge_global_agg_block = std::move(other.edge_global_agg_block);
-    node_global_agg_block = std::move(other.node_global_agg_block);
-
-    num_nodes = std::move(other.num_nodes);
-    num_edges = std::move(other.num_edges);
-
-    fName = std::move(other.fName);
-    fFileName = std::move(other.fFileName);
-    fParseTime = std::move(other.fParseTime);
-}
-
-RModel_GNN& RModel_GNN::operator=(RModel_GNN&& other) {
-    edges_update_block = std::move(other.edges_update_block);
-    nodes_update_block = std::move(other.nodes_update_block);
-    globals_update_block = std::move(other.globals_update_block);
-
-    edge_node_agg_block = std::move(other.edge_node_agg_block);
-    edge_global_agg_block = std::move(other.edge_global_agg_block);
-    node_global_agg_block = std::move(other.node_global_agg_block);
-
-    num_nodes = std::move(other.num_nodes);
-    num_edges = std::move(other.num_edges);
-
-    fName = std::move(other.fName);
-    fFileName = std::move(other.fFileName);
-    fParseTime = std::move(other.fParseTime);
-
-    return *this;
-}
-
 RModel_GNN::RModel_GNN(GNN_Init& graph_input_struct) {
     edges_update_block = std::move(graph_input_struct.edges_update_block);
     nodes_update_block = std::move(graph_input_struct.nodes_update_block);

--- a/tmva/sofie/src/RModel_GraphIndependent.cxx
+++ b/tmva/sofie/src/RModel_GraphIndependent.cxx
@@ -8,34 +8,6 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
-RModel_GraphIndependent::RModel_GraphIndependent(RModel_GraphIndependent&& other) {
-    edges_update_block = std::move(other.edges_update_block);
-    nodes_update_block = std::move(other.nodes_update_block);
-    globals_update_block = std::move(other.globals_update_block);
-
-    num_nodes = std::move(other.num_nodes);
-    num_edges = std::move(other.num_edges);
-
-    fName = std::move(other.fName);
-    fFileName = std::move(other.fFileName);
-    fParseTime = std::move(other.fParseTime);
-}
-
-RModel_GraphIndependent& RModel_GraphIndependent::operator=(RModel_GraphIndependent&& other) {
-    edges_update_block = std::move(other.edges_update_block);
-    nodes_update_block = std::move(other.nodes_update_block);
-    globals_update_block = std::move(other.globals_update_block);
-
-    num_nodes = std::move(other.num_nodes);
-    num_edges = std::move(other.num_edges);
-
-    fName = std::move(other.fName);
-    fFileName = std::move(other.fFileName);
-    fParseTime = std::move(other.fParseTime);
-
-    return *this;
-}
-
 RModel_GraphIndependent::RModel_GraphIndependent(GraphIndependent_Init& graph_input_struct) {
     edges_update_block = std::move(graph_input_struct.edges_update_block);
     nodes_update_block = std::move(graph_input_struct.nodes_update_block);


### PR DESCRIPTION
Follows up on 035cf0c12cda8.

 * Remove IO constructors of classes that don't support IO anyway because there is no `ClassDef` macro call, etc.

 * Use implicit move constructors and assignments for GNN RModel classes, because all data members can be correctly moved

 * Delete explicit destructors of helper classes that only reset the unique pointers, which would happen by default anyway

 * Don't delete copying of RModel and derived classes explicitly. Copying is already implicitly deleted because of the `std::unique_ptr` data members