### PR TITLE
Revert "Restrict `ipython<9.0.0` in requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ numba>=0.48
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel
-ipython<9.0.0 # ipython 9.0.0 is incompatible the the latest metakernel, as of 03/03/25
 notebook>=4.4.1
 metakernel>=0.20.0
 


### PR DESCRIPTION
A new release of `metakernel` that is compatible with ipython 9 came out last week:

https://github.com/Calysto/metakernel/releases/tag/v0.30.3

Hence, we don't need to restrict the ipython version anymore.

This reverts commit 795a48d609474e82f81ff759c3effc07a42eef19.