### PR TITLE
[clad] Bump clad to v1.10.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -74,7 +74,7 @@ if (DEFINED CLAD_SOURCE_DIR)
   list(APPEND _clad_extra_settings SOURCE_DIR ${CLAD_SOURCE_DIR})
 else()
   list(APPEND _clad_extra_settings GIT_REPOSITORY https://github.com/vgvassilev/clad.git)
-  list(APPEND _clad_extra_settings GIT_TAG v1.9)
+  list(APPEND _clad_extra_settings GIT_TAG v1.10)
 endif()
 
 #list(APPEND _clad_patches_list "patch1.patch" "patch2.patch")


### PR DESCRIPTION
This release introduces significant updates, including support for clang versions 10 through 20 and improved diagnostics for unsupported features. Forward mode now handles variadic functions, while reverse mode sees major enhancements like marking const methods as non-differentiable, enabling differentiation of global variables and static member functions, generating constructor pullbacks automatically, and reducing tape usage through optimizations. CUDA support has been expanded with better handling of device pullbacks and kernel variables. For details, please see the release [notes](https://github.com/vgvassilev/clad/releases/tag/v1.10).