### PR TITLE
[ntuple] Remove deprecated typedefs

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCreateFieldOptions.hxx
@@ -34,12 +34,6 @@ public:
    bool GetEmulateUnknownTypes() const { return fEmulateUnknownTypes; }
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RCreateFieldOptions [[deprecated("ROOT::Experimental::RCreateFieldOptions moved to ROOT::RCreateFieldOptions")]] =
-   ROOT::RCreateFieldOptions;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -62,10 +62,6 @@ class REntry {
    friend class Experimental::RNTupleChainProcessor;
    friend class Experimental::RNTupleJoinProcessor;
 
-public:
-   // TODO: remove before branching ROOT v6.36
-   using RFieldToken [[deprecated("REntry::RFieldToken moved to ROOT::RFieldToken")]] = ROOT::RFieldToken;
-
 private:
    /// The entry must be linked to a specific model, identified by a model ID
    std::uint64_t fModelId = 0;
@@ -247,10 +243,6 @@ public:
    ConstIterator_t end() const { return fValues.cend(); }
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using REntry [[deprecated("ROOT::Experimental::REntry moved to ROOT::REntry")]] = ROOT::REntry;
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -516,24 +516,6 @@ template <>
 std::unique_ptr<void, typename RFieldBase::RCreateObjectDeleter<void>::deleter>
 ROOT::RFieldBase::CreateObject<void>() const;
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RFieldZero [[deprecated("ROOT::Experimental::RFieldZero moved to ROOT::RFieldZero")]] = ROOT::RFieldZero;
-using RClassField [[deprecated("ROOT::Experimental::RClassField moved to ROOT::RClassField")]] = ROOT::RClassField;
-using REnumField [[deprecated("ROOT::Experimental::REnumField moved to ROOT::REnumField")]] = ROOT::REnumField;
-using RStreamerField [[deprecated("ROOT::Experimental::RStreamerField moved to ROOT::RStreamerField")]] =
-   ROOT::RStreamerField;
-template <typename T>
-using RSimpleField [[deprecated("ROOT::Experimental::RSimpleField moved to ROOT::RSimpleField")]] =
-   ROOT::RSimpleField<T>;
-using RInvalidField [[deprecated("ROOT::Experimental::RInvalidField moved to ROOT::RInvalidField")]] =
-   ROOT::RInvalidField;
-using RCardinalityField [[deprecated("ROOT::Experimental::RCardinalityField moved to ROOT::RCardinalityField")]] =
-   ROOT::RCardinalityField;
-template <typename T>
-using RField [[deprecated("ROOT::Experimental::RField moved to ROOT::RField")]] = ROOT::RField<T>;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldFundamental.hxx
@@ -520,13 +520,6 @@ public:
    void SetDouble32();
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-template <typename T>
-using RIntegralField [[deprecated("ROOT::Experimental::RIntegralField moved to ROOT::RIntegralField")]] =
-   ROOT::RIntegralField<T>;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -413,15 +413,6 @@ public:
    ~RField() final = default;
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RSetField [[deprecated("ROOT::Experimental::RSetField moved to ROOT::RSetField")]] = ROOT::RSetField;
-using RMapField [[deprecated("ROOT::Experimental::RMapField moved to ROOT::RMapField")]] = ROOT::RMapField;
-using RProxiedCollectionField
-   [[deprecated("ROOT::Experimental::RProxiedCollectionField moved to ROOT::RProxiedCollectionField")]] =
-      ROOT::RProxiedCollectionField;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldRecord.hxx
@@ -249,13 +249,6 @@ public:
    ~RField() final = default;
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RRecordField [[deprecated("ROOT::Experimental::RRecordField moved to ROOT::RRecordField")]] = ROOT::RRecordField;
-using RPairField [[deprecated("ROOT::Experimental::RPairField moved to ROOT::RPairField")]] = ROOT::RPairField;
-using RTupleField [[deprecated("ROOT::Experimental::RTupleField moved to ROOT::RTupleField")]] = ROOT::RTupleField;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -431,16 +431,6 @@ public:
    ~RField() final = default;
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RAtomicField [[deprecated("ROOT::Experimental::RAtomicField moved to ROOT::RAtomicField")]] = ROOT::RAtomicField;
-using RVariantField [[deprecated("ROOT::Experimental::RVariantField moved to ROOT::RVariantField")]] =
-   ROOT::RVariantField;
-using RNullableField [[deprecated("ROOT::Experimental::RNullableField moved to ROOT::RNullableField")]] =
-   ROOT::RNullableField;
-using RBitsetField [[deprecated("ROOT::Experimental::RBitsetField moved to ROOT::RBitsetField")]] = ROOT::RBitsetField;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -361,15 +361,6 @@ public:
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RArrayField [[deprecated("ROOT::Experimental::RArrayField moved to ROOT::RArrayField")]] = ROOT::RArrayField;
-using RVectorField [[deprecated("ROOT::Experimental::RVectorField moved to ROOT::RVectorField")]] = ROOT::RVectorField;
-using RRVecField [[deprecated("ROOT::Experimental::RRVecField moved to ROOT::RRVecField")]] = ROOT::RRVecField;
-using RArrayAsRVecField [[deprecated("ROOT::Experimental::RArrayAsRVecField moved to ROOT::RArrayAsRVecField")]] =
-   ROOT::RArrayAsRVecField;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldBase.hxx
@@ -881,12 +881,6 @@ struct RFieldRepresentationModifier {
    }
 };
 } // namespace Internal
-
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RFieldBase [[deprecated("ROOT::Experimental::RFieldBase moved to ROOT::RFieldBase")]] = ROOT::RFieldBase;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -1598,25 +1598,6 @@ inline RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc)
 }
 
 } // namespace Internal
-
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleDescriptor [[deprecated("ROOT::Experimental::RNTupleDescriptor moved to ROOT::RNTupleDescriptor")]] =
-   ROOT::RNTupleDescriptor;
-using RFieldDescriptor [[deprecated("ROOT::Experimental::RFieldDescriptor moved to ROOT::RFieldDescriptor")]] =
-   ROOT::RFieldDescriptor;
-using RColumnDescriptor [[deprecated("ROOT::Experimental::RColumnDescriptor moved to ROOT::RColumnDescriptor")]] =
-   ROOT::RColumnDescriptor;
-using RClusterDescriptor [[deprecated("ROOT::Experimental::RClusterDescriptor moved to ROOT::RClusterDescriptor")]] =
-   ROOT::RClusterDescriptor;
-using RClusterGroupDescriptor
-   [[deprecated("ROOT::Experimental::RClusterGroupDescriptor moved to ROOT::RClusterGroupDescriptor")]] =
-      ROOT::RClusterGroupDescriptor;
-using RExtraTypeInfoDescriptor
-   [[deprecated("ROOT::Experimental::RExtraTypeInfoDescriptor moved to ROOT::RExtraTypeInfoDescriptor")]] =
-      ROOT::RExtraTypeInfoDescriptor;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleDescriptor

--- a/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleFillStatus.hxx
@@ -59,11 +59,6 @@ public:
    bool ShouldFlushCluster() const { return fShouldFlushCluster; }
 }; // class RNTupleFillContext
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleFillStatus [[deprecated("ROOT::Experimental::RNTupleFillStatus moved to ROOT::RNTupleFillStatus")]] =
-   ROOT::RNTupleFillStatus;
-} // namespace Experimental
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleFillStatus

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -460,11 +460,6 @@ public:
    RResult<void> AddProjectedField(std::unique_ptr<ROOT::RFieldBase> field, FieldMappingFunc_t mapping);
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleModel [[deprecated("ROOT::Experimental::RNTupleModel moved to ROOT::RNTupleModel")]] = ROOT::RNTupleModel;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleRange.hxx
@@ -129,14 +129,6 @@ public:
    ROOT::NTupleSize_t size() const { return fEnd - fStart; }
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleGlobalRange [[deprecated("ROOT::Experimental::RNTupleGlobalRange moved to ROOT::RNTupleGlobalRange")]] =
-   ROOT::RNTupleGlobalRange;
-using RNTupleClusterRange [[deprecated("ROOT::Experimental::RNTupleClusterRange moved to ROOT::RNTupleLocalRange")]] =
-   ROOT::RNTupleLocalRange;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReadOptions.hxx
@@ -124,13 +124,6 @@ inline void RNTupleReadOptionsManip::SetClusterBunchSize(RNTupleReadOptions &opt
 }
 
 } // namespace Internal
-
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleReadOptions [[deprecated("ROOT::Experimental::RNTupleReadOptions moved to ROOT::RNTupleReadOptions")]] =
-   ROOT::RNTupleReadOptions;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleReader.hxx
@@ -445,10 +445,6 @@ public:
    const Experimental::Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 }; // class RNTupleReader
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleReader [[deprecated("ROOT::RNTupleReader moved to ROOT::RNTupleReader")]] = ROOT::RNTupleReader;
-} // namespace Experimental
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleReader

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -329,19 +329,6 @@ static_assert(kTestLocatorType < RNTupleLocator::ELocatorType::kLastSerializable
 RResult<void> EnsureValidNameForRNTuple(std::string_view name, std::string_view where);
 
 } // namespace Internal
-
-namespace Experimental {
-
-// TODO(jblomer): remove before branching ROOT v6.36
-using EColumnType [[deprecated("ROOT::Experimental::EColumnType moved to ROOT::ENTupleColumnType")]] =
-   ROOT::ENTupleColumnType;
-using ENTupleStructure [[deprecated("ROOT::Experimental::ENTupleStructure moved to ROOT::ENTupleStructure")]] =
-   ROOT::ENTupleStructure;
-using NTupleSize_t [[deprecated("ROOT::Experimental::NTupleSize_t moved to ROOT::NTupleSize_t")]] = ROOT::NTupleSize_t;
-using DescriptorId_t [[deprecated("ROOT::Experimental::DescriptorId_t moved to ROOT::DescriptorId_t")]] =
-   ROOT::DescriptorId_t;
-
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -426,21 +426,6 @@ public:
    }
 };
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-template <typename T>
-using RNTupleViewBase [[deprecated("ROOT::Experimental::RNTupleViewBase moved to ROOT::RNTupleViewBase")]] =
-   ROOT::RNTupleViewBase<T>;
-template <typename T>
-using RNTupleView [[deprecated("ROOT::Experimental::RNTupleView moved to ROOT::RNTupleView")]] = ROOT::RNTupleView<T>;
-template <typename T>
-using RNTupleDirectAccessView
-   [[deprecated("ROOT::Experimental::RNTupleDirectAccessView moved to ROOT::RNTupleDirectAccessView")]] =
-      ROOT::RNTupleDirectAccessView<T>;
-using RNTupleCollectionView
-   [[deprecated("ROOT::Experimental::RNTupleCollectionView moved to ROOT::RNTupleCollectionView")]] =
-      ROOT::RNTupleCollectionView;
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriteOptions.hxx
@@ -268,13 +268,6 @@ inline void RNTupleWriteOptionsManip::SetMaxKeySize(RNTupleWriteOptions &options
 }
 
 } // namespace Internal
-
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleWriteOptions [[deprecated("ROOT::Experimental::RNTupleWriteOptions moved to ROOT::RNTupleWriteOptions")]] =
-   ROOT::RNTupleWriteOptions;
-} // namespace Experimental
-
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleWriteOptions

--- a/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleWriter.hxx
@@ -182,11 +182,6 @@ public:
    }
 }; // class RNTupleWriter
 
-namespace Experimental {
-// TODO(gparolini): remove before branching ROOT v6.36
-using RNTupleWriter [[deprecated("ROOT::Experimental::RNTupleWriter moved to ROOT::RNTupleWriter")]] =
-   ROOT::RNTupleWriter;
-} // namespace Experimental
 } // namespace ROOT
 
 #endif // ROOT7_RNTupleWriter

--- a/tree/ntuple/v7/test/ntuple_basics.py
+++ b/tree/ntuple/v7/test/ntuple_basics.py
@@ -2,7 +2,6 @@ import unittest
 
 import ROOT
 
-RNTupleReader = ROOT.Experimental.RNTupleReader
 
 class RNTupleBasics(unittest.TestCase):
     """Basic tests of using RNTuple from Python"""
@@ -22,7 +21,7 @@ class RNTupleBasics(unittest.TestCase):
         # The model should not have been destroyed (a clone has been used).
         self.assertFalse(model.IsFrozen())
 
-        reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
+        reader = ROOT.RNTupleReader.Open("ntpl", "test_ntuple_py_write_read.root")
         self.assertEqual(reader.GetNEntries(), 1)
         entry = reader.CreateEntry()
         reader.LoadEntry(0, entry)
@@ -39,7 +38,7 @@ class RNTupleBasics(unittest.TestCase):
             entry["f"] = 42
             writer.Fill(entry)
 
-        reader = RNTupleReader.Open("ntpl", "test_ntuple_py_write_fields.root")
+        reader = ROOT.RNTupleReader.Open("ntpl", "test_ntuple_py_write_fields.root")
         self.assertEqual(reader.GetNEntries(), 1)
         entry = reader.CreateEntry()
         reader.LoadEntry(0, entry)
@@ -60,7 +59,7 @@ class RNTupleBasics(unittest.TestCase):
         self.assertFalse(model.IsFrozen())
 
         with ROOT.TFile.Open("test_ntuple_py_append.root") as f:
-            reader = RNTupleReader.Open(f["ntpl"])
+            reader = ROOT.RNTupleReader.Open(f["ntpl"])
             self.assertEqual(reader.GetNEntries(), 1)
             entry = reader.CreateEntry()
             reader.LoadEntry(0, entry)
@@ -80,7 +79,7 @@ class RNTupleBasics(unittest.TestCase):
         read_model = ROOT.RNTupleModel.Create()
         read_model.MakeField["int"]("f1")
 
-        reader = RNTupleReader.Open(read_model, "ntpl", "test_ntuple_py_read_model.root")
+        reader = ROOT.RNTupleReader.Open(read_model, "ntpl", "test_ntuple_py_read_model.root")
         entry = reader.CreateEntry()
         with self.assertRaises(Exception):
             # Field f2 does not exist in imposed model

--- a/tutorials/io/ntuple/ntpl011_global_temperatures.C
+++ b/tutorials/io/ntuple/ntpl011_global_temperatures.C
@@ -46,7 +46,8 @@
 
 using Clock = std::chrono::high_resolution_clock;
 using RRawFile = ROOT::Internal::RRawFile;
-using namespace ROOT::Experimental;
+using ROOT::Experimental::RCanvas;
+using ROOT::Experimental::TObjectDrawable;
 
 // Helper function to handle histogram pointer ownership.
 std::shared_ptr<TH1D> GetDrawableHist(ROOT::RDF::RResultPtr<TH1D> &h)
@@ -72,7 +73,7 @@ void Ingest()
    auto t1 = Clock::now();
 
    // Create a unique pointer to an empty data model.
-   auto model = RNTupleModel::Create();
+   auto model = ROOT::RNTupleModel::Create();
    // To define the data model, create fields with a given C++ type and name.  Fields are roughly TTree branches.
    // MakeField returns a shared pointer to a memory location to fill the ntuple with data.
    auto fieldYear = model->MakeField<std::uint32_t>("Year");
@@ -87,7 +88,7 @@ void Ingest()
 
    // Hand-over the data model to a newly created ntuple of name "globalTempData", stored in kNTupleFileName.
    // In return, get a unique pointer to a fillable ntuple (first compress the file).
-   auto writer = RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName);
+   auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "GlobalTempData", kNTupleFileName);
 
    // Download data in 4MB blocks
    RRawFile::ROptions options;


### PR DESCRIPTION
# This Pull request:
removes the deprecated `using` declarations for the RNTuple public types moved out of Experimental.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
