### PR TITLE
[ci] Remove Ubuntu 24.10 builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -370,8 +370,6 @@ jobs:
             overrides: ["imt=Off", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2404
             overrides: ["CMAKE_BUILD_TYPE=Debug"]
-          - image: ubuntu2410
-            overrides: ["CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2504
             overrides: ["CMAKE_BUILD_TYPE=Debug", "CMAKE_CXX_STANDARD=23"]
           - image: debian125


### PR DESCRIPTION
6.36 will be released at the end of May. EOL of that distro is scheduled for July 11th.
This will also free one linux build slot for each and every PR to the main and future v6-36-00-patches branch.

