### PR TITLE
[ci] Add a workflow to check pull request changes with Clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,31 @@
+name: clang-tidy-review
+
+# You can be more specific, but it currently only works on pull requests
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'doc/**'
+      - 'documentation/**'
+      - 'interpreter/llvm-project/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Optionally generate compile_commands.json
+
+    - uses: ZedThree/clang-tidy-review@v0.21.0
+      id: review
+
+    # Uploads an artefact containing clang_fixes.json
+    - uses: ZedThree/clang-tidy-review/upload@v0.21.0
+      id: upload-review
+
+    # If there are any comments, fail the check
+    - if: steps.review.outputs.total_comments > 0
+      run: exit 1

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -203,7 +203,7 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
     stream.next_out  = (Bytef*)(&tgt[HDRSIZE]);
     stream.avail_out = (uInt)(*tgtsize) - HDRSIZE;
 
-    stream.zalloc = nullptr;
+    stream.zalloc = (alloc_func) 0;
     stream.zfree = nullptr;
     stream.opaque = nullptr;
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Informs new pull request from adding potential bugs,

TO-DO:
- Create .clang-tidy files on each folder depending on wanted checks.
- core folder should be 'at least': modernize-use-nullptr, modernize-use-override, which already pass.
- explore faster alternative: https://github.com/lljbash/clangd-tidy

Related:
- https://github.com/root-project/root/pull/8773
- https://github.com/root-project/root/pull/18469