### PR TITLE
[graphics] set TMathText color in TLatex

### DIFF
--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -2235,6 +2235,7 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
       TMathText tm;
       tm.SetTextAlign(GetTextAlign());
       tm.SetTextFont(GetTextFont());
+      tm.SetTextColor(GetTextColor());
       tm.PaintMathText(x, y, angle, size, text1);
       // If PDF, paint using TLatex
       if (gVirtualPS) {


### PR DESCRIPTION
Set the TMathText color in TLatex when a TLatex is painted with TMathText.
The problem was seen here https://root-forum.cern.ch/t/issue-with-text-size-and-color-in-tlatex/63380

