### PR TITLE
[ntuple] Remove experimental notice from tutorials

### DIFF
--- a/tutorials/io/ntuple/ntpl001_staff.C
+++ b/tutorials/io/ntuple/ntpl001_staff.C
@@ -11,9 +11,6 @@
 /// \date April 2019
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriter.hxx>

--- a/tutorials/io/ntuple/ntpl002_vector.C
+++ b/tutorials/io/ntuple/ntpl002_vector.C
@@ -9,9 +9,6 @@
 /// \date April 2019
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriter.hxx>

--- a/tutorials/io/ntuple/ntpl004_dimuon.C
+++ b/tutorials/io/ntuple/ntpl004_dimuon.C
@@ -13,12 +13,7 @@
 /// \date April 2019
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/RDataFrame.hxx>
-#include <ROOT/RNTupleDS.hxx>
-#include <ROOT/RVec.hxx>
 
 #include <TCanvas.h>
 #include <TH1D.h>
@@ -32,9 +27,6 @@
 #include <string>
 #include <vector>
 #include <utility>
-
-// Import classes from experimental namespace for the time being
-using RNTupleDS = ROOT::RDF::RNTupleDS;
 
 constexpr char const *kNTupleFileName = "http://root.cern/files/tutorials/ntpl004_dimuon_v1.root";
 

--- a/tutorials/io/ntuple/ntpl005_introspection.C
+++ b/tutorials/io/ntuple/ntpl005_introspection.C
@@ -10,9 +10,6 @@
 /// \date April 2020
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>

--- a/tutorials/io/ntuple/ntpl007_mtFill.C
+++ b/tutorials/io/ntuple/ntpl007_mtFill.C
@@ -9,9 +9,6 @@
 /// \date July 2021
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>

--- a/tutorials/io/ntuple/ntpl008_import.C
+++ b/tutorials/io/ntuple/ntpl008_import.C
@@ -9,7 +9,7 @@
 /// \date December 2022
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleImporter class is experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RNTupleDS.hxx>

--- a/tutorials/io/ntuple/ntpl009_parallelWriter.C
+++ b/tutorials/io/ntuple/ntpl009_parallelWriter.C
@@ -9,7 +9,7 @@
 /// \date Feburary 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleParallelWriter class is experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RNTupleFillContext.hxx>

--- a/tutorials/io/ntuple/ntpl010_skim.C
+++ b/tutorials/io/ntuple/ntpl010_skim.C
@@ -9,9 +9,6 @@
 /// \date February 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
-
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriter.hxx>

--- a/tutorials/io/ntuple/ntpl011_global_temperatures.C
+++ b/tutorials/io/ntuple/ntpl011_global_temperatures.C
@@ -13,8 +13,6 @@
 /// \date 2021-02-26
 /// \author John Yoon
 
-// NOTE: The RNTuple classes are experimental at this point.
-// Functionality and interface are still subject to changes.
 // During ROOT setup, configure the following flags:
 // `-DCMAKE_CXX_STANDARD=17 -Droot7=ON -Dwebgui=ON`
 // When running, make sure the ROOT web-based canvas is enabled,

--- a/tutorials/io/ntuple/ntpl012_processor_chain.C
+++ b/tutorials/io/ntuple/ntpl012_processor_chain.C
@@ -9,7 +9,7 @@
 /// \date April 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleProcessor and related classes are experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RNTupleModel.hxx>

--- a/tutorials/io/ntuple/ntpl013_staged.C
+++ b/tutorials/io/ntuple/ntpl013_staged.C
@@ -8,7 +8,7 @@
 /// \date September 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleParallelWriter is experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RNTupleFillContext.hxx>

--- a/tutorials/io/ntuple/ntpl014_framework.C
+++ b/tutorials/io/ntuple/ntpl014_framework.C
@@ -24,7 +24,7 @@
 /// \date September 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleParallelWriter, RNTupleFillContext, and RRawPtrWriteEntry are experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RRawPtrWriteEntry.hxx>

--- a/tutorials/io/ntuple/ntpl015_processor_join.C
+++ b/tutorials/io/ntuple/ntpl015_processor_join.C
@@ -9,7 +9,7 @@
 /// \date November 2024
 /// \author The ROOT Team
 
-// NOTE: The RNTuple classes are experimental at this point.
+// NOTE: The RNTupleProcessor and related classes are experimental at this point.
 // Functionality and interface are still subject to changes.
 
 #include <ROOT/RNTupleModel.hxx>


### PR DESCRIPTION
... if they use only public interfaces that will be stable in 6.36.