### PR TITLE
[tmva][sofie] Add overload for inference code that takes output params

### DIFF
--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -618,19 +618,24 @@ void col2im(const Dtype* data_col, const int channels,
   //std::cout << "finishing col2imp" << std::endl;
 }
 
-// Used at the end of infer() to create the return object.
+// Used at the end of infer() to fill the return object.
 template <class T>
-std::vector<T> CreateOutput(T const *arr, std::size_t n)
+void FillOutput(T const *arr, std::vector<T> &out, std::size_t n)
 {
-   return {arr, arr + n};
+   out.resize(n);
+   for (std::size_t i = 0; i < n; ++i) {
+      out[i] = arr[i];
+   }
 }
 
 // Special case for std::vector<bool>.
-inline std::vector<std::uint8_t> CreateOutput(std::vector<bool> const &vec, std::size_t n)
+inline void FillOutput(std::vector<bool> const &vec, std::vector<std::uint8_t> &out, std::size_t n)
 {
-   return {vec.begin(), vec.begin() + n};
+   out.resize(n);
+   for (std::size_t i = 0; i < n; ++i) {
+      out[i] = vec[i];
+   }
 }
-
 
 }  // end namespace UTILITY
 


### PR DESCRIPTION
This makes it possible to avoid memory allocations during inference, also also will help when differentiating through the code with Clad.

Here is a showcase of how the output code of SOFIE would look like with this change. Note that I chose the name `doInfer` for the new function to better distinguish it from the existing `infer` method, but I'm happy to rename it to anything including `infer` as well.
```c++
struct Session {
   ...
   // Inference implementation is forward declared:
   void doInfer(float *tensor_x,
                float *tensor_theory_params,
                std::vector<float> &output_tensor_linear_3);
   ...

   std::vector<float> infer(float *tensor_x, float *tensor_theory_params)
   {
      std::vector<float> output_tensor_linear_3;
      doInfer(tensor_x, tensor_theory_params, output_tensor_linear_3);
      return output_tensor_linear_3;
   }
}; // end of Session

void Session::doInfer(float *tensor_x,
                      float *tensor_theory_params,
                      std::vector<float> &output_tensor_linear_3)
{
   // inference code dumped here:
   ...

   // outputs are filled at the end
   using TMVA::Experimental::SOFIE::UTILITY::FillOutput;
   FillOutput(tensor_linear_3, output_tensor_linear_3, 1);
}
```
