### PR TITLE
[io] Prevent losing data due to SIGTERM (under Unix)

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -344,6 +344,7 @@ public:
    Int_t             Timer() const { return fTimer; }
 
    //---- static functions
+   static void        CleanUpROOTAtExit();
    static Int_t       DecreaseDirLevel();
    static Int_t       GetDirLevel();
    static const char *GetMacroPath();
@@ -356,6 +357,7 @@ public:
    static Int_t       ConvertVersionCode2Int(Int_t code);
    static Int_t       ConvertVersionInt2Code(Int_t v);
    static Int_t       RootVersionCode();
+   static void        WriteCloseAllFiles();
    static const std::vector<std::string> &AddExtraInterpreterArgs(const std::vector<std::string> &args);
    static const char**&GetExtraInterpreterArgs();
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -119,6 +119,7 @@ FARPROC dlsym(void *library, const char *function_name)
 #include "TClass.h"
 #include "TClassEdit.h"
 #include "TClassGenerator.h"
+#include "TDirectory.h"
 #include "TDataType.h"
 #include "TStyle.h"
 #include "TObjectTable.h"
@@ -238,14 +239,10 @@ void TROOT::WriteCloseAllFiles()
          TIter next(gROOT->GetListOfFiles());
          while (TObject *obj = next()) {
             if (obj && obj->InheritsFrom(TClass::GetClass("TFile", kFALSE, kTRUE))) {
-               TMethodCall callIsWritable(obj->IsA(), "IsWritable", "");
-               Longptr_t retLong = 0;
-               callIsWritable.Execute((void *)(obj), retLong);
-               if (retLong == 1) {
-                  TMethodCall callWrite(obj->IsA(), "Write", "");
-                  callWrite.Execute((void *)(obj));
-                  TMethodCall callClose(obj->IsA(), "Close", "");
-                  callClose.Execute((void *)(obj));
+               auto fobj = static_cast<TDirectory *>(obj);
+               if (fobj->IsWritable()) {
+                  fobj->Write();
+                  fobj->Close();
                }
             }
          }

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -227,9 +227,31 @@ static Int_t ITIMQQ(const char *time)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Write and Close all open Files, useful to be called when SIGTERM is caught.
+
+void TROOT::WriteCloseAllFiles()
+{
+   if (gROOT) {
+      R__LOCKGUARD(gROOTMutex);
+
+      if (gROOT->GetListOfFiles()) {
+         TIter next(gROOT->GetListOfFiles());
+         while(TObject* obj = next()) {
+            if (obj) {
+               TMethodCall callwrite(obj->IsA(), "Write", "");
+               callwrite.Execute((void *)(obj));
+               TMethodCall callclose(obj->IsA(), "Close", "");
+               callclose.Execute((void *)(obj));
+            }
+         }
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Clean up at program termination before global objects go out of scope.
 
-static void CleanUpROOTAtExit()
+void TROOT::CleanUpROOTAtExit()
 {
    if (gROOT) {
       R__LOCKGUARD(gROOTMutex);

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -227,7 +227,7 @@ static Int_t ITIMQQ(const char *time)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Write and Close all open Files, useful to be called when SIGTERM is caught.
+/// Write and Close all open writable TFiles, useful to be called when SIGTERM is caught.
 
 void TROOT::WriteCloseAllFiles()
 {
@@ -236,12 +236,17 @@ void TROOT::WriteCloseAllFiles()
 
       if (gROOT->GetListOfFiles()) {
          TIter next(gROOT->GetListOfFiles());
-         while(TObject* obj = next()) {
-            if (obj) {
-               TMethodCall callwrite(obj->IsA(), "Write", "");
-               callwrite.Execute((void *)(obj));
-               TMethodCall callclose(obj->IsA(), "Close", "");
-               callclose.Execute((void *)(obj));
+         while (TObject *obj = next()) {
+            if (obj && obj->InheritsFrom(TClass::GetClass("TFile", kFALSE, kTRUE))) {
+               TMethodCall callIsWritable(obj->IsA(), "IsWritable", "");
+               Longptr_t retLong = 0;
+               callIsWritable.Execute((void *)(obj), retLong);
+               if (retLong == 1) {
+                  TMethodCall callWrite(obj->IsA(), "Write", "");
+                  callWrite.Execute((void *)(obj));
+                  TMethodCall callClose(obj->IsA(), "Close", "");
+                  callClose.Execute((void *)(obj));
+               }
             }
          }
       }

--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -107,7 +107,7 @@ TerminalConfigUnix::HandleSignal(int signum) {
   }
 
   // No previous handler found, re-raise to get default handling:
-    if (signum == SIGTERM) { // gentle save and close if SIGTERM
+  if (signum == SIGTERM) { // gentle save and close if SIGTERM
      TROOT::WriteCloseAllFiles();
      TROOT::CleanUpROOTAtExit();
   }

--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -106,11 +106,12 @@ TerminalConfigUnix::HandleSignal(int signum) {
     }
   }
 
-  // No previous handler found, re-raise to get default handling:
-  if (signum == SIGTERM) { // gentle save and close if SIGTERM
+  // gentle save and close if SIGTERM
+  if (signum == SIGTERM) {
      TROOT::WriteCloseAllFiles();
      TROOT::CleanUpROOTAtExit();
   }
+  // No previous handler found, re-raise to get default handling:
   signal(signum, SIG_DFL); // unregister ourselves
   raise(signum); // terminate through default handler
 

--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <cstring>
 
+#include <TROOT.h>
+
 using namespace textinput;
 using std::memcpy;
 using std::signal;
@@ -105,6 +107,10 @@ TerminalConfigUnix::HandleSignal(int signum) {
   }
 
   // No previous handler found, re-raise to get default handling:
+    if (signum == SIGTERM) { // gentle save and close if SIGTERM
+     TROOT::WriteCloseAllFiles();
+     TROOT::CleanUpROOTAtExit();
+  }
   signal(signum, SIG_DFL); // unregister ourselves
   raise(signum); // terminate through default handler
 

--- a/io/io/test/CMakeLists.txt
+++ b/io/io/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 ROOT_ADD_GTEST(RRawFile RRawFile.cxx LIBRARIES RIO)
-ROOT_ADD_GTEST(TFile TFileTests.cxx LIBRARIES RIO)
+ROOT_ADD_GTEST(TFile TFileTests.cxx LIBRARIES RIO Hist)
 ROOT_ADD_GTEST(TBufferFile TBufferFileTests.cxx LIBRARIES RIO)
 ROOT_ADD_GTEST(TBufferMerger TBufferMerger.cxx LIBRARIES RIO Imt Tree)
 ROOT_ADD_GTEST(TBufferJSON TBufferJSONTests.cxx LIBRARIES RIO)

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -1,10 +1,13 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <cstring>
+#include <csignal>
 
 #include "gtest/gtest.h"
 
 #include "TFile.h"
+#include "TH1I.h"
 #include "TMemFile.h"
 #include "TDirectory.h"
 #include "TKey.h"
@@ -202,4 +205,32 @@ TEST(TFile, MakeSubDirectory)
    EXPECT_EQ(c, gDirectory);
    EXPECT_EQ(std::string(gDirectory->GetPath()), "dirTest17824.root:/a/b/c");
    EXPECT_EQ(std::string(gDirectory->GetName()), "c");
+}
+
+void handle_sigterm(int signum)
+{
+   terminated = 1;
+   std::cout << "handled signal " << strsignal(signum) << " on PID " << getpid() << std::endl;
+}
+
+// https://github.com/root-project/root/issues/13300
+TEST(TFile, Sigterm)
+{
+   auto filename = "out13300.root";
+   {
+      TFile file(filename, "RECREATE");
+      file.mkdir("subdir")->cd();
+      TH1I hist("h", "h", 10, 0., 1.);
+      hist.Fill(0.4);
+      // Since the real behavior is save+close+crash which would make the test fail,
+      // rather than calling directly std::raise(SIGTERM),
+      // we emulate the response to SIGTERM in TerminalConfigUnix before crash:
+      TROOT::WriteCloseAllFiles();
+      TROOT::CleanUpROOTAtExit();
+   }
+   {
+      TFile file(filename, "READ");
+      ASSERT_EQ(file.Get<TH1I>("subdir/h")->GetBinContent(5), 1);
+   }
+   gSystem->Unlink(filename);
 }

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -1,7 +1,6 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include <cstring>
 #include <csignal>
 
 #include "gtest/gtest.h"
@@ -205,12 +204,6 @@ TEST(TFile, MakeSubDirectory)
    EXPECT_EQ(c, gDirectory);
    EXPECT_EQ(std::string(gDirectory->GetPath()), "dirTest17824.root:/a/b/c");
    EXPECT_EQ(std::string(gDirectory->GetName()), "c");
-}
-
-void handle_sigterm(int signum)
-{
-   terminated = 1;
-   std::cout << "handled signal " << strsignal(signum) << " on PID " << getpid() << std::endl;
 }
 
 // https://github.com/root-project/root/issues/13300


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://github.com/root-project/root/issues/13300

- I tested this locally on Ubu22 and it works fine.
- I do not know how to properly test it using GTEST, I only found test_polling.cxx doing something like that but it looked too complicated, so I ended up simplifying.
- I do not know if Windows must catch SIGTERM somewhere else @bellenot ?

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

