### PR TITLE
Fix the module map for GCC 15 and bump the C++ standard to 23 for the Fedora 42 build

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -362,7 +362,7 @@ jobs:
         include:
           - image: fedora41
           - image: fedora42
-            overrides: ["CMAKE_CXX_STANDARD=20"]
+            overrides: ["CMAKE_CXX_STANDARD=23"]
           - image: alma8
           - image: alma9
             overrides: ["CMAKE_BUILD_TYPE=Debug"]

--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -288,6 +288,11 @@ module "std" [system] {
     export *
     header "random"
   }
+  module "ranges" {
+    requires cplusplus20
+    export *
+    header "ranges"
+  }
   module "ratio" {
     export *
     header "ratio"


### PR DESCRIPTION
Thanks @vgvassilev for the commit fixing the module map.