### PR TITLE
[ci] Skip invalid ranges with ruff format

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -73,6 +73,10 @@ jobs:
             while IFS=- read -r start length; do
               [ -z "$start" ] && continue
               length=${length:-1}
+              # Skip invalid ranges
+              if [ "$start" -eq 0 ] || [ "$length" -eq 0 ]; then
+                continue
+              fi
               end=$((start + length))
               diff_command+="ruff format --diff --range $start-$end $file && "
               apply_command+="ruff format --range $start-$end $file && "


### PR DESCRIPTION
When the first lines of a file are removed (as we can see in [18412](https://github.com/root-project/root/actions/runs/14465867825/job/40567985665?pr=18412)), `git diff` hunks produce a range of `0-0`. This range is invalid to pass to ruff format and results in an error.
This addresses the issue by skipping such ranges.