### PR TITLE
[RFC] [cmake] Add core/base headers to target HEADERS file_set

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -198,10 +198,26 @@ set(BASE_SOURCES
   src/TVirtualX.cxx
 )
 
+set(FULL_BASE_HEADERS ${BASE_HEADERS})
+list(TRANSFORM FULL_BASE_HEADERS PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/inc/)
+
 # only here complete list of headers can be propogated to parent cmake file
 set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${BASE_HEADERS})
 
 target_sources(Core PRIVATE ${BASE_SOURCES})
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0") # https://discourse.cmake.org/t/file-set-xyz-is-listed-in-interface-file-sets-of-w-but-has-not-been-exported/9131/3
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/ src/
+      FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/TListOfTypes.h
+          ${FULL_BASE_HEADERS}
+  )
+endif()
 
 target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Gives a taste on how it would look like to properly add HEADERS to targets in CMake.

This does not just help with the IDE workflow, it gives an idea on future paths:

One could make them PUBLIC instead of PRIVATE, then you would not need the target_include_directories line, and installing and cpacking would be easier.

Related:
- https://github.com/root-project/root/issues/16327
- https://github.com/root-project/root/pull/8709
- https://github.com/root-project/root/pull/6014
- https://its.cern.ch/jira/browse/ROOT-6428
- https://its.cern.ch/jira/browse/ROOT-10915
- https://github.com/root-project/root/pull/17607

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

