### PR TITLE
[skip-ci][doc] force full build of root

### DIFF
--- a/.github/workflows/root-docs-master.yml
+++ b/.github/workflows/root-docs-master.yml
@@ -9,10 +9,10 @@ on:
   workflow_dispatch:
     inputs:
       incremental:
-        description: 'Do incremental build'
+        description: 'Do full build'
         type: boolean
-        required: true
-        default: true
+        required: false
+        default: false
       # docu_input: # opportunity: overwrite makeinput.sh with these args
       #   description: Folders to build documentation for. All folders are built if empty.
       #   type: string


### PR DESCRIPTION
Force the full build of ROOT for doc master. The incremental build might be the cause
of the problem we have now to build the doc after this [root-project/root#17722](https://github.com/root-project/root/pull/17722)

