### PR TITLE
Revert PR #18386

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -80,19 +80,31 @@ foreach(dict ${stldicts})
   target_include_directories(${dict}Dict PRIVATE ${CMAKE_SOURCE_DIR}/interpreter/cling/include/cling/cint)
 endforeach()
 
+set(CLANG_RESOURCE_DIR_STEM)
 if (builtin_clang)
-    set(CLANG_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/interpreter/llvm-project/llvm/${CMAKE_CFG_INTDIR})
+  set(CLANG_RESOURCE_DIR_STEM ${CMAKE_BINARY_DIR}/interpreter/llvm-project/llvm/${CMAKE_CFG_INTDIR}/lib/clang)
+  set(CLANG_RESOURCE_DIR_VERSION ${LLVM_VERSION_MAJOR})
 else ()
-  # If no explicit Clang prefix is set, assume it lives inside LLVM prefix.
-  if(NOT DEFINED CLANG_INSTALL_PREFIX)
-    set(CLANG_INSTALL_PREFIX ${LLVM_DIR})
+  set(CLANG_RESOURCE_DIR_STEM ${LLVM_LIBRARY_DIR}/clang)
+  # A user can define a clang version to use, otherwise find it (but will error if more than one version is present)
+  if (NOT DEFINED CLANG_RESOURCE_DIR_VERSION)
+    if (NOT EXISTS ${CLANG_RESOURCE_DIR_STEM})
+      message(FATAL_ERROR "${CLANG_RESOURCE_DIR_STEM} does not exist. Please install clang.")
+    endif()
+    # There is no reasonable way to get the version of clang under which is its resource directory.
+    # For example, lib/clang/5.0.0/include. Deduce it.
+    file(GLOB CHILDREN RELATIVE ${CLANG_RESOURCE_DIR_STEM} ${CLANG_RESOURCE_DIR_STEM}/*)
+    list(LENGTH CHILDREN CHILDREN_LENGTH)
+    if (${CHILDREN_LENGTH} GREATER 1)
+      message(FATAL_ERROR "Found more than one version of clang. CLANG_RESOURCE_DIR_VERSION contains: '${CHILDREN}'." )
+    endif()
+
+    list(GET CHILDREN 0 CLANG_RESOURCE_DIR_VERSION)
   endif()
 endif()
 
-# We only look for the Clang version that matches the LLVM version, because other setups are not supported.
-set(CLANG_RESOURCE_DIR_VERSION ${LLVM_VERSION_MAJOR})
 
-set(CLANG_RESOURCE_DIR ${CLANG_INSTALL_PREFIX}/lib/clang/${CLANG_RESOURCE_DIR_VERSION}/include)
+set(CLANG_RESOURCE_DIR ${CLANG_RESOURCE_DIR_STEM}/${CLANG_RESOURCE_DIR_VERSION}/include)
 
 #---Deal with clang resource here----------------------------------------------
 install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/cling/lib/clang/${CLANG_RESOURCE_DIR_VERSION}/include/

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -407,12 +407,6 @@ if (builtin_clang)
 else()
   find_package(Clang REQUIRED CONFIG)
   message(STATUS "Found Clang ${CLANG_PACKAGE_VERSION} in ${CLANG_CMAKE_DIR}")
-
-  # Disable linking against shared LLVM.
-  # We have to do this after find_package(Clang). Finding Clang internally
-  # calls find_package(LLVM), which overwrites LLVM_LINK_LLVM_DYLIB to what it
-  # was set when building LLVM.
-  set(LLVM_LINK_LLVM_DYLIB FALSE)
 endif()
 
 # Reset the compiler flags after compiling LLVM and Clang


### PR DESCRIPTION
This reverts commit https://github.com/root-project/root/commit/02b0dc129d0c62e6bf7252bb89e8ec0777a40640. It was partially incorrect and should not use LLVM_DIR, which is only a hint specified by the user.   We need more time to decide on and test a better solution.

This reverts commit https://github.com/root-project/root/commit/3ef1193b0bd3d937e87815d0dfdc12370f8d190d. The
taken approach is not the right direction, this should be handled on the linking side of libCling as discussed post-merge in the pull request:  https://github.com/root-project/root/pull/18386