### PR TITLE
[io] reduce compression buffer length

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -250,7 +250,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(GetFile() ? GetFile()->GetCompressionAlgorithm() : 0);
    if (cxlevel > 0 && fObjlen > 256) {
       Int_t nbuffers = 1 + (fObjlen - 1)/kMAXZIPBUF;
-      Int_t buflen = std::max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
+      Int_t buflen = std::max(512, fKeylen + fObjlen);
       fBuffer = new char[buflen];
       char *objbuf = fBufferRef->Buffer() + fKeylen;
       char *bufcur = &fBuffer[fKeylen];
@@ -345,7 +345,7 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(GetFile() ? GetFile()->GetCompressionAlgorithm() : 0);
    if (cxlevel > 0 && fObjlen > 256) {
       Int_t nbuffers = 1 + (fObjlen - 1)/kMAXZIPBUF;
-      Int_t buflen = std::max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
+      Int_t buflen = std::max(512, fKeylen + fObjlen);
       fBuffer = new char[buflen];
       char *objbuf = fBufferRef->Buffer() + fKeylen;
       char *bufcur = &fBuffer[fKeylen];

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -361,7 +361,7 @@ Int_t TMessage::Compress()
    Int_t messlen  = Length() - hdrlen;
    Int_t nbuffers = 1 + (messlen - 1) / kMAXZIPBUF;
    Int_t chdrlen  = 3*sizeof(UInt_t);   // compressed buffer header length
-   Int_t buflen   = std::max(512, chdrlen + messlen + 9*nbuffers);
+   Int_t buflen   = std::max(512, chdrlen + messlen);
    fBufComp       = new char[buflen];
    char *messbuf  = Buffer() + hdrlen;
    char *bufcur   = fBufComp + chdrlen;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1227,7 +1227,7 @@ Int_t TBasket::WriteBuffer()
       cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(file->GetCompressionAlgorithm());
    if (cxlevel > 0) {
       Int_t nbuffers = 1 + (fObjlen - 1) / kMAXZIPBUF;
-      Int_t buflen = fKeylen + fObjlen + 9 * nbuffers + 28; //add 28 bytes in case object is placed in a deleted gap
+      Int_t buflen = fKeylen + fObjlen;
       InitializeCompressedBuffer(buflen, file);
       if (!fCompressedBufferRef) {
          Warning("WriteBuffer", "Unable to allocate the compressed buffer");


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Explore suggestions proposed in https://github.com/root-project/root/issues/14651

However: Not sure what to change though in line  `if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed`

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

