### PR TITLE
[meta] Return exec id of TRef, TRefArray and derived data members

### DIFF
--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -23,6 +23,7 @@ ROOT_ADD_GTEST(CoreBaseTests
   TStringTest.cxx
   TUrlTest.cxx
   TBitsTests.cxx
+  TRefTests.cxx
   LIBRARIES ${extralibs} RIO Core)
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)

--- a/core/base/test/TRefTests.cxx
+++ b/core/base/test/TRefTests.cxx
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+
+#include "TClass.h"
+#include "TInterpreter.h"
+#include "TStreamerElement.h"
+#include "TVirtualStreamerInfo.h"
+
+#include <ROOT/TestSupport.hxx>
+
+// See ROOT-7052
+TEST(TRef, Exec)
+{
+
+   // Needed because we do not generate dictionaries and we do no not want to see warnings
+   ROOT::TestSupport::CheckDiagsRAII checkDiag;
+   checkDiag.requiredDiag(kWarning, "TStreamerInfo::Build", "MyClass: ", /*matchFullMessage=*/false);
+
+   gInterpreter->ProcessLine("class Foo1 : public TRef {\n"
+                             "   int i;\n"
+                             "ClassDef(Foo1, 1);\n"
+                             "};"
+                             "class Foo2 : public TRefArray {\n"
+                             "   int i;\n"
+                             "ClassDef(Foo2, 1);\n"
+                             "};"
+                             "class TRefFoo {int i;};\n"
+                             "class Foo3 {int i;};\n"
+                             " class MyClass {\n"
+                             "    Foo1 m1; // EXEC:GetFoo\n"
+                             "    Foo2 m2; // EXEC:GetFoo\n"
+                             "    TRefFoo m3; // EXEC:GetFoo\n"
+                             "    Foo3 m4; // EXEC:GetFoo\n"
+                             "};");
+
+   auto c = TClass::GetClass("MyClass");
+   auto si = c->GetStreamerInfo();
+   int o;
+   auto se1 = si->GetStreamerElement("m1", o);
+   auto se2 = si->GetStreamerElement("m2", o);
+   auto se3 = si->GetStreamerElement("m3", o);
+   auto se4 = si->GetStreamerElement("m4", o);
+
+   EXPECT_EQ(1, se1->GetExecID());
+   EXPECT_EQ(1, se2->GetExecID());
+   EXPECT_EQ(0, se3->GetExecID());
+   EXPECT_EQ(0, se4->GetExecID());
+}


### PR DESCRIPTION
Instead of all data members the type of which has a name beginning with "TRef".

Fixes [ROOT-7052](https://its.cern.ch/jira/browse/ROOT-7052)

This PR builds on top of the solid work done here https://github.com/root-project/root/pull/14930.