### PR TITLE
Add dictionary for TBulkBranchRead.

### DIFF
--- a/tree/tree/inc/LinkDef.h
+++ b/tree/tree/inc/LinkDef.h
@@ -96,4 +96,5 @@
 #pragma link C++ class ROOT::Internal::TreeUtils::RNoCleanupNotifier;
 #pragma link C++ class TNotifyLink<ROOT::Internal::TreeUtils::RNoCleanupNotifierHelper>;
 
+#pragma link C++ class ROOT::Experimental::Internal::TBulkBranchRead+;
 #endif


### PR DESCRIPTION
The class is transient so the dictionary is not needed by itself.  However not having the dictionary leads to a lookup for the class namespace 'ROOT::Experimental' and this leads to loading of the 'first' library that has a dictionary for something in 'ROOT::Experimental'. This is undesirable (i.e. load the Eve library for a simple TTree job), so we create the dictionary for TBulkBranchRead.

This solves the unexpected test failures seen in https://github.com/root-project/root/pull/18396

The test will be added in the roottest companion PR for https://github.com/root-project/root/pull/18402 (as it makes testing this much easier).