### PR TITLE
[io] Delete unused std::pair StreamerInfo.

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -960,8 +960,7 @@ TROOT::~TROOT()
       SafeDelete(fGlobalFunctions);
       fEnums.load()->Delete();
 
-      // FIXME: Causes segfault in rootcling, debug and uncomment
-      // fClasses->Delete();    SafeDelete(fClasses);     // TClass'es must be deleted last
+      fClasses->Delete(); SafeDelete(fClasses);     // TClass'es must be deleted last
 #endif
 
       // Remove shared libraries produced by the TSystem::CompileMacro() call

--- a/core/meta/inc/TProtoClass.h
+++ b/core/meta/inc/TProtoClass.h
@@ -82,6 +82,7 @@ private:
    Long_t   fProperty;       // Class properties, see EProperties
    Long_t   fClassProperty;  // Class C++ properties, see EClassProperties
    Long_t   fOffsetStreamer; // Offset to streamer function
+   bool     fOwner = true;   //! True if owns its content, false if it got a reference to the TClass content.
 
    TProtoClass(const TProtoClass &) = delete;
    TProtoClass &operator=(const TProtoClass &) = delete;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -579,6 +579,7 @@ TGenCollectionProxy::TGenCollectionProxy(const TGenCollectionProxy& copy)
    fKey            = copy.fKey   ? new Value(*copy.fKey)   : 0;
    fOnFileClass    = copy.fOnFileClass;
    fReadMemberWise = new TObjArray(TCollection::kInitCapacity,-1);
+   fReadMemberWise->SetOwner(true);
    fConversionReadMemberWise = 0;
    fWriteMemberWise = 0;
    fProperties     = copy.fProperties;
@@ -625,6 +626,7 @@ TGenCollectionProxy::TGenCollectionProxy(Info_t info, size_t iter_size)
             (Long_t)sizeof(e.fIterator));
    }
    fReadMemberWise = new TObjArray(TCollection::kInitCapacity,-1);
+   fReadMemberWise->SetOwner(true);
    fConversionReadMemberWise   = 0;
    fWriteMemberWise            = 0;
    fFunctionCreateIterators    = 0;
@@ -676,6 +678,7 @@ TGenCollectionProxy::TGenCollectionProxy(const ROOT::Detail::TCollectionProxyInf
             (Long_t)sizeof(e.fIterator));
    }
    fReadMemberWise = new TObjArray(TCollection::kInitCapacity,-1);
+   fReadMemberWise->SetOwner(true);
    fConversionReadMemberWise   = 0;
    fWriteMemberWise            = 0;
    fFunctionCreateIterators    = info.fCreateIterators;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -6034,6 +6034,15 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    gErrorIgnoreLevel = kError;
    i->BuildCheck(nullptr, kFALSE); // Skipping the loading part (it would leads to infinite recursion on this very routine)
    gErrorIgnoreLevel = oldlevel;
+   if (i->TestBit(kCanDelete)) {
+      // The StreamerInfo was deemed to be a duplicated (most likely case is
+      // that we have the interpreter information already loaded for the
+      // pair), so we need to delete it and return the one we already have.
+      auto cl = i->GetClass();
+      delete i;
+      return cl->GetStreamerInfo();
+   }
+
    // In the state emulated, BuildOld would recalculate the offset and undo the offset update.
    // Note: we should consider adding a new state just for this (the hints indicates that we are mapping a compiled class but
    // then we would have to investigate all use of the state with <= and >= condition to make sure they are still appropriate).


### PR DESCRIPTION
In the case when we need a TStreamerInfo for a pair and:
* There is no dictionary for that pair
* There is not yet a TClass created for that pair
* There is interpreter information about that pair

Then the interpreter information takes precedence over the one
`TStreamerInfo::GenerateInfoForPair` is generating and thus the
one being generated need to be deleted.

This fixes #18343 

A side effect of the investigation was fixing double deletes and additional memory leak when deleting TClass which could now be enable in 'TROOT::~TROOT`.