### PR TITLE
[python][UHI] Add UHI plotting pythonizations to TH2 and TH3 derived classes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
@@ -29,3 +29,8 @@ _th2_derived_classes_to_pythonize = [
 
 for klass in _th2_derived_classes_to_pythonize:
     pythonization(klass)(inject_constructor_releasing_ownership)
+
+    from ROOT._pythonization._uhi import _add_plotting_features
+
+    # Add UHI plotting features
+    pythonization(klass)(_add_plotting_features)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th3.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th3.py
@@ -26,3 +26,8 @@ _th3_derived_classes_to_pythonize = [
 
 for klass in _th3_derived_classes_to_pythonize:
     pythonization(klass)(inject_constructor_releasing_ownership)
+
+    from ROOT._pythonization._uhi import _add_plotting_features
+
+    # Add UHI plotting features
+    pythonization(klass)(_add_plotting_features)

--- a/bindings/pyroot/pythonizations/test/conftest.py
+++ b/bindings/pyroot/pythonizations/test/conftest.py
@@ -1,0 +1,41 @@
+import pytest
+import ROOT
+from ROOT._pythonization._th1 import _th1_derived_classes_to_pythonize
+from ROOT._pythonization._th2 import _th2_derived_classes_to_pythonize
+from ROOT._pythonization._th3 import _th3_derived_classes_to_pythonize
+from ROOT._pythonization._uhi import _temporarily_disable_add_directory
+
+th1_classes = {
+    ("test_hist", "Test Histogram", 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th1_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), 1.0),
+    },
+    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th2_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0),
+    },
+    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4, 10, 1, 4): {
+        "classes": [getattr(ROOT, klass) for klass in _th3_derived_classes_to_pythonize],
+        "fill": lambda hist: hist.Fill(
+            ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0
+        ),
+    },
+}
+
+
+@pytest.fixture(
+    params=[
+        (constructor_args, hist_class, hist_config["fill"])
+        for constructor_args, hist_config in th1_classes.items()
+        for hist_class in hist_config["classes"]
+    ],
+    scope="function",
+    ids=lambda param: param[1].__name__,
+)
+def hist_setup(request):
+    constructor_args, hist_class, fill = request.param
+    with _temporarily_disable_add_directory():
+        hist = hist_class(*constructor_args)
+        for _ in range(10000):
+            fill(hist)
+        yield hist

--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -4,52 +4,13 @@ Tests to verify that TH1 and derived histograms conform to the UHI Indexing inte
 
 import pytest
 import ROOT
-from ROOT._pythonization._th1 import _th1_derived_classes_to_pythonize
-from ROOT._pythonization._th2 import _th2_derived_classes_to_pythonize
-from ROOT._pythonization._th3 import _th3_derived_classes_to_pythonize
 from ROOT._pythonization._uhi import (
     _get_axis,
     _get_processed_slices,
     _get_slice_indices,
     _shape,
-    _temporarily_disable_add_directory,
 )
 from ROOT.uhi import loc, overflow, rebin, sum, underflow
-
-th1_classes = {
-    ("test_hist", "Test Histogram", 10, 1, 4): {
-        "classes": [getattr(ROOT, klass) for klass in _th1_derived_classes_to_pythonize],
-        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), 1.0),
-    },
-    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4): {
-        "classes": [getattr(ROOT, klass) for klass in _th2_derived_classes_to_pythonize],
-        "fill": lambda hist: hist.Fill(ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0),
-    },
-    ("test_hist", "Test Histogram", 10, 1, 4, 10, 1, 4, 10, 1, 4): {
-        "classes": [getattr(ROOT, klass) for klass in _th3_derived_classes_to_pythonize],
-        "fill": lambda hist: hist.Fill(
-            ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5), 1.0
-        ),
-    },
-}
-
-
-@pytest.fixture(
-    params=[
-        (constructor_args, hist_class, hist_config["fill"])
-        for constructor_args, hist_config in th1_classes.items()
-        for hist_class in hist_config["classes"]
-    ],
-    scope="function",
-    ids=lambda param: param[1].__name__,
-)
-def hist_setup(request):
-    constructor_args, hist_class, fill = request.param
-    with _temporarily_disable_add_directory():
-        hist = hist_class(*constructor_args)
-        for _ in range(10000):
-            fill(hist)
-        yield hist
 
 
 def _special_setting(hist):

--- a/bindings/pyroot/pythonizations/test/uhi_plotting.py
+++ b/bindings/pyroot/pythonizations/test/uhi_plotting.py
@@ -2,29 +2,30 @@
 Tests to verify that th1 1D histograms conform to the UHI PlottableHistogram protocol.
 """
 
-import ROOT
-from ROOT._pythonization._th1 import _th1_derived_classes_to_pythonize
-
-import pytest
-from uhi.typing.plottable import PlottableHistogram
 import numpy as np
+import pytest
+from ROOT._pythonization._uhi import _shape
+from uhi.typing.plottable import PlottableHistogram
 
-th1_classes = [getattr(ROOT, klass) for klass in _th1_derived_classes_to_pythonize]
 
-@pytest.mark.parametrize("hist_type", th1_classes)
+def _iterate_bins(hist):
+    dim = hist.GetDimension()
+    for i in range(1, hist.GetNbinsX() + 1):
+        for j in range(1, hist.GetNbinsY() + 1) if dim > 1 else [None]:
+            for k in range(1, hist.GetNbinsZ() + 1) if dim > 2 else [None]:
+                yield tuple(filter(None, (i, j, k)))
+
+
 class TestTH1Plotting:
-    @pytest.fixture
-    def hist_setup(self, hist_type):
-        hist = hist_type("h", "h", 10, 0, 5)
-        for _ in range(100):
-            hist.Fill(ROOT.gRandom.Uniform(0, 5), ROOT.gRandom.Uniform(0, 5))
-        yield hist
-
     def test_isinstance_plottablehistogram(self, hist_setup):
         assert isinstance(hist_setup, PlottableHistogram)
 
     def test_histogram_values(self, hist_setup):
-        assert np.allclose(hist_setup.values(), [hist_setup.GetBinContent(i) for i in range(1, hist_setup.GetNbinsX() + 1)])
+        values = np.array(
+            [hist_setup.GetBinContent(*bin_indices) for bin_indices in _iterate_bins(hist_setup)]
+        ).reshape(_shape(hist_setup, include_flow_bins=False))
+        assert np.array_equal(hist_setup.values(), values)
+
 
 if __name__ == "__main__":
     pytest.main(args=[__file__])


### PR DESCRIPTION
# This Pull request:

## Adds:

As a follow-up to #17950, this PR extends the [Unified Histogram Interface](https://uhi.readthedocs.io/en/latest/index.html) plottable histogram functionality in ROOT to `TH2` and `TH3` derived classes.

## Checklist:

- [x] tested changes locally
