### PR TITLE
[core] Add missing includes

### DIFF
--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -23,6 +23,7 @@
 #include "TError.h"
 #include <vector>
 #include <forward_list>
+#include <typeinfo>
 #include <utility>
 
 #if defined(_WIN32)

--- a/math/mathcore/inc/Math/DistSampler.h
+++ b/math/mathcore/inc/Math/DistSampler.h
@@ -17,6 +17,7 @@
 
 #include "Math/WrappedFunction.h"
 
+#include <algorithm>
 #include <vector>
 #include <cassert>
 

--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -20,8 +20,10 @@
 // #include "Math/StaticCheck.h"
 // #endif
 
+#include <algorithm>
 #include <memory>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 namespace ROOT {

--- a/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
@@ -30,6 +30,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <utility>
 


### PR DESCRIPTION
This will fix build errors like:
`error: declaration of 'type_info' must be imported from module 'std.std_typeinfo' before it is required`

in https://github.com/root-project/root/pull/18369 when building with C++23

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

