### PR TITLE
[math][GenVector] Add access operator for Rotation3D

### DIFF
--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -34,6 +34,7 @@
 #include "Math/GenVector/RotationYfwd.h"
 #include "Math/GenVector/RotationZfwd.h"
 
+#include "Math/GenVector/GenVector_exception.h"
 
 #include <algorithm>
 #include <cassert>
@@ -345,6 +346,18 @@ public:
 
    // =========== operations ==============
 
+   /**
+      Access operator
+   */
+   Scalar operator()(size_t i, size_t j) const
+   {
+      if (i < 3 && j < 3)
+         return fM[i + 3 * j];
+      else
+         GenVector::Throw("Rotation3D::operator(size_t i, size_t j):\n"
+                          "    indices i and j must range in {0,1,2}");
+      return 0.0;
+   }
 
    /**
       Rotation operation on a displacement vector in any coordinate system

--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -347,7 +347,9 @@ public:
    // =========== operations ==============
 
    /**
-      Access operator
+      Access operator, used to have direct access to rotation matrix's entries
+      \param i row index in {0,1,2}
+      \param j column index in {0,1,2}
    */
    Scalar operator()(size_t i, size_t j) const
    {


### PR DESCRIPTION
# This Pull request:

Fixes https://root-forum.cern.ch/t/tvector3-rotate-to-arbitrary-rotation-using-xyzvector/63244

Alternative to https://github.com/root-project/root/pull/18462

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

