### PR TITLE
[json] improve roottest/io/json testing

### DIFF
--- a/roottest/root/io/json/.rootrc
+++ b/roottest/root/io/json/.rootrc
@@ -1,1 +1,0 @@
-Rint.History:            .root_hist

--- a/roottest/root/io/json/CMakeLists.txt
+++ b/roottest/root/io/json/CMakeLists.txt
@@ -1,3 +1,58 @@
 
-ROOTTEST_COMPILE_MACRO(test_classes.h FIXTURES_SETUP json-test-classes-build)
-ROOTTEST_ADD_AUTOMACROS(FIXTURES_REQUIRED json-test-classes-build)
+ROOTTEST_ADD_TEST(ArrayCompress
+                  MACRO runArrayCompress.C
+                  OUTREF ArrayCompress.ref)
+
+ROOTTEST_ADD_TEST(PolyMarker
+                  MACRO runPolyMarker.C
+                  OUTREF PolyMarker.ref)
+
+ROOTTEST_GENERATE_DICTIONARY(libJsonTestClasses
+                  test_classes.h
+                  LINKDEF LinkDef.h
+                  NO_ROOTMAP NO_CXXMODULE)
+
+ROOTTEST_ADD_TEST(BasicTypes
+                  MACRO runBasicTypes.C
+                  OUTREF BasicTypes.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(Objects
+                  MACRO runObjects.C
+                  OUTREF Objects.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(RootClasses
+                  MACRO runRootClasses.C
+                  OUTREF RootClasses.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(STL
+                  MACRO runSTL.C
+                  OUTREF STL.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(STL0
+                  MACRO runSTL0.C
+                  OUTREF STL0.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(STL1
+                  MACRO runSTL1.C
+                  OUTREF STL1.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(StreamerLoop
+                  MACRO runStreamerLoop.C
+                  OUTREF StreamerLoop.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(Map
+                  MACRO runMap.C
+                  OUTREF Map.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(String
+                  MACRO runString.C
+                  OUTREF String.ref
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})

--- a/roottest/root/io/json/CMakeLists.txt
+++ b/roottest/root/io/json/CMakeLists.txt
@@ -10,49 +10,50 @@ ROOTTEST_ADD_TEST(PolyMarker
 ROOTTEST_GENERATE_DICTIONARY(libJsonTestClasses
                   test_classes.h
                   LINKDEF LinkDef.h
-                  NO_ROOTMAP NO_CXXMODULE)
+                  NO_ROOTMAP NO_CXXMODULE
+                  FIXTURES_SETUP jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(BasicTypes
                   MACRO runBasicTypes.C
                   OUTREF BasicTypes.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(Objects
                   MACRO runObjects.C
                   OUTREF Objects.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(RootClasses
                   MACRO runRootClasses.C
                   OUTREF RootClasses.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(STL
                   MACRO runSTL.C
                   OUTREF STL.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(STL0
                   MACRO runSTL0.C
                   OUTREF STL0.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(STL1
                   MACRO runSTL1.C
                   OUTREF STL1.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(StreamerLoop
                   MACRO runStreamerLoop.C
                   OUTREF StreamerLoop.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(Map
                   MACRO runMap.C
                   OUTREF Map.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)
 
 ROOTTEST_ADD_TEST(String
                   MACRO runString.C
                   OUTREF String.ref
-                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+                  FIXTURES_REQUIRED jsonTestClasses_fixture)

--- a/roottest/root/io/json/LinkDef.h
+++ b/roottest/root/io/json/LinkDef.h
@@ -1,0 +1,24 @@
+#ifdef __CLING__
+
+#pragma link off all    globals;
+#pragma link off all    classes;
+#pragma link off all    functions;
+
+#pragma link C++ class std::map<std::string,int>+;
+
+#pragma link C++ class TJsonEx1+;
+#pragma link C++ class TJsonEx2+;
+#pragma link C++ class TJsonEx3+;
+#pragma link C++ class TJsonEx4+;
+#pragma link C++ class TJsonEx5+;
+#pragma link C++ class TJsonEx6+;
+#pragma link C++ class TJsonEx7+;
+#pragma link C++ class TJsonEx8+;
+#pragma link C++ class TJsonEx9+;
+#pragma link C++ class TJsonEx10+;
+#pragma link C++ class TJsonEx11+;
+#pragma link C++ class TJsonEx12+;
+#pragma link C++ class TJsonEx13+;
+#pragma link C++ class TJsonEx14+;
+
+#endif

--- a/roottest/root/io/json/runBasicTypes.C
+++ b/roottest/root/io/json/runBasicTypes.C
@@ -1,13 +1,8 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runBasicTypes.C");
-#else
+void runBasicTypes()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx1 ex1; ex1.Init();
    TJsonEx2 ex2; ex2.Init();
@@ -15,31 +10,24 @@
    TJsonEx11 ex11; ex11.Init();
    TString json;
 
-   cout << " ====== basic data types TJsonEx1 ===== " << endl;
+   std::cout << " ====== basic data types TJsonEx1 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex1);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== inheritance from TJsonEx1, TJsonEx11 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== inheritance from TJsonEx1, TJsonEx11 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex11);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== arrays of basic data types TJsonEx2 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== arrays of basic data types TJsonEx2 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex2);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== dynamic arrays of basic data types TJsonEx3 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== dynamic arrays of basic data types TJsonEx3 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex3);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ============ selected data members ======== " << endl;
-   cout << "ex2.fInt = " << TBufferJSON::ToJSON(&ex2, 0, "fInt") << endl;
-   cout << "ex3.fChar = " << TBufferJSON::ToJSON(&ex3, 0, "fChar") << endl;
-   cout << "ex3.fLong = " << TBufferJSON::ToJSON(&ex3, 0, "fLong") << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ============ selected data members ======== " << std::endl;
+   std::cout << "ex2.fInt = " << TBufferJSON::ToJSON(&ex2, 0, "fInt") << std::endl;
+   std::cout << "ex3.fChar = " << TBufferJSON::ToJSON(&ex3, 0, "fChar") << std::endl;
+   std::cout << "ex3.fLong = " << TBufferJSON::ToJSON(&ex3, 0, "fLong") << std::endl;
 }

--- a/roottest/root/io/json/runMap.C
+++ b/roottest/root/io/json/runMap.C
@@ -29,6 +29,9 @@ void testJson(std::map<std::string,int> &data, int compact, const char *name)
 
 void runMap()
 {
+   // for dictionary
+   gSystem->Load("libJsonTestClasses");
+
    std::map<std::string,int> data;
 
    for (int n=0;n<10;++n) {

--- a/roottest/root/io/json/runObjects.C
+++ b/roottest/root/io/json/runObjects.C
@@ -1,41 +1,29 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runObjects.C");
-#else
+void runObjects()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx5 ex5; ex5.Init();
    TJsonEx6 ex6; ex6.Init();
    TJsonEx10 ex10; ex10.Init();
    TString json;
 
-   cout << " ====== objects as class members TJsonEx5 ===== " << endl;
+   std::cout << " ====== objects as class members TJsonEx5 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex5);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== arrays of objects as class members TJsonEx6 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== arrays of objects as class members TJsonEx6 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex6);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== ROOT TObject/TNamed/TString as class members TJsonEx10 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== ROOT TObject/TNamed/TString as class members TJsonEx10 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex10);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ============ selected data members ======== " << endl;
-   cout << "ex5.fObj1 = " << TBufferJSON::ToJSON(&ex5, 0, "fObj1") << endl;
-   cout << "ex5.fPtr1 = " << TBufferJSON::ToJSON(&ex5, 0, "fPtr1") << endl;
-   cout << "ex5.fSafePtr1 = " << TBufferJSON::ToJSON(&ex5, 0, "fSafePtr1") << endl;
-   cout << "ex6.fObj1 = " << TBufferJSON::ToJSON(&ex6, 0, "fObj1") << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ============ selected data members ======== " << std::endl;
+   std::cout << "ex5.fObj1 = " << TBufferJSON::ToJSON(&ex5, 0, "fObj1") << std::endl;
+   std::cout << "ex5.fPtr1 = " << TBufferJSON::ToJSON(&ex5, 0, "fPtr1") << std::endl;
+   std::cout << "ex5.fSafePtr1 = " << TBufferJSON::ToJSON(&ex5, 0, "fSafePtr1") << std::endl;
+   std::cout << "ex6.fObj1 = " << TBufferJSON::ToJSON(&ex6, 0, "fObj1") << std::endl;
 }

--- a/roottest/root/io/json/runPolyMarker.C
+++ b/roottest/root/io/json/runPolyMarker.C
@@ -13,5 +13,5 @@ void runPolyMarker()
 
    TString json = TBufferJSON::ToJSON(&marker);
 
-   cout << json << endl;
+   std::cout << json << std::endl;
 }

--- a/roottest/root/io/json/runRootClasses.C
+++ b/roottest/root/io/json/runRootClasses.C
@@ -1,13 +1,9 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runRootClasses.C");
-#else
+void runRootClasses()
+{
+   gSystem->Load("libJsonTestClasses");
+
 
    TH1I *h1 = new TH1I("histo1","histo title", 100, -10., 10.);
    for (Int_t bin=1;bin<=100;++bin)
@@ -39,34 +35,34 @@
 
    TString json;
 
-   cout << " ====== TObject representation ===== " << endl;
+   std::cout << " ====== TObject representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(obj);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TH1I representation ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TH1I representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(h1);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TBox representation ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TBox representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(box);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TList representation ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TList representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(arr);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TClonesArray representation ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TClonesArray representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(clones);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TMap representation ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TMap representation ===== " << std::endl;
    json = TBufferJSON::ToJSON(map);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== TJsonEx14 with different ROOT collections ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== TJsonEx14 with different ROOT collections ===== " << std::endl;
    json = TBufferJSON::ToJSON(ex14);
    testJsonReading(json);
-   cout << json << endl << endl;
+   std::cout << json << std::endl << std::endl;
 
    delete obj;
    delete h1;
@@ -75,12 +71,4 @@
    delete clones;
    delete map;
    delete ex14;
-
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
 }

--- a/roottest/root/io/json/runSTL.C
+++ b/roottest/root/io/json/runSTL.C
@@ -1,13 +1,8 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runSTL.C");
-#else
+void runSTL()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx7 ex7; ex7.Init();
    TJsonEx8 ex8; ex8.Init();
@@ -15,27 +10,20 @@
    TJsonEx13 ex13; ex13.Init();
    TString json;
 
-   cout << " ====== different STL containers TJsonEx7 ===== " << endl;
+   std::cout << " ====== different STL containers TJsonEx7 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex7);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL as base class TJsonEx8 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL as base class TJsonEx8 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex8);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL vector of complex classes TJsonEx12 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL vector of complex classes TJsonEx12 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex12);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex13);
    testJsonReading(json);
-   cout << json << endl << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
 }

--- a/roottest/root/io/json/runSTL0.C
+++ b/roottest/root/io/json/runSTL0.C
@@ -1,13 +1,8 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runSTL0.C");
-#else
+void runSTL0()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx7 ex7;
    TJsonEx8 ex8;
@@ -15,27 +10,20 @@
    TJsonEx13 ex13;
    TString json;
 
-   cout << " ====== different STL containers TJsonEx7 (len=0) ===== " << endl;
+   std::cout << " ====== different STL containers TJsonEx7 (len=0) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex7);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL as base class TJsonEx8 (len=0) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL as base class TJsonEx8 (len=0) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex8);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL vector of complex classes TJsonEx12 (len=0) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL vector of complex classes TJsonEx12 (len=0) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex12);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 (len=0) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 (len=0) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex13);
    testJsonReading(json);
-   cout << json << endl << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
 }

--- a/roottest/root/io/json/runSTL1.C
+++ b/roottest/root/io/json/runSTL1.C
@@ -1,13 +1,8 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runSTL1.C");
-#else
+void runSTL1()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx7 ex7; ex7.Init(1);
    TJsonEx8 ex8; ex8.Init(1);
@@ -15,27 +10,20 @@
    TJsonEx13 ex13; ex13.Init(1);
    TString json;
 
-   cout << " ====== different STL containers TJsonEx7 (len=1) ===== " << endl;
+   std::cout << " ====== different STL containers TJsonEx7 (len=1) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex7);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL as base class TJsonEx8 (len=1) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL as base class TJsonEx8 (len=1) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex8);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== STL vector of complex classes TJsonEx12 (len=1) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== STL vector of complex classes TJsonEx12 (len=1) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex12);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 (len=1) ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== More exotic STL containers as set or map with TRef inside TJsonEx13 (len=1) ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex13);
    testJsonReading(json);
-   cout << json << endl << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
 }

--- a/roottest/root/io/json/runStreamerLoop.C
+++ b/roottest/root/io/json/runStreamerLoop.C
@@ -1,36 +1,24 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runStreamerLoop.C");
-#else
+void runStreamerLoop()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx9 ex9_0;
    TJsonEx9 ex9_1; ex9_1.Init(1);
    TJsonEx9 ex9_7; ex9_7.Init(7);
    TString json;
 
-   cout << " ====== kStreamerLoop members with Counter==0 TJsonEx9 ===== " << endl;
+   std::cout << " ====== kStreamerLoop members with Counter==0 TJsonEx9 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex9_0);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== kStreamerLoop members with Counter==1 TJsonEx9 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== kStreamerLoop members with Counter==1 TJsonEx9 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex9_1);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ====== kStreamerLoop members with Counter==7 TJsonEx9 ===== " << endl;
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ====== kStreamerLoop members with Counter==7 TJsonEx9 ===== " << std::endl;
    json = TBufferJSON::ToJSON(&ex9_7);
    testJsonReading(json);
-   cout << json << endl << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
 }

--- a/roottest/root/io/json/runString.C
+++ b/roottest/root/io/json/runString.C
@@ -1,30 +1,18 @@
-{
-// Fill out the code of the actual test
-#ifndef SECOND_RUN
-   gROOT->ProcessLine(".L test_classes.h+");
-#endif
+#include "test_classes.h"
 
-#if defined(ClingWorkAroundMissingDynamicScope) && !defined(SECOND_RUN)
-#define SECOND_RUN
-   gROOT->ProcessLine(".x runString.C");
-#else
+void runString()
+{
+   gSystem->Load("libJsonTestClasses");
 
    TJsonEx4 ex4; ex4.Init();
 
-   cout << " ====== string data types TJsonEx4 ===== " << endl;
+   std::cout << " ====== string data types TJsonEx4 ===== " << std::endl;
    TString json = TBufferJSON::ToJSON(&ex4);
    testJsonReading(json);
-   cout << json << endl << endl;
-   cout << " ============ selected data members ======== " << endl;
-   cout << "ex4.fStr1 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr1") << endl;
-   cout << "ex4.fStr2 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr2") << endl;
-   cout << "ex4.fStr3 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr3") << endl;
-   cout << "ex4.fStr4 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr4") << endl;
-
-#endif
-#ifdef ClingWorkAroundBrokenUnnamedReturn
-   gApplication->Terminate(0);
-#else
-   return 0;
-#endif
+   std::cout << json << std::endl << std::endl;
+   std::cout << " ============ selected data members ======== " << std::endl;
+   std::cout << "ex4.fStr1 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr1") << std::endl;
+   std::cout << "ex4.fStr2 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr2") << std::endl;
+   std::cout << "ex4.fStr3 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr3") << std::endl;
+   std::cout << "ex4.fStr4 = " << TBufferJSON::ToJSON(&ex4, 0, "fStr4") << std::endl;
 }

--- a/roottest/root/io/json/test_classes.h
+++ b/roottest/root/io/json/test_classes.h
@@ -8,8 +8,8 @@
 #include <map>
 #include <set>
 #include <bitset>
-
-#include <string.h>
+#include <iostream>
+#include <cstring>
 
 #include "TNamed.h"
 #include "TBox.h"
@@ -19,7 +19,6 @@
 #include "TMap.h"
 #include "TClonesArray.h"
 #include "TArrayI.h"
-#include "Riostream.h"
 #include "TBufferJSON.h"
 #include "TClass.h"
 
@@ -61,13 +60,13 @@ class TJsonEx1 {
 
      virtual void Print()
      {
-         cout << "   fBool = " << fBool << endl;
-         cout << "   fChar = " << fChar << endl;
-         cout << "   fShort = " << fShort << endl;
-         cout << "   fInt = " << fInt << endl;
-         cout << "   fLong = " << fLong << endl;
-         cout << "   fFloat = " << fFloat << endl;
-         cout << "   fDouble = " << fDouble << endl;
+         std::cout << "   fBool = " << fBool << std::endl;
+         std::cout << "   fChar = " << fChar << std::endl;
+         std::cout << "   fShort = " << fShort << std::endl;
+         std::cout << "   fInt = " << fInt << std::endl;
+         std::cout << "   fLong = " << fLong << std::endl;
+         std::cout << "   fFloat = " << fFloat << std::endl;
+         std::cout << "   fDouble = " << fDouble << std::endl;
      }
 
 };
@@ -157,19 +156,19 @@ class TJsonEx2 {
      void Print()
      {
          for (int i=0;i<4;i++)
-           cout << "   fTest1[" << i << "] = " << fTest1[i] << endl;
+            std::cout << "   fTest1[" << i << "] = " << fTest1[i] << std::endl;
 
          for (int i=0;i<2;i++)
          for (int j=0;j<3;j++)
          for (int k=0;k<4;k++) {
-            cout << "  for indexes ["<<i<<"]["<<j<<"]["<<k<<"]" << endl;
-            cout << "     fBool = " << fBool[i][j][k] << endl;
-            cout << "     fChar = " << fChar[i][j][k] << endl;
-            cout << "     fShort = " << fShort[i][j][k] << endl;
-            cout << "     fInt = " << fInt[i][j][k] << endl;
-            cout << "     fLong = " << fLong[i][j][k] << endl;
-            cout << "     fFloat = " << fFloat[i][j][k] << endl;
-            cout << "     fDouble = " << fDouble[i][j][k] << endl;
+            std::cout << "  for indexes ["<<i<<"]["<<j<<"]["<<k<<"]" << std::endl;
+            std::cout << "     fBool = " << fBool[i][j][k] << std::endl;
+            std::cout << "     fChar = " << fChar[i][j][k] << std::endl;
+            std::cout << "     fShort = " << fShort[i][j][k] << std::endl;
+            std::cout << "     fInt = " << fInt[i][j][k] << std::endl;
+            std::cout << "     fLong = " << fLong[i][j][k] << std::endl;
+            std::cout << "     fFloat = " << fFloat[i][j][k] << std::endl;
+            std::cout << "     fDouble = " << fDouble[i][j][k] << std::endl;
          }
      }
 };
@@ -260,14 +259,14 @@ class TJsonEx3 {
      void Print()
      {
          for (int i=0;i<fSize;i++) {
-            cout << "  index = " << i << endl;
-            cout << "     fBool = " << fBool[i] << endl;
-            cout << "     fChar = " << fChar[i] << endl;
-            cout << "     fShort = " << fShort[i] << endl;
-            cout << "     fInt = " << fInt[i] << endl;
-            cout << "     fLong = " << fLong[i] << endl;
-            cout << "     fFloat = " << fFloat[i] << endl;
-            cout << "     fDouble = " << fDouble[i] << endl;
+            std::cout << "  index = " << i << std::endl;
+            std::cout << "     fBool = " << fBool[i] << std::endl;
+            std::cout << "     fChar = " << fChar[i] << std::endl;
+            std::cout << "     fShort = " << fShort[i] << std::endl;
+            std::cout << "     fInt = " << fInt[i] << std::endl;
+            std::cout << "     fLong = " << fLong[i] << std::endl;
+            std::cout << "     fFloat = " << fFloat[i] << std::endl;
+            std::cout << "     fDouble = " << fDouble[i] << std::endl;
          }
      }
 
@@ -309,10 +308,10 @@ class TJsonEx4 : public TJsonEx1 {
       void Print()
       {
           TJsonEx1::Print();
-          cout << "   fStr1 = " << fStr1 << endl;
-          cout << "   fStr2 = " << (fStr2 ? fStr2 : "null") << endl;
-          cout << "   fDummy2 = " << fDummy2 << endl;
-          cout << "   fStr3 = " << fStr3 << endl;
+          std::cout << "   fStr1 = " << fStr1 << std::endl;
+          std::cout << "   fStr2 = " << (fStr2 ? fStr2 : "null") << std::endl;
+          std::cout << "   fDummy2 = " << fDummy2 << std::endl;
+          std::cout << "   fStr3 = " << fStr3 << std::endl;
       }
 };
 
@@ -375,31 +374,31 @@ class TJsonEx5 {
 
      void Print()
      {
-        cout << endl << "!!!!!!!!!! fObj1 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fObj1 !!!!!!!!!!!" << std::endl;
         fObj1.Print();
 
-        cout << endl << "!!!!!!!!!! fObj2 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fObj2 !!!!!!!!!!!" << std::endl;
         fObj2.Print();
 
-        cout << endl << "!!!!!!!!!! fObj3 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fObj3 !!!!!!!!!!!" << std::endl;
         fObj3.Print();
 
-        cout << endl << "!!!!!!!!!! fPtr1 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fPtr1 !!!!!!!!!!!" << std::endl;
         if (fPtr1) fPtr1->Print();
 
-        cout << endl << "!!!!!!!!!! fPtr2 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fPtr2 !!!!!!!!!!!" << std::endl;
         if (fPtr2) fPtr2->Print();
 
-        cout << endl << "!!!!!!!!!! fPtr3 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fPtr3 !!!!!!!!!!!" << std::endl;
         if (fPtr3) fPtr3->Print();
 
-        cout << endl << "!!!!!!!!!! fSafePtr1 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fSafePtr1 !!!!!!!!!!!" << std::endl;
         if (fSafePtr1) fSafePtr1->Print();
 
-        cout << endl << "!!!!!!!!!! fSafePtr2 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fSafePtr2 !!!!!!!!!!!" << std::endl;
         if (fSafePtr2) fSafePtr2->Print();
 
-        cout << endl << "!!!!!!!!!! fSafePtr3 !!!!!!!!!!!" << endl;
+        std::cout << std::endl << "!!!!!!!!!! fSafePtr3 !!!!!!!!!!!" << std::endl;
         if (fSafePtr3) fSafePtr3->Print();
      }
 };
@@ -480,31 +479,31 @@ class TJsonEx6 {
      void Print()
      {
         for (int n=0;n<3;n++) {
-           cout << endl << "!!!!!!!!!! fObj1["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fObj1["<<n<<"] !!!!!!!!!!!" << std::endl;
            fObj1[n].Print();
 
-           cout << endl << "!!!!!!!!!! fObj2["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fObj2["<<n<<"] !!!!!!!!!!!" << std::endl;
            fObj2[n].Print();
 
-           cout << endl << "!!!!!!!!!! fObj3["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fObj3["<<n<<"] !!!!!!!!!!!" << std::endl;
            fObj3[n].Print();
 
-           cout << endl << "!!!!!!!!!! fPtr1["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fPtr1["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fPtr1[n]) fPtr1[n]->Print();
 
-           cout << endl << "!!!!!!!!!! fPtr2["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fPtr2["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fPtr2[n]) fPtr2[n]->Print();
 
-           cout << endl << "!!!!!!!!!! fPtr3["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fPtr3["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fPtr3[n]) fPtr3[n]->Print();
 
-           cout << endl << "!!!!!!!!!! fSafePtr1["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fSafePtr1["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fSafePtr1[n]) fSafePtr1[n]->Print();
 
-           cout << endl << "!!!!!!!!!! fSafePtr2["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fSafePtr2["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fSafePtr2[n]) fSafePtr2[n]->Print();
 
-           cout << endl << "!!!!!!!!!! fSafePtr3["<<n<<"] !!!!!!!!!!!" << endl;
+           std::cout << std::endl << "!!!!!!!!!! fSafePtr3["<<n<<"] !!!!!!!!!!!" << std::endl;
            if (fSafePtr3[n]) fSafePtr3[n]->Print();
         }
      }
@@ -604,12 +603,12 @@ class TJsonEx7 {
       fStrArr[1] = "Value of fStrArr[1]";
       fStrArr[2] = "Value of fStrArr[2]";
 
-      fStrPtr1 = new string("Value of < >  &lt; &gt; string fStrPtr1");
-      fStrPtr2 = nullptr; // new string("Value of string fStrPtr2");
+      fStrPtr1 = new std::string("Value of < >  &lt; &gt; string fStrPtr1");
+      fStrPtr2 = nullptr; // new std::string("Value of string fStrPtr2");
 
-      fStrPtrArr[0] = new string("value of fStrPtrArr[0]");
-      fStrPtrArr[1] = new string("value of fStrPtrArr[1]");
-      fStrPtrArr[2] = new string("value of fStrPtrArr[2]");
+      fStrPtrArr[0] = new std::string("value of fStrPtrArr[0]");
+      fStrPtrArr[1] = new std::string("value of fStrPtrArr[1]");
+      fStrPtrArr[2] = new std::string("value of fStrPtrArr[2]");
 
       for (int n=0;n<10;n++)
          fBoolArr[n] = (n%3 == 1);
@@ -668,7 +667,7 @@ class TJsonEx7 {
 
       for (int n=0;n<sz5;n++) {
         fVectString.push_back(Form("string %d content",n));
-        fVectStringPtr.push_back(new string(Form("string pointer %d content",n)));
+        fVectStringPtr.push_back(new std::string(Form("string pointer %d content",n)));
       }
 
 
@@ -701,8 +700,8 @@ class TJsonEx7 {
          fMapIntEx1[n] = TJsonEx1(); fMapIntEx1[n].Init(n+8);
          fMapIntEx1Ptr[n] = new TJsonEx1; fMapIntEx1Ptr[n]->Init(n+3);
 
-         fMultimapIntDouble.insert(pair<int,double>(n,n*6));
-         fMultimapIntDouble.insert(pair<int,double>(n,1000+n*6));
+         fMultimapIntDouble.insert(std::pair<int,double>(n,n*6));
+         fMultimapIntDouble.insert(std::pair<int,double>(n,1000+n*6));
          fSetDouble.insert(n+2);
          fMultisetDouble.insert((n+1)*17);
       }
@@ -718,17 +717,17 @@ class TJsonEx7 {
 
    void Print()
    {
-      cout << "Do not print everything, just something..." << endl;
+      std::cout << "Do not print everything, just something..." << std::endl;
 
-      cout << " fStr1 = " << fStr1 << endl;
+      std::cout << " fStr1 = " << fStr1 << std::endl;
 
-      cout << " fStrArr[1] = " << fStrArr[1] << endl;
+      std::cout << " fStrArr[1] = " << fStrArr[1] << std::endl;
 
-      //cout << " fVectEx1.back().Print()" << endl;
+      //std::cout << " fVectEx1.back().Print()" << std::endl;
       //fVectEx1.back().Print();
-      //cout << " fVectEx1Ptr.size() = " << fVectEx1Ptr.size() << endl;
-      //cout << " fVectStringPtr.size() = " << fVectStringPtr.size() << endl;
-      //cout << " fMapIntEx1Ptr.size() = " << fMapIntEx1Ptr.size() << endl;
+      //std::cout << " fVectEx1Ptr.size() = " << fVectEx1Ptr.size() << std::endl;
+      //std::cout << " fVectStringPtr.size() = " << fVectStringPtr.size() << std::endl;
+      //std::cout << " fMapIntEx1Ptr.size() = " << fMapIntEx1Ptr.size() << std::endl;
    }
 };
 
@@ -754,11 +753,11 @@ class TJsonEx8 : public std::vector<int> {
 
    void Print()
    {
-      cout << "vector size = " << size() << endl;
+      std::cout << "vector size = " << size() << std::endl;
       for (unsigned n=0;n<size(); n++)
-        cout << "vector.at(" << n << ") = " << at(n) << endl;
-      cout << " fInt = " << fInt << endl;
-      cout << " fStdString = " << fStdString << endl;
+        std::cout << "vector.at(" << n << ") = " << at(n) << std::endl;
+      std::cout << " fInt = " << fInt << std::endl;
+      std::cout << " fStdString = " << fStdString << std::endl;
    }
 };
 


### PR DESCRIPTION
1. Generate dictionary for custom tested classes
2. Load this library when running test macros
3. Avoid multiple cling workarounds
4. All ref files remains as is
