### PR TITLE
[cmake] Use consistent uppercase in `if(NOT WIN32)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if(NOT $ENV{ROOTSYS} STREQUAL "" AND NOT $ENV{ROOTSYS} STREQUAL "${CMAKE_BINARY_
     endif()
   endfunction()
   strip_path("PATH" "$ENV{ROOTSYS}/bin")
-  if(not WIN32)
+  if(NOT WIN32)
     strip_path("LD_LIBRARY_PATH" "$ENV{ROOTSYS}/lib")
   endif()
   if(APPLE)


### PR DESCRIPTION
Build on lxplus was failing after this commit:
dd2ec8be32539b31e6f1e65f4f3fa9e19c25984d

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

