### PR TITLE
[Windows] Fix warning C4477 + code formatting

### DIFF
--- a/roottest/root/io/bigevent/IoBigEventGeneration.cxx
+++ b/roottest/root/io/bigevent/IoBigEventGeneration.cxx
@@ -141,16 +141,18 @@ Event::Event()
    fDequePair.clear();
    
    fVectorshort.clear();
-   for (i = 0; i < 120; i++) fVectorshort.push_back(i);
+   for (i = 0; i < 120; i++)
+      fVectorshort.push_back(i);
 
    fVectorTobject = new vector<TObject>;
    TObject a1,a2,a3;
    fVectorTobject->push_back(a1);
    fVectorTobject->push_back(a2);
    fVectorTobject->push_back(a3);
-   
-   for (i = 0; i < 6; i++) fVectorTnamed[i] = new vector<TNamed>;
-      
+
+   for (i = 0; i < 6; i++)
+      fVectorTnamed[i] = new vector<TNamed>;
+
    TLine line;
    fVectorTLine.clear();
    for (i = 0; i < 40; i++) {
@@ -160,22 +162,22 @@ Event::Event()
       line.SetY2(gRandom->Rndm());
       line.SetLineColor(i); 
       fVectorTLine.push_back(line);
-   }  
-      
+   }
+
    TAttLine attline;
    fDeque.clear();
    for (i = 0; i < 4; i++) {
       attline.SetLineColor(i);
       fDeque.push_back(attline);
    }
-   
+
    fArrayF.Set(24);
    fArrayI = new TArrayI(24);
    for (i = 0; i < 24; i++) {
       fArrayI->fArray[i] = 24 - i;
       fArrayF.fArray[i] = 48 - 2 * i;
-   } 
-   
+   }
+
    fRefH = 0;
    fEventName = 0;
    fTracksInVertex = 0;
@@ -199,13 +201,14 @@ Event::Event(Int_t /*enumber*/)
          fMatrix[i0][i1] = 0.0;
       }
    }
-   for (i0 = 0; i0 < 10; i0++) fMeasures[i0] = 0;
+   for (i0 = 0; i0 < 10; i0++)
+      fMeasures[i0] = 0;
    fClosestDistance = 0;
    
    Int_t i;
    for (i = 0; i < 12; i++)
       fVectorint.push_back(i);
-   
+
    fString = "this is a C++ string";
    fTstringp = 0;
    fVaxis[0] = new TAxis();
@@ -217,7 +220,7 @@ Event::Event(Int_t /*enumber*/)
    fMapTAxisp = 0;
    fSetTAxisp = 0;
    fMultiSetTAxisp = 0;
-   
+
    fVectorshort.clear();
    for (i = 0; i < 120; i++)
       fVectorshort.push_back(i);
@@ -227,10 +230,10 @@ Event::Event(Int_t /*enumber*/)
    fVectorTobject->push_back(a1);
    fVectorTobject->push_back(a2);
    fVectorTobject->push_back(a3);
-   
+
    for (i = 0; i < 6; i++)
       fVectorTnamed[i] = new vector<TNamed>;
-      
+
    TAttLine attline;
    fDeque.clear();
    for (i = 0; i < 40; i++) {
@@ -253,9 +256,9 @@ Event::~Event()
    delete fVaxis[1];
    delete fVaxis[2];
    if (fEventName)
-      delete [] fEventName;
+      delete[] fEventName;
    if (fTracksInVertex)
-      delete [] fTracksInVertex;
+      delete[] fTracksInVertex;
 }
 
 //______________________________________________________________________________
@@ -268,8 +271,8 @@ void Event::AddTrack(Float_t random)
    // otherwise the previous Track[i] will be overwritten.
 
    TClonesArray &tracks = *fTracks;
-   //new(tracks[fNtrack++]) Track(random);
-   new(tracks[fNtrack]) BigTrack(random, fNtrack % 100);
+   // new (tracks[fNtrack++]) Track(random);
+   new (tracks[fNtrack]) BigTrack(random, fNtrack % 100);
    ++fNtrack;
 }
 
@@ -287,7 +290,7 @@ void Event::Reset(Option_t * /*option*/)
    // fgTracks->Delete(option);
    delete fgTracks;
    fgTracks = 0;
-   fgHist   = 0;
+   fgHist = 0;
 }
 
 //______________________________________________________________________________
@@ -303,7 +306,7 @@ void Event::SetHeader(Int_t i, Int_t run, Int_t date, Float_t random)
    if (i > 10000)
       nch += 3;
    if (fEventName)
-      delete [] fEventName;
+      delete[] fEventName;
    fEventName = new char[nch];
    snprintf(fEventName, nch, "Event%d_Run%d", i, 200);
    fNtrack = 0;
@@ -348,7 +351,7 @@ void Event::SetRandomVertex() {
    fMultiMapTNamedp.clear();
    fSetTAxis.clear();
    //delete fMapTAxisp;
-   fMapTAxisp = new map<TAxis*, int>;
+   fMapTAxisp = new map<TAxis *, int>;
    fSetTAxisp = new set<TAxis*>;
    fMultiSetTAxisp = new multiset<TAxis*>;
    for (Int_t k = 0; k < fNvertex; k++ ) {
@@ -362,10 +365,10 @@ void Event::SetRandomVertex() {
       fMultiMapTNamedp.insert(make_pair(new TNamed("ii", "jj"), k));
       fMultiSetTAxisp->insert(new TAxis());
    }
-   Double_t x=gRandom->Gaus(0, 1);
-   Double_t y=gRandom->Gaus(0, 1);
-   Double_t z=gRandom->Gaus(0, 100);
-   Double_t t=TMath::Sqrt(x * x + y * y + z * z);
+   Double_t x = gRandom->Gaus(0, 1);
+   Double_t y = gRandom->Gaus(0, 1);
+   Double_t z = gRandom->Gaus(0, 100);
+   Double_t t = TMath::Sqrt(x * x + y * y + z * z);
    fLorentz.SetXYZT(x, y, z, t);
 }
 
@@ -391,10 +394,10 @@ BigTrack::BigTrack(Float_t random, Int_t special) : Track(random)
 {
    // Create a big track object.
    fSpecial = special;
-   Double_t x=gRandom->Gaus(0, 1);
-   Double_t y=gRandom->Gaus(0, 1);
-   Double_t z=gRandom->Gaus(0, 100);
-   Double_t t=TMath::Sqrt(x * x + y * y + z * z);
+   Double_t x = gRandom->Gaus(0, 1);
+   Double_t y = gRandom->Gaus(0, 1);
+   Double_t z = gRandom->Gaus(0, 100);
+   Double_t t = TMath::Sqrt(x * x + y * y + z * z);
    fKine.SetXYZT(x, y, z, t);
 }
 
@@ -426,18 +429,18 @@ Track::Track(Float_t random) : TObject()
    fMeanCharge = 0.01 * gRandom->Rndm(1);
    gRandom->Rannor(a, b);
    fXfirst = a * 10;
-   fXlast  = b * 10;
+   fXlast = b * 10;
    gRandom->Rannor(a, b);
    fYfirst = a * 12;
-   fYlast  = b * 16;
+   fYlast = b * 16;
    gRandom->Rannor(a, b);
    fZfirst = 50 + 5 * a;
-   fZlast  = 200 + 10 * b;
+   fZlast = 200 + 10 * b;
    fCharge = Float_t(Int_t(3 * gRandom->Rndm(1)) - 1);
    fVertex[0] = gRandom->Gaus(0, 0.1);
    fVertex[1] = gRandom->Gaus(0, 0.2);
    fVertex[2] = gRandom->Gaus(0, 10);
-   for (Int_t i0(0), in(0); i0 <3; i0++) {
+   for (Int_t i0(0), in(0); i0 < 3; i0++) {
       for (Int_t i1 = 0; i1 < 4; i1++) {
          fCovar[i0][i1] = in;
          for (Int_t i2 = 0; i2 < 2; i2++) {
@@ -448,10 +451,11 @@ Track::Track(Float_t random) : TObject()
    }
 
    fNpoint = Int_t(60 + 10 * gRandom->Rndm(1));
-   fValid  = Int_t(0.6 + gRandom->Rndm(1));
+   fValid = Int_t(0.6 + gRandom->Rndm(1));
    if (fNpoint) {
       fPoints = new Short_t[fNpoint];
-      for (Int_t j = 0; j < fNpoint; j++) fPoints[j] = j;
+      for (Int_t j = 0; j < fNpoint; j++)
+         fPoints[j] = j;
    } else {
       fPoints = 0;
    }
@@ -466,7 +470,7 @@ Track::Track(Float_t random) : TObject()
       nch += 3;
    if (trackNumber > 10000)
       nch += 3;
-   //if (fTrackName) delete [] fTrackName;
+   // if (fTrackName) delete[] fTrackName;
    fTrackName = new char[nch];
    snprintf(fTrackName, nch, "Track%d", trackNumber);
    //Int_t i;
@@ -478,10 +482,10 @@ Track::Track(Float_t random) : TObject()
 //______________________________________________________________________________
 Track::~Track()
 {
-   delete [] fPoints;
+   delete[] fPoints;
    fPoints = 0;
    if (fTrackName)
-      delete [] fTrackName;
+      delete[] fTrackName;
    fTrackName = 0;
 }
 
@@ -495,26 +499,26 @@ HistogramManager::HistogramManager(TDirectory *dir)
    TDirectory *saved = gDirectory;
    dir->cd();
 
-   fNtrack      = new TH1F("hNtrack",    "Ntrack", 100, 575, 625);
-   fNseg        = new TH1F("hNseg",      "Nseg", 100, 5800, 6200);
-   fTemperature = new TH1F("hTemperature","Temperature", 100, 19.5, 20.5);
-   fPx          = new TH1F("hPx",        "Px", 100, -4, 4);
-   fPy          = new TH1F("hPy",        "Py", 100, -4, 4);
-   fPz          = new TH1F("hPz",        "Pz", 100, 0, 5);
-   fRandom      = new TH1F("hRandom",    "Random", 100, 0, 1000);
-   fMass2       = new TH1F("hMass2",     "Mass2", 100, 0, 12);
-   fBx          = new TH1F("hBx",        "Bx", 100, -0.5, 0.5);
-   fBy          = new TH1F("hBy",        "By", 100, -0.5, 0.5);
-   fMeanCharge  = new TH1F("hMeanCharge","MeanCharge", 100, 0, 0.01);
-   fXfirst      = new TH1F("hXfirst",    "Xfirst", 100, -40, 40);
-   fXlast       = new TH1F("hXlast",     "Xlast", 100, -40, 40);
-   fYfirst      = new TH1F("hYfirst",    "Yfirst", 100, -40, 40);
-   fYlast       = new TH1F("hYlast",     "Ylast", 100, -40, 40);
-   fZfirst      = new TH1F("hZfirst",    "Zfirst", 100, 0, 80);
-   fZlast       = new TH1F("hZlast",     "Zlast", 100, 0, 250);
-   fCharge      = new TH1F("hCharge",    "Charge", 100, -1.5, 1.5);
-   fNpoint      = new TH1F("hNpoint",    "Npoint", 100, 50, 80);
-   fValid       = new TH1F("hValid",     "Valid", 100, 0, 1.2);
+   fNtrack = new TH1F("hNtrack", "Ntrack", 100, 575, 625);
+   fNseg = new TH1F("hNseg", "Nseg", 100, 5800, 6200);
+   fTemperature = new TH1F("hTemperature", "Temperature", 100, 19.5, 20.5);
+   fPx = new TH1F("hPx", "Px", 100, -4, 4);
+   fPy = new TH1F("hPy", "Py", 100, -4, 4);
+   fPz = new TH1F("hPz", "Pz", 100, 0, 5);
+   fRandom = new TH1F("hRandom", "Random", 100, 0, 1000);
+   fMass2 = new TH1F("hMass2", "Mass2", 100, 0, 12);
+   fBx = new TH1F("hBx", "Bx", 100, -0.5, 0.5);
+   fBy = new TH1F("hBy", "By", 100, -0.5, 0.5);
+   fMeanCharge = new TH1F("hMeanCharge", "MeanCharge", 100, 0, 0.01);
+   fXfirst = new TH1F("hXfirst", "Xfirst", 100, -40, 40);
+   fXlast = new TH1F("hXlast", "Xlast", 100, -40, 40);
+   fYfirst = new TH1F("hYfirst", "Yfirst", 100, -40, 40);
+   fYlast = new TH1F("hYlast", "Ylast", 100, -40, 40);
+   fZfirst = new TH1F("hZfirst", "Zfirst", 100, 0, 80);
+   fZlast = new TH1F("hZlast", "Zlast", 100, 0, 250);
+   fCharge = new TH1F("hCharge", "Charge", 100, -1.5, 1.5);
+   fNpoint = new TH1F("hNpoint", "Npoint", 100, 50, 80);
+   fValid = new TH1F("hValid", "Valid", 100, 0, 1.2);
 
    // cd back to original directory
    saved->cd();

--- a/roottest/root/io/bigevent/IoBigEventGeneration.cxx
+++ b/roottest/root/io/bigevent/IoBigEventGeneration.cxx
@@ -130,9 +130,9 @@ Event::Event()
    
    fVectAxis.clear();
    static vector<TAxis*> vecta;
-   for (i=0;i<4;i++) {
+   for (i = 0; i < 4; i++) {
       vecta.clear();
-      for (j=0;j<i+2;j++) {
+      for (j = 0; j < i + 2; j++) {
          vecta.push_back(new TAxis());
       }
       fVectAxis.push_back(vecta);
@@ -141,7 +141,7 @@ Event::Event()
    fDequePair.clear();
    
    fVectorshort.clear();
-   for (i=0;i<120;i++) fVectorshort.push_back(i);
+   for (i = 0; i < 120; i++) fVectorshort.push_back(i);
 
    fVectorTobject = new vector<TObject>;
    TObject a1,a2,a3;
@@ -149,11 +149,11 @@ Event::Event()
    fVectorTobject->push_back(a2);
    fVectorTobject->push_back(a3);
    
-   for (i=0;i<6;i++) fVectorTnamed[i] = new vector<TNamed>;
+   for (i = 0; i < 6; i++) fVectorTnamed[i] = new vector<TNamed>;
       
    TLine line;
    fVectorTLine.clear();
-   for (i=0;i<40;i++) {
+   for (i = 0; i < 40; i++) {
       line.SetX1(gRandom->Rndm());
       line.SetX2(gRandom->Rndm());
       line.SetY1(gRandom->Rndm());
@@ -164,13 +164,16 @@ Event::Event()
       
    TAttLine attline;
    fDeque.clear();
-   for (i=0;i<4;i++) {attline.SetLineColor(i); fDeque.push_back(attline);}  
+   for (i = 0; i < 4; i++) {
+      attline.SetLineColor(i);
+      fDeque.push_back(attline);
+   }
    
    fArrayF.Set(24);
    fArrayI = new TArrayI(24);
-   for (i=0;i<24;i++) {
-      fArrayI->fArray[i] = 24-i; 
-      fArrayF.fArray[i] = 48-2*i;
+   for (i = 0; i < 24; i++) {
+      fArrayI->fArray[i] = 24 - i;
+      fArrayF.fArray[i] = 48 - 2 * i;
    } 
    
    fRefH = 0;
@@ -185,21 +188,23 @@ Event::Event(Int_t /*enumber*/)
    // When the constructor is invoked for the first time, the class static
    // variable fgTracks is 0 and the TClonesArray fgTracks is created.
 
-   if (!fgTracks) fgTracks = new TClonesArray("Track", 1000);
+   if (!fgTracks)
+      fgTracks = new TClonesArray("Track", 1000);
    fTracks = fgTracks;
    fNtrack = 0;
    fH      = 0;
-   Int_t i0,i1;
+   Int_t i0, i1;
    for (i0 = 0; i0 < 4; i0++) {
       for (i1 = 0; i1 < 4; i1++) {
          fMatrix[i0][i1] = 0.0;
       }
    }
-   for (i0 = 0; i0 <10; i0++) fMeasures[i0] = 0;
+   for (i0 = 0; i0 < 10; i0++) fMeasures[i0] = 0;
    fClosestDistance = 0;
    
    Int_t i;
-   for (i=0;i<12;i++) fVectorint.push_back(i);
+   for (i = 0; i < 12; i++)
+      fVectorint.push_back(i);
    
    fString = "this is a C++ string";
    fTstringp = 0;
@@ -214,19 +219,24 @@ Event::Event(Int_t /*enumber*/)
    fMultiSetTAxisp = 0;
    
    fVectorshort.clear();
-   for (i=0;i<120;i++) fVectorshort.push_back(i);
+   for (i = 0; i < 120; i++)
+      fVectorshort.push_back(i);
 
    fVectorTobject = new vector<TObject>;
-   TObject a1,a2,a3;
+   TObject a1, a2, a3;
    fVectorTobject->push_back(a1);
    fVectorTobject->push_back(a2);
    fVectorTobject->push_back(a3);
    
-   for (i=0;i<6;i++) fVectorTnamed[i] = new vector<TNamed>;
+   for (i = 0; i < 6; i++)
+      fVectorTnamed[i] = new vector<TNamed>;
       
    TAttLine attline;
    fDeque.clear();
-   for (i=0;i<40;i++) {attline.SetLineColor(i); fDeque.push_back(attline);}   
+   for (i = 0; i < 40; i++) {
+      attline.SetLineColor(i);
+      fDeque.push_back(attline);
+   }
    fEventName = 0;
 }
 
@@ -234,15 +244,18 @@ Event::Event(Int_t /*enumber*/)
 Event::~Event()
 {
    Clear();
-   if (fH == fgHist) fgHist = 0;
+   if (fH == fgHist)
+      fgHist = 0;
    delete fH;
    fH = 0;
    delete [] fClosestDistance;
    delete fVaxis[0];
    delete fVaxis[1];
    delete fVaxis[2];
-   if (fEventName) delete [] fEventName; 
-   if (fTracksInVertex) delete [] fTracksInVertex;  
+   if (fEventName)
+      delete [] fEventName;
+   if (fTracksInVertex)
+      delete [] fTracksInVertex;
 }
 
 //______________________________________________________________________________
@@ -256,7 +269,7 @@ void Event::AddTrack(Float_t random)
 
    TClonesArray &tracks = *fTracks;
    //new(tracks[fNtrack++]) Track(random);
-   new(tracks[fNtrack]) BigTrack(random,fNtrack%100);
+   new(tracks[fNtrack]) BigTrack(random, fNtrack % 100);
    ++fNtrack;
 }
 
@@ -270,32 +283,39 @@ void Event::Clear(Option_t *option)
 //______________________________________________________________________________
 void Event::Reset(Option_t * /*option*/)
 {
-// Static function to reset all static objects for this event
-//   fgTracks->Delete(option);
-   delete fgTracks; fgTracks = 0;
+   // Static function to reset all static objects for this event
+   // fgTracks->Delete(option);
+   delete fgTracks;
+   fgTracks = 0;
    fgHist   = 0;
 }
 
 //______________________________________________________________________________
 void Event::SetHeader(Int_t i, Int_t run, Int_t date, Float_t random)
 {
-   if (i%10 <3) fBoolA = kTRUE;
-   else         fBoolA = kFALSE;
+   if (i % 10 < 3)
+      fBoolA = kTRUE;
+   else
+      fBoolA = kFALSE;
    Int_t nch = 15;
-   if (i > 100)   nch += 3;
-   if (i > 10000) nch += 3;
-   if (fEventName) delete [] fEventName;
+   if (i > 100)
+      nch += 3;
+   if (i > 10000)
+      nch += 3;
+   if (fEventName)
+      delete [] fEventName;
    fEventName = new char[nch];
    snprintf(fEventName, nch, "Event%d_Run%d", i, 200);
    fNtrack = 0;
    fEvtHdr.Set(i, run, date);
-   if (!fgHist) fgHist = new TH1F("hstat","Event Histogram",100,0,1);
+   if (!fgHist)
+      fgHist = new TH1F("hstat", "Event Histogram", 100, 0, 1);
    fH = fgHist;
    fH->Fill(random);
    fRefH = fH;
    //fill Lachaud strings
    fLachaud.clear();
-   nch = Int_t(10*random);
+   nch = Int_t(10 * random);
    char lachaud[64];
    string lac;
    for (Int_t j=0;j<nch;j++) {
@@ -307,7 +327,8 @@ void Event::SetHeader(Int_t i, Int_t run, Int_t date, Float_t random)
 
 //______________________________________________________________________________
 void Event::SetMeasure(UChar_t which, Int_t what) {
-   if (which<10) fMeasures[which] = what;
+   if (which < 10)
+      fMeasures[which] = what;
 }
 
 //______________________________________________________________________________
@@ -327,34 +348,34 @@ void Event::SetRandomVertex() {
    fMultiMapTNamedp.clear();
    fSetTAxis.clear();
    //delete fMapTAxisp;
-   fMapTAxisp = new map<TAxis*,int>;
+   fMapTAxisp = new map<TAxis*, int>;
    fSetTAxisp = new set<TAxis*>;
    fMultiSetTAxisp = new multiset<TAxis*>;
    for (Int_t k = 0; k < fNvertex; k++ ) {
       fTracksInVertex[k] = k;
-      fClosestDistance[k] = gRandom->Gaus(1,1);
+      fClosestDistance[k] = gRandom->Gaus(1, 1);
       fTstringp[k] = "fTstringp";
       fQaxis[k] = new TAxis();
-      fMapTNamedp.insert(make_pair(new TNamed("ii","jj"),k));
-      fMapTAxisp->insert(make_pair(new TAxis(),k));
+      fMapTNamedp.insert(make_pair(new TNamed("ii", "jj"), k));
+      fMapTAxisp->insert(make_pair(new TAxis(), k));
       fSetTAxisp->insert(new TAxis());
-      fMultiMapTNamedp.insert(make_pair(new TNamed("ii","jj"),k));
+      fMultiMapTNamedp.insert(make_pair(new TNamed("ii", "jj"), k));
       fMultiSetTAxisp->insert(new TAxis());
    }
-  Double_t x=gRandom->Gaus(0,1);
-  Double_t y=gRandom->Gaus(0,1);
-  Double_t z=gRandom->Gaus(0,100);
-  Double_t t=TMath::Sqrt(x*x+y*y+z*z);
-  fLorentz.SetXYZT(x,y,z,t);
+   Double_t x=gRandom->Gaus(0, 1);
+   Double_t y=gRandom->Gaus(0, 1);
+   Double_t z=gRandom->Gaus(0, 100);
+   Double_t t=TMath::Sqrt(x * x + y * y + z * z);
+   fLorentz.SetXYZT(x, y, z, t);
 }
 
 //______________________________________________________________________________
 void Event::ShowLachaud() {
    
    vector<string>::iterator R__k;
-   printf("Lachaud vector has %ld entries\n",fLachaud.size());
+   printf("Lachaud vector has %zd entries\n", fLachaud.size());
    for (R__k = fLachaud.begin(); R__k != fLachaud.end(); ++R__k) {
-      printf(" %s\n",(*R__k).c_str());
+      printf(" %s\n", (*R__k).c_str());
    }
 }
 
@@ -370,11 +391,11 @@ BigTrack::BigTrack(Float_t random, Int_t special) : Track(random)
 {
    // Create a big track object.
    fSpecial = special;
-  Double_t x=gRandom->Gaus(0,1);
-  Double_t y=gRandom->Gaus(0,1);
-  Double_t z=gRandom->Gaus(0,100);
-  Double_t t=TMath::Sqrt(x*x+y*y+z*z);
-  fKine.SetXYZT(x,y,z,t);
+   Double_t x=gRandom->Gaus(0, 1);
+   Double_t y=gRandom->Gaus(0, 1);
+   Double_t z=gRandom->Gaus(0, 100);
+   Double_t t=TMath::Sqrt(x * x + y * y + z * z);
+   fKine.SetXYZT(x, y, z, t);
 }
 
 //______________________________________________________________________________
@@ -383,62 +404,69 @@ Track::Track(Float_t random) : TObject()
    // Create a track object.
    // Note that in this example, data members do not have any physical meaning.
 
-   Float_t a,b,px,py;
-   gRandom->Rannor(px,py);
+   Float_t a, b, px, py;
+   gRandom->Rannor(px, py);
    fPx = px;
    fPy = py;
-   fPz = TMath::Sqrt(px*px+py*py);
-   fRandom = 1000*random;
-   if (fRandom < 10) fMass2 = 0.08;
-   else if (fRandom < 100) fMass2 = 0.8;
-   else if (fRandom < 500) fMass2 = 4.5;
-   else if (fRandom < 900) fMass2 = 8.9;
-   else  fMass2 = 9.8;
-   gRandom->Rannor(a,b);
-   fBx = 0.1*a;
-   fBy = 0.1*b;
-   fMeanCharge = 0.01*gRandom->Rndm(1);
-   gRandom->Rannor(a,b);
-   fXfirst = a*10;
-   fXlast  = b*10;
-   gRandom->Rannor(a,b);
-   fYfirst = a*12;
-   fYlast  = b*16;
-   gRandom->Rannor(a,b);
-   fZfirst = 50 + 5*a;
-   fZlast  = 200 + 10*b;
-   fCharge = Float_t(Int_t(3*gRandom->Rndm(1)) - 1);
-   fVertex[0] = gRandom->Gaus(0,0.1);
-   fVertex[1] = gRandom->Gaus(0,0.2);
-   fVertex[2] = gRandom->Gaus(0,10);
-   for (Int_t i0(0),in(0);i0<3;i0++) {
-      for (Int_t i1 = 0;i1<4;i1++) {
+   fPz = TMath::Sqrt(px * px + py * py);
+   fRandom = 1000 * random;
+   if (fRandom < 10)
+      fMass2 = 0.08;
+   else if (fRandom < 100)
+      fMass2 = 0.8;
+   else if (fRandom < 500)
+      fMass2 = 4.5;
+   else if (fRandom < 900)
+      fMass2 = 8.9;
+   else
+      fMass2 = 9.8;
+   gRandom->Rannor(a, b);
+   fBx = 0.1 * a;
+   fBy = 0.1 * b;
+   fMeanCharge = 0.01 * gRandom->Rndm(1);
+   gRandom->Rannor(a, b);
+   fXfirst = a * 10;
+   fXlast  = b * 10;
+   gRandom->Rannor(a, b);
+   fYfirst = a * 12;
+   fYlast  = b * 16;
+   gRandom->Rannor(a, b);
+   fZfirst = 50 + 5 * a;
+   fZlast  = 200 + 10 * b;
+   fCharge = Float_t(Int_t(3 * gRandom->Rndm(1)) - 1);
+   fVertex[0] = gRandom->Gaus(0, 0.1);
+   fVertex[1] = gRandom->Gaus(0, 0.2);
+   fVertex[2] = gRandom->Gaus(0, 10);
+   for (Int_t i0(0), in(0); i0 <3; i0++) {
+      for (Int_t i1 = 0; i1 < 4; i1++) {
          fCovar[i0][i1] = in;
-         for (Int_t i2 = 0;i2<2;i2++) {
+         for (Int_t i2 = 0; i2 < 2; i2++) {
             fCovara[i0][i1][i2] = in;
             in++;
          }
       }
    }
-          
 
-   fNpoint = Int_t(60+10*gRandom->Rndm(1));
-   fValid  = Int_t(0.6+gRandom->Rndm(1));
+   fNpoint = Int_t(60 + 10 * gRandom->Rndm(1));
+   fValid  = Int_t(0.6 + gRandom->Rndm(1));
    if (fNpoint) {
       fPoints = new Short_t[fNpoint];
-      for (Int_t j=0;j<fNpoint;j++) fPoints[j] = j;
+      for (Int_t j = 0; j < fNpoint; j++) fPoints[j] = j;
    } else {
       fPoints = 0;
    }
-   Int_t nints = (Int_t)gRandom->Rndm()*4;
+   Int_t nints = (Int_t)gRandom->Rndm() * 4;
    fInts.Set(nints);
-   for (Int_t i=0;i<nints;i++) fInts.fArray[i] = i;
+   for (Int_t i = 0; i < nints; i++)
+      fInts.fArray[i] = i;
    static Int_t trackNumber = 0;
    trackNumber++;
    Int_t nch = 15;
-   if (trackNumber > 100)   nch += 3;
-   if (trackNumber > 10000) nch += 3;
-//    if (fTrackName) delete [] fTrackName;
+   if (trackNumber > 100)
+      nch += 3;
+   if (trackNumber > 10000)
+      nch += 3;
+   //if (fTrackName) delete [] fTrackName;
    fTrackName = new char[nch];
    snprintf(fTrackName, nch, "Track%d", trackNumber);
    //Int_t i;
@@ -452,7 +480,8 @@ Track::~Track()
 {
    delete [] fPoints;
    fPoints = 0;
-   if (fTrackName) delete [] fTrackName;
+   if (fTrackName)
+      delete [] fTrackName;
    fTrackName = 0;
 }
 
@@ -466,26 +495,26 @@ HistogramManager::HistogramManager(TDirectory *dir)
    TDirectory *saved = gDirectory;
    dir->cd();
 
-   fNtrack      = new TH1F("hNtrack",    "Ntrack",100,575,625);
-   fNseg        = new TH1F("hNseg",      "Nseg",100,5800,6200);
-   fTemperature = new TH1F("hTemperature","Temperature",100,19.5,20.5);
-   fPx          = new TH1F("hPx",        "Px",100,-4,4);
-   fPy          = new TH1F("hPy",        "Py",100,-4,4);
-   fPz          = new TH1F("hPz",        "Pz",100,0,5);
-   fRandom      = new TH1F("hRandom",    "Random",100,0,1000);
-   fMass2       = new TH1F("hMass2",     "Mass2",100,0,12);
-   fBx          = new TH1F("hBx",        "Bx",100,-0.5,0.5);
-   fBy          = new TH1F("hBy",        "By",100,-0.5,0.5);
-   fMeanCharge  = new TH1F("hMeanCharge","MeanCharge",100,0,0.01);
-   fXfirst      = new TH1F("hXfirst",    "Xfirst",100,-40,40);
-   fXlast       = new TH1F("hXlast",     "Xlast",100,-40,40);
-   fYfirst      = new TH1F("hYfirst",    "Yfirst",100,-40,40);
-   fYlast       = new TH1F("hYlast",     "Ylast",100,-40,40);
-   fZfirst      = new TH1F("hZfirst",    "Zfirst",100,0,80);
-   fZlast       = new TH1F("hZlast",     "Zlast",100,0,250);
-   fCharge      = new TH1F("hCharge",    "Charge",100,-1.5,1.5);
-   fNpoint      = new TH1F("hNpoint",    "Npoint",100,50,80);
-   fValid       = new TH1F("hValid",     "Valid",100,0,1.2);
+   fNtrack      = new TH1F("hNtrack",    "Ntrack", 100, 575, 625);
+   fNseg        = new TH1F("hNseg",      "Nseg", 100, 5800, 6200);
+   fTemperature = new TH1F("hTemperature","Temperature", 100, 19.5, 20.5);
+   fPx          = new TH1F("hPx",        "Px", 100, -4, 4);
+   fPy          = new TH1F("hPy",        "Py", 100, -4, 4);
+   fPz          = new TH1F("hPz",        "Pz", 100, 0, 5);
+   fRandom      = new TH1F("hRandom",    "Random", 100, 0, 1000);
+   fMass2       = new TH1F("hMass2",     "Mass2", 100, 0, 12);
+   fBx          = new TH1F("hBx",        "Bx", 100, -0.5, 0.5);
+   fBy          = new TH1F("hBy",        "By", 100, -0.5, 0.5);
+   fMeanCharge  = new TH1F("hMeanCharge","MeanCharge", 100, 0, 0.01);
+   fXfirst      = new TH1F("hXfirst",    "Xfirst", 100, -40, 40);
+   fXlast       = new TH1F("hXlast",     "Xlast", 100, -40, 40);
+   fYfirst      = new TH1F("hYfirst",    "Yfirst", 100, -40, 40);
+   fYlast       = new TH1F("hYlast",     "Ylast", 100, -40, 40);
+   fZfirst      = new TH1F("hZfirst",    "Zfirst", 100, 0, 80);
+   fZlast       = new TH1F("hZlast",     "Zlast", 100, 0, 250);
+   fCharge      = new TH1F("hCharge",    "Charge", 100, -1.5, 1.5);
+   fNpoint      = new TH1F("hNpoint",    "Npoint", 100, 50, 80);
+   fValid       = new TH1F("hValid",     "Valid", 100, 0, 1.2);
 
    // cd back to original directory
    saved->cd();


### PR DESCRIPTION
Fix the following compilation warning on Windows:
```
IoBigEventGeneration.cxx(355): warning C4477: 'printf' : format string '%ld' requires an argument of type 'long', but variadic argument 1 has type 'unsigned __int64'
IoBigEventGeneration.cxx(355): note: consider using '%zd' in the format string
```