### PR TITLE
[DF][Win] Fix compiler error C3493

### DIFF
--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -81,7 +81,7 @@ TEST(RDataFrameNodes, RSlotStackUnique)
       remove(slot.fSlot, threadId);
    };
 
-   auto runThreads = [&slotTask]() {
+   auto runThreads = [&slotTask, &N]() {
       std::vector<std::thread> ts;
       for (unsigned int i = 0; i < 2 * N; ++i) {
          ts.emplace_back(slotTask, i);


### PR DESCRIPTION
Fix the following compiler error on Windows:
```
dataframe_nodes.cxx(86,40): error C3493: 'N' cannot be implicitly captured because no default capture mode has been specified
```
