### PR TITLE
[6.36][skip-ci][ntuple] Fix-up `RField<T>` documentation

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
@@ -431,7 +431,7 @@ public:
 
    /// Sets this field to use a half precision representation, occupying half as much storage space (16 bits:
    /// 1 sign bit, 5 exponent bits, 10 mantissa bits) on disk.
-   /// This is mutually exclusive with `SetTruncated` and `SetQuantized` and supersedes them if called after them.
+   /// This is mutually exclusive with SetTruncated() and SetQuantized() and supersedes them if called after them.
    void SetHalfPrecision() { SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal16}}); }
 
    /// Set the on-disk representation of this field to a single-precision float truncated to `nBits`.
@@ -439,7 +439,7 @@ public:
    /// `nBits` must be $10 <= nBits <= 31$ (this means that at least 1 bit
    /// of mantissa is always preserved). Note that this effectively rounds the number towards 0.
    /// For a double-precision field, this implies first a cast to single-precision, then the truncation.
-   /// This is mutually exclusive with `SetHalfPrecision` and `SetQuantized` and supersedes them if called after them.
+   /// This is mutually exclusive with SetHalfPrecision() and SetQuantized() and supersedes them if called after them.
    void SetTruncated(std::size_t nBits)
    {
       const auto &[minBits, maxBits] =
@@ -455,12 +455,12 @@ public:
 
    /// Sets this field to use a quantized integer representation using `nBits` per value.
    /// It must be $1 <= nBits <= 32$.
-   /// `minValue` and `maxValue` must not be infinity, NaN or denormal floats, and they must be representable by the
-   /// type T.
+   /// `minValue` and `maxValue` must not be infinity, `NaN` or denormal floats, and they must be representable by the
+   /// type `T`.
    /// Calling this function establishes a promise by the caller to RNTuple that this field will only contain values
    /// contained in `[minValue, maxValue]` inclusive. If a value outside this range is assigned to this field, the
    /// behavior is undefined.
-   /// This is mutually exclusive with `SetTruncated` and `SetHalfPrecision` and supersedes them if called after them.
+   /// This is mutually exclusive with SetTruncated() and SetHalfPrecision() and supersedes them if called after them.
    void SetQuantized(double minValue, double maxValue, std::size_t nBits)
    {
       const auto &[minBits, maxBits] =
@@ -514,7 +514,7 @@ public:
 
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 
-   // Set the column representation to 32 bit floating point and the type alias to Double32_t
+   // Set the column representation to 32 bit floating point and the type alias to `Double32_t`
    void SetDouble32();
 };
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -205,43 +205,45 @@ struct HasCollectionProxyMemberType<
    : std::true_type {
 };
 
-/// The point here is that we can only tell at run time if a class has an associated collection proxy.
-/// For compile time, in the first iteration of this PR we had an extra template argument that acted as a "tag" to
-/// differentiate the RField specialization for classes with an associated collection proxy (inherits
-/// RProxiedCollectionField) from the RField primary template definition (RClassField-derived), as in:
-/// ```
-/// auto field = std::make_unique<RField<MyClass>>("klass");
-/// // vs
-/// auto otherField = std::make_unique<RField<MyClass, ROOT::Experimental::TagIsCollectionProxy>>("klass");
-/// ```
-///
-/// That is convenient only for non-nested types, i.e. it doesn't work with, e.g. `RField<std::vector<MyClass>,
-/// ROOT::Experimental::TagIsCollectionProxy>`, as the tag is not forwarded to the instantiation of the inner RField
-/// (that for the value type of the vector).  The following two possible solutions were considered:
-/// - A wrapper type (much like `ntuple/inc/ROOT/RNTupleUtil.hxx:49`), that helps to differentiate both cases.
-/// There we would have:
-/// ```
-/// auto field = std::make_unique<RField<RProxiedCollection<MyClass>>>("klass"); // Using collection proxy
-/// ```
-/// - A helper IsCollectionProxy<T> type, that can be used in a similar way to those in the `<type_traits>` header.
-/// We found this more convenient and is the implemented thing below.  Here, classes can be marked as a
-/// collection proxy with either of the following two forms (whichever is more convenient for the user):
-/// ```
-/// template <>
-/// struct IsCollectionProxy<MyClass> : std::true_type {};
-/// ```
-/// or by adding a member type to the class as follows:
-/// ```
-/// class MyClass {
-/// public:
-///    using IsCollectionProxy = std::true_type;
-/// };
-/// ```
-///
-/// Of course, there is another possible solution which is to have a single RClassField that implements both
-/// the regular-class and the collection-proxy behaviors, and always chooses appropriately at run time.
-/// We found that less clean and probably has more overhead, as most probably it involves an additional branch + call
-/// in each of the member functions.
+/* The point here is that we can only tell at run time if a class has an associated collection proxy.
+For compile time, in the first iteration of this PR we had an extra template argument that acted as a "tag" to
+differentiate the RField specialization for classes with an associated collection proxy (inherits
+RProxiedCollectionField) from the RField primary template definition (RClassField-derived), as in:
+```
+auto field = std::make_unique<RField<MyClass>>("klass");
+// vs
+auto otherField = std::make_unique<RField<MyClass, ROOT::Experimental::TagIsCollectionProxy>>("klass");
+```
+
+That is convenient only for non-nested types, i.e. it doesn't work with, e.g. `RField<std::vector<MyClass>,
+ROOT::Experimental::TagIsCollectionProxy>`, as the tag is not forwarded to the instantiation of the inner RField
+(that for the value type of the vector).  The following two possible solutions were considered:
+- A wrapper type that helps to differentiate both cases.
+There we would have:
+```
+auto field = std::make_unique<RField<RProxiedCollection<MyClass>>>("klass"); // Using collection proxy
+```
+- A helper IsCollectionProxy<T> type, that can be used in a similar way to those in the `<type_traits>` header.
+We found this more convenient and is the implemented thing below.  Here, classes can be marked as a
+collection proxy with either of the following two forms (whichever is more convenient for the user):
+```
+template <>
+struct IsCollectionProxy<MyClass> : std::true_type {};
+```
+or by adding a member type to the class as follows:
+```
+class MyClass {
+public:
+   using IsCollectionProxy = std::true_type;
+};
+```
+
+Of course, there is another possible solution which is to have a single RClassField that implements both
+the regular-class and the collection-proxy behaviors, and always chooses appropriately at run time.
+We found that less clean and probably has more overhead, as most probably it involves an additional branch + call
+in each of the member functions. */
+/// Helper type trait for marking classes as a collection proxy.
+/// This type trait must be set for collection proxy-based RNTuple fields created through MakeField<T>.
 template <typename T, typename = void>
 struct IsCollectionProxy : HasCollectionProxyMemberType<T> {
 };

--- a/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -39,19 +39,19 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
-/// The field for a class representing a collection of elements via `TVirtualCollectionProxy`.
+/// The field for a class representing a collection of elements via TVirtualCollectionProxy.
 /// Objects of such type behave as collections that can be accessed through the corresponding member functions in
-/// `TVirtualCollectionProxy`. For STL collections, these proxies are provided. Custom classes need to implement the
-/// corresponding member functions in `TVirtualCollectionProxy`. At a bare minimum, the user is required to provide an
-/// implementation for the following functions in `TVirtualCollectionProxy`: `HasPointers()`, `GetProperties()`,
-/// `GetValueClass()`, `GetType()`, `PushProxy()`, `PopProxy()`, `GetFunctionCreateIterators()`, `GetFunctionNext()`,
-/// and `GetFunctionDeleteTwoIterators()`.
+/// TVirtualCollectionProxy. For STL collections, these proxies are provided. Custom classes need to implement the
+/// corresponding member functions in TVirtualCollectionProxy. At a bare minimum, the user is required to provide an
+/// implementation for the following functions in TVirtualCollectionProxy: HasPointers(), GetProperties(),
+/// GetValueClass(), GetType(), PushProxy(), PopProxy(), GetFunctionCreateIterators(), GetFunctionNext(),
+/// and GetFunctionDeleteTwoIterators().
 ///
-/// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
+/// The collection proxy for a given class can be set via TClass::CopyCollectionProxy().
 class RProxiedCollectionField : public RFieldBase {
 protected:
    /// Allows for iterating over the elements of a proxied collection. RCollectionIterableOnce avoids an additional
-   /// iterator copy (see `TVirtualCollectionProxy::GetFunctionCopyIterator`) and thus can only be iterated once.
+   /// iterator copy (see TVirtualCollectionProxy::GetFunctionCopyIterator) and thus can only be iterated once.
    class RCollectionIterableOnce {
    public:
       struct RIteratorFuncs {
@@ -70,7 +70,7 @@ protected:
          void Advance()
          {
             auto fnNext_Contig = [&]() {
-               // Array-backed collections (e.g. kSTLvector) directly use the pointer-to-iterator-data as a
+               // Array-backed collections (e.g. `kSTLvector`) directly use the pointer-to-iterator-data as a
                // pointer-to-element, thus saving an indirection level (see documentation for TVirtualCollectionProxy)
                auto &iter = reinterpret_cast<unsigned char *&>(fIterator), p = iter;
                iter += fOwner.fStride;
@@ -105,7 +105,7 @@ protected:
       void *fEnd = &fEndSmallBuf;
 
    public:
-      /// Construct a `RCollectionIterableOnce` that iterates over `collection`.  If elements are guaranteed to be
+      /// Construct a RCollectionIterableOnce that iterates over `collection`.  If elements are guaranteed to be
       /// contiguous in memory (e.g. a vector), `stride` can be provided for faster iteration, i.e. the address of each
       /// element is known given the base pointer.
       RCollectionIterableOnce(void *collection, const RIteratorFuncs &ifuncs, TVirtualCollectionProxy *proxy,
@@ -152,7 +152,7 @@ protected:
    /// Constructor used when the value type of the collection is not known in advance, i.e. in the case of custom
    /// collections.
    RProxiedCollectionField(std::string_view fieldName, TClass *classp);
-   /// Constructor used when the value type of the collection is known in advance, e.g. in `RSetField`.
+   /// Constructor used when the value type of the collection is known in advance, e.g. in RSetField.
    RProxiedCollectionField(std::string_view fieldName, std::string_view typeName,
                            std::unique_ptr<RFieldBase> itemField);
 
@@ -208,7 +208,7 @@ struct HasCollectionProxyMemberType<
 /// The point here is that we can only tell at run time if a class has an associated collection proxy.
 /// For compile time, in the first iteration of this PR we had an extra template argument that acted as a "tag" to
 /// differentiate the RField specialization for classes with an associated collection proxy (inherits
-/// `RProxiedCollectionField`) from the RField primary template definition (`RClassField`-derived), as in:
+/// RProxiedCollectionField) from the RField primary template definition (RClassField-derived), as in:
 /// ```
 /// auto field = std::make_unique<RField<MyClass>>("klass");
 /// // vs
@@ -223,7 +223,7 @@ struct HasCollectionProxyMemberType<
 /// ```
 /// auto field = std::make_unique<RField<RProxiedCollection<MyClass>>>("klass"); // Using collection proxy
 /// ```
-/// - A helper `IsCollectionProxy<T>` type, that can be used in a similar way to those in the `<type_traits>` header.
+/// - A helper IsCollectionProxy<T> type, that can be used in a similar way to those in the `<type_traits>` header.
 /// We found this more convenient and is the implemented thing below.  Here, classes can be marked as a
 /// collection proxy with either of the following two forms (whichever is more convenient for the user):
 /// ```
@@ -238,7 +238,7 @@ struct HasCollectionProxyMemberType<
 /// };
 /// ```
 ///
-/// Of course, there is another possible solution which is to have a single `RClassField` that implements both
+/// Of course, there is another possible solution which is to have a single RClassField that implements both
 /// the regular-class and the collection-proxy behaviors, and always chooses appropriately at run time.
 /// We found that less clean and probably has more overhead, as most probably it involves an additional branch + call
 /// in each of the member functions.
@@ -246,7 +246,7 @@ template <typename T, typename = void>
 struct IsCollectionProxy : HasCollectionProxyMemberType<T> {
 };
 
-/// Classes behaving as a collection of elements that can be queried via the `TVirtualCollectionProxy` interface
+/// Classes behaving as a collection of elements that can be queried via the TVirtualCollectionProxy interface
 /// The use of a collection proxy for a particular class can be enabled via:
 /// ```
 /// namespace ROOT::Experimental {
@@ -277,7 +277,7 @@ public:
 /// Template specializations for C++ std::[unordered_][multi]map
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The generic field for a std::map<KeyType, ValueType> and std::unordered_map<KeyType, ValueType>
+/// The generic field for a `std::map<KeyType, ValueType>` and `std::unordered_map<KeyType, ValueType>`
 class RMapField : public RProxiedCollectionField {
 public:
    RMapField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
@@ -358,7 +358,7 @@ public:
 /// Template specializations for C++ std::[unordered_][multi]set
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The generic field for a std::set<Type> and std::unordered_set<Type>
+/// The generic field for a `std::set<Type>` and `std::unordered_set<Type>`
 class RSetField : public RProxiedCollectionField {
 public:
    RSetField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);

--- a/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
@@ -39,7 +39,7 @@ std::unique_ptr<RFieldBase> CreateEmulatedField(std::string_view fieldName,
                                                 std::string_view emulatedFromType);
 }
 
-/// The field for an untyped record. The subfields are stored consequitively in a memory block, i.e.
+/// The field for an untyped record. The subfields are stored consecutively in a memory block, i.e.
 /// the memory layout is identical to one that a C++ struct would have
 class RRecordField : public RFieldBase {
    friend std::unique_ptr<RFieldBase> Internal::CreateEmulatedField(std::string_view fieldName,

--- a/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -82,7 +82,7 @@ public:
 /// Template specializations for C++ std::bitset
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The generic field an std::bitset<N>. All compilers we care about store the bits in an array of unsigned long.
+/// The generic field an `std::bitset<N>`. All compilers we care about store the bits in an array of unsigned long.
 /// TODO(jblomer): reading and writing efficiency should be improved; currently it is one bit at a time
 /// with an array of bools on the page level.
 class RBitsetField : public RFieldBase {
@@ -116,7 +116,7 @@ public:
    size_t GetAlignment() const final { return alignof(Word_t); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 
-   /// Get the number of bits in the bitset, i.e. the N in std::bitset<N>
+   /// Get the number of bits in the bitset, i.e. the `N` in `std::bitset<N>`
    std::size_t GetN() const { return fN; }
 };
 
@@ -163,7 +163,7 @@ public:
 /// The field for values that may or may not be present in an entry. Parent class for unique pointer field and
 /// optional field. A nullable field cannot be instantiated itself but only its descendants.
 /// The RNullableField takes care of the on-disk representation. Child classes are responsible for the in-memory
-/// representation.  Nullable fields use a (Split)Index[64|32] column to point to the available items.
+/// representation.  Nullable fields use a `(Split)Index[64|32]` column to point to the available items.
 class RNullableField : public RFieldBase {
    /// The number of written non-null items in this cluster
    ROOT::Internal::RColumnIndex fNWritten{0};
@@ -178,7 +178,7 @@ protected:
    void CommitClusterImpl() final { fNWritten = 0; }
 
    /// Given the index of the nullable field, returns the corresponding global index of the subfield or,
-   /// if it is null, returns kInvalidNTupleIndex
+   /// if it is null, returns `kInvalidNTupleIndex`
    RNTupleLocalIndex GetItemIndex(ROOT::NTupleSize_t globalIndex);
 
    RNullableField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<RFieldBase> itemField);
@@ -205,8 +205,8 @@ class ROptionalField : public RNullableField {
 
    std::unique_ptr<RDeleter> fItemDeleter;
 
-   /// Given a pointer to an std::optional<T> in `optionalPtr`, extract a pointer to the engagement boolean.
-   /// Assumes that an std::optional<T> is stored as `struct { T t; bool engagement; };`
+   /// Given a pointer to an `std::optional<T>` in `optionalPtr`, extract a pointer to the engagement boolean.
+   /// Assumes that an `std::optional<T>` is stored as `struct { T t; bool engagement; };`
    const bool *GetEngagementPtr(const void *optionalPtr) const;
    bool *GetEngagementPtr(void *optionalPtr) const;
    std::size_t GetEngagementPtrOffset() const;
@@ -354,14 +354,14 @@ private:
 
    size_t fMaxItemSize = 0;
    size_t fMaxAlignment = 1;
-   /// In the std::variant memory layout, at which byte number is the index stored
+   /// In the `std::variant` memory layout, at which byte number is the index stored
    size_t fTagOffset = 0;
-   /// In the std::variant memory layout, the actual union of types may start at an offset > 0
+   /// In the `std::variant` memory layout, the actual union of types may start at an offset > 0
    size_t fVariantOffset = 0;
    std::vector<ROOT::Internal::RColumnIndex::ValueType> fNWritten;
 
    static std::string GetTypeList(const std::vector<std::unique_ptr<RFieldBase>> &itemFields);
-   /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column
+   /// Extracts the index from an `std::variant` and transforms it into the 1-based index used for the switch column
    /// The implementation supports two memory layouts that are in use: a trailing unsigned byte, zero-indexed,
    /// having the exception caused empty state encoded by the max tag value,
    /// or a trailing unsigned int instead of a char.

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -186,7 +186,7 @@ public:
 /// Template specializations for C++ std::vector
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The generic field for a (nested) std::vector<Type> except for std::vector<bool>
+/// The generic field for a (nested) `std::vector<Type>` except for `std::vector<bool>`
 /// The field can be constructed as untyped collection through CreateUntyped().
 class RVectorField : public RFieldBase {
 private:
@@ -260,7 +260,7 @@ public:
    ~RField() final = default;
 };
 
-// std::vector<bool> is a template specialization and needs special treatment
+// `std::vector<bool>` is a template specialization and needs special treatment
 template <>
 class RField<std::vector<bool>> final : public RFieldBase {
 private:
@@ -317,7 +317,7 @@ public:
 \brief A field for fixed-size arrays that are represented as RVecs in memory.
 \ingroup NTuple
 This class is used only for reading. In particular, it helps exposing
-arbitrarily-nested std::array on-disk fields as RVecs for usage in RDataFrame.
+arbitrarily-nested `std::array` on-disk fields as RVecs for usage in RDataFrame.
 */
 class RArrayAsRVecField final : public RFieldBase {
 private:
@@ -341,7 +341,7 @@ protected:
 
 public:
    /**
-      Constructor of the field. The itemField argument represents the inner
+      Constructor of the field. The `itemField` argument represents the inner
       item of the on-disk array, i.e. for an `std::array<float>` it is the `float`
       field and not the `std::array` itself.
    */

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -341,7 +341,7 @@ protected:
 
 public:
    /**
-      Constructor of the field. the \p itemField argument represents the inner
+      Constructor of the field. The itemField argument represents the inner
       item of the on-disk array, i.e. for an `std::array<float>` it is the `float`
       field and not the `std::array` itself.
    */


### PR DESCRIPTION
Backport of #18116.
