### PR TITLE
[skip-ci] Fixup `ntuple` path in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@ interpreter/cling/tools/packaging @vgvassilev
 /tutorials/ @couet
 /tree/dataframe/ @martamaja10 @vepadulano
 /tree/readspeed/ @martamaja10
-/tree/ntuple/v7/ @jblomer
+/tree/ntuple/ @jblomer
 /tree/ntupleutil/v7/ @jblomer
 /tutorials/sql/ @linev
 


### PR DESCRIPTION
All RNTuple code has been moved outside of the `v7` directory.


