### PR TITLE
[RF] bivariate ellipse confidence contour is not at 1-sigma confidence level

### DIFF
--- a/roofit/roofitcore/inc/RooEllipse.h
+++ b/roofit/roofitcore/inc/RooEllipse.h
@@ -22,7 +22,7 @@
 class RooEllipse : public TGraph, public RooPlotable {
 public:
   RooEllipse() = default;
-  RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho= 0, Int_t points= 100);
+  RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho = 0, Int_t points = 100, double k = 1);
 
 
   void printName(std::ostream& os) const override ;

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -34,30 +34,31 @@ Two-dimensional ellipse that can be used to represent an error contour.
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a 2-dimensional ellipse centered at (x1,x2) that represents the confidence
 /// level contour for a measurement with errors (s1,s2) and correlation coefficient rho.
-/// The resulting curve is defined as the unique ellipse that passes through these points:
+/// The resulting curve (for k=1) is defined as the unique ellipse that passes through these points:
 ///
 ///   (x1+rho*s1,x2+s2) , (x1-rho*s1,x2-s2) , (x1+s1,x2+rho*s2) , (x1-s1,x2-rho*s2)
 ///
 /// and is described by the implicit equation:
 ///
 ///   x*x      2*rho*x*y      y*y
-///  -----  -  ---------  +  -----  =  1 - rho*rho
+///  -----  -  ---------  +  -----  =  k * (1 - rho*rho)
 ///  s1*s1       s1*s2       s2*s2
 ///
-/// The input parameters s1,s2 must be > 0 and also |rho| <= 1.
+/// The input parameters s1,s2,k must be > 0 and also |rho| <= 1.
 /// The degenerate case |rho|=1 corresponds to a straight line and
 /// is handled as a special case.
+/// The default value of k = - 2 * nll ratio corresponds to the 39% CL contour. For 1 sigma (68%) set k ~ 2.3
 
-RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho, Int_t points)
+RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho, Int_t points, double k)
 {
   SetName(name);
   SetTitle(name);
 
-  if(s1 <= 0 || s2 <= 0) {
-    coutE(InputArguments) << "RooEllipse::RooEllipse: bad parameter s1 or s2 < 0" << std::endl;
+  if(s1 <= 0 || s2 <= 0 || k <= 0) {
+    coutE(InputArguments) << "RooEllipse::RooEllipse: bad parameter s1, s2 or k <= 0" << std::endl;
     return;
   }
-  double tmp= 1-rho*rho;
+  double tmp= k*(1-rho*rho);
   if(tmp < 0) {
     coutE(InputArguments) << "RooEllipse::RooEllipse: bad parameter |rho| > 1" << std::endl;
     return;

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -45,10 +45,10 @@ Two-dimensional ellipse that can be used to represent an error contour.
 /// As demonstrated in https://root-forum.cern.ch/t/drawing-convergence-ellipse-in-2d/61936/10, the
 /// "oriented" ellipse with semi-axis = (k * s_1, k * s_2) includes 39% (for k = 1) of
 /// all data, this confidence ellipse can thus be interpreted as a confidence contour level.
-/// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k = - 2 * nll ratio`, or explictly:
+/// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k^2 = - 2 * nll ratio`, or explictly:
 ///
 ///   x*x      2*rho*x*y      y*y
-///  -----  -  ---------  +  -----  =  k * (1 - rho*rho)
+///  -----  -  ---------  +  -----  =  k*k * (1 - rho*rho)
 ///  s1*s1       s1*s2       s2*s2
 ///
 /// The input parameters s1,s2,k must be > 0 and also |rho| <= 1.
@@ -66,7 +66,7 @@ RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double
     coutE(InputArguments) << "RooEllipse::RooEllipse: bad parameter s1, s2 or k <= 0" << std::endl;
     return;
   }
-  double tmp= k*(1-rho*rho);
+  double tmp = k*k*(1-rho*rho);
   if(tmp < 0) {
     coutE(InputArguments) << "RooEllipse::RooEllipse: bad parameter |rho| > 1" << std::endl;
     return;

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -43,7 +43,7 @@ Two-dimensional ellipse that can be used to represent an error contour.
 /// with:
 ///  \f[ z = ((x-x_1)^2/s_1^2 + (y-x_2)^2/s_2^2 - 2 \rho x y/(s_1s_2)) \f]
 /// As demonstrated in https://root-forum.cern.ch/t/drawing-convergence-ellipse-in-2d/61936/10, the
-/// "oriented" ellipse with semi-axis = (k * s_1, k * s_2) includes 39% (k = 1) and 86% (k = 2) of
+/// "oriented" ellipse with semi-axis = (k * s_1, k * s_2) includes 39% (for k = 1) of
 /// all data, this confidence ellipse can thus be interpreted as a confidence contour level.
 /// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k = - 2 * nll ratio`, or explictly:
 ///

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -55,7 +55,7 @@ Two-dimensional ellipse that can be used to represent an error contour.
 /// The degenerate case |rho|=1 corresponds to a straight line and
 /// is handled as a special case.
 /// \warning The default value of k = 1 (semiaxes at +/-sigma) corresponds to the 39% CL contour. For a 1-sigma confidence
-/// level (68%), set instead k ~ 2.3 (semiaxes at +/-2.3sigma).
+/// level (68%), set instead k ~ 1.51 (semiaxes at +/-1.51sigma).
 
 RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho, Int_t points, double k)
 {

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -45,7 +45,7 @@ Two-dimensional ellipse that can be used to represent an error contour.
 /// As demonstrated in https://root-forum.cern.ch/t/drawing-convergence-ellipse-in-2d/61936/10, the
 /// "oriented" ellipse with semi-axis = (k * s_1, k * s_2) includes 39% (k = 1) and 86% (k = 2) of
 /// all data, this confidence ellipse can thus be interpreted as a confidence contour level.
-/// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k  = - 2 * nll ratio`, or explictly:
+/// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k = - 2 * nll ratio`, or explictly:
 ///
 ///   x*x      2*rho*x*y      y*y
 ///  -----  -  ---------  +  -----  =  k * (1 - rho*rho)

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -32,13 +32,20 @@ Two-dimensional ellipse that can be used to represent an error contour.
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Create a 2-dimensional ellipse centered at (x1,x2) that represents the confidence
-/// level contour for a measurement with errors (s1,s2) and correlation coefficient rho.
-/// The resulting curve (for k=1) is defined as the unique ellipse that passes through these points:
-///
-///   (x1+rho*s1,x2+s2) , (x1-rho*s1,x2-s2) , (x1+s1,x2+rho*s2) , (x1-s1,x2-rho*s2)
-///
-/// and is described by the implicit equation:
+/// Create a 2-dimensional ellipse centered at `(x1,x2)` that represents the confidence
+/// level contour for a measurement with standard deviations`(s1,s2)` and correlation coefficient rho,
+/// and semiaxes corresponding to `k` standard deviations.
+/// It is assumed that the data are distributed according to a bivariate normal distribution:
+///  \f[ p(x,y) = {1 \over 2 \pi s_1 s_2 \sqrt{1-\rho^2}} \exp (-((x-x_1)^2/s_1^2 + (y-x_2)^2/s_2^2 - 2 \rho x y/(s_1s_2))/2(1-\rho^2)) \f]
+/// \see ROOT::Math::bigaussian_pdf
+/// Or in a split form:
+/// \f[ p(z(x,y)) = {1 \over 2 \pi s_1 s_2 \sqrt{1-\rho^2}} \exp (-z/2(1-\rho^2)) \f]
+/// with:
+///  \f[ z = ((x-x_1)^2/s_1^2 + (y-x_2)^2/s_2^2 - 2 \rho x y/(s_1s_2)) \f]
+/// As demonstrated in https://root-forum.cern.ch/t/drawing-convergence-ellipse-in-2d/61936/10, the
+/// "oriented" ellipse with semi-axis = (k * s_1, k * s_2) includes 39% (k = 1) and 86% (k = 2) of
+/// all data, this confidence ellipse can thus be interpreted as a confidence contour level.
+/// This ellipse can be described by the implicit equation `z/(1-rho*rho) = k  = - 2 * nll ratio`, or explictly:
 ///
 ///   x*x      2*rho*x*y      y*y
 ///  -----  -  ---------  +  -----  =  k * (1 - rho*rho)
@@ -47,7 +54,8 @@ Two-dimensional ellipse that can be used to represent an error contour.
 /// The input parameters s1,s2,k must be > 0 and also |rho| <= 1.
 /// The degenerate case |rho|=1 corresponds to a straight line and
 /// is handled as a special case.
-/// The default value of k = - 2 * nll ratio corresponds to the 39% CL contour. For 1 sigma (68%) set k ~ 2.3
+/// \warning The default value of k = 1 (semiaxes at +/-sigma) corresponds to the 39% CL contour. For a 1-sigma confidence
+/// level (68%), set instead k ~ 2.3 (semiaxes at +/-2.3sigma).
 
 RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double s2, double rho, Int_t points, double k)
 {

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -216,7 +216,7 @@ const char* RooFitResult::statusLabelHistory(UInt_t icycle) const
 /// of the following (not case sensitive):
 ///
 /// *  M - a marker at the best fit result
-/// *  E - an error ellipse calculated at 1-sigma using the error matrix at the minimum
+/// *  E - an error ellipse calculated at 39%CL using the error matrix at the minimum
 /// *  1 - the 1-sigma error bar for parameter 1
 /// *  2 - the 1-sigma error bar for parameter 2
 /// *  B - the bounding box for the error ellipse
@@ -259,9 +259,9 @@ RooPlot *RooFitResult::plotOn(RooPlot *frame, const char *parName1, const char *
   double s2= par2->getError();
   double rho= correlation(parName1, parName2);
 
-  // add a 1-sigma error ellipse, if requested
+  // add a 39%CL error ellipse, if requested
   if(opt.Contains("E")) {
-    RooEllipse *contour= new RooEllipse("contour",x1,x2,s1,s2,rho);
+    RooEllipse *contour= new RooEllipse("contour",x1,x2,s1,s2,rho,100,1);
     contour->SetLineWidth(2) ;
     frame->addPlotable(contour);
   }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-8730 by @wiso

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

