### PR TITLE
[jsroot] version 7.9.0 for [6.36]

### DIFF
--- a/js/LICENSE
+++ b/js/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright � 2013-2024 JavaScript ROOT authors
+Copyright � 2013-2025 JavaScript ROOT authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,36 +1,50 @@
 # JSROOT changelog
 
-## Changes in dev
-1. Implement 'cont5' draw option for `TGraph2D` using Delaunay algorithm
-1. Implement 'pol' and 'arr_colz' draw option for `TH2`
-1. Only 'col7' draw option uses bar offset and width for color `TH2` drawing
-1. Interactive zooming and context menu on 'chord' `TH2` drawing
-1. Implement 'box1' for `TH3` with negative bins
-1. Introduce `settings.FilesTimeout` to configure global timeout for file reading operations
-1. Introduce `settings.FilesRemap` to let provide fallback address for http server, used for `root.cern`
-1. Adjust histogram title drawing with native implementation
-1. Improve float to string conversion when 'g' is specified
-1. Support 'same' option for first histogram, draw directly on pad
-1. Display underflow/overflow bins when configured for the axis, implement 'allbins' draw option for histograms
-1. Support different angle coordinates in `TGraphPolargram`, handle 'N' and 'O' draw options
-1. Support fAxisAngle in `TGraphPolargram`, provide 'rangleNN' draw option
-1. Implement 'arc' draw option for `TPave`
-1. Provide context menus for all derived from `TPave` classes
-1. Let edit histograms and graphs title via context menu
-1. Support Poisson errors for `TH1`/`TH2`, https://root-forum.cern.ch/t/62335/
-1. Test fSumw2 when detect empty TH2 bin, sync with https://github.com/root-project/root/pull/17948
-1. Support `TLink` and `TButton` object, used in `TInspectCanvas`
-1. Support `TF12` - projection of `TF2`
-1. Upgrade three.js r168 -> r174
-1. Remove support of qt5 webengine, only qt6web is supported
-1. Set 'user-select: none' style in drawings to exclude text selection, using `settings.UserSelect` value
-1. Internals - use private members and methods
-1. Internals - use `WeakRef` class for cross-referencing of painters
-1. Internals - use negative indexes in arrays and Strings
-1. Fix - handle `TPave` NDC position also when fInit is not set
-1. Fix - properly handle image sizes in svg2pdf
-1. Fix - drawing `TPaveText` with zero text size
-1. Fix - correct axis range in `TScatter` drawing
+## Changes in 7.9.0
+1. New draw options:
+   - 'pol' and 'arr_colz' draw option for `TH2`
+   - 'col7' uses bar offset and width for `TH2`
+   - 'cont5' for `TGraph2D` using Delaunay algorithm
+   - 'chord' drawing of `TH2` implements zooming
+   - 'box1' for `TH3` with negative bins
+   - 'same' option for first histogram on pad, draw without creating `TFrame`
+   - 'rangleNN' for `TGraphPolargram`, also support fAxisAngle member
+   - 'N' and 'O' for `TGraphPolargram` for angle coordinate systems
+   - 'arc' for `TPave` and derived classes
+   - 'allbins' for histograms to display underflow/overflow bins
+   - Poisson errors for `TH1`/`TH2`, https://root-forum.cern.ch/t/62335/
+   - test fSumw2 when detect empty `TH2` bin, sync with https://github.com/root-project/root/pull/17948
+2. New supported classes:
+   - `TF12` - projection of `TF2`
+   - `TLink` and `TButton`, used in `TInspectCanvas`
+3. New partameters in `TTree::Draw`:
+   - '>>elist' to request entries matching cut conditions
+   - 'elist' to specify entries for processing
+   - 'nmatch' to process exactly the specified number of entries, break processing afterwards
+   - 'staged' algorithm to first select entries and then process only these entries
+4. New settings parameters:
+   - `settings.FilesTimeout` global timeout for file reading operations
+   - `settings.FilesRemap` fallback address for http server, used for `root.cern`
+   - `settings.TreeReadBunchSize` bunch read size for `TTree` processing
+   - `settings.UserSelect` to set 'user-select: none' style in drawings to exclude text selection
+5. Context menus:
+   - all `TPave`-derived classes
+   - in 'chord' drawings of `TH2`
+   - editing histogram and graph title
+6. Fixes:
+   - match histogram title drawing with native ROOT implementation
+   - float to string conversion when 'g' is specified
+   - handle `TPave` NDC position also when fInit is not set
+   - properly handle image sizes in svg2pdf
+   - drawing `TPaveText` with zero text size
+   - correct axis range in `TScatter` drawing
+   - use draw option also for graph drawing in `TTree::Draw`
+7. Internals:
+   - upgrade three.js r168 -> r174
+   - use private members and methods
+   - use `WeakRef` class for cross-referencing of painters
+   - use negative indexes in arrays and Strings
+   - remove support of qt5 webengine, only qt6web can be used
 
 
 ## Changes in 7.8.2

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -1,10 +1,10 @@
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = 'dev',
+const version_id = '7.9.0',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '4/04/2025',
+version_date = '25/04/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -330,6 +330,10 @@ settings = {
      * @desc Some http server has limitations for number of bytes ranges therefore let change maximal number via setting
      * @default 200 */
    MaxRanges: 200,
+   /** @summary Number of bytes requested once by TTree::Draw processing
+     * @desc TTree can be very large and data from baskets read by portion specified by this variable
+     * @default 1e6 */
+   TreeReadBunchSize: 1e6,
    /** @summary File read timeout in ms
      * @desc Configures timeout for each http operation for reading ROOT files
      * @default 0 */

--- a/js/modules/draw/TTree.mjs
+++ b/js/modules/draw/TTree.mjs
@@ -83,8 +83,9 @@ async function treeDrawProgress(obj, final) {
    if (!final && !this.last_pr)
       return;
 
-   if (this.dump || this.testio) {
-      if (!final) return;
+   if (this.dump || this.dump_entries || this.testio) {
+      if (!final)
+         return;
       if (isBatchMode()) {
          const painter = new BasePainter(this.drawid);
          painter.selectDom().property('_json_object_', obj);
@@ -103,7 +104,8 @@ async function treeDrawProgress(obj, final) {
    // critical is last drawing which should wait for previous one
    // therefore last_pr is kept as indication that promise is not yet processed
 
-   if (!this.last_pr) this.last_pr = Promise.resolve(true);
+   if (!this.last_pr)
+      this.last_pr = Promise.resolve(true);
 
    return this.last_pr.then(() => {
       if (this.obj_painter)
@@ -112,7 +114,7 @@ async function treeDrawProgress(obj, final) {
          if (final) console.log('no result after tree drawing');
          this.last_pr = false; // return false indicating no drawing is done
       } else {
-         this.last_pr = drawTreeDrawResult(this.drawid, obj).then(p => {
+         this.last_pr = drawTreeDrawResult(this.drawid, obj, this.drawopt).then(p => {
             this.obj_painter = p;
             if (!final) this.last_pr = null;
             return p; // return painter for histogram
@@ -143,7 +145,7 @@ function createTreePlayer(player) {
 
    player.showExtraButtons = function(args) {
       const main = this.selectDom(),
-         numentries = this.local_tree?.fEntries || 0;
+            numentries = this.local_tree?.fEntries || 0;
 
       main.select('.treedraw_more').remove(); // remove more button first
 

--- a/js/modules/gui/utils.mjs
+++ b/js/modules/gui/utils.mjs
@@ -97,7 +97,7 @@ function tryOpenOpenUI(sources, args) {
    element.setAttribute('src', src + (args.ui5dbg ? 'resources/sap-ui-core-dbg.js' : 'resources/sap-ui-core.js')); // latest openui5 version
 
    element.setAttribute('data-sap-ui-libs', args.openui5libs ?? 'sap.m, sap.ui.layout, sap.ui.unified, sap.ui.commons');
-
+   // element.setAttribute('data-sap-ui-language', args.openui5language ?? 'en');
    element.setAttribute('data-sap-ui-theme', args.openui5theme || 'sap_belize');
    element.setAttribute('data-sap-ui-compatVersion', 'edge');
    element.setAttribute('data-sap-ui-async', 'true');
@@ -115,7 +115,7 @@ function tryOpenOpenUI(sources, args) {
    };
 
    element.onload = function() {
-      console.log(`Load openui5 from ${src}`);
+      args.load_src = src;
    };
 
    document.head.appendChild(element);
@@ -167,6 +167,8 @@ async function loadOpenui5(args) {
       args.rejectFunc = reject;
 
       globalThis.completeUI5Loading = function() {
+         console.log(`Load openui5 version ${globalThis.sap.ui.version} from ${args.load_src}`);
+
          globalThis.sap.ui.loader.config({
             paths: {
                jsroot: source_dir,
@@ -178,6 +180,8 @@ async function loadOpenui5(args) {
             args.resolveFunc(globalThis.sap);
             args.resolveFunc = null;
          }
+
+         delete globalThis.completeUI5Loading;
       };
 
       tryOpenOpenUI(openui5_sources, args);

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -1104,8 +1104,12 @@ class THistPainter extends ObjectPainter {
          if (histo.TestBit(kNoStats) !== obj.TestBit(kNoStats)) {
             histo.SetBit(kNoStats, obj.TestBit(kNoStats));
             // here check only stats bit
-            if (statpainter)
+            if (statpainter) {
                statpainter.Enabled = !histo.TestBit(kNoStats) && !this.options.NoStat; // && (!this.options.Same || this.options.ForceStat)
+               // remove immediately when redraw not called for disabled stats
+               if (!statpainter.Enabled)
+                  statpainter.removeG();
+            }
          }
 
          histo.SetBit(kIsZoomed, obj.TestBit(kIsZoomed));

--- a/js/modules/webwindow.mjs
+++ b/js/modules/webwindow.mjs
@@ -435,16 +435,14 @@ class WebWindowHandle {
       if (!Number.isInteger(chid))
          chid = 1; // when not configured, channel 1 is used - main widget
 
-      if (this.cansend <= 0)
-         console.error(`should be queued before sending cansend: ${this.cansend}`);
+      if (this.cansend === 0)
+         console.error('No credits for send, increase "WebGui.ConnCredits" value on server');
 
-      const prefix = `${this.send_seq++}:${this.ackn}:${this.cansend}:${chid}:`;
+      const prefix = `${this.send_seq++}:${this.ackn}:${this.cansend}:${chid}:`,
+            hash = this.key && sessionKey ? HMAC(this.key, `${prefix}${msg}`) : 'none';
+
       this.ackn = 0;
       this.cansend--; // decrease number of allowed send packets
-
-      let hash = 'none';
-      if (this.key && sessionKey)
-         hash = HMAC(this.key, `${prefix}${msg}`);
 
       this._websocket.send(`${hash}:${prefix}${msg}`);
 


### PR DESCRIPTION
1. New draw options:
   - 'pol' and 'arr_colz' draw option for `TH2`
   - 'col7' uses bar offset and width for `TH2`
   - 'cont5' for `TGraph2D` using Delaunay algorithm
   - 'chord' drawing of `TH2` implements zooming
   - 'box1' for `TH3` with negative bins
   - 'same' option for first histogram on pad, draw without creating `TFrame`
   - 'rangleNN' for `TGraphPolargram`, also support fAxisAngle member
   - 'N' and 'O' for `TGraphPolargram` for angle coordinate systems
   - 'arc' for `TPave` and derived classes
   - 'allbins' for histograms to display underflow/overflow bins
   - Poisson errors for `TH1`/`TH2`, https://root-forum.cern.ch/t/62335/
   - test fSumw2 when detect empty `TH2` bin, sync with https://github.com/root-project/root/pull/17948
2. New supported classes:
   - `TF12` - projection of `TF2`
   - `TLink` and `TButton`, used in `TInspectCanvas`
3. New partameters in `TTree::Draw`:
   - '>>elist' to request entries matching cut conditions
   - 'elist' to specify entries for processing
   - 'nmatch' to process exactly the specified number of entries, break processing afterwards
   - 'staged' algorithm to first select entries and then process only these entries
4. New settings parameters:
   - `settings.FilesTimeout` global timeout for file reading operations
   - `settings.FilesRemap` fallback address for http server, used for `root.cern`
   - `settings.TreeReadBunchSize` bunch read size for `TTree` processing
   - `settings.UserSelect` to set 'user-select: none' style in drawings to exclude text selection
5. Context menus:
   - all `TPave`-derived classes
   - in 'chord' drawings of `TH2`
   - editing histogram and graph title
6. Fixes:
   - match histogram title drawing with native ROOT implementation
   - float to string conversion when 'g' is specified
   - handle `TPave` NDC position also when fInit is not set
   - properly handle image sizes in svg2pdf
   - drawing `TPaveText` with zero text size
   - correct axis range in `TScatter` drawing
   - use draw option also for graph drawing in `TTree::Draw`
7. Internals:
   - upgrade three.js r168 -> r174
   - use private members and methods
   - use `WeakRef` class for cross-referencing of painters
   - use negative indexes in arrays and Strings
   - remove support of qt5 webengine, only qt6web can be used

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

