### PR TITLE
[runtime_cxxmodules] Fix  '_FilesystemClock' build warning with macos 15.4 and mac-beta

### DIFF
--- a/core/base/inc/Riostream.h
+++ b/core/base/inc/Riostream.h
@@ -21,6 +21,12 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#ifdef __APPLE__
+// Workaround for https://github.com/llvm/llvm-project/issues/138683
+// Include <chrono> before <fstream> to ensure _FilesystemClock is defined
+// Can be removed once the upstream issue is fixed.
+#include <chrono>
+#endif
 #include <fstream>
 #include <iostream>
 #include <iomanip>


### PR DESCRIPTION
# This Pull request:
Including `chrono` first forces the private clock module to be imported before `fstream` transitively includes `filesystem`

Fixes the warning:
```
[79/2727] Generating G__Core.cxx, ../lib/Core.pcm
In module 'std' imported from input_line_1:1:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/__chrono/time_point.h:33:52: error: definition of '_FilesystemClock' must be imported from module 'std.std_private_chrono_file_clock' before it is required
template <class _Clock, class _Duration = typename _Clock::duration>
                                                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/__chrono/time_point.h:33:1: note: in instantiation of default argument for 'time_point<std::filesystem::_FilesystemClock>' required here
template <class _Clock, class _Duration = typename _Clock::duration>
^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/__chrono/file_clock.h:49:8: note: definition here is not reachable
struct _FilesystemClock {
```

Upstream issue: https://github.com/llvm/llvm-project/issues/138683

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

