### PR TITLE
roottest: Do not use copy in test execROOT-7775

### DIFF
--- a/roottest/cling/staticinit/CMakeLists.txt
+++ b/roottest/cling/staticinit/CMakeLists.txt
@@ -1,5 +1,4 @@
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/ROOT-7775
-                                                           ${CMAKE_CURRENT_BINARY_DIR}/ROOT-7775)
+set(RootExternalIncludes -e "gInterpreter->AddIncludePath(\"-I${CMAKE_CURRENT_SOURCE_DIR}\");")
 
 ROOTTEST_ADD_TEST(ROOT-7775
                   MACRO  execROOT-7775.C

--- a/roottest/cling/staticinit/execROOT-7775.C
+++ b/roottest/cling/staticinit/execROOT-7775.C
@@ -1,5 +1,4 @@
 {
-gROOT->ProcessLine(".include .");
 gROOT->ProcessLine("#include \"ROOT-7775/part1.h\"");
 gROOT->ProcessLine("#include \"ROOT-7775/CaloCell_ID.h\"");
 gROOT->ProcessLine("#include \"ROOT-7775/part3.h\"");


### PR DESCRIPTION
The copy is unnecessary, we just have to use the existing `RootExternalIncludes` CMake variable to accomplish the same goal.

