### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdmaster.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdmaster.c
@@ -302,7 +302,8 @@ master_selection (j_decompress_ptr cinfo)
     if (cinfo->raw_data_out)
       ERREXIT(cinfo, JERR_NOTIMPL);
     /* 2-pass quantizer only works in 3-component color space. */
-    if (cinfo->out_color_components != 3) {
+    if (cinfo->out_color_components != 3 ||
+        cinfo->out_color_space == JCS_RGB565) {
       cinfo->enable_1pass_quant = TRUE;
       cinfo->enable_external_quant = FALSE;
       cinfo->enable_2pass_quant = FALSE;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jquant2.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jquant2.c
@@ -1256,7 +1256,8 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   cquantize->error_limiter = NULL;
 
   /* Make sure jdmaster didn't give me a case I can't handle */
-  if (cinfo->out_color_components != 3)
+  if (cinfo->out_color_components != 3 ||
+      cinfo->out_color_space == JCS_RGB565)
     ERREXIT(cinfo, JERR_NOTIMPL);
 
   /* Allocate the histogram/inverse colormap storage */


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability that was cloned from libjpeg-turbo but did not receive the security patch. The original issue was reported and fixed under https://github.com/libjpeg-turbo/libjpeg-turbo/commit/42ce199c9cfe129e5e21afd48dfe757a6acf87c4.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2023-2804
https://github.com/libjpeg-turbo/libjpeg-turbo/commit/42ce199c9cfe129e5e21afd48dfe757a6acf87c4

