### PR TITLE
meta: Prevent memory hoarding for `GetClass("int")`

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3160,6 +3160,19 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    Bool_t nameChanged = kFALSE;
 
    if (!cl) {
+      // First look at known types but without triggering any loads
+      {
+         THashTable *typeTable = dynamic_cast<THashTable *>(gROOT->GetListOfTypes());
+         TDataType *type = (TDataType *)typeTable->THashTable::FindObject(name);
+         if (type) {
+            if (type->GetType() > 0)
+               // This is a numerical type
+               return nullptr;
+            // This is a typedef
+            normalizedName = type->GetTypeName();
+            nameChanged = kTRUE;
+         }
+      }
       {
          TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
          TClassEdit::GetNormalizedName(normalizedName, name);


### PR DESCRIPTION
Prevent memory hoarding for `GetClass("int")` or any other numerical types.

This addresses https://root-forum.cern.ch/t/repeatedly-mapping-branches-slowly-fills-memory/63412.
This fix #18536.

This relates to https://github.com/root-project/root/issues/9029 but does not solve it completely.  It solves the sub-cases of #9029 where the typedef is known to `TROOT::GetListOfTypes`.
