### PR TITLE
[HF] Prevent a crash when an empty measurement is created.

### DIFF
--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -190,6 +190,9 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
 
     // Use HistFactory to combine the individual channel workspaces
     std::unique_ptr<RooWorkspace> ws{factory.MakeCombinedModel(channel_names, channel_workspaces)};
+    if (!ws) {
+      return nullptr;
+    }
 
     // Configure that workspace
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement("simPdf", ws.get(), measurement);


### PR DESCRIPTION
The following code provided by Tomas Dado lead to a crash:
```
  RooStats::HistFactory::Measurement meas("meas", "meas");
  meas.SetOutputFilePrefix("test");
  meas.SetPOI("pt0_m0_y0_XSec");
  meas.CollectHistograms();

  std::unique_ptr<RooWorkspace> work(RooStats::HistFactory::MakeModelAndMeasurementFast(meas));
```

This is caused by a nullptr being passed to a HistFactory function. By returning early, the crash is avoided, and the following error message is produced:
`Error in <RooStats::HistFactory::HistoToWorkspaceFactoryFast::MakeCombinedModel>: Input vectors are empty - return a nullptr`