### PR TITLE
[RF] Use the actual proxy list as input for RooFormula::doEval()

### DIFF
--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -225,7 +225,7 @@ RooFormula::RooFormula(const char *name, const char *formula, const RooArgList &
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 RooFormula::RooFormula(const RooFormula& other, const char* name) :
-  TNamed(name ? name : other.GetName(), other.GetTitle()), RooPrintable(other)
+  TNamed(name ? name : other.GetName(), other.GetTitle())
 {
   _origList.add(other._origList);
 
@@ -330,11 +330,6 @@ RooArgList RooFormula::usedVariables() const {
   return useList;
 }
 
-void RooFormula::dump() const
-{
-  printMultiline(std::cout, 0);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Change used variables to those with the same name in given list.
 /// \param[in] newDeps New dependents to replace the old ones.
@@ -430,50 +425,6 @@ void RooFormula::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*
   indent.Append("  ");
   os << indent << "Servers: " << _origList << "\n";
   os << indent << "In use : " << actualDependents() << std::endl;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print value of formula
-
-void RooFormula::printValue(ostream& os) const
-{
-  os << const_cast<RooFormula*>(this)->eval(nullptr) ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print name of formula
-
-void RooFormula::printName(ostream& os) const
-{
-  os << GetName() ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print title of formula
-
-void RooFormula::printTitle(ostream& os) const
-{
-  os << GetTitle() ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print class name of formula
-
-void RooFormula::printClassName(ostream& os) const
-{
-  os << ClassName() ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print arguments of formula, i.e. dependents that are actually used
-
-void RooFormula::printArgs(ostream& os) const
-{
-  os << "[ actualVars=";
-  for (const auto arg : usedVariables()) {
-     os << " " << arg->GetName();
-  }
-  os << " ]";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -44,7 +44,7 @@ public:
    bool ok() const { return _tFormula != nullptr; }
    /// Evaluate all parameters/observables, and then evaluate formula.
    double eval(const RooArgSet *nset = nullptr) const;
-   void doEval(RooFit::EvalContext &) const;
+   void doEval(RooArgList const &actualVars, RooFit::EvalContext &) const;
 
    void printMultiline(std::ostream &os, Int_t contents, bool verbose = false, TString indent = "") const;
 
@@ -56,6 +56,7 @@ private:
    RooArgList usedVariables() const;
    void installFormulaOrThrow(const std::string &formula);
 
+   std::vector<bool> _varIsUsed;        ///<! Track whether a given variable is in use or not
    RooArgList _origList;                ///<! Original list of dependents
    std::unique_ptr<TFormula> _tFormula; ///<! The formula used to compute values
 };

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -79,7 +79,6 @@ private:
    void installFormulaOrThrow(const std::string &formula);
 
    RooArgList _origList;                ///<! Original list of dependents
-   std::vector<bool> _isCategory;       ///<! Whether an element of the _origList is a category.
    std::unique_ptr<TFormula> _tFormula; ///<! The formula used to compute values
 };
 

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -26,7 +26,7 @@
 
 class RooAbsReal;
 
-class RooFormula : public TNamed, public RooPrintable {
+class RooFormula : public TNamed {
 public:
    // Constructors etc.
    RooFormula(const char *name, const char *formula, const RooArgList &varList, bool checkVariables = true);
@@ -41,34 +41,12 @@ public:
    RooArgSet actualDependents() const { return usedVariables(); }
    bool changeDependents(const RooAbsCollection &newDeps, bool mustReplaceAll, bool nameChange);
 
-   /// Return pointer to the parameter with given name.
-   /// \return Parameter if in use, nullptr if not in use.
-   RooAbsArg *getParameter(const char *name) const { return usedVariables().find(name); }
-
-   /// Return pointer to parameter at given index. This returns
-   /// irrespective of whether the parameter is in use.
-   RooAbsArg *getParameter(Int_t index) const { return _origList.at(index); }
-
    bool ok() const { return _tFormula != nullptr; }
    /// Evaluate all parameters/observables, and then evaluate formula.
    double eval(const RooArgSet *nset = nullptr) const;
    void doEval(RooFit::EvalContext &) const;
 
-   /// DEBUG: Dump state information
-   void dump() const;
-
-   void printValue(std::ostream &os) const override;
-   void printName(std::ostream &os) const override;
-   void printTitle(std::ostream &os) const override;
-   void printClassName(std::ostream &os) const override;
-   void printArgs(std::ostream &os) const override;
-   void printMultiline(std::ostream &os, Int_t contents, bool verbose = false, TString indent = "") const override;
-
-   void Print(Option_t *options = nullptr) const override
-   {
-      // Printing interface (human readable)
-      printStream(defaultPrintStream(), defaultPrintContents(options), defaultPrintStyle(options));
-   }
+   void printMultiline(std::ostream &os, Int_t contents, bool verbose = false, TString indent = "") const;
 
    std::string formulaString() const { return _tFormula ? _tFormula->GetTitle() : ""; }
    TFormula* getTFormula() const { return _tFormula.get(); }

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -162,7 +162,14 @@ double RooFormulaVar::evaluate() const
 
 void RooFormulaVar::doEval(RooFit::EvalContext &ctx) const
 {
+   std::cout << "RooFormulaVar::doEval " << GetName() << std::endl;
+
+   for (auto *arg : _actualVars) {
+     std::cout << arg->GetName() << "   " << ctx.at(arg)[0] << std::endl;
+   }
+
    getFormula().doEval(ctx);
+   std::cout << ctx.output()[0] << std::endl;
 }
 
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -162,7 +162,7 @@ double RooFormulaVar::evaluate() const
 
 void RooFormulaVar::doEval(RooFit::EvalContext &ctx) const
 {
-   getFormula().doEval(ctx);
+   getFormula().doEval(_actualVars, ctx);
 }
 
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -148,7 +148,7 @@ RooFormula& RooFormulaVar::getFormula() const
 bool RooFormulaVar::ok() const { return getFormula().ok() ; }
 
 
-void RooFormulaVar::dumpFormula() { getFormula().dump() ; }
+void RooFormulaVar::dumpFormula() { getFormula().printMultiline(std::cout, 0) ; }
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -162,14 +162,7 @@ double RooFormulaVar::evaluate() const
 
 void RooFormulaVar::doEval(RooFit::EvalContext &ctx) const
 {
-   std::cout << "RooFormulaVar::doEval " << GetName() << std::endl;
-
-   for (auto *arg : _actualVars) {
-     std::cout << arg->GetName() << "   " << ctx.at(arg)[0] << std::endl;
-   }
-
    getFormula().doEval(ctx);
-   std::cout << ctx.output()[0] << std::endl;
 }
 
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -136,7 +136,7 @@ double RooGenericPdf::evaluate() const
 ////////////////////////////////////////////////////////////////////////////////
 void RooGenericPdf::doEval(RooFit::EvalContext & ctx) const
 {
-  formula().doEval(ctx);
+  formula().doEval(_actualVars, ctx);
 }
 
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -176,7 +176,7 @@ void RooGenericPdf::printMetaArgs(ostream& os) const
 }
 
 
-void RooGenericPdf::dumpFormula() { formula().dump() ; }
+void RooGenericPdf::dumpFormula() { formula().printMultiline(std::cout, 0) ; }
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes problems when the variable ist in the RooFormula gets out of
sync with the proxies in the RooFormulaVar or the RooGenericPdf, which
are using the RooFormula under the hood. This can happen when the
variables are renamed using `SetName()`, for example in the NLL creation
for simultaneous pdfs with the new RooFit CPU backend.

This fixes a bug reported by ATLAS.

Also some general `RooFormula` improvements in separate PRs.