### PR TITLE
[v634][cling] The LookupHelper routines need the ROOT lock.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,8 @@ function(relatedrepo_GetClosestMatch)
 
   set(${__FETCHURL_VARIABLE} ${__UPSTREAM_PREFIX}/${__REPO_NAME} PARENT_SCOPE)
 
-  if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  # .git is usually a directory but can also be a file, for example in the case of clone created via `worktree`
+  if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     set(${__FETCHREF_VARIABLE} v${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION} PARENT_SCOPE)
     return()
   endif()

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -54,6 +54,7 @@
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Utils/AST.h"
+#include "cling/Interpreter/InterpreterAccessRAII.h"
 
 #include "llvm/Support/Path.h"
 #include "llvm/Support/FileSystem.h"
@@ -569,6 +570,9 @@ void TClingLookupHelper::GetPartiallyDesugaredName(std::string &nameLong)
 bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nondef,
                                                          const std::string &nameLong)
 {
+   // We are going to use and possibly update the interpreter information.
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
+
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    clang::QualType t = lh.findType(nondef.c_str(), ToLHDS(WantDiags()));
    if (!t.isNull()) {
@@ -584,6 +588,9 @@ bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nond
 
 bool TClingLookupHelper::IsDeclaredScope(const std::string &base, bool &isInlined)
 {
+   // We are going to use and possibly update the interpreter information.
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
+
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    const clang::Decl *scope = lh.findScope(base.c_str(), ToLHDS(WantDiags()), nullptr);
 
@@ -617,6 +624,9 @@ bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::s
    }
 
    if (fAutoParse) fAutoParse(tname.c_str());
+
+   // We are going to use and possibly update the interpreter information.
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
 
    // Since we already check via other means (TClassTable which is populated by
    // the dictonary loading, and the gROOT list of classes and enums, which are

--- a/interpreter/cling/include/cling/Interpreter/InterpreterAccessRAII.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterAccessRAII.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Vassil Vassilev <vvasilev@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_INTERPRETERACCESSRAII_H
+#define CLING_INTERPRETERACCESSRAII_H
+
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterCallbacks.h"
+
+namespace cling {
+///\brief Locks and unlocks access to the interpreter.
+struct InterpreterAccessRAII {
+  /// Callbacks used to un/lock.
+  InterpreterCallbacks* fCallbacks;
+  /// Info provided to UnlockCompilationDuringUserCodeExecution().
+  void* fStateInfo = nullptr;
+
+  InterpreterAccessRAII(InterpreterCallbacks* callbacks):
+    fCallbacks(callbacks)
+  {
+    if (fCallbacks)
+      // The return value is alway a nullptr.
+      fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
+  }
+
+  InterpreterAccessRAII(Interpreter& interp):
+    InterpreterAccessRAII(interp.getCallbacks()) {}
+
+  ~InterpreterAccessRAII()
+  {
+    if (fCallbacks)
+      fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
+  }
+};
+}
+
+#endif // CLING_ENTERUSERCODERAII_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,22 +178,24 @@ if(ROOT_opengl_FOUND)
                 COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/stressGraphics.cxx
                 FAILREGEX "FAILED|Error in"
                 DEPENDS test-stressgraphics)
-  # Disabled until the failures on Fedora 41 are addressed
-  # if(CHROME_EXECUTABLE)
-  #   ROOT_ADD_TEST(test-stressgraphics-chrome
-  #                 RUN_SERIAL
-  #                 ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-  #                 COMMAND stressGraphics -b -k -p=sgc --web=chrome
-  #                 FAILREGEX "FAILED|Error in"
-  #                 LABELS longtest)
-  # endif()
-  if(FIREFOX_EXECUTABLE AND NOT APPLE)
-    ROOT_ADD_TEST(test-stressgraphics-firefox-skip3d
-                  RUN_SERIAL
-                  ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-                  COMMAND stressGraphics -b -k -p=sgf --web=firefox -skip3d
-                  FAILREGEX "FAILED|Error in"
-                  LABELS longtest)
+  if(webgui)
+    # Disabled until the failures on Fedora 41 are addressed
+    # if(CHROME_EXECUTABLE)
+    #   ROOT_ADD_TEST(test-stressgraphics-chrome
+    #                 RUN_SERIAL
+    #                 ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
+    #                 COMMAND stressGraphics -b -k -p=sgc --web=chrome
+    #                 FAILREGEX "FAILED|Error in"
+    #                 LABELS longtest)
+    # endif()
+    if(FIREFOX_EXECUTABLE AND NOT APPLE)
+      ROOT_ADD_TEST(test-stressgraphics-firefox-skip3d
+                    RUN_SERIAL
+                    ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
+                    COMMAND stressGraphics -b -k -p=sgf --web=firefox -skip3d
+                    FAILREGEX "FAILED|Error in"
+                    LABELS longtest)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Those routines are at the very least looking up information into Clang and thus need to prevent concurrent updates. Some of the routines can also sometimes induces changes in Clang (eg. template instantiation).

This fixes https://github.com/root-project/root/issues/18520 and https://github.com/root-project/root/issues/18519

Back-port of https://github.com/root-project/root/pull/18522