### PR TITLE
cling: Deduplicate lock code. Keep semantic distinction.

### DIFF
--- a/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
+++ b/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
@@ -11,6 +11,7 @@
 #define CLING_ENTERUSERCODERAII_H
 
 #include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterAccessRAII.h"
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 namespace cling {
@@ -34,25 +35,7 @@ struct EnterUserCodeRAII {
   }
 };
 
-struct LockCompilationDuringUserCodeExecutionRAII {
-  /// Callbacks used to un/lock.
-  InterpreterCallbacks* fCallbacks;
-  /// Info provided to UnlockCompilationDuringUserCodeExecution().
-  void* fStateInfo = nullptr;
-  LockCompilationDuringUserCodeExecutionRAII(InterpreterCallbacks* callbacks):
-  fCallbacks(callbacks) {
-    if (fCallbacks)
-      fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
-  }
-
-  LockCompilationDuringUserCodeExecutionRAII(Interpreter& interp):
-  LockCompilationDuringUserCodeExecutionRAII(interp.getCallbacks()) {}
-
-  ~LockCompilationDuringUserCodeExecutionRAII() {
-    if (fCallbacks)
-      fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
-  }
-};
+using LockCompilationDuringUserCodeExecutionRAII = cling::InterpreterAccessRAII;
 }
 
 #endif // CLING_ENTERUSERCODERAII_H

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -479,7 +479,7 @@ namespace cling {
     // the ResolvedTypedef code paths.  Through that code path nothing is
     // taking the ROOT/Interpreter lock and since this code can modify the
     // interpreter, we do need to take lock.
-    LockCompilationDuringUserCodeExecutionRAII LCDUCER(*m_Interpreter);
+    InterpreterAccessRAII LockAccess(*m_Interpreter);
 
     // Could trigger deserialization of decls.
     Interpreter::PushTransactionRAII RAII(m_Interpreter);


### PR DESCRIPTION
LockCompilationDuringUserCodeExecutionRAII: to be used right before compiling/executing user code
InterpreterAccessRAII: to be used during loookups
