### PR TITLE
[jsroot] 7.9.x 29/04/2025 [6.36]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,5 +1,11 @@
 # JSROOT changelog
 
+## Changes in 7.9.x
+1. Fix - colz handling on `THStack`, avoid multiple palette drawings
+2. Fix - bug in pad.Divide context menu command
+3. Fix - drag and drop of histograms on empty sub-pads
+
+
 ## Changes in 7.9.0
 1. New draw options:
    - 'pol' and 'arr_colz' draw option for `TH2`

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -1,10 +1,10 @@
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = '7.9.0',
+const version_id = '7.9.x',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '25/04/2025',
+version_date = '29/04/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -1774,7 +1774,7 @@ function getMethods(typename, obj) {
                   pad.fAbsWNDC = (x2-x1) * this.fAbsWNDC;
                   pad.fAbsHNDC = (y2-y1) * this.fAbsHNDC;
                   pad.fAbsXlowNDC = this.fAbsXlowNDC + x1 * this.fAbsWNDC;
-                  pad.fAbsYlowNDC = this.fAbsYlowNDC + y1 * this.fAbsWNDC;
+                  pad.fAbsYlowNDC = this.fAbsYlowNDC + y1 * this.fAbsHNDC;
                } else {
                   pad.fAbsWNDC = x2 - x1;
                   pad.fAbsHNDC = y2 - y1;

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -395,8 +395,8 @@ class TPadPainter extends ObjectPainter {
 
       for (let k = this.painters.length - 1; k >= 0; --k) {
          const subp = this.painters[k];
-         if (selector(subp)) {
-            subp.cleanup();
+         if (!subp || selector(subp)) {
+            subp?.cleanup();
             this.painters.splice(k, 1);
             is_any = true;
          }
@@ -556,7 +556,8 @@ class TPadPainter extends ObjectPainter {
          this.is_active_pad = is_active;
       }
 
-      if (this.is_active_pad === undefined) return;
+      if (this.is_active_pad === undefined)
+         return;
 
       if (!svg_rect)
          svg_rect = this.iscan ? this.getCanvSvg().selectChild('.canvas_fillrect') : this.svg_this_pad().selectChild('.root_pad_border');
@@ -1370,11 +1371,16 @@ class TPadPainter extends ObjectPainter {
          const do_divide = arg => {
             if (!arg || !isStr(arg))
                return;
-            const arr = arg.split('x');
+            // workaround - prevent full deletion of canvas
+            if (this.normal_canvas === false)
+               this.normal_canvas = true;
             this.cleanPrimitives(true);
+            if (arg === 'reset')
+               return;
+            const arr = arg.split('x');
             if (arr.length === 1)
                this.divide(Number.parseInt(arr[0]));
-            if (arr.length === 2)
+            else if (arr.length === 2)
                this.divide(Number.parseInt(arr[0]), Number.parseInt(arr[1]));
          };
 
@@ -1382,7 +1388,7 @@ class TPadPainter extends ObjectPainter {
             menu.add('Build legend', () => this.buildLegend());
 
          menu.sub('Divide', () => menu.input('Input divide arg', '2x2').then(do_divide), 'Divide on sub-pads');
-         ['1x2', '2x1', '2x2', '2x3', '3x2', '3x3', '4x4', '0'].forEach(item => menu.add(item, item, do_divide));
+         ['1x2', '2x1', '2x2', '2x3', '3x2', '3x3', '4x4', 'reset'].forEach(item => menu.add(item, item, do_divide));
          menu.endsub();
 
          menu.add('Save to gStyle', () => {

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -2251,7 +2251,7 @@ class HierarchyPainter extends BasePainter {
          const cp = getElementCanvPainter(dom);
 
          if (cp) {
-            if (sett?.has_same)
+            if (sett?.has_same && mp)
                opt = 'same ' + opt;
          } else
             this.cleanupFrame(dom);

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -2750,8 +2750,13 @@ class TH2Painter extends THistPainter {
       } else if (this.options.Same && this._ignore_frame)
          this.getFrameSvg().style('display', 'none');
 
-      if (!this.draw_content)
+      if (!this.draw_content) {
+         if (this.options.Zscale && this.options.ohmin && this.options.ohmax) {
+            this.getContour(true);
+            this.getHistPalette();
+         }
          return this.removeG();
+      }
 
       this.createHistDrawAttributes();
 

--- a/js/modules/hist2d/THStackPainter.mjs
+++ b/js/modules/hist2d/THStackPainter.mjs
@@ -199,6 +199,11 @@ class THStackPainter extends ObjectPainter {
          hopt += ' ' + this.options.hopt;
       if (this.options.draw_errors && !hopt)
          hopt = 'E';
+      if (this.options.zscale) {
+         const p = hopt.toUpperCase().indexOf('COLZ');
+         if (p >= 0)
+            hopt = hopt.slice(0, p + 3) + hopt.slice(p + 4);
+      }
       if (!this.options.pads)
          hopt += ' same nostat' + this.options.auto;
       return hopt;
@@ -294,11 +299,13 @@ class THStackPainter extends ObjectPainter {
       this.options.pads = d.check('PADS');
       if (this.options.pads) this.options.nostack = true;
 
-      this.options.hopt = d.remain(); // use remaining draw options for histogram draw
+      this.options.hopt = d.remain().trim(); // use remaining draw options for histogram draw
 
       const dolego = d.check('LEGO');
 
       this.options.errors = d.check('E');
+
+      this.options.zscale = d.check('COLZ');
 
       // if any histogram appears with pre-calculated errors, use E for all histograms
       if (!this.options.nostack && this.options.has_errors && !dolego && !d.check('HIST') && (this.options.hopt.indexOf('E') < 0))


### PR DESCRIPTION
1. Fix - colz handling on `THStack`, avoid multiple palette drawings
2. Fix - bug in pad.Divide context menu command
3. Fix - drag and drop of histograms on empty sub-pads
