### PR TITLE
[python][RDF] Add Support for String Columns in AsRVec

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -1,8 +1,9 @@
-import unittest
-import ROOT
-import numpy as np
-import sys
 import gc
+import sys
+import unittest
+
+import numpy as np
+import ROOT
 
 
 class DataFrameFromNumpy(unittest.TestCase):
@@ -11,9 +12,7 @@ class DataFrameFromNumpy(unittest.TestCase):
     with RDataFrame.
     """
 
-    dtypes = [
-        "int32", "int64", "uint32", "uint64", "float32", "float64"
-    ]
+    dtypes = ["int32", "int64", "uint32", "uint64", "float32", "float64"]
 
     def test_dtypes(self):
         """
@@ -23,6 +22,19 @@ class DataFrameFromNumpy(unittest.TestCase):
             data = {"x": np.array([1, 2, 3], dtype=dtype)}
             df = ROOT.RDF.FromNumpy(data)
             self.assertEqual(df.Mean("x").GetValue(), 2)
+
+    def test_object_dtype_strings(self):
+        """
+        Test reading numpy arrays with dtype=object containing strings
+        """
+        data = {"x": np.array(["test_string_1", "test_string_2"], dtype=object)}
+        df = ROOT.RDF.FromNumpy(data)
+        colnames = df.GetColumnNames()
+
+        self.assertIn("x", colnames)
+
+        entries = df.AsNumpy()["x"]
+        self.assertTrue(np.array_equal(entries, np.array(["test_string_1", "test_string_2"], dtype=object)))
 
     def test_multiple_columns(self):
         """
@@ -146,14 +158,14 @@ class DataFrameFromNumpy(unittest.TestCase):
         """
         Test correct reading of a sliced numpy array (#13690)
         """
-        table = np.array([[1,2], [3,4]], dtype="int64")
-        columns = {'x': table[:,0], 'y': table[:,1]}
+        table = np.array([[1, 2], [3, 4]], dtype="int64")
+        columns = {"x": table[:, 0], "y": table[:, 1]}
         df = ROOT.RDF.FromNumpy(columns)
-        x_col = df.Take['Long64_t']("x")
-        y_col = df.Take['Long64_t']("y")
-        self.assertEqual(list(x_col.GetValue()), [1,3])
-        self.assertEqual(list(y_col.GetValue()), [2,4])
+        x_col = df.Take["Long64_t"]("x")
+        y_col = df.Take["Long64_t"]("y")
+        self.assertEqual(list(x_col.GetValue()), [1, 3])
+        self.assertEqual(list(y_col.GetValue()), [2, 4])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/rvec_asrvec.py
+++ b/bindings/pyroot/pythonizations/test/rvec_asrvec.py
@@ -1,8 +1,9 @@
-import unittest
-import ROOT
-import numpy as np
-import sys
 import gc
+import sys
+import unittest
+
+import numpy as np
+import ROOT
 
 
 def get_maximum_for_dtype(dtype):
@@ -10,6 +11,7 @@ def get_maximum_for_dtype(dtype):
         return np.iinfo(dtype).max
     if np.issubdtype(dtype, np.floating):
         return np.finfo(dtype).max
+
 
 def get_minimum_for_dtype(dtype):
     if np.issubdtype(dtype, np.integer):
@@ -25,9 +27,7 @@ class AsRVec(unittest.TestCase):
     """
 
     # Helpers
-    dtypes = [
-        "int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64", "bool"
-    ]
+    dtypes = ["int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64", "bool"]
 
     def check_memory_adoption(self, root_obj, np_obj):
         np_obj[0] = get_maximum_for_dtype(np_obj.dtype)
@@ -48,6 +48,31 @@ class AsRVec(unittest.TestCase):
             root_obj = ROOT.VecOps.AsRVec(np_obj)
             self.check_memory_adoption(root_obj, np_obj)
             self.check_size(2, root_obj)
+
+    def test_object_dtype_strings(self):
+        """
+        Test adoption of numpy arrays with dtype=object and dtype=str containing strings
+        """
+        for dtype in [object, np.str_, "<U13"]:
+            with self.subTest(dtype=dtype):
+                np_obj = np.array(["test_string_1", "test_string_2"], dtype=dtype)
+                root_obj = ROOT.VecOps.AsRVec(np_obj)
+
+                self.check_size(2, root_obj)
+                self.assertEqual(root_obj[0], np_obj[0])
+                self.assertEqual(root_obj[1], np_obj[1])
+
+    def test_object_dtype_mixed_types(self):
+        """
+        Test that a TypeError is raised for numpy arrays with dtype=object
+        containing elements of different types
+        """
+        np_obj = np.array(["string", {}], dtype=object)
+
+        with self.assertRaises(TypeError) as context:
+            ROOT.VecOps.AsRVec(np_obj)
+
+        self.assertIn("All elements in the numpy array must be of the same type", str(context.exception))
 
     def test_multidim(self):
         """
@@ -114,5 +139,5 @@ class AsRVec(unittest.TestCase):
         self.assertEqual(sys.getrefcount(np_obj), 2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR extends support for strings stored in NumPy arrays with `dtype=object` or `dtype=numpy.str_` in `AsRVec`, enabling conversions of dataframes with string columns to `RDataFrame` using `FromNumpy` and `FromPandas`.

## Checklist:

- [x] tested changes locally

This PR fixes #18534 

