### PR TITLE
[BP 6.36][geom] Fix vecgeom interface

### DIFF
--- a/geom/vecgeom/inc/TGeoVGShape.h
+++ b/geom/vecgeom/inc/TGeoVGShape.h
@@ -43,7 +43,7 @@ public:
    static TGeoVGShape *Create(TGeoShape *shape);
    Double_t Capacity() const override;
    void ComputeBBox() override;
-   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
    Bool_t Contains(const Double_t *point) const override;
    Bool_t CouldBeCrossed(const Double_t *point, const Double_t *dir) const override
    {

--- a/geom/vecgeom/src/TGeoVGShape.cxx
+++ b/geom/vecgeom/src/TGeoVGShape.cxx
@@ -427,7 +427,7 @@ Double_t TGeoVGShape::Capacity() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal computation.
 
-void TGeoVGShape::ComputeNormal(const Double_t *point, const Double_t * /*dir*/, Double_t *norm)
+void TGeoVGShape::ComputeNormal(const Double_t *point, const Double_t * /*dir*/, Double_t *norm) const
 {
    vecgeom::cxx::Vector3D<Double_t> vnorm;
    fVGShape->Normal(vecgeom::cxx::Vector3D<Double_t>(point[0], point[1], point[2]), vnorm);


### PR DESCRIPTION
BP of https://github.com/root-project/root/pull/18530

The signature of the function ComputeNormal has changed in the base class TGeoBBox. Add const qualifier to the function also in the derrived class.

(cherry picked from commit 8dc927038f56b3a91997dda4d22fdde7a00febc6)

This supersedes https://github.com/root-project/root/pull/18508 
