### PR TITLE
[v634] meta: Prevent memory hoarding for `GetClass("int")`

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3124,6 +3124,19 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    Bool_t nameChanged = kFALSE;
 
    if (!cl) {
+      // First look at known types but without triggering any loads
+      {
+         THashTable *typeTable = dynamic_cast<THashTable *>(gROOT->GetListOfTypes());
+         TDataType *type = (TDataType *)typeTable->THashTable::FindObject(name);
+         if (type) {
+            if (type->GetType() > 0)
+               // This is a numerical type
+               return nullptr;
+            // This is a typedef
+            normalizedName = type->GetTypeName();
+            nameChanged = kTRUE;
+         }
+      }
       {
          TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
          TClassEdit::GetNormalizedName(normalizedName, name);


### PR DESCRIPTION
or any other numerical types.# This Pull request:

Backport of https://github.com/root-project/root/pull/18537