### PR TITLE
[cling] Add a debug facility to dump the object file and IR from the JIT

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -554,6 +554,40 @@ IncrementalJIT::~IncrementalJIT() {
   }
 }
 
+class DebuggingSimpleCompiler : public llvm::orc::SimpleCompiler {
+public:
+  DebuggingSimpleCompiler(llvm::TargetMachine& TM,
+                          llvm::ObjectCache* ObjCache = nullptr)
+      : llvm::orc::SimpleCompiler(TM, ObjCache) {}
+  llvm::Expected<CompileResult> operator()(llvm::Module& M) override {
+    auto R = llvm::orc::SimpleCompiler::operator()(M);
+
+#ifndef NDEBUG
+#define DEBUG_TYPE "orc"
+    bool Debugging = DebugFlag && isCurrentDebugType(DEBUG_TYPE);
+    if (R && Debugging) {
+      std::string FileStem;
+      {
+        static unsigned counter = 0;
+        llvm::raw_string_ostream FileStemStream(FileStem);
+        FileStemStream << M.getModuleIdentifier() << "." << ++counter;
+      }
+      std::error_code EC;
+      llvm::raw_fd_ostream ModuleStream(FileStem + ".ll", EC);
+      ModuleStream << M;
+      llvm::raw_fd_ostream ObjectStream(FileStem + ".o", EC);
+      ObjectStream << (*R)->getBuffer();
+      LLVM_DEBUG(dbgs() << "Created file '" << FileStem + ".ll"
+                        << "'\n");
+      LLVM_DEBUG(dbgs() << "Created file '" << FileStem + ".o"
+                        << "'\n");
+    }
+#undef DEBUG_TYPE
+#endif // NDEBUG
+    return R;
+  }
+};
+
 IncrementalJIT::IncrementalJIT(
     IncrementalExecutor& Executor, const clang::CompilerInstance &CI,
     std::unique_ptr<llvm::orc::ExecutorProcessControl> EPC, Error& Err,
@@ -627,10 +661,12 @@ IncrementalJIT::IncrementalJIT(
     return Layer;
   });
 
-  Builder.setCompileFunctionCreator([&](llvm::orc::JITTargetMachineBuilder)
-  -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
-    return std::make_unique<SimpleCompiler>(*m_TM);
-  });
+  Builder.setCompileFunctionCreator(
+      [&](llvm::orc::JITTargetMachineBuilder)
+          -> llvm::Expected<
+              std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
+        return std::make_unique<DebuggingSimpleCompiler>(*m_TM);
+      });
 
   char LinkerPrefix = this->m_TM->createDataLayout().getGlobalPrefix();
 


### PR DESCRIPTION
This would help when debugging ABI mismatches. This patch stores the llvm ir and the object files from the jit in files named cling-module-X.Y.{o,ll} where X is the number of the incremental input compiled and Y is the number of dumped module. X and Y are different because some transactions of Cling do not produce IR.

This functionality can be enabled by:
`EXTRA_CLING_ARGS=" --debug-only=orc " root.exe -l -b -q`
