### PR TITLE
[v636][HF] Prevent histograms from registering in the list of cleanups.

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -16,6 +16,7 @@
 #include <iostream>
 
 #include "TH1.h"
+#include "TDirectory.h"
 #include "RooStats/HistFactory/HistRef.h"
 
 namespace RooStats{
@@ -107,7 +108,10 @@ namespace HistFactory {
     fInputFileHigh{oth.fInputFileHigh}, fHistoNameHigh{oth.fHistoNameHigh}, fHistoPathHigh{oth.fHistoPathHigh},
     fhLow{oth.fhLow ? static_cast<TH1*>(oth.fhLow->Clone()) : nullptr},
     fhHigh{oth.fhHigh ? static_cast<TH1*>(oth.fhHigh->Clone()) : nullptr} {
-
+       if (fhLow)
+          fhLow->SetDirectory(nullptr);
+       if (fhHigh)
+          fhHigh->SetDirectory(nullptr);
     }
     HistogramUncertaintyBase(HistogramUncertaintyBase&&) = default;
 
@@ -123,6 +127,8 @@ namespace HistFactory {
       fInputFileHigh = oth.fInputFileHigh;
       fHistoNameHigh = oth.fHistoNameHigh;
       fHistoPathHigh = oth.fHistoPathHigh;
+
+      TDirectory::TContext ctx{nullptr}; // Don't associate clones to directories
       fhLow.reset(oth.fhLow ? static_cast<TH1*>(oth.fhLow->Clone()) : nullptr);
       fhHigh.reset(oth.fhHigh ? static_cast<TH1*>(oth.fhHigh->Clone()) : nullptr);
 

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -27,6 +27,7 @@
 #include "TFile.h"
 #include "TKey.h"
 #include "TTimeStamp.h"
+#include "TDirectory.h"
 
 #include "RooStats/HistFactory/HistFactoryException.h"
 
@@ -464,7 +465,7 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
-
+  TDirectory::TContext ctx{nullptr};
   TH1 * ptr = static_cast<TH1 *>(hist->Clone());
 
   if(!ptr){
@@ -474,9 +475,6 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
          << "obj: " << HistoName << std::endl;
     throw hf_exc();
   }
-
-  ptr->SetDirectory(nullptr);
-
 
 #ifdef DEBUG
   std::cout << "Found Histogram: " << HistoName " at address: " << ptr

--- a/roofit/histfactory/src/HistRef.cxx
+++ b/roofit/histfactory/src/HistRef.cxx
@@ -15,8 +15,10 @@
  * HistFactory class
  */
 
-#include "TH1.h"
 #include "RooStats/HistFactory/HistRef.h"
+
+#include "TH1.h"
+#include "TDirectory.h"
 
 namespace RooStats{
 namespace HistFactory {
@@ -25,6 +27,8 @@ namespace HistFactory {
       // implementation of method copying the contained pointer
       // (just use Clone)
       if (!h) return nullptr;
+
+      TDirectory::TContext ctx{nullptr}; // Don't associate histogram with currently open file
       return static_cast<TH1*>(h->Clone());
    }
 }


### PR DESCRIPTION
For HistFactory models with numerous histograms, a significant amount of time (minutes) could be spend cleaning the list of cleanups. Here, the registration of histograms to directories is blocked, so the list of cleanups stays empty.

Fix #18172.

