### PR TITLE
[python][RDF] Handle the creation of an empty RDataFrame in _MakeNumpyDataFrame

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -36,6 +36,26 @@ class DataFrameFromNumpy(unittest.TestCase):
         entries = df.AsNumpy()["x"]
         self.assertTrue(np.array_equal(entries, np.array(["test_string_1", "test_string_2"], dtype=object)))
 
+    def test_empty_arrays(self):
+        """
+        Test creating an RDataFrame from an empty numpy array with different data types
+        """
+        for dtype in self.dtypes:
+            data = {"x": np.array([], dtype=dtype)}
+            df = ROOT.RDF.FromNumpy(data)
+            colnames = df.GetColumnNames()
+            self.assertIn("x", colnames)
+            self.assertEqual(df.Count().GetValue(), 0)
+
+        data_obj = {"x": np.array([], dtype="object")}
+        with self.assertRaises(RuntimeError) as context:
+            df = ROOT.RDF.FromNumpy(data_obj)
+
+        self.assertIn(
+            "Failure in creating column 'x' for RDataFrame: the input column type is 'object', which is not supported. Make sure your column type is supported",
+            str(context.exception),
+        )
+
     def test_multiple_columns(self):
         """
         Test reading multiple columns


### PR DESCRIPTION
# This Pull request:

> [!NOTE]  
> This PR should be merged **after**  #18571.

## Changes or fixes:
This PR introduces logic to detect and handle the creation of empty RDataframes from empty numpy arrays, as long as the array's `dtype` is supported by `RVec`, see the [docs](https://root.cern/doc/master/classROOT_1_1VecOps_1_1RVec.html).
As explained on the issue's thread, the issue's reproducer will still not work with this PR.

## Checklist:

- [x] tested changes locally

This PR fixes #18581

