### PR TITLE
[meta] Correct TClass::LoadClassInfo.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5971,10 +5971,10 @@ void TClass::LoadClassInfo() const
 
    bool autoParse = !gInterpreter->IsAutoParsingSuspended();
 
-   if (autoParse)
+   if (autoParse && !fClassInfo)
       gInterpreter->AutoParse(GetName());
 
-   if (!fClassInfo)
+   if (!fClassInfo) // Could be indirectly set by the parsing
       gInterpreter->SetClassInfo(const_cast<TClass *>(this));
 
    if (autoParse && !fClassInfo) {
@@ -5987,10 +5987,13 @@ void TClass::LoadClassInfo() const
                                           " even though it has a TClass initialization routine.",
                  fName.Data());
       }
-      return;
    }
 
-   fCanLoadClassInfo = false;
+   // Keep trying to load the ClassInfo, since we have no ClassInfo yet,
+   // we will get an update even when there is an explicit load.  So whether
+   // or not the autoparsing is on, we will need to keep trying to load
+   // the ClassInfo.
+   fCanLoadClassInfo = !fClassInfo;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roottest/root/meta/tclass/CMakeLists.txt
+++ b/roottest/root/meta/tclass/CMakeLists.txt
@@ -93,18 +93,20 @@ ROOTTEST_ADD_TEST(datamemberload
 ROOTTEST_GENERATE_DICTIONARY(libInitOrderDups
                              InitOrderDups.h
                              LINKDEF InitOrderDupsLinkDef.h
-                             NO_ROOTMAP NO_CXXMODULE)
+                             NO_ROOTMAP NO_CXXMODULE
+                             FIXTURES_SETUP InitOrder)
 
 ROOTTEST_GENERATE_DICTIONARY(libInitOrder
                              InitOrder.h
                              LINKDEF InitOrderLinkDef.h
-                             NO_ROOTMAP NO_CXXMODULE)
+                             NO_ROOTMAP NO_CXXMODULE
+                             FIXTURES_SETUP InitOrder)
 
 ROOTTEST_ADD_TEST(execInitOrder
                   MACRO execInitOrder.cxx+
                   COPY_TO_BUILDDIR InitOrder.h
                   OUTREF execInitOrder.ref
-                  DEPENDS libInitOrder-build libInitOrderDups-build)
+                  FIXTURES_REQUIRED InitOrder)
 
 ROOTTEST_ADD_TEST(tclassStl
                   MACRO tclassStl.cxx+

--- a/roottest/root/meta/tclass/InitOrder.h
+++ b/roottest/root/meta/tclass/InitOrder.h
@@ -14,3 +14,4 @@ using UserClass_t2 = UserClassViaUsing;
 
 class UserClassNotSelected {};
 using UserClassOnlyTypedef_t = UserClassNotSelected;
+

--- a/roottest/root/meta/tclass/InitOrder.h
+++ b/roottest/root/meta/tclass/InitOrder.h
@@ -14,4 +14,3 @@ using UserClass_t2 = UserClassViaUsing;
 
 class UserClassNotSelected {};
 using UserClassOnlyTypedef_t = UserClassNotSelected;
-

--- a/roottest/root/meta/tclass/execInitOrder.cxx
+++ b/roottest/root/meta/tclass/execInitOrder.cxx
@@ -4,10 +4,13 @@
 #include "TSystem.h"
 #include "TInterpreter.h"
 
+#ifndef DEFINED_DERIVE
+#define DEFINED_DERIVE
 class Derived : public TObject {
    int fValue;
    ClassDef(Derived, 1);
 };
+#endif
 
 int i = Derived::Class()->GetClassVersion();
 
@@ -26,6 +29,10 @@ int execInitOrder()
    if (!cl) {
       std::cerr << "Could not find the TClass for Derived\n";
       return 2;
+   }
+   if(!cl->GetClassInfo()) {
+      std::cerr << "No ClassInfo found by TClass for Derived\n";
+      return 3;
    }
 
    auto inh = cl->InheritsFrom(TObject::Class());

--- a/roottest/root/meta/tclass/execInitOrder.cxx
+++ b/roottest/root/meta/tclass/execInitOrder.cxx
@@ -30,7 +30,7 @@ int execInitOrder()
       std::cerr << "Could not find the TClass for Derived\n";
       return 2;
    }
-   if(!cl->GetClassInfo()) {
+   if (!cl->GetClassInfo()) {
       std::cerr << "No ClassInfo found by TClass for Derived\n";
       return 3;
    }


### PR DESCRIPTION
This fixes #18556.

We should keep trying to try to load a `ClassInfo` until we try the auto-parsing.  `TClass::LoadClassInfo` should set `fCanLoadClassInfo` to `false` when the `ClassInfo` is found *and* set it to false also when we tried auto parsing but did not find the `ClassInfo`.

In the later case, the `ClassInfo` might still be loaded (via a different routine/mechanims) if information about the class is later loaded/parsed.