### PR TITLE
[ci] Add back `pythia8=ON` to alma9 and Fedoras

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,5 +1,4 @@
 builtin_nlohmannjson=ON
 builtin_vdt=ON
 ccache=ON
-pythia8=OFF
 tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -2,5 +2,4 @@ builtin_zstd=ON
 builtin_zlib=ON
 builtin_nlohmannjson=On
 builtin_vdt=On
-pythia8=Off
 ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/fedora42.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora42.txt
@@ -2,5 +2,4 @@ builtin_nlohmannjson=ON
 builtin_zlib=ON
 builtin_zstd=ON
 ccache=ON
-pythia8=OFF
 vdt=OFF


### PR DESCRIPTION
A new version of Pythia 8 was released recently and propagated to the Fedora and AlmaLinux packages, which should have fixed the build failures of our Pythia 8 bindings.

This reverts #17732 and also adds the pythia8 interface to the Fedora builds.