### PR TITLE
[tmva][sofie] Mark input arrays to interence function as `const`

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_GRU.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_GRU.icc
@@ -238,7 +238,7 @@ auto ROperator_GRU<T>::Generate(std::string OpName)
 
    // set the input
    if (fAttrLayout == 0) {
-      out << SP << fType << " *" << OpName << "_input = tensor_" << fNX << ";\n";
+      out << SP << fType << " const* " << OpName << "_input = tensor_" << fNX << ";\n";
    } else {
       if (fUseSession) {
          out << SP << fType << " * " << OpName << "_input = fVec_" << OpName << "_input.data();\n";

--- a/tmva/sofie/inc/TMVA/ROperator_LSTM.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_LSTM.icc
@@ -292,7 +292,7 @@ auto ROperator_LSTM<T>::Generate(std::string OpName)
 
    // set the input
    if (fAttrLayout == 0) {
-      out << SP << fType << " *" << OpName << "_input = tensor_" << fNX << ";\n";
+      out << SP << fType << " const *" << OpName << "_input = tensor_" << fNX << ";\n";
    } else {
       if (fUseSession)
          out << SP << fType << " * " << OpName << "_input = fVec_" << OpName << "_input.data();\n";

--- a/tmva/sofie/inc/TMVA/ROperator_RNN.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_RNN.icc
@@ -231,7 +231,7 @@ auto ROperator_RNN<T>::Generate(std::string OpName)
    // set the input
    if (fAttrLayout == 0) {
       if (fType == "float") {
-         out << SP << "float *" << OpName << "_input = tensor_" << fNX << ";\n";
+         out << SP << "float const*" << OpName << "_input = tensor_" << fNX << ";\n";
       }
    } else {
       if (fUseSession)

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -21,9 +21,9 @@
 #include <cassert>
 #include <limits>
 
-namespace TMVA{
-namespace Experimental{
-namespace SOFIE{
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
 
 enum class ETensorType{
    UNDEFINED = 0, FLOAT = 1, UINT8 = 2, INT8 = 3, UINT16 = 4, INT16 = 5, INT32 = 6, INT64 = 7, STRING = 8, BOOL = 9, //order sensitive
@@ -735,8 +735,32 @@ inline void Gemm_Call(float *output, bool transa, bool transb, int m, int n, int
                                            &beta, output, ldc);
 }
 
-}//SOFIE
-}//Experimental
-}//TMVA
+template <class T>
+void ReadTensorFromStream(std::istream &is, T &target, std::string const &expectedName, std::size_t expectedLength)
+{
+   std::string name;
+   std::size_t length;
+   is >> name >> length;
+   if (name != expectedName) {
+      std::string err_msg =
+         "TMVA-SOFIE failed to read the correct tensor name; expected name is " + expectedName + " , read " + name;
+      throw std::runtime_error(err_msg);
+   }
+   if (length != expectedLength) {
+      std::string err_msg = "TMVA-SOFIE failed to read the correct tensor size; expected size is " +
+                            std::to_string(expectedLength) + " , read " + std::to_string(length);
+      throw std::runtime_error(err_msg);
+   }
+   for (size_t i = 0; i < length; ++i) {
+      is >> target[i];
+   }
+   if (is.fail()) {
+      throw std::runtime_error("TMVA-SOFIE failed to read the values for tensor " + expectedName);
+   }
+}
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
 #endif //TMVA_SOFIE_RMODEL

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -687,7 +687,7 @@ std::string RModel::GenerateInferSignature(bool isdecl) {
          if (type == "other")
             throw std::runtime_error("TMVA-SOFIE: input tensor " + name +
                                      " is of a data type which is not yet supported.");
-         rGC += type + "* ";
+         rGC += type + " const* ";
       }
       rGC += "tensor_" + name + ",";
       i_input++;

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -987,8 +987,7 @@ void RModel::ReadInitializedTensorsFromFile(long pos) {
             fGC += "   f.seekg(" + std::to_string(pos) + ");\n";
         }
 
-        fGC += "   std::string tensor_name;\n";
-        fGC += "   size_t length;\n";
+        fGC += "   using TMVA::Experimental::SOFIE::ReadTensorFromStream;\n";
 
         // loop on tensors and parse the file
         for (auto& i: fInitializedTensors) {
@@ -996,25 +995,8 @@ void RModel::ReadInitializedTensorsFromFile(long pos) {
             if (!i.second.IsWeightTensor()) continue;
             std::string tensor_name = "tensor_" + i.first;
             if (i.second.type() == ETensorType::FLOAT) {
-                size_t length = 1;
-                length = ConvertShapeToLength(i.second.shape());
-                std::string slength = std::to_string(length);
-                fGC += "   f >> tensor_name >> length;\n";
-                fGC += "   if (tensor_name != \"" + tensor_name + "\" ) {\n";
-                fGC += "      std::string err_msg = \"TMVA-SOFIE failed to read the correct tensor name; expected name is " +
-                       tensor_name + " , read \" + tensor_name;\n";
-                fGC += "      throw std::runtime_error(err_msg);\n";
-                fGC += "    }\n";
-                fGC += "   if (length != " + slength + ") {\n";
-                fGC += "      std::string err_msg = \"TMVA-SOFIE failed to read the correct tensor size; expected size is " +
-                       slength + " , read \" + std::to_string(length) ;\n";
-                fGC += "      throw std::runtime_error(err_msg);\n";
-                fGC += "    }\n";
-                fGC += "   for (size_t i = 0; i < length; ++i)\n";
-                fGC += "      f >> " + tensor_name + "[i];\n";
-                fGC += "   if (f.fail()) {\n";
-                fGC += "      throw std::runtime_error(\"TMVA-SOFIE failed to read the values for tensor " + tensor_name + "\");\n";
-                fGC += "   }\n";
+               std::string length = std::to_string(ConvertShapeToLength(i.second.shape()));
+               fGC += "   ReadTensorFromStream(f, " + tensor_name + ", \"" + tensor_name + "\", " + length + ");\n";
             } else {
                std::runtime_error("tmva-sofie tensor " + tensor_name + " with type " + ConvertTypeToString(i.second.type()) + " cannot be read from a file");
             }

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -1,11 +1,12 @@
 #include "TMVA/SOFIE_common.hxx"
-#include<cctype>
+
+#include <cctype>
 #include <sstream>
 #include <stdexcept>
 
-namespace TMVA{
-namespace Experimental{
-namespace SOFIE{
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
 
 /// @brief  Convert shape from integer format to dynamic one (based on Dim)
 /// @param shape
@@ -430,7 +431,6 @@ std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> & shape)
    return strides;
 }
 
-
-}//SOFIE
-}//Experimental
-}//TMVA
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA


### PR DESCRIPTION
This is good practice, as it makes it clear to the reader and compiler that the data will not be modified. This also helps Clad in generating optimized gradients. Actually, it is a requirement for differentiation through the emitted code with the new Clad v1.10, which is now part of ROOT.

In a separate commit, refactor the reading of tensors from an input stream to avoid duplicating boilerplate code in the generated inference session code.