### PR TITLE
[ci] Set `builtin_nlohmannjson=OFF` also for AlmaLinux and Fedora

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
@@ -1,4 +1,3 @@
-builtin_nlohmannjson=ON
 builtin_vdt=On
 tmva-sofie=On
 ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,4 +1,3 @@
-builtin_nlohmannjson=ON
 builtin_vdt=ON
 ccache=ON
 tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -1,5 +1,4 @@
 builtin_zstd=ON
 builtin_zlib=ON
-builtin_nlohmannjson=On
 builtin_vdt=On
 ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/fedora42.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora42.txt
@@ -1,4 +1,3 @@
-builtin_nlohmannjson=ON
 builtin_zlib=ON
 builtin_zstd=ON
 ccache=ON


### PR DESCRIPTION
When these configurations were created, it was thought that AlmaLinux and Fedora don't have any package for nlohmann-json. I guess that was an understandable oversight, because the package doesn't have "nlohmann" in the name. It's just called `json-devel`, and was added to all relevant CI images earlier today.