### PR TITLE
[v626][ci] Also run on `alma9`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,0 +1,5 @@
+builtin_vdt=ON
+dataframe=OFF
+tmva=OFF
+tmva-cpu=OFF
+xml=OFF

--- a/.github/workflows/root-ci-config/buildconfig/ubuntu20.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu20.txt
@@ -1,5 +1,0 @@
-builtin_nlohmannjson=ON
-builtin_vdt=ON
-builtin_xrootd=ON
-builtin_xxhash=ON
-tmva-sofie=On

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -99,6 +99,8 @@ jobs:
         include:
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
+          - image: alma9
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu22
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -175,13 +175,22 @@ if(NOT ROOT_r_FOUND)
   set(r_veto  r/*.C)
 endif()
 
-if(WIN32)
-  set(histfactory_veto histfactory/*.C
-                       roostats/StandardFrequentistDiscovery.C) # histfactory doesn't work on Windows
-else()
-  set(histfactory_veto histfactory/makeExample.C)
+# The following tests use hist2workspace, which requires xml
+if(NOT ROOT_xml_FOUND)
+  list(APPEND xml_veto roostats/OneSidedFrequentistUpperLimitWithBands.C
+                       roostats/StandardBayesianMCMCDemo.C
+                       roostats/StandardBayesianNumericalDemo.C
+                       roostats/StandardFeldmanCousinsDemo.C
+                       roostats/StandardFrequentistDiscovery.C
+                       roostats/StandardHistFactoryPlotsWithCategories.C
+                       roostats/StandardHypoTestDemo.C
+                       roostats/StandardHypoTestInvDemo.C
+                       roostats/StandardProfileInspectorDemo.C
+                       roostats/StandardProfileLikelihoodDemo.C
+                       roostats/StandardTestStatDistributionDemo.C
+                       roostats/TwoSidedFrequentistUpperLimitWithBands.C)
 endif()
-
+set(histfactory_veto histfactory/makeExample.C)
 
 if(NOT ROOT_fitsio_FOUND)
   set(fitsio_veto  fitsio/*.C)


### PR DESCRIPTION
AlmaLinux 9 is the main platform supported by ROOT, so if the 6.26 build can also succeed for this platform, it would be good to add it to the CI matrix. Like this we can be sure that there is still some way to build older ROOT releases.