### PR TITLE
[ci] Set `builtin_vdt=OFF` also for AlmaLinuxes and Fedora 41

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -1,7 +1,6 @@
 builtin_gtest=ON
 builtin_nlohmannjson=ON
 builtin_tbb=ON
-builtin_vdt=On
 fortran=OFF
 tmva-sofie=On
 ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-clang.txt
@@ -1,4 +1,3 @@
 builtin_nlohmannjson=ON
-builtin_vdt=On
 tmva-sofie=On
 ccache=On

--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,4 +1,3 @@
 builtin_nlohmannjson=ON
-builtin_vdt=ON
 ccache=ON
 tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -1,5 +1,4 @@
 builtin_zstd=ON
 builtin_zlib=ON
 builtin_nlohmannjson=On
-builtin_vdt=On
 ccache=On


### PR DESCRIPTION
Most likely, there is also no need to use the builtin VDT anymore. For example, Fedora 42 already disables it.