### PR TITLE
[CMake] Update `builtin_cling=OFF` configuration code

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -85,18 +85,6 @@ add_dependencies(MetaCling CLING clangCppInterOp)
 
 ##### libCling #############################################################
 
-if(NOT builtin_clang)
-  set(prefixed_link_libraries)
-  foreach(dep ${CLING_DEPEND_LIBS})
-    if("${dep}" MATCHES "^clang")
-      set(dep "${LLVM_LIBRARY_DIR}/lib${dep}.a")
-     endif()
-     list(APPEND prefixed_link_libraries "${dep}")
-   endforeach()
-  set(LINK_LIBS "${prefixed_link_libraries}")
-  link_directories("${LLVM_LIBRARY_DIR}")
-endif()
-
 # We need to paste the content of the cling plugins disabling link symbol optimizations.
 set(CLING_PLUGIN_LINK_LIBS)
 if (clad)

--- a/core/rootcling_stage1/CMakeLists.txt
+++ b/core/rootcling_stage1/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 if(builtin_clang)
   set(CLING_LIBRARIES "clingMetaProcessor")
 else()
-  list(APPEND CLING_LIBRARIES ${CLING_DEPEND_LIBS})
   link_directories("${LLVM_LIBRARY_DIR}")
 endif()
 

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -471,42 +471,19 @@ if (builtin_cling)
     endif()
   endif()
 else()
-  set(Cling_DIR ${LLVM_BINARY_DIR}/lib/cmake/cling/)
-  find_package(Cling REQUIRED CONFIG PATHS ${Cling_DIR} "${Cling_DIR}/lib/cmake/cling" "${Cling_DIR}/cmake" NO_DEFAULT_PATH)
-  find_package(Clang REQUIRED CONFIG PATHS ${Cling_DIR} "${Cling_DIR}/lib/cmake/clang" "${Cling_DIR}/cmake" NO_DEFAULT_PATH)
+  # We're using the GLOBAL argument to find_package(Cling) to make the
+  # imported targets available everywhere. This feature was only introduced
+  # with CMake 3.24, so we error out if the version is lower.
+  # TODO: remove once minimum CMake version required for ROOT is >= 3.24.
+  if(CMAKE_VERSION VERSION_LESS 3.24.0)
+    message(FATAL_ERROR "Building ROOT with builtin_cling=OFF requires at least CMake 3.24.0 (current CMake version is ${CMAKE_VERSION})")
+  endif()
 
-  # We need to consider not just the direct link dependencies, but also the
-  # transitive link dependencies. Do this by starting with the set of direct
-  # dependencies, then the dependencies of those dependencies, and so on.
-  set(new_libs "clingMetaProcessor")
-  set(link_libs ${new_libs})
-  while(NOT "${new_libs}" STREQUAL "")
-    foreach(lib ${new_libs})
-      if(TARGET ${lib})
-        get_target_property(lib_type ${lib} TYPE)
-        if("${lib_type}" STREQUAL "STATIC_LIBRARY")
-          list(APPEND static_libs ${lib})
-        else()
-          list(APPEND other_libs ${lib})
-        endif()
-        get_target_property(transitive_libs ${lib} INTERFACE_LINK_LIBRARIES)
-        if (NOT transitive_libs)
-          continue()
-        endif()
-        foreach(transitive_lib ${transitive_libs})
-          list(FIND link_libs ${transitive_lib} idx)
-          #if(TARGET ${transitive_lib} AND idx EQUAL -1)
-          if(idx EQUAL -1)
-            list(APPEND newer_libs ${transitive_lib})
-            list(APPEND link_libs ${transitive_lib})
-          endif()
-        endforeach(transitive_lib)
-      endif()
-    endforeach(lib)
-    set(new_libs ${newer_libs})
-    set(newer_libs "")
-  endwhile()
-  set(CLING_DEPEND_LIBS ${link_libs} CACHE STRING "")
+  find_package(Cling REQUIRED CONFIG GLOBAL)
+  find_package(Clang REQUIRED CONFIG)
+
+  # Forward CLING_INCLUDE_DIRS so it can be used outside the interpreter subdirectory
+  set(CLING_INCLUDE_DIRS ${CLING_INCLUDE_DIRS} PARENT_SCOPE)
 endif(builtin_cling)
 
 


### PR DESCRIPTION
In an attempt to further reduce build times, I attempted to build ROOT with `builtin_cling=OFF`, using a custom cling build that I install on my system.

However, I ran into several errors with cling header files not being found, as well as linker errors.

The simplest fix was to set the `GLOBAL` argument in `find_package(Cling)`, to make all the Cling targets available globally. Then, one also doesn't need all this code for the transient dependencies anymore (this is all handled correctly in the ClingConfig.cmake).

The only caveat of this is that the `GLOBAL` argument is only available from CMake 3.24 onwards, so the configuration with `builtin_cling=OFF` will now error out if the CMake version is lower. That should be acceptable, since users that are adventurous enough to build ROOT like this probably also have a CMake version that is new enough (RHEL 9 has CMake version 3.26, and Ubuntu 24.04 has CMake version 3.28).

Also, don't add any custom search paths to `find_package(Cling)` and `find_package(Clang)`, so that one is forced to use the `Clang_DIR` and `Cling_DIR` hints correctly.