### PR TITLE
[Python] Don't call `TClass::GetClass()` on branch type in TTreePyz

### DIFF
--- a/bindings/pyroot/pythonizations/src/TTreePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TTreePyz.cxx
@@ -86,13 +86,12 @@ static std::pair<void *, std::string> ResolveBranch(TTree *tree, const char *nam
 
    // for return of a full object
    if (branch->IsA() == TBranchElement::Class() || branch->IsA() == TBranchObject::Class()) {
-      TClass *klass = TClass::GetClass(branch->GetClassName());
-      if (klass && branch->GetAddress())
+      if (branch->GetAddress())
          return {*(void **)branch->GetAddress(), branch->GetClassName()};
 
       // try leaf, otherwise indicate failure by returning a typed null-object
       TObjArray *leaves = branch->GetListOfLeaves();
-      if (klass && !tree->GetLeaf(name) && !(leaves->GetSize() && (leaves->First() == leaves->Last())))
+      if (!tree->GetLeaf(name) && !(leaves->GetSize() && (leaves->First() == leaves->Last())))
          return {nullptr, branch->GetClassName()};
    }
 


### PR DESCRIPTION
It's not clear to me how it can even happen that TClass::GetClass() is `nullptr` for the type of a TTree branch.

It looks like the check is superfluous, and by not doing it we can avoid the memory hogging of `GetClass()` for standard vector types.

My suspicion is that the `klass` variable was there because many years ago, cppyy used ROOT casting via TClass, which got replaced at some point from `BindRootObjectNoCast( *(char**)branch->GetAddress(), klass )` to `BindCppObjectNoCast( *(char**)branch->GetAddress(), Cppyy::GetScope( branch->GetClassName() ) )` (see commit 968759856e777). Before that refactor, making the sanity check that `klass` was not `nullptr` made sense. But it looks like this is not needed anymore since the casting is done exclusively with cppyy.

Closes #18524.