### PR TITLE
[webgui] let configure window queue length

### DIFF
--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1657,7 +1657,7 @@ void RWebWindow::SubmitData(unsigned connid, bool txt, std::string &&data, int c
          else
             conn->fQueue.emplace(chid, txt, std::move(data));  // move content
       } else {
-         R__LOG_ERROR(WebGUILog()) << "Maximum queue length achieved";
+         R__LOG_ERROR(WebGUILog()) << "Maximum queue length " << maxqlen << " achieved, can be changed with SetMaxQueueLength(v) method";
       }
    }
 

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -660,6 +660,10 @@ std::shared_ptr<RWebWindow> RWebWindowsManager::CreateWindow()
       win->RecordData(fname, prefix);
    }
 
+   int queuelen = gEnv->GetValue("WebGui.QueueLength", 10);
+   if (queuelen > 0)
+      win->SetMaxQueueLength(queuelen);
+
    if (fExternalProcessEvents) {
       // special mode when window communication performed in THttpServer::ProcessRequests
       // used only with python which create special thread - but is has to be ignored!!!
@@ -786,6 +790,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 ///      WebGui.Console: -1 - output only console.error(), 0 - add console.warn(), 1  - add console.log() output
 ///      WebGui.Debug: "no" (default), "yes" - enable more debug output on JSROOT side
 ///      WebGui.ConnCredits: 10 - number of packets which can be send by server or client without acknowledge from receiving side
+///      WebGui.QueueLength: 10 - maximal number of entires in window send queue
 ///      WebGui.openui5src: alternative location for openui5 like https://openui5.hana.ondemand.com/1.128.0/
 ///      WebGui.openui5libs: list of pre-loaded ui5 libs like sap.m, sap.ui.layout, sap.ui.unified
 ///      WebGui.openui5theme: openui5 theme like sap_belize (default) or sap_fiori_3


### PR DESCRIPTION
By default it is 10 and normally not used - 
all  messages directly send by ROOT via WebSocket to the clients. 
But in some special applications default value too low and need to be adjusted.

Now default value can be changed with "WebGui.QueueLength" rootrc parameter.

Print more info in error message

