### PR TITLE
[ntuple] Simplify `RNTupleProcessor` factory methods

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -392,11 +392,11 @@ private:
    /// \brief Construct a new RNTupleProcessor for processing a single RNTuple.
    ///
    /// \param[in] ntuple The source specification (name and storage location) for the RNTuple to process.
+   /// \param[in] model The model that specifies which fields should be read by the processor.
    /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::Create, this is
    /// the name of the underlying RNTuple.
-   /// \param[in] model The model that specifies which fields should be read by the processor.
-   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::string_view processorName,
-                          std::unique_ptr<ROOT::RNTupleModel> model);
+   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::unique_ptr<ROOT::RNTupleModel> model,
+                          std::string_view processorName);
 
 public:
    RNTupleSingleProcessor(const RNTupleSingleProcessor &) = delete;
@@ -447,15 +447,15 @@ private:
    /// \brief Construct a new RNTupleChainProcessor.
    ///
    /// \param[in] ntuples The source specification (name and storage location) for each RNTuple to process.
-   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateChain, this
-   /// is the name of the first inner processor.
    /// \param[in] model The model that specifies which fields should be read by the processor. The pointer returned by
    /// RNTupleModel::MakeField can be used to access a field's value during the processor iteration. When no model is
    /// specified, it is created from the descriptor of the first RNTuple specified in `ntuples`.
+   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateChain, this
+   /// is the name of the first inner processor.
    ///
    /// RNTuples are processed in the order in which they are specified.
-   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName,
-                         std::unique_ptr<ROOT::RNTupleModel> model);
+   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors,
+                         std::unique_ptr<ROOT::RNTupleModel> model, std::string_view processorName);
 
 public:
    RNTupleChainProcessor(const RNTupleChainProcessor &) = delete;
@@ -526,19 +526,18 @@ private:
    /// \param[in] joinFields The names of the fields on which to join, in case the specified processors are unaligned.
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified processor. If an empty list is provided, it is assumed that the processors are fully aligned.
-   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateJoin, this
-   /// is the name of the primary processor.
    /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary processor can be read by the
    /// processor. If no model is provided, one will be created based on the descriptor of the primary processor.
    /// \param[in] auxModels A list of RNTupleModels specifying which fields from the corresponding auxiliary processor
    /// (according to the order of `auxProcessors`) can be read by the processor. If this vector is empty, the models
    /// will be inferred from their corresponding processors. This also applies to individual auxiliary processors for
    /// which the provided model is a `nullptr`.
+   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateJoin, this
+   /// is the name of the primary processor.
    RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                         std::vector<std::unique_ptr<RNTupleProcessor>> auxProcessors,
-                        const std::vector<std::string> &joinFields, std::string_view processorName,
-                        std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-                        std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {});
+                        const std::vector<std::string> &joinFields, std::unique_ptr<ROOT::RNTupleModel> primaryModel,
+                        std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels, std::string_view processorName);
 
 public:
    RNTupleJoinProcessor(const RNTupleJoinProcessor &) = delete;

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -260,24 +260,12 @@ public:
    /// \param[in] ntuple The name and storage location of the RNTuple to process.
    /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
    /// one will be created based on the descriptor of the first ntuple specified.
+   /// \param[in] processorName The name to give to the processor. If empty, the name of the input RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   Create(RNTupleOpenSpec ntuple, std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create an RNTupleProcessor for a single RNTuple.
-   ///
-   /// \param[in] ntuple The name and storage location of the RNTuple to process.
-   /// \param[in] processorName The name to give to the processor. Use
-   /// Create(const RNTupleOpenSpec &, std::unique_ptr<RNTupleModel>) to automatically use the name of the input RNTuple
-   /// instead.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the descriptor of the first ntuple specified.
-   ///
-   /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   Create(RNTupleOpenSpec ntuple, std::string_view processorName, std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
+   static std::unique_ptr<RNTupleProcessor> Create(RNTupleOpenSpec ntuple,
+                                                   std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
+                                                   std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of RNTuples.
@@ -285,25 +273,12 @@ public:
    /// \param[in] ntuples A list specifying the names and locations of the RNTuples to process.
    /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
    /// one will be created based on the descriptor of the first RNTuple specified.
-   ///
-   /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   CreateChain(std::vector<RNTupleOpenSpec> ntuples, std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of RNTuples.
-   ///
-   /// \param[in] ntuples A list specifying the names and locations of the RNTuples to process.
-   /// \param[in] processorName The name to give to the processor. Use
-   /// CreateChain(const RNTupleOpenSpec &, std::unique_ptr<RNTupleModel>) to automatically use the name of the first
-   /// input RNTuple instead.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the descriptor of the first RNTuple specified.
+   /// \param[in] processorName The name to give to the processor. If empty, the name of the first RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor> CreateChain(std::vector<RNTupleOpenSpec> ntuples,
-                                                        std::string_view processorName,
-                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
+                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
+                                                        std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of other RNTupleProcessors.
@@ -311,25 +286,13 @@ public:
    /// \param[in] innerProcessors A list with the processors to chain.
    /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
    /// one will be created based on the model used by the first inner processor.
+   /// \param[in] processorName The name to give to the processor. If empty, the name of the first inner processor is
+   /// used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor> CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
-                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of other RNTupleProcessors.
-   ///
-   /// \param[in] innerProcessors A list with the processors to chain.
-   /// \param[in] processorName The name to give to the processor. Use
-   /// CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>>, std::unique_ptr<RNTupleModel>) to automatically use
-   /// the name of the first inner processor instead.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the model used by the first inner processor.
-   ///
-   /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
-                                                        std::string_view processorName,
-                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr);
+                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
+                                                        std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -348,42 +311,13 @@ public:
    /// (according to the order of `auxNTuples`) can be read by the processor. If this vector is empty, the models will
    /// be created based on the descriptors of their corresponding RNTuples. This also applies to individual auxiliary
    /// RNTuples for which the provided model is a `nullptr`.
+   /// \param[in] processorName The name to give to the processor. If empty, the name of the primary RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
    CreateJoin(RNTupleOpenSpec primaryNTuple, std::vector<RNTupleOpenSpec> auxNTuples,
               const std::vector<std::string> &joinFields, std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-              std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {});
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
-   ///
-   /// \param[in] primaryNTuple The name and location of the primary RNTuple. Its entries are processed in sequential
-   /// order.
-   /// \param[in] auxNTuples The names and locations of the RNTuples to join the primary RNTuple with. The order in
-   /// which their entries are processed are determined by the primary RNTuple and doesn't necessarily have to be
-   /// sequential.
-   /// \param[in] joinFields The names of the fields on which to join, in case the specified RNTuples are unaligned.
-   /// The join is made based on the combined join field values, and therefore each field has to be present in each
-   /// specified RNTuple. If an empty list is provided, it is assumed that the specified RNTuple are fully aligned.
-   /// \param[in] processorName The name to give to the processor. Use
-   /// CreateJoin(const RNTupleOpenSpec &, const std::vector<RNTupleOpenSpec> &, const std::vector<std::string> &,
-   /// std::unique_ptr<RNTupleModel>, std::vector<std::unique_ptr<RNTupleModel>>) to automatically use the name of the
-   /// input RNTuple instead.
-   /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary RNTuple
-   /// can be read by the processor. If no model is provided, one will be created based on the descriptor of the primary
-   /// RNTuple.
-   /// \param[in] auxModels A list of RNTupleModels specifying which fields from the corresponding auxiliary
-   /// RNTuple (according to the order of `auxNTuples`) can be read by the processor. If this vector is empty, the
-   /// models will be created based on the descriptors of their corresponding RNTuples. This also applies to individual
-   /// auxiliary RNTuples for which the provided model is a `nullptr`.
-   ///
-   /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   CreateJoin(RNTupleOpenSpec primaryNTuple, std::vector<RNTupleOpenSpec> auxNTuples,
-              const std::vector<std::string> &joinFields, std::string_view processorName,
-              std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-              std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {});
+              std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {}, std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -401,41 +335,14 @@ public:
    /// (according to the order of `auxProcessors`) can be read by the processor. If this vector is empty, the models
    /// will be inferred from their corresponding processors. This also applies to individual auxiliary processors for
    /// which the provided model is a `nullptr`.
-   ///
-   /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor,
-                                                       std::vector<std::unique_ptr<RNTupleProcessor>> auxProcessors,
-                                                       const std::vector<std::string> &joinFields,
-                                                       std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-                                                       std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {});
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
-   ///
-   /// \param[in] primaryProcessor The primary processor. Its entries are processed in sequential order.
-   /// \param[in] auxProcessors The processors to join the primary processor with. The order in which their entries are
-   /// processed are determined by the primary processor and doesn't necessarily have to be sequential.
-   /// \param[in] joinFields The names of the fields on which to join, in case the specified processors are unaligned.
-   /// The join is made based on the combined join field values, and therefore each field has to be present in each
-   /// specified processors. If an empty list is provided, it is assumed that the specified processors are fully
-   /// aligned.
-   /// \param[in] processorName The name to give to the processor. Use
-   /// CreateJoin(std::unique_ptr<RNTupleProcessor>, std::vector<std::unique_ptr<RNTupleProcessor>>,
-   /// const std::vector<std::string> &, std::unique_ptr<RNTupleModel>, std::vector<std::unique_ptr<RNTupleModel>>)
-   /// to automatically use the name of the input processor instead.
-   /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary processor can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the primary processor.
-   /// \param[in] auxModels A list of RNTupleModels specifying which fields from the corresponding auxiliary processor
-   /// (according to the order of `auxProcessors`) can be read by the processor. If this vector is empty, the models
-   /// will be inferred from their corresponding processors. This also applies to individual auxiliary processors for
-   /// which the provided model is a `nullptr`.
+   /// \param[in] processorName The name to give to the processor. If empty, the name of the primary processor is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
    CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor,
               std::vector<std::unique_ptr<RNTupleProcessor>> auxProcessors, const std::vector<std::string> &joinFields,
-              std::string_view processorName, std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-              std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {});
+              std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
+              std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels = {}, std::string_view processorName = "");
 };
 
 // clang-format off

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -36,7 +36,7 @@ ROOT::Experimental::RNTupleProcessor::Create(RNTupleOpenSpec ntuple, std::unique
                                              std::string_view processorName)
 {
    return std::unique_ptr<RNTupleSingleProcessor>(
-      new RNTupleSingleProcessor(std::move(ntuple), processorName, std::move(model)));
+      new RNTupleSingleProcessor(std::move(ntuple), std::move(model), processorName));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
@@ -78,7 +78,7 @@ ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<std::unique_ptr<RN
    }
 
    return std::unique_ptr<RNTupleChainProcessor>(
-      new RNTupleChainProcessor(std::move(innerProcessors), processorName, std::move(model)));
+      new RNTupleChainProcessor(std::move(innerProcessors), std::move(model), processorName));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
@@ -145,15 +145,15 @@ std::unique_ptr<ROOT::Experimental::RNTupleProcessor> ROOT::Experimental::RNTupl
    }
 
    return std::unique_ptr<RNTupleJoinProcessor>(
-      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessors), joinFields, processorName,
-                               std::move(primaryModel), std::move(auxModels)));
+      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessors), joinFields,
+                               std::move(primaryModel), std::move(auxModels), processorName));
 }
 
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(RNTupleOpenSpec ntuple,
-                                                                   std::string_view processorName,
-                                                                   std::unique_ptr<ROOT::RNTupleModel> model)
+                                                                   std::unique_ptr<ROOT::RNTupleModel> model,
+                                                                   std::string_view processorName)
    : RNTupleProcessor(processorName, std::move(model)), fNTupleSpec(std::move(ntuple))
 {
    if (!fModel) {
@@ -251,8 +251,8 @@ void ROOT::Experimental::RNTupleSingleProcessor::AddEntriesToJoinTable(Internal:
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
-   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName,
-   std::unique_ptr<ROOT::RNTupleModel> model)
+   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::unique_ptr<ROOT::RNTupleModel> model,
+   std::string_view processorName)
    : RNTupleProcessor(processorName, std::move(model)), fInnerProcessors(std::move(processors))
 {
    if (fProcessorName.empty()) {
@@ -357,8 +357,8 @@ void ROOT::Experimental::RNTupleChainProcessor::AddEntriesToJoinTable(Internal::
 
 ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(
    std::unique_ptr<RNTupleProcessor> primaryProcessor, std::vector<std::unique_ptr<RNTupleProcessor>> auxProcessors,
-   const std::vector<std::string> &joinFields, std::string_view processorName,
-   std::unique_ptr<ROOT::RNTupleModel> primaryModel, std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels)
+   const std::vector<std::string> &joinFields, std::unique_ptr<ROOT::RNTupleModel> primaryModel,
+   std::vector<std::unique_ptr<ROOT::RNTupleModel>> auxModels, std::string_view processorName)
    : RNTupleProcessor(processorName, nullptr),
      fPrimaryProcessor(std::move(primaryProcessor)),
      fAuxiliaryProcessors(std::move(auxProcessors))

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -195,7 +195,7 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
    EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
 
    {
-      auto namedProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, "my_ntuple");
+      auto namedProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, nullptr, "my_ntuple");
       EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
    }
 
@@ -351,7 +351,7 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedPrimary)
       RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}}, {});
 
    std::vector<std::unique_ptr<RNTupleProcessor>> auxProcs;
-   auxProcs.emplace_back(RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, "ntuple_aux2"));
+   auxProcs.emplace_back(RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2"));
 
    auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProcs), {"i"});
 
@@ -377,7 +377,8 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedAuxiliary)
    auto primaryProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
 
    std::vector<std::unique_ptr<RNTupleProcessor>> auxProcsIntermediate;
-   auxProcsIntermediate.emplace_back(RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, "ntuple_aux2"));
+   auxProcsIntermediate.emplace_back(
+      RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2"));
 
    std::vector<std::unique_ptr<RNTupleProcessor>> auxProcs;
    auxProcs.emplace_back(RNTupleProcessor::CreateJoin(RNTupleProcessor::Create({fNTupleNames[1], fFileNames[1]}),

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -104,8 +104,8 @@ TEST_F(RNTupleChainProcessorTest, Basic)
    EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
 
    {
-      auto namedProc =
-         RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, "my_ntuple");
+      auto namedProc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}},
+                                                     nullptr, "my_ntuple");
       EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
    }
 

--- a/tree/ntuple/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/test/ntuple_processor_join.cxx
@@ -90,7 +90,7 @@ TEST_F(RNTupleJoinProcessorTest, PrimaryOnly)
    EXPECT_STREQ("ntuple1", proc->GetProcessorName().c_str());
 
    {
-      auto namedProc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {}, {}, "my_ntuple");
+      auto namedProc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {}, {}, nullptr, {}, "my_ntuple");
       EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
    }
 


### PR DESCRIPTION
As discussed in https://github.com/root-project/root/pull/18224#discussion_r2055968876, having a separate overload for `processorName` causes a lot of bloat. With this PR, instead of having an overload that takes `processorName`, now it is just an optional argument with the empty
string as a default argument. This simplifies and de-bloats the interface quite significantly.

The constructors for each `RNTupleProcessor` subclass have been refactored to reflect this new argument order, and the "burden" of inferring the processor's name has been moved from the factories to the constructors.
