### PR TITLE
[ntuple] Save a memcpy when reading a compressed Anchor in RMiniFile

### DIFF
--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -763,25 +763,27 @@ ROOT::RResult<ROOT::RNTuple> ROOT::Internal::RMiniFileReader::GetNTupleProper(st
    if (key.fObjLen < kMinNTupleSize) {
       return R__FAIL("invalid anchor size: " + std::to_string(key.fObjLen) + " < " + std::to_string(sizeof(RTFNTuple)));
    }
+
    // The object length can be smaller than the size of RTFNTuple if it comes from a past RNTuple class version,
    // or larger than it if it comes from a future RNTuple class version.
    auto bufAnchor = MakeUninitArray<unsigned char>(std::max<size_t>(key.fObjLen, sizeof(RTFNTuple)));
    RTFNTuple *ntuple = new (bufAnchor.get()) RTFNTuple;
 
-   auto objNbytes = key.GetSize() - key.fKeyLen;
-   ReadBuffer(ntuple, objNbytes, offset);
+   const auto objNbytes = key.GetSize() - key.fKeyLen;
    if (objNbytes != key.fObjLen) {
-      // Decompress into a temporary buffer
-      auto unzipBuf = MakeUninitArray<unsigned char>(key.fObjLen);
-      RNTupleDecompressor::Unzip(bufAnchor.get(), objNbytes, key.fObjLen, unzipBuf.get());
-      // Then copy back to bufAnchor
-      memcpy(bufAnchor.get(), unzipBuf.get(), key.fObjLen);
+      // Read into a temporary buffer
+      auto unzipBuf = MakeUninitArray<unsigned char>(std::max<size_t>(key.fObjLen, sizeof(RTFNTuple)));
+      ReadBuffer(unzipBuf.get(), objNbytes, offset);
+      // Unzip into the final buffer
+      RNTupleDecompressor::Unzip(unzipBuf.get(), objNbytes, key.fObjLen, ntuple);
+   } else {
+      ReadBuffer(ntuple, objNbytes, offset);
    }
 
    // We require that future class versions only append members and store the checksum in the last 8 bytes
    // Checksum calculation: strip byte count, class version, fChecksum member
-   auto lenCkData = key.fObjLen - ntuple->GetOffsetCkData() - sizeof(uint64_t);
-   auto ckCalc = XXH3_64bits(ntuple->GetPtrCkData(), lenCkData);
+   const auto lenCkData = key.fObjLen - ntuple->GetOffsetCkData() - sizeof(uint64_t);
+   const auto ckCalc = XXH3_64bits(ntuple->GetPtrCkData(), lenCkData);
    uint64_t ckOnDisk;
 
    RUInt64BE *ckOnDiskPtr = reinterpret_cast<RUInt64BE *>(bufAnchor.get() + key.fObjLen - sizeof(uint64_t));


### PR DESCRIPTION
Do:
  (read into unzipBuf) -> (unzip into finalBuf)

instead of:
  (read into finalBuf) -> (unzip into unzipBuf) -> (copy back to finalBuf)


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


