### PR TITLE
[ntuple] Fix setting of trivial traits for `RStreamerField`

### DIFF
--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -828,9 +828,12 @@ ROOT::RStreamerField::RStreamerField(std::string_view fieldName, TClass *classp)
      fIndex(0)
 {
    fTraits |= kTraitTypeChecksum;
-   if (!(fClass->ClassProperty() & kClassHasExplicitCtor))
+   // For RClassField, we only check for explicit constructors and destructors and then recursively combine traits from
+   // all member subfields. For RStreamerField, we treat the class as a black box and additionally need to check for
+   // implicit constructors and destructors.
+   if (!(fClass->ClassProperty() & (kClassHasExplicitCtor | kClassHasImplicitCtor)))
       fTraits |= kTraitTriviallyConstructible;
-   if (!(fClass->ClassProperty() & kClassHasExplicitDtor))
+   if (!(fClass->ClassProperty() & (kClassHasExplicitDtor | kClassHasImplicitDtor)))
       fTraits |= kTraitTriviallyDestructible;
 }
 

--- a/tree/ntuple/test/StreamerField.hxx
+++ b/tree/ntuple/test/StreamerField.hxx
@@ -6,6 +6,30 @@
 #include <memory>
 #include <vector>
 
+struct TrivialStreamedClass {
+   int fA;
+};
+
+struct ContainsTrivialStreamedClass {
+   TrivialStreamedClass fStreamed;
+};
+
+struct ConstructorStreamedClass {
+   ConstructorStreamedClass() {}
+};
+
+struct ContainsConstructorStreamedClass {
+   ConstructorStreamedClass fStreamed;
+};
+
+struct DestructorStreamedClass {
+   ~DestructorStreamedClass() {}
+};
+
+struct ContainsDestructorStreamedClass {
+   DestructorStreamedClass fStreamed;
+};
+
 struct CyclicMember {
    float fB = 0.0;
    std::vector<CyclicMember> fV;

--- a/tree/ntuple/test/StreamerFieldLinkDef.h
+++ b/tree/ntuple/test/StreamerFieldLinkDef.h
@@ -1,5 +1,12 @@
 #ifdef __CLING__
 
+#pragma link C++ struct TrivialStreamedClass + ;
+#pragma link C++ struct ContainsTrivialStreamedClass + ;
+#pragma link C++ struct ConstructorStreamedClass + ;
+#pragma link C++ struct ContainsConstructorStreamedClass + ;
+#pragma link C++ struct DestructorStreamedClass + ;
+#pragma link C++ struct ContainsDestructorStreamedClass + ;
+
 #pragma link C++ struct CyclicMember;
 #pragma link C++ class ClassWithStreamedMember + ;
 #pragma link C++ class CustomStreamer - ;

--- a/tree/ntuple/test/rfield_streamer.cxx
+++ b/tree/ntuple/test/rfield_streamer.cxx
@@ -7,6 +7,28 @@
 #include "StreamerField.hxx"
 #include "StreamerFieldXML.h"
 
+TEST(RField, StreamerTraits)
+{
+   auto trivial = std::make_unique<ROOT::RStreamerField>("trivial", "TrivialStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTrivialType | RFieldBase::kTraitTypeChecksum, trivial->GetTraits());
+   auto containsTrivial = std::make_unique<ROOT::RStreamerField>("containsTrivial", "ContainsTrivialStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTrivialType | RFieldBase::kTraitTypeChecksum, containsTrivial->GetTraits());
+
+   auto constructor = std::make_unique<ROOT::RStreamerField>("constructor", "ConstructorStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible | RFieldBase::kTraitTypeChecksum, constructor->GetTraits());
+   auto containsConstructor =
+      std::make_unique<ROOT::RStreamerField>("containsConstructor", "ContainsConstructorStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible | RFieldBase::kTraitTypeChecksum,
+             containsConstructor->GetTraits());
+
+   auto destructor = std::make_unique<ROOT::RStreamerField>("destructor", "DestructorStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyConstructible | RFieldBase::kTraitTypeChecksum, destructor->GetTraits());
+   auto containsDestructor =
+      std::make_unique<ROOT::RStreamerField>("containsDestructor", "ContainsDestructorStreamedClass");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyConstructible | RFieldBase::kTraitTypeChecksum,
+             containsDestructor->GetTraits());
+}
+
 TEST(RField, StreamerDirect)
 {
    FileRaii fileGuard("test_ntuple_rfield_streamer_direct.root");


### PR DESCRIPTION
Before, classes without explicit constructor / destructor but containing a non-trivial member would still be flagged as trivial.

This fixes the first of two issues causing crashes found by CMS: https://github.com/cms-sw/cmssw/issues/48005