### PR TITLE
[ntuple] Correctly construct values in staging area

### DIFF
--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -190,7 +190,7 @@ public:
    RClassField(std::string_view fieldName, std::string_view className);
    RClassField(RClassField &&other) = default;
    RClassField &operator=(RClassField &&other) = default;
-   ~RClassField() override = default;
+   ~RClassField() override;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final;

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -366,7 +366,8 @@ void ROOT::RClassField::PrepareStagingArea(const std::vector<const TSchemaRule *
 
    if (stagingAreaSize) {
       R__ASSERT(static_cast<Int_t>(stagingAreaSize) <= fStagingClass->Size()); // we may have removed rules
-      fStagingArea = ROOT::Internal::MakeUninitArray<unsigned char>(stagingAreaSize);
+      // We use std::make_unique instead of MakeUninitArray to zero-initialize the staging area.
+      fStagingArea = std::make_unique<unsigned char[]>(stagingAreaSize);
    }
 }
 

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -286,6 +286,21 @@ struct NewName {
    T fValue;
 };
 
+struct SourceStruct {
+   int fValue;
+   int fTransient; //!
+   SourceStruct()
+   {
+      fValue = 17;
+      fTransient = 23;
+   }
+};
+
+struct StructWithSourceStruct {
+   SourceStruct fSource;
+   int fTransient = 0; //!
+};
+
 struct Cyclic {
    std::vector<Cyclic> fMember;
 };

--- a/tree/ntuple/test/CustomStructLinkDef.h
+++ b/tree/ntuple/test/CustomStructLinkDef.h
@@ -128,6 +128,12 @@
 #pragma link C++ options = version(3) class NewName < NewName < int>> + ;
 #pragma read sourceClass = "OldName<OldName<int>>" targetClass = "NewName<OldName<int>>" version = "[3]"
 
+#pragma link C++ struct SourceStruct + ;
+#pragma link C++ struct StructWithSourceStruct + ;
+#pragma read sourceClass = "StructWithSourceStruct" source = "SourceStruct fSource" targetClass = \
+   "StructWithSourceStruct" target = "fTransient" code =                                          \
+      "{ fTransient = onfile.fSource.fValue + onfile.fSource.fTransient; }"
+
 #pragma link C++ class Cyclic + ;
 #pragma link C++ class CyclicCollectionProxy + ;
 #pragma link C++ class Unsupported + ;


### PR DESCRIPTION
... and delete them in the destructor of `RClassField`. This is important for non-trivial types where zero-initialization is not sufficient or that need to free resources in their destructor (for example a `std::vector` constructed by an `RVectorField`).

This fixes the second issue causing crashes found by CMS: https://github.com/cms-sw/cmssw/issues/48005