### PR TITLE
[core] Improve class name normalisation | fix crash in tutorial-analysis-dataframe-df014_CSVDataSource-py

### DIFF
--- a/core/meta/test/testTClass.cxx
+++ b/core/meta/test/testTClass.cxx
@@ -69,3 +69,14 @@ TEST(TClass, BuildRealData)
 {
    TClass::GetClass("TClass")->BuildRealData();
 }
+
+// https://github.com/root-project/root/issues/18654
+TEST(TClass, ConsistentSTLLookup)
+{
+   // The lookup via normalised shortened name yielded a different class
+   // than lookup via typeid. This lead to crashes in cppyy.
+   auto first = TClass::GetClass("unordered_map<string,char>", true, true);
+   std::unordered_map<std::string, char> map;
+   auto second = first->GetActualClass(&map);
+   EXPECT_EQ(first, second);
+}


### PR DESCRIPTION
When looking up a TClass via name vs via typeid, the lookup proceeded
without default template arguments in the former, and with default
arguments in the latter case.
This lead to a situation where
`tclass->GetActualClass(std::map<x,y>*)`
could delete itself while performing the lookup, since a new instance
was created that replaced the existing instance.

In the df014 tutorial, cppyy was essentially calling
```c++
   auto first = TClass::GetClass("unordered_map<string,char>", true, true);
   std::unordered_map<std::string,char> map;
   auto second = first->GetActualClass(&map);
```
Before this PR, `first != second`, and `first` was being deleted while `first->GetActualClass` was still running.

Now, the class lookup in such a case is retried without the default STL arguments, which should lead to `first == second` in the above example. A test for this behaviour was added.

Thanks to @pcanal for advice.