### PR TITLE
[ntuple] Cast min/max to the actual type when quantizing/unquantizing in Real32Quant

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
@@ -455,13 +455,12 @@ public:
 
    /// Sets this field to use a quantized integer representation using `nBits` per value.
    /// It must be $1 <= nBits <= 32$.
-   /// `minValue` and `maxValue` must not be infinity, `NaN` or denormal floats, and they must be representable by the
-   /// type `T`.
+   /// `minValue` and `maxValue` must not be infinity, `NaN` or denormal floats.
    /// Calling this function establishes a promise by the caller to RNTuple that this field will only contain values
    /// contained in `[minValue, maxValue]` inclusive. If a value outside this range is assigned to this field, the
    /// behavior is undefined.
    /// This is mutually exclusive with SetTruncated() and SetHalfPrecision() and supersedes them if called after them.
-   void SetQuantized(double minValue, double maxValue, std::size_t nBits)
+   void SetQuantized(T minValue, T maxValue, std::size_t nBits)
    {
       const auto &[minBits, maxBits] =
          ROOT::Internal::RColumnElementBase::GetValidBitRange(ROOT::ENTupleColumnType::kReal32Quant);

--- a/tree/ntuple/src/RColumnElement.hxx
+++ b/tree/ntuple/src/RColumnElement.hxx
@@ -1028,6 +1028,11 @@ int QuantizeReals(Quantized_t *dst, const T *src, std::size_t count, double min,
    static_assert(sizeof(T) <= sizeof(double));
    assert(1 <= nQuantBits && nQuantBits <= 8 * sizeof(Quantized_t));
 
+   // `min` and `max` are supposed to be exactly representable by type `T` because we cast them to `T` in
+   // SetQuantized().
+   assert(min == static_cast<double>(static_cast<T>(min)));
+   assert(max == static_cast<double>(static_cast<T>(max)));
+
    const std::size_t quantMax = (1ull << nQuantBits) - 1;
    const double scale = quantMax / (max - min);
    const std::size_t unusedBits = sizeof(Quantized_t) * 8 - nQuantBits;
@@ -1067,8 +1072,7 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
    const double scale = (max - min) / quantMax;
    const std::size_t unusedBits = sizeof(Quantized_t) * 8 - nQuantBits;
    const double eps = std::numeric_limits<double>::epsilon();
-   const double emin = min - std::abs(min) * eps;
-   const double emax = max + std::abs(max) * eps;
+   const double emax = max + std::max(1.0, std::abs(max)) * eps;
 
    int nOutOfRange = 0;
 
@@ -1080,10 +1084,20 @@ int UnquantizeReals(T *dst, const Quantized_t *src, std::size_t count, double mi
       ByteSwapIfNecessary(elem);
 
       const double fq = static_cast<double>(elem);
-      const double e = fq * scale + min;
-      dst[i] = static_cast<T>(e);
+      double e = fq * scale + min;
 
-      nOutOfRange += !(emin <= dst[i] && dst[i] <= emax);
+      // NOTE: `e` must be greater or equal than precisely `min` because the min value is represented
+      // by a quantized value of 0, meaning there is no floating point error accumulation coming from
+      // `e = fq * scale + min` (as it just becomes `e = min`).
+      // For the max value, however, some error is introduced by the operation, therefore we allow for
+      // some leeway in the out of range check.
+      nOutOfRange += !(min <= e && e <= emax);
+
+      // Since we want to guarantee that the out value is always within `min` and `max`,
+      // after the bounds check we clamp the value to the stored `max`.
+      e = std::min(e, max);
+
+      dst[i] = static_cast<T>(e);
    }
 
    return nOutOfRange;

--- a/tree/ntuple/test/ntuple_packing.cxx
+++ b/tree/ntuple/test/ntuple_packing.cxx
@@ -449,7 +449,7 @@ TEST(Packing, Real32TruncFloat)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 3.5f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -490,7 +490,7 @@ TEST(Packing, Real32TruncFloat)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 992.f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -521,7 +521,7 @@ TEST(Packing, Real32TruncFloat)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 2.126f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -608,7 +608,7 @@ TEST(Packing, Real32TruncDouble)
       element.Unpack(nullptr, nullptr, 0);
 
       double f1 = 3.5f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       double f2;
@@ -649,7 +649,7 @@ TEST(Packing, Real32TruncDouble)
       element.Unpack(nullptr, nullptr, 0);
 
       double f1 = 992.f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       double f2;
@@ -680,7 +680,7 @@ TEST(Packing, Real32TruncDouble)
       element.Unpack(nullptr, nullptr, 0);
 
       double f1 = 2.126f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       double f2;
@@ -841,7 +841,7 @@ TEST(Packing, Real32QuantFloat)
       element.Unpack(nullptr, nullptr, 0);
 
       float f1 = 3.5f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       float f2;
@@ -883,7 +883,7 @@ TEST(Packing, Real32QuantFloat)
       element.SetValueRange(-10.f, 10.f);
 
       float f1 = -10.f;
-      unsigned char out[1];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
       float f2;
       element.Unpack(&f2, out, 1);
@@ -902,7 +902,7 @@ TEST(Packing, Real32QuantFloat)
       element.SetValueRange(-10.f, 10.f);
 
       float f1 = -5.f;
-      unsigned char out[4];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
       float f2;
       element.Unpack(&f2, out, 1);
@@ -966,7 +966,7 @@ TEST(Packing, Real32QuantDouble)
       element.Unpack(nullptr, nullptr, 0);
 
       double f1 = 3.5f;
-      unsigned char out[8];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
 
       double f2;
@@ -1008,7 +1008,7 @@ TEST(Packing, Real32QuantDouble)
       element.SetValueRange(-10.f, 10.f);
 
       double f1 = -10.f;
-      unsigned char out[1];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
       double f2;
       element.Unpack(&f2, out, 1);
@@ -1027,7 +1027,7 @@ TEST(Packing, Real32QuantDouble)
       element.SetValueRange(-10.f, 10.f);
 
       double f1 = -5.f;
-      unsigned char out[4];
+      unsigned char out[BitPacking::MinBufSize(1, kBitsOnStorage)];
       element.Pack(out, &f1, 1);
       double f2;
       element.Unpack(&f2, out, 1);


### PR DESCRIPTION
See the commit message for more details.

This PR should be backported, probably even to 6.34 to make it work with the rntuple validation suite.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


