### PR TITLE
[ntuple] Accept a single auxiliary processor in `RNTupleProcessor::CreateJoin`

### DIFF
--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -384,3 +384,18 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedAuxiliary)
       EXPECT_THAT(err.what(), testing::HasSubstr("auxiliary RNTupleJoinProcessors are currently not supported"));
    }
 }
+
+TEST_F(RNTupleProcessorTest, JoinedJoinComposedSameName)
+{
+   auto primaryProc =
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {});
+
+   try {
+      auto auxProc = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]});
+      auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {"i"});
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("a field or nested auxiliary processor named \"ntuple_aux\" "
+                                                 "is already present in the model of the primary processor; rename "
+                                                 "the auxiliary processor to avoid conflicts"));
+   }
+}

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -243,9 +243,9 @@ TEST_F(RNTupleProcessorTest, ChainedJoin)
 {
    std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
    innerProcs.push_back(
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}}, {}));
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {}));
    innerProcs.push_back(
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}}, {}));
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {}));
 
    auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
 
@@ -269,9 +269,9 @@ TEST_F(RNTupleProcessorTest, ChainedJoinUnaligned)
 {
    std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
    innerProcs.push_back(
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[2], fFileNames[2]}}, {"i"}));
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[2], fFileNames[2]}, {"i"}));
    innerProcs.push_back(
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[2], fFileNames[2]}}, {"i"}));
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[2], fFileNames[2]}, {"i"}));
 
    auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
 
@@ -296,9 +296,8 @@ TEST_F(RNTupleProcessorTest, JoinedChain)
    auto primaryChain =
       RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}});
 
-   std::vector<std::unique_ptr<RNTupleProcessor>> auxiliaryChain;
-   auxiliaryChain.emplace_back(
-      RNTupleProcessor::CreateChain({{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[1], fFileNames[1]}}));
+   auto auxiliaryChain =
+      RNTupleProcessor::CreateChain({{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[1], fFileNames[1]}});
 
    auto proc = RNTupleProcessor::CreateJoin(std::move(primaryChain), std::move(auxiliaryChain), {});
 
@@ -323,9 +322,8 @@ TEST_F(RNTupleProcessorTest, JoinedChainUnaligned)
    auto primaryChain =
       RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}});
 
-   std::vector<std::unique_ptr<RNTupleProcessor>> auxiliaryChain;
-   auxiliaryChain.emplace_back(
-      RNTupleProcessor::CreateChain({{fNTupleNames[2], fFileNames[2]}, {fNTupleNames[2], fFileNames[2]}}));
+   auto auxiliaryChain =
+      RNTupleProcessor::CreateChain({{fNTupleNames[2], fFileNames[2]}, {fNTupleNames[2], fFileNames[2]}});
 
    auto proc = RNTupleProcessor::CreateJoin(std::move(primaryChain), std::move(auxiliaryChain), {"i"});
 
@@ -348,12 +346,11 @@ TEST_F(RNTupleProcessorTest, JoinedChainUnaligned)
 TEST_F(RNTupleProcessorTest, JoinedJoinComposedPrimary)
 {
    auto primaryProc =
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}}, {});
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {});
 
-   std::vector<std::unique_ptr<RNTupleProcessor>> auxProcs;
-   auxProcs.emplace_back(RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2"));
+   auto auxProc = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2");
 
-   auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProcs), {"i"});
+   auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {"i"});
 
    int nEntries = 0;
 
@@ -376,16 +373,13 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedAuxiliary)
 {
    auto primaryProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
 
-   std::vector<std::unique_ptr<RNTupleProcessor>> auxProcsIntermediate;
-   auxProcsIntermediate.emplace_back(
-      RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2"));
+   auto auxProcIntermediate = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, nullptr, "ntuple_aux2");
 
-   std::vector<std::unique_ptr<RNTupleProcessor>> auxProcs;
-   auxProcs.emplace_back(RNTupleProcessor::CreateJoin(RNTupleProcessor::Create({fNTupleNames[1], fFileNames[1]}),
-                                                      std::move(auxProcsIntermediate), {"i"}));
+   auto auxProc = RNTupleProcessor::CreateJoin(RNTupleProcessor::Create({fNTupleNames[1], fFileNames[1]}),
+                                               std::move(auxProcIntermediate), {"i"});
 
    try {
-      auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProcs), {});
+      auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {});
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("auxiliary RNTupleJoinProcessors are currently not supported"));
    }

--- a/tree/ntuple/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/test/ntuple_processor_join.cxx
@@ -83,41 +83,16 @@ protected:
    }
 };
 
-TEST_F(RNTupleJoinProcessorTest, PrimaryOnly)
-{
-   // Primary ntuple only
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {}, {});
-   EXPECT_STREQ("ntuple1", proc->GetProcessorName().c_str());
-
-   {
-      auto namedProc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {}, {}, nullptr, {}, "my_ntuple");
-      EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
-   }
-
-   int nEntries = 0;
-   for (const auto &entry : *proc) {
-      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
-      ;
-
-      auto i = entry.GetPtr<int>("i");
-      EXPECT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
-   }
-
-   EXPECT_EQ(5, proc->GetNEntriesProcessed());
-}
-
 TEST_F(RNTupleJoinProcessorTest, Aligned)
 {
    try {
-      auto proc =
-         RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[0], fFileNames[0]}}, {});
+      auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}, {});
       FAIL() << "ntuples with the same name cannot be joined horizontally";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("joining RNTuples with the same name is not allowed"));
    }
 
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {{fNTupleNames[2], fFileNames[2]}}, {});
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}, {});
 
    int nEntries = 0;
    std::vector<float> yExpected;
@@ -138,7 +113,7 @@ TEST_F(RNTupleJoinProcessorTest, Aligned)
 
 TEST_F(RNTupleJoinProcessorTest, IdenticalFieldNames)
 {
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {{fNTupleNames[2], fFileNames[2]}}, {});
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}, {});
 
    auto i = proc->GetEntry().GetPtr<int>("i");
    for (auto &entry : *proc) {
@@ -151,8 +126,7 @@ TEST_F(RNTupleJoinProcessorTest, IdenticalFieldNames)
 
 TEST_F(RNTupleJoinProcessorTest, UnalignedSingleJoinField)
 {
-   auto proc =
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}}, {"i"});
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {"i"});
 
    int nEntries = 0;
    auto i = proc->GetEntry().GetPtr<int>("i");
@@ -175,7 +149,7 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedSingleJoinField)
 TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
 {
    try {
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[3], fFileNames[3]}},
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[3], fFileNames[3]},
                                    {"i", "j", "k", "l", "m"});
       FAIL() << "trying to create a join processor with more than four join fields should throw";
    } catch (const ROOT::RException &err) {
@@ -183,14 +157,14 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
    }
 
    try {
-      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[3], fFileNames[3]}}, {"i", "i"});
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[3], fFileNames[3]}, {"i", "i"});
       FAIL() << "trying to create a join processor with duplicate join fields should throw";
    } catch (const ROOT::RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("join fields must be unique"));
    }
 
    try {
-      auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}},
+      auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]},
                                                {"i", "j", "k"});
       proc->begin();
       FAIL() << "trying to use a join processor where not all join fields are present should throw";
@@ -198,8 +172,8 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
       EXPECT_THAT(err.what(), testing::HasSubstr("could not find join field \"j\" in RNTuple \"ntuple2\""));
    }
 
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[3], fFileNames[3]}},
-                                            {"i", "j", "k"});
+   auto proc =
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[3], fFileNames[3]}, {"i", "j", "k"});
 
    int nEntries = 0;
    auto i = proc->GetEntry().GetPtr<int>("i");
@@ -218,8 +192,7 @@ TEST_F(RNTupleJoinProcessorTest, UnalignedMultipleJoinFields)
 
 TEST_F(RNTupleJoinProcessorTest, MissingEntries)
 {
-   auto proc =
-      RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {{fNTupleNames[3], fFileNames[3]}}, {"i"});
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {fNTupleNames[3], fFileNames[3]}, {"i"});
 
    auto i = proc->GetEntry().GetPtr<int>("i");
    auto a = proc->GetEntry().GetPtr<float>("ntuple4.a");
@@ -246,17 +219,11 @@ TEST_F(RNTupleJoinProcessorTest, WithModel)
    auto i = primaryModel->MakeField<int>("i");
    auto x = primaryModel->MakeField<float>("x");
 
-   std::vector<std::unique_ptr<RNTupleModel>> auxModels;
+   auto auxModel = RNTupleModel::Create();
+   auto y = auxModel->MakeField<std::vector<float>>("y");
 
-   auxModels.push_back(RNTupleModel::Create());
-   auto y = auxModels.back()->MakeField<std::vector<float>>("y");
-
-   auxModels.push_back(RNTupleModel::Create());
-   auto z = auxModels.back()->MakeField<float>("z");
-
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]},
-                                            {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-                                            std::move(primaryModel), std::move(auxModels));
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {"i"},
+                                            std::move(primaryModel), std::move(auxModel));
 
    int nEntries = 0;
    std::vector<float> yExpected;
@@ -272,8 +239,6 @@ TEST_F(RNTupleJoinProcessorTest, WithModel)
       yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
       EXPECT_EQ(yExpected, *y);
       EXPECT_EQ(*entry.GetPtr<std::vector<float>>("ntuple2.y"), *y);
-      EXPECT_FLOAT_EQ(static_cast<float>(*i * 2.f), *z);
-      EXPECT_FLOAT_EQ(*entry.GetPtr<float>("ntuple3.z"), *z);
 
       try {
          entry.GetPtr<float>("ntuple2.z");
@@ -292,22 +257,15 @@ TEST_F(RNTupleJoinProcessorTest, WithBareModel)
    primaryModel->MakeField<int>("i");
    primaryModel->MakeField<float>("x");
 
-   std::vector<std::unique_ptr<RNTupleModel>> auxModels;
+   auto auxModel = RNTupleModel::CreateBare();
+   auxModel->MakeField<std::vector<float>>("y");
 
-   auxModels.push_back(RNTupleModel::CreateBare());
-   auxModels.back()->MakeField<std::vector<float>>("y");
-
-   auxModels.push_back(RNTupleModel::CreateBare());
-   auxModels.back()->MakeField<float>("z");
-
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]},
-                                            {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-                                            std::move(primaryModel), std::move(auxModels));
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {"i"},
+                                            std::move(primaryModel), std::move(auxModel));
 
    auto i = proc->GetEntry().GetPtr<int>("i");
    auto x = proc->GetEntry().GetPtr<float>("x");
    auto y = proc->GetEntry().GetPtr<std::vector<float>>("ntuple2.y");
-   auto z = proc->GetEntry().GetPtr<float>("ntuple3.z");
 
    int nEntries = 0;
    std::vector<float> yExpected;
@@ -320,7 +278,6 @@ TEST_F(RNTupleJoinProcessorTest, WithBareModel)
 
       yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
       EXPECT_EQ(yExpected, *y);
-      EXPECT_FLOAT_EQ(static_cast<float>(*i * 2.f), *z);
 
       try {
          entry.GetPtr<float>("ntuple2.z");
@@ -331,100 +288,6 @@ TEST_F(RNTupleJoinProcessorTest, WithBareModel)
    }
 
    EXPECT_EQ(5, proc->GetNEntriesProcessed());
-}
-
-TEST_F(RNTupleJoinProcessorTest, PartialModels)
-{
-   {
-      std::vector<std::unique_ptr<RNTupleModel>> auxModels;
-
-      auxModels.emplace_back(RNTupleModel::Create());
-      auto y = auxModels.back()->MakeField<std::vector<float>>("y");
-
-      auxModels.emplace_back(RNTupleModel::Create());
-      auto z = auxModels.back()->MakeField<float>("z");
-
-      // no primary model provided, aux models have been provided
-      auto procNoPrimaryModel = RNTupleProcessor::CreateJoin(
-         {fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-         nullptr, std::move(auxModels));
-
-      auto i = procNoPrimaryModel->GetEntry().GetPtr<int>("i");
-      std::vector<float> yExpected;
-      for (auto &entry : *procNoPrimaryModel) {
-         EXPECT_EQ(procNoPrimaryModel->GetCurrentEntryNumber() * 2, *i);
-         EXPECT_FLOAT_EQ(*i * 0.5f, *entry.GetPtr<float>("x"));
-         yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
-         EXPECT_EQ(yExpected, *y);
-         EXPECT_FLOAT_EQ(static_cast<float>(*i * 2.f), *z);
-
-         try {
-            entry.GetPtr<float>("ntuple2.z");
-            FAIL() << "should not be able to access values from fields not present in the provided models";
-         } catch (const ROOT::RException &err) {
-            EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: ntuple2.z"));
-         }
-      }
-   }
-   {
-      // primary model provided, no aux models have been provided
-      auto primaryModel = RNTupleModel::Create();
-      auto i = primaryModel->MakeField<int>("i");
-      auto x = primaryModel->MakeField<float>("x");
-
-      auto procNoAuxModels = RNTupleProcessor::CreateJoin(
-         {fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-         std::move(primaryModel));
-
-      std::vector<float> yExpected;
-      for (auto &entry : *procNoAuxModels) {
-         EXPECT_EQ(procNoAuxModels->GetCurrentEntryNumber() * 2, *i);
-         EXPECT_FLOAT_EQ(*i * 0.5f, *x);
-         yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
-         EXPECT_EQ(yExpected, *entry.GetPtr<std::vector<float>>("ntuple2.y"));
-         EXPECT_FLOAT_EQ(static_cast<float>(*i * 2.f), *entry.GetPtr<float>("ntuple3.z"));
-
-         try {
-            entry.GetPtr<float>("ntuple2.z");
-            FAIL() << "should not be able to access values from fields not present in the provided models";
-         } catch (const ROOT::RException &err) {
-            EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: ntuple2.z"));
-         }
-      }
-   }
-   {
-      // primary model and model for first aux ntuple has been provided, but not for the second
-      auto primaryModel = RNTupleModel::Create();
-      auto i = primaryModel->MakeField<int>("i");
-      auto x = primaryModel->MakeField<float>("x");
-
-      std::vector<std::unique_ptr<RNTupleModel>> partialAuxModels;
-
-      partialAuxModels.emplace_back(RNTupleModel::Create());
-      auto y = partialAuxModels.back()->MakeField<std::vector<float>>("y");
-
-      partialAuxModels.emplace_back(nullptr);
-
-      auto procPartialAuxModels = RNTupleProcessor::CreateJoin(
-         {fNTupleNames[0], fFileNames[0]}, {{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}}, {"i"},
-         std::move(primaryModel), std::move(partialAuxModels));
-
-      std::vector<float> yExpected;
-      for (auto &entry : *procPartialAuxModels) {
-         EXPECT_EQ(procPartialAuxModels->GetCurrentEntryNumber() * 2, *i);
-         EXPECT_FLOAT_EQ(*i * 0.5f, *x);
-         yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
-         EXPECT_EQ(yExpected, *y);
-         EXPECT_FLOAT_EQ(static_cast<float>(*i * 2.f), *entry.GetPtr<float>("ntuple3.z"));
-
-         try {
-            entry.GetPtr<float>("ntuple2.z");
-            FAIL() << "should not be able to access values from fields not present in the provided models";
-         } catch (const ROOT::RException &err) {
-            EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: ntuple2.z"));
-         }
-      }
-   }
 }
 
 TEST_F(RNTupleJoinProcessorTest, TMemFile)
@@ -443,7 +306,7 @@ TEST_F(RNTupleJoinProcessorTest, TMemFile)
       }
    }
 
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {{"ntuple_aux", &memFile}}, {"i"});
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {"ntuple_aux", &memFile}, {"i"});
 
    int nEntries = 0;
    auto i = proc->GetEntry().GetPtr<int>("i");

--- a/tree/ntuple/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/test/ntuple_processor_join.cxx
@@ -85,13 +85,6 @@ protected:
 
 TEST_F(RNTupleJoinProcessorTest, Aligned)
 {
-   try {
-      auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}, {});
-      FAIL() << "ntuples with the same name cannot be joined horizontally";
-   } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("joining RNTuples with the same name is not allowed"));
-   }
-
    auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}, {});
 
    int nEntries = 0;

--- a/tutorials/io/ntuple/ntpl015_processor_join.C
+++ b/tutorials/io/ntuple/ntpl015_processor_join.C
@@ -84,7 +84,7 @@ void Read()
    // field values is used. It is possible to specify up to 4 join fields. Providing an empty list of join fields
    // signals to the processor that all entries are aligned.
    auto processor =
-      RNTupleProcessor::CreateJoin({kMainNTupleName, kMainNTuplePath}, {{kAuxNTupleName, kAuxNTuplePath}}, {"i"});
+      RNTupleProcessor::CreateJoin({kMainNTupleName, kMainNTuplePath}, {kAuxNTupleName, kAuxNTuplePath}, {"i"});
 
    float px, py;
    for (const auto &entry : *processor) {


### PR DESCRIPTION
Instead of having the `RNTupleJoinProcessor` keep track of multiple auxiliary processors per instance, it now only has one at a time. In case a multiway join is desired (i.e. with multiple auxiliary processors), the now-recommended way is to compose it using multiple `RNTupleJoinProcessor`s.

The main rationale behind this change is the fact that this removes some overhead when creating the join processors (i.e., no need anymore to first create a vector of `RNTupleOpenSpecs` or processors), and that we currently foresee the majority of joins to only involve one auxiliary RNTuple (or combination thereof) anyways.

As a semi-related change, name conflicts are now handled differently. Fields from the auxiliary processor get added to the model of the primary processor wrapped in an untyped collection with the name of the auxiliary processor. Therefore, instead of checking that the primary and auxiliary processors don't share the same name, we should check that the primary processor doesn't already have a field with the name of the auxiliary processor.