### PR TITLE
Do not execute the test case that assumes geometry is there if there is no geometry

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -496,6 +496,12 @@ if (uring)
 else()
   set(hasuring undef)
 endif()
+if (geom)
+  set(hasgeom define)
+else()
+  set(hasgeom undef)
+endif()
+
 
 CHECK_CXX_SOURCE_COMPILES("
 inline __attribute__((always_inline)) bool TestBit(unsigned long f) { return f != 0; };

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -74,4 +74,6 @@
 
 #@hasuring@ R__HAS_URING /**/
 
+#@hasgeom@ R__HAS_GEOM /**/
+
 #endif

--- a/core/metacling/test/TClingDataMemberInfoTests.cxx
+++ b/core/metacling/test/TClingDataMemberInfoTests.cxx
@@ -241,7 +241,7 @@ TEST(TClingDataMemberInfo, Offset)
    // Make sure ROOT's Core constexpr constants work
    EXPECT_EQ(3000, *(int*)gROOT->GetGlobal("kError")->GetAddress());
 
-#ifdef R__USE_CXXMODULES
+#if defined(R__USE_CXXMODULES) && defined(R__HAS_GEOM)
    // gGeoManager is defined in the Geom libraries and we want to make sure we
    // do not load it when autoloading is off. We can only test this in modules
    // mode because gGeoManager is not part of the PCH and non-modular ROOT has
@@ -250,5 +250,5 @@ TEST(TClingDataMemberInfo, Offset)
    TGlobal *GeoManagerInfo = gROOT->GetGlobal("gGeoManager");
    TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
    EXPECT_EQ(-1L, (ptrdiff_t)GeoManagerInfo->GetAddress());
-#endif // R__USE_CXXMODULES
+#endif // R__USE_CXXMODULES and R__HAS_GEOM
 }


### PR DESCRIPTION
Noticed while doing unrelated work.