### PR TITLE
[ci] Try to fix retry logic

### DIFF
--- a/.github/workflows/root-ci-config/build_utils.py
+++ b/.github/workflows/root-ci-config/build_utils.py
@@ -258,7 +258,7 @@ def upload_file(connection: Connection, container: str, dest_object: str, src_fi
         except:
             success = False
             sleep_time = sleep_time_unit * attempt
-            build_utils.print_warning(f"""Attempt {attempt} to upload {src_file} to {dest_object} failed. Retrying in {sleep_time} seconds...""")
+            print_warning(f"""Attempt {attempt} to upload {src_file} to {dest_object} failed. Retrying in {sleep_time} seconds...""")
             time.sleep(sleep_time)
         if success: break
 


### PR DESCRIPTION
When there is a problem during upload, the exception is correctly caught but then during handling, another exception occurs:
```
File "/__w/root/root/.github/workflows/root-ci-config/build_utils.py", line 261, in upload_file
  build_utils.print_warning(f"""Attempt {attempt} to upload {src_file} to {dest_object} failed. Retrying in {sleep_time} seconds...""")
NameError: name 'build_utils' is not defined
```

---

Note: I didn't test if this fully fixes the try logic...