### PR TITLE
[Math][GenVector] Replace `M_PI*` with `TMath` function calls

### DIFF
--- a/math/genvector/inc/Math/GenVector/Cylindrical3D.h
+++ b/math/genvector/inc/Math/GenVector/Cylindrical3D.h
@@ -16,7 +16,7 @@
 #ifndef ROOT_Math_GenVector_Cylindrical3D
 #define ROOT_Math_GenVector_Cylindrical3D  1
 
-#include "Math/Math.h"
+#include "TMath.h"
 
 #include "Math/GenVector/eta.h"
 
@@ -109,7 +109,7 @@ public :
    {rho=fRho; zz=fZ; phi=fPhi;}
 
 private:
-   inline static Scalar pi() { return Scalar(M_PI); }
+   inline static Scalar pi() { return Scalar(TMath::Pi()); }
    inline void          Restrict()
    {
       using std::floor;

--- a/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
+++ b/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
@@ -24,7 +24,7 @@
 
 #include "Math/GenVector/etaMax.h"
 
-
+#include "TMath.h"
 #include <limits>
 #include <cmath>
 
@@ -125,7 +125,7 @@ public :
    {rho=fRho; eta=fEta; phi=fPhi;}
 
 private:
-   inline static Scalar pi() { return M_PI; }
+   inline static Scalar pi() { return TMath::Pi(); }
    inline void Restrict() {
       using std::floor;
       if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();

--- a/math/genvector/inc/Math/GenVector/EulerAngles.h
+++ b/math/genvector/inc/Math/GenVector/EulerAngles.h
@@ -22,6 +22,7 @@
 #include "Math/GenVector/PositionVector3D.h"
 #include "Math/GenVector/LorentzVector.h"
 #include "Math/GenVector/3DConversions.h"
+#include "TMath.h"
 #include <algorithm>
 #include <cassert>
 
@@ -345,7 +346,7 @@ private:
    double fTheta;   // X rotation angle (second) defined only [0,PI]
    double fPsi;     // Z rotation angle (third)  defined in [-PI,PI]
 
-   static double Pi() { return M_PI; }
+   static double Pi() { return TMath::Pi(); }
 
 };  // EulerAngles
 

--- a/math/genvector/inc/Math/GenVector/Polar2D.h
+++ b/math/genvector/inc/Math/GenVector/Polar2D.h
@@ -20,6 +20,7 @@
 #define ROOT_Math_GenVector_Polar2D  1
 
 #include "Math/Math.h"
+#include "TMath.h"
 
 #include "Math/GenVector/etaMax.h"
 
@@ -131,7 +132,7 @@ public :
 
 
 private:
-   inline static double pi()  { return M_PI; }
+   inline static double pi() { return TMath::Pi(); }
 
    /**
       restrict abgle hi to be between -PI and PI

--- a/math/genvector/inc/Math/GenVector/Polar3D.h
+++ b/math/genvector/inc/Math/GenVector/Polar3D.h
@@ -23,6 +23,7 @@
 
 #include "Math/GenVector/eta.h"
 
+#include "TMath.h"
 #include <cmath>
 
 namespace ROOT {
@@ -158,7 +159,7 @@ public :
 
 
 private:
-   inline static Scalar pi()  { return M_PI; }
+   inline static Scalar pi() { return TMath::Pi(); }
    inline void Restrict() {
       using std::floor;
       if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -19,6 +19,7 @@
 #define ROOT_Math_GenVector_PtEtaPhiM4D  1
 
 #include "Math/Math.h"
+#include "TMath.h"
 
 #include "Math/GenVector/etaMax.h"
 
@@ -250,7 +251,7 @@ public :
    Scalar Et() const { using std::cosh; return E() / cosh(fEta); }
 
 private:
-   inline static Scalar pi() { return M_PI; }
+   inline static Scalar pi() { return TMath::Pi(); }
    inline void RestrictPhi() {
       using std::floor;
       if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();

--- a/math/genvector/inc/Math/GenVector/RotationX.h
+++ b/math/genvector/inc/Math/GenVector/RotationX.h
@@ -26,6 +26,7 @@
 
 #include "Math/GenVector/RotationXfwd.h"
 
+#include <TMath.h>
 #include <cmath>
 
 namespace ROOT {
@@ -72,9 +73,9 @@ public:
       Rectify makes sure the angle is in (-pi,pi]
    */
    void Rectify()  {
-      if ( std::fabs(fAngle) >= M_PI ) {
-         double x = fAngle / (2.0 * M_PI);
-         fAngle =  (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      if (std::fabs(fAngle) >= TMath::Pi()) {
+         double x = fAngle / TMath::TwoPi();
+         fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
          fSin = std::sin(fAngle);
          fCos = std::cos(fAngle);
       }
@@ -195,8 +196,8 @@ public:
    */
    RotationX operator * (const RotationX & r) const {
       RotationX ans;
-      double x   = (fAngle + r.fAngle) / (2.0 * M_PI);
-      ans.fAngle = (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      double x = (fAngle + r.fAngle) / TMath::TwoPi();
+      ans.fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
       ans.fSin   = fSin*r.fCos + fCos*r.fSin;
       ans.fCos   = fCos*r.fCos - fSin*r.fSin;
       return ans;

--- a/math/genvector/inc/Math/GenVector/RotationY.h
+++ b/math/genvector/inc/Math/GenVector/RotationY.h
@@ -27,6 +27,7 @@
 #include "Math/GenVector/RotationYfwd.h"
 
 #include <cmath>
+#include <TMath.h>
 
 namespace ROOT {
 namespace Math {
@@ -72,9 +73,9 @@ public:
       Rectify makes sure the angle is in (-pi,pi]
    */
    void Rectify()  {
-      if ( std::fabs(fAngle) >= M_PI ) {
-         double x = fAngle / (2.0 * M_PI);
-         fAngle =  (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      if (std::fabs(fAngle) >= TMath::Pi()) {
+         double x = fAngle / TMath::TwoPi();
+         fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
          fSin = std::sin(fAngle);
          fCos = std::cos(fAngle);
       }
@@ -195,8 +196,8 @@ public:
    */
    RotationY operator * (const RotationY & r) const {
       RotationY ans;
-      double x   = (fAngle + r.fAngle) / (2.0 * M_PI);
-      ans.fAngle = (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      double x = (fAngle + r.fAngle) / TMath::TwoPi();
+      ans.fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
       ans.fSin   = fSin*r.fCos + fCos*r.fSin;
       ans.fCos   = fCos*r.fCos - fSin*r.fSin;
       return ans;

--- a/math/genvector/inc/Math/GenVector/RotationZ.h
+++ b/math/genvector/inc/Math/GenVector/RotationZ.h
@@ -26,6 +26,7 @@
 
 #include "Math/GenVector/RotationZfwd.h"
 
+#include "TMath.h"
 #include <cmath>
 
 namespace ROOT {
@@ -72,9 +73,9 @@ public:
       Rectify makes sure the angle is in (-pi,pi]
    */
    void Rectify()  {
-      if ( std::fabs(fAngle) >= M_PI ) {
-         double x = fAngle / (2.0 * M_PI);
-         fAngle =  (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      if (std::fabs(fAngle) >= TMath::Pi()) {
+         double x = fAngle / TMath::TwoPi();
+         fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
          fSin = std::sin(fAngle);
          fCos = std::cos(fAngle);
       }
@@ -195,8 +196,8 @@ public:
    */
    RotationZ operator * (const RotationZ & r) const {
       RotationZ ans;
-      double x   = (fAngle + r.fAngle) / (2.0 * M_PI);
-      ans.fAngle = (2.0 * M_PI) * ( x + std::floor(.5-x) );
+      double x = (fAngle + r.fAngle) / TMath::TwoPi();
+      ans.fAngle = TMath::TwoPi() * (x + std::floor(.5 - x));
       ans.fSin   = fSin*r.fCos + fCos*r.fSin;
       ans.fCos   = fCos*r.fCos - fSin*r.fSin;
       return ans;

--- a/math/genvector/inc/Math/GenVector/RotationZYX.h
+++ b/math/genvector/inc/Math/GenVector/RotationZYX.h
@@ -31,6 +31,7 @@
 
 #include "Math/GenVector/3DConversions.h"
 
+#include "TMath.h"
 
 #include <algorithm>
 #include <cassert>
@@ -318,7 +319,7 @@ private:
    double fTheta;    // Y' rotation angle (pitch) defined in [-PI/2,PI/2]
    double fPsi;      // X'' rotation angle (roll) defined in (-PI,PI]
 
-   static double Pi() { return M_PI; }
+   static double Pi() { return TMath::Pi(); }
 
 };  // RotationZYX
 

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -18,8 +18,7 @@
 #ifndef ROOT_Math_GenVector_VectorUtil
 #define ROOT_Math_GenVector_VectorUtil  1
 
-#include "Math/Math.h"
-
+#include "TMath.h"
 
 #include "Math/GenVector/Boost.h"
 
@@ -60,10 +59,10 @@ namespace ROOT {
          template <class Vector1, class Vector2>
          inline typename Vector1::Scalar DeltaPhi( const Vector1 & v1, const Vector2 & v2) {
             typename Vector1::Scalar dphi = v2.Phi() - v1.Phi();
-            if ( dphi > M_PI ) {
-               dphi -= 2.0*M_PI;
-            } else if ( dphi <= -M_PI ) {
-               dphi += 2.0*M_PI;
+            if (dphi > TMath::Pi()) {
+               dphi -= 2.0 * TMath::Pi();
+            } else if (dphi <= -TMath::Pi()) {
+               dphi += 2.0 * TMath::Pi();
             }
             return dphi;
          }
@@ -283,7 +282,7 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateX(const Vector & v, double alpha) {
-            if (std::fmod(alpha, 2 * M_PI) == 0.)
+            if (std::fmod(alpha, 2 * TMath::Pi()) == 0.)
                return v;
             using std::sin;
             double sina = sin(alpha);
@@ -304,7 +303,7 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateY(const Vector & v, double alpha) {
-            if (std::fmod(alpha, 2 * M_PI) == 0.)
+            if (std::fmod(alpha, 2 * TMath::Pi()) == 0.)
                return v;
             using std::sin;
             double sina = sin(alpha);
@@ -325,7 +324,7 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateZ(const Vector & v, double alpha) {
-            if (std::fmod(alpha, 2 * M_PI) == 0.)
+            if (std::fmod(alpha, 2 * TMath::Pi()) == 0.)
                return v;
             using std::sin;
             double sina = sin(alpha);
@@ -347,7 +346,7 @@ namespace ROOT {
          template <class Vector>
          Vector Rotate(const Vector &v, double alpha, const Vector &axis)
          {
-            if (std::fmod(alpha, 2 * M_PI) == 0.)
+            if (std::fmod(alpha, 2 * TMath::Pi()) == 0.)
                return v;
             const double ll = std::sqrt(axis.X() * axis.X() + axis.Y() * axis.Y() + axis.Z() * axis.Z());
             if (ll == 0.)

--- a/math/genvector/src/3DConversions.cxx
+++ b/math/genvector/src/3DConversions.cxx
@@ -21,7 +21,7 @@
 
 #include "Math/GenVector/3DConversions.h"
 
-#include "Math/Math.h"
+#include "TMath.h"
 
 #include "Math/GenVector/Rotation3D.h"
 #include "Math/GenVector/AxisAngle.h"
@@ -73,7 +73,7 @@ void convert( Rotation3D const & from, AxisAngle   & to)
 
    u.SetCoordinates( uX, uY, uZ );
 
-   static const double pi = M_PI;
+   static const double pi = TMath::Pi();
 
    double angle;
    const double cosdelta = (m[kXX] + m[kYY] + m[kZZ] - 1.0) / 2.0;
@@ -93,7 +93,7 @@ void convert( Rotation3D const & from, AxisAngle   & to)
 } // convert to AxisAngle
 
 static void correctByPi ( double& psi, double& phi ) {
-   static const double pi = M_PI;
+   static const double pi = TMath::Pi();
    if (psi > 0) {
       psi -= pi;
    } else {
@@ -117,8 +117,8 @@ void convert( Rotation3D const & from, EulerAngles & to)
 
    double phi, theta, psi;
    double psiPlusPhi, psiMinusPhi;
-   static const double pi = M_PI;
-   static const double pi_2 = M_PI_2;
+   static const double pi = TMath::Pi();
+   static const double pi_2 = TMath::PiOver2();
 
    theta = (std::fabs(r[kZZ]) <= 1.0) ? std::acos(r[kZZ]) :
       (r[kZZ]  >  0.0) ?     0            : pi;
@@ -260,7 +260,7 @@ void convert( Rotation3D const & from, RotationZYX  & to)
    // theta is assumed to be in range [-PI/2,PI/2].
    // this is guaranteed by the Rectify function
 
-   static const double pi_2 = M_PI_2;
+   static const double pi_2 = TMath::PiOver2();
 
    double r[9];
    from.GetComponents(r,r+9);

--- a/math/genvector/src/RotationZYX.cxx
+++ b/math/genvector/src/RotationZYX.cxx
@@ -25,8 +25,8 @@
 #include "Math/GenVector/RotationX.h"
 #include "Math/GenVector/RotationY.h"
 #include "Math/GenVector/RotationZ.h"
-
 #include "Math/GenVector/AxisAnglefwd.h"
+#include "TMath.h"
 
 namespace ROOT {
 
@@ -111,7 +111,7 @@ void RotationZYX::Rectify()
    //  same as Euler- Angles, just here Theta is shifted by PI/2 with respect to
    // the theta of the EulerAngles class
 
-   Scalar theta2 = fTheta + M_PI_2;
+   Scalar theta2 = fTheta + TMath::PiOver2();
    if ( theta2 < 0 || theta2 > Pi() ) {
       Scalar t = theta2 - std::floor( theta2/(2*Pi() ) ) * 2*Pi();
       if ( t <= Pi() ) {
@@ -122,7 +122,7 @@ void RotationZYX::Rectify()
          fPsi =  fPsi + Pi();
       }
       // ftheta is shifted of PI/2 w.r.t theta2
-      fTheta = theta2 - M_PI_2;
+      fTheta = theta2 - TMath::PiOver2();
    }
 
    if ( fPhi <= -Pi()|| fPhi > Pi() ) {

--- a/math/genvector/src/VectorUtil.cxx
+++ b/math/genvector/src/VectorUtil.cxx
@@ -13,6 +13,7 @@
 // Created by: Lorenzo Moneta 22 Aug 2006
 //
 #include "Math/GenVector/VectorUtil.h"
+#include "TMath.h"
 
 namespace ROOT {
 
@@ -21,14 +22,15 @@ namespace Math {
 
 double VectorUtil::Phi_0_2pi(double angle) {
    // returns phi angle in the interval (0,2*PI]
-   if ( angle <= 2.*M_PI && angle > 0 ) return angle;
+   if (angle <= 2. * TMath::Pi() && angle > 0)
+      return angle;
 
    if ( angle > 0 ) {
-      int n = static_cast<int>( angle/(2.*M_PI) );
-      angle -= 2.*M_PI*n;
+      int n = static_cast<int>(angle / (2. * TMath::Pi()));
+      angle -= 2. * TMath::Pi() * n;
    } else {
-      int n = static_cast<int>( -(angle)/(2.*M_PI) );
-      angle += 2.*M_PI*(n+1);
+      int n = static_cast<int>(-(angle) / (2. * TMath::Pi()));
+      angle += 2. * TMath::Pi() * (n + 1);
    }
    return angle;
 }
@@ -36,14 +38,15 @@ double VectorUtil::Phi_0_2pi(double angle) {
 double VectorUtil::Phi_mpi_pi(double angle) {
    // returns phi angle in the interval (-PI,PI]
 
-   if ( angle <= M_PI && angle > -M_PI ) return angle;
+   if (angle <= TMath::Pi() && angle > -TMath::Pi())
+      return angle;
 
    if ( angle > 0 ) {
-      int n = static_cast<int>( (angle+M_PI)/(2.*M_PI) );
-      angle -= 2*M_PI*n;
+      int n = static_cast<int>((angle + TMath::Pi()) / (2. * TMath::Pi()));
+      angle -= 2 * TMath::Pi() * n;
    } else {
-      int n = static_cast<int>( -(angle-M_PI)/(2.*M_PI) );
-      angle += 2*M_PI*n;
+      int n = static_cast<int>(-(angle - TMath::Pi()) / (2. * TMath::Pi()));
+      angle += 2 * TMath::Pi() * n;
    }
    return angle;
 }


### PR DESCRIPTION
# This Pull request:
Replaces `M_PI*` occurences with `TMath` function calls, following discussion in https://github.com/root-project/root/pull/18462

