### PR TITLE
[ntuple] Improve error reporting consistency

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -79,7 +79,7 @@ public:
       return representations;
    }
    // Field is only used for reading
-   void GenerateColumns() final { assert(false && "Cardinality fields must only be used for reading"); }
+   void GenerateColumns() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
    void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final
    {
       GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
@@ -121,7 +121,7 @@ private:
    {
       return std::make_unique<RArraySizeField>(fArrayLength);
    }
-   void GenerateColumns() final { assert(false && "RArraySizeField fields must only be used for reading"); }
+   void GenerateColumns() final { throw RException(R__FAIL("RArraySizeField fields must only be used for reading")); }
    void GenerateColumns(const ROOT::RNTupleDescriptor &) final {}
    void ReadGlobalImpl(ROOT::NTupleSize_t /*globalIndex*/, void *to) final
    {

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -329,7 +329,7 @@ private:
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 
-   void GenerateColumns() final { R__ASSERT(false && "RArrayAsRVec fields must only be used for reading"); }
+   void GenerateColumns() final { throw RException(R__FAIL("RArrayAsRVec fields must only be used for reading")); }
    using RFieldBase::GenerateColumns;
 
    void ConstructValue(void *where) const final;

--- a/tree/ntuple/src/RColumnElement.cxx
+++ b/tree/ntuple/src/RColumnElement.cxx
@@ -61,7 +61,7 @@ std::pair<std::uint16_t, std::uint16_t> ROOT::Internal::RColumnElementBase::GetV
    default:
       if (type == kTestFutureColumnType)
          return std::make_pair(32, 32);
-      assert(false);
+      R__ASSERT(false);
    }
    // never here
    return std::make_pair(0, 0);
@@ -145,7 +145,7 @@ ROOT::Internal::RColumnElementBase::Generate<void>(ENTupleColumnType onDiskType)
    default:
       if (onDiskType == kTestFutureColumnType)
          return std::make_unique<RColumnElement<Internal::RTestFutureColumn, kTestFutureColumnType>>();
-      assert(false);
+      R__ASSERT(false);
    }
    //clang-format on
    // never here


### PR DESCRIPTION
`RException` for field misuse, `R__ASSERT(false)` for unhandled column types.