### PR TITLE
[meta] Properly handle _Atomic type specifier

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4184,10 +4184,18 @@ void ROOT::TMetaUtils::GetNormalizedName(std::string &norm_name, const clang::Qu
    cling::Interpreter::PushTransactionRAII clingRAII(const_cast<cling::Interpreter*>(&interpreter));
    normalizedType.getAsStringInternal(normalizedNameStep1,policy);
 
+   // Remove the _Atomic type specifyier if present before normalising
+   TClassEdit::AtomicTypeNameHandlerRAII atomicTypeNameHandler_step1(
+      normalizedNameStep1, TClassEdit::AtomicTypeNameHandlerRAII::EBehavior::kDetectStrip);
+
    // Still remove the std:: and default template argument for STL container and
    // normalize the location and amount of white spaces.
    TClassEdit::TSplitType splitname(normalizedNameStep1.c_str(),(TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kKeepOuterConst));
    splitname.ShortType(norm_name,TClassEdit::kDropStd | TClassEdit::kDropStlDefault );
+
+   TClassEdit::AtomicTypeNameHandlerRAII atomicTypeNameHandler_norm_name(
+      norm_name, atomicTypeNameHandler_step1.IsAtomic() ? TClassEdit::AtomicTypeNameHandlerRAII::EBehavior::kReadd
+                                                        : TClassEdit::AtomicTypeNameHandlerRAII::EBehavior::kNoOp);
 
    // The result of this routine is by definition a fully qualified name.  There is an implicit starting '::' at the beginning of the name.
    // Depending on how the user typed their code, in particular typedef declarations, we may end up with an explicit '::' being

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -175,7 +175,8 @@ namespace TClassEdit {
       AtomicTypeNameHandlerRAII(std::string &typeName, EBehavior behavior = EBehavior::kDetectStripReadd)
          : fTypeName(typeName), fBehavior(behavior)
       {
-         if (fBehavior == EBehavior::kReadd || fBehavior == EBehavior::kNoOp) return;
+         if (fBehavior == EBehavior::kReadd || fBehavior == EBehavior::kNoOp)
+            return;
          if (0 == fTypeName.find(fgPrefix)) {
             fIsAtomic = true;
             if (fBehavior == EBehavior::kDetectStrip || fBehavior == EBehavior::kDetectStripReadd) {

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -16,6 +16,7 @@
 #include <ROOT/RConfig.hxx>
 #include "RConfigure.h"
 #include <stdlib.h>
+#include <stdexcept>
 #ifdef R__WIN32
 #ifndef UNDNAME_COMPLETE
 #define UNDNAME_COMPLETE 0x0000
@@ -151,6 +152,50 @@ namespace TClassEdit {
    private:
       TSplitType(const TSplitType&) = delete;
       TSplitType &operator=(const TSplitType &) = delete;
+   };
+
+   /// A RAII helper to remove and readd enclosing _Atomic()
+   /// It expects no spaces at the beginning or end of the string
+   class AtomicTypeNameHandlerRAII {
+   public:
+      enum class EBehavior : short {
+         kDetectStripReadd, // Detect if the _Atomic specifier is used, if yes, strip it and re-add it in the dtor
+         kDetectStrip,      // Detect if the _Atomic specifier is used, if yes, strip it
+         kReadd,            // Re-add the _Atomic specifier in the dtor
+         kNoOp              // Do nothing
+      };
+
+   private:
+      std::string &fTypeName;
+      bool fIsAtomic = false;
+      EBehavior fBehavior;
+      const char *fgPrefix = "_Atomic(";
+
+   public:
+      AtomicTypeNameHandlerRAII(std::string &typeName, EBehavior behavior = EBehavior::kDetectStripReadd)
+         : fTypeName(typeName), fBehavior(behavior)
+      {
+         if (fBehavior == EBehavior::kReadd || fBehavior == EBehavior::kNoOp) return;
+         if (0 == fTypeName.find(fgPrefix)) {
+            fIsAtomic = true;
+            if (fBehavior == EBehavior::kDetectStrip || fBehavior == EBehavior::kDetectStripReadd) {
+               fTypeName.erase(0, 8);
+               if (0 == fTypeName.size() || ')' != fTypeName[fTypeName.size() - 1]) {
+                  throw std::runtime_error("Cannot remove substring \")\" at the end of typename \"" + typeName + "\"");
+               }
+               fTypeName.pop_back();
+            }
+         }
+      }
+
+      bool IsAtomic() { return fIsAtomic; }
+
+      ~AtomicTypeNameHandlerRAII()
+      {
+         if (fBehavior == EBehavior::kReadd || (fBehavior == EBehavior::kDetectStripReadd && fIsAtomic)) {
+            fTypeName = fgPrefix + fTypeName + ")";
+         }
+      }
    };
 
    void        Init(TClassEdit::TInterpreterLookupHelper *helper);

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -875,6 +875,8 @@ void TClassEdit::GetNormalizedName(std::string &norm_name, std::string_view name
       return;
    }
 
+   AtomicTypeNameHandlerRAII nameHandler(norm_name);
+
    // Remove the std:: and default template argument and insert the Long64_t and change basic_string to string.
    TClassEdit::TSplitType splitname(norm_name.c_str(),(TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kKeepOuterConst));
    splitname.ShortType(norm_name, TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kResolveTypedef | TClassEdit::kKeepOuterConst);

--- a/core/foundation/test/testClassEdit.cxx
+++ b/core/foundation/test/testClassEdit.cxx
@@ -285,10 +285,20 @@ TEST(TClassEdit, DefAlloc)
    EXPECT_TRUE(TClassEdit::IsDefAlloc("class std::allocator<float>", "float"));
 }
 
-// https://github.com/root-project/root/issues/6607
+
 TEST(TClassEdit, GetNormalizedName)
 {
    std::string n;
+   
+   // https://github.com/root-project/root/issues/6607
    TClassEdit::GetNormalizedName(n, "std::vector<float, class std::allocator<float>>");
    EXPECT_STREQ("vector<float>", n.c_str());
+
+   // https://github.com/root-project/root/issues/18643
+   n.clear();
+   TClassEdit::GetNormalizedName(n, "_Atomic(map<string, TObjArray* >*)");
+   EXPECT_STREQ("_Atomic(map<string,TObjArray*>*)", n.c_str());
+
+   n.clear();
+   EXPECT_THROW(TClassEdit::GetNormalizedName(n, "_Atomic(map<string, TObjArray* >*"), std::runtime_error);
 }

--- a/core/meta/test/testTClass.cxx
+++ b/core/meta/test/testTClass.cxx
@@ -63,3 +63,9 @@ TEST(TClass, TypeNameDouble)
    TClass *clTypeID32 = TClass::GetClass(typeid(ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >));
    EXPECT_EQ(clLVd, clTypeID32) << "LV<double> should have priority; typeid lookup should find it.";
 }
+
+// https://github.com/root-project/root/issues/18643
+TEST(TClass, BuildRealData)
+{
+   TClass::GetClass("TClass")->BuildRealData();
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Updates the name normalisation routines in order to properly take into accoung the C11 atomic type specifier `_Atomic`. In absence of this treatment, ill formed type names end up in the lexer of Clang, causing an infinite recursion.

## Checklist:

- [v] tested changes locally
- [v] updated the docs (if necessary)

This PR fixes #18643

