### PR TITLE
[ntuple] Remove unused private `REntry` methods

### DIFF
--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -94,10 +94,6 @@ private:
       return value.template GetPtr<T>();
    }
 
-   /// Return the RValue currently bound to the provided field.
-   ROOT::RFieldBase::RValue &GetValue(ROOT::RFieldToken token) { return fValues.at(token.fIndex); }
-   ROOT::RFieldBase::RValue &GetValue(std::string_view fieldName) { return GetValue(GetToken(fieldName)); }
-
    void Read(ROOT::NTupleSize_t index)
    {
       for (auto &v : fValues) {

--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -94,17 +94,6 @@ private:
       return value.template GetPtr<T>();
    }
 
-   /// Update the RValue for a field in the entry. To be used when its underlying ROOT::RFieldBase changes, which
-   /// typically happens when the page source from which the field values are read changes.
-   void UpdateValue(ROOT::RFieldToken token, ROOT::RFieldBase::RValue &&value)
-   {
-      std::swap(fValues.at(token.fIndex), value);
-   }
-   void UpdateValue(ROOT::RFieldToken token, ROOT::RFieldBase::RValue &value)
-   {
-      std::swap(fValues.at(token.fIndex), value);
-   }
-
    /// Return the RValue currently bound to the provided field.
    ROOT::RFieldBase::RValue &GetValue(ROOT::RFieldToken token) { return fValues.at(token.fIndex); }
    ROOT::RFieldBase::RValue &GetValue(std::string_view fieldName) { return GetValue(GetToken(fieldName)); }


### PR DESCRIPTION
Both `UpdateValue` and `GetValue` were originally added to be used by the `RNTupleProcessor`, but are not used there anymore. Since they are private methods and have no uses anywhere else in the code base, there's no reason to keep them around.