### PR TITLE
[RF][HF] Add configuration parameter to disable workspace writing

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -11,45 +11,49 @@
 #ifndef ROOSTATS_HISTOTOWORKSPACEFACTORYFAST
 #define ROOSTATS_HISTOTOWORKSPACEFACTORYFAST
 
+#include <RooStats/HistFactory/Systematics.h>
+
+#include <RooArgSet.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
+#include <RooPlot.h>
+#include <RooWorkspace.h>
+
+#include <TH1.h>
+#include <TObject.h>
+
 #include <vector>
 #include <string>
 #include <map>
-#include <iostream>
-#include <sstream>
 #include <memory>
 
-#include <RooPlot.h>
-#include <RooArgSet.h>
-#include <RooFitResult.h>
-#include <RooAbsReal.h>
-#include <RooRealVar.h>
-#include <RooWorkspace.h>
-#include <TObject.h>
-#include <TH1.h>
-#include <TDirectory.h>
 
-#include "RooStats/HistFactory/Systematics.h"
 class ParamHistFunc;
 class RooProduct;
 class RooHistFunc;
 
-namespace RooStats{
-  namespace HistFactory{
+namespace RooStats {
+namespace HistFactory {
 
-    // Forward Declarations FTW
-    class Measurement;
-    class Channel;
-    class Sample;
+// Forward Declarations FTW
+class Measurement;
+class Channel;
+class Sample;
 
-    class HistoToWorkspaceFactoryFast: public TObject {
+class HistoToWorkspaceFactoryFast : public TObject {
 
-    public:
-
-      struct Configuration {
-        bool binnedFitOptimization = true;
-        bool createPerRegionWorkspaces = true;
-        bool storeDataError = false;
-      };
+public:
+   /// \brief Configuration settings for HistFactory behavior.
+   struct Configuration {
+      /// \brief Enable or disable optimization for binned likelihood fits (default `true`).
+      bool binnedFitOptimization = true;
+      /// \brief Control whether whether combined workspace is written to a ROOT file (default `true`).
+      bool createWorkspaceFile = true;
+      /// \brief Control whether individual workspace files are created for each channel (default `true`).
+      bool createPerRegionWorkspaces = true;
+      /// \brief Control whether errors on the data histograms are stored in the workspace (default `false`).
+      bool storeDataError = false;
+   };
 
       HistoToWorkspaceFactoryFast() {}
       HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& Meas);

--- a/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
@@ -2,28 +2,18 @@
 #define HISTFACTORY_MAKEMODELANDMEASUREMENTSFAST_H
 
 #include "RooStats/HistFactory/Measurement.h"
-#include "RooStats/HistFactory/Channel.h"
 #include "RooStats/HistFactory/HistoToWorkspaceFactoryFast.h"
 
 #include "RooWorkspace.h"
-#include "RooPlot.h"
 
-#include <iostream>
-#include <string>
-#include <vector>
+namespace RooStats {
+namespace HistFactory {
 
-class TFile;
+RooFit::OwningPtr<RooWorkspace> MakeModelAndMeasurementFast(RooStats::HistFactory::Measurement &measurement,
+                                                            HistoToWorkspaceFactoryFast::Configuration const &cfg = {});
 
-namespace RooStats{
-  namespace HistFactory{
-
-      RooFit::OwningPtr<RooWorkspace> MakeModelAndMeasurementFast(
-            RooStats::HistFactory::Measurement& measurement,
-            HistoToWorkspaceFactoryFast::Configuration const& cfg={}
-    );
-
-  }
 }
+} // namespace RooStats
 
 
 #endif

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -10,7 +10,7 @@
 
 #include "RooStats/HistFactory/MakeModelAndMeasurementsFast.h"
 
-// from roofit
+// from RooFit
 #include "RooFit/ModelConfig.h"
 
 // from this package
@@ -24,8 +24,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
-#include <fstream>
 #include <sstream>
 
 /** ********************************************************************************************
@@ -79,6 +77,25 @@
   </ul>
   </ul>
 */
+
+
+/// \brief Creates a statistical model and associated RooFit workspace(s) from a
+///        HistFactory measurement configuration.
+///
+/// This function processes a RooStats::HistFactory::Measurement using the fast
+/// RooStats::HistFactory::HistoToWorkspaceFactoryFast machinery. It creates
+/// individual channel workspaces, optionally writes them to disk, and then
+/// combines them into a single RooWorkspace representing the full statistical
+/// model.
+///
+/// \param measurement Object containing the configuration of the statistical
+///                    analysis, including luminosity, binning, systematic
+///                    uncertainties, and channels.
+/// \param cfg Configuration object that controls behavior such as workspace
+///            file creation.
+///
+/// \return The combined `RooWorkspace`, or `nullptr` if workspace creation fails.
+
 RooFit::OwningPtr<RooWorkspace>
 RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measurement &measurement,
                                                    HistoToWorkspaceFactoryFast::Configuration const &cfg)
@@ -200,7 +217,7 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
     // Configure that workspace
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement("simPdf", ws.get(), measurement);
 
-    {
+    if (cfg.createWorkspaceFile) {
       std::string CombinedFileName = measurement.GetOutputFilePrefix() + "_combined_"
         + rowTitle + "_model.root";
       cxcoutPHF << "Writing combined workspace to file: " << CombinedFileName << std::endl;

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -83,10 +83,13 @@ RooFit::OwningPtr<RooWorkspace>
 RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measurement &measurement,
                                                    HistoToWorkspaceFactoryFast::Configuration const &cfg)
 {
-  std::unique_ptr<TFile> outFile;
+   std::unique_ptr<TFile> outFile;
 
-  auto& msgSvc = RooMsgService::instance();
-  msgSvc.getStream(1).removeTopic(RooFit::ObjectHandling);
+   // Make sure that topic is added back on function return.
+   struct RemoveTopicRAII {
+      RemoveTopicRAII() { RooMsgService::instance().getStream(1).removeTopic(RooFit::ObjectHandling); }
+      ~RemoveTopicRAII() { RooMsgService::instance().getStream(1).addTopic(RooFit::ObjectHandling); }
+   } removeTopicRaii;
 
     cxcoutIHF << "Making Model and Measurements (Fast) for measurement: " << measurement.GetName() << std::endl;
 
@@ -210,8 +213,6 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
       cxcoutPHF << "Writing combined measurement to file: " << CombinedFileName << std::endl;
       measurement.writeToFile( combFile.get() );
     }
-
-  msgSvc.getStream(1).addTopic(RooFit::ObjectHandling);
 
   return RooFit::makeOwningPtr(std::move(ws));
 }

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -22,9 +22,9 @@
 #include <TFile.h>
 #include <TSystem.h>
 
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 /** ********************************************************************************************
   \ingroup HistFactory
@@ -100,8 +100,6 @@ RooFit::OwningPtr<RooWorkspace>
 RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measurement &measurement,
                                                    HistoToWorkspaceFactoryFast::Configuration const &cfg)
 {
-   std::unique_ptr<TFile> outFile;
-
    // Make sure that topic is added back on function return.
    struct RemoveTopicRAII {
       RemoveTopicRAII() { RooMsgService::instance().getStream(1).removeTopic(RooFit::ObjectHandling); }
@@ -128,41 +126,36 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
     std::vector<std::unique_ptr<RooWorkspace>> channel_workspaces;
     std::vector<std::string>        channel_names;
 
-    // Create the outFile - first check if the outputfile exists
-    std::string prefix =  measurement.GetOutputFilePrefix();
-    // parse prefix to find output directory -
-    // assume there is a file prefix after the last "/" that we remove
-    // to get the directory name.
-    // We do by finding last occurrence of "/" and using as directory name what is before
-    // if we do not have a "/" in the prefix there is no output directory to be checked or created
-    size_t pos = prefix.rfind('/');
-    if (pos != std::string::npos) {
+    auto createOutputDirectory = [](std::string const &prefix) {
+       // Parse prefix to find output directory - assume there is a file prefix
+       // after the last "/" that we remove to get the directory name. We do by
+       // finding last occurrence of "/" and using as directory name what is
+       // before if we do not have a "/" in the prefix there is no output
+       // directory to be checked or created.
+       size_t pos = prefix.rfind('/');
+       if (pos == std::string::npos) {
+          return;
+       }
        std::string outputDir = prefix.substr(0,pos);
        cxcoutDHF << "Checking if output directory : " << outputDir << " -  exists" << std::endl;
        void *outdir = gSystem->OpenDirectory( outputDir.c_str() );
-       if (outdir == nullptr) {
-          cxcoutDHF << "Output directory : " << outputDir << " - does not exist, try to create" << std::endl;
-          int success = gSystem->MakeDirectory( outputDir.c_str() );
-          if( success != 0 ) {
-             std::string fullOutputDir = std::string(gSystem->pwd()) + std::string("/") + outputDir;
-             cxcoutEHF << "Error: Failed to make output directory: " <<  fullOutputDir << std::endl;
-             throw hf_exc();
-          }
-       } else {
+       if (outdir) {
           gSystem->FreeDirectory(outdir);
+          return;
        }
-    }
+       cxcoutDHF << "Output directory : " << outputDir << " - does not exist, try to create" << std::endl;
+       int success = gSystem->MakeDirectory( outputDir.c_str() );
+       if( success != 0 ) {
+          std::string fullOutputDir = gSystem->pwd() + std::string("/") + outputDir;
+          cxcoutEHF << "Error: Failed to make output directory: " <<  fullOutputDir << std::endl;
+          throw hf_exc();
+       }
+    };
 
-    // This holds the TGraphs that are created during the fit
-    std::string outputFileName = measurement.GetOutputFilePrefix() + "_" + measurement.GetName() + ".root";
-    cxcoutIHF << "Creating the output file: " << outputFileName << std::endl;
-    outFile = std::make_unique<TFile>(outputFileName.c_str(), "recreate");
-
+    // Make the factory, and do some preprocessing
     cxcoutIHF << "Creating the HistoToWorkspaceFactoryFast factory" << std::endl;
     HistoToWorkspaceFactoryFast factory{measurement, cfg};
 
-    // Make the factory, and do some preprocessing
-    // HistoToWorkspaceFactoryFast factory(measurement, rowTitle, outFile);
     cxcoutIHF << "Setting preprocess functions" << std::endl;
     factory.SetFunctionsToPreprocess( measurement.GetPreprocessFunctions() );
 
@@ -183,8 +176,10 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
       std::unique_ptr<RooWorkspace> ws_single{factory.MakeSingleChannelModel( measurement, channel )};
 
       if (cfg.createPerRegionWorkspaces) {
+        std::string prefix =  measurement.GetOutputFilePrefix();
+        createOutputDirectory(prefix);
         // Make the output
-        std::string ChannelFileName = measurement.GetOutputFilePrefix() + "_" 
+        std::string ChannelFileName = prefix + "_" 
           + ch_name + "_" + rowTitle + "_model.root";
         cxcoutIHF << "Opening File to hold channel: " << ChannelFileName << std::endl;
         std::unique_ptr<TFile> chanFile{TFile::Open( ChannelFileName.c_str(), "RECREATE" )};
@@ -218,7 +213,9 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement("simPdf", ws.get(), measurement);
 
     if (cfg.createWorkspaceFile) {
-      std::string CombinedFileName = measurement.GetOutputFilePrefix() + "_combined_"
+      std::string prefix =  measurement.GetOutputFilePrefix();
+      createOutputDirectory(prefix);
+      std::string CombinedFileName = prefix + "_combined_"
         + rowTitle + "_model.root";
       cxcoutPHF << "Writing combined workspace to file: " << CombinedFileName << std::endl;
       std::unique_ptr<TFile> combFile{TFile::Open( CombinedFileName.c_str(), "RECREATE" )};


### PR DESCRIPTION
It should be possible to disable writing the combined RooWorkspace to
disk, because often the workspace is created and used in the same
script. In that case, writing the workspace to a file is unnecessary
overhead.

Tested by running the `hf001` tutorial with this flag, because the
tutorial is one of these cases where the workspace doesn't need to be
written to a file.

Closes https://github.com/root-project/root/issues/18667.

Also, ensure that the logging is correctly reset and that no output directory is created if not needed (there are separate commits for that).