### PR TITLE
[macOS] Include <chrono> to fix `_FilesystemClock` build warning

### DIFF
--- a/core/base/inc/Riostream.h
+++ b/core/base/inc/Riostream.h
@@ -21,6 +21,12 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#ifdef __APPLE__
+// Workaround for https://github.com/llvm/llvm-project/issues/138683
+// Include <chrono> before <fstream> to ensure _FilesystemClock is defined
+// Can be removed once the upstream issue is fixed.
+#include <chrono>
+#endif
 #include <fstream>
 #include <iostream>
 #include <iomanip>


### PR DESCRIPTION
# This Pull request:
Backport of: https://github.com/root-project/root/pull/18515

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

