### PR TITLE
[skip-ci] Fix the script filtering the wrong namespaces

### DIFF
--- a/documentation/doxygen/modifyNamespacesWebpage.sh
+++ b/documentation/doxygen/modifyNamespacesWebpage.sh
@@ -67,34 +67,34 @@ sed -e '/<compound kind="namespace">/,/<\/compound>/ {
   }
 }' "$file" > "$HTMLPATH/TMP_FILE"
 mv "$HTMLPATH/TMP_FILE" "$file"
-   	 
+       
 # clean namespace in $HTMLPATH/search
 find "$HTMLPATH/search" -type f | xargs -P 12 -n 100 grep -s -l "$s" | while IFS= read -r file; do
   if test -e "$file"; then
-	 echo "   Patching:" $file
-	 # Remove the line containing the namespace
-	 sed -e "/$s/d" "$file" > "$HTMLPATH/TMP_FILE"
-	 mv "$HTMLPATH/TMP_FILE" "$file"
+    echo "   Patching:" $file
+    # Remove the line containing the namespace
+    sed -e "/$s/d" "$file" > "$HTMLPATH/TMP_FILE"
+    mv "$HTMLPATH/TMP_FILE" "$file"
   fi
 done
 
 # remove references to namespace in $HTMLPATH 
 find "$HTMLPATH" -type f | xargs -P 12 -n 100 grep -s -l "$s" | while IFS= read -r file; do
   if test -e "$file"; then
-	 echo "   Patching:" $file
-	 # Remove the links to the namespace
-     sed -e "s/<a class.*href=.$s.*>\(.*\)<\/a>/\1/" "$file" > "$HTMLPATH/TMP_FILE"
-	 mv "$HTMLPATH/TMP_FILE" "$file"
+    echo "   Patching:" $file
+    # Remove the links to the namespace
+    sed -e "s/<a class[^<]*href=.$s[^>]*>\(.*\)<\/a>/\1/" "$file" > "$HTMLPATH/TMP_FILE"
+    mv "$HTMLPATH/TMP_FILE" "$file"
   fi
 done
 
 # remove references to namespace in $HTMLPATH/*.js 
 find "$HTMLPATH" -type f -name "*.js" | xargs -P 12 -n 100 grep -s -l "$s" | while IFS= read -r file; do
   if test -e "$file"; then
-	 echo "   Patching:" $file
+    echo "   Patching:" $file
      # Remove the line containing the namespace
-	 sed -e "/$s/d" "$file" > "$HTMLPATH/TMP_FILE"
-	 mv "$HTMLPATH/TMP_FILE" "$file"
+    sed -e "/$s/d" "$file" > "$HTMLPATH/TMP_FILE"
+    mv "$HTMLPATH/TMP_FILE" "$file"
   fi
 done
 


### PR DESCRIPTION
This pull request fixes this issue https://github.com/root-project/root/issues/18631
rf408_RDataFrameToRooFit.C was corrupted.
The script cleaning the faulty namespaces was not general enough.
This PR also remove tabs in that script.

