### PR TITLE
[CMake][RF] Correctly declare dependencies in RooFitHS3 and xRooFit

### DIFF
--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -23,11 +23,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitHS3
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   DEPENDENCIES
+    HistFactory
+    RooFit
     RooFitCore
     RooFitJSONInterface
-  LIBRARIES
-    RooFit
-    HistFactory
 )
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/xroofit/CMakeLists.txt
+++ b/roofit/xroofit/CMakeLists.txt
@@ -1,36 +1,35 @@
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitXRooFit
-        HEADERS
-        RooBrowser.h
-        XRooFit.h
-        RooFit/xRooFit/xRooFit.h
-        RooFit/xRooFit/xRooNode.h
-        RooFit/xRooFit/xRooNLLVar.h
-        RooFit/xRooFit/xRooHypoSpace.h
-        RooFit/xRooFit/xRooBrowser.h
-        SOURCES
-        src/Asymptotics.cxx
-        src/xRooBrowser.cxx
-        src/xRooFit.cxx
-        src/xRooHypoSpace.cxx
-        src/xRooNLLVar.cxx
-        src/xRooNode.cxx
-        src/xRooNode_interactive.cxx
-        DICTIONARY_OPTIONS
-        "-writeEmptyRootPCM"
-        LIBRARIES
-        HistFactory
-        RooFit
-        RooFitHS3
-        RooStats
-        FitPanel
-        DEPENDENCIES
-        Gui
-        Ged
-        RooFitCore
-        FitPanel
-        LINKDEF
-        inc/LinkDef.h
-        )
+  HEADERS
+    RooBrowser.h
+    XRooFit.h
+    RooFit/xRooFit/xRooFit.h
+    RooFit/xRooFit/xRooNode.h
+    RooFit/xRooFit/xRooNLLVar.h
+    RooFit/xRooFit/xRooHypoSpace.h
+    RooFit/xRooFit/xRooBrowser.h
+  SOURCES
+    src/Asymptotics.cxx
+    src/xRooBrowser.cxx
+    src/xRooFit.cxx
+    src/xRooHypoSpace.cxx
+    src/xRooNLLVar.cxx
+    src/xRooNode.cxx
+    src/xRooNode_interactive.cxx
+  DICTIONARY_OPTIONS
+    "-writeEmptyRootPCM"
+  DEPENDENCIES
+    HistFactory
+    RooFit
+    RooFitHS3
+    RooStats
+    FitPanel
+    Gui
+    Ged
+    RooFitCore
+    FitPanel
+  LINKDEF
+    inc/LinkDef.h
+)
 
 target_include_directories(RooFitXRooFit PRIVATE inc/RooFit)
 


### PR DESCRIPTION
`LIBRARIES` is for external libraries.

Closes #18697.