### PR TITLE
[math] fix initialization bug in halfsamplemode algorithm

### DIFF
--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -1507,7 +1507,7 @@ template <typename T> Double_t TMath::ModeHalfSample(Long64_t n, const T *a, con
 
    // Do recursive calls dividing each time the interval by two
    while (n > 3) {
-      Double_t min_v_range = values[n - 1] - values[0];
+      Double_t min_v_range = values[jMin + n - 1] - values[jMin];
       const size_t N = std::ceil(n * 0.5);
       const size_t start = jMin;
       const size_t stop = start + n - N + 1; // +1 since we use < and not <=


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

I am sorry, I had fixed this bug in V2 of the pull request, but then we merged V1 and I forgot to 'backport' this modification.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)