### PR TITLE
[skip-ci] Some small improvements in the doc

### DIFF
--- a/core/base/src/TExec.cxx
+++ b/core/base/src/TExec.cxx
@@ -82,7 +82,7 @@ such as TPad::GetEvent, TPad::GetEventX, TPad::GetEventY to find
 which type of event and the X,Y position of the mouse.
 By default, the list of TExecs is executed. This can be disabled
 via the canvas menu "Option".
-See $ROOTSYS/tutorials/hist/hist058_TExec_th2.C for an example.
+See hist058_TExec_th2.C for an example.
 ~~~ {.cpp}
    Root > TFile f("hsimple.root");
    Root > hpxpy.Draw();

--- a/core/base/src/TPRegexp.cxx
+++ b/core/base/src/TPRegexp.cxx
@@ -666,7 +666,7 @@ Supports main Perl operations using regular expressions (Match,
 Substitute and Split). To retrieve the results one can simply use
 operator[] returning a TString.
 
-See regexp_pme.C for examples.
+See regexp_pme.C for example.
 */
 
 ClassImp(TPMERegexp);

--- a/core/base/src/TPRegexp.cxx
+++ b/core/base/src/TPRegexp.cxx
@@ -666,7 +666,7 @@ Supports main Perl operations using regular expressions (Match,
 Substitute and Split). To retrieve the results one can simply use
 operator[] returning a TString.
 
-See $ROOTSYS/tutorials/regexp_pme.C for examples.
+See regexp_pme.C for examples.
 */
 
 ClassImp(TPMERegexp);

--- a/geom/geom/doc/materials.md
+++ b/geom/geom/doc/materials.md
@@ -255,9 +255,8 @@ The method will create the mixture that result from the decay of a
 initial material/mixture at time, while all resulting elements having a
 fractional weight less than precision are excluded.
 
-A demo macro for radioactive material features is
-`$ROOTSYS/tutorials/visualisation/geom/RadioNuclides.C` It demonstrates also the decay
-of a mixture made of radionuclides.
+A demo macro for radioactive material features is RadioNuclides.C .
+It demonstrates also the decay of a mixture made of radionuclides.
 
 \image html geometry004.png width=600px
 

--- a/geom/geom/doc/materials.md
+++ b/geom/geom/doc/materials.md
@@ -256,7 +256,7 @@ initial material/mixture at time, while all resulting elements having a
 fractional weight less than precision are excluded.
 
 A demo macro for radioactive material features is RadioNuclides.C .
-It demonstrates also the decay of a mixture made of radionuclides.
+It also demonstrates the decay of a mixture made of radionuclides.
 
 \image html geometry004.png width=600px
 

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -138,7 +138,7 @@ this process.
 ## An interactive session
 
   Provided that a geometry was successfully built and closed (for instance the
-previous example $ROOTSYS/tutorials/visualisation/geom/rootgeom.C ), the manager class will register
+previous example rootgeom.C ), the manager class will register
 itself to ROOT and the logical/physical structures will become immediately browsable.
 The ROOT browser will display starting from the geometry folder : the list of
 transformations and media, the top volume and the top logical node. These last

--- a/graf2d/gpad/src/TButton.cxx
+++ b/graf2d/gpad/src/TButton.cxx
@@ -67,7 +67,7 @@ void but() {
    but3->Draw();
 
 // Create last button with no name. Instead a graph is draw inside the button
-// Clicking on this button will invoke the macro $ROOTSYS/tutorials/visualisation/graphs/gr001_simple.C
+// Clicking on this button will invoke the macro gr001_simple.C
    button = new TButton("",".x tutorials/visualisation/graphs/gr001_simple.C",0.15,0.15,0.85,0.38);
    button->SetFillColor(42);
    button->Draw();

--- a/graf3d/gl/src/TGLHistPainter.cxx
+++ b/graf3d/gl/src/TGLHistPainter.cxx
@@ -101,7 +101,7 @@ The following types of plots are provided:
    The supported option is:
 
   - `"GLCOL" :` TH3 is drawn using semi-transparent colored boxes.
-  See `$ROOTSYS/tutorials/visualisation/gl/glvox1.C`.
+  See glvox1.C .
 
 
 #### `TF3` (implicit function) - (`TGLTF3Painter`)
@@ -111,7 +111,7 @@ The following types of plots are provided:
 
 
 #### Parametric surfaces - (`TGLParametricPlot`)
-  `$ROOTSYS/tutorials/visualisation/gl/glparametric.C` shows how to create parametric equations and
+  glparametric.C shows how to create parametric equations and
   visualize the surface.
 
 

--- a/graf3d/gl/src/TGLParametric.cxx
+++ b/graf3d/gl/src/TGLParametric.cxx
@@ -103,9 +103,9 @@ where -pi <= u <= pi, -pi <= v <= pi.
                               "1 / (sqrt(2) + cos(v))");
 ~~~
 
- `$ROOTSYS/tutorials/visualisation/gl/glparametric.C` contains more examples.
+glparametric.C contains more examples.
 
- Parametric equations can be specified:
+Parametric equations can be specified:
   - 1. by string expressions, as with TF2, but with 'u' instead of 'x' and
        'v' instead of 'y'.
   - 2. by function - see ParametricEquation_t declaration.

--- a/hist/hist/src/TGraph2DAsymmErrors.cxx
+++ b/hist/hist/src/TGraph2DAsymmErrors.cxx
@@ -27,7 +27,7 @@ Graph 2D class with errors.
 A TGraph2DAsymmErrors is a TGraph2D with asymmetric errors. It behaves like a TGraph2D and has
 the same drawing options.
 
-The **"ERR"** drawing option allows to display the error bars. The
+The "ERR" drawing option allows to display the error bars. The
 following example shows how to use it:
 
 Begin_Macro(source)

--- a/hist/hist/src/TGraphSmooth.cxx
+++ b/hist/hist/src/TGraphSmooth.cxx
@@ -30,7 +30,7 @@ ClassImp(TGraphSmooth);
 /** \class TGraphSmooth
     \ingroup Graphs
 A helper class to smooth TGraph.
-see examples in $ROOTSYS/tutorials/visualisation/graphs/gr010_approx_smooth.C and $ROOTSYS/tutorials/visualisation/graphs/gr015_smooth.C
+see examples the gr010_approx_smooth.C and gr015_smooth.C .
 */
 
 TGraphSmooth::TGraphSmooth()

--- a/hist/hist/src/TGraphSmooth.cxx
+++ b/hist/hist/src/TGraphSmooth.cxx
@@ -30,7 +30,7 @@ ClassImp(TGraphSmooth);
 /** \class TGraphSmooth
     \ingroup Graphs
 A helper class to smooth TGraph.
-see examples the gr010_approx_smooth.C and gr015_smooth.C .
+see the following examples: gr010_approx_smooth.C and gr015_smooth.C.
 */
 
 TGraphSmooth::TGraphSmooth()

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -24,7 +24,7 @@ ClassImp(TGraphTime);
 TGraphTime is used to draw a set of objects evolving with nsteps in time between tmin and tmax.
 Each time step has a new list of objects. This list can be identical to
 the list of objects in the previous steps, but with different attributes.
-See example of use in $ROOTSYS/tutorials/visualisation/graphs/gr017_time.C
+See example of use in gr017_time.C
 */
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -656,7 +656,7 @@ NOTE all parameters of user function are taken from
   - `x` is highlighted x-th (i-th) point for graph
   - `y` not in use (only for 2D histogram)
 
-For more complex demo please see for example hlquantiles.C example.
+For more complex demo please see, for example, hlquantiles.C.
 
 */
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -656,7 +656,7 @@ NOTE all parameters of user function are taken from
   - `x` is highlighted x-th (i-th) point for graph
   - `y` not in use (only for 2D histogram)
 
-For more complex demo please see for example `$ROOTSYS/tutorials/math/hlquantiles.C` file.
+For more complex demo please see for example hlquantiles.C example.
 
 */
 

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -2922,7 +2922,7 @@ The supported option is:
 
 | Option   | Description                                                       |
 |----------|-------------------------------------------------------------------|
-| "GLCOL"  | H3 is drawn using semi-transparent colored boxes.  See `$ROOTSYS/tutorials/visualisation/gl/glvox1.C`.|
+| "GLCOL"  | H3 is drawn using semi-transparent colored boxes.  See glvox1.C .|
 
 
 
@@ -2963,8 +2963,7 @@ The supported option is:
 \anchor HP29e
 #### Parametric surfaces
 
-`$ROOTSYS/tutorials/visualisation/gl/glparametric.C` shows how to create parametric
-equations and visualize the surface.
+glparametric.C shows how to create parametric equations and visualize the surface.
 
 \anchor HP29f
 #### Interaction with the plots
@@ -3074,7 +3073,7 @@ graphically. Bin will be highlighted as "bin box" (presented by box
 object). Moreover, any highlight (change of bin) emits signal
 `TCanvas::Highlighted()` which allows the user to react and call their own
 function. For a better understanding see also the tutorial `hist043` to `hist046`
-lacated in `$ROOTSYS/tutorials/hist/`.
+located in `$ROOTSYS/tutorials/hist/`.
 
 Highlight mode is switched on/off by `TH1::SetHighlight()` function
 or interactively from `TH1` context menu. `TH1::IsHighlight()` to verify
@@ -3154,7 +3153,7 @@ void hlprint()
 
 \image html hlsimple.gif "Highlight mode and simple user function"
 
-For more complex demo please see for example `$ROOTSYS/tutorials/io/tree/tree200_temperature.C` file.
+For more complex demo please see for example tree200_temperature.C file.
 
 */
 

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -653,8 +653,7 @@ def copyRootObjectRecursive(sourceFile, sourcePathSplit, destFile, destPathSplit
     to an other file or directory (destFile,destPathSplit)
     - Has the will to be unix-like
     - that's a recursive function
-    - Python adaptation of a root input/output tutorial :
-      $ROOTSYS/tutorials/io/copyFiles.C
+    - Python adaptation of a root input/output tutorial : copyFiles.C
     """
     retcode = 0
     replaceOption = replace

--- a/math/mathcore/src/TKDTreeBinning.cxx
+++ b/math/mathcore/src/TKDTreeBinning.cxx
@@ -24,7 +24,7 @@ ClassImp(TKDTreeBinning);
 
 /**
 \class TKDTreeBinning
-<- TKDTreeBinning - A class providing multidimensional binning ->
+A class providing multidimensional binning
 
 The class implements multidimensional binning by constructing a TKDTree inner structure from the
 data which is used as the bins.
@@ -35,7 +35,7 @@ The bin edges of d-dimensional data is a d-tet of the bin's thresholds. For exam
 edges of bin b is of the form of the following array: {xbmin, ybmin, zbmin}.
 You also have the possibility to sort the bins by their density.
 
-Details of usage can be found in `$ROOTSYS/tutorials/math/kdTreeBinning.C` and more information on
+kdTreeBinning.C and more information on
 the embedded TKDTree documentation.
 
 @ingroup MathCore
@@ -172,7 +172,7 @@ void TKDTreeBinning::SortBinsByDensity(Bool_t sortAsc) {
       }
       std::vector<Double_t> binMinEdges(fNBins * fDim);
       std::vector<Double_t> binMaxEdges(fNBins * fDim);
-      std::vector<UInt_t> binContent(fNBins );    // reajust also content (not needed bbut better in general!)
+      std::vector<UInt_t> binContent(fNBins );    // readjust also content (not needed but better in general!)
       fIndices.resize(fNBins);
       for (UInt_t i = 0; i < fNBins; ++i) {
          for (UInt_t j = 0; j < fDim; ++j) {
@@ -524,7 +524,7 @@ const Double_t * TKDTreeBinning::SortOneDimBinEdges(Bool_t sortAsc) {
 
    std::vector<Double_t> binMinEdges(fNBins );
    std::vector<Double_t> binMaxEdges(fNBins );
-   std::vector<UInt_t> binContent(fNBins );    // reajust also content (not needed but better in general!)
+   std::vector<UInt_t> binContent(fNBins );    // readjust also content (not needed but better in general!)
    fIndices.resize( fNBins );
    for (UInt_t i = 0; i < fNBins; ++i) {
       binMinEdges[i ] = fBinMinEdges[indices[i] ];

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -648,7 +648,7 @@ Int_t TMinuit::Command(const char *command)
 /// to a TGraph*. Note that the TGraph is created with npoints+1 in order to
 /// close the contour (setting last point equal to first point).
 ///
-/// You can find an example in $ROOTSYS/tutorials/fit/fitcont.C
+/// You can find an example in fitcont.C
 
 TObject *TMinuit::Contour(Int_t npoints, Int_t pa1, Int_t pa2)
 {

--- a/math/physics/src/TFeldmanCousins.cxx
+++ b/math/physics/src/TFeldmanCousins.cxx
@@ -36,7 +36,7 @@ fMuMax, fMuStep and fNMax are those used in the PRD:
 but there is total flexibility in changing this should you desire.
 
 
-see example of use in $ROOTSYS/tutorials/math/FeldmanCousins.C
+see example of use in FeldmanCousins.C
 
 see note about: "Should I use TRolke, TFeldmanCousins, TLimit?"
  in the TRolke class description.

--- a/montecarlo/pythia8/src/TPythia8.cxx
+++ b/montecarlo/pythia8/src/TPythia8.cxx
@@ -12,7 +12,7 @@
 /** \class TPythia8
     \ingroup pythia8
 
-TPythia8 is an interface class to C++ version of Pythia 8.1           
+TPythia8 is an interface class to C++ version of Pythia 8.1
 event generators, written by T.Sjostrand.
 
 The user is assumed to be familiar with the Pythia package.
@@ -22,8 +22,6 @@ compiled C++ script.
 
 To call Pythia functions not available in this interface a dictionary must
 be generated.
-
-See $ROOTSYS/tutorials/pythia/pythia8.C for an example of use from CINT.
 
 Author: Andreas Morsch   27/10/2007
 

--- a/montecarlo/pythia8/src/TPythia8.cxx
+++ b/montecarlo/pythia8/src/TPythia8.cxx
@@ -23,6 +23,8 @@ compiled C++ script.
 To call Pythia functions not available in this interface a dictionary must
 be generated.
 
+See evegen_000_pythia8.C for an example of use from CLING.
+
 Author: Andreas Morsch   27/10/2007
 
 \verbatim

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4341,7 +4341,7 @@ Long64_t TTree::Draw(const char* varexp, const TCut& selection, Option_t* option
 /// ### Making a 5D plot using GL
 ///
 /// If option GL5D is specified together with 5 variables, a 5D plot is drawn
-/// using OpenGL. See $ROOTSYS/tutorials/io/tree/tree502_staff.C as example.
+/// using OpenGL. See tree502_staff.C as example.
 ///
 /// ### Making a parallel coordinates plot
 ///

--- a/tutorials/evegen/evegen_000_pythia8.C
+++ b/tutorials/evegen/evegen_000_pythia8.C
@@ -5,7 +5,7 @@
 /// to run, do:
 ///
 /// ~~~{.cpp}
-///  root > .x pythia8.C
+///  root > .x evegen_000_pythia8.C
 /// ~~~
 ///
 /// \macro_code

--- a/tutorials/io/tree/tree502_staff.C
+++ b/tutorials/io/tree/tree502_staff.C
@@ -4,7 +4,6 @@
 /// Create a plot of the data in `cernstaff.root`
 /// To create `cernstaff.root`, execute tutorial `$ROOTSYS/tutorials/io/tree/tree500_cernbuild.C`
 ///
-/// \macro_image
 /// \macro_code
 ///
 /// \author Rene Brun


### PR DESCRIPTION
- doxygen automatically makes reference links to tutorials when then are simply named `tutorial.C`. In several  places some tutorials were mentioned as `$ROOTSYS/tutorials/path_to_the_tutorial/tutorial.C`. This prevented doxygen to automatically make the link to the `tutorial.C`. This PR simplify  `$ROOTSYS/tutorials/path_to_the_tutorial/tutorial.C` to `tutorial.C` to allow doxygen to make the link.
- remove `\macro_image` from`tree502_staff.C` because the macro does not generate any image when run in batch.
- in Pythia8.cxx: remove the reference to `pythia8.C` which does not exist and change it to evegen_000_pythia8.C.

