### PR TITLE
[python][UHI] Implement Slicing in TH1 and adapt the UHI backend and tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -4,12 +4,7 @@ Tests to verify that TH1 and derived histograms conform to the UHI Indexing inte
 
 import pytest
 import ROOT
-from ROOT._pythonization._uhi import (
-    _get_axis,
-    _get_processed_slices,
-    _get_slice_indices,
-    _shape,
-)
+from ROOT._pythonization._uhi import _get_axis, _get_processed_slices, _overflow, _shape, _underflow
 from ROOT.uhi import loc, overflow, rebin, sum, underflow
 
 
@@ -32,6 +27,14 @@ def _iterate_bins(hist):
                 yield tuple(filter(None, (i, j, k)))
 
 
+def _get_slice_indices(slices):
+    import numpy as np
+
+    ranges = [range(start, stop) for start, stop in slices]
+    grids = np.meshgrid(*ranges, indexing="ij")
+    return np.array(grids).reshape(len(slices), -1).T
+
+
 class TestTH1Indexing:
     def test_access_with_bin_number(self, hist_setup):
         for index in [0, 8]:
@@ -52,7 +55,7 @@ class TestTH1Indexing:
 
     def test_access_with_len(self, hist_setup):
         len_indices = (len,) * hist_setup.GetDimension()
-        bin_counts = (_get_axis(hist_setup, i).GetNbins() for i in range(hist_setup.GetDimension()))
+        bin_counts = (_get_axis(hist_setup, i).GetNbins() + 1 for i in range(hist_setup.GetDimension()))
         assert hist_setup[len_indices] == hist_setup.GetBinContent(*bin_counts)
 
     def test_access_with_ellipsis(self, hist_setup):
@@ -104,23 +107,48 @@ class TestTH1Indexing:
         if _special_setting(hist_setup):
             pytest.skip("Setting cannot be tested here")
 
+        hist_setup.Reset()
         hist_setup[...] = 3
         for bin_indices in _iterate_bins(hist_setup):
             assert hist_setup.GetBinContent(*bin_indices) == 3
 
+        # Check that flow bins are not set
+        for flow_type in [underflow, overflow]:
+            flow_indices = (flow_type,) * hist_setup.GetDimension()
+            assert hist_setup[flow_indices] == 0, (
+                f"{hist_setup.values()}, {hist_setup[underflow]}, {hist_setup[overflow]}"
+            )
+
     def _test_slices_match(self, hist_setup, slice_ranges, processed_slices):
         dim = hist_setup.GetDimension()
-        slices, _, _ = _get_processed_slices(hist_setup, processed_slices[dim])
+        slices, _ = _get_processed_slices(hist_setup, processed_slices[dim])
         expected_indices = _get_slice_indices(slices)
         sliced_hist = hist_setup[tuple(slice_ranges[dim])]
 
         for bin_indices in expected_indices:
             bin_indices = tuple(map(int, bin_indices))
-            assert sliced_hist.GetBinContent(*bin_indices) == hist_setup.GetBinContent(*bin_indices)
+            shifted_indices = []
+            is_flow_bin = False
+            for i, idx in enumerate(bin_indices):
+                shift = slice_ranges[dim][i].start
+                if callable(shift):
+                    shift = shift(hist_setup, i)
+                elif shift is None:
+                    shift = 1
+                else:
+                    shift += 1
 
-        for bin_indices in _iterate_bins(hist_setup):
-            if list(bin_indices) not in expected_indices.tolist():
-                assert sliced_hist.GetBinContent(*bin_indices) == 0
+                shifted_idx = idx - shift + 1
+                if shifted_idx <= 0 or shifted_idx == _overflow(hist_setup, i):
+                    is_flow_bin = True
+                    break
+
+                shifted_indices.append(shifted_idx)
+
+            if is_flow_bin:
+                continue
+
+            assert sliced_hist.GetBinContent(*tuple(shifted_indices)) == hist_setup.GetBinContent(*bin_indices)
 
     def test_slicing_with_endpoints(self, hist_setup):
         if _special_setting(hist_setup):
@@ -144,13 +172,13 @@ class TestTH1Indexing:
 
         processed_slices = {
             1: [slice(0, 8)],
-            2: [slice(0, 8), slice(4, 11)],
-            3: [slice(0, 8), slice(4, 11), slice(3, 6)],
+            2: [slice(0, 8), slice(0, 8)],
+            3: [slice(0, 8), slice(0, 8), slice(3, 6)],
         }
         slice_ranges = {
             1: [slice(None, 7)],
-            2: [slice(None, 7), slice(3, None)],
-            3: [slice(None, 7), slice(3, None), slice(2, 5)],
+            2: [slice(None, 7), slice(None, 7)],
+            3: [slice(None, 7), slice(None, 7), slice(2, 5)],
         }
         self._test_slices_match(hist_setup, slice_ranges, processed_slices)
 
@@ -160,17 +188,17 @@ class TestTH1Indexing:
 
         processed_slices = {
             1: [slice(hist_setup.FindBin(2), 11)],
-            2: [slice(hist_setup.FindBin(2), 11), slice(hist_setup.FindBin(3), 11)],
+            2: [slice(hist_setup.FindBin(2) - 1, 11), slice(2, 11)],
             3: [
                 slice(hist_setup.FindBin(2), 11),
-                slice(hist_setup.FindBin(3), 11),
-                slice(hist_setup.FindBin(1.5), 11),
+                slice(2, 11),
+                slice(2, 11),
             ],
         }
         slice_ranges = {
             1: [slice(loc(2), None)],
-            2: [slice(loc(2), None), slice(loc(3), None)],
-            3: [slice(loc(2), None), slice(loc(3), None), slice(loc(1.5), None)],
+            2: [slice(loc(2), None), slice(3, None)],
+            3: [slice(loc(2), None), slice(3, None), slice(3, None)],
         }
         self._test_slices_match(hist_setup, slice_ranges, processed_slices)
 
@@ -191,7 +219,10 @@ class TestTH1Indexing:
         dim = hist_setup.GetDimension()
 
         if dim == 1:
-            integral = hist_setup[::sum]
+            full_integral = hist_setup[::sum]
+            assert full_integral == hist_setup.Integral(_underflow(hist_setup, 0), _overflow(hist_setup, 0))
+
+            integral = hist_setup[0:len:sum]
             assert integral == hist_setup.Integral()
 
         if dim == 2:
@@ -225,7 +256,7 @@ class TestTH1Indexing:
         if dim == 1:
             sliced_hist_rebin = hist_setup[5 : 9 : rebin(2)]
             assert isinstance(sliced_hist_rebin, ROOT.TH1)
-            assert sliced_hist_rebin.GetNbinsX() == hist_setup.GetNbinsX() // 2
+            assert sliced_hist_rebin.GetNbinsX() == 2
 
             sliced_hist_sum = hist_setup[5:9:sum]
             assert isinstance(sliced_hist_sum, float)
@@ -237,10 +268,10 @@ class TestTH1Indexing:
             assert sliced_hist.GetNbinsX() == hist_setup.GetNbinsX() // 2
 
         if dim == 3:
-            sliced_hist = hist_setup[:: rebin(2), ::sum, 5 : 9 : rebin(3)]
+            sliced_hist = hist_setup[:: rebin(2), ::sum, 3 : 9 : rebin(3)]
             assert isinstance(sliced_hist, ROOT.TH2)
             assert sliced_hist.GetNbinsX() == hist_setup.GetNbinsX() // 2
-            assert sliced_hist.GetNbinsY() == hist_setup.GetNbinsZ() // 3
+            assert sliced_hist.GetNbinsY() == 2
 
     def test_slicing_with_dict_syntax(self, hist_setup):
         if _special_setting(hist_setup):
@@ -262,19 +293,25 @@ class TestTH1Indexing:
         assert hist_setup.Integral() == pytest.approx(sliced_hist.Integral(), rel=10e-6)
 
     def test_statistics_slice(self, hist_setup):
-        if _special_setting(hist_setup):
+        if _special_setting(hist_setup) or isinstance(hist_setup, (ROOT.TH1C, ROOT.TH2C, ROOT.TH3C)):
             pytest.skip("Setting cannot be tested here")
+
+        # Check if slicing over everything preserves the statistics
+        sliced_hist_full = hist_setup[...]
+
+        assert hist_setup.GetEffectiveEntries() == sliced_hist_full.GetEffectiveEntries()
+        assert hist_setup.Integral() == sliced_hist_full.Integral()
 
         # Check if slicing over a range updates the statistics
         dim = hist_setup.GetDimension()
-        [_get_axis(hist_setup, i).SetRange(3, 5) for i in range(dim)]
+        [_get_axis(hist_setup, i).SetRange(3, 7) for i in range(dim)]
         slice_indices = tuple(slice(2, 7) for _ in range(dim))
         sliced_hist = hist_setup[slice_indices]
 
-        assert hist_setup.Integral() == pytest.approx(sliced_hist.Integral(), rel=1e-6)
-        assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), abs=1e-3)
-        assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), abs=1e-3)
+        assert hist_setup.Integral() == sliced_hist.Integral()
         assert hist_setup.GetEffectiveEntries() == sliced_hist.GetEffectiveEntries()
+        assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), rel=10e-5)
+        assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), rel=10e-5)
 
 
 if __name__ == "__main__":

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -35,6 +35,7 @@
 #include "TArrayL64.h"
 #include "TArrayF.h"
 #include "TArrayD.h"
+#include "TDirectory.h"
 #include "Foption.h"
 
 #include "TVectorFfwd.h"
@@ -44,6 +45,10 @@
 
 #include <cfloat>
 #include <string>
+#include <stdexcept>
+#include <type_traits>
+#include <array>
+#include <numeric>
 
 class TF1;
 class TH1D;
@@ -55,6 +60,50 @@ class TVirtualFFT;
 class TVirtualHistPainter;
 class TRandom;
 
+namespace ROOT::Internal {
+/**
+ * \brief Creates a sliced copy of the given histogram.
+ *
+ * \tparam T The type of the histogram.
+ * \param histo The histogram to slice.
+ * \param args A vector of integers specifying the low and upper edges of the slice for each dimension.
+ *
+ * \return A new histogram object that is a sliced version of the input histogram.
+ */
+template <typename T>
+T Slice(const T &histo, std::vector<Int_t> &args)
+{
+   static_assert(std::is_pointer_v<decltype(histo.fArray)>,
+                 "The type of the histogram to slice must expose the internal array data.");
+
+   TDirectory::TContext _{nullptr};
+   T slicedHisto = histo;
+
+   using ValueType = std::remove_pointer_t<decltype(slicedHisto.fArray)>;
+   slicedHisto.template SliceHistoInPlace<ValueType>(args, slicedHisto.fArray, slicedHisto.fN);
+   return slicedHisto;
+}
+
+/**
+ * \brief Sets the content of a slice in a histogram.
+ *
+ * \tparam T The type of the histogram.
+ * \param histo The histogram to set the slice content for.
+ * \param input A vector of values to assign to the bins in the specified slice. All input types are converted
+ *              to Double_t as that's the type `SetBinContent` eventually uses.
+ * \param sliceEdges A vector of pairs specifying the low and upper edges of the slice for each dimension.
+ */
+template <typename T>
+void SetSliceContent(T &histo, const std::vector<Double_t> &input,
+                     const std::vector<std::pair<Int_t, Int_t>> &sliceEdges)
+{
+   static_assert(std::is_pointer_v<decltype(histo.fArray)>,
+                 "The type of the histogram to slice must expose the internal array data.");
+
+   using ValueType = std::remove_pointer_t<decltype(histo.fArray)>;
+   histo.template SetSliceContent<ValueType>(input, sliceEdges, histo.fArray);
+}
+} // namespace ROOT::Internal
 
 class TH1 : public TNamed, public TAttLine, public TAttFill, public TAttMarker {
 
@@ -136,6 +185,186 @@ private:
 
    TH1(const TH1&) = delete;
    TH1& operator=(const TH1&) = delete;
+
+   /**
+    * \brief Slices a histogram in place based on the specified bin ranges for each dimension.
+    *
+    * This function modifies the histogram by extracting a sub-region defined by the provided
+    * bin ranges for each dimension. The resulting histogram will have updated bin counts,
+    * edges, and contents. Bin contents outside the range fall into the flow bins.
+    * The histogram's internal data array is freed and reallocated by this function.
+    * This function is used by the python implementation of the Unified Histogram Interface (UHI)
+    * for slicing.
+    *
+    * \tparam ValueType The type of the histogram's data.
+    * \param args A vector of integers specifying the low and upper edges of the slice for each dimension.
+    * \param dataArray A pointer to the histogram's data array.
+    * \param fN The size of dataArray.
+    */
+   template <typename ValueType>
+   void SliceHistoInPlace(std::vector<Int_t> &args, ValueType *&dataArray, Int_t &fN)
+   {
+      constexpr Int_t kMaxDim = 3;
+      Int_t ndim = args.size() / 2;
+      if (ndim != fDimension) {
+         throw std::invalid_argument(
+            Form("Number of dimensions in slice (%d) does not match histogram dimension (%d).", ndim, fDimension));
+      }
+
+      // Compute new bin counts and edges
+      std::array<Int_t, kMaxDim> nBins{}, totalBins{};
+      std::array<Double_t, kMaxDim> lowEdge{}, upEdge{};
+      for (decltype(ndim) d = 0; d < ndim; ++d) {
+         const auto &axis = (d == 0 ? fXaxis : d == 1 ? fYaxis : fZaxis);
+         auto start = std::max(1, args[d * 2]);
+         auto end = std::min(axis.GetNbins() + 1, args[d * 2 + 1]);
+         nBins[d] = end - start;
+         lowEdge[d] = axis.GetBinLowEdge(start);
+         upEdge[d] = axis.GetBinLowEdge(end);
+         totalBins[d] = axis.GetNbins() + 2;
+         args[2 * d] = start;
+         args[2 * d + 1] = end;
+      }
+
+      // Compute layout sizes for slice
+      size_t rowSz = nBins[0] + 2;
+      size_t planeSz = rowSz * (ndim > 1 ? nBins[1] + 2 : 1);
+      size_t newSize = planeSz * (ndim > 2 ? nBins[2] + 2 : 1);
+
+      // Allocate the new array
+      auto *newArr = new ValueType[newSize]();
+
+      auto rowIncr = 1 + (ndim > 1 ? (rowSz - 1) : 0);
+      ValueType under = 0, over = 0;
+      Bool_t firstUnder = false;
+      Int_t lastOverIdx = 0;
+
+      // Copy the valid slice bins
+      size_t dstIdx = 1 + (ndim > 1 ? rowSz : 0) + (ndim > 2 ? planeSz : 0);
+      for (auto z = (ndim > 2 ? args[4] : 0); z < (ndim > 2 ? args[5] : 1); ++z) {
+         for (auto y = (ndim > 1 ? args[2] : 0); y < (ndim > 1 ? args[3] : 1); ++y) {
+            size_t rowStart = z * totalBins[1] * totalBins[0] + y * totalBins[0] + args[0];
+            std::copy_n(dataArray + rowStart, nBins[0], newArr + dstIdx);
+            if (!firstUnder) {
+               under = std::accumulate(dataArray, dataArray + rowStart, ValueType{});
+               firstUnder = true;
+            } else {
+               under += std::accumulate(dataArray + rowStart - args[0], dataArray + rowStart, ValueType{});
+            }
+            lastOverIdx = rowStart - args[0] + totalBins[0];
+            over += std::accumulate(dataArray + rowStart + nBins[0], dataArray + lastOverIdx, ValueType{});
+            dstIdx += rowIncr;
+         }
+         if (ndim > 2) {
+            dstIdx += 2 * rowIncr;
+         }
+      }
+
+      // Copy the flow bins
+      over += std::accumulate(dataArray + lastOverIdx, dataArray + fN, ValueType{});
+      newArr[0] = under;
+      newArr[newSize - 1] = over;
+
+      // Assign the new array
+      delete[] dataArray;
+      dataArray = newArr;
+
+      // Reconfigure Axes
+      if (ndim == 1) {
+         this->SetBins(nBins[0], lowEdge[0], upEdge[0]);
+      } else if (ndim == 2) {
+         this->SetBins(nBins[0], lowEdge[0], upEdge[0], nBins[1], lowEdge[1], upEdge[1]);
+      } else if (ndim == 3) {
+         this->SetBins(nBins[0], lowEdge[0], upEdge[0], nBins[1], lowEdge[1], upEdge[1], nBins[2], lowEdge[2],
+                       upEdge[2]);
+      }
+
+      // Update the statistics
+      ResetStats();
+      fEntries = std::accumulate(dataArray, dataArray + newSize, 0.0);
+   }
+
+   template <typename T>
+   friend T ROOT::Internal::Slice(const T &histo, std::vector<Int_t> &args);
+
+   /**
+    * \brief Sets the content of a slice of bins in a histogram.
+    *
+    * This function allows setting the content of a slice of bins in a histogram
+    * by specifying the edges of the slice and the corresponding values to assign.
+    *
+    * \tparam ValueType The type of the histogram's data.
+    * \param values A vector of values to assign to the bins in the specified slice.
+    * \param sliceEdges A vector of pairs specifying the low and upper edges of the slice for each dimension.
+    * \param dataArray A pointer to the histogram's data array.
+    */
+   template <typename ValueType>
+   void SetSliceContent(const std::vector<Double_t> &values, const std::vector<std::pair<Int_t, Int_t>> &sliceEdges,
+                        ValueType *dataArray)
+   {
+      const Int_t ndim = sliceEdges.size();
+      if (ndim != fDimension) {
+         throw std::invalid_argument(Form(
+            "Number of edges in the specified slice (%d) does not match histogram dimension (%d).", ndim, fDimension));
+      }
+
+      // Get the indices to set
+      auto getSliceIndices = [](const std::vector<std::pair<Int_t, Int_t>> &edges) -> std::vector<std::vector<Int_t>> {
+         const auto dim = edges.size();
+         if (dim == 0) {
+            return {};
+         }
+
+         std::vector<std::vector<Int_t>> slices(dim);
+         for (size_t d = 0; d < dim; ++d) {
+            for (auto val = edges[d].first; val < edges[d].second; ++val) {
+               slices[d].push_back(val);
+            }
+         }
+
+         size_t totalCombinations = 1;
+         for (const auto &slice : slices) {
+            totalCombinations *= slice.size();
+         }
+
+         std::vector<std::vector<Int_t>> result(totalCombinations, std::vector<Int_t>(3, 0));
+         for (size_t d = 0; d < slices.size(); ++d) {
+            size_t repeat = 1;
+            for (size_t i = d + 1; i < slices.size(); ++i) {
+               repeat *= slices[i].size();
+            }
+
+            size_t index = 0;
+            for (size_t i = 0; i < totalCombinations; ++i) {
+               result[i][d] = slices[d][(index / repeat) % slices[d].size()];
+               ++index;
+            }
+         }
+
+         return result;
+      };
+
+      auto sliceIndices = getSliceIndices(sliceEdges);
+
+      if (values.size() != sliceIndices.size()) {
+         throw std::invalid_argument("Number of provided values does not match number of bins to set.");
+      }
+
+      for (size_t i = 0; i < sliceIndices.size(); ++i) {
+         auto globalBin = this->GetBin(sliceIndices[i][0], sliceIndices[i][1], sliceIndices[i][2]);
+
+         // Set the bin content
+         dataArray[globalBin] = values[i];
+      }
+
+      // Update the statistics
+      ResetStats();
+      fEntries += std::accumulate(values.begin(), values.end(), 0.0);
+   }
+
+   template <typename T>
+   friend void ROOT::Internal::SetSliceContent(T &histo, const std::vector<Double_t> &input,
+                                               const std::vector<std::pair<Int_t, Int_t>> &sliceEdges);
 
 protected:
    TH1();


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Previously, slicing was implemented at the pythonization level: when slicing a histogram, the values within the specified slice were kept and the ones outside were set to 0, without resizing the sliced axis (leading to inconsistencies..).
This PR implements the slicing logic in `TH1` directly, adapting the pythonizations to make use of the new internal functions.

Other changes are made to enhance the interface and fully comply with the UHI specifications, improvements can be summarized here:
- The sliced axis is resized after slicing, which correctly adjusts the statistics.
- Integration operations now support full-range integration, non-flow integration, and ranged integration.
- Histograms can now be set with either a scalar, numpy.ndarray, or any ArrayLike instance.
- Broadcasting is now also supported (e.g., `h[0:2, 0:2] = np.array([[42], [3]])`).
- Enhance error handling.

## Checklist:
- [x] tested changes locally


