### PR TITLE
[RF][HF] Avoid unnecessary creation of Asimov datasets

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -161,20 +161,6 @@ namespace HistFactory{
     // Name of an 'edited' model, if necessary
     std::string NewModelName = "newSimPdf"; // <- This name is hard-coded in HistoToWorkspaceFactoryFast::EditSyt.  Probably should be changed to : std::string("new") + ModelName;
 
-    // Set the ModelConfig's Params of Interest
-    RooAbsData* expData = ws_single->data("asimovData");
-    if( !expData ) {
-      std::cout << "Error: Failed to find dataset: " << expData
-      << " in workspace" << std::endl;
-      throw hf_exc();
-    }
-    if(!measurement.GetPOIList().empty()){
-      proto_config->GuessObsAndNuisance(*expData->get(), RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::INFO));
-    }
-
-    // Now, let's loop over any additional asimov datasets
-    // that we need to make
-
     // Get the pdf
     // Notice that we get the "new" pdf, this is the one that is
     // used in the creation of these asimov datasets since they
@@ -182,6 +168,14 @@ namespace HistFactory{
     RooAbsPdf* pdf = ws_single->pdf(NewModelName);
     if( !pdf ) pdf = ws_single->pdf( ModelName );
     const RooArgSet* observables = ws_single->set("observables");
+
+    // Set the ModelConfig's Params of Interest
+    if(!measurement.GetPOIList().empty()){
+      proto_config->GuessObsAndNuisance(*observables, RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::INFO));
+    }
+
+    // Now, let's loop over any additional asimov datasets
+    // that we need to make
 
     // Create a SnapShot of the nominal values
     std::string SnapShotName = "NominalParamValues";
@@ -1352,8 +1346,14 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     if (RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::INFO)) asymcalcPrintLevel = 1;
     if (RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::DEBUG)) asymcalcPrintLevel = 2;
     AsymptoticCalculator::SetPrintLevel(asymcalcPrintLevel);
-    unique_ptr<RooAbsData> asimov_dataset(AsymptoticCalculator::GenerateAsimovData(*model, observables));
-    proto.import(*asimov_dataset, RooFit::Rename("asimovData"));
+    if (fCfg.createPerRegionWorkspaces) {
+      // Creating the per-channel asimov dataset is only meaningful if we
+      // actually create the files with the stored per-channel workspaces.
+      // Otherwise, we just spend time calculating something that gets thrown
+      // away anyway (for the combined workspace, we'll create a new Asimov).
+      unique_ptr<RooAbsData> asimov_dataset(AsymptoticCalculator::GenerateAsimovData(*model, observables));
+      proto.import(*asimov_dataset, RooFit::Rename("asimovData"));
+    }
 
     // GHL: Determine to use data if the hist isn't 'nullptr'
     if(TH1 const* mnominal = channel.GetData().GetHisto()) {

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -169,7 +169,7 @@ namespace HistFactory{
       throw hf_exc();
     }
     if(!measurement.GetPOIList().empty()){
-      proto_config->GuessObsAndNuisance(*expData, RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::INFO));
+      proto_config->GuessObsAndNuisance(*expData->get(), RooMsgService::instance().isActive(nullptr, RooFit::HistFactory, RooFit::INFO));
     }
 
     // Now, let's loop over any additional asimov datasets

--- a/roofit/roofitcore/inc/RooFit/ModelConfig.h
+++ b/roofit/roofitcore/inc/RooFit/ModelConfig.h
@@ -309,7 +309,9 @@ public:
    /// alias for GetWS()
    RooWorkspace *GetWorkspace() const { return GetWS(); }
 
-   void GuessObsAndNuisance(const RooAbsData &data, bool printModelConfig = true);
+   void GuessObsAndNuisance(const RooArgSet &obsSet, bool printModelConfig = true);
+
+   inline void GuessObsAndNuisance(const RooDataSet &data, bool printModelConfig = true) { return GuessObsAndNuisance(data, printModelConfig); }
 
    /// overload the print method
    void Print(Option_t *option = "") const override;

--- a/roofit/roofitcore/src/ModelConfig.cxx
+++ b/roofit/roofitcore/src/ModelConfig.cxx
@@ -83,17 +83,17 @@ namespace RooStats {
 /// We use nullptr to mean not set, so we don't want to fill
 /// with empty RooArgSets.
 
-void ModelConfig::GuessObsAndNuisance(const RooAbsData &data, bool printModelConfig)
+void ModelConfig::GuessObsAndNuisance(const RooArgSet &obsSet, bool printModelConfig)
 {
 
    // observables
    if (!GetObservables()) {
-      SetObservables(*std::unique_ptr<RooArgSet>{GetPdf()->getObservables(data)});
+      SetObservables(*std::unique_ptr<RooArgSet>{GetPdf()->getObservables(obsSet)});
    }
    // global observables
    if (!GetGlobalObservables()) {
       RooArgSet co(*GetObservables());
-      co.remove(*std::unique_ptr<RooArgSet>{GetPdf()->getObservables(data)});
+      co.remove(*std::unique_ptr<RooArgSet>{GetPdf()->getObservables(obsSet)});
       removeConstantParameters(co);
       if (!co.empty())
          SetGlobalObservables(co);
@@ -112,7 +112,7 @@ void ModelConfig::GuessObsAndNuisance(const RooAbsData &data, bool printModelCon
    //   }
    if (!GetNuisanceParameters()) {
       RooArgSet params;
-      GetPdf()->getParameters(data.get(), params);
+      GetPdf()->getParameters(&obsSet, params);
       RooArgSet p(params);
       p.remove(*GetParametersOfInterest());
       removeConstantParameters(p);

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -217,7 +217,7 @@ PointSetInterval* FeldmanCousins::GetInterval() const {
   //  RooAbsData* data = fData; //fWS->data(fDataName);
 
   // fill in implied variables given data
-  fModel.GuessObsAndNuisance(fData);
+  fModel.GuessObsAndNuisance(*fData.get());
 
   // create the test statistic sampler (private data member fTestStatSampler)
   if(!fTestStatSampler)

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -106,8 +106,8 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    // initial setup
    PreHook();
-   const_cast<ModelConfig*>(fNullModel)->GuessObsAndNuisance(*fData);
-   const_cast<ModelConfig*>(fAltModel)->GuessObsAndNuisance(*fData);
+   const_cast<ModelConfig*>(fNullModel)->GuessObsAndNuisance(*fData->get());
+   const_cast<ModelConfig*>(fAltModel)->GuessObsAndNuisance(*fData->get());
 
    std::unique_ptr<const RooArgSet> nullSnapshot {fNullModel->GetSnapshot()};
    if(nullSnapshot == nullptr) {


### PR DESCRIPTION
Creating the per-channel asimov dataset is only meaningful if we
actually create the files with the stored per-channel workspaces.
Otherwise, we just spend time calculating something that gets thrown
away anyway (for the combined workspace, we'll create a new Asimov).

This improves the performance for large workspace creation in TRexFitter
by about 20 %, which can be significant if the total runtime is in the
order of hours.

FYI @TomasDado, @superharz