### PR TITLE
[core] Slightly improve TSystem::ConcatFileName()

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -434,12 +434,13 @@ public:
    const char             *pwd() { return WorkingDirectory(); }
    virtual const char     *TempDirectory() const;
    virtual FILE           *TempFileName(TString &base, const char *dir = nullptr, const char *suffix = nullptr);
+   virtual char            DirectorySeparator() const { return '/'; }
 
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);
    virtual const char     *DirName(const char *pathname);
    virtual TString         GetDirName(const char *pathname);
-   virtual char           *ConcatFileName(const char *dir, const char *name);
+   char                   *ConcatFileName(const char *dir, const char *name);
    virtual Bool_t          IsAbsoluteFileName(const char *dir);
    virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = nullptr);
    virtual const char     *PrependPathName(const char *dir, TString& name);

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1082,9 +1082,13 @@ const char *TSystem::UnixPathName(const char *name)
 
 char *TSystem::ConcatFileName(const char *dir, const char *name)
 {
-   TString nameString(name);
-   PrependPathName(dir, nameString);
-   return StrDup(nameString.Data());
+   const auto dirLen = strlen(dir);
+   const auto nameLen = strlen(name);
+   char *result = new char[nameLen + dirLen + 2];
+   memcpy(result, dir, dirLen);
+   result[dirLen] = DirectorySeparator();
+   memcpy(result + dirLen + 1, name, nameLen + 1); // NOTE: also copies the null terminator
+   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -160,6 +160,7 @@ public:
    std::string       GetHomeDirectory(const char *userName = nullptr) const override;
    const char       *TempDirectory() const override;
    FILE             *TempFileName(TString &base, const char *dir = nullptr, const char *suffix = nullptr) override;
+   char              DirectorySeparator() const final { return '\\'; }
 
    //---- Users & Groups ---------------------------------------
    Int_t             GetUid(const char *user = nullptr) override;


### PR DESCRIPTION
Imho this function should be marked as deprecated and replaced with one that returns a `std::string` (or at least a `TString`). It's unclear to me why this wasn't done in the first place, considering the function internally allocates a TString anyway, but I assume it was created when TString wasn't a thing yet and later changed.

In the meantime, we can at least improve a bit its implementation. This PR does the following:

- save a couple of memory allocations per call (now guaranteed to only allocate once) and a bunch of memmoves;
- don't do the extra work of replacing '/' with '\\' in the entire string (that is not specified by the function's documentation);
- the function is not virtual anymore (although it internally uses a virtual method to get the correct directory separator; this could be avoided if had a platform-dependent `#define` or `constexpr` public constant for it, but this for now seems like the simplest solution).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


