### PR TITLE
[ntuple] Adapt hashing to 32-bit

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
@@ -118,11 +118,19 @@ private:
 
          inline std::size_t mix(std::size_t init) const
          {
+#ifdef R__B64
             init ^= init >> 32;
             init *= 0xe9846af9b1a615d;
             init ^= init >> 32;
             init *= 0xe9846af9b1a615d;
             init ^= init >> 28;
+#else
+            init ^= init >> 16;
+            init *= 0x21f0aaad;
+            init ^= init >> 15;
+            init *= 0x735a2d97;
+            init ^= init >> 15;
+#endif
             return init;
          }
       };


### PR DESCRIPTION
On 32-bit platforms or platforms where `std::size_t` is 32-bit instead of 64-bit, the current `mix` function doesn't work. The alternative added with this change also originates from the [`boost::hash_combine` writeup](https://www.boost.org/doc/libs/1_87_0/libs/container_hash/doc/html/hash.html#notes_hash_combine) linked in the `RCombinedJoinFieldValueHash` class documentation.
