### PR TITLE
[RF] Disable loading architecture-specific RooBatchCompute by default

### DIFF
--- a/roofit/batchcompute/res/RooBatchCompute.h
+++ b/roofit/batchcompute/res/RooBatchCompute.h
@@ -62,7 +62,14 @@ private:
    CudaInterface::CudaStream *_cudaStream = nullptr;
 };
 
-enum class Architecture { AVX512, AVX2, AVX, SSE4, GENERIC, CUDA };
+enum class Architecture {
+   AVX512,
+   AVX2,
+   AVX,
+   SSE4,
+   GENERIC,
+   CUDA
+};
 
 enum Computer {
    AddPdf,
@@ -229,6 +236,9 @@ inline ReduceNLLOutput reduceNLL(Config cfg, std::span<const double> probas, std
    auto dispatch = cfg.useCuda() ? dispatchCUDA : dispatchCPU;
    return dispatch->reduceNLL(cfg, probas, weights, offsetProbas);
 }
+
+std::string getBatchComputeChoice();
+void setBatchComputeChoice(std::string const &value);
 
 } // End namespace RooBatchCompute
 

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -78,6 +78,9 @@ RooCmdArg ParallelDescentOptions(bool enable=false, int splitStrategy=0, int num
 
 } // Experimental
 
+std::string getBatchCompute();
+void setBatchCompute(std::string const &value);
+
 /**
  * \defgroup CmdArgs RooFit command arguments
  * These arguments can be passed to functions of RooFit objects.

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -20,6 +20,7 @@
 
 #include <RooAbsData.h>
 #include <RooAbsPdf.h>
+#include <RooBatchCompute.h>
 #include <RooCategory.h>
 #include <RooDataHist.h>
 #include <RooDataSet.h>
@@ -37,6 +38,23 @@
 #include <algorithm>
 
 namespace RooFit {
+
+/// Get the global choice for the RooBatchCompute library that RooFit will load.
+/// \see RooFit::setBatchCompute().
+std::string getBatchCompute()
+{
+   return RooBatchCompute::getBatchComputeChoice();
+}
+
+/// Globally select the RooBatchCompute CPU implementation that will be loaded
+/// in RooFit.
+/// Supported options are "auto" (default), "avx512", "avx2", "avx", "sse", "generic".
+/// \note It is not possible to change the selection after RooFit has already
+/// loaded a library (which is usually triggered by likelihood creation or fitting).
+void setBatchCompute(std::string const &value)
+{
+   return RooBatchCompute::setBatchComputeChoice(value);
+}
 
 // anonymous namespace for helper functions for the implementation of the global functions
 namespace {


### PR DESCRIPTION
Change the default policy for selecting an optimized computation library from `"auto"` to `"generic"`. This ensures that results are reproducible across different hardware.

Also, add an easy-to-use interface to globally change the `BatchCompute` setting.

Closes #18738.