### PR TITLE
[core] make static vars constexpr for thread safety v3

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1274,15 +1274,13 @@ int TClassEdit::GetSplit(const char *type, vector<string>& output, int &nestedLo
 
 string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
 {
-   static const char* remove[] = {"class", "const", "volatile", nullptr};
-   auto initLengthsVector = []() {
-      std::vector<size_t> create_lengths;
-      for (int k=0; remove[k]; ++k) {
-         create_lengths.push_back(strlen(remove[k]));
-      }
-      return create_lengths;
-   };
-   static std::vector<size_t> lengths{ initLengthsVector() };
+   constexpr static std::array<const char *, 3> remove{"class", "const", "volatile"};
+   constexpr static auto lengths = []() constexpr {
+      std::array<std::size_t, 3> ret{};
+      for(std::size_t i = 0; i < remove.size(); i++)
+         ret[i] = std::char_traits<char>::length(remove[i]);
+      return ret;
+   }();
 
    string result;
    result.reserve(strlen(typeDesc)*2);
@@ -1296,11 +1294,11 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
       }
       if (kbl && (mode>=2 || lev==0)) { //remove "const' etc...
          int done = 0;
-         int n = (mode) ? 999 : 1;
+         int n = (mode) ? static_cast<int>(std::size(remove)) : 1;
 
          // loop on all the keywords we want to remove
-         for (int k=0; k<n && remove[k]; k++) {
-            int rlen = lengths[k];
+         for (int k = 0; k < n; k++) {
+            auto rlen = static_cast<int>(lengths[k]);
 
             // Do we have a match
             if (strncmp(remove[k],c,rlen)) continue;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1294,11 +1294,11 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
       }
       if (kbl && (mode>=2 || lev==0)) { //remove "const' etc...
          int done = 0;
-         int n = (mode) ? static_cast<int>(std::size(remove)) : 1;
+         size_t n = (mode) ? std::size(remove) : 1;
 
          // loop on all the keywords we want to remove
-         for (int k = 0; k < n; k++) {
-            auto rlen = static_cast<int>(lengths[k]);
+         for (size_t k = 0; k < n; k++) {
+            auto rlen = lengths[k];
 
             // Do we have a match
             if (strncmp(remove[k],c,rlen)) continue;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1276,7 +1276,7 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
 {
    constexpr static std::array<const char *, 3> remove{"class", "const", "volatile"};
    constexpr static auto lengths = []() constexpr {
-      std::array<std::size_t, 3> ret{};
+      std::array<std::size_t, std::size(remove)> ret{};
       for (std::size_t i = 0; i < remove.size(); i++)
          ret[i] = std::char_traits<char>::length(remove[i]);
       return ret;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1277,7 +1277,7 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
    constexpr static std::array<const char *, 3> remove{"class", "const", "volatile"};
    constexpr static auto lengths = []() constexpr {
       std::array<std::size_t, 3> ret{};
-      for(std::size_t i = 0; i < remove.size(); i++)
+      for (std::size_t i = 0; i < remove.size(); i++)
          ret[i] = std::char_traits<char>::length(remove[i]);
       return ret;
    }();


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/18751

Please squash.

All credit goes to vepadulano and guitargeek

Alternatives to https://github.com/root-project/root/pull/18753 and https://github.com/root-project/root/pull/18756/

Of course, I could also make a version 4 which just does `lengths {5,5,8}` which is even more compact :) and this array did not change in 22 years, so...