### PR TITLE
[ntuple] Rename `RBulk` to `RBulkValues`

### DIFF
--- a/tree/ntuple/doc/Architecture.md
+++ b/tree/ntuple/doc/Architecture.md
@@ -254,7 +254,7 @@ The user-provided model can be limited to a subset of fields.
 Data is populated to an explicit `REntry` or the model's default entry through `RNTupleReader::LoadEntry()`.
 
 The reader can create `RNTupleView` objects for the independent reading of individual fields.
-The reader can create `RBulk` objects for bulk reading of individual fields.
+The reader can create `RBulkValues` objects for bulk reading of individual fields.
 
 Additionally, the reader provides access to a cached copy of the descriptor.
 It can display individual entries (`RNTupleReader::Show()`) and summary information (`RNTupleReader::PrintInfo()`).

--- a/tree/ntuple/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleModel.hxx
@@ -347,7 +347,7 @@ public:
    /// Creates a token to be used in REntry methods to address a field present in the entry
    ROOT::RFieldToken GetToken(std::string_view fieldName) const;
    /// Calls the given field's CreateBulk() method. Throws an RException if no field with the given name exists.
-   ROOT::RFieldBase::RBulk CreateBulk(std::string_view fieldName) const;
+   ROOT::RFieldBase::RBulkValues CreateBulk(std::string_view fieldName) const;
 
    /// Retrieves the default entry of this model.
    /// Throws an RException if this is a bare model (i.e. if it was created with CreateBare()).

--- a/tree/ntuple/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleView.hxx
@@ -131,7 +131,7 @@ public:
    ~RNTupleViewBase() = default;
 
    const ROOT::RFieldBase &GetField() const { return *fField; }
-   ROOT::RFieldBase::RBulk CreateBulk() { return fField->CreateBulk(); }
+   ROOT::RFieldBase::RBulkValues CreateBulk() { return fField->CreateBulk(); }
 
    const ROOT::RFieldBase::RValue &GetValue() const { return fValue; }
    /// Returns the global field range of this view.

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -120,7 +120,7 @@ void ROOT::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 
 //------------------------------------------------------------------------------
 
-ROOT::RFieldBase::RBulk::RBulk(RBulk &&other)
+ROOT::RFieldBase::RBulkValues::RBulkValues(RBulkValues &&other)
    : fField(other.fField),
      fValueSize(other.fValueSize),
      fCapacity(other.fCapacity),
@@ -134,7 +134,7 @@ ROOT::RFieldBase::RBulk::RBulk(RBulk &&other)
    std::swap(fMaskAvail, other.fMaskAvail);
 }
 
-ROOT::RFieldBase::RBulk &ROOT::RFieldBase::RBulk::operator=(RBulk &&other)
+ROOT::RFieldBase::RBulkValues &ROOT::RFieldBase::RBulkValues::operator=(RBulkValues &&other)
 {
    std::swap(fField, other.fField);
    std::swap(fDeleter, other.fDeleter);
@@ -149,13 +149,13 @@ ROOT::RFieldBase::RBulk &ROOT::RFieldBase::RBulk::operator=(RBulk &&other)
    return *this;
 }
 
-ROOT::RFieldBase::RBulk::~RBulk()
+ROOT::RFieldBase::RBulkValues::~RBulkValues()
 {
    if (fValues)
       ReleaseValues();
 }
 
-void ROOT::RFieldBase::RBulk::ReleaseValues()
+void ROOT::RFieldBase::RBulkValues::ReleaseValues()
 {
    if (fIsAdopted)
       return;
@@ -169,7 +169,7 @@ void ROOT::RFieldBase::RBulk::ReleaseValues()
    operator delete(fValues);
 }
 
-void ROOT::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, std::size_t size)
+void ROOT::RFieldBase::RBulkValues::Reset(RNTupleLocalIndex firstIndex, std::size_t size)
 {
    if (fCapacity < size) {
       if (fIsAdopted) {
@@ -195,14 +195,14 @@ void ROOT::RFieldBase::RBulk::Reset(RNTupleLocalIndex firstIndex, std::size_t si
    fSize = size;
 }
 
-void ROOT::RFieldBase::RBulk::CountValidValues()
+void ROOT::RFieldBase::RBulkValues::CountValidValues()
 {
    fNValidValues = 0;
    for (std::size_t i = 0; i < fSize; ++i)
       fNValidValues += static_cast<std::size_t>(fMaskAvail[i]);
 }
 
-void ROOT::RFieldBase::RBulk::AdoptBuffer(void *buf, std::size_t capacity)
+void ROOT::RFieldBase::RBulkValues::AdoptBuffer(void *buf, std::size_t capacity)
 {
    ReleaseValues();
    fValues = buf;
@@ -784,9 +784,9 @@ std::size_t ROOT::RFieldBase::Append(const void *from)
    return fPrincipalColumn->GetElement()->GetPackedSize();
 }
 
-ROOT::RFieldBase::RBulk ROOT::RFieldBase::CreateBulk()
+ROOT::RFieldBase::RBulkValues ROOT::RFieldBase::CreateBulk()
 {
-   return RBulk(this);
+   return RBulkValues(this);
 }
 
 ROOT::RFieldBase::RValue ROOT::RFieldBase::BindValue(std::shared_ptr<void> objPtr)

--- a/tree/ntuple/src/RNTupleModel.cxx
+++ b/tree/ntuple/src/RNTupleModel.cxx
@@ -533,7 +533,7 @@ ROOT::RFieldToken ROOT::RNTupleModel::GetToken(std::string_view fieldName) const
    return ROOT::RFieldToken(std::distance(topLevelFields.begin(), it), fSchemaId);
 }
 
-ROOT::RFieldBase::RBulk ROOT::RNTupleModel::CreateBulk(std::string_view fieldName) const
+ROOT::RFieldBase::RBulkValues ROOT::RNTupleModel::CreateBulk(std::string_view fieldName) const
 {
    switch (fModelState) {
    case EState::kBuilding: throw RException(R__FAIL("invalid attempt to create bulk of unfrozen model"));

--- a/tree/ntuple/test/ntuple_bulk.cxx
+++ b/tree/ntuple/test/ntuple_bulk.cxx
@@ -14,7 +14,7 @@ TEST(RNTupleBulk, Simple)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   RFieldBase::RBulk bulk = reader->GetModel().CreateBulk("int");
+   RFieldBase::RBulkValues bulk = reader->GetModel().CreateBulk("int");
 
    auto mask = std::make_unique<bool[]>(10);
    std::fill(mask.get(), mask.get() + 10, false /* the optimization for simple fields should ignore the mask */);
@@ -47,7 +47,7 @@ TEST(RNTupleBulk, Complex)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   RFieldBase::RBulk bulk = reader->GetModel().CreateBulk("S");
+   RFieldBase::RBulkValues bulk = reader->GetModel().CreateBulk("S");
    auto mask = std::make_unique<bool[]>(10);
    for (unsigned int i = 0; i < 10; ++i)
       mask[i] = (i % 2 == 0);
@@ -98,8 +98,8 @@ TEST(RNTupleBulk, CardinalityField)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    const auto &model = reader->GetModel();
 
-   RFieldBase::RBulk bulk32 = model.CreateBulk("card32");
-   RFieldBase::RBulk bulk64 = model.CreateBulk("card64");
+   RFieldBase::RBulkValues bulk32 = model.CreateBulk("card32");
+   RFieldBase::RBulkValues bulk64 = model.CreateBulk("card64");
 
    auto mask = std::make_unique<bool[]>(10);
    std::fill(mask.get(), mask.get() + 10, false /* the cardinality field optimization should ignore the mask */);
@@ -140,9 +140,9 @@ TEST(RNTupleBulk, RVec)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    const auto &model = reader->GetModel();
 
-   RFieldBase::RBulk bulkI = model.CreateBulk("vint");
-   RFieldBase::RBulk bulkS = model.CreateBulk("vs");
-   RFieldBase::RBulk bulkVI = model.CreateBulk("vvint");
+   RFieldBase::RBulkValues bulkI = model.CreateBulk("vint");
+   RFieldBase::RBulkValues bulkS = model.CreateBulk("vs");
+   RFieldBase::RBulkValues bulkVI = model.CreateBulk("vvint");
 
    auto mask = std::make_unique<bool[]>(10);
    std::fill(mask.get(), mask.get() + 10, true);
@@ -191,7 +191,7 @@ TEST(RNTupleBulk, Adopted)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   RFieldBase::RBulk bulkI = reader->GetModel().CreateBulk("vint");
+   RFieldBase::RBulkValues bulkI = reader->GetModel().CreateBulk("vint");
 
    auto mask = std::make_unique<bool[]>(10);
    std::fill(mask.get(), mask.get() + 10, true);

--- a/tree/ntuple/test/ntuple_multi_column.cxx
+++ b/tree/ntuple/test/ntuple_multi_column.cxx
@@ -366,7 +366,7 @@ TEST(RNTuple, MultiColumnRepresentationBulk)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   RFieldBase::RBulk bulk = reader->GetModel().CreateBulk("px");
+   RFieldBase::RBulkValues bulk = reader->GetModel().CreateBulk("px");
 
    auto mask = std::make_unique<bool[]>(1);
    mask[0] = true;


### PR DESCRIPTION
This better represents what the class is actually responsible for (i.e., managing the values that are read as a result of a bulk read).