### PR TITLE
[webgui] workaround WebGL problem in Firefox

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -837,6 +837,11 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
             // do not put tabs in title
             user_js << "user_pref(\"browser.tabs.inTitlebar\", 0);" << std::endl;
 
+#ifdef R__LINUX
+            // fix WebGL creation problem on some Linux platforms
+            user_js << "user_pref(\"webgl.out-of-process\", false);" << std::endl;
+#endif
+
             std::ofstream times_json(profile_dir + "/times.json", std::ios::trunc);
             times_json << "{" << std::endl;
             times_json << "   \"created\": 1699968480952," << std::endl;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '16/05/2025',
+version_date = '19/05/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/hist/TH1Painter.mjs
+++ b/js/modules/hist/TH1Painter.mjs
@@ -11,7 +11,7 @@ import { TH1Painter as TH1Painter2D } from '../hist2d/TH1Painter.mjs';
 class TH1Painter extends TH1Painter2D {
 
    /** @summary draw TH1 object in 3D mode */
-   draw3D(reason) {
+   async draw3D(reason) {
       this.mode3d = true;
 
       const fp = this.getFramePainter(), // who makes axis drawing

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -3565,10 +3565,21 @@ class TH2Painter extends THistPainter {
       const main = this.getMainPainter(),
             fp = this.getFramePainter();
 
-     if ((main !== this) && fp && (fp.mode3d !== this.options.Mode3D))
-        this.copyOptionsFrom(main);
+      if ((main !== this) && fp && (fp.mode3d !== this.options.Mode3D))
+         this.copyOptionsFrom(main);
 
-      return this.options.Mode3D ? this.draw3D(reason) : this.draw2D(reason);
+      if (!this.options.Mode3D)
+         return this.draw2D(reason);
+
+      return this.draw3D(reason).catch(err => {
+         const cp = this.getCanvPainter();
+         if (isFunc(cp?.showConsoleError))
+            cp.showConsoleError(err);
+         else
+            console.error('Fail to draw histogram in 3D - back to 2D');
+         this.options.Mode3D = false;
+         return this.draw2D(reason);
+      });
    }
 
    /** @summary Redraw histogram */

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -242,7 +242,7 @@ exports.decodeUrl = function(url) {
    while (url) {
       // try to correctly handle quotes in the URL
       let pos = 0, nq = 0, eq = -1, firstq = -1;
-      while ((pos < url.length) && ((nq !== 0) || ((url[pos] !== '&') && (url[pos] !== '#')))) {
+      while ((pos < url.length) && (nq || ((url[pos] !== '&') && (url[pos] !== '#')))) {
          switch (url[pos]) {
             case "'": if (nq >= 0) nq = (nq+1)%2; if (firstq < 0) firstq = pos; break;
             case '"': if (nq <= 0) nq = (nq-1)%2; if (firstq < 0) firstq = pos; break;


### PR DESCRIPTION
On some Linux platforms firefox does not create WebGL context
when browser starts not from default profile.
To workaround it, "webgl.out-of-process: false" has to be set for firefox preferences.

Provide fall-back solution in JSROOT when histogram 3D drawing fails.