### PR TITLE
[RF] Avoid infinite recursion in `ModelConfig::GuessObsAndNuisance`

### DIFF
--- a/roofit/roofitcore/inc/RooFit/ModelConfig.h
+++ b/roofit/roofitcore/inc/RooFit/ModelConfig.h
@@ -311,7 +311,10 @@ public:
 
    void GuessObsAndNuisance(const RooArgSet &obsSet, bool printModelConfig = true);
 
-   inline void GuessObsAndNuisance(const RooDataSet &data, bool printModelConfig = true) { return GuessObsAndNuisance(data, printModelConfig); }
+   inline void GuessObsAndNuisance(const RooDataSet &data, bool printModelConfig = true)
+   {
+      return GuessObsAndNuisance(*data.get(), printModelConfig);
+   }
 
    /// overload the print method
    void Print(Option_t *option = "") const override;


### PR DESCRIPTION
This follows up on commit f15e44c26cb3, which missed to get the `RooArgSet` from the `RooDataSet` in the backwards-compatibility overload of `ModelConfig::GuessObsAndNuisance`.

Thanks to @hahnjo for noticing this!