### PR TITLE
[v626][ci] Enable `dataframe` on alma9

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,5 +1,5 @@
+BLA_VENDOR=OpenBLAS
 builtin_vdt=ON
-dataframe=OFF
-tmva=OFF
 tmva-cpu=OFF
+tmva=OFF
 xml=OFF


### PR DESCRIPTION
Set `dataframe=ON` for the build on AlmaLinux 9.