### PR TITLE
[v636] [meta] Correct TClass::LoadClassInfo.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5971,10 +5971,10 @@ void TClass::LoadClassInfo() const
 
    bool autoParse = !gInterpreter->IsAutoParsingSuspended();
 
-   if (autoParse)
+   if (autoParse && !fClassInfo)
       gInterpreter->AutoParse(GetName());
 
-   if (!fClassInfo)
+   if (!fClassInfo) // Could be indirectly set by the parsing
       gInterpreter->SetClassInfo(const_cast<TClass *>(this));
 
    if (autoParse && !fClassInfo) {
@@ -5987,10 +5987,13 @@ void TClass::LoadClassInfo() const
                                           " even though it has a TClass initialization routine.",
                  fName.Data());
       }
-      return;
    }
 
-   fCanLoadClassInfo = false;
+   // Keep trying to load the ClassInfo, since we have no ClassInfo yet,
+   // we will get an update even when there is an explicit load.  So whether
+   // or not the autoparsing is on, we will need to keep trying to load
+   // the ClassInfo.
+   fCanLoadClassInfo = !fClassInfo;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes #18556.

We should keep trying to try to load a ClassInfo until we try the auto-parsing. TClass::LoadClassInfo should set fCanLoadClassInfo to false when the ClassInfo is found *and* set it to false also when we tried auto parsing but did not find the ClassInfo.

In the later case, the ClassInfo might still be loaded if information about the class is later loaded/parsed.

Backport of https://github.com/root-project/root/pull/18587