### PR TITLE
[meta] Correct thread behavior in TEnum::GetEnum.

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2060,6 +2060,7 @@ void TROOT::InitThreads()
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize the interpreter. Should be called only after main(),
 /// to make sure LLVM/Clang is fully initialized.
+/// This function must be called in a single thread context (static initialization)
 
 void TROOT::InitInterpreter()
 {
@@ -2531,6 +2532,8 @@ static void CallCloseFiles()
 /// for headers. Calls TCling::RegisterModule() unless gCling
 /// is NULL, i.e. during startup, where the information is buffered in
 /// the static GetModuleHeaderInfoBuffer().
+/// The caller of this function should be holding the ROOT Write lock or be
+/// single threaded (dlopen)
 
 void TROOT::RegisterModule(const char* modulename,
                            const char** headers,

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -977,7 +977,6 @@ void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
    }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Global function called by the dtor of a class's init class
 /// (see the ClassImp macro).

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -454,6 +454,7 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Add a class to the class table (this is a static function).
+/// The caller of this function should be holding the ROOT Write lock.
 
 void TClassTable::Add(TProtoClass *proto)
 {
@@ -980,6 +981,7 @@ void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
 ////////////////////////////////////////////////////////////////////////////////
 /// Global function called by the dtor of a class's init class
 /// (see the ClassImp macro).
+/// The caller of this function should be holding the ROOT Write lock.
 
 void ROOT::RemoveClass(const char *cname, TClass *oldcl)
 {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1438,6 +1438,7 @@ void TClass::ForceReload (TClass* oldcl)
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize a TClass object. This object contains the full dictionary
 /// of a class. It has list to baseclasses, datamembers and methods.
+/// The caller of this function should be holding the ROOT Write lock.
 
 void TClass::Init(const char *name, Version_t cversion,
                   const std::type_info *typeinfo, TVirtualIsAProxy *isa,
@@ -6436,6 +6437,7 @@ void TClass::SetGlobalIsA(IsAGlobalFunc_t func)
 ////////////////////////////////////////////////////////////////////////////////
 /// Call this method to indicate that the shared library containing this
 /// class's code has been removed (unloaded) from the process's memory
+/// The caller of this calss should be holding the ROOT Write lock.
 
 void TClass::SetUnloaded()
 {

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -254,19 +254,18 @@ TEnum *TEnum::GetEnum(const char *enumName, ESearchAction sa)
          const bool scopeIsNamespace (tClassScope->Property() & kIsNamespace);
 
          const bool autoParseSuspended = gInterpreter->IsAutoParsingSuspended();
-         const bool suspendAutoParse = autoParseSuspended || scopeIsNamespace;
 
-         TInterpreter::SuspendAutoParsing autoParseRaii(gInterpreter, suspendAutoParse);
+         if (scopeIsNamespace && !autoParseSuspended) {
+            TInterpreter::SuspendAutoParsing autoParseRaii(gInterpreter, true);
 
-         if (scopeIsNamespace && !autoParseSuspended){
-            canLoadEnums=true;
+            auto listOfEnums = tClassScope->GetListOfEnums(true);
+            // Previous incarnation of the code re-enabled the auto parsing,
+            // before executing findEnumInList
+            theEnum = findEnumInList(listOfEnums, enName, sa_local);
+         } else {
+            auto listOfEnums = tClassScope->GetListOfEnums(canLoadEnums);
+            theEnum = findEnumInList(listOfEnums, enName, sa_local);
          }
-
-         auto listOfEnums = tClassScope->GetListOfEnums(canLoadEnums);
-
-         // Previous incarnation of the code re-enabled the auto parsing,
-         // before executing findEnumInList
-         theEnum = findEnumInList(listOfEnums, enName, sa_local);
       }
       // Check if the scope is still a protoclass
       else if (auto tProtoClassscope = static_cast<TProtoClass *>((gClassTable->GetProtoNorm(scopeName)))) {

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -256,6 +256,8 @@ TEnum *TEnum::GetEnum(const char *enumName, ESearchAction sa)
          const bool autoParseSuspended = gInterpreter->IsAutoParsingSuspended();
 
          if (scopeIsNamespace && !autoParseSuspended) {
+            // Lock down the autoparsing state.
+            R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
             TInterpreter::SuspendAutoParsing autoParseRaii(gInterpreter, true);
 
             auto listOfEnums = tClassScope->GetListOfEnums(true);

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -191,6 +191,7 @@ void TProtoClass::Delete(Option_t* opt /*= ""*/)
 /// Returns 'false' if nothing was done.  This can happen in the case where
 /// there is more than one dictionary for the same entity.  Note having
 /// duplicate dictionary is acceptable for namespace or STL collections.
+/// The caller of this function should be holding the ROOT Write lock.
 
 Bool_t TProtoClass::FillTClass(TClass* cl) {
    if (cl->fRealData || cl->fBase.load() || cl->fData.load() || cl->fEnums.load() || cl->fCanSplit >= 0 ||

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1705,6 +1705,7 @@ void TCling::RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llv
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Tries to load a PCM from TFile; returns true on success.
+/// The caller of this function should be holding the ROOT Write lock.
 
 void TCling::LoadPCMImpl(TFile &pcmFile)
 {
@@ -1820,6 +1821,7 @@ void TCling::LoadPCMImpl(TFile &pcmFile)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Tries to load a rdict PCM, issues diagnostics if it fails.
+/// The caller of this function should be holding the ROOT Write lock.
 
 void TCling::LoadPCM(std::string pcmFileNameFullPath)
 {
@@ -2019,6 +2021,7 @@ void TCling::ProcessClassesToUpdate()
 /// libraries.
 /// The payload code is injected "as is" in the interpreter.
 /// The value of 'triggerFunc' is used to find the shared library location.
+/// The caller of this function should be holding the ROOT Write lock.
 
 void TCling::RegisterModule(const char* modulename,
                             const char** headers,


### PR DESCRIPTION
The code within GetEnum change the autoparsing state (inside `searchEnum\') and thus needs to have the Write lock (instead of just the read lock)

Fixes https://github.com/root-project/root/issues/18792

