### PR TITLE
[roottest] Fixes to tree/cloning/CMakeLists.txt

### DIFF
--- a/roottest/root/tree/cloning/CMakeLists.txt
+++ b/roottest/root/tree/cloning/CMakeLists.txt
@@ -1,76 +1,24 @@
-if(ROOTTEST_DIR)
-      set(ROOT_EVENT_DIR ${ROOTTEST_DIR}/root/treeformula/event/)
-else()
-      set(ROOT_EVENT_DIR ${ROOT_SOURCE_DIR}/roottest/root/treeformula/event/)
-endif()
-
 # Generating dataset from roottest-treeformula-event-make test
 # FIXME: it will be nice to move roottest-treeformula-event to CMake and add it as dependency
 # To fix runtime_cxxmodules, we need to use already build artefacts.
 
-if(TARGET onepcm)
-      set(EventDependencies "onepcm")
-endif()
-
-if(NOT TARGET eventexe)
-      ROOT_GENERATE_DICTIONARY(EventDict ${ROOT_EVENT_DIR}/Event.h
-                  LINKDEF ${ROOT_EVENT_DIR}/EventLinkDef.h)
-
-      ROOTTEST_LINKER_LIBRARY(EventTreeFormula TEST ${ROOT_EVENT_DIR}/Event.cxx EventDict.cxx
-                  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
-
-      ROOTTEST_GENERATE_EXECUTABLE(EventGenerate ${ROOT_EVENT_DIR}/MainEvent.cxx
-                  LIBRARIES ROOT::Core ROOT::RIO ROOT::Net ROOT::Tree ROOT::Hist ROOT::MathCore EventTreeFormula)
-
-      if(MSVC)
-        add_dependencies(EventGenerate EventTreeFormula)
-      endif()
-
-      add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Event.root
-                  COMMAND ./EventGenerate 6 0 0 1 30 > log
-                  DEPENDS EventGenerate ${EventDependencies})
-
-      add_custom_target(event-generation ALL DEPENDS Event.root)
-
-      add_custom_command(
-        TARGET event-generation
-        COMMAND ${CMAKE_COMMAND} -E copy
-                Event.root
-                event1.root
-        COMMAND ${CMAKE_COMMAND} -E copy
-                Event.root
-                event2.root)
-
-      set(RootExeOptions -e "gSystem->Load(\"libEventTreeFormula\")")
-
-      ROOTTEST_ADD_TEST(treeCloneTest
-                  MACRO runEvent.C
-                  PRECMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/run.C
-                  OUTREF references/treeCloneTest.ref)
-
-else()
-   if(MSVC)
-      if(CMAKE_GENERATOR MATCHES Ninja)
-         set(RootExeOptions -e "gSystem->Load(\"${ROOTSYS}/test/libEvent\")")
-      else()
-         set(RootExeOptions -e "gSystem->Load(\"${ROOTSYS}/test/$<CONFIG>/libEvent\")")
-      endif()
+if(MSVC)
+   if(CMAKE_GENERATOR MATCHES Ninja)
+      set(test_bin_dir "${ROOTSYS}/test")
    else()
-      set(RootExeOptions -e "gSystem->Load(\"../test/libEvent\")")
-
-      ROOTTEST_ADD_TEST(treeCloneTest
-                  PRECMD sh ${CMAKE_CURRENT_SOURCE_DIR}/generate-eventfile.sh ${ROOT_DIR}
-                  COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/run.C -e "gSystem->Load(\"../test/libEvent\")"
-                  POSTCMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/runEvent.C -e "gSystem->Load(\"../test/libEvent\")"
-                  OUTREF references/treeCloneTest.ref)
+      set(test_bin_dir "${ROOTSYS}/test/$<CONFIG>")
    endif()
+else()
+   set(test_bin_dir "${CMAKE_BINARY_DIR}/test")
 endif()
 
-if(ROOTTEST_DIR)
-      set(ROOT_DIR ${ROOTSYS})
-else()
-      set(ROOT_DIR ${ROOT_SOURCE_DIR})
-endif()
+set(RootExeOptions -e "gSystem->Load(\"${test_bin_dir}/libEvent\")")
+
+ROOTTEST_ADD_TEST(treeCloneTest
+            PRECMD ${test_bin_dir}/eventexe${CMAKE_EXECUTABLE_SUFFIX} 6 0 0 1 30 0 1 event1.root event2.root
+            COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/run.C ${RootExeOptions}
+            POSTCMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/runEvent.C ${RootExeOptions}
+            OUTREF references/treeCloneTest.ref)
 
 if(NOT TARGET hsimple)
       add_custom_target(hsimple-file ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root)

--- a/roottest/root/tree/cloning/generate-eventfile.sh
+++ b/roottest/root/tree/cloning/generate-eventfile.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-ROOT_DIR=$1
-
-${ROOT_DIR}/test/eventexe 6 0 0 1 30 > eventgenerate.out
-cp Event.root event1.root
-cp Event.root event2.root


### PR DESCRIPTION
Remove unused variables and code branches.

Updated version of the following `roottest` PR:

  * https://github.com/root-project/roottest/pull/669