### PR TITLE
[RF] Change return type of `RooAbsData::split()` away from TList

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1434,9 +1434,9 @@ RooJSONFactoryWSTool::CombinedData RooJSONFactoryWSTool::exportCombinedData(RooA
    // use the RooAbsData::split() overload that takes the RooSimultaneous.
    // Like this, the observables that are not relevant for a given channel
    // are automatically split from the component datasets.
-   std::unique_ptr<TList> dataList{simPdf ? data.split(*simPdf, true) : data.split(*cat, true)};
+   std::vector<std::unique_ptr<RooAbsData>> dataList{simPdf ? data.split(*simPdf, true) : data.split(*cat, true)};
 
-   for (RooAbsData *absData : static_range_cast<RooAbsData *>(*dataList)) {
+   for (std::unique_ptr<RooAbsData> const &absData : dataList) {
       std::string catName(absData->GetName());
       std::string dataName;
       if (std::isalpha(catName[0])) {

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -195,10 +195,10 @@ public:
   } ;
 
   // Split a dataset by a category
-  virtual RooFit::OwningPtr<TList> split(const RooAbsCategory& splitCat, bool createEmptyDataSets=false) const ;
+  std::vector<std::unique_ptr<RooAbsData>> split(const RooAbsCategory& splitCat, bool createEmptyDataSets=false) const;
 
   // Split a dataset by categories of a RooSimultaneous
-  virtual RooFit::OwningPtr<TList> split(const RooSimultaneous& simpdf, bool createEmptyDataSets=false) const ;
+  std::vector<std::unique_ptr<RooAbsData>> split(const RooSimultaneous& simpdf, bool createEmptyDataSets=false) const;
 
   // Fast splitting for SimMaster setData
   bool canSplitFast() const ;

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -205,20 +205,20 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string c
    std::vector<std::pair<std::string, RooAbsData const *>> datasets;
    std::vector<bool> isBinnedL;
    bool splitRange = false;
+
+   // The split datasets need to be kept alive because the datamap points to their content
    std::vector<std::unique_ptr<RooAbsData>> splitDataSets;
 
    if (simPdf) {
-      std::unique_ptr<TList> splits{data.split(*simPdf, true)};
-      for (auto *d : static_range_cast<RooAbsData *>(*splits)) {
+      splitDataSets = data.split(*simPdf, true);
+      for (auto const &d : splitDataSets) {
          RooAbsPdf *simComponent = simPdf->getPdf(d->GetName());
          // If there is no PDF for that component, we also don't need to fill the data
          if (!simComponent) {
             continue;
          }
-         datasets.emplace_back(std::string("_") + d->GetName() + "_", d);
+         datasets.emplace_back(std::string("_") + d->GetName() + "_", d.get());
          isBinnedL.emplace_back(simComponent->getAttribute("BinnedLikelihoodActive"));
-         // The dataset need to be kept alive because the datamap points to their content
-         splitDataSets.emplace_back(d);
       }
       splitRange = simPdf->getAttribute("SplitRange");
    } else {

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1482,15 +1482,16 @@ SplittingSetup initSplit(RooAbsData const &data, RooAbsCategory const &splitCat)
    return setup;
 }
 
-RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool createEmptyDataSets,
-                                   std::function<std::unique_ptr<RooAbsData>(const char *label)> createEmptyData)
+std::vector<std::unique_ptr<RooAbsData>>
+splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool createEmptyDataSets,
+          std::function<std::unique_ptr<RooAbsData>(const char *label)> createEmptyData)
 {
-   auto dsetList = std::make_unique<TList>();
+   std::vector<std::unique_ptr<RooAbsData>> dsetList;
 
    // If createEmptyDataSets is true, prepopulate with empty sets corresponding to all states
    if (createEmptyDataSets) {
       for (const auto &nameIdx : cloneCat) {
-         dsetList->Add(createEmptyData(nameIdx.first.c_str()).release());
+         dsetList.emplace_back(createEmptyData(nameIdx.first.c_str()).release());
       }
    }
 
@@ -1499,10 +1500,13 @@ RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory 
    // Loop over dataset and copy event to matching subset
    for (int i = 0; i < data.numEntries(); ++i) {
       const RooArgSet *row = data.get(i);
-      auto subset = static_cast<RooAbsData *>(dsetList->FindObject(cloneCat.getCurrentLabel()));
+      auto found = std::find_if(dsetList.begin(), dsetList.end(), [&](auto const &item) {
+         return strcmp(item->GetName(), cloneCat.getCurrentLabel()) == 0;
+      });
+      RooAbsData *subset = found != dsetList.end() ? found->get() : nullptr;
       if (!subset) {
-         subset = createEmptyData(cloneCat.getCurrentLabel()).release();
-         dsetList->Add(subset);
+         dsetList.emplace_back(createEmptyData(cloneCat.getCurrentLabel()));
+         subset = dsetList.back().get();
       }
 
       // For datasets with weight errors or sumW2, the interface to fill
@@ -1514,7 +1518,7 @@ RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory 
       }
    }
 
-   return RooFit::makeOwningPtr(std::move(dsetList));
+   return dsetList;
 }
 
 } // namespace
@@ -1542,13 +1546,14 @@ RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory 
  *         Returns `nullptr` if an error occurs.
  */
 
-RooFit::OwningPtr<TList> RooAbsData::split(const RooAbsCategory &splitCat, bool createEmptyDataSets) const
+std::vector<std::unique_ptr<RooAbsData>>
+RooAbsData::split(const RooAbsCategory &splitCat, bool createEmptyDataSets) const
 {
    SplittingSetup setup = initSplit(*this, splitCat);
 
    // Something went wrong
    if (!setup.cloneCat)
-      return nullptr;
+      throw std::runtime_error("runtime error in RooAbsData::split");
 
    auto createEmptyData = [&](const char *label) -> std::unique_ptr<RooAbsData> {
       return std::unique_ptr<RooAbsData>{
@@ -1574,7 +1579,8 @@ RooFit::OwningPtr<TList> RooAbsData::split(const RooAbsCategory &splitCat, bool 
  * \return An owning pointer to a TList of subsets of the dataset.
  *         Returns `nullptr` if an error occurs.
  */
-RooFit::OwningPtr<TList> RooAbsData::split(const RooSimultaneous &simPdf, bool createEmptyDataSets) const
+std::vector<std::unique_ptr<RooAbsData>>
+RooAbsData::split(const RooSimultaneous &simPdf, bool createEmptyDataSets) const
 {
    auto &splitCat = const_cast<RooAbsCategoryLValue &>(simPdf.indexCat());
 
@@ -1582,7 +1588,7 @@ RooFit::OwningPtr<TList> RooAbsData::split(const RooSimultaneous &simPdf, bool c
 
    // Something went wrong
    if (!setup.cloneCat)
-      return nullptr;
+      throw std::runtime_error("runtime error in RooAbsData::split");
 
    // Get the observables for a given pdf in the RooSimultaneous, or an empty
    // RooArgSet if no pdf is set

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -786,8 +786,8 @@ TEST(RooDataHist, SplitDataHistWithSumW2)
 
    data1.add({x, cat}, 2.0, 0.3);
 
-   std::unique_ptr<TList> dataList{data1.split(cat, true)};
-   auto &data2 = static_cast<RooDataHist &>(*dataList->At(0));
+   std::vector<std::unique_ptr<RooAbsData>> dataList{data1.split(cat, true)};
+   RooAbsData &data2 = *dataList[0];
 
    data1.get(0);
    data2.get(0);

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -391,8 +391,8 @@ TEST(RooDataSet, SplitDataSetWithWeightErrors)
 
    data1.add({x, cat}, 2.0, 0.3);
 
-   std::unique_ptr<TList> dataList{data1.split(cat, true)};
-   auto &data2 = static_cast<RooDataSet &>(*dataList->At(0));
+   std::vector<std::unique_ptr<RooAbsData>> dataList{data1.split(cat, true)};
+   RooAbsData &data2 = *dataList[0];
 
    data1.Print();
 


### PR DESCRIPTION
Change return type of `RooAbsData::split()` away from TList to `std::vector<std::unique_ptr<RooAbsData>>`. This makes sure that the memory owner ship is clear, preventing leaks like reported in #18778 and also present in other parts of the RooFit codebase (see the changes in this commit).

Closes #18778.