### PR TITLE
[io] TFileMerger: fail by default on invalid keys

### DIFF
--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -181,6 +181,9 @@ This release changes that behavior, meaning the `Scale(bool)` command argument i
 * The logic to retrieve branch names of a TTree has been improved, leading to O(10) speedup. For example, an RDataFrame
   wrapping a TTree with O(10K) columns could be spending multiple minutes just to retrieve the full dataset schema,
   whereas now it will take seconds.
+* `TFileMerger`'s (and `hadd`'s) default behavior on encountering invalid/corrupt objects while merging has changed: previously the corrupt object would be skipped without aborting the merging process; now the merging process will abort by default. The "skip" behavior can be restored by:
+  * calling the new method `TFileMerger::SetErrorBehavior()` (if using `TFileMerger` directly), or
+  * using the `-k` flag if using `hadd`.
 
 ### RNTuple
 

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -28,6 +28,14 @@ class TIOFeatures;
 }  // namespace ROOT
 
 class TFileMerger : public TObject {
+public:
+   enum class EErrorBehavior {
+      /// The merging process will stop and yield failure when encountering invalid objects
+      kFailOnError,
+      /// The merging process will skip invalid objects and continue
+      kSkipOnError      
+   };
+
 private:
    using TIOFeatures = ROOT::TIOFeatures;
 
@@ -47,6 +55,7 @@ protected:
    TString        fMergeOptions;              ///< Options (in string format) to be passed down to the Merge functions
    TIOFeatures   *fIOFeatures{nullptr};       ///< IO features to use in the output file.
    TString        fMsgPrefix{"TFileMerger"};  ///< Prefix to be used when printing informational message (default TFileMerger)
+   EErrorBehavior fErrBehavior = EErrorBehavior::kFailOnError; ///< What to do in case of errors during merging
 
    Int_t          fMaxOpenedFiles;            ///< Maximum number of files opened at the same time by the TFileMerger
    Bool_t         fLocal;                     ///< Makes local copies of merging files if True (default is kTRUE)
@@ -126,6 +135,10 @@ public:
            Bool_t GetNotrees() const { return fNoTrees; }
    virtual void   SetNotrees(Bool_t notrees=kFALSE) {fNoTrees = notrees;}
            void   RecursiveRemove(TObject *obj) override;
+           /// Determines how the merging process should behave when encontering invalid objects.
+           /// By default the merging will be aborted.
+           /// \sa EErrorBehavior
+           void   SetErrorBehavior(EErrorBehavior errBehavior) { fErrBehavior = errBehavior; }
 
    ClassDefOverride(TFileMerger, 6)  // File copying and merging services
 };

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -657,10 +657,18 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
                   if (key2) {
                      hobj = key2->ReadObj();
                      if (!hobj) {
-                        Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                           keyname, keytitle, nextsource->GetName());
-                              nextsource = (TFile*)sourcelist->After(nextsource);
-                              return kTRUE;
+                        switch (fErrBehavior) {
+                        case EErrorBehavior::kFailOnError:
+                           Error("MergeRecursive", "could not read object for key {%s, %s}; in file %s",
+                              keyname, keytitle, nextsource->GetName());
+                           nextsource = (TFile*)sourcelist->After(nextsource);
+                           return kFALSE;
+                        case EErrorBehavior::kSkipOnError:
+                           Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                              keyname, keytitle, nextsource->GetName());
+                           nextsource = (TFile*)sourcelist->After(nextsource);
+                           return kTRUE;
+                        }
                      }
                      todelete.Add(hobj);
                   }
@@ -735,10 +743,18 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
                   if (key2) {
                      TObject *hobj = key2->ReadObj();
                      if (!hobj) {
-                        Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                        switch (fErrBehavior) {
+                        case EErrorBehavior::kFailOnError:
+                           Error("MergeRecursive", "could not read object for key {%s, %s}; in file %s",
                               keyname, keytitle, nextsource->GetName());
-                        nextsource = (TFile*)sourcelist->After(nextsource);
-                        return kTRUE;
+                           nextsource = (TFile*)sourcelist->After(nextsource);
+                           return kFALSE;
+                        case EErrorBehavior::kSkipOnError:
+                           Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                              keyname, keytitle, nextsource->GetName());
+                           nextsource = (TFile*)sourcelist->After(nextsource);
+                           return kTRUE;
+                        }
                      }
                      // Set ownership for collections
                      if (hobj->InheritsFrom(TCollection::Class())) {

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -817,6 +817,7 @@ int main(int argc, char **argv)
       }
       merger.SetNotrees(args.fNoTrees);
       merger.SetMergeOptions(TString(merger.GetMergeOptions()) + " " + cacheSize);
+      merger.SetErrorBehavior(args.fSkipErrors ? TFileMerger::EErrorBehavior::kSkipOnError : TFileMerger::EErrorBehavior::kFailOnError);
       merger.SetIOFeatures(features);
       Int_t fileMergerFlags = TFileMerger::kAll;
       Int_t extraFlags = ParseFilterFile(args.fObjectFilterFile, args.fObjectFilterType, merger);


### PR DESCRIPTION
This commit introduces a `Error Behavior` flag in TFileMerger that determines what should happen upon encountering errors. The only place where this flag is currently honored is when reading an object's key inside MergeOne(): up until now if an error happened when retrieving an object from a file, the file would just be skipped. With the introduction of this flag, you can decide whether the file is skipped or if the merging process should abort.
For consistency with hadd, the default behavior has been set to Fail. Using `hadd -k` will set the behavior to Skip.

**NOTE that this is a potentially-breaking change**: should we keep Skip by default? But then how would we keep consistency with `hadd`?

This PR fixes #18665

