### PR TITLE
[clang-format] change standard to c++17 [skip-ci]

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,7 +79,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++11
+Standard:        c++17
 TabWidth:        3
 UseTab:          Never
 


### PR DESCRIPTION
Avoid failures when formatting C++ string literals as shown in #18785
