### PR TITLE
[6.36] [df] Remove unused constructor in RNTupleDS

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -169,7 +169,6 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
 
 public:
    RNTupleDS(std::string_view ntupleName, std::string_view fileName);
-   RNTupleDS(ROOT::RNTuple *ntuple);
    RNTupleDS(std::string_view ntupleName, const std::vector<std::string> &fileNames);
    // Rule of five
    RNTupleDS(const RNTupleDS &) = delete;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -413,10 +413,6 @@ ROOT::RDF::RNTupleDS::RNTupleDS(std::string_view ntupleName, std::string_view fi
 {
 }
 
-ROOT::RDF::RNTupleDS::RNTupleDS(RNTuple *ntuple) : RNTupleDS(ROOT::Internal::RPageSourceFile::CreateFromAnchor(*ntuple))
-{
-}
-
 ROOT::RDF::RNTupleDS::RNTupleDS(std::string_view ntupleName, const std::vector<std::string> &fileNames)
    : RNTupleDS(CreatePageSource(ntupleName, fileNames[0]))
 {


### PR DESCRIPTION
Since the removal of the corresponding factory function in https://github.com/root-project/root/commit/a85fc79a51cc9415397cad40c3e068d7831ff889, this constructor is not necessary anymore. Remove it for good measure.
