### PR TITLE
[v630][ci] Follow up on adding AlmaLinux 10

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -472,6 +472,14 @@ if(MSVC AND NOT llvm13_broken_tests)
       dataframe/df017_vecOpsHEP.py)
 endif()
 
+# Some PROOF tutorial doesn't work on AlmaLinux 10, so veto it for the el10
+# Linux flavor. PROOF is deprecated in later ROOT versions, hence this failure
+# is not worth debugging at this point.
+string(REGEX MATCH "\\.el10" el10_suffix ${CMAKE_SYSTEM})
+if(NOT "${el10_suffix}" STREQUAL "")
+  set(el10_veto multicore/mp105_processEntryList.C)
+endif()
+
 set(all_veto hsimple.C
              geom/geometry.C
              ${extra_veto}
@@ -502,6 +510,7 @@ set(all_veto hsimple.C
              ${dataframe_veto}
              ${macm1_veto}
              ${clad_veto}
+             ${el10_veto}
              )
 
 file(GLOB_RECURSE tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.C)


### PR DESCRIPTION
Some PROOF tutorial doesn't work on AlmaLinux 10, so veto it for the el10 Linux flavor. PROOF is deprecated in later ROOT versions, hence this failure is not worth debugging at this point.

Follows up on the addition of Alma 10 to the CI