### PR TITLE
[v6-36][test][win] Fix compiler error with stabilityTests on Windows

### DIFF
--- a/roofit/roofit/test/CMakeLists.txt
+++ b/roofit/roofit/test/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # @author Stephan Hageboeck, CERN, 2019
 
-ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES RooFit)
+ROOT_ADD_GTEST(teststabilityTests stabilityTests.cxx LIBRARIES RooFit)
 ROOT_ADD_GTEST(testRooBernstein testRooBernstein.cxx LIBRARIES RooFit)
 ROOT_ADD_GTEST(testRooBifurGauss testRooBifurGauss.cxx LIBRARIES RooFit)
 ROOT_ADD_GTEST(testRooCrystalBall testRooCrystalBall.cxx LIBRARIES Gpad RooFit)


### PR DESCRIPTION
Fixes the following errors:
```
    roofitstats\stabilityTests.cxx(13,10): error C1083: Cannot open include file: 'gtest/gtest.h': No such file or directory

    LINK : error LNK2001: unresolved external symbol _tls_index/EXPORT:_Init_thread_abort
    roofit/roofit/test/Release/stabilityTests.lib : fatal error LNK1120: 1 unresolved externals`
```
